### PR TITLE
ep: Add the editable region coverage metric

### DIFF
--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -1243,6 +1243,7 @@ fn main() {
                                                 app_state.clone(),
                                                 &example_progress,
                                                 cx.clone(),
+                                                false,
                                             )
                                             .await?;
                                         }
@@ -1253,6 +1254,7 @@ fn main() {
                                                 app_state.clone(),
                                                 &example_progress,
                                                 cx.clone(),
+                                                true,
                                             )
                                             .await?;
                                         }

--- a/crates/edit_prediction_cli/src/score.rs
+++ b/crates/edit_prediction_cli/src/score.rs
@@ -23,8 +23,11 @@ pub async fn run_scoring(
     app_state: Arc<EpAppState>,
     example_progress: &ExampleProgress,
     cx: AsyncApp,
+    allow_missing_predictions: bool,
 ) -> anyhow::Result<()> {
-    run_prediction(example, args, app_state, example_progress, cx).await?;
+    if !(allow_missing_predictions && args.provider.is_none() && example.predictions.is_empty()) {
+        run_prediction(example, args, app_state, example_progress, cx).await?;
+    }
 
     let progress = example_progress.start(Step::Score);
 
@@ -64,6 +67,25 @@ pub async fn run_scoring(
 
     progress.set_substatus("computing metrics");
     let mut scores = vec![];
+    if allow_missing_predictions && example.predictions.is_empty() {
+        scores.push(edit_prediction_metrics::score_prediction(
+            PredictionScoringInput {
+                original_text,
+                expected_patches: &prepared_expected_patches,
+                actual_patch: None,
+                actual_cursor: None,
+                reversal_context: Some(PredictionReversalContext {
+                    edit_history: &prompt_inputs.events,
+                    excerpt_start_row: prompt_inputs.excerpt_start_row,
+                    cursor_path,
+                }),
+                cumulative_logprob: None,
+                avg_logprob: None,
+                context: Some(&context),
+            },
+        ));
+    }
+
     for prediction in &example.predictions {
         let actual_patch = prediction.actual_patch.clone().or_else(|| {
             parse_prediction_output(example, &prediction.actual_output, prediction.provider)

--- a/crates/edit_prediction_cli/src/score.rs
+++ b/crates/edit_prediction_cli/src/score.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use anyhow::Context as _;
 use edit_prediction_metrics::{
-    ActualPredictionCursor, PredictionReversalContext, PredictionScoringInput,
+    ActualPredictionCursor, Excerpt, PredictionReversalContext, PredictionScoringInput,
 };
 use gpui::AsyncApp;
 use std::fs::File;
@@ -60,6 +60,7 @@ pub async fn run_scoring(
     .with_context(|| format!("Expected patch did not apply for {}", example.spec.name))?;
 
     let cursor_path = example.spec.cursor_path.as_ref();
+    let context = context_excerpts(example, prompt_inputs);
 
     progress.set_substatus("computing metrics");
     let mut scores = vec![];
@@ -92,12 +93,43 @@ pub async fn run_scoring(
                 }),
                 cumulative_logprob: prediction.cumulative_logprob,
                 avg_logprob: prediction.avg_logprob,
+                context: Some(&context),
             },
         ));
     }
 
     example.score = scores;
     Ok(())
+}
+
+fn context_excerpts(
+    example: &Example,
+    prompt_inputs: &zeta_prompt::ZetaPromptInput,
+) -> Vec<Excerpt> {
+    let mut context = Vec::new();
+
+    if let Some(excerpt_start_row) = prompt_inputs.excerpt_start_row {
+        let row_count = prompt_inputs.cursor_excerpt.lines().count() as u32;
+        context.push(Excerpt {
+            path: example.spec.cursor_path.to_string_lossy().to_string(),
+            row_range: excerpt_start_row..excerpt_start_row.saturating_add(row_count),
+            content: prompt_inputs.cursor_excerpt.to_string(),
+        });
+    }
+
+    if let Some(related_files) = &prompt_inputs.related_files {
+        for related_file in related_files {
+            for excerpt in &related_file.excerpts {
+                context.push(Excerpt {
+                    path: related_file.path.to_string_lossy().to_string(),
+                    row_range: excerpt.row_range.clone(),
+                    content: excerpt.text.to_string(),
+                });
+            }
+        }
+    }
+
+    context
 }
 
 pub fn print_report(examples: &[Example], verbose: bool) {
@@ -141,6 +173,10 @@ pub fn print_report(examples: &[Example], verbose: bool) {
     let mut discarded_chars_total: usize = 0;
     let mut recall_rate_sum: f64 = 0.0;
     let mut recall_rate_count: usize = 0;
+    let mut editable_context_coverage_sum: f64 = 0.0;
+    let mut editable_context_coverage_count: usize = 0;
+    let mut changed_lines_reachable: usize = 0;
+    let mut total_changed_lines: usize = 0;
     let mut patch_inserted_tokens: Vec<usize> = Vec::new();
     let mut patch_deleted_tokens: Vec<usize> = Vec::new();
     let mut predictions_with_patch: usize = 0;
@@ -250,6 +286,12 @@ pub fn print_report(examples: &[Example], verbose: bool) {
             if let Some(rr) = score.recall_rate {
                 recall_rate_sum += rr;
                 recall_rate_count += 1;
+            }
+            if let Some(coverage) = &score.editable_context_coverage {
+                editable_context_coverage_sum += coverage.score;
+                editable_context_coverage_count += 1;
+                changed_lines_reachable += coverage.changed_lines_reachable;
+                total_changed_lines += coverage.total_changed_lines;
             }
 
             // Accumulate token change metrics (only for predictions that produced a patch)
@@ -399,6 +441,17 @@ pub fn print_report(examples: &[Example], verbose: bool) {
                 "Recall rate: {:.1}% avg ({} evaluated)",
                 avg_recall_rate * 100.0,
                 recall_rate_count
+            );
+        }
+        if editable_context_coverage_count > 0 {
+            let avg_editable_context_coverage =
+                editable_context_coverage_sum / editable_context_coverage_count as f64;
+            println!(
+                "Editable context coverage: {:.1}% avg ({} evaluated, {} out of {} edits covered)",
+                avg_editable_context_coverage * 100.0,
+                editable_context_coverage_count,
+                changed_lines_reachable,
+                total_changed_lines
             );
         }
 

--- a/crates/edit_prediction_metrics/src/edit_prediction_metrics.rs
+++ b/crates/edit_prediction_metrics/src/edit_prediction_metrics.rs
@@ -1,4 +1,6 @@
+mod jumps;
 mod kept_rate;
+mod patch;
 mod patch_metrics;
 mod prediction_score;
 mod reversal;
@@ -6,6 +8,7 @@ mod summary;
 mod tokenize;
 mod tree_sitter;
 
+pub use jumps::{EditableContextCoverage, Excerpt, editable_context_coverage};
 pub use kept_rate::AnnotatedToken;
 pub use kept_rate::KeptRateResult;
 pub use kept_rate::TokenAnnotation;

--- a/crates/edit_prediction_metrics/src/jumps.rs
+++ b/crates/edit_prediction_metrics/src/jumps.rs
@@ -1,0 +1,199 @@
+use std::ops::Range;
+
+use crate::patch::{Patch, PatchLine};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Excerpt {
+    pub path: String,
+    pub row_range: Range<u32>,
+    pub content: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct EditableContextCoverage {
+    pub changed_lines_reachable: usize,
+    pub total_changed_lines: usize,
+    pub score: f64,
+}
+
+impl EditableContextCoverage {
+    pub fn new(changed_lines_reachable: usize, total_changed_lines: usize) -> Self {
+        let score = if total_changed_lines == 0 {
+            1.0
+        } else {
+            changed_lines_reachable as f64 / total_changed_lines as f64
+        };
+        Self {
+            changed_lines_reachable,
+            total_changed_lines,
+            score,
+        }
+    }
+}
+
+/// Measures how much of the expected edits are covered by the context.
+pub fn editable_context_coverage(
+    expected_patch: &str,
+    context: &[Excerpt],
+) -> EditableContextCoverage {
+    let patch = Patch::parse_unified_diff(expected_patch);
+    let mut changed_lines_reachable = 0;
+    let mut total_changed_lines = 0;
+    for hunk in patch.hunks {
+        let mut old_row = hunk.old_start.saturating_sub(1) as u32;
+        for line in hunk.lines {
+            match line {
+                PatchLine::Addition(_) => {
+                    total_changed_lines += 1;
+                    if context_contains_insertion_point(&context, &hunk.filename, old_row) {
+                        changed_lines_reachable += 1;
+                    }
+                }
+                PatchLine::Deletion(_) => {
+                    total_changed_lines += 1;
+                    if context_contains_line(&context, &hunk.filename, old_row) {
+                        changed_lines_reachable += 1;
+                    }
+                    old_row = old_row.saturating_add(1);
+                }
+                PatchLine::Context(_) => {
+                    old_row = old_row.saturating_add(1);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    EditableContextCoverage::new(changed_lines_reachable, total_changed_lines)
+}
+
+fn context_contains_line(context: &[Excerpt], filename: &str, row: u32) -> bool {
+    context
+        .iter()
+        .any(|excerpt| excerpt.path == filename && excerpt.row_range.contains(&row))
+}
+
+fn context_contains_insertion_point(context: &[Excerpt], filename: &str, row: u32) -> bool {
+    context.iter().any(|excerpt| {
+        excerpt.path == filename && excerpt.row_range.start <= row && row <= excerpt.row_range.end
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+
+    fn excerpt(path: &str, row_range: Range<u32>) -> Excerpt {
+        Excerpt {
+            path: path.to_string(),
+            row_range,
+            content: String::new(),
+        }
+    }
+
+    #[test]
+    fn deletion_is_reachable_when_zero_based_excerpt_contains_diff_line() {
+        let patch = indoc! {"
+            --- a/src/main.rs
+            +++ b/src/main.rs
+            @@ -2,1 +2,0 @@
+            -let value = 1;
+        "};
+
+        let score = editable_context_coverage(patch, &vec![excerpt("src/main.rs", 1..2)]);
+
+        assert_eq!(score.changed_lines_reachable, 1);
+        assert_eq!(score.total_changed_lines, 1);
+        assert_eq!(score.score, 1.0);
+    }
+
+    #[test]
+    fn searches_all_excerpts_for_matching_path() {
+        let patch = indoc! {"
+            --- a/src/main.rs
+            +++ b/src/main.rs
+            @@ -4,1 +4,0 @@
+            -let value = 4;
+        "};
+
+        let score = editable_context_coverage(
+            patch,
+            &vec![excerpt("src/main.rs", 0..1), excerpt("src/main.rs", 3..4)],
+        );
+
+        assert_eq!(score.changed_lines_reachable, 1);
+        assert_eq!(score.total_changed_lines, 1);
+        assert_eq!(score.score, 1.0);
+    }
+
+    #[test]
+    fn replacement_addition_is_reachable_at_deleted_line_boundary() {
+        let patch = indoc! {"
+            --- a/src/main.rs
+            +++ b/src/main.rs
+            @@ -1,3 +1,3 @@
+             fn main() {
+            -    let value = 1;
+            +    let value = 2;
+             }
+        "};
+
+        let score = editable_context_coverage(patch, &vec![excerpt("src/main.rs", 1..2)]);
+
+        assert_eq!(score.changed_lines_reachable, 2);
+        assert_eq!(score.total_changed_lines, 2);
+        assert_eq!(score.score, 1.0);
+    }
+
+    #[test]
+    fn insertion_is_reachable_at_excerpt_end_boundary() {
+        let patch = indoc! {"
+            --- a/src/main.rs
+            +++ b/src/main.rs
+            @@ -1,2 +1,3 @@
+             fn main() {
+            +    let value = 1;
+             }
+        "};
+
+        let score = editable_context_coverage(patch, &vec![excerpt("src/main.rs", 0..1)]);
+
+        assert_eq!(score.changed_lines_reachable, 1);
+        assert_eq!(score.total_changed_lines, 1);
+        assert_eq!(score.score, 1.0);
+    }
+
+    #[test]
+    fn counts_unreachable_changed_lines() {
+        let patch = indoc! {"
+            --- a/src/main.rs
+            +++ b/src/main.rs
+            @@ -1,3 +1,3 @@
+            -let first = 1;
+            +let first = 2;
+             let middle = 3;
+            -let last = 4;
+            +let last = 5;
+        "};
+
+        let score = editable_context_coverage(patch, &vec![excerpt("src/main.rs", 0..1)]);
+
+        assert_eq!(score.changed_lines_reachable, 2);
+        assert_eq!(score.total_changed_lines, 4);
+        assert_eq!(score.score, 0.5);
+    }
+
+    #[test]
+    fn empty_patch_has_perfect_reachability() {
+        let score = editable_context_coverage(
+            indoc! {"
+            "},
+            &Vec::new(),
+        );
+
+        assert_eq!(score.changed_lines_reachable, 0);
+        assert_eq!(score.total_changed_lines, 0);
+        assert_eq!(score.score, 1.0);
+    }
+}

--- a/crates/edit_prediction_metrics/src/jumps.rs
+++ b/crates/edit_prediction_metrics/src/jumps.rs
@@ -2,14 +2,14 @@ use std::ops::Range;
 
 use crate::patch::{Patch, PatchLine};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Excerpt {
     pub path: String,
     pub row_range: Range<u32>,
     pub content: String,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EditableContextCoverage {
     pub changed_lines_reachable: usize,
     pub total_changed_lines: usize,
@@ -40,18 +40,18 @@ pub fn editable_context_coverage(
     let mut changed_lines_reachable = 0;
     let mut total_changed_lines = 0;
     for hunk in patch.hunks {
-        let mut old_row = hunk.old_start.saturating_sub(1) as u32;
+        let mut old_row = hunk.old_start.saturating_sub(1).max(0) as u32;
         for line in hunk.lines {
             match line {
                 PatchLine::Addition(_) => {
                     total_changed_lines += 1;
-                    if context_contains_insertion_point(&context, &hunk.filename, old_row) {
+                    if context_contains_insertion_point(context, &hunk.filename, old_row) {
                         changed_lines_reachable += 1;
                     }
                 }
                 PatchLine::Deletion(_) => {
                     total_changed_lines += 1;
-                    if context_contains_line(&context, &hunk.filename, old_row) {
+                    if context_contains_line(context, &hunk.filename, old_row) {
                         changed_lines_reachable += 1;
                     }
                     old_row = old_row.saturating_add(1);
@@ -101,7 +101,7 @@ mod tests {
             -let value = 1;
         "};
 
-        let score = editable_context_coverage(patch, &vec![excerpt("src/main.rs", 1..2)]);
+        let score = editable_context_coverage(patch, &[excerpt("src/main.rs", 1..2)]);
 
         assert_eq!(score.changed_lines_reachable, 1);
         assert_eq!(score.total_changed_lines, 1);
@@ -119,7 +119,7 @@ mod tests {
 
         let score = editable_context_coverage(
             patch,
-            &vec![excerpt("src/main.rs", 0..1), excerpt("src/main.rs", 3..4)],
+            &[excerpt("src/main.rs", 0..1), excerpt("src/main.rs", 3..4)],
         );
 
         assert_eq!(score.changed_lines_reachable, 1);
@@ -139,7 +139,7 @@ mod tests {
              }
         "};
 
-        let score = editable_context_coverage(patch, &vec![excerpt("src/main.rs", 1..2)]);
+        let score = editable_context_coverage(patch, &[excerpt("src/main.rs", 1..2)]);
 
         assert_eq!(score.changed_lines_reachable, 2);
         assert_eq!(score.total_changed_lines, 2);
@@ -157,7 +157,7 @@ mod tests {
              }
         "};
 
-        let score = editable_context_coverage(patch, &vec![excerpt("src/main.rs", 0..1)]);
+        let score = editable_context_coverage(patch, &[excerpt("src/main.rs", 0..1)]);
 
         assert_eq!(score.changed_lines_reachable, 1);
         assert_eq!(score.total_changed_lines, 1);
@@ -177,7 +177,7 @@ mod tests {
             +let last = 5;
         "};
 
-        let score = editable_context_coverage(patch, &vec![excerpt("src/main.rs", 0..1)]);
+        let score = editable_context_coverage(patch, &[excerpt("src/main.rs", 0..1)]);
 
         assert_eq!(score.changed_lines_reachable, 2);
         assert_eq!(score.total_changed_lines, 4);
@@ -189,7 +189,7 @@ mod tests {
         let score = editable_context_coverage(
             indoc! {"
             "},
-            &Vec::new(),
+            &[],
         );
 
         assert_eq!(score.changed_lines_reachable, 0);

--- a/crates/edit_prediction_metrics/src/main.rs
+++ b/crates/edit_prediction_metrics/src/main.rs
@@ -63,34 +63,7 @@ fn run() -> Result<(), String> {
             let example: JsonExample = serde_json::from_str(&json)
                 .map_err(|err| format!("failed to parse {}: {err}", json_path.display()))?;
 
-            let context = get_context_excerpts(&example);
-            let base = example.prompt_inputs.cursor_excerpt;
-            let excerpt_start_row = example.prompt_inputs.excerpt_start_row;
-            let expected_patch = example
-                .expected_patches
-                .into_iter()
-                .next()
-                .ok_or_else(|| "JSON input is missing expected_patches[0]".to_string())?;
-            let actual_patch = example
-                .predictions
-                .into_iter()
-                .nth(prediction_index)
-                .ok_or_else(|| {
-                    format!("JSON input does not contain predictions[{prediction_index}]")
-                })?
-                .actual_patch;
-
-            let expected = apply_patch_to_excerpt(&base, &expected_patch, excerpt_start_row)?;
-            let actual = apply_patch_to_excerpt(&base, &actual_patch, excerpt_start_row)?;
-
-            EvaluationReport::new(
-                base,
-                expected_patch,
-                actual_patch,
-                expected,
-                actual,
-                &context,
-            )
+            report_from_json_example(example, prediction_index)?
         }
     };
 
@@ -124,6 +97,42 @@ fn get_cursor_excerpt(example: &JsonExample) -> Excerpt {
         row_range,
         content,
     }
+}
+
+fn report_from_json_example(
+    example: JsonExample,
+    prediction_index: usize,
+) -> Result<EvaluationReport, String> {
+    let context = get_context_excerpts(&example);
+    let excerpt_start_row = example.prompt_inputs.excerpt_start_row;
+    let base = example.prompt_inputs.cursor_excerpt;
+    let expected_patch = example
+        .expected_patches
+        .into_iter()
+        .next()
+        .ok_or_else(|| "JSON input is missing expected_patches[0]".to_string())?;
+    let actual_patch = if example.predictions.is_empty() {
+        String::new()
+    } else {
+        example
+            .predictions
+            .into_iter()
+            .nth(prediction_index)
+            .ok_or_else(|| format!("JSON input does not contain predictions[{prediction_index}]"))?
+            .actual_patch
+    };
+
+    let expected = apply_patch_to_excerpt(&base, &expected_patch, excerpt_start_row)?;
+    let actual = apply_patch_to_excerpt(&base, &actual_patch, excerpt_start_row)?;
+
+    Ok(EvaluationReport::new(
+        base,
+        expected_patch,
+        actual_patch,
+        expected,
+        actual,
+        &context,
+    ))
 }
 
 fn print_usage() {
@@ -269,7 +278,7 @@ impl EvaluationReport {
         let editable_region_correct = is_editable_region_correct(&actual_patch);
         let expected_braces_disbalance = braces_disbalance(&expected);
         let actual_braces_disbalance = braces_disbalance(&actual);
-        let editable_context_coverage = editable_context_coverage(&actual_patch, context);
+        let editable_context_coverage = editable_context_coverage(&expected_patch, context);
 
         Self {
             base,
@@ -432,6 +441,7 @@ struct JsonExample {
     prompt_inputs: PromptInputs,
     cursor_path: String,
     expected_patches: Vec<String>,
+    #[serde(default)]
     predictions: Vec<Prediction>,
 }
 
@@ -778,5 +788,58 @@ mod tests {
 
         let actual = apply_patch_to_excerpt(base, patch, 5).unwrap();
         assert_eq!(actual, "x\ny\nc\n");
+    }
+
+    fn json_example(predictions: Option<&str>) -> String {
+        let predictions = predictions
+            .map(|predictions| {
+                format!(
+                    r#",
+    "predictions": {predictions}"#
+                )
+            })
+            .unwrap_or_default();
+
+        format!(
+            r#"{{
+    "prompt_inputs": {{
+        "cursor_excerpt": "first\nsecond\nthird\n",
+        "excerpt_start_row": 0
+    }},
+    "cursor_path": "src/main.rs",
+    "expected_patches": [
+        "--- a/src/main.rs\n+++ b/src/main.rs\n@@ -2,1 +2,1 @@\n-second\n+changed\n"
+    ]{predictions}
+}}"#
+        )
+    }
+
+    fn report_from_json(predictions: Option<&str>) -> EvaluationReport {
+        let example = serde_json::from_str(&json_example(predictions)).unwrap();
+        report_from_json_example(example, 0).unwrap()
+    }
+
+    #[test]
+    fn json_report_with_missing_predictions_uses_expected_patch_for_context_coverage() {
+        let report = report_from_json(None);
+
+        assert_eq!(report.actual, "first\nsecond\nthird\n");
+        assert_eq!(report.actual_changed_lines, 0);
+        assert_eq!(
+            report.editable_context_coverage,
+            EditableContextCoverage::new(2, 2)
+        );
+    }
+
+    #[test]
+    fn json_report_with_empty_predictions_uses_expected_patch_for_context_coverage() {
+        let report = report_from_json(Some("[]"));
+
+        assert_eq!(report.actual, "first\nsecond\nthird\n");
+        assert_eq!(report.actual_changed_lines, 0);
+        assert_eq!(
+            report.editable_context_coverage,
+            EditableContextCoverage::new(2, 2)
+        );
     }
 }

--- a/crates/edit_prediction_metrics/src/main.rs
+++ b/crates/edit_prediction_metrics/src/main.rs
@@ -41,8 +41,8 @@ fn run() -> Result<(), String> {
             let actual_patch = fs::read_to_string(&actual_patch_path)
                 .map_err(|err| format!("failed to read {}: {err}", actual_patch_path.display()))?;
 
-            let expected = apply_patch_to_excerpt(&base, &expected_patch, 0)?;
-            let actual = apply_patch_to_excerpt(&base, &actual_patch, 0)?;
+            let expected = apply_patch_to_excerpt(&base, &expected_patch, 0, None)?;
+            let actual = apply_patch_to_excerpt(&base, &actual_patch, 0, None)?;
             let context = [];
 
             EvaluationReport::new(
@@ -105,6 +105,7 @@ fn report_from_json_example(
 ) -> Result<EvaluationReport, String> {
     let context = get_context_excerpts(&example);
     let excerpt_start_row = example.prompt_inputs.excerpt_start_row;
+    let cursor_path = example.cursor_path;
     let base = example.prompt_inputs.cursor_excerpt;
     let expected_patch = example
         .expected_patches
@@ -122,8 +123,14 @@ fn report_from_json_example(
             .actual_patch
     };
 
-    let expected = apply_patch_to_excerpt(&base, &expected_patch, excerpt_start_row)?;
-    let actual = apply_patch_to_excerpt(&base, &actual_patch, excerpt_start_row)?;
+    let expected = apply_patch_to_excerpt(
+        &base,
+        &expected_patch,
+        excerpt_start_row,
+        Some(&cursor_path),
+    )?;
+    let actual =
+        apply_patch_to_excerpt(&base, &actual_patch, excerpt_start_row, Some(&cursor_path))?;
 
     Ok(EvaluationReport::new(
         base,
@@ -380,8 +387,8 @@ fn print_report(report: &EvaluationReport) {
     println!("Jumps metrics");
     println!("-------------");
     println!(
-        "Editable context coverage: {} ({} / {})",
-        report.editable_context_coverage.score,
+        "Editable context coverage: {}% ({} out of {} edits covered)",
+        (report.editable_context_coverage.score * 100.0).round(),
         report.editable_context_coverage.changed_lines_reachable,
         report.editable_context_coverage.total_changed_lines
     );
@@ -473,6 +480,7 @@ struct Prediction {
 #[derive(Debug, Clone)]
 struct ParsedHunk {
     old_start: u32,
+    filename: Option<String>,
     lines: Vec<HunkLine>,
 }
 
@@ -487,8 +495,20 @@ fn apply_patch_to_excerpt(
     base: &str,
     patch: &str,
     excerpt_start_row: u32,
+    target_path: Option<&str>,
 ) -> Result<String, String> {
     let hunks = parse_diff_hunks(patch);
+    let hunks = if let Some(target_path) = target_path {
+        hunks
+            .into_iter()
+            .filter(|hunk| match hunk.filename.as_deref() {
+                Some(filename) => filename == target_path,
+                None => true,
+            })
+            .collect::<Vec<_>>()
+    } else {
+        hunks
+    };
 
     let result = try_apply_hunks(base, &hunks, excerpt_start_row);
 
@@ -680,6 +700,7 @@ fn filter_hunk_to_excerpt(
 
     Some(ParsedHunk {
         old_start: filtered_old_start.unwrap_or(excerpt_start_row),
+        filename: hunk.filename.clone(),
         lines: filtered_lines,
     })
 }
@@ -687,8 +708,14 @@ fn filter_hunk_to_excerpt(
 fn parse_diff_hunks(diff: &str) -> Vec<ParsedHunk> {
     let mut hunks = Vec::new();
     let mut current_hunk: Option<ParsedHunk> = None;
+    let mut current_filename = None;
 
     for line in diff.lines() {
+        if let Some(filename) = parse_diff_filename(line) {
+            current_filename = Some(filename);
+            continue;
+        }
+
         if let Some((old_start, old_count, _new_start, _new_count)) = parse_hunk_header(line) {
             if let Some(hunk) = current_hunk.take() {
                 hunks.push(hunk);
@@ -696,6 +723,7 @@ fn parse_diff_hunks(diff: &str) -> Vec<ParsedHunk> {
             let _ = old_count;
             current_hunk = Some(ParsedHunk {
                 old_start,
+                filename: current_filename.clone(),
                 lines: Vec::new(),
             });
             continue;
@@ -746,6 +774,27 @@ fn parse_hunk_range(part: &str) -> Option<(u32, u32)> {
     }
 }
 
+fn parse_diff_filename(line: &str) -> Option<String> {
+    let path = line
+        .strip_prefix("--- ")
+        .or_else(|| line.strip_prefix("+++ "))?;
+    normalize_diff_path(path)
+}
+
+fn normalize_diff_path(path: &str) -> Option<String> {
+    let path = path.trim();
+    let path = path
+        .strip_prefix("a/")
+        .or_else(|| path.strip_prefix("b/"))
+        .unwrap_or(path);
+
+    if path == "/dev/null" {
+        None
+    } else {
+        Some(path.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -755,7 +804,7 @@ mod tests {
         let base = "fn main() {\n    println!(\"hello\");\n}\n";
         let patch = "@@ -1,3 +1,3 @@\n fn main() {\n-    println!(\"hello\");\n+    println!(\"world\");\n }\n";
 
-        let actual = apply_patch_to_excerpt(base, patch, 0).unwrap();
+        let actual = apply_patch_to_excerpt(base, patch, 0, None).unwrap();
         assert_eq!(actual, "fn main() {\n    println!(\"world\");\n}\n");
     }
 
@@ -764,7 +813,7 @@ mod tests {
         let base = "b\nc\nd\n";
         let patch = "@@ -2,2 +2,2 @@\n-b\n-c\n+x\n+y\n";
 
-        let actual = apply_patch_to_excerpt(base, patch, 1).unwrap();
+        let actual = apply_patch_to_excerpt(base, patch, 1, None).unwrap();
         assert_eq!(actual, "x\ny\nd\n");
     }
 
@@ -775,7 +824,7 @@ mod tests {
         // even though the excerpt starts at file row 100.
         let patch = "@@ -2,2 +2,2 @@\n-b\n-c\n+x\n+y\n";
 
-        let actual = apply_patch_to_excerpt(base, patch, 100).unwrap();
+        let actual = apply_patch_to_excerpt(base, patch, 100, None).unwrap();
         assert_eq!(actual, "a\nx\ny\nd\n");
     }
 
@@ -786,8 +835,35 @@ mod tests {
         // hunk targets line 6 (1-based) = row 5 (0-based) = first line.
         let patch = "@@ -6,2 +6,2 @@\n-a\n-b\n+x\n+y\n";
 
-        let actual = apply_patch_to_excerpt(base, patch, 5).unwrap();
+        let actual = apply_patch_to_excerpt(base, patch, 5, None).unwrap();
         assert_eq!(actual, "x\ny\nc\n");
+    }
+
+    #[test]
+    fn json_patch_application_ignores_unrelated_file_hunks() {
+        let base = "first\nsecond\nthird\n";
+        let patch = "--- a/src/other.rs\n+++ b/src/other.rs\n@@ -2,1 +2,1 @@\n-second\n+changed\n";
+
+        let actual = apply_patch_to_excerpt(base, patch, 0, Some("src/main.rs")).unwrap();
+        assert_eq!(actual, base);
+    }
+
+    #[test]
+    fn json_patch_application_applies_matching_file_hunks() {
+        let base = "first\nsecond\nthird\n";
+        let patch = "--- a/src/main.rs\n+++ b/src/main.rs\n@@ -2,1 +2,1 @@\n-second\n+changed\n";
+
+        let actual = apply_patch_to_excerpt(base, patch, 0, Some("src/main.rs")).unwrap();
+        assert_eq!(actual, "first\nchanged\nthird\n");
+    }
+
+    #[test]
+    fn json_patch_application_applies_headerless_hunks() {
+        let base = "first\nsecond\nthird\n";
+        let patch = "@@ -2,1 +2,1 @@\n-second\n+changed\n";
+
+        let actual = apply_patch_to_excerpt(base, patch, 0, Some("src/main.rs")).unwrap();
+        assert_eq!(actual, "first\nchanged\nthird\n");
     }
 
     fn json_example(predictions: Option<&str>) -> String {

--- a/crates/edit_prediction_metrics/src/main.rs
+++ b/crates/edit_prediction_metrics/src/main.rs
@@ -5,10 +5,10 @@ use std::path::Path;
 use std::process;
 
 use edit_prediction_metrics::{
-    ClassificationMetrics, DeltaChrFMetrics, KeptRateResult, TokenAnnotation,
-    annotate_kept_rate_tokens, braces_disbalance, compute_kept_rate, count_patch_token_changes,
-    delta_chr_f, exact_lines_match, extract_changed_lines_from_diff,
-    has_isolated_whitespace_changes, is_editable_region_correct,
+    ClassificationMetrics, DeltaChrFMetrics, EditableContextCoverage, Excerpt, KeptRateResult,
+    TokenAnnotation, annotate_kept_rate_tokens, braces_disbalance, compute_kept_rate,
+    count_patch_token_changes, delta_chr_f, editable_context_coverage, exact_lines_match,
+    extract_changed_lines_from_diff, has_isolated_whitespace_changes, is_editable_region_correct,
 };
 use serde::Deserialize;
 
@@ -43,8 +43,16 @@ fn run() -> Result<(), String> {
 
             let expected = apply_patch_to_excerpt(&base, &expected_patch, 0)?;
             let actual = apply_patch_to_excerpt(&base, &actual_patch, 0)?;
+            let context = [];
 
-            EvaluationReport::new(base, expected_patch, actual_patch, expected, actual)
+            EvaluationReport::new(
+                base,
+                expected_patch,
+                actual_patch,
+                expected,
+                actual,
+                &context,
+            )
         }
         CliInput::Json {
             json_path,
@@ -55,6 +63,7 @@ fn run() -> Result<(), String> {
             let example: JsonExample = serde_json::from_str(&json)
                 .map_err(|err| format!("failed to parse {}: {err}", json_path.display()))?;
 
+            let context = get_context_excerpts(&example);
             let base = example.prompt_inputs.cursor_excerpt;
             let excerpt_start_row = example.prompt_inputs.excerpt_start_row;
             let expected_patch = example
@@ -74,12 +83,47 @@ fn run() -> Result<(), String> {
             let expected = apply_patch_to_excerpt(&base, &expected_patch, excerpt_start_row)?;
             let actual = apply_patch_to_excerpt(&base, &actual_patch, excerpt_start_row)?;
 
-            EvaluationReport::new(base, expected_patch, actual_patch, expected, actual)
+            EvaluationReport::new(
+                base,
+                expected_patch,
+                actual_patch,
+                expected,
+                actual,
+                &context,
+            )
         }
     };
 
     print_report(&report);
     Ok(())
+}
+
+fn get_context_excerpts(example: &JsonExample) -> Vec<Excerpt> {
+    let mut context = vec![get_cursor_excerpt(example)];
+
+    if let Some(related) = &example.prompt_inputs.related_files {
+        context.extend(related.iter().flat_map(|file| {
+            file.excerpts.iter().map(|excerpt| Excerpt {
+                path: file.path.clone(),
+                row_range: excerpt.row_range.clone(),
+                content: excerpt.text.clone(),
+            })
+        }));
+    }
+
+    context
+}
+
+fn get_cursor_excerpt(example: &JsonExample) -> Excerpt {
+    let content = example.prompt_inputs.cursor_excerpt.clone();
+    let start_row = example.prompt_inputs.excerpt_start_row;
+    let rows = content.lines().count() as u32;
+    let row_range = start_row..start_row + rows;
+    Excerpt {
+        path: example.cursor_path.clone(),
+        row_range,
+        content,
+    }
 }
 
 fn print_usage() {
@@ -199,6 +243,7 @@ struct EvaluationReport {
     editable_region_correct: bool,
     expected_braces_disbalance: usize,
     actual_braces_disbalance: usize,
+    editable_context_coverage: EditableContextCoverage,
 }
 
 impl EvaluationReport {
@@ -208,6 +253,7 @@ impl EvaluationReport {
         actual_patch: String,
         expected: String,
         actual: String,
+        context: &[Excerpt],
     ) -> Self {
         let kept_rate = compute_kept_rate(&base, &actual, &expected);
         let exact_lines = exact_lines_match(&expected_patch, &actual_patch);
@@ -223,6 +269,7 @@ impl EvaluationReport {
         let editable_region_correct = is_editable_region_correct(&actual_patch);
         let expected_braces_disbalance = braces_disbalance(&expected);
         let actual_braces_disbalance = braces_disbalance(&actual);
+        let editable_context_coverage = editable_context_coverage(&actual_patch, context);
 
         Self {
             base,
@@ -238,6 +285,7 @@ impl EvaluationReport {
             editable_region_correct,
             expected_braces_disbalance,
             actual_braces_disbalance,
+            editable_context_coverage,
         }
     }
 }
@@ -319,6 +367,15 @@ fn print_report(report: &EvaluationReport) {
     println!();
 
     print_kept_rate_explanation(&report.base, &report.actual, &report.expected);
+
+    println!("Jumps metrics");
+    println!("-------------");
+    println!(
+        "Editable context coverage: {} ({} / {})",
+        report.editable_context_coverage.score,
+        report.editable_context_coverage.changed_lines_reachable,
+        report.editable_context_coverage.total_changed_lines
+    );
 }
 
 fn print_kept_rate_explanation(base: &str, actual: &str, expected: &str) {
@@ -373,6 +430,7 @@ fn visualize_whitespace(token: &str) -> String {
 #[derive(Debug, Deserialize)]
 struct JsonExample {
     prompt_inputs: PromptInputs,
+    cursor_path: String,
     expected_patches: Vec<String>,
     predictions: Vec<Prediction>,
 }
@@ -381,6 +439,20 @@ struct JsonExample {
 struct PromptInputs {
     cursor_excerpt: String,
     excerpt_start_row: u32,
+    pub related_files: Option<Vec<RelatedFile>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Hash, Deserialize)]
+pub struct RelatedFile {
+    pub path: String,
+    pub max_row: u32,
+    pub excerpts: Vec<RelatedExcerpt>,
+}
+
+#[derive(Clone, Debug, PartialEq, Hash, Deserialize)]
+pub struct RelatedExcerpt {
+    pub row_range: std::ops::Range<u32>,
+    pub text: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/edit_prediction_metrics/src/patch.rs
+++ b/crates/edit_prediction_metrics/src/patch.rs
@@ -1,0 +1,127 @@
+#[derive(Debug, Default, Clone)]
+pub struct Patch {
+    pub hunks: Vec<Hunk>,
+}
+
+impl Patch {
+    pub fn parse_unified_diff(unified_diff: &str) -> Patch {
+        let mut current_file = String::new();
+        let mut is_filename_inherited = false;
+        let mut hunk = Hunk::default();
+        let mut patch = Patch::default();
+        let mut in_header = true;
+
+        for line in unified_diff.lines() {
+            if line.starts_with("--- ") || line.starts_with("+++") || line.starts_with("@@") {
+                in_header = false;
+            }
+
+            if in_header {
+                continue;
+            }
+
+            if line.starts_with("@@") {
+                if !hunk.lines.is_empty() {
+                    patch.hunks.push(hunk);
+                }
+                hunk = Hunk::from_header(line, &current_file, is_filename_inherited);
+                is_filename_inherited = true;
+            } else if let Some(path) = line.strip_prefix("--- ") {
+                is_filename_inherited = false;
+                let path = path.trim().strip_prefix("a/").unwrap_or(path);
+                if path != "/dev/null" {
+                    current_file = path.into();
+                }
+            } else if let Some(path) = line.strip_prefix("+++ ") {
+                is_filename_inherited = false;
+                let path = path.trim().strip_prefix("b/").unwrap_or(path);
+                if path != "/dev/null" {
+                    current_file = path.into();
+                }
+            } else if let Some(line) = line.strip_prefix('+') {
+                hunk.lines.push(PatchLine::Addition(line.to_string()));
+            } else if let Some(line) = line.strip_prefix('-') {
+                hunk.lines.push(PatchLine::Deletion(line.to_string()));
+            } else if let Some(line) = line.strip_prefix(' ') {
+                hunk.lines.push(PatchLine::Context(line.to_string()));
+            } else {
+                hunk.lines.push(PatchLine::Garbage(line.to_string()));
+            }
+        }
+
+        if !hunk.lines.is_empty() {
+            patch.hunks.push(hunk);
+        }
+
+        patch
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Hunk {
+    pub old_start: isize,
+    pub new_start: isize,
+    pub lines: Vec<PatchLine>,
+    pub filename: String,
+}
+
+impl Hunk {
+    pub fn from_header(header: &str, filename: &str, _is_filename_inherited: bool) -> Self {
+        let (old_start, _, new_start, _, _) = Self::parse_hunk_header(header);
+        Self {
+            old_start,
+            new_start,
+            lines: Vec::new(),
+            filename: filename.to_string(),
+        }
+    }
+
+    fn parse_hunk_header(line: &str) -> (isize, isize, isize, isize, String) {
+        let header_part = line.trim_start_matches("@@").trim();
+        let parts: Vec<&str> = header_part.split_whitespace().collect();
+
+        if parts.len() < 2 {
+            return (0, 0, 0, 0, String::new());
+        }
+
+        let old_part = parts[0].trim_start_matches('-');
+        let new_part = parts[1].trim_start_matches('+');
+
+        let (old_start, old_count) = Hunk::parse_hunk_header_range(old_part);
+        let (new_start, new_count) = Hunk::parse_hunk_header_range(new_part);
+
+        let comment = if parts.len() > 2 {
+            parts[2..]
+                .join(" ")
+                .trim_start_matches("@@")
+                .trim()
+                .to_string()
+        } else {
+            String::new()
+        };
+
+        (
+            old_start as isize,
+            old_count as isize,
+            new_start as isize,
+            new_count as isize,
+            comment,
+        )
+    }
+
+    fn parse_hunk_header_range(part: &str) -> (usize, usize) {
+        if let Some((start, count)) = part.split_once(',') {
+            (start.parse().unwrap_or(0), count.parse().unwrap_or(0))
+        } else {
+            (part.parse().unwrap_or(0), 1)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PatchLine {
+    Context(String),
+    Addition(String),
+    Deletion(String),
+    Garbage(String),
+}

--- a/crates/edit_prediction_metrics/src/patch_metrics.rs
+++ b/crates/edit_prediction_metrics/src/patch_metrics.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use crate::tokenize::tokenize;
+use crate::{
+    patch::{Patch, PatchLine},
+    tokenize::tokenize,
+};
 use serde::Serialize;
 use similar::{DiffTag, TextDiff};
 
@@ -715,129 +718,6 @@ pub fn reconstruct_texts_from_diff(patch_str: &str) -> (String, String) {
     }
 
     (old_lines.join("\n"), new_lines.join("\n"))
-}
-#[derive(Debug, Default, Clone)]
-struct Patch {
-    hunks: Vec<Hunk>,
-}
-
-impl Patch {
-    fn parse_unified_diff(unified_diff: &str) -> Patch {
-        let mut current_file = String::new();
-        let mut is_filename_inherited = false;
-        let mut hunk = Hunk::default();
-        let mut patch = Patch::default();
-        let mut in_header = true;
-
-        for line in unified_diff.lines() {
-            if line.starts_with("--- ") || line.starts_with("+++") || line.starts_with("@@") {
-                in_header = false;
-            }
-
-            if in_header {
-                continue;
-            }
-
-            if line.starts_with("@@") {
-                if !hunk.lines.is_empty() {
-                    patch.hunks.push(hunk);
-                }
-                hunk = Hunk::from_header(line, &current_file, is_filename_inherited);
-                is_filename_inherited = true;
-            } else if let Some(path) = line.strip_prefix("--- ") {
-                is_filename_inherited = false;
-                let path = path.trim().strip_prefix("a/").unwrap_or(path);
-                if path != "/dev/null" {
-                    current_file = path.into();
-                }
-            } else if let Some(path) = line.strip_prefix("+++ ") {
-                is_filename_inherited = false;
-                let path = path.trim().strip_prefix("b/").unwrap_or(path);
-                if path != "/dev/null" {
-                    current_file = path.into();
-                }
-            } else if let Some(line) = line.strip_prefix('+') {
-                hunk.lines.push(PatchLine::Addition(line.to_string()));
-            } else if let Some(line) = line.strip_prefix('-') {
-                hunk.lines.push(PatchLine::Deletion(line.to_string()));
-            } else if let Some(line) = line.strip_prefix(' ') {
-                hunk.lines.push(PatchLine::Context(line.to_string()));
-            } else {
-                hunk.lines.push(PatchLine::Garbage(line.to_string()));
-            }
-        }
-
-        if !hunk.lines.is_empty() {
-            patch.hunks.push(hunk);
-        }
-
-        patch
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-struct Hunk {
-    new_start: isize,
-    lines: Vec<PatchLine>,
-}
-
-impl Hunk {
-    fn from_header(header: &str, _filename: &str, _is_filename_inherited: bool) -> Self {
-        let (_, _, new_start, _, _) = Self::parse_hunk_header(header);
-        Self {
-            new_start,
-            lines: Vec::new(),
-        }
-    }
-
-    fn parse_hunk_header(line: &str) -> (isize, isize, isize, isize, String) {
-        let header_part = line.trim_start_matches("@@").trim();
-        let parts: Vec<&str> = header_part.split_whitespace().collect();
-
-        if parts.len() < 2 {
-            return (0, 0, 0, 0, String::new());
-        }
-
-        let old_part = parts[0].trim_start_matches('-');
-        let new_part = parts[1].trim_start_matches('+');
-
-        let (old_start, old_count) = Hunk::parse_hunk_header_range(old_part);
-        let (new_start, new_count) = Hunk::parse_hunk_header_range(new_part);
-
-        let comment = if parts.len() > 2 {
-            parts[2..]
-                .join(" ")
-                .trim_start_matches("@@")
-                .trim()
-                .to_string()
-        } else {
-            String::new()
-        };
-
-        (
-            old_start as isize,
-            old_count as isize,
-            new_start as isize,
-            new_count as isize,
-            comment,
-        )
-    }
-
-    fn parse_hunk_header_range(part: &str) -> (usize, usize) {
-        if let Some((start, count)) = part.split_once(',') {
-            (start.parse().unwrap_or(0), count.parse().unwrap_or(0))
-        } else {
-            (part.parse().unwrap_or(0), 1)
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum PatchLine {
-    Context(String),
-    Addition(String),
-    Deletion(String),
-    Garbage(String),
 }
 
 #[cfg(test)]

--- a/crates/edit_prediction_metrics/src/prediction_score.rs
+++ b/crates/edit_prediction_metrics/src/prediction_score.rs
@@ -5,12 +5,15 @@ use std::path::Path;
 use std::sync::Arc;
 use zeta_prompt::udiff::{apply_diff_to_string, apply_diff_to_string_with_hunk_offset};
 
-use crate::patch_metrics::{
-    ClassificationMetrics, DeltaChrFMetrics, braces_disbalance, count_patch_token_changes,
-    delta_chr_f, delta_chr_f_beta, exact_lines_match, has_isolated_whitespace_changes,
-    is_editable_region_correct,
-};
 use crate::reversal::compute_prediction_reversal_ratio_from_history;
+use crate::{
+    jumps::{EditableContextCoverage, Excerpt, editable_context_coverage},
+    patch_metrics::{
+        ClassificationMetrics, DeltaChrFMetrics, braces_disbalance, count_patch_token_changes,
+        delta_chr_f, delta_chr_f_beta, exact_lines_match, has_isolated_whitespace_changes,
+        is_editable_region_correct,
+    },
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PredictionScore {
@@ -61,6 +64,8 @@ pub struct PredictionScore {
     pub cumulative_logprob: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub avg_logprob: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub editable_context_coverage: Option<EditableContextCoverage>,
 }
 
 impl PredictionScore {
@@ -91,6 +96,7 @@ impl PredictionScore {
             discarded_chars: None,
             cumulative_logprob: None,
             avg_logprob: None,
+            editable_context_coverage: None,
         }
     }
 
@@ -193,11 +199,22 @@ pub struct PredictionScoringInput<'a> {
     pub reversal_context: Option<PredictionReversalContext<'a>>,
     pub cumulative_logprob: Option<f64>,
     pub avg_logprob: Option<f64>,
+    pub context: Option<&'a [Excerpt]>,
 }
 
 pub fn score_prediction(input: PredictionScoringInput<'_>) -> PredictionScore {
+    let editable_context_coverage = input.context.and_then(|context| {
+        input
+            .expected_patches
+            .iter()
+            .map(|expected| editable_context_coverage(&expected.patch, context))
+            .max_by(|left, right| left.score.total_cmp(&right.score))
+    });
+
     let Some(actual_patch) = input.actual_patch else {
-        return PredictionScore::zero();
+        let mut score = PredictionScore::zero();
+        score.editable_context_coverage = editable_context_coverage;
+        return score;
     };
 
     let token_changes = count_patch_token_changes(actual_patch);
@@ -208,6 +225,7 @@ pub fn score_prediction(input: PredictionScoringInput<'_>) -> PredictionScore {
             let mut score = PredictionScore::zero();
             score.inserted_tokens = token_changes.inserted_tokens;
             score.deleted_tokens = token_changes.deleted_tokens;
+            score.editable_context_coverage = editable_context_coverage;
             return score;
         }
     };
@@ -302,6 +320,7 @@ pub fn score_prediction(input: PredictionScoringInput<'_>) -> PredictionScore {
         discarded_chars,
         cumulative_logprob: input.cumulative_logprob,
         avg_logprob: input.avg_logprob,
+        editable_context_coverage,
     }
 }
 
@@ -343,6 +362,7 @@ mod tests {
             reversal_context: None,
             cumulative_logprob: None,
             avg_logprob: None,
+            context: None,
         });
 
         assert_eq!(score.delta_chr_f, 0.0);

--- a/crates/edit_prediction_metrics/src/summary.rs
+++ b/crates/edit_prediction_metrics/src/summary.rs
@@ -56,6 +56,12 @@ pub struct SummaryJson {
     pub total_correctly_deleted_chars: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total_discarded_chars: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg_editable_context_coverage: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub editable_context_changed_lines_reachable: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub editable_context_total_changed_lines: Option<usize>,
 }
 
 pub fn compute_summary<'a>(
@@ -91,6 +97,10 @@ pub fn compute_summary<'a>(
     let mut discarded_chars_count: usize = 0;
     let mut recall_rate_sum: f64 = 0.0;
     let mut recall_rate_count: usize = 0;
+    let mut editable_context_coverage_sum: f64 = 0.0;
+    let mut editable_context_coverage_count: usize = 0;
+    let mut editable_context_changed_lines_reachable: usize = 0;
+    let mut editable_context_total_changed_lines: usize = 0;
 
     for prediction in predictions {
         let score = prediction.score;
@@ -148,6 +158,12 @@ pub fn compute_summary<'a>(
         if let Some(recall_rate) = score.recall_rate {
             recall_rate_sum += recall_rate;
             recall_rate_count += 1;
+        }
+        if let Some(coverage) = &score.editable_context_coverage {
+            editable_context_coverage_sum += coverage.score;
+            editable_context_coverage_count += 1;
+            editable_context_changed_lines_reachable += coverage.changed_lines_reachable;
+            editable_context_total_changed_lines += coverage.total_changed_lines;
         }
 
         if let Some(exact_match) = score.cursor_exact_match {
@@ -252,6 +268,22 @@ pub fn compute_summary<'a>(
         None
     };
 
+    let avg_editable_context_coverage = if editable_context_coverage_count > 0 {
+        Some(editable_context_coverage_sum / editable_context_coverage_count as f64)
+    } else {
+        None
+    };
+    let editable_context_changed_lines_reachable = if editable_context_coverage_count > 0 {
+        Some(editable_context_changed_lines_reachable)
+    } else {
+        None
+    };
+    let editable_context_total_changed_lines = if editable_context_coverage_count > 0 {
+        Some(editable_context_total_changed_lines)
+    } else {
+        None
+    };
+
     SummaryJson {
         total_examples: total_scores,
         avg_delta_chr_f,
@@ -289,5 +321,8 @@ pub fn compute_summary<'a>(
         total_kept_chars,
         total_correctly_deleted_chars,
         total_discarded_chars,
+        avg_editable_context_coverage,
+        editable_context_changed_lines_reachable,
+        editable_context_total_changed_lines,
     }
 }


### PR DESCRIPTION
This metric checks how much the retrieved context (related files and the cursor snippet) covers the regions expected to be edited according to `expected_patches`


Release Notes:

- N/A