### PR TITLE
agent_ui: Collapse open "thinking" details by hitting the left border

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -5710,7 +5710,7 @@ impl ThreadView {
             .when(is_open, |this| {
                 this.child(
                     div()
-                        .when(is_constrained, |this| this.relative())
+                        .relative()
                         .child(
                             div()
                                 .id(("thinking-content", chunk_ix))
@@ -5727,6 +5727,22 @@ impl ThreadView {
                                     chunk,
                                     MarkdownStyle::themed(MarkdownFont::Agent, window, cx),
                                     cx,
+                                )),
+                        )
+                        .child(
+                            div()
+                                .id(("thinking-toggle-strip", chunk_ix))
+                                .absolute()
+                                .top_0()
+                                .left_0()
+                                .w(rems(1.))
+                                .h_full()
+                                .cursor_pointer()
+                                .hover(|s| s.bg(cx.theme().colors().element_hover))
+                                .on_click(cx.listener(
+                                    move |this, _: &ClickEvent, _, cx| {
+                                        this.toggle_thinking_block_expansion(key, cx);
+                                    },
                                 )),
                         )
                         .when(is_constrained, |this| {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Doesn't really close, but  does help to alleviate the issue #55242  (Agent thinking will lag the app) 

The issue is making Zed semi-unusable because the lag is directly proportional to the amount of output displayed for thinking spoiler = the more you have to scroll up to close the spoiler and reduce the lag ->  the harder it is to scroll due to the lag

This way you can review the entire thought process of the agent and once you are satisfied - click on the border (that has already looked interact-able) to close the spoiler (easing the lag for any subsequent action)


Release Notes:

Improved Agent UI "Thinking" section by allowing user to collapse details by hitting the left border