### PR TITLE
git: Kill git blame process on task drop

### DIFF
--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -63,6 +63,7 @@ async fn run_git_blame(
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .kill_on_drop(true)
             .spawn()
             .context("starting git blame process")?
     };


### PR DESCRIPTION
We replace these tasks often, so we should clean up after ourselves
here.

Release Notes:

- git: Fix git blame processes not getting dropped properly.
