### PR TITLE
vim: Make % motion multi-char-bracket aware

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -2685,9 +2685,19 @@ fn matching(
             Some('/') => {}
             _ => {
                 if opening_range.contains(&offset) {
-                    return closing_range.start.to_display_point(map);
+                    return (closing_range.end - 1).to_display_point(map);
                 } else if closing_range.contains(&offset) {
-                    return opening_range.start.to_display_point(map);
+                    let mut target = opening_range.start;
+                    for (ch, char_offset) in map.buffer_chars_at(opening_range.start) {
+                        if char_offset >= opening_range.end {
+                            break;
+                        }
+                        if !ch.is_whitespace() {
+                            target = char_offset;
+                            break;
+                        }
+                    }
+                    return target.to_display_point(map);
                 }
             }
         }
@@ -2735,7 +2745,8 @@ fn matching(
             {
                 let distance = open_range.start.saturating_sub(offset);
                 if distance < closest_distance {
-                    closest_pair_destination = Some(close_range.start);
+                    let offset_into_open = offset.saturating_sub(open_range.start);
+                    closest_pair_destination = Some(close_range.end - 1 - offset_into_open);
                     closest_distance = distance;
                 }
             }
@@ -2745,7 +2756,8 @@ fn matching(
             {
                 let distance = close_range.start.saturating_sub(offset);
                 if distance < closest_distance {
-                    closest_pair_destination = Some(open_range.start);
+                    let offset_into_close = offset.saturating_sub(close_range.start);
+                    closest_pair_destination = Some(open_range.end - 1 - offset_into_close);
                     closest_distance = distance;
                 }
             }


### PR DESCRIPTION
## Summary

Improves the vim `%` motion to behave correctly with multi-character open/close tokens declared in `brackets.scm` (Liquid's `{{`/`}}` and `{%`/`%}`, ERB's `<%`/`%>`, Twig/Jinja's `{%`/`%}`, Handlebars `{{`/`}}`, etc.).

Today, with the cursor on the first `{` of `{%- if foo -%}`, `%` lands on the first `}` of `-%}`. Pressing `%` again returns to the first `{`, so the user oscillates over only two of the six characters. After this change `%` from the first `{` lands on the last `}` of `-%}`, and the inverse jump returns to the first `{` — vim's traditional symmetric depth-tracking behavior. Single-char brackets (`()`, `{}`, `[]`) are unaffected.

The HTML `<...>` branch in the same function already handled this via `close_range.end - 1`; this change generalises that to all bracket pairs.

## Reproduction (before this change)

In any language with multi-char brackets declared in `brackets.scm`:

```liquid
{%
...
%}

{%- if vehicle_definition != blank -%}

```

1. Cursor on the first `{` of `{%-`.
2. `%` → lands on the first `-` of `-%}` (3rd of 6 bracket chars).
3. `%` again → jumps to '}' on line above

Expected (and what this PR produces):

1. Cursor on first `{` of `{%-` → `%` → last `}` of `-%}`.
2. `%` → first `{` of `{%-`.
3. Cursor on second `{`  of `{{`→ `%` → first `}` of `}}` (inner-symmetric match).


```liquid
# Another example:
data-test="{{ test }}"
```

1. Cursor on the first `{`.
2. `%` → lands on the first double-quote.
3. `%` again → jumps to matching double-quote instead of bracket

Expected (and what this PR produces):

1. Cursor on first `{` → `%` → last `}` of `}}`.
2. `%` → first/last `}` of `}}`.
3. Cursor lands on matching curly brace.

## Changes

Four small hunks in `fn matching` in `crates/vim/src/motion.rs`, across the two tree-sitter paths (innermost-enclosing result, and the visible-line-range fallback). All are no-ops for single-char brackets.

### 1. Open→close, innermost-enclosing path

Return `closing_range.end - 1` instead of `closing_range.start`. Mirrors the existing `<...>` branch's behaviour; cursor lands on the last char of the close token.

### 2. Close→open, innermost-enclosing path

Scan forward from `opening_range.start` to the first non-whitespace char within the open range. For well-formed token ranges this is a no-op (the start char is the actual delimiter). For grammars that report the leading anonymous token of a named parent with a `byte_range` that includes preceding extras, this prevents `%` from jumping into the preceding blank line.

Verified the quirk with the tree-sitter CLI against `tree-sitter-liquid`:

```
("{%-" @open "-%}" @close) on:

%}

{%- if foo -%}
```

The first `{%-` is captured as `(2, 2)..(4, 3)` — 5 bytes including `\n\n` — instead of `(4, 0)..(4, 3)`. The `endif` `{%-` (mid-block, not the first child of its parent) is captured correctly. Without this hunk, the close→open jump from the `}` of `-%}` lands on the blank line above.

### 3 & 4. Visible-line-range fallback (both directions)

Replace `close_range.start` / `open_range.start` with mirrored positions: land on the character at the same offset-from-token-end on the matching side (i-th char of open ↔ (len-1-i)-th char of close). Implements vim's symmetric depth-tracking semantics on multi-char tokens.

## Compatibility

| Bracket shape | Before | After |
|---|---|---|
| `()`, `[]`, `{}` (single char) | works | unchanged — `end - 1 == start` and `offset_into_*` is always 0 |
| `<...>` HTML tag | works | unchanged — handled in its own pre-existing branch |
| `{{ }}`, `{% %}`, `<% %>`, `{{- -}}`, `{%- -%}`, etc. (multi-char) | lands on interior char; oscillates | lands on outer/symmetric char (vim semantics) |

## Test plan

- [ ] `%` on `(`, `)`, `{`, `}`, `[`, `]` in Rust/JS/etc. — unchanged.
- [ ] `%` on `<` of `<div>` in HTML — unchanged.
- [ ] `%` on first `{` of `{{ x }}` in a Liquid file — lands on last `}` of `}}`; `%` again returns to first `{`.
- [ ] `%` on second `{` of `{{ x }}` — lands on first `}` of `}}` (inner-symmetric).
- [ ] `%` on first `{` of `{%- if foo -%}` with a blank line above — lands on last `}` of `-%}`; `%` again lands on first `{`, NOT the previous blank line.
- [ ] Existing vim `%` tests pass.

Tested locally on Liquid (.liquid Shopify templates) on Linux against a release build off `main`.

Release Notes:

- Fixed the vim `%` motion to handle multi-character bracket delimiters (e.g., Liquid's `{{`/`}}` and `{%`/`%}`).