### PR TITLE
docs: Document how to open the Skill Creator

### DIFF
--- a/docs/src/ai/skills.md
+++ b/docs/src/ai/skills.md
@@ -15,7 +15,7 @@ A skill is a folder containing a `SKILL.md` file with metadata and instructions.
 
 Zed includes a built-in `create-skill` skill — invoke it with `/create-skill` and the agent walks you through the process.
 
-You can also open the Skill Creator directly with the {#action agent::OpenSkillCreator} action. It opens a window where you fill in the skill's name, description, scope (global or project-local), body, and optionally toggle `disable-model-invocation`.
+You can also open the Skill Creator from the Agent Panel using {#kb agent::OpenRulesLibrary}, or by clicking `...` and selecting **Skills**. Outside the panel, use the {#action agent::OpenSkillCreator} action from the command palette. It opens a window where you fill in the skill's name, description, scope (global or project-local), body, and optionally toggle `disable-model-invocation`.
 
 See [Skill format](#skill-format) below for the full format reference.
 


### PR DESCRIPTION
Documents the ways to open the Skill Creator in `docs/src/ai/skills.md`:

- From the Agent Panel using the keybinding ({#kb agent::OpenRulesLibrary})
- From the Agent Panel `...` menu > **Skills**
- From the command palette via {#action agent::OpenSkillCreator}

Release Notes:

- N/A