### PR TITLE
opencode: Model updates

### DIFF
--- a/crates/language_models/src/provider/opencode.rs
+++ b/crates/language_models/src/provider/opencode.rs
@@ -602,11 +602,11 @@ impl LanguageModel for OpenCodeLanguageModel {
     }
 
     fn max_token_count(&self) -> u64 {
-        self.model.max_token_count()
+        self.model.max_token_count(self.subscription)
     }
 
     fn max_output_tokens(&self) -> Option<u64> {
-        self.model.max_output_tokens()
+        self.model.max_output_tokens(self.subscription)
     }
 
     fn stream_completion(
@@ -646,7 +646,9 @@ impl LanguageModel for OpenCodeLanguageModel {
                     request,
                     self.model.id().to_string(),
                     1.0,
-                    self.model.max_output_tokens().unwrap_or(8192),
+                    self.model
+                        .max_output_tokens(self.subscription)
+                        .unwrap_or(8192),
                     mode,
                     anthropic::completion::AnthropicPromptCacheMode::Automatic,
                 );
@@ -671,7 +673,7 @@ impl LanguageModel for OpenCodeLanguageModel {
                     self.model.id(),
                     false,
                     false,
-                    self.model.max_output_tokens(),
+                    self.model.max_output_tokens(self.subscription),
                     reasoning_effort,
                     self.model.interleaved_reasoning(),
                 );
@@ -692,7 +694,7 @@ impl LanguageModel for OpenCodeLanguageModel {
                     self.model.id(),
                     false,
                     false,
-                    self.model.max_output_tokens(),
+                    self.model.max_output_tokens(self.subscription),
                     None,
                     supports_none_reasoning_effort,
                 );

--- a/crates/opencode/src/opencode.rs
+++ b/crates/opencode/src/opencode.rs
@@ -389,6 +389,7 @@ impl Model {
             | Self::MimoV2_5Pro
             | Self::Glm5
             | Self::Glm5_1
+            | Self::Nemotron3SuperFree
             | Self::BigPickle => true,
 
             Self::Custom {
@@ -400,7 +401,7 @@ impl Model {
         }
     }
 
-    pub fn max_token_count(&self) -> u64 {
+    pub fn max_token_count(&self, subscription: OpenCodeSubscription) -> u64 {
         match self {
             // Anthropic models
             Self::ClaudeOpus4_7 => 1_000_000,
@@ -429,7 +430,13 @@ impl Model {
             // OpenAI-compatible models
             Self::MiniMaxM2_7 => 204_800,
             Self::MiniMaxM2_5 | Self::MiniMaxM2_5Free => 204_800,
-            Self::Glm5 | Self::Glm5_1 => 202_725,
+            Self::Glm5 | Self::Glm5_1 => {
+                if subscription == OpenCodeSubscription::Go {
+                    202_752
+                } else {
+                    204_800
+                }
+            }
             Self::KimiK2_6 | Self::KimiK2_5 => 262_144,
             Self::MimoV2_5Pro => 1_048_576,
             Self::MimoV2_5 => 1_000_000,
@@ -442,7 +449,7 @@ impl Model {
         }
     }
 
-    pub fn max_output_tokens(&self) -> Option<u64> {
+    pub fn max_output_tokens(&self, subscription: OpenCodeSubscription) -> Option<u64> {
         match self {
             // Anthropic models
             Self::ClaudeOpus4_7 | Self::ClaudeOpus4_6 => Some(128_000),
@@ -477,8 +484,21 @@ impl Model {
 
             // OpenAI-compatible models
             Self::MiniMaxM2_7 => Some(131_072),
-            Self::MiniMaxM2_5 | Self::MiniMaxM2_5Free => Some(131_072),
-            Self::Glm5 | Self::Glm5_1 => Some(32_768),
+            Self::MiniMaxM2_5Free => Some(131_072),
+            Self::MiniMaxM2_5 => {
+                if subscription == OpenCodeSubscription::Go {
+                    Some(65_536)
+                } else {
+                    Some(131_072)
+                }
+            }
+            Self::Glm5 | Self::Glm5_1 => {
+                if subscription == OpenCodeSubscription::Go {
+                    Some(32_768)
+                } else {
+                    Some(131_072)
+                }
+            }
             Self::BigPickle => Some(128_000),
             Self::KimiK2_6 | Self::KimiK2_5 => Some(65_536),
             Self::Qwen3_5Plus | Self::Qwen3_6Plus => Some(65_536),
@@ -516,7 +536,6 @@ impl Model {
             | Self::Gpt5_4Mini
             | Self::Gpt5_4Nano
             | Self::Gpt5_3Codex
-            | Self::Gpt5_3Spark
             | Self::Gpt5_2
             | Self::Gpt5_2Codex
             | Self::Gpt5_1
@@ -526,6 +545,9 @@ impl Model {
             | Self::Gpt5
             | Self::Gpt5Codex
             | Self::Gpt5Nano => true,
+
+            // OpenAI models without image support
+            Self::Gpt5_3Spark => false,
 
             // Google models support images
             Self::Gemini3_1Pro | Self::Gemini3Flash => true,

--- a/crates/opencode/src/opencode.rs
+++ b/crates/opencode/src/opencode.rs
@@ -141,8 +141,6 @@ pub enum Model {
     MimoV2_5,
     #[serde(rename = "big-pickle")]
     BigPickle,
-    #[serde(rename = "ring-2.6-1t-free")]
-    Ring2_6_1TFree,
     #[serde(rename = "nemotron-3-super-free")]
     Nemotron3SuperFree,
     #[serde(rename = "qwen3.5-plus")]
@@ -204,10 +202,9 @@ impl Model {
             | Self::DeepSeekV4Flash => &[OpenCodeSubscription::Go],
 
             // Free models
-            Self::MiniMaxM2_5Free
-            | Self::Nemotron3SuperFree
-            | Self::BigPickle
-            | Self::Ring2_6_1TFree => &[OpenCodeSubscription::Free],
+            Self::MiniMaxM2_5Free | Self::Nemotron3SuperFree | Self::BigPickle => {
+                &[OpenCodeSubscription::Free]
+            }
 
             // Custom models get their subscription from settings, not from here
             Self::Custom { .. } => &[],
@@ -263,7 +260,6 @@ impl Model {
             Self::Qwen3_5Plus => "qwen3.5-plus",
             Self::Qwen3_6Plus => "qwen3.6-plus",
             Self::BigPickle => "big-pickle",
-            Self::Ring2_6_1TFree => "ring-2.6-1t-free",
             Self::Nemotron3SuperFree => "nemotron-3-super-free",
 
             Self::Custom { name, .. } => name,
@@ -316,7 +312,6 @@ impl Model {
             Self::Qwen3_5Plus => "Qwen3.5 Plus",
             Self::Qwen3_6Plus => "Qwen3.6 Plus",
             Self::BigPickle => "Big Pickle",
-            Self::Ring2_6_1TFree => "Ring 2.6 1T Free",
             Self::Nemotron3SuperFree => "Nemotron 3 Super Free",
 
             Self::Custom {
@@ -378,7 +373,6 @@ impl Model {
             | Self::DeepSeekV4Pro
             | Self::DeepSeekV4Flash
             | Self::BigPickle
-            | Self::Ring2_6_1TFree
             | Self::Nemotron3SuperFree => ApiProtocol::OpenAiChat,
 
             Self::Custom { protocol, .. } => *protocol,
@@ -395,8 +389,7 @@ impl Model {
             | Self::MimoV2_5Pro
             | Self::Glm5
             | Self::Glm5_1
-            | Self::BigPickle
-            | Self::Ring2_6_1TFree => true,
+            | Self::BigPickle => true,
 
             Self::Custom {
                 interleaved_reasoning,
@@ -442,7 +435,6 @@ impl Model {
             Self::MimoV2_5 => 1_000_000,
             Self::Qwen3_5Plus | Self::Qwen3_6Plus => 262_144,
             Self::BigPickle => 200_000,
-            Self::Ring2_6_1TFree => 262_000,
             Self::Nemotron3SuperFree => 204_800,
             Self::DeepSeekV4Pro | Self::DeepSeekV4Flash => 1_000_000,
 
@@ -488,7 +480,6 @@ impl Model {
             Self::MiniMaxM2_5 | Self::MiniMaxM2_5Free => Some(131_072),
             Self::Glm5 | Self::Glm5_1 => Some(32_768),
             Self::BigPickle => Some(128_000),
-            Self::Ring2_6_1TFree => Some(66_000),
             Self::KimiK2_6 | Self::KimiK2_5 => Some(65_536),
             Self::Qwen3_5Plus | Self::Qwen3_6Plus => Some(65_536),
             Self::DeepSeekV4Pro | Self::DeepSeekV4Flash => Some(384_000),
@@ -556,7 +547,6 @@ impl Model {
             | Self::DeepSeekV4Pro
             | Self::DeepSeekV4Flash
             | Self::BigPickle
-            | Self::Ring2_6_1TFree
             | Self::Nemotron3SuperFree => false,
 
             Self::Custom { protocol, .. } => matches!(
@@ -571,7 +561,7 @@ impl Model {
 
     pub fn supported_reasoning_effort_levels(&self) -> Option<Vec<ReasoningEffort>> {
         match self {
-            Self::Ring2_6_1TFree | Self::MimoV2_5Pro | Self::MimoV2_5 => Some(vec![
+            Self::MimoV2_5Pro | Self::MimoV2_5 => Some(vec![
                 ReasoningEffort::Low,
                 ReasoningEffort::Medium,
                 ReasoningEffort::High,

--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -656,6 +656,8 @@ By default, models from all subscription types are shown. Optionally, you can hi
 }
 ```
 
+**Note:** Zed only bundles configuration for long-term OpenCode Free models! Free models that are only available for a limited time are not included in Zed. To use such models, create a Custom Model using the configuration settings published on [the OpenCode website](https://opencode.ai/docs/zen#pricing) and on [models.dev](https://github.com/anomalyco/models.dev/tree/dev/providers/opencode/models).
+
 #### Custom Models {#opencode-custom-models}
 
 The Zed agent comes pre-configured with OpenCode models. If you wish to use newer models or models with custom endpoints, you can do so by adding the following to your Zed settings file ([how to edit](../configuring-zed.md#settings-files)):


### PR DESCRIPTION
**TL;DR**: clearer docs + models cleanup.

----

**Docs**: 
- as per the discussion in https://github.com/zed-industries/zed/issues/56869, added a note to the docs highlighting that temporary models should be configured using Custom Models. Adding a whole example felt redundant considering the full example is literally 2 rows below.


**Model updates**:
- **Ring 2.6 1T Free**: removed
- **GLM 5 and GLM 5.1**: different settings based on subscription — [131k](https://github.com/anomalyco/models.dev/blob/8e710e19eabbfa464764afe54d67585cbee9f4d8/providers/opencode/models/glm-5.1.toml#L22) [output](https://github.com/anomalyco/models.dev/blob/8e710e19eabbfa464764afe54d67585cbee9f4d8/providers/opencode/models/glm-5.toml#L22) on OpenCode but [32k](https://github.com/anomalyco/models.dev/blob/8e710e19eabbfa464764afe54d67585cbee9f4d8/providers/opencode-go/models/glm-5.1.toml#L22) [output](https://github.com/anomalyco/models.dev/blob/8e710e19eabbfa464764afe54d67585cbee9f4d8/providers/opencode-go/models/glm-5.toml#L22) on OpenCode Go
- **MiniMax M2.5**: different settings based on subscription — [131k output on OpenCode](https://github.com/anomalyco/models.dev/blob/8e710e19eabbfa464764afe54d67585cbee9f4d8/providers/opencode/models/minimax-m2.5.toml#L22) and [65k on OpenCode Go](https://github.com/anomalyco/models.dev/blob/8e710e19eabbfa464764afe54d67585cbee9f4d8/providers/opencode-go/models/minimax-m2.5.toml#L19)
- **Nemotron 3 Super Free**: enabled interleaved reasoning as per [docs](https://github.com/anomalyco/models.dev/blob/8e710e19eabbfa464764afe54d67585cbee9f4d8/providers/opencode/models/nemotron-3-super-free.toml#L13). Ran some quick tests and confirmed everything seems to work fine (_"rename this variable. add a simple function. remove the function. tell me a joke"_)
- **GPT 5.3 Codex Spark**: removed image support as per [docs](https://github.com/anomalyco/models.dev/blob/dev/providers/opencode/models/gpt-5.3-codex-spark.toml#L23-L25)

The [docs say GLM 5 in OpenCode Zen has a deprecation date of May 14](https://opencode.ai/docs/zen/#deprecated-models) but that seems to still be active and is [not marked as deprecated on models.dev](https://github.com/anomalyco/models.dev/blob/8e710e19eabbfa464764afe54d67585cbee9f4d8/providers/opencode/models/glm-5.toml) so I didn't remove it yet 🤷 

----

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes https://github.com/zed-industries/zed/issues/56869

Release Notes:
- OpenCode: updated models (removed Ring 2.6 1T Free, enabled interleaved reasoning for Nemotron 3 Super Free, deleted incorrect image support for GPT 5.3 Codex Spark, and updated token counts for MiniMax M2.5, GLM 5, and GLM 5.1)
- OpenCode Free: clearer docs for temporary free models
