### PR TITLE
Diff LSP format responses that replace the whole buffer

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2399,7 +2399,7 @@ impl LocalLspStore {
 
         let lsp_edits = if matches!(formatting_provider, Some(p) if *p != OneOf::Left(false)) {
             let _timer = zlog::time!(logger => "format-full");
-            language_server
+            let response = language_server
                 .request::<lsp::request::Formatting>(
                     lsp::DocumentFormattingParams {
                         text_document,
@@ -2409,7 +2409,64 @@ impl LocalLspStore {
                     request_timeout,
                 )
                 .await
-                .into_response()?
+                .into_response()?;
+
+            let Some(edits) = response else {
+                return Ok(Vec::with_capacity(0));
+            };
+
+            match edits.len() {
+                0 => None,
+                1 => {
+                    let text_edit = &edits[0];
+
+                    let te_start = text_edit.range.start;
+                    let te_end = text_edit.range.end;
+                    let buf_end = buffer.update(cx, |buffer, _| {
+                        let rope = buffer.as_rope();
+                        let endpos = rope.max_point();
+                        (endpos.row, endpos.column)
+                    });
+
+                    let did_replace_whole_buffer = te_start.line == 0
+                        && te_start.character == 0
+                        && te_end.line == buf_end.0
+                        && te_end.character == buf_end.1;
+
+                    if !did_replace_whole_buffer {
+                        Some(edits)
+                    } else {
+                        // prevents scrolling to the bottom of the buffer every format
+                        let diff = buffer
+                            .update(cx, |buffer, cx| buffer.diff(text_edit.new_text.clone(), cx))
+                            .await;
+                        Some(buffer.update(cx, |buffer, _| {
+                            let rope = buffer.as_rope();
+                            diff.edits
+                                .iter()
+                                .map(|(range, text)| {
+                                    let start_point = rope.offset_to_point(range.start);
+                                    let end_point = rope.offset_to_point(range.end);
+                                    TextEdit {
+                                        range: lsp::Range {
+                                            start: lsp::Position {
+                                                line: start_point.row,
+                                                character: start_point.column,
+                                            },
+                                            end: lsp::Position {
+                                                line: end_point.row,
+                                                character: end_point.column,
+                                            },
+                                        },
+                                        new_text: text.to_string(),
+                                    }
+                                })
+                                .collect::<Vec<TextEdit>>()
+                        }))
+                    }
+                }
+                _ => Some(edits),
+            }
         } else if matches!(range_formatting_provider, Some(p) if *p != OneOf::Left(false)) {
             let _timer = zlog::time!(logger => "format-range");
             let buffer_start = lsp::Position::new(0, 0);


### PR DESCRIPTION
#29120: https://github.com/zed-industries/zed/issues/29120#issuecomment-2819789736

On format, some language servers, rather than responding with ranges to change, just send a response to replace the entire buffer. This PR makes it so that when this happens, it first diffs the buffer with the new text to replace ranges instead.

This fixes a bug where formatting would select the whole document and scroll all the way to the bottom

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior -- I couldn't figure out how to test lsp things. I checked existing tests, but as far as I searched there wasn't anything like that
- [ ] Performance impact has been considered and is acceptable -- it does Vec iteration and some String copying which I believe is okay but I haven't tried it on huge unformatted documents

Closes #29120, closes #41184