### PR TITLE
Improve update button version display

### DIFF
--- a/crates/title_bar/src/update_version.rs
+++ b/crates/title_bar/src/update_version.rs
@@ -66,9 +66,9 @@ impl UpdateVersion {
     }
 
     fn version_tooltip_message(version: &VersionCheckType) -> String {
-        format!("Version: {}", {
+        format!("Update to Version: {}", {
             match version {
-                VersionCheckType::Sha(sha) => format!("{}…", sha.short()),
+                VersionCheckType::Sha(sha) => sha.full(),
                 VersionCheckType::Semantic(semantic_version) => semantic_version.to_string(),
             }
         })
@@ -85,16 +85,16 @@ impl Render for UpdateVersion {
                 UpdateButton::checking().into_any_element()
             }
             AutoUpdateStatus::Downloading { version } => {
-                let tooltip = Self::version_tooltip_message(&version);
-                UpdateButton::downloading(tooltip).into_any_element()
+                let version = Self::version_tooltip_message(&version);
+                UpdateButton::downloading(version).into_any_element()
             }
             AutoUpdateStatus::Installing { version } => {
-                let tooltip = Self::version_tooltip_message(&version);
-                UpdateButton::installing(tooltip).into_any_element()
+                let version = Self::version_tooltip_message(&version);
+                UpdateButton::installing(version).into_any_element()
             }
             AutoUpdateStatus::Updated { version } => {
-                let tooltip = Self::version_tooltip_message(&version);
-                UpdateButton::updated(tooltip)
+                let version = Self::version_tooltip_message(&version);
+                UpdateButton::updated(version)
                     .on_click(|_, _, cx| {
                         workspace::reload(cx);
                     })
@@ -140,6 +140,6 @@ mod tests {
             AppCommitSha::new("14d9a4189f058d8736339b06ff2340101eaea5af".to_string()),
         ));
 
-        assert_eq!(message, "Version: 14d9a41…");
+        assert_eq!(message, "Version: 14d9a4189f058d8736339b06ff2340101eaea5af");
     }
 }

--- a/crates/title_bar/src/update_version.rs
+++ b/crates/title_bar/src/update_version.rs
@@ -134,12 +134,15 @@ mod tests {
             Version::new(1, 0, 0),
         ));
 
-        assert_eq!(message, "Version: 1.0.0");
+        assert_eq!(message, "Update to Version: 1.0.0");
 
         let message = UpdateVersion::version_tooltip_message(&VersionCheckType::Sha(
             AppCommitSha::new("14d9a4189f058d8736339b06ff2340101eaea5af".to_string()),
         ));
 
-        assert_eq!(message, "Version: 14d9a4189f058d8736339b06ff2340101eaea5af");
+        assert_eq!(
+            message,
+            "Update to Version: 14d9a4189f058d8736339b06ff2340101eaea5af"
+        );
     }
 }

--- a/crates/ui/src/components/collab/update_button.rs
+++ b/crates/ui/src/components/collab/update_button.rs
@@ -72,15 +72,15 @@ impl UpdateButton {
     }
 
     pub fn checking() -> Self {
-        Self::new(IconName::ArrowCircle, "Checking for Zed updates…").icon_animate(true)
+        Self::new(IconName::LoadCircle, "Checking for Zed Updates…").icon_animate(true)
     }
 
     pub fn downloading(version: impl Into<SharedString>) -> Self {
-        Self::new(IconName::Download, "Downloading Zed update…").tooltip(version)
+        Self::new(IconName::Download, "Downloading Zed Update…").tooltip(version)
     }
 
     pub fn installing(version: impl Into<SharedString>) -> Self {
-        Self::new(IconName::ArrowCircle, "Installing Zed update…")
+        Self::new(IconName::LoadCircle, "Installing Zed Update…")
             .icon_animate(true)
             .tooltip(version)
     }
@@ -92,7 +92,7 @@ impl UpdateButton {
     }
 
     pub fn errored(error: impl Into<SharedString>) -> Self {
-        Self::new(IconName::Warning, "Failed to update Zed")
+        Self::new(IconName::Warning, "Failed to Update")
             .icon_color(Color::Warning)
             .tooltip(error)
             .with_dismiss()
@@ -101,7 +101,7 @@ impl UpdateButton {
 
 impl RenderOnce for UpdateButton {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let border_color = cx.theme().colors().border;
+        let border_color = cx.theme().colors().text.opacity(0.1);
 
         let icon = Icon::new(self.icon)
             .size(IconSize::XSmall)
@@ -162,7 +162,7 @@ impl Component for UpdateButton {
     }
 
     fn preview(_window: &mut Window, _cx: &mut App) -> Option<AnyElement> {
-        let version = "1.99.0";
+        let version = "1.3.0+stable.2025051";
 
         Some(
             v_flex()

--- a/crates/ui/src/components/collab/update_button.rs
+++ b/crates/ui/src/components/collab/update_button.rs
@@ -10,6 +10,7 @@ pub struct UpdateButton {
     icon_color: Option<Color>,
     message: SharedString,
     tooltip: Option<SharedString>,
+    disabled: bool,
     show_dismiss: bool,
     on_click: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
     on_dismiss: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
@@ -23,6 +24,7 @@ impl UpdateButton {
             icon_color: None,
             message: message.into(),
             tooltip: None,
+            disabled: false,
             show_dismiss: false,
             on_click: None,
             on_dismiss: None,
@@ -71,18 +73,28 @@ impl UpdateButton {
         self
     }
 
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
     pub fn checking() -> Self {
-        Self::new(IconName::LoadCircle, "Checking for Zed Updates…").icon_animate(true)
+        Self::new(IconName::LoadCircle, "Checking for Zed Updates…")
+            .icon_animate(true)
+            .disabled(true)
     }
 
     pub fn downloading(version: impl Into<SharedString>) -> Self {
-        Self::new(IconName::Download, "Downloading Zed Update…").tooltip(version)
+        Self::new(IconName::Download, "Downloading Zed Update…")
+            .tooltip(version)
+            .disabled(true)
     }
 
     pub fn installing(version: impl Into<SharedString>) -> Self {
         Self::new(IconName::LoadCircle, "Installing Zed Update…")
             .icon_animate(true)
             .tooltip(version)
+            .disabled(true)
     }
 
     pub fn updated(version: impl Into<SharedString>) -> Self {
@@ -101,13 +113,17 @@ impl UpdateButton {
 
 impl RenderOnce for UpdateButton {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let border_color = cx.theme().colors().text.opacity(0.1);
+        let border_color = if self.disabled {
+            cx.theme().colors().border
+        } else {
+            cx.theme().colors().text.opacity(0.12)
+        };
 
         let icon = Icon::new(self.icon)
             .size(IconSize::XSmall)
             .when_some(self.icon_color, |this, color| this.color(color));
         let icon_element = if self.icon_animate {
-            icon.with_rotate_animation(3).into_any_element()
+            icon.with_rotate_animation(2).into_any_element()
         } else {
             icon.into_any_element()
         };
@@ -131,6 +147,7 @@ impl RenderOnce for UpdateButton {
                     .when_some(tooltip, |this, tooltip| {
                         this.tooltip(Tooltip::text(tooltip))
                     })
+                    .disabled(self.disabled)
                     .when_some(self.on_click, |this, handler| this.on_click(handler)),
             )
             .when(self.show_dismiss, |this| {

--- a/crates/ui/src/components/collab/update_button.rs
+++ b/crates/ui/src/components/collab/update_button.rs
@@ -116,7 +116,7 @@ impl RenderOnce for UpdateButton {
         let border_color = if self.disabled {
             cx.theme().colors().border
         } else {
-            cx.theme().colors().text.opacity(0.12)
+            cx.theme().colors().text.opacity(0.15)
         };
 
         let icon = Icon::new(self.icon)


### PR DESCRIPTION
This PR adds a small refinement to the update button, removing truncation from the version we display. Instead of just showing the short version of a SHA, we now display it in full, providing more detailed information that sometimes was lost. Also am making the button disabled when it's in the checking, downloading, and installing states, given clicking on it at these moments doesn't do anything.

Release Notes:

- N/A
