### PR TITLE
docs: Fix skill installation instructions

### DIFF
--- a/docs/src/ai/skills.md
+++ b/docs/src/ai/skills.md
@@ -13,9 +13,9 @@ A skill is a folder containing a `SKILL.md` file with metadata and instructions.
 
 ### Create your own {#create-your-own}
 
-Open the Skill Creator with the {#action assistant::OpenSkillCreator} action. It opens a window where you fill in the skill's name, description, scope (global or project-local), body, and optionally toggle `disable-model-invocation`.
+Zed includes a built-in `create-skill` skill — invoke it with `/create-skill` and the agent walks you through the process.
 
-You can also ask the agent to help. Zed includes a built-in `create-skill` skill — invoke it with `/create-skill` and the agent walks you through the process.
+You can also open the Skill Creator directly with the {#action assistant::OpenSkillCreator} action. It opens a window where you fill in the skill's name, description, scope (global or project-local), body, and optionally toggle `disable-model-invocation`.
 
 See [Skill format](#skill-format) below for the full format reference.
 

--- a/docs/src/ai/skills.md
+++ b/docs/src/ai/skills.md
@@ -27,18 +27,7 @@ See [Skill format](#skill-format) below for the full format reference.
 - [`frontend-design`](https://skills.sh/anthropics/skills/frontend-design): production-grade frontend interfaces with design polish
 - [`pdf`](https://skills.sh/anthropics/skills/pdf): PDF text extraction, merging, splitting, form filling, and OCR
 
-To install a skill from it, copy or clone its folder into your global or project-local skills folder.
-
-For example, to install the `frontend-design` skill from GitHub globally:
-
-```sh
-cd ~/.agents/skills
-git clone --filter=blob:none --sparse https://github.com/anthropics/skills
-cd skills
-git sparse-checkout set frontend-design
-```
-
-For a project-local install, do the same inside your project's `.agents/skills/` folder.
+To install a skill, copy the skill's folder into `~/.agents/skills/` for global use, or into your project's `.agents/skills/` folder for project-local use.
 
 ## Managing Skills {#managing-skills}
 

--- a/docs/src/ai/skills.md
+++ b/docs/src/ai/skills.md
@@ -15,7 +15,7 @@ A skill is a folder containing a `SKILL.md` file with metadata and instructions.
 
 Zed includes a built-in `create-skill` skill — invoke it with `/create-skill` and the agent walks you through the process.
 
-You can also open the Skill Creator directly with the {#action assistant::OpenSkillCreator} action. It opens a window where you fill in the skill's name, description, scope (global or project-local), body, and optionally toggle `disable-model-invocation`.
+You can also open the Skill Creator directly with the {#action agent::OpenSkillCreator} action. It opens a window where you fill in the skill's name, description, scope (global or project-local), body, and optionally toggle `disable-model-invocation`.
 
 See [Skill format](#skill-format) below for the full format reference.
 

--- a/docs/src/ai/skills.md
+++ b/docs/src/ai/skills.md
@@ -11,11 +11,13 @@ A skill is a folder containing a `SKILL.md` file with metadata and instructions.
 
 ## Adding Skills {#adding-skills}
 
-### Create Your Own {#create-your-own}
+### Create your own {#create-your-own}
 
-Zed includes a built-in `create-skill` skill that guides the agent through creating a new skill. Invoke it with `/create-skill`, or let the agent pick it up automatically when you ask it to help create a skill.
+Open the Skill Creator with the {#action assistant::OpenSkillCreator} action. It opens a window where you fill in the skill's name, description, scope (global or project-local), body, and optionally toggle `disable-model-invocation`.
 
-See [Skill format](#skill-format) below for the folder structure and `SKILL.md` reference.
+You can also ask the agent to help. Zed includes a built-in `create-skill` skill — invoke it with `/create-skill` and the agent walks you through the process.
+
+See [Skill format](#skill-format) below for the full format reference.
 
 ### From the skills.sh Registry {#from-the-registry}
 
@@ -37,6 +39,19 @@ git sparse-checkout set frontend-design
 ```
 
 For a project-local install, do the same inside your project's `.agents/skills/` folder.
+
+## Managing Skills {#managing-skills}
+
+Open the Settings Editor (`Cmd+,` on macOS, `Ctrl+,` on Linux/Windows) and navigate to **AI > Skills**, or go directly to [agent.skills](zed://settings/agent.skills).
+
+The **User** tab shows your global skills. The **Project** tab shows skills for the current project.
+
+For each skill you can:
+
+- **Open** — opens the skill's `SKILL.md` file in the editor
+- **Delete** — removes the skill folder from disk
+
+If no skills are installed, the page shows a **Create a Skill** button that opens the Skill Creator.
 
 ## Using Skills {#using-skills}
 


### PR DESCRIPTION
Fixes the skill installation instructions in `docs/src/ai/skills.md`.

The previous steps used a `git sparse-checkout` approach that was inaccurate — the cloned repo would land nested inside the skills folder, and the sparse-checkout path was wrong for repos that store skills in a subdirectory. Replaced with a simple instruction to copy the skill's folder into the appropriate location.

Release Notes:

- N/A