### PR TITLE
grammars: Add `runnables.scm` for C++

### DIFF
--- a/crates/grammars/src/cpp/runnables.scm
+++ b/crates/grammars/src/cpp/runnables.scm
@@ -1,0 +1,6 @@
+; Tag the main function
+((function_definition
+  declarator: (function_declarator
+    declarator: (identifier) @run)) @_cpp-main
+  (#eq? @run "main")
+  (#set! tag cpp-main))


### PR DESCRIPTION
Added a runnables.scm for cpp grammar so that tasks can be made with the play button. It is already implemented for C.

Release Notes:

- Added runnables for C++