### PR TITLE
debugger_ui: Enable search in debugger terminal panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4768,6 +4768,7 @@ dependencies = [
  "project",
  "rpc",
  "schemars 1.0.4",
+ "search",
  "serde",
  "serde_json",
  "serde_json_lenient",

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -57,6 +57,7 @@ pretty_assertions.workspace = true
 project.workspace = true
 rpc.workspace = true
 schemars.workspace = true
+search.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -32,8 +32,8 @@ use dap::{
 };
 use futures::{SinkExt, channel::mpsc};
 use gpui::{
-    Action as _, AnyView, AppContext, Axis, Entity, EntityId, EventEmitter, FocusHandle, Focusable,
-    NoAction, Pixels, Point, Subscription, Task, TaskExt, WeakEntity,
+    Action as _, AnyView, App, AppContext, Axis, Entity, EntityId, EventEmitter, FocusHandle,
+    Focusable, NoAction, Pixels, Point, Subscription, Task, TaskExt, WeakEntity,
 };
 use language::Buffer;
 use loaded_source_list::LoadedSourceList;
@@ -132,7 +132,14 @@ impl Render for RunningState {
         self.variable_list.update(cx, |this, cx| {
             this.disabled(thread_status != ThreadStatus::Stopped, cx);
         });
-        v_flex()
+        let outer = cx
+            .try_global::<workspace::PaneSearchBarCallbacks>()
+            .map(|callbacks| {
+                (callbacks.wrap_div_with_search_actions)(div(), self.active_pane.clone())
+            })
+            .unwrap_or_else(div);
+        outer
+            .v_flex()
             .size_full()
             .key_context("DebugSessionItem")
             .track_focus(&self.focus_handle(cx))
@@ -372,6 +379,19 @@ impl Item for SubView {
         });
 
         true
+    }
+
+    fn as_searchable(
+        &self,
+        _: &Entity<Self>,
+        cx: &App,
+    ) -> Option<Box<dyn workspace::searchable::SearchableItemHandle>> {
+        if self.kind != DebuggerPaneItem::Terminal {
+            return None;
+        }
+        let debug_terminal = self.inner.clone().downcast::<DebugTerminal>().ok()?;
+        let terminal_view = debug_terminal.read(cx).terminal.clone()?;
+        Some(Box::new(terminal_view))
     }
 }
 
@@ -620,6 +640,11 @@ pub(crate) fn new_debugger_pane(
                     .into_any_element()
             }
         });
+        let toolbar = pane.toolbar().clone();
+        if let Some(callbacks) = cx.try_global::<workspace::PaneSearchBarCallbacks>() {
+            let languages = Some(project.read(cx).languages().clone());
+            (callbacks.setup_search_bar)(languages, &toolbar, window, cx);
+        }
         pane
     })
 }
@@ -1168,6 +1193,7 @@ impl RunningState {
                         debug_terminal.terminal = Some(terminal_view);
                         cx.notify();
                     });
+                    this.refresh_terminal_toolbars(window, cx);
                 })?;
 
                 let exit_status = terminal
@@ -1332,6 +1358,7 @@ impl RunningState {
                     debug_terminal.terminal = Some(terminal_view);
                     cx.notify();
                 });
+                running.refresh_terminal_toolbars(window, cx);
             })?;
 
             terminal.read_with(cx, |terminal, _| {
@@ -1433,6 +1460,26 @@ impl RunningState {
         pane.update(cx, |pane, cx| {
             pane.add_item_inner(sub_view, false, false, false, None, window, cx);
         })
+    }
+
+    fn refresh_terminal_toolbars(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let panes: Vec<Entity<Pane>> = self.panes.panes().into_iter().cloned().collect();
+        for pane in panes {
+            let is_active_terminal = pane.read(cx).active_item().is_some_and(|item| {
+                item.act_as::<SubView>(cx)
+                    .is_some_and(|s| s.read(cx).kind == DebuggerPaneItem::Terminal)
+            });
+            if !is_active_terminal {
+                continue;
+            }
+            pane.update(cx, |pane, cx| {
+                let active = pane.active_item();
+                let toolbar = pane.toolbar().clone();
+                toolbar.update(cx, |toolbar, cx| {
+                    toolbar.set_active_item(active.as_deref(), window, cx);
+                });
+            });
+        }
     }
 
     pub(crate) fn add_pane_item(

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -18,7 +18,7 @@ use editor::{
     ActiveDebugLine, Editor, EditorMode, MultiBuffer,
     actions::{self},
 };
-use gpui::{BackgroundExecutor, TestAppContext, VisualTestContext};
+use gpui::{AppContext, BackgroundExecutor, TestAppContext, VisualTestContext};
 use project::{
     FakeFs, Project,
     debugger::session::{ThreadId, ThreadStatus},
@@ -2554,4 +2554,81 @@ async fn test_restart_request_is_not_sent_more_than_once_until_response(
         2,
         "A second restart should be allowed after the first one completes"
     );
+}
+
+#[gpui::test]
+async fn test_debugger_terminal_pane_has_search_bar(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    cx.update(|cx| {
+        cx.set_global(workspace::PaneSearchBarCallbacks {
+            setup_search_bar: |languages, toolbar, window, cx| {
+                let search_bar =
+                    cx.new(|cx| search::BufferSearchBar::new(languages, window, cx));
+                toolbar.update(cx, |toolbar, cx| {
+                    toolbar.add_item(search_bar, window, cx);
+                });
+            },
+            wrap_div_with_search_actions: search::buffer_search::register_pane_search_actions,
+        });
+    });
+
+    let fs = FakeFs::new(executor.clone());
+    fs.insert_tree(path!("/project"), json!({"main.rs": ""}))
+        .await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+
+    client.on_request::<Threads, _>(move |_, _| {
+        Ok(dap::ThreadsResponse {
+            threads: vec![dap::Thread {
+                id: 1,
+                name: "main".into(),
+            }],
+        })
+    });
+    client.on_request::<StackTrace, _>(move |_, _| {
+        Ok(dap::StackTraceResponse {
+            stack_frames: vec![],
+            total_frames: None,
+        })
+    });
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Breakpoint,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+    cx.run_until_parked();
+
+    workspace
+        .update(cx, |workspace, _, cx| {
+            let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
+            let session = debug_panel.read(cx).active_session().expect("active session");
+            let running_state = session.read(cx).running_state().clone();
+            let active_pane = running_state.read(cx).active_pane().clone();
+            let search_bar = active_pane
+                .read(cx)
+                .toolbar()
+                .read(cx)
+                .item_of_type::<search::BufferSearchBar>();
+            assert!(
+                search_bar.is_some(),
+                "active debugger pane toolbar should have BufferSearchBar for cmd-f support"
+            );
+        })
+        .unwrap();
 }


### PR DESCRIPTION
## Summary

pressing `cmd-f` (or using **Edit → Find**) while focused in the debugger terminal panel had no effect. The Edit menu item was not greyed out but nothing happened.

### Root cause

Three things were missing:

1. **No `BufferSearchBar` on toolbar** — debugger panes never registered a search bar, so there was no UI to deploy.
2. **`SubView::as_searchable` returned `None`** — the pane item wrapping the terminal had no searchable delegate, so even with a search bar present it could not find a target.
3. **No search action handlers on the render div** — `RunningState::render` did not wrap its output with `wrap_div_with_search_actions`, so `buffer_search::Deploy` was never caught.

### Changes

- **`new_debugger_pane`**: calls `PaneSearchBarCallbacks::setup_search_bar` to register `BufferSearchBar` on each debugger pane's toolbar (same pattern as `terminal_view::new_terminal_pane`).
- **`SubView::as_searchable`**: for `DebuggerPaneItem::Terminal`, delegates to the inner `TerminalView` which already implements `SearchableItem` (regex search, highlight matches).
- **`RunningState::render`**: wraps the outer div with `wrap_div_with_search_actions(active_pane)` so `buffer_search::Deploy` reaches the pane's toolbar.
- **`refresh_terminal_toolbars`**: re-fires `toolbar.set_active_item` when `DebugTerminal.terminal` is set, covering the edge case where the Terminal tab was already active before the terminal entity existed. Only refreshes panes where Terminal is the current active item (not background tabs).
- **`debugger_ui/Cargo.toml`**: adds `search` dependency.
- **Test**: `test_debugger_terminal_pane_has_search_bar` verifies the active pane toolbar has a `BufferSearchBar` after a debug session starts.

Release Notes:

- Fixed `cmd-f` search not working in the debugger terminal panel.