### PR TITLE
agent: Show checkpoints as soon as the model edits files

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -10,14 +10,20 @@ pub use connection::*;
 pub use diff::*;
 use feature_flags::{AcpBetaFeatureFlag, FeatureFlagAppExt as _};
 use futures::{FutureExt, channel::oneshot, future::BoxFuture};
-use gpui::{AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Task, WeakEntity};
+use gpui::{
+    AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Subscription, Task,
+    WeakEntity,
+};
 use itertools::Itertools;
 use language::language_settings::FormatOnSave;
 use language::{Anchor, Buffer, BufferSnapshot, LanguageRegistry, Point, ToPoint, text_diff};
 use markdown::Markdown;
 pub use mention::*;
 use project::lsp_store::{FormatTrigger, LspFormatTarget};
-use project::{AgentLocation, Project, git_store::GitStoreCheckpoint};
+use project::{
+    AgentLocation, Project,
+    git_store::{GitStoreCheckpoint, GitStoreEvent, RepositoryEvent},
+};
 use serde::{Deserialize, Serialize};
 use serde_json::to_string_pretty;
 use std::collections::HashMap;
@@ -1096,6 +1102,8 @@ pub struct AcpThread {
     plan: Plan,
     project: Entity<Project>,
     action_log: Entity<ActionLog>,
+    _git_store_subscription: Subscription,
+    update_last_checkpoint_if_changed_task: Option<Task<Result<()>>>,
     shared_buffers: HashMap<Entity<Buffer>, BufferSnapshot>,
     turn_id: u32,
     running_turn: Option<RunningTurn>,
@@ -1278,10 +1286,27 @@ impl AcpThread {
             }
         });
 
+        let git_store = project.read(cx).git_store().clone();
+        let _git_store_subscription = cx.subscribe(&git_store, |this, _, event, cx| {
+            if matches!(
+                event,
+                GitStoreEvent::RepositoryUpdated(
+                    _,
+                    RepositoryEvent::StatusesChanged | RepositoryEvent::HeadChanged,
+                    _
+                )
+            ) {
+                this.update_last_checkpoint_if_changed_task =
+                    Some(this.update_last_checkpoint_if_changed(cx));
+            }
+        });
+
         Self {
             parent_session_id,
             work_dirs,
             action_log,
+            _git_store_subscription,
+            update_last_checkpoint_if_changed_task: None,
             shared_buffers: Default::default(),
             entries: Default::default(),
             plan: Default::default(),
@@ -2571,6 +2596,79 @@ impl AcpThread {
                 })
             })?
             .await;
+            Ok(())
+        })
+    }
+
+    fn update_last_checkpoint_if_changed(&mut self, cx: &mut Context<Self>) -> Task<Result<()>> {
+        let Some(turn_id) = self.running_turn.as_ref().map(|turn| turn.id) else {
+            return Task::ready(Ok(()));
+        };
+
+        let git_store = self.project.read(cx).git_store().clone();
+
+        let Some((user_message_id, checkpoint)) =
+            self.last_user_message().and_then(|(_, message)| {
+                let id = message.id.clone()?;
+                let checkpoint = message.checkpoint.as_ref()?;
+                Some((id, checkpoint))
+            })
+        else {
+            return Task::ready(Ok(()));
+        };
+        if checkpoint.show {
+            return Task::ready(Ok(()));
+        }
+        let old_checkpoint = checkpoint.git_checkpoint.clone();
+
+        let new_checkpoint = git_store.update(cx, |git, cx| git.checkpoint(cx));
+        cx.spawn(async move |this, cx| {
+            let Some(new_checkpoint) = new_checkpoint
+                .await
+                .context("failed to get new checkpoint")
+                .log_err()
+            else {
+                return Ok(());
+            };
+
+            let Some(equal) = git_store
+                .update(cx, |git, cx| {
+                    git.compare_checkpoints(old_checkpoint.clone(), new_checkpoint, cx)
+                })
+                .await
+                .context("failed to compare checkpoints")
+                .log_err()
+            else {
+                return Ok(());
+            };
+
+            if equal {
+                return Ok(());
+            }
+
+            this.update(cx, |this, cx| {
+                if !this
+                    .running_turn
+                    .as_ref()
+                    .is_some_and(|turn| turn.id == turn_id)
+                {
+                    return;
+                }
+
+                let Some((ix, message)) = this.last_user_message() else {
+                    return;
+                };
+                if message.id.as_ref() != Some(&user_message_id) {
+                    return;
+                }
+                if let Some(checkpoint) = message.checkpoint.as_mut()
+                    && !checkpoint.show
+                {
+                    checkpoint.show = true;
+                    cx.emit(AcpThreadEvent::EntryUpdated(ix));
+                }
+            })?;
+
             Ok(())
         })
     }
@@ -4202,6 +4300,119 @@ mod tests {
             );
         });
         assert_eq!(fs.files(), vec![Path::new(path!("/test/file-0"))]);
+    }
+
+    #[gpui::test(iterations = 10)]
+    async fn test_checkpoint_shows_when_file_changes_during_pending_message(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/test"),
+            json!({
+                ".git": {}
+            }),
+        )
+        .await;
+        let project = Project::test(fs, [path!("/test").as_ref()], cx).await;
+
+        let (request_started_tx, request_started_rx) = oneshot::channel::<()>();
+        let request_started_tx = Rc::new(RefCell::new(Some(request_started_tx)));
+        let (write_file_tx, write_file_rx) = oneshot::channel::<()>();
+        let write_file_rx = Rc::new(RefCell::new(Some(write_file_rx)));
+        let (file_written_tx, file_written_rx) = oneshot::channel::<()>();
+        let file_written_tx = Rc::new(RefCell::new(Some(file_written_tx)));
+        let (finish_response_tx, finish_response_rx) = oneshot::channel::<()>();
+        let finish_response_tx = Rc::new(RefCell::new(Some(finish_response_tx)));
+        let finish_response_rx = Rc::new(RefCell::new(Some(finish_response_rx)));
+        let connection = Rc::new(FakeAgentConnection::new().on_user_message({
+            let request_started_tx = request_started_tx.clone();
+            let write_file_rx = write_file_rx.clone();
+            let file_written_tx = file_written_tx.clone();
+            let finish_response_rx = finish_response_rx.clone();
+            move |_request, thread, mut cx| {
+                let write_file_rx = write_file_rx.borrow_mut().take();
+                let finish_response_rx = finish_response_rx.borrow_mut().take();
+                let request_started_tx = request_started_tx.borrow_mut().take();
+                let file_written_tx = file_written_tx.borrow_mut().take();
+                async move {
+                    if let Some(request_started_tx) = request_started_tx {
+                        request_started_tx.send(()).ok();
+                    }
+                    if let Some(write_file_rx) = write_file_rx {
+                        write_file_rx.await.ok();
+                    }
+
+                    thread
+                        .update(&mut cx, |thread, cx| {
+                            thread.write_text_file(
+                                PathBuf::from(path!("/test/file")),
+                                String::new(),
+                                cx,
+                            )
+                        })?
+                        .await?;
+
+                    if let Some(file_written_tx) = file_written_tx {
+                        file_written_tx.send(()).ok();
+                    }
+                    if let Some(finish_response_rx) = finish_response_rx {
+                        finish_response_rx.await.ok();
+                    }
+
+                    Ok(acp::PromptResponse::new(acp::StopReason::EndTurn))
+                }
+                .boxed_local()
+            }
+        }));
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(project, PathList::new(&[Path::new(path!("/test"))]), cx)
+            })
+            .await
+            .unwrap();
+
+        let send = thread.update(cx, |thread, cx| thread.send(vec!["hello".into()], cx));
+        let send_task = cx.background_executor.spawn(send);
+        request_started_rx.await.unwrap();
+        cx.run_until_parked();
+
+        thread.read_with(cx, |thread, cx| {
+            assert_eq!(
+                thread.to_markdown(cx),
+                indoc! {"
+                    ## User
+
+                    hello
+
+                "}
+            );
+        });
+
+        write_file_tx.send(()).ok();
+        file_written_rx.await.unwrap();
+        cx.run_until_parked();
+
+        thread.read_with(cx, |thread, cx| {
+            assert_eq!(
+                thread.to_markdown(cx),
+                indoc! {"
+                    ## User (checkpoint)
+
+                    hello
+
+                "}
+            );
+        });
+
+        finish_response_tx
+            .borrow_mut()
+            .take()
+            .unwrap()
+            .send(())
+            .ok();
+        send_task.await.unwrap();
     }
 
     #[gpui::test]


### PR DESCRIPTION
Makes it so that "Restore checkpoint" shows up as soon as the model performs an edit, instead of waiting until the turn ends

Release Notes:

- Fixed the agent panel to show "Restore checkpoint" as soon as the agent starts editing instead of waiting until the turn ends
