### PR TITLE
Improve robustness of lib finding in linux bundle script

### DIFF
--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -151,15 +151,39 @@ cp "${target_dir}/${target_triple}/release/zed" "${zed_dir}/libexec/zed-editor"
 cp "${target_dir}/${target_triple}/release/cli" "${zed_dir}/bin/zed"
 
 # Libs
+# parse ldd output, in case the user failed to run script/linux or someone forgets
+# to add a dep there
 find_libs() {
-    ldd ${target_dir}/${target_triple}/release/zed |\
-        cut -d' ' -f3 |\
+    ldd "${target_dir}/${target_triple}/release/zed" |
+        awk '
+            /=> not found/ {
+                print "Missing shared library: " $1 > "/dev/stderr"
+                missing = 1
+                next
+            }
+
+            /=>/ && $3 ~ /^\// {
+                print $3
+                next
+            }
+
+            $1 ~ /^\// {
+                print $1
+                next
+            }
+
+            END {
+                exit missing
+            }
+        ' |
         grep -v '\<\(libstdc++.so\|libc.so\|libgcc_s.so\|libm.so\|libpthread.so\|libdl.so\|libasound.so\)'
 }
+libs=$(find_libs)
+mapfile -t libs <<< "$libs"
 
 mkdir -p "${zed_dir}/lib"
-rm -rf "${zed_dir}/lib/*"
-cp $(find_libs) "${zed_dir}/lib"
+rm -rf "${zed_dir:?}/lib"/*
+cp -- "${libs[@]}" "${zed_dir}/lib"
 
 # Icons
 mkdir -p "${zed_dir}/share/icons/hicolor/512x512/apps"


### PR DESCRIPTION
Parses the output of `ldd` in a slightly more robust way using `awk` to give a better error message if someone doesn't have one or more of the required shared libraries on their system.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (N/A)
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) (N/A)
- [x] Tests cover the new/changed behavior (N/A)
- [x] Performance impact has been considered and is acceptable (N/A)

Release Notes:

- N/A
