### PR TITLE
vim: Fix helix paste crash with normalized clipboard text

### DIFF
--- a/crates/vim/src/helix/paste.rs
+++ b/crates/vim/src/helix/paste.rs
@@ -523,4 +523,58 @@ mod test {
             Mode::HelixNormal,
         );
     }
+
+    // Regression test for https://github.com/zed-industries/zed/issues/56982:
+    // clipboard text containing CRLF is normalized to LF on insert, so the
+    // byte length of the pre-edit string overshoots the inserted region. The
+    // helix paste handler must compute the post-paste selection from anchors
+    // rather than from the pre-normalization byte count.
+    #[gpui::test]
+    async fn test_paste_crlf_text(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        // Paste after the cursor (action.before = false). Without the fix this
+        // panics in the buffer offset assertion.
+        cx.set_state("ˇX", Mode::HelixNormal);
+        cx.write_to_clipboard(ClipboardItem::new_string("a\r\nb".to_string()));
+        cx.simulate_keystrokes("p");
+        cx.assert_state(
+            indoc! {"
+            X«a
+            bˇ»"},
+            Mode::HelixNormal,
+        );
+
+        // Paste before the cursor (action.before = true). Without the fix the
+        // resulting selection is wrong because the stale byte length leaks into
+        // saturating_sub.
+        cx.set_state("Yˇ", Mode::HelixNormal);
+        cx.write_to_clipboard(ClipboardItem::new_string("a\r\nb".to_string()));
+        cx.simulate_keystrokes("shift-p");
+        cx.assert_state(
+            indoc! {"
+            Y«a
+            bˇ»"},
+            Mode::HelixNormal,
+        );
+    }
+
+    // Regression test for https://github.com/zed-industries/zed/issues/56982:
+    // U+2028 / U+2029 from external sources (e.g. Okular on Windows) are
+    // converted to CRLF by the OS clipboard layer, which previously crashed.
+    // The fix is independent of whatever normalization happens at insert time,
+    // so this also stays robust if those characters ever start getting
+    // normalized inside Zed.
+    #[gpui::test]
+    async fn test_paste_text_with_line_separator(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.set_state("ˇX", Mode::HelixNormal);
+        cx.write_to_clipboard(ClipboardItem::new_string(
+            "a\u{2028}b\u{2029}c".to_string(),
+        ));
+        cx.simulate_keystrokes("p");
+        cx.assert_state("X«a\u{2028}b\u{2029}cˇ»", Mode::HelixNormal);
+    }
 }

--- a/crates/vim/src/helix/paste.rs
+++ b/crates/vim/src/helix/paste.rs
@@ -120,27 +120,24 @@ impl Vim {
                         sel.end
                     };
                     let point = display_point.to_point(&display_map);
-                    let anchor = if action.before {
-                        display_map.buffer_snapshot().anchor_after(point)
-                    } else {
-                        display_map.buffer_snapshot().anchor_before(point)
-                    };
+                    let buffer_snapshot = display_map.buffer_snapshot();
+                    let start_anchor = buffer_snapshot.anchor_before(point);
+                    let end_anchor = buffer_snapshot.anchor_after(point);
                     edits.push((point..point, to_insert.repeat(count)));
-                    new_selections.push((anchor, to_insert.len() * count));
+                    new_selections.push((start_anchor, end_anchor));
                 }
 
                 editor.edit(edits, cx);
 
                 let snapshot = editor.buffer().read(cx).snapshot(cx);
                 editor.change_selections(Default::default(), window, cx, |s| {
-                    s.select_ranges(new_selections.into_iter().map(|(anchor, len)| {
-                        let offset = anchor.to_offset(&snapshot);
-                        if action.before {
-                            offset.saturating_sub_usize(len)..offset
-                        } else {
-                            offset..(offset + len)
-                        }
-                    }));
+                    s.select_ranges(new_selections.into_iter().map(
+                        |(start_anchor, end_anchor)| {
+                            let start = start_anchor.to_offset(&snapshot);
+                            let end = end_anchor.to_offset(&snapshot);
+                            start..end
+                        },
+                    ));
                 })
             });
         });


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Summary

Pressing `p` in Helix normal mode crashed Zed on Windows when the clipboard contained CRLF line endings. The two repros in #56982 (about 5000 bytes of plain text from Windows-native sources, and short text from Okular containing U+2028 / U+2029, which the OS clipboard layer rewrites to CRLF) both hit the same path.

## Root cause

`crates/vim/src/helix/paste.rs` built the post-paste selection from `to_insert.len()`, the pre-normalization byte count. After `editor.edit(edits, cx)` runs, the buffer's text layer normalizes line endings via `LineEnding::normalize_arc` (the regex `\r\n|\r` rewrites CR / CRLF to LF), so the inserted region is shorter than `to_insert.len()`.

The handler then computed `offset + to_insert.len()` against the post-edit snapshot, which overshoots `snapshot.len()` and trips the debug assertion in `crates/multi_buffer/src/multi_buffer.rs:8152`:

```rust
assert!(*self <= snapshot.len(),
    "offset {} is greater than the snapshot.len() {}", ...);
```

The reporter's log (`offset 5012 is greater than the snapshot.len() 5000`) matches: about 12 stripped CR bytes pushed the end past the snapshot.

The `shift-p` (`action.before = true`) path didn't crash because of `saturating_sub`, but it produced a selection that ran left of the inserted region.

## Fix

Replace the `(anchor, byte_len)` pair with a pair of anchors at the insertion point: `anchor_before(point)` and `anchor_after(point)`. After the edit, both resolve to the actual start and end of the inserted region in the post-edit snapshot, regardless of what transformation the buffer applied.

This removes the only place in the helix paste handler that mixed pre-edit byte counts with post-edit offsets. `vim/src/normal/paste.rs` is unaffected; it already updates selections via `replace_cursors_with`, which re-resolves positions in the post-edit map.

## Tests

Two regression tests in `crates/vim/src/helix/paste.rs`:

- `test_paste_crlf_text` covers both the `p` crash path and the `shift-p` wrong-selection path with `a\r\nb` clipboard text.
- `test_paste_text_with_line_separator` covers U+2028 / U+2029 in clipboard text. These don't normalize on Linux today, but the anchor-based fix stays valid if they ever do.

Verified locally:

```
cargo check -p vim --tests        # clean
cargo test -p vim helix::paste    # 8/8 (6 existing + 2 new)
cargo test -p vim normal::paste   # 17/17
./script/clippy -p vim            # clean
```

## Out of scope

The `clipboard_selections.get(ix)` byte-slice branch (lines 71-77) only runs for Zed-internal clipboard data with metadata. The repros in #56982 paste external text, so `clipboard_selections` is `None` and that branch isn't on the crash trace.

Closes #56982

Release Notes:

- Fixed a crash when pasting clipboard text containing CRLF line endings in Helix mode
