### PR TITLE
editor: Remove redundant allocation when merging highlight ranges

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -10410,20 +10410,13 @@ impl Element for EditorElement {
                         cx,
                     );
 
-                    let merged_highlighted_ranges =
-                        if let Some((_, colors)) = document_colors.as_ref() {
-                            &highlighted_ranges
-                                .clone()
-                                .into_iter()
-                                .chain(colors.clone())
-                                .collect()
-                        } else {
-                            &highlighted_ranges
-                        };
+                    if let Some((_, colors)) = document_colors.as_ref() {
+                        highlighted_ranges.extend(colors.iter().cloned());
+                    }
                     let bg_segments_per_row = Self::bg_segments_per_row(
                         start_row..end_row,
                         &selections,
-                        &merged_highlighted_ranges,
+                        &highlighted_ranges,
                         self.style.background,
                     );
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3682,7 +3682,7 @@ impl EditorElement {
     fn bg_segments_per_row(
         rows: Range<DisplayRow>,
         selections: &[(PlayerColor, Vec<SelectionLayout>)],
-        highlight_ranges: &[(Range<DisplayPoint>, Hsla)],
+        highlight_ranges: impl IntoIterator<Item = (Range<DisplayPoint>, Hsla)>,
         base_background: Hsla,
     ) -> Vec<Vec<(Range<DisplayPoint>, Hsla)>> {
         if rows.start >= rows.end {
@@ -3692,7 +3692,7 @@ impl EditorElement {
             // We don't actually know what color is behind this editor.
             return Vec::new();
         }
-        let highlight_iter = highlight_ranges.iter().cloned();
+        let highlight_iter = highlight_ranges.into_iter();
         let selection_iter = selections.iter().flat_map(|(player_color, layouts)| {
             let color = player_color.selection;
             layouts.iter().filter_map(move |selection_layout| {
@@ -10410,13 +10410,12 @@ impl Element for EditorElement {
                         cx,
                     );
 
-                    if let Some((_, colors)) = document_colors.as_ref() {
-                        highlighted_ranges.extend(colors.iter().cloned());
-                    }
                     let bg_segments_per_row = Self::bg_segments_per_row(
                         start_row..end_row,
                         &selections,
-                        &highlighted_ranges,
+                        highlighted_ranges.iter().cloned().chain(
+                            document_colors.iter().flat_map(|(_, colors)| colors.iter().cloned()),
+                        ),
                         self.style.background,
                     );
 
@@ -13842,7 +13841,7 @@ mod tests {
             let result = EditorElement::bg_segments_per_row(
                 DisplayRow(0)..DisplayRow(5),
                 &selections,
-                &[],
+                [].into_iter(),
                 base_bg,
             );
 
@@ -13891,7 +13890,7 @@ mod tests {
             let result = EditorElement::bg_segments_per_row(
                 DisplayRow(0)..DisplayRow(4),
                 &selections,
-                &[],
+                [].into_iter(),
                 base_bg,
             );
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -10414,7 +10414,9 @@ impl Element for EditorElement {
                         start_row..end_row,
                         &selections,
                         highlighted_ranges.iter().cloned().chain(
-                            document_colors.iter().flat_map(|(_, colors)| colors.iter().cloned()),
+                            document_colors
+                                .iter()
+                                .flat_map(|(_, colors)| colors.iter().cloned()),
                         ),
                         self.style.background,
                     );


### PR DESCRIPTION
Reduce one Vec clone + collect allocation per frame

Release Notes:

- N/A or Added/Fixed/Improved ...
