### PR TITLE
collab: Remove unused fields from database user model

### DIFF
--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -3,16 +3,10 @@ use super::*;
 impl Database {
     /// Creates a new user.
     #[cfg(feature = "test-support")]
-    pub async fn create_user(
-        &self,
-        email_address: &str,
-        admin: bool,
-        params: NewUserParams,
-    ) -> Result<NewUserResult> {
+    pub async fn create_user(&self, admin: bool, params: NewUserParams) -> Result<NewUserResult> {
         self.transaction(|tx| async {
             let tx = tx;
             let user = user::Entity::insert(user::ActiveModel {
-                email_address: ActiveValue::set(Some(email_address.into())),
                 github_login: ActiveValue::set(params.github_login.clone()),
                 github_user_id: ActiveValue::set(params.github_user_id),
                 admin: ActiveValue::set(admin),
@@ -20,11 +14,7 @@ impl Database {
             })
             .on_conflict(
                 OnConflict::column(user::Column::GithubUserId)
-                    .update_columns([
-                        user::Column::Admin,
-                        user::Column::EmailAddress,
-                        user::Column::GithubLogin,
-                    ])
+                    .update_columns([user::Column::Admin, user::Column::GithubLogin])
                     .to_owned(),
             )
             .exec_with_returning(&*tx)

--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -6,7 +6,6 @@ impl Database {
     pub async fn create_user(
         &self,
         email_address: &str,
-        name: Option<&str>,
         admin: bool,
         params: NewUserParams,
     ) -> Result<NewUserResult> {
@@ -14,7 +13,6 @@ impl Database {
             let tx = tx;
             let user = user::Entity::insert(user::ActiveModel {
                 email_address: ActiveValue::set(Some(email_address.into())),
-                name: ActiveValue::set(name.map(|s| s.into())),
                 github_login: ActiveValue::set(params.github_login.clone()),
                 github_user_id: ActiveValue::set(params.github_user_id),
                 admin: ActiveValue::set(admin),

--- a/crates/collab/src/db/tables/user.rs
+++ b/crates/collab/src/db/tables/user.rs
@@ -1,5 +1,4 @@
 use crate::db::UserId;
-use chrono::NaiveDateTime;
 use sea_orm::entity::prelude::*;
 use serde::Serialize;
 
@@ -15,7 +14,6 @@ pub struct Model {
     pub name: Option<String>,
     pub admin: bool,
     pub connected_once: bool,
-    pub created_at: NaiveDateTime,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/collab/src/db/tables/user.rs
+++ b/crates/collab/src/db/tables/user.rs
@@ -10,7 +10,7 @@ pub struct Model {
     pub id: UserId,
     pub github_login: String,
     pub github_user_id: i32,
-    pub email_address: Option<String>,
+    // pub email_address: Option<String>,
     pub admin: bool,
     pub connected_once: bool,
 }

--- a/crates/collab/src/db/tables/user.rs
+++ b/crates/collab/src/db/tables/user.rs
@@ -11,7 +11,6 @@ pub struct Model {
     pub id: UserId,
     pub github_login: String,
     pub github_user_id: i32,
-    pub github_user_created_at: Option<NaiveDateTime>,
     pub email_address: Option<String>,
     pub name: Option<String>,
     pub admin: bool,

--- a/crates/collab/src/db/tables/user.rs
+++ b/crates/collab/src/db/tables/user.rs
@@ -10,7 +10,6 @@ pub struct Model {
     pub id: UserId,
     pub github_login: String,
     pub github_user_id: i32,
-    // pub email_address: Option<String>,
     pub admin: bool,
     pub connected_once: bool,
 }

--- a/crates/collab/src/db/tables/user.rs
+++ b/crates/collab/src/db/tables/user.rs
@@ -11,7 +11,6 @@ pub struct Model {
     pub github_login: String,
     pub github_user_id: i32,
     pub email_address: Option<String>,
-    pub name: Option<String>,
     pub admin: bool,
     pub connected_once: bool,
 }

--- a/crates/collab/tests/integration/db_tests.rs
+++ b/crates/collab/tests/integration/db_tests.rs
@@ -210,7 +210,6 @@ static GITHUB_USER_ID: AtomicI32 = AtomicI32::new(5);
 async fn new_test_user(db: &Arc<Database>, email: &str) -> UserId {
     db.create_user(
         email,
-        None,
         false,
         NewUserParams {
             github_login: email[0..email.find('@').unwrap()].to_string(),

--- a/crates/collab/tests/integration/db_tests.rs
+++ b/crates/collab/tests/integration/db_tests.rs
@@ -209,7 +209,6 @@ static GITHUB_USER_ID: AtomicI32 = AtomicI32::new(5);
 
 async fn new_test_user(db: &Arc<Database>, email: &str) -> UserId {
     db.create_user(
-        email,
         false,
         NewUserParams {
             github_login: email[0..email.find('@').unwrap()].to_string(),

--- a/crates/collab/tests/integration/db_tests/buffer_tests.rs
+++ b/crates/collab/tests/integration/db_tests/buffer_tests.rs
@@ -13,7 +13,6 @@ test_both_dbs!(
 async fn test_channel_buffers(db: &Arc<Database>) {
     let a_id = db
         .create_user(
-            "user_a@example.com",
             false,
             NewUserParams {
                 github_login: "user_a".into(),
@@ -25,7 +24,6 @@ async fn test_channel_buffers(db: &Arc<Database>) {
         .user_id;
     let b_id = db
         .create_user(
-            "user_b@example.com",
             false,
             NewUserParams {
                 github_login: "user_b".into(),
@@ -39,7 +37,6 @@ async fn test_channel_buffers(db: &Arc<Database>) {
     // This user will not be a part of the channel
     let c_id = db
         .create_user(
-            "user_c@example.com",
             false,
             NewUserParams {
                 github_login: "user_c".into(),
@@ -185,7 +182,6 @@ test_both_dbs!(
 async fn test_channel_buffers_last_operations(db: &Database) {
     let user_id = db
         .create_user(
-            "user_a@example.com",
             false,
             NewUserParams {
                 github_login: "user_a".into(),
@@ -197,7 +193,6 @@ async fn test_channel_buffers_last_operations(db: &Database) {
         .user_id;
     let observer_id = db
         .create_user(
-            "user_b@example.com",
             false,
             NewUserParams {
                 github_login: "user_b".into(),

--- a/crates/collab/tests/integration/db_tests/buffer_tests.rs
+++ b/crates/collab/tests/integration/db_tests/buffer_tests.rs
@@ -14,7 +14,6 @@ async fn test_channel_buffers(db: &Arc<Database>) {
     let a_id = db
         .create_user(
             "user_a@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "user_a".into(),
@@ -27,7 +26,6 @@ async fn test_channel_buffers(db: &Arc<Database>) {
     let b_id = db
         .create_user(
             "user_b@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "user_b".into(),
@@ -42,7 +40,6 @@ async fn test_channel_buffers(db: &Arc<Database>) {
     let c_id = db
         .create_user(
             "user_c@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "user_c".into(),
@@ -189,7 +186,6 @@ async fn test_channel_buffers_last_operations(db: &Database) {
     let user_id = db
         .create_user(
             "user_a@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "user_a".into(),
@@ -202,7 +198,6 @@ async fn test_channel_buffers_last_operations(db: &Database) {
     let observer_id = db
         .create_user(
             "user_b@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "user_b".into(),

--- a/crates/collab/tests/integration/db_tests/channel_tests.rs
+++ b/crates/collab/tests/integration/db_tests/channel_tests.rs
@@ -263,7 +263,6 @@ async fn test_channel_renames(db: &Arc<Database>) {
 
     let user_1 = db
         .create_user(
-            "user1@example.com",
             false,
             NewUserParams {
                 github_login: "user1".into(),
@@ -276,7 +275,6 @@ async fn test_channel_renames(db: &Arc<Database>) {
 
     let user_2 = db
         .create_user(
-            "user2@example.com",
             false,
             NewUserParams {
                 github_login: "user2".into(),
@@ -312,7 +310,6 @@ test_both_dbs!(
 async fn test_db_channel_moving(db: &Arc<Database>) {
     let a_id = db
         .create_user(
-            "user1@example.com",
             false,
             NewUserParams {
                 github_login: "user1".into(),
@@ -401,7 +398,6 @@ test_both_dbs!(
 async fn test_channel_reordering(db: &Arc<Database>) {
     let admin_id = db
         .create_user(
-            "admin@example.com",
             false,
             NewUserParams {
                 github_login: "admin".into(),
@@ -414,7 +410,6 @@ async fn test_channel_reordering(db: &Arc<Database>) {
 
     let user_id = db
         .create_user(
-            "user@example.com",
             false,
             NewUserParams {
                 github_login: "user".into(),
@@ -594,7 +589,6 @@ test_both_dbs!(
 async fn test_db_channel_moving_bugs(db: &Arc<Database>) {
     let user_id = db
         .create_user(
-            "user1@example.com",
             false,
             NewUserParams {
                 github_login: "user1".into(),

--- a/crates/collab/tests/integration/db_tests/channel_tests.rs
+++ b/crates/collab/tests/integration/db_tests/channel_tests.rs
@@ -264,7 +264,6 @@ async fn test_channel_renames(db: &Arc<Database>) {
     let user_1 = db
         .create_user(
             "user1@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "user1".into(),
@@ -278,7 +277,6 @@ async fn test_channel_renames(db: &Arc<Database>) {
     let user_2 = db
         .create_user(
             "user2@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "user2".into(),
@@ -315,7 +313,6 @@ async fn test_db_channel_moving(db: &Arc<Database>) {
     let a_id = db
         .create_user(
             "user1@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "user1".into(),
@@ -405,7 +402,6 @@ async fn test_channel_reordering(db: &Arc<Database>) {
     let admin_id = db
         .create_user(
             "admin@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "admin".into(),
@@ -419,7 +415,6 @@ async fn test_channel_reordering(db: &Arc<Database>) {
     let user_id = db
         .create_user(
             "user@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "user".into(),
@@ -600,7 +595,6 @@ async fn test_db_channel_moving_bugs(db: &Arc<Database>) {
     let user_id = db
         .create_user(
             "user1@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "user1".into(),

--- a/crates/collab/tests/integration/db_tests/db_tests.rs
+++ b/crates/collab/tests/integration/db_tests/db_tests.rs
@@ -19,7 +19,6 @@ async fn test_add_contacts(db: &Arc<Database>) {
         user_ids.push(
             db.create_user(
                 &format!("user{i}@example.com"),
-                None,
                 false,
                 NewUserParams {
                     github_login: format!("user{i}"),
@@ -179,7 +178,6 @@ async fn test_project_count(db: &Arc<Database>) {
     let user1 = db
         .create_user(
             "admin@example.com",
-            None,
             true,
             NewUserParams {
                 github_login: "admin".into(),
@@ -191,7 +189,6 @@ async fn test_project_count(db: &Arc<Database>) {
     let user2 = db
         .create_user(
             "user@example.com",
-            None,
             false,
             NewUserParams {
                 github_login: "user".into(),

--- a/crates/collab/tests/integration/db_tests/db_tests.rs
+++ b/crates/collab/tests/integration/db_tests/db_tests.rs
@@ -18,7 +18,6 @@ async fn test_add_contacts(db: &Arc<Database>) {
     for i in 0..3 {
         user_ids.push(
             db.create_user(
-                &format!("user{i}@example.com"),
                 false,
                 NewUserParams {
                     github_login: format!("user{i}"),
@@ -177,7 +176,6 @@ async fn test_project_count(db: &Arc<Database>) {
 
     let user1 = db
         .create_user(
-            "admin@example.com",
             true,
             NewUserParams {
                 github_login: "admin".into(),
@@ -188,7 +186,6 @@ async fn test_project_count(db: &Arc<Database>) {
         .unwrap();
     let user2 = db
         .create_user(
-            "user@example.com",
             false,
             NewUserParams {
                 github_login: "user".into(),

--- a/crates/collab/tests/integration/randomized_test_helpers.rs
+++ b/crates/collab/tests/integration/randomized_test_helpers.rs
@@ -225,7 +225,6 @@ impl<T: RandomizedTest> TestPlan<T> {
                 .app_state
                 .db
                 .create_user(
-                    &format!("{username}@example.com"),
                     false,
                     NewUserParams {
                         github_login: username.clone(),

--- a/crates/collab/tests/integration/randomized_test_helpers.rs
+++ b/crates/collab/tests/integration/randomized_test_helpers.rs
@@ -226,7 +226,6 @@ impl<T: RandomizedTest> TestPlan<T> {
                 .db
                 .create_user(
                     &format!("{username}@example.com"),
-                    None,
                     false,
                     NewUserParams {
                         github_login: username.clone(),


### PR DESCRIPTION
This PR removes some more unused fields from the database user model:

- `github_user_created_at`
- `email_address`
- `name`
- `created_at`

These fields were not being used anywhere, and are nullable/defaulted in the database in tests.

Release Notes:

- N/A
