### PR TITLE
Add FreeBSD remote_server CI  job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -610,6 +610,61 @@ jobs:
         path: target/zed-remote-server-windows-x86_64.zip
         if-no-files-found: error
     timeout-minutes: 60
+  bundle_freebsd_x86_64:
+    needs:
+    - run_tests_linux
+    - clippy_linux
+    - check_scripts
+    runs-on: namespace-profile-32x64-ubuntu-2004
+    env:
+      CARGO_INCREMENTAL: 0
+      ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}
+      ZED_MINIDUMP_ENDPOINT: ${{ secrets.ZED_SENTRY_MINIDUMP_ENDPOINT }}
+    steps:
+    - name: steps::checkout_repo
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      with:
+        clean: false
+    - name: steps::setup_sentry
+      uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b
+      with:
+        token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    - name: steps::install_rustup_target
+      run: rustup target add x86_64-unknown-freebsd
+    - name: run_bundling::bundle_freebsd
+      run: pip install ziglang cargo-zigbuild --break-system-packages
+    - name: run_bundling::bundle_freebsd
+      run: |
+        set -eu
+        mkdir -p ~/freebsd-sysroot
+        if [ ! -f ~/freebsd-sysroot/usr/include/stdio.h ]; then
+          curl -L -o /tmp/base.txz \
+            https://download.freebsd.org/releases/amd64/amd64/15.0-RELEASE/base.txz
+          tar -xJf /tmp/base.txz -C ~/freebsd-sysroot ./lib ./usr
+        fi
+    - name: run_bundling::bundle_freebsd
+      run: |
+        set -eu
+        export CFLAGS_x86_64_unknown_freebsd="\
+            -fPIC \
+            -I$HOME/freebsd-sysroot/usr/include \
+            -L$HOME/freebsd-sysroot/lib \
+            -L$HOME/freebsd-sysroot/usr/lib"
+        export RUSTFLAGS="\
+            -L $HOME/freebsd-sysroot/lib \
+            -L $HOME/freebsd-sysroot/usr/lib \
+            -C link-arg=$HOME/freebsd-sysroot/usr/lib/libkvm.so \
+            -C link-arg=$HOME/freebsd-sysroot/usr/lib/libprocstat.so"
+        cargo zigbuild -p remote_server --release --target x86_64-unknown-freebsd
+        gzip -f --stdout --best target/x86_64-unknown-freebsd/release/remote_server \
+            > target/zed-remote-server-freebsd-x86_64.gz
+    - name: '@actions/upload-artifact zed-remote-server-freebsd-x86_64.gz'
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+      with:
+        name: zed-remote-server-freebsd-x86_64.gz
+        path: target/zed-remote-server-freebsd-x86_64.gz
+        if-no-files-found: error
+    timeout-minutes: 60
   upload_release_assets:
     needs:
     - create_draft_release
@@ -619,6 +674,7 @@ jobs:
     - bundle_mac_x86_64
     - bundle_windows_aarch64
     - bundle_windows_x86_64
+    - bundle_freebsd_x86_64
     runs-on: namespace-profile-4x8-ubuntu-2204
     steps:
     - name: release::download_workflow_artifacts
@@ -643,6 +699,7 @@ jobs:
         mv ./artifacts/zed-remote-server-linux-x86_64.gz/zed-remote-server-linux-x86_64.gz release-artifacts/zed-remote-server-linux-x86_64.gz
         mv ./artifacts/zed-remote-server-windows-aarch64.zip/zed-remote-server-windows-aarch64.zip release-artifacts/zed-remote-server-windows-aarch64.zip
         mv ./artifacts/zed-remote-server-windows-x86_64.zip/zed-remote-server-windows-x86_64.zip release-artifacts/zed-remote-server-windows-x86_64.zip
+        mv ./artifacts/zed-remote-server-freebsd-x86_64.gz/zed-remote-server-freebsd-x86_64.gz release-artifacts/zed-remote-server-freebsd-x86_64.gz
     - name: gh release upload "$GITHUB_REF_NAME" --repo=zed-industries/zed release-artifacts/*
       run: gh release upload "$GITHUB_REF_NAME" --repo=zed-industries/zed release-artifacts/*
       env:
@@ -654,7 +711,7 @@ jobs:
     steps:
     - name: release::validate_release_assets
       run: |
-        EXPECTED_ASSETS='["Zed-aarch64.dmg", "Zed-x86_64.dmg", "zed-linux-aarch64.tar.gz", "zed-linux-x86_64.tar.gz", "Zed-x86_64.exe", "Zed-aarch64.exe", "zed-remote-server-macos-aarch64.gz", "zed-remote-server-macos-x86_64.gz", "zed-remote-server-linux-aarch64.gz", "zed-remote-server-linux-x86_64.gz", "zed-remote-server-windows-aarch64.zip", "zed-remote-server-windows-x86_64.zip"]'
+        EXPECTED_ASSETS='["Zed-aarch64.dmg", "Zed-x86_64.dmg", "zed-linux-aarch64.tar.gz", "zed-linux-x86_64.tar.gz", "Zed-x86_64.exe", "Zed-aarch64.exe", "zed-remote-server-macos-aarch64.gz", "zed-remote-server-macos-x86_64.gz", "zed-remote-server-linux-aarch64.gz", "zed-remote-server-linux-x86_64.gz", "zed-remote-server-windows-aarch64.zip", "zed-remote-server-windows-x86_64.zip", "zed-remote-server-freebsd-x86_64.gz"]'
         TAG="$GITHUB_REF_NAME"
 
         ACTUAL_ASSETS=$(gh release view "$TAG" --repo=zed-industries/zed --json assets -q '[.assets[].name]')
@@ -799,6 +856,7 @@ jobs:
     - bundle_mac_x86_64
     - bundle_windows_aarch64
     - bundle_windows_x86_64
+    - bundle_freebsd_x86_64
     if: always()
     runs-on: namespace-profile-2x4-ubuntu-2404
     steps:
@@ -826,6 +884,7 @@ jobs:
                 if [ "$RESULT_BUNDLE_MAC_X86_64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_mac_x86_64"; fi
                 if [ "$RESULT_BUNDLE_WINDOWS_AARCH64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_windows_aarch64"; fi
                 if [ "$RESULT_BUNDLE_WINDOWS_X86_64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_windows_x86_64"; fi
+                if [ "$RESULT_BUNDLE_FREEBSD_X86_64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_freebsd_x86_64"; fi
                 FAILED_JOBS=$(echo "$FAILED_JOBS" | xargs)
                 if [ "$UPLOAD_RESULT" == "cancelled" ]; then
                     if [ -n "$FAILED_JOBS" ]; then
@@ -878,6 +937,7 @@ jobs:
         RESULT_BUNDLE_MAC_X86_64: ${{ needs.bundle_mac_x86_64.result }}
         RESULT_BUNDLE_WINDOWS_AARCH64: ${{ needs.bundle_windows_aarch64.result }}
         RESULT_BUNDLE_WINDOWS_X86_64: ${{ needs.bundle_windows_x86_64.result }}
+        RESULT_BUNDLE_FREEBSD_X86_64: ${{ needs.bundle_freebsd_x86_64.result }}
     - name: release::send_slack_message
       if: steps.generate-webhook-message.outputs.message != ''
       run: 'curl -X POST -H ''Content-type: application/json'' --data "$(jq -n --arg text "$SLACK_MESSAGE" ''{"text": $text}'')" "$SLACK_WEBHOOK"'

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -393,6 +393,67 @@ jobs:
         path: target/zed-remote-server-windows-x86_64.zip
         if-no-files-found: error
     timeout-minutes: 60
+  bundle_freebsd_x86_64:
+    needs:
+    - check_style
+    - run_tests_windows
+    - clippy_windows
+    runs-on: namespace-profile-32x64-ubuntu-2004
+    env:
+      CARGO_INCREMENTAL: 0
+      ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}
+      ZED_MINIDUMP_ENDPOINT: ${{ secrets.ZED_SENTRY_MINIDUMP_ENDPOINT }}
+    steps:
+    - name: steps::checkout_repo
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      with:
+        clean: false
+    - name: run_bundling::set_release_channel_to_nightly
+      run: |
+        set -eu
+        version=$(git rev-parse --short HEAD)
+        echo "Publishing version: ${version} on release channel nightly"
+        echo "nightly" > crates/zed/RELEASE_CHANNEL
+    - name: steps::setup_sentry
+      uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b
+      with:
+        token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    - name: steps::install_rustup_target
+      run: rustup target add x86_64-unknown-freebsd
+    - name: run_bundling::bundle_freebsd
+      run: pip install ziglang cargo-zigbuild --break-system-packages
+    - name: run_bundling::bundle_freebsd
+      run: |
+        set -eu
+        mkdir -p ~/freebsd-sysroot
+        if [ ! -f ~/freebsd-sysroot/usr/include/stdio.h ]; then
+          curl -L -o /tmp/base.txz \
+            https://download.freebsd.org/releases/amd64/amd64/15.0-RELEASE/base.txz
+          tar -xJf /tmp/base.txz -C ~/freebsd-sysroot ./lib ./usr
+        fi
+    - name: run_bundling::bundle_freebsd
+      run: |
+        set -eu
+        export CFLAGS_x86_64_unknown_freebsd="\
+            -fPIC \
+            -I$HOME/freebsd-sysroot/usr/include \
+            -L$HOME/freebsd-sysroot/lib \
+            -L$HOME/freebsd-sysroot/usr/lib"
+        export RUSTFLAGS="\
+            -L $HOME/freebsd-sysroot/lib \
+            -L $HOME/freebsd-sysroot/usr/lib \
+            -C link-arg=$HOME/freebsd-sysroot/usr/lib/libkvm.so \
+            -C link-arg=$HOME/freebsd-sysroot/usr/lib/libprocstat.so"
+        cargo zigbuild -p remote_server --release --target x86_64-unknown-freebsd
+        gzip -f --stdout --best target/x86_64-unknown-freebsd/release/remote_server \
+            > target/zed-remote-server-freebsd-x86_64.gz
+    - name: '@actions/upload-artifact zed-remote-server-freebsd-x86_64.gz'
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+      with:
+        name: zed-remote-server-freebsd-x86_64.gz
+        path: target/zed-remote-server-freebsd-x86_64.gz
+        if-no-files-found: error
+    timeout-minutes: 60
   build_nix_linux_x86_64:
     needs:
     - check_style
@@ -484,6 +545,7 @@ jobs:
     - bundle_mac_x86_64
     - bundle_windows_aarch64
     - bundle_windows_x86_64
+    - bundle_freebsd_x86_64
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
     runs-on: namespace-profile-4x8-ubuntu-2204
     steps:
@@ -514,6 +576,7 @@ jobs:
         mv ./artifacts/zed-remote-server-linux-x86_64.gz/zed-remote-server-linux-x86_64.gz release-artifacts/zed-remote-server-linux-x86_64.gz
         mv ./artifacts/zed-remote-server-windows-aarch64.zip/zed-remote-server-windows-aarch64.zip release-artifacts/zed-remote-server-windows-aarch64.zip
         mv ./artifacts/zed-remote-server-windows-x86_64.zip/zed-remote-server-windows-x86_64.zip release-artifacts/zed-remote-server-windows-x86_64.zip
+        mv ./artifacts/zed-remote-server-freebsd-x86_64.gz/zed-remote-server-freebsd-x86_64.gz release-artifacts/zed-remote-server-freebsd-x86_64.gz
     - name: ./script/upload-nightly
       run: ./script/upload-nightly
       env:
@@ -546,6 +609,7 @@ jobs:
     - bundle_mac_x86_64
     - bundle_windows_aarch64
     - bundle_windows_x86_64
+    - bundle_freebsd_x86_64
     if: failure()
     runs-on: namespace-profile-2x4-ubuntu-2404
     steps:

--- a/.github/workflows/run_bundling.yml
+++ b/.github/workflows/run_bundling.yml
@@ -264,6 +264,60 @@ jobs:
         path: target/zed-remote-server-windows-x86_64.zip
         if-no-files-found: error
     timeout-minutes: 60
+  bundle_freebsd_x86_64:
+    if: |-
+      (github.event.action == 'labeled' && github.event.label.name == 'run-bundling') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-bundling'))
+    runs-on: namespace-profile-32x64-ubuntu-2004
+    env:
+      CARGO_INCREMENTAL: 0
+      ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}
+      ZED_MINIDUMP_ENDPOINT: ${{ secrets.ZED_SENTRY_MINIDUMP_ENDPOINT }}
+    steps:
+    - name: steps::checkout_repo
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      with:
+        clean: false
+    - name: steps::setup_sentry
+      uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b
+      with:
+        token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    - name: steps::install_rustup_target
+      run: rustup target add x86_64-unknown-freebsd
+    - name: run_bundling::bundle_freebsd
+      run: pip install ziglang cargo-zigbuild --break-system-packages
+    - name: run_bundling::bundle_freebsd
+      run: |
+        set -eu
+        mkdir -p ~/freebsd-sysroot
+        if [ ! -f ~/freebsd-sysroot/usr/include/stdio.h ]; then
+          curl -L -o /tmp/base.txz \
+            https://download.freebsd.org/releases/amd64/amd64/15.0-RELEASE/base.txz
+          tar -xJf /tmp/base.txz -C ~/freebsd-sysroot ./lib ./usr
+        fi
+    - name: run_bundling::bundle_freebsd
+      run: |
+        set -eu
+        export CFLAGS_x86_64_unknown_freebsd="\
+            -fPIC \
+            -I$HOME/freebsd-sysroot/usr/include \
+            -L$HOME/freebsd-sysroot/lib \
+            -L$HOME/freebsd-sysroot/usr/lib"
+        export RUSTFLAGS="\
+            -L $HOME/freebsd-sysroot/lib \
+            -L $HOME/freebsd-sysroot/usr/lib \
+            -C link-arg=$HOME/freebsd-sysroot/usr/lib/libkvm.so \
+            -C link-arg=$HOME/freebsd-sysroot/usr/lib/libprocstat.so"
+        cargo zigbuild -p remote_server --release --target x86_64-unknown-freebsd
+        gzip -f --stdout --best target/x86_64-unknown-freebsd/release/remote_server \
+            > target/zed-remote-server-freebsd-x86_64.gz
+    - name: '@actions/upload-artifact zed-remote-server-freebsd-x86_64.gz'
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+      with:
+        name: zed-remote-server-freebsd-x86_64.gz
+        path: target/zed-remote-server-freebsd-x86_64.gz
+        if-no-files-found: error
+    timeout-minutes: 60
   build_nix_linux_x86_64:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions') && ((github.event.action == 'labeled' && github.event.label.name == 'run-bundling') || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-bundling')))
     runs-on: namespace-profile-32x64-ubuntu-2004

--- a/tooling/xtask/src/tasks/workflows/nix_build.rs
+++ b/tooling/xtask/src/tasks/workflows/nix_build.rs
@@ -74,6 +74,7 @@ pub(crate) fn build_nix(
         Platform::Windows => unimplemented!(),
         Platform::Linux => runners::LINUX_X86_BUNDLER,
         Platform::Mac => runners::MAC_DEFAULT,
+        Platform::Freebsd => unimplemented!(),
     };
     let mut job = Job::default()
         .timeout_minutes(60u32)
@@ -116,6 +117,7 @@ pub(crate) fn build_nix(
             .add_step(build(&flake_output))
             .add_step(export_to_local_nix_cache()),
         Platform::Windows => unimplemented!(),
+        Platform::Freebsd => unimplemented!(),
     };
 
     NamedJob {

--- a/tooling/xtask/src/tasks/workflows/release.rs
+++ b/tooling/xtask/src/tasks/workflows/release.rs
@@ -2,7 +2,7 @@ use gh_workflow::{Event, Expression, Level, Push, Run, Step, Use, Workflow, ctx:
 use indoc::formatdoc;
 
 use crate::tasks::workflows::{
-    run_bundling::{bundle_linux, bundle_mac, bundle_windows, upload_artifact},
+    run_bundling::{bundle_freebsd, bundle_linux, bundle_mac, bundle_windows, upload_artifact},
     run_tests,
     runners::{self, Arch, Platform},
     steps::{self, FluentBuilder, NamedJob, TokenPermissions, dependant_job, named, release_job},
@@ -54,6 +54,11 @@ pub(crate) fn release() -> Workflow {
             Arch::X86_64,
             None,
             &[&windows_tests, &windows_clippy, &check_scripts],
+        ),
+        freebsd_x86_64: bundle_freebsd(
+            Arch::X86_64,
+            None,
+            &[&linux_tests, &linux_clippy, &check_scripts],
         ),
     };
 
@@ -124,6 +129,7 @@ pub(crate) struct ReleaseBundleJobs {
     pub mac_x86_64: NamedJob,
     pub windows_aarch64: NamedJob,
     pub windows_x86_64: NamedJob,
+    pub freebsd_x86_64: NamedJob,
 }
 
 impl ReleaseBundleJobs {
@@ -135,6 +141,7 @@ impl ReleaseBundleJobs {
             &self.mac_x86_64,
             &self.windows_aarch64,
             &self.windows_x86_64,
+            &self.freebsd_x86_64,
         ]
     }
 
@@ -146,6 +153,7 @@ impl ReleaseBundleJobs {
             self.mac_x86_64,
             self.windows_aarch64,
             self.windows_x86_64,
+            self.freebsd_x86_64,
         ]
     }
 }

--- a/tooling/xtask/src/tasks/workflows/release_nightly.rs
+++ b/tooling/xtask/src/tasks/workflows/release_nightly.rs
@@ -4,7 +4,7 @@ use crate::tasks::workflows::{
         ReleaseBundleJobs, create_sentry_release, download_workflow_artifacts, notify_on_failure,
         prep_release_artifacts,
     },
-    run_bundling::{bundle_linux, bundle_mac, bundle_windows},
+    run_bundling::{bundle_freebsd, bundle_linux, bundle_mac, bundle_windows},
     run_tests::{clippy, run_platform_tests_no_filter},
     runners::{Arch, Platform, ReleaseChannel},
     steps::{CommonJobConditions, FluentBuilder, NamedJob},
@@ -28,6 +28,7 @@ pub fn release_nightly() -> Workflow {
         mac_x86_64: bundle_mac(Arch::X86_64, nightly, &[&style, &tests, &clippy_job]),
         windows_aarch64: bundle_windows(Arch::AARCH64, nightly, &[&style, &tests, &clippy_job]),
         windows_x86_64: bundle_windows(Arch::X86_64, nightly, &[&style, &tests, &clippy_job]),
+        freebsd_x86_64: bundle_freebsd(Arch::X86_64, nightly, &[&style, &tests, &clippy_job]),
     };
 
     let nix_linux_x86 = build_nix(

--- a/tooling/xtask/src/tasks/workflows/run_bundling.rs
+++ b/tooling/xtask/src/tasks/workflows/run_bundling.rs
@@ -20,6 +20,7 @@ pub fn run_bundling() -> Workflow {
         mac_x86_64: bundle_mac(Arch::X86_64, None, &[]),
         windows_aarch64: bundle_windows(Arch::AARCH64, None, &[]),
         windows_x86_64: bundle_windows(Arch::X86_64, None, &[]),
+        freebsd_x86_64: bundle_freebsd(Arch::X86_64, None, &[]),
     };
     let nix_linux_x86_64 = nix_job(Platform::Linux, Arch::X86_64);
     let nix_mac_aarch64 = nix_job(Platform::Mac, Arch::AARCH64);
@@ -201,6 +202,58 @@ pub(crate) fn bundle_windows(
     }
 }
 
+pub(crate) fn bundle_freebsd(
+    _arch: Arch,
+    release_channel: Option<ReleaseChannel>,
+    deps: &[&NamedJob],
+) -> NamedJob {
+    let platform = Platform::Freebsd;
+    let remote_server_artifact_name = assets::REMOTE_SERVER_FREEBSD_X86_64;
+    NamedJob {
+        name: "bundle_freebsd_x86_64".to_owned(),
+        job: bundle_job(deps)
+            .runs_on(runners::LINUX_X86_BUNDLER)
+            .envs(bundle_envs(platform))
+            .add_step(steps::checkout_repo())
+            .when_some(release_channel, |job, release_channel| {
+                job.add_step(set_release_channel(platform, release_channel))
+            })
+            .add_step(steps::setup_sentry())
+            .add_step(steps::install_rustup_target("x86_64-unknown-freebsd"))
+            .add_step(named::bash(
+                "pip install ziglang cargo-zigbuild --break-system-packages",
+            ))
+            .add_step(named::bash(indoc! {r#"
+                set -eu
+                mkdir -p ~/freebsd-sysroot
+                if [ ! -f ~/freebsd-sysroot/usr/include/stdio.h ]; then
+                  curl -L -o /tmp/base.txz \
+                    https://download.freebsd.org/releases/amd64/amd64/15.0-RELEASE/base.txz
+                  tar -xJf /tmp/base.txz -C ~/freebsd-sysroot ./lib ./usr
+                fi
+            "#}))
+            .add_step(named::bash(indoc! {r#"
+                set -eu
+                export CFLAGS_x86_64_unknown_freebsd="\
+                    -fPIC \
+                    -I$HOME/freebsd-sysroot/usr/include \
+                    -L$HOME/freebsd-sysroot/lib \
+                    -L$HOME/freebsd-sysroot/usr/lib"
+                export RUSTFLAGS="\
+                    -L $HOME/freebsd-sysroot/lib \
+                    -L $HOME/freebsd-sysroot/usr/lib \
+                    -C link-arg=$HOME/freebsd-sysroot/usr/lib/libkvm.so \
+                    -C link-arg=$HOME/freebsd-sysroot/usr/lib/libprocstat.so"
+                cargo zigbuild -p remote_server --release --target x86_64-unknown-freebsd
+                gzip -f --stdout --best target/x86_64-unknown-freebsd/release/remote_server \
+                    > target/zed-remote-server-freebsd-x86_64.gz
+            "#}))
+            .add_step(upload_artifact(&format!(
+                "target/{remote_server_artifact_name}"
+            ))),
+    }
+}
+
 fn set_release_channel(platform: Platform, release_channel: ReleaseChannel) -> Step<Run> {
     match release_channel {
         ReleaseChannel::Nightly => set_release_channel_to_nightly(platform),
@@ -209,7 +262,7 @@ fn set_release_channel(platform: Platform, release_channel: ReleaseChannel) -> S
 
 fn set_release_channel_to_nightly(platform: Platform) -> Step<Run> {
     match platform {
-        Platform::Linux | Platform::Mac => named::bash(indoc::indoc! {r#"
+        Platform::Linux | Platform::Mac | Platform::Freebsd => named::bash(indoc::indoc! {r#"
             set -eu
             version=$(git rev-parse --short HEAD)
             echo "Publishing version: ${version} on release channel nightly"

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -523,6 +523,7 @@ pub(crate) fn clippy(platform: Platform, arch: Option<Arch>) -> NamedJob {
         Platform::Windows => runners::WINDOWS_DEFAULT,
         Platform::Linux => runners::LINUX_DEFAULT,
         Platform::Mac => runners::MAC_DEFAULT,
+        Platform::Freebsd => unimplemented!(),
     };
     let mut job = release_job(&[])
         .runs_on(runner)
@@ -565,6 +566,7 @@ fn run_platform_tests_impl(platform: Platform, filter_packages: bool) -> NamedJo
         Platform::Windows => runners::WINDOWS_DEFAULT,
         Platform::Linux => runners::LINUX_DEFAULT,
         Platform::Mac => runners::MAC_DEFAULT,
+        Platform::Freebsd => unimplemented!(),
     };
     NamedJob {
         name: format!("run_tests_{platform}"),

--- a/tooling/xtask/src/tasks/workflows/runners.rs
+++ b/tooling/xtask/src/tasks/workflows/runners.rs
@@ -51,6 +51,7 @@ pub enum Platform {
     Windows,
     Linux,
     Mac,
+    Freebsd,
 }
 
 impl std::fmt::Display for Platform {
@@ -59,6 +60,7 @@ impl std::fmt::Display for Platform {
             Platform::Windows => write!(f, "windows"),
             Platform::Linux => write!(f, "linux"),
             Platform::Mac => write!(f, "mac"),
+            Platform::Freebsd => write!(f, "freebsd"),
         }
     }
 }

--- a/tooling/xtask/src/tasks/workflows/steps.rs
+++ b/tooling/xtask/src/tasks/workflows/steps.rs
@@ -207,7 +207,7 @@ pub fn setup_cargo_config(platform: Platform) -> Step<Run> {
             Copy-Item -Path "./.cargo/ci-config.toml" -Destination "./../.cargo/config.toml"
         "#}),
 
-        Platform::Linux | Platform::Mac => named::bash(indoc::indoc! {r#"
+        Platform::Linux | Platform::Mac | Platform::Freebsd => named::bash(indoc::indoc! {r#"
             mkdir -p ./../.cargo
             cp ./.cargo/ci-config.toml ./../.cargo/config.toml
         "#}),
@@ -219,7 +219,7 @@ pub fn cleanup_cargo_config(platform: Platform) -> Step<Run> {
         Platform::Windows => named::pwsh(indoc::indoc! {r#"
             Remove-Item -Recurse -Path "./../.cargo" -Force -ErrorAction SilentlyContinue
         "#}),
-        Platform::Linux | Platform::Mac => named::bash(indoc::indoc! {r#"
+        Platform::Linux | Platform::Mac | Platform::Freebsd => named::bash(indoc::indoc! {r#"
             rm -rf ./../.cargo
         "#}),
     };
@@ -230,8 +230,9 @@ pub fn cleanup_cargo_config(platform: Platform) -> Step<Run> {
 pub fn clear_target_dir_if_large(platform: Platform) -> Step<Run> {
     match platform {
         Platform::Windows => named::pwsh("./script/clear-target-dir-if-larger-than.ps1 350 200"),
-        Platform::Linux => named::bash("./script/clear-target-dir-if-larger-than 350 200"),
-        Platform::Mac => named::bash("./script/clear-target-dir-if-larger-than 350 200"),
+        Platform::Linux | Platform::Mac | Platform::Freebsd => {
+            named::bash("./script/clear-target-dir-if-larger-than 350 200")
+        }
     }
 }
 
@@ -262,7 +263,9 @@ pub fn cache_rust_dependencies_namespace() -> Step<Use> {
 pub fn setup_sccache(platform: Platform) -> Step<Run> {
     let step = match platform {
         Platform::Windows => named::pwsh("./script/setup-sccache.ps1"),
-        Platform::Linux | Platform::Mac => named::bash("./script/setup-sccache"),
+        Platform::Linux | Platform::Mac | Platform::Freebsd => {
+            named::bash("./script/setup-sccache")
+        }
     };
     step.add_env(("R2_ACCOUNT_ID", vars::R2_ACCOUNT_ID))
         .add_env(("R2_ACCESS_KEY_ID", vars::R2_ACCESS_KEY_ID))
@@ -278,7 +281,9 @@ pub fn show_sccache_stats(platform: Platform) -> Step<Run> {
         Platform::Windows => {
             named::pwsh("if ($env:RUSTC_WRAPPER) { & $env:RUSTC_WRAPPER --show-stats }; exit 0")
         }
-        Platform::Linux | Platform::Mac => named::bash("sccache --show-stats || true"),
+        Platform::Linux | Platform::Mac | Platform::Freebsd => {
+            named::bash("sccache --show-stats || true")
+        }
     }
 }
 
@@ -466,7 +471,9 @@ pub mod named {
     pub fn run(platform: Platform, script: &str) -> Step<Run> {
         match platform {
             Platform::Windows => Step::new(function_name(1)).run(script).shell(PWSH_SHELL),
-            Platform::Linux | Platform::Mac => Step::new(function_name(1)).run(script),
+            Platform::Linux | Platform::Mac | Platform::Freebsd => {
+                Step::new(function_name(1)).run(script)
+            }
         }
     }
 

--- a/tooling/xtask/src/tasks/workflows/vars.rs
+++ b/tooling/xtask/src/tasks/workflows/vars.rs
@@ -68,6 +68,7 @@ pub fn bundle_envs(platform: Platform) -> Env {
 
     match platform {
         Platform::Linux => env,
+        Platform::Freebsd => env,
         Platform::Mac => env
             .add("MACOS_CERTIFICATE", MACOS_CERTIFICATE)
             .add("MACOS_CERTIFICATE_PASSWORD", MACOS_CERTIFICATE_PASSWORD)
@@ -393,6 +394,7 @@ pub mod assets {
     pub const REMOTE_SERVER_LINUX_X86_64: &str = "zed-remote-server-linux-x86_64.gz";
     pub const REMOTE_SERVER_WINDOWS_AARCH64: &str = "zed-remote-server-windows-aarch64.zip";
     pub const REMOTE_SERVER_WINDOWS_X86_64: &str = "zed-remote-server-windows-x86_64.zip";
+    pub const REMOTE_SERVER_FREEBSD_X86_64: &str = "zed-remote-server-freebsd-x86_64.gz";
 
     pub fn all() -> Vec<&'static str> {
         vec![
@@ -408,6 +410,7 @@ pub mod assets {
             REMOTE_SERVER_LINUX_X86_64,
             REMOTE_SERVER_WINDOWS_AARCH64,
             REMOTE_SERVER_WINDOWS_X86_64,
+            REMOTE_SERVER_FREEBSD_X86_64,
         ]
     }
 }


### PR DESCRIPTION
## Summary

Add FreeBSD `remote_server` cross-compilation to the CI pipeline. This extends the existing xtask workflow generation system with a `bundle_freebsd_x86_64` job that runs on a Linux Ubuntu 20.04 runner and uses `cargo-zigbuild` with a FreeBSD 15.0 sysroot to produce `zed-remote-server-freebsd-x86_64.gz`.

This PR is a companion to #55388 which adds the source-level FreeBSD support. Together they enable building and shipping the FreeBSD remote server binary.

### What changed

**xtask (Rust source):**
- Added `Platform::Freebsd` variant to the `Platform` enum
- Added `REMOTE_SERVER_FREEBSD_X86_64` asset constant and updated `assets::all()`
- Added `Platform::Freebsd` handling in `steps.rs` (cargo config, sccache, etc.)
- Added `bundle_freebsd()` function in `run_bundling.rs` that:
  1. Installs the `x86_64-unknown-freebsd` Rust target
  2. Installs `ziglang` and `cargo-zigbuild` via pip
  3. Downloads and caches the FreeBSD 15.0 sysroot
  4. Cross-compiles `remote_server` with appropriate `CFLAGS`/`RUSTFLAGS`
  5. Gzips and uploads the artifact
- Extended `ReleaseBundleJobs` with `freebsd_x86_64` field in release and nightly workflows

**CI workflows (auto-generated YAML):**
- Rebuilt all workflows via `cargo xtask workflows`
- `release.yml`, `release_nightly.yml`, and `run_bundling.yml` now include `bundle_freebsd_x86_64`
- The FreeBSD remote server artifact is included in release asset validation and nightly uploads

Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- N/A