### PR TITLE
Cache markdown code block highlights

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -14,7 +14,9 @@ use feature_flags::AcpBetaFeatureFlag;
 
 use crate::message_editor::SharedSessionCapabilities;
 
+use gpui::AnyView;
 use gpui::List;
+use gpui::StyleRefinement;
 use gpui::TaskExt;
 use heapless::Vec as ArrayVec;
 use language_model::{LanguageModelEffortLevel, Speed};
@@ -6505,14 +6507,8 @@ impl ThreadView {
                                 .when(is_raw_input_expanded, |this| {
                                     this.children(tool_call.raw_input_markdown.clone().map(
                                         |input| {
-                                            self.render_markdown(
-                                                input,
-                                                MarkdownStyle::themed(
-                                                    MarkdownFont::Agent,
-                                                    window,
-                                                    cx,
-                                                ),
-                                                cx,
+                                            self.render_raw_input_markdown(
+                                                entry_ix, input, window, cx,
                                             )
                                         },
                                     ))
@@ -6553,11 +6549,7 @@ impl ThreadView {
                                 .child(input_output_header("Raw Input:".into()))
                                 .children(tool_call.raw_input_markdown.clone().map(|input| {
                                     div().id(("tool-call-raw-input-markdown", entry_ix)).child(
-                                        self.render_markdown(
-                                            input,
-                                            MarkdownStyle::themed(MarkdownFont::Agent, window, cx),
-                                            cx,
-                                        ),
+                                        self.render_raw_input_markdown(entry_ix, input, window, cx),
                                     )
                                 }))
                                 .child(input_output_header("Output:".into())),
@@ -8684,6 +8676,39 @@ impl ThreadView {
         cx: &App,
     ) -> MarkdownElement {
         render_agent_markdown(markdown, style, &self.workspace, &self.project, cx)
+    }
+
+    /// Render a tool call's `raw_input` markdown as a *cached* `AnyView`.
+    ///
+    /// The view is created once in `EntryViewState::sync_entry` and reused
+    /// across frames. Wrapping it with `AnyView::cached(style)` lets GPUI
+    /// recycle the previous frame's layout and paint when nothing has changed
+    /// (matching the pattern used by `dock.rs` and `pane_group.rs`).
+    fn render_raw_input_markdown(
+        &self,
+        entry_ix: usize,
+        input: Entity<Markdown>,
+        window: &Window,
+        cx: &Context<Self>,
+    ) -> AnyElement {
+        if let Some(view) = self
+            .entry_view_state
+            .read(cx)
+            .entry(entry_ix)
+            .and_then(|entry| entry.markdown_view(&input))
+        {
+            return AnyView::from(view)
+                .cached(StyleRefinement::default())
+                .into_any_element();
+        }
+        // Fallback: sync_entry should have created the view first, but if it
+        // hasn't, render inline so we don't lose content.
+        self.render_markdown(
+            input,
+            MarkdownStyle::themed(MarkdownFont::Agent, window, cx),
+            cx,
+        )
+        .into_any_element()
     }
 
     fn create_copy_button(&self, message: impl Into<String>) -> impl IntoElement {

--- a/crates/agent_ui/src/entry_view_state.rs
+++ b/crates/agent_ui/src/entry_view_state.rs
@@ -10,6 +10,7 @@ use gpui::{
     ScrollHandle, TextStyleRefinement, WeakEntity, Window,
 };
 use language::language_settings::SoftWrap;
+use markdown::{MarkdownFont, MarkdownStyle, MarkdownView};
 use project::{AgentId, Project};
 use prompt_store::PromptStore;
 use rope::Point;
@@ -117,6 +118,7 @@ impl EntryViewState {
                 let id = tool_call.id.clone();
                 let terminals = tool_call.terminals().cloned().collect::<Vec<_>>();
                 let diffs = tool_call.diffs().cloned().collect::<Vec<_>>();
+                let raw_input_markdown = tool_call.raw_input_markdown.clone();
 
                 let views = if let Some(Entry::ToolCall(tool_call)) = self.entries.get_mut(index) {
                     &mut tool_call.content
@@ -163,6 +165,16 @@ impl EntryViewState {
                             }
                         }
                     }
+                }
+
+                if let Some(raw_input_markdown) = raw_input_markdown {
+                    views
+                        .entry(raw_input_markdown.entity_id())
+                        .or_insert_with(|| {
+                            let style = MarkdownStyle::themed(MarkdownFont::Agent, window, cx);
+                            cx.new(|cx| MarkdownView::new(raw_input_markdown, style, cx))
+                                .into_any()
+                        });
                 }
 
                 for diff in diffs {
@@ -360,6 +372,16 @@ impl Entry {
             .get(&terminal.entity_id())
             .cloned()
             .map(|entity| entity.downcast::<TerminalView>().unwrap())
+    }
+
+    pub fn markdown_view(
+        &self,
+        markdown: &Entity<markdown::Markdown>,
+    ) -> Option<Entity<MarkdownView>> {
+        self.content_map()?
+            .get(&markdown.entity_id())
+            .cloned()
+            .map(|entity| entity.downcast::<MarkdownView>().unwrap())
     }
 
     pub fn scroll_handle_for_assistant_message_chunk(

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -19,6 +19,7 @@ use settings::Settings as _;
 use theme_settings::ThemeSettings;
 
 use std::borrow::Cow;
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::iter;
 use std::mem;
@@ -34,21 +35,90 @@ use gpui::{
     FocusHandle, Focusable, FontStyle, FontWeight, GlobalElementId, Hitbox, Hsla, Image,
     ImageFormat, ImageSource, KeyContext, Length, MouseButton, MouseDownEvent, MouseEvent,
     MouseMoveEvent, MouseUpEvent, Point, ScrollHandle, Stateful, StrikethroughStyle,
-    StyleRefinement, StyledImage, StyledText, Task, TextAlign, TextLayout, TextRun, TextStyle,
-    TextStyleRefinement, actions, img, point, quad,
+    StyleRefinement, StyledImage, StyledText, Subscription, Task, TextAlign, TextLayout, TextRun,
+    TextStyle, TextStyleRefinement, actions, img, point, quad,
 };
-use language::{CharClassifier, Language, LanguageRegistry, Rope};
+use language::{CharClassifier, HighlightId, Language, LanguageId, LanguageRegistry, Rope};
 use parser::CodeBlockMetadata;
 use parser::{
     MarkdownEvent, MarkdownTag, MarkdownTagEnd, parse_links_only, parse_markdown_with_options,
 };
 use pulldown_cmark::{Alignment, BlockQuoteKind};
+use settings::SettingsStore;
 use sum_tree::TreeMap;
 use theme::SyntaxTheme;
 use ui::{Checkbox, CopyButton, ScrollAxes, Scrollbars, Tooltip, WithScrollbar, prelude::*};
 use util::ResultExt;
 
 use crate::parser::CodeBlockKind;
+
+const HIGHLIGHT_CACHE_MAX_ENTRIES: usize = 16;
+
+type CachedHighlightRuns = Arc<[(Range<usize>, HighlightId)]>;
+
+#[derive(Hash, Eq, PartialEq, Clone, Copy)]
+struct HighlightCacheKey {
+    source_start: usize,
+    source_end: usize,
+    language_id: LanguageId,
+}
+
+struct HighlightCacheEntry {
+    runs: CachedHighlightRuns,
+    last_used_seq: u64,
+}
+
+#[derive(Default)]
+struct HighlightCache {
+    entries: HashMap<HighlightCacheKey, HighlightCacheEntry>,
+    next_seq: u64,
+}
+
+impl HighlightCache {
+    fn get_or_insert<F>(&mut self, key: HighlightCacheKey, compute: F) -> CachedHighlightRuns
+    where
+        F: FnOnce() -> Vec<(Range<usize>, HighlightId)>,
+    {
+        if let Some(entry) = self.entries.get_mut(&key) {
+            self.next_seq += 1;
+            entry.last_used_seq = self.next_seq;
+            return entry.runs.clone();
+        }
+
+        let runs: CachedHighlightRuns = Arc::from(compute());
+        self.next_seq += 1;
+        self.entries.insert(
+            key,
+            HighlightCacheEntry {
+                runs: runs.clone(),
+                last_used_seq: self.next_seq,
+            },
+        );
+        self.evict_if_needed();
+        runs
+    }
+
+    fn evict_if_needed(&mut self) {
+        while self.entries.len() > HIGHLIGHT_CACHE_MAX_ENTRIES {
+            let oldest_key = self
+                .entries
+                .iter()
+                .min_by_key(|(_, e)| e.last_used_seq)
+                .map(|(k, _)| *k);
+            match oldest_key {
+                Some(key) => {
+                    self.entries.remove(&key);
+                }
+                None => break,
+            }
+        }
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.next_seq = 0;
+    }
+}
 
 /// A callback function that can be used to customize the style of links based on the destination URL.
 /// If the callback returns `None`, the default link style will be used.
@@ -339,6 +409,8 @@ pub struct Markdown {
     context_menu_selected_text: Option<String>,
     search_highlights: Vec<Range<usize>>,
     active_search_highlight: Option<usize>,
+    highlight_cache: Rc<RefCell<HighlightCache>>,
+    _settings_subscription: Subscription,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -487,6 +559,9 @@ impl Markdown {
         cx: &mut Context<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
+        let settings_subscription = cx.observe_global::<SettingsStore>(|this: &mut Self, _cx| {
+            this.highlight_cache.borrow_mut().clear();
+        });
         let mut this = Self {
             source,
             selection: Selection::default(),
@@ -510,6 +585,8 @@ impl Markdown {
             context_menu_selected_text: None,
             search_highlights: Vec::new(),
             active_search_highlight: None,
+            highlight_cache: Rc::new(RefCell::new(HighlightCache::default())),
+            _settings_subscription: settings_subscription,
         };
         this.parse(cx);
         this
@@ -763,6 +840,7 @@ impl Markdown {
     }
 
     fn parse(&mut self, cx: &mut Context<Self>) {
+        self.highlight_cache.borrow_mut().clear();
         if self.source.is_empty() {
             self.should_reparse = false;
             self.pending_parse.take();
@@ -899,6 +977,7 @@ impl Markdown {
             let (parsed, images_by_source_offset) = parsed.await;
 
             this.update(cx, |this, cx| {
+                this.highlight_cache.borrow_mut().clear();
                 this.parsed_markdown = parsed;
                 this.images_by_source_offset = images_by_source_offset;
                 if this.active_root_block.is_some_and(|block_index| {
@@ -1670,10 +1749,12 @@ impl Element for MarkdownElement {
         window: &mut Window,
         cx: &mut App,
     ) -> (gpui::LayoutId, Self::RequestLayoutState) {
+        let highlight_cache = self.markdown.read(cx).highlight_cache.clone();
         let mut builder = MarkdownElementBuilder::new(
             &self.style.container_style,
             self.style.base_text_style.clone(),
             self.style.syntax.clone(),
+            highlight_cache,
         );
         let (parsed_markdown, images, active_root_block, render_mermaid_diagrams, mermaid_state) = {
             let markdown = self.markdown.read(cx);
@@ -2581,6 +2662,7 @@ struct MarkdownElementBuilder {
     list_stack: Vec<ListStackEntry>,
     table: TableState,
     syntax_theme: Arc<SyntaxTheme>,
+    highlight_cache: Rc<RefCell<HighlightCache>>,
 }
 
 #[derive(Default)]
@@ -2599,6 +2681,7 @@ impl MarkdownElementBuilder {
         container_style: &StyleRefinement,
         base_text_style: TextStyle,
         syntax_theme: Arc<SyntaxTheme>,
+        highlight_cache: Rc<RefCell<HighlightCache>>,
     ) -> Self {
         Self {
             div_stack: vec![{
@@ -2619,6 +2702,7 @@ impl MarkdownElementBuilder {
             list_stack: Vec::new(),
             table: TableState::default(),
             syntax_theme,
+            highlight_cache,
         }
     }
 
@@ -2788,8 +2872,20 @@ impl MarkdownElementBuilder {
         self.current_source_index = source_range.end;
 
         if let Some(Some(language)) = self.code_block_stack.last() {
+            let language = language.clone();
+            let key = HighlightCacheKey {
+                source_start: source_range.start,
+                source_end: source_range.end,
+                language_id: language.id(),
+            };
+            let highlight_runs = self.highlight_cache.borrow_mut().get_or_insert(key, || {
+                language.highlight_text(&Rope::from(text), 0..text.len())
+            });
+
             let mut offset = 0;
-            for (range, highlight_id) in language.highlight_text(&Rope::from(text), 0..text.len()) {
+            for (range, highlight_id) in highlight_runs.iter() {
+                let range = range.clone();
+                let highlight_id = *highlight_id;
                 if range.start > offset {
                     self.pending_line
                         .runs

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -27,7 +27,7 @@ use std::ops::Range;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use collections::{HashMap, HashSet};
 use gpui::{
@@ -53,6 +53,49 @@ use util::ResultExt;
 use crate::parser::CodeBlockKind;
 
 const HIGHLIGHT_CACHE_MAX_ENTRIES: usize = 16;
+
+// Aggregated rate logging. Logs once per second per source so we can observe
+// the effect of `MarkdownView` + `AnyView::cached` without spamming.
+thread_local! {
+    static ELEMENT_RENDER_STATS: RefCell<RenderRateStats> = RefCell::new(RenderRateStats::new("MarkdownElement::request_layout"));
+    static VIEW_RENDER_STATS: RefCell<RenderRateStats> = RefCell::new(RenderRateStats::new("MarkdownView::render (cache MISS)"));
+    static VIEW_INVALIDATE_MARKDOWN: RefCell<RenderRateStats> = RefCell::new(RenderRateStats::new("MarkdownView invalidated by Markdown notify"));
+    static VIEW_INVALIDATE_SETTINGS: RefCell<RenderRateStats> = RefCell::new(RenderRateStats::new("MarkdownView invalidated by SettingsStore notify"));
+}
+
+struct RenderRateStats {
+    label: &'static str,
+    window_start: Option<Instant>,
+    count: u64,
+}
+
+impl RenderRateStats {
+    fn new(label: &'static str) -> Self {
+        Self {
+            label,
+            window_start: None,
+            count: 0,
+        }
+    }
+
+    fn tick(&mut self) {
+        let now = Instant::now();
+        let window_start = *self.window_start.get_or_insert(now);
+        self.count += 1;
+        let elapsed = now.duration_since(window_start);
+        if elapsed >= Duration::from_secs(1) {
+            log::info!(
+                "{}: {} in {:.2?} ({:.1}/s)",
+                self.label,
+                self.count,
+                elapsed,
+                self.count as f64 / elapsed.as_secs_f64(),
+            );
+            self.window_start = None;
+            self.count = 0;
+        }
+    }
+}
 
 type CachedHighlightRuns = Arc<[(Range<usize>, HighlightId)]>;
 
@@ -1749,6 +1792,7 @@ impl Element for MarkdownElement {
         window: &mut Window,
         cx: &mut App,
     ) -> (gpui::LayoutId, Self::RequestLayoutState) {
+        ELEMENT_RENDER_STATS.with(|stats| stats.borrow_mut().tick());
         let highlight_cache = self.markdown.read(cx).highlight_cache.clone();
         let mut builder = MarkdownElementBuilder::new(
             &self.style.container_style,
@@ -3412,6 +3456,63 @@ impl RenderedText {
         self.footnote_refs
             .iter()
             .find(|fref| fref.source_range.contains(&source_index))
+    }
+}
+
+/// A `Render`-implementing view wrapper around a [`Markdown`] entity so it can
+/// be turned into an [`AnyView`] and cached with `AnyView::cached(style)`.
+///
+/// `MarkdownElement` is an immediate-mode `Element` that has to be reconstructed
+/// on every frame, which prevents GPUI's view-level caching from helping. By
+/// stashing a long-lived `Entity<MarkdownView>` on the parent and rendering it
+/// via `markdown_view.clone().into_any().cached(...)`, the previous frame's
+/// layout and paint are reused unless the underlying `Markdown` entity notifies,
+/// the theme changes, or `Window::refresh` is called.
+///
+/// Caveat: do not place editable inputs (`Editor`, etc.) inside cached views;
+/// see https://github.com/zed-industries/zed/issues/50456.
+pub struct MarkdownView {
+    markdown: Entity<Markdown>,
+    style: MarkdownStyle,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl MarkdownView {
+    pub fn new(markdown: Entity<Markdown>, style: MarkdownStyle, cx: &mut Context<Self>) -> Self {
+        let subscriptions = vec![
+            cx.observe(&markdown, |_, _, cx| {
+                VIEW_INVALIDATE_MARKDOWN.with(|stats| stats.borrow_mut().tick());
+                cx.notify();
+            }),
+            cx.observe_global::<SettingsStore>(|_, cx| {
+                VIEW_INVALIDATE_SETTINGS.with(|stats| stats.borrow_mut().tick());
+                cx.notify();
+            }),
+        ];
+        Self {
+            markdown,
+            style,
+            _subscriptions: subscriptions,
+        }
+    }
+
+    pub fn markdown(&self) -> &Entity<Markdown> {
+        &self.markdown
+    }
+
+    /// Replace the rendering style. Call this from the parent when the theme or
+    /// surrounding text style changes, otherwise the cached layout will keep
+    /// using the stale style.
+    pub fn set_style(&mut self, style: MarkdownStyle, cx: &mut Context<Self>) {
+        self.style = style;
+        cx.notify();
+    }
+}
+
+impl Render for MarkdownView {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        VIEW_RENDER_STATS.with(|stats| stats.borrow_mut().tick());
+        MarkdownElement::new(self.markdown.clone(), self.style.clone())
     }
 }
 


### PR DESCRIPTION
Fixes lag when expanding and scrolling tool call UI elements that contain large code blocks (such as a `read_file` of `crates/editor/src/editor.rs`).

The markdown renderer was re-running tree-sitter syntax highlighting on every frame for every visible code block. We now cache the highlight ranges per code block and invalidate only when the source or language changes.

Closes AI-234

Release Notes:

- Improved performance when scrolling through agent tool calls that contain large code blocks