### PR TITLE
agent: Remove unused `LanguageModelImage` APIs

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4394,7 +4394,6 @@ impl From<UserMessageContent> for acp::ContentBlock {
 fn convert_image(image_content: acp::ImageContent) -> LanguageModelImage {
     LanguageModelImage {
         source: image_content.data.into(),
-        size: None,
     }
 }
 

--- a/crates/agent_ui/src/context.rs
+++ b/crates/agent_ui/src/context.rs
@@ -53,7 +53,6 @@ pub fn load_context(mention_set: &Entity<MentionSet>, cx: &mut App) -> Task<Opti
                 }
                 Mention::Image(mention_image) => loaded_context.images.push(LanguageModelImage {
                     source: mention_image.data,
-                    ..LanguageModelImage::empty()
                 }),
                 Mention::Link => {}
             }

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -118,13 +118,7 @@ impl LanguageModelImageExt for LanguageModelImage {
             // SAFETY: The base64 encoder should not produce non-UTF8.
             let source = unsafe { String::from_utf8_unchecked(base64_image) };
 
-            let (final_width, final_height) = processed_image.dimensions();
-
             Some(LanguageModelImage {
-                size: Some(ImageSize {
-                    width: final_width as i32,
-                    height: final_height as i32,
-                }),
                 source: source.into(),
             })
         })
@@ -228,16 +222,6 @@ mod tests {
             "Dimensions should have shrunk: got {}×{}",
             w,
             h
-        );
-
-        let size = lm_image.size.expect("ImageSize should be present");
-        assert_eq!(
-            size.width, w as i32,
-            "ImageSize.width should match the encoded PNG width after downscaling"
-        );
-        assert_eq!(
-            size.height, h as i32,
-            "ImageSize.height should match the encoded PNG height after downscaling"
         );
     }
 }

--- a/crates/language_model_core/src/request.rs
+++ b/crates/language_model_core/src/request.rs
@@ -16,8 +16,6 @@ pub struct ImageSize {
 pub struct LanguageModelImage {
     /// A base64-encoded PNG image.
     pub source: SharedString,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub size: Option<ImageSize>,
 }
 
 impl LanguageModelImage {
@@ -30,57 +28,24 @@ impl LanguageModelImage {
     }
 
     pub fn empty() -> Self {
-        Self {
-            source: "".into(),
-            size: None,
-        }
+        Self { source: "".into() }
     }
 
     /// Parse Self from a JSON object with case-insensitive field names
     pub fn from_json(obj: &serde_json::Map<String, serde_json::Value>) -> Option<Self> {
         let mut source = None;
-        let mut size_obj = None;
 
         for (k, v) in obj.iter() {
             match k.to_lowercase().as_str() {
                 "source" => source = v.as_str(),
-                "size" => size_obj = v.as_object(),
                 _ => {}
             }
         }
 
         let source = source?;
-        let size_obj = size_obj?;
-
-        let mut width = None;
-        let mut height = None;
-
-        for (k, v) in size_obj.iter() {
-            match k.to_lowercase().as_str() {
-                "width" => width = v.as_i64().map(|w| w as i32),
-                "height" => height = v.as_i64().map(|h| h as i32),
-                _ => {}
-            }
-        }
-
         Some(Self {
-            size: Some(ImageSize {
-                width: width?,
-                height: height?,
-            }),
             source: SharedString::from(source.to_string()),
         })
-    }
-
-    pub fn estimate_tokens(&self) -> usize {
-        let Some(size) = self.size.as_ref() else {
-            return 0;
-        };
-        let width = size.width.unsigned_abs() as usize;
-        let height = size.height.unsigned_abs() as usize;
-
-        // From: https://docs.anthropic.com/en/docs/build-with-claude/vision#calculate-image-costs
-        (width * height) / 750
     }
 
     pub fn to_base64_url(&self) -> String {
@@ -92,7 +57,6 @@ impl std::fmt::Debug for LanguageModelImage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LanguageModelImage")
             .field("source", &format!("<{} bytes>", self.source.len()))
-            .field("size", &self.size)
             .finish()
     }
 }
@@ -480,9 +444,6 @@ mod tests {
         match content {
             LanguageModelToolResultContent::Image(image) => {
                 assert_eq!(image.source.as_ref(), "base64encodedimagedata");
-                let size = image.size.expect("size");
-                assert_eq!(size.width, 100);
-                assert_eq!(size.height, 200);
             }
             _ => panic!("Expected Image variant"),
         }
@@ -491,16 +452,12 @@ mod tests {
         let json = serde_json::json!({
             "image": {
                 "source": "wrappedimagedata",
-                "size": {"width": 50, "height": 75}
             }
         });
         let content: LanguageModelToolResultContent = serde_json::from_value(json).unwrap();
         match content {
             LanguageModelToolResultContent::Image(image) => {
                 assert_eq!(image.source.as_ref(), "wrappedimagedata");
-                let size = image.size.expect("size");
-                assert_eq!(size.width, 50);
-                assert_eq!(size.height, 75);
             }
             _ => panic!("Expected Image variant"),
         }
@@ -508,15 +465,11 @@ mod tests {
         // Test case insensitive
         let json = serde_json::json!({
             "Source": "caseinsensitive",
-            "Size": {"Width": 30, "Height": 40}
         });
         let content: LanguageModelToolResultContent = serde_json::from_value(json).unwrap();
         match content {
             LanguageModelToolResultContent::Image(image) => {
                 assert_eq!(image.source.as_ref(), "caseinsensitive");
-                let size = image.size.expect("size");
-                assert_eq!(size.width, 30);
-                assert_eq!(size.height, 40);
             }
             _ => panic!("Expected Image variant"),
         }
@@ -524,15 +477,11 @@ mod tests {
         // Test direct image object
         let json = serde_json::json!({
             "source": "directimage",
-            "size": {"width": 200, "height": 300}
         });
         let content: LanguageModelToolResultContent = serde_json::from_value(json).unwrap();
         match content {
             LanguageModelToolResultContent::Image(image) => {
                 assert_eq!(image.source.as_ref(), "directimage");
-                let size = image.size.expect("size");
-                assert_eq!(size.width, 200);
-                assert_eq!(size.height, 300);
             }
             _ => panic!("Expected Image variant"),
         }

--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -1003,7 +1003,6 @@ mod tests {
                     MessageContent::Text("What's in this image?".into()),
                     MessageContent::Image(LanguageModelImage {
                         source: "base64data".into(),
-                        size: None,
                     }),
                 ],
                 cache: false,

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -1340,7 +1340,6 @@ mod tests {
         };
         let user_image = LanguageModelImage {
             source: SharedString::from("aGVsbG8="),
-            size: None,
         };
         let expected_image_url = user_image.to_base64_url();
 


### PR DESCRIPTION
Pulled out from #56866. Will help with MCP image support

Release Notes:

- N/A
