### PR TITLE
Fix window crash

### DIFF
--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -378,7 +378,21 @@ impl AppContext for AsyncWindowContext {
     where
         T: 'static,
     {
-        self.app.new(build_entity)
+        let mut build_entity = Some(build_entity);
+        match self.app.update_window(self.window, |_, _, cx| {
+            cx.new(
+                build_entity
+                    .take()
+                    .expect("build_entity is taken exactly once"),
+            )
+        }) {
+            Ok(entity) => entity,
+            Err(_) => self.app.new(
+                build_entity
+                    .take()
+                    .expect("update_window returned Err without invoking the closure"),
+            ),
+        }
     }
 
     fn reserve_entity<T: 'static>(&mut self) -> Reservation<T> {
@@ -390,7 +404,19 @@ impl AppContext for AsyncWindowContext {
         reservation: Reservation<T>,
         build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Entity<T> {
-        self.app.insert_entity(reservation, build_entity)
+        let mut args = Some((reservation, build_entity));
+        match self.app.update_window(self.window, |_, _, cx| {
+            let (reservation, build_entity) = args.take().expect("args are taken exactly once");
+            cx.insert_entity(reservation, build_entity)
+        }) {
+            Ok(entity) => entity,
+            Err(_) => {
+                let (reservation, build_entity) = args
+                    .take()
+                    .expect("update_window returned Err without invoking the closure");
+                self.app.insert_entity(reservation, build_entity)
+            }
+        }
     }
 
     fn update_entity<T: 'static, R>(

--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -378,12 +378,7 @@ impl AppContext for AsyncWindowContext {
     where
         T: 'static,
     {
-        // Associate the new entity with our captured window so that
-        // `with_window` can resolve a dispatch target before the entity has
-        // been rendered.
-        self.app
-            .update_window(self.window, |_, _, cx| cx.new(build_entity))
-            .expect("window was unexpectedly closed")
+        self.app.new(build_entity)
     }
 
     fn reserve_entity<T: 'static>(&mut self) -> Reservation<T> {
@@ -395,11 +390,7 @@ impl AppContext for AsyncWindowContext {
         reservation: Reservation<T>,
         build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Entity<T> {
-        self.app
-            .update_window(self.window, |_, _, cx| {
-                cx.insert_entity(reservation, build_entity)
-            })
-            .expect("window was unexpectedly closed")
+        self.app.insert_entity(reservation, build_entity)
     }
 
     fn update_entity<T: 'static, R>(


### PR DESCRIPTION
Closes ZED-86Q. Closes FR-8.

Fixes this (rare) crash by making entity creation via a window context infallible.

The shape of the result is a bit clunky due to the type signatures involved. The real solution is to remove AsyncWindowContext entirely and move it's fallible APIs into WindowHandle, but until then this will give you a simple starting point.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
