### PR TITLE
Fix activity indicator menu opening when actions are running

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -712,7 +712,7 @@ impl Render for ActivityIndicator {
                                     has_cancellable_work = true;
                                     let language_server_id = work.language_server_id;
                                     let token = work.progress_token.clone();
-                                    let title = SharedString::from(title);
+                                    let title = SharedString::from(format!("Cancel {title}"));
                                     menu = menu.custom_entry(
                                         move |_, _| {
                                             h_flex()
@@ -720,7 +720,7 @@ impl Render for ActivityIndicator {
                                                 .gap_1()
                                                 .child(
                                                     Icon::new(IconName::Close)
-                                                        .color(Color::Error)
+                                                        .color(Color::Muted)
                                                         .size(IconSize::Small),
                                                 )
                                                 .child(Label::new(title.clone()))

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -377,7 +377,7 @@ impl ActivityIndicator {
                 return Some(Content {
                     icon: ActivityIcon::LoadingSpinner,
                     message,
-                    on_click: Some(Arc::new(Self::toggle_language_server_work_context_menu)),
+                    on_click: None,
                     tooltip_message: None,
                 });
             }
@@ -639,14 +639,6 @@ impl ActivityIndicator {
 
         None
     }
-
-    fn toggle_language_server_work_context_menu(
-        &mut self,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.context_menu_handle.toggle(window, cx);
-    }
 }
 
 impl EventEmitter<Event> for ActivityIndicator {}
@@ -659,15 +651,16 @@ impl Render for ActivityIndicator {
             .id("activity-indicator")
             .on_action(cx.listener(Self::show_error_message))
             .on_action(cx.listener(Self::dismiss_message));
+
         let Some(content) = self.content_to_render(cx) else {
             return result;
         };
+
         let activity_indicator = cx.entity().downgrade();
         let truncate_content = content.message.len() > MAX_MESSAGE_LEN;
-
         let has_click_handler = content.on_click.is_some();
 
-        result.gap_2().child(
+        result.child(
             PopoverMenu::new("activity-indicator-popover")
                 .trigger(
                     Button::new("activity-indicator-trigger", {
@@ -705,10 +698,9 @@ impl Render for ActivityIndicator {
                 .when(!has_click_handler, |this| {
                     this.menu(move |window, cx| {
                         let strong_this = activity_indicator.upgrade()?;
-                        let mut has_work = false;
+                        let mut has_cancellable_work = false;
                         let menu = ContextMenu::build(window, cx, |mut menu, _, cx| {
                             for work in strong_this.read(cx).pending_language_server_work(cx) {
-                                has_work = true;
                                 let activity_indicator = activity_indicator.clone();
                                 let mut title = work
                                     .progress
@@ -717,6 +709,7 @@ impl Render for ActivityIndicator {
                                     .unwrap_or(work.progress_token.to_string());
 
                                 if work.progress.is_cancellable {
+                                    has_cancellable_work = true;
                                     let language_server_id = work.language_server_id;
                                     let token = work.progress_token.clone();
                                     let title = SharedString::from(title);
@@ -724,9 +717,13 @@ impl Render for ActivityIndicator {
                                         move |_, _| {
                                             h_flex()
                                                 .w_full()
-                                                .justify_between()
+                                                .gap_1()
+                                                .child(
+                                                    Icon::new(IconName::Close)
+                                                        .color(Color::Error)
+                                                        .size(IconSize::Small),
+                                                )
                                                 .child(Label::new(title.clone()))
-                                                .child(Icon::new(IconName::XCircle))
                                                 .into_any_element()
                                         },
                                         move |_, cx| {
@@ -760,7 +757,7 @@ impl Render for ActivityIndicator {
                             }
                             menu
                         });
-                        has_work.then_some(menu)
+                        has_cancellable_work.then_some(menu)
                     })
                 }),
         )


### PR DESCRIPTION
The fix comes based on that if the button is already wrapped in the popover menu, it doesn't need to have a click handler for the menu to open!

Release Notes:

- FIxed bug where the activity indicator in the status bar wouldn't open a menu with menu items to cancel running actions.
