### PR TITLE
Make custom git commands more discoverable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7367,6 +7367,7 @@ dependencies = [
  "project",
  "project_panel",
  "rand 0.9.4",
+ "release_channel",
  "remote_connection",
  "search",
  "serde_json",

--- a/crates/git_graph/Cargo.toml
+++ b/crates/git_graph/Cargo.toml
@@ -35,6 +35,7 @@ picker.workspace = true
 project.workspace = true
 project_panel.workspace = true
 rand = { workspace = true, optional = true }
+release_channel.workspace = true
 search.workspace = true
 settings.workspace = true
 smallvec.workspace = true

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -65,6 +65,7 @@ const LINE_WIDTH: Pixels = px(1.5);
 const RESIZE_HANDLE_WIDTH: f32 = 8.0;
 const COPIED_STATE_DURATION: Duration = Duration::from_secs(2);
 const COMMIT_TAG_LIST_WIDTH_IN_REMS: Rems = rems(10.);
+const CUSTOM_GIT_COMMANDS_DOCS_SLUG: &str = "tasks#custom-git-commands";
 // Extra vertical breathing room added to the UI line height when computing
 // the git graph's row height, so commit dots and lines have space around them.
 const ROW_VERTICAL_PADDING: Pixels = px(4.0);
@@ -2192,8 +2193,24 @@ impl GitGraph {
                         }),
                     }
                 })
-                .when(!git_tasks.is_empty(), |mut menu| {
-                    menu = menu.separator().header("Custom Git Commands");
+                .map(|mut menu| {
+                    menu = menu.separator().header("Custom Commands");
+
+                    if git_tasks.is_empty() {
+                        return menu.item(
+                            ContextMenuEntry::new("Learn More")
+                                .icon(IconName::ArrowUpRight)
+                                .icon_color(Color::Muted)
+                                .icon_position(IconPosition::End)
+                                .handler(|_window, cx| {
+                                    let docs_url = release_channel::docs_url(
+                                        CUSTOM_GIT_COMMANDS_DOCS_SLUG,
+                                        cx,
+                                    );
+                                    cx.open_url(&docs_url);
+                                }),
+                        );
+                    }
 
                     for (task_source_kind, resolved_task) in git_tasks {
                         let label = resolved_task.display_label().to_string();


### PR DESCRIPTION
<img width="541" height="245" alt="SCR-20260515-phfs" src="https://github.com/user-attachments/assets/30413912-5c83-49c1-8874-4f987af222d3" />

Might be nice to in the future, have this open a modal to allow inputting, similar to configuring MCP servers, but this is nice quick fix for now.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- N/A
