### PR TITLE
git_graph: Add `ctrl-f` keybinding to focus search

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1547,6 +1547,7 @@
   {
     "context": "GitGraph",
     "bindings": {
+      "ctrl-f": "git_graph::FocusSearch",
       "tab": "git_graph::FocusNextTabStop",
       "shift-tab": "git_graph::FocusPreviousTabStop",
     },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1640,6 +1640,7 @@
   {
     "context": "GitGraph",
     "bindings": {
+      "cmd-f": "git_graph::FocusSearch",
       "tab": "git_graph::FocusNextTabStop",
       "shift-tab": "git_graph::FocusPreviousTabStop",
     },

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1566,6 +1566,7 @@
   {
     "context": "GitGraph",
     "bindings": {
+      "ctrl-f": "git_graph::FocusSearch",
       "tab": "git_graph::FocusNextTabStop",
       "shift-tab": "git_graph::FocusPreviousTabStop",
     },


### PR DESCRIPTION
Release Notes:

- Added a default keybinding to focus the search on the git graph (ctrl-f/cmd-f)

