### PR TITLE
gpui: Remove duplicated words in docs

### DIFF
--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -1080,7 +1080,7 @@ pub type JustifyContent = AlignContent;
 
 /// Sets the layout used for the children of this node
 ///
-/// The default values depends on on which feature flags are enabled. The order of precedence is: Flex, Grid, Block, None.
+/// The default values depends on which feature flags are enabled. The order of precedence is: Flex, Grid, Block, None.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, JsonSchema)]
 // Copy of taffy::style type of the same name, to derive JsonSchema.
 pub enum Display {

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -83,7 +83,7 @@ Here are the steps:
 
 <img width="1964" height="auto" alt="Scroll to zoom in" src="https://github.com/user-attachments/assets/625c2bf4-a68d-40c4-becb-ade16bc9a8bc" />
 
-7. Click on a caller to to get statistics on _it_.
+7. Click on a caller to get statistics on _it_.
 
 <img width="1888" height="auto" alt="Click on any of the zones to get statistics" src="https://github.com/user-attachments/assets/7e578825-2b63-4b7f-88f7-0cb16b8a3387" />
 


### PR DESCRIPTION
Two one-line typo fixes for duplicated words:
- `docs/src/performance.md` — "7. Click on a caller to to get statistics on _it_." → "7. Click on a caller to get statistics on _it_."
- `crates/gpui/src/style.rs` — "/// The default values depends on on which feature flags are enabled." → "/// The default values depends on which feature flags are enabled."

No code/behavior change.