### PR TITLE
csv_preview: #4 Make horizontal scrollbar width respect pinned columns config

### DIFF
--- a/crates/ui/src/components/data_table.rs
+++ b/crates/ui/src/components/data_table.rs
@@ -108,6 +108,20 @@ impl ResizableColumnsState {
         self.widths[col_idx] = self.initial_widths[col_idx];
     }
 
+    pub fn pinned_width(&self, pinned_cols: usize, rem_size: Pixels) -> Pixels {
+        self.widths[..pinned_cols]
+            .iter()
+            .map(|w| w.to_pixels(rem_size))
+            .fold(px(0.), |acc, x| acc + x)
+    }
+
+    pub fn scrollable_width(&self, pinned_cols: usize, rem_size: Pixels) -> Pixels {
+        self.widths[pinned_cols..]
+            .iter()
+            .map(|w| w.to_pixels(rem_size))
+            .fold(px(0.), |acc, x| acc + x)
+    }
+
     fn apply_min_size(
         &self,
         width: Pixels,
@@ -916,10 +930,9 @@ fn render_resize_handles_resizable(
     window: &mut Window,
     cx: &mut App,
 ) -> AnyElement {
-    let (widths, resize_behavior) = {
-        let state = columns_state.read(cx);
-        (state.widths.clone(), state.resize_behavior.clone())
-    };
+    let state = columns_state.read(cx);
+    let widths = state.widths.clone();
+    let resize_behavior = state.resize_behavior().clone();
 
     let rem_size = window.rem_size();
     let n_cols = widths.cols();
@@ -945,14 +958,8 @@ fn render_resize_handles_resizable(
             .into_any_element();
     }
 
-    let pinned_width: Pixels = widths[..pinned_cols]
-        .iter()
-        .map(|w| w.to_pixels(rem_size))
-        .fold(px(0.), |acc, x| acc + x);
-    let total_scrollable_width: Pixels = widths[pinned_cols..]
-        .iter()
-        .map(|w| w.to_pixels(rem_size))
-        .fold(px(0.), |acc, x| acc + x);
+    let pinned_width = state.pinned_width(pinned_cols, rem_size);
+    let total_scrollable_width = state.scrollable_width(pinned_cols, rem_size);
 
     // Non-interactive: pinned columns don't visually shift with scroll, so resizing them would
     // need separate drag-math from the scrollable columns. Header double-click reset still works.
@@ -1265,12 +1272,30 @@ impl RenderOnce for Table {
 
             // Works for both modes since they share horizontal_scroll_handle.
             if is_resizable {
-                content = content.custom_scrollbars(
-                    Scrollbars::new(ScrollAxes::Horizontal)
-                        .tracked_scroll_handle(&state.read(cx).horizontal_scroll_handle),
-                    window,
-                    cx,
-                );
+                if let ColumnWidthConfig::Resizable(rc_state) = self.column_width_config {
+                    let pinned_width = rc_state
+                        .read(cx)
+                        .pinned_width(pinned_cols, window.rem_size());
+                    // With pinned columns the scrollbar should only span the scrollable area.
+                    // An absolute overlay inset on all sides then overriding left to pinned_width
+                    // gives the correct bounds (full height via top+bottom, correct width via
+                    // right+left) without needing to hardcode the scrollbar thickness.
+                    let h_scrollbar = div().absolute().inset_0().left(pinned_width);
+                    let h_scrollbar = h_scrollbar.custom_scrollbars(
+                        Scrollbars::new(ScrollAxes::Horizontal)
+                            .tracked_scroll_handle(&state.read(cx).horizontal_scroll_handle),
+                        window,
+                        cx,
+                    );
+                    content = content.child(h_scrollbar);
+                } else {
+                    content = content.custom_scrollbars(
+                        Scrollbars::new(ScrollAxes::Horizontal)
+                            .tracked_scroll_handle(&state.read(cx).horizontal_scroll_handle),
+                        window,
+                        cx,
+                    );
+                }
             }
             content.style().restrict_scroll_to_axis = Some(true);
 

--- a/crates/ui/src/components/data_table.rs
+++ b/crates/ui/src/components/data_table.rs
@@ -1030,9 +1030,12 @@ impl RenderOnce for Table {
             .interaction_state
             .clone()
             .and_then(|state| state.upgrade());
-        let pinned_cols = self.pinned_cols;
-        let uses_pinned_layout = is_pinned_layout(pinned_cols, self.cols);
-        let resize_handle_pinned_cols = if uses_pinned_layout { pinned_cols } else { 0 };
+        let uses_pinned_layout = is_pinned_layout(self.pinned_cols, self.cols);
+        let pinned_cols = if uses_pinned_layout {
+            self.pinned_cols
+        } else {
+            0
+        };
 
         // Shared by every row's scrollable section so they scroll in lockstep, and read by
         // on_drag_move to compensate drag_x for the horizontal scroll offset.
@@ -1096,7 +1099,7 @@ impl RenderOnce for Table {
                         Some(entity.clone()),
                         Some(render_resize_handles_resizable(
                             entity,
-                            resize_handle_pinned_cols,
+                            pinned_cols,
                             h_scroll_handle.as_ref(),
                             window,
                             cx,

--- a/crates/ui/src/components/data_table/tests.rs
+++ b/crates/ui/src/components/data_table/tests.rs
@@ -385,6 +385,13 @@ mod resizable_drag {
         s.drag_to(0, px(-50.), px(REM));
         assert_eq!(widths_px(&s), vec![16., 100.]);
     }
+
+    #[test]
+    fn pinned_and_scrollable_width_split() {
+        let s = state(&[100., 100., 100.], vec![TableResizeBehavior::None; 3]);
+        assert_eq!(f32::from(s.pinned_width(2, px(REM))), 200.);
+        assert_eq!(f32::from(s.scrollable_width(2, px(REM))), 100.);
+    }
 }
 
 mod pin_layout {


### PR DESCRIPTION
## Data table: Add left inset for scrollbar alignment with pinned columns

When pinned columns are enabled in the data table, the horizontal scrollbar previously extended across the full table width, including behind the pinned columns. This change adds a left inset to the scrollbar so it only spans the scrollable area, properly aligning with the content layout.

## Demo (look at bottom scrollbar)
| Before | After|
| --- | --- |
| <img width="1614" height="482" alt="image_2026-05-20_12-29-22" src="https://github.com/user-attachments/assets/87050173-0f3a-46dd-a7e1-10f769c7b5b8" /> | <img width="1526" height="420" alt="image_2026-05-20_12-32-48" src="https://github.com/user-attachments/assets/5041069f-2289-449b-8d30-8bcb3d0890eb" /> |
### Changes

- Add `pinned_width()` and `scrollable_width()` helper methods to `ResizableColumnsState` to compute column widths
- Refactor scrollbar rendering to use absolute positioning with inset when pinned columns are present
- Scrollbar now correctly positions itself to span only the scrollable (non-pinned) column area

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Improved horizontal scrollbar alignment when pinned columns are active

- N/A or Added/Fixed/Improved ...
