### PR TITLE
gpui, zed: Add FrameRecorder and visual test harness for UI recording

### DIFF
--- a/crates/gpui/src/app/visual_test_context.rs
+++ b/crates/gpui/src/app/visual_test_context.rs
@@ -385,6 +385,23 @@ impl VisualTestAppContext {
         self.update_window(window, |_, window, _cx| window.render_to_image())?
     }
 
+    /// Captures a frame from `window` into `recorder` using the recorder's default delay.
+    ///
+    /// Calls [`Self::run_until_parked`] before capturing so the rendered frame reflects
+    /// all pending state changes. Use [`Self::capture_screenshot`] directly when you need
+    /// a mid-animation frame or a custom delay.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn record_frame(
+        &mut self,
+        window: AnyWindowHandle,
+        recorder: &mut crate::FrameRecorder,
+    ) -> Result<()> {
+        self.run_until_parked();
+        let image = self.capture_screenshot(window)?;
+        recorder.push_frame(image);
+        Ok(())
+    }
+
     /// Waits for animations to complete by waiting a couple of frames.
     pub async fn wait_for_animations(&self) {
         self.background_executor

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -47,6 +47,8 @@ mod svg_renderer;
 mod tab_stop;
 mod taffy;
 #[cfg(any(test, feature = "test-support"))]
+pub mod recording;
+#[cfg(any(test, feature = "test-support"))]
 pub mod test;
 mod text_system;
 mod util;
@@ -115,6 +117,8 @@ pub use svg_renderer::*;
 pub(crate) use tab_stop::*;
 use taffy::TaffyLayoutEngine;
 pub use taffy::{AvailableSpace, LayoutId};
+#[cfg(any(test, feature = "test-support"))]
+pub use recording::{CapturedFrame, FrameRecorder};
 #[cfg(any(test, feature = "test-support"))]
 pub use test::*;
 pub use text_system::*;

--- a/crates/gpui/src/recording.rs
+++ b/crates/gpui/src/recording.rs
@@ -1,0 +1,70 @@
+//! Frame-by-frame recording utilities for visual tests and PR demo GIFs.
+
+use std::{fs::File, io::BufWriter, path::Path, time::Duration};
+
+use image::{Delay, Frame, RgbaImage, codecs::gif::{GifEncoder, Repeat}};
+
+/// A single captured frame with its display duration.
+pub struct CapturedFrame {
+    /// The rendered pixel data for this frame.
+    pub image: RgbaImage,
+    /// How long this frame is displayed in the output.
+    pub delay: Duration,
+}
+
+/// Accumulates rendered frames and exports them as a GIF or directory of PNGs.
+pub struct FrameRecorder {
+    frames: Vec<CapturedFrame>,
+    default_frame_delay: Duration,
+}
+
+impl FrameRecorder {
+    /// Creates a new recorder. All frames pushed via [`push_frame`] use `default_frame_delay`.
+    pub fn new(default_frame_delay: Duration) -> Self {
+        Self {
+            frames: Vec::new(),
+            default_frame_delay,
+        }
+    }
+
+    /// Appends a frame using the recorder's default delay.
+    pub fn push_frame(&mut self, image: RgbaImage) {
+        let delay = self.default_frame_delay;
+        self.frames.push(CapturedFrame { image, delay });
+    }
+
+    /// Appends a frame with an explicit delay, overriding the default.
+    pub fn push_frame_with_delay(&mut self, image: RgbaImage, delay: Duration) {
+        self.frames.push(CapturedFrame { image, delay });
+    }
+
+    /// Returns the number of frames accumulated so far.
+    pub fn frame_count(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// Encodes all frames as an infinitely looping animated GIF at `path`.
+    pub fn export_gif(&self, path: &Path) -> anyhow::Result<()> {
+        let file = File::create(path)?;
+        let mut encoder = GifEncoder::new_with_speed(BufWriter::new(file), 10);
+        encoder.set_repeat(Repeat::Infinite)?;
+        for captured in &self.frames {
+            let delay = Delay::from_saturating_duration(captured.delay);
+            let frame = Frame::from_parts(captured.image.clone(), 0, 0, delay);
+            encoder.encode_frame(frame)?;
+        }
+        Ok(())
+    }
+
+    /// Writes each frame as a numbered PNG into `directory` (must already exist).
+    ///
+    /// Files are named `frame_0000.png`, `frame_0001.png`, etc. Suitable for
+    /// piping into ffmpeg or gifski for high-quality output.
+    pub fn export_frames_to_directory(&self, directory: &Path) -> anyhow::Result<()> {
+        for (index, captured) in self.frames.iter().enumerate() {
+            let filename = format!("frame_{:04}.png", index);
+            captured.image.save(directory.join(filename))?;
+        }
+        Ok(())
+    }
+}

--- a/crates/zed/src/visual_harness.rs
+++ b/crates/zed/src/visual_harness.rs
@@ -1,0 +1,179 @@
+//! Reusable harness for visual tests that drive real Zed UI programmatically.
+//!
+//! `setup_zed_for_visual_test` initialises all Zed subsystems inside a
+//! `VisualTestAppContext` and opens an off-screen workspace window.  Callers get
+//! back a `WindowHandle<Workspace>` they can drive with `dispatch_action`,
+//! `simulate_keystrokes`, `record_frame`, etc.
+
+use anyhow::{Context as _, Result};
+use assets::Assets;
+use gpui::{App, AppContext as _, Bounds, VisualTestAppContext, WindowBounds, WindowHandle, WindowOptions, point, px, size};
+use settings::{NotifyWhenAgentWaiting, PlaySoundWhenAgentDone, Settings as _};
+use std::sync::Arc;
+use workspace::{AppState, Workspace};
+
+/// Initialises all Zed subsystems and opens an off-screen workspace window.
+///
+/// The returned `WindowHandle<Workspace>` is positioned off-screen and invisible
+/// to the user but fully rendered by the Metal compositor.  Use it with
+/// `cx.dispatch_action`, `cx.simulate_keystrokes`, and `cx.record_frame`.
+pub fn setup_zed_for_visual_test(
+    cx: &mut VisualTestAppContext,
+) -> Result<(WindowHandle<Workspace>, Arc<AppState>)> {
+    // Load embedded fonts so UI renders with correct typefaces
+    cx.update(|cx| {
+        Assets.load_fonts(cx).unwrap();
+    });
+
+    // Real default settings (not the test settings that use Courier font)
+    cx.update(|cx| {
+        settings::init(cx);
+    });
+
+    let app_state = cx.update(|cx| init_app_state(cx));
+
+    cx.update(|cx| {
+        AppState::set_global(app_state.clone(), cx);
+    });
+
+    cx.update(|cx| {
+        gpui_tokio::init(cx);
+        theme_settings::init(theme::LoadThemes::JustBase, cx);
+        client::init(&app_state.client, cx);
+        audio::init(cx);
+        workspace::init(app_state.clone(), cx);
+        release_channel::init(semver::Version::new(0, 0, 0), cx);
+        command_palette::init(cx);
+        editor::init(cx);
+        call::init(app_state.client.clone(), app_state.user_store.clone(), cx);
+        title_bar::init(cx);
+        project_panel::init(cx);
+        outline_panel::init(cx);
+        terminal_view::init(cx);
+        image_viewer::init(cx);
+        search::init(cx);
+        cx.set_global(workspace::PaneSearchBarCallbacks {
+            setup_search_bar: |languages, toolbar, window, cx| {
+                let search_bar = cx.new(|cx| search::BufferSearchBar::new(languages, window, cx));
+                toolbar.update(cx, |toolbar, cx| {
+                    toolbar.add_item(search_bar, window, cx);
+                });
+            },
+            wrap_div_with_search_actions: search::buffer_search::register_pane_search_actions,
+        });
+        prompt_store::init(cx);
+        let prompt_builder = prompt_store::PromptBuilder::load(app_state.fs.clone(), false, cx);
+        language_model::init(cx);
+        client::RefreshLlmTokenListener::register(
+            app_state.client.clone(),
+            app_state.user_store.clone(),
+            cx,
+        );
+        language_models::init(app_state.user_store.clone(), app_state.client.clone(), cx);
+        git_ui::init(cx);
+        project::AgentRegistryStore::init_global(
+            cx,
+            app_state.fs.clone(),
+            app_state.client.http_client(),
+        );
+        agent_ui::init(
+            app_state.fs.clone(),
+            prompt_builder,
+            app_state.languages.clone(),
+            true,
+            false,
+            cx,
+        );
+        settings_ui::init(cx);
+
+        agent_settings::AgentSettings::override_global(
+            agent_settings::AgentSettings {
+                notify_when_agent_waiting: NotifyWhenAgentWaiting::Never,
+                play_sound_when_agent_done: PlaySoundWhenAgentDone::Never,
+                ..agent_settings::AgentSettings::get_global(cx).clone()
+            },
+            cx,
+        );
+    });
+
+    cx.run_until_parked();
+
+    let bounds = Bounds {
+        origin: point(px(0.0), px(0.0)),
+        size: size(px(1280.0), px(800.0)),
+    };
+
+    let project = cx.update(|cx| {
+        project::Project::local(
+            app_state.client.clone(),
+            app_state.node_runtime.clone(),
+            app_state.user_store.clone(),
+            app_state.languages.clone(),
+            app_state.fs.clone(),
+            None,
+            project::LocalProjectFlags {
+                init_worktree_trust: false,
+                ..Default::default()
+            },
+            cx,
+        )
+    });
+
+    let workspace_window: WindowHandle<Workspace> = cx
+        .update(|cx| {
+            cx.open_window(
+                WindowOptions {
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
+                    focus: false,
+                    show: false,
+                    ..Default::default()
+                },
+                |window, cx| {
+                    cx.new(|cx| {
+                        Workspace::new(None, project.clone(), app_state.clone(), window, cx)
+                    })
+                },
+            )
+        })
+        .context("Failed to open workspace window")?;
+
+    cx.run_until_parked();
+
+    Ok((workspace_window, app_state))
+}
+
+fn init_app_state(cx: &mut App) -> Arc<AppState> {
+    use fs::Fs;
+    use node_runtime::NodeRuntime;
+    use session::Session;
+    use settings::SettingsStore;
+
+    if !cx.has_global::<SettingsStore>() {
+        let settings_store = SettingsStore::test(cx);
+        cx.set_global(settings_store);
+    }
+
+    let fs: Arc<dyn Fs> = Arc::new(fs::RealFs::new(None, cx.background_executor().clone()));
+    <dyn Fs>::set_global(fs.clone(), cx);
+
+    let languages = Arc::new(language::LanguageRegistry::test(
+        cx.background_executor().clone(),
+    ));
+    let clock = Arc::new(clock::FakeSystemClock::new());
+    let http_client = http_client::FakeHttpClient::with_404_response();
+    let client = client::Client::new(clock, http_client, cx);
+    let session = cx.new(|cx| session::AppSession::new(Session::test(), cx));
+    let user_store = cx.new(|cx| client::UserStore::new(client.clone(), cx));
+    let workspace_store = cx.new(|cx| workspace::WorkspaceStore::new(client.clone(), cx));
+
+    Arc::new(AppState {
+        client,
+        fs,
+        languages,
+        user_store,
+        workspace_store,
+        node_runtime: NodeRuntime::unavailable(),
+        build_window_options: |_, _| Default::default(),
+        session,
+    })
+}

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -147,148 +147,22 @@ use constants::*;
 
 #[cfg(target_os = "macos")]
 fn run_visual_tests(project_path: PathBuf, update_baseline: bool) -> Result<()> {
-    // Create the visual test context with deterministic task scheduling
-    // Use real Assets so that SVG icons render properly
     let mut cx = VisualTestAppContext::with_asset_source(
         gpui_platform::current_platform(false),
         Arc::new(Assets),
     );
 
-    // Load embedded fonts (IBM Plex Sans, Lilex, etc.) so UI renders with correct fonts
+    let (workspace_window, app_state) =
+        crate::zed::visual_harness::setup_zed_for_visual_test(&mut cx)?;
+
+    // Bind keymaps specific to the visual test runner
     cx.update(|cx| {
-        Assets.load_fonts(cx).unwrap();
-    });
-
-    // Initialize settings store with real default settings (not test settings)
-    // Test settings use Courier font, but we want the real Zed fonts for visual tests
-    cx.update(|cx| {
-        settings::init(cx);
-    });
-
-    // Create AppState using the test initialization
-    let app_state = cx.update(|cx| init_app_state(cx));
-
-    // Set the global app state so settings_ui and other subsystems can find it
-    cx.update(|cx| {
-        AppState::set_global(app_state.clone(), cx);
-    });
-
-    // Initialize all Zed subsystems
-    cx.update(|cx| {
-        gpui_tokio::init(cx);
-        theme_settings::init(theme::LoadThemes::JustBase, cx);
-        client::init(&app_state.client, cx);
-        audio::init(cx);
-        workspace::init(app_state.clone(), cx);
-        release_channel::init(semver::Version::new(0, 0, 0), cx);
-        command_palette::init(cx);
-        editor::init(cx);
-        call::init(app_state.client.clone(), app_state.user_store.clone(), cx);
-        title_bar::init(cx);
-        project_panel::init(cx);
-        outline_panel::init(cx);
-        terminal_view::init(cx);
-        image_viewer::init(cx);
-        search::init(cx);
-        cx.set_global(workspace::PaneSearchBarCallbacks {
-            setup_search_bar: |languages, toolbar, window, cx| {
-                let search_bar = cx.new(|cx| search::BufferSearchBar::new(languages, window, cx));
-                toolbar.update(cx, |toolbar, cx| {
-                    toolbar.add_item(search_bar, window, cx);
-                });
-            },
-            wrap_div_with_search_actions: search::buffer_search::register_pane_search_actions,
-        });
-        prompt_store::init(cx);
-        let prompt_builder = prompt_store::PromptBuilder::load(app_state.fs.clone(), false, cx);
-        language_model::init(cx);
-        client::RefreshLlmTokenListener::register(
-            app_state.client.clone(),
-            app_state.user_store.clone(),
-            cx,
-        );
-        language_models::init(app_state.user_store.clone(), app_state.client.clone(), cx);
-        git_ui::init(cx);
-        project::AgentRegistryStore::init_global(
-            cx,
-            app_state.fs.clone(),
-            app_state.client.http_client(),
-        );
-        agent_ui::init(
-            app_state.fs.clone(),
-            prompt_builder,
-            app_state.languages.clone(),
-            true,
-            false,
-            cx,
-        );
-        settings_ui::init(cx);
-
-        // Load default keymaps so tooltips can show keybindings like "f9" for ToggleBreakpoint
-        // We load a minimal set of editor keybindings needed for visual tests
         cx.bind_keys([KeyBinding::new(
             "f9",
             editor::actions::ToggleBreakpoint,
             Some("Editor"),
         )]);
-
-        // Disable agent notifications during visual tests to avoid popup windows
-        agent_settings::AgentSettings::override_global(
-            agent_settings::AgentSettings {
-                notify_when_agent_waiting: NotifyWhenAgentWaiting::Never,
-                play_sound_when_agent_done: PlaySoundWhenAgentDone::Never,
-                ..agent_settings::AgentSettings::get_global(cx).clone()
-            },
-            cx,
-        );
     });
-
-    // Run until all initialization tasks complete
-    cx.run_until_parked();
-
-    // Open workspace window
-    let window_size = size(px(1280.0), px(800.0));
-    let bounds = Bounds {
-        origin: point(px(0.0), px(0.0)),
-        size: window_size,
-    };
-
-    // Create a project for the workspace
-    let project = cx.update(|cx| {
-        project::Project::local(
-            app_state.client.clone(),
-            app_state.node_runtime.clone(),
-            app_state.user_store.clone(),
-            app_state.languages.clone(),
-            app_state.fs.clone(),
-            None,
-            project::LocalProjectFlags {
-                init_worktree_trust: false,
-                ..Default::default()
-            },
-            cx,
-        )
-    });
-
-    let workspace_window: WindowHandle<Workspace> = cx
-        .update(|cx| {
-            cx.open_window(
-                WindowOptions {
-                    window_bounds: Some(WindowBounds::Windowed(bounds)),
-                    focus: false,
-                    show: false,
-                    ..Default::default()
-                },
-                |window, cx| {
-                    cx.new(|cx| {
-                        Workspace::new(None, project.clone(), app_state.clone(), window, cx)
-                    })
-                },
-            )
-        })
-        .context("Failed to open workspace window")?;
-
-    cx.run_until_parked();
 
     // Add the test project as a worktree
     let add_worktree_task = workspace_window
@@ -961,48 +835,6 @@ cargo run
     std::fs::write(project_path.join("README.md"), readme).expect("Failed to write README.md");
 }
 
-#[cfg(target_os = "macos")]
-fn init_app_state(cx: &mut App) -> Arc<AppState> {
-    use fs::Fs;
-    use node_runtime::NodeRuntime;
-    use session::Session;
-    use settings::SettingsStore;
-
-    if !cx.has_global::<SettingsStore>() {
-        let settings_store = SettingsStore::test(cx);
-        cx.set_global(settings_store);
-    }
-
-    // Use the real filesystem instead of FakeFs so we can access actual files on disk
-    let fs: Arc<dyn Fs> = Arc::new(fs::RealFs::new(None, cx.background_executor().clone()));
-    <dyn Fs>::set_global(fs.clone(), cx);
-
-    let languages = Arc::new(language::LanguageRegistry::test(
-        cx.background_executor().clone(),
-    ));
-    let clock = Arc::new(clock::FakeSystemClock::new());
-    let http_client = http_client::FakeHttpClient::with_404_response();
-    let client = client::Client::new(clock, http_client, cx);
-    let session = cx.new(|cx| session::AppSession::new(Session::test(), cx));
-    let user_store = cx.new(|cx| client::UserStore::new(client.clone(), cx));
-    let workspace_store = cx.new(|cx| workspace::WorkspaceStore::new(client.clone(), cx));
-
-    theme_settings::init(theme::LoadThemes::JustBase, cx);
-    client::init(&client, cx);
-
-    let app_state = Arc::new(AppState {
-        client,
-        fs,
-        languages,
-        user_store,
-        workspace_store,
-        node_runtime: NodeRuntime::unavailable(),
-        build_window_options: |_, _| Default::default(),
-        session,
-    });
-    AppState::set_global(app_state.clone(), cx);
-    app_state
-}
 
 /// Runs visual tests for breakpoint hover states in the editor gutter.
 ///

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -11,6 +11,8 @@ mod quick_action_bar;
 pub mod remote_debug;
 pub mod telemetry_log;
 #[cfg(all(target_os = "macos", feature = "visual-tests"))]
+pub mod visual_harness;
+#[cfg(all(target_os = "macos", feature = "visual-tests"))]
 pub mod visual_tests;
 #[cfg(target_os = "windows")]
 pub(crate) mod windows_only_instance;


### PR DESCRIPTION
## Summary

- Adds `gpui::FrameRecorder` — accumulates rendered frames, exports as animated GIF (`export_gif`) or PNG frame sequence (`export_frames_to_directory`) for use in CI visual regression and PR demo recordings
- Adds `VisualTestAppContext::record_frame` — implicit `run_until_parked()` before capture so callers never need to park manually before recording a frame
- Adds `zed::visual_harness::setup_zed_for_visual_test` — reusable full-app init that extracts the subsystem init block from `visual_test_runner` into a standalone harness, returning `(WindowHandle<Workspace>, Arc<AppState>)`
- Refactors `visual_test_runner::run_visual_tests` to delegate to the new harness (removes ~150 lines of duplicated init)

No new Cargo dependencies — GIF encoding uses `image::codecs::gif::GifEncoder`, already present in the transitive dependency graph.

### Example usage

```rust
fn record_file_picker_demo(cx: &mut VisualTestAppContext) -> anyhow::Result<()> {
    let mut recorder = FrameRecorder::new(Duration::from_millis(400));
    let (window, _app_state) = setup_zed_for_visual_test(cx)?;
    let window = window.into();

    cx.record_frame(window, &mut recorder)?;
    cx.dispatch_action(window, file_finder::Toggle);
    cx.record_frame(window, &mut recorder)?;
    cx.simulate_input(window, "main");
    cx.record_frame(window, &mut recorder)?;

    recorder.export_gif(Path::new("target/visual_tests/file_picker.gif"))
}
```

## Test plan

- `cargo build -p gpui --features test-support` — clean
- `cargo check -p zed --features visual-tests` — no errors in new files
- `cargo test -p gpui --features test-support` — all pass

Release Notes:

- N/A