### PR TITLE
Add a function to produce docs scoped to release channel

### DIFF
--- a/crates/release_channel/src/lib.rs
+++ b/crates/release_channel/src/lib.rs
@@ -7,6 +7,8 @@ use std::{env, str::FromStr, sync::LazyLock};
 use gpui::{App, Global};
 use semver::Version;
 
+const ZED_DOCS_URL: &str = "https://zed.dev/docs";
+
 /// stable | dev | nightly | preview
 pub static RELEASE_CHANNEL_NAME: LazyLock<String> = LazyLock::new(|| {
     if cfg!(debug_assertions) {
@@ -153,6 +155,14 @@ pub fn init_test(app_version: Version, release_channel: ReleaseChannel, cx: &mut
     cx.set_global(GlobalReleaseChannel(release_channel))
 }
 
+/// Returns the Zed docs URL for the current release channel for the given
+/// `slug`.
+pub fn docs_url(slug: &str, cx: &App) -> String {
+    ReleaseChannel::try_global(cx)
+        .unwrap_or(*RELEASE_CHANNEL)
+        .docs_url(slug)
+}
+
 impl ReleaseChannel {
     /// All release channels.
     pub const ALL: [ReleaseChannel; 4] = [
@@ -219,6 +229,23 @@ impl ReleaseChannel {
             Self::Stable => None,
         }
     }
+
+    /// Returns the Zed docs URL for this [`ReleaseChannel`] for the given
+    /// `slug`.
+    pub fn docs_url(&self, slug: &str) -> String {
+        let channel_path_segment = match self {
+            Self::Dev | Self::Nightly => Some("nightly"),
+            Self::Preview => Some("preview"),
+            Self::Stable => None,
+        };
+
+        match channel_path_segment {
+            Some(channel) if slug.is_empty() => format!("{ZED_DOCS_URL}/{channel}"),
+            Some(channel) => format!("{ZED_DOCS_URL}/{channel}/{slug}"),
+            None if slug.is_empty() => ZED_DOCS_URL.to_string(),
+            None => format!("{ZED_DOCS_URL}/{slug}"),
+        }
+    }
 }
 
 /// Error indicating that release channel string does not match any known release channel names.
@@ -236,5 +263,30 @@ impl FromStr for ReleaseChannel {
             "stable" => ReleaseChannel::Stable,
             _ => return Err(InvalidReleaseChannel),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReleaseChannel;
+
+    #[test]
+    fn test_docs_url_for_release_channel() {
+        assert_eq!(
+            ReleaseChannel::Dev.docs_url("settings"),
+            "https://zed.dev/docs/nightly/settings"
+        );
+        assert_eq!(
+            ReleaseChannel::Nightly.docs_url("settings"),
+            "https://zed.dev/docs/nightly/settings"
+        );
+        assert_eq!(
+            ReleaseChannel::Preview.docs_url("settings"),
+            "https://zed.dev/docs/preview/settings"
+        );
+        assert_eq!(
+            ReleaseChannel::Stable.docs_url("settings"),
+            "https://zed.dev/docs/settings"
+        );
     }
 }


### PR DESCRIPTION
Now that we have per-channel docs, it'll be nice to have a method to link to "this" channel's docs when we ship features that link out to them.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- N/A
