### PR TITLE
agent_ui: Fix ACP toggle thinking with keybinds and Zed agent thinking traversal

### DIFF
--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -28,6 +28,7 @@ pub struct ConfigOptionsView {
     selectors: Vec<Entity<ConfigOptionSelector>>,
     agent_server: Rc<dyn AgentServer>,
     fs: Arc<dyn Fs>,
+    persist_selected_categories_as_defaults: Vec<acp::SessionConfigOptionCategory>,
     config_option_ids: Vec<acp::SessionConfigId>,
     _refresh_task: Task<()>,
 }
@@ -37,10 +38,18 @@ impl ConfigOptionsView {
         config_options: Rc<dyn AgentSessionConfigOptions>,
         agent_server: Rc<dyn AgentServer>,
         fs: Arc<dyn Fs>,
+        persist_selected_categories_as_defaults: Vec<acp::SessionConfigOptionCategory>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let selectors = Self::build_selectors(&config_options, &agent_server, &fs, window, cx);
+        let selectors = Self::build_selectors(
+            &config_options,
+            &agent_server,
+            &fs,
+            &persist_selected_categories_as_defaults,
+            window,
+            cx,
+        );
         let config_option_ids = Self::config_option_ids(&config_options);
 
         let rx = config_options.watch(cx);
@@ -61,6 +70,7 @@ impl ConfigOptionsView {
             selectors,
             agent_server,
             fs,
+            persist_selected_categories_as_defaults,
             config_option_ids,
             _refresh_task: refresh_task,
         }
@@ -72,7 +82,7 @@ impl ConfigOptionsView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        let Some(config_id) = self.first_config_option_id(category) else {
+        let Some(config_id) = self.first_config_option_id(category.clone()) else {
             return false;
         };
 
@@ -93,13 +103,25 @@ impl ConfigOptionsView {
         favorites_only: bool,
         cx: &mut Context<Self>,
     ) -> bool {
-        let Some(config_id) = self.first_config_option_id(category) else {
+        let Some(config_id) = self.first_config_option_id(category.clone()) else {
             return false;
         };
 
         let Some(next_value) = self.next_value_for_config(&config_id, favorites_only, cx) else {
             return false;
         };
+
+        if self
+            .persist_selected_categories_as_defaults
+            .contains(&category)
+        {
+            self.agent_server.set_default_config_option(
+                config_id.0.as_ref(),
+                Some(next_value.0.as_ref()),
+                self.fs.clone(),
+                cx,
+            );
+        }
 
         let task = self
             .config_options
@@ -191,6 +213,7 @@ impl ConfigOptionsView {
             &self.config_options,
             &self.agent_server,
             &self.fs,
+            &self.persist_selected_categories_as_defaults,
             window,
             cx,
         );
@@ -201,6 +224,7 @@ impl ConfigOptionsView {
         config_options: &Rc<dyn AgentSessionConfigOptions>,
         agent_server: &Rc<dyn AgentServer>,
         fs: &Arc<dyn Fs>,
+        persist_selected_categories_as_defaults: &[acp::SessionConfigOptionCategory],
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Vec<Entity<ConfigOptionSelector>> {
@@ -211,12 +235,17 @@ impl ConfigOptionsView {
                 let config_options = config_options.clone();
                 let agent_server = agent_server.clone();
                 let fs = fs.clone();
+                let should_persist_selected_value_as_default =
+                    option.category.as_ref().is_some_and(|category| {
+                        persist_selected_categories_as_defaults.contains(category)
+                    });
                 cx.new(|cx| {
                     ConfigOptionSelector::new(
                         config_options,
                         option.id.clone(),
                         agent_server,
                         fs,
+                        should_persist_selected_value_as_default,
                         window,
                         cx,
                     )
@@ -253,15 +282,15 @@ impl ConfigOptionSelector {
         config_id: acp::SessionConfigId,
         agent_server: Rc<dyn AgentServer>,
         fs: Arc<dyn Fs>,
+        should_persist_selected_value_as_default: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let option_count = config_options
+        let option = config_options
             .config_options()
-            .iter()
-            .find(|opt| opt.id == config_id)
-            .map(count_config_options)
-            .unwrap_or(0);
+            .into_iter()
+            .find(|opt| opt.id == config_id);
+        let option_count = option.as_ref().map(count_config_options).unwrap_or(0);
 
         let is_searchable = option_count >= PICKER_THRESHOLD;
 
@@ -276,6 +305,7 @@ impl ConfigOptionSelector {
                     config_id,
                     agent_server,
                     fs,
+                    should_persist_selected_value_as_default,
                     window,
                     picker_cx,
                 );
@@ -409,6 +439,7 @@ struct ConfigOptionPickerDelegate {
     config_id: acp::SessionConfigId,
     agent_server: Rc<dyn AgentServer>,
     fs: Arc<dyn Fs>,
+    should_persist_selected_value_as_default: bool,
     filtered_entries: Vec<ConfigOptionPickerEntry>,
     all_options: Vec<ConfigOptionValue>,
     selected_index: usize,
@@ -423,6 +454,7 @@ impl ConfigOptionPickerDelegate {
         config_id: acp::SessionConfigId,
         agent_server: Rc<dyn AgentServer>,
         fs: Arc<dyn Fs>,
+        should_persist_selected_value_as_default: bool,
         window: &mut Window,
         cx: &mut Context<Picker<Self>>,
     ) -> Self {
@@ -459,6 +491,7 @@ impl ConfigOptionPickerDelegate {
             config_id,
             agent_server,
             fs,
+            should_persist_selected_value_as_default,
             filtered_entries,
             all_options,
             selected_index,
@@ -564,6 +597,15 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
                     self.fs.clone(),
                     cx,
                 );
+            } else {
+                if self.should_persist_selected_value_as_default {
+                    self.agent_server.set_default_config_option(
+                        self.config_id.0.as_ref(),
+                        Some(option.value.0.as_ref()),
+                        self.fs.clone(),
+                        cx,
+                    );
+                }
             }
 
             let task = self.config_options.set_config_option(

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1087,7 +1087,14 @@ impl ConversationView {
             let fs = self.project.read(cx).fs().clone();
             config_options_view =
                 Some(cx.new(|cx| {
-                    ConfigOptionsView::new(config_options, agent_server, fs, window, cx)
+                    ConfigOptionsView::new(
+                        config_options,
+                        agent_server,
+                        fs,
+                        vec![acp::SessionConfigOptionCategory::ThoughtLevel],
+                        window,
+                        cx,
+                    )
                 }));
             model_selector = None;
             mode_selector = None;

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -9023,6 +9023,15 @@ impl ThreadView {
 
     fn cycle_thinking_effort(&mut self, cx: &mut Context<Self>) {
         let Some(thread) = self.as_native_thread(cx) else {
+            if let Some(config_options_view) = self.config_options_view.clone() {
+                config_options_view.update(cx, |view, cx| {
+                    view.cycle_category_option(
+                        acp::SessionConfigOptionCategory::ThoughtLevel,
+                        false,
+                        cx,
+                    )
+                });
+            }
             return;
         };
 
@@ -9081,6 +9090,19 @@ impl ThreadView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.as_native_thread(cx).is_none() {
+            if let Some(config_options_view) = self.config_options_view.clone() {
+                config_options_view.update(cx, |view, cx| {
+                    view.toggle_category_picker(
+                        acp::SessionConfigOptionCategory::ThoughtLevel,
+                        window,
+                        cx,
+                    )
+                });
+            }
+            return;
+        }
+
         let menu_handle = self.thinking_effort_menu_handle.clone();
         window.defer(cx, move |window, cx| {
             menu_handle.toggle(window, cx);

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -3908,9 +3908,9 @@ impl ThreadView {
                 .cloned()
         });
 
-        let label = selected
+        let active_effort = selected.clone().or(default_effort_level);
+        let label = active_effort
             .clone()
-            .or(default_effort_level)
             .map_or("Select Effort".into(), |effort| effort.name);
 
         let (label_color, icon) = if self.thinking_effort_menu_handle.is_deployed() {
@@ -3966,11 +3966,16 @@ impl ThreadView {
                 tooltip,
             )
             .menu(move |window, cx| {
-                Some(ContextMenu::build(window, cx, |mut menu, _window, _cx| {
+                Some(ContextMenu::build(window, cx, |mut menu, window, cx| {
                     menu = menu.header("Change Thinking Effort");
+                    let selected_index = active_effort.as_ref().and_then(|active_effort| {
+                        supported_effort_levels
+                            .iter()
+                            .position(|level| level.value == active_effort.value)
+                    });
 
                     for effort_level in supported_effort_levels.clone() {
-                        let is_selected = selected
+                        let is_selected = active_effort
                             .as_ref()
                             .is_some_and(|selected| selected.value == effort_level.value);
                         let entry = ContextMenuEntry::new(effort_level.name)
@@ -4025,6 +4030,13 @@ impl ThreadView {
                                     .ok();
                             }
                         }));
+                    }
+
+                    if let Some(selected_index) = selected_index {
+                        menu.select_first(&menu::SelectFirst, window, cx);
+                        for _ in 0..selected_index {
+                            menu.select_next(&menu::SelectNext, window, cx);
+                        }
                     }
 
                     menu


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #56074

Release Notes:

- Added ability to use cycle thinking mode and open thinking menu keybinds for ACP agents (at least for Codex)
- Fixed the bug where opening the Zed agent's thinking effort panel did not set the current thinking level as active. The new change allows using up and down arrows without having to press the arrows once to select the current mode.

Before: pressing up arrow once does nothing, and the second up arrow changes the thinking mode.
After: pressing up arrow once actually changes


https://github.com/user-attachments/assets/cabcac59-4e5a-4afe-a8a9-834e67bfb7b1


https://github.com/user-attachments/assets/0342f7df-981e-45fa-9499-e8aa118e4c10

