### PR TITLE
Handle MCP resource content in tool call results

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -5207,13 +5207,20 @@ fn mcp_message_content_to_acp_content_block(
         context_server::types::MessageContent::Resource {
             resource,
             annotations: _,
-        } => {
-            let mut link =
-                acp::ResourceLink::new(resource.uri.to_string(), resource.uri.to_string());
-            if let Some(mime_type) = resource.mime_type {
-                link = link.mime_type(mime_type);
+        } => match resource {
+            context_server::types::ResourceContentsType::Text(text_resource) => {
+                text_resource.text.into()
             }
-            acp::ContentBlock::ResourceLink(link)
-        }
+            context_server::types::ResourceContentsType::Blob(blob_resource) => {
+                let mut link = acp::ResourceLink::new(
+                    blob_resource.uri.to_string(),
+                    blob_resource.uri.to_string(),
+                );
+                if let Some(mime_type) = blob_resource.mime_type {
+                    link = link.mime_type(mime_type);
+                }
+                acp::ContentBlock::ResourceLink(link)
+            }
+        },
     }
 }

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -1705,6 +1705,135 @@ async fn test_mcp_tool_multi_content_response(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_mcp_tool_resource_content_response(cx: &mut TestAppContext) {
+    let ThreadTest {
+        model,
+        thread,
+        context_server_store,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    fs.insert_file(
+        paths::settings_file(),
+        json!({
+            "agent": {
+                "tool_permissions": { "default": "allow" },
+                "profiles": {
+                    "test": {
+                        "name": "Test Profile",
+                        "enable_all_context_servers": true,
+                        "tools": {}
+                    },
+                }
+            }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    cx.run_until_parked();
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test".into()), cx)
+    });
+
+    let mut mcp_tool_calls = setup_context_server(
+        "github_server",
+        vec![context_server::types::Tool {
+            name: "get_file_contents".into(),
+            title: None,
+            description: Some("Get file contents from a repository".into()),
+            input_schema: json!({"type": "object", "properties": {}}),
+            output_schema: None,
+            annotations: None,
+        }],
+        &context_server_store,
+        cx,
+    );
+
+    let events = thread.update(cx, |thread, cx| {
+        thread
+            .send(UserMessageId::new(), ["Get the file contents"], cx)
+            .unwrap()
+    });
+    cx.run_until_parked();
+
+    let completion = fake_model.pending_completions().pop().unwrap();
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "tool_1".into(),
+            name: "get_file_contents".into(),
+            raw_input: json!({}).to_string(),
+            input: json!({}),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+    let _ = completion;
+
+    let (tool_call_params, tool_call_response) = mcp_tool_calls.next().await.unwrap();
+    assert_eq!(tool_call_params.name, "get_file_contents");
+
+    // Simulate the response from github-mcp-server: a text block plus a resource block
+    tool_call_response
+        .send(context_server::types::CallToolResponse {
+            content: vec![
+                context_server::types::ToolResponseContent::Text {
+                    text: "successfully downloaded text file".into(),
+                },
+                context_server::types::ToolResponseContent::Resource {
+                    resource: context_server::types::ResourceContentsType::Text(
+                        context_server::types::TextResourceContents {
+                            uri: url::Url::parse("repo://owner/repo/contents/path/to/file.py")
+                                .unwrap(),
+                            mime_type: Some("text/plain; charset=utf-8".into()),
+                            text: "def hello():\n    print(\"hello world\")\n".into(),
+                        },
+                    ),
+                },
+            ],
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    // Verify both the text and resource content are surfaced to the model
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let tool_result = completion
+        .messages
+        .last()
+        .unwrap()
+        .content
+        .iter()
+        .find_map(|c| match c {
+            MessageContent::ToolResult(r) => Some(r.clone()),
+            _ => None,
+        })
+        .expect("expected a tool result");
+    assert_eq!(tool_result.tool_use_id, "tool_1".into());
+    assert_eq!(tool_result.content.len(), 2);
+    assert_eq!(
+        tool_result.content[0],
+        language_model::LanguageModelToolResultContent::Text(Arc::from(
+            "successfully downloaded text file"
+        ))
+    );
+    assert_eq!(
+        tool_result.content[1],
+        language_model::LanguageModelToolResultContent::Text(Arc::from(
+            "def hello():\n    print(\"hello world\")\n"
+        ))
+    );
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+}
+
+#[gpui::test]
 async fn test_mcp_tool_result_displayed_when_server_disconnected(cx: &mut TestAppContext) {
     let ThreadTest {
         model,

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -407,8 +407,21 @@ impl AnyAgentTool for ContextServerTool {
                     context_server::types::ToolResponseContent::Audio { .. } => {
                         log::warn!("Ignoring audio content from tool response");
                     }
-                    context_server::types::ToolResponseContent::Resource { .. } => {
-                        log::warn!("Ignoring resource content from tool response");
+                    context_server::types::ToolResponseContent::Resource { resource } => {
+                        match resource {
+                            context_server::types::ResourceContentsType::Text(text_resource) => {
+                                concatenated_text.push_str(&text_resource.text);
+                                llm_output.push(LanguageModelToolResultContent::Text(
+                                    text_resource.text.into(),
+                                ));
+                            }
+                            context_server::types::ResourceContentsType::Blob(blob_resource) => {
+                                concatenated_text.push_str(&blob_resource.blob);
+                                llm_output.push(LanguageModelToolResultContent::Text(
+                                    blob_resource.blob.into(),
+                                ));
+                            }
+                        }
                     }
                     context_server::types::ToolResponseContent::ResourceLink { .. } => {
                         log::warn!("Ignoring resource link content from tool response");

--- a/crates/context_server/src/types.rs
+++ b/crates/context_server/src/types.rs
@@ -381,7 +381,7 @@ pub enum MessageContent {
     },
     #[serde(rename = "resource")]
     Resource {
-        resource: ResourceContents,
+        resource: ResourceContentsType,
         #[serde(skip_serializing_if = "Option::is_none")]
         annotations: Option<MessageAnnotations>,
     },
@@ -748,7 +748,7 @@ pub enum ToolResponseContent {
     #[serde(rename = "audio", rename_all = "camelCase")]
     Audio { data: String, mime_type: String },
     #[serde(rename = "resource")]
-    Resource { resource: ResourceContents },
+    Resource { resource: ResourceContentsType },
     /// Link to an MCP resource on the server, without inlining its contents.
     /// Added in MCP 2025-06-18.
     #[serde(rename = "resource_link", rename_all = "camelCase")]
@@ -808,4 +808,86 @@ pub struct Root {
     pub uri: Url,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_tool_response_with_resource_text() {
+        // This is the exact JSON shape returned by github-mcp-server v0.5.0+
+        let json = serde_json::json!({
+            "content": [
+                {"type": "text", "text": "successfully downloaded text file"},
+                {"type": "resource", "resource": {
+                    "uri": "repo://owner/repo/contents/path/to/file.py",
+                    "mimeType": "text/plain; charset=utf-8",
+                    "text": "def hello():\n    print(\"hello world\")\n"
+                }}
+            ]
+        });
+
+        let response: CallToolResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(response.content.len(), 2);
+
+        match &response.content[0] {
+            ToolResponseContent::Text { text } => {
+                assert_eq!(text, "successfully downloaded text file");
+            }
+            other => panic!("expected Text, got {:?}", other),
+        }
+
+        match &response.content[1] {
+            ToolResponseContent::Resource { resource } => match resource {
+                ResourceContentsType::Text(text_resource) => {
+                    assert_eq!(
+                        text_resource.uri.as_str(),
+                        "repo://owner/repo/contents/path/to/file.py"
+                    );
+                    assert_eq!(
+                        text_resource.mime_type.as_deref(),
+                        Some("text/plain; charset=utf-8")
+                    );
+                    assert_eq!(
+                        text_resource.text,
+                        "def hello():\n    print(\"hello world\")\n"
+                    );
+                }
+                other => panic!("expected Text resource, got {:?}", other),
+            },
+            other => panic!("expected Resource, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_tool_response_with_resource_blob() {
+        let json = serde_json::json!({
+            "content": [
+                {"type": "resource", "resource": {
+                    "uri": "repo://owner/repo/contents/image.png",
+                    "mimeType": "image/png",
+                    "blob": "iVBORw0KGgoAAAANSUhEUg=="
+                }}
+            ]
+        });
+
+        let response: CallToolResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(response.content.len(), 1);
+
+        match &response.content[0] {
+            ToolResponseContent::Resource { resource } => match resource {
+                ResourceContentsType::Blob(blob_resource) => {
+                    assert_eq!(
+                        blob_resource.uri.as_str(),
+                        "repo://owner/repo/contents/image.png"
+                    );
+                    assert_eq!(blob_resource.mime_type.as_deref(), Some("image/png"));
+                    assert_eq!(blob_resource.blob, "iVBORw0KGgoAAAANSUhEUg==");
+                }
+                other => panic!("expected Blob resource, got {:?}", other),
+            },
+            other => panic!("expected Resource, got {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
When MCP servers return tool call results containing `type: "resource"` content blocks (as defined in MCP spec 2025-03-26), the embedded text or blob content is silently dropped. This affects `github-mcp-server` v0.5.0+ and any other server using `EmbeddedResource` in tool responses.

## The problem

Two issues combine to cause this:

1. **Wrong deserialization type:** `ToolResponseContent::Resource` and `MessageContent::Resource` use `ResourceContents` (which only has `uri` + `mimeType`). The MCP spec's embedded resource actually includes `text` or `blob` content, but serde silently discards these fields during deserialization since they aren't in the struct.

2. **Explicit discard in handler:** Even if deserialized correctly, the handler in `context_server_registry.rs` was explicitly ignoring resource content with `log::warn!("Ignoring resource content from tool response")`.

The result is that when `github-mcp-server`'s `get_file_contents` tool returns a response like:

```json
{
  "content": [
    {"type": "text", "text": "successfully downloaded text file"},
    {"type": "resource", "resource": {
      "uri": "repo://owner/repo/contents/path/to/file.py",
      "mimeType": "text/plain; charset=utf-8",
      "text": "actual file content here..."
    }}
  ]
}
```

...the model only ever sees `"successfully downloaded text file"`. The actual file content is lost.

## The fix

- Changed `ToolResponseContent::Resource` and `MessageContent::Resource` to use `ResourceContentsType` (the existing untagged enum of `TextResourceContents` / `BlobResourceContents`) which correctly deserializes the `text` or `blob` field.
- Updated the tool response handler to extract text/blob content and surface it to the model.
- Updated `mcp_message_content_to_acp_content_block` to inline text resource content directly (blob resources remain as resource links).

Reference: https://github.com/github/github-mcp-server/issues/607

Release Notes:

- Fixed MCP tool responses containing `resource` content blocks (e.g. from github-mcp-server) being silently dropped instead of surfaced to the model
