### PR TITLE
cloud_api_client: Add update_system_settings

### DIFF
--- a/crates/cloud_api_client/src/cloud_api_client.rs
+++ b/crates/cloud_api_client/src/cloud_api_client.rs
@@ -239,6 +239,56 @@ impl CloudApiClient {
         serde_json::from_str(&body).map_err(|e| ClientApiError::InvalidResponse(e.into()))
     }
 
+    pub async fn update_system_settings(
+        &self,
+        system_id: String,
+        body: UpdateSystemSettingsBody,
+    ) -> Result<SystemSettings, ClientApiError> {
+        let host = self.cloud_host();
+        let request_builder = Request::builder()
+            .method(Method::PATCH)
+            .uri(
+                self.http_client
+                    .build_zed_cloud_url("/client/system_settings")
+                    .map_err(ClientApiError::RequestBuildFailed)?
+                    .as_ref(),
+            )
+            .header(ZED_SYSTEM_ID_HEADER_NAME, system_id);
+
+        let request = self.build_request(request_builder, Json(body))?;
+
+        let mut response = self.http_client.send(request).await.map_err(|source| {
+            ClientApiError::ConnectionFailed {
+                host: host.clone(),
+                source,
+            }
+        })?;
+
+        if !response.status().is_success() {
+            if response.status() == StatusCode::UNAUTHORIZED {
+                return Err(ClientApiError::Unauthorized);
+            }
+
+            let mut body = String::new();
+            response.body_mut().read_to_string(&mut body).await.ok();
+
+            return Err(ClientApiError::ServerError {
+                host,
+                status: response.status(),
+                body,
+            });
+        }
+
+        let mut body = String::new();
+        response
+            .body_mut()
+            .read_to_string(&mut body)
+            .await
+            .map_err(|e| ClientApiError::InvalidResponse(e.into()))?;
+
+        serde_json::from_str(&body).map_err(|e| ClientApiError::InvalidResponse(e.into()))
+    }
+
     pub async fn validate_credentials(&self, user_id: u32, access_token: &str) -> Result<bool> {
         let request = build_request(
             Request::builder().method(Method::GET).uri(

--- a/crates/cloud_api_types/src/cloud_api_types.rs
+++ b/crates/cloud_api_types/src/cloud_api_types.rs
@@ -87,6 +87,16 @@ pub struct CreateLlmTokenResponse {
     pub token: LlmToken,
 }
 
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+pub struct UpdateSystemSettingsBody {
+    pub selected_organization_id: Option<OrganizationId>,
+}
+
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+pub struct SystemSettings {
+    pub selected_organization_id: Option<OrganizationId>,
+}
+
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct SubmitAgentThreadFeedbackBody {
     pub organization_id: Option<OrganizationId>,


### PR DESCRIPTION
Wire up the client side of the new `PATCH /client/system_settings` endpoint added in zed-industries/cloud#2444, so we can persist the currently selected organization on a per-system basis. This PR only adds the request types and the client method; hooking it up to the actual organization switcher in the editor will come next.

The endpoint requires the `x-zed-system-id` header (the server returns 400 without it), so the method does not take an Option like the other client calls.

Release Notes:

- N/A