### PR TITLE
agent: Make fast mode more obvious

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3777,7 +3777,7 @@ impl ThreadView {
         let thread = self.as_native_thread(cx)?.read(cx);
 
         let (tooltip_label, color, icon) = if matches!(thread.speed(), Some(Speed::Fast)) {
-            ("Disable Fast Mode", Color::Muted, IconName::FastForward)
+            ("Disable Fast Mode", Color::Accent, IconName::FastForward)
         } else {
             (
                 "Enable Fast Mode",


### PR DESCRIPTION
Makes the fast mode toggle more obvious when it's enabled

<img width="154" height="34" alt="image" src="https://github.com/user-attachments/assets/0468c9bd-a2c8-4368-9b19-7e068360f5d5" />

<img width="154" height="34" alt="image" src="https://github.com/user-attachments/assets/d35199ce-b22e-4323-94d7-1dd8afaa8f04" />


Release Notes:

- N/A or Added/Fixed/Improved ...
