### PR TITLE
  gpui_linux: Update DPI scale dynamically when X11 monitor configuration changes

### DIFF
--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -182,6 +182,8 @@ pub struct X11ClientState {
     pub(crate) compositor_gpu: Option<CompositorGpuHint>,
 
     pub(crate) scale_factor: f32,
+    pub(crate) scale_locked: bool,
+    pub(crate) randr_monitor_support: bool,
 
     xkb_context: xkbc::Context,
     pub(crate) xcb_connection: Rc<XCBConnection>,
@@ -441,7 +443,11 @@ impl X11Client {
 
         let resource_database = x11rb::resource_manager::new_from_default(&xcb_connection)
             .context("Failed to create resource database")?;
-        let scale_factor = get_scale_factor(&xcb_connection, &resource_database, x_root_index);
+        let ScaleInfo {
+            scale_factor,
+            scale_locked,
+            randr_monitor_support,
+        } = get_scale_factor(&xcb_connection, &resource_database, x_root_index);
         let cursor_handle = cursor::Handle::new(&xcb_connection, x_root_index, &resource_database)
             .context("Failed to initialize cursor theme handler")?
             .reply()
@@ -453,6 +459,26 @@ impl X11Client {
         let compositor_gpu = detect_compositor_gpu(&xcb_connection, screen);
 
         let xcb_connection = Rc::new(xcb_connection);
+
+        // X11 does not push DPI updates to windows. Without this subscription scale
+        // changes are only detected when the user moves the window.
+        if !scale_locked && randr_monitor_support {
+            let randr_root = xcb_connection.setup().roots[x_root_index].root;
+            match xcb_connection.randr_select_input(randr_root, randr::NotifyMask::SCREEN_CHANGE) {
+                Err(err) => log::warn!(
+                    "Failed to select RandR events for DPI change detection: {:?}",
+                    err
+                ),
+                Ok(cookie) => {
+                    if let Err(err) = cookie.check() {
+                        log::warn!(
+                            "Failed to select RandR events for DPI change detection: {:?}",
+                            err
+                        );
+                    }
+                }
+            }
+        }
 
         let ximc = X11rbClient::init(Rc::clone(&xcb_connection), x_root_index, None).ok();
         let xim_handler = if ximc.is_some() {
@@ -524,6 +550,8 @@ impl X11Client {
             gpu_context: Rc::new(RefCell::new(None)),
             compositor_gpu,
             scale_factor,
+            scale_locked,
+            randr_monitor_support,
 
             xkb_context,
             xcb_connection,
@@ -948,6 +976,25 @@ impl X11Client {
                     .set_bounds(bounds)
                     .context("X11: Failed to set window bounds")
                     .log_err();
+            }
+            Event::RandrScreenChangeNotify(_) => {
+                let state = self.0.borrow();
+                if !state.scale_locked {
+                    let windows: Vec<X11WindowStatePtr> =
+                        state.windows.values().map(|w| w.window.clone()).collect();
+                    let xcb_connection = state.xcb_connection.clone();
+                    let x_root_index = state.x_root_index;
+                    drop(state);
+                    for window in windows {
+                        window.update_scale_from_randr();
+                    }
+                    // Keep the client-level scale current so new windows opened
+                    // after this event start at the right scale.
+                    let randr_root = xcb_connection.setup().roots[x_root_index].root;
+                    if let Some(scale) = scale_from_randr_monitors(&xcb_connection, randr_root) {
+                        self.0.borrow_mut().scale_factor = scale;
+                    }
+                }
             }
             Event::PropertyNotify(event) => {
                 let window = self.get_window(event.window)?;
@@ -1606,6 +1653,8 @@ impl LinuxClient for X11Client {
         let x_root_index = state.x_root_index;
         let atoms = state.atoms;
         let scale_factor = state.scale_factor;
+        let scale_locked = state.scale_locked;
+        let randr_monitor_support = state.randr_monitor_support;
         let appearance = state.common.appearance;
         let compositor_gpu = state.compositor_gpu.take();
         let supports_xinput_gestures = state.supports_xinput_gestures;
@@ -1626,6 +1675,8 @@ impl LinuxClient for X11Client {
             x_window,
             &atoms,
             scale_factor,
+            scale_locked,
+            randr_monitor_support,
             appearance,
             parent_window,
             supports_xinput_gestures,
@@ -2518,11 +2569,17 @@ enum DpiMode {
     NotSet,
 }
 
+struct ScaleInfo {
+    scale_factor: f32,
+    scale_locked: bool,
+    randr_monitor_support: bool,
+}
+
 fn get_scale_factor(
     connection: &XCBConnection,
     resource_database: &Database,
     screen_index: usize,
-) -> f32 {
+) -> ScaleInfo {
     let env_dpi = std::env::var(GPUI_X11_SCALE_FACTOR_ENV)
         .ok()
         .map(|var| {
@@ -2548,28 +2605,43 @@ fn get_scale_factor(
         })
         .unwrap_or(DpiMode::NotSet);
 
-    match env_dpi {
-        DpiMode::Scale(scale) => {
+    // randr_monitor_support is irrelevant when scale is pinned because all per-monitor
+    // detection is gated on !scale_locked.
+    let is_randr_explicit = matches!(&env_dpi, DpiMode::Randr);
+    if let DpiMode::Scale(scale) = env_dpi {
+        log::info!(
+            "Using scale factor from {}: {}",
+            GPUI_X11_SCALE_FACTOR_ENV,
+            scale
+        );
+        return ScaleInfo {
+            scale_factor: scale,
+            scale_locked: true,
+            randr_monitor_support: false,
+        };
+    }
+
+    let (randr_scale, randr_monitor_support) = get_randr_info(connection, screen_index);
+
+    if is_randr_explicit {
+        if let Some(scale) = randr_scale {
             log::info!(
-                "Using scale factor from {}: {}",
+                "Using RandR scale factor from {}=randr: {}",
                 GPUI_X11_SCALE_FACTOR_ENV,
                 scale
             );
-            return scale;
+            return ScaleInfo {
+                scale_factor: scale,
+                scale_locked: false,
+                randr_monitor_support,
+            };
         }
-        DpiMode::Randr => {
-            if let Some(scale) = get_randr_scale_factor(connection, screen_index) {
-                log::info!(
-                    "Using RandR scale factor from {}=randr: {}",
-                    GPUI_X11_SCALE_FACTOR_ENV,
-                    scale
-                );
-                return scale;
-            }
-            log::warn!("Failed to calculate RandR scale factor, falling back to default");
-            return 1.0;
-        }
-        DpiMode::NotSet => {}
+        log::warn!("Failed to calculate RandR scale factor, falling back to default");
+        return ScaleInfo {
+            scale_factor: 1.0,
+            scale_locked: false,
+            randr_monitor_support,
+        };
     }
 
     // TODO: Use scale factor from XSettings here
@@ -2581,34 +2653,68 @@ fn get_scale_factor(
     {
         let scale = dpi / 96.0; // base dpi
         log::info!("Using scale factor from Xft.dpi: {}", scale);
-        return scale;
+        // Xft.dpi is an explicit user or DE override. Locking scale prevents a
+        // subsequent RandR event from replacing it with raw physical DPI, which
+        // disagrees with Xft.dpi on GNOME/KDE fractional or integer scaling setups.
+        return ScaleInfo {
+            scale_factor: scale,
+            scale_locked: true,
+            randr_monitor_support: false,
+        };
     }
 
-    if let Some(scale) = get_randr_scale_factor(connection, screen_index) {
+    if let Some(scale) = randr_scale {
         log::info!("Using RandR scale factor: {}", scale);
-        return scale;
+        return ScaleInfo {
+            scale_factor: scale,
+            scale_locked: false,
+            randr_monitor_support,
+        };
     }
 
     log::info!("Using default scale factor: 1.0");
-    1.0
+    ScaleInfo {
+        scale_factor: 1.0,
+        scale_locked: false,
+        randr_monitor_support,
+    }
 }
 
-fn get_randr_scale_factor(connection: &XCBConnection, screen_index: usize) -> Option<f32> {
-    let root = connection.setup().roots.get(screen_index)?.root;
+fn get_randr_info(connection: &XCBConnection, screen_index: usize) -> (Option<f32>, bool) {
+    let root = match connection.setup().roots.get(screen_index) {
+        Some(screen) => screen.root,
+        None => return (None, false),
+    };
 
-    let version_cookie = connection.randr_query_version(1, 6).ok()?;
-    let version_reply = version_cookie.reply().ok()?;
-    if version_reply.major_version < 1
-        || (version_reply.major_version == 1 && version_reply.minor_version < 5)
+    let version_reply = match connection
+        .randr_query_version(1, 6)
+        .ok()
+        .and_then(|c| c.reply().ok())
     {
-        return legacy_get_randr_scale_factor(connection, root); // for randr <1.5
+        Some(r) => r,
+        None => return (None, false),
+    };
+
+    let randr_monitor_support = version_reply.major_version > 1
+        || (version_reply.major_version == 1 && version_reply.minor_version >= 5);
+
+    if !randr_monitor_support {
+        return (legacy_get_randr_scale_factor(connection, root), false);
     }
 
-    let monitors_cookie = connection.randr_get_monitors(root, true).ok()?; // true for active only
-    let monitors_reply = monitors_cookie.reply().ok()?;
+    let scale = scale_from_randr_monitors(connection, root);
 
-    let mut fallback_scale: Option<f32> = None;
-    for monitor in monitors_reply.monitors {
+    (scale, true)
+}
+
+fn scale_from_randr_monitors(connection: &XCBConnection, root: xproto::Window) -> Option<f32> {
+    let reply = connection
+        .randr_get_monitors(root, true)
+        .ok()?
+        .reply()
+        .ok()?;
+    let mut fallback: Option<f32> = None;
+    for monitor in reply.monitors {
         if monitor.width_in_millimeters == 0 || monitor.height_in_millimeters == 0 {
             continue;
         }
@@ -2621,12 +2727,11 @@ fn get_randr_scale_factor(connection: &XCBConnection, screen_index: usize) -> Op
         );
         if monitor.primary {
             return Some(scale_factor);
-        } else if fallback_scale.is_none() {
-            fallback_scale = Some(scale_factor);
+        } else if fallback.is_none() {
+            fallback = Some(scale_factor);
         }
     }
-
-    fallback_scale
+    fallback
 }
 
 fn legacy_get_randr_scale_factor(connection: &XCBConnection, root: u32) -> Option<f32> {
@@ -2728,6 +2833,55 @@ fn legacy_get_randr_scale_factor(connection: &XCBConnection, root: u32) -> Optio
     }
 
     fallback_scale
+}
+
+pub(crate) fn get_monitor_scale_at_bounds(
+    connection: &XCBConnection,
+    root: xproto::Window,
+    bounds: Bounds<i32>,
+) -> Option<f32> {
+    let monitors = connection
+        .randr_get_monitors(root, true)
+        .ok()?
+        .reply()
+        .ok()?
+        .monitors;
+
+    let win_left = bounds.origin.x;
+    let win_top = bounds.origin.y;
+    let win_right = bounds.origin.x + bounds.size.width;
+    let win_bottom = bounds.origin.y + bounds.size.height;
+
+    let mut best_scale: Option<f32> = None;
+    let mut best_area: i64 = -1;
+
+    for monitor in monitors {
+        if monitor.width_in_millimeters == 0 || monitor.height_in_millimeters == 0 {
+            continue;
+        }
+
+        let mon_left = monitor.x as i32;
+        let mon_top = monitor.y as i32;
+        let mon_right = mon_left + monitor.width as i32;
+        let mon_bottom = mon_top + monitor.height as i32;
+
+        let overlap_w = (win_right.min(mon_right) - win_left.max(mon_left)).max(0);
+        let overlap_h = (win_bottom.min(mon_bottom) - win_top.max(mon_top)).max(0);
+        let area = overlap_w as i64 * overlap_h as i64;
+
+        if area > best_area {
+            best_area = area;
+            best_scale = Some(get_dpi_factor(
+                (monitor.width as u32, monitor.height as u32),
+                (
+                    monitor.width_in_millimeters as u64,
+                    monitor.height_in_millimeters as u64,
+                ),
+            ));
+        }
+    }
+
+    best_scale
 }
 
 fn get_dpi_factor((width_px, height_px): (u32, u32), (width_mm, height_mm): (u64, u64)) -> f32 {

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -32,7 +32,9 @@ use std::{
     cell::RefCell, ffi::c_void, fmt::Display, num::NonZeroU32, ptr::NonNull, rc::Rc, sync::Arc,
 };
 
-use super::{X11Display, XINPUT_ALL_DEVICE_GROUPS, XINPUT_ALL_DEVICES};
+use super::{
+    X11Display, XINPUT_ALL_DEVICE_GROUPS, XINPUT_ALL_DEVICES, get_monitor_scale_at_bounds,
+};
 
 x11rb::atom_manager! {
     pub XcbAtoms: AtomsCookie {
@@ -268,6 +270,8 @@ pub struct X11WindowState {
     pub(crate) last_sync_counter: Option<sync::Int64>,
     bounds: Bounds<Pixels>,
     scale_factor: f32,
+    scale_locked: bool,
+    randr_monitor_support: bool,
     renderer: WgpuRenderer,
     display: Rc<dyn PlatformDisplay>,
     input_handler: Option<PlatformInputHandler>,
@@ -422,6 +426,8 @@ impl X11WindowState {
         x_window: xproto::Window,
         atoms: &XcbAtoms,
         scale_factor: f32,
+        scale_locked: bool,
+        randr_monitor_support: bool,
         appearance: WindowAppearance,
         parent_window: Option<X11WindowStatePtr>,
         supports_xinput_gestures: bool,
@@ -783,6 +789,8 @@ impl X11WindowState {
                 visual_id: visual.id,
                 bounds: bounds.to_pixels(scale_factor),
                 scale_factor,
+                scale_locked,
+                randr_monitor_support,
                 renderer,
                 atoms: *atoms,
                 input_handler: None,
@@ -883,6 +891,8 @@ impl X11Window {
         x_window: xproto::Window,
         atoms: &XcbAtoms,
         scale_factor: f32,
+        scale_locked: bool,
+        randr_monitor_support: bool,
         appearance: WindowAppearance,
         parent_window: Option<X11WindowStatePtr>,
         supports_xinput_gestures: bool,
@@ -902,6 +912,8 @@ impl X11Window {
                 x_window,
                 atoms,
                 scale_factor,
+                scale_locked,
+                randr_monitor_support,
                 appearance,
                 parent_window,
                 supports_xinput_gestures,
@@ -1234,17 +1246,55 @@ impl X11WindowStatePtr {
     pub fn set_bounds(&self, bounds: Bounds<i32>) -> anyhow::Result<()> {
         let (is_resize, content_size, scale_factor) = {
             let mut state = self.state.borrow_mut();
-            let bounds = bounds.map(|f| px(f as f32 / state.scale_factor));
 
-            let is_resize = bounds.size.width != state.bounds.size.width
-                || bounds.size.height != state.bounds.size.height;
+            let scale_changed = if !state.scale_locked && state.randr_monitor_support {
+                // Only query RandR when origin changes. A pure resize cannot move
+                // the window to a different monitor.
+                let cur_px_x = (f32::from(state.bounds.origin.x) * state.scale_factor) as i32;
+                let cur_px_y = (f32::from(state.bounds.origin.y) * state.scale_factor) as i32;
+                let origin_moved = bounds.origin.x != cur_px_x || bounds.origin.y != cur_px_y;
+                if origin_moved {
+                    if let Some(new_scale) =
+                        get_monitor_scale_at_bounds(&self.xcb, state.x_root_window, bounds)
+                    {
+                        if (new_scale - state.scale_factor).abs() > 0.001 {
+                            state.scale_factor = new_scale;
+                            if let Ok(display) =
+                                X11Display::new(&self.xcb, new_scale, state.x_screen_index)
+                            {
+                                state.display = Rc::new(display);
+                            }
+                            true
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+
+            let bounds_logical = bounds.map(|f| px(f as f32 / state.scale_factor));
+
+            // When scale changes the window moved to a different monitor. Treat as a full
+            // bounds update not a resize.
+            let is_resize = if scale_changed {
+                false
+            } else {
+                bounds_logical.size.width != state.bounds.size.width
+                    || bounds_logical.size.height != state.bounds.size.height
+            };
 
             // If it's a resize event (only width/height changed), we ignore `bounds.origin`
             // because it contains wrong values.
             if is_resize {
-                state.bounds.size = bounds.size;
+                state.bounds.size = bounds_logical.size;
             } else {
-                state.bounds = bounds;
+                state.bounds = bounds_logical;
             }
 
             let gpu_size = query_render_extent(&self.xcb, self.x_window)?;
@@ -1269,6 +1319,59 @@ impl X11WindowStatePtr {
         }
 
         Ok(())
+    }
+
+    pub fn update_scale_from_randr(&self) {
+        let (root, pixel_bounds) = {
+            let state = self.state.borrow();
+            if state.scale_locked || !state.randr_monitor_support {
+                return;
+            }
+            let scale = state.scale_factor;
+            let logical = state.bounds;
+            let pixel_bounds = Bounds {
+                origin: Point {
+                    x: (f32::from(logical.origin.x) * scale) as i32,
+                    y: (f32::from(logical.origin.y) * scale) as i32,
+                },
+                size: Size {
+                    width: (f32::from(logical.size.width) * scale) as i32,
+                    height: (f32::from(logical.size.height) * scale) as i32,
+                },
+            };
+            (state.x_root_window, pixel_bounds)
+        };
+
+        let Some(new_scale) = get_monitor_scale_at_bounds(&self.xcb, root, pixel_bounds) else {
+            return;
+        };
+
+        let (content_size, scale_factor) = {
+            let mut state = self.state.borrow_mut();
+            if (new_scale - state.scale_factor).abs() <= 0.001 {
+                return;
+            }
+            state.scale_factor = new_scale;
+            state.bounds = Bounds {
+                origin: Point {
+                    x: px(pixel_bounds.origin.x as f32 / new_scale),
+                    y: px(pixel_bounds.origin.y as f32 / new_scale),
+                },
+                size: Size {
+                    width: px(pixel_bounds.size.width as f32 / new_scale),
+                    height: px(pixel_bounds.size.height as f32 / new_scale),
+                },
+            };
+            if let Ok(display) = X11Display::new(&self.xcb, new_scale, state.x_screen_index) {
+                state.display = Rc::new(display);
+            }
+            (state.content_size(), state.scale_factor)
+        };
+
+        let mut callbacks = self.callbacks.borrow_mut();
+        if let Some(ref mut fun) = callbacks.resize {
+            fun(content_size, scale_factor);
+        }
     }
 
     pub fn set_active(&self, focus: bool) {


### PR DESCRIPTION
x11 does not deliver dpi change notifications to running clients. scale factor was read once at startup; plugging in a monitor, changing display scaling in gnome or kde, or moving a window to a higher or lower dpi display all required a restart.

subscribes to `RandrScreenChangeNotify` at client startup when randr >= 1.5 is available and scale is not pinned via `GPUI_X11_SCALE_FACTOR`. when the event fires every open window queries the monitor it currently occupies via `scale_from_randr_monitors` and fires the resize callback if the scale changed. the client-level scale is also refreshed so windows opened after the event start at the correct dpi.

window moves between monitors are handled inline in `ConfigureNotify`: `set_bounds` calls `get_monitor_scale_at_bounds` (largest pixel-overlap) when the origin changes so the scale updates without waiting for a separate screen-change event.

users with `Xft.dpi` set are excluded from dynamic updates. `Xft.dpi` is an explicit user or de override; applying raw physical dpi from randr on top of it produces wrong scale on gnome and kde fractional and integer scaling setups.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #21851

Release Notes:

- added support for per-monitor DPI scaling on Linux X11: scale factor now updates automatically when monitor configuration changes or when a window is moved to a display with a different DPI.

