### PR TITLE
agent_ui: Show skill source in slash command autocomplete

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -87,6 +87,25 @@ pub fn subagent_session_info_from_meta(meta: &Option<acp::Meta>) -> Option<Subag
         .and_then(|v| serde_json::from_value(v.clone()).ok())
 }
 
+/// Key used in ACP `AvailableCommand` meta to indicate where a skill
+/// originated from (e.g. `"global"` or a worktree root name). Set by
+/// the native agent so the completion popup can surface skill origin to
+/// disambiguate same-named global vs. project-local skills.
+pub const SKILL_SOURCE_META_KEY: &str = "zed.skill_source";
+
+/// Helper to extract skill source label from ACP meta.
+pub fn skill_source_from_meta(meta: &Option<acp::Meta>) -> Option<SharedString> {
+    meta.as_ref()
+        .and_then(|m| m.get(SKILL_SOURCE_META_KEY))
+        .and_then(|v| v.as_str())
+        .map(|s| SharedString::from(s.to_owned()))
+}
+
+/// Helper to create meta tagging an `AvailableCommand` with a skill source.
+pub fn meta_with_skill_source(source: &str) -> acp::Meta {
+    acp::Meta::from_iter([(SKILL_SOURCE_META_KEY.into(), source.into())])
+}
+
 #[derive(Debug)]
 pub struct UserMessage {
     pub id: Option<UserMessageId>,

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -93,12 +93,22 @@ pub fn subagent_session_info_from_meta(meta: &Option<acp::Meta>) -> Option<Subag
 /// disambiguate same-named global vs. project-local skills.
 pub const SKILL_SOURCE_META_KEY: &str = "zed.skill_source";
 
-/// Helper to extract skill source label from ACP meta.
-pub fn skill_source_from_meta(meta: &Option<acp::Meta>) -> Option<SharedString> {
+/// Borrowing accessor for the skill source label stored in ACP meta.
+/// Prefer this over [`skill_source_from_meta`] in hot paths (e.g. per-
+/// command iteration during validation), since it avoids allocating
+/// a `SharedString` for callers that only need to compare against a
+/// `&str`.
+pub fn skill_source_str_from_meta(meta: &Option<acp::Meta>) -> Option<&str> {
     meta.as_ref()
         .and_then(|m| m.get(SKILL_SOURCE_META_KEY))
         .and_then(|v| v.as_str())
-        .map(|s| SharedString::from(s.to_owned()))
+}
+
+/// Helper to extract skill source label from ACP meta as an owned
+/// `SharedString`. Use this when the value needs to outlive the meta
+/// reference; otherwise prefer [`skill_source_str_from_meta`].
+pub fn skill_source_from_meta(meta: &Option<acp::Meta>) -> Option<SharedString> {
+    skill_source_str_from_meta(meta).map(|s| SharedString::from(s.to_owned()))
 }
 
 /// Helper to create meta tagging an `AvailableCommand` with a skill source.

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1859,7 +1859,16 @@ impl NativeAgentConnection {
 struct Command<'a> {
     prompt_name: &'a str,
     arg_value: &'a str,
+    /// MCP server prefix from `/<server>.<prompt>` syntax. Mutually
+    /// exclusive with `skill_scope` — the two grammars are
+    /// distinguished by the leading dot of the skill form.
     explicit_server_id: Option<&'a str>,
+    /// Skill scope qualifier from `/.<scope>.<name>` syntax, where
+    /// `<scope>` is either the literal `global` or a worktree root
+    /// name. The leading dot namespaces these against MCP server
+    /// prefixes so an MCP server literally named `global` (or named
+    /// after a worktree) can still be addressed unambiguously.
+    skill_scope: Option<&'a str>,
 }
 
 impl<'a> Command<'a> {
@@ -1873,17 +1882,47 @@ impl<'a> Command<'a> {
             .split_once(char::is_whitespace)
             .unwrap_or((command, ""));
 
+        // Skill scope qualifier: `/.<scope>.<name>`. The leading dot
+        // namespaces these away from MCP's `/<server>.<name>` grammar.
+        // Skill names are restricted to `[a-z0-9-]+` (no dots), so
+        // `rsplit_once('.')` cleanly separates the (possibly-dotted)
+        // scope from the skill name even when a worktree's root name
+        // contains dots (e.g. `my.cool.project`).
+        if let Some(rest) = command.strip_prefix('.') {
+            if let Some((scope, prompt_name)) = rest.rsplit_once('.')
+                && !scope.is_empty()
+                && !prompt_name.is_empty()
+            {
+                return Some(Self {
+                    prompt_name,
+                    arg_value,
+                    explicit_server_id: None,
+                    skill_scope: Some(scope),
+                });
+            }
+            // Malformed `/.something` — fall through as a bare command
+            // so validation downstream produces a useful error.
+            return Some(Self {
+                prompt_name: command,
+                arg_value,
+                explicit_server_id: None,
+                skill_scope: None,
+            });
+        }
+
         if let Some((server_id, prompt_name)) = command.split_once('.') {
             Some(Self {
                 prompt_name,
                 arg_value,
                 explicit_server_id: Some(server_id),
+                skill_scope: None,
             })
         } else {
             Some(Self {
                 prompt_name: command,
                 arg_value,
                 explicit_server_id: None,
+                skill_scope: None,
             })
         }
     }
@@ -2116,16 +2155,13 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
         };
 
         if let Some(parsed_command) = Command::parse(&params.prompt) {
-            // Skill scope qualifiers (`/global.<name>` and `/local.<name>`)
-            // are checked BEFORE MCP. The autocomplete popup inserts a
-            // qualified form for every skill so picking the global row
-            // unambiguously runs the global skill even when a same-named
-            // project-local one exists. An MCP server literally named
-            // `global` or `local` would collide here, but the qualified
-            // form remains usable as long as no skill with that name
-            // exists in the matching scope — we fall through to the MCP
-            // path below if the scope lookup misses.
-            if let Some(scope) = parsed_command.explicit_server_id
+            // Skill scope qualifiers (`/.global.<name>` and
+            // `/.<worktree>.<name>`) are namespaced by a leading dot so
+            // they can't collide with MCP server prefixes. The popup
+            // inserts a qualified form for every skill so picking the
+            // global row unambiguously runs the global skill even when
+            // a same-named project-local one exists.
+            if let Some(scope) = parsed_command.skill_scope
                 && let Some(skill) = project_state.skills.iter().find(|skill| {
                     skill.name == parsed_command.prompt_name && skill.source.matches_scope(scope)
                 })
@@ -2179,14 +2215,14 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
             }
 
             // Unqualified skill match (`/skill-name` with no scope
-            // prefix). Slash commands work for *all* skills regardless
-            // of `disable_model_invocation` — that flag only hides the
-            // skill from the model's catalog. The user explicitly typed
-            // the name, so they get to invoke it. Resolves against the
-            // override-applied view so that `/skill-name` runs the same
-            // entry the model would see in its catalog (project-local
-            // wins over global).
-            if parsed_command.explicit_server_id.is_none() {
+            // prefix and no MCP server prefix). Slash commands work
+            // for *all* skills regardless of `disable_model_invocation`
+            // — that flag only hides the skill from the model's catalog.
+            // The user explicitly typed the name, so they get to invoke
+            // it. Resolves against the override-applied view so that
+            // `/skill-name` runs the same entry the model would see in
+            // its catalog (project-local wins over global).
+            if parsed_command.explicit_server_id.is_none() && parsed_command.skill_scope.is_none() {
                 let resolved = apply_skill_overrides(&project_state.skills);
                 if let Some(skill) = resolved
                     .iter()
@@ -3074,19 +3110,31 @@ mod internal_tests {
         let global = SkillSource::Global;
         assert_eq!(global.scope_label(), "global");
         assert!(global.matches_scope("global"));
-        assert!(!global.matches_scope("local"));
+        assert!(!global.matches_scope("zed"));
         assert!(!global.matches_scope("some-mcp-server"));
 
         let project = SkillSource::ProjectLocal {
             worktree_id: SkillScopeId(1),
             worktree_root_name: "zed".into(),
         };
-        assert_eq!(project.scope_label(), "local");
-        assert!(project.matches_scope("local"));
+        // Project-local skills are scoped by their worktree root name
+        // so multiple open worktrees with same-named skills can each
+        // be addressed unambiguously.
+        assert_eq!(project.scope_label(), "zed");
+        assert!(project.matches_scope("zed"));
         assert!(!project.matches_scope("global"));
-        // The worktree root name isn't a valid scope qualifier — only
-        // the literal `global` / `local` strings are.
-        assert!(!project.matches_scope("zed"));
+        // An unrelated worktree name (or MCP server name) must not
+        // match a project skill from a different worktree.
+        assert!(!project.matches_scope("extensions"));
+
+        // Edge case: a worktree literally named `global` cannot
+        // shadow the global scope qualifier, so `/global.<name>`
+        // always resolves to a global skill.
+        let project_named_global = SkillSource::ProjectLocal {
+            worktree_id: SkillScopeId(2),
+            worktree_root_name: "global".into(),
+        };
+        assert!(!project_named_global.matches_scope("global"));
     }
 
     #[test]

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1257,10 +1257,16 @@ impl NativeAgent {
         // `disable_model_invocation`. The flag controls catalog visibility
         // for the model, not user-driven invocation — that's the whole
         // point of marking a skill model-disabled.
-        let skill_commands = state
-            .skills
-            .iter()
-            .map(|skill| acp::AvailableCommand::new(skill.name.clone(), skill.description.clone()));
+        let skill_commands = state.skills.iter().map(|skill| {
+            let source_label = match &skill.source {
+                SkillSource::Global => "global".to_string(),
+                SkillSource::ProjectLocal {
+                    worktree_root_name, ..
+                } => worktree_root_name.to_string(),
+            };
+            acp::AvailableCommand::new(skill.name.clone(), skill.description.clone())
+                .meta(acp_thread::meta_with_skill_source(&source_label))
+        });
 
         mcp_commands.chain(skill_commands).collect()
     }

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1269,12 +1269,12 @@ impl NativeAgent {
         // for the model, not user-driven invocation — that's the whole
         // point of marking a skill model-disabled.
         let skill_commands = state.skills.iter().map(|skill| {
-            // `scope_label` doubles as the popup source label and the
-            // `/<scope>.<name>` prefix the completion inserts — see the
-            // doc on `SkillSource::scope_label` for why these have to
-            // stay equal.
+            // The meta carries the literal scope prefix the popup
+            // inserts as `/<prefix>:<name>`: empty for globals (so
+            // the inserted text is `/:<name>`) and the worktree root
+            // name for project-locals. See `SkillSource::scope_prefix`.
             acp::AvailableCommand::new(skill.name.clone(), skill.description.clone()).meta(
-                acp_thread::meta_with_skill_source(skill.source.scope_label()),
+                acp_thread::meta_with_skill_source(skill.source.scope_prefix()),
             )
         });
 
@@ -1886,10 +1886,15 @@ impl<'a> Command<'a> {
         // Skill scope qualifier: `/<scope>:<name>`. Checked before the
         // MCP `.` grammar because `:` and `.` are different delimiters
         // — the two namespaces can't collide. Skill names are
-        // restricted to `[a-z0-9-]+` (no colons), so `split_once(':')`
-        // is unambiguous.
-        if let Some((scope, prompt_name)) = command.split_once(':')
-            && !scope.is_empty()
+        // restricted to `[a-z0-9-]+` (no colons), so the LAST `:` is
+        // always the scope/name boundary; using `rsplit_once` lets
+        // scope labels (e.g. a worktree root name) themselves contain
+        // colons without breaking the parse.
+        //
+        // An empty scope (`/:<name>`) is the qualified form for a
+        // global skill — see `SkillSource::scope_prefix`. The name
+        // must be non-empty for the colon to be meaningful.
+        if let Some((scope, prompt_name)) = command.rsplit_once(':')
             && !prompt_name.is_empty()
         {
             return Some(Self {
@@ -2209,15 +2214,34 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
             // for *all* skills regardless of `disable_model_invocation`
             // — that flag only hides the skill from the model's catalog.
             // The user explicitly typed the name, so they get to invoke
-            // it. Resolves against the override-applied view so that
-            // `/skill-name` runs the same entry the model would see in
-            // its catalog (project-local wins over global).
-            if parsed_command.explicit_server_id.is_none() && parsed_command.skill_scope.is_none() {
-                let resolved = apply_skill_overrides(&project_state.skills);
-                if let Some(skill) = resolved
+            // it.
+            //
+            // Inlined rather than calling `apply_skill_overrides` so
+            // we don't clone the entire skill list on every prompt
+            // (including prompts like `/help` that aren't skills at
+            // all). The resolution rule matches the override-applied
+            // view: prefer a project-local with the matching name,
+            // falling back to a global, so the slash command picks the
+            // same entry the model sees in its catalog.
+            if parsed_command.explicit_server_id.is_none()
+                && parsed_command.skill_scope.is_none()
+                && !project_state.skills.is_empty()
+            {
+                let prompt_name = parsed_command.prompt_name;
+                let resolved = project_state
+                    .skills
                     .iter()
-                    .find(|skill| skill.name == parsed_command.prompt_name)
-                {
+                    .find(|skill| {
+                        skill.name == prompt_name
+                            && matches!(skill.source, SkillSource::ProjectLocal { .. })
+                    })
+                    .or_else(|| {
+                        project_state
+                            .skills
+                            .iter()
+                            .find(|skill| skill.name == prompt_name)
+                    });
+                if let Some(skill) = resolved {
                     let skill = skill.clone();
                     return self.0.update(cx, |agent, cx| {
                         agent.send_skill_invocation(
@@ -2906,8 +2930,7 @@ pub(crate) fn skills_resolver_for_project(
 /// interacts with skills (system-prompt catalog, `SkillTool` lookup,
 /// slash-command invocation).
 ///
-/// Globals come first so that `apply_skill_overrides` can rely on a
-/// stable iteration order when picking the winner of a name collision.
+/// Global versions of skills will be before the local versions
 fn combine_skills(
     global: Vec<Result<Skill, SkillLoadError>>,
     project: impl Iterator<Item = Result<Skill, SkillLoadError>>,
@@ -2969,9 +2992,12 @@ fn log_skill_conflicts(skills: &[Skill]) {
 /// users can see what's shadowed.
 fn apply_skill_overrides(skills: &[Skill]) -> Vec<Skill> {
     let mut result: Vec<Skill> = Vec::new();
-    let mut indices: HashMap<String, usize> = HashMap::default();
+    // Borrow names from the input slice so the dedup index doesn't
+    // need to allocate a `String` per skill. The borrow is valid for
+    // the body of the function because `skills` outlives `indices`.
+    let mut indices: HashMap<&str, usize> = HashMap::default();
     for skill in skills {
-        match indices.get(&skill.name).copied() {
+        match indices.get(skill.name.as_str()).copied() {
             Some(idx) => {
                 if matches!(result[idx].source, SkillSource::Global)
                     && matches!(skill.source, SkillSource::ProjectLocal { .. })
@@ -2980,7 +3006,7 @@ fn apply_skill_overrides(skills: &[Skill]) -> Vec<Skill> {
                 }
             }
             None => {
-                indices.insert(skill.name.clone(), result.len());
+                indices.insert(skill.name.as_str(), result.len());
                 result.push(skill.clone());
             }
         }
@@ -3093,15 +3119,18 @@ mod internal_tests {
     }
 
     #[test]
-    fn test_skill_source_scope_label_and_matches_scope() {
-        // The popup's source label and the `/<scope>.<name>` prefix it
-        // inserts come from the same place; this test pins that
-        // contract so the two can't drift apart.
+    fn test_skill_source_scope_prefix_and_matches_scope() {
+        // The popup inserts `/<prefix>:<name>` using `scope_prefix`,
+        // and the resolver routes via `matches_scope`. This test pins
+        // the contract that the two stay in sync.
         let global = SkillSource::Global;
-        assert_eq!(global.scope_label(), "global");
-        assert!(global.matches_scope("global"));
+        // Globals use an empty prefix, so the popup inserts `/:<name>`.
+        assert_eq!(global.scope_prefix(), "");
+        assert!(global.matches_scope(""));
+        // Hand-typed `/global:<name>` is not aliased to the global
+        // source; it looks for a worktree literally named `global`.
+        assert!(!global.matches_scope("global"));
         assert!(!global.matches_scope("zed"));
-        assert!(!global.matches_scope("some-mcp-server"));
 
         let project = SkillSource::ProjectLocal {
             worktree_id: SkillScopeId(1),
@@ -3110,21 +3139,24 @@ mod internal_tests {
         // Project-local skills are scoped by their worktree root name
         // so multiple open worktrees with same-named skills can each
         // be addressed unambiguously.
-        assert_eq!(project.scope_label(), "zed");
+        assert_eq!(project.scope_prefix(), "zed");
         assert!(project.matches_scope("zed"));
-        assert!(!project.matches_scope("global"));
+        // The empty scope is reserved for globals.
+        assert!(!project.matches_scope(""));
         // An unrelated worktree name (or MCP server name) must not
         // match a project skill from a different worktree.
         assert!(!project.matches_scope("extensions"));
 
-        // Edge case: a worktree literally named `global` cannot
-        // shadow the global scope qualifier, so `/global.<name>`
-        // always resolves to a global skill.
+        // A worktree literally named `global` is no longer ambiguous
+        // with the global source: its skills are invoked as
+        // `/global:<name>` while globals are invoked as `/:<name>`.
         let project_named_global = SkillSource::ProjectLocal {
             worktree_id: SkillScopeId(2),
             worktree_root_name: "global".into(),
         };
-        assert!(!project_named_global.matches_scope("global"));
+        assert_eq!(project_named_global.scope_prefix(), "global");
+        assert!(project_named_global.matches_scope("global"));
+        assert!(!project_named_global.matches_scope(""));
     }
 
     #[test]

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1860,14 +1860,15 @@ struct Command<'a> {
     prompt_name: &'a str,
     arg_value: &'a str,
     /// MCP server prefix from `/<server>.<prompt>` syntax. Mutually
-    /// exclusive with `skill_scope` — the two grammars are
-    /// distinguished by the leading dot of the skill form.
+    /// exclusive with `skill_scope` — the two grammars use different
+    /// delimiters (`.` for MCP, `:` for skill scopes) so they can't
+    /// collide.
     explicit_server_id: Option<&'a str>,
-    /// Skill scope qualifier from `/.<scope>.<name>` syntax, where
+    /// Skill scope qualifier from `/<scope>:<name>` syntax, where
     /// `<scope>` is either the literal `global` or a worktree root
-    /// name. The leading dot namespaces these against MCP server
-    /// prefixes so an MCP server literally named `global` (or named
-    /// after a worktree) can still be addressed unambiguously.
+    /// name. The `:` separator namespaces these against MCP server
+    /// prefixes (which use `.`) so an MCP server literally named
+    /// `global` or named after a worktree still parses unambiguously.
     skill_scope: Option<&'a str>,
 }
 
@@ -1882,31 +1883,20 @@ impl<'a> Command<'a> {
             .split_once(char::is_whitespace)
             .unwrap_or((command, ""));
 
-        // Skill scope qualifier: `/.<scope>.<name>`. The leading dot
-        // namespaces these away from MCP's `/<server>.<name>` grammar.
-        // Skill names are restricted to `[a-z0-9-]+` (no dots), so
-        // `rsplit_once('.')` cleanly separates the (possibly-dotted)
-        // scope from the skill name even when a worktree's root name
-        // contains dots (e.g. `my.cool.project`).
-        if let Some(rest) = command.strip_prefix('.') {
-            if let Some((scope, prompt_name)) = rest.rsplit_once('.')
-                && !scope.is_empty()
-                && !prompt_name.is_empty()
-            {
-                return Some(Self {
-                    prompt_name,
-                    arg_value,
-                    explicit_server_id: None,
-                    skill_scope: Some(scope),
-                });
-            }
-            // Malformed `/.something` — fall through as a bare command
-            // so validation downstream produces a useful error.
+        // Skill scope qualifier: `/<scope>:<name>`. Checked before the
+        // MCP `.` grammar because `:` and `.` are different delimiters
+        // — the two namespaces can't collide. Skill names are
+        // restricted to `[a-z0-9-]+` (no colons), so `split_once(':')`
+        // is unambiguous.
+        if let Some((scope, prompt_name)) = command.split_once(':')
+            && !scope.is_empty()
+            && !prompt_name.is_empty()
+        {
             return Some(Self {
-                prompt_name: command,
+                prompt_name,
                 arg_value,
                 explicit_server_id: None,
-                skill_scope: None,
+                skill_scope: Some(scope),
             });
         }
 
@@ -2155,9 +2145,9 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
         };
 
         if let Some(parsed_command) = Command::parse(&params.prompt) {
-            // Skill scope qualifiers (`/.global.<name>` and
-            // `/.<worktree>.<name>`) are namespaced by a leading dot so
-            // they can't collide with MCP server prefixes. The popup
+            // Skill scope qualifiers (`/global:<name>` and
+            // `/<worktree>:<name>`) use a colon separator that can't
+            // collide with MCP's `/<server>.<name>` grammar. The popup
             // inserts a qualified form for every skill so picking the
             // global row unambiguously runs the global skill even when
             // a same-named project-local one exists.

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1269,14 +1269,13 @@ impl NativeAgent {
         // for the model, not user-driven invocation — that's the whole
         // point of marking a skill model-disabled.
         let skill_commands = state.skills.iter().map(|skill| {
-            let source_label = match &skill.source {
-                SkillSource::Global => "global".to_string(),
-                SkillSource::ProjectLocal {
-                    worktree_root_name, ..
-                } => worktree_root_name.to_string(),
-            };
-            acp::AvailableCommand::new(skill.name.clone(), skill.description.clone())
-                .meta(acp_thread::meta_with_skill_source(&source_label))
+            // `scope_label` doubles as the popup source label and the
+            // `/<scope>.<name>` prefix the completion inserts — see the
+            // doc on `SkillSource::scope_label` for why these have to
+            // stay equal.
+            acp::AvailableCommand::new(skill.name.clone(), skill.description.clone()).meta(
+                acp_thread::meta_with_skill_source(skill.source.scope_label()),
+            )
         });
 
         mcp_commands.chain(skill_commands).collect()
@@ -2117,6 +2116,26 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
         };
 
         if let Some(parsed_command) = Command::parse(&params.prompt) {
+            // Skill scope qualifiers (`/global.<name>` and `/local.<name>`)
+            // are checked BEFORE MCP. The autocomplete popup inserts a
+            // qualified form for every skill so picking the global row
+            // unambiguously runs the global skill even when a same-named
+            // project-local one exists. An MCP server literally named
+            // `global` or `local` would collide here, but the qualified
+            // form remains usable as long as no skill with that name
+            // exists in the matching scope — we fall through to the MCP
+            // path below if the scope lookup misses.
+            if let Some(scope) = parsed_command.explicit_server_id
+                && let Some(skill) = project_state.skills.iter().find(|skill| {
+                    skill.name == parsed_command.prompt_name && skill.source.matches_scope(scope)
+                })
+            {
+                let skill = skill.clone();
+                return self.0.update(cx, |agent, cx| {
+                    agent.send_skill_invocation(id, session_id.clone(), skill, params.prompt, cx)
+                });
+            }
+
             // MCP prompts and skills both register slash commands. MCP
             // prompts are checked first — if a user has both an MCP prompt
             // and a skill with the same name, the MCP prompt wins (matching
@@ -2159,17 +2178,14 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
                 });
             }
 
-            // Skill match. Slash commands work for *all* skills regardless
+            // Unqualified skill match (`/skill-name` with no scope
+            // prefix). Slash commands work for *all* skills regardless
             // of `disable_model_invocation` — that flag only hides the
             // skill from the model's catalog. The user explicitly typed
-            // the name, so they get to invoke it.
-            //
-            // The autocomplete popup shows every skill (with source
-            // labels for same-named entries), but the underlying
-            // `/<name>` text is the same regardless of which row the
-            // user picked. To stay consistent with what the model sees,
-            // we resolve the typed name against the override-applied
-            // view so project-local wins over a same-named global.
+            // the name, so they get to invoke it. Resolves against the
+            // override-applied view so that `/skill-name` runs the same
+            // entry the model would see in its catalog (project-local
+            // wins over global).
             if parsed_command.explicit_server_id.is_none() {
                 let resolved = apply_skill_overrides(&project_state.skills);
                 if let Some(skill) = resolved
@@ -3048,6 +3064,29 @@ mod internal_tests {
         assert_eq!(resolved.len(), 3);
         let names: Vec<&str> = resolved.iter().map(|s| s.name.as_str()).collect();
         assert_eq!(names, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn test_skill_source_scope_label_and_matches_scope() {
+        // The popup's source label and the `/<scope>.<name>` prefix it
+        // inserts come from the same place; this test pins that
+        // contract so the two can't drift apart.
+        let global = SkillSource::Global;
+        assert_eq!(global.scope_label(), "global");
+        assert!(global.matches_scope("global"));
+        assert!(!global.matches_scope("local"));
+        assert!(!global.matches_scope("some-mcp-server"));
+
+        let project = SkillSource::ProjectLocal {
+            worktree_id: SkillScopeId(1),
+            worktree_root_name: "zed".into(),
+        };
+        assert_eq!(project.scope_label(), "local");
+        assert!(project.matches_scope("local"));
+        assert!(!project.matches_scope("global"));
+        // The worktree root name isn't a valid scope qualifier — only
+        // the literal `global` / `local` strings are.
+        assert!(!project.matches_scope("zed"));
     }
 
     #[test]

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -2150,7 +2150,7 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
         };
 
         if let Some(parsed_command) = Command::parse(&params.prompt) {
-            // Skill scope qualifiers (`/global:<name>` and
+            // Skill scope qualifiers (`/:<name>` and
             // `/<worktree>:<name>`) use a colon separator that can't
             // collide with MCP's `/<server>.<name>` grammar. The popup
             // inserts a qualified form for every skill so picking the

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -922,16 +922,27 @@ impl NativeAgent {
                 })
                 .collect::<Vec<_>>();
 
-            // Load and merge skills
+            // Load and combine skills. `combine_skills` deliberately
+            // does NOT deduplicate — the autocomplete popup needs to
+            // see every entry so users can disambiguate same-named
+            // global vs. project-local skills via the source label.
+            // Project-overrides-global is applied below, only for the
+            // model-facing catalog.
             let global_skills = global_skills_task.await;
             let project_skills_results = project_skills_task.await;
             let (skills, mut skill_errors) =
-                merge_skills(global_skills, project_skills_results.into_iter().flatten());
+                combine_skills(global_skills, project_skills_results.into_iter().flatten());
+
+            // Apply project-overrides-global before catalog selection
+            // so the model sees at most one entry per name. The full
+            // `skills` list is still stored on `ProjectState` and used
+            // by the autocomplete popup.
+            let overridden = apply_skill_overrides(&skills);
 
             // Enforce the catalog size budget here so that skills which
             // don't fit produce a load error in the UI rather than being
             // silently swallowed by ProjectContext.
-            let (catalog_skills, budget_errors) = select_catalog_skills(&skills);
+            let (catalog_skills, budget_errors) = select_catalog_skills(&overridden);
             skill_errors.extend(budget_errors);
 
             let project_context =
@@ -2152,16 +2163,30 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
             // of `disable_model_invocation` — that flag only hides the
             // skill from the model's catalog. The user explicitly typed
             // the name, so they get to invoke it.
-            if parsed_command.explicit_server_id.is_none()
-                && let Some(skill) = project_state
-                    .skills
+            //
+            // The autocomplete popup shows every skill (with source
+            // labels for same-named entries), but the underlying
+            // `/<name>` text is the same regardless of which row the
+            // user picked. To stay consistent with what the model sees,
+            // we resolve the typed name against the override-applied
+            // view so project-local wins over a same-named global.
+            if parsed_command.explicit_server_id.is_none() {
+                let resolved = apply_skill_overrides(&project_state.skills);
+                if let Some(skill) = resolved
                     .iter()
                     .find(|skill| skill.name == parsed_command.prompt_name)
-            {
-                let skill = skill.clone();
-                return self.0.update(cx, |agent, cx| {
-                    agent.send_skill_invocation(id, session_id.clone(), skill, params.prompt, cx)
-                });
+                {
+                    let skill = skill.clone();
+                    return self.0.update(cx, |agent, cx| {
+                        agent.send_skill_invocation(
+                            id,
+                            session_id.clone(),
+                            skill,
+                            params.prompt,
+                            cx,
+                        )
+                    });
+                }
             }
         };
 
@@ -2807,10 +2832,11 @@ fn select_catalog_skills(skills: &[Skill]) -> (Vec<SkillSummary>, Vec<SkillLoadE
 }
 
 /// Build a closure that, when called, reads the latest `state.skills`
-/// for the given project from the `NativeAgent`. This is the resolver
-/// the `SkillTool` consults at invocation time so that skill changes
-/// after thread construction become visible without re-registering the
-/// tool.
+/// for the given project from the `NativeAgent` and applies
+/// project-overrides-global so the `SkillTool` resolves a name to the
+/// same entry the model sees in its catalog. Run at invocation time
+/// (not thread-build time) so skill changes after thread construction
+/// become visible without re-registering the tool.
 pub(crate) fn skills_resolver_for_project(
     weak_agent: WeakEntity<NativeAgent>,
     project_id: EntityId,
@@ -2823,72 +2849,101 @@ pub(crate) fn skills_resolver_for_project(
                     .read(cx)
                     .projects
                     .get(&project_id)
-                    .map(|state| state.skills.clone())
+                    .map(|state| Arc::new(apply_skill_overrides(&state.skills)))
             })
             .unwrap_or_else(|| Arc::new(Vec::new()))
     }
 }
 
-/// Merge global and project-local skills.
-/// Project-local skills override global skills with the same name.
-fn merge_skills(
+/// Collect successfully-loaded global and project-local skills into a
+/// single list, preserving every entry — even when two skills share a
+/// name. The autocomplete popup shows the full list with origin labels
+/// so users can tell same-named skills apart; override resolution
+/// (project-local wins over global) happens later via
+/// [`apply_skill_overrides`] at the boundaries where the model
+/// interacts with skills (system-prompt catalog, `SkillTool` lookup,
+/// slash-command invocation).
+///
+/// Globals come first so that `apply_skill_overrides` can rely on a
+/// stable iteration order when picking the winner of a name collision.
+fn combine_skills(
     global: Vec<Result<Skill, SkillLoadError>>,
     project: impl Iterator<Item = Result<Skill, SkillLoadError>>,
 ) -> (Vec<Skill>, Vec<SkillLoadError>) {
     let mut skills = Vec::new();
     let mut errors = Vec::new();
-    let mut seen_names: HashMap<String, (usize, SkillSource, PathBuf)> = HashMap::default();
-
     for result in global.into_iter().chain(project) {
         match result {
-            Ok(skill) => {
-                if let Some((existing_index, existing_source, existing_path)) =
-                    seen_names.get(&skill.name).cloned()
-                {
-                    match (&existing_source, &skill.source) {
-                        (SkillSource::Global, SkillSource::ProjectLocal { .. }) => {
-                            log::warn!(
-                                "Project skill '{}' at '{}' overrides global skill at '{}'",
-                                skill.name,
-                                skill.skill_file_path.display(),
-                                existing_path.display()
-                            );
-                            seen_names.insert(
-                                skill.name.clone(),
-                                (
-                                    existing_index,
-                                    skill.source.clone(),
-                                    skill.skill_file_path.clone(),
-                                ),
-                            );
-                            skills[existing_index] = skill;
-                        }
-                        _ => {
-                            log::warn!(
-                                "Skill '{}' at '{}' conflicts with skill at '{}'; keeping the first one",
-                                skill.name,
-                                skill.skill_file_path.display(),
-                                existing_path.display()
-                            );
-                        }
-                    }
-                } else {
-                    seen_names.insert(
-                        skill.name.clone(),
-                        (
-                            skills.len(),
-                            skill.source.clone(),
-                            skill.skill_file_path.clone(),
-                        ),
-                    );
-                    skills.push(skill);
-                }
-            }
+            Ok(skill) => skills.push(skill),
             Err(e) => errors.push(e),
         }
     }
-
+    log_skill_conflicts(&skills);
     (skills, errors)
+}
+
+/// Emit a warning for each name collision between skills. Called once
+/// per skill load (not per query), so the log isn't spammed by repeated
+/// catalog rebuilds.
+fn log_skill_conflicts(skills: &[Skill]) {
+    let mut by_name: HashMap<&str, &Skill> = HashMap::default();
+    for skill in skills {
+        match by_name.get(skill.name.as_str()) {
+            Some(existing) => match (&existing.source, &skill.source) {
+                (SkillSource::Global, SkillSource::ProjectLocal { .. }) => {
+                    log::warn!(
+                        "Project skill '{}' at '{}' overrides global skill at '{}' for the model; both appear in the slash-command popup with their source",
+                        skill.name,
+                        skill.skill_file_path.display(),
+                        existing.skill_file_path.display(),
+                    );
+                    by_name.insert(skill.name.as_str(), skill);
+                }
+                _ => {
+                    log::warn!(
+                        "Skill '{}' at '{}' conflicts with skill at '{}'; the model will see the first one, but both appear in the slash-command popup with their source",
+                        skill.name,
+                        skill.skill_file_path.display(),
+                        existing.skill_file_path.display(),
+                    );
+                }
+            },
+            None => {
+                by_name.insert(skill.name.as_str(), skill);
+            }
+        }
+    }
+}
+
+/// Project-local skills override same-named global skills. Returns a
+/// new list with at most one entry per name. Two skills of the same
+/// source colliding (e.g. two globals or two project-locals) keep the
+/// first one to match the historical behavior.
+///
+/// This is the projection of `state.skills` used by everything the
+/// model interacts with: the system-prompt catalog, the `SkillTool`'s
+/// name resolver, and slash-command invocation. The autocomplete popup
+/// deliberately does *not* go through this — it shows the full list so
+/// users can see what's shadowed.
+fn apply_skill_overrides(skills: &[Skill]) -> Vec<Skill> {
+    let mut result: Vec<Skill> = Vec::new();
+    let mut indices: HashMap<String, usize> = HashMap::default();
+    for skill in skills {
+        match indices.get(&skill.name).copied() {
+            Some(idx) => {
+                if matches!(result[idx].source, SkillSource::Global)
+                    && matches!(skill.source, SkillSource::ProjectLocal { .. })
+                {
+                    result[idx] = skill.clone();
+                }
+            }
+            None => {
+                indices.insert(skill.name.clone(), result.len());
+                result.push(skill.clone());
+            }
+        }
+    }
+    result
 }
 
 #[cfg(test)]
@@ -2908,35 +2963,91 @@ mod internal_tests {
     use settings::SettingsStore;
     use util::{path, rel_path::rel_path};
 
-    #[test]
-    fn test_project_skills_override_global_skills() {
-        let global_skill = Skill {
-            name: "review".to_string(),
-            description: "Global review".to_string(),
+    fn make_global_skill(name: &str, description: &str) -> Skill {
+        Skill {
+            name: name.to_string(),
+            description: description.to_string(),
             source: SkillSource::Global,
-            directory_path: PathBuf::from("/home/user/.agents/skills/review"),
-            skill_file_path: PathBuf::from("/home/user/.agents/skills/review/SKILL.md"),
+            directory_path: PathBuf::from(format!("/home/user/.agents/skills/{name}")),
+            skill_file_path: PathBuf::from(format!("/home/user/.agents/skills/{name}/SKILL.md")),
             disable_model_invocation: false,
-        };
-        let project_skill = Skill {
-            name: "review".to_string(),
-            description: "Project review".to_string(),
+        }
+    }
+
+    fn make_project_skill(name: &str, description: &str, worktree: &str) -> Skill {
+        Skill {
+            name: name.to_string(),
+            description: description.to_string(),
             source: SkillSource::ProjectLocal {
                 worktree_id: SkillScopeId(1),
-                worktree_root_name: "project".into(),
+                worktree_root_name: worktree.into(),
             },
-            directory_path: PathBuf::from("/project/.agents/skills/review"),
-            skill_file_path: PathBuf::from("/project/.agents/skills/review/SKILL.md"),
+            directory_path: PathBuf::from(format!("/{worktree}/.agents/skills/{name}")),
+            skill_file_path: PathBuf::from(format!("/{worktree}/.agents/skills/{name}/SKILL.md")),
             disable_model_invocation: false,
-        };
+        }
+    }
 
-        let (skills, errors) =
-            merge_skills(vec![Ok(global_skill)], vec![Ok(project_skill)].into_iter());
+    #[test]
+    fn test_combine_skills_keeps_every_entry_for_autocomplete() {
+        // The autocomplete popup needs both same-named entries so the
+        // source label can disambiguate them. `combine_skills` must not
+        // drop the global when a project-local shares its name.
+        let global = make_global_skill("review", "Global review");
+        let project = make_project_skill("review", "Project review", "project");
+
+        let (skills, errors) = combine_skills(vec![Ok(global)], vec![Ok(project)].into_iter());
 
         assert!(errors.is_empty());
-        assert_eq!(skills.len(), 1);
-        assert_eq!(skills[0].description, "Project review");
-        assert!(matches!(skills[0].source, SkillSource::ProjectLocal { .. }));
+        assert_eq!(skills.len(), 2);
+        assert!(matches!(skills[0].source, SkillSource::Global));
+        assert!(matches!(skills[1].source, SkillSource::ProjectLocal { .. }));
+    }
+
+    #[test]
+    fn test_apply_skill_overrides_project_wins_over_global() {
+        // The model-facing projection collapses the same name to a
+        // single entry, with the project-local winning. This is what
+        // `select_catalog_skills`, `SkillTool`, and the slash-command
+        // resolver all see.
+        let global = make_global_skill("review", "Global review");
+        let project = make_project_skill("review", "Project review", "project");
+
+        let resolved = apply_skill_overrides(&[global, project]);
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].description, "Project review");
+        assert!(matches!(
+            resolved[0].source,
+            SkillSource::ProjectLocal { .. }
+        ));
+    }
+
+    #[test]
+    fn test_apply_skill_overrides_same_source_collision_keeps_first() {
+        // Two globals (or two project-locals from different worktrees)
+        // colliding don't have a clear winner; preserve the historical
+        // "first one wins" behavior.
+        let first = make_global_skill("review", "First");
+        let second = make_global_skill("review", "Second");
+
+        let resolved = apply_skill_overrides(&[first, second]);
+
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].description, "First");
+    }
+
+    #[test]
+    fn test_apply_skill_overrides_preserves_unique_skills() {
+        let global_a = make_global_skill("alpha", "a");
+        let global_b = make_global_skill("beta", "b");
+        let project_c = make_project_skill("gamma", "c", "project");
+
+        let resolved = apply_skill_overrides(&[global_a, global_b, project_c]);
+
+        assert_eq!(resolved.len(), 3);
+        let names: Vec<&str> = resolved.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "beta", "gamma"]);
     }
 
     #[test]

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -65,31 +65,22 @@ pub enum SkillSource {
     },
 }
 
-/// Scope qualifier used in `/global:<name>` slash-command syntax to
-/// unambiguously target the global version of a same-named skill.
-/// Project-local skills use their worktree root name (e.g. `zed` for a
-/// worktree rooted at `~/code/zed`) as their scope qualifier instead
-/// of a fixed literal, so multiple open worktrees with same-named
-/// skills can each be addressed unambiguously.
-pub const SKILL_SCOPE_GLOBAL: &str = "global";
-
 impl SkillSource {
-    /// Returns the scope label that identifies this source in user-
-    /// visible places: the autocomplete popup's source column, and the
-    /// `<scope>:<name>` slash-command prefix that the popup inserts so
-    /// the resolver can route `/global:foo` and `/<worktree>:foo` to
-    /// the correct entry. The two uses MUST stay in sync — if the
-    /// popup shows `zed` the inserted text has to start with `/zed:`
-    /// or the resolver won't find the skill.
+    /// Scope prefix used in the `/<prefix>:<name>` slash-command
+    /// syntax that the autocomplete popup inserts. Global skills use
+    /// an empty prefix (so the inserted text is `/:<name>`), and
+    /// project-local skills use their worktree root name (so the
+    /// inserted text is `/<worktree>:<name>`).
     ///
-    /// Edge case: a worktree literally named `global` collides with
-    /// the global scope qualifier. `matches_scope` resolves the
-    /// ambiguity in favor of the global source; the project-local
-    /// skill in such a worktree can still be invoked unqualified as
-    /// `/<name>`.
-    pub fn scope_label(&self) -> &str {
+    /// Using an empty prefix for globals rather than a literal
+    /// `global` means a worktree literally named `global` is no
+    /// longer ambiguous with the global source: the global skill is
+    /// invoked as `/:<name>`, and the worktree's skill is invoked as
+    /// `/global:<name>`. The two grammars never collide on the
+    /// inserted text.
+    pub fn scope_prefix(&self) -> &str {
         match self {
-            Self::Global => SKILL_SCOPE_GLOBAL,
+            Self::Global => "",
             Self::ProjectLocal {
                 worktree_root_name, ..
             } => worktree_root_name.as_ref(),
@@ -97,21 +88,21 @@ impl SkillSource {
     }
 
     /// Whether this source matches the given scope qualifier from a
-    /// `/<scope>:<name>` slash command. Unknown scopes never match —
-    /// in that case the resolver leaves the prompt alone so unknown
-    /// scopes surface as a validation error rather than silently
-    /// being treated as plain text.
+    /// `/<scope>:<name>` slash command. The empty scope is reserved
+    /// for global skills; non-empty scopes match a project-local
+    /// skill whose worktree root name equals the scope.
     ///
-    /// `/global:<name>` is reserved for the global source even when a
-    /// project-local skill comes from a worktree named `global`, so
-    /// the literal global scope can never be shadowed by a worktree's
-    /// name.
+    /// Hand-typed `/global:<name>` is NOT treated as an alias for
+    /// `/:<name>`. It looks for a project-local skill from a worktree
+    /// named `global` and fails if none exists. The popup always
+    /// inserts the unambiguous form (`/:<name>` for globals), so this
+    /// strictness only affects users typing by memory.
     pub fn matches_scope(&self, scope: &str) -> bool {
         match self {
-            Self::Global => scope == SKILL_SCOPE_GLOBAL,
+            Self::Global => scope.is_empty(),
             Self::ProjectLocal {
                 worktree_root_name, ..
-            } => scope != SKILL_SCOPE_GLOBAL && worktree_root_name.as_ref() == scope,
+            } => !scope.is_empty() && worktree_root_name.as_ref() == scope,
         }
     }
 }

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -65,7 +65,7 @@ pub enum SkillSource {
     },
 }
 
-/// Scope qualifier used in `/global.<name>` slash-command syntax to
+/// Scope qualifier used in `/global:<name>` slash-command syntax to
 /// unambiguously target the global version of a same-named skill.
 /// Project-local skills use their worktree root name (e.g. `zed` for a
 /// worktree rooted at `~/code/zed`) as their scope qualifier instead
@@ -76,10 +76,10 @@ pub const SKILL_SCOPE_GLOBAL: &str = "global";
 impl SkillSource {
     /// Returns the scope label that identifies this source in user-
     /// visible places: the autocomplete popup's source column, and the
-    /// `<scope>.<name>` slash-command prefix that the popup inserts so
-    /// the resolver can route `/global.foo` and `/<worktree>.foo` to
+    /// `<scope>:<name>` slash-command prefix that the popup inserts so
+    /// the resolver can route `/global:foo` and `/<worktree>:foo` to
     /// the correct entry. The two uses MUST stay in sync — if the
-    /// popup shows `zed` the inserted text has to start with `/zed.`
+    /// popup shows `zed` the inserted text has to start with `/zed:`
     /// or the resolver won't find the skill.
     ///
     /// Edge case: a worktree literally named `global` collides with
@@ -97,12 +97,12 @@ impl SkillSource {
     }
 
     /// Whether this source matches the given scope qualifier from a
-    /// `/<scope>.<name>` slash command. Unknown scopes never match — in
-    /// that case the resolver falls through to MCP, preserving the
-    /// existing MCP-server-prefix grammar for any prefix that isn't a
-    /// known skill scope.
+    /// `/<scope>:<name>` slash command. Unknown scopes never match —
+    /// in that case the resolver leaves the prompt alone so unknown
+    /// scopes surface as a validation error rather than silently
+    /// being treated as plain text.
     ///
-    /// `/global.<name>` is reserved for the global source even when a
+    /// `/global:<name>` is reserved for the global source even when a
     /// project-local skill comes from a worktree named `global`, so
     /// the literal global scope can never be shadowed by a worktree's
     /// name.

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -67,25 +67,32 @@ pub enum SkillSource {
 
 /// Scope qualifier used in `/global.<name>` slash-command syntax to
 /// unambiguously target the global version of a same-named skill.
+/// Project-local skills use their worktree root name (e.g. `zed` for a
+/// worktree rooted at `~/code/zed`) as their scope qualifier instead
+/// of a fixed literal, so multiple open worktrees with same-named
+/// skills can each be addressed unambiguously.
 pub const SKILL_SCOPE_GLOBAL: &str = "global";
-
-/// Scope qualifier used in `/local.<name>` slash-command syntax to
-/// unambiguously target the project-local version of a same-named
-/// skill.
-pub const SKILL_SCOPE_LOCAL: &str = "local";
 
 impl SkillSource {
     /// Returns the scope label that identifies this source in user-
     /// visible places: the autocomplete popup's source column, and the
     /// `<scope>.<name>` slash-command prefix that the popup inserts so
-    /// the resolver can route `/global.foo` and `/local.foo` to the
-    /// correct entry. The two uses MUST stay in sync — if the popup
-    /// shows "local" the inserted text has to start with `/local.` or
-    /// the resolver won't find the skill.
-    pub fn scope_label(&self) -> &'static str {
+    /// the resolver can route `/global.foo` and `/<worktree>.foo` to
+    /// the correct entry. The two uses MUST stay in sync — if the
+    /// popup shows `zed` the inserted text has to start with `/zed.`
+    /// or the resolver won't find the skill.
+    ///
+    /// Edge case: a worktree literally named `global` collides with
+    /// the global scope qualifier. `matches_scope` resolves the
+    /// ambiguity in favor of the global source; the project-local
+    /// skill in such a worktree can still be invoked unqualified as
+    /// `/<name>`.
+    pub fn scope_label(&self) -> &str {
         match self {
             Self::Global => SKILL_SCOPE_GLOBAL,
-            Self::ProjectLocal { .. } => SKILL_SCOPE_LOCAL,
+            Self::ProjectLocal {
+                worktree_root_name, ..
+            } => worktree_root_name.as_ref(),
         }
     }
 
@@ -94,8 +101,18 @@ impl SkillSource {
     /// that case the resolver falls through to MCP, preserving the
     /// existing MCP-server-prefix grammar for any prefix that isn't a
     /// known skill scope.
+    ///
+    /// `/global.<name>` is reserved for the global source even when a
+    /// project-local skill comes from a worktree named `global`, so
+    /// the literal global scope can never be shadowed by a worktree's
+    /// name.
     pub fn matches_scope(&self, scope: &str) -> bool {
-        self.scope_label() == scope
+        match self {
+            Self::Global => scope == SKILL_SCOPE_GLOBAL,
+            Self::ProjectLocal {
+                worktree_root_name, ..
+            } => scope != SKILL_SCOPE_GLOBAL && worktree_root_name.as_ref() == scope,
+        }
     }
 }
 

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -283,8 +283,8 @@ pub async fn load_skills_from_directory(
         .collect()
         .await;
 
-    // Sort by path so name-conflict resolution in `merge_skills` is
-    // deterministic — `fs.read_dir` order is filesystem-dependent.
+    // Sort by path so name-conflict resolution in `apply_skill_overrides`
+    // is deterministic — `fs.read_dir` order is filesystem-dependent.
     results.sort_by(|a, b| {
         let path_a: &Path = match a {
             Ok(skill) => &skill.skill_file_path,
@@ -1045,11 +1045,12 @@ description: A skill with no body content
 
     #[gpui::test]
     async fn test_load_skills_returns_results_sorted_by_path(cx: &mut TestAppContext) {
-        // `merge_skills` resolves name conflicts by keeping the first
-        // entry in iteration order. Without a stable sort here, the
-        // result depends on `fs.read_dir`, which is OS/filesystem-
-        // dependent. Assert the contract: results come back sorted by
-        // skill file path regardless of insertion order.
+        // `apply_skill_overrides` resolves same-source name collisions
+        // by keeping the first entry in iteration order. Without a
+        // stable sort here, the result depends on `fs.read_dir`, which
+        // is OS/filesystem-dependent. Assert the contract: results
+        // come back sorted by skill file path regardless of insertion
+        // order.
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
             "/skills",

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -65,6 +65,40 @@ pub enum SkillSource {
     },
 }
 
+/// Scope qualifier used in `/global.<name>` slash-command syntax to
+/// unambiguously target the global version of a same-named skill.
+pub const SKILL_SCOPE_GLOBAL: &str = "global";
+
+/// Scope qualifier used in `/local.<name>` slash-command syntax to
+/// unambiguously target the project-local version of a same-named
+/// skill.
+pub const SKILL_SCOPE_LOCAL: &str = "local";
+
+impl SkillSource {
+    /// Returns the scope label that identifies this source in user-
+    /// visible places: the autocomplete popup's source column, and the
+    /// `<scope>.<name>` slash-command prefix that the popup inserts so
+    /// the resolver can route `/global.foo` and `/local.foo` to the
+    /// correct entry. The two uses MUST stay in sync — if the popup
+    /// shows "local" the inserted text has to start with `/local.` or
+    /// the resolver won't find the skill.
+    pub fn scope_label(&self) -> &'static str {
+        match self {
+            Self::Global => SKILL_SCOPE_GLOBAL,
+            Self::ProjectLocal { .. } => SKILL_SCOPE_LOCAL,
+        }
+    }
+
+    /// Whether this source matches the given scope qualifier from a
+    /// `/<scope>.<name>` slash command. Unknown scopes never match — in
+    /// that case the resolver falls through to MCP, preserving the
+    /// existing MCP-server-prefix grammar for any prefix that isn't a
+    /// known skill scope.
+    pub fn matches_scope(&self, scope: &str) -> bool {
+        self.scope_label() == scope
+    }
+}
+
 /// Just the frontmatter, used for parsing
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillMetadata {

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -1261,27 +1261,36 @@ impl<T: PromptCompletionProviderDelegate> CompletionProvider for PromptCompletio
                         .into_iter()
                         .map(|command| {
                             // Qualify the inserted text with the skill's
-                            // source as `/<scope>:<name>` when the
-                            // command carries one. The `:` separator
-                            // namespaces skill scopes away from MCP
-                            // server prefixes (`/<server>.<name>`), so
-                            // a worktree literally named after an MCP
-                            // server doesn't collide. Without this,
-                            // picking the global row and the project
-                            // row would both insert `/<name>` and the
-                            // resolver couldn't tell which the user
-                            // intended. MCP commands have no source so
-                            // they keep the bare `/<name>` form.
-                            let qualified_name: std::borrow::Cow<'_, str> =
-                                if let Some(source) = command.source.as_ref() {
-                                    format!("{}:{}", source, command.name).into()
-                                } else {
-                                    command.name.as_ref().into()
-                                };
-                            let new_text = if let Some(argument) = argument.as_ref() {
-                                format!("/{} {}", qualified_name, argument)
-                            } else {
-                                format!("/{} ", qualified_name)
+                            // scope prefix as `/<prefix>:<name>` when the
+                            // command carries one. The prefix is empty
+                            // for global skills (so the inserted text
+                            // is `/:<name>`) and the worktree root name
+                            // for project-locals (so the inserted text
+                            // is `/<worktree>:<name>`). The `:`
+                            // separator namespaces skill scopes away
+                            // from MCP server prefixes
+                            // (`/<server>.<name>`), and the empty
+                            // prefix means a worktree literally named
+                            // `global` no longer collides with the
+                            // global source. MCP commands have no
+                            // source meta and keep the bare `/<name>`
+                            // form.
+                            //
+                            // Composed in a single `format!` to avoid
+                            // building an intermediate `qualified_name`
+                            // string just to splice it into the final
+                            // text.
+                            let new_text = match (command.source.as_ref(), argument.as_ref()) {
+                                (Some(source), Some(argument)) => {
+                                    format!("/{}:{} {}", source, command.name, argument)
+                                }
+                                (Some(source), None) => {
+                                    format!("/{}:{} ", source, command.name)
+                                }
+                                (None, Some(argument)) => {
+                                    format!("/{} {}", command.name, argument)
+                                }
+                                (None, None) => format!("/{} ", command.name),
                             };
 
                             let is_missing_argument =
@@ -2163,15 +2172,22 @@ pub fn extract_file_name_and_directory(
 }
 
 /// Build the autocomplete-popup label for a slash command, appending
-/// the command's origin (e.g. `"global"` or a worktree root name for
-/// skills) after the name when one is present. The suffix is styled
-/// with the muted `variable` highlight and excluded from the fuzzy
-/// filter range so typing the source doesn't match the entry.
+/// the command's origin (a worktree root name for project-local
+/// skills) after the name when one is present and non-empty. The
+/// suffix is styled with the muted `variable` highlight and excluded
+/// from the fuzzy filter range so typing the source doesn't match
+/// the entry.
+///
+/// Global skills carry an empty source (the literal scope prefix is
+/// empty so the popup inserts `/:<name>`), and render with no
+/// subtext — the source column is reserved for project-local skills
+/// where the worktree name disambiguates same-named entries.
 fn build_slash_command_label(
     command: &AvailableCommand,
     source_highlight_id: Option<HighlightId>,
 ) -> CodeLabel {
-    let Some(source) = command.source.as_ref() else {
+    let source = command.source.as_ref().filter(|source| !source.is_empty());
+    let Some(source) = source else {
         return CodeLabel::plain(command.name.to_string(), None);
     };
     let mut builder = CodeLabelBuilder::default();

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -1261,8 +1261,8 @@ impl<T: PromptCompletionProviderDelegate> CompletionProvider for PromptCompletio
                         .into_iter()
                         .map(|command| {
                             // Qualify the inserted text with the skill's
-                            // source as `/.<scope>.<name>` when the
-                            // command carries one. The leading dot
+                            // source as `/<scope>:<name>` when the
+                            // command carries one. The `:` separator
                             // namespaces skill scopes away from MCP
                             // server prefixes (`/<server>.<name>`), so
                             // a worktree literally named after an MCP
@@ -1274,7 +1274,7 @@ impl<T: PromptCompletionProviderDelegate> CompletionProvider for PromptCompletio
                             // they keep the bare `/<name>` form.
                             let qualified_name: std::borrow::Cow<'_, str> =
                                 if let Some(source) = command.source.as_ref() {
-                                    format!(".{}.{}", source, command.name).into()
+                                    format!("{}:{}", source, command.name).into()
                                 } else {
                                     command.name.as_ref().into()
                                 };

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -302,6 +302,11 @@ pub struct AvailableCommand {
     pub name: Arc<str>,
     pub description: Arc<str>,
     pub requires_argument: bool,
+    /// Origin label for this command (e.g. `"global"` or a worktree
+    /// root name for skills). When present, it's displayed in the
+    /// autocomplete popup after the command name so users can
+    /// disambiguate same-named commands from different scopes.
+    pub source: Option<SharedString>,
 }
 
 pub trait PromptCompletionProviderDelegate: Send + Sync + 'static {
@@ -1242,6 +1247,14 @@ impl<T: PromptCompletionProviderDelegate> CompletionProvider for PromptCompletio
                 command, argument, ..
             }) => {
                 let search_task = self.search_slash_commands(command.unwrap_or_default(), cx);
+                // Resolve the muted-text highlight up front: the
+                // completion build happens on a background thread where
+                // `cx.theme()` isn't available.
+                let source_highlight_id = cx
+                    .theme()
+                    .syntax()
+                    .highlight_id("variable")
+                    .map(HighlightId::new);
                 cx.background_spawn(async move {
                     let completions = search_task
                         .await
@@ -1256,10 +1269,12 @@ impl<T: PromptCompletionProviderDelegate> CompletionProvider for PromptCompletio
                             let is_missing_argument =
                                 command.requires_argument && argument.is_none();
 
+                            let label = build_slash_command_label(&command, source_highlight_id);
+
                             Completion {
                                 replace_range: source_range.clone(),
                                 new_text,
-                                label: CodeLabel::plain(command.name.to_string(), None),
+                                label,
                                 documentation: Some(CompletionDocumentation::MultiLinePlainText(
                                     command.description.into(),
                                 )),
@@ -2127,6 +2142,35 @@ pub fn extract_file_name_and_directory(
         file_name.to_string().into(),
         Some(SharedString::new(directory)).filter(|dir| !dir.is_empty()),
     )
+}
+
+/// Build the autocomplete-popup label for a slash command, appending
+/// the command's origin (e.g. `"global"` or a worktree root name for
+/// skills) after the name when one is present. The suffix is styled
+/// with the muted `variable` highlight and excluded from the fuzzy
+/// filter range so typing the source doesn't match the entry.
+fn build_slash_command_label(
+    command: &AvailableCommand,
+    source_highlight_id: Option<HighlightId>,
+) -> CodeLabel {
+    let Some(source) = command.source.as_ref() else {
+        return CodeLabel::plain(command.name.to_string(), None);
+    };
+    let mut builder = CodeLabelBuilder::default();
+    builder.push_str(&command.name, None);
+    // Two spaces gives a touch of breathing room between the name and
+    // the muted source label.
+    builder.push_str("  ", None);
+    builder.push_str(source, source_highlight_id);
+    // The filter range defaults to the entire label after `build()`,
+    // which would let the source text participate in fuzzy filtering.
+    // Slash commands are matched up-front in `search_slash_commands`
+    // against the command name, and the editor doesn't re-filter
+    // (`filter_completions()` is false), so this is mostly defensive
+    // — but it keeps the displayed filter consistent with what we
+    // actually matched against.
+    builder.respan_filter_range(Some(&command.name));
+    builder.build()
 }
 
 fn build_code_label_for_path(

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -1261,16 +1261,20 @@ impl<T: PromptCompletionProviderDelegate> CompletionProvider for PromptCompletio
                         .into_iter()
                         .map(|command| {
                             // Qualify the inserted text with the skill's
-                            // source (`/global.<name>` or `/local.<name>`)
-                            // when the command carries a source. Without
-                            // this, picking the global row and the local
+                            // source as `/.<scope>.<name>` when the
+                            // command carries one. The leading dot
+                            // namespaces skill scopes away from MCP
+                            // server prefixes (`/<server>.<name>`), so
+                            // a worktree literally named after an MCP
+                            // server doesn't collide. Without this,
+                            // picking the global row and the project
                             // row would both insert `/<name>` and the
                             // resolver couldn't tell which the user
-                            // intended. MCP commands have no source, so
+                            // intended. MCP commands have no source so
                             // they keep the bare `/<name>` form.
                             let qualified_name: std::borrow::Cow<'_, str> =
                                 if let Some(source) = command.source.as_ref() {
-                                    format!("{}.{}", source, command.name).into()
+                                    format!(".{}.{}", source, command.name).into()
                                 } else {
                                     command.name.as_ref().into()
                                 };

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -1260,10 +1260,24 @@ impl<T: PromptCompletionProviderDelegate> CompletionProvider for PromptCompletio
                         .await
                         .into_iter()
                         .map(|command| {
+                            // Qualify the inserted text with the skill's
+                            // source (`/global.<name>` or `/local.<name>`)
+                            // when the command carries a source. Without
+                            // this, picking the global row and the local
+                            // row would both insert `/<name>` and the
+                            // resolver couldn't tell which the user
+                            // intended. MCP commands have no source, so
+                            // they keep the bare `/<name>` form.
+                            let qualified_name: std::borrow::Cow<'_, str> =
+                                if let Some(source) = command.source.as_ref() {
+                                    format!("{}.{}", source, command.name).into()
+                                } else {
+                                    command.name.as_ref().into()
+                                };
                             let new_text = if let Some(argument) = argument.as_ref() {
-                                format!("/{} {}", command.name, argument)
+                                format!("/{} {}", qualified_name, argument)
                             } else {
-                                format!("/{} ", command.name)
+                                format!("/{} ", qualified_name)
                             };
 
                             let is_missing_argument =

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -729,26 +729,34 @@ impl MessageEditor {
                 //    (`/github.create_pr`), and skills (whose bare name
                 //    is registered for the unqualified `/<name>` form).
                 //
-                // 2. Skill scope qualifier. The popup inserts
-                //    `/global.<name>` or `/local.<name>` to disambiguate
-                //    same-named skills, so the validator has to look
-                //    inside the meta tag on each available command to
-                //    confirm that a skill with the bare name exists in
-                //    the requested scope. Without this branch, every
-                //    autocomplete pick of a same-named skill would be
-                //    rejected as "not supported" before reaching the
-                //    resolver.
+                // 2. Skill scope qualifier `/.<scope>.<name>`. The
+                //    popup inserts this leading-dot form to
+                //    disambiguate same-named skills, so the validator
+                //    strips the leading dot and rsplits on `.` (skill
+                //    names can't contain dots, so this safely handles
+                //    worktrees whose root names are themselves dotted)
+                //    to recover scope + bare name. The validator then
+                //    confirms an available command with that bare name
+                //    has a matching `zed.skill_source` meta tag.
+                //    Without this branch, every autocomplete pick of a
+                //    same-named skill would be rejected as "not
+                //    supported" before reaching the resolver.
                 let direct_match = available_commands
                     .iter()
                     .any(|cmd| cmd.name == command_name);
                 let scope_match = !direct_match
-                    && command_name.split_once('.').is_some_and(|(scope, bare)| {
-                        available_commands.iter().any(|cmd| {
-                            cmd.name == bare
-                                && acp_thread::skill_source_from_meta(&cmd.meta).as_deref()
-                                    == Some(scope)
-                        })
-                    });
+                    && command_name
+                        .strip_prefix('.')
+                        .and_then(|rest| rest.rsplit_once('.'))
+                        .is_some_and(|(scope, bare)| {
+                            !scope.is_empty()
+                                && !bare.is_empty()
+                                && available_commands.iter().any(|cmd| {
+                                    cmd.name == bare
+                                        && acp_thread::skill_source_from_meta(&cmd.meta).as_deref()
+                                            == Some(scope)
+                                })
+                        });
 
                 if !direct_match && !scope_match {
                     return Err(anyhow!(
@@ -764,10 +772,10 @@ impl MessageEditor {
     }
 
     /// Render the available-commands list for error messages. Skills
-    /// are shown in their qualified `/<scope>.<name>` form so users see
-    /// the exact text the popup would insert — otherwise the listing
-    /// would contain confusing duplicates like `/foo, /foo` when both a
-    /// global and a project-local skill share a name.
+    /// are shown in their qualified `/.<scope>.<name>` form so users
+    /// see the exact text the popup would insert — otherwise the
+    /// listing would contain confusing duplicates like `/foo, /foo`
+    /// when both a global and a project-local skill share a name.
     fn format_available_commands(commands: &[acp::AvailableCommand]) -> String {
         if commands.is_empty() {
             return "none".to_string();
@@ -776,7 +784,7 @@ impl MessageEditor {
             .iter()
             .map(|cmd| {
                 if let Some(scope) = acp_thread::skill_source_from_meta(&cmd.meta) {
-                    format!("/{}.{}", scope, cmd.name)
+                    format!("/.{}.{}", scope, cmd.name)
                 } else {
                     format!("/{}", cmd.name)
                 }
@@ -2118,9 +2126,13 @@ mod tests {
             acp::AvailableCommand::new(name, "desc").meta(acp_thread::meta_with_skill_source(scope))
         };
 
+        // Project-local skills are tagged with their worktree root
+        // name (here `zed`), not a fixed literal, so the same skill
+        // name in two different worktrees can be addressed
+        // unambiguously.
         let commands = vec![
             make_skill_command("deploy", "global"),
-            make_skill_command("deploy", "local"),
+            make_skill_command("deploy", "zed"),
             acp::AvailableCommand::new("help", "Get help"),
         ];
 
@@ -2130,30 +2142,41 @@ mod tests {
             .expect("bare /deploy should validate when a skill named `deploy` exists");
 
         // Scope-qualified forms both validate, each pointing at the
-        // matching source.
-        MessageEditor::validate_slash_commands("/global.deploy", &commands, &agent_id)
-            .expect("/global.deploy should validate when a global skill named `deploy` exists");
-        MessageEditor::validate_slash_commands("/local.deploy", &commands, &agent_id)
-            .expect("/local.deploy should validate when a project skill named `deploy` exists");
+        // matching source. The leading dot namespaces these against
+        // MCP server prefixes.
+        MessageEditor::validate_slash_commands("/.global.deploy", &commands, &agent_id)
+            .expect("/.global.deploy should validate when a global skill named `deploy` exists");
+        MessageEditor::validate_slash_commands("/.zed.deploy", &commands, &agent_id).expect(
+            "/.zed.deploy should validate when a project skill named `deploy` exists in the `zed` worktree",
+        );
+
+        // The leading dot is what distinguishes a skill scope from an
+        // MCP server prefix — without it, the validator treats
+        // `zed.deploy` as a literal command name lookup, which fails.
+        MessageEditor::validate_slash_commands("/zed.deploy", &commands, &agent_id).expect_err(
+            "/zed.deploy (without leading dot) should be treated as an MCP-style prefix and fail",
+        );
 
         // Wrong scope is rejected so the resolver doesn't silently
-        // fall through to MCP when the user meant a skill.
-        let err = MessageEditor::validate_slash_commands("/local.help", &commands, &agent_id)
-            .expect_err("/local.help should fail — `help` is an MCP command, not a local skill");
+        // fall through when the user meant a skill. `.zed.help` looks
+        // like a skill scope qualifier but no skill named `help`
+        // exists in the `zed` worktree (it's an MCP command).
+        let err = MessageEditor::validate_slash_commands("/.zed.help", &commands, &agent_id)
+            .expect_err("/.zed.help should fail — `help` is an MCP command, not a worktree skill");
         let err_message = err.to_string();
         assert!(
-            err_message.contains("/local.help"),
+            err_message.contains("/.zed.help"),
             "error should mention the typed command: {err_message}"
         );
         // Error listing shows qualified forms for skills so users see
         // the exact text the popup would have inserted.
         assert!(
-            err_message.contains("/global.deploy"),
+            err_message.contains("/.global.deploy"),
             "error listing should show qualified global form: {err_message}"
         );
         assert!(
-            err_message.contains("/local.deploy"),
-            "error listing should show qualified local form: {err_message}"
+            err_message.contains("/.zed.deploy"),
+            "error listing should show qualified worktree form: {err_message}"
         );
         assert!(
             err_message.contains("/help"),

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -732,24 +732,30 @@ impl MessageEditor {
                 // 2. Skill scope qualifier `/<scope>:<name>`. The popup
                 //    inserts this colon-separated form to disambiguate
                 //    same-named skills, so the validator splits on the
-                //    first `:` to recover scope + bare name. Skill
+                //    LAST `:` to recover scope + bare name. Skill
                 //    names are restricted to `[a-z0-9-]+` (no colons),
-                //    so the split is unambiguous. The validator then
-                //    confirms an available command with that bare name
-                //    has a matching `zed.skill_source` meta tag.
-                //    Without this branch, every autocomplete pick of a
-                //    same-named skill would be rejected as "not
-                //    supported" before reaching the resolver.
+                //    so the rightmost colon is always the scope/name
+                //    boundary — this lets scope labels (e.g. worktree
+                //    root names) themselves contain colons. The
+                //    scope is allowed to be empty: `/:<name>` is the
+                //    qualified form for a global skill (see
+                //    `SkillSource::scope_prefix`). The validator then
+                //    confirms an available command with that bare
+                //    name has a `zed.skill_source` meta tag whose
+                //    value equals the typed scope (including empty
+                //    for globals). Without this branch, every
+                //    autocomplete pick of a same-named skill would be
+                //    rejected as "not supported" before reaching the
+                //    resolver.
                 let direct_match = available_commands
                     .iter()
                     .any(|cmd| cmd.name == command_name);
                 let scope_match = !direct_match
-                    && command_name.split_once(':').is_some_and(|(scope, bare)| {
-                        !scope.is_empty()
-                            && !bare.is_empty()
+                    && command_name.rsplit_once(':').is_some_and(|(scope, bare)| {
+                        !bare.is_empty()
                             && available_commands.iter().any(|cmd| {
                                 cmd.name == bare
-                                    && acp_thread::skill_source_from_meta(&cmd.meta).as_deref()
+                                    && acp_thread::skill_source_str_from_meta(&cmd.meta)
                                         == Some(scope)
                             })
                     });
@@ -772,6 +778,7 @@ impl MessageEditor {
     /// see the exact text the popup would insert — otherwise the
     /// listing would contain confusing duplicates like `/foo, /foo`
     /// when both a global and a project-local skill share a name.
+    /// Globals carry an empty scope and so render as `/:<name>`.
     fn format_available_commands(commands: &[acp::AvailableCommand]) -> String {
         if commands.is_empty() {
             return "none".to_string();
@@ -779,7 +786,7 @@ impl MessageEditor {
         commands
             .iter()
             .map(|cmd| {
-                if let Some(scope) = acp_thread::skill_source_from_meta(&cmd.meta) {
+                if let Some(scope) = acp_thread::skill_source_str_from_meta(&cmd.meta) {
                     format!("/{}:{}", scope, cmd.name)
                 } else {
                     format!("/{}", cmd.name)
@@ -2122,12 +2129,12 @@ mod tests {
             acp::AvailableCommand::new(name, "desc").meta(acp_thread::meta_with_skill_source(scope))
         };
 
-        // Project-local skills are tagged with their worktree root
-        // name (here `zed`), not a fixed literal, so the same skill
-        // name in two different worktrees can be addressed
-        // unambiguously.
+        // Global skills carry an empty scope (so the popup inserts
+        // `/:<name>`); project-local skills carry their worktree root
+        // name. The empty-scope encoding means a worktree literally
+        // named `global` no longer collides with the global source.
         let commands = vec![
-            make_skill_command("deploy", "global"),
+            make_skill_command("deploy", ""),
             make_skill_command("deploy", "zed"),
             acp::AvailableCommand::new("help", "Get help"),
         ];
@@ -2138,12 +2145,20 @@ mod tests {
             .expect("bare /deploy should validate when a skill named `deploy` exists");
 
         // Scope-qualified forms both validate, each pointing at the
-        // matching source. The `:` separator namespaces these against
-        // MCP server prefixes (which use `.`).
-        MessageEditor::validate_slash_commands("/global:deploy", &commands, &agent_id)
-            .expect("/global:deploy should validate when a global skill named `deploy` exists");
+        // matching source. `/:<name>` is the qualified form for a
+        // global skill; `/<worktree>:<name>` is the qualified form
+        // for a project-local skill.
+        MessageEditor::validate_slash_commands("/:deploy", &commands, &agent_id)
+            .expect("/:deploy should validate when a global skill named `deploy` exists");
         MessageEditor::validate_slash_commands("/zed:deploy", &commands, &agent_id).expect(
             "/zed:deploy should validate when a project skill named `deploy` exists in the `zed` worktree",
+        );
+
+        // Hand-typed `/global:<name>` is NOT an alias for `/:<name>`.
+        // It looks for a project-local skill from a worktree named
+        // `global`, and fails when no such worktree skill exists.
+        MessageEditor::validate_slash_commands("/global:deploy", &commands, &agent_id).expect_err(
+            "/global:deploy should fail when no worktree named `global` has a `deploy` skill",
         );
 
         // The `:` separator is what distinguishes a skill scope from
@@ -2164,9 +2179,10 @@ mod tests {
             "error should mention the typed command: {err_message}"
         );
         // Error listing shows qualified forms for skills so users see
-        // the exact text the popup would have inserted.
+        // the exact text the popup would have inserted. Globals
+        // render with an empty scope as `/:<name>`.
         assert!(
-            err_message.contains("/global:deploy"),
+            err_message.contains("/:deploy"),
             "error listing should show qualified global form: {err_message}"
         );
         assert!(

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -721,30 +721,68 @@ impl MessageEditor {
     ) -> Result<()> {
         if let Some(parsed_command) = SlashCommandCompletion::try_parse(text, 0) {
             if let Some(command_name) = parsed_command.command {
-                // Check if this command is in the list of available commands from the server
-                let is_supported = available_commands
+                // Two acceptance paths:
+                //
+                // 1. Direct name match. Covers bare slash commands
+                //    (`/help`), MCP prompts that were prefixed at the
+                //    agent because of a server-name collision
+                //    (`/github.create_pr`), and skills (whose bare name
+                //    is registered for the unqualified `/<name>` form).
+                //
+                // 2. Skill scope qualifier. The popup inserts
+                //    `/global.<name>` or `/local.<name>` to disambiguate
+                //    same-named skills, so the validator has to look
+                //    inside the meta tag on each available command to
+                //    confirm that a skill with the bare name exists in
+                //    the requested scope. Without this branch, every
+                //    autocomplete pick of a same-named skill would be
+                //    rejected as "not supported" before reaching the
+                //    resolver.
+                let direct_match = available_commands
                     .iter()
                     .any(|cmd| cmd.name == command_name);
+                let scope_match = !direct_match
+                    && command_name.split_once('.').is_some_and(|(scope, bare)| {
+                        available_commands.iter().any(|cmd| {
+                            cmd.name == bare
+                                && acp_thread::skill_source_from_meta(&cmd.meta).as_deref()
+                                    == Some(scope)
+                        })
+                    });
 
-                if !is_supported {
+                if !direct_match && !scope_match {
                     return Err(anyhow!(
                         "The /{} command is not supported by {}.\n\nAvailable commands: {}",
                         command_name,
                         agent_id,
-                        if available_commands.is_empty() {
-                            "none".to_string()
-                        } else {
-                            available_commands
-                                .iter()
-                                .map(|cmd| format!("/{}", cmd.name))
-                                .collect::<Vec<_>>()
-                                .join(", ")
-                        }
+                        Self::format_available_commands(available_commands),
                     ));
                 }
             }
         }
         Ok(())
+    }
+
+    /// Render the available-commands list for error messages. Skills
+    /// are shown in their qualified `/<scope>.<name>` form so users see
+    /// the exact text the popup would insert — otherwise the listing
+    /// would contain confusing duplicates like `/foo, /foo` when both a
+    /// global and a project-local skill share a name.
+    fn format_available_commands(commands: &[acp::AvailableCommand]) -> String {
+        if commands.is_empty() {
+            return "none".to_string();
+        }
+        commands
+            .iter()
+            .map(|cmd| {
+                if let Some(scope) = acp_thread::skill_source_from_meta(&cmd.meta) {
+                    format!("/{}.{}", scope, cmd.name)
+                } else {
+                    format!("/{}", cmd.name)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 
     pub fn contents(
@@ -2056,7 +2094,7 @@ mod tests {
     use language_model::LanguageModelRegistry;
     use lsp::{CompletionContext, CompletionTriggerKind};
     use parking_lot::RwLock;
-    use project::{CompletionIntent, Project, ProjectPath};
+    use project::{AgentId, CompletionIntent, Project, ProjectPath};
     use serde_json::{Value, json};
 
     use text::Point;
@@ -2072,6 +2110,56 @@ mod tests {
             Mention, MessageEditor, MessageEditorEvent, SessionCapabilities, parse_mention_links,
         },
     };
+
+    #[test]
+    fn test_validate_slash_commands_accepts_scope_qualified_skill() {
+        let agent_id = AgentId::from("Zed");
+        let make_skill_command = |name: &str, scope: &str| {
+            acp::AvailableCommand::new(name, "desc").meta(acp_thread::meta_with_skill_source(scope))
+        };
+
+        let commands = vec![
+            make_skill_command("deploy", "global"),
+            make_skill_command("deploy", "local"),
+            acp::AvailableCommand::new("help", "Get help"),
+        ];
+
+        // Bare name still works (current behavior — the resolver
+        // applies project-overrides-global for unqualified commands).
+        MessageEditor::validate_slash_commands("/deploy", &commands, &agent_id)
+            .expect("bare /deploy should validate when a skill named `deploy` exists");
+
+        // Scope-qualified forms both validate, each pointing at the
+        // matching source.
+        MessageEditor::validate_slash_commands("/global.deploy", &commands, &agent_id)
+            .expect("/global.deploy should validate when a global skill named `deploy` exists");
+        MessageEditor::validate_slash_commands("/local.deploy", &commands, &agent_id)
+            .expect("/local.deploy should validate when a project skill named `deploy` exists");
+
+        // Wrong scope is rejected so the resolver doesn't silently
+        // fall through to MCP when the user meant a skill.
+        let err = MessageEditor::validate_slash_commands("/local.help", &commands, &agent_id)
+            .expect_err("/local.help should fail — `help` is an MCP command, not a local skill");
+        let err_message = err.to_string();
+        assert!(
+            err_message.contains("/local.help"),
+            "error should mention the typed command: {err_message}"
+        );
+        // Error listing shows qualified forms for skills so users see
+        // the exact text the popup would have inserted.
+        assert!(
+            err_message.contains("/global.deploy"),
+            "error listing should show qualified global form: {err_message}"
+        );
+        assert!(
+            err_message.contains("/local.deploy"),
+            "error listing should show qualified local form: {err_message}"
+        );
+        assert!(
+            err_message.contains("/help"),
+            "error listing should still show bare MCP commands: {err_message}"
+        );
+    }
 
     #[test]
     fn test_parse_mention_links() {

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -95,6 +95,7 @@ impl SessionCapabilities {
                 name: cmd.name.clone().into(),
                 description: cmd.description.clone().into(),
                 requires_argument: cmd.input.is_some(),
+                source: acp_thread::skill_source_from_meta(&cmd.meta),
             })
             .collect()
     }

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -729,13 +729,12 @@ impl MessageEditor {
                 //    (`/github.create_pr`), and skills (whose bare name
                 //    is registered for the unqualified `/<name>` form).
                 //
-                // 2. Skill scope qualifier `/.<scope>.<name>`. The
-                //    popup inserts this leading-dot form to
-                //    disambiguate same-named skills, so the validator
-                //    strips the leading dot and rsplits on `.` (skill
-                //    names can't contain dots, so this safely handles
-                //    worktrees whose root names are themselves dotted)
-                //    to recover scope + bare name. The validator then
+                // 2. Skill scope qualifier `/<scope>:<name>`. The popup
+                //    inserts this colon-separated form to disambiguate
+                //    same-named skills, so the validator splits on the
+                //    first `:` to recover scope + bare name. Skill
+                //    names are restricted to `[a-z0-9-]+` (no colons),
+                //    so the split is unambiguous. The validator then
                 //    confirms an available command with that bare name
                 //    has a matching `zed.skill_source` meta tag.
                 //    Without this branch, every autocomplete pick of a
@@ -745,18 +744,15 @@ impl MessageEditor {
                     .iter()
                     .any(|cmd| cmd.name == command_name);
                 let scope_match = !direct_match
-                    && command_name
-                        .strip_prefix('.')
-                        .and_then(|rest| rest.rsplit_once('.'))
-                        .is_some_and(|(scope, bare)| {
-                            !scope.is_empty()
-                                && !bare.is_empty()
-                                && available_commands.iter().any(|cmd| {
-                                    cmd.name == bare
-                                        && acp_thread::skill_source_from_meta(&cmd.meta).as_deref()
-                                            == Some(scope)
-                                })
-                        });
+                    && command_name.split_once(':').is_some_and(|(scope, bare)| {
+                        !scope.is_empty()
+                            && !bare.is_empty()
+                            && available_commands.iter().any(|cmd| {
+                                cmd.name == bare
+                                    && acp_thread::skill_source_from_meta(&cmd.meta).as_deref()
+                                        == Some(scope)
+                            })
+                    });
 
                 if !direct_match && !scope_match {
                     return Err(anyhow!(
@@ -772,7 +768,7 @@ impl MessageEditor {
     }
 
     /// Render the available-commands list for error messages. Skills
-    /// are shown in their qualified `/.<scope>.<name>` form so users
+    /// are shown in their qualified `/<scope>:<name>` form so users
     /// see the exact text the popup would insert — otherwise the
     /// listing would contain confusing duplicates like `/foo, /foo`
     /// when both a global and a project-local skill share a name.
@@ -784,7 +780,7 @@ impl MessageEditor {
             .iter()
             .map(|cmd| {
                 if let Some(scope) = acp_thread::skill_source_from_meta(&cmd.meta) {
-                    format!("/.{}.{}", scope, cmd.name)
+                    format!("/{}:{}", scope, cmd.name)
                 } else {
                     format!("/{}", cmd.name)
                 }
@@ -2142,40 +2138,39 @@ mod tests {
             .expect("bare /deploy should validate when a skill named `deploy` exists");
 
         // Scope-qualified forms both validate, each pointing at the
-        // matching source. The leading dot namespaces these against
-        // MCP server prefixes.
-        MessageEditor::validate_slash_commands("/.global.deploy", &commands, &agent_id)
-            .expect("/.global.deploy should validate when a global skill named `deploy` exists");
-        MessageEditor::validate_slash_commands("/.zed.deploy", &commands, &agent_id).expect(
-            "/.zed.deploy should validate when a project skill named `deploy` exists in the `zed` worktree",
+        // matching source. The `:` separator namespaces these against
+        // MCP server prefixes (which use `.`).
+        MessageEditor::validate_slash_commands("/global:deploy", &commands, &agent_id)
+            .expect("/global:deploy should validate when a global skill named `deploy` exists");
+        MessageEditor::validate_slash_commands("/zed:deploy", &commands, &agent_id).expect(
+            "/zed:deploy should validate when a project skill named `deploy` exists in the `zed` worktree",
         );
 
-        // The leading dot is what distinguishes a skill scope from an
-        // MCP server prefix — without it, the validator treats
-        // `zed.deploy` as a literal command name lookup, which fails.
-        MessageEditor::validate_slash_commands("/zed.deploy", &commands, &agent_id).expect_err(
-            "/zed.deploy (without leading dot) should be treated as an MCP-style prefix and fail",
-        );
+        // The `:` separator is what distinguishes a skill scope from
+        // an MCP server prefix — the dotted form `/zed.deploy` is an
+        // MCP-style lookup, which doesn't match here.
+        MessageEditor::validate_slash_commands("/zed.deploy", &commands, &agent_id)
+            .expect_err("/zed.deploy (dotted) should be treated as an MCP-style prefix and fail");
 
         // Wrong scope is rejected so the resolver doesn't silently
-        // fall through when the user meant a skill. `.zed.help` looks
+        // fall through when the user meant a skill. `zed:help` looks
         // like a skill scope qualifier but no skill named `help`
         // exists in the `zed` worktree (it's an MCP command).
-        let err = MessageEditor::validate_slash_commands("/.zed.help", &commands, &agent_id)
-            .expect_err("/.zed.help should fail — `help` is an MCP command, not a worktree skill");
+        let err = MessageEditor::validate_slash_commands("/zed:help", &commands, &agent_id)
+            .expect_err("/zed:help should fail — `help` is an MCP command, not a worktree skill");
         let err_message = err.to_string();
         assert!(
-            err_message.contains("/.zed.help"),
+            err_message.contains("/zed:help"),
             "error should mention the typed command: {err_message}"
         );
         // Error listing shows qualified forms for skills so users see
         // the exact text the popup would have inserted.
         assert!(
-            err_message.contains("/.global.deploy"),
+            err_message.contains("/global:deploy"),
             "error listing should show qualified global form: {err_message}"
         );
         assert!(
-            err_message.contains("/.zed.deploy"),
+            err_message.contains("/zed:deploy"),
             "error listing should show qualified worktree form: {err_message}"
         );
         assert!(

--- a/crates/prompt_store/src/prompts.rs
+++ b/crates/prompt_store/src/prompts.rs
@@ -162,7 +162,6 @@ mod tests {
             source: SkillSource::Global,
             directory_path: PathBuf::from("/skills/oversized"),
             skill_file_path: PathBuf::from("/skills/oversized/SKILL.md"),
-            content: "Content".to_string(),
             disable_model_invocation: false,
         };
         let summary = SkillSummary::from(&skill);


### PR DESCRIPTION
Append a muted origin label to each skill in the slash-command autocomplete popup so users can tell which skill is which when global and project-local skills share a name.

Project-local skills already shadow same-named globals during merge in `merge_skills`, but until now the popup gave no indication of which scope the winning entry came from. Now each skill row shows its name followed by `global` (for `~/.agents/skills/`) or the worktree root name (for `<project>/.agents/skills/`), styled with the theme's `variable` highlight so it reads as secondary text. MCP prompts are unchanged and render without a source label.

The origin is carried from `NativeAgent::build_available_commands_for_project` to the UI through `acp::AvailableCommand.meta` (key: `zed.skill_source`), following the same extensibility pattern already used for `tool_name` and `subagent_session_info`. `acp::AvailableCommand` is `#[non_exhaustive]` and lives in the external `agent-client-protocol-schema` crate, so the `meta` field is the right place for Zed-specific data.

The displayed-text suffix is excluded from the fuzzy filter range, so typing the source name doesn't match the entry. Slash-command filtering already happens up-front in `search_slash_commands` and the editor's `filter_completions()` returns false, so this is mostly defensive but keeps the displayed filter consistent with what was matched.

Stacked on top of #AI-139/skills.

Closes AI-139

Release Notes:

- N/A
