### PR TITLE
Add flags to linux bundle and install scripts to skip (re)building `remote_server` and licenses

### DIFF
--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -12,8 +12,13 @@ Build a release .tar.gz for Linux.
 Options:
   -h, --help     Display this help and exit.
   --flatpak      Set ZED_BUNDLE_TYPE=flatpak so that this can be included in system info
+  --no-remote    Don't build or bundle remote_server
+  --no-licenses  Don't build licenses if the artifact already exists
   "
 }
+
+WITH_REMOTE=true
+WITH_LICENSES=true
 
 # Parse all arguments manually
 while [[ $# -gt 0 ]]; do
@@ -24,6 +29,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --flatpak)
             export ZED_BUNDLE_TYPE=flatpak
+            shift
+            ;;
+        --no-remote)
+            WITH_REMOTE=false
+            shift
+            ;;
+        --no-licenses)
+            WITH_LICENSES=false
             shift
             ;;
         --)
@@ -64,11 +77,13 @@ if command -v rustup >/dev/null 2>&1; then
     rustup_installed=true
 fi
 
-# Generate the licenses first, so they can be baked into the binaries
-script/generate-licenses
-
-if "$rustup_installed"; then
+if [[ "$rustup_installed" == true ]] && [[ "$WITH_REMOTE" == true ]]; then
     rustup target add "$remote_server_triple"
+fi
+
+# Generate the licenses first, so they can be baked into the binaries
+if [[ "$WITH_LICENSES" == true ]] || test ! -f "assets/licenses.md"; then
+    script/generate-licenses
 fi
 
 export CC=${CC:-$(which clang)}
@@ -84,12 +99,15 @@ else
     export RUSTFLAGS="${RUSTFLAGS:-} -C link-args=-Wl,--disable-new-dtags,-rpath,\$ORIGIN/../lib"
 fi
 cargo build --release --target "${target_triple}" --package zed --package cli
-# Build remote_server in separate invocation to prevent feature unification from other crates
-# from influencing dynamic libraries required by it.
-if [[ "$remote_server_triple" == "$musl_triple" ]]; then
-    export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
+
+if [[ "$WITH_REMOTE" == true ]]; then
+    # Build remote_server in separate invocation to prevent feature unification from other crates
+    # from influencing dynamic libraries required by it.
+    if [[ "$remote_server_triple" == "$musl_triple" ]]; then
+        export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
+    fi
+    cargo build --release --target "${remote_server_triple}" --package remote_server
 fi
-cargo build --release --target "${remote_server_triple}" --package remote_server
 
 # Upload debug info to sentry.io
 if ! command -v sentry-cli >/dev/null 2>&1; then
@@ -102,9 +120,11 @@ else
         # .eh_frame data for stack unwinding. see https://github.com/getsentry/symbolic/issues/783
         for attempt in 1 2 3; do
             echo "Attempting sentry upload (attempt $attempt/3)..."
-            if sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev \
-                "${target_dir}/${target_triple}"/release/zed \
-                "${target_dir}/${remote_server_triple}"/release/remote_server; then
+            debug_files=("${target_dir}/${target_triple}"/release/zed)
+            if [[ "$WITH_REMOTE" == true ]]; then
+                debug_files+=("${target_dir}/${remote_server_triple}"/release/remote_server)
+            fi
+            if sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev "${debug_files[@]}"; then
                 echo "Sentry upload successful on attempt $attempt"
                 break
             else
@@ -124,10 +144,12 @@ fi
 # doesn't understand CREL sections produced by newer LLVM.
 llvm-objcopy --strip-debug "${target_dir}/${target_triple}/release/zed"
 llvm-objcopy --strip-debug "${target_dir}/${target_triple}/release/cli"
-llvm-objcopy --strip-debug "${target_dir}/${remote_server_triple}/release/remote_server"
+if [[ "$WITH_REMOTE" == true ]]; then
+    llvm-objcopy --strip-debug "${target_dir}/${remote_server_triple}/release/remote_server"
+fi
 
 # Ensure that remote_server does not depend on libssl nor libcrypto, as we got rid of these deps.
-if ldd "${target_dir}/${remote_server_triple}/release/remote_server" | grep -q 'libcrypto\|libssl'; then
+if [[ "$WITH_REMOTE" == true ]] && ldd "${target_dir}/${remote_server_triple}/release/remote_server" | grep -q 'libcrypto\|libssl'; then
     if [[ "$remote_server_triple" == *-musl ]]; then
         echo "Error: remote_server still depends on libssl or libcrypto" && exit 1
     else
@@ -202,4 +224,6 @@ remove_match="zed(-[a-zA-Z0-9]+)?-linux-$(uname -m)\.tar\.gz"
 ls "${target_dir}/release" | grep -E ${remove_match} | xargs -d "\n" -I {} rm -f "${target_dir}/release/{}" || true
 tar -czvf "${target_dir}/release/$archive" -C ${temp_dir} "zed$suffix.app"
 
-gzip -f --stdout --best "${target_dir}/${remote_server_triple}/release/remote_server" > "${target_dir}/zed-remote-server-linux-${arch}.gz"
+if [[ "$WITH_REMOTE" == true ]]; then
+    gzip -f --stdout --best "${target_dir}/${remote_server_triple}/release/remote_server" > "${target_dir}/zed-remote-server-linux-${arch}.gz"
+fi

--- a/script/install-linux
+++ b/script/install-linux
@@ -2,18 +2,59 @@
 
 set -euxo pipefail
 
-if [[ $# -gt 0 ]]; then
+# Function for displaying help info
+help_info() {
   echo "
-  Usage: ${0##*/}
-  Builds and installs zed onto your system into ~/.local, making it available as ~/.local/bin/zed.
+Usage: ${0##*/} [options]
+Builds and installs zed onto your system into ~/.local, making it available as ~/.local/bin/zed.
 
-  Before running this you should ensure you have all the build dependencies installed with `./script/linux`.
+Before running this you should ensure you have all the build dependencies installed with \`./script/linux\`.
+
+Options:
+  -h, --help     Display this help and exit.
+  --no-remote    Don't build or bundle remote_server
+  --no-licenses  Don't build licenses if the artifact already exists
   "
-  exit 1
-fi
+}
+
+bundle_args=()
+
+# Parse all arguments manually
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            help_info
+            exit 0
+            ;;
+        --no-remote)
+            bundle_args+=("--no-remote")
+            shift
+            ;;
+        --no-licenses)
+            bundle_args+=("--no-licenses")
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            help_info
+            exit 1
+            ;;
+        *)
+            echo "Error: Unexpected argument: $1" >&2
+            help_info
+            exit 1
+            ;;
+    esac
+done
+
 export ZED_CHANNEL=$(<crates/zed/RELEASE_CHANNEL)
 export ZED_UPDATE_EXPLANATION="You need to fetch and rebuild zed in $(pwd)"
-script/bundle-linux
+
+script/bundle-linux "${bundle_args[@]}"
 
 arch="$(uname -m)"
 commit=$(git rev-parse HEAD | cut -c 1-7)


### PR DESCRIPTION
Does what it says on the tin.

### Why

I want to have a faster flow for just re-building and installing current changes to a system-wide development install of zed.

Right now the license build step runs unconditionally and causes a rebuild on the editor crate due to dependent files changing, thus the build always takes a while for no reason.

Similarly, I don't need to build the remote server for this workflow and it complicates the build steps and can cause needless rebuilds.

### How

Re-uses the existing pattern of arg parsing from the bundle script for the install script

## Etc

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (N/A)
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) (N/A)
- [x] Tests cover the new/changed behavior (N/A)
- [x] Performance impact has been considered and is acceptable (N/A)

Release Notes:

- N/A
