### PR TITLE
Add horizontal scrolling setting for code blocks in LSP popovers

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2481,6 +2481,9 @@
     //
     // Default rules are viewable via the "zed: show default semantic token rules" action.
     "semantic_token_rules": [],
+    // Whether to enable horizontal scrolling for code blocks in LSP hover popovers.
+    // Default: false
+    "hover_code_block_horizontal_scroll": false,
   },
   // Jupyter settings
   "jupyter": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2481,9 +2481,10 @@
     //
     // Default rules are viewable via the "zed: show default semantic token rules" action.
     "semantic_token_rules": [],
-    // Whether to enable horizontal scrolling for code blocks in LSP hover popovers.
+    // Whether to enable horizontal scrolling for code blocks in hover popovers,
+    // signature help, and code context menus instead of wrapping text.
     // Default: false
-    "hover_code_block_horizontal_scroll": false,
+    "code_block_horizontal_scroll": false,
   },
   // Jupyter settings
   "jupyter": {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -664,6 +664,7 @@ pub fn hover_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
         color: Some(cx.theme().colors().editor_foreground),
         ..Default::default()
     });
+    let project_settings = project::project_settings::ProjectSettings::get_global(cx);
     MarkdownStyle {
         base_text_style,
         code_block: StyleRefinement::default()
@@ -671,6 +672,9 @@ pub fn hover_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
             .font_buffer(cx)
             .font_features(buffer_font_features.clone())
             .font_weight(buffer_font_weight),
+        code_block_overflow_x_scroll: project_settings
+            .global_lsp_settings
+            .hover_code_block_horizontal_scroll,
         inline_code: TextStyleRefinement {
             background_color: Some(cx.theme().colors().background),
             font_family: Some(buffer_font_family),

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -674,7 +674,7 @@ pub fn hover_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
             .font_weight(buffer_font_weight),
         code_block_overflow_x_scroll: project_settings
             .global_lsp_settings
-            .hover_code_block_horizontal_scroll,
+            .code_block_horizontal_scroll,
         inline_code: TextStyleRefinement {
             background_color: Some(cx.theme().colors().background),
             font_family: Some(buffer_font_family),

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -138,10 +138,11 @@ pub struct GlobalLspSettings {
     /// Rules for highlighting semantic tokens.
     pub semantic_token_rules: SemanticTokenRules,
 
-    /// Whether to enable horizontal scrolling for code blocks in LSP hover popovers.
+    /// Whether to enable horizontal scrolling for code blocks in hover popovers,
+    /// signature help, and code context menus instead of wrapping text.
     ///
     /// Default: `false`
-    pub hover_code_block_horizontal_scroll: bool,
+    pub code_block_horizontal_scroll: bool,
 }
 
 impl Default for GlobalLspSettings {
@@ -151,7 +152,7 @@ impl Default for GlobalLspSettings {
             request_timeout: DEFAULT_LSP_REQUEST_TIMEOUT_SECS,
             notifications: LspNotificationSettings::default(),
             semantic_token_rules: SemanticTokenRules::default(),
-            hover_code_block_horizontal_scroll: false,
+            code_block_horizontal_scroll: false,
         }
     }
 }
@@ -712,11 +713,11 @@ impl Settings for ProjectSettings {
                     .as_ref()
                     .unwrap()
                     .clone(),
-                hover_code_block_horizontal_scroll: content
+                code_block_horizontal_scroll: content
                     .global_lsp_settings
                     .as_ref()
                     .unwrap()
-                    .hover_code_block_horizontal_scroll
+                    .code_block_horizontal_scroll
                     .unwrap(),
             },
             dap: project

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -137,6 +137,11 @@ pub struct GlobalLspSettings {
 
     /// Rules for highlighting semantic tokens.
     pub semantic_token_rules: SemanticTokenRules,
+
+    /// Whether to enable horizontal scrolling for code blocks in LSP hover popovers.
+    ///
+    /// Default: `false`
+    pub hover_code_block_horizontal_scroll: bool,
 }
 
 impl Default for GlobalLspSettings {
@@ -146,6 +151,7 @@ impl Default for GlobalLspSettings {
             request_timeout: DEFAULT_LSP_REQUEST_TIMEOUT_SECS,
             notifications: LspNotificationSettings::default(),
             semantic_token_rules: SemanticTokenRules::default(),
+            hover_code_block_horizontal_scroll: false,
         }
     }
 }
@@ -706,6 +712,12 @@ impl Settings for ProjectSettings {
                     .as_ref()
                     .unwrap()
                     .clone(),
+                hover_code_block_horizontal_scroll: content
+                    .global_lsp_settings
+                    .as_ref()
+                    .unwrap()
+                    .hover_code_block_horizontal_scroll
+                    .unwrap(),
             },
             dap: project
                 .dap

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -209,11 +209,11 @@ pub struct GlobalLspSettingsContent {
     pub notifications: Option<LspNotificationSettingsContent>,
     /// Rules for rendering LSP semantic tokens.
     pub semantic_token_rules: Option<SemanticTokenRules>,
-    /// Whether to enable horizontal scrolling for code blocks in LSP hover popovers.
-    /// When enabled, code blocks will have a horizontal scrollbar instead of wrapping text.
+    /// Whether to enable horizontal scrolling for code blocks in hover popovers,
+    /// signature help, and code context menus instead of wrapping text.
     ///
     /// Default: `false`
-    pub hover_code_block_horizontal_scroll: Option<bool>,
+    pub code_block_horizontal_scroll: Option<bool>,
 }
 
 #[with_fallible_options]

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -209,6 +209,11 @@ pub struct GlobalLspSettingsContent {
     pub notifications: Option<LspNotificationSettingsContent>,
     /// Rules for rendering LSP semantic tokens.
     pub semantic_token_rules: Option<SemanticTokenRules>,
+    /// Whether to enable horizontal scrolling for code blocks in LSP hover popovers.
+    /// When enabled, code blocks will have a horizontal scrollbar instead of wrapping text.
+    ///
+    /// Default: `false`
+    pub hover_code_block_horizontal_scroll: Option<bool>,
 }
 
 #[with_fallible_options]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1811,7 +1811,7 @@ fn editor_page() -> SettingsPage {
         ]
     }
 
-    fn hover_popover_section() -> [SettingsPageItem; 5] {
+    fn hover_popover_section() -> [SettingsPageItem; 6] {
         [
             SettingsPageItem::SectionHeader("Hover Popover"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -1865,6 +1865,27 @@ fn editor_page() -> SettingsPage {
                     },
                     write: |settings_content, value, _| {
                         settings_content.editor.hover_popover_hiding_delay = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Code Block Horizontal Scroll",
+                description: "When enabled, code blocks in the hover popover will have a horizontal scrollbar instead of wrapping text.",
+                field: Box::new(SettingField {
+                    json_path: Some("global_lsp_settings.hover_code_block_horizontal_scroll"),
+                    pick: |settings_content| {
+                        settings_content
+                            .global_lsp_settings
+                            .as_ref()
+                            .and_then(|s| s.hover_code_block_horizontal_scroll.as_ref())
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .global_lsp_settings
+                            .get_or_insert_default()
+                            .hover_code_block_horizontal_scroll = value;
                     },
                 }),
                 metadata: None,
@@ -9718,5 +9739,42 @@ mod tests {
         write_vim_mode_inner(&mut settings, Some(true));
         assert_eq!(settings.vim_mode, Some(true));
         assert_eq!(settings.helix_mode, Some(false));
+    }
+
+    #[test]
+    fn test_hover_code_block_horizontal_scroll() {
+        let mut settings = SettingsContent::default();
+        assert_eq!(
+            settings
+                .global_lsp_settings
+                .as_ref()
+                .and_then(|s| s.hover_code_block_horizontal_scroll),
+            None,
+            "new setting should be None by default (default.json provides the fallback)",
+        );
+
+        settings
+            .global_lsp_settings
+            .get_or_insert_default()
+            .hover_code_block_horizontal_scroll = Some(true);
+        assert_eq!(
+            settings
+                .global_lsp_settings
+                .as_ref()
+                .and_then(|s| s.hover_code_block_horizontal_scroll),
+            Some(true),
+        );
+
+        settings
+            .global_lsp_settings
+            .get_or_insert_default()
+            .hover_code_block_horizontal_scroll = Some(false);
+        assert_eq!(
+            settings
+                .global_lsp_settings
+                .as_ref()
+                .and_then(|s| s.hover_code_block_horizontal_scroll),
+            Some(false),
+        );
     }
 }

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1811,7 +1811,7 @@ fn editor_page() -> SettingsPage {
         ]
     }
 
-    fn hover_popover_section() -> [SettingsPageItem; 6] {
+    fn hover_popover_section() -> [SettingsPageItem; 5] {
         [
             SettingsPageItem::SectionHeader("Hover Popover"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -1865,27 +1865,6 @@ fn editor_page() -> SettingsPage {
                     },
                     write: |settings_content, value, _| {
                         settings_content.editor.hover_popover_hiding_delay = value;
-                    },
-                }),
-                metadata: None,
-                files: USER,
-            }),
-            SettingsPageItem::SettingItem(SettingItem {
-                title: "Code Block Horizontal Scroll",
-                description: "When enabled, code blocks in the hover popover will have a horizontal scrollbar instead of wrapping text.",
-                field: Box::new(SettingField {
-                    json_path: Some("global_lsp_settings.hover_code_block_horizontal_scroll"),
-                    pick: |settings_content| {
-                        settings_content
-                            .global_lsp_settings
-                            .as_ref()
-                            .and_then(|s| s.hover_code_block_horizontal_scroll.as_ref())
-                    },
-                    write: |settings_content, value, _| {
-                        settings_content
-                            .global_lsp_settings
-                            .get_or_insert_default()
-                            .hover_code_block_horizontal_scroll = value;
                     },
                 }),
                 metadata: None,
@@ -9191,7 +9170,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
 /// LanguageSettings items that should be included in the "Languages & Tools" page
 /// not the "Editor" page
 fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
-    fn lsp_section() -> [SettingsPageItem; 9] {
+    fn lsp_section() -> [SettingsPageItem; 10] {
         [
             SettingsPageItem::SectionHeader("LSP"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -9363,6 +9342,27 @@ fn non_editor_language_settings_data() -> Box<[SettingsPageItem]> {
                 }),
                 metadata: None,
                 files: USER | PROJECT,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Code Block Horizontal Scroll",
+                description: "When enabled, code blocks in hover popovers, signature help, and code context menus will have a horizontal scrollbar instead of wrapping text.",
+                field: Box::new(SettingField {
+                    json_path: Some("global_lsp_settings.code_block_horizontal_scroll"),
+                    pick: |settings_content| {
+                        settings_content
+                            .global_lsp_settings
+                            .as_ref()
+                            .and_then(|s| s.code_block_horizontal_scroll.as_ref())
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .global_lsp_settings
+                            .get_or_insert_default()
+                            .code_block_horizontal_scroll = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
             }),
         ]
     }
@@ -9742,13 +9742,13 @@ mod tests {
     }
 
     #[test]
-    fn test_hover_code_block_horizontal_scroll() {
+    fn test_code_block_horizontal_scroll() {
         let mut settings = SettingsContent::default();
         assert_eq!(
             settings
                 .global_lsp_settings
                 .as_ref()
-                .and_then(|s| s.hover_code_block_horizontal_scroll),
+                .and_then(|s| s.code_block_horizontal_scroll),
             None,
             "new setting should be None by default (default.json provides the fallback)",
         );
@@ -9756,24 +9756,24 @@ mod tests {
         settings
             .global_lsp_settings
             .get_or_insert_default()
-            .hover_code_block_horizontal_scroll = Some(true);
+            .code_block_horizontal_scroll = Some(true);
         assert_eq!(
             settings
                 .global_lsp_settings
                 .as_ref()
-                .and_then(|s| s.hover_code_block_horizontal_scroll),
+                .and_then(|s| s.code_block_horizontal_scroll),
             Some(true),
         );
 
         settings
             .global_lsp_settings
             .get_or_insert_default()
-            .hover_code_block_horizontal_scroll = Some(false);
+            .code_block_horizontal_scroll = Some(false);
         assert_eq!(
             settings
                 .global_lsp_settings
                 .as_ref()
-                .and_then(|s| s.hover_code_block_horizontal_scroll),
+                .and_then(|s| s.code_block_horizontal_scroll),
             Some(false),
         );
     }


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Adds a `code_block_horizontal_scroll` setting under `global_lsp_settings` to control whether code blocks in hover popovers, signature help, and code context menus wrap text or show a horizontal scrollbar.

Release Notes:

-  Added `global_lsp_settings.code_block_horizontal_scroll` setting to enable horizontal scrolling for code blocks in hover popovers, signature help, and code context menus