### PR TITLE
gpui: Trim trailing whitespace and punctuation before ellipsis

### DIFF
--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -201,9 +201,11 @@ impl LineWrapper {
                     "{truncation_affix}{}",
                     &line[line.ceil_char_boundary(truncate_ix + 1)..]
                 )),
-                TruncateFrom::End => {
-                    SharedString::from(format!("{}{truncation_affix}", &line[..truncate_ix]))
-                }
+                TruncateFrom::End => SharedString::from(format!(
+                    "{}{truncation_affix}",
+                    line[..truncate_ix]
+                        .trim_end_matches(|c: char| c.is_whitespace() || c.is_ascii_punctuation())
+                )),
             };
             let mut runs = runs.to_vec();
             update_runs_after_truncation(&result, truncation_affix, &mut runs, truncate_from);


### PR DESCRIPTION
When truncating text at the end with an ellipsis, the truncation point can land right after a space or punctuation character, producing results like `"some text …"` or `"some text-…"`.

This trims trailing whitespace and ASCII punctuation from the truncated prefix before appending the ellipsis affix, so you get clean results like `"some text…"` instead.

Release Notes:

- Improved text truncation to avoid trailing spaces or punctuation before the ellipsis.