### PR TITLE
Disable rubydex by default in Ruby language servers

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2271,6 +2271,7 @@
         "!steep",
         "!kanayago",
         "!fuzzy-ruby-server",
+        "!rubydex",
         "...",
       ],
     },


### PR DESCRIPTION
## Summary

Add `!rubydex` to the Ruby language servers list in the default settings so it is opt-in rather than enabled by default for all users.

This is a prerequisite for working to integrate this new Ruby library for indexing: https://github.com/Shopify/rubydex

Release Notes:

- Disabled `rubydex` by default for Ruby files.

Reference: https://github.com/zed-industries/zed/pull/55215
