### PR TITLE
git_panel: Allow to switch between changes and history tab with keyboard

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -980,6 +980,13 @@
     },
   },
   {
+    "context": "GitPanel",
+    "bindings": {
+      "ctrl-1": "git_panel::ActivateChangesTab",
+      "ctrl-2": "git_panel::ActivateHistoryTab",
+    },
+  },
+  {
     "context": "GitPanel && ChangesList && !GitBranchSelector",
     "bindings": {
       "left": "git_panel::CollapseSelectedEntry",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1041,6 +1041,13 @@
     },
   },
   {
+    "context": "GitPanel",
+    "bindings": {
+      "cmd-1": "git_panel::ActivateChangesTab",
+      "cmd-2": "git_panel::ActivateHistoryTab",
+    },
+  },
+  {
     "context": "GitPanel && ChangesList && !GitBranchSelector",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -973,6 +973,13 @@
     },
   },
   {
+    "context": "GitPanel",
+    "bindings": {
+      "ctrl-1": "git_panel::ActivateChangesTab",
+      "ctrl-2": "git_panel::ActivateHistoryTab",
+    },
+  },
+  {
     "context": "GitPanel && ChangesList && !GitBranchSelector",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -121,6 +121,10 @@ actions!(
         ExpandSelectedEntry,
         /// Collapses the selected entry to hide its children.
         CollapseSelectedEntry,
+        /// Activates the Changes tab.
+        ActivateChangesTab,
+        /// Activates the History tab.
+        ActivateHistoryTab,
     ]
 );
 
@@ -4927,11 +4931,15 @@ impl GitPanel {
     fn render_tab_bar(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let active_tab = self.active_tab;
 
+        let focus_handle = self.focus_handle.clone();
         let tab = |id: ElementId,
                    active: bool,
                    show_changes: bool,
                    label: SharedString,
-                   set_active_tab: GitPanelTab| {
+                   set_active_tab: GitPanelTab,
+                   tooltip_action: Box<dyn Action>| {
+            let focus_handle = focus_handle.clone();
+
             h_flex()
                 .cursor_pointer()
                 .id(id)
@@ -4946,7 +4954,7 @@ impl GitPanel {
                     s.bg(cx.theme().colors().editor_background.opacity(0.6))
                         .border_color(cx.theme().colors().border.opacity(0.6))
                 })
-                .child(Label::new(label).when(!active, |this| this.color(Color::Muted)))
+                .child(Label::new(label.clone()).when(!active, |this| this.color(Color::Muted)))
                 .when(show_changes && self.changes_count > 0, |this| {
                     this.child(
                         Label::new(format!("({})", self.changes_count))
@@ -4954,9 +4962,14 @@ impl GitPanel {
                             .color(Color::Muted),
                     )
                 })
-                .on_click(
-                    cx.listener(move |this, _, _, cx| this.set_active_tab(set_active_tab, cx)),
-                )
+                .tooltip(Tooltip::for_action_title_in(
+                    format!("Toggle {} Tab", label),
+                    tooltip_action.as_ref(),
+                    &focus_handle,
+                ))
+                .on_click(cx.listener(move |this, _, window, cx| {
+                    this.set_active_tab(set_active_tab, window, cx)
+                }))
         };
 
         h_flex()
@@ -4969,6 +4982,7 @@ impl GitPanel {
                 true,
                 "Changes".into(),
                 GitPanelTab::Changes,
+                ActivateChangesTab.boxed_clone(),
             ))
             .child(Divider::vertical().color(ui::DividerColor::BorderFaded))
             .child(tab(
@@ -4977,6 +4991,7 @@ impl GitPanel {
                 false,
                 "History".into(),
                 GitPanelTab::History,
+                ActivateHistoryTab.boxed_clone(),
             ))
     }
 
@@ -5046,17 +5061,37 @@ impl GitPanel {
         );
     }
 
-    fn set_active_tab(&mut self, tab: GitPanelTab, cx: &mut Context<Self>) {
+    fn activate_changes_tab(
+        &mut self,
+        _: &ActivateChangesTab,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.set_active_tab(GitPanelTab::Changes, window, cx);
+    }
+
+    fn activate_history_tab(
+        &mut self,
+        _: &ActivateHistoryTab,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.set_active_tab(GitPanelTab::History, window, cx);
+    }
+
+    fn set_active_tab(&mut self, tab: GitPanelTab, window: &mut Window, cx: &mut Context<Self>) {
         if self.active_tab == tab {
             return;
         }
         self.active_tab = tab;
         match tab {
             GitPanelTab::History => {
+                self.focus_handle.focus(window, cx);
                 self.load_commit_history(cx);
                 self.focused_history_entry = Some(0);
             }
             GitPanelTab::Changes => {
+                self.focus_handle.focus(window, cx);
                 self.commit_history_shas.clear();
                 self.focused_history_entry = None;
                 self._repo_subscriptions.clear();
@@ -6545,6 +6580,8 @@ impl Render for GitPanel {
             })
             .on_action(cx.listener(Self::toggle_sort_by_path))
             .on_action(cx.listener(Self::toggle_tree_view))
+            .on_action(cx.listener(Self::activate_changes_tab))
+            .on_action(cx.listener(Self::activate_history_tab))
             .size_full()
             .overflow_hidden()
             .bg(cx.theme().colors().panel_background)


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/56500. Was missing this ability very much :)

Release Notes:

- Git Panel: Added the ability to switch between the changes and history tabs with the keyboard.
