### PR TITLE
recent_projects: Fix activation defaulting to main worktree

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -1135,24 +1135,41 @@ impl PickerDelegate for RecentProjectsDelegate {
                 }
 
                 let key = key.clone();
-                let path_list = key.path_list().clone();
                 if let Some(handle) = window.window_handle().downcast::<MultiWorkspace>() {
                     cx.defer(move |cx| {
-                        if let Some(task) = handle
-                            .update(cx, |multi_workspace, window, cx| {
-                                multi_workspace.find_or_create_local_workspace(
-                                    path_list,
-                                    Some(key.clone()),
-                                    &[],
-                                    None,
-                                    OpenMode::Activate,
-                                    window,
-                                    cx,
-                                )
+                        // Try to activate an existing workspace for this project group
+                        // first, so we preserve the actual worktree paths (which may
+                        // differ from the main git worktree paths stored in the key).
+                        if let Some(workspace) = handle
+                            .update(cx, |multi_workspace, _window, cx| {
+                                multi_workspace.last_active_workspace_for_group(&key, cx)
                             })
                             .log_err()
+                            .flatten()
                         {
-                            task.detach_and_log_err(cx);
+                            handle
+                                .update(cx, |multi_workspace, window, cx| {
+                                    multi_workspace.activate(workspace, None, window, cx);
+                                })
+                                .log_err();
+                        } else {
+                            let path_list = key.path_list().clone();
+                            if let Some(task) = handle
+                                .update(cx, |multi_workspace, window, cx| {
+                                    multi_workspace.find_or_create_local_workspace(
+                                        path_list,
+                                        Some(key.clone()),
+                                        &[],
+                                        None,
+                                        OpenMode::Activate,
+                                        window,
+                                        cx,
+                                    )
+                                })
+                                .log_err()
+                            {
+                                task.detach_and_log_err(cx);
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
Closes AI-280

When navigating between projects opened in the same window through the recent projects picker, the confirm action would always default to picking the main worktree in a project. So if you were in a Git worktree in project A, switched to project B, and then back to project A, when coming back, you wouldn't be in the Git worktree you were in before. The fix is done through matching by project group key instead of file system paths. Since both the main and linked worktrees share the same key, it will just find the previously active workspace and activate it.

Release Notes:

- Fixed a bug where navigating through open projects in the same window through the recent projects would always default to the main worktree of a given project, instead of activating the last active worktree/workspace.
