### PR TITLE
Fix scrollbar track clicks in project panel and settings

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -62,7 +62,7 @@ use theme_settings::ThemeSettings;
 use ui::{
     Color, ContextMenu, ContextMenuEntry, DecoratedIcon, Icon, IconDecoration, IconDecorationKind,
     IndentGuideColors, IndentGuideLayout, Indicator, KeyBinding, Label, LabelSize, ListItem,
-    ListItemSpacing, ProjectEmptyState, ScrollAxes, ScrollableHandle, Scrollbars, StickyCandidate,
+    ListItemSpacing, ProjectEmptyState, ScrollableHandle, Scrollbars, StickyCandidate,
     Tooltip, WithScrollbar, prelude::*, v_flex,
 };
 use util::{
@@ -7087,15 +7087,9 @@ impl Render for ProjectPanel {
                 )
                 .custom_scrollbars(
                     {
-                        let mut scrollbars =
-                            Scrollbars::for_settings::<ProjectPanelScrollbarProxy>()
-                                .tracked_scroll_handle(&self.scroll_handle)
-                                .with_overlay_track_along(ScrollAxes::Vertical);
-                        if horizontal_scroll {
-                            scrollbars =
-                                scrollbars.with_overlay_track_along(ScrollAxes::Horizontal);
-                        }
-                        scrollbars.notify_content()
+                        Scrollbars::for_settings::<ProjectPanelScrollbarProxy>()
+                            .tracked_scroll_handle(&self.scroll_handle)
+                            .notify_content()
                     },
                     window,
                     cx,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -7089,12 +7089,11 @@ impl Render for ProjectPanel {
                     {
                         let mut scrollbars =
                             Scrollbars::for_settings::<ProjectPanelScrollbarProxy>()
-                                .tracked_scroll_handle(&self.scroll_handle);
+                                .tracked_scroll_handle(&self.scroll_handle)
+                                .with_overlay_track_along(ScrollAxes::Vertical);
                         if horizontal_scroll {
-                            scrollbars = scrollbars.with_track_along(
-                                ScrollAxes::Horizontal,
-                                cx.theme().colors().panel_background,
-                            );
+                            scrollbars =
+                                scrollbars.with_overlay_track_along(ScrollAxes::Horizontal);
                         }
                         scrollbars.notify_content()
                     },

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -3477,12 +3477,19 @@ impl SettingsWindow {
                 window.focus_prev(cx);
             }))
             .when(current_sub_page.is_none(), |this| {
-                this.vertical_scrollbar_for(&self.list_state, window, cx)
+                this.custom_scrollbars(
+                    Scrollbars::new(ui::ScrollAxes::Vertical)
+                        .tracked_scroll_handle(&self.list_state)
+                        .with_overlay_track_along(ui::ScrollAxes::Vertical),
+                    window,
+                    cx,
+                )
             })
             .when_some(current_sub_page, |this, current_sub_page| {
                 this.custom_scrollbars(
                     Scrollbars::new(ui::ScrollAxes::Vertical)
                         .tracked_scroll_handle(&current_sub_page.scroll_handle)
+                        .with_overlay_track_along(ui::ScrollAxes::Vertical)
                         .id((current_sub_page.link.title.clone(), 42)),
                     window,
                     cx,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -3477,19 +3477,12 @@ impl SettingsWindow {
                 window.focus_prev(cx);
             }))
             .when(current_sub_page.is_none(), |this| {
-                this.custom_scrollbars(
-                    Scrollbars::new(ui::ScrollAxes::Vertical)
-                        .tracked_scroll_handle(&self.list_state)
-                        .with_overlay_track_along(ui::ScrollAxes::Vertical),
-                    window,
-                    cx,
-                )
+                this.vertical_scrollbar_for(&self.list_state, window, cx)
             })
             .when_some(current_sub_page, |this, current_sub_page| {
                 this.custom_scrollbars(
                     Scrollbars::new(ui::ScrollAxes::Vertical)
                         .tracked_scroll_handle(&current_sub_page.scroll_handle)
-                        .with_overlay_track_along(ui::ScrollAxes::Vertical)
                         .id((current_sub_page.link.title.clone(), 42)),
                     window,
                     cx,

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -785,21 +785,26 @@ impl<T: ScrollableHandle> ScrollbarState<T> {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.set_thumb_state(
-            if let Some(&ScrollbarLayout { axis, .. }) =
-                self.last_prepaint_state.as_ref().and_then(|state| {
-                    state
-                        .thumb_for_position(position)
-                        .filter(|thumb| thumb.cursor_hitbox.is_hovered(window))
-                })
-            {
-                ThumbState::Hover(axis)
-            } else {
-                ThumbState::Inactive
-            },
-            window,
-            cx,
-        );
+        let thumb_state = if let Some(&ScrollbarLayout { axis, .. }) =
+            self.last_prepaint_state.as_ref().and_then(|state| {
+                state
+                    .thumb_for_position(position)
+                    .filter(|thumb| thumb.cursor_hitbox.is_hovered(window))
+            }) {
+            ThumbState::Hover(axis)
+        } else if let Some(&ScrollbarLayout { axis, .. }) =
+            self.last_prepaint_state.as_ref().and_then(|state| {
+                state
+                    .thumbs
+                    .iter()
+                    .find(|thumb| thumb.cursor_hitbox.is_hovered(window))
+            })
+        {
+            ThumbState::Hover(axis)
+        } else {
+            ThumbState::Inactive
+        };
+        self.set_thumb_state(thumb_state, window, cx);
     }
 
     fn set_thumb_state(&mut self, state: ThumbState, window: &mut Window, cx: &mut Context<Self>) {
@@ -835,9 +840,13 @@ impl<T: ScrollableHandle> ScrollbarState<T> {
     }
 
     fn parent_hovered(&self, window: &Window) -> bool {
-        self.last_prepaint_state
-            .as_ref()
-            .is_some_and(|state| state.parent_bounds_hitbox.is_hovered(window))
+        self.last_prepaint_state.as_ref().is_some_and(|state| {
+            state.parent_bounds_hitbox.is_hovered(window)
+                || state
+                    .thumbs
+                    .iter()
+                    .any(|thumb| thumb.cursor_hitbox.is_hovered(window))
+        })
     }
 
     fn hit_for_position(&self, position: &Point<Pixels>) -> Option<&ScrollbarLayout> {

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -321,7 +321,6 @@ enum ReservedSpace {
     None,
     Thumb,
     Track,
-    OverlayTrack,
     StableTrack,
 }
 
@@ -331,7 +330,7 @@ impl ReservedSpace {
     }
 
     fn needs_scroll_track(&self) -> bool {
-        matches!(self, Self::Track | Self::OverlayTrack | Self::StableTrack)
+        matches!(self, Self::Thumb | Self::Track | Self::StableTrack)
     }
 
     fn needs_space_reserved(&self, max_offset: Pixels) -> bool {
@@ -471,11 +470,6 @@ impl<ScrollHandle: ScrollableHandle> Scrollbars<ScrollHandle> {
     pub fn with_track_along(mut self, along: ScrollAxes, background_color: Hsla) -> Self {
         self.visibility = along.apply_to(self.visibility, ReservedSpace::Track);
         self.track_color = Some(background_color);
-        self
-    }
-
-    pub fn with_overlay_track_along(mut self, along: ScrollAxes) -> Self {
-        self.visibility = along.apply_to(self.visibility, ReservedSpace::OverlayTrack);
         self
     }
 

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -321,6 +321,7 @@ enum ReservedSpace {
     None,
     Thumb,
     Track,
+    OverlayTrack,
     StableTrack,
 }
 
@@ -330,7 +331,7 @@ impl ReservedSpace {
     }
 
     fn needs_scroll_track(&self) -> bool {
-        matches!(self, Self::Track | Self::StableTrack)
+        matches!(self, Self::Track | Self::OverlayTrack | Self::StableTrack)
     }
 
     fn needs_space_reserved(&self, max_offset: Pixels) -> bool {
@@ -470,6 +471,11 @@ impl<ScrollHandle: ScrollableHandle> Scrollbars<ScrollHandle> {
     pub fn with_track_along(mut self, along: ScrollAxes, background_color: Hsla) -> Self {
         self.visibility = along.apply_to(self.visibility, ReservedSpace::Track);
         self.track_color = Some(background_color);
+        self
+    }
+
+    pub fn with_overlay_track_along(mut self, along: ScrollAxes) -> Self {
+        self.visibility = along.apply_to(self.visibility, ReservedSpace::OverlayTrack);
         self
     }
 


### PR DESCRIPTION
Add `ReservedSpace::OverlayTrack` to the scrollbar component: a track hitbox that intercepts clicks without reserving layout space. This differs from `Track` (reserves padding when scrollable) and `StableTrack` (always reserves padding).

Project panel previously had no vertical track, so clicks below/above the scrollbar thumb fell through to tree items. Settings used `Thumb`-only, so track clicks did nothing and fell through to settings items. Both now use `with_overlay_track_along` so track clicks scroll correctly without causing layout asymmetry.

https://github.com/user-attachments/assets/724802ba-d17a-4389-9ab3-287a0bed4060

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #56405

Release Notes:

- Improve scrollbar behavior in project panel and settings.
