### PR TITLE
settings_ui: Fix skills link

### DIFF
--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7487,7 +7487,7 @@ fn ai_page(cx: &App) -> SettingsPage {
             SettingsPageItem::SubPageLink(SubPageLink {
                 title: "Skills".into(),
                 r#type: Default::default(),
-                json_path: None,
+                json_path: Some("agent.skills"),
                 description: Some("View and manage agent skills installed globally or in project worktrees.".into()),
                 in_json: false,
                 files: USER | PROJECT,


### PR DESCRIPTION
This PR ensures clicking to copy the skills link in the settings UI works properly.

Release Notes:

- N/A
