### PR TITLE
terminal: Stop caching FDs for every system process per PTY

### DIFF
--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -10,7 +10,7 @@ use std::{path::PathBuf, sync::Arc};
 #[cfg(target_os = "windows")]
 use windows::Win32::{Foundation::HANDLE, System::Threading::GetProcessId};
 
-use sysinfo::{Pid, Process, ProcessRefreshKind, RefreshKind, System, UpdateKind};
+use sysinfo::{Pid, Process, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
 use crate::{Event, Terminal};
 
@@ -101,17 +101,34 @@ pub struct PtyProcessInfo {
 
 impl PtyProcessInfo {
     pub fn new(pty: &Pty) -> PtyProcessInfo {
+        // `ProcessRefreshKind::nothing()` has `tasks: true` by default; without
+        // `.without_tasks()` sysinfo enumerates `/proc/<pid>/task/<tid>/stat` on every
+        // refresh and caches an open FD per task. We don't read task information here,
+        // so disable it explicitly.
         let process_refresh_kind = ProcessRefreshKind::nothing()
+            .without_tasks()
             .with_cmd(UpdateKind::Always)
             .with_cwd(UpdateKind::Always)
             .with_exe(UpdateKind::Always);
-        let refresh_kind = RefreshKind::nothing().with_processes(process_refresh_kind);
-        let system = System::new_with_specifics(refresh_kind);
+        let pid_getter = ProcessIdGetter::new(pty);
+        // Avoid `System::new_with_specifics`, which triggers a `ProcessesToUpdate::All`
+        // scan and causes sysinfo to cache an open FD for every `/proc/<pid>/stat` on
+        // the host (up to `RLIMIT_NOFILE / 2`). We only ever consult this `System` for
+        // our own PID via `refresh_processes_specifics(Some(&[pid]), ...)`, so we start
+        // empty and seed just that PID.
+        let mut system = System::new();
+        if let Some(pid) = pid_getter.pid() {
+            system.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[pid]),
+                true,
+                process_refresh_kind,
+            );
+        }
 
         PtyProcessInfo {
             system: RwLock::new(system),
             refresh_kind: process_refresh_kind,
-            pid_getter: ProcessIdGetter::new(pty),
+            pid_getter,
             current: RwLock::new(None),
             task: Mutex::new(None),
         }
@@ -124,7 +141,7 @@ impl PtyProcessInfo {
     fn refresh(&self) -> Option<MappedRwLockReadGuard<'_, Process>> {
         let pid = self.pid_getter.pid()?;
         if self.system.write().refresh_processes_specifics(
-            sysinfo::ProcessesToUpdate::Some(&[pid]),
+            ProcessesToUpdate::Some(&[pid]),
             true,
             self.refresh_kind,
         ) == 1


### PR DESCRIPTION
Generated by Claude Opus 4.7 max. Not tested yet.

------

`PtyProcessInfo::new` initializes its `sysinfo::System` via
`System::new_with_specifics`, which performs a `ProcessesToUpdate::All`
refresh on construction. Combined with `ProcessRefreshKind::nothing()`
defaulting to `tasks: true` (a sysinfo gotcha — see [the
docstring](https://docs.rs/sysinfo/0.37.2/sysinfo/struct.ProcessRefreshKind.html#impl-Default-for-ProcessRefreshKind)),
sysinfo opens and caches a file descriptor for every `/proc/<pid>/stat`
and every `/proc/<pid>/task/<tid>/stat` on the host, up to its internal
budget of `RLIMIT_NOFILE / 2`.

The `System` is never consulted with `ProcessesToUpdate::All` after
construction; only the PTY's own PID is refreshed via
`refresh_processes_specifics(Some(&[pid]), ...)`. The system-wide scan
is pure waste, but the cached FDs persist for the lifetime of the PTY,
and **each new PTY creates an independent `System` with its own cache**.

In an agent-heavy session that opens many real PTYs — every
`Project::create_terminal_task` / `create_terminal_shell` call — this
accumulates hundreds of thousands of stat FDs. Once sysinfo's budget is
hit, subsequent `open()`s on `/proc/<pid>/stat` silently fail (see
`FileCounter::new` in `sysinfo/src/unix/linux/process.rs`), and the
editor reports "Too many open files" when spawning subprocesses.

The other three `sysinfo::System` call sites in Zed already call
`.without_tasks()` (`lsp_button.rs:94`, `attach_modal.rs:390`,
`headless_project.rs:1226`); `pty_info.rs` is the one that didn't.

This change:

1. Adds `.without_tasks()` to `process_refresh_kind`, eliminating the
   per-thread FD cache.
2. Replaces `System::new_with_specifics(...)` with `System::new()` plus
   a targeted refresh of just the PTY's PID, so a single `System`
   caches one FD instead of thousands.

### Empirical impact

In a <2h session on Linux that hit this bug, the editor was holding
**263,371 FDs**, of which **262,144 (99.5%)** were `/proc/<pid>/stat`
and `/proc/<pid>/task/<tid>/stat` — exactly sysinfo's
`RLIMIT_NOFILE / 2` cap. 696 of the 1,940 tracked PIDs were already
dead. The same PID was opened ~195 times across separate `System`
instances (one per PTY ever created in the session).

After this change, each `PtyProcessInfo` opens 1 FD (for its target
PID) instead of approximately `n_processes + n_threads_across_them`.

### Refs

- #49776 — exact same `/proc/[PID]/stat` accumulation pattern, Linux
- #47064 / #20806 — related macOS variant fixed by #47322
  (`MacWatcher` → `notify::FsEventWatcher`); same shape of bug
  ("per-resource subsystem creates a thing that holds many FDs"),
  different leaking subsystem
- sysinfo
  [#242](https://github.com/GuillaumeGomez/sysinfo/issues/242) —
  upstream confirmation that the FD-caching behavior is intentional;
  `set_open_files_limit` is the provided knob

Investigation write-up: [zed-industries/zed#49776 (comment).](https://github.com/zed-industries/zed/issues/49776#issuecomment-4481612281).

Release Notes:

- Fixed a file descriptor leak on Linux where opening a terminal would
  cause Zed to hold open `/proc/<pid>/stat` for every process on the
  system, eventually breaking subprocess spawning after long sessions
