### PR TITLE
Hide Rules UI when Skills feature flag is enabled

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -4149,13 +4149,6 @@ impl AgentPanel {
             _ => false,
         };
 
-        // When the Skills feature flag is on, Rules are surfaced through
-        // the Skills UI instead, so we hide the legacy Rules menu entry.
-        // The flag is read from a global store populated asynchronously,
-        // and the menu closure runs on every open, so by the time the
-        // user clicks the ellipsis the resolved value is reflected here.
-        let skills_enabled = cx.has_flag::<SkillsFeatureFlag>();
-
         PopoverMenu::new("agent-options-menu")
             .trigger_with_tooltip(
                 IconButton::new("agent-options-menu", IconName::Ellipsis)
@@ -4176,6 +4169,12 @@ impl AgentPanel {
             .with_handle(self.agent_panel_menu_handle.clone())
             .menu({
                 move |window, cx| {
+                    // When the Skills feature flag is on, hide the legacy Rules menu entry.
+                    // The flag is read from a global store populated asynchronously, and
+                    // this menu builder runs on every open, so the latest resolved value is
+                    // reflected when the user clicks the ellipsis.
+                    let skills_enabled = cx.has_flag::<SkillsFeatureFlag>();
+
                     Some(ContextMenu::build(window, cx, |mut menu, _window, _| {
                         menu = menu.context(focus_handle.clone());
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -60,6 +60,7 @@ use collections::HashMap;
 use editor::{Editor, MultiBuffer};
 use extension::ExtensionEvents;
 use extension_host::ExtensionStore;
+use feature_flags::{FeatureFlagAppExt as _, SkillsFeatureFlag};
 use fs::Fs;
 use gpui::{
     Action, Anchor, Animation, AnimationExt, AnyElement, App, AsyncWindowContext, ClipboardItem,
@@ -4148,6 +4149,13 @@ impl AgentPanel {
             _ => false,
         };
 
+        // When the Skills feature flag is on, Rules are surfaced through
+        // the Skills UI instead, so we hide the legacy Rules menu entry.
+        // The flag is read from a global store populated asynchronously,
+        // and the menu closure runs on every open, so by the time the
+        // user clicks the ellipsis the resolved value is reflected here.
+        let skills_enabled = cx.has_flag::<SkillsFeatureFlag>();
+
         PopoverMenu::new("agent-options-menu")
             .trigger_with_tooltip(
                 IconButton::new("agent-options-menu", IconName::Ellipsis)
@@ -4202,9 +4210,13 @@ impl AgentPanel {
                                     }),
                                 )
                                 .action("Add Custom Server…", Box::new(AddContextServer))
-                                .separator()
-                                .action("Rules", Box::new(OpenRulesLibrary::default()))
-                                .action("Profiles", Box::new(ManageProfiles::default()));
+                                .separator();
+
+                            if !skills_enabled {
+                                menu = menu.action("Rules", Box::new(OpenRulesLibrary::default()));
+                            }
+
+                            menu = menu.action("Profiles", Box::new(ManageProfiles::default()));
                         }
 
                         menu = menu

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -651,6 +651,12 @@ fn update_command_palette_filter(cx: &mut App) {
         .edit_predictions
         .provider;
 
+    // The Skills feature flag is loaded asynchronously, so this value may
+    // be `false` before flags resolve. `update_command_palette_filter`
+    // gets re-run from `cx.on_flags_ready` (see `init`), which means the
+    // filter is reapplied with the correct value once flags arrive.
+    let skills_enabled = cx.has_flag::<SkillsFeatureFlag>();
+
     CommandPaletteFilter::update_global(cx, |filter, _| {
         use editor::actions::{
             AcceptEditPrediction, AcceptNextLineEditPrediction, AcceptNextWordEditPrediction,
@@ -666,6 +672,8 @@ fn update_command_palette_filter(cx: &mut App) {
             TypeId::of::<PreviousEditPrediction>(),
             TypeId::of::<ToggleEditPrediction>(),
         ];
+
+        let open_rules_library_action = [TypeId::of::<zed_actions::assistant::OpenRulesLibrary>()];
 
         if disable_ai {
             filter.hide_namespace("agent");
@@ -714,6 +722,17 @@ fn update_command_palette_filter(cx: &mut App) {
             filter.show_action_types(&[TypeId::of::<zed_actions::OpenZedPredictOnboarding>()]);
 
             filter.show_namespace("multi_workspace");
+        }
+
+        // Hide `assistant: open rules library` when Skills are enabled —
+        // Rules are surfaced through the Skills UI in that case. Applied
+        // after the disable-ai / agent-enabled branches so it overrides
+        // the `show_namespace("assistant")` call above without affecting
+        // the rest of that namespace's actions.
+        if !disable_ai && skills_enabled {
+            filter.hide_action_types(&open_rules_library_action);
+        } else {
+            filter.show_action_types(open_rules_library_action.iter());
         }
     });
 }


### PR DESCRIPTION
Hides the legacy Rules surfaces when the `skills` feature flag is enabled, since Rules are surfaced through the Skills UI in that case:

- The **Rules** entry in the agent panel's ellipsis (triple-dot) dropdown menu is hidden.
- The `assistant: open rules library` command palette action is hidden.

The `@rules` autocomplete in the chat input is intentionally left alone for now.

### Implementation notes

`cx.has_flag::<SkillsFeatureFlag>()` reads from a global feature-flag store that is populated asynchronously from the server:

- **Command palette**: `update_command_palette_filter` is already re-run via `cx.on_flags_ready` once flags arrive, so the filter is reapplied with the correct value. No new wiring needed.
- **Dropdown menu**: the popover's menu closure runs on every open, so the latest flag value is reflected at click time.

Release Notes:

- N/A