### PR TITLE
Add `Fix with Agent` to the code actions menu

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -18,7 +18,7 @@ use db::kvp::{Dismissable, KeyValueStore};
 use itertools::Itertools;
 use project::AgentId;
 use serde::{Deserialize, Serialize};
-use settings::{LanguageModelProviderSetting, LanguageModelSelection};
+use settings: :{LanguageModelProviderSetting, LanguageModelSelection};
 
 use zed_actions::{
     DecreaseBufferFontSize, IncreaseBufferFontSize, ResetBufferFontSize,
@@ -541,6 +541,8 @@ pub fn init(cx: &mut App) {
                 .register_action(
                     |workspace: &mut Workspace, action: &FixDiagnosticWithAgent, window, cx| {
                         let diagnostic_message = action.diagnostic_message.clone();
+                        let diagnostic_source = action.source.clone();
+                        let diagnostic_code = action.code.clone();
 
                         let Some(active_editor) = workspace
                             .active_item(cx)
@@ -571,14 +573,12 @@ pub fn init(cx: &mut App) {
                             return;
                         };
 
-                        let source =
-                            AgentContextSource::from_focused(workspace, window, cx)
-                                .or_else(|| {
-                                    let cached =
-                                        agent_panel.read(cx).last_context_source.clone()?;
-                                    cached.exists(workspace, cx).then_some(cached)
-                                })
-                                .or_else(|| AgentContextSource::from_active(workspace, cx));
+                        let source = AgentContextSource::from_focused(workspace, window, cx)
+                            .or_else(|| {
+                                let cached = agent_panel.read(cx).last_context_source.clone()?;
+                                cached.exists(workspace, cx).then_some(cached)
+                            })
+                            .or_else(|| AgentContextSource::from_active(workspace, cx));
 
                         let Some(source) = source else {
                             return;
@@ -600,6 +600,8 @@ pub fn init(cx: &mut App) {
                                     conversation_view.update(cx, |conversation_view, cx| {
                                         conversation_view.insert_diagnostic_fix(
                                             &diagnostic_message,
+                                            diagnostic_source.as_deref(),
+                                            diagnostic_code.as_deref(),
                                             selection,
                                             window,
                                             cx,
@@ -610,7 +612,7 @@ pub fn init(cx: &mut App) {
                         });
                     },
                 );
-    },
+        },
     )
     .detach();
 }
@@ -3878,7 +3880,11 @@ impl Panel for AgentPanel {
 }
 
 impl AgentPanel {
-    pub(crate) fn ensure_thread_initialized(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    pub(crate) fn ensure_thread_initialized(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if matches!(self.base_view, BaseView::Uninitialized) {
             self.activate_draft(false, AgentThreadSource::AgentPanel, window, cx);
         }
@@ -9650,11 +9656,7 @@ mod tests {
         // Open a draft with a connection that hasn't completed yet (still loading).
         let connection = StubAgentConnection::new();
         panel.update_in(cx, |panel, window, cx| {
-            panel.open_draft_with_server(
-                Rc::new(StubAgentServer::new(connection)),
-                window,
-                cx,
-            );
+            panel.open_draft_with_server(Rc::new(StubAgentServer::new(connection)), window, cx);
         });
         // Do NOT run_until_parked — the draft ConversationView is still in Loading state.
 
@@ -9675,6 +9677,8 @@ mod tests {
 
         cx.dispatch_action(FixDiagnosticWithAgent {
             diagnostic_message: "mismatched types: expected `i32`, found `&str`".into(),
+            source: Some("rust-analyzer".into()),
+            code: Some("E0308".into()),
         });
 
         // Now let the connection complete and the thread view be created.
@@ -9686,7 +9690,7 @@ mod tests {
             let text = editor.text(cx);
             assert!(
                 text.starts_with(
-                    "Fix this diagnostic error:\n\n```\nmismatched types: expected `i32`, found `&str`\n```\n\n"
+                    "Fix this diagnostic error (rust-analyzer E0308):\n\n```\nmismatched types: expected `i32`, found `&str`\n```\n\n"
                 ),
                 "message editor should be pre-filled with fix prompt (loading path), got: {text:?}"
             );
@@ -9745,6 +9749,8 @@ mod tests {
 
         cx.dispatch_action(FixDiagnosticWithAgent {
             diagnostic_message: "mismatched types: expected `i32`, found `&str`".into(),
+            source: Some("rust-analyzer".into()),
+            code: Some("E0308".into()),
         });
 
         cx.run_until_parked();
@@ -9755,7 +9761,7 @@ mod tests {
             let text = editor.text(cx);
             assert!(
                 text.starts_with(
-                    "Fix this diagnostic error:\n\n```\nmismatched types: expected `i32`, found `&str`\n```\n\n"
+                    "Fix this diagnostic error (rust-analyzer E0308):\n\n```\nmismatched types: expected `i32`, found `&str`\n```\n\n"
                 ),
                 "message editor should be pre-filled with fix prompt, got: {text:?}"
             );

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -23,9 +23,9 @@ use settings::{LanguageModelProviderSetting, LanguageModelSelection};
 use zed_actions::{
     DecreaseBufferFontSize, IncreaseBufferFontSize, ResetBufferFontSize,
     agent::{
-        AddSelectionToThread, ConflictContent, OpenSettings, ReauthenticateAgent, ResetAgentZoom,
-        ResetOnboarding, ResolveConflictedFilesWithAgent, ResolveConflictsWithAgent,
-        ReviewBranchDiff,
+        AddSelectionToThread, ConflictContent, FixDiagnosticWithAgent, OpenSettings,
+        ReauthenticateAgent, ResetAgentZoom, ResetOnboarding, ResolveConflictedFilesWithAgent,
+        ResolveConflictsWithAgent, ReviewBranchDiff,
     },
     assistant::{FocusAgent, OpenRulesLibrary, Toggle, ToggleFocus},
 };
@@ -57,7 +57,7 @@ use chrono::{DateTime, Utc};
 use client::UserStore;
 use cloud_api_types::Plan;
 use collections::HashMap;
-use editor::{Editor, MultiBuffer};
+use editor::{Editor, MultiBuffer, SelectionEffects};
 use extension::ExtensionEvents;
 use extension_host::ExtensionStore;
 use fs::Fs;
@@ -536,8 +536,79 @@ pub fn init(cx: &mut App) {
                             });
                         });
                     },
+                )
+                .register_action(
+                    |workspace: &mut Workspace, action: &FixDiagnosticWithAgent, window, cx| {
+                        let diagnostic_message = action.diagnostic_message.clone();
+
+                        let Some(active_editor) = workspace
+                            .active_item(cx)
+                            .and_then(|item| item.act_as::<Editor>(cx))
+                        else {
+                            return;
+                        };
+
+                        // If no selection, auto-select the active diagnostic range so
+                        // the context mention covers the relevant code.
+                        active_editor.update(cx, |editor, cx| {
+                            let display_snapshot = editor.display_snapshot(cx);
+                            if !editor.has_non_empty_selection(&display_snapshot) {
+                                if let Some(range) = editor.active_diagnostic_range() {
+                                    editor.change_selections(
+                                        SelectionEffects::no_scroll(),
+                                        window,
+                                        cx,
+                                        |s| {
+                                            s.select_anchor_ranges([range]);
+                                        },
+                                    );
+                                }
+                            }
+                        });
+
+                        let Some(agent_panel) = workspace.panel::<AgentPanel>(cx) else {
+                            return;
+                        };
+
+                        let source =
+                            AgentContextSource::from_focused(workspace, window, cx)
+                                .or_else(|| {
+                                    let cached =
+                                        agent_panel.read(cx).last_context_source.clone()?;
+                                    cached.exists(workspace, cx).then_some(cached)
+                                })
+                                .or_else(|| AgentContextSource::from_active(workspace, cx));
+
+                        let Some(source) = source else {
+                            return;
+                        };
+
+                        let Some(selection) = source.read_selection(workspace, true, cx) else {
+                            return;
+                        };
+
+                        if !agent_panel.focus_handle(cx).contains_focused(window, cx) {
+                            workspace.toggle_panel_focus::<AgentPanel>(window, cx);
+                        }
+
+                        agent_panel.update(cx, |panel, cx| {
+                            panel.last_context_source = Some(source);
+                            cx.defer_in(window, move |panel, window, cx| {
+                                if let Some(conversation_view) = panel.active_conversation_view() {
+                                    conversation_view.update(cx, |conversation_view, cx| {
+                                        conversation_view.insert_diagnostic_fix(
+                                            &diagnostic_message,
+                                            selection,
+                                            window,
+                                            cx,
+                                        );
+                                    });
+                                }
+                            });
+                        });
+                    },
                 );
-        },
+    },
     )
     .detach();
 }
@@ -5247,6 +5318,7 @@ mod tests {
     use acp_thread::{AgentConnection, StubAgentConnection, ThreadStatus, UserMessageId};
     use action_log::ActionLog;
     use anyhow::{Result, anyhow};
+    use editor::MultiBufferOffset;
     use feature_flags::FeatureFlagAppExt;
     use fs::FakeFs;
     use gpui::{App, TestAppContext, VisualTestContext};
@@ -9540,6 +9612,75 @@ mod tests {
             assert!(
                 panel.active_agent_thread(cx).is_some(),
                 "panel should have an active, connected agent thread"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_fix_diagnostic_with_agent_prefills_message_editor(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+        fs.insert_tree("/project", json!({ "main.rs": "fn foo() { let x = 1; }" }))
+            .await;
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |mw, _cx| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        // Create the panel and register it with the workspace so
+        // workspace.panel::<AgentPanel>() resolves correctly in the action handler.
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, None, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        let connection = StubAgentConnection::new();
+        open_thread_with_connection(&panel, connection, cx);
+
+        // Open a file editor with a text selection as the agent context source.
+        let buffer = project.update(cx, |project, cx| {
+            project.create_local_buffer("fn foo() { let x = 1; }", None, false, cx)
+        });
+        workspace.update_in(cx, |workspace, window, cx| {
+            let editor = cx.new(|cx| {
+                let mut editor =
+                    Editor::for_buffer(buffer.clone(), Some(project.clone()), window, cx);
+                editor.change_selections(Default::default(), window, cx, |s| {
+                    s.select_ranges([MultiBufferOffset(11)..MultiBufferOffset(22)]);
+                });
+                editor
+            });
+            workspace.add_item_to_active_pane(Box::new(editor), None, true, window, cx);
+        });
+
+        cx.run_until_parked();
+
+        cx.dispatch_action(FixDiagnosticWithAgent {
+            diagnostic_message: "mismatched types: expected `i32`, found `&str`".into(),
+        });
+
+        cx.run_until_parked();
+
+        let thread_view = panel.read_with(cx, |panel, cx| panel.active_thread_view(cx).unwrap());
+        let message_editor = thread_view.read_with(cx, |view, _cx| view.message_editor.clone());
+        message_editor.read_with(cx, |editor, cx| {
+            let text = editor.text(cx);
+            assert!(
+                text.starts_with(
+                    "Fix this diagnostic error:\n\n```\nmismatched types: expected `i32`, found `&str`\n```\n\n"
+                ),
+                "message editor should be pre-filled with fix prompt, got: {text:?}"
             );
         });
     }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -527,6 +527,7 @@ pub fn init(cx: &mut App) {
 
                         agent_panel.update(cx, |panel, cx| {
                             panel.last_context_source = Some(source);
+                            panel.ensure_thread_initialized(window, cx);
                             cx.defer_in(window, move |panel, window, cx| {
                                 if let Some(conversation_view) = panel.active_conversation_view() {
                                     conversation_view.update(cx, |conversation_view, cx| {
@@ -593,6 +594,7 @@ pub fn init(cx: &mut App) {
 
                         agent_panel.update(cx, |panel, cx| {
                             panel.last_context_source = Some(source);
+                            panel.ensure_thread_initialized(window, cx);
                             cx.defer_in(window, move |panel, window, cx| {
                                 if let Some(conversation_view) = panel.active_conversation_view() {
                                     conversation_view.update(cx, |conversation_view, cx| {
@@ -3876,7 +3878,7 @@ impl Panel for AgentPanel {
 }
 
 impl AgentPanel {
-    fn ensure_thread_initialized(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    pub(crate) fn ensure_thread_initialized(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if matches!(self.base_view, BaseView::Uninitialized) {
             self.activate_draft(false, AgentThreadSource::AgentPanel, window, cx);
         }
@@ -9612,6 +9614,81 @@ mod tests {
             assert!(
                 panel.active_agent_thread(cx).is_some(),
                 "panel should have an active, connected agent thread"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_fix_diagnostic_with_agent_prefills_message_editor_while_loading(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+        fs.insert_tree("/project", json!({ "main.rs": "fn foo() { let x = 1; }" }))
+            .await;
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |mw, _cx| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, None, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        // Open a draft with a connection that hasn't completed yet (still loading).
+        let connection = StubAgentConnection::new();
+        panel.update_in(cx, |panel, window, cx| {
+            panel.open_draft_with_server(
+                Rc::new(StubAgentServer::new(connection)),
+                window,
+                cx,
+            );
+        });
+        // Do NOT run_until_parked — the draft ConversationView is still in Loading state.
+
+        let buffer = project.update(cx, |project, cx| {
+            project.create_local_buffer("fn foo() { let x = 1; }", None, false, cx)
+        });
+        workspace.update_in(cx, |workspace, window, cx| {
+            let editor = cx.new(|cx| {
+                let mut editor =
+                    Editor::for_buffer(buffer.clone(), Some(project.clone()), window, cx);
+                editor.change_selections(Default::default(), window, cx, |s| {
+                    s.select_ranges([MultiBufferOffset(11)..MultiBufferOffset(22)]);
+                });
+                editor
+            });
+            workspace.add_item_to_active_pane(Box::new(editor), None, true, window, cx);
+        });
+
+        cx.dispatch_action(FixDiagnosticWithAgent {
+            diagnostic_message: "mismatched types: expected `i32`, found `&str`".into(),
+        });
+
+        // Now let the connection complete and the thread view be created.
+        cx.run_until_parked();
+
+        let thread_view = panel.read_with(cx, |panel, cx| panel.active_thread_view(cx).unwrap());
+        let message_editor = thread_view.read_with(cx, |view, _cx| view.message_editor.clone());
+        message_editor.read_with(cx, |editor, cx| {
+            let text = editor.text(cx);
+            assert!(
+                text.starts_with(
+                    "Fix this diagnostic error:\n\n```\nmismatched types: expected `i32`, found `&str`\n```\n\n"
+                ),
+                "message editor should be pre-filled with fix prompt (loading path), got: {text:?}"
             );
         });
     }

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -509,7 +509,16 @@ pub struct ConversationView {
     /// causes mermaid diagrams to re-render).
     last_theme_id: Option<String>,
     draft_prompt_persist_task: Option<Task<()>>,
+    pending_editor_insert: Option<PendingEditorInsert>,
     _subscriptions: Vec<Subscription>,
+}
+
+enum PendingEditorInsert {
+    Selection(AgentContextSelection),
+    DiagnosticFix {
+        diagnostic_message: SharedString,
+        selection: AgentContextSelection,
+    },
 }
 
 impl ConversationView {
@@ -758,6 +767,7 @@ impl ConversationView {
             auth_task: None,
             last_theme_id: Some(cx.theme().id.clone()),
             draft_prompt_persist_task: None,
+            pending_editor_insert: None,
             _subscriptions: subscriptions,
             focus_handle: cx.focus_handle(),
         }
@@ -972,6 +982,29 @@ impl ConversationView {
                             window,
                             cx,
                         );
+
+                        if let Some(pending) = this.pending_editor_insert.take() {
+                            current.update(cx, |thread_view, cx| match pending {
+                                PendingEditorInsert::Selection(selection) => {
+                                    thread_view.message_editor.update(cx, |editor, cx| {
+                                        editor.insert_selections(selection, window, cx);
+                                    });
+                                }
+                                PendingEditorInsert::DiagnosticFix {
+                                    diagnostic_message,
+                                    selection,
+                                } => {
+                                    thread_view.message_editor.update(cx, |editor, cx| {
+                                        editor.insert_diagnostic_fix(
+                                            &diagnostic_message,
+                                            selection,
+                                            window,
+                                            cx,
+                                        );
+                                    });
+                                }
+                            });
+                        }
 
                         if this.focus_handle.contains_focused(window, cx) {
                             current
@@ -2843,7 +2876,7 @@ impl ConversationView {
     /// Inserts the selected text into the message editor or the message being
     /// edited, if any.
     pub(crate) fn insert_selection(
-        &self,
+        &mut self,
         selection: AgentContextSelection,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -2854,11 +2887,13 @@ impl ConversationView {
                     editor.insert_selections(selection, window, cx);
                 })
             });
+        } else {
+            self.pending_editor_insert = Some(PendingEditorInsert::Selection(selection));
         }
     }
 
     pub(crate) fn insert_diagnostic_fix(
-        &self,
+        &mut self,
         diagnostic_message: &str,
         selection: AgentContextSelection,
         window: &mut Window,
@@ -2869,6 +2904,11 @@ impl ConversationView {
                 thread.active_editor(cx).update(cx, |editor, cx| {
                     editor.insert_diagnostic_fix(diagnostic_message, selection, window, cx);
                 })
+            });
+        } else {
+            self.pending_editor_insert = Some(PendingEditorInsert::DiagnosticFix {
+                diagnostic_message: diagnostic_message.to_string().into(),
+                selection,
             });
         }
     }

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -517,6 +517,8 @@ enum PendingEditorInsert {
     Selection(AgentContextSelection),
     DiagnosticFix {
         diagnostic_message: SharedString,
+        source: Option<SharedString>,
+        code: Option<SharedString>,
         selection: AgentContextSelection,
     },
 }
@@ -992,11 +994,15 @@ impl ConversationView {
                                 }
                                 PendingEditorInsert::DiagnosticFix {
                                     diagnostic_message,
+                                    source,
+                                    code,
                                     selection,
                                 } => {
                                     thread_view.message_editor.update(cx, |editor, cx| {
                                         editor.insert_diagnostic_fix(
                                             &diagnostic_message,
+                                            source.as_deref(),
+                                            code.as_deref(),
                                             selection,
                                             window,
                                             cx,
@@ -2895,6 +2901,8 @@ impl ConversationView {
     pub(crate) fn insert_diagnostic_fix(
         &mut self,
         diagnostic_message: &str,
+        source: Option<&str>,
+        code: Option<&str>,
         selection: AgentContextSelection,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -2902,12 +2910,21 @@ impl ConversationView {
         if let Some(active_thread) = self.active_thread() {
             active_thread.update(cx, |thread, cx| {
                 thread.active_editor(cx).update(cx, |editor, cx| {
-                    editor.insert_diagnostic_fix(diagnostic_message, selection, window, cx);
+                    editor.insert_diagnostic_fix(
+                        diagnostic_message,
+                        source,
+                        code,
+                        selection,
+                        window,
+                        cx,
+                    );
                 })
             });
         } else {
             self.pending_editor_insert = Some(PendingEditorInsert::DiagnosticFix {
                 diagnostic_message: diagnostic_message.to_string().into(),
+                source: source.map(SharedString::from),
+                code: code.map(SharedString::from),
                 selection,
             });
         }

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -2857,6 +2857,22 @@ impl ConversationView {
         }
     }
 
+    pub(crate) fn insert_diagnostic_fix(
+        &self,
+        diagnostic_message: &str,
+        selection: AgentContextSelection,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(active_thread) = self.active_thread() {
+            active_thread.update(cx, |thread, cx| {
+                thread.active_editor(cx).update(cx, |editor, cx| {
+                    editor.insert_diagnostic_fix(diagnostic_message, selection, window, cx);
+                })
+            });
+        }
+    }
+
     fn current_model_name(&self, cx: &App) -> SharedString {
         // For native agent (Zed Agent), use the specific model name (e.g., "Claude 3.5 Sonnet")
         // For ACP agents, use the agent name (e.g., "Claude Agent", "Gemini CLI")

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -1491,11 +1491,20 @@ impl MessageEditor {
     pub(crate) fn insert_diagnostic_fix(
         &mut self,
         diagnostic_message: &str,
+        source: Option<&str>,
+        code: Option<&str>,
         selection: AgentContextSelection,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let prompt = format!("Fix this diagnostic error:\n\n```\n{diagnostic_message}\n```\n\n");
+        let reporter = match (source, code) {
+            (Some(s), Some(c)) => format!(" ({s} {c})"),
+            (Some(s), None) => format!(" ({s})"),
+            (None, Some(c)) => format!(" ({c})"),
+            (None, None) => String::new(),
+        };
+        let prompt =
+            format!("Fix this diagnostic error{reporter}:\n\n```\n{diagnostic_message}\n```\n\n");
         self.insert_text(&prompt, window, cx);
         self.insert_selections(selection, window, cx);
     }

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -1488,6 +1488,18 @@ impl MessageEditor {
         }
     }
 
+    pub(crate) fn insert_diagnostic_fix(
+        &mut self,
+        diagnostic_message: &str,
+        selection: AgentContextSelection,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let prompt = format!("Fix this diagnostic error:\n\n```\n{diagnostic_message}\n```\n\n");
+        self.insert_text(&prompt, window, cx);
+        self.insert_selections(selection, window, cx);
+    }
+
     pub fn add_images_from_picker(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if !self.session_capabilities.read().supports_images() {
             return;

--- a/crates/editor/src/code_actions.rs
+++ b/crates/editor/src/code_actions.rs
@@ -64,20 +64,40 @@ impl Editor {
         );
         // Prefer the already-active (hovered) diagnostic; fall back to
         // querying the buffer so ⌘. works without hovering first.
-        let active_diagnostic_message = if !disable_ai {
-            self.active_diagnostic_message()
+        // Source and code are always taken from the buffer query.
+        let fix_diagnostic_info = if !disable_ai {
+            let buf = snapshot.buffer_snapshot();
+            let anchor = buf.anchor_before(multibuffer_point);
+            let offset = anchor.to_offset(&buf);
+            let buf_entry = buf
+                .diagnostics_in_range::<MultiBufferOffset>(
+                    MultiBufferOffset(offset.0.saturating_sub(1))
+                        ..MultiBufferOffset(offset.0 + 1),
+                )
+                .next();
+            let message = self
+                .active_diagnostic_message()
                 .map(|msg| SharedString::from(msg.to_owned()))
                 .or_else(|| {
-                    let buf = snapshot.buffer_snapshot();
-                    let anchor = buf.anchor_before(multibuffer_point);
-                    let offset = anchor.to_offset(&buf);
-                    buf.diagnostics_in_range::<MultiBufferOffset>(
-                        MultiBufferOffset(offset.0.saturating_sub(1))
-                            ..MultiBufferOffset(offset.0 + 1),
-                    )
-                    .next()
-                    .map(|d| SharedString::from(d.diagnostic.message.clone()))
-                })
+                    buf_entry
+                        .as_ref()
+                        .map(|d| SharedString::from(d.diagnostic.message.clone()))
+                });
+            message.map(|message| code_context_menus::FixDiagnosticInfo {
+                message,
+                source: buf_entry
+                    .as_ref()
+                    .and_then(|d| d.diagnostic.source.as_deref())
+                    .map(SharedString::from),
+                code: buf_entry.as_ref().and_then(|d| {
+                    d.diagnostic.code.as_ref().map(|c| {
+                        SharedString::from(match c {
+                            lsp::NumberOrString::Number(n) => n.to_string(),
+                            lsp::NumberOrString::String(s) => s.clone(),
+                        })
+                    })
+                }),
+            })
         } else {
             None
         };
@@ -170,7 +190,7 @@ impl Editor {
                     debug_scenarios,
                     task_context.unwrap_or_default(),
                 );
-                actions.fix_diagnostic = active_diagnostic_message;
+                actions.fix_diagnostic = fix_diagnostic_info;
 
                 // Don't show the menu if there are no actions available
                 if actions.is_empty() {
@@ -284,9 +304,13 @@ impl Editor {
                 });
                 Some(Task::ready(Ok(())))
             }
-            CodeActionsItem::FixDiagnostic(diagnostic_message) => {
+            CodeActionsItem::FixDiagnostic(info) => {
                 window.dispatch_action(
-                    Box::new(zed_actions::agent::FixDiagnosticWithAgent { diagnostic_message }),
+                    Box::new(zed_actions::agent::FixDiagnosticWithAgent {
+                        diagnostic_message: info.message,
+                        source: info.source,
+                        code: info.code,
+                    }),
                     cx,
                 );
                 Some(Task::ready(Ok(())))

--- a/crates/editor/src/code_actions.rs
+++ b/crates/editor/src/code_actions.rs
@@ -58,6 +58,30 @@ impl Editor {
             .runnables((buffer_id, buffer_row))
             .map(|t| Arc::new(t.to_owned()));
 
+        let disable_ai = DisableAiSettings::is_ai_disabled_for_buffer(
+            self.buffer.read(cx).as_singleton().as_ref(),
+            cx,
+        );
+        // Prefer the already-active (hovered) diagnostic; fall back to
+        // querying the buffer so ⌘. works without hovering first.
+        let active_diagnostic_message = if !disable_ai {
+            self.active_diagnostic_message()
+                .map(|msg| SharedString::from(msg.to_owned()))
+                .or_else(|| {
+                    let buf = snapshot.buffer_snapshot();
+                    let anchor = buf.anchor_before(multibuffer_point);
+                    let offset = anchor.to_offset(&buf);
+                    buf.diagnostics_in_range::<MultiBufferOffset>(
+                        MultiBufferOffset(offset.0.saturating_sub(1))
+                            ..MultiBufferOffset(offset.0 + 1),
+                    )
+                    .next()
+                    .map(|d| SharedString::from(d.diagnostic.message.clone()))
+                })
+        } else {
+            None
+        };
+
         let project = self.project.clone();
         let runnable_task = match deployed_from {
             Some(CodeActionSource::Indicator(_)) => Task::ready(Ok(Default::default())),
@@ -140,12 +164,13 @@ impl Editor {
                     && debug_scenarios.is_empty();
 
                 crate::hover_popover::hide_hover(editor, cx);
-                let actions = CodeActionContents::new(
+                let mut actions = CodeActionContents::new(
                     resolved_tasks,
                     code_actions,
                     debug_scenarios,
                     task_context.unwrap_or_default(),
                 );
+                actions.fix_diagnostic = active_diagnostic_message;
 
                 // Don't show the menu if there are no actions available
                 if actions.is_empty() {
@@ -257,6 +282,13 @@ impl Editor {
                         cx,
                     );
                 });
+                Some(Task::ready(Ok(())))
+            }
+            CodeActionsItem::FixDiagnostic(diagnostic_message) => {
+                window.dispatch_action(
+                    Box::new(zed_actions::agent::FixDiagnosticWithAgent { diagnostic_message }),
+                    cx,
+                );
                 Some(Task::ready(Ok(())))
             }
         }

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1559,12 +1559,19 @@ pub struct AvailableCodeAction {
 }
 
 #[derive(Clone)]
+pub struct FixDiagnosticInfo {
+    pub message: SharedString,
+    pub source: Option<SharedString>,
+    pub code: Option<SharedString>,
+}
+
+#[derive(Clone)]
 pub struct CodeActionContents {
     tasks: Option<Rc<ResolvedTasks>>,
     actions: Option<Rc<[AvailableCodeAction]>>,
     debug_scenarios: Vec<DebugScenario>,
     pub(crate) context: TaskContext,
-    pub(crate) fix_diagnostic: Option<SharedString>,
+    pub(crate) fix_diagnostic: Option<FixDiagnosticInfo>,
 }
 
 impl CodeActionContents {
@@ -1622,7 +1629,7 @@ impl CodeActionContents {
             .chain(
                 self.fix_diagnostic
                     .iter()
-                    .map(|msg| CodeActionsItem::FixDiagnostic(msg.clone())),
+                    .map(|info| CodeActionsItem::FixDiagnostic(info.clone())),
             )
     }
 
@@ -1649,7 +1656,7 @@ impl CodeActionContents {
         }
         index -= self.debug_scenarios.len();
         if index == 0 {
-            return self.fix_diagnostic.as_ref().map(|msg| CodeActionsItem::FixDiagnostic(msg.clone()));
+            return self.fix_diagnostic.as_ref().map(|info| CodeActionsItem::FixDiagnostic(info.clone()));
         }
         None
     }
@@ -1663,7 +1670,7 @@ pub enum CodeActionsItem {
         provider: Rc<dyn CodeActionProvider>,
     },
     DebugScenario(DebugScenario),
-    FixDiagnostic(SharedString),
+    FixDiagnostic(FixDiagnosticInfo),
 }
 
 impl CodeActionsItem {
@@ -1908,20 +1915,24 @@ mod tests {
     #[test]
     fn test_code_action_contents_fix_diagnostic_is_last() {
         let mut contents = CodeActionContents::new(None, None, vec![], TaskContext::default());
-        contents.fix_diagnostic = Some("type mismatch".into());
+        contents.fix_diagnostic = Some(FixDiagnosticInfo {
+            message: "type mismatch".into(),
+            source: Some("eslint".into()),
+            code: Some("2322".into()),
+        });
 
         assert!(!contents.is_empty());
 
         let items: Vec<_> = contents.iter().collect();
         assert_eq!(items.len(), 1);
         assert!(
-            matches!(&items[0], CodeActionsItem::FixDiagnostic(msg) if msg.as_ref() == "type mismatch"),
+            matches!(&items[0], CodeActionsItem::FixDiagnostic(info) if info.message.as_ref() == "type mismatch"),
             "FixDiagnostic should be the only (last) item"
         );
 
         let item = contents.get(0);
         assert!(
-            matches!(item, Some(CodeActionsItem::FixDiagnostic(msg)) if msg.as_ref() == "type mismatch")
+            matches!(item, Some(CodeActionsItem::FixDiagnostic(info)) if info.message.as_ref() == "type mismatch")
         );
         assert!(contents.get(1).is_none());
     }

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1564,6 +1564,7 @@ pub struct CodeActionContents {
     actions: Option<Rc<[AvailableCodeAction]>>,
     debug_scenarios: Vec<DebugScenario>,
     pub(crate) context: TaskContext,
+    pub(crate) fix_diagnostic: Option<SharedString>,
 }
 
 impl CodeActionContents {
@@ -1578,6 +1579,7 @@ impl CodeActionContents {
             actions,
             debug_scenarios,
             context,
+            fix_diagnostic: None,
         }
     }
 
@@ -1588,14 +1590,15 @@ impl CodeActionContents {
     fn len(&self) -> usize {
         let tasks_len = self.tasks.as_ref().map_or(0, |tasks| tasks.templates.len());
         let code_actions_len = self.actions.as_ref().map_or(0, |actions| actions.len());
-        tasks_len + code_actions_len + self.debug_scenarios.len()
+        let fix_len = self.fix_diagnostic.is_some() as usize;
+        tasks_len + code_actions_len + self.debug_scenarios.len() + fix_len
     }
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    fn iter(&self) -> impl Iterator<Item = CodeActionsItem> + '_ {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = CodeActionsItem> + '_ {
         self.tasks
             .iter()
             .flat_map(|tasks| {
@@ -1615,6 +1618,11 @@ impl CodeActionContents {
                     .iter()
                     .cloned()
                     .map(CodeActionsItem::DebugScenario),
+            )
+            .chain(
+                self.fix_diagnostic
+                    .iter()
+                    .map(|msg| CodeActionsItem::FixDiagnostic(msg.clone())),
             )
     }
 
@@ -1636,11 +1644,14 @@ impl CodeActionContents {
                 index -= actions.len();
             }
         }
-
-        self.debug_scenarios
-            .get(index)
-            .cloned()
-            .map(CodeActionsItem::DebugScenario)
+        if index < self.debug_scenarios.len() {
+            return self.debug_scenarios.get(index).cloned().map(CodeActionsItem::DebugScenario);
+        }
+        index -= self.debug_scenarios.len();
+        if index == 0 {
+            return self.fix_diagnostic.as_ref().map(|msg| CodeActionsItem::FixDiagnostic(msg.clone()));
+        }
+        None
     }
 }
 
@@ -1652,6 +1663,7 @@ pub enum CodeActionsItem {
         provider: Rc<dyn CodeActionProvider>,
     },
     DebugScenario(DebugScenario),
+    FixDiagnostic(SharedString),
 }
 
 impl CodeActionsItem {
@@ -1660,6 +1672,7 @@ impl CodeActionsItem {
             Self::CodeAction { action, .. } => action.lsp_action.title().to_owned(),
             Self::Task(_, task) => task.resolved_label.clone(),
             Self::DebugScenario(scenario) => scenario.label.to_string(),
+            Self::FixDiagnostic(_) => "Fix with Agent".to_owned(),
         }
     }
 
@@ -1668,6 +1681,7 @@ impl CodeActionsItem {
             Self::CodeAction { action, .. } => action.lsp_action.title().replace("\n", ""),
             Self::Task(_, task) => task.resolved_label.replace("\n", ""),
             Self::DebugScenario(scenario) => format!("debug: {}", scenario.label),
+            Self::FixDiagnostic(_) => "Fix with Agent".to_owned(),
         }
     }
 }
@@ -1825,6 +1839,7 @@ impl CodeActionsMenu {
                     CodeActionsItem::DebugScenario(scenario) => {
                         format!("debug: {}", scenario.label).chars().count()
                     }
+                    CodeActionsItem::FixDiagnostic(_) => "Fix with Agent".chars().count(),
                 })
                 .map(|(ix, _)| ix),
         )
@@ -1873,5 +1888,41 @@ impl CodeActionsMenu {
                 )
                 .into_any_element(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_code_action_contents_fix_diagnostic_absent_by_default() {
+        let contents = CodeActionContents::new(None, None, vec![], TaskContext::default());
+        assert!(contents.is_empty());
+        assert!(!contents
+            .iter()
+            .any(|item| matches!(item, CodeActionsItem::FixDiagnostic(_))));
+        assert!(contents.get(0).is_none());
+    }
+
+    #[test]
+    fn test_code_action_contents_fix_diagnostic_is_last() {
+        let mut contents = CodeActionContents::new(None, None, vec![], TaskContext::default());
+        contents.fix_diagnostic = Some("type mismatch".into());
+
+        assert!(!contents.is_empty());
+
+        let items: Vec<_> = contents.iter().collect();
+        assert_eq!(items.len(), 1);
+        assert!(
+            matches!(&items[0], CodeActionsItem::FixDiagnostic(msg) if msg.as_ref() == "type mismatch"),
+            "FixDiagnostic should be the only (last) item"
+        );
+
+        let item = contents.get(0);
+        assert!(
+            matches!(item, Some(CodeActionsItem::FixDiagnostic(msg)) if msg.as_ref() == "type mismatch")
+        );
+        assert!(contents.get(1).is_none());
     }
 }

--- a/crates/editor/src/diagnostics.rs
+++ b/crates/editor/src/diagnostics.rs
@@ -185,11 +185,18 @@ impl Editor {
         self.refresh_edit_prediction(false, true, window, cx);
     }
 
-    #[cfg(any(test, feature = "test-support"))]
     pub fn active_diagnostic_message(&self) -> Option<&str> {
         match &self.active_diagnostics {
             ActiveDiagnostic::Group(group) => Some(group.active_message.as_str()),
             _ => None,
+        }
+    }
+
+    pub fn active_diagnostic_range(&self) -> Option<Range<Anchor>> {
+        if let ActiveDiagnostic::Group(group) = &self.active_diagnostics {
+            Some(group.active_range.clone())
+        } else {
+            None
         }
     }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -20452,6 +20452,123 @@ async fn go_to_prev_overlapping_diagnostic(executor: BackgroundExecutor, cx: &mu
 }
 
 #[gpui::test]
+async fn test_fix_with_agent_in_code_actions(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let lsp_store =
+        cx.update_editor(|editor, _, cx| editor.project().unwrap().read(cx).lsp_store());
+
+    // Position cursor inside a diagnostic range
+    cx.set_state("fn func(ˇabc def: i32) {}");
+
+    cx.update(|_, cx| {
+        lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store
+                .update_diagnostics(
+                    LanguageServerId(0),
+                    lsp::PublishDiagnosticsParams {
+                        uri: lsp::Uri::from_file_path(path!("/root/file")).unwrap(),
+                        version: None,
+                        diagnostics: vec![lsp::Diagnostic {
+                            range: lsp::Range::new(
+                                lsp::Position::new(0, 8),
+                                lsp::Position::new(0, 18),
+                            ),
+                            severity: Some(lsp::DiagnosticSeverity::ERROR),
+                            message: "expected one of `:` or `@`".to_string(),
+                            ..Default::default()
+                        }],
+                    },
+                    None,
+                    DiagnosticSourceKind::Pushed,
+                    &[],
+                    cx,
+                )
+                .unwrap()
+        });
+    });
+
+    cx.run_until_parked();
+
+    cx.update_editor(|editor, window, cx| {
+        editor.toggle_code_actions(
+            &ToggleCodeActions {
+                deployed_from: None,
+                quick_launch: false,
+            },
+            window,
+            cx,
+        );
+    });
+
+    cx.condition(|editor, _| editor.context_menu_visible()).await;
+
+    cx.update_editor(|editor, _, _| {
+        let menu = editor.context_menu.borrow();
+        let Some(crate::code_context_menus::CodeContextMenu::CodeActions(actions_menu)) =
+            menu.as_ref()
+        else {
+            panic!("expected code actions menu to be open");
+        };
+        let items: Vec<_> = actions_menu.actions.iter().collect();
+        assert!(!items.is_empty(), "code actions menu should not be empty");
+        assert!(
+            matches!(
+                items.last().unwrap(),
+                crate::code_context_menus::CodeActionsItem::FixDiagnostic(_)
+            ),
+            "Fix with Agent should be the last item in the code actions menu"
+        );
+        if let crate::code_context_menus::CodeActionsItem::FixDiagnostic(msg) =
+            items.last().unwrap()
+        {
+            assert!(
+                msg.contains("expected one of"),
+                "diagnostic message should be preserved, got: {msg}"
+            );
+        }
+    });
+}
+
+#[gpui::test]
+async fn test_fix_with_agent_absent_without_diagnostic(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state("fn funcˇ() {}");
+
+    cx.update_editor(|editor, window, cx| {
+        editor.toggle_code_actions(
+            &ToggleCodeActions {
+                deployed_from: None,
+                quick_launch: false,
+            },
+            window,
+            cx,
+        );
+    });
+
+    cx.run_until_parked();
+
+    // No diagnostic + no tasks → menu is empty (not shown) or contains no FixDiagnostic
+    cx.update_editor(|editor, _, _| {
+        let menu = editor.context_menu.borrow();
+        if let Some(crate::code_context_menus::CodeContextMenu::CodeActions(actions_menu)) =
+            menu.as_ref()
+        {
+            let has_fix = actions_menu.actions.iter().any(|item| {
+                matches!(
+                    item,
+                    crate::code_context_menus::CodeActionsItem::FixDiagnostic(_)
+                )
+            });
+            assert!(!has_fix, "Fix with Agent should not appear without a diagnostic");
+        }
+    });
+}
+
+#[gpui::test]
 async fn test_go_to_hunk(executor: BackgroundExecutor, cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -526,6 +526,12 @@ pub mod agent {
     pub struct FixDiagnosticWithAgent {
         /// The diagnostic message to fix.
         pub diagnostic_message: SharedString,
+        /// The language server source that reported this diagnostic (e.g. "eslint").
+        #[serde(default)]
+        pub source: Option<SharedString>,
+        /// The language server error code for this diagnostic (e.g. "2322").
+        #[serde(default)]
+        pub code: Option<SharedString>,
     }
 
     /// Opens a new agent thread with the provided branch diff for review.

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -519,6 +519,15 @@ pub mod agent {
         ]
     );
 
+    /// Fix the diagnostic at the current cursor position using the agent.
+    #[derive(Clone, PartialEq, Deserialize, JsonSchema, Action)]
+    #[action(namespace = agent)]
+    #[serde(deny_unknown_fields)]
+    pub struct FixDiagnosticWithAgent {
+        /// The diagnostic message to fix.
+        pub diagnostic_message: SharedString,
+    }
+
     /// Opens a new agent thread with the provided branch diff for review.
     #[derive(Clone, PartialEq, Deserialize, JsonSchema, Action)]
     #[action(namespace = agent)]


### PR DESCRIPTION
Adds a **Fix with Agent** item to the code actions menu when the cursor sits on a diagnostic. Selecting it opens the agent panel and pre-fills the message editor with the diagnostic message, source, code, and a selection mention for the affected code range.

####  Example Prompt

````
Fix this diagnostic error (rust-analyzer E0308):

```
mismatched types: expected `i32`, found `&str`
```
````

## Demo

https://github.com/user-attachments/assets/bd06fcb0-9a65-4b7e-841a-42050e4061be

## What changed

- `zed_actions`: new `FixDiagnosticWithAgent` action carrying `diagnostic_message`, `source`, and `code`
- `editor`: `code_actions.rs` collects the diagnostic fields and builds a `FixDiagnosticInfo`; `code_context_menus.rs` surfaces a **Fix with Agent** item at the bottom of the menu (hidden when AI is disabled for the buffer)
- `agent_ui`: new `insert_diagnostic_fix` method on `MessageEditor` and `ConversationView`; `AgentPanel` registers the action handler

Also fixes a pre-existing bug where **Add to Agent Thread** silently dropped the editor insertion when the agent panel was in a loading or uninitialized state. The insertion is now queued and applied once the thread is ready.

Related: https://github.com/zed-industries/zed/discussions/43648

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added **Fix with Agent** to the code actions menu for diagnostics, opening the agent panel pre-filled with the error message and affected code