### PR TITLE
gpui: Make text decoration painting bidi-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7758,6 +7758,7 @@ dependencies = [
  "taffy",
  "thiserror 2.0.17",
  "ttf-parser",
+ "unicode-bidi",
  "unicode-segmentation",
  "url",
  "usvg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -789,6 +789,7 @@ tree-sitter-typescript = { git = "https://github.com/zed-industries/tree-sitter-
 tree-sitter-yaml = { git = "https://github.com/zed-industries/tree-sitter-yaml", rev = "baff0b51c64ef6a1fb1f8390f3ad6015b83ec13a" }
 tracing = "0.1.40"
 unicase = "2.6"
+unicode-bidi = "0.3.18"
 unicode-script = "0.5.7"
 unicode-segmentation = "1.10"
 unicode-width = "0.2"

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -83,6 +83,7 @@ resvg = { version = "0.45.0", default-features = false, features = [
 ] }
 usvg = { version = "0.45.0", default-features = false }
 ttf-parser = "0.25"
+unicode-bidi.workspace = true
 util_macros.workspace = true
 schemars.workspace = true
 seahash = "4.1"

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -915,6 +915,7 @@ impl PlatformTextSystem for NoopTextSystem {
             descent: font_size * (metrics.descent / metrics.units_per_em as f32),
             runs,
             len: text.len(),
+            index_positions: Vec::new(),
         }
     }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -916,6 +916,7 @@ impl PlatformTextSystem for NoopTextSystem {
             runs,
             len: text.len(),
             index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
         }
     }
 

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -75,6 +75,11 @@ impl ShapedLine {
             descent: layout.descent,
             runs: layout.runs.clone(),
             len,
+            index_positions: if len == layout.len {
+                layout.index_positions.clone()
+            } else {
+                Vec::new()
+            },
         });
         self
     }
@@ -222,28 +227,36 @@ impl ShapedLine {
         let left_width = x_offset;
         let right_width = self.layout.width - left_width;
 
+        let mut left_layout = LineLayout {
+            font_size: self.layout.font_size,
+            width: left_width,
+            ascent: self.layout.ascent,
+            descent: self.layout.descent,
+            runs: left_runs,
+            len: byte_index,
+            index_positions: Vec::new(),
+        };
+        left_layout.compute_bidi_index_positions(&left_text);
+
+        let mut right_layout = LineLayout {
+            font_size: self.layout.font_size,
+            width: right_width,
+            ascent: self.layout.ascent,
+            descent: self.layout.descent,
+            runs: right_runs,
+            len: self.layout.len - byte_index,
+            index_positions: Vec::new(),
+        };
+        right_layout.compute_bidi_index_positions(&right_text);
+
         let left = ShapedLine {
-            layout: Arc::new(LineLayout {
-                font_size: self.layout.font_size,
-                width: left_width,
-                ascent: self.layout.ascent,
-                descent: self.layout.descent,
-                runs: left_runs,
-                len: byte_index,
-            }),
+            layout: Arc::new(left_layout),
             text: left_text,
             decoration_runs: left_decorations,
         };
 
         let right = ShapedLine {
-            layout: Arc::new(LineLayout {
-                font_size: self.layout.font_size,
-                width: right_width,
-                ascent: self.layout.ascent,
-                descent: self.layout.descent,
-                runs: right_runs,
-                len: self.layout.len - byte_index,
-            }),
+            layout: Arc::new(right_layout),
             text: right_text,
             decoration_runs: right_decorations,
         };
@@ -783,6 +796,7 @@ mod tests {
                     glyphs: shaped_glyphs,
                 }],
                 len: text.len(),
+                index_positions: Vec::new(),
             }),
             text: SharedString::new(text),
             decoration_runs: SmallVec::from(decorations.to_vec()),
@@ -901,6 +915,7 @@ mod tests {
                     },
                 ],
                 len: 6,
+                index_positions: Vec::new(),
             }),
             text: "abcdef".into(),
             decoration_runs: SmallVec::new(),

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -439,6 +439,91 @@ impl WrappedLine {
     }
 }
 
+struct DecorationRunLookup<'a> {
+    runs: &'a [DecorationRun],
+    run_ends: SmallVec<[usize; 32]>,
+}
+
+impl<'a> DecorationRunLookup<'a> {
+    fn new(runs: &'a [DecorationRun]) -> Self {
+        let mut offset = 0;
+        let mut run_ends = SmallVec::with_capacity(runs.len());
+
+        for run in runs {
+            offset += run.len as usize;
+            run_ends.push(offset);
+        }
+
+        Self { runs, run_ends }
+    }
+
+    fn run_for_index(&self, index: usize) -> Option<&'a DecorationRun> {
+        let run_ix = self.run_ends.partition_point(|end| *end <= index);
+        self.runs.get(run_ix)
+    }
+}
+
+fn resolved_underline(run: &DecorationRun) -> Option<UnderlineStyle> {
+    run.underline.map(|underline| UnderlineStyle {
+        color: Some(underline.color.unwrap_or(run.color)),
+        thickness: underline.thickness,
+        wavy: underline.wavy,
+    })
+}
+
+fn resolved_strikethrough(run: &DecorationRun) -> Option<StrikethroughStyle> {
+    run.strikethrough.map(|strikethrough| StrikethroughStyle {
+        color: Some(strikethrough.color.unwrap_or(run.color)),
+        thickness: strikethrough.thickness,
+    })
+}
+
+fn paint_underline_span(
+    window: &mut Window,
+    mut origin: Point<Pixels>,
+    end_x: Pixels,
+    style: &UnderlineStyle,
+    max_glyph_width: Pixels,
+) {
+    if end_x == origin.x {
+        origin.x -= max_glyph_width.half();
+    };
+    window.paint_underline(origin, end_x - origin.x, style);
+}
+
+fn paint_strikethrough_span(
+    window: &mut Window,
+    mut origin: Point<Pixels>,
+    end_x: Pixels,
+    style: &StrikethroughStyle,
+    max_glyph_width: Pixels,
+) {
+    if end_x == origin.x {
+        origin.x -= max_glyph_width.half();
+    };
+    window.paint_strikethrough(origin, end_x - origin.x, style);
+}
+
+fn paint_background_span(
+    window: &mut Window,
+    mut origin: Point<Pixels>,
+    end_x: Pixels,
+    line_height: Pixels,
+    color: Hsla,
+    max_glyph_width: Pixels,
+) {
+    if end_x == origin.x {
+        origin.x -= max_glyph_width.half();
+    }
+    window.paint_quad(fill(
+        Bounds {
+            origin,
+            size: size(end_x - origin.x, line_height),
+        },
+        color,
+    ));
+}
+
 fn paint_line(
     origin: Point<Pixels>,
     layout: &LineLayout,
@@ -460,10 +545,8 @@ fn paint_line(
     window.paint_layer(line_bounds, |window| {
         let padding_top = (line_height - layout.ascent - layout.descent) / 2.;
         let baseline_offset = point(px(0.), padding_top + layout.ascent);
-        let mut decoration_runs = decoration_runs.iter();
+        let decoration_lookup = DecorationRunLookup::new(decoration_runs);
         let mut wraps = wrap_boundaries.iter().peekable();
-        let mut run_end = 0;
-        let mut color = black();
         let mut current_underline: Option<(Point<Pixels>, UnderlineStyle)> = None;
         let mut current_strikethrough: Option<(Point<Pixels>, StrikethroughStyle)> = None;
         let text_system = cx.text_system().clone();
@@ -492,39 +575,25 @@ fn paint_line(
 
                 if wraps.peek() == Some(&&WrapBoundary { run_ix, glyph_ix }) {
                     wraps.next();
-                    if let Some((underline_origin, underline_style)) = current_underline.as_mut() {
-                        if glyph_origin.x == underline_origin.x {
-                            underline_origin.x -= max_glyph_size.width.half();
-                        };
-                        window.paint_underline(
-                            *underline_origin,
-                            glyph_origin.x - underline_origin.x,
-                            underline_style,
+                    if let Some((underline_origin, underline_style)) = current_underline.take() {
+                        paint_underline_span(
+                            window,
+                            underline_origin,
+                            glyph_origin.x,
+                            &underline_style,
+                            max_glyph_size.width,
                         );
-                        if glyph.index < run_end {
-                            underline_origin.x = origin.x;
-                            underline_origin.y += line_height;
-                        } else {
-                            current_underline = None;
-                        }
                     }
                     if let Some((strikethrough_origin, strikethrough_style)) =
-                        current_strikethrough.as_mut()
+                        current_strikethrough.take()
                     {
-                        if glyph_origin.x == strikethrough_origin.x {
-                            strikethrough_origin.x -= max_glyph_size.width.half();
-                        };
-                        window.paint_strikethrough(
-                            *strikethrough_origin,
-                            glyph_origin.x - strikethrough_origin.x,
-                            strikethrough_style,
+                        paint_strikethrough_span(
+                            window,
+                            strikethrough_origin,
+                            glyph_origin.x,
+                            &strikethrough_style,
+                            max_glyph_size.width,
                         );
-                        if glyph.index < run_end {
-                            strikethrough_origin.x = origin.x;
-                            strikethrough_origin.y += line_height;
-                        } else {
-                            current_strikethrough = None;
-                        }
                     }
 
                     glyph_origin.x = aligned_origin_x(
@@ -539,89 +608,62 @@ fn paint_line(
                 }
                 prev_glyph_position = glyph.position;
 
-                let mut finished_underline: Option<(Point<Pixels>, UnderlineStyle)> = None;
-                let mut finished_strikethrough: Option<(Point<Pixels>, StrikethroughStyle)> = None;
-                if glyph.index >= run_end {
-                    let mut style_run = decoration_runs.next();
+                let decoration = decoration_lookup.run_for_index(glyph.index);
+                let color = decoration.map_or_else(black, |run| run.color);
+                let underline = decoration.and_then(resolved_underline);
+                let strikethrough = decoration.and_then(resolved_strikethrough);
 
-                    // ignore style runs that apply to a partial glyph
-                    while let Some(run) = style_run {
-                        if glyph.index < run_end + (run.len as usize) {
-                            break;
-                        }
-                        run_end += run.len as usize;
-                        style_run = decoration_runs.next();
-                    }
-
-                    if let Some(style_run) = style_run {
-                        if let Some((_, underline_style)) = &mut current_underline
-                            && style_run.underline.as_ref() != Some(underline_style)
-                        {
-                            finished_underline = current_underline.take();
-                        }
-                        if let Some(run_underline) = style_run.underline.as_ref() {
-                            current_underline.get_or_insert((
-                                point(
-                                    glyph_origin.x,
-                                    glyph_origin.y + baseline_offset.y + (layout.descent * 0.618),
-                                ),
-                                UnderlineStyle {
-                                    color: Some(run_underline.color.unwrap_or(style_run.color)),
-                                    thickness: run_underline.thickness,
-                                    wavy: run_underline.wavy,
-                                },
-                            ));
-                        }
-                        if let Some((_, strikethrough_style)) = &mut current_strikethrough
-                            && style_run.strikethrough.as_ref() != Some(strikethrough_style)
-                        {
-                            finished_strikethrough = current_strikethrough.take();
-                        }
-                        if let Some(run_strikethrough) = style_run.strikethrough.as_ref() {
-                            current_strikethrough.get_or_insert((
-                                point(
-                                    glyph_origin.x,
-                                    glyph_origin.y
-                                        + (((layout.ascent * 0.5) + baseline_offset.y) * 0.5),
-                                ),
-                                StrikethroughStyle {
-                                    color: Some(run_strikethrough.color.unwrap_or(style_run.color)),
-                                    thickness: run_strikethrough.thickness,
-                                },
-                            ));
-                        }
-
-                        run_end += style_run.len as usize;
-                        color = style_run.color;
-                    } else {
-                        run_end = layout.len;
-                        finished_underline = current_underline.take();
-                        finished_strikethrough = current_strikethrough.take();
-                    }
-                }
-
-                if let Some((mut underline_origin, underline_style)) = finished_underline {
-                    if underline_origin.x == glyph_origin.x {
-                        underline_origin.x -= max_glyph_size.width.half();
-                    };
-                    window.paint_underline(
-                        underline_origin,
-                        glyph_origin.x - underline_origin.x,
-                        &underline_style,
-                    );
-                }
-
-                if let Some((mut strikethrough_origin, strikethrough_style)) =
-                    finished_strikethrough
+                if current_underline
+                    .as_ref()
+                    .is_some_and(|(_, style)| Some(*style) != underline)
+                    && let Some((underline_origin, underline_style)) = current_underline.take()
                 {
-                    if strikethrough_origin.x == glyph_origin.x {
-                        strikethrough_origin.x -= max_glyph_size.width.half();
-                    };
-                    window.paint_strikethrough(
-                        strikethrough_origin,
-                        glyph_origin.x - strikethrough_origin.x,
-                        &strikethrough_style,
+                    paint_underline_span(
+                        window,
+                        underline_origin,
+                        glyph_origin.x,
+                        &underline_style,
+                        max_glyph_size.width,
                     );
+                }
+
+                if current_underline.is_none()
+                    && let Some(underline) = underline
+                {
+                    current_underline = Some((
+                        point(
+                            glyph_origin.x,
+                            glyph_origin.y + baseline_offset.y + (layout.descent * 0.618),
+                        ),
+                        underline,
+                    ));
+                }
+
+                if current_strikethrough
+                    .as_ref()
+                    .is_some_and(|(_, style)| Some(*style) != strikethrough)
+                    && let Some((strikethrough_origin, strikethrough_style)) =
+                        current_strikethrough.take()
+                {
+                    paint_strikethrough_span(
+                        window,
+                        strikethrough_origin,
+                        glyph_origin.x,
+                        &strikethrough_style,
+                        max_glyph_size.width,
+                    );
+                }
+
+                if current_strikethrough.is_none()
+                    && let Some(strikethrough) = strikethrough
+                {
+                    current_strikethrough = Some((
+                        point(
+                            glyph_origin.x,
+                            glyph_origin.y + (((layout.ascent * 0.5) + baseline_offset.y) * 0.5),
+                        ),
+                        strikethrough,
+                    ));
                 }
 
                 let max_glyph_bounds = Bounds {
@@ -659,25 +701,23 @@ fn paint_line(
             last_line_end_x -= glyph.position.x;
         }
 
-        if let Some((mut underline_start, underline_style)) = current_underline.take() {
-            if last_line_end_x == underline_start.x {
-                underline_start.x -= max_glyph_size.width.half()
-            };
-            window.paint_underline(
+        if let Some((underline_start, underline_style)) = current_underline.take() {
+            paint_underline_span(
+                window,
                 underline_start,
-                last_line_end_x - underline_start.x,
+                last_line_end_x,
                 &underline_style,
+                max_glyph_size.width,
             );
         }
 
-        if let Some((mut strikethrough_start, strikethrough_style)) = current_strikethrough.take() {
-            if last_line_end_x == strikethrough_start.x {
-                strikethrough_start.x -= max_glyph_size.width.half()
-            };
-            window.paint_strikethrough(
+        if let Some((strikethrough_start, strikethrough_style)) = current_strikethrough.take() {
+            paint_strikethrough_span(
+                window,
                 strikethrough_start,
-                last_line_end_x - strikethrough_start.x,
+                last_line_end_x,
                 &strikethrough_style,
+                max_glyph_size.width,
             );
         }
 
@@ -704,9 +744,8 @@ fn paint_line_background(
         ),
     );
     window.paint_layer(line_bounds, |window| {
-        let mut decoration_runs = decoration_runs.iter();
+        let decoration_lookup = DecorationRunLookup::new(decoration_runs);
         let mut wraps = wrap_boundaries.iter().peekable();
-        let mut run_end = 0;
         let mut current_background: Option<(Point<Pixels>, Hsla)> = None;
         let text_system = cx.text_system().clone();
         let mut glyph_origin = point(
@@ -730,24 +769,15 @@ fn paint_line_background(
 
                 if wraps.peek() == Some(&&WrapBoundary { run_ix, glyph_ix }) {
                     wraps.next();
-                    if let Some((background_origin, background_color)) = current_background.as_mut()
-                    {
-                        if glyph_origin.x == background_origin.x {
-                            background_origin.x -= max_glyph_size.width.half()
-                        }
-                        window.paint_quad(fill(
-                            Bounds {
-                                origin: *background_origin,
-                                size: size(glyph_origin.x - background_origin.x, line_height),
-                            },
-                            *background_color,
-                        ));
-                        if glyph.index < run_end {
-                            background_origin.x = origin.x;
-                            background_origin.y += line_height;
-                        } else {
-                            current_background = None;
-                        }
+                    if let Some((background_origin, background_color)) = current_background.take() {
+                        paint_background_span(
+                            window,
+                            background_origin,
+                            glyph_origin.x,
+                            line_height,
+                            background_color,
+                            max_glyph_size.width,
+                        );
                     }
 
                     glyph_origin.x = aligned_origin_x(
@@ -762,50 +792,29 @@ fn paint_line_background(
                 }
                 prev_glyph_position = glyph.position;
 
-                let mut finished_background: Option<(Point<Pixels>, Hsla)> = None;
-                if glyph.index >= run_end {
-                    let mut style_run = decoration_runs.next();
+                let background = decoration_lookup
+                    .run_for_index(glyph.index)
+                    .and_then(|run| run.background_color);
 
-                    // ignore style runs that apply to a partial glyph
-                    while let Some(run) = style_run {
-                        if glyph.index < run_end + (run.len as usize) {
-                            break;
-                        }
-                        run_end += run.len as usize;
-                        style_run = decoration_runs.next();
-                    }
-
-                    if let Some(style_run) = style_run {
-                        if let Some((_, background_color)) = &mut current_background
-                            && style_run.background_color.as_ref() != Some(background_color)
-                        {
-                            finished_background = current_background.take();
-                        }
-                        if let Some(run_background) = style_run.background_color {
-                            current_background.get_or_insert((
-                                point(glyph_origin.x, glyph_origin.y),
-                                run_background,
-                            ));
-                        }
-                        run_end += style_run.len as usize;
-                    } else {
-                        run_end = layout.len;
-                        finished_background = current_background.take();
-                    }
+                if current_background
+                    .as_ref()
+                    .is_some_and(|(_, color)| Some(*color) != background)
+                    && let Some((background_origin, background_color)) = current_background.take()
+                {
+                    paint_background_span(
+                        window,
+                        background_origin,
+                        glyph_origin.x,
+                        line_height,
+                        background_color,
+                        max_glyph_size.width,
+                    );
                 }
 
-                if let Some((mut background_origin, background_color)) = finished_background {
-                    let mut width = glyph_origin.x - background_origin.x;
-                    if background_origin.x == glyph_origin.x {
-                        background_origin.x -= max_glyph_size.width.half();
-                    };
-                    window.paint_quad(fill(
-                        Bounds {
-                            origin: background_origin,
-                            size: size(width, line_height),
-                        },
-                        background_color,
-                    ));
+                if current_background.is_none()
+                    && let Some(background) = background
+                {
+                    current_background = Some((point(glyph_origin.x, glyph_origin.y), background));
                 }
             }
         }
@@ -817,17 +826,15 @@ fn paint_line_background(
             last_line_end_x -= glyph.position.x;
         }
 
-        if let Some((mut background_origin, background_color)) = current_background.take() {
-            if last_line_end_x == background_origin.x {
-                background_origin.x -= max_glyph_size.width.half()
-            };
-            window.paint_quad(fill(
-                Bounds {
-                    origin: background_origin,
-                    size: size(last_line_end_x - background_origin.x, line_height),
-                },
+        if let Some((background_origin, background_color)) = current_background.take() {
+            paint_background_span(
+                window,
+                background_origin,
+                last_line_end_x,
+                line_height,
                 background_color,
-            ));
+                max_glyph_size.width,
+            );
         }
 
         Ok(())
@@ -919,6 +926,76 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_decoration_lookup_handles_visual_rtl_glyph_order() {
+        let red = Hsla {
+            h: 0.0,
+            s: 1.0,
+            l: 0.5,
+            a: 1.0,
+        };
+        let green = Hsla {
+            h: 0.3,
+            s: 1.0,
+            l: 0.5,
+            a: 1.0,
+        };
+        let blue = Hsla {
+            h: 0.6,
+            s: 1.0,
+            l: 0.5,
+            a: 1.0,
+        };
+        let inherited_underline = UnderlineStyle {
+            color: None,
+            thickness: px(1.0),
+            wavy: false,
+        };
+        let blue_strikethrough = StrikethroughStyle {
+            color: Some(blue),
+            thickness: px(2.0),
+        };
+        let runs = [
+            DecorationRun {
+                len: "א".len() as u32,
+                color: red,
+                background_color: Some(red),
+                underline: Some(inherited_underline),
+                strikethrough: None,
+            },
+            DecorationRun {
+                len: "ב".len() as u32,
+                color: green,
+                background_color: Some(green),
+                underline: None,
+                strikethrough: None,
+            },
+            DecorationRun {
+                len: "ג".len() as u32,
+                color: blue,
+                background_color: Some(blue),
+                underline: None,
+                strikethrough: Some(blue_strikethrough),
+            },
+        ];
+        let lookup = DecorationRunLookup::new(&runs);
+
+        let colors_in_visual_order =
+            [4, 2, 0].map(|index| lookup.run_for_index(index).unwrap().color);
+        assert_eq!(colors_in_visual_order, [blue, green, red]);
+        assert!(lookup.run_for_index("אבג".len()).is_none());
+
+        let alef_decoration = lookup.run_for_index(0).unwrap();
+        assert_eq!(
+            resolved_underline(alef_decoration).unwrap().color,
+            Some(red)
+        );
+        assert_eq!(
+            resolved_strikethrough(lookup.run_for_index(4).unwrap()),
+            Some(blue_strikethrough)
+        );
     }
 
     #[test]

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -80,6 +80,11 @@ impl ShapedLine {
             } else {
                 Vec::new()
             },
+            visual_index_positions: if len == layout.len {
+                layout.visual_index_positions.clone()
+            } else {
+                Vec::new()
+            },
         });
         self
     }
@@ -149,42 +154,81 @@ impl ShapedLine {
             .layout
             .runs
             .iter()
-            .flat_map(|run| run.glyphs.iter())
+            .enumerate()
+            .flat_map(|(run_ix, run)| {
+                run.glyphs
+                    .iter()
+                    .enumerate()
+                    .map(move |(glyph_ix, glyph)| (run_ix, glyph_ix, glyph))
+            })
             .collect::<Vec<_>>();
         glyph_edges.sort_by(|a, b| {
-            a.position
+            a.2.position
                 .x
-                .partial_cmp(&b.position.x)
+                .partial_cmp(&b.2.position.x)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
-        let mut left_origin = None;
+        let mut left_positions = self
+            .layout
+            .runs
+            .iter()
+            .map(|run| vec![None; run.glyphs.len()])
+            .collect::<Vec<_>>();
+        let mut right_positions = self
+            .layout
+            .runs
+            .iter()
+            .map(|run| vec![None; run.glyphs.len()])
+            .collect::<Vec<_>>();
         let mut left_right = Pixels::ZERO;
-        let mut right_origin = None;
         let mut right_right = Pixels::ZERO;
-
-        for (ix, glyph) in glyph_edges.iter().enumerate() {
-            let glyph_left = glyph.position.x;
-            let glyph_right = glyph_edges[ix + 1..]
-                .iter()
-                .find(|next_glyph| next_glyph.position.x > glyph_left)
-                .map_or(self.layout.width, |next_glyph| next_glyph.position.x);
-
-            if glyph.index < byte_index {
-                left_origin =
-                    Some(left_origin.map_or(glyph_left, |origin: Pixels| origin.min(glyph_left)));
-                left_right = left_right.max(glyph_right);
-            } else {
-                right_origin =
-                    Some(right_origin.map_or(glyph_left, |origin: Pixels| origin.min(glyph_left)));
-                right_right = right_right.max(glyph_right);
+        let mut ix = 0;
+        while ix < glyph_edges.len() {
+            let glyph_left = glyph_edges[ix].2.position.x;
+            let mut next_ix = ix + 1;
+            while next_ix < glyph_edges.len() && glyph_edges[next_ix].2.position.x == glyph_left {
+                next_ix += 1;
             }
+            let glyph_right = glyph_edges
+                .get(next_ix)
+                .map_or(self.layout.width, |(_, _, next_glyph)| {
+                    next_glyph.position.x
+                });
+            let glyph_width = glyph_right - glyph_left;
+            let glyph_group = &glyph_edges[ix..next_ix];
+
+            if glyph_group
+                .iter()
+                .any(|(_, _, glyph)| glyph.index < byte_index)
+            {
+                for (run_ix, glyph_ix, glyph) in glyph_group {
+                    if glyph.index < byte_index {
+                        left_positions[*run_ix][*glyph_ix] =
+                            Some(left_right + (glyph.position.x - glyph_left));
+                    }
+                }
+                left_right += glyph_width;
+            }
+
+            if glyph_group
+                .iter()
+                .any(|(_, _, glyph)| glyph.index >= byte_index)
+            {
+                for (run_ix, glyph_ix, glyph) in glyph_group {
+                    if glyph.index >= byte_index {
+                        right_positions[*run_ix][*glyph_ix] =
+                            Some(right_right + (glyph.position.x - glyph_left));
+                    }
+                }
+                right_right += glyph_width;
+            }
+
+            ix = next_ix;
         }
 
-        let left_origin = left_origin.unwrap_or(Pixels::ZERO);
-        let right_origin = right_origin.unwrap_or(Pixels::ZERO);
-        let left_width = left_right - left_origin;
-        let right_width = right_right - right_origin;
+        let left_width = left_right;
+        let right_width = right_right;
 
         // Partition glyph runs by logical byte index. Glyphs are not guaranteed
         // to be stored in logical order after RTL shaping, so this must not use
@@ -192,22 +236,22 @@ impl ShapedLine {
         let mut left_runs = Vec::new();
         let mut right_runs = Vec::new();
 
-        for run in &self.layout.runs {
+        for (run_ix, run) in self.layout.runs.iter().enumerate() {
             let mut left_glyphs = Vec::new();
             let mut right_glyphs = Vec::new();
 
-            for glyph in &run.glyphs {
-                if glyph.index < byte_index {
+            for (glyph_ix, glyph) in run.glyphs.iter().enumerate() {
+                if let Some(x) = left_positions[run_ix][glyph_ix] {
                     left_glyphs.push(ShapedGlyph {
                         id: glyph.id,
-                        position: point(glyph.position.x - left_origin, glyph.position.y),
+                        position: point(x, glyph.position.y),
                         index: glyph.index,
                         is_emoji: glyph.is_emoji,
                     });
-                } else {
+                } else if let Some(x) = right_positions[run_ix][glyph_ix] {
                     right_glyphs.push(ShapedGlyph {
                         id: glyph.id,
-                        position: point(glyph.position.x - right_origin, glyph.position.y),
+                        position: point(x, glyph.position.y),
                         index: glyph.index - byte_index,
                         is_emoji: glyph.is_emoji,
                     });
@@ -284,6 +328,7 @@ impl ShapedLine {
             runs: left_runs,
             len: byte_index,
             index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
         };
         left_layout.compute_bidi_index_positions(&left_text);
 
@@ -295,6 +340,7 @@ impl ShapedLine {
             runs: right_runs,
             len: self.layout.len - byte_index,
             index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
         };
         right_layout.compute_bidi_index_positions(&right_text);
 
@@ -845,6 +891,7 @@ mod tests {
             }],
             len: text.len(),
             index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
         };
         layout.compute_bidi_index_positions(text);
 
@@ -987,6 +1034,7 @@ mod tests {
                 ],
                 len: 6,
                 index_positions: Vec::new(),
+                visual_index_positions: Vec::new(),
             }),
             text: "abcdef".into(),
             decoration_runs: SmallVec::new(),
@@ -1165,6 +1213,24 @@ mod tests {
         assert_eq!(left.text.as_ref(), "abc א");
         assert_eq!(right.text.as_ref(), "בג def");
         assert_eq!(left.len() + right.len(), text.len());
+        assert_eq!(left.width(), px(50.0));
+        assert_eq!(right.width(), px(60.0));
+        assert_eq!(
+            left.runs[0]
+                .glyphs
+                .iter()
+                .map(|glyph| glyph.position.x)
+                .collect::<Vec<_>>(),
+            [px(0.0), px(10.0), px(20.0), px(30.0), px(40.0)]
+        );
+        assert_eq!(
+            right.runs[0]
+                .glyphs
+                .iter()
+                .map(|glyph| glyph.position.x)
+                .collect::<Vec<_>>(),
+            [px(0.0), px(10.0), px(20.0), px(30.0), px(40.0), px(50.0)]
+        );
         assert_glyph_indices_within_text(&left);
         assert_glyph_indices_within_text(&right);
     }

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -136,40 +136,92 @@ impl ShapedLine {
 
     /// Split this shaped line at a byte index, returning `(prefix, suffix)`.
     ///
-    /// - `prefix` contains glyphs for bytes `[0, byte_index)` with original positions.
-    ///   Its width equals the x-advance up to the split point.
+    /// - `prefix` contains glyphs for bytes `[0, byte_index)`, normalized to
+    ///   the left edge of the prefix's visual bounds.
     /// - `suffix` contains glyphs for bytes `[byte_index, len)` with positions
-    ///   shifted left so the first glyph starts at x=0, and byte indices rebased to 0.
+    ///   normalized to the left edge of the suffix's visual bounds, and byte
+    ///   indices rebased to 0.
     /// - Decoration runs are partitioned at the boundary; a run that straddles it is
     ///   split into two with adjusted lengths.
     /// - `font_size`, `ascent`, and `descent` are copied to both halves.
     pub fn split_at(&self, byte_index: usize) -> (ShapedLine, ShapedLine) {
-        let x_offset = self.layout.x_for_index(byte_index);
+        let mut glyph_edges = self
+            .layout
+            .runs
+            .iter()
+            .flat_map(|run| run.glyphs.iter())
+            .collect::<Vec<_>>();
+        glyph_edges.sort_by(|a, b| {
+            a.position
+                .x
+                .partial_cmp(&b.position.x)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
-        // Partition glyph runs. A single run may contribute glyphs to both halves.
+        let mut left_origin = None;
+        let mut left_right = Pixels::ZERO;
+        let mut right_origin = None;
+        let mut right_right = Pixels::ZERO;
+
+        for (ix, glyph) in glyph_edges.iter().enumerate() {
+            let glyph_left = glyph.position.x;
+            let glyph_right = glyph_edges[ix + 1..]
+                .iter()
+                .find(|next_glyph| next_glyph.position.x > glyph_left)
+                .map_or(self.layout.width, |next_glyph| next_glyph.position.x);
+
+            if glyph.index < byte_index {
+                left_origin =
+                    Some(left_origin.map_or(glyph_left, |origin: Pixels| origin.min(glyph_left)));
+                left_right = left_right.max(glyph_right);
+            } else {
+                right_origin =
+                    Some(right_origin.map_or(glyph_left, |origin: Pixels| origin.min(glyph_left)));
+                right_right = right_right.max(glyph_right);
+            }
+        }
+
+        let left_origin = left_origin.unwrap_or(Pixels::ZERO);
+        let right_origin = right_origin.unwrap_or(Pixels::ZERO);
+        let left_width = left_right - left_origin;
+        let right_width = right_right - right_origin;
+
+        // Partition glyph runs by logical byte index. Glyphs are not guaranteed
+        // to be stored in logical order after RTL shaping, so this must not use
+        // partition_point.
         let mut left_runs = Vec::new();
         let mut right_runs = Vec::new();
 
         for run in &self.layout.runs {
-            let split_pos = run.glyphs.partition_point(|g| g.index < byte_index);
+            let mut left_glyphs = Vec::new();
+            let mut right_glyphs = Vec::new();
 
-            if split_pos > 0 {
+            for glyph in &run.glyphs {
+                if glyph.index < byte_index {
+                    left_glyphs.push(ShapedGlyph {
+                        id: glyph.id,
+                        position: point(glyph.position.x - left_origin, glyph.position.y),
+                        index: glyph.index,
+                        is_emoji: glyph.is_emoji,
+                    });
+                } else {
+                    right_glyphs.push(ShapedGlyph {
+                        id: glyph.id,
+                        position: point(glyph.position.x - right_origin, glyph.position.y),
+                        index: glyph.index - byte_index,
+                        is_emoji: glyph.is_emoji,
+                    });
+                }
+            }
+
+            if !left_glyphs.is_empty() {
                 left_runs.push(ShapedRun {
                     font_id: run.font_id,
-                    glyphs: run.glyphs[..split_pos].to_vec(),
+                    glyphs: left_glyphs,
                 });
             }
 
-            if split_pos < run.glyphs.len() {
-                let right_glyphs = run.glyphs[split_pos..]
-                    .iter()
-                    .map(|g| ShapedGlyph {
-                        id: g.id,
-                        position: point(g.position.x - x_offset, g.position.y),
-                        index: g.index - byte_index,
-                        is_emoji: g.is_emoji,
-                    })
-                    .collect();
+            if !right_glyphs.is_empty() {
                 right_runs.push(ShapedRun {
                     font_id: run.font_id,
                     glyphs: right_glyphs,
@@ -223,9 +275,6 @@ impl ShapedLine {
         } else {
             SharedString::new(&self.text[byte_index..])
         };
-
-        let left_width = x_offset;
-        let right_width = self.layout.width - left_width;
 
         let mut left_layout = LineLayout {
             font_size: self.layout.font_size,
@@ -785,21 +834,43 @@ mod tests {
             })
             .collect();
 
+        let mut layout = LineLayout {
+            font_size: px(16.0),
+            width: px(width),
+            ascent: px(12.0),
+            descent: px(4.0),
+            runs: vec![ShapedRun {
+                font_id: FontId(0),
+                glyphs: shaped_glyphs,
+            }],
+            len: text.len(),
+            index_positions: Vec::new(),
+        };
+        layout.compute_bidi_index_positions(text);
+
         ShapedLine {
-            layout: Arc::new(LineLayout {
-                font_size: px(16.0),
-                width: px(width),
-                ascent: px(12.0),
-                descent: px(4.0),
-                runs: vec![ShapedRun {
-                    font_id: FontId(0),
-                    glyphs: shaped_glyphs,
-                }],
-                len: text.len(),
-                index_positions: Vec::new(),
-            }),
+            layout: Arc::new(layout),
             text: SharedString::new(text),
             decoration_runs: SmallVec::from(decorations.to_vec()),
+        }
+    }
+
+    fn assert_glyph_indices_within_text(line: &ShapedLine) {
+        for run in &line.runs {
+            for glyph in &run.glyphs {
+                assert!(
+                    glyph.index < line.text.len(),
+                    "glyph index {} must be within {:?}",
+                    glyph.index,
+                    line.text
+                );
+                assert!(
+                    line.text.is_char_boundary(glyph.index),
+                    "glyph index {} must be a UTF-8 boundary in {:?}",
+                    glyph.index,
+                    line.text
+                );
+            }
         }
     }
 
@@ -1035,34 +1106,34 @@ mod tests {
 
         assert_eq!(left.text.as_ref(), "א");
         assert_eq!(right.text.as_ref(), "בג");
-        assert_eq!(left.width(), px(30.0));
-        assert_eq!(right.width(), px(0.0));
-        assert_eq!(left.x_for_index(0), px(30.0));
-        assert_eq!(right.x_for_index(0), px(0.0));
+        assert_eq!(left.width(), px(10.0));
+        assert_eq!(right.width(), px(20.0));
+        assert_eq!(left.x_for_index(0), px(10.0));
+        assert_eq!(left.x_for_index(left.len()), px(0.0));
+        assert_eq!(right.x_for_index(0), px(20.0));
+        assert_eq!(right.x_for_index(right.len()), px(0.0));
+        assert_glyph_indices_within_text(&left);
+        assert_glyph_indices_within_text(&right);
     }
 
     #[test]
     fn test_split_at_persian_with_zwnj() {
         let text = "می\u{200c}روم";
         let split_index = "می\u{200c}".len();
-        let line = make_shaped_line(
-            text,
-            &[
-                (12, 0.0),
-                (10, 10.0),
-                (8, 20.0),
-                (5, 30.0),
-                (3, 40.0),
-                (0, 50.0),
-            ],
-            60.0,
-            &[],
-        );
+        let glyphs = text
+            .char_indices()
+            .rev()
+            .enumerate()
+            .map(|(position, (index, _))| (index, position as f32 * 10.0))
+            .collect::<Vec<_>>();
+        let line = make_shaped_line(text, &glyphs, glyphs.len() as f32 * 10.0, &[]);
         let (left, right) = line.split_at(split_index);
 
         assert_eq!(left.text.as_ref(), "می\u{200c}");
         assert_eq!(right.text.as_ref(), "روم");
         assert_eq!(left.len() + right.len(), text.len());
+        assert_glyph_indices_within_text(&left);
+        assert_glyph_indices_within_text(&right);
     }
 
     #[test]
@@ -1094,5 +1165,7 @@ mod tests {
         assert_eq!(left.text.as_ref(), "abc א");
         assert_eq!(right.text.as_ref(), "בג def");
         assert_eq!(left.len() + right.len(), text.len());
+        assert_glyph_indices_within_text(&left);
+        assert_glyph_indices_within_text(&right);
     }
 }

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -1027,4 +1027,72 @@ mod tests {
         assert_eq!(right.decoration_runs[1].len, 1);
         assert_eq!(right.decoration_runs[1].color, blue);
     }
+
+    #[test]
+    fn test_split_at_pure_hebrew_after_first_character() {
+        let line = make_shaped_line("אבג", &[(4, 0.0), (2, 10.0), (0, 20.0)], 30.0, &[]);
+        let (left, right) = line.split_at("א".len());
+
+        assert_eq!(left.text.as_ref(), "א");
+        assert_eq!(right.text.as_ref(), "בג");
+        assert_eq!(left.width(), px(30.0));
+        assert_eq!(right.width(), px(0.0));
+        assert_eq!(left.x_for_index(0), px(30.0));
+        assert_eq!(right.x_for_index(0), px(0.0));
+    }
+
+    #[test]
+    fn test_split_at_persian_with_zwnj() {
+        let text = "می\u{200c}روم";
+        let split_index = "می\u{200c}".len();
+        let line = make_shaped_line(
+            text,
+            &[
+                (12, 0.0),
+                (10, 10.0),
+                (8, 20.0),
+                (5, 30.0),
+                (3, 40.0),
+                (0, 50.0),
+            ],
+            60.0,
+            &[],
+        );
+        let (left, right) = line.split_at(split_index);
+
+        assert_eq!(left.text.as_ref(), "می\u{200c}");
+        assert_eq!(right.text.as_ref(), "روم");
+        assert_eq!(left.len() + right.len(), text.len());
+    }
+
+    #[test]
+    fn test_split_at_mixed_text_inside_rtl_run() {
+        let text = "abc אבג def";
+        let Some(bet_index) = text.find('ב') else {
+            panic!("expected bet in test text");
+        };
+        let line = make_shaped_line(
+            text,
+            &[
+                (0, 0.0),
+                (1, 10.0),
+                (2, 20.0),
+                (3, 30.0),
+                (8, 40.0),
+                (6, 50.0),
+                (4, 60.0),
+                (10, 70.0),
+                (11, 80.0),
+                (12, 90.0),
+                (13, 100.0),
+            ],
+            110.0,
+            &[],
+        );
+
+        let (left, right) = line.split_at(bet_index);
+        assert_eq!(left.text.as_ref(), "abc א");
+        assert_eq!(right.text.as_ref(), "בג def");
+        assert_eq!(left.len() + right.len(), text.len());
+    }
 }

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -29,6 +29,8 @@ pub struct LineLayout {
     pub len: usize,
     /// Bidi-aware caret stops, sorted by logical UTF-8 byte index.
     pub index_positions: Vec<IndexPosition>,
+    /// Bidi-aware caret stops, sorted by visual x position.
+    pub visual_index_positions: Vec<IndexPosition>,
 }
 
 /// A caret stop for a logical UTF-8 byte index.
@@ -70,47 +72,33 @@ impl LineLayout {
     pub fn index_for_x(&self, x: Pixels) -> Option<usize> {
         if x >= self.width {
             None
-        } else if !self.index_positions.is_empty() {
-            let mut exact_position = None;
-            let mut left_position = None;
-            let mut right_position = None;
+        } else if !self.visual_index_positions.is_empty() {
+            if let Some(group) = Self::exact_visual_group(&self.visual_index_positions, x) {
+                return Some(Self::preferred_index_for_visual_group(
+                    &self.visual_index_positions,
+                    group,
+                ));
+            }
 
-            for position in &self.index_positions {
-                if position.x == x {
-                    if exact_position
-                        .is_none_or(|exact: IndexPosition| position.index > exact.index)
-                    {
-                        exact_position = Some(*position);
-                    }
-                } else if position.x < x {
-                    if left_position.is_none_or(|left: IndexPosition| {
-                        position.x > left.x || position.x == left.x && position.index > left.index
-                    }) {
-                        left_position = Some(*position);
-                    }
-                } else if right_position.is_none_or(|right: IndexPosition| {
-                    position.x < right.x || position.x == right.x && position.index < right.index
-                }) {
-                    right_position = Some(*position);
+            let mut left = *self.visual_index_positions.first()?;
+            for right in self.visual_index_positions.iter().copied().skip(1) {
+                if right.x == left.x {
+                    left = right;
+                    continue;
                 }
-            }
 
-            if let Some(exact) = exact_position {
-                return Some(exact.index);
-            }
-
-            match (left_position, right_position) {
-                (Some(left), Some(right)) => {
-                    if left.index <= right.index {
+                if x < right.x {
+                    return if left.index <= right.index {
                         Some(left.index)
                     } else {
                         Some(right.index)
-                    }
+                    };
                 }
-                (Some(left), None) => Some(left.index),
-                (None, Some(right)) => Some(right.index),
-                (None, None) => None,
+
+                left = right;
             }
+
+            Some(left.index)
         } else {
             for run in self.runs.iter().rev() {
                 for glyph in run.glyphs.iter().rev() {
@@ -126,17 +114,34 @@ impl LineLayout {
     /// closest_index_for_x returns the character boundary closest to the given x coordinate
     /// (e.g. to handle aligning up/down arrow keys)
     pub fn closest_index_for_x(&self, x: Pixels) -> usize {
-        if !self.index_positions.is_empty() {
-            return self
-                .index_positions
-                .iter()
-                .min_by(|a, b| {
-                    (a.x - x)
-                        .abs()
-                        .partial_cmp(&(b.x - x).abs())
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                })
-                .map_or(self.len, |position| position.index);
+        if !self.visual_index_positions.is_empty() {
+            if let Some(group) = Self::exact_visual_group(&self.visual_index_positions, x) {
+                return Self::preferred_index_for_visual_group(&self.visual_index_positions, group);
+            }
+
+            let mut left = *self.visual_index_positions.first().unwrap();
+            if x < left.x {
+                return left.index;
+            }
+
+            for right in self.visual_index_positions.iter().copied().skip(1) {
+                if right.x == left.x {
+                    left = right;
+                    continue;
+                }
+
+                if x < right.x {
+                    if right.x - x < x - left.x {
+                        return right.index;
+                    } else {
+                        return left.index;
+                    }
+                }
+
+                left = right;
+            }
+
+            return left.index;
         }
 
         let mut prev_index = 0;
@@ -197,22 +202,116 @@ impl LineLayout {
         self.width
     }
 
+    fn exact_visual_group(positions: &[IndexPosition], x: Pixels) -> Option<Range<usize>> {
+        let start = positions.iter().position(|position| position.x == x)?;
+        let end = positions[start..]
+            .iter()
+            .position(|position| position.x != x)
+            .map_or(positions.len(), |offset| start + offset);
+        Some(start..end)
+    }
+
+    fn preferred_index_for_visual_group(positions: &[IndexPosition], group: Range<usize>) -> usize {
+        if group.len() == 1 {
+            return positions[group.start].index;
+        }
+
+        let previous_interval = group
+            .start
+            .checked_sub(1)
+            .map(|left_ix| (positions[left_ix], positions[group.start]));
+        let next_interval = positions
+            .get(group.end)
+            .map(|right| (positions[group.end - 1], *right));
+
+        if previous_interval.is_some_and(|(left, right)| left.index < right.index) {
+            positions[group.start].index
+        } else if next_interval.is_some_and(|(left, right)| left.index < right.index) {
+            positions[group.end - 1].index
+        } else {
+            positions[group.start].index
+        }
+    }
+
+    fn index_before_visual_boundary(&self, x: Pixels) -> usize {
+        if let Some(group) = Self::exact_visual_group(&self.visual_index_positions, x) {
+            self.visual_index_positions[group.start].index
+        } else {
+            self.closest_index_for_x(x)
+        }
+    }
+
+    fn index_after_visual_boundary(&self, x: Pixels) -> usize {
+        if let Some(group) = Self::exact_visual_group(&self.visual_index_positions, x) {
+            self.visual_index_positions[group.end - 1].index
+        } else {
+            self.closest_index_for_x(x)
+        }
+    }
+
+    /// The visual x ranges covered by a logical UTF-8 byte range.
+    pub fn x_ranges_for_range(&self, range: Range<usize>) -> SmallVec<[Range<Pixels>; 2]> {
+        let mut ranges = SmallVec::new();
+        if range.start >= range.end {
+            return ranges;
+        }
+
+        if self.visual_index_positions.is_empty() {
+            Self::push_x_range(
+                &mut ranges,
+                self.x_for_index(range.start),
+                self.x_for_index(range.end),
+            );
+            return ranges;
+        }
+
+        for adjacent_positions in self.visual_index_positions.windows(2) {
+            let left = adjacent_positions[0];
+            let right = adjacent_positions[1];
+            if left.x == right.x {
+                continue;
+            }
+
+            let logical_start = left.index.min(right.index);
+            let logical_end = left.index.max(right.index);
+            if logical_start < range.end && range.start < logical_end {
+                Self::push_x_range(&mut ranges, left.x, right.x);
+            }
+        }
+
+        ranges
+    }
+
+    fn push_x_range(ranges: &mut SmallVec<[Range<Pixels>; 2]>, start_x: Pixels, end_x: Pixels) {
+        let (start_x, end_x) = if start_x <= end_x {
+            (start_x, end_x)
+        } else {
+            (end_x, start_x)
+        };
+
+        if start_x == end_x {
+            return;
+        }
+
+        if let Some(last_range) = ranges.last_mut()
+            && last_range.end == start_x
+        {
+            last_range.end = end_x;
+            return;
+        }
+
+        ranges.push(start_x..end_x);
+    }
+
     pub(crate) fn compute_bidi_index_positions(&mut self, text: &str) {
         self.index_positions.clear();
+        self.visual_index_positions.clear();
         if text.is_empty() || !contains_rtl_or_bidi_control(text) {
             return;
         }
 
         let bidi_info = BidiInfo::new(text, None);
         if !bidi_info.has_rtl() {
-            return;
-        }
-
-        let Some(paragraph) = bidi_info.paragraphs.first() else {
-            return;
-        };
-        let (_levels, visual_runs) = bidi_info.visual_runs(paragraph, 0..text.len());
-        if visual_runs.is_empty() {
             return;
         }
 
@@ -236,58 +335,76 @@ impl LineLayout {
             run_edges.push((glyph.index, glyph.position.x, next_x));
         }
 
-        for visual_run in visual_runs {
-            let Some(level) = bidi_info.levels.get(visual_run.start) else {
-                continue;
-            };
-            let mut run_glyphs = run_edges
-                .iter()
-                .filter(|(index, _, _)| visual_run.contains(index))
-                .copied()
-                .collect::<Vec<_>>();
-            if run_glyphs.is_empty() {
+        for paragraph in &bidi_info.paragraphs {
+            let (_levels, visual_runs) = bidi_info.visual_runs(paragraph, paragraph.range.clone());
+            if visual_runs.is_empty() {
                 continue;
             }
-            run_glyphs.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
 
-            let run_left = run_glyphs
-                .first()
-                .map_or(Pixels::ZERO, |(_, left, _)| *left);
-            let run_right = run_glyphs.last().map_or(self.width, |(_, _, right)| *right);
-
-            let mut boundaries = text[visual_run.clone()]
-                .char_indices()
-                .map(|(offset, _)| visual_run.start + offset)
-                .chain([visual_run.end])
-                .collect::<Vec<_>>();
-            boundaries.sort_unstable();
-            boundaries.dedup();
-
-            if level.is_rtl() {
-                for boundary in boundaries {
-                    let x = if boundary == visual_run.start {
-                        run_right
-                    } else {
-                        run_glyphs
-                            .iter()
-                            .find(|(index, _, _)| *index < boundary)
-                            .map_or(run_left, |(_, left, _)| *left)
-                    };
-                    self.index_positions
-                        .push(IndexPosition { index: boundary, x });
+            for visual_run in visual_runs {
+                let Some(level) = bidi_info.levels.get(visual_run.start) else {
+                    continue;
+                };
+                let run_glyphs = run_edges
+                    .iter()
+                    .filter(|(index, _, _)| visual_run.contains(index))
+                    .copied()
+                    .collect::<Vec<_>>();
+                if run_glyphs.is_empty() {
+                    continue;
                 }
-            } else {
-                for boundary in boundaries {
-                    let x = if boundary == visual_run.end {
-                        run_right
-                    } else {
-                        run_glyphs
-                            .iter()
-                            .find(|(index, _, _)| *index >= boundary)
-                            .map_or(run_left, |(_, left, _)| *left)
-                    };
-                    self.index_positions
-                        .push(IndexPosition { index: boundary, x });
+
+                let run_left = run_glyphs
+                    .first()
+                    .map_or(Pixels::ZERO, |(_, left, _)| *left);
+                let run_right = run_glyphs.last().map_or(self.width, |(_, _, right)| *right);
+
+                let mut run_glyphs_by_index = run_glyphs.clone();
+                run_glyphs_by_index.sort_by_key(|(index, _, _)| *index);
+
+                let mut boundaries = text[visual_run.clone()]
+                    .char_indices()
+                    .map(|(offset, _)| visual_run.start + offset)
+                    .chain([visual_run.end])
+                    .collect::<Vec<_>>();
+                boundaries.sort_unstable();
+                boundaries.dedup();
+
+                let mut glyph_ix = 0;
+                if level.is_rtl() {
+                    for boundary in boundaries {
+                        while glyph_ix < run_glyphs_by_index.len()
+                            && run_glyphs_by_index[glyph_ix].0 < boundary
+                        {
+                            glyph_ix += 1;
+                        }
+                        let x = if boundary == visual_run.start {
+                            run_right
+                        } else if glyph_ix > 0 {
+                            run_glyphs_by_index[glyph_ix - 1].1
+                        } else {
+                            run_left
+                        };
+                        self.index_positions
+                            .push(IndexPosition { index: boundary, x });
+                    }
+                } else {
+                    for boundary in boundaries {
+                        while glyph_ix < run_glyphs_by_index.len()
+                            && run_glyphs_by_index[glyph_ix].0 < boundary
+                        {
+                            glyph_ix += 1;
+                        }
+                        let x = if boundary == visual_run.end {
+                            run_right
+                        } else {
+                            run_glyphs_by_index
+                                .get(glyph_ix)
+                                .map_or(run_left, |(_, left, _)| *left)
+                        };
+                        self.index_positions
+                            .push(IndexPosition { index: boundary, x });
+                    }
                 }
             }
         }
@@ -299,6 +416,12 @@ impl LineLayout {
         });
         self.index_positions
             .dedup_by(|a, b| a.index == b.index && a.x == b.x);
+        self.visual_index_positions = self.index_positions.clone();
+        self.visual_index_positions.sort_by(|a, b| {
+            a.x.partial_cmp(&b.x)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.index.cmp(&b.index))
+        });
     }
 
     /// The corresponding Font at the given index
@@ -530,10 +653,10 @@ impl WrappedLineLayout {
         };
         let wrapped_line_start_index = self
             .unwrapped_layout
-            .closest_index_for_x(wrapped_line_start_x);
+            .index_after_visual_boundary(wrapped_line_start_x);
         let wrapped_line_end_index = self
             .unwrapped_layout
-            .closest_index_for_x(wrapped_line_end_x);
+            .index_before_visual_boundary(wrapped_line_end_x);
 
         let mut position_in_unwrapped_line = position;
         position_in_unwrapped_line.x += wrapped_line_start_x;
@@ -1189,6 +1312,7 @@ mod tests {
             }],
             len: 0,
             index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
         }
     }
 
@@ -1296,6 +1420,7 @@ mod tests {
             }],
             len: text.len(),
             index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
         };
 
         layout.compute_bidi_index_positions(text);
@@ -1309,6 +1434,58 @@ mod tests {
         assert_eq!(layout.index_for_x(px(29.)), Some(0));
         assert_eq!(layout.index_for_x(px(19.)), Some("א".len()));
         assert_eq!(layout.index_for_x(px(9.)), Some("אב".len()));
+        assert_eq!(
+            layout.x_ranges_for_range(0.."א".len()).as_slice(),
+            [px(20.)..px(30.)]
+        );
+        assert_eq!(
+            layout.x_ranges_for_range(0..text.len()).as_slice(),
+            [px(0.)..px(30.)]
+        );
+    }
+
+    #[test]
+    fn test_bidi_index_positions_for_multiple_paragraphs() {
+        let text = "abc\nאבג";
+        let Some(alef) = text.find('א') else {
+            panic!("expected alef in test text");
+        };
+        let Some(bet) = text.find('ב') else {
+            panic!("expected bet in test text");
+        };
+        let Some(gimel) = text.find('ג') else {
+            panic!("expected gimel in test text");
+        };
+        let after_gimel = gimel + 'ג'.len_utf8();
+        let mut layout = LineLayout {
+            font_size: px(16.),
+            width: px(60.),
+            ascent: px(12.),
+            descent: px(4.),
+            runs: vec![ShapedRun {
+                font_id: FontId(0),
+                glyphs: vec![
+                    glyph_at(0., 0),
+                    glyph_at(10., 1),
+                    glyph_at(20., 2),
+                    glyph_at(30., gimel),
+                    glyph_at(40., bet),
+                    glyph_at(50., alef),
+                ],
+            }],
+            len: text.len(),
+            index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
+        };
+
+        layout.compute_bidi_index_positions(text);
+
+        assert_eq!(layout.x_for_index(alef), px(60.));
+        assert_eq!(layout.x_for_index(bet), px(50.));
+        assert_eq!(layout.x_for_index(gimel), px(40.));
+        assert_eq!(layout.x_for_index(after_gimel), px(30.));
+        assert_eq!(layout.index_for_x(px(59.)), Some(alef));
+        assert_eq!(layout.index_for_x(px(39.)), Some(gimel));
     }
 
     #[test]
@@ -1330,6 +1507,7 @@ mod tests {
             }],
             len: text.len(),
             index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
         };
         layout.compute_bidi_index_positions(text);
 
@@ -1396,6 +1574,7 @@ mod tests {
                 }],
                 len: text.len(),
                 index_positions: Vec::new(),
+                visual_index_positions: Vec::new(),
             };
 
             layout.compute_bidi_index_positions(text);
@@ -1446,16 +1625,37 @@ mod tests {
             }],
             len: text.len(),
             index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
         };
 
         layout.compute_bidi_index_positions(text);
 
         assert_eq!(layout.x_for_index(bet), px(60.));
         assert_eq!(layout.x_for_index(gimel), px(50.));
+        assert_eq!(layout.index_for_x(px(40.)), Some(alef));
+        assert_eq!(layout.index_for_x(px(70.)), Some(after_gimel));
+        assert_eq!(layout.closest_index_for_x(px(40.)), alef);
+        assert_eq!(layout.closest_index_for_x(px(70.)), after_gimel);
+        assert_eq!(layout.index_before_visual_boundary(px(40.)), alef);
+        assert_eq!(layout.index_after_visual_boundary(px(40.)), after_gimel);
+        assert_eq!(layout.index_before_visual_boundary(px(70.)), alef);
+        assert_eq!(layout.index_after_visual_boundary(px(70.)), after_gimel);
         assert_eq!(layout.closest_index_for_x(px(59.)), bet);
         assert_eq!(layout.closest_index_for_x(px(51.)), gimel);
         assert_eq!(layout.index_for_x(px(55.)), Some(bet));
         assert_eq!(layout.index_for_x(px(45.)), Some(gimel));
+        assert_eq!(
+            layout.x_ranges_for_range(0..bet).as_slice(),
+            [px(0.)..px(40.), px(60.)..px(70.)]
+        );
+        assert_eq!(
+            layout.x_ranges_for_range(alef..after_gimel).as_slice(),
+            [px(40.)..px(70.)]
+        );
+        assert_eq!(
+            layout.x_ranges_for_range(bet..gimel).as_slice(),
+            [px(50.)..px(60.)]
+        );
     }
 
     #[test]
@@ -1500,6 +1700,7 @@ mod tests {
             }],
             len: text.len(),
             index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
         };
 
         layout.compute_bidi_index_positions(text);

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -489,6 +489,32 @@ impl WrappedLineLayout {
         self._index_for_position(position, line_height, true)
     }
 
+    fn wrapped_line_x_range(&self, wrapped_line_ix: usize) -> Option<(Pixels, Pixels)> {
+        if wrapped_line_ix > self.wrap_boundaries.len() {
+            return None;
+        }
+
+        let start_x = if wrapped_line_ix > 0 {
+            self.wrap_boundary_x(self.wrap_boundaries[wrapped_line_ix - 1])?
+        } else {
+            Pixels::ZERO
+        };
+
+        let end_x = if wrapped_line_ix < self.wrap_boundaries.len() {
+            self.wrap_boundary_x(self.wrap_boundaries[wrapped_line_ix])?
+        } else {
+            self.unwrapped_layout.width
+        };
+
+        Some((start_x, end_x))
+    }
+
+    fn wrap_boundary_x(&self, boundary: WrapBoundary) -> Option<Pixels> {
+        let run = self.unwrapped_layout.runs.get(boundary.run_ix)?;
+        let glyph = run.glyphs.get(boundary.glyph_ix)?;
+        Some(glyph.position.x)
+    }
+
     fn _index_for_position(
         &self,
         mut position: Point<Pixels>,
@@ -497,34 +523,17 @@ impl WrappedLineLayout {
     ) -> Result<usize, usize> {
         let wrapped_line_ix = (position.y / line_height) as usize;
 
-        let wrapped_line_start_index;
-        let wrapped_line_start_x;
-        if wrapped_line_ix > 0 {
-            let Some(line_start_boundary) = self.wrap_boundaries.get(wrapped_line_ix - 1) else {
-                return Err(0);
-            };
-            let run = &self.unwrapped_layout.runs[line_start_boundary.run_ix];
-            let glyph = &run.glyphs[line_start_boundary.glyph_ix];
-            wrapped_line_start_index = glyph.index;
-            wrapped_line_start_x = glyph.position.x;
-        } else {
-            wrapped_line_start_index = 0;
-            wrapped_line_start_x = Pixels::ZERO;
+        let Some((wrapped_line_start_x, wrapped_line_end_x)) =
+            self.wrapped_line_x_range(wrapped_line_ix)
+        else {
+            return Err(0);
         };
-
-        let wrapped_line_end_index;
-        let wrapped_line_end_x;
-        if wrapped_line_ix < self.wrap_boundaries.len() {
-            let next_wrap_boundary_ix = wrapped_line_ix;
-            let next_wrap_boundary = self.wrap_boundaries[next_wrap_boundary_ix];
-            let run = &self.unwrapped_layout.runs[next_wrap_boundary.run_ix];
-            let glyph = &run.glyphs[next_wrap_boundary.glyph_ix];
-            wrapped_line_end_index = glyph.index;
-            wrapped_line_end_x = glyph.position.x;
-        } else {
-            wrapped_line_end_index = self.unwrapped_layout.len;
-            wrapped_line_end_x = self.unwrapped_layout.width;
-        };
+        let wrapped_line_start_index = self
+            .unwrapped_layout
+            .closest_index_for_x(wrapped_line_start_x);
+        let wrapped_line_end_index = self
+            .unwrapped_layout
+            .closest_index_for_x(wrapped_line_end_x);
 
         let mut position_in_unwrapped_line = position;
         position_in_unwrapped_line.x += wrapped_line_start_x;
@@ -548,28 +557,19 @@ impl WrappedLineLayout {
 
     /// Returns the pixel position for the given byte index.
     pub fn position_for_index(&self, index: usize, line_height: Pixels) -> Option<Point<Pixels>> {
-        let mut line_start_ix = 0;
-        let mut line_end_indices = self
-            .wrap_boundaries
-            .iter()
-            .map(|wrap_boundary| {
-                let run = &self.unwrapped_layout.runs[wrap_boundary.run_ix];
-                let glyph = &run.glyphs[wrap_boundary.glyph_ix];
-                glyph.index
-            })
-            .chain([self.len()])
-            .enumerate();
-        for (ix, line_end_ix) in line_end_indices {
-            let line_y = ix as f32 * line_height;
-            if index < line_start_ix {
+        let x = self.unwrapped_layout.x_for_index(index);
+
+        for ix in 0..=self.wrap_boundaries.len() {
+            let Some((line_start_x, line_end_x)) = self.wrapped_line_x_range(ix) else {
                 break;
-            } else if index > line_end_ix {
-                line_start_ix = line_end_ix;
+            };
+            let line_y = ix as f32 * line_height;
+            if x < line_start_x {
+                break;
+            } else if x > line_end_x {
                 continue;
             } else {
-                let line_start_x = self.unwrapped_layout.x_for_index(line_start_ix);
-                let x = self.unwrapped_layout.x_for_index(index) - line_start_x;
-                return Some(point(x, line_y));
+                return Some(point(x - line_start_x, line_y));
             }
         }
 
@@ -1309,6 +1309,66 @@ mod tests {
         assert_eq!(layout.index_for_x(px(29.)), Some(0));
         assert_eq!(layout.index_for_x(px(19.)), Some("א".len()));
         assert_eq!(layout.index_for_x(px(9.)), Some("אב".len()));
+    }
+
+    #[test]
+    fn test_wrapped_rtl_positioning_uses_visual_x_ranges() {
+        let text = "אבגד";
+        let mut layout = LineLayout {
+            font_size: px(16.),
+            width: px(40.),
+            ascent: px(12.),
+            descent: px(4.),
+            runs: vec![ShapedRun {
+                font_id: FontId(0),
+                glyphs: vec![
+                    glyph_at(0., "אבג".len()),
+                    glyph_at(10., "אב".len()),
+                    glyph_at(20., "א".len()),
+                    glyph_at(30., 0),
+                ],
+            }],
+            len: text.len(),
+            index_positions: Vec::new(),
+        };
+        layout.compute_bidi_index_positions(text);
+
+        let mut wrap_boundaries = SmallVec::new();
+        wrap_boundaries.push(WrapBoundary {
+            run_ix: 0,
+            glyph_ix: 2,
+        });
+        let wrapped = WrappedLineLayout {
+            unwrapped_layout: Arc::new(layout),
+            wrap_boundaries,
+            wrap_width: Some(px(20.)),
+        };
+        let line_height = px(18.);
+
+        assert_eq!(
+            wrapped.position_for_index(0, line_height),
+            Some(point(px(20.), line_height))
+        );
+        assert_eq!(
+            wrapped.position_for_index("אב".len(), line_height),
+            Some(point(px(20.), px(0.)))
+        );
+        assert_eq!(
+            wrapped.position_for_index(text.len(), line_height),
+            Some(point(px(0.), px(0.)))
+        );
+        assert_eq!(
+            wrapped.index_for_position(point(px(19.), line_height), line_height),
+            Ok(0)
+        );
+        assert_eq!(
+            wrapped.index_for_position(point(px(-1.), px(0.)), line_height),
+            Err(text.len())
+        );
+        assert_eq!(
+            wrapped.index_for_position(point(px(21.), line_height), line_height),
+            Err(0)
+        );
     }
 
     #[test]

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -8,6 +8,7 @@ use std::{
     ops::Range,
     sync::Arc,
 };
+use unicode_bidi::BidiInfo;
 
 use super::LineWrapper;
 
@@ -26,6 +27,17 @@ pub struct LineLayout {
     pub runs: Vec<ShapedRun>,
     /// The length of the line in utf-8 bytes
     pub len: usize,
+    /// Bidi-aware caret stops, sorted by logical UTF-8 byte index.
+    pub index_positions: Vec<IndexPosition>,
+}
+
+/// A caret stop for a logical UTF-8 byte index.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct IndexPosition {
+    /// The logical UTF-8 byte index.
+    pub index: usize,
+    /// The visual x position for this logical boundary.
+    pub x: Pixels,
 }
 
 /// A run of text that has been shaped .
@@ -58,6 +70,12 @@ impl LineLayout {
     pub fn index_for_x(&self, x: Pixels) -> Option<usize> {
         if x >= self.width {
             None
+        } else if !self.index_positions.is_empty() {
+            self.index_positions
+                .iter()
+                .filter(|position| position.x <= x)
+                .max_by(|a, b| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal))
+                .map(|position| position.index)
         } else {
             for run in self.runs.iter().rev() {
                 for glyph in run.glyphs.iter().rev() {
@@ -73,6 +91,19 @@ impl LineLayout {
     /// closest_index_for_x returns the character boundary closest to the given x coordinate
     /// (e.g. to handle aligning up/down arrow keys)
     pub fn closest_index_for_x(&self, x: Pixels) -> usize {
+        if !self.index_positions.is_empty() {
+            return self
+                .index_positions
+                .iter()
+                .min_by(|a, b| {
+                    (a.x - x)
+                        .abs()
+                        .partial_cmp(&(b.x - x).abs())
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
+                .map_or(self.len, |position| position.index);
+        }
+
         let mut prev_index = 0;
         let mut prev_x = px(0.);
 
@@ -103,6 +134,14 @@ impl LineLayout {
 
     /// The x position of the character at the given index
     pub fn x_for_index(&self, index: usize) -> Pixels {
+        if let Some(position) = self
+            .index_positions
+            .iter()
+            .find(|position| position.index >= index)
+        {
+            return position.x;
+        }
+
         for run in &self.runs {
             for glyph in &run.glyphs {
                 if glyph.index >= index {
@@ -111,6 +150,105 @@ impl LineLayout {
             }
         }
         self.width
+    }
+
+    pub(crate) fn compute_bidi_index_positions(&mut self, text: &str) {
+        self.index_positions.clear();
+        if text.is_empty() || !contains_rtl_or_bidi_control(text) {
+            return;
+        }
+
+        let bidi_info = BidiInfo::new(text, None);
+        if !bidi_info.has_rtl() {
+            return;
+        }
+
+        let Some(paragraph) = bidi_info.paragraphs.first() else {
+            return;
+        };
+        let (_levels, visual_runs) = bidi_info.visual_runs(paragraph, 0..text.len());
+        if visual_runs.is_empty() {
+            return;
+        }
+
+        let mut glyphs = self
+            .runs
+            .iter()
+            .flat_map(|run| run.glyphs.iter())
+            .collect::<Vec<_>>();
+        glyphs.sort_by(|a, b| {
+            a.position
+                .x
+                .partial_cmp(&b.position.x)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let mut run_edges = Vec::with_capacity(glyphs.len());
+        for (ix, glyph) in glyphs.iter().enumerate() {
+            let next_x = glyphs
+                .get(ix + 1)
+                .map_or(self.width, |next_glyph| next_glyph.position.x);
+            run_edges.push((glyph.index, glyph.position.x, next_x));
+        }
+
+        for visual_run in visual_runs {
+            let Some(level) = bidi_info.levels.get(visual_run.start) else {
+                continue;
+            };
+            let mut run_glyphs = run_edges
+                .iter()
+                .filter(|(index, _, _)| visual_run.contains(index))
+                .copied()
+                .collect::<Vec<_>>();
+            if run_glyphs.is_empty() {
+                continue;
+            }
+            run_glyphs.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+            let run_left = run_glyphs
+                .first()
+                .map_or(Pixels::ZERO, |(_, left, _)| *left);
+            let run_right = run_glyphs.last().map_or(self.width, |(_, _, right)| *right);
+
+            let mut boundaries = text[visual_run.clone()]
+                .char_indices()
+                .map(|(offset, _)| visual_run.start + offset)
+                .chain([visual_run.end])
+                .collect::<Vec<_>>();
+            boundaries.sort_unstable();
+            boundaries.dedup();
+
+            if level.is_rtl() {
+                for boundary in boundaries {
+                    let x = if boundary == visual_run.start {
+                        run_right
+                    } else {
+                        run_glyphs
+                            .iter()
+                            .find(|(index, _, _)| *index < boundary)
+                            .map_or(run_left, |(_, left, _)| *left)
+                    };
+                    self.index_positions
+                        .push(IndexPosition { index: boundary, x });
+                }
+            } else {
+                for boundary in boundaries {
+                    let x = if boundary == visual_run.end {
+                        run_right
+                    } else {
+                        run_glyphs
+                            .iter()
+                            .find(|(index, _, _)| *index >= boundary)
+                            .map_or(run_left, |(_, left, _)| *left)
+                    };
+                    self.index_positions
+                        .push(IndexPosition { index: boundary, x });
+                }
+            }
+        }
+
+        self.index_positions.sort_by_key(|position| position.index);
+        self.index_positions.dedup_by_key(|position| position.index);
     }
 
     /// The corresponding Font at the given index
@@ -612,6 +750,7 @@ impl LineLayoutCache {
             if let Some(force_width) = force_width {
                 apply_force_width_to_layout(&mut layout, force_width);
             }
+            layout.compute_bidi_index_positions(&text);
 
             let key = Arc::new(CacheKey {
                 text,
@@ -761,6 +900,7 @@ impl LineLayoutCache {
         if let Some(force_width) = force_width {
             apply_force_width_to_layout(&mut layout, force_width);
         }
+        layout.compute_bidi_index_positions(&text);
 
         let key = Arc::new(HashedCacheKey {
             text_hash,
@@ -807,6 +947,22 @@ fn apply_force_width_to_layout(layout: &mut LineLayout, force_width: Pixels) {
             }
         }
     }
+}
+
+fn contains_rtl_or_bidi_control(text: &str) -> bool {
+    text.chars().any(|character| {
+        matches!(
+            character,
+            '\u{0590}'..='\u{08ff}'
+                | '\u{200e}'..='\u{200f}'
+                | '\u{202a}'..='\u{202e}'
+                | '\u{2066}'..='\u{2069}'
+                | '\u{fb1d}'..='\u{fdff}'
+                | '\u{fe70}'..='\u{fefc}'
+                | '\u{10800}'..='\u{10fff}'
+                | '\u{1e800}'..='\u{1eFFF}'
+        )
+    })
 }
 
 /// A run of text with a single font.
@@ -982,6 +1138,7 @@ mod tests {
                 glyphs,
             }],
             len: 0,
+            index_positions: Vec::new(),
         }
     }
 
@@ -1074,5 +1231,112 @@ mod tests {
 
         let positions = glyph_x_positions(&layout);
         assert_eq!(positions, vec![0.5, 0.5]);
+    }
+    #[test]
+    fn test_bidi_index_positions_for_hebrew_line() {
+        let text = "אבג";
+        let mut layout = LineLayout {
+            font_size: px(16.),
+            width: px(30.),
+            ascent: px(12.),
+            descent: px(4.),
+            runs: vec![ShapedRun {
+                font_id: FontId(0),
+                glyphs: vec![glyph_at(0., 4), glyph_at(10., 2), glyph_at(20., 0)],
+            }],
+            len: text.len(),
+            index_positions: Vec::new(),
+        };
+
+        layout.compute_bidi_index_positions(text);
+
+        assert_eq!(layout.x_for_index(0), px(30.));
+        assert_eq!(layout.x_for_index("א".len()), px(20.));
+        assert_eq!(layout.x_for_index("אב".len()), px(10.));
+        assert_eq!(layout.x_for_index(text.len()), px(0.));
+        assert_eq!(layout.closest_index_for_x(px(29.)), 0);
+        assert_eq!(layout.closest_index_for_x(px(1.)), text.len());
+    }
+
+    #[test]
+    fn test_bidi_index_positions_for_arabic_and_persian_zwnj_lines() {
+        for text in ["مرحبا", "می\u{200c}روم"] {
+            let character_indices = text
+                .char_indices()
+                .map(|(index, _)| index)
+                .collect::<Vec<_>>();
+            let mut glyphs = character_indices
+                .iter()
+                .rev()
+                .enumerate()
+                .map(|(position, index)| glyph_at(position as f32 * 10., *index))
+                .collect::<Vec<_>>();
+            let width = glyphs.len() as f32 * 10.;
+            let mut layout = LineLayout {
+                font_size: px(16.),
+                width: px(width),
+                ascent: px(12.),
+                descent: px(4.),
+                runs: vec![ShapedRun {
+                    font_id: FontId(0),
+                    glyphs: std::mem::take(&mut glyphs),
+                }],
+                len: text.len(),
+                index_positions: Vec::new(),
+            };
+
+            layout.compute_bidi_index_positions(text);
+
+            assert_eq!(layout.x_for_index(0), px(width));
+            assert_eq!(layout.x_for_index(text.len()), px(0.));
+            assert_eq!(layout.closest_index_for_x(px(width - 1.)), 0);
+            assert_eq!(layout.closest_index_for_x(px(1.)), text.len());
+        }
+    }
+
+    #[test]
+    fn test_bidi_index_positions_for_mixed_ltr_and_hebrew_line() {
+        let text = "abc אבג def";
+        let Some(alef) = text.find('א') else {
+            panic!("expected alef in test text");
+        };
+        let Some(bet) = text.find('ב') else {
+            panic!("expected bet in test text");
+        };
+        let Some(gimel) = text.find('ג') else {
+            panic!("expected gimel in test text");
+        };
+        let after_gimel = gimel + 'ג'.len_utf8();
+        let mut layout = LineLayout {
+            font_size: px(16.),
+            width: px(110.),
+            ascent: px(12.),
+            descent: px(4.),
+            runs: vec![ShapedRun {
+                font_id: FontId(0),
+                glyphs: vec![
+                    glyph_at(0., 0),
+                    glyph_at(10., 1),
+                    glyph_at(20., 2),
+                    glyph_at(30., 3),
+                    glyph_at(40., gimel),
+                    glyph_at(50., bet),
+                    glyph_at(60., alef),
+                    glyph_at(70., after_gimel),
+                    glyph_at(80., after_gimel + 1),
+                    glyph_at(90., after_gimel + 2),
+                    glyph_at(100., after_gimel + 3),
+                ],
+            }],
+            len: text.len(),
+            index_positions: Vec::new(),
+        };
+
+        layout.compute_bidi_index_positions(text);
+
+        assert_eq!(layout.x_for_index(bet), px(60.));
+        assert_eq!(layout.x_for_index(gimel), px(50.));
+        assert_eq!(layout.closest_index_for_x(px(59.)), bet);
+        assert_eq!(layout.closest_index_for_x(px(51.)), gimel);
     }
 }

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -71,29 +71,46 @@ impl LineLayout {
         if x >= self.width {
             None
         } else if !self.index_positions.is_empty() {
-            let mut positions_by_x = self.index_positions.clone();
-            positions_by_x
-                .sort_by(|a, b| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal));
+            let mut exact_position = None;
+            let mut left_position = None;
+            let mut right_position = None;
 
-            if let Some(first_position) = positions_by_x.first()
-                && x < first_position.x
-            {
-                return Some(first_position.index);
-            }
-
-            for window in positions_by_x.windows(2) {
-                let left = window[0];
-                let right = window[1];
-                if x >= left.x && x < right.x {
-                    return if left.index <= right.index {
-                        Some(left.index)
-                    } else {
-                        Some(right.index)
-                    };
+            for position in &self.index_positions {
+                if position.x == x {
+                    if exact_position
+                        .is_none_or(|exact: IndexPosition| position.index > exact.index)
+                    {
+                        exact_position = Some(*position);
+                    }
+                } else if position.x < x {
+                    if left_position.is_none_or(|left: IndexPosition| {
+                        position.x > left.x || position.x == left.x && position.index > left.index
+                    }) {
+                        left_position = Some(*position);
+                    }
+                } else if right_position.is_none_or(|right: IndexPosition| {
+                    position.x < right.x || position.x == right.x && position.index < right.index
+                }) {
+                    right_position = Some(*position);
                 }
             }
 
-            positions_by_x.last().map(|position| position.index)
+            if let Some(exact) = exact_position {
+                return Some(exact.index);
+            }
+
+            match (left_position, right_position) {
+                (Some(left), Some(right)) => {
+                    if left.index <= right.index {
+                        Some(left.index)
+                    } else {
+                        Some(right.index)
+                    }
+                }
+                (Some(left), None) => Some(left.index),
+                (None, Some(right)) => Some(right.index),
+                (None, None) => None,
+            }
         } else {
             for run in self.runs.iter().rev() {
                 for glyph in run.glyphs.iter().rev() {
@@ -155,7 +172,17 @@ impl LineLayout {
         if let Some(position) = self
             .index_positions
             .iter()
-            .find(|position| position.index >= index)
+            .filter(|position| position.index == index)
+            .max_by(|a, b| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal))
+        {
+            return position.x;
+        }
+
+        if let Some(position) = self
+            .index_positions
+            .iter()
+            .filter(|position| position.index > index)
+            .min_by_key(|position| position.index)
         {
             return position.x;
         }
@@ -265,8 +292,13 @@ impl LineLayout {
             }
         }
 
-        self.index_positions.sort_by_key(|position| position.index);
-        self.index_positions.dedup_by_key(|position| position.index);
+        self.index_positions.sort_by(|a, b| {
+            a.index
+                .cmp(&b.index)
+                .then_with(|| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal))
+        });
+        self.index_positions
+            .dedup_by(|a, b| a.index == b.index && a.x == b.x);
     }
 
     /// The corresponding Font at the given index
@@ -1275,7 +1307,8 @@ mod tests {
         assert_eq!(layout.closest_index_for_x(px(29.)), 0);
         assert_eq!(layout.closest_index_for_x(px(1.)), text.len());
         assert_eq!(layout.index_for_x(px(29.)), Some(0));
-        assert_eq!(layout.index_for_x(px(1.)), Some(text.len()));
+        assert_eq!(layout.index_for_x(px(19.)), Some("א".len()));
+        assert_eq!(layout.index_for_x(px(9.)), Some("אב".len()));
     }
 
     #[test]
@@ -1312,7 +1345,8 @@ mod tests {
             assert_eq!(layout.closest_index_for_x(px(width - 1.)), 0);
             assert_eq!(layout.closest_index_for_x(px(1.)), text.len());
             assert_eq!(layout.index_for_x(px(width - 1.)), Some(0));
-            assert_eq!(layout.index_for_x(px(1.)), Some(text.len()));
+            let last_character_index = text.char_indices().last().map(|(index, _)| index).unwrap();
+            assert_eq!(layout.index_for_x(px(1.)), Some(last_character_index));
         }
     }
 
@@ -1377,6 +1411,23 @@ mod tests {
             panic!("expected arabic text in test");
         };
         let after_arabic = arabic_end + 'ا'.len_utf8();
+        let arabic_indices = text[arabic_start..after_arabic]
+            .char_indices()
+            .map(|(offset, _)| arabic_start + offset)
+            .collect::<Vec<_>>();
+        let mut glyphs = vec![glyph_at(0., 0), glyph_at(10., 1), glyph_at(20., 2)];
+        glyphs.push(glyph_at(30., after_arabic));
+        glyphs.extend(
+            arabic_indices
+                .iter()
+                .rev()
+                .enumerate()
+                .map(|(position, index)| glyph_at(40. + position as f32 * 10., *index)),
+        );
+        glyphs.extend([
+            glyph_at(90., after_arabic + 1),
+            glyph_at(100., after_arabic + 2),
+        ]);
 
         let mut layout = LineLayout {
             font_size: px(16.),
@@ -1385,19 +1436,7 @@ mod tests {
             descent: px(4.),
             runs: vec![ShapedRun {
                 font_id: FontId(0),
-                glyphs: vec![
-                    glyph_at(0., 0),
-                    glyph_at(10., 1),
-                    glyph_at(20., 2),
-                    glyph_at(30., after_arabic),
-                    glyph_at(40., arabic_end),
-                    glyph_at(50., arabic_second),
-                    glyph_at(60., arabic_start),
-                    glyph_at(70., after_arabic + 1),
-                    glyph_at(80., after_arabic + 2),
-                    glyph_at(90., after_arabic + 3),
-                    glyph_at(100., after_arabic + 4),
-                ],
+                glyphs,
             }],
             len: text.len(),
             index_positions: Vec::new(),
@@ -1405,8 +1444,8 @@ mod tests {
 
         layout.compute_bidi_index_positions(text);
 
-        assert_eq!(layout.index_for_x(px(59.)), Some(arabic_start));
-        assert_eq!(layout.index_for_x(px(49.)), Some(arabic_second));
-        assert_eq!(layout.index_for_x(px(39.)), Some(arabic_end));
+        assert_eq!(layout.index_for_x(px(89.)), Some(arabic_start));
+        assert_eq!(layout.index_for_x(px(79.)), Some(arabic_second));
+        assert_eq!(layout.index_for_x(px(49.)), Some(arabic_end));
     }
 }

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -71,11 +71,29 @@ impl LineLayout {
         if x >= self.width {
             None
         } else if !self.index_positions.is_empty() {
-            self.index_positions
-                .iter()
-                .filter(|position| position.x <= x)
-                .max_by(|a, b| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal))
-                .map(|position| position.index)
+            let mut positions_by_x = self.index_positions.clone();
+            positions_by_x
+                .sort_by(|a, b| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal));
+
+            if let Some(first_position) = positions_by_x.first()
+                && x < first_position.x
+            {
+                return Some(first_position.index);
+            }
+
+            for window in positions_by_x.windows(2) {
+                let left = window[0];
+                let right = window[1];
+                if x >= left.x && x < right.x {
+                    return if left.index <= right.index {
+                        Some(left.index)
+                    } else {
+                        Some(right.index)
+                    };
+                }
+            }
+
+            positions_by_x.last().map(|position| position.index)
         } else {
             for run in self.runs.iter().rev() {
                 for glyph in run.glyphs.iter().rev() {
@@ -1256,6 +1274,8 @@ mod tests {
         assert_eq!(layout.x_for_index(text.len()), px(0.));
         assert_eq!(layout.closest_index_for_x(px(29.)), 0);
         assert_eq!(layout.closest_index_for_x(px(1.)), text.len());
+        assert_eq!(layout.index_for_x(px(29.)), Some(0));
+        assert_eq!(layout.index_for_x(px(1.)), Some(text.len()));
     }
 
     #[test]
@@ -1291,6 +1311,8 @@ mod tests {
             assert_eq!(layout.x_for_index(text.len()), px(0.));
             assert_eq!(layout.closest_index_for_x(px(width - 1.)), 0);
             assert_eq!(layout.closest_index_for_x(px(1.)), text.len());
+            assert_eq!(layout.index_for_x(px(width - 1.)), Some(0));
+            assert_eq!(layout.index_for_x(px(1.)), Some(text.len()));
         }
     }
 
@@ -1338,5 +1360,53 @@ mod tests {
         assert_eq!(layout.x_for_index(gimel), px(50.));
         assert_eq!(layout.closest_index_for_x(px(59.)), bet);
         assert_eq!(layout.closest_index_for_x(px(51.)), gimel);
+        assert_eq!(layout.index_for_x(px(55.)), Some(bet));
+        assert_eq!(layout.index_for_x(px(45.)), Some(gimel));
+    }
+
+    #[test]
+    fn test_index_for_x_for_mixed_english_and_arabic_punctuation() {
+        let text = "x (مرحبا) y";
+        let Some(arabic_start) = text.find('م') else {
+            panic!("expected arabic text in test");
+        };
+        let Some(arabic_second) = text.find('ر') else {
+            panic!("expected arabic text in test");
+        };
+        let Some(arabic_end) = text.find('ا') else {
+            panic!("expected arabic text in test");
+        };
+        let after_arabic = arabic_end + 'ا'.len_utf8();
+
+        let mut layout = LineLayout {
+            font_size: px(16.),
+            width: px(110.),
+            ascent: px(12.),
+            descent: px(4.),
+            runs: vec![ShapedRun {
+                font_id: FontId(0),
+                glyphs: vec![
+                    glyph_at(0., 0),
+                    glyph_at(10., 1),
+                    glyph_at(20., 2),
+                    glyph_at(30., after_arabic),
+                    glyph_at(40., arabic_end),
+                    glyph_at(50., arabic_second),
+                    glyph_at(60., arabic_start),
+                    glyph_at(70., after_arabic + 1),
+                    glyph_at(80., after_arabic + 2),
+                    glyph_at(90., after_arabic + 3),
+                    glyph_at(100., after_arabic + 4),
+                ],
+            }],
+            len: text.len(),
+            index_positions: Vec::new(),
+        };
+
+        layout.compute_bidi_index_positions(text);
+
+        assert_eq!(layout.index_for_x(px(59.)), Some(arabic_start));
+        assert_eq!(layout.index_for_x(px(49.)), Some(arabic_second));
+        assert_eq!(layout.index_for_x(px(39.)), Some(arabic_end));
     }
 }

--- a/crates/gpui_macos/src/text_system.rs
+++ b/crates/gpui_macos/src/text_system.rs
@@ -601,6 +601,7 @@ impl MacTextSystemState {
             descent: max_descent.into(),
             len: text.len(),
             index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
         }
     }
 }

--- a/crates/gpui_macos/src/text_system.rs
+++ b/crates/gpui_macos/src/text_system.rs
@@ -600,6 +600,7 @@ impl MacTextSystemState {
             ascent: max_ascent.into(),
             descent: max_descent.into(),
             len: text.len(),
+            index_positions: Vec::new(),
         }
     }
 }

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -559,6 +559,7 @@ impl CosmicTextSystemState {
                 runs: Vec::new(),
                 len: text.len(),
                 index_positions: Vec::new(),
+                visual_index_positions: Vec::new(),
             };
         };
 
@@ -616,6 +617,7 @@ impl CosmicTextSystemState {
             runs,
             len: text.len(),
             index_positions: Vec::new(),
+            visual_index_positions: Vec::new(),
         }
     }
 }

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -558,6 +558,7 @@ impl CosmicTextSystemState {
                 descent: Pixels::ZERO,
                 runs: Vec::new(),
                 len: text.len(),
+                index_positions: Vec::new(),
             };
         };
 
@@ -614,6 +615,7 @@ impl CosmicTextSystemState {
             descent: layout.max_descent.into(),
             runs,
             len: text.len(),
+            index_positions: Vec::new(),
         }
     }
 }

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -631,6 +631,7 @@ impl DirectWriteState {
                 runs,
                 len: text.len(),
                 index_positions: Vec::new(),
+                visual_index_positions: Vec::new(),
             })
         }
     }

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -630,6 +630,7 @@ impl DirectWriteState {
                 descent,
                 runs,
                 len: text.len(),
+                index_positions: Vec::new(),
             })
         }
     }

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -1362,65 +1362,9 @@ impl TextRenderer {
 struct RendererContext<'t, 'a, 'b> {
     text_system: &'t mut DirectWriteState,
     components: &'a DirectWriteComponents,
-    index_converter: StringIndexConverter<'a>,
+    index_converter: StringIndexConverter,
     runs: &'b mut Vec<ShapedRun>,
     width: f32,
-}
-
-#[derive(Debug)]
-struct ClusterAnalyzer<'t> {
-    utf16_idx: usize,
-    glyph_idx: usize,
-    glyph_count: usize,
-    cluster_map: &'t [u16],
-}
-
-impl<'t> ClusterAnalyzer<'t> {
-    fn new(cluster_map: &'t [u16], glyph_count: usize) -> Self {
-        ClusterAnalyzer {
-            utf16_idx: 0,
-            glyph_idx: 0,
-            glyph_count,
-            cluster_map,
-        }
-    }
-}
-
-impl Iterator for ClusterAnalyzer<'_> {
-    type Item = (usize, usize);
-
-    fn next(&mut self) -> Option<(usize, usize)> {
-        if self.utf16_idx >= self.cluster_map.len() {
-            return None; // No more clusters
-        }
-        let start_utf16_idx = self.utf16_idx;
-        let current_glyph = self.cluster_map[start_utf16_idx] as usize;
-
-        // Find the end of current cluster (where glyph index changes)
-        let mut end_utf16_idx = start_utf16_idx + 1;
-        while end_utf16_idx < self.cluster_map.len()
-            && self.cluster_map[end_utf16_idx] as usize == current_glyph
-        {
-            end_utf16_idx += 1;
-        }
-
-        let utf16_len = end_utf16_idx - start_utf16_idx;
-
-        // Calculate glyph count for this cluster
-        let next_glyph = if end_utf16_idx < self.cluster_map.len() {
-            self.cluster_map[end_utf16_idx] as usize
-        } else {
-            self.glyph_count
-        };
-
-        let glyph_count = next_glyph - current_glyph;
-
-        // Update state for next call
-        self.utf16_idx = end_utf16_idx;
-        self.glyph_idx = next_glyph;
-
-        Some((utf16_len, glyph_count))
-    }
 }
 
 #[allow(non_snake_case)]
@@ -1463,7 +1407,7 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
     fn DrawGlyphRun(
         &self,
         clientdrawingcontext: *const ::core::ffi::c_void,
-        _baselineoriginx: f32,
+        baselineoriginx: f32,
         _baselineoriginy: f32,
         _measuringmode: DWRITE_MEASURING_MODE,
         glyphrun: *const DWRITE_GLYPH_RUN,
@@ -1527,35 +1471,43 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
         let cluster_map =
             unsafe { std::slice::from_raw_parts(desc.clusterMap, desc.stringLength as usize) };
 
-        let cluster_analyzer = ClusterAnalyzer::new(cluster_map, glyph_count);
-        let mut utf16_idx = desc.textPosition as usize;
-        let mut glyph_idx = 0;
+        let glyph_utf16_starts = glyph_utf16_start_indices(cluster_map, glyph_count);
+        let is_rtl = glyphrun.bidiLevel % 2 == 1;
+        let run_advance = glyph_advances.iter().sum::<f32>();
+        let mut run_right = if is_rtl {
+            baselineoriginx
+        } else {
+            baselineoriginx + run_advance
+        };
+        let mut advance = 0.0;
         let mut glyphs = Vec::with_capacity(glyph_count);
-        for (cluster_utf16_len, cluster_glyph_count) in cluster_analyzer {
-            context.index_converter.advance_to_utf16_ix(utf16_idx);
-            utf16_idx += cluster_utf16_len;
-            for (cluster_glyph_idx, glyph_id) in glyph_ids
-                [glyph_idx..(glyph_idx + cluster_glyph_count)]
-                .iter()
-                .enumerate()
-            {
-                let id = GlyphId(*glyph_id as u32);
-                let is_emoji =
-                    color_font && is_color_glyph(font_face, id, &context.components.factory);
-                let this_glyph_idx = glyph_idx + cluster_glyph_idx;
-                glyphs.push(ShapedGlyph {
-                    id,
-                    position: point(
-                        px(context.width + glyph_offsets[this_glyph_idx].advanceOffset),
-                        px(-glyph_offsets[this_glyph_idx].ascenderOffset),
-                    ),
-                    index: context.index_converter.utf8_ix,
-                    is_emoji,
-                });
-                context.width += glyph_advances[this_glyph_idx];
-            }
-            glyph_idx += cluster_glyph_count;
+        for (glyph_idx, glyph_id) in glyph_ids.iter().enumerate() {
+            let id = GlyphId(*glyph_id as u32);
+            let is_emoji = color_font && is_color_glyph(font_face, id, &context.components.factory);
+            let glyph_advance = glyph_advances[glyph_idx];
+            let offset = glyph_offsets[glyph_idx];
+            let x = if is_rtl {
+                baselineoriginx - advance - glyph_advance - offset.advanceOffset
+            } else {
+                baselineoriginx + advance + offset.advanceOffset
+            };
+            run_right = run_right.max(x + glyph_advance);
+            let utf16_idx = desc.textPosition as usize + glyph_utf16_starts[glyph_idx];
+            glyphs.push(ShapedGlyph {
+                id,
+                position: point(px(x), px(-offset.ascenderOffset)),
+                index: context.index_converter.utf8_ix_for_utf16_ix(utf16_idx),
+                is_emoji,
+            });
+            advance += glyph_advance;
         }
+        glyphs.sort_by(|a, b| {
+            a.position
+                .x
+                .partial_cmp(&b.position.x)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        context.width = context.width.max(run_right);
         context.runs.push(ShapedRun { font_id, glyphs });
         Ok(())
     }
@@ -1605,43 +1557,70 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
     }
 }
 
-struct StringIndexConverter<'a> {
-    text: &'a str,
-    utf8_ix: usize,
-    utf16_ix: usize,
+struct StringIndexConverter {
+    utf16_to_utf8: Vec<usize>,
 }
 
-impl<'a> StringIndexConverter<'a> {
-    fn new(text: &'a str) -> Self {
-        Self {
-            text,
-            utf8_ix: 0,
-            utf16_ix: 0,
+impl StringIndexConverter {
+    fn new(text: &str) -> Self {
+        let mut utf16_to_utf8 = vec![text.len(); text.encode_utf16().count() + 1];
+        let mut utf16_ix = 0;
+        for (utf8_ix, c) in text.char_indices() {
+            let next_utf16_ix = utf16_ix + c.len_utf16();
+            let next_utf8_ix = utf8_ix + c.len_utf8();
+            utf16_to_utf8[utf16_ix] = utf8_ix;
+            for target_utf16_ix in utf16_ix + 1..=next_utf16_ix {
+                utf16_to_utf8[target_utf16_ix] = next_utf8_ix;
+            }
+            utf16_ix = next_utf16_ix;
+        }
+
+        if let Some(last) = utf16_to_utf8.last_mut() {
+            *last = text.len();
+        }
+
+        Self { utf16_to_utf8 }
+    }
+
+    fn utf8_ix_for_utf16_ix(&self, utf16_target: usize) -> usize {
+        self.utf16_to_utf8
+            .get(utf16_target)
+            .copied()
+            .unwrap_or_else(|| self.utf16_to_utf8.last().copied().unwrap_or_default())
+    }
+}
+
+fn glyph_utf16_start_indices(cluster_map: &[u16], glyph_count: usize) -> Vec<usize> {
+    if cluster_map.is_empty() {
+        return (0..glyph_count).collect();
+    }
+
+    let mut glyph_utf16_starts = vec![usize::MAX; glyph_count];
+    let mut saw_cluster = false;
+    for (utf16_idx, glyph_start) in cluster_map.iter().copied().enumerate() {
+        let glyph_start = glyph_start as usize;
+        if glyph_start >= glyph_count {
+            continue;
+        }
+
+        saw_cluster = true;
+        glyph_utf16_starts[glyph_start] = glyph_utf16_starts[glyph_start].min(utf16_idx);
+    }
+
+    if !saw_cluster {
+        return vec![0; glyph_count];
+    }
+
+    let mut last_utf16_idx = 0;
+    for utf16_idx in &mut glyph_utf16_starts {
+        if *utf16_idx == usize::MAX {
+            *utf16_idx = last_utf16_idx;
+        } else {
+            last_utf16_idx = *utf16_idx;
         }
     }
 
-    #[allow(dead_code)]
-    fn advance_to_utf8_ix(&mut self, utf8_target: usize) {
-        for (ix, c) in self.text[self.utf8_ix..].char_indices() {
-            if self.utf8_ix + ix >= utf8_target {
-                self.utf8_ix += ix;
-                return;
-            }
-            self.utf16_ix += c.len_utf16();
-        }
-        self.utf8_ix = self.text.len();
-    }
-
-    fn advance_to_utf16_ix(&mut self, utf16_target: usize) {
-        for (ix, c) in self.text[self.utf8_ix..].char_indices() {
-            if self.utf16_ix >= utf16_target {
-                self.utf8_ix += ix;
-                return;
-            }
-            self.utf16_ix += c.len_utf16();
-        }
-        self.utf8_ix = self.text.len();
-    }
+    glyph_utf16_starts
 }
 
 fn font_style_to_dwrite(style: FontStyle) -> DWRITE_FONT_STYLE {
@@ -1879,42 +1858,43 @@ const DEFAULT_LOCALE_NAME: PCWSTR = windows::core::w!("en-US");
 
 #[cfg(test)]
 mod tests {
-    use crate::direct_write::ClusterAnalyzer;
+    use crate::direct_write::{StringIndexConverter, glyph_utf16_start_indices};
 
     #[test]
     fn test_cluster_map() {
         let cluster_map = [0];
-        let mut analyzer = ClusterAnalyzer::new(&cluster_map, 1);
-        let next = analyzer.next();
-        assert_eq!(next, Some((1, 1)));
-        let next = analyzer.next();
-        assert_eq!(next, None);
+        assert_eq!(glyph_utf16_start_indices(&cluster_map, 1), [0]);
 
         let cluster_map = [0, 1, 2];
-        let mut analyzer = ClusterAnalyzer::new(&cluster_map, 3);
-        let next = analyzer.next();
-        assert_eq!(next, Some((1, 1)));
-        let next = analyzer.next();
-        assert_eq!(next, Some((1, 1)));
-        let next = analyzer.next();
-        assert_eq!(next, Some((1, 1)));
-        let next = analyzer.next();
-        assert_eq!(next, None);
+        assert_eq!(glyph_utf16_start_indices(&cluster_map, 3), [0, 1, 2]);
+
         // 👨‍👩‍👧‍👦👩‍💻
         let cluster_map = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 4, 4, 4];
-        let mut analyzer = ClusterAnalyzer::new(&cluster_map, 5);
-        let next = analyzer.next();
-        assert_eq!(next, Some((11, 4)));
-        let next = analyzer.next();
-        assert_eq!(next, Some((5, 1)));
-        let next = analyzer.next();
-        assert_eq!(next, None);
+        assert_eq!(glyph_utf16_start_indices(&cluster_map, 5), [0, 0, 0, 0, 11]);
+
         // 👩‍💻
         let cluster_map = [0, 0, 0, 0, 0];
-        let mut analyzer = ClusterAnalyzer::new(&cluster_map, 1);
-        let next = analyzer.next();
-        assert_eq!(next, Some((5, 1)));
-        let next = analyzer.next();
-        assert_eq!(next, None);
+        assert_eq!(glyph_utf16_start_indices(&cluster_map, 1), [0]);
+    }
+
+    #[test]
+    fn test_cluster_map_handles_rtl_clusters() {
+        assert_eq!(
+            glyph_utf16_start_indices(&[4, 3, 2, 1, 0], 5),
+            [4, 3, 2, 1, 0]
+        );
+        assert_eq!(glyph_utf16_start_indices(&[2, 2, 0], 3), [2, 2, 0]);
+    }
+
+    #[test]
+    fn test_string_index_converter_handles_descending_utf16_indices() {
+        let text = "a😀ب";
+        let converter = StringIndexConverter::new(text);
+
+        assert_eq!(converter.utf8_ix_for_utf16_ix(4), text.len());
+        assert_eq!(converter.utf8_ix_for_utf16_ix(3), "a😀".len());
+        assert_eq!(converter.utf8_ix_for_utf16_ix(2), "a😀".len());
+        assert_eq!(converter.utf8_ix_for_utf16_ix(1), "a".len());
+        assert_eq!(converter.utf8_ix_for_utf16_ix(99), text.len());
     }
 }


### PR DESCRIPTION
## Summary

This is part 3 of the incremental RTL support series.

Series order:

1. #57237 - Windows DirectWrite RTL glyph runs
2. #57239 - GPUI bidi line mapping and caret/range primitives
3. This PR - bidi-safe GPUI decoration painting
4. #57241 - editor visual selection behavior

This PR makes GPUI text decoration painting follow logical decoration runs even when glyphs are stored or painted in visual RTL order.

- look up decoration runs by logical glyph index instead of assuming visual glyph order is logical order
- keep underline, strikethrough, and background spans consistent across RTL glyph ordering
- preserve wrapping behavior while closing decoration spans at visual wrap boundaries
- add regression coverage for decoration lookup with visual RTL glyph order

## Scope

This does not change editor selection behavior. It only addresses text decoration painting over already-shaped GPUI lines.

Because GitHub cross-fork PRs cannot use another branch in the fork as the upstream base, this PR is opened against `main` and should be reviewed after #57239.

## Testing

- `cargo test -p gpui text_system::line::tests --lib`
- `cargo check -p editor --lib`
