### PR TITLE
Document ChatGPT Subscription provider

### DIFF
--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -23,6 +23,7 @@ Zed supports these providers with your own API keys:
 
 - [Amazon Bedrock](#amazon-bedrock)
 - [Anthropic](#anthropic)
+- [ChatGPT Subscription](#chatgpt-subscription)
 - [DeepSeek](#deepseek)
 - [GitHub Copilot Chat](#github-copilot-chat)
 - [Google AI](#google-ai)
@@ -224,6 +225,18 @@ You can configure a model to use [extended thinking](https://docs.anthropic.com/
   }
 }
 ```
+
+### ChatGPT Subscription {#chatgpt-subscription}
+
+Use your existing ChatGPT Plus or Pro subscription to access OpenAI models directly in Zed — no separate API key required.
+
+1. Open the settings view ({#action agent::OpenSettings}) and go to the ChatGPT Subscription section
+2. Click **Sign in** and complete the OpenAI authentication in your browser
+3. Once signed in, models appear in the model dropdown, including GPT-5.5 and GPT-5.3 Codex
+
+To sign out, click **Sign Out** in the ChatGPT Subscription settings.
+
+> **Note:** Model availability depends on your ChatGPT subscription tier. Some models may require ChatGPT Pro.
 
 ### DeepSeek {#deepseek}
 


### PR DESCRIPTION
## Summary

- Document the new ChatGPT Subscription provider from #53166
- Add to the LLM Providers page alphabetically between Anthropic and DeepSeek
- Cover sign-in flow, available models (GPT-5.5, GPT-5.3 Codex), and sign-out

## Test plan

- [ ] Verify section renders correctly in docs preview
- [ ] Confirm links and anchors work

Release Notes:

- N/A