### PR TITLE
languages: Exclude angle brackets from rainbow bracket colorization for Javascript

### DIFF
--- a/crates/grammars/src/javascript/brackets.scm
+++ b/crates/grammars/src/javascript/brackets.scm
@@ -7,14 +7,17 @@
 ("{" @open
   "}" @close)
 
-("<" @open
+(("<" @open
   ">" @close)
+  (#set! rainbow.exclude))
 
-("<" @open
+(("<" @open
   "/>" @close)
+  (#set! rainbow.exclude))
 
-("</" @open
+(("</" @open
   ">" @close)
+  (#set! rainbow.exclude))
 
 (("\"" @open
   "\"" @close)


### PR DESCRIPTION
## Summary

Extends #51311 to JSX in JavaScript files, which uses the same javascript grammar for both .js and .jsx.

## Changes

- Added (#set! rainbow.exclude) to the three angle bracket patterns in crates/grammars/src/javascript/brackets.scm, matching the TSX fix in #51311.

## Before / After

Before: angle brackets in JSX tags receive rainbow colors alongside `{}`, `()`, `[]`, making every tag visually noisy.

After: only `{}`, `()`, and `[]` receive rainbow colors — angle brackets are excluded, matching the HTML extension behavior.

Release Notes:

- Fixed angled brackets being included in rainbow bracket highlights for JavaScript.