### PR TITLE
Fix title generation when using openai models via subscription

### DIFF
--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -444,9 +444,7 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
             }
             true
         });
-        if !instructions.is_empty() {
-            responses_request.instructions = Some(instructions.join("\n\n"));
-        }
+        responses_request.instructions = Some(instructions.join("\n\n"));
 
         let state = self.state.downgrade();
         let http_client = self.http_client.clone();


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes: #56857 Title generation failing on agent threads with OpenAI models from subscription

Currently title generation requests are made without any system prompt which causes instructions to be not set, and the request fails. This change makes sure there is always instructions set (api does not seem to care if its empty or not)

Release Notes:

- N/A
