### PR TITLE
editor: Fix hidden choices menu on snippet insert

### DIFF
--- a/crates/editor/src/completions.rs
+++ b/crates/editor/src/completions.rs
@@ -310,9 +310,15 @@ impl Editor {
 
         drop(multibuffer_snapshot);
 
+        let is_showing_snippet_choices = matches!(
+            completions_source,
+            Some(CompletionsMenuSource::SnippetChoices)
+        );
+
         // Hide the current completions menu when query is empty. Without this, cached
-        // completions from before the trigger char may be reused (#32774).
-        if query.is_none() && menu_is_open {
+        // completions from before the trigger char may be reused (#32774). Keep snippet
+        // choice menus open so choice placeholders remain visible after snippet insertion.
+        if query.is_none() && menu_is_open && !is_showing_snippet_choices {
             self.hide_context_menu(window, cx);
         }
 


### PR DESCRIPTION
## Summary

This fixes a bug whereby a snippet choices menu is not revealed for a placeholder if it is the first selection immediately after inserting the snippet.

## Problem

Choice menus are initially hidden for a placeholder if it is the first selection immediately after snippet insertion. Navigating to any other placeholder, including returning back to the first one, will successfully reveal choice menus as expected.

### Reproduction

1. Create a snippet where the first placeholder's value is configured as a choice, e.g the Python snippet below:

```sh
mkdir -p ~/.config/zed/snippets && cat >~/.config/zed/snippets/python.json <<'EOF'
{
  "Python logger": {
    "prefix": "log",
    "body": "logger.${1|debug,info,warning,error|}(\"${2:message}: %s\", ${3|response,error|})",
    "description": "Python logger call"
  }
}
EOF
```

2. Open a Python file in Zed
3. Type the snippet name `log` in the editor to  reveal the completion menu
4. Press enter to accept the snippet completion

### Expected behaviour

After accepting the snippet, the first placeholder should be selected and a completion menu should appear with these choices: `debug`, `info`, `warning` and `error`:

<img width="683" height="187" alt="Screenshot 2026-05-16 at 19 58 18" src="https://github.com/user-attachments/assets/1c8997ce-cb93-4711-bcd1-3057d03eb813" />

### Actual behaviour

The first placeholder is selected correctly, but its choice menu is not shown:

<img width="381" height="44" alt="Screenshot 2026-05-16 at 20 35 01" src="https://github.com/user-attachments/assets/447b9e09-ae1c-4657-9973-1272e4b094a0" />

If the user presses `Tab` to navigate to another choice placeholder, that menu will appear correctly. If the user then presses `Shift-Tab` to return back to the first placeholder, the first choice menu will now function correctly:

https://github.com/user-attachments/assets/35610659-78ae-4abd-9281-684453d68568

## Root cause

In [editor/src/completions.rs](https://github.com/zed-industries/zed/blob/main/crates/editor/src/completions.rs#L313), `open_or_update_completions_menu()` hides completion menus when the completion query is empty. This prevents stale cached completion results from remaining visible after the query is cleared.

Snippet choice menus are represented as completion menus, therefore they can also be affected by this logic.

After snippet insertion, the trigger text is replaced by the snippet body, so the completion query becomes empty even though a snippet choice menu has just been opened.

The empty completion query causes the active snippet choice menu to be hidden.

## Solution

Preserve the active completion menu when its source is `CompletionsMenuSource::SnippetChoices`.

This keeps snippet choice menus visible after snippet insertion while preserving the existing empty-query cleanup behaviour for normal completion menus.

## Testing

Tested manually with:

- a snippet whose first placeholder uses choices
- snippets with multiple choice placeholders
- tab and shift-tab navigation between choice placeholders
- snippets without choice placeholders
- normal completion behaviour

## UI / UX checklist

- [x] The change has been tested manually.
- [x] Existing completion behaviour remains unchanged for normal completions.
- [x] Snippet placeholder navigation still behaves correctly.
- [x] No visual regressions were observed during testing.

Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A or Added/Fixed/Improved ...
