### PR TITLE
dev_container: Start containers from the project directory

### DIFF
--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -1841,6 +1841,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
 
         let docker_cli = self.docker_client.docker_cli();
         let mut command = Command::new(&docker_cli);
+        command.current_dir(&self.local_project_directory);
 
         command.arg("run");
 
@@ -3100,6 +3101,12 @@ mod test {
         let docker_run_command = docker_run_command.expect("ok");
 
         assert_eq!(docker_run_command.get_program(), "docker");
+        assert_eq!(
+            docker_run_command.get_current_dir(),
+            Some(Path::new(TEST_PROJECT_PATH)),
+            "docker run must execute with cwd set to the project directory so \
+             relative paths in `runArgs` (e.g. `--env-file .devcontainer/.env`) resolve correctly"
+        );
         let expected_config_file_label = PathBuf::from(TEST_PROJECT_PATH)
             .join(".devcontainer")
             .join("devcontainer.json");

--- a/crates/util/src/command.rs
+++ b/crates/util/src/command.rs
@@ -72,6 +72,10 @@ impl Command {
         self.0.get_args()
     }
 
+    pub fn get_current_dir(&self) -> Option<&Path> {
+        self.0.get_current_dir()
+    }
+
     pub fn env(&mut self, key: impl AsRef<OsStr>, val: impl AsRef<OsStr>) -> &mut Self {
         self.0.env(key, val);
         self

--- a/crates/util/src/command/darwin.rs
+++ b/crates/util/src/command/darwin.rs
@@ -225,6 +225,10 @@ impl Command {
     pub fn get_program(&self) -> &OsStr {
         self.program.as_os_str()
     }
+
+    pub fn get_current_dir(&self) -> Option<&Path> {
+        self.current_dir.as_deref()
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The `initializeCommand` lifecycle hook already runs with `cwd` set to the project directory, but the subsequent `docker run` / `podman run` inherited Zed’s own working directory. Relative paths in `runArgs` such as `--env-file .devcontainer/.env` therefore failed to resolve.

To me, the fix seems simple: set `current_dir` on the spawned command so relative `runArgs` paths line up with where lifecycle scripts already run, matching the behavior of the upstream Dev Container CLI.

I also added a `get_current_dir` accessor on `util::command::Command` so the regression test can verify the working directory is set. I think the assertion is helpful in this instance, but LMK if you think otherwise.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #57039.

Release Notes:

- Fixed Dev Containers not resolving relative paths in `runArgs` against the project directory

