### PR TITLE
ui: Don't panic on invalid highlight indices in `HighlightedLabel`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19196,6 +19196,7 @@ dependencies = [
  "gpui_util",
  "icons",
  "itertools 0.14.0",
+ "log",
  "menu",
  "num-format",
  "schemars 1.0.4",

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -37,5 +37,8 @@ windows.workspace = true
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }
 
+[package.metadata.cargo-machete]
+ignored = ["log"]
+
 [features]
 default = []

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -20,6 +20,7 @@ gpui.workspace = true
 gpui_macros.workspace = true
 icons.workspace = true
 itertools.workspace = true
+log.workspace = true
 menu.workspace = true
 num-format.workspace = true
 schemars.workspace = true

--- a/crates/ui/src/components/label/highlighted_label.rs
+++ b/crates/ui/src/components/label/highlighted_label.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use gpui::{FontWeight, HighlightStyle, StyleRefinement, StyledText};
+use gpui_util::debug_panic;
 
 use crate::{LabelCommon, LabelLike, LabelSize, LineHeightStyle, prelude::*};
 
@@ -14,14 +15,21 @@ pub struct HighlightedLabel {
 impl HighlightedLabel {
     /// Constructs a label with the given characters highlighted.
     /// Characters are identified by UTF-8 byte position.
-    pub fn new(label: impl Into<SharedString>, highlight_indices: Vec<usize>) -> Self {
+    #[track_caller]
+    pub fn new(label: impl Into<SharedString>, mut highlight_indices: Vec<usize>) -> Self {
         let label = label.into();
-        for &run in &highlight_indices {
-            assert!(
-                label.is_char_boundary(run),
-                "highlight index {run} is not a valid UTF-8 boundary"
+
+        if let Some(index) = highlight_indices
+            .iter()
+            .find(|&i| !label.is_char_boundary(*i))
+        {
+            let location = std::panic::Location::caller();
+            debug_panic!(
+                "highlight index {index} is not a valid UTF-8 boundary (called from {location})"
             );
+            highlight_indices.clear();
         }
+
         Self {
             base: LabelLike::new(),
             label,


### PR DESCRIPTION
HighlightedLabel would crash the application if any provided highlight index was invalid. In theory, this should never happen. In practice, this can happen due to race conditions at call sites.

After this change, we only panic in debug builds. In release builds, we log an error and return a label with no highlights. The error message includes the call site so that it's easier to fix the root cause.

Related to #57290

Part of FR-11.

Release Notes:

- N/A
