### PR TITLE
vim: Stop space-leader bindings from triggering 1s delay in Panels

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -928,7 +928,7 @@
     },
   },
   {
-    "context": "!Editor && !Terminal",
+    "context": "!Editor && !Terminal && !ProjectPanel && !OutlinePanel && !ThreadsSidebar && !GitPanel && !CollabPanel && !BreakpointList",
     "bindings": {
       ":": "command_palette::Toggle",
       "g /": "pane::DeploySearch",
@@ -943,7 +943,7 @@
       "space w j": "workspace::ActivatePaneDown",
       "space w k": "workspace::ActivatePaneUp",
       "space w l": "workspace::ActivatePaneRight",
-	  "space w q": "pane::CloseActiveItem",
+      "space w q": "pane::CloseActiveItem",
     },
   },
   {
@@ -1056,8 +1056,8 @@
       "ctrl-d": "git_graph::ScrollDown",
       "ctrl-u": "git_graph::ScrollUp",
       "shift-g": "menu::SelectLast",
-      "g g": "menu::SelectFirst"
-    }
+      "g g": "menu::SelectFirst",
+    },
   },
   {
     "context": "GitPanel && ChangesList && !GitBranchSelector",


### PR DESCRIPTION
The `!Editor && !Terminal` context in `vim.json` (introduced by #51434 to support Helix-style space-leader bindings when no tabs are open) also matches the dispatch context of every dock Panel -- `BreakpointList`, `CollabPanel`, `GitPanel`, `OutlinePanel`, `ProjectPanel`, `ThreadsSidebar`.

Each of those Panels binds `space → <leaf action>` in its own context. When Helix or Vim mode is enabled, the matcher sees `space` as a partial prefix of `space f / space / / space w h / ...` from the leaked block, parks the keystroke in `pending` for 1 second (`crates/gpui/src/window.rs:4558`), then finally fires the Panel’s binding. Result: noticeable lag every time a vim/helix user presses space in a panel.

Narrow the predicate to exclude those six panel contexts. The intended “helix space-leader when no tabs open” behavior is preserved (those Panels are the only contexts being excluded -- the welcome / empty-pane state still satisfies the predicate).


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #56254.

Release Notes:

- Fixed a ~1 second delay when pressing space in the Project Panel and other docked Panels with Helix or Vim mode enabled
