### PR TITLE
Address review feedback on skills announcement toast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
  "gpui",
  "markdown_preview",
  "notifications",
+ "prompt_store",
  "release_channel",
  "semver",
  "serde",

--- a/crates/auto_update_ui/Cargo.toml
+++ b/crates/auto_update_ui/Cargo.toml
@@ -22,6 +22,7 @@ feature_flags.workspace = true
 gpui.workspace = true
 markdown_preview.workspace = true
 notifications.workspace = true
+prompt_store.workspace = true
 release_channel.workspace = true
 semver.workspace = true
 serde.workspace = true

--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -10,6 +10,7 @@ use gpui::{
     prelude::*,
 };
 use markdown_preview::markdown_preview_view::{MarkdownPreviewMode, MarkdownPreviewView};
+use prompt_store::rules_to_skills_migration;
 use release_channel::{AppVersion, ReleaseChannel};
 use semver::Version;
 use serde::Deserialize;
@@ -184,7 +185,7 @@ struct AnnouncementContent {
     description: SharedString,
     bullet_items: Vec<SharedString>,
     primary_action_label: SharedString,
-    secondary_action_label: Option<SharedString>,
+    secondary_action_label: SharedString,
     primary_action_url: Option<SharedString>,
     primary_action_callback: Option<Arc<dyn Fn(&mut Window, &mut App) + Send + Sync>>,
     secondary_action_url: Option<SharedString>,
@@ -194,7 +195,7 @@ struct AnnouncementContent {
 struct SkillsAnnouncement;
 
 impl Dismissable for SkillsAnnouncement {
-    const KEY: &'static str = "skills_migration_announcement_banner_dismissed_at";
+    const KEY: &'static str = "skills_announcement_dismissed";
 }
 
 fn announcement_for_version(version: &Version, cx: &App) -> Option<AnnouncementContent> {
@@ -210,19 +211,32 @@ fn announcement_for_version(version: &Version, cx: &App) -> Option<AnnouncementC
         && !SkillsAnnouncement::dismissed(cx)
         && cx.has_flag::<SkillsFeatureFlag>()
     {
+        // Only mention the Rules → Skills migration if the user actually
+        // had Rules that got migrated. New users (and existing users who
+        // never created a Rule) would otherwise be confused by a bullet
+        // referring to "your rules" that don't exist.
+        let migrated_anything =
+            rules_to_skills_migration::migration_result().is_some_and(|result| !result.is_empty());
+
+        let mut bullet_items: Vec<SharedString> = Vec::with_capacity(3);
+        bullet_items
+            .push(format!("Skills live in {GLOBAL_SKILLS_DIR_DISPLAY}/<name>/SKILL.md").into());
+        if migrated_anything {
+            bullet_items.push(
+                "Default Rules are converted into your global AGENTS.md; all other rules become skills".into(),
+            );
+        }
+        bullet_items.push("Type / to manually invoke a skill".into());
+
         Some(AnnouncementContent {
             heading: "Introducing Skills Support".into(),
             description: "Extend the agent with focused instructions and domain knowledge.".into(),
-            bullet_items: vec![
-                format!("Skills live in {GLOBAL_SKILLS_DIR_DISPLAY}/<name>/SKILL.md").into(),
-                "Default Rules are converted into your global AGENTS.md; all other rules become skills".into(),
-                "Type / to manually invoke a skill".into(),
-            ],
+            bullet_items,
             primary_action_label: "Try Now".into(),
-            secondary_action_label: Some("Read Documentation".into()),
+            secondary_action_label: "Read Documentation".into(),
             primary_action_url: None,
             primary_action_callback: Some(Arc::new(move |window, cx| {
-                window.dispatch_action(Box::new(zed_actions::assistant::ToggleFocus), cx);
+                window.dispatch_action(Box::new(zed_actions::assistant::FocusAgent), cx);
             })),
             on_dismiss: Some(Arc::new(|cx| SkillsAnnouncement::set_dismissed(true, cx))),
             secondary_action_url: Some("https://zed.dev/docs/ai/skills".into()),
@@ -276,15 +290,12 @@ impl Render for AnnouncementToastNotification {
                     .map(|item| ListBulletItem::new(item.clone())),
             )
             .primary_action_label(self.content.primary_action_label.clone())
-            .when_some(
-                self.content.secondary_action_label.clone(),
-                |toast, label| toast.secondary_action_label(label),
-            )
+            .secondary_action_label(self.content.secondary_action_label.clone())
             .primary_on_click(cx.listener({
                 let url = self.content.primary_action_url.clone();
                 let callback = self.content.primary_action_callback.clone();
                 move |this, _, window, cx| {
-                    telemetry::event!("Announcement Main Click");
+                    telemetry::event!("Skills Announcement Main Click");
                     if let Some(callback) = &callback {
                         callback(window, cx);
                     }
@@ -297,14 +308,14 @@ impl Render for AnnouncementToastNotification {
             .secondary_on_click(cx.listener({
                 let url = self.content.secondary_action_url.clone();
                 move |_, _, _window, cx| {
-                    telemetry::event!("Announcement Secondary Click");
+                    telemetry::event!("Skills Announcement Secondary Click");
                     if let Some(url) = &url {
                         cx.open_url(url);
                     }
                 }
             }))
             .dismiss_on_click(cx.listener(|this, _, _window, cx| {
-                telemetry::event!("Announcement Dismiss");
+                telemetry::event!("Skills Announcement Dismiss");
                 this.dismiss(cx);
             }))
     }

--- a/crates/prompt_store/src/rules_to_skills_migration.rs
+++ b/crates/prompt_store/src/rules_to_skills_migration.rs
@@ -62,15 +62,15 @@ pub const MIGRATION_DONE_KEY: &str = "rules_to_skills_migration_done";
 
 /// Global KVP key for the JSON-serialized [`MigrationResult`] produced by
 /// the most recent migration run — the lists of source-Rule titles that
-/// were migrated to each destination. The title-bar banner and its
-/// explainer modal read this to decide what (if anything) to tell the
-/// user about what changed.
+/// were migrated to each destination. The skills announcement toast
+/// reads this to decide whether to mention the migration in its copy.
 pub const MIGRATION_RESULT_KEY: &str = "rules_to_skills_migration_result";
 
 /// A persistent record of what the rules-to-skills migration actually
 /// migrated. Persisted in [`GlobalKeyValueStore`] under
-/// [`MIGRATION_RESULT_KEY`] and read back by the announcement UI so the
-/// modal can list specific rule names instead of vaguely gesturing.
+/// [`MIGRATION_RESULT_KEY`] and read back by the skills announcement
+/// toast so it can tailor its copy to users who actually had Rules to
+/// migrate.
 ///
 /// All three lists hold the *original* user-facing Rule titles, not the
 /// derived skill slug or any other transformed identifier — those are
@@ -92,10 +92,9 @@ pub struct MigrationResult {
 
 impl MigrationResult {
     /// `true` if the migration didn't actually move any Rule anywhere —
-    /// i.e. the user had no Rules of any kind to migrate. The
-    /// announcement banner/modal uses this to switch between the
-    /// "Introducing: Skills" generic intro and the "Skills have replaced
-    /// Rules" migration summary.
+    /// i.e. the user had no Rules of any kind to migrate. The skills
+    /// announcement toast uses this to omit the migration-flavored
+    /// bullet for users who never had any Rules.
     pub fn is_empty(&self) -> bool {
         self.skill_names.is_empty()
             && self.agents_md_names.is_empty()


### PR DESCRIPTION
Follow-ups from code review on #skills-announcement. Items #5 (the doc-comment removal was intentional), #7 (illustration skill names), and #9 (the TODO on the version match) are intentionally left as-is per discussion.

### Changes

**`Try Now` no longer un-focuses an already-focused agent panel.** `ToggleFocus` dispatches `workspace.toggle_panel_focus` which un-focuses when already focused. Swapped for `FocusAgent`, which calls `focus_panel` unconditionally.

**Migration bullet is omitted for users who never had Rules.** The deleted `RulesToSkillsModal` had two flavors (generic intro vs migration summary) gated on `MigrationResult::is_empty()`. The toast now reads `migration_result()` and only includes the "Default Rules are converted into your global AGENTS.md\u2026" bullet when the migration actually moved something. New users (and existing users without Rules) see a cleaner two-bullet message that doesn't reference rules they don't have.

**Telemetry events prefixed with `Skills`.** Previously `Announcement Main Click` etc., which would collide with the past parallel-agent announcement data and any future announcement reusing this code path. Now `Skills Announcement Main Click` / `Skills Announcement Secondary Click` / `Skills Announcement Dismiss`.

**Dropped `Option<SharedString>` around `secondary_action_label`.** The underlying `AnnouncementToast` field is a plain `SharedString` with a default of `"Learn More"`, so `None` didn't actually hide the button \u2014 it just kept the default label. Made the field a plain `SharedString` to match.

**Renamed dismiss key** from `skills_migration_announcement_banner_dismissed_at` to `skills_announcement_dismissed`. "banner" was leftover from when this was a title-bar banner; `_at` suggested a timestamp value but it's a bool. Safe to rename because this PR hasn't shipped yet.

**Refreshed stale doc comments** in `prompt_store/src/rules_to_skills_migration.rs` that still referenced the deleted modal and title-bar banner.

### Files

- `crates/auto_update_ui/Cargo.toml` \u2014 add `prompt_store` dep
- `crates/auto_update_ui/src/auto_update_ui.rs` \u2014 all the toast-side changes above
- `crates/prompt_store/src/rules_to_skills_migration.rs` \u2014 doc-comment refresh only, no behavior change
- `Cargo.lock` \u2014 `prompt_store` added to `auto_update_ui`'s deps

`cargo check -p auto_update_ui` is clean.

Release Notes:

- N/A