### PR TITLE
docs: Document Terminal Threads feature

### DIFF
--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -40,7 +40,7 @@ From the "New Thread…" menu you can:
 
 - Pick **Zed Agent** or any installed [external agent](./external-agents.md) to start a new thread with that agent.
 - Choose **New From Summary** to start a fresh Zed Agent thread seeded with a summary of the current conversation — useful for compacting long threads as you approach the context window limit.
-- Choose **Terminal** to open an interactive terminal directly in the Agent Panel — see [Terminals](#terminals) for details.
+- Choose **Terminal** to open a Terminal Thread directly in the Agent Panel — see [Terminal Threads](#terminal-threads) for details.
 
 {#action agent::NewExternalAgentThread} creates a new thread with the specified external agent id.
 
@@ -124,25 +124,25 @@ Edit diffs also appear in singleton buffers.
 If your active tab had edits made by the AI, you'll see diffs with the same accept/reject controls as in the multi-buffer.
 You can turn this off, though, through the `agent.single_file_review` setting.
 
-## Terminals {#terminals}
+## Terminal Threads {#terminal-threads}
 
-The Agent Panel can host interactive terminals alongside your threads. Each terminal appears as its own entry in the [Threads Sidebar](./parallel-agents.md#threads-sidebar) with a terminal icon, letting you switch between conversations and shell sessions from the same list.
+The Agent Panel can host terminal threads alongside your agent threads. Each Terminal Thread appears as its own entry in the [Threads Sidebar](./parallel-agents.md#threads-sidebar) with a terminal icon, letting you switch between conversations and shell sessions from the same list.
 
-### Opening a Terminal {#opening-a-terminal}
+### Opening a Terminal Thread {#opening-a-terminal-thread}
 
 Open the menu using the agent selector button on the left (in the empty state) or the `+` icon in the top-right of the panel toolbar, and choose **Terminal**. The terminal opens in the panel body, just like switching to a thread. You can open as many terminals as you like — each gets its own sidebar entry.
 
-### Terminal Titles {#terminal-titles}
+### Terminal Thread Titles {#terminal-thread-titles}
 
 The terminal title in the toolbar updates automatically to reflect the running shell or process. You can also set a custom name by clicking the title or the pencil icon that appears on hover.
 
-### Notifications {#terminal-notifications}
+### Notifications {#terminal-thread-notifications}
 
 When a terminal produces a bell character while not in focus, Zed notifies you the same way it does when an agent finishes — with a visual pop-up and an optional sound. Clicking the notification brings the terminal into focus and clears the indicator. The same `agent.notify_when_agent_waiting` and `agent.play_sound_when_agent_done` settings apply.
 
-### Closing Terminals {#closing-terminals}
+### Closing Terminal Threads {#closing-terminal-threads}
 
-Unlike threads, terminals are closed rather than archived — they don't go to Thread History. To close a terminal, hover over it in the Threads Sidebar and click the **×** button, or select it and press {#kb agent::ArchiveSelectedThread}.
+Unlike agent threads, terminal threads are closed rather than archived — they don't go to Thread History. To close one, hover over it in the Threads Sidebar and click the **×** button, or select it and press {#kb agent::ArchiveSelectedThread}.
 
 ## Adding Context {#adding-context}
 

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -128,6 +128,8 @@ You can turn this off, though, through the `agent.single_file_review` setting.
 
 The Agent Panel can host terminal threads alongside your agent threads. Each Terminal Thread appears as its own entry in the [Threads Sidebar](./parallel-agents.md#threads-sidebar) with a terminal icon, letting you switch between conversations and shell sessions from the same list.
 
+External agents like Claude Agent and Codex can also run as terminal threads. Some support terminal signals — such as bell notifications or title updates — that Zed uses to show useful context in the sidebar. See the [External Agents](./external-agents.md) docs for how to configure this per agent.
+
 ### Opening a Terminal Thread {#opening-a-terminal-thread}
 
 Open the menu using the agent selector button on the left (in the empty state) or the `+` icon in the top-right of the panel toolbar, and choose **Terminal**. The terminal opens in the panel body, just like switching to a thread. You can open as many terminals as you like — each gets its own sidebar entry.

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -40,6 +40,7 @@ From the "New Thread…" menu you can:
 
 - Pick **Zed Agent** or any installed [external agent](./external-agents.md) to start a new thread with that agent.
 - Choose **New From Summary** to start a fresh Zed Agent thread seeded with a summary of the current conversation — useful for compacting long threads as you approach the context window limit.
+- Choose **Terminal** to open an interactive terminal directly in the Agent Panel — see [Terminals](#terminals) for details.
 
 {#action agent::NewExternalAgentThread} creates a new thread with the specified external agent id.
 
@@ -122,6 +123,26 @@ You can accept or reject each individual change hunk, or the whole set of change
 Edit diffs also appear in singleton buffers.
 If your active tab had edits made by the AI, you'll see diffs with the same accept/reject controls as in the multi-buffer.
 You can turn this off, though, through the `agent.single_file_review` setting.
+
+## Terminals {#terminals}
+
+The Agent Panel can host interactive terminals alongside your threads. Each terminal appears as its own entry in the [Threads Sidebar](./parallel-agents.md#threads-sidebar) with a terminal icon, letting you switch between conversations and shell sessions from the same list.
+
+### Opening a Terminal {#opening-a-terminal}
+
+Open the menu using the agent selector button on the left (in the empty state) or the `+` icon in the top-right of the panel toolbar, and choose **Terminal**. The terminal opens in the panel body, just like switching to a thread. You can open as many terminals as you like — each gets its own sidebar entry.
+
+### Terminal Titles {#terminal-titles}
+
+The terminal title in the toolbar updates automatically to reflect the running shell or process. You can also set a custom name by clicking the title or the pencil icon that appears on hover.
+
+### Notifications {#terminal-notifications}
+
+When a terminal produces a bell character while not in focus, Zed notifies you the same way it does when an agent finishes — with a visual pop-up and an optional sound. Clicking the notification brings the terminal into focus and clears the indicator. The same `agent.notify_when_agent_waiting` and `agent.play_sound_when_agent_done` settings apply.
+
+### Closing Terminals {#closing-terminals}
+
+Unlike threads, terminals are closed rather than archived — they don't go to Thread History. To close a terminal, hover over it in the Threads Sidebar and click the **×** button, or select it and press {#kb agent::ArchiveSelectedThread}.
 
 ## Adding Context {#adding-context}
 

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -40,7 +40,7 @@ From the "New Thread…" menu you can:
 
 - Pick **Zed Agent** or any installed [external agent](./external-agents.md) to start a new thread with that agent.
 - Choose **New From Summary** to start a fresh Zed Agent thread seeded with a summary of the current conversation — useful for compacting long threads as you approach the context window limit.
-- Choose **Terminal** to open a Terminal Thread directly in the Agent Panel — see [Terminal Threads](#terminal-threads) for details.
+- Choose **Terminal** to open a terminal thread directly in the Agent Panel — see [Terminal Threads](#terminal-threads) for details.
 
 {#action agent::NewExternalAgentThread} creates a new thread with the specified external agent id.
 
@@ -126,13 +126,13 @@ You can turn this off, though, through the `agent.single_file_review` setting.
 
 ## Terminal Threads {#terminal-threads}
 
-The Agent Panel can host terminal threads alongside your agent threads. Each Terminal Thread appears as its own entry in the [Threads Sidebar](./parallel-agents.md#threads-sidebar) with a terminal icon, letting you switch between conversations and shell sessions from the same list.
+The Agent Panel can host terminal threads alongside your agent threads. Each terminal thread appears as its own entry in the [Threads Sidebar](./parallel-agents.md#threads-sidebar) with a terminal icon, letting you switch between conversations and shell sessions from the same list.
 
-External agents like Claude Agent and Codex can also run as terminal threads. Some support terminal signals — such as bell notifications or title updates — that Zed uses to show useful context in the sidebar. See the [External Agents](./external-agents.md) docs for how to configure this per agent.
+External agents like Claude Agent and Codex can also run as terminal threads. Some support terminal signals — such as bell notifications or title updates — that Zed uses to show useful context in the sidebar.
 
 ### Opening a Terminal Thread {#opening-a-terminal-thread}
 
-Open the menu using the agent selector button on the left (in the empty state) or the `+` icon in the top-right of the panel toolbar, and choose **Terminal**. The terminal opens in the panel body, just like switching to a thread. You can open as many terminals as you like — each gets its own sidebar entry.
+Open the menu using the agent selector button on the left (in the empty state) or the `+` icon in the top-right of the panel toolbar, and choose **Terminal**. The terminal thread opens in the panel body, just like switching to a thread. You can open as many as you like — each gets its own sidebar entry.
 
 ### Terminal Thread Titles {#terminal-thread-titles}
 
@@ -145,6 +145,37 @@ When a terminal produces a bell character while not in focus, Zed notifies you t
 ### Closing Terminal Threads {#closing-terminal-threads}
 
 Unlike agent threads, terminal threads are closed rather than archived — they don't go to Thread History. To close one, hover over it in the Threads Sidebar and click the **×** button, or select it and press {#kb agent::ArchiveSelectedThread}.
+
+### Claude Code Notifications {#claude-code-notifications}
+
+Claude Code can ring the terminal bell when it finishes a task or pauses for permission. To enable this, set `preferredNotifChannel` to `"terminal_bell"` in your Claude Code user settings:
+
+```json
+{
+  "preferredNotifChannel": "terminal_bell"
+}
+```
+
+You can also set this from within Claude Code by running `/config`, selecting `Local Notifications`, and choosing `Terminal Bell`.
+
+> If you run Claude Code inside tmux, bell notifications may not reach the outer terminal unless passthrough is enabled. Add this to `~/.tmux.conf`:
+>
+> ```
+> set -g allow-passthrough on
+> ```
+
+For more, see the [Claude Code documentation](https://code.claude.com/docs/en/terminal-config).
+
+### Codex Terminal Titles {#codex-terminal-titles}
+
+Codex can update the terminal title as it works, which Zed uses to show useful context for Codex terminal threads in the sidebar — such as the project, current status, branch, model, or task progress.
+
+To configure this from within Codex, run `/title` and use the picker to choose which fields appear and in what order. Codex saves the selection to `tui.terminal_title` in `~/.codex/config.toml`. You can also edit it directly:
+
+```toml
+[tui]
+terminal_title = ["spinner", "project-name", "run-state", "thread-title"]
+```
 
 ## Adding Context {#adding-context}
 

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -122,26 +122,6 @@ However, the SDK doesn't yet expose everything needed to fully support all of th
 
 > Some [agent panel](./agent-panel.md) features are not yet available with Claude Agent: editing past messages, resuming threads from history, and checkpointing.
 
-#### Claude Code Notifications
-
-Claude Code can ring the terminal bell when it finishes a task or pauses for permission. To enable this, set `preferredNotifChannel` to `"terminal_bell"` in your Claude Code user settings:
-
-```json
-{
-  "preferredNotifChannel": "terminal_bell"
-}
-```
-
-You can also set this from within Claude Code by running `/config`, selecting `Local Notifications`, and choosing `Terminal Bell`.
-
-> If you run Claude Code inside tmux, bell notifications may not reach the outer terminal unless passthrough is enabled. Add this to `~/.tmux.conf`:
->
-> ```
-> set -g allow-passthrough on
-> ```
-
-For more, see the [Claude Code documentation](https://code.claude.com/docs/en/terminal-config).
-
 #### CLAUDE.md
 
 Claude Agent in Zed will automatically use any `CLAUDE.md` file found in your project root, project subdirectories, or root `.claude` directory.
@@ -198,17 +178,6 @@ Zed will always use this managed version of Codex even if you have it installed 
 Codex supports the same workflows as Zed's first-party agent. Add context by @-mentioning files or symbols.
 
 > Some agent panel features are not yet available with Codex: editing past messages, resuming threads from history, and checkpointing.
-
-#### Codex Terminal Titles
-
-Codex can update the terminal title as it works, which Zed uses to show useful context for Codex terminal threads in the sidebar — such as the project, current status, branch, model, or task progress.
-
-To configure this from within Codex, run `/title` and use the picker to choose which fields appear and in what order. Codex saves the selection to `tui.terminal_title` in `~/.codex/config.toml`. You can also edit it directly:
-
-```toml
-[tui]
-terminal_title = ["spinner", "project-name", "run-state", "thread-title"]
-```
 
 ## Add More Agents {#add-more-agents}
 

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -122,6 +122,25 @@ However, the SDK doesn't yet expose everything needed to fully support all of th
 
 > Some [agent panel](./agent-panel.md) features are not yet available with Claude Agent: editing past messages, resuming threads from history, and checkpointing.
 
+#### Claude Code Notifications
+
+Claude Agent runs Claude Code under the hood. Claude Code can ring the terminal bell when it finishes a task or pauses for permission. To enable this, set `preferredNotifChannel` to `"terminal_bell"` in your Claude Code user settings:
+
+```json
+{
+  "preferredNotifChannel": "terminal_bell"
+}
+```
+
+You can also set this from within Claude Code by running `/config`, selecting `Local Notifications`, and choosing `Terminal Bell`.
+
+> If you run Claude Code inside tmux, bell notifications may not reach the outer terminal unless passthrough is enabled. Add this to `~/.tmux.conf`:
+> ```
+> set -g allow-passthrough on
+> ```
+
+For more, see the [Claude Code documentation](https://code.claude.com/docs/en/terminal-config).
+
 #### CLAUDE.md
 
 Claude Agent in Zed will automatically use any `CLAUDE.md` file found in your project root, project subdirectories, or root `.claude` directory.
@@ -178,6 +197,17 @@ Zed will always use this managed version of Codex even if you have it installed 
 Codex supports the same workflows as Zed's first-party agent. Add context by @-mentioning files or symbols.
 
 > Some agent panel features are not yet available with Codex: editing past messages, resuming threads from history, and checkpointing.
+
+#### Codex Terminal Titles
+
+Codex can update the terminal title as it works, which Zed uses to show useful context for Codex terminal threads in the sidebar — such as the project, current status, branch, model, or task progress.
+
+To configure this from within Codex, run `/title` and use the picker to choose which fields appear and in what order. Codex saves the selection to `tui.terminal_title` in `~/.codex/config.toml`. You can also edit it directly:
+
+```toml
+[tui]
+terminal_title = ["spinner", "project-name", "run-state", "thread-title"]
+```
 
 ## Add More Agents {#add-more-agents}
 

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -124,7 +124,7 @@ However, the SDK doesn't yet expose everything needed to fully support all of th
 
 #### Claude Code Notifications
 
-Claude Agent runs Claude Code under the hood. Claude Code can ring the terminal bell when it finishes a task or pauses for permission. To enable this, set `preferredNotifChannel` to `"terminal_bell"` in your Claude Code user settings:
+Claude Code can ring the terminal bell when it finishes a task or pauses for permission. To enable this, set `preferredNotifChannel` to `"terminal_bell"` in your Claude Code user settings:
 
 ```json
 {

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -135,6 +135,7 @@ Claude Agent runs Claude Code under the hood. Claude Code can ring the terminal 
 You can also set this from within Claude Code by running `/config`, selecting `Local Notifications`, and choosing `Terminal Bell`.
 
 > If you run Claude Code inside tmux, bell notifications may not reach the outer terminal unless passthrough is enabled. Add this to `~/.tmux.conf`:
+>
 > ```
 > set -g allow-passthrough on
 > ```

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -18,7 +18,7 @@ Zed's AI features run inside a native, GPU-accelerated application built in Rust
 
 ## Agentic editing
 
-The [Threads Sidebar](./parallel-agents.md#threads-sidebar) is where you organize agent work. Start a thread, give it a task, and the agent reads, edits, and runs code in your project. You can also open interactive terminals directly in the sidebar alongside your threads. Run multiple threads and terminals at once, each using a different agent and working against different projects. See [Tools](./tools.md) for the capabilities available to Zed's built-in agent.
+The [Threads Sidebar](./parallel-agents.md#threads-sidebar) is where you organize agent work. Start a thread, give it a task, and the agent reads, edits, and runs code in your project. You can also open terminal threads directly in the sidebar alongside your agent threads. Run multiple agent threads and terminal threads at once, each using a different agent and working against different projects. See [Tools](./tools.md) for the capabilities available to Zed's built-in agent.
 
 The [Agent Panel](./agent-panel.md) is the conversation view for the active thread. Use it to send prompts, review changes, add context, and interact with the agent as it works.
 

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -18,7 +18,7 @@ Zed's AI features run inside a native, GPU-accelerated application built in Rust
 
 ## Agentic editing
 
-The [Threads Sidebar](./parallel-agents.md#threads-sidebar) is where you organize agent work. Start a thread, give it a task, and the agent reads, edits, and runs code in your project. You can run multiple threads at once, each using a different agent and working against different projects. See [Tools](./tools.md) for the capabilities available to Zed's built-in agent.
+The [Threads Sidebar](./parallel-agents.md#threads-sidebar) is where you organize agent work. Start a thread, give it a task, and the agent reads, edits, and runs code in your project. You can also open interactive terminals directly in the sidebar alongside your threads. Run multiple threads and terminals at once, each using a different agent and working against different projects. See [Tools](./tools.md) for the capabilities available to Zed's built-in agent.
 
 The [Agent Panel](./agent-panel.md) is the conversation view for the active thread. Use it to send prompts, review changes, add context, and interact with the agent as it works.
 

--- a/docs/src/ai/parallel-agents.md
+++ b/docs/src/ai/parallel-agents.md
@@ -1,11 +1,11 @@
 ---
 title: Parallel Agents - Zed
-description: Run multiple agent threads concurrently using the Threads Sidebar, manage them across projects, and isolate work using Git worktrees.
+description: Run multiple agent threads and terminals concurrently using the Threads Sidebar, manage them across projects, and isolate work using Git worktrees.
 ---
 
 # Parallel Agents
 
-Parallel Agents lets you run multiple agent threads at once, each working independently with its own agent, context window, and conversation history. The Threads Sidebar is where you start, manage, and switch between them.
+Parallel Agents lets you run multiple agent threads and terminals at once from the Threads Sidebar. Each thread works independently with its own agent, context window, and conversation history. Terminals appear alongside threads in the same sidebar, so you can switch between them without leaving the Agent Panel.
 
 Open the Threads Sidebar with {#kb multi_workspace::ToggleWorkspaceSidebar}.
 
@@ -14,6 +14,8 @@ Open the Threads Sidebar with {#kb multi_workspace::ToggleWorkspaceSidebar}.
 ## Threads Sidebar {#threads-sidebar}
 
 The sidebar shows your threads grouped by project. Each project gets its own section with a header. Threads appear below with their title, status indicator, and which agent is running them. Threads running in linked Git worktrees appear under the same project as their main worktree. See [Worktree Isolation](#worktree-isolation).
+
+Terminals opened in the Agent Panel also appear as entries in the sidebar alongside threads, identified by a terminal icon. Click a terminal entry to switch to it. See [Terminals](./agent-panel.md#terminals) for details.
 
 To focus the sidebar without toggling it, use {#kb multi_workspace::FocusWorkspaceSidebar}. To search your threads, press {#kb agents_sidebar::FocusSidebarFilter} while the sidebar is focused.
 

--- a/docs/src/ai/parallel-agents.md
+++ b/docs/src/ai/parallel-agents.md
@@ -15,7 +15,7 @@ Open the Threads Sidebar with {#kb multi_workspace::ToggleWorkspaceSidebar}.
 
 The sidebar shows your threads grouped by project. Each project gets its own section with a header. Threads appear below with their title, status indicator, and which agent is running them. Threads running in linked Git worktrees appear under the same project as their main worktree. See [Worktree Isolation](#worktree-isolation).
 
-Terminal threads also appear as entries in the sidebar alongside agent threads, identified by a terminal icon. Click one to switch to it. See [Terminal Threads](./agent-panel.md#terminal-threads) for details.
+Terminal threads also appear as entries in the sidebar alongside agent threads, identified by a terminal icon. Click one to switch to it. See [terminal threads](./agent-panel.md#terminal-threads) for details.
 
 To focus the sidebar without toggling it, use {#kb multi_workspace::FocusWorkspaceSidebar}. To search your threads, press {#kb agents_sidebar::FocusSidebarFilter} while the sidebar is focused.
 

--- a/docs/src/ai/parallel-agents.md
+++ b/docs/src/ai/parallel-agents.md
@@ -1,11 +1,11 @@
 ---
 title: Parallel Agents - Zed
-description: Run multiple agent threads and terminals concurrently using the Threads Sidebar, manage them across projects, and isolate work using Git worktrees.
+description: Run multiple agent threads and terminal threads concurrently using the Threads Sidebar, manage them across projects, and isolate work using Git worktrees.
 ---
 
 # Parallel Agents
 
-Parallel Agents lets you run multiple agent threads and terminals at once from the Threads Sidebar. Each thread works independently with its own agent, context window, and conversation history. Terminals appear alongside threads in the same sidebar, so you can switch between them without leaving the Agent Panel.
+Parallel Agents lets you run multiple agent threads and terminal threads at once from the Threads Sidebar. Each thread works independently with its own agent, context window, and conversation history. Terminal threads appear alongside agent threads in the same sidebar, so you can switch between them without leaving the Agent Panel.
 
 Open the Threads Sidebar with {#kb multi_workspace::ToggleWorkspaceSidebar}.
 
@@ -15,7 +15,7 @@ Open the Threads Sidebar with {#kb multi_workspace::ToggleWorkspaceSidebar}.
 
 The sidebar shows your threads grouped by project. Each project gets its own section with a header. Threads appear below with their title, status indicator, and which agent is running them. Threads running in linked Git worktrees appear under the same project as their main worktree. See [Worktree Isolation](#worktree-isolation).
 
-Terminals opened in the Agent Panel also appear as entries in the sidebar alongside threads, identified by a terminal icon. Click a terminal entry to switch to it. See [Terminals](./agent-panel.md#terminals) for details.
+Terminal threads also appear as entries in the sidebar alongside agent threads, identified by a terminal icon. Click one to switch to it. See [Terminal Threads](./agent-panel.md#terminal-threads) for details.
 
 To focus the sidebar without toggling it, use {#kb multi_workspace::FocusWorkspaceSidebar}. To search your threads, press {#kb agents_sidebar::FocusSidebarFilter} while the sidebar is focused.
 


### PR DESCRIPTION
Adds documentation for the Terminal Threads feature — the ability to open interactive terminals in the Agent Panel alongside threads.

## Changes

- **`agent-panel.md`**: Adds a new `## Terminals` section covering how to open terminals, terminal titles, bell notifications, and closing. Also adds a Terminal bullet to the `+` menu description in "Creating New Threads".
- **`parallel-agents.md`**: Updates the page title, description, and opening paragraph to include terminals alongside threads. Adds a note in the Threads Sidebar section that terminals appear there too.

Release Notes:

- N/A