### PR TITLE
terminal: Fix pty info change detection race

### DIFF
--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -192,8 +192,9 @@ impl PtyProcessInfo {
         }
         let this = self.clone();
         let has_changed = cx.background_executor().spawn(async move {
+            let previous = this.current.read().clone();
             let current = this.load();
-            let has_changed = match (this.current.read().as_ref(), current.as_ref()) {
+            let has_changed = match (previous.as_ref(), current.as_ref()) {
                 (None, None) => false,
                 (Some(prev), Some(now)) => prev.cwd != now.cwd || prev.name != now.name,
                 _ => true,


### PR DESCRIPTION
I think I introduced this at some point in the terminal agent situation.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
