### PR TITLE
agent: Auto-create missing parent directories on write

### DIFF
--- a/crates/agent/src/tools/edit_session.rs
+++ b/crates/agent/src/tools/edit_session.rs
@@ -1094,29 +1094,34 @@ fn resolve_path(
                 .parent()
                 .ok_or_else(|| "Can't create file: incorrect path".to_string())?;
 
-            let parent_project_path = project.find_project_path(&parent_path, cx);
-
-            let parent_entry = parent_project_path
-                .as_ref()
-                .and_then(|path| project.entry_for_path(path, cx))
-                .ok_or_else(|| "Can't create file: parent directory doesn't exist")?;
-
-            if !parent_entry.is_dir() {
-                return Err("Can't create file: parent is not a directory".to_string());
-            }
-
             let file_name = path
                 .file_name()
                 .and_then(|file_name| file_name.to_str())
                 .and_then(|file_name| RelPath::unix(file_name).ok())
                 .ok_or_else(|| "Can't create file: invalid filename".to_string())?;
 
-            let new_file_path = parent_project_path.map(|parent| ProjectPath {
-                path: parent.path.join(file_name),
-                ..parent
-            });
+            let project_path = project
+                .find_project_path(&parent_path, cx)
+                .map(|parent| ProjectPath {
+                    path: parent.path.join(file_name),
+                    ..parent
+                })
+                .or_else(|| project.find_project_path(&path, cx))
+                .ok_or_else(|| "Can't create file".to_string())?;
 
-            new_file_path.ok_or_else(|| "Can't create file".to_string())
+            if project_path.path.ancestors().any(|ancestor| {
+                let path = ProjectPath {
+                    path: ancestor.into(),
+                    ..project_path.clone()
+                };
+                project
+                    .entry_for_path(&path, cx)
+                    .is_some_and(|entry| !entry.is_dir())
+            }) {
+                return Err("Can't create file: parent is not a directory".to_string());
+            }
+
+            Ok(project_path)
         }
     }
 }

--- a/crates/agent/src/tools/edit_session.rs
+++ b/crates/agent/src/tools/edit_session.rs
@@ -1100,22 +1100,28 @@ fn resolve_path(
                 .and_then(|file_name| RelPath::unix(file_name).ok())
                 .ok_or_else(|| "Can't create file: invalid filename".to_string())?;
 
-            let project_path = project
+            let parent_project_path = project
                 .find_project_path(&parent_path, cx)
-                .map(|parent| ProjectPath {
-                    path: parent.path.join(file_name),
-                    ..parent
-                })
-                .or_else(|| project.find_project_path(&path, cx))
-                .ok_or_else(|| "Can't create file".to_string())?;
+                .ok_or_else(|| "Can't create file: path is not inside a worktree".to_string())?;
 
-            if project_path.path.ancestors().any(|ancestor| {
-                let path = ProjectPath {
+            let worktree_id = parent_project_path.worktree_id;
+            let project_path = ProjectPath {
+                worktree_id,
+                path: parent_project_path.path.join(file_name),
+            };
+
+            // Walk only the *ancestors* of the new file (skip the file path itself,
+            // since we already established above that it doesn't exist). The underlying
+            // `fs.save` will `create_dir_all` any missing intermediate directories, so
+            // we just need to reject the case where some ancestor already exists as a
+            // non-directory and would block creation.
+            if project_path.path.ancestors().skip(1).any(|ancestor| {
+                let ancestor_path = ProjectPath {
+                    worktree_id,
                     path: ancestor.into(),
-                    ..project_path.clone()
                 };
                 project
-                    .entry_for_path(&path, cx)
+                    .entry_for_path(&ancestor_path, cx)
                     .is_some_and(|entry| !entry.is_dir())
             }) {
                 return Err("Can't create file: parent is not a directory".to_string());

--- a/crates/agent/src/tools/write_file_tool.rs
+++ b/crates/agent/src/tools/write_file_tool.rs
@@ -480,6 +480,14 @@ mod tests {
 
         let result = test_resolve_path(&mode, "root/dir/nonexistent_dir/new.txt", cx);
         assert_resolved_path_eq(result.await, rel_path("dir/nonexistent_dir/new.txt"));
+
+        // An existing file in the middle of the path blocks creation, even though
+        // intermediate directories would otherwise be auto-created.
+        let result = test_resolve_path(&mode, "root/dir/subdir/existing.txt/new.txt", cx);
+        assert_eq!(
+            result.await.unwrap_err(),
+            "Can't create file: parent is not a directory"
+        );
     }
 
     #[gpui::test]

--- a/crates/agent/src/tools/write_file_tool.rs
+++ b/crates/agent/src/tools/write_file_tool.rs
@@ -301,6 +301,36 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_streaming_write_create_file_with_missing_parent_directories(
+        cx: &mut TestAppContext,
+    ) {
+        let (write_tool, _project, _action_log, fs, _thread) = setup_test(cx, json!({})).await;
+        let result = cx
+            .update(|cx| {
+                write_tool.clone().run(
+                    ToolInput::resolved(WriteFileToolInput {
+                        path: "root/foo/bar/new_file.txt".into(),
+                        content: "Hello, World!".into(),
+                    }),
+                    ToolCallEventStream::test().0,
+                    cx,
+                )
+            })
+            .await;
+
+        let EditSessionOutput::Success { new_text, .. } = result.unwrap() else {
+            panic!("expected success");
+        };
+        assert_eq!(new_text, "Hello, World!");
+        assert_eq!(
+            fs.load(path!("/root/foo/bar/new_file.txt").as_ref())
+                .await
+                .unwrap(),
+            "Hello, World!"
+        );
+    }
+
+    #[gpui::test]
     async fn test_streaming_write_overwrite_file(cx: &mut TestAppContext) {
         let (write_tool, _project, _action_log, _fs, _thread) =
             setup_test(cx, json!({"file.txt": "old content"})).await;
@@ -449,10 +479,7 @@ mod tests {
         );
 
         let result = test_resolve_path(&mode, "root/dir/nonexistent_dir/new.txt", cx);
-        assert_eq!(
-            result.await.unwrap_err(),
-            "Can't create file: parent directory doesn't exist"
-        );
+        assert_resolved_path_eq(result.await, rel_path("dir/nonexistent_dir/new.txt"));
     }
 
     #[gpui::test]


### PR DESCRIPTION
Previously, the agent's `write_file` / `edit_file` tools rejected paths whose parent directory didn't already exist, forcing the model to call `create_directory` first. This change lets the tools create any missing intermediate directories automatically (the underlying `Fs::save` already does `create_dir_all` on the parent). Paths where some ancestor exists as a regular file are still rejected.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Agent: `write_file` and `edit_file` now automatically create missing parent directories when writing a new file
