### PR TITLE
Add clickable_element_cursor setting to replace hand cursor with arrow cursor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19163,6 +19163,7 @@ dependencies = [
  "menu",
  "schemars 1.0.4",
  "serde",
+ "settings",
  "smallvec",
  "strum 0.27.2",
  "theme",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -240,6 +240,12 @@
   // 3. Hide on typing and on key bindings that resolve to an action:
   //    "on_typing_and_action"
   "hide_mouse": "on_typing_and_action",
+  // Controls the mouse cursor style shown when hovering over clickable
+  // elements (buttons, tabs, list items, etc.).
+  // Can be:
+  // 1. "pointer" (default) - Shows the pointing hand cursor
+  // 2. "default" - Shows the default arrow cursor
+  "clickable_element_cursor": "pointer",
   // Determines whether the focused panel follows the mouse location.
   "focus_follows_mouse": {
     "enabled": false,

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -666,6 +666,7 @@ pub struct App {
     pub(crate) window_update_stack: Vec<WindowId>,
     pub(crate) mode: GpuiMode,
     pub(crate) cursor_hide_mode: CursorHideMode,
+    clickable_cursor_style: Option<CursorStyle>,
     flushing_effects: bool,
     pending_updates: usize,
     quit_mode: QuitMode,
@@ -755,6 +756,7 @@ impl App {
                 quit_mode: QuitMode::default(),
                 quitting: false,
                 cursor_hide_mode: CursorHideMode::default(),
+                clickable_cursor_style: None,
 
                 #[cfg(any(test, feature = "test-support", debug_assertions))]
                 name: None,
@@ -905,6 +907,20 @@ impl App {
     /// to keyboard input.
     pub fn set_cursor_hide_mode(&mut self, mode: CursorHideMode) {
         self.cursor_hide_mode = mode;
+    }
+
+    /// Returns the cursor style override for clickable elements.
+    /// When `Some(CursorStyle::Arrow)`, all `PointingHand` cursors
+    /// are replaced with `Arrow`.
+    pub fn clickable_cursor_style(&self) -> Option<CursorStyle> {
+        self.clickable_cursor_style
+    }
+
+    /// Sets the cursor style override for clickable elements.
+    /// When `Some(CursorStyle::Arrow)`, all `PointingHand` cursors
+    /// are replaced with `Arrow`.
+    pub fn set_clickable_cursor_style(&mut self, style: Option<CursorStyle>) {
+        self.clickable_cursor_style = style;
     }
 
     /// Returns whether the cursor is currently visible according to the

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4221,6 +4221,15 @@ impl Window {
                 .rendered_frame
                 .cursor_style(self)
                 .unwrap_or(CursorStyle::Arrow);
+
+            // Allow replacing the hand cursor with the default arrow cursor
+            // when the user has configured clickable element cursor style.
+            let style = if style == CursorStyle::PointingHand {
+                cx.clickable_cursor_style().unwrap_or(CursorStyle::PointingHand)
+            } else {
+                style
+            };
+
             cx.platform.set_cursor_style(style);
         }
     }

--- a/crates/settings/src/clickable_element_cursor_setting.rs
+++ b/crates/settings/src/clickable_element_cursor_setting.rs
@@ -1,0 +1,14 @@
+use crate::{self as settings, RegisterSetting, Settings};
+use gpui::CursorStyle;
+
+#[derive(Debug, Clone, Copy, RegisterSetting)]
+pub struct ClickableElementCursorSettings(pub CursorStyle);
+
+impl Settings for ClickableElementCursorSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        Self(match content.clickable_element_cursor.unwrap_or_default() {
+            settings::ClickableElementCursor::Pointer => CursorStyle::PointingHand,
+            settings::ClickableElementCursor::Default => CursorStyle::Arrow,
+        })
+    }
+}

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -1,4 +1,5 @@
 mod base_keymap_setting;
+mod clickable_element_cursor_setting;
 mod content_into_gpui;
 mod editable_setting_control;
 mod editorconfig_store;
@@ -32,6 +33,7 @@ use util::asset_str;
 
 pub use ::settings_content::*;
 pub use base_keymap_setting::*;
+pub use clickable_element_cursor_setting::ClickableElementCursorSettings;
 pub use content_into_gpui::IntoGpui;
 pub use editable_setting_control::*;
 pub use editorconfig_store::{

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -193,6 +193,7 @@ impl VsCodeSettings {
             }),
             helix_mode: None,
             hide_mouse: None,
+            clickable_element_cursor: None,
             image_viewer: None,
             journal: None,
             language_models: None,

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -111,6 +111,33 @@ pub enum HideMouseMode {
     OnTypingAndAction,
 }
 
+/// Controls the mouse cursor style shown when hovering over clickable
+/// elements (buttons, tabs, list items, etc.).
+///
+/// Default: pointer
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ClickableElementCursor {
+    /// Use the pointing hand cursor (CSS `pointer`)
+    #[default]
+    Pointer,
+    /// Use the default arrow cursor (CSS `default`)
+    Default,
+}
+
 #[with_fallible_options]
 #[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct SettingsContent {
@@ -191,6 +218,12 @@ pub struct SettingsContent {
     ///
     /// Default: on_typing_and_action
     pub hide_mouse: Option<HideMouseMode>,
+
+    /// Controls the mouse cursor style shown when hovering over clickable
+    /// elements (buttons, tabs, list items, etc.).
+    ///
+    /// Default: pointer
+    pub clickable_element_cursor: Option<ClickableElementCursor>,
 
     pub journal: Option<JournalSettingsContent>,
 

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1098,7 +1098,7 @@ fn appearance_page() -> SettingsPage {
         ]
     }
 
-    fn cursor_section() -> [SettingsPageItem; 5] {
+    fn cursor_section() -> [SettingsPageItem; 6] {
         [
             SettingsPageItem::SectionHeader("Cursor"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -1148,6 +1148,19 @@ fn appearance_page() -> SettingsPage {
                     pick: |settings_content| settings_content.hide_mouse.as_ref(),
                     write: |settings_content, value, _| {
                         settings_content.hide_mouse = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Clickable Element Cursor",
+                description: "Mouse cursor style when hovering over clickable elements (buttons, tabs, list items, etc.).",
+                field: Box::new(SettingField {
+                    json_path: Some("clickable_element_cursor"),
+                    pick: |settings_content| settings_content.clickable_element_cursor.as_ref(),
+                    write: |settings_content, value, _| {
+                        settings_content.clickable_element_cursor = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -465,6 +465,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::BaseKeymapContent>(render_dropdown)
         .add_basic_renderer::<settings::MultiCursorModifier>(render_dropdown)
         .add_basic_renderer::<settings::HideMouseMode>(render_dropdown)
+        .add_basic_renderer::<settings::ClickableElementCursor>(render_dropdown)
         .add_basic_renderer::<settings::CurrentLineHighlight>(render_dropdown)
         .add_basic_renderer::<settings::ShowWhitespaceSetting>(render_dropdown)
         .add_basic_renderer::<settings::SoftWrap>(render_dropdown)

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -28,6 +28,7 @@ strum.workspace = true
 theme.workspace = true
 ui_macros.workspace = true
 gpui_util.workspace = true
+settings.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true

--- a/crates/ui/src/components/ai/agent_setup_button.rs
+++ b/crates/ui/src/components/ai/agent_setup_button.rs
@@ -94,12 +94,15 @@ impl RenderOnce for AgentSetupButton {
             .border_1()
             .border_color(cx.theme().colors().border_variant)
             .rounded_sm()
-            .when(is_clickable, |this| {
-                this.cursor_pointer().hover(|style| {
-                    style
-                        .bg(cx.theme().colors().element_hover)
-                        .border_color(cx.theme().colors().border)
-                })
+            .when(is_clickable, {
+                let cursor = crate::utils::clickable_element_cursor(cx);
+                move |this| {
+                    this.cursor(cursor).hover(|style| {
+                        style
+                            .bg(cx.theme().colors().element_hover)
+                            .border_color(cx.theme().colors().border)
+                    })
+                }
             })
             .when_some(top_section, |this, section| this.child(section))
             .when_some(bottom_section, |this, section| this.child(section))

--- a/crates/ui/src/components/ai/thread_item.rs
+++ b/crates/ui/src/components/ai/thread_item.rs
@@ -384,7 +384,7 @@ impl RenderOnce for ThreadItem {
 
         v_flex()
             .id(self.id.clone())
-            .cursor_pointer()
+            .cursor(crate::utils::clickable_element_cursor(cx))
             .group("thread-item")
             .relative()
             .flex_shrink_0()

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -6,6 +6,8 @@ use gpui::{
 };
 use smallvec::SmallVec;
 
+use settings::{ClickableElementCursorSettings, Settings};
+
 use crate::{DynamicSpacing, ElevationIndex, prelude::*};
 
 /// A trait for buttons that can be Selected. Enables setting the [`ButtonStyle`] of a button when it is selected.
@@ -495,6 +497,7 @@ pub struct ButtonLike {
     tooltip: Option<Box<dyn Fn(&mut Window, &mut App) -> AnyView>>,
     hoverable_tooltip: Option<Box<dyn Fn(&mut Window, &mut App) -> AnyView>>,
     cursor_style: CursorStyle,
+    cursor_style_explicitly_set: bool,
     on_click: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
     on_right_click: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
     children: SmallVec<[AnyElement; 2]>,
@@ -518,6 +521,7 @@ impl ButtonLike {
             hoverable_tooltip: None,
             children: SmallVec::new(),
             cursor_style: CursorStyle::PointingHand,
+            cursor_style_explicitly_set: false,
             on_click: None,
             on_right_click: None,
             layer: None,
@@ -599,6 +603,7 @@ impl Clickable for ButtonLike {
 
     fn cursor_style(mut self, cursor_style: CursorStyle) -> Self {
         self.cursor_style = cursor_style;
+        self.cursor_style_explicitly_set = true;
         self
     }
 }
@@ -676,6 +681,12 @@ impl RenderOnce for ButtonLike {
             ButtonStyle::Outlined | ButtonStyle::OutlinedGhost | ButtonStyle::OutlinedCustom(_)
         );
 
+        let effective_cursor = if self.cursor_style_explicitly_set {
+            self.cursor_style
+        } else {
+            ClickableElementCursorSettings::get_global(cx).0
+        };
+
         self.base
             .h_flex()
             .id(self.id.clone())
@@ -708,10 +719,10 @@ impl RenderOnce for ButtonLike {
             .border_color(style.enabled(self.layer, cx).border_color)
             .bg(style.enabled(self.layer, cx).background)
             .when(self.disabled, |this| {
-                if self.cursor_style == CursorStyle::PointingHand {
+                if effective_cursor == CursorStyle::PointingHand {
                     this.cursor_not_allowed()
                 } else {
-                    this.cursor(self.cursor_style)
+                    this.cursor(effective_cursor)
                 }
             })
             .when(!self.disabled, |this| {
@@ -719,7 +730,7 @@ impl RenderOnce for ButtonLike {
                 let focus_color =
                     |refinement: StyleRefinement| refinement.bg(hovered_style.background);
 
-                this.cursor(self.cursor_style)
+                this.cursor(effective_cursor)
                     .hover(focus_color)
                     .map(|this| {
                         if is_outlined {

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -299,7 +299,10 @@ impl RenderOnce for ListItem {
                     })
                     .when_some(
                         self.on_click.filter(|_| !self.disabled),
-                        |this, on_click| this.cursor_pointer().on_click(on_click),
+                        {
+                            let cursor = crate::utils::clickable_element_cursor(cx);
+                            move |this, on_click| this.cursor(cursor).on_click(on_click)
+                        },
                     )
                     .when(self.outlined, |this| {
                         this.border_1()

--- a/crates/ui/src/components/tab.rs
+++ b/crates/ui/src/components/tab.rs
@@ -164,7 +164,7 @@ impl RenderOnce for Tab {
                 TabPosition::Middle(Ordering::Less) => this.border_l_1().pr_px().border_b_1(),
                 TabPosition::Middle(Ordering::Greater) => this.border_r_1().pl_px().border_b_1(),
             })
-            .cursor_pointer()
+            .cursor(crate::utils::clickable_element_cursor(cx))
             .child(
                 h_flex()
                     .group("")

--- a/crates/ui/src/components/toggle.rs
+++ b/crates/ui/src/components/toggle.rs
@@ -260,7 +260,7 @@ impl RenderOnce for Checkbox {
                 } else if self.visualization {
                     this.cursor_default()
                 } else {
-                    this.cursor_pointer()
+                    this.cursor(crate::utils::clickable_element_cursor(cx))
                 }
             })
             .gap(DynamicSpacing::Base06.rems(cx))
@@ -499,7 +499,7 @@ impl RenderOnce for Switch {
 
         h_flex()
             .id(self.id)
-            .cursor_pointer()
+            .cursor(crate::utils::clickable_element_cursor(cx))
             .gap(DynamicSpacing::Base06.rems(cx))
             .when(self.full_width, |this| this.w_full().justify_between())
             .when(
@@ -614,7 +614,7 @@ impl SwitchField {
 }
 
 impl RenderOnce for SwitchField {
-    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let tooltip = self
             .tooltip
             .zip(self.label.clone())
@@ -635,8 +635,9 @@ impl RenderOnce for SwitchField {
 
         h_flex()
             .id((self.id.clone(), "container"))
-            .when(!self.disabled, |this| {
-                this.hover(|this| this.cursor_pointer())
+            .when(!self.disabled, {
+                let cursor = crate::utils::clickable_element_cursor(cx);
+                move |this| this.hover(move |this| this.cursor(cursor))
             })
             .w_full()
             .gap_4()

--- a/crates/ui/src/components/tree_view_item.rs
+++ b/crates/ui/src/components/tree_view_item.rs
@@ -158,7 +158,7 @@ impl RenderOnce for TreeViewItem {
             .child(
                 h_flex()
                     .id("inner_tree_view_item")
-                    .cursor_pointer()
+                    .cursor(crate::utils::clickable_element_cursor(cx))
                     .size_full()
                     .h(item_size)
                     .pl_0p5()

--- a/crates/ui/src/utils.rs
+++ b/crates/ui/src/utils.rs
@@ -1,6 +1,7 @@
 //! UI-related utilities
 
-use gpui::App;
+use gpui::{App, CursorStyle};
+use settings::{ClickableElementCursorSettings, Settings};
 use theme::ActiveTheme;
 
 mod apca_contrast;
@@ -55,4 +56,10 @@ pub fn capitalize(str: &str) -> String {
         None => String::new(),
         Some(first_char) => first_char.to_uppercase().collect::<String>() + chars.as_str(),
     }
+}
+
+/// Returns the cursor style that should be used for clickable elements
+/// based on the user's settings.
+pub fn clickable_element_cursor(cx: &App) -> CursorStyle {
+    ClickableElementCursorSettings::get_global(cx).0
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -35,11 +35,11 @@ use git_ui::commit_view::CommitViewToolbar;
 use git_ui::git_panel::GitPanel;
 use git_ui::project_diff::{BranchDiffToolbar, ProjectDiffToolbar};
 use gpui::{
-    Action, App, AppContext as _, AsyncWindowContext, ClipboardItem, Context, DismissEvent,
-    Element, Entity, FocusHandle, Focusable, Image, ImageFormat, KeyBinding, ParentElement,
-    PathPromptOptions, PromptLevel, ReadGlobal, SharedString, Size, Task, TaskExt, TitlebarOptions,
-    UpdateGlobal, WeakEntity, Window, WindowBounds, WindowHandle, WindowKind, WindowOptions,
-    actions, image_cache, img, point, px, retain_all,
+    Action, App, AppContext as _, AsyncWindowContext, ClipboardItem, Context, CursorStyle,
+    DismissEvent, Element, Entity, FocusHandle, Focusable, Image, ImageFormat, KeyBinding,
+    ParentElement, PathPromptOptions, PromptLevel, ReadGlobal, SharedString, Size, Task, TaskExt,
+    TitlebarOptions, UpdateGlobal, WeakEntity, Window, WindowBounds, WindowHandle, WindowKind,
+    WindowOptions, actions, image_cache, img, point, px, retain_all,
 };
 use image_viewer::ImageInfo;
 use language::Capability;
@@ -65,10 +65,10 @@ use release_channel::{AppCommitSha, AppVersion, ReleaseChannel};
 use rope::Rope;
 use search::project_search::ProjectSearchBar;
 use settings::{
-    BaseKeymap, DEFAULT_KEYMAP_PATH, InvalidSettingsError, KeybindSource, KeymapFile,
-    KeymapFileLoadResult, MigrationStatus, Settings, SettingsFile, SettingsStore, VIM_KEYMAP_PATH,
-    initial_local_debug_tasks_content, initial_project_settings_content, initial_tasks_content,
-    update_settings_file,
+    BaseKeymap, ClickableElementCursorSettings, DEFAULT_KEYMAP_PATH, InvalidSettingsError,
+    KeybindSource, KeymapFile, KeymapFileLoadResult, MigrationStatus, Settings, SettingsFile,
+    SettingsStore, VIM_KEYMAP_PATH, initial_local_debug_tasks_content,
+    initial_project_settings_content, initial_tasks_content, update_settings_file,
 };
 use sidebar::Sidebar;
 
@@ -386,6 +386,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
     .detach();
 
     init_cursor_hide_mode(cx);
+    init_clickable_element_cursor(cx);
 
     cx.observe_new(|_multi_workspace: &mut MultiWorkspace, window, cx| {
         let Some(window) = window else {
@@ -1872,6 +1873,21 @@ impl Settings for CursorHideModeSetting {
 
 fn init_cursor_hide_mode(cx: &mut App) {
     let apply = |cx: &mut App| cx.set_cursor_hide_mode(CursorHideModeSetting::get_global(cx).0);
+    apply(cx);
+    cx.observe_global::<SettingsStore>(apply).detach();
+}
+
+fn init_clickable_element_cursor(cx: &mut App) {
+    let apply = |cx: &mut App| {
+        let cursor = ClickableElementCursorSettings::get_global(cx).0;
+        cx.set_clickable_cursor_style(
+            if cursor == CursorStyle::Arrow {
+                Some(CursorStyle::Arrow)
+            } else {
+                None
+            },
+        );
+    };
     apply(cx);
     cx.observe_global::<SettingsStore>(apply).detach();
 }


### PR DESCRIPTION
This adds a new clickable_element_cursor setting that lets users
choose between the pointing hand cursor and the default arrow cursor
when hovering over clickable elements like buttons, tabs, and list
items. The setting appears in the settings GUI under Appearance >
Cursor.

Release Notes:

- Added a clickable_element_cursor setting to control whether clickable elements show a pointing hand cursor or default arrow cursor