### PR TITLE
project: Deduplicate symbols from multiple LSP servers

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4130,7 +4130,7 @@ struct CoreSymbol {
     pub container_name: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum SymbolLocation {
     InProject(ProjectPath),
     OutsideProject {
@@ -8005,6 +8005,11 @@ impl LspStore {
                     )
                     .await;
                 }
+
+                let mut seen = std::collections::HashSet::new();
+                symbols.retain(|symbol| {
+                    seen.insert((symbol.name.clone(), symbol.path.clone(), symbol.range.start))
+                });
 
                 Ok(symbols)
             })

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -626,16 +626,15 @@ mod tests {
             .await
             .unwrap();
 
-        // Simulate two language servers both reporting the same symbol by returning it twice.
-        let duplicate_symbol = symbol("foo", path!("/dir/test.rs"));
+        let fake_symbol = symbol("foo", path!("/dir/test.rs"));
         let fake_server = fake_servers.next().await.unwrap();
         fake_server.set_request_handler::<lsp::WorkspaceSymbolRequest, _, _>(
             move |_params: lsp::WorkspaceSymbolParams, _cx| {
-                let duplicate_symbol = duplicate_symbol.clone();
+                let symbol = fake_symbol.clone();
                 async move {
                     Ok(Some(lsp::WorkspaceSymbolResponse::Flat(vec![
-                        duplicate_symbol.clone(),
-                        duplicate_symbol,
+                        symbol.clone(),
+                        symbol,
                     ])))
                 }
             },

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -586,6 +586,88 @@ mod tests {
         });
     }
 
+    #[gpui::test]
+    async fn test_project_symbols_deduplication(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/dir"), json!({ "test.rs": "" }))
+            .await;
+
+        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+
+        let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+        language_registry.add(Arc::new(Language::new(
+            LanguageConfig {
+                name: "Rust".into(),
+                matcher: LanguageMatcher {
+                    path_suffixes: vec!["rs".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            None,
+        )));
+        let mut fake_servers = language_registry.register_fake_lsp(
+            "Rust",
+            FakeLspAdapter {
+                capabilities: lsp::ServerCapabilities {
+                    workspace_symbol_provider: Some(OneOf::Left(true)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+
+        let _buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer_with_lsp(path!("/dir/test.rs"), cx)
+            })
+            .await
+            .unwrap();
+
+        // Simulate two language servers both reporting the same symbol by returning it twice.
+        let duplicate_symbol = symbol("foo", path!("/dir/test.rs"));
+        let fake_server = fake_servers.next().await.unwrap();
+        fake_server.set_request_handler::<lsp::WorkspaceSymbolRequest, _, _>(
+            move |_params: lsp::WorkspaceSymbolParams, _cx| {
+                let duplicate_symbol = duplicate_symbol.clone();
+                async move {
+                    Ok(Some(lsp::WorkspaceSymbolResponse::Flat(vec![
+                        duplicate_symbol.clone(),
+                        duplicate_symbol,
+                    ])))
+                }
+            },
+        );
+
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        let symbols = cx.new_window_entity(|window, cx| {
+            Picker::uniform_list(
+                ProjectSymbolsDelegate::new(workspace.downgrade(), project.clone()),
+                window,
+                cx,
+            )
+        });
+
+        symbols.update_in(cx, |p, window, cx| {
+            p.update_matches("foo".to_string(), window, cx);
+        });
+
+        cx.run_until_parked();
+        symbols.read_with(cx, |symbols, _| {
+            assert_eq!(
+                symbols.delegate.matches.len(),
+                1,
+                "duplicate symbols should be deduplicated"
+            );
+            assert_eq!(symbols.delegate.matches[0].string, "foo");
+        });
+    }
+
     fn init_test(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let store = SettingsStore::test(cx);


### PR DESCRIPTION
Use HashSet to filter duplicate (name, path, range.start) tuples when multiple LSP servers report same symbol.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #56652

Release Notes:

- Improved project symbols search by removing duplicates.

### Before

<img width="983" height="747" alt="CleanShot 2026-05-19 at 18 02 15" src="https://github.com/user-attachments/assets/8d7f53cd-d0fb-441a-8bb4-384de6fe8671" />

### After

https://github.com/user-attachments/assets/eb8f6d6f-4901-4049-bc04-fa7eb171450a

### Open question

While I was working on this, I noticed that we show "No matches" by default when opening the project symbols search. This causes a short flicker. It's not that noticeable but it still bothers me. I would like to fix that but didn't think it should be part of this pull request.
