### PR TITLE
go: Fix table test detection in large files

### DIFF
--- a/crates/grammars/src/go/runnables.scm
+++ b/crates/grammars/src/go/runnables.scm
@@ -85,24 +85,26 @@
           (#eq? @_key_type "string"))
       ]
       body: (literal_value
-        [
+        ([
           (literal_element
             (literal_value
-              (keyed_element
+              ((keyed_element
                 (literal_element
                   (identifier) @_field_name)
                 (literal_element
                   [
                     (interpreted_string_literal) @run @_table_test_case_name
                     (raw_string_literal) @run @_table_test_case_name
-                  ]))))
+                  ]))
+                ","?)+))
           (keyed_element
             (literal_element
               [
                 (interpreted_string_literal) @run @_table_test_case_name
                 (raw_string_literal) @run @_table_test_case_name
               ]))
-        ]))))
+        ] @run_item
+          ","?)+))))
   (for_statement
     (range_clause
       left: (expression_list
@@ -127,8 +129,7 @@
                 (selector_expression
                   operand: (identifier) @_tc_var
                   (#eq? @_tc_var @_loop_var_inner)
-                  field: (field_identifier) @_field_check
-                  (#eq? @_field_check @_field_name))
+                  field: (field_identifier) @_field_check)
                 (identifier) @_arg_var
                 (#eq? @_arg_var @_loop_var_outer)
               ]
@@ -162,24 +163,26 @@
           (#eq? @_key_type "string"))
       ]
       body: (literal_value
-        [
+        ([
           (literal_element
             (literal_value
-              (keyed_element
+              ((keyed_element
                 (literal_element
                   (identifier) @_field_name)
                 (literal_element
                   [
                     (interpreted_string_literal) @run @_table_test_case_name
                     (raw_string_literal) @run @_table_test_case_name
-                  ]))))
+                  ]))
+                ","?)+))
           (keyed_element
             (literal_element
               [
                 (interpreted_string_literal) @run @_table_test_case_name
                 (raw_string_literal) @run @_table_test_case_name
               ]))
-        ])))
+        ] @run_item
+          ","?)+)))
   body: (block
     (statement_list
       (expression_statement
@@ -194,8 +197,7 @@
               (selector_expression
                 operand: (identifier) @_tc_var
                 (#eq? @_tc_var @_loop_var_inner)
-                field: (field_identifier) @_field_check
-                (#eq? @_field_check @_field_name))
+                field: (field_identifier) @_field_check)
               (identifier) @_arg_var
               (#eq? @_arg_var @_loop_var_outer)
             ]

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -586,6 +586,53 @@ fn adjust_runs(
 
 pub(crate) struct GoContextProvider;
 
+pub(crate) struct GoRunnableResolver;
+
+impl RunnableResolver for GoRunnableResolver {
+    fn resolve(
+        &self,
+        local_captures: &[RunnableMatchCapture],
+        shared_captures: &[RunnableMatchCapture],
+        buffer: &BufferSnapshot,
+    ) -> Option<ResolvedRunnable> {
+        const FIELD_CHECK: &str = "_field_check";
+        const FIELD_NAME: &str = "_field_name";
+        const TABLE_TEST_CASE_NAME: &str = "_table_test_case_name";
+
+        // A row may declare several string fields (e.g. `{ name: "x", label: "y" }`), so
+        // the query emits one `@_field_name` + `@run` pair per field, in source order.
+        //
+        // When the loop body calls `t.Run(tc.<field>, ...)`, `@_field_check` names that
+        // field; pick the pair whose `@_field_name` matches it. Without a `@_field_check`
+        // (e.g. map-keyed tables) the first pair wins.
+        let reference_text = shared_captures
+            .iter()
+            .find(|capture| capture.name() == Some(FIELD_CHECK))
+            .map(|capture| buffer.text_for_range(capture.range()).collect::<String>());
+        let pair_index = match &reference_text {
+            Some(reference) => local_captures
+                .iter()
+                .filter(|capture| capture.name() == Some(FIELD_NAME))
+                .position(|capture| buffer.text_for_range(capture.range()).equals_str(reference))?,
+            None => 0,
+        };
+
+        // `@run` and `@_table_test_case_name` tag the same string literal, so the chosen
+        // run's text is the case name.
+        let run_capture = local_captures
+            .iter()
+            .filter(|capture| capture.is_run())
+            .nth(pair_index)?;
+        Some(ResolvedRunnable {
+            run_range: run_capture.range(),
+            extra_captures: smallvec::smallvec![(
+                TABLE_TEST_CASE_NAME.to_string(),
+                buffer.text_for_range(run_capture.range()).collect(),
+            )],
+        })
+    }
+}
+
 const GO_PACKAGE_TASK_VARIABLE: VariableName = VariableName::Custom(Cow::Borrowed("GO_PACKAGE"));
 const GO_MODULE_ROOT_TASK_VARIABLE: VariableName =
     VariableName::Custom(Cow::Borrowed("GO_MODULE_ROOT"));
@@ -864,6 +911,10 @@ impl ContextProvider for GoContextProvider {
             },
         ])))
     }
+
+    fn runnable_resolver(&self) -> Option<Arc<dyn RunnableResolver>> {
+        Some(Arc::new(GoRunnableResolver))
+    }
 }
 
 fn extract_subtest_name(input: &str) -> Option<String> {
@@ -894,10 +945,19 @@ mod tests {
     use gpui::{AppContext, Hsla, TestAppContext};
     use theme::SyntaxTheme;
 
+    fn go_language() -> Arc<Language> {
+        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        Arc::new(
+            Arc::try_unwrap(language)
+                .unwrap()
+                .with_context_provider(Some(Arc::new(GoContextProvider))),
+        )
+    }
+
     #[gpui::test]
     async fn test_go_label_for_completion() {
         let adapter = Arc::new(GoLspAdapter);
-        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        let language = go_language();
 
         let theme = SyntaxTheme::new_test([
             ("type", Hsla::default()),
@@ -985,7 +1045,7 @@ mod tests {
 
     #[gpui::test]
     fn test_go_test_main_ignored(cx: &mut TestAppContext) {
-        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        let language = go_language();
 
         let example_test = r#"
         package main
@@ -1019,7 +1079,7 @@ mod tests {
 
     #[gpui::test]
     fn test_testify_suite_detection(cx: &mut TestAppContext) {
-        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        let language = go_language();
 
         let testify_suite = r#"
         package main
@@ -1072,7 +1132,7 @@ mod tests {
 
     #[gpui::test]
     fn test_go_runnable_detection(cx: &mut TestAppContext) {
-        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        let language = go_language();
 
         let interpreted_string_subtest = r#"
         package main
@@ -1161,7 +1221,7 @@ mod tests {
 
     #[gpui::test]
     fn test_go_example_test_detection(cx: &mut TestAppContext) {
-        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        let language = go_language();
 
         let example_test = r#"
         package main
@@ -1198,7 +1258,7 @@ mod tests {
 
     #[gpui::test]
     fn test_go_table_test_slice_detection(cx: &mut TestAppContext) {
-        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        let language = go_language();
 
         let table_test = r#"
         package main
@@ -1272,27 +1332,54 @@ mod tests {
         );
 
         let go_test_count = tag_strings.iter().filter(|&tag| tag == "go-test").count();
-        // This is currently broken; see #39148
-        // let go_table_test_count = tag_strings
-        //     .iter()
-        //     .filter(|&tag| tag == "go-table-test-case")
-        //     .count();
+        let go_table_test_count = tag_strings
+            .iter()
+            .filter(|&tag| tag == "go-table-test-case")
+            .count();
 
         assert!(
             go_test_count == 1,
             "Should find exactly 1 go-test, found: {}",
             go_test_count
         );
-        // assert!(
-        //     go_table_test_count == 3,
-        //     "Should find exactly 3 go-table-test-case, found: {}",
-        //     go_table_test_count
-        // );
+        assert!(
+            go_table_test_count == 3,
+            "Should find exactly 3 go-table-test-case, found: {}",
+            go_table_test_count
+        );
+
+        let Some(first_case_offset) = table_test.find("anotherStr: \"foo\"") else {
+            panic!("missing first table test case");
+        };
+        let first_case_offset = first_case_offset + "anotherStr".len();
+        let first_case_runnables: Vec<_> = buffer.update(cx, |buffer, _| {
+            let snapshot = buffer.snapshot();
+            snapshot
+                .runnable_ranges(first_case_offset..first_case_offset)
+                .collect()
+        });
+        let table_test_case_names: Vec<_> = first_case_runnables
+            .iter()
+            .filter(|runnable| {
+                runnable
+                    .runnable
+                    .tags
+                    .iter()
+                    .any(|tag| tag.0 == "go-table-test-case")
+            })
+            .filter_map(|runnable| runnable.extra_captures.get("_table_test_case_name"))
+            .collect();
+
+        assert_eq!(
+            table_test_case_names,
+            vec!["\"test case 1\""],
+            "Should only return the table test case containing the requested range"
+        );
     }
 
     #[gpui::test]
     fn test_go_table_test_slice_without_explicit_variable_detection(cx: &mut TestAppContext) {
-        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        let language = go_language();
 
         let table_test = r#"
         package main
@@ -1351,17 +1438,26 @@ mod tests {
         );
 
         let go_test_count = tag_strings.iter().filter(|&tag| tag == "go-test").count();
+        let go_table_test_count = tag_strings
+            .iter()
+            .filter(|&tag| tag == "go-table-test-case-without-explicit-variable")
+            .count();
 
         assert!(
             go_test_count == 1,
             "Should find exactly 1 go-test, found: {}",
             go_test_count
         );
+        assert!(
+            go_table_test_count == 3,
+            "Should find exactly 3 go-table-test-case-without-explicit-variable, found: {}",
+            go_table_test_count
+        );
     }
 
     #[gpui::test]
     fn test_go_table_test_map_without_explicit_variable_detection(cx: &mut TestAppContext) {
-        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        let language = go_language();
 
         let table_test = r#"
         package main
@@ -1435,7 +1531,7 @@ mod tests {
 
     #[gpui::test]
     fn test_go_table_test_slice_ignored(cx: &mut TestAppContext) {
-        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        let language = go_language();
 
         let table_test = r#"
         package main
@@ -1485,7 +1581,7 @@ mod tests {
 
     #[gpui::test]
     fn test_go_table_test_map_detection(cx: &mut TestAppContext) {
-        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        let language = go_language();
 
         let table_test = r#"
         package main
@@ -1574,7 +1670,7 @@ mod tests {
 
     #[gpui::test]
     fn test_go_table_test_map_ignored(cx: &mut TestAppContext) {
-        let language = language("go", tree_sitter_go::LANGUAGE.into());
+        let language = go_language();
 
         let table_test = r#"
         package main
@@ -1619,6 +1715,237 @@ mod tests {
             !tag_strings.contains(&"go-table-test-case".to_string()),
             "Should find go-table-test-case tag, found: {:?}",
             tag_strings
+        );
+    }
+
+    #[gpui::test]
+    fn test_go_table_test_stress(cx: &mut TestAppContext) {
+        let language = go_language();
+
+        let mut entries = String::new();
+        for i in 0..100 {
+            entries.push_str(&format!(
+                "                {{ name: \"case {}\", value: {} }},\n",
+                i, i
+            ));
+        }
+        let table_test = format!(
+            r#"
+        package main
+
+        import "testing"
+
+        func TestStress(t *testing.T) {{
+            testCases := []struct{{
+                name  string
+                value int
+            }}{{
+{entries}            }}
+
+            for _, tc := range testCases {{
+                t.Run(tc.name, func(t *testing.T) {{
+                    _ = tc.value
+                }})
+            }}
+        }}
+        "#,
+            entries = entries
+        );
+
+        let buffer = cx.new(|cx| {
+            crate::Buffer::local(table_test.clone(), cx).with_language(language.clone(), cx)
+        });
+        cx.executor().run_until_parked();
+
+        let runnables: Vec<_> = buffer.update(cx, |buffer, _| {
+            let snapshot = buffer.snapshot();
+            snapshot.runnable_ranges(0..table_test.len()).collect()
+        });
+
+        let tag_strings: Vec<String> = runnables
+            .iter()
+            .flat_map(|r| &r.runnable.tags)
+            .map(|tag| tag.0.to_string())
+            .collect();
+
+        let go_table_test_count = tag_strings
+            .iter()
+            .filter(|&tag| tag == "go-table-test-case")
+            .count();
+
+        assert_eq!(
+            go_table_test_count, 100,
+            "Should emit one go-table-test-case per row (got {}); tree-sitter match_limit overflow has regressed",
+            go_table_test_count
+        );
+    }
+
+    #[gpui::test]
+    fn test_go_table_test_mismatched_field(cx: &mut TestAppContext) {
+        let language = go_language();
+
+        let table_test = r#"
+        package main
+
+        import "testing"
+
+        func TestMismatchedField(t *testing.T) {
+            testCases := []struct{
+                name string
+            }{
+                { name: "test case 1" },
+                { name: "test case 2" },
+            }
+
+            for _, tc := range testCases {
+                t.Run(tc.desc, func(t *testing.T) {
+                    // test code here
+                })
+            }
+        }
+        "#;
+
+        let buffer =
+            cx.new(|cx| crate::Buffer::local(table_test, cx).with_language(language.clone(), cx));
+        cx.executor().run_until_parked();
+
+        let runnables: Vec<_> = buffer.update(cx, |buffer, _| {
+            let snapshot = buffer.snapshot();
+            snapshot.runnable_ranges(0..table_test.len()).collect()
+        });
+
+        let tag_strings: Vec<String> = runnables
+            .iter()
+            .flat_map(|r| &r.runnable.tags)
+            .map(|tag| tag.0.to_string())
+            .collect();
+
+        let go_table_test_count = tag_strings
+            .iter()
+            .filter(|&tag| tag == "go-table-test-case")
+            .count();
+
+        assert_eq!(
+            go_table_test_count, 0,
+            "Should not emit table-test runnables when t.Run uses a missing row field"
+        );
+    }
+
+    #[gpui::test]
+    fn test_go_table_test_slice_picks_correct_field_when_not_first(cx: &mut TestAppContext) {
+        // The subtest-name field `name` is declared AFTER `anotherStr`, but `t.Run(tc.name, ...)`
+        // still selects on `name`. The resolver must match `@_field_check` text to the right
+        // `@_field_name` regardless of source order; "first string field wins" would be a bug.
+        let language = go_language();
+
+        let table_test = r#"
+        package main
+
+        import "testing"
+
+        func TestExample(t *testing.T) {
+            testCases := []struct{
+                anotherStr string
+                name       string
+            }{
+                {
+                    anotherStr: "alpha",
+                    name:       "case alpha",
+                },
+                {
+                    anotherStr: "beta",
+                    name:       "case beta",
+                },
+            }
+
+            for _, tc := range testCases {
+                t.Run(tc.name, func(t *testing.T) {
+                    _ = tc.anotherStr
+                })
+            }
+        }
+        "#;
+
+        let buffer =
+            cx.new(|cx| crate::Buffer::local(table_test, cx).with_language(language.clone(), cx));
+        cx.executor().run_until_parked();
+
+        let case_offset = table_test
+            .find("anotherStr: \"alpha\"")
+            .expect("source should contain the first case body");
+        let first_case_runnables: Vec<_> = buffer.update(cx, |buffer, _| {
+            let snapshot = buffer.snapshot();
+            snapshot.runnable_ranges(case_offset..case_offset).collect()
+        });
+
+        let case_names: Vec<_> = first_case_runnables
+            .iter()
+            .filter(|runnable| {
+                runnable
+                    .runnable
+                    .tags
+                    .iter()
+                    .any(|tag| tag.0 == "go-table-test-case")
+            })
+            .filter_map(|runnable| runnable.extra_captures.get("_table_test_case_name"))
+            .collect();
+
+        assert_eq!(
+            case_names,
+            vec!["\"case alpha\""],
+            "Resolver should pick the field matching `tc.name`, not the first string field"
+        );
+    }
+
+    #[gpui::test]
+    fn test_go_table_test_map_extras_include_case_name(cx: &mut TestAppContext) {
+        let language = go_language();
+
+        let table_test = r#"
+        package main
+
+        import "testing"
+
+        func TestExample(t *testing.T) {
+            testCases := map[string]struct {
+                fail bool
+            }{
+                "test failure": {fail: true},
+                "test success": {fail: false},
+            }
+
+            for name, tc := range testCases {
+                t.Run(name, func(t *testing.T) {
+                    _ = tc.fail
+                })
+            }
+        }
+        "#;
+
+        let buffer =
+            cx.new(|cx| crate::Buffer::local(table_test, cx).with_language(language.clone(), cx));
+        cx.executor().run_until_parked();
+
+        let all_runnables: Vec<_> = buffer.update(cx, |buffer, _| {
+            let snapshot = buffer.snapshot();
+            snapshot.runnable_ranges(0..table_test.len()).collect()
+        });
+        let all_case_names: Vec<_> = all_runnables
+            .iter()
+            .filter(|runnable| {
+                runnable
+                    .runnable
+                    .tags
+                    .iter()
+                    .any(|tag| tag.0 == "go-table-test-case")
+            })
+            .filter_map(|runnable| runnable.extra_captures.get("_table_test_case_name"))
+            .cloned()
+            .collect();
+        assert_eq!(
+            all_case_names,
+            vec!["\"test failure\"", "\"test success\""],
+            "Map-based table tests should surface each row's key as `_table_test_case_name`"
         );
     }
 


### PR DESCRIPTION
Closes #46881

Depends on #57276.

Implements `GoRunnableResolver` to post-process table test matches. The resolver picks the correct string field by comparing against the field used in `t.Run(tc.<field>, ...)`.

Release Notes:

- Fixed Go table tests not showing run buttons in files with many test cases.
