### PR TITLE
Respect `sort_mode` in `workspace: open files`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11877,6 +11877,7 @@ dependencies = [
  "gpui",
  "picker",
  "project",
+ "project_panel",
  "schemars 1.0.4",
  "serde",
  "serde_json",

--- a/crates/open_path_prompt/Cargo.toml
+++ b/crates/open_path_prompt/Cargo.toml
@@ -12,6 +12,7 @@ fuzzy.workspace = true
 gpui.workspace = true
 picker.workspace = true
 project.workspace = true
+project_panel.workspace = true
 schemars.workspace = true
 serde.workspace = true
 settings.workspace = true

--- a/crates/open_path_prompt/src/open_path_prompt.rs
+++ b/crates/open_path_prompt/src/open_path_prompt.rs
@@ -346,7 +346,8 @@ impl PickerDelegate for OpenPathDelegate {
                             DirectoryState::None { create: true }
                             | DirectoryState::Create { .. } => match paths {
                                 Ok(paths) => {
-                                    let mut entries = path_candidates(parent_path_is_root, paths, sort_mode);
+                                    let mut entries =
+                                        path_candidates(parent_path_is_root, paths, sort_mode);
                                     let mut exists = false;
                                     let mut is_dir = false;
                                     let mut new_id = None;

--- a/crates/open_path_prompt/src/open_path_prompt.rs
+++ b/crates/open_path_prompt/src/open_path_prompt.rs
@@ -10,7 +10,8 @@ use fuzzy::{CharBag, StringMatch, StringMatchCandidate};
 use gpui::{HighlightStyle, StyledText, Task};
 use picker::{Picker, PickerDelegate};
 use project::{DirectoryItem, DirectoryLister};
-use settings::Settings;
+use project_panel::project_panel_settings::ProjectPanelSettings;
+use settings::{ProjectPanelSortMode, Settings};
 use std::{
     path::{self, Path, PathBuf},
     sync::{
@@ -42,6 +43,7 @@ pub struct OpenPathDelegate {
     render_footer:
         Arc<dyn Fn(&mut Window, &mut Context<Picker<Self>>) -> Option<AnyElement> + 'static>,
     hidden_entries: bool,
+    sort_mode: ProjectPanelSortMode,
 }
 
 impl OpenPathDelegate {
@@ -52,6 +54,9 @@ impl OpenPathDelegate {
         cx: &App,
     ) -> Self {
         let path_style = lister.path_style(cx);
+        let sort_mode = ProjectPanelSettings::try_get(cx)
+            .map(|s| s.sort_mode)
+            .unwrap_or_default();
         Self {
             tx: Some(tx),
             lister,
@@ -70,6 +75,7 @@ impl OpenPathDelegate {
             replace_prompt: Task::ready(()),
             render_footer: Arc::new(|_, _| None),
             hidden_entries: false,
+            sort_mode,
         }
     }
 
@@ -313,6 +319,7 @@ impl PickerDelegate for OpenPathDelegate {
         let hidden_entries = self.hidden_entries;
         let parent_path_is_root = self.prompt_root == dir;
         let current_dir = self.current_dir();
+        let sort_mode = self.sort_mode;
         cx.spawn_in(window, async move |this, cx| {
             if let Some(query) = query {
                 let paths = query.await;
@@ -326,7 +333,7 @@ impl PickerDelegate for OpenPathDelegate {
                             DirectoryState::None { create: false }
                             | DirectoryState::List { .. } => match paths {
                                 Ok(paths) => DirectoryState::List {
-                                    entries: path_candidates(parent_path_is_root, paths),
+                                    entries: path_candidates(parent_path_is_root, paths, sort_mode),
                                     parent_path: dir.clone(),
                                     error: None,
                                 },
@@ -339,7 +346,7 @@ impl PickerDelegate for OpenPathDelegate {
                             DirectoryState::None { create: true }
                             | DirectoryState::Create { .. } => match paths {
                                 Ok(paths) => {
-                                    let mut entries = path_candidates(parent_path_is_root, paths);
+                                    let mut entries = path_candidates(parent_path_is_root, paths, sort_mode);
                                     let mut exists = false;
                                     let mut is_dir = false;
                                     let mut new_id = None;
@@ -877,6 +884,7 @@ impl PickerDelegate for OpenPathDelegate {
 fn path_candidates(
     parent_path_is_root: bool,
     mut children: Vec<DirectoryItem>,
+    sort_mode: ProjectPanelSortMode,
 ) -> Vec<CandidateInfo> {
     if parent_path_is_root {
         children.push(DirectoryItem {
@@ -885,7 +893,14 @@ fn path_candidates(
         });
     }
 
-    children.sort_by(|a, b| compare_paths((&a.path, true), (&b.path, true)));
+    children.sort_by(|a, b| {
+        let (a_is_file, b_is_file) = match sort_mode {
+            ProjectPanelSortMode::DirectoriesFirst => (!a.is_dir, !b.is_dir),
+            ProjectPanelSortMode::FilesFirst => (a.is_dir, b.is_dir),
+            ProjectPanelSortMode::Mixed => (true, true),
+        };
+        compare_paths((&a.path, a_is_file), (&b.path, b_is_file))
+    });
     children
         .iter()
         .enumerate()

--- a/crates/open_path_prompt/src/open_path_prompt_tests.rs
+++ b/crates/open_path_prompt/src/open_path_prompt_tests.rs
@@ -58,7 +58,7 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec![expected_separator, "a1", "a2", "a3", "dir1", "dir2"]
+        vec![expected_separator, "dir1", "dir2", "a1", "a2", "a3"]
     );
 
     // Show candidates for the query "a".
@@ -82,7 +82,7 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec![expected_separator, "c", "d1", "d2", "d3", "dir3", "dir4"]
+        vec![expected_separator, "dir3", "dir4", "c", "d1", "d2", "d3"]
     );
 
     // Show candidates for the query "d".
@@ -90,7 +90,7 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec!["d1", "d2", "d3", "dir3", "dir4"]
+        vec!["dir3", "dir4", "d1", "d2", "d3"]
     );
 
     let query = path!("/root/dir2/di");
@@ -113,7 +113,7 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec![expected_separator, "a1", "a2", "a3", "dir1", "dir2"]
+        vec![expected_separator, "dir1", "dir2", "a1", "a2", "a3"]
     );
 
     // Show candidates for the query "../". Show parent contents.
@@ -121,7 +121,7 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec![expected_separator, "a1", "a2", "a3", "dir1", "dir2"]
+        vec![expected_separator, "dir1", "dir2", "a1", "a2", "a3"]
     );
 }
 
@@ -158,7 +158,7 @@ async fn test_open_path_prompt_completion(cx: &mut TestAppContext) {
         path!("/root/")
     );
 
-    // Confirm completion for the query "/root/", selecting the first candidate "a", since it's a file, it should not add a trailing slash.
+    // Confirm completion for the query "/root/", selecting the first candidate "dir1", since it's a directory, it should add a trailing slash.
     let query = path!("/root/");
     insert_query(query, &picker, cx).await;
     assert_eq!(
@@ -168,16 +168,16 @@ async fn test_open_path_prompt_completion(cx: &mut TestAppContext) {
     );
     assert_eq!(
         confirm_completion(query, 1, &picker, cx).unwrap(),
-        path!("/root/a"),
-        "Second entry is the first entry of a directory that we want to be completed"
+        path!("/root/dir1/"),
+        "Second entry is the first directory"
     );
 
-    // Confirm completion for the query "/root/", selecting the second candidate "dir1", since it's a directory, it should add a trailing slash.
+    // Confirm completion for the query "/root/", selecting the third candidate "a", since it's a file, it should not add a trailing slash.
     let query = path!("/root/");
     insert_query(query, &picker, cx).await;
     assert_eq!(
-        confirm_completion(query, 2, &picker, cx).unwrap(),
-        path!("/root/dir1/")
+        confirm_completion(query, 3, &picker, cx).unwrap(),
+        path!("/root/a")
     );
 
     let query = path!("/root/a");
@@ -205,28 +205,28 @@ async fn test_open_path_prompt_completion(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         confirm_completion(query, 1, &picker, cx).unwrap(),
-        path!("/root/dir2/c")
+        path!("/root/dir2/dir3/")
     );
 
     let query = path!("/root/dir2/");
     insert_query(query, &picker, cx).await;
     assert_eq!(
         confirm_completion(query, 3, &picker, cx).unwrap(),
-        path!("/root/dir2/dir3/")
+        path!("/root/dir2/c")
     );
 
     let query = path!("/root/dir2/d");
     insert_query(query, &picker, cx).await;
     assert_eq!(
         confirm_completion(query, 0, &picker, cx).unwrap(),
-        path!("/root/dir2/d")
+        path!("/root/dir2/dir3/")
     );
 
     let query = path!("/root/dir2/d");
     insert_query(query, &picker, cx).await;
     assert_eq!(
         confirm_completion(query, 1, &picker, cx).unwrap(),
-        path!("/root/dir2/dir3/")
+        path!("/root/dir2/dir4/")
     );
 
     let query = path!("/root/dir2/di");
@@ -263,7 +263,7 @@ async fn test_open_path_prompt_on_windows(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec![".\\", "a", "dir1", "dir2"]
+        vec![".\\", "dir1", "dir2", "a"]
     );
     assert_eq!(
         confirm_completion(query, 0, &picker, cx),
@@ -272,30 +272,30 @@ async fn test_open_path_prompt_on_windows(cx: &mut TestAppContext) {
     );
     assert_eq!(
         confirm_completion(query, 1, &picker, cx).unwrap(),
-        "C:/root/a",
-        "Second entry is the first entry of a directory that we want to be completed"
+        "C:/root/dir1\\",
+        "Second entry is the first directory"
     );
 
     let query = "C:\\root/";
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec![".\\", "a", "dir1", "dir2"]
+        vec![".\\", "dir1", "dir2", "a"]
     );
     assert_eq!(
         confirm_completion(query, 1, &picker, cx).unwrap(),
-        "C:\\root/a"
+        "C:\\root/dir1\\"
     );
 
     let query = "C:\\root\\";
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec![".\\", "a", "dir1", "dir2"]
+        vec![".\\", "dir1", "dir2", "a"]
     );
     assert_eq!(
         confirm_completion(query, 1, &picker, cx).unwrap(),
-        "C:\\root\\a"
+        "C:\\root\\dir1\\"
     );
 
     // Confirm completion for the query "C:/root/d", selecting the second candidate "dir2", since it's a directory, it should add a trailing slash.


### PR DESCRIPTION
It's possible to configure `sort_mode` for the project panel like that:

```json
"project_panel": {
"sort_mode":"directories_first"
}
```

However, `workspace: open files` doesn't respect this setting and always shows files and directories mixed. This change fixes the issue.

Release Notes:

- Improved sorting in `workspace: open files`
