### PR TITLE
x11: Fix window not drawing after workspace switch in xmonad / i3

### DIFF
--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -795,6 +795,8 @@ impl X11Client {
                 let mut state = self.0.borrow_mut();
                 if let Some(window_ref) = state.windows.get_mut(&event.window) {
                     window_ref.is_mapped = true;
+                    // see #56668 - without this, window may be transparent after workspace switch
+                    window_ref.window.state.borrow_mut().force_render = true;
                 }
                 state.update_refresh_loop(event.window);
             }
@@ -1980,9 +1982,8 @@ impl X11ClientState {
                         if let Some(window) = state.windows.get_mut(&x_window) {
                             let expose_event_received = window.expose_event_received;
                             window.expose_event_received = false;
-                            let force_render = std::mem::take(
-                                &mut window.window.state.borrow_mut().force_render_after_recovery,
-                            );
+                            let force_render =
+                                std::mem::take(&mut window.window.state.borrow_mut().force_render);
                             let window = window.window.clone();
                             drop(state);
                             window.refresh(RequestFrameOptions {

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -278,7 +278,7 @@ pub struct X11WindowState {
     hidden: bool,
     active: bool,
     hovered: bool,
-    pub(crate) force_render_after_recovery: bool,
+    pub(crate) force_render: bool,
     fullscreen: bool,
     client_side_decorations_supported: bool,
     decorations: WindowDecorations,
@@ -788,7 +788,7 @@ impl X11WindowState {
                 input_handler: None,
                 active: false,
                 hovered: false,
-                force_render_after_recovery: false,
+                force_render: false,
                 fullscreen: false,
                 maximized_vertical: false,
                 maximized_horizontal: false,
@@ -1677,14 +1677,14 @@ impl PlatformWindow for X11Window {
                 }
             }
 
-            inner.force_render_after_recovery = true;
+            inner.force_render = true;
             return;
         }
 
         inner.renderer.draw(scene);
 
         if inner.renderer.needs_redraw() {
-            inner.force_render_after_recovery = true;
+            inner.force_render = true;
         }
     }
 


### PR DESCRIPTION
Closes #56668

It isn't clear exactly what is going wrong here.  In theory it should be fine to continue using the old buffers / pixmaps, and just re-present, but that isn't working.  Forcing a redraw seems to reliably fix it.  Since re-mapping a window is typically infrequent, seems fine to force a redraw.

This bug certainly wasn't around a few months ago.  Two theories:

1. Consequence of the work on GPU failure recovery

2. Perhaps issues with spurious dirtiness causing redraw were fixed, so the issue is no longer hidden.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- GPUI: Fixed an issue on Linux/X11 where the window is sometimes transparent after switching tiling window manager workspace