### PR TITLE
google_ai: Support Gemini 3.5 Flash

### DIFF
--- a/crates/google_ai/src/completion.rs
+++ b/crates/google_ai/src/completion.rs
@@ -65,6 +65,7 @@ pub fn into_google(
                         function_call: crate::FunctionCall {
                             name: tool_use.name.to_string(),
                             args: tool_use.input,
+                            id: Some(tool_use.id.to_string()),
                         },
                         thought_signature,
                     })]
@@ -99,6 +100,7 @@ pub fn into_google(
                             response: serde_json::json!({
                                 "output": output
                             }),
+                            id: Some(tool_result.tool_use_id.to_string()),
                         },
                     })];
                     parts.extend(images.into_iter().map(Part::InlineDataPart));
@@ -147,10 +149,30 @@ pub fn into_google(
             candidate_count: Some(1),
             stop_sequences: Some(request.stop),
             max_output_tokens: None,
-            temperature: request.temperature.map(|t| t as f64).or(Some(1.0)),
+            temperature: request.temperature.map(|t| t as f64),
             thinking_config: match (request.thinking_allowed, mode) {
                 (true, GoogleModelMode::Thinking { budget_tokens }) => {
-                    budget_tokens.map(|thinking_budget| ThinkingConfig { thinking_budget })
+                    let effort = request.thinking_effort.as_deref().map(|s| s.to_lowercase());
+                    let thinking_level = match effort.as_deref() {
+                        Some("high") => Some(crate::ThinkingLevel::High),
+                        Some("medium") => Some(crate::ThinkingLevel::Medium),
+                        Some("low") => Some(crate::ThinkingLevel::Low),
+                        Some("minimal") => Some(crate::ThinkingLevel::Minimal),
+                        _ => None,
+                    };
+
+                    Some(ThinkingConfig {
+                        thinking_budget: budget_tokens,
+                        thinking_level,
+                    })
+                    .filter(
+                        |ThinkingConfig {
+                             thinking_budget,
+                             thinking_level,
+                         }| {
+                            thinking_level.is_some() || thinking_budget.is_some()
+                        },
+                    )
                 }
                 _ => None,
             },
@@ -272,10 +294,14 @@ impl GoogleEventMapper {
                         Part::FunctionCallPart(function_call_part) => {
                             wants_to_use_tool = true;
                             let name: Arc<str> = function_call_part.function_call.name.into();
-                            let next_tool_id =
-                                TOOL_CALL_COUNTER.fetch_add(1, atomic::Ordering::SeqCst);
                             let id: LanguageModelToolUseId =
-                                format!("{}-{}", name, next_tool_id).into();
+                                if let Some(ref call_id) = function_call_part.function_call.id {
+                                    call_id.clone().into()
+                                } else {
+                                    let next_tool_id =
+                                        TOOL_CALL_COUNTER.fetch_add(1, atomic::Ordering::SeqCst);
+                                    format!("{}-{}", name, next_tool_id).into()
+                                };
 
                             // Normalize empty string signatures to None
                             let thought_signature = function_call_part
@@ -370,6 +396,7 @@ mod tests {
                         function_call: FunctionCall {
                             name: "test_function".to_string(),
                             args: json!({"arg": "value"}),
+                            id: None,
                         },
                         thought_signature: Some("test_signature_123".to_string()),
                     })],
@@ -410,6 +437,7 @@ mod tests {
                         function_call: FunctionCall {
                             name: "test_function".to_string(),
                             args: json!({"arg": "value"}),
+                            id: None,
                         },
                         thought_signature: None,
                     })],
@@ -446,6 +474,7 @@ mod tests {
                         function_call: FunctionCall {
                             name: "test_function".to_string(),
                             args: json!({"arg": "value"}),
+                            id: None,
                         },
                         thought_signature: Some("".to_string()),
                     })],

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -264,7 +264,19 @@ pub struct UsageMetadata {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ThinkingConfig {
-    pub thinking_budget: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_budget: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_level: Option<ThinkingLevel>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ThinkingLevel {
+    Minimal,
+    Low,
+    Medium,
+    High,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -352,12 +364,16 @@ pub struct SafetyRating {
 pub struct FunctionCall {
     pub name: String,
     pub args: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FunctionResponse {
     pub name: String,
     pub response: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -469,6 +485,8 @@ pub enum Model {
     Gemini31FlashLite,
     #[serde(rename = "gemini-3-flash-preview")]
     Gemini3Flash,
+    #[serde(rename = "gemini-3.5-flash")]
+    Gemini35Flash,
     #[serde(rename = "gemini-3.1-pro-preview", alias = "gemini-3-pro-preview")]
     Gemini31Pro,
     #[serde(rename = "custom")]
@@ -494,6 +512,7 @@ impl Model {
             Self::Gemini25Pro => "gemini-2.5-pro",
             Self::Gemini31FlashLite => "gemini-3.1-flash-lite",
             Self::Gemini3Flash => "gemini-3-flash-preview",
+            Self::Gemini35Flash => "gemini-3.5-flash",
             Self::Gemini31Pro => "gemini-3.1-pro-preview",
             Self::Custom { name, .. } => name,
         }
@@ -505,6 +524,7 @@ impl Model {
             Self::Gemini25Pro => "gemini-2.5-pro",
             Self::Gemini31FlashLite => "gemini-3.1-flash-lite",
             Self::Gemini3Flash => "gemini-3-flash-preview",
+            Self::Gemini35Flash => "gemini-3.5-flash",
             Self::Gemini31Pro => "gemini-3.1-pro-preview",
             Self::Custom { name, .. } => name,
         }
@@ -517,6 +537,7 @@ impl Model {
             Self::Gemini25Pro => "Gemini 2.5 Pro",
             Self::Gemini31FlashLite => "Gemini 3.1 Flash Lite",
             Self::Gemini3Flash => "Gemini 3 Flash",
+            Self::Gemini35Flash => "Gemini 3.5 Flash",
             Self::Gemini31Pro => "Gemini 3.1 Pro",
             Self::Custom {
                 name, display_name, ..
@@ -531,6 +552,7 @@ impl Model {
             | Self::Gemini25Pro
             | Self::Gemini31FlashLite
             | Self::Gemini3Flash
+            | Self::Gemini35Flash
             | Self::Gemini31Pro => 1_048_576,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
@@ -543,6 +565,7 @@ impl Model {
             | Model::Gemini25Pro
             | Model::Gemini31FlashLite
             | Model::Gemini3Flash
+            | Model::Gemini35Flash
             | Model::Gemini31Pro => Some(65_536),
             Model::Custom { .. } => None,
         }
@@ -567,6 +590,9 @@ impl Model {
             }
             Self::Gemini3Flash => GoogleModelMode::Default,
             Self::Gemini31FlashLite => GoogleModelMode::Default,
+            Self::Gemini35Flash => GoogleModelMode::Thinking {
+                budget_tokens: None,
+            },
             Self::Gemini31Pro => GoogleModelMode::Thinking {
                 budget_tokens: None,
             },
@@ -592,6 +618,7 @@ mod tests {
             function_call: FunctionCall {
                 name: "test_function".to_string(),
                 args: json!({"arg": "value"}),
+                id: None,
             },
             thought_signature: Some("test_signature".to_string()),
         };
@@ -609,6 +636,7 @@ mod tests {
             function_call: FunctionCall {
                 name: "test_function".to_string(),
                 args: json!({"arg": "value"}),
+                id: None,
             },
             thought_signature: None,
         };
@@ -658,6 +686,7 @@ mod tests {
             function_call: FunctionCall {
                 name: "test_function".to_string(),
                 args: json!({"arg": "value", "nested": {"key": "val"}}),
+                id: None,
             },
             thought_signature: Some("round_trip_signature".to_string()),
         };
@@ -676,6 +705,7 @@ mod tests {
             function_call: FunctionCall {
                 name: "test_function".to_string(),
                 args: json!({"arg": "value"}),
+                id: None,
             },
             thought_signature: Some("".to_string()),
         };


### PR DESCRIPTION
Implements the [official upgrade instructions](https://ai.google.dev/gemini-api/docs/whats-new-gemini-3.5#migrate-from-3-flash-preview) for Gemini 3.5 Flash, and adds BYOK support.

The changes about thinking_level and temperature apply to our situation, but they are only recommendations, and we have to support older models, so I preferred not trying to force the preferred / remove the discouraged parameters for now.

`temperature` becomes optional - we don't fill in a default anymore, since passing it is now discouraged.

This commit also adds support for `thinking_level`, since it is now preferred to `thinking_budget`.

`FunctionCall` and `FunctionResponse` now support passing an `id` to properly maintain chain-of-thought preservation and match execution IDs across turns. When resolving incoming tool uses, the mapper prefers the execution ID returned by Gemini, falling back to sequential naming in other scenarios.

Release Notes:

- Added support for Gemini 3.5 Flash in the Google AI model provider.