### PR TITLE
Add auto_preview setting for Markdown, SVG, and CSV files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17270,6 +17270,7 @@ dependencies = [
  "gpui",
  "language",
  "multi_buffer",
+ "settings",
  "ui",
  "workspace",
  "zed_actions",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1334,8 +1334,8 @@
     // Whether to keep tabs in preview mode when code navigation is used to navigate away from them.
     // If `enable_preview_file_from_code_navigation` or `enable_preview_multibuffer_from_code_navigation` is also true, the new tab may replace the existing one.
     "enable_keep_preview_on_code_navigation": false,
-    // Whether to automatically open a preview when opening previewable files
-    // (Markdown, SVG, and CSV). Possible values:
+    // Whether to automatically open a preview when opening files with preview capabilities.
+    // Possible values:
     //   - "off": Do not automatically open previews (default).
     //   - "same_pane": Open the preview in the same pane, replacing the editor tab.
     //   - "to_side": Open the preview in an adjacent pane to the side.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1334,6 +1334,12 @@
     // Whether to keep tabs in preview mode when code navigation is used to navigate away from them.
     // If `enable_preview_file_from_code_navigation` or `enable_preview_multibuffer_from_code_navigation` is also true, the new tab may replace the existing one.
     "enable_keep_preview_on_code_navigation": false,
+    // Whether to automatically open a preview when opening previewable files
+    // (Markdown, SVG, and CSV). Possible values:
+    //   - "off": Do not automatically open previews (default).
+    //   - "same_pane": Open the preview in the same pane, replacing the editor tab.
+    //   - "to_side": Open the preview in an adjacent pane to the side.
+    "auto_preview": "off",
   },
   // Settings related to the file finder.
   "file_finder": {

--- a/crates/csv_preview/src/csv_preview.rs
+++ b/crates/csv_preview/src/csv_preview.rs
@@ -13,6 +13,7 @@ use ui::{
     AbsoluteLength, ResizableColumnsState, SharedString, TableInteractionState,
     TableResizeBehavior, prelude::*,
 };
+use workspace::item::Settings as _;
 use workspace::{Item, SplitDirection, Workspace};
 
 use crate::{parser::EditorState, settings::CsvPreviewSettings, types::TableLikeContent};
@@ -50,8 +51,103 @@ pub struct CsvPreviewView {
 }
 
 pub fn init(cx: &mut App) {
-    cx.observe_new(|workspace: &mut Workspace, _, _| {
+    cx.observe_new(|workspace: &mut Workspace, window, cx| {
         CsvPreviewView::register(workspace);
+
+        let Some(window) = window else {
+            return;
+        };
+        let workspace_handle = cx.entity();
+        cx.subscribe_in(
+            &workspace_handle,
+            window,
+            move |_workspace, _, event, window, cx| {
+                let workspace::Event::ItemAdded { item } = event else {
+                    return;
+                };
+                if !cx.has_flag::<TabularDataPreviewFeatureFlag>() {
+                    return;
+                }
+                let auto_preview = workspace::PreviewTabsSettings::get_global(cx).auto_preview;
+                if matches!(auto_preview, workspace::item::AutoPreviewMode::Off) {
+                    return;
+                }
+                let Some(editor) = item.act_as::<Editor>(cx) else {
+                    return;
+                };
+                if !CsvPreviewView::is_csv_file(&editor, cx) {
+                    return;
+                }
+
+                let weak_workspace = cx.entity().downgrade();
+                window.defer(cx, move |window, cx| {
+                    let Some(workspace) = weak_workspace.upgrade() else {
+                        return;
+                    };
+                    workspace.update(cx, |workspace, cx| {
+                        let csv_preview = CsvPreviewView::new(&editor, cx);
+
+                        match auto_preview {
+                            workspace::item::AutoPreviewMode::SamePane => {
+                                workspace.active_pane().update(cx, |pane, cx| {
+                                    let has_existing = pane
+                                        .items_of_type::<CsvPreviewView>()
+                                        .any(|view| view.read(cx).editor_state().editor == editor);
+                                    if !has_existing {
+                                        pane.add_item(
+                                            Box::new(csv_preview),
+                                            true,
+                                            true,
+                                            None,
+                                            window,
+                                            cx,
+                                        );
+                                    }
+                                });
+                            }
+                            workspace::item::AutoPreviewMode::ToSide => {
+                                let active_pane = workspace.active_pane().clone();
+                                let pane = workspace
+                                    .find_pane_in_direction(SplitDirection::Right, cx)
+                                    .or_else(|| {
+                                        workspace
+                                            .panes()
+                                            .iter()
+                                            .find(|p| **p != active_pane)
+                                            .cloned()
+                                    })
+                                    .unwrap_or_else(|| {
+                                        workspace.split_pane(
+                                            active_pane,
+                                            SplitDirection::Right,
+                                            window,
+                                            cx,
+                                        )
+                                    });
+                                pane.update(cx, |pane, cx| {
+                                    let has_existing = pane
+                                        .items_of_type::<CsvPreviewView>()
+                                        .any(|view| view.read(cx).editor_state().editor == editor);
+                                    if !has_existing {
+                                        pane.add_item(
+                                            Box::new(csv_preview),
+                                            false,
+                                            false,
+                                            None,
+                                            window,
+                                            cx,
+                                        );
+                                    }
+                                });
+                            }
+                            workspace::item::AutoPreviewMode::Off => {}
+                        }
+                        cx.notify();
+                    });
+                });
+            },
+        )
+        .detach();
     })
     .detach()
 }

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -1,5 +1,8 @@
-use gpui::{App, actions};
-use workspace::Workspace;
+use editor::Editor;
+use gpui::{App, Focusable, actions};
+use settings::{AutoPreviewMode, Settings};
+use workspace::item::PreviewTabsSettings;
+use workspace::{Event as WorkspaceEvent, Workspace};
 
 pub mod markdown_preview_view;
 
@@ -37,6 +40,89 @@ pub fn init(cx: &mut App) {
             return;
         };
         markdown_preview_view::MarkdownPreviewView::register(workspace, window, cx);
+
+        let workspace_handle = cx.entity();
+        cx.subscribe_in(&workspace_handle, window, move |_workspace, _, event, window, cx| {
+            let WorkspaceEvent::ItemAdded { item } = event else {
+                return;
+            };
+            let auto_preview = PreviewTabsSettings::get_global(cx).auto_preview;
+            if matches!(auto_preview, AutoPreviewMode::Off) {
+                return;
+            }
+            let Some(editor) = item.act_as::<Editor>(cx) else {
+                return;
+            };
+            if !is_markdown_file_by_extension(&editor, cx) {
+                return;
+            }
+
+            let weak_workspace = cx.entity().downgrade();
+            window.defer(cx, move |window, cx| {
+                let Some(workspace) = weak_workspace.upgrade() else {
+                    return;
+                };
+                workspace.update(cx, |workspace, cx| {
+                    let view = markdown_preview_view::MarkdownPreviewView::create_markdown_view(
+                        workspace,
+                        editor.clone(),
+                        window,
+                        cx,
+                    );
+
+                    match auto_preview {
+                        AutoPreviewMode::SamePane => {
+                            workspace.active_pane().update(cx, |pane, cx| {
+                                if markdown_preview_view::MarkdownPreviewView::find_existing_independent_preview_item_idx(pane, &editor, cx).is_none() {
+                                    pane.add_item(Box::new(view), true, true, None, window, cx);
+                                }
+                            });
+                        }
+                        AutoPreviewMode::ToSide => {
+                            let active_pane = workspace.active_pane().clone();
+                            let pane = workspace
+                                .find_pane_in_direction(workspace::SplitDirection::Right, cx)
+                                .or_else(|| {
+                                    workspace.panes().iter().find(|p| **p != active_pane).cloned()
+                                })
+                                .unwrap_or_else(|| {
+                                    workspace.split_pane(
+                                        active_pane,
+                                        workspace::SplitDirection::Right,
+                                        window,
+                                        cx,
+                                    )
+                                });
+                            pane.update(cx, |pane, cx| {
+                                if markdown_preview_view::MarkdownPreviewView::find_existing_independent_preview_item_idx(pane, &editor, cx).is_none() {
+                                    pane.add_item(Box::new(view), false, false, None, window, cx);
+                                }
+                            });
+                            editor.focus_handle(cx).focus(window, cx);
+                        }
+                        AutoPreviewMode::Off => {}
+                    }
+                    cx.notify();
+                });
+            });
+        })
+        .detach();
     })
     .detach();
+}
+
+fn is_markdown_file_by_extension(editor: &gpui::Entity<Editor>, cx: &gpui::App) -> bool {
+    editor
+        .read(cx)
+        .buffer()
+        .read(cx)
+        .as_singleton()
+        .and_then(|buffer| buffer.read(cx).file())
+        .is_some_and(|file| {
+            std::path::Path::new(file.file_name(cx))
+                .extension()
+                .is_some_and(|ext| {
+                    ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown")
+                })
+        })
 }

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -137,7 +137,7 @@ impl MarkdownPreviewView {
         });
     }
 
-    fn find_existing_independent_preview_item_idx(
+    pub(crate) fn find_existing_independent_preview_item_idx(
         pane: &Pane,
         editor: &Entity<Editor>,
         cx: &App,
@@ -169,7 +169,7 @@ impl MarkdownPreviewView {
         None
     }
 
-    fn create_markdown_view(
+    pub(crate) fn create_markdown_view(
         workspace: &mut Workspace,
         editor: Entity<Editor>,
         window: &mut Window,
@@ -1210,6 +1210,9 @@ mod tests {
     use util::test::TempTree;
     use workspace::{AppState, MultiWorkspace, SaveIntent, Workspace, open_paths};
 
+    use gpui::UpdateGlobal as _;
+    use settings::SettingsStore;
+
     use super::{MarkdownPreviewView, resolve_preview_path};
 
     #[test]
@@ -1449,6 +1452,160 @@ mod tests {
         assert_eq!(
             editor.read_with(cx, |editor, cx| editor.buffer().read(cx).read(cx).text()),
             "- [x] Finish work\n"
+        );
+    }
+
+    #[gpui::test]
+    async fn auto_preview_same_pane_opens_preview_for_markdown(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                path!("/project"),
+                json!({
+                    "readme.md": "# Hello\n\nWorld",
+                    "main.rs": "fn main() {}"
+                }),
+            )
+            .await;
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.preview_tabs.get_or_insert_default().auto_preview =
+                        Some(settings::AutoPreviewMode::SamePane);
+                });
+            });
+        });
+
+        cx.update(|cx| {
+            open_paths(
+                &[PathBuf::from(path!("/project/readme.md"))],
+                app_state.clone(),
+                workspace::OpenOptions::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+        cx.run_until_parked();
+
+        let multi_workspace = cx.update(|cx| cx.windows()[0].downcast::<MultiWorkspace>().unwrap());
+        let has_preview = multi_workspace
+            .update(cx, |multi_workspace, _window, cx| {
+                let workspace = multi_workspace.workspace().read(cx);
+                workspace
+                    .active_pane()
+                    .read(cx)
+                    .items_of_type::<MarkdownPreviewView>()
+                    .next()
+                    .is_some()
+            })
+            .unwrap();
+
+        assert!(
+            has_preview,
+            "Opening a markdown file with auto_preview=same_pane should create a preview"
+        );
+    }
+
+    #[gpui::test]
+    async fn auto_preview_off_does_not_open_preview(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                path!("/project"),
+                json!({
+                    "readme.md": "# Hello"
+                }),
+            )
+            .await;
+
+        cx.update(|cx| {
+            open_paths(
+                &[PathBuf::from(path!("/project/readme.md"))],
+                app_state.clone(),
+                workspace::OpenOptions::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+        cx.run_until_parked();
+
+        let multi_workspace = cx.update(|cx| cx.windows()[0].downcast::<MultiWorkspace>().unwrap());
+        let has_preview = multi_workspace
+            .update(cx, |multi_workspace, _window, cx| {
+                let workspace = multi_workspace.workspace().read(cx);
+                workspace
+                    .active_pane()
+                    .read(cx)
+                    .items_of_type::<MarkdownPreviewView>()
+                    .next()
+                    .is_some()
+            })
+            .unwrap();
+
+        assert!(
+            !has_preview,
+            "With auto_preview=off (default), no preview should be created"
+        );
+    }
+
+    #[gpui::test]
+    async fn auto_preview_does_not_trigger_for_non_markdown(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                path!("/project"),
+                json!({
+                    "main.rs": "fn main() {}"
+                }),
+            )
+            .await;
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.preview_tabs.get_or_insert_default().auto_preview =
+                        Some(settings::AutoPreviewMode::SamePane);
+                });
+            });
+        });
+
+        cx.update(|cx| {
+            open_paths(
+                &[PathBuf::from(path!("/project/main.rs"))],
+                app_state.clone(),
+                workspace::OpenOptions::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+        cx.run_until_parked();
+
+        let multi_workspace = cx.update(|cx| cx.windows()[0].downcast::<MultiWorkspace>().unwrap());
+        let has_preview = multi_workspace
+            .update(cx, |multi_workspace, _window, cx| {
+                let workspace = multi_workspace.workspace().read(cx);
+                workspace
+                    .active_pane()
+                    .read(cx)
+                    .items_of_type::<MarkdownPreviewView>()
+                    .next()
+                    .is_some()
+            })
+            .unwrap();
+
+        assert!(
+            !has_preview,
+            "Auto preview should not trigger for non-markdown files"
         );
     }
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -764,6 +764,15 @@ impl VsCodeSettings {
             enable_preview_file_from_code_navigation: None,
             enable_keep_preview_on_code_navigation: self
                 .read_bool("workbench.editor.enablePreviewFromCodeNavigation"),
+            auto_preview: self
+                .read_bool("markdown.extension.preview.autoShowPreviewToSide")
+                .map(|enabled| {
+                    if enabled {
+                        AutoPreviewMode::ToSide
+                    } else {
+                        AutoPreviewMode::Off
+                    }
+                }),
         })
     }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -195,6 +195,36 @@ pub struct PreviewTabsSettingsContent {
     ///
     /// Default: false
     pub enable_keep_preview_on_code_navigation: Option<bool>,
+    /// Whether to automatically open a preview when opening previewable files
+    /// (Markdown, SVG, and CSV).
+    ///
+    /// Default: off
+    pub auto_preview: Option<AutoPreviewMode>,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum AutoPreviewMode {
+    /// Do not automatically open previews.
+    #[default]
+    Off,
+    /// Open the preview in the same pane, replacing the editor tab.
+    SamePane,
+    /// Open the preview in an adjacent pane to the side.
+    ToSide,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4346,7 +4346,7 @@ fn window_and_layout_page() -> SettingsPage {
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Auto Preview",
-                description: "Whether to automatically open a preview when opening previewable files (Markdown, SVG, and CSV).",
+                description: "Whether to automatically open a preview when opening files with preview capababilities.",
                 field: Box::new(SettingField {
                     json_path: Some("preview_tabs.auto_preview"),
                     pick: |settings_content| {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4346,7 +4346,7 @@ fn window_and_layout_page() -> SettingsPage {
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Auto Preview",
-                description: "Whether to automatically open a preview when opening files with preview capababilities.",
+                description: "Whether to automatically open a preview when opening files with preview capabilities.",
                 field: Box::new(SettingField {
                     json_path: Some("preview_tabs.auto_preview"),
                     pick: |settings_content| {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4191,7 +4191,7 @@ fn window_and_layout_page() -> SettingsPage {
         ]
     }
 
-    fn preview_tabs_section() -> [SettingsPageItem; 8] {
+    fn preview_tabs_section() -> [SettingsPageItem; 9] {
         [
             SettingsPageItem::SectionHeader("Preview Tabs"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -4339,6 +4339,28 @@ fn window_and_layout_page() -> SettingsPage {
                             .preview_tabs
                             .get_or_insert_default()
                             .enable_keep_preview_on_code_navigation = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Auto Preview",
+                description: "Whether to automatically open a preview when opening previewable files (Markdown, SVG, and CSV).",
+                field: Box::new(SettingField {
+                    json_path: Some("preview_tabs.auto_preview"),
+                    pick: |settings_content| {
+                        settings_content
+                            .preview_tabs
+                            .as_ref()?
+                            .auto_preview
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .preview_tabs
+                            .get_or_insert_default()
+                            .auto_preview = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -563,6 +563,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::AudioInputDeviceName>(render_input_audio_device_dropdown)
         .add_basic_renderer::<settings::AudioOutputDeviceName>(render_output_audio_device_dropdown)
         .add_basic_renderer::<settings::TerminalBell>(render_dropdown)
+        .add_basic_renderer::<settings::AutoPreviewMode>(render_dropdown)
         // please semicolon stay on next line
         ;
 }

--- a/crates/svg_preview/Cargo.toml
+++ b/crates/svg_preview/Cargo.toml
@@ -16,6 +16,7 @@ multi_buffer.workspace = true
 file_icons.workspace = true
 gpui.workspace = true
 language.workspace = true
+settings.workspace = true
 ui.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true

--- a/crates/svg_preview/src/svg_preview.rs
+++ b/crates/svg_preview/src/svg_preview.rs
@@ -1,5 +1,8 @@
 use gpui::{App, actions};
-use workspace::Workspace;
+use multi_buffer::MultiBuffer;
+use settings::{AutoPreviewMode, Settings};
+use workspace::item::PreviewTabsSettings;
+use workspace::{Event as WorkspaceEvent, Workspace};
 
 pub mod svg_preview_view;
 
@@ -19,6 +22,73 @@ pub fn init(cx: &mut App) {
             return;
         };
         crate::svg_preview_view::SvgPreviewView::register(workspace, window, cx);
+
+        let workspace_handle = cx.entity();
+        cx.subscribe_in(&workspace_handle, window, move |_workspace, _, event, window, cx| {
+            let WorkspaceEvent::ItemAdded { item } = event else {
+                return;
+            };
+            let auto_preview = PreviewTabsSettings::get_global(cx).auto_preview;
+            if matches!(auto_preview, AutoPreviewMode::Off) {
+                return;
+            }
+            let Some(buffer) = item.act_as::<MultiBuffer>(cx) else {
+                return;
+            };
+            if !svg_preview_view::SvgPreviewView::is_svg_file(&buffer, cx) {
+                return;
+            }
+
+            let weak_workspace = cx.entity().downgrade();
+            window.defer(cx, move |window, cx| {
+                let Some(workspace) = weak_workspace.upgrade() else {
+                    return;
+                };
+                workspace.update(cx, |workspace, cx| {
+                    let view = svg_preview_view::SvgPreviewView::create_svg_view(
+                        svg_preview_view::SvgPreviewMode::Default,
+                        workspace,
+                        buffer.clone(),
+                        window,
+                        cx,
+                    );
+
+                    match auto_preview {
+                        AutoPreviewMode::SamePane => {
+                            workspace.active_pane().update(cx, |pane, cx| {
+                                if svg_preview_view::SvgPreviewView::find_existing_preview_item_idx(pane, &buffer, cx).is_none() {
+                                    pane.add_item(Box::new(view), true, true, None, window, cx);
+                                }
+                            });
+                        }
+                        AutoPreviewMode::ToSide => {
+                            let active_pane = workspace.active_pane().clone();
+                            let pane = workspace
+                                .find_pane_in_direction(workspace::SplitDirection::Right, cx)
+                                .or_else(|| {
+                                    workspace.panes().iter().find(|p| **p != active_pane).cloned()
+                                })
+                                .unwrap_or_else(|| {
+                                    workspace.split_pane(
+                                        active_pane,
+                                        workspace::SplitDirection::Right,
+                                        window,
+                                        cx,
+                                    )
+                                });
+                            pane.update(cx, |pane, cx| {
+                                if svg_preview_view::SvgPreviewView::find_existing_preview_item_idx(pane, &buffer, cx).is_none() {
+                                    pane.add_item(Box::new(view), false, false, None, window, cx);
+                                }
+                            });
+                        }
+                        AutoPreviewMode::Off => {}
+                    }
+                    cx.notify();
+                });
+            });
+        })
+        .detach();
     })
     .detach();
 }

--- a/crates/svg_preview/src/svg_preview_view.rs
+++ b/crates/svg_preview/src/svg_preview_view.rs
@@ -136,7 +136,7 @@ impl SvgPreviewView {
         cx.notify();
     }
 
-    fn find_existing_preview_item_idx(
+    pub(crate) fn find_existing_preview_item_idx(
         pane: &Pane,
         buffer: &Entity<MultiBuffer>,
         cx: &App,
@@ -162,7 +162,7 @@ impl SvgPreviewView {
             .filter(|buffer| Self::is_svg_file(&buffer, cx))
     }
 
-    fn create_svg_view(
+    pub(crate) fn create_svg_view(
         mode: SvgPreviewMode,
         workspace: &mut Workspace,
         buffer: Entity<MultiBuffer>,

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -19,8 +19,8 @@ use language::Capability;
 pub use language::HighlightedText;
 use project::{Project, ProjectEntryId, ProjectPath};
 pub use settings::{
-    ActivateOnClose, ClosePosition, RegisterSetting, Settings, SettingsLocation, ShowCloseButton,
-    ShowDiagnostics,
+    ActivateOnClose, AutoPreviewMode, ClosePosition, RegisterSetting, Settings, SettingsLocation,
+    ShowCloseButton, ShowDiagnostics,
 };
 use smallvec::SmallVec;
 use std::{
@@ -72,6 +72,7 @@ pub struct PreviewTabsSettings {
     pub enable_preview_multibuffer_from_code_navigation: bool,
     pub enable_preview_file_from_code_navigation: bool,
     pub enable_keep_preview_on_code_navigation: bool,
+    pub auto_preview: AutoPreviewMode,
 }
 
 impl Settings for ItemSettings {
@@ -114,6 +115,7 @@ impl Settings for PreviewTabsSettings {
             enable_keep_preview_on_code_navigation: preview_tabs
                 .enable_keep_preview_on_code_navigation
                 .unwrap(),
+            auto_preview: preview_tabs.auto_preview.unwrap(),
         }
     }
 }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3222,7 +3222,8 @@ Examples:
     "enable_preview_from_multibuffer": true,
     "enable_preview_multibuffer_from_code_navigation": false,
     "enable_preview_file_from_code_navigation": true,
-    "enable_keep_preview_on_code_navigation": false
+    "enable_keep_preview_on_code_navigation": false,
+    "auto_preview": "off"
   }
 }
 ```
@@ -3286,6 +3287,18 @@ Examples:
 **Options**
 
 `boolean` values
+
+### Auto preview
+
+- Description: Whether to automatically open a preview when opening previewable files (Markdown, SVG, and CSV).
+- Setting: `auto_preview`
+- Default: `off`
+
+**Options**
+
+1. `off` (default): Do not automatically open previews.
+2. `same_pane`: Open the preview in the same pane, replacing the editor tab.
+3. `to_side`: Open the preview in an adjacent pane to the side.
 
 ## File Finder
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3290,7 +3290,7 @@ Examples:
 
 ### Auto preview
 
-- Description: Whether to automatically open a preview when opening previewable files (Markdown, SVG, and CSV).
+- Description: Whether to automatically open a preview when opening files with preview capabilities (e.g. Markdown, SVG, CSV).
 - Setting: `auto_preview`
 - Default: `off`
 


### PR DESCRIPTION
Closes #10966

## Summary

Adds an `auto_preview` setting under `preview_tabs` that automatically opens a preview when opening previewable files (Markdown, SVG, and CSV). The setting accepts three values:

- `"off"` (default) — no automatic preview
- `"same_pane"` — opens the preview in the same pane, replacing the editor tab
- `"to_side"` — opens the preview in an adjacent pane to the side

```jsonc
{
  "preview_tabs": {
    "auto_preview": "same_pane"
  }
}
```

## Demo

https://github.com/user-attachments/assets/eb2b09be-ba8e-4e9b-96eb-62d05d31fc6e

## Approach

Each preview crate (`markdown_preview`, `svg_preview`, `csv_preview`) subscribes to `workspace::Event::ItemAdded`. When a new editor is added:

1. Check the `auto_preview` setting
2. Verify the file is previewable (by extension for Markdown/SVG/CSV)
3. Use `window.defer` to create the preview view after the editor item is fully mounted

Using `window.defer` and calling preview creation functions directly (bypassing the action system) avoids both the dispatch timing issue from #48733 and reentrancy panics from nested `pane.add_item` calls. For `to_side` mode, the code falls back to any existing non-active pane before attempting `split_pane`, since `find_pane_in_direction` depends on bounding boxes that may not exist yet in the deferred context.

### Changes

- **Setting**: 3-variant `AutoPreviewMode` enum (`Off`, `SamePane`, `ToSide`) in `PreviewTabsSettingsContent`
- **Markdown**: auto-preview via file extension (`.md`, `.markdown`)
- **SVG**: auto-preview via file extension (`.svg`)
- **CSV**: auto-preview via file extension (`.csv`), gated behind `TabularDataPreviewFeatureFlag`
- **Settings UI**: dropdown in the Preview Tabs section (registered in `SettingFieldRenderer`)
- **VSCode import**: maps `markdown.extension.preview.autoShowPreviewToSide` → `auto_preview: "to_side"`
- **Documentation**: `all-settings.md` and `default.json` updated
- **Tests**: 3 integration tests (same_pane creates preview, off doesn't, non-markdown is ignored)

### Context

This is a resubmission of #56950 with fixes for the settings UI renderer registration ("NO RENDERER" issue) and a `to_side` pane resolution bug. Built and tested end-to-end on macOS 15 with Xcode 26.

Prior art: #44346, #48733. Addresses all review feedback from @SomeoneToIgnore's #48733 review cycle.

Release Notes:

- Added `auto_preview` setting to automatically open a preview when opening Markdown, SVG, or CSV files