### PR TITLE
agent: Correct `single_file_review` default in docs and schema comment

### DIFF
--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -151,7 +151,11 @@ pub struct AgentSettingsContent {
     pub play_sound_when_agent_done: Option<PlaySoundWhenAgentDone>,
     /// Whether to display agent edits in single-file editors in addition to the review multibuffer pane.
     ///
-    /// Default: true
+    /// When enabled, opened buffers that the agent has modified show inline
+    /// hunk controls to keep/reject individual hunks. Note that this temporarily
+    /// overrides the buffer's git diff while review is active.
+    ///
+    /// Default: false
     pub single_file_review: Option<bool>,
     /// Additional parameters for language model requests. When making a request
     /// to a model, parameters will be taken from the last entry in this list

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -119,9 +119,18 @@ To see which files specifically have been edited, expand the accordion bar that 
 
 You can accept or reject each individual change hunk, or the whole set of changes made by the agent.
 
-Edit diffs also appear in singleton buffers.
-If your active tab had edits made by the AI, you'll see diffs with the same accept/reject controls as in the multi-buffer.
-You can turn this off, though, through the `agent.single_file_review` setting.
+Edit diffs can also appear inline in singleton buffers, with the same
+keep/reject hunk controls as the multi-buffer review pane. This is opt-in
+(it temporarily overrides the buffer's git diff while review is active);
+enable it by setting `agent.single_file_review` to `true` in your settings:
+
+```json
+{
+  "agent": {
+    "single_file_review": true
+  }
+}
+```
 
 ## Adding Context {#adding-context}
 


### PR DESCRIPTION
The default was flipped to `false` in #48619, but the doc comment in `settings_content` and the agent-panel docs still implied it was on by default. Update both to match the shipped default and explain that the setting is opt-in because it temporarily overrides the buffers git diff while review is active.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments - N/A
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) - N/A
- [ ] Tests cover the new/changed behavior - N/A
- [ ] Performance impact has been considered and is acceptable - N/A

Closes #ISSUE: N/A

Release Notes:

- N/A 
