### PR TITLE
Make workspace: open files add files to the current workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12292,6 +12292,7 @@ dependencies = [
  "futures 0.3.32",
  "fuzzy",
  "gpui",
+ "menu",
  "picker",
  "project",
  "project_panel",

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -99,6 +99,8 @@ pub fn init(cx: &mut App) {
     cx.observe_new(FileFinder::register).detach();
     cx.observe_new(OpenPathPrompt::register).detach();
     cx.observe_new(OpenPathPrompt::register_new_path).detach();
+    cx.observe_new(OpenPathPrompt::register_for_open_files)
+        .detach();
 }
 
 impl FileFinder {

--- a/crates/open_path_prompt/Cargo.toml
+++ b/crates/open_path_prompt/Cargo.toml
@@ -10,6 +10,7 @@ file_icons.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
+menu.workspace = true
 picker.workspace = true
 project.workspace = true
 project_panel.workspace = true

--- a/crates/open_path_prompt/src/open_path_prompt.rs
+++ b/crates/open_path_prompt/src/open_path_prompt.rs
@@ -7,7 +7,9 @@ use file_finder_settings::FileFinderSettings;
 use file_icons::FileIcons;
 use futures::channel::oneshot;
 use fuzzy::{CharBag, StringMatch, StringMatchCandidate};
+use gpui::Action;
 use gpui::{HighlightStyle, StyledText, Task};
+use menu;
 use picker::{Picker, PickerDelegate};
 use project::{DirectoryItem, DirectoryLister};
 use project_panel::project_panel_settings::ProjectPanelSettings;
@@ -19,18 +21,19 @@ use std::{
         atomic::{self, AtomicBool},
     },
 };
-use ui::{Context, LabelLike, ListItem, Window};
+use ui::{Context, KeyBinding, LabelLike, ListItem, Window};
 use ui::{HighlightedLabel, ListItemSpacing, prelude::*};
 use util::{
     maybe,
     paths::{PathStyle, compare_paths},
 };
-use workspace::Workspace;
+use workspace::{OpenFilesMode, Workspace};
 
 pub struct OpenPathPrompt;
 
 pub struct OpenPathDelegate {
     tx: Option<oneshot::Sender<Option<Vec<PathBuf>>>>,
+    files_tx: Option<oneshot::Sender<Option<(Vec<PathBuf>, OpenFilesMode)>>>,
     lister: DirectoryLister,
     selected_index: usize,
     directory_state: DirectoryState,
@@ -59,6 +62,7 @@ impl OpenPathDelegate {
             .unwrap_or_default();
         Self {
             tx: Some(tx),
+            files_tx: None,
             lister,
             selected_index: 0,
             directory_state: DirectoryState::None {
@@ -93,6 +97,15 @@ impl OpenPathDelegate {
         self.hidden_entries = true;
         self
     }
+
+    pub fn with_files_tx(
+        mut self,
+        tx: oneshot::Sender<Option<(Vec<PathBuf>, OpenFilesMode)>>,
+    ) -> Self {
+        self.files_tx = Some(tx);
+        self
+    }
+
     fn get_entry(&self, selected_match_index: usize) -> Option<CandidateInfo> {
         match &self.directory_state {
             DirectoryState::List { entries, .. } => {
@@ -207,6 +220,72 @@ impl OpenPathPrompt {
         }));
     }
 
+    pub fn register_for_open_files(
+        workspace: &mut Workspace,
+        _window: Option<&mut Window>,
+        _: &mut Context<Workspace>,
+    ) {
+        workspace.set_prompt_for_open_files(Box::new(|workspace, lister, window, cx| {
+            let (tx, rx) = futures::channel::oneshot::channel();
+            let (dummy_tx, _dummy_rx) = futures::channel::oneshot::channel();
+            workspace.toggle_modal(window, cx, |window, cx| {
+                let delegate = OpenPathDelegate::new(dummy_tx, lister.clone(), false, cx)
+                    .show_hidden()
+                    .with_files_tx(tx)
+                    .with_footer(Arc::new(|window, cx| {
+                        let secondary = window.modifiers().secondary();
+                        Some(
+                            h_flex()
+                                .flex_1()
+                                .p_1p5()
+                                .gap_1()
+                                .justify_end()
+                                .border_t_1()
+                                .border_color(cx.theme().colors().border_variant)
+                                .on_modifiers_changed(cx.listener(|_, _, _, cx| cx.notify()))
+                                .map(|this| {
+                                    if secondary {
+                                        this.child(
+                                            Button::new("open-in-new-window", "Open In New Window")
+                                                .key_binding(KeyBinding::for_action(
+                                                    &menu::SecondaryConfirm,
+                                                    cx,
+                                                ))
+                                                .on_click(|_, window, cx| {
+                                                    window.dispatch_action(
+                                                        menu::SecondaryConfirm.boxed_clone(),
+                                                        cx,
+                                                    )
+                                                }),
+                                        )
+                                    } else {
+                                        this.child(
+                                            Button::new("open", "Open")
+                                                .key_binding(KeyBinding::for_action(
+                                                    &menu::Confirm,
+                                                    cx,
+                                                ))
+                                                .on_click(|_, window, cx| {
+                                                    window.dispatch_action(
+                                                        menu::Confirm.boxed_clone(),
+                                                        cx,
+                                                    )
+                                                }),
+                                        )
+                                    }
+                                })
+                                .into_any_element(),
+                        )
+                    }));
+                let picker = Picker::uniform_list(delegate, window, cx).width(rems(34.));
+                let query = lister.default_query(cx);
+                picker.set_query(&query, window, cx);
+                picker
+            });
+            rx
+        }));
+    }
+
     pub fn register_new_path(
         workspace: &mut Workspace,
         _window: Option<&mut Window>,
@@ -252,6 +331,16 @@ impl OpenPathPrompt {
         cx: &mut Context<Workspace>,
     ) {
         Self::prompt_for_open_path(workspace, lister, true, suggested_name, tx, window, cx);
+    }
+}
+
+impl OpenPathDelegate {
+    fn send_paths(&mut self, paths: Vec<PathBuf>, mode: OpenFilesMode) {
+        if let Some(tx) = self.files_tx.take() {
+            tx.send(Some((paths, mode))).ok();
+        } else if let Some(tx) = self.tx.take() {
+            tx.send(Some(paths)).ok();
+        }
     }
 }
 
@@ -616,9 +705,15 @@ impl PickerDelegate for OpenPathDelegate {
         )
     }
 
-    fn confirm(&mut self, _: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+    fn confirm(&mut self, secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
         let Some(candidate) = self.get_entry(self.selected_index) else {
             return;
+        };
+
+        let mode = if secondary {
+            OpenFilesMode::OpenInNewWindow
+        } else {
+            OpenFilesMode::OpenInCurrentWindow
         };
 
         match &self.directory_state {
@@ -631,9 +726,7 @@ impl PickerDelegate for OpenPathDelegate {
                         Path::new(self.lister.resolve_tilde(parent_path, cx).as_ref())
                             .join(&candidate.path.string)
                     };
-                if let Some(tx) = self.tx.take() {
-                    tx.send(Some(vec![confirmed_path])).ok();
-                }
+                self.send_paths(vec![confirmed_path], mode);
             }
             DirectoryState::Create {
                 parent_path,
@@ -671,16 +764,14 @@ impl PickerDelegate for OpenPathDelegate {
                                     if answer != Some(0) {
                                         return;
                                     }
-                                    if let Some(tx) = picker.delegate.tx.take() {
-                                        tx.send(Some(vec![prompted_path])).ok();
-                                    }
+                                    picker.delegate.send_paths(vec![prompted_path], mode);
                                     cx.emit(gpui::DismissEvent);
                                 })
                                 .ok();
                         });
                         return;
-                    } else if let Some(tx) = self.tx.take() {
-                        tx.send(Some(vec![prompted_path])).ok();
+                    } else {
+                        self.send_paths(vec![prompted_path], mode);
                     }
                 }
             },
@@ -695,7 +786,9 @@ impl PickerDelegate for OpenPathDelegate {
 
     fn dismissed(&mut self, _: &mut Window, cx: &mut Context<Picker<Self>>) {
         self.cancel_flag.store(true, atomic::Ordering::Release);
-        if let Some(tx) = self.tx.take() {
+        if let Some(tx) = self.files_tx.take() {
+            tx.send(None).ok();
+        } else if let Some(tx) = self.tx.take() {
             tx.send(None).ok();
         }
         cx.emit(gpui::DismissEvent)

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -766,6 +766,97 @@ pub fn prompt_for_open_path_and_open(
     .detach();
 }
 
+pub fn prompt_for_open_files_and_open(
+    workspace: &mut Workspace,
+    app_state: Arc<AppState>,
+    options: PathPromptOptions,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let result = workspace.prompt_for_open_files(
+        options,
+        DirectoryLister::Local(workspace.project().clone(), app_state.fs.clone()),
+        window,
+        cx,
+    );
+    cx.spawn_in(window, async move |this, cx| {
+        let Some((paths, mode)) = result.await.log_err().flatten() else {
+            return;
+        };
+        match mode {
+            OpenFilesMode::OpenInCurrentWindow => {
+                if let Some(task) = this
+                    .update_in(cx, |workspace, window, cx| {
+                        workspace.open_paths(
+                            paths,
+                            OpenOptions {
+                                visible: Some(OpenVisible::None),
+                                ..Default::default()
+                            },
+                            None,
+                            window,
+                            cx,
+                        )
+                    })
+                    .log_err()
+                {
+                    task.await;
+                }
+            }
+            OpenFilesMode::OpenInNewWindow => {
+                if let Some(task) = this
+                    .update_in(cx, |workspace, window, cx| {
+                        workspace.open_workspace_for_paths(OpenMode::NewWindow, paths, window, cx)
+                    })
+                    .log_err()
+                {
+                    task.await.log_err();
+                }
+            }
+        }
+    })
+    .detach();
+}
+
+fn prompt_and_open_files(app_state: Arc<AppState>, options: PathPromptOptions, cx: &mut App) {
+    if let Some(workspace_window) =
+        workspace_windows_for_location(&SerializedWorkspaceLocation::Local, cx)
+            .into_iter()
+            .next()
+    {
+        workspace_window
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    prompt_for_open_files_and_open(workspace, app_state, options, window, cx);
+                });
+            })
+            .ok();
+    } else {
+        let task = Workspace::new_local(
+            Vec::new(),
+            app_state.clone(),
+            None,
+            None,
+            None,
+            OpenMode::Activate,
+            cx,
+        );
+        cx.spawn(async move |cx| {
+            let OpenResult { window, .. } = task.await?;
+            window.update(cx, |multi_workspace, window, cx| {
+                window.activate_window();
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    prompt_for_open_files_and_open(workspace, app_state, options, window, cx);
+                });
+            })?;
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
+    }
+}
+
 pub fn init(app_state: Arc<AppState>, cx: &mut App) {
     component::init();
     theme_preview::init(cx);
@@ -796,7 +887,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut App) {
         .on_action(|_: &OpenFiles, cx: &mut App| {
             let directories = cx.can_select_mixed_files_and_dirs();
             let app_state = AppState::global(cx);
-            prompt_and_open_paths(
+            prompt_and_open_files(
                 app_state,
                 PathPromptOptions {
                     files: true,
@@ -804,7 +895,6 @@ pub fn init(app_state: Arc<AppState>, cx: &mut App) {
                     multiple: true,
                     prompt: None,
                 },
-                true,
                 cx,
             );
         });
@@ -1341,6 +1431,21 @@ type PromptForOpenPath = Box<
     ) -> oneshot::Receiver<Option<Vec<PathBuf>>>,
 >;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum OpenFilesMode {
+    OpenInCurrentWindow,
+    OpenInNewWindow,
+}
+
+type PromptForOpenFiles = Box<
+    dyn Fn(
+        &mut Workspace,
+        DirectoryLister,
+        &mut Window,
+        &mut Context<Workspace>,
+    ) -> oneshot::Receiver<Option<(Vec<PathBuf>, OpenFilesMode)>>,
+>;
+
 #[derive(Default)]
 struct DispatchingKeystrokes {
     dispatched: HashSet<Vec<Keystroke>>,
@@ -1399,6 +1504,7 @@ pub struct Workspace {
     bounds_save_task_queued: Option<Task<()>>,
     on_prompt_for_new_path: Option<PromptForNewPath>,
     on_prompt_for_open_path: Option<PromptForOpenPath>,
+    on_prompt_for_open_files: Option<PromptForOpenFiles>,
     terminal_provider: Option<Box<dyn TerminalProvider>>,
     debugger_provider: Option<Arc<dyn DebuggerProvider>>,
     serializable_items_tx: UnboundedSender<Box<dyn SerializableItemHandle>>,
@@ -1852,6 +1958,7 @@ impl Workspace {
             bounds_save_task_queued: None,
             on_prompt_for_new_path: None,
             on_prompt_for_open_path: None,
+            on_prompt_for_open_files: None,
             terminal_provider: None,
             debugger_provider: None,
             serializable_items_tx,
@@ -2959,6 +3066,34 @@ impl Workspace {
 
     pub fn set_prompt_for_open_path(&mut self, prompt: PromptForOpenPath) {
         self.on_prompt_for_open_path = Some(prompt)
+    }
+
+    pub fn set_prompt_for_open_files(&mut self, prompt: PromptForOpenFiles) {
+        self.on_prompt_for_open_files = Some(prompt)
+    }
+
+    pub fn prompt_for_open_files(
+        &mut self,
+        path_prompt_options: PathPromptOptions,
+        lister: DirectoryLister,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> oneshot::Receiver<Option<(Vec<PathBuf>, OpenFilesMode)>> {
+        if let Some(prompt) = self.on_prompt_for_open_files.take() {
+            let rx = prompt(self, lister, window, cx);
+            self.on_prompt_for_open_files = Some(prompt);
+            return rx;
+        }
+        // Fall back to simple path prompt, always opening in the current window.
+        let simple_rx = self.prompt_for_open_path(path_prompt_options, lister, window, cx);
+        let (tx, rx) = oneshot::channel();
+        cx.spawn_in(window, async move |_, _| {
+            let paths = simple_rx.await.ok().flatten();
+            tx.send(paths.map(|p| (p, OpenFilesMode::OpenInCurrentWindow)))
+                .ok();
+        })
+        .detach();
+        rx
     }
 
     pub fn set_terminal_provider(&mut self, provider: impl TerminalProvider + 'static) {
@@ -11200,7 +11335,7 @@ fn load_legacy_panel_size(
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, rc::Rc, sync::Arc, time::Duration};
+    use std::{cell::RefCell, path::PathBuf, rc::Rc, sync::Arc, time::Duration};
 
     use super::*;
     use crate::{
@@ -16323,5 +16458,203 @@ mod tests {
             workspace.open_url_or_file("nonexistent.txt", None, window, cx);
         });
         assert_eq!(cx.opened_url(), Some("nonexistent.txt".to_string()));
+    }
+
+    #[gpui::test]
+    async fn test_open_files_ctrl_enter_opens_new_window(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.workspace.use_system_path_prompts = Some(false);
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/root", json!({ "file.txt": "" })).await;
+
+        let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        cx.run_until_parked();
+
+        let initial_window_count = cx.windows().len();
+        let initial_worktree_count = project.read_with(cx, |p, cx| p.worktrees(cx).count());
+
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_prompt_for_open_files(Box::new(|_, _, _, _| {
+                let (tx, rx) = oneshot::channel();
+                tx.send(Some((
+                    vec![PathBuf::from("/root/file.txt")],
+                    OpenFilesMode::OpenInNewWindow,
+                )))
+                .ok();
+                rx
+            }));
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let app_state = workspace.app_state().clone();
+            prompt_for_open_files_and_open(
+                workspace,
+                app_state,
+                PathPromptOptions {
+                    files: true,
+                    directories: false,
+                    multiple: true,
+                    prompt: None,
+                },
+                window,
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        assert_eq!(
+            cx.windows().len(),
+            initial_window_count + 1,
+            "ctrl-enter should open the file in a new window"
+        );
+        assert_eq!(
+            project.read_with(cx, |p, cx| p.worktrees(cx).count()),
+            initial_worktree_count,
+            "the original project worktree count must not change"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_open_files_in_existing_project_does_not_add_worktree(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.workspace.use_system_path_prompts = Some(false);
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/root", json!({ "existing.txt": "hello" }))
+            .await;
+
+        let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        cx.run_until_parked();
+
+        let initial_window_count = cx.windows().len();
+        let initial_worktree_count = project.read_with(cx, |p, cx| p.worktrees(cx).count());
+
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_prompt_for_open_path(Box::new(|_, _, _, _| {
+                let (tx, rx) = oneshot::channel();
+                tx.send(Some(vec![PathBuf::from("/root/existing.txt")]))
+                    .ok();
+                rx
+            }));
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let app_state = workspace.app_state().clone();
+            prompt_for_open_files_and_open(
+                workspace,
+                app_state,
+                PathPromptOptions {
+                    files: true,
+                    directories: false,
+                    multiple: true,
+                    prompt: None,
+                },
+                window,
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        assert_eq!(
+            cx.windows().len(),
+            initial_window_count,
+            "no new window should be opened for a file already in the project"
+        );
+        assert_eq!(
+            project.read_with(cx, |p, cx| p.worktrees(cx).count()),
+            initial_worktree_count,
+            "no new worktree should be added for a file already in the project"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_open_files_outside_project_does_not_add_visible_worktree(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.workspace.use_system_path_prompts = Some(false);
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/root", json!({ "file.txt": "" })).await;
+        fs.insert_tree("/external", json!({ "other.txt": "" }))
+            .await;
+
+        let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        cx.run_until_parked();
+
+        let initial_window_count = cx.windows().len();
+        let initial_visible_worktree_count =
+            project.read_with(cx, |p, cx| p.visible_worktrees(cx).count());
+
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_prompt_for_open_path(Box::new(|_, _, _, _| {
+                let (tx, rx) = oneshot::channel();
+                tx.send(Some(vec![PathBuf::from("/external/other.txt")]))
+                    .ok();
+                rx
+            }));
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            let app_state = workspace.app_state().clone();
+            prompt_for_open_files_and_open(
+                workspace,
+                app_state,
+                PathPromptOptions {
+                    files: true,
+                    directories: false,
+                    multiple: true,
+                    prompt: None,
+                },
+                window,
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        assert_eq!(
+            cx.windows().len(),
+            initial_window_count,
+            "opening a file outside the project must not open a new window"
+        );
+        assert_eq!(
+            project.read_with(cx, |p, cx| p.visible_worktrees(cx).count()),
+            initial_visible_worktree_count,
+            "the external file should not be added as a visible project worktree"
+        );
     }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -959,7 +959,7 @@ fn register_actions(
         })
         .register_action(|workspace, _: &workspace::OpenFiles, window, cx| {
             let directories = cx.can_select_mixed_files_and_dirs();
-            workspace::prompt_for_open_path_and_open(
+            workspace::prompt_for_open_files_and_open(
                 workspace,
                 workspace.app_state().clone(),
                 PathPromptOptions {
@@ -968,7 +968,6 @@ fn register_actions(
                     multiple: true,
                     prompt: None,
                 },
-                true,
                 window,
                 cx,
             );


### PR DESCRIPTION
Make `workspace: open files` add files to the current workspace

Currently, `workspace: open files` opens the chosen files in a new window with a clean workspace. Most of the time, this is not the intended behavior. Instead, users want to simply open the file if it's in the current project, or open invisibly (without adding it to the current project).

This change makes the above the default behavior, while preserving the original behavior as a separate keybinding active when the file picker is open (ctrl+enter vs enter).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Release Notes:

- Improved `workspace: open` files — files and directories are now opened in the current workspace by default; use `ctrl+enter` to open them in a new window instead

[Screencast_20260515_132614.webm](https://github.com/user-attachments/assets/23f53917-d104-413b-8873-8c0955559e9e)
