### PR TITLE
markdown_preview: Independent code font family

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -179,6 +179,11 @@ impl MarkdownStyle {
         } else {
             theme_settings.ui_font.family.clone()
         };
+        let code_font_family = if is_preview {
+            theme_settings.markdown_preview_code_font_family().clone()
+        } else {
+            theme_settings.buffer_font.family.clone()
+        };
 
         let text_color = colors.text;
 
@@ -235,7 +240,7 @@ impl MarkdownStyle {
                 border_color: Some(colors.border_variant),
                 background: Some(colors.editor_background.into()),
                 text: TextStyleRefinement {
-                    font_family: Some(theme_settings.buffer_font.family.clone()),
+                    font_family: Some(code_font_family.clone()),
                     font_fallbacks: theme_settings.buffer_font.fallbacks.clone(),
                     font_features: Some(theme_settings.buffer_font.features.clone()),
                     font_size: Some(buffer_font_size.into()),
@@ -245,7 +250,7 @@ impl MarkdownStyle {
                 ..Default::default()
             },
             inline_code: TextStyleRefinement {
-                font_family: Some(theme_settings.buffer_font.family.clone()),
+                font_family: Some(code_font_family),
                 font_fallbacks: theme_settings.buffer_font.fallbacks.clone(),
                 font_features: Some(theme_settings.buffer_font.features.clone()),
                 font_size: Some(buffer_font_size.into()),

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -978,6 +978,7 @@ impl VsCodeSettings {
             agent_ui_font_size: None,
             agent_buffer_font_size: None,
             markdown_preview_font_family: None,
+            markdown_preview_code_font_family: None,
             markdown_preview_theme: None,
             theme: None,
             icon_theme: None,

--- a/crates/settings_content/src/theme.rs
+++ b/crates/settings_content/src/theme.rs
@@ -152,6 +152,9 @@ pub struct ThemeSettingsContent {
     /// The name of a font to use for rendering in the markdown preview.
     /// Falls back to the UI font if unset.
     pub markdown_preview_font_family: Option<FontFamilyName>,
+    /// The name of a font to use for code (code blocks and inline code) in the
+    /// markdown preview. Falls back to the buffer font if unset.
+    pub markdown_preview_code_font_family: Option<FontFamilyName>,
     /// The theme to use for the markdown preview.
     /// Falls back to the main editor theme if unset.
     pub markdown_preview_theme: Option<ThemeSelection>,

--- a/crates/theme_settings/src/settings.rs
+++ b/crates/theme_settings/src/settings.rs
@@ -59,6 +59,9 @@ pub struct ThemeSettings {
     /// The font family to use for rendering in the markdown preview.
     /// Falls back to the UI font family if unset.
     markdown_preview_font_family: Option<SharedString>,
+    /// The font family to use for code in the markdown preview.
+    /// Falls back to the buffer font family if unset.
+    markdown_preview_code_font_family: Option<SharedString>,
     /// The theme to use for the markdown preview.
     /// Falls back to the main editor theme if unset.
     pub markdown_preview_theme: Option<ThemeSelection>,
@@ -415,6 +418,14 @@ impl ThemeSettings {
             .unwrap_or(&self.ui_font.family)
     }
 
+    /// Returns the font family to use for code in the markdown preview,
+    /// falling back to the buffer font family when unset.
+    pub fn markdown_preview_code_font_family(&self) -> &SharedString {
+        self.markdown_preview_code_font_family
+            .as_ref()
+            .unwrap_or(&self.buffer_font.family)
+    }
+
     /// Returns the buffer font size, read from the settings.
     ///
     /// The real buffer font size is stored in-memory, to support temporary font size changes.
@@ -649,6 +660,10 @@ impl settings::Settings for ThemeSettings {
             agent_buffer_font_size: content.agent_buffer_font_size.map(|s| s.into_gpui()),
             markdown_preview_font_family: content
                 .markdown_preview_font_family
+                .as_ref()
+                .map(|f| f.0.clone().into()),
+            markdown_preview_code_font_family: content
+                .markdown_preview_code_font_family
                 .as_ref()
                 .map(|f| f.0.clone().into()),
             markdown_preview_theme: content


### PR DESCRIPTION
Adds a `markdown_preview_code_font_family` setting that overrides the font used in the markdown preview for code — inline `code` spans and fenced code blocks.
This is the counterpart to `markdown_preview_font_family` (#54003), which already does this for body text. Together they let you choose a typographically matched body + code font pair for the preview without forcing the code font onto editor buffers, where it may not be a good coding font:

```json
{
  "markdown_preview_font_family": "Noto Serif",
  "markdown_preview_code_font_family": "Noto Sans Mono"
}
```

Behavior mirrors `markdown_preview_font_family`:
- Scoped to the markdown preview only (`MarkdownFont::Preview`). The agent panel, notifications, hover popovers, and REPL output are unaffected — they keep using the buffer font for code.
- Falls back to the buffer font family when unset, so existing previews are unchanged.
- Overrides the font family only; fallbacks and features still come from the buffer font.

Before (uses buffer font, here Iosevka):

<img width="509" height="368" alt="Screenshot 2026-05-14 at 1 39 51 PM" src="https://github.com/user-attachments/assets/6b7e49b2-fc6e-4db1-9679-392b3447f411" />

After (uses specified font, here Noto Sans Mono):

<img width="508" height="368" alt="Screenshot 2026-05-14 at 1 40 51 PM" src="https://github.com/user-attachments/assets/f911c99b-08f8-4336-83eb-54b555f11c54" />

Release Notes:

- Added `markdown_preview_code_font_family` to override the code font in the markdown preview
