### PR TITLE
build: Reduce dev debug info level from full to limited

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -898,6 +898,16 @@ codegen-units = 16
 split-debuginfo = "unpacked"
 debug = "limited"
 
+
+# "debug" is reserved.
+[profile.dbg]
+inherits = "dev"
+debug = "full"
+
+[profile.dbg.build-override]
+debug = "full"
+
+
 [profile.dev.package]
 # proc-macros start
 gpui_macros = { opt-level = 3 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -898,15 +898,13 @@ codegen-units = 16
 split-debuginfo = "unpacked"
 debug = "limited"
 
-
-# "debug" is reserved.
+# "debug" is a reserved profile name.
 [profile.dbg]
 inherits = "dev"
 debug = "full"
 
 [profile.dbg.build-override]
 debug = "full"
-
 
 [profile.dev.package]
 # proc-macros start

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -889,13 +889,14 @@ webrtc-sys = { git = "https://github.com/zed-industries/livekit-rust-sdks", rev 
 split-debuginfo = "unpacked"
 incremental = true
 codegen-units = 16
+debug = "limited"
 
 # mirror configuration for crates compiled for the build platform
 # (without this cargo will compile ~400 crates twice)
 [profile.dev.build-override]
 codegen-units = 16
 split-debuginfo = "unpacked"
-debug = true
+debug = "limited"
 
 [profile.dev.package]
 # proc-macros start


### PR DESCRIPTION
This reduces a rebuild time from editor (a legit one) from 28s to 18s. For those of you who do use the debugger, there's a new `dbg` profile.

Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A or Added/Fixed/Improved ...
