### PR TITLE
git: Improve git repo error propagation to interface

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1335,6 +1335,7 @@ struct FakeFsState {
     moves: std::collections::HashMap<u64, PathBuf>,
     job_event_subscribers: Arc<Mutex<Vec<JobEventSender>>>,
     trash: Vec<(TrashedEntry, FakeFsEntry)>,
+    simulated_open_errors: std::collections::HashMap<PathBuf, String>,
 }
 
 #[cfg(feature = "test-support")]
@@ -1621,6 +1622,7 @@ impl FakeFs {
                 moves: Default::default(),
                 job_event_subscribers: Arc::new(Mutex::new(Vec::new())),
                 trash: Vec::new(),
+                simulated_open_errors: Default::default(),
             })),
         });
 
@@ -2336,6 +2338,13 @@ impl FakeFs {
                 }
             }
         }).unwrap();
+    }
+
+    pub fn set_open_repo_error(&self, dot_git: &Path, error: String) {
+        self.state
+            .lock()
+            .simulated_open_errors
+            .insert(dot_git.to_owned(), error);
     }
 
     pub fn set_error_message_for_index_write(&self, dot_git: &Path, message: Option<String>) {
@@ -3096,6 +3105,15 @@ impl Fs for FakeFs {
         abs_dot_git: &Path,
         _system_git_binary: Option<&Path>,
     ) -> Result<Arc<dyn GitRepository>> {
+        if let Some(error) = self
+            .state
+            .lock()
+            .simulated_open_errors
+            .get(abs_dot_git)
+            .cloned()
+        {
+            anyhow::bail!(error);
+        }
         self.with_git_state_and_paths(
             abs_dot_git,
             false,

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -3517,14 +3517,6 @@ impl GitBinary {
             command.env("GIT_INDEX_FILE", index_file_path);
         }
         command.envs(&self.envs);
-        log::debug!(
-            "git: {}",
-            std::iter::once(command.get_program())
-                .chain(command.get_args())
-                .map(|a| a.to_string_lossy())
-                .collect::<Vec<_>>()
-                .join(" ")
-        );
         command
     }
 }

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -3517,6 +3517,14 @@ impl GitBinary {
             command.env("GIT_INDEX_FILE", index_file_path);
         }
         command.envs(&self.envs);
+        log::debug!(
+            "git: {}",
+            std::iter::once(command.get_program())
+                .chain(command.get_args())
+                .map(|a| a.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
         command
     }
 }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -5491,14 +5491,11 @@ impl GitPanel {
             .as_ref()
             .map_or(false, |repo| repo.read(cx).error().is_some());
 
-        let content: AnyElement = if has_open_error {
-            self.render_open_error_ui(cx)
-        } else {
-            match (self.git_access, &self.active_repository) {
-                (GitAccess::No, Some(repository)) => self.render_unsafe_repo_ui(repository, cx),
-                (_, None) => self.render_uninitialized_ui(cx),
-                (_, Some(_)) => self.render_no_changes_ui(cx),
-            }
+        let content: AnyElement = match (self.git_access, has_open_error, &self.active_repository) {
+            (GitAccess::No, _, Some(repository)) => self.render_unsafe_repo_ui(repository, cx),
+            (_, true, _) => self.render_open_error_ui(cx),
+            (_, _, None) => self.render_uninitialized_ui(cx),
+            (_, _, Some(_)) => self.render_no_changes_ui(cx),
         };
 
         v_flex()
@@ -9327,17 +9324,17 @@ mod tests {
             );
         });
 
-        // When the repo is owned by a different user, the panel should render
-        // the unsafe repository UI (with the "Trust Directory" button)
-        panel.read_with(cx, |panel, cx| {
-            let has_open_error = panel
-                .active_repository
-                .as_ref()
-                .map_or(false, |repo| repo.read(cx).error().is_some());
+        // When the repo is owned by a different user, `has_active_repo` should be set
+        // to something and `git_access` should be `No`, which takes priority over `open_error`
+        // causing the unsafe repository UI (with the "Trust Directory" button) to be shown.
+        panel.read_with(cx, |panel, _cx| {
+            let has_active_repo = panel.active_repository.is_some();
+            let is_no_access = matches!(panel.git_access, GitAccess::No);
             assert!(
-                !has_open_error,
-                "`panel` should not treat a dubious ownership failure as an open error; \
-                 it should render the unsafe repository UI instead so the user can trust the directory"
+                has_active_repo && is_no_access,
+                "panel should have an active repository with GitAccess::No so that \
+                 render_unsafe_repo_ui is chosen over render_open_error_ui; \
+                 got git_access=No:{is_no_access}, active_repository=Some:{has_active_repo}"
             );
         });
     }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -701,7 +701,6 @@ pub struct GitPanel {
 
     _settings_subscription: Subscription,
     git_access: GitAccess,
-    repository_open_error: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -836,7 +835,6 @@ impl GitPanel {
                         this.schedule_update(window, cx);
                     }
                     GitStoreEvent::ActiveRepositoryChanged(_) => {
-                        this.repository_open_error = false;
                         this.schedule_update(window, cx);
                     }
                     GitStoreEvent::IndexWriteError(error) => {
@@ -853,8 +851,7 @@ impl GitPanel {
                             .map(|repo| repo.read(cx).id == *id)
                             .unwrap_or(false);
                         if is_active {
-                            this.repository_open_error = true;
-                            cx.notify();
+                            this.schedule_update(window, cx);
                         }
                         this.workspace
                             .update(cx, |workspace, cx| {
@@ -917,7 +914,6 @@ impl GitPanel {
                 _repo_subscriptions: Vec::new(),
                 _settings_subscription,
                 git_access: GitAccess::Yes,
-                repository_open_error: false,
             };
 
             this.schedule_update(window, cx);
@@ -5492,14 +5488,20 @@ impl GitPanel {
     }
 
     fn render_empty_state(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let content = match (self.git_access, &self.active_repository) {
-            (GitAccess::No, Some(repository)) => {
-                if self.repository_open_error {
-                    self.render_open_error_ui(cx)
-                } else {
-                    self.render_unsafe_repo_ui(repository, cx)
-                }
+        if let Some(repository) = &self.active_repository {
+            if repository.read(cx).error().is_some() {
+                return v_flex()
+                    .gap_1p5()
+                    .flex_1()
+                    .items_center()
+                    .justify_center()
+                    .child(self.render_open_error_ui(cx))
+                    .into_any_element();
             }
+        }
+
+        let content = match (self.git_access, &self.active_repository) {
+            (GitAccess::No, Some(repository)) => self.render_unsafe_repo_ui(repository, cx),
             (_, None) => self.render_uninitialized_ui(cx),
             (_, Some(_)) => self.render_no_changes_ui(cx),
         };
@@ -5510,6 +5512,7 @@ impl GitPanel {
             .items_center()
             .justify_center()
             .child(content)
+            .into_any_element()
     }
 
     fn render_no_changes_ui(&self, cx: &Context<Self>) -> AnyElement {
@@ -5540,7 +5543,7 @@ impl GitPanel {
             .gap_1()
             .child(Label::new("Could not open repository.").color(Color::Muted))
             .child(
-                Label::new("Check the error notification or Zed log for details.")
+                Label::new("Check the Zed log for details.")
                     .color(Color::Muted)
                     .size(LabelSize::Small),
             )

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -842,6 +842,13 @@ impl GitPanel {
                             })
                             .ok();
                     }
+                    GitStoreEvent::RepositoryOpenError(_, error) => {
+                        this.workspace
+                            .update(cx, |workspace, cx| {
+                                workspace.show_error(error, cx);
+                            })
+                            .ok();
+                    }
                     GitStoreEvent::RepositoryUpdated(_, _, _) => {}
                     GitStoreEvent::JobsUpdated | GitStoreEvent::ConflictsUpdated => {}
                 },

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -831,10 +831,8 @@ impl GitPanel {
                     )
                     | GitStoreEvent::RepositoryAdded
                     | GitStoreEvent::RepositoryRemoved(_)
-                    | GitStoreEvent::GlobalConfigurationUpdated => {
-                        this.schedule_update(window, cx);
-                    }
-                    GitStoreEvent::ActiveRepositoryChanged(_) => {
+                    | GitStoreEvent::GlobalConfigurationUpdated
+                    | GitStoreEvent::ActiveRepositoryChanged(_) => {
                         this.schedule_update(window, cx);
                     }
                     GitStoreEvent::IndexWriteError(error) => {
@@ -5488,22 +5486,19 @@ impl GitPanel {
     }
 
     fn render_empty_state(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        if let Some(repository) = &self.active_repository {
-            if repository.read(cx).error().is_some() {
-                return v_flex()
-                    .gap_1p5()
-                    .flex_1()
-                    .items_center()
-                    .justify_center()
-                    .child(self.render_open_error_ui(cx))
-                    .into_any_element();
-            }
-        }
+        let has_open_error = self
+            .active_repository
+            .as_ref()
+            .map_or(false, |repo| repo.read(cx).error().is_some());
 
-        let content = match (self.git_access, &self.active_repository) {
-            (GitAccess::No, Some(repository)) => self.render_unsafe_repo_ui(repository, cx),
-            (_, None) => self.render_uninitialized_ui(cx),
-            (_, Some(_)) => self.render_no_changes_ui(cx),
+        let content: AnyElement = if has_open_error {
+            self.render_open_error_ui(cx)
+        } else {
+            match (self.git_access, &self.active_repository) {
+                (GitAccess::No, Some(repository)) => self.render_unsafe_repo_ui(repository, cx),
+                (_, None) => self.render_uninitialized_ui(cx),
+                (_, Some(_)) => self.render_no_changes_ui(cx),
+            }
         };
 
         v_flex()
@@ -5512,7 +5507,6 @@ impl GitPanel {
             .items_center()
             .justify_center()
             .child(content)
-            .into_any_element()
     }
 
     fn render_no_changes_ui(&self, cx: &Context<Self>) -> AnyElement {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -701,6 +701,7 @@ pub struct GitPanel {
 
     _settings_subscription: Subscription,
     git_access: GitAccess,
+    repository_open_error: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -831,8 +832,11 @@ impl GitPanel {
                     )
                     | GitStoreEvent::RepositoryAdded
                     | GitStoreEvent::RepositoryRemoved(_)
-                    | GitStoreEvent::GlobalConfigurationUpdated
-                    | GitStoreEvent::ActiveRepositoryChanged(_) => {
+                    | GitStoreEvent::GlobalConfigurationUpdated => {
+                        this.schedule_update(window, cx);
+                    }
+                    GitStoreEvent::ActiveRepositoryChanged(_) => {
+                        this.repository_open_error = false;
                         this.schedule_update(window, cx);
                     }
                     GitStoreEvent::IndexWriteError(error) => {
@@ -842,7 +846,16 @@ impl GitPanel {
                             })
                             .ok();
                     }
-                    GitStoreEvent::RepositoryOpenError(_, error) => {
+                    GitStoreEvent::RepositoryOpenError(id, error) => {
+                        let is_active = this
+                            .active_repository
+                            .as_ref()
+                            .map(|repo| repo.read(cx).id == *id)
+                            .unwrap_or(false);
+                        if is_active {
+                            this.repository_open_error = true;
+                            cx.notify();
+                        }
                         this.workspace
                             .update(cx, |workspace, cx| {
                                 workspace.show_error(error, cx);
@@ -904,6 +917,7 @@ impl GitPanel {
                 _repo_subscriptions: Vec::new(),
                 _settings_subscription,
                 git_access: GitAccess::Yes,
+                repository_open_error: false,
             };
 
             this.schedule_update(window, cx);
@@ -5479,7 +5493,13 @@ impl GitPanel {
 
     fn render_empty_state(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let content = match (self.git_access, &self.active_repository) {
-            (GitAccess::No, Some(repository)) => self.render_unsafe_repo_ui(repository, cx),
+            (GitAccess::No, Some(repository)) => {
+                if self.repository_open_error {
+                    self.render_open_error_ui(cx)
+                } else {
+                    self.render_unsafe_repo_ui(repository, cx)
+                }
+            }
             (_, None) => self.render_uninitialized_ui(cx),
             (_, Some(_)) => self.render_no_changes_ui(cx),
         };
@@ -5511,6 +5531,27 @@ impl GitPanel {
                         }),
                 )
             })
+            .into_any_element()
+    }
+
+    fn render_open_error_ui(&self, cx: &mut Context<Self>) -> AnyElement {
+        v_flex()
+            .px_4()
+            .gap_1()
+            .child(Label::new("Could not open repository.").color(Color::Muted))
+            .child(
+                Label::new("Check the error notification or Zed log for details.")
+                    .color(Color::Muted)
+                    .size(LabelSize::Small),
+            )
+            .child(
+                Button::new("open_log", "Open Zed Log")
+                    .label_size(LabelSize::Small)
+                    .style(ButtonStyle::Outlined)
+                    .on_click(cx.listener(|_, _, window, cx| {
+                        window.dispatch_action(workspace::OpenLog.boxed_clone(), cx);
+                    })),
+            )
             .into_any_element()
     }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -9267,6 +9267,82 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_panel_shows_unsafe_repo_ui(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "main.rs": "fn main() {}",
+                },
+            }),
+        )
+        .await;
+        // Simulate the error git emits when the .git directory is owned by a different user
+        fs.set_open_repo_error(
+            Path::new(path!("/root/project/.git")),
+            "fatal: detected dubious ownership in repository at '/root/project'".to_string(),
+        );
+
+        let project =
+            Project::test(fs.clone(), [Path::new(path!("/root/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+
+        cx.executor().run_until_parked();
+
+        let panel = workspace.update_in(cx, GitPanel::new);
+
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+
+        panel.read_with(cx, |panel, _| {
+            assert!(
+                matches!(panel.git_access, GitAccess::No),
+                "`git_access` should be `No` when the repo is owned by a different user"
+            );
+        });
+
+        // When the repo is owned by a different user, the panel should render
+        // the unsafe repository UI (with the "Trust Directory" button)
+        panel.read_with(cx, |panel, cx| {
+            let has_open_error = panel
+                .active_repository
+                .as_ref()
+                .map_or(false, |repo| repo.read(cx).error().is_some());
+            assert!(
+                !has_open_error,
+                "`panel` should not treat a dubious ownership failure as an open error; \
+                 it should render the unsafe repository UI instead so the user can trust the directory"
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_panel_editor_style_uses_buffer_font_size(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -5493,8 +5493,8 @@ impl GitPanel {
 
         let content: AnyElement = match (self.git_access, has_open_error, &self.active_repository) {
             (GitAccess::No, _, Some(repository)) => self.render_unsafe_repo_ui(repository, cx),
-            (_, true, _) => self.render_open_error_ui(cx),
             (_, _, None) => self.render_uninitialized_ui(cx),
+            (_, true, Some(_)) => self.render_open_error_ui(cx),
             (_, _, Some(_)) => self.render_no_changes_ui(cx),
         };
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -9196,4 +9196,94 @@ mod tests {
             ));
         });
     }
+
+    #[gpui::test]
+    async fn test_panel_shows_generic_open_error(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "main.rs": "fn main() {}",
+                },
+            }),
+        )
+        .await;
+        fs.set_open_repo_error(
+            Path::new(path!("/root/project/.git")),
+            "fatal: not a git repository".to_string(),
+        );
+
+        let project =
+            Project::test(fs.clone(), [Path::new(path!("/root/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+
+        cx.executor().run_until_parked();
+
+        let panel = workspace.update_in(cx, GitPanel::new);
+
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+
+        panel.read_with(cx, |panel, cx| {
+            let repository = panel
+                .active_repository
+                .as_ref()
+                .expect("panel should have an active repository even when it fails to open");
+            let error = repository
+                .read(cx)
+                .error()
+                .expect("active repository should expose the open error so the panel can render the error UI");
+            assert!(
+                error.contains("fatal: not a git repository"),
+                "open error should contain the underlying failure message, got: {error}"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_panel_editor_style_uses_buffer_font_size(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.theme.buffer_font_size = Some(20.0.into());
+                });
+            });
+        });
+
+        cx.add_window(|window, cx| {
+            let style = panel_editor_style(true, window, cx);
+
+            assert_eq!(style.text.font_size.to_pixels(window.rem_size()), px(20.0));
+
+            Editor::single_line(window, cx)
+        });
+    }
 }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4545,8 +4545,8 @@ impl MergeDetails {
 }
 
 impl Repository {
-    pub fn error(&self) -> Option<String> {
-        self.open_error.clone()
+    pub fn error(&self) -> Option<&str> {
+        self.open_error.as_deref()
     }
 
     pub fn is_trusted(&self) -> bool {
@@ -7981,7 +7981,7 @@ impl Repository {
                         repo.open_error = Some(err.clone());
                         let id = repo.id;
                         if let Some(git_store) = repo.git_store.upgrade() {
-                            let error = anyhow::anyhow!("{}", err);
+                            let error = anyhow::anyhow!(err.clone());
                             git_store.update(cx, |_, cx| {
                                 cx.emit(GitStoreEvent::RepositoryOpenError(id, error));
                             });

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -390,6 +390,7 @@ pub struct Repository {
     askpass_delegates: Arc<Mutex<HashMap<u64, AskPassDelegate>>>,
     latest_askpass_id: u64,
     repository_state: Shared<Task<Result<RepositoryState, String>>>,
+    open_error: Option<String>,
     initial_graph_data: HashMap<(LogSource, LogOrder), InitialGitGraphData>,
     commit_data_handler: CommitDataHandlerState,
     commit_data: HashMap<Oid, CommitDataState>,
@@ -571,6 +572,7 @@ impl GitStore {
                                         is_trusted,
                                         cx,
                                     );
+                                    repo.open_error = None;
                                     repo.schedule_scan(None, cx);
                                 })
                             }
@@ -4544,10 +4546,7 @@ impl MergeDetails {
 
 impl Repository {
     pub fn error(&self) -> Option<String> {
-        match self.repository_state.peek() {
-            Some(Err(e)) => Some(e.clone()),
-            _ => None,
-        }
+        self.open_error.clone()
     }
 
     pub fn is_trusted(&self) -> bool {
@@ -4663,6 +4662,7 @@ impl Repository {
             pending_ops: Default::default(),
             repository_state: Task::ready(Err("not yet initialized".into())).shared(),
             _worker_task: Task::ready(()),
+            open_error: None,
             commit_message_buffer: None,
             askpass_delegates: Default::default(),
             paths_needing_status_update: Default::default(),
@@ -4715,6 +4715,7 @@ impl Repository {
             job_sender,
             _worker_task: worker_task,
             repository_state,
+            open_error: None,
             askpass_delegates: Default::default(),
             latest_askpass_id: 0,
             active_jobs: Default::default(),
@@ -7977,6 +7978,7 @@ impl Repository {
                 Ok(state) => state,
                 Err(err) => {
                     this.update(cx, |repo, cx| {
+                        repo.open_error = Some(err.clone());
                         let id = repo.id;
                         if let Some(git_store) = repo.git_store.upgrade() {
                             let error = anyhow::anyhow!("{}", err);

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -9364,6 +9364,45 @@ mod tests {
             repo_paths(&["submodule/a.txt", "submodule/nested/b.txt", "top_level.rs"])
         );
     }
+
+    #[gpui::test]
+    async fn test_repository_open_error_is_stored(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            Path::new("/project"),
+            json!({
+                ".git": {},
+                "file.txt": "content",
+            }),
+        )
+        .await;
+        fs.set_open_repo_error(
+            Path::new("/project/.git"),
+            "fatal: not a git repository".to_string(),
+        );
+
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        cx.run_until_parked();
+
+        let repository = project.read_with(cx, |project, cx| {
+            project
+                .active_repository(cx)
+                .expect("project should detect the repository even when it fails to open")
+        });
+        repository.read_with(cx, |repository, _| {
+            let error = repository
+                .error()
+                .expect("open_error should be set when the repository fails to open");
+            assert!(
+                error.contains("fatal: not a git repository"),
+                "open_error should contain the underlying failure message, got: {error}"
+            );
+        });
+    }
 }
 
 /// This snapshot computes the repository state on the foreground thread while

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4589,7 +4589,7 @@ impl Repository {
                     cx,
                 )
                 .await
-                .map_err(|err| err.to_string())
+                .map_err(|err| format!("{:#}", err))
             })
             .shared();
         self.job_sender.close_channel();

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4543,6 +4543,13 @@ impl MergeDetails {
 }
 
 impl Repository {
+    pub fn error(&self) -> Option<String> {
+        match self.repository_state.peek() {
+            Some(Err(e)) => Some(e.clone()),
+            _ => None,
+        }
+    }
+
     pub fn is_trusted(&self) -> bool {
         match self.repository_state.peek() {
             Some(Ok(RepositoryState::Local(state))) => state.backend.is_trusted(),

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -7981,13 +7981,15 @@ impl Repository {
                         repo.open_error = Some(err.clone());
                         let id = repo.id;
                         if let Some(git_store) = repo.git_store.upgrade() {
-                            let error = anyhow::anyhow!(err.clone());
+                            let error = anyhow::anyhow!(err);
                             git_store.update(cx, |_, cx| {
                                 cx.emit(GitStoreEvent::RepositoryOpenError(id, error));
                             });
+                        } else {
+                            log::warn!("git_store dropped before repository open error could be emitted for repository {id:?}");
                         }
                     })
-                    .ok();
+                    .log_err();
                     return;
                 }
             };

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -494,6 +494,7 @@ pub enum GitStoreEvent {
     RepositoryAdded,
     RepositoryRemoved(RepositoryId),
     IndexWriteError(anyhow::Error),
+    RepositoryOpenError(RepositoryId, anyhow::Error),
     JobsUpdated,
     ConflictsUpdated,
     GlobalConfigurationUpdated,
@@ -7965,8 +7966,21 @@ impl Repository {
         let (job_tx, mut job_rx) = mpsc::unbounded::<GitJob>();
 
         let worker_task = cx.spawn(async move |this, cx| {
-            let Some(state) = state.await.log_err() else {
-                return;
+            let state = match state.await {
+                Ok(state) => state,
+                Err(err) => {
+                    this.update(cx, |repo, cx| {
+                        let id = repo.id;
+                        if let Some(git_store) = repo.git_store.upgrade() {
+                            let error = anyhow::anyhow!("{}", err);
+                            git_store.update(cx, |_, cx| {
+                                cx.emit(GitStoreEvent::RepositoryOpenError(id, error));
+                            });
+                        }
+                    })
+                    .ok();
+                    return;
+                }
             };
             if let Some(git_hosting_provider_registry) =
                 cx.update(|cx| GitHostingProviderRegistry::try_global(cx))


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #56795 

Release Notes:

- Improved git repository error propagation to interface

---

PR adds fields to track errors that happen when a repository is opened, as well as UI changes to show the error in  a toast/notification, and a new generic error state for the git panel.

Main changes are:

- Storing errors in `Repository`:
  - Added `open_error: Option<String>` and  `pub fn error(&self) -> Option<&str>`
  - Set based on result from `spawn_local_git_worker`
  - Error branch also emits `GitStoreEvent::RepositoryOpenError(id, error)`
- Error event in`GitStoreEvent`:
  - `RepositoryOpenError` 
  - Calls `workspace.show_error` when it occurs
- Generic open error state for git panel:
  - Added `render_open_error_ui`
  - Used when `active_repository` has some kind of `open_error`
  - Shows a pretty generic message saying to look in the logs with a button to open them directly
  - Error notification shows the message already so adding it in the panel as well seemed redundant

Issue that lead to this PR was caused by using a mildly obscure git setting/extension for relative working trees (`git init && git worktree --relative-paths rel-worktree`), this would show the "Dubious ownership" message, with this PR it shows:

<img width="900" height="681" alt="Image" src="https://github.com/user-attachments/assets/df1144c3-cb79-471b-babf-fe0dcac5a3bf" />

Found a few issues where people ran into the dubious ownership message, a bunch of which seem to be confusion caused by the dubious ownership error being shown for any(?) errors that happen when libgit2 is called when the repo is initially opened.

Another example is when in a repo made with `git init --object-format=sha256`, which also shows the dubious ownership message, with this it shows:

<img width="901" height="681" alt="Image" src="https://github.com/user-attachments/assets/efb5a073-6e61-4cb7-b1fe-810ba7dbace6" />
