### PR TITLE
editor: Fix hit testing when the editor is clipped

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -12193,9 +12193,9 @@ impl PositionMap {
         let x = position.x + (scroll_position.x as f32 * self.em_layout_width);
         let row = ((y / self.line_height) as f64 + scroll_position.y) as u32;
 
-        let (column, x_overshoot_after_line_end) = if let Some(line) = self
-            .line_layouts
-            .get(row as usize - scroll_position.y as usize)
+        let (column, x_overshoot_after_line_end) = if let Some(line_index) =
+            row.checked_sub(self.visible_row_range.start.0)
+            && let Some(line) = self.line_layouts.get(line_index as usize)
         {
             let alignment_offset = line.alignment_offset(self.text_align, self.content_width);
             let x_relative_to_text = x - alignment_offset;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -12928,6 +12928,47 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_point_for_position_clipped_rows(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let text = "aaa\nbbb";
+        let window = cx.add_window(|window, cx| {
+            let buffer = MultiBuffer::build_simple(text, cx);
+            Editor::new(EditorMode::full(), buffer, None, window, cx)
+        });
+
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        let editor = window.root(cx).unwrap();
+        let style = editor.update(cx, |editor, cx| editor.style(cx).clone());
+        let line_height = window
+            .update(cx, |_, window, _| {
+                style.text.line_height_in_pixels(window.rem_size())
+            })
+            .unwrap();
+
+        // the first line is clipped
+        let (_, state) = cx.draw(
+            point(Pixels::ZERO, Pixels::ZERO - line_height * 1.5),
+            size(px(500.), px(500.)),
+            |_, _| EditorElement::new(&editor, style),
+        );
+
+        // click at the end of the second line
+        let target_point = DisplayPoint::new(DisplayRow(1), 3);
+        let click_x = state.content_origin.x
+            + editor.update_in(cx, |editor, window, cx| {
+                editor
+                    .snapshot(window, cx)
+                    .x_for_display_point(target_point, &editor.text_layout_details(window, cx))
+            });
+
+        let point = state
+            .position_map
+            .point_for_position(point(click_x, px(0.)));
+        assert_eq!(point.nearest_valid, target_point);
+    }
+
+    #[gpui::test]
     fn test_navigation_overlay_covered_text_highlights_are_replaced(cx: &mut TestAppContext) {
         init_test(cx, |_| {});
         let window = cx.add_window(|window, cx| {


### PR DESCRIPTION
Fixes editor hit testing when the editor is clipped, most easily noticeable in a partially off-screen markdown block in the agent panel.

`PositionMap::point_for_position` was indexing into `self.line_layouts` relative to the editor's scroll position (which in this example doesn't apply because these editors don't scroll), rather than relative to `self.visible_row_range.start`. This caused the reported column to not always be computed using the correct row, which especially impacted rows closer to the bottom of the editor. Notice how closer to the bottom, `point_for_position` reports the correct row, but reports the column as 0:

https://github.com/user-attachments/assets/2a5b2c8b-2994-4983-a33b-ede209ba00e6




Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixes selection not always matching the mouse position in a markdown block in the agent panel
