### PR TITLE
git_ui: Improve GitHub avatar display

### DIFF
--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -96,6 +96,15 @@ impl<'a> CommitAvatar<'a> {
     }
 
     pub fn avatar(&'a self, window: &mut Window, cx: &mut App) -> Option<Avatar> {
+        // Bail early if the email isn't available yet. Without it,
+        // the GitHub provider skips the fast CDN path and falls back
+        // to an unauthenticated per-commit API call that is slow and
+        // rate-limited. Worse, a failed lookup gets permanently
+        // cached under the key (sha, host) — so even when the email
+        // arrives on a later render, the cached None shadows the
+        // fast path forever.
+        self.author_email.as_ref()?;
+
         let remote = self
             .remote
             .filter(|remote| remote.host_supports_avatars())?;


### PR DESCRIPTION
We had a problem that became more evident to me in the newly-introduced History tab in the Git panel where the avatars wouldn't show up for a long time. Problem was that we were trying to render the avatar before the GitHub user email came in, and that wouldn't work well because it would 1) skip the fast CDN (which could get rate-limited fast), and 2) cache the `None` result. So this improvement works by only attempting to render the avatar when the email is available.

Release Notes:

- Git UI: Improve the display of user avatars in Git-related surfaces.
