### PR TITLE
Use a submenu for Copy Tag in Git Graph context menu

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -64,6 +64,7 @@ const LEFT_PADDING: Pixels = px(12.0);
 const LINE_WIDTH: Pixels = px(1.5);
 const RESIZE_HANDLE_WIDTH: f32 = 8.0;
 const COPIED_STATE_DURATION: Duration = Duration::from_secs(2);
+const COMMIT_TAG_LIST_WIDTH_IN_REMS: Rems = rems(10.);
 // Extra vertical breathing room added to the UI line height when computing
 // the git graph's row height, so commit dots and lines have space around them.
 const ROW_VERTICAL_PADDING: Pixels = px(4.0);
@@ -117,7 +118,9 @@ impl Focusable for CommitTagPicker {
 
 impl Render for CommitTagPicker {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(18.)).child(self.picker.clone())
+        v_flex()
+            .w(COMMIT_TAG_LIST_WIDTH_IN_REMS)
+            .child(self.picker.clone())
     }
 }
 
@@ -2120,14 +2123,6 @@ impl GitGraph {
         };
         let sha = commit.data.sha;
         let sha_short = sha.display_short();
-        let tag_names = commit.data.tag_names();
-        let copy_tag_label = "Copy Tag";
-        let copy_tag_label: SharedString = match tag_names.as_slice() {
-            [] => copy_tag_label.into(),
-            [tag_name] => format!("{copy_tag_label}: {tag_name}").into(),
-            _ => format!("{copy_tag_label}…").into(),
-        };
-        let copy_tag_disabled = tag_names.is_empty();
         let git_tasks = self
             .git_task_context(sha, cx)
             .map(|task_context| self.git_context_menu_tasks(&task_context, cx))
@@ -2153,14 +2148,50 @@ impl GitGraph {
                         this.copy_commit_sha(index, cx);
                     }),
                 )
-                .item(
-                    ContextMenuEntry::new(copy_tag_label)
-                        .action(CopyCommitTag.boxed_clone())
-                        .disabled(copy_tag_disabled)
-                        .handler(window.handler_for(&git_graph, move |this, window, cx| {
-                            this.copy_commit_tag(index, window, cx);
-                        })),
-                )
+                .map(|menu| {
+                    let tag_names = commit
+                        .data
+                        .tag_names()
+                        .into_iter()
+                        .map(|tag_name| SharedString::from(tag_name.to_string()))
+                        .collect::<Vec<_>>();
+                    let copy_tag_label = "Copy Tag";
+
+                    match tag_names.as_slice() {
+                        [] => menu.item(
+                            ContextMenuEntry::new(copy_tag_label)
+                                .action(CopyCommitTag.boxed_clone())
+                                .disabled(true),
+                        ),
+                        [tag_name] => {
+                            let tag_name = tag_name.clone();
+                            let label = format!("{copy_tag_label}: {tag_name}");
+                            menu.entry(
+                                label,
+                                Some(CopyCommitTag.boxed_clone()),
+                                move |_window, cx| {
+                                    cx.write_to_clipboard(ClipboardItem::new_string(
+                                        tag_name.to_string(),
+                                    ));
+                                },
+                            )
+                        }
+                        _ => menu.submenu(copy_tag_label, move |menu, _window, _cx| {
+                            let mut menu = menu.fixed_width(COMMIT_TAG_LIST_WIDTH_IN_REMS.into());
+
+                            for tag_name in tag_names.clone() {
+                                let tag_name_to_copy = tag_name.clone();
+
+                                menu = menu.entry(tag_name, None, move |_window, cx| {
+                                    cx.write_to_clipboard(ClipboardItem::new_string(
+                                        tag_name_to_copy.to_string(),
+                                    ));
+                                });
+                            }
+                            menu
+                        }),
+                    }
+                })
                 .when(!git_tasks.is_empty(), |mut menu| {
                     menu = menu.separator().header("Custom Git Commands");
 


### PR DESCRIPTION
The command palette action `git graph: copy commit tag` still deploys a context picker.

<img width="276" height="169" alt="SCR-20260515-mttj" src="https://github.com/user-attachments/assets/635e93eb-8617-4a99-8727-ca32a587d8e2" />

But the context menu now uses a submenu when there are multiple tags:

0 tags:

<img width="383" height="284" alt="SCR-20260515-mtgo" src="https://github.com/user-attachments/assets/b9520725-887e-42ff-910d-08264b2976ba" />

1: tag:

<img width="524" height="298" alt="SCR-20260515-mtmb" src="https://github.com/user-attachments/assets/17eaf2fa-81f2-43d2-9175-ba99be8faa23" />

multiple tags:

<img width="471" height="288" alt="SCR-20260515-mtau" src="https://github.com/user-attachments/assets/881705e3-9281-4be4-9d44-931b4810352a" />

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Improved `Copy Tag` workflow from Git Graph context menu to deploy a submenu instead of a modal picker.
