### PR TITLE
Fix thinking mode for Xiaomi (MiMo) model

### DIFF
--- a/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
@@ -211,6 +211,7 @@ impl ModelInput {
                 prompt_cache_key: self.capabilities.supports_prompt_cache_key.selected(),
                 chat_completions: self.capabilities.supports_chat_completions.selected(),
                 interleaved_reasoning: false,
+                strip_openai_extensions: false,
             },
         })
     }

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -375,12 +375,9 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
         >,
     > {
         if self.model.capabilities.chat_completions {
-            let api_url = self
-                .state
-                .read_with(cx, |state, _cx| state.settings.api_url.clone());
-            let is_mimo = is_mimo_provider(&api_url);
+            let strip = self.model.capabilities.strip_openai_extensions;
 
-            let interleaved_reasoning = if is_mimo {
+            let interleaved_reasoning = if strip {
                 true
             } else {
                 self.model.capabilities.interleaved_reasoning
@@ -396,7 +393,7 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
                 interleaved_reasoning,
             );
 
-            if is_mimo {
+            if strip {
                 strip_openai_extensions(&mut request);
             }
 
@@ -426,10 +423,6 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
             .boxed()
         }
     }
-}
-
-fn is_mimo_provider(api_url: &str) -> bool {
-    api_url.contains("xiaomimimo")
 }
 
 fn strip_openai_extensions(request: &mut open_ai::Request) {

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -375,15 +375,31 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
         >,
     > {
         if self.model.capabilities.chat_completions {
-            let request = into_open_ai(
+            let api_url = self
+                .state
+                .read_with(cx, |state, _cx| state.settings.api_url.clone());
+            let is_mimo = is_mimo_provider(&api_url);
+
+            let interleaved_reasoning = if is_mimo {
+                true
+            } else {
+                self.model.capabilities.interleaved_reasoning
+            };
+
+            let mut request = into_open_ai(
                 request,
                 &self.model.name,
                 self.model.capabilities.parallel_tool_calls,
                 self.model.capabilities.prompt_cache_key,
                 self.max_output_tokens(),
                 self.model.reasoning_effort,
-                self.model.capabilities.interleaved_reasoning,
+                interleaved_reasoning,
             );
+
+            if is_mimo {
+                strip_openai_extensions(&mut request);
+            }
+
             let completions = self.stream_completion(request, cx);
             async move {
                 let mapper = OpenAiEventMapper::new();
@@ -409,6 +425,52 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
             }
             .boxed()
         }
+    }
+}
+
+fn is_mimo_provider(api_url: &str) -> bool {
+    api_url.contains("xiaomimimo")
+}
+
+fn strip_openai_extensions(request: &mut open_ai::Request) {
+    request.stream_options = None;
+    request.parallel_tool_calls = None;
+
+    for tool in &mut request.tools {
+        let open_ai::ToolDefinition::Function { function } = tool;
+        if let Some(ref mut params) = function.parameters {
+            strip_additional_properties(params);
+        }
+    }
+
+    for msg in &mut request.messages {
+        if let open_ai::RequestMessage::Assistant {
+            content,
+            tool_calls,
+            ..
+        } = msg
+        {
+            if !tool_calls.is_empty() && content.is_none() {
+                *content = Some(open_ai::MessageContent::Plain(String::new()));
+            }
+        }
+    }
+}
+
+fn strip_additional_properties(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.remove("additionalProperties");
+            for v in map.values_mut() {
+                strip_additional_properties(v);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                strip_additional_properties(v);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/language_models/src/provider/vercel_ai_gateway.rs
+++ b/crates/language_models/src/provider/vercel_ai_gateway.rs
@@ -575,6 +575,7 @@ async fn list_models(
                 prompt_cache_key,
                 chat_completions: true,
                 interleaved_reasoning: false,
+                strip_openai_extensions: false,
             },
         });
     }

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -319,6 +319,8 @@ pub struct OpenAiCompatibleModelCapabilities {
     pub chat_completions: bool,
     #[serde(default)]
     pub interleaved_reasoning: bool,
+    #[serde(default)]
+    pub strip_openai_extensions: bool,
 }
 
 impl Default for OpenAiCompatibleModelCapabilities {
@@ -330,6 +332,7 @@ impl Default for OpenAiCompatibleModelCapabilities {
             prompt_cache_key: false,
             chat_completions: default_true(),
             interleaved_reasoning: false,
+            strip_openai_extensions: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

Add `strip_openai_extensions` capability to the OpenAI Compatible provider, allowing models that reject OpenAI-specific fields (like Xiaomi MiMo) to work correctly. When enabled, the request is sanitized before sending: `stream_options` and `parallel_tool_calls` are removed, `additionalProperties` is stripped from tool schemas, and assistant messages with tool calls get non-empty content.

## Problem

Some OpenAI-compatible providers (like Xiaomi MiMo) return 400 "Param Incorrect" errors when the request includes OpenAI-specific extensions. Specifically:

1. **`reasoning_content` not passed back**: `into_open_ai()` only populates `reasoning_content` on assistant messages when `interleaved_reasoning = true` (default is `false`), so thinking content is sent as plain text and `reasoning_content` is `None`. MiMo requires `reasoning_content` to be echoed back.

2. **OpenAI-specific extensions rejected**: The request includes `stream_options`, `parallel_tool_calls`, `additionalProperties` in tool schemas, and empty `content` on assistant messages with tool calls — all of which MiMo's API rejects.

## What changed

**File: `crates/settings_content/src/language_model.rs`**

- Added `strip_openai_extensions: bool` field to `OpenAiCompatibleModelCapabilities` (default `false`).

**File: `crates/language_models/src/provider/open_ai_compatible.rs`**

- Added `strip_openai_extensions(request: &mut open_ai::Request)` — post-processes the request when the capability is enabled:
  - Sets `stream_options = None`
  - Sets `parallel_tool_calls = None`
  - Recursively removes `additionalProperties` from tool parameter JSON schemas
  - Sets empty string content on assistant messages with tool calls but `content: None`

- Added `strip_additional_properties(value: &mut serde_json::Value)` — recursive helper for schema cleanup.

- Modified `LanguageModel::stream_completion()` — when `strip_openai_extensions` is enabled:
  - Forces `interleaved_reasoning = true` so thinking content is correctly mapped to `reasoning_content` on assistant messages
  - Applies `strip_openai_extensions()` to the request after `into_open_ai()`

**File: `crates/language_models/src/provider/vercel_ai_gateway.rs`**

- Added `strip_openai_extensions: false` to `ModelCapabilities` construction to satisfy the new field.

## Why

MiMo models use the OpenAI Compatible API format but require `reasoning_content` to be echoed back in multi-turn conversations and reject several OpenAI-specific extensions. This change provides an opt-in capability that users can enable per-model, without affecting other providers.

## Configuration

```json
{
  "openai_compatible": {
    "mimo": {
      "api_url": "https://token-plan-sgp.xiaomimimo.com/v1",
      "available_models": [
        {
          "name": "mimo-v2.5-pro",
          "display_name": "MiMo V2.5 Pro",
          "max_tokens": 1048576,
          "capabilities": {
            "strip_openai_extensions": true
          }
        }
      ]
    }
  }
}
```

Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #56600

Release Notes:

- N/A
