### PR TITLE
Dismiss Settings overlay when invoking New Thread

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2094,7 +2094,15 @@ impl AgentPanel {
         let draft = self.ensure_draft(source, window, cx);
         if let BaseView::AgentThread { conversation_view } = &self.base_view {
             if conversation_view.entity_id() == draft.entity_id() {
-                if focus {
+                // If we're already viewing the draft as the base view but an
+                // overlay (e.g. Settings) is covering it, clear the overlay
+                // so the user actually sees the draft they asked for.
+                // Otherwise pressing "New Thread" from the Settings panel is
+                // a silent no-op because the early return below would leave
+                // the overlay on top of the draft.
+                if self.overlay_view.is_some() {
+                    self.clear_overlay(focus, window, cx);
+                } else if focus {
                     self.focus_handle(cx).focus(window, cx);
                 }
                 return;
@@ -6678,6 +6686,63 @@ mod tests {
             assert_eq!(panel.active_terminal_id(), None);
             assert!(panel.has_terminal(terminal_id));
             assert!(!panel.should_create_terminal_for_new_entry(cx));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_new_thread_dismisses_settings_overlay(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+
+        // Put the panel on its ephemeral new-draft view so the base view
+        // already contains the draft that `NewThread` would activate.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.activate_new_thread(true, AgentThreadSource::AgentPanel, window, cx);
+        });
+        cx.run_until_parked();
+
+        panel.read_with(&cx, |panel, cx| {
+            assert!(
+                panel.active_view_is_new_draft(cx),
+                "precondition: base view should be the ephemeral draft"
+            );
+            assert!(!panel.is_overlay_open());
+        });
+
+        // Simulate the Settings overlay being open on top of the draft.
+        // We don't go through `open_configuration` here because it would
+        // build provider configuration views, which call into
+        // `LanguageModelProvider::configuration_view` — unimplemented for
+        // the fake provider used in tests. The bug being exercised lives
+        // entirely in the overlay/base-view bookkeeping, so toggling the
+        // overlay flag directly is sufficient.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.set_overlay(OverlayView::Configuration, true, window, cx);
+        });
+        cx.run_until_parked();
+
+        panel.read_with(&cx, |panel, _cx| {
+            assert!(
+                panel.is_overlay_open(),
+                "precondition: Settings overlay should be open"
+            );
+        });
+
+        // Dispatching `NewThread` while Settings is open must dismiss the
+        // overlay so the user actually sees the new thread. Previously
+        // this was a silent no-op: `activate_draft` early-returned without
+        // clearing the overlay because the base view already held the
+        // draft.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.new_thread(&NewThread, window, cx);
+        });
+        cx.run_until_parked();
+
+        panel.read_with(&cx, |panel, cx| {
+            assert!(
+                !panel.is_overlay_open(),
+                "Settings overlay should be dismissed when invoking NewThread"
+            );
+            assert!(panel.active_view_is_new_draft(cx));
         });
     }
 


### PR DESCRIPTION
When the Agent Panel had the Settings overlay open on top of the
ephemeral new-draft thread, pressing **Cmd-N** (or clicking *Start New
Thread* in Settings) silently did nothing — the action ran, but the
Settings overlay stayed painted on top.

The bug was in `AgentPanel::activate_draft`. Every other `activate_*`
path goes through `set_base_view`, which clears the overlay. But
`activate_draft` has an early return for the case where the base view
already holds the requested draft, and that early return only refocused
— it never touched `overlay_view`. So when the user was already on the
draft and the Settings overlay was on top, "new thread" had nothing
visible to do.

Fix: in that early-return branch, if an overlay is currently open, clear
it (which also handles focusing and emits `ActiveViewChanged`).

Added a regression test that puts the panel on the draft, sets the
Settings overlay, dispatches `NewThread`, and asserts the overlay is
gone. The test directly toggles `set_overlay(OverlayView::Configuration,
…)` rather than calling `open_configuration`, because the latter builds
provider configuration views and panics on the fake LM provider's
`unimplemented!()` `configuration_view` — and the bug being exercised
lives entirely in the overlay/base-view bookkeeping.

Closes AI-237

Release Notes:

- Fixed pressing "New Thread" (or Cmd-N) doing nothing when the Agent Panel's Settings view was open
