### PR TITLE
git_graph: Show full commit message in tooltip on hover

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1538,13 +1538,16 @@ impl GitGraph {
                 let mut formatted_time = String::new();
                 let subject: SharedString;
                 let author_name: SharedString;
+                let message: SharedString;
 
-                if let CommitDataState::Loaded(data) = data {
+                if let CommitDataState::Loaded(data) = &data {
                     subject = data.subject.clone();
+                    message = data.message.clone();
                     author_name = data.author_name.clone();
                     formatted_time = format_timestamp(data.commit_timestamp);
                 } else {
                     subject = "Loading…".into();
+                    message = "Loading…".into();
                     author_name = "".into();
                 }
 
@@ -1607,7 +1610,16 @@ impl GitGraph {
                         .id(ElementId::NamedInteger("commit-subject".into(), idx as u64))
                         .overflow_hidden()
                         .when(!has_context_menu, |this| {
-                            this.tooltip(Tooltip::text(subject))
+                            const MAX_CHARS: usize = 800;
+                            let tooltip_message: SharedString = if message.chars().count()
+                                > MAX_CHARS
+                            {
+                                let truncated: String = message.chars().take(MAX_CHARS).collect();
+                                format!("{}…", truncated).into()
+                            } else {
+                                message.clone()
+                            };
+                            this.tooltip(Tooltip::text(tooltip_message))
                         })
                         .child(
                             h_flex()

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1544,7 +1544,7 @@ impl GitGraph {
                 let subject: SharedString;
                 let author_name: SharedString;
 
-                if let CommitDataState::Loaded(data) = data {
+                if let CommitDataState::Loaded(ref data) = data {
                     subject = data.subject.clone();
                     author_name = data.author_name.clone();
                     formatted_time = format_timestamp(data.commit_timestamp);

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1599,12 +1599,12 @@ impl GitGraph {
                             (!ranges.is_empty()).then_some(ranges)
                         })
                         .unwrap_or_default();
-                    HighlightedLabel::from_ranges(subject.clone(), highlight_ranges)
+                    HighlightedLabel::from_ranges(subject, highlight_ranges)
                         .when(!is_selected, |c| c.color(Color::Muted))
                         .truncate()
                         .into_any_element()
                 } else {
-                    column_label(subject.clone())
+                    column_label(subject)
                 };
 
                 vec![
@@ -1614,30 +1614,34 @@ impl GitGraph {
                         .when(!has_context_menu, |this| {
                             if let CommitDataState::Loaded(commit_data) = &data {
                                 let sha = commit.data.sha.to_string();
-                                let remote_url = repository.read(cx).default_remote_url();
-                                let provider_registry =
-                                    GitHostingProviderRegistry::default_global(cx);
-                                let commit_details = CommitDetails {
-                                    sha: sha.clone().into(),
-                                    author_name: commit_data.author_name.clone(),
-                                    author_email: commit_data.author_email.clone(),
-                                    commit_time: OffsetDateTime::from_unix_timestamp(
-                                        commit_data.commit_timestamp,
-                                    )
-                                    .unwrap_or_else(|_| OffsetDateTime::now_utc()),
-                                    message: Some(ParsedCommitMessage::parse(
-                                        sha,
-                                        commit_data.message.to_string(),
-                                        remote_url.as_deref(),
-                                        Some(provider_registry),
-                                    )),
-                                };
+                                let author_name = commit_data.author_name.clone();
+                                let author_email = commit_data.author_email.clone();
+                                let message = commit_data.message.clone();
+                                let commit_timestamp = commit_data.commit_timestamp;
                                 let workspace = self.workspace.clone();
                                 let repository = repository.clone();
                                 this.hoverable_tooltip(move |_window, cx| {
+                                    let remote_url = repository.read(cx).default_remote_url();
+                                    let provider_registry =
+                                        GitHostingProviderRegistry::default_global(cx);
+                                    let commit_details = CommitDetails {
+                                        sha: sha.clone().into(),
+                                        author_name: author_name.clone(),
+                                        author_email: author_email.clone(),
+                                        commit_time: OffsetDateTime::from_unix_timestamp(
+                                            commit_timestamp,
+                                        )
+                                        .unwrap_or_else(|_| OffsetDateTime::now_utc()),
+                                        message: Some(ParsedCommitMessage::parse(
+                                            sha.clone(),
+                                            message.to_string(),
+                                            remote_url.as_deref(),
+                                            Some(provider_registry),
+                                        )),
+                                    };
                                     cx.new(|cx| {
                                         CommitTooltip::new(
-                                            commit_details.clone(),
+                                            commit_details,
                                             repository.clone(),
                                             workspace.clone(),
                                             cx,

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -2,6 +2,7 @@ use collections::{BTreeMap, HashMap, IndexSet};
 use editor::Editor;
 use git::{
     BuildCommitPermalinkParams, GitHostingProviderRegistry, GitRemote, Oid, ParsedGitRemote,
+    commit::ParsedCommitMessage,
     parse_git_remote_url,
     repository::{
         CommitDiff, CommitFile, InitialGraphCommitData, LogOrder, LogSource, RepoPath,
@@ -9,7 +10,11 @@ use git::{
     },
     status::{FileStatus, StatusCode, TrackedStatus},
 };
-use git_ui::{commit_tooltip::CommitAvatar, commit_view::CommitView, git_status_icon};
+use git_ui::{
+    commit_tooltip::{CommitAvatar, CommitDetails, CommitTooltip},
+    commit_view::CommitView,
+    git_status_icon,
+};
 use gpui::{
     Action, Anchor, AnyElement, App, Bounds, ClickEvent, ClipboardItem, DefiniteLength,
     DismissEvent, DragMoveEvent, ElementId, Empty, Entity, EventEmitter, FocusHandle, Focusable,
@@ -428,16 +433,6 @@ fn format_timestamp(timestamp: i64) -> String {
 
 fn accent_colors_count(accents: &AccentColors) -> usize {
     accents.0.len()
-}
-
-fn truncate(s: &str, max_chars: usize) -> SharedString {
-    let mut chars = s.chars();
-    let truncated: String = chars.by_ref().take(max_chars).collect();
-    if chars.next().is_some() {
-        format!("{}…", truncated).into()
-    } else {
-        s.into()
-    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -1548,16 +1543,13 @@ impl GitGraph {
                 let mut formatted_time = String::new();
                 let subject: SharedString;
                 let author_name: SharedString;
-                let message: SharedString;
 
-                if let CommitDataState::Loaded(data) = &data {
+                if let CommitDataState::Loaded(data) = data {
                     subject = data.subject.clone();
-                    message = data.message.clone();
                     author_name = data.author_name.clone();
                     formatted_time = format_timestamp(data.commit_timestamp);
                 } else {
                     subject = "Loading…".into();
-                    message = "Loading…".into();
                     author_name = "".into();
                 }
 
@@ -1620,8 +1612,42 @@ impl GitGraph {
                         .id(ElementId::NamedInteger("commit-subject".into(), idx as u64))
                         .overflow_hidden()
                         .when(!has_context_menu, |this| {
-                            // Prevents excessively tall tooltips; commit messages rarely exceed this
-                            this.tooltip(Tooltip::text(truncate(&message, 800)))
+                            if let CommitDataState::Loaded(commit_data) = &data {
+                                let sha = commit.data.sha.to_string();
+                                let remote_url = repository.read(cx).default_remote_url();
+                                let provider_registry =
+                                    GitHostingProviderRegistry::default_global(cx);
+                                let commit_details = CommitDetails {
+                                    sha: sha.clone().into(),
+                                    author_name: commit_data.author_name.clone(),
+                                    author_email: commit_data.author_email.clone(),
+                                    commit_time: OffsetDateTime::from_unix_timestamp(
+                                        commit_data.commit_timestamp,
+                                    )
+                                    .unwrap_or_else(|_| OffsetDateTime::now_utc()),
+                                    message: Some(ParsedCommitMessage::parse(
+                                        sha,
+                                        commit_data.message.to_string(),
+                                        remote_url.as_deref(),
+                                        Some(provider_registry),
+                                    )),
+                                };
+                                let workspace = self.workspace.clone();
+                                let repository = repository.clone();
+                                this.hoverable_tooltip(move |_window, cx| {
+                                    cx.new(|cx| {
+                                        CommitTooltip::new(
+                                            commit_details.clone(),
+                                            repository.clone(),
+                                            workspace.clone(),
+                                            cx,
+                                        )
+                                    })
+                                    .into()
+                                })
+                            } else {
+                                this
+                            }
                         })
                         .child(
                             h_flex()
@@ -6278,34 +6304,5 @@ mod tests {
             resolved_task.resolved.env.get("REPOSITORY"),
             Some(&"project".to_string())
         );
-    }
-
-    #[test]
-    fn test_truncate_short() {
-        assert_eq!(truncate("hello", 10), "hello");
-    }
-
-    #[test]
-    fn test_truncate_exactly_max() {
-        assert_eq!(truncate("abcde", 5), "abcde");
-    }
-
-    #[test]
-    fn test_truncate_over_max() {
-        let result = truncate("abcdef", 5);
-        assert_eq!(result, "abcde…");
-    }
-
-    #[test]
-    fn test_truncate_unicode() {
-        let result = truncate("🦊🦊🦊🦊🦊🦊", 5);
-        assert!(result.ends_with('…'));
-        assert_eq!(result.chars().filter(|c| *c == '🦊').count(), 5);
-    }
-
-    #[test]
-    fn test_truncate_multiline() {
-        let msg = "Subject line\n\nBody paragraph with details.";
-        assert_eq!(truncate(msg, 100), msg);
     }
 }

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -430,6 +430,16 @@ fn accent_colors_count(accents: &AccentColors) -> usize {
     accents.0.len()
 }
 
+fn truncate(s: &str, max_chars: usize) -> SharedString {
+    let mut chars = s.chars();
+    let truncated: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_some() {
+        format!("{}…", truncated).into()
+    } else {
+        s.into()
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 struct BranchColor(u8);
 
@@ -1610,16 +1620,8 @@ impl GitGraph {
                         .id(ElementId::NamedInteger("commit-subject".into(), idx as u64))
                         .overflow_hidden()
                         .when(!has_context_menu, |this| {
-                            const MAX_CHARS: usize = 800;
-                            let tooltip_message: SharedString = if message.chars().count()
-                                > MAX_CHARS
-                            {
-                                let truncated: String = message.chars().take(MAX_CHARS).collect();
-                                format!("{}…", truncated).into()
-                            } else {
-                                message.clone()
-                            };
-                            this.tooltip(Tooltip::text(tooltip_message))
+                            // Prevents excessively tall tooltips; commit messages rarely exceed this
+                            this.tooltip(Tooltip::text(truncate(&message, 800)))
                         })
                         .child(
                             h_flex()
@@ -6276,5 +6278,34 @@ mod tests {
             resolved_task.resolved.env.get("REPOSITORY"),
             Some(&"project".to_string())
         );
+    }
+
+    #[test]
+    fn test_truncate_short() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_truncate_exactly_max() {
+        assert_eq!(truncate("abcde", 5), "abcde");
+    }
+
+    #[test]
+    fn test_truncate_over_max() {
+        let result = truncate("abcdef", 5);
+        assert_eq!(result, "abcde…");
+    }
+
+    #[test]
+    fn test_truncate_unicode() {
+        let result = truncate("🦊🦊🦊🦊🦊🦊", 5);
+        assert!(result.ends_with('…'));
+        assert_eq!(result.chars().filter(|c| *c == '🦊').count(), 5);
+    }
+
+    #[test]
+    fn test_truncate_multiline() {
+        let msg = "Subject line\n\nBody paragraph with details.";
+        assert_eq!(truncate(msg, 100), msg);
     }
 }

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -299,11 +299,10 @@ impl Render for CommitTooltip {
                 .child(
                     v_flex()
                         .w(gpui::rems(30.))
-                        .gap_4()
                         .child(
                             h_flex()
-                                .pb_1p5()
-                                .gap_x_2()
+                                .pb_1()
+                                .gap_2()
                                 .overflow_x_hidden()
                                 .flex_wrap()
                                 .child(avatar)
@@ -321,23 +320,24 @@ impl Render for CommitTooltip {
                         .child(
                             div()
                                 .id("inline-blame-commit-message")
-                                .child(message)
+                                .track_scroll(&self.scroll_handle)
+                                .py_1p5()
                                 .max_h(message_max_height)
                                 .overflow_y_scroll()
-                                .track_scroll(&self.scroll_handle),
+                                .child(message),
                         )
                         .child(
                             h_flex()
                                 .text_color(cx.theme().colors().text_muted)
                                 .w_full()
                                 .justify_between()
-                                .pt_1p5()
+                                .pt_1()
                                 .border_t_1()
                                 .border_color(cx.theme().colors().border_variant)
                                 .child(absolute_timestamp)
                                 .child(
                                     h_flex()
-                                        .gap_1p5()
+                                        .gap_1()
                                         .when_some(pull_request, |this, pr| {
                                             this.child(
                                                 Button::new(
@@ -347,9 +347,9 @@ impl Render for CommitTooltip {
                                                 .color(Color::Muted)
                                                 .start_icon(
                                                     Icon::new(IconName::PullRequest)
+                                                        .size(IconSize::Small)
                                                         .color(Color::Muted),
                                                 )
-                                                .style(ButtonStyle::Subtle)
                                                 .on_click(move |_, _, cx| {
                                                     cx.stop_propagation();
                                                     cx.open_url(pr.url.as_str())
@@ -362,10 +362,11 @@ impl Render for CommitTooltip {
                                                 "commit-sha-button",
                                                 short_commit_id.clone(),
                                             )
-                                            .style(ButtonStyle::Subtle)
                                             .color(Color::Muted)
                                             .start_icon(
-                                                Icon::new(IconName::FileGit).color(Color::Muted),
+                                                Icon::new(IconName::FileGit)
+                                                    .size(IconSize::Small)
+                                                    .color(Color::Muted),
                                             )
                                             .on_click(
                                                 move |_, window, cx| {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #56903 

Release Notes:

- Improved commit tooltip in Git Graph.

## Screenshots

Showing full commit message:

<img width="3024" height="1898" alt="CleanShot 2026-05-17 at 21 59 35@2x" src="https://github.com/user-attachments/assets/503ca832-fc07-4f90-961f-a9c4e25fcba2" />

Truncating messages with more than 800 characters:

<img width="1536" height="1096" alt="CleanShot 2026-05-17 at 22 12 07" src="https://github.com/user-attachments/assets/314be9a9-0aaa-44ff-aa15-de5eb38c863a" />


## Alternative

One thing I was considering is whether we should be using a `HoverPopover` instead so that the preview is wider and we don't have to truncate the commit message body. I would love to hear your thoughts on this. For now, I stuck with the `Tooltip` for simplicity reasons.

<img width="3024" height="1896" alt="CleanShot 2026-05-17 at 22 04 39@2x" src="https://github.com/user-attachments/assets/5b8806f6-3dce-4675-9150-df9257ad6269" />


