### PR TITLE
agent_ui: Make 'Edit Thread Title' pencil button functional

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3921,6 +3921,47 @@ impl AgentPanel {
         }
     }
 
+    fn focus_active_title_editor(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.visible_surface() {
+            VisibleSurface::AgentThread(conversation_view) => {
+                if let Some(title_editor) = conversation_view
+                    .read(cx)
+                    .root_thread_view()
+                    .map(|view| view.read(cx).title_editor.clone())
+                {
+                    title_editor.update(cx, |editor, cx| {
+                        editor.focus_handle(cx).focus(window, cx);
+                        editor.select_all(&editor::actions::SelectAll, window, cx);
+                    });
+                }
+            }
+            VisibleSurface::Terminal(_) => {
+                if let Some(terminal_id) = self.active_terminal_id() {
+                    if self
+                        .terminals
+                        .get(&terminal_id)
+                        .and_then(|terminal| terminal.title_editor.as_ref())
+                        .is_none()
+                    {
+                        self.edit_terminal_title(terminal_id, window, cx);
+                    }
+                    if let Some(title_editor) = self
+                        .terminals
+                        .get(&terminal_id)
+                        .and_then(|terminal| terminal.title_editor.as_ref())
+                        .cloned()
+                    {
+                        title_editor.update(cx, |editor, cx| {
+                            editor.focus_handle(cx).focus(window, cx);
+                            editor.select_all(&editor::actions::SelectAll, window, cx);
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn render_title_view(&self, window: &mut Window, cx: &Context<Self>) -> AnyElement {
         let content = match self.visible_surface() {
             VisibleSurface::AgentThread(conversation_view) => {
@@ -4077,7 +4118,10 @@ impl AgentPanel {
                             .child(
                                 IconButton::new("edit_tile", IconName::Pencil)
                                     .icon_size(IconSize::Small)
-                                    .tooltip(Tooltip::text("Edit Thread Title")),
+                                    .tooltip(Tooltip::text("Edit Thread Title"))
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.focus_active_title_editor(window, cx);
+                                    })),
                             ),
                     )
                 },


### PR DESCRIPTION
The "Edit Thread Title" pencil `IconButton` next to the thread title in the agent panel header (`render_title_view`) shows on hover with the tooltip `"Edit Thread Title"` but had no `on_click` handler — clicking it does nothing. The title editor is only reachable by clicking directly on the title text, which is not visually obvious because the title looks like a plain label.

This particularly bites users in AI Agent mode who try the pencil affordance, observe nothing happens, and conclude that thread titles can't be renamed (#56446 made ACP titles editable, but the pencil button itself remained inert).

This PR wires the pencil button to a new helper, `focus_active_title_editor`, that focuses the active title editor (agent thread or terminal) and selects all of its text — mirroring the pattern used by `edit_terminal_title`.

Behavior:

- Agent thread: focuses the existing `title_editor` from the active `ThreadView` and selects all text.
- Terminal: if a title editor already exists, focuses it and selects all; otherwise calls `edit_terminal_title` (which itself creates, focuses, and selects all).
- Other surfaces: no-op (the pencil is already gated behind `has_open_project` and the existing focus check).

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed the "Edit Thread Title" pencil button in the agent panel header not doing anything when clicked.
