### PR TITLE
dev_container: Do not add `--userns=keep-id` if remote user is root

### DIFF
--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -415,7 +415,9 @@ impl DevContainerManifest {
         Ok(())
     }
 
-    async fn download_feature_and_dockerfile_resources(&mut self) -> Result<(), DevContainerError> {
+    async fn download_feature_and_dockerfile_resources(
+        &mut self,
+    ) -> Result<String, DevContainerError> {
         let dev_container = match &self.config {
             ConfigStatus::Deserialized(_) => {
                 log::error!(
@@ -677,7 +679,7 @@ impl DevContainerManifest {
         self.root_image = Some(root_image);
         self.features_build_info = Some(build_info);
 
-        Ok(())
+        Ok(remote_user)
     }
 
     fn generate_dockerfile_extended(
@@ -872,6 +874,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
     async fn run_dev_container(
         &self,
         build_resources: DevContainerBuildResources,
+        remote_user: &str,
     ) -> Result<DevContainerUp, DevContainerError> {
         let ConfigStatus::VariableParsed(_) = &self.config else {
             log::error!(
@@ -884,7 +887,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
                 self.run_docker_compose(resources).await?
             }
             DevContainerBuildResources::Docker(resources) => {
-                self.run_docker_image(resources).await?
+                self.run_docker_image(resources, remote_user).await?
             }
         };
 
@@ -1827,8 +1830,10 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
     async fn run_docker_image(
         &self,
         build_resources: DockerBuildResources,
+        remote_user: &str,
     ) -> Result<DockerInspect, DevContainerError> {
-        let mut docker_run_command = self.create_docker_run_command(build_resources)?;
+        let mut docker_run_command =
+            self.create_docker_run_command(build_resources, remote_user)?;
 
         let output = self
             .command_runner
@@ -1917,6 +1922,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
     fn create_docker_run_command(
         &self,
         build_resources: DockerBuildResources,
+        remote_user: &str,
     ) -> Result<Command, DevContainerError> {
         let remote_workspace_mount = self.remote_workspace_mount()?;
 
@@ -1955,7 +1961,13 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
                 "--security-opt=label=disable",
                 &mut command,
             );
-            run_if_missing("--userns", "--userns=keep-id", &mut command);
+            if remote_user != "root"
+                && remote_user != "0"
+                && !remote_user.starts_with("root:")
+                && !remote_user.starts_with("0:")
+            {
+                run_if_missing("--userns", "--userns=keep-id", &mut command);
+            }
         }
 
         run_if_missing("--sig-proxy", "--sig-proxy=false", &mut command);
@@ -2025,11 +2037,13 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
 
         self.run_initialize_commands().await?;
 
-        self.download_feature_and_dockerfile_resources().await?;
+        let remote_user = self.download_feature_and_dockerfile_resources().await?;
 
         let build_resources = self.build_resources().await?;
 
-        let devcontainer_up = self.run_dev_container(build_resources).await?;
+        let devcontainer_up = self
+            .run_dev_container(build_resources, &remote_user)
+            .await?;
 
         self.run_remote_scripts(&devcontainer_up, true).await?;
 


### PR DESCRIPTION
When `podman` is used and `remoteUser` is `root` (which usually is the case) and user that runs `podman` is not `root` (which usually is the case) following happens:

* `podman` creates new user inside the container with the same name and the same UID as user ouside of the container.
* Nothing inside the container actually uses this newly created user as `remoteUser` is set to `root`.
* `root` inside the container is idmapped to some random sub-UID outside of the container.
* All files created inside the container are owned by that bogus sub-UID outside.
* This breaks many tools (like git, for example) outside of the devcontainer.

Note that `--userns=keep-id` also overrides the effect of `USER` directive from Dockerfile that was used to build the devcontainer image. ~~Not sure that this affects anything though...~~ (see next comment)

This patch mirrors https://github.com/devcontainers/cli/pull/1018 from the reference implementation.

Also see https://github.com/devcontainers/cli/issues/1004

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Closes https://github.com/zed-industries/zed/issues/54257

Release Notes:

- Fixed permission denied uploading server binary onto Dev Container when Podman is used and `remoteUser` is not set explicitly in `devcontainer.json` (https://github.com/zed-industries/zed/issues/54257)
- Fixed file ownership mismatch between inside and outside of the Dev Container when Podman is used and remote user is `root`.
