### PR TITLE
Disable auto watch when leaving a call

### DIFF
--- a/crates/call/src/call_impl/mod.rs
+++ b/crates/call/src/call_impl/mod.rs
@@ -222,6 +222,7 @@ impl AnyActiveCall for ActiveCallEntity {
                     room::Event::LocalScreenShareStopped => {
                         Some(ActiveCallEvent::LocalScreenShareStopped)
                     }
+                    room::Event::RoomLeft { .. } => Some(ActiveCallEvent::RoomLeft),
                     _ => None,
                 };
                 if let Some(event) = mapped {

--- a/crates/collab/tests/integration/auto_watch_tests.rs
+++ b/crates/collab/tests/integration/auto_watch_tests.rs
@@ -463,17 +463,11 @@ async fn test_auto_watch_is_disabled_when_leaving_call(
         .unwrap();
     executor.run_until_parked();
 
-    active_call_a
-        .update(user_a, |call, cx| call.join_channel(setup.channel_id, cx))
-        .await
-        .unwrap();
-    executor.run_until_parked();
-
     workspace_a.update(user_a, |workspace, _cx| {
         assert_eq!(
             *workspace.auto_watch_state(),
             AutoWatch::Off,
-            "auto-watch should be off after leaving and rejoining a call"
+            "auto-watch should be off after leaving the call"
         );
     });
 }

--- a/crates/collab/tests/integration/auto_watch_tests.rs
+++ b/crates/collab/tests/integration/auto_watch_tests.rs
@@ -430,6 +430,54 @@ async fn test_auto_watch_is_disabled_when_following_collaborator(
     });
 }
 
+#[gpui::test]
+async fn test_auto_watch_is_disabled_when_leaving_call(
+    executor: BackgroundExecutor,
+    user_a: &mut TestAppContext,
+    user_b: &mut TestAppContext,
+    user_c: &mut TestAppContext,
+) {
+    let mut server = TestServer::start(executor.clone()).await;
+    let setup = setup_auto_watch_test(&mut server, user_a, user_b, user_c).await;
+    let (workspace_a, user_a) = setup
+        .client_a
+        .build_workspace(&setup.user_a_project, user_a);
+
+    workspace_a.update_in(user_a, |workspace, window, cx| {
+        workspace.toggle_auto_watch(window, cx);
+    });
+    executor.run_until_parked();
+
+    workspace_a.update(user_a, |workspace, _cx| {
+        assert_eq!(
+            *workspace.auto_watch_state(),
+            AutoWatch::Active { watched_peer: None },
+            "auto-watch should be enabled after toggling on"
+        );
+    });
+
+    let active_call_a = user_a.read(ActiveCall::global);
+    active_call_a
+        .update(user_a, |call, cx| call.hang_up(cx))
+        .await
+        .unwrap();
+    executor.run_until_parked();
+
+    active_call_a
+        .update(user_a, |call, cx| call.join_channel(setup.channel_id, cx))
+        .await
+        .unwrap();
+    executor.run_until_parked();
+
+    workspace_a.update(user_a, |workspace, _cx| {
+        assert_eq!(
+            *workspace.auto_watch_state(),
+            AutoWatch::Off,
+            "auto-watch should be off after leaving and rejoining a call"
+        );
+    });
+}
+
 #[track_caller]
 fn assert_no_screen_share_tabs_exist(workspace: &Workspace, message: &str, cx: &App) {
     let has_shared_screen_tab = workspace

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6685,6 +6685,12 @@ impl Workspace {
             ActiveCallEvent::LocalScreenShareStopped => {
                 self.handle_auto_watch_local_share_stopped(window, cx);
             }
+            ActiveCallEvent::RoomLeft => {
+                if self.auto_watch.enabled() {
+                    self.auto_watch = AutoWatch::Off;
+                    cx.notify();
+                }
+            }
         }
     }
 
@@ -8136,6 +8142,7 @@ pub enum ActiveCallEvent {
     RemoteVideoTracksChanged { participant_id: PeerId },
     LocalScreenShareStarted,
     LocalScreenShareStopped,
+    RoomLeft,
 }
 
 fn leader_border_for_pane(


### PR DESCRIPTION
Auto watch's lifespan should be tied to that of the call and it should not be assumed the user wants to have this on indefinitely (until app restart), as it's more of a niche feature. This PR disables it when the user leaves a call.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- N/A
