### PR TITLE
Add settings UI page for skills

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16231,6 +16231,7 @@ version = "0.1.0"
 dependencies = [
  "agent",
  "agent_settings",
+ "agent_skills",
  "anyhow",
  "audio",
  "codestral",

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -31,8 +31,9 @@ use acp_thread::{
 };
 use agent_client_protocol::schema as acp;
 use agent_skills::{
-    MAX_SKILL_DESCRIPTIONS_SIZE, Skill, SkillLoadError, SkillScopeId, SkillSource, SkillSummary,
-    global_skills_dir, load_skills_from_directory, project_skills_relative_path,
+    MAX_SKILL_DESCRIPTIONS_SIZE, ProjectSkillGroup, Skill, SkillIndex, SkillLoadError,
+    SkillScopeId, SkillSource, SkillSummary, global_skills_dir, load_skills_from_directory,
+    project_skills_relative_path,
 };
 use anyhow::{Context as _, Result, anyhow};
 use chrono::{DateTime, Utc};
@@ -367,6 +368,10 @@ impl NativeAgent {
             )];
             if let Some(prompt_store) = prompt_store.as_ref() {
                 subscriptions.push(cx.subscribe(prompt_store, Self::handle_prompts_updated_event))
+            }
+
+            if !cx.has_global::<SkillIndex>() {
+                cx.set_global(SkillIndex::default());
             }
 
             Self {
@@ -796,6 +801,7 @@ impl NativeAgent {
                 // the available commands) can change without affecting the
                 // skill error list.
                 this.update_available_commands_for_project(project_id, cx);
+                this.publish_skill_index(cx);
             })?;
         }
 
@@ -1213,6 +1219,49 @@ impl NativeAgent {
         }
     }
 
+    fn publish_skill_index(&self, cx: &mut Context<Self>) {
+        let mut global_skills = Vec::new();
+        let mut project_groups: Vec<ProjectSkillGroup> = Vec::new();
+        let mut seen_global = false;
+
+        for state in self.projects.values() {
+            for skill in state.skills.iter() {
+                match &skill.source {
+                    SkillSource::Global => {
+                        if !seen_global {
+                            global_skills.push(skill.clone());
+                        }
+                    }
+                    SkillSource::ProjectLocal {
+                        worktree_id,
+                        worktree_root_name,
+                    } => {
+                        if let Some(group) = project_groups
+                            .iter_mut()
+                            .find(|g| g.worktree_id == *worktree_id)
+                        {
+                            group.skills.push(skill.clone());
+                        } else {
+                            project_groups.push(ProjectSkillGroup {
+                                worktree_id: *worktree_id,
+                                worktree_root_name: SharedString::from(worktree_root_name.clone()),
+                                skills: vec![skill.clone()],
+                            });
+                        }
+                    }
+                }
+            }
+            if !global_skills.is_empty() {
+                seen_global = true;
+            }
+        }
+
+        cx.set_global(SkillIndex {
+            global_skills,
+            project_skills: project_groups,
+        });
+    }
+
     fn update_available_commands_for_project(&self, project_id: EntityId, cx: &mut Context<Self>) {
         let available_commands =
             Self::build_available_commands_for_project(self.projects.get(&project_id), cx);
@@ -1450,6 +1499,7 @@ impl NativeAgent {
         let has_remaining = self.sessions.values().any(|s| s.project_id == project_id);
         if !has_remaining {
             self.projects.remove(&project_id);
+            self.publish_skill_index(cx);
         }
 
         session.pending_save

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -2,6 +2,7 @@ use anyhow::{Context as _, Result};
 use const_format::concatcp;
 use fs::Fs;
 use futures::StreamExt;
+use gpui::{Global, SharedString};
 use serde::{Deserialize, Serialize};
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -119,6 +120,31 @@ impl SkillSource {
         }
     }
 }
+
+/// App-wide index of loaded skills, published by NativeAgent and read
+/// by any UI that needs to display the skill list (e.g. Settings UI).
+pub struct SkillIndex {
+    pub global_skills: Vec<Skill>,
+    pub project_skills: Vec<ProjectSkillGroup>,
+}
+
+#[derive(Clone)]
+pub struct ProjectSkillGroup {
+    pub worktree_id: SkillScopeId,
+    pub worktree_root_name: SharedString,
+    pub skills: Vec<Skill>,
+}
+
+impl Default for SkillIndex {
+    fn default() -> Self {
+        Self {
+            global_skills: Vec::new(),
+            project_skills: Vec::new(),
+        }
+    }
+}
+
+impl Global for SkillIndex {}
 
 /// Just the frontmatter, used for parsing
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -123,6 +123,7 @@ impl SkillSource {
 
 /// App-wide index of loaded skills, published by NativeAgent and read
 /// by any UI that needs to display the skill list (e.g. Settings UI).
+#[derive(Default)]
 pub struct SkillIndex {
     pub global_skills: Vec<Skill>,
     pub project_skills: Vec<ProjectSkillGroup>,
@@ -133,15 +134,6 @@ pub struct ProjectSkillGroup {
     pub worktree_id: SkillScopeId,
     pub worktree_root_name: SharedString,
     pub skills: Vec<Skill>,
-}
-
-impl Default for SkillIndex {
-    fn default() -> Self {
-        Self {
-            global_skills: Vec::new(),
-            project_skills: Vec::new(),
-        }
-    }
 }
 
 impl Global for SkillIndex {}

--- a/crates/settings_ui/Cargo.toml
+++ b/crates/settings_ui/Cargo.toml
@@ -18,6 +18,7 @@ test-support = []
 [dependencies]
 agent.workspace = true
 agent_settings.workspace = true
+agent_skills.workspace = true
 anyhow.workspace = true
 audio.workspace = true
 component.workspace = true

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -13,7 +13,7 @@ use crate::{
     ActionLink, DynamicItem, PROJECT, SettingField, SettingItem, SettingsFieldMetadata,
     SettingsPage, SettingsPageItem, SubPageLink, USER, active_language, all_language_names,
     pages::{
-        open_audio_test_window, render_edit_prediction_setup_page,
+        open_audio_test_window, render_edit_prediction_setup_page, render_skills_setup_page,
         render_tool_permissions_setup_page,
     },
 };
@@ -7484,6 +7484,15 @@ fn ai_page(cx: &App) -> SettingsPage {
     fn agent_configuration_section(_cx: &App) -> Box<[SettingsPageItem]> {
         let mut items = vec![
             SettingsPageItem::SectionHeader("Agent Configuration"),
+            SettingsPageItem::SubPageLink(SubPageLink {
+                title: "Skills".into(),
+                r#type: Default::default(),
+                json_path: None,
+                description: Some("View and manage agent skills installed globally or in project worktrees.".into()),
+                in_json: false,
+                files: USER | PROJECT,
+                render: render_skills_setup_page,
+            }),
             SettingsPageItem::SubPageLink(SubPageLink {
                 title: "Tool Permissions".into(),
                 r#type: Default::default(),

--- a/crates/settings_ui/src/pages.rs
+++ b/crates/settings_ui/src/pages.rs
@@ -2,6 +2,7 @@ mod audio_input_output_setup;
 mod audio_test_window;
 mod edit_prediction_provider_setup;
 mod feature_flags;
+mod skills_setup;
 mod tool_permissions_setup;
 
 pub(crate) use audio_input_output_setup::{
@@ -10,6 +11,7 @@ pub(crate) use audio_input_output_setup::{
 pub(crate) use audio_test_window::open_audio_test_window;
 pub(crate) use edit_prediction_provider_setup::render_edit_prediction_setup_page;
 pub(crate) use feature_flags::render_feature_flags_page;
+pub(crate) use skills_setup::render_skills_setup_page;
 pub(crate) use tool_permissions_setup::render_tool_permissions_setup_page;
 
 pub use tool_permissions_setup::{

--- a/crates/settings_ui/src/pages/skills_setup.rs
+++ b/crates/settings_ui/src/pages/skills_setup.rs
@@ -1,6 +1,6 @@
 use agent_skills::{Skill, SkillIndex};
 use fs::RemoveOptions;
-use gpui::{ScrollHandle, SharedString, prelude::*};
+use gpui::{Action as _, ScrollHandle, SharedString, prelude::*};
 
 use ui::{Divider, Tooltip, prelude::*};
 use util::ResultExt as _;
@@ -44,14 +44,43 @@ pub(crate) fn render_skills_setup_page(
         .pb_16()
         .map(|this| {
             if skills.is_empty() {
-                this.items_center().justify_center().child({
-                    let message = match &settings_window.current_file {
-                        SettingsUiFile::User => "No global skills installed.".to_string(),
-                        SettingsUiFile::Project(_) => "No project skills found.".to_string(),
-                        _ => "No skills available for this context.".to_string(),
-                    };
-                    Label::new(message).color(Color::Muted)
-                })
+                let message = match &settings_window.current_file {
+                    SettingsUiFile::User => "No global skills installed.",
+                    SettingsUiFile::Project(_) => "No project skills found.",
+                    _ => "No skills available for this context.",
+                };
+                let original_window = settings_window.original_window;
+                this.items_center().justify_center().child(
+                    v_flex()
+                        .items_center()
+                        .gap_2()
+                        .child(Label::new(message).color(Color::Muted))
+                        .child(
+                            Button::new("open-agent-panel", "Create with Agent")
+                                .tab_index(0_isize)
+                                .style(ButtonStyle::Outlined)
+                                .end_icon(
+                                    Icon::new(IconName::ArrowUpRight)
+                                        .size(IconSize::Small)
+                                        .color(Color::Muted),
+                                )
+                                .on_click(cx.listener(move |_this, _event, window, cx| {
+                                    let Some(original_window) = original_window else {
+                                        return;
+                                    };
+                                    original_window
+                                        .update(cx, |_workspace, original_window, cx| {
+                                            original_window.dispatch_action(
+                                                zed_actions::assistant::ToggleFocus.boxed_clone(),
+                                                cx,
+                                            );
+                                            original_window.activate_window();
+                                        })
+                                        .log_err();
+                                    window.remove_window();
+                                })),
+                        ),
+                )
             } else {
                 this.track_scroll(scroll_handle)
                     .overflow_y_scroll()
@@ -96,6 +125,7 @@ fn render_skill_row(skill: &Skill, cx: &mut Context<SettingsWindow>) -> AnyEleme
                         SharedString::from(format!("delete-{}", skill.name)),
                         IconName::Trash,
                     )
+                    .tab_index(0_isize)
                     .icon_size(IconSize::Small)
                     .tooltip(Tooltip::text("Delete Skill"))
                     .on_click(cx.listener(
@@ -120,6 +150,7 @@ fn render_skill_row(skill: &Skill, cx: &mut Context<SettingsWindow>) -> AnyEleme
                 )
                 .child(
                     Button::new(SharedString::from(format!("open-{}", skill.name)), "Open")
+                        .tab_index(0_isize)
                         .style(ButtonStyle::OutlinedGhost)
                         .size(ButtonSize::Medium)
                         .end_icon(

--- a/crates/settings_ui/src/pages/skills_setup.rs
+++ b/crates/settings_ui/src/pages/skills_setup.rs
@@ -1,0 +1,155 @@
+use agent_skills::{Skill, SkillIndex};
+use fs::RemoveOptions;
+use gpui::{ScrollHandle, SharedString, prelude::*};
+
+use ui::{Divider, Tooltip, prelude::*};
+use util::ResultExt as _;
+
+use crate::{SettingsUiFile, SettingsWindow};
+
+pub(crate) fn render_skills_setup_page(
+    settings_window: &SettingsWindow,
+    scroll_handle: &ScrollHandle,
+    _window: &mut Window,
+    cx: &mut Context<SettingsWindow>,
+) -> AnyElement {
+    let skill_index = cx.try_global::<SkillIndex>();
+
+    // Pick skills that match the current settings file tab:
+    // - User tab → global skills only
+    // - Project tab → project-local skills for that worktree only
+    let skills: Vec<Skill> = match &settings_window.current_file {
+        SettingsUiFile::User => skill_index
+            .map(|idx| idx.global_skills.clone())
+            .unwrap_or_default(),
+        SettingsUiFile::Project((worktree_id, _)) => {
+            let wt_id = usize::from(*worktree_id);
+            skill_index
+                .and_then(|idx| {
+                    idx.project_skills
+                        .iter()
+                        .find(|g| g.worktree_id.0 == wt_id)
+                        .map(|g| g.skills.clone())
+                })
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    };
+
+    v_flex()
+        .id("skills-page")
+        .size_full()
+        .pt_2p5()
+        .px_8()
+        .pb_16()
+        .map(|this| {
+            if skills.is_empty() {
+                this.items_center().justify_center().child({
+                    let message = match &settings_window.current_file {
+                        SettingsUiFile::User => "No global skills installed.".to_string(),
+                        SettingsUiFile::Project(_) => "No project skills found.".to_string(),
+                        _ => "No skills available for this context.".to_string(),
+                    };
+                    Label::new(message).color(Color::Muted)
+                })
+            } else {
+                this.track_scroll(scroll_handle)
+                    .overflow_y_scroll()
+                    .children(skills.iter().enumerate().flat_map(|(i, skill)| {
+                        let mut elements: Vec<AnyElement> = vec![render_skill_row(skill, cx)];
+                        if i + 1 < skills.len() {
+                            elements.push(Divider::horizontal().into_any_element());
+                        }
+                        elements
+                    }))
+            }
+        })
+        .into_any_element()
+}
+
+fn render_skill_row(skill: &Skill, cx: &mut Context<SettingsWindow>) -> AnyElement {
+    let skill_file_path = skill.skill_file_path.clone();
+    let directory_path = skill.directory_path.clone();
+
+    h_flex()
+        .w_full()
+        .justify_between()
+        .py_2p5()
+        .gap_4()
+        .child(
+            v_flex()
+                .gap_0p5()
+                .min_w_0()
+                .flex_1()
+                .child(Label::new(skill.name.clone()))
+                .child(
+                    Label::new(skill.description.clone())
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                ),
+        )
+        .child(
+            h_flex()
+                .gap_2()
+                .child(
+                    IconButton::new(
+                        SharedString::from(format!("delete-{}", skill.name)),
+                        IconName::Trash,
+                    )
+                    .icon_size(IconSize::Small)
+                    .tooltip(Tooltip::text("Delete Skill"))
+                    .on_click(cx.listener(
+                        move |_this, _event, _window, cx| {
+                            let directory_path = directory_path.clone();
+                            let app_state = workspace::AppState::global(cx);
+                            let fs = app_state.fs.clone();
+                            cx.spawn(async move |_this, _cx| {
+                                fs.remove_dir(
+                                    &directory_path,
+                                    RemoveOptions {
+                                        recursive: true,
+                                        ignore_if_not_exists: true,
+                                    },
+                                )
+                                .await
+                                .log_err();
+                            })
+                            .detach();
+                        },
+                    )),
+                )
+                .child(
+                    Button::new(SharedString::from(format!("open-{}", skill.name)), "Open")
+                        .style(ButtonStyle::OutlinedGhost)
+                        .size(ButtonSize::Medium)
+                        .end_icon(
+                            Icon::new(IconName::ArrowUpRight)
+                                .size(IconSize::Small)
+                                .color(Color::Muted),
+                        )
+                        .on_click(cx.listener(move |settings_window, _event, window, cx| {
+                            let skill_file_path = skill_file_path.clone();
+                            let Some(original_window) = settings_window.original_window else {
+                                return;
+                            };
+                            original_window
+                                .update(cx, |multi_workspace, original_window, cx| {
+                                    let workspace = multi_workspace.workspace().clone();
+                                    workspace.update(cx, |workspace, cx| {
+                                        workspace
+                                            .open_abs_path(
+                                                skill_file_path,
+                                                Default::default(),
+                                                original_window,
+                                                cx,
+                                            )
+                                            .detach_and_log_err(cx);
+                                    });
+                                })
+                                .log_err();
+                            window.remove_window();
+                        })),
+                ),
+        )
+        .into_any_element()
+}


### PR DESCRIPTION
Closes AI-267

This PR adds a skills subpage in the settings UI, where we display global skills in the user tab and project skills in the corresponding project tab. The approach taken here was the simplest one out of the possible avenues we could've taken to implement this (which would possibly require bigger refactors), given this is potentially the very first page in the settings UI where we're displaying stuff that does not correspond to data available in the `settings.json`.

Important to note that a major limitation of the global approach is that it's dependent on the native agent having loaded the skill index, meaning there's an edge case where, if you open the settings UI _before_ having opened the agent panel, you won't immediately see the available skills. Something to discuss but that it felt like a viable option for a first ship.

Release Notes:

- Agent: Added a skills section to the settings UI.
