### PR TITLE
repl: Add notebook cell stop button

### DIFF
--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -15,6 +15,7 @@ use settings::Settings as _;
 use theme_settings::ThemeSettings;
 use ui::{CommonAnimationExt, IconButtonShape, prelude::*};
 use util::ResultExt;
+use zed_actions::notebook::InterruptKernel;
 
 use crate::{
     notebook::{CODE_BLOCK_INSET, GUTTER_WIDTH},
@@ -32,6 +33,7 @@ pub enum CellPosition {
 pub enum CellControlType {
     RunCell,
     RerunCell,
+    StopCell,
     ClearCell,
     CellOptions,
     CollapseCell,
@@ -53,6 +55,7 @@ impl CellControlType {
         match self {
             CellControlType::RunCell => IconName::PlayFilled,
             CellControlType::RerunCell => IconName::ArrowCircle,
+            CellControlType::StopCell => IconName::Stop,
             CellControlType::ClearCell => IconName::ListX,
             CellControlType::CellOptions => IconName::Ellipsis,
             CellControlType::CollapseCell => IconName::ChevronDown,
@@ -951,21 +954,30 @@ impl RenderableCell for CodeCell {
     }
 
     fn control(&self, _window: &mut Window, cx: &mut Context<Self>) -> Option<CellControl> {
-        let control_type = if self.has_outputs() {
+        let control_type = if self.is_executing {
+            CellControlType::StopCell
+        } else if self.has_outputs() {
             CellControlType::RerunCell
         } else {
             CellControlType::RunCell
         };
 
         let cell_control = CellControl::new(
-            if self.has_outputs() {
-                "rerun-cell"
-            } else {
-                "run-cell"
+            match control_type {
+                CellControlType::StopCell => "stop-cell",
+                CellControlType::RerunCell => "rerun-cell",
+                CellControlType::RunCell => "run-cell",
+                _ => "run-cell",
             },
             control_type,
         )
-        .on_click(cx.listener(move |this, _, window, cx| this.run(window, cx)));
+        .on_click(cx.listener(move |this, _, window, cx| {
+            if this.is_executing {
+                window.dispatch_action(Box::new(InterruptKernel), cx);
+            } else {
+                this.run(window, cx);
+            }
+        }));
 
         Some(cell_control)
     }

--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -62,6 +62,17 @@ impl CellControlType {
             CellControlType::ExpandCell => IconName::ChevronRight,
         }
     }
+    fn id(&self) -> &'static str {
+        match self {
+            CellControlType::RunCell => "CellControlType::RunCell",
+            CellControlType::RerunCell => "CellControlType::RerunCell",
+            CellControlType::StopCell => "CellControlType::StopCell",
+            CellControlType::ClearCell => "CellControlType::ClearCell",
+            CellControlType::CellOptions => "CellControlType::CellOptions",
+            CellControlType::CollapseCell => "CellControlType::CollapseCelln",
+            CellControlType::ExpandCell => "CellControlType::ExpandCell",
+        }
+    }
 }
 
 pub struct CellControl {
@@ -962,24 +973,17 @@ impl RenderableCell for CodeCell {
             CellControlType::RunCell
         };
 
-        let cell_control = CellControl::new(
-            match control_type {
-                CellControlType::StopCell => "stop-cell",
-                CellControlType::RerunCell => "rerun-cell",
-                CellControlType::RunCell => "run-cell",
-                _ => "run-cell",
-            },
-            control_type,
+        Some(
+            CellControl::new(control_type.id(), control_type).on_click(cx.listener(
+                move |this, _, window, cx| {
+                    if this.is_executing {
+                        window.dispatch_action(Box::new(InterruptKernel), cx);
+                    } else {
+                        this.run(window, cx);
+                    }
+                },
+            )),
         )
-        .on_click(cx.listener(move |this, _, window, cx| {
-            if this.is_executing {
-                window.dispatch_action(Box::new(InterruptKernel), cx);
-            } else {
-                this.run(window, cx);
-            }
-        }));
-
-        Some(cell_control)
     }
 
     fn selected(&self) -> bool {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #57092

Before:

<img width="3400" height="2210" alt="image" src="https://github.com/user-attachments/assets/0056817e-4826-46c1-85d4-e84c9c8d80f1" />

After:

<img width="1700" height="1105" alt="image" src="https://github.com/user-attachments/assets/0ed86e42-20d7-41a0-90b6-102dfb57cc33" />

Release Notes:

- Add notebook cell stop button.
