### PR TITLE
ui: Add thousands separators to diff stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19130,6 +19130,7 @@ dependencies = [
  "icons",
  "itertools 0.14.0",
  "menu",
+ "num-format",
  "schemars 1.0.4",
  "serde",
  "smallvec",

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -21,6 +21,7 @@ gpui_macros.workspace = true
 icons.workspace = true
 itertools.workspace = true
 menu.workspace = true
+num-format.workspace = true
 schemars.workspace = true
 serde.workspace = true
 smallvec.workspace = true

--- a/crates/ui/src/components/diff_stat.rs
+++ b/crates/ui/src/components/diff_stat.rs
@@ -1,5 +1,6 @@
 use crate::Tooltip;
 use crate::prelude::*;
+use num_format::{Locale, ToFormattedString};
 
 #[derive(IntoElement, RegisterComponent)]
 pub struct DiffStat {
@@ -35,16 +36,19 @@ impl DiffStat {
 impl RenderOnce for DiffStat {
     fn render(self, _: &mut Window, _cx: &mut App) -> impl IntoElement {
         let tooltip = self.tooltip;
+        let added = self.added.to_formatted_string(&Locale::en);
+        let removed = self.removed.to_formatted_string(&Locale::en);
+
         h_flex()
             .id(self.id)
             .gap_1()
             .child(
-                Label::new(format!("+\u{2009}{}", self.added))
+                Label::new(format!("+\u{2009}{added}"))
                     .color(Color::Success)
                     .size(self.label_size),
             )
             .child(
-                Label::new(format!("\u{2012}\u{2009}{}", self.removed))
+                Label::new(format!("\u{2012}\u{2009}{removed}"))
                     .color(Color::Error)
                     .size(self.label_size),
             )
@@ -73,7 +77,7 @@ impl Component for DiffStat {
         let diff_stat_example = vec![single_example(
             "Default",
             container()
-                .child(DiffStat::new("id", 1, 2))
+                .child(DiffStat::new("id", 1_234, 5_678))
                 .into_any_element(),
         )];
 


### PR DESCRIPTION

<img width="282" height="90" alt="CleanShot 2026-05-14 at 11 28 40@2x" src="https://github.com/user-attachments/assets/34516022-0e26-4380-9e80-568256483309"></img>

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Improved diff stats by formatting large line counts with thousand separators.