### PR TITLE
Add branch name to status bar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -982,6 +982,10 @@
     //
     // Default: false
     "show_count_badge": false,
+    // Whether to show the active branch name next to the git panel icon in the status bar.
+    //
+    // Default: false
+    "show_branch_name_in_status_bar": false,
     "scrollbar": {
       // When to show the scrollbar in the git panel.
       //

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -84,7 +84,7 @@ use util::{ResultExt, TryFutureExt, markdown::MarkdownInlineCode, maybe, rel_pat
 use workspace::SERIALIZATION_THROTTLE_TIME;
 use workspace::{
     Workspace,
-    dock::{DockPosition, Panel, PanelEvent},
+    dock::{DockPosition, Panel, PanelButtonLabel, PanelEvent},
     notifications::{DetachAndPromptErr, ErrorMessagePrompt, NotificationId, NotifyResultExt},
 };
 
@@ -6753,7 +6753,7 @@ impl Panel for GitPanel {
         Some("Git Panel")
     }
 
-    fn icon_label(&self, _: &Window, cx: &App) -> Option<String> {
+    fn icon_label(&self, _: &Window, cx: &App) -> Option<PanelButtonLabel> {
         let settings = GitPanelSettings::get_global(cx);
 
         if settings.show_branch_name_in_status_bar {
@@ -6762,21 +6762,22 @@ impl Panel for GitPanel {
                 .as_ref()
                 .and_then(|repo| repo.read(cx).branch.as_ref().map(|branch| branch.name()));
 
-            return branch_name.map(|branch_name| {
-                let max_label_length = 24;
-                if branch_name.len() <= max_label_length {
+            if let Some(branch_name) = branch_name {
+                const MAX_LABEL_LENGTH: usize = 24;
+                let label = if branch_name.len() <= MAX_LABEL_LENGTH {
                     branch_name.to_string()
                 } else {
-                    util::truncate_and_trailoff(branch_name.trim_ascii(), max_label_length)
-                }
-            });
+                    util::truncate_and_trailoff(branch_name.trim_ascii(), MAX_LABEL_LENGTH)
+                };
+                return Some(PanelButtonLabel::Text(label.into()));
+            }
         }
 
         if !settings.show_count_badge {
             return None;
         }
         let total = self.changes_count;
-        (total > 0).then(|| total.to_string())
+        (total > 0).then_some(PanelButtonLabel::Count(total))
     }
 
     fn toggle_action(&self) -> Box<dyn Action> {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6754,7 +6754,25 @@ impl Panel for GitPanel {
     }
 
     fn icon_label(&self, _: &Window, cx: &App) -> Option<String> {
-        if !GitPanelSettings::get_global(cx).show_count_badge {
+        let settings = GitPanelSettings::get_global(cx);
+
+        if settings.show_branch_name_in_status_bar {
+            let branch_name = self
+                .active_repository
+                .as_ref()
+                .and_then(|repo| repo.read(cx).branch.as_ref().map(|branch| branch.name()));
+
+            return branch_name.map(|branch_name| {
+                let max_label_length = 24;
+                if branch_name.len() <= max_label_length {
+                    branch_name.to_string()
+                } else {
+                    util::truncate_and_trailoff(branch_name.trim_ascii(), max_label_length)
+                }
+            });
+        }
+
+        if !settings.show_count_badge {
             return None;
         }
         let total = self.changes_count;

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6718,6 +6718,28 @@ impl editor::Addon for GitPanelAddon {
     }
 }
 
+const STATUS_BAR_BRANCH_LABEL_MAX_LEN: usize = 24;
+
+fn icon_label_for(
+    show_branch_name: bool,
+    branch_name: Option<&str>,
+    show_count_badge: bool,
+    changes_count: usize,
+) -> Option<PanelButtonLabel> {
+    if show_branch_name
+        && let Some(branch_name) = branch_name.map(str::trim_ascii).filter(|s| !s.is_empty())
+    {
+        let label = util::truncate_and_trailoff(branch_name, STATUS_BAR_BRANCH_LABEL_MAX_LEN);
+        return Some(PanelButtonLabel::Text(label.into()));
+    }
+
+    if show_count_badge && changes_count > 0 {
+        return Some(PanelButtonLabel::Count(changes_count));
+    }
+
+    None
+}
+
 impl Panel for GitPanel {
     fn persistent_name() -> &'static str {
         "GitPanel"
@@ -6755,29 +6777,16 @@ impl Panel for GitPanel {
 
     fn icon_label(&self, _: &Window, cx: &App) -> Option<PanelButtonLabel> {
         let settings = GitPanelSettings::get_global(cx);
-
-        if settings.show_branch_name_in_status_bar {
-            let branch_name = self
-                .active_repository
-                .as_ref()
-                .and_then(|repo| repo.read(cx).branch.as_ref().map(|branch| branch.name()));
-
-            if let Some(branch_name) = branch_name {
-                const MAX_LABEL_LENGTH: usize = 24;
-                let label = if branch_name.len() <= MAX_LABEL_LENGTH {
-                    branch_name.to_string()
-                } else {
-                    util::truncate_and_trailoff(branch_name.trim_ascii(), MAX_LABEL_LENGTH)
-                };
-                return Some(PanelButtonLabel::Text(label.into()));
-            }
-        }
-
-        if !settings.show_count_badge {
-            return None;
-        }
-        let total = self.changes_count;
-        (total > 0).then_some(PanelButtonLabel::Count(total))
+        let branch_name = self
+            .active_repository
+            .as_ref()
+            .and_then(|repo| repo.read(cx).branch.as_ref().map(|branch| branch.name()));
+        icon_label_for(
+            settings.show_branch_name_in_status_bar,
+            branch_name,
+            settings.show_count_badge,
+            self.changes_count,
+        )
     }
 
     fn toggle_action(&self) -> Box<dyn Action> {
@@ -7511,6 +7520,74 @@ mod tests {
             editor::init(cx);
             crate::init(cx);
         });
+    }
+
+    #[test]
+    fn test_icon_label_for_shows_branch_text_when_enabled() {
+        let label = icon_label_for(true, Some("main"), true, 3);
+        assert!(matches!(label, Some(PanelButtonLabel::Text(s)) if s == "main"));
+    }
+
+    #[test]
+    fn test_icon_label_for_text_label_takes_priority_over_count_badge() {
+        let label = icon_label_for(true, Some("feature"), true, 7);
+        assert!(matches!(label, Some(PanelButtonLabel::Text(_))));
+    }
+
+    #[test]
+    fn test_icon_label_for_renders_digits_only_branch_as_text() {
+        let label = icon_label_for(true, Some("123"), true, 0);
+        assert!(matches!(label, Some(PanelButtonLabel::Text(s)) if s == "123"));
+    }
+
+    #[test]
+    fn test_icon_label_for_truncates_long_branch_names() {
+        let long = "feature/very-long-branch-name-that-exceeds-the-limit";
+        let label = icon_label_for(true, Some(long), false, 0);
+        let Some(PanelButtonLabel::Text(s)) = label else {
+            panic!("expected text label");
+        };
+        assert!(s.chars().count() <= STATUS_BAR_BRANCH_LABEL_MAX_LEN + 1);
+        assert!(s.ends_with('…'));
+    }
+
+    #[test]
+    fn test_icon_label_for_trims_whitespace_around_branch_name() {
+        let label = icon_label_for(true, Some("  develop  "), false, 0);
+        assert!(matches!(label, Some(PanelButtonLabel::Text(s)) if s == "develop"));
+    }
+
+    #[test]
+    fn test_icon_label_for_falls_back_to_count_when_no_branch() {
+        let label = icon_label_for(true, None, true, 5);
+        assert!(matches!(label, Some(PanelButtonLabel::Count(5))));
+    }
+
+    #[test]
+    fn test_icon_label_for_falls_back_to_count_when_branch_name_is_blank() {
+        let label = icon_label_for(true, Some("   "), true, 2);
+        assert!(matches!(label, Some(PanelButtonLabel::Count(2))));
+    }
+
+    #[test]
+    fn test_icon_label_for_returns_none_when_no_branch_and_count_disabled() {
+        assert!(icon_label_for(true, None, false, 5).is_none());
+    }
+
+    #[test]
+    fn test_icon_label_for_returns_count_when_branch_disabled() {
+        let label = icon_label_for(false, Some("main"), true, 7);
+        assert!(matches!(label, Some(PanelButtonLabel::Count(7))));
+    }
+
+    #[test]
+    fn test_icon_label_for_returns_none_when_count_badge_disabled() {
+        assert!(icon_label_for(false, Some("main"), false, 5).is_none());
+    }
+
+    #[test]
+    fn test_icon_label_for_returns_none_when_count_zero() {
+        assert!(icon_label_for(false, None, true, 0).is_none());
     }
 
     #[test]

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -29,6 +29,7 @@ pub struct GitPanelSettings {
     pub tree_view: bool,
     pub diff_stats: bool,
     pub show_count_badge: bool,
+    pub show_branch_name_in_status_bar: bool,
     pub starts_open: bool,
     pub commit_title_max_length: usize,
 }
@@ -76,6 +77,7 @@ impl Settings for GitPanelSettings {
             tree_view: git_panel.tree_view.unwrap(),
             diff_stats: git_panel.diff_stats.unwrap(),
             show_count_badge: git_panel.show_count_badge.unwrap(),
+            show_branch_name_in_status_bar: git_panel.show_branch_name_in_status_bar.unwrap(),
             starts_open: git_panel.starts_open.unwrap(),
             commit_title_max_length: git_panel.commit_title_max_length.unwrap(),
         }

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -706,6 +706,11 @@ pub struct GitPanelSettingsContent {
     /// Default: false
     pub show_count_badge: Option<bool>,
 
+    /// Whether to show the current branch name next to the git panel icon in the status bar.
+    ///
+    /// Default: false
+    pub show_branch_name_in_status_bar: Option<bool>,
+
     /// Whether the git panel should open on startup.
     ///
     /// Default: false

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5499,7 +5499,7 @@ fn panels_page() -> SettingsPage {
         ]
     }
 
-    fn git_panel_section() -> [SettingsPageItem; 15] {
+    fn git_panel_section() -> [SettingsPageItem; 16] {
         [
             SettingsPageItem::SectionHeader("Git Panel"),
             SettingsPageItem::SettingItem(SettingItem {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5718,6 +5718,28 @@ fn panels_page() -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
+                title: "Show Branch Name in Status Bar",
+                description: "Whether to show the active branch name next to the git panel icon in the status bar.",
+                field: Box::new(SettingField {
+                    json_path: Some("git_panel.show_branch_name_in_status_bar"),
+                    pick: |settings_content| {
+                        settings_content
+                            .git_panel
+                            .as_ref()?
+                            .show_branch_name_in_status_bar
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .git_panel
+                            .get_or_insert_default()
+                            .show_branch_name_in_status_bar = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
                 title: "Commit Title Max Length",
                 description: "Maximum length of the commit message title before a warning is shown. Set to 0 to disable.",
                 field: Box::new(SettingField {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -32,7 +32,7 @@ use workspace::{
     MoveItemToPaneInDirection, MovePaneDown, MovePaneLeft, MovePaneRight, MovePaneUp, Pane,
     PaneGroup, SplitDirection, SplitDown, SplitLeft, SplitMode, SplitRight, SplitUp, SwapPaneDown,
     SwapPaneLeft, SwapPaneRight, SwapPaneUp, ToggleZoom, Workspace,
-    dock::{DockPosition, Panel, PanelEvent, PanelHandle},
+    dock::{DockPosition, Panel, PanelButtonLabel, PanelEvent, PanelHandle},
     item::SerializableItem,
     move_active_item, pane,
 };
@@ -1616,7 +1616,7 @@ impl Panel for TerminalPanel {
         })
     }
 
-    fn icon_label(&self, _window: &Window, cx: &App) -> Option<String> {
+    fn icon_label(&self, _window: &Window, cx: &App) -> Option<PanelButtonLabel> {
         if !TerminalSettings::get_global(cx).show_count_badge {
             return None;
         }
@@ -1626,11 +1626,7 @@ impl Panel for TerminalPanel {
             .into_iter()
             .map(|pane| pane.read(cx).items_len())
             .sum::<usize>();
-        if count == 0 {
-            None
-        } else {
-            Some(count.to_string())
-        }
+        (count > 0).then_some(PanelButtonLabel::Count(count))
     }
 
     fn persistent_name() -> &'static str {

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -17,7 +17,8 @@ use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore, TerminalDockPosition};
 use std::sync::Arc;
 use ui::{
-    ContextMenu, CountBadge, Divider, DividerColor, IconButton, Tooltip, prelude::*,
+    Button, ContextMenu, CountBadge, Divider, DividerColor, Icon, IconButton, IconSize, Tooltip,
+    prelude::*,
     right_click_menu,
 };
 use util::ResultExt as _;
@@ -1349,27 +1350,50 @@ impl Render for PanelButtons {
                         .trigger(move |is_active, _window, _cx| {
                             // Include active state in element ID to invalidate the cached
                             // tooltip when panel state changes (e.g., via keyboard shortcut)
-                            let button = IconButton::new((name, is_active_button as u64), icon)
-                                .icon_size(IconSize::Small)
-                                .toggle_state(is_active_button)
-                                .on_click({
-                                    let action = action.boxed_clone();
-                                    move |_, window, cx| {
-                                        window.focus(&focus_handle, cx);
-                                        window.dispatch_action(action.boxed_clone(), cx)
-                                    }
+                            let numeric_icon_label = icon_label
+                                .clone()
+                                .and_then(|label| label.parse::<usize>().ok());
+                            let text_icon_label = icon_label
+                                .clone()
+                                .filter(|label| label.parse::<usize>().is_err());
+                            let action_for_click = action.boxed_clone();
+                            let button = text_icon_label.map_or_else(
+                                || {
+                                    IconButton::new((name, is_active_button as u64), icon)
+                                        .icon_size(IconSize::Small)
+                                        .toggle_state(is_active_button)
+                                        .on_click({
+                                            let action = action_for_click.boxed_clone();
+                                            move |_, window, cx| {
+                                                window.focus(&focus_handle, cx);
+                                                window.dispatch_action(action.boxed_clone(), cx)
+                                            }
+                                        })
+                                        .into_any_element()
+                                },
+                                |label| {
+                                    Button::new((name, is_active_button as u64), label)
+                                        .start_icon(Icon::new(icon).size(IconSize::Small))
+                                        .label_size(LabelSize::Small)
+                                        .toggle_state(is_active_button)
+                                        .on_click({
+                                            let action = action_for_click.boxed_clone();
+                                            move |_, window, cx| {
+                                                window.focus(&focus_handle, cx);
+                                                window.dispatch_action(action.boxed_clone(), cx)
+                                            }
+                                        })
+                                        .into_any_element()
+                                },
+                            );
+                            let button = div().child(button).when(!is_active, |this| {
+                                this.tooltip(move |_window, cx| {
+                                    Tooltip::for_action(tooltip.clone(), &*action, cx)
                                 })
-                                .when(!is_active, |this| {
-                                    this.tooltip(move |_window, cx| {
-                                        Tooltip::for_action(tooltip.clone(), &*action, cx)
-                                    })
-                                });
+                            });
 
                             div().relative().child(button).when_some(
-                                icon_label
-                                    .clone()
-                                    .filter(|_| !is_active_button)
-                                    .and_then(|label| label.parse::<usize>().ok()),
+                                numeric_icon_label.filter(|_| !is_active_button),
                                 |this, count| this.child(CountBadge::new(count)),
                             )
                         }),

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -18,8 +18,7 @@ use settings::{Settings, SettingsStore, TerminalDockPosition};
 use std::sync::Arc;
 use ui::{
     Button, ContextMenu, CountBadge, Divider, DividerColor, Icon, IconButton, IconSize, Tooltip,
-    prelude::*,
-    right_click_menu,
+    prelude::*, right_click_menu,
 };
 use util::ResultExt as _;
 
@@ -1356,18 +1355,32 @@ impl Render for PanelButtons {
                             let text_icon_label = icon_label
                                 .clone()
                                 .filter(|label| label.parse::<usize>().is_err());
-                            let action_for_click = action.boxed_clone();
+                            let icon_focus_handle = focus_handle.clone();
+                            let text_focus_handle = focus_handle.clone();
+                            let icon_tooltip = tooltip.clone();
+                            let text_tooltip = tooltip.clone();
+                            let icon_click_action = action.boxed_clone();
+                            let text_click_action = action.boxed_clone();
+                            let icon_tooltip_action = action.boxed_clone();
+                            let text_tooltip_action = action.boxed_clone();
                             let button = text_icon_label.map_or_else(
                                 || {
                                     IconButton::new((name, is_active_button as u64), icon)
                                         .icon_size(IconSize::Small)
                                         .toggle_state(is_active_button)
                                         .on_click({
-                                            let action = action_for_click.boxed_clone();
+                                            let action = icon_click_action.boxed_clone();
                                             move |_, window, cx| {
-                                                window.focus(&focus_handle, cx);
+                                                window.focus(&icon_focus_handle, cx);
                                                 window.dispatch_action(action.boxed_clone(), cx)
                                             }
+                                        })
+                                        .when(!is_active, |this| {
+                                            let action = icon_tooltip_action.boxed_clone();
+                                            let tooltip = icon_tooltip.clone();
+                                            this.tooltip(move |_window, cx| {
+                                                Tooltip::for_action(tooltip.clone(), &*action, cx)
+                                            })
                                         })
                                         .into_any_element()
                                 },
@@ -1377,20 +1390,22 @@ impl Render for PanelButtons {
                                         .label_size(LabelSize::Small)
                                         .toggle_state(is_active_button)
                                         .on_click({
-                                            let action = action_for_click.boxed_clone();
+                                            let action = text_click_action.boxed_clone();
                                             move |_, window, cx| {
-                                                window.focus(&focus_handle, cx);
+                                                window.focus(&text_focus_handle, cx);
                                                 window.dispatch_action(action.boxed_clone(), cx)
                                             }
+                                        })
+                                        .when(!is_active, |this| {
+                                            let action = text_tooltip_action.boxed_clone();
+                                            let tooltip = text_tooltip.clone();
+                                            this.tooltip(move |_window, cx| {
+                                                Tooltip::for_action(tooltip.clone(), &*action, cx)
+                                            })
                                         })
                                         .into_any_element()
                                 },
                             );
-                            let button = div().child(button).when(!is_active, |this| {
-                                this.tooltip(move |_window, cx| {
-                                    Tooltip::for_action(tooltip.clone(), &*action, cx)
-                                })
-                            });
 
                             div().relative().child(button).when_some(
                                 numeric_icon_label.filter(|_| !is_active_button),

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -33,6 +33,14 @@ pub enum PanelEvent {
 
 pub use proto::PanelId;
 
+/// Label shown next to a panel's status-bar icon button.
+pub enum PanelButtonLabel {
+    /// A numeric badge rendered alongside the icon-only button.
+    Count(usize),
+    /// A textual label rendered inside the button, replacing the icon-only form.
+    Text(SharedString),
+}
+
 pub trait Panel: Focusable + EventEmitter<PanelEvent> + Render + Sized {
     fn persistent_name() -> &'static str;
     fn panel_key() -> &'static str;
@@ -63,7 +71,7 @@ pub trait Panel: Focusable + EventEmitter<PanelEvent> + Render + Sized {
     fn icon(&self, window: &Window, cx: &App) -> Option<ui::IconName>;
     fn icon_tooltip(&self, window: &Window, cx: &App) -> Option<&'static str>;
     fn toggle_action(&self) -> Box<dyn Action>;
-    fn icon_label(&self, _window: &Window, _: &App) -> Option<String> {
+    fn icon_label(&self, _window: &Window, _: &App) -> Option<PanelButtonLabel> {
         None
     }
     fn is_zoomed(&self, _window: &Window, _cx: &App) -> bool {
@@ -117,7 +125,7 @@ pub trait PanelHandle: Send + Sync {
     fn icon(&self, window: &Window, cx: &App) -> Option<ui::IconName>;
     fn icon_tooltip(&self, window: &Window, cx: &App) -> Option<&'static str>;
     fn toggle_action(&self, window: &Window, cx: &App) -> Box<dyn Action>;
-    fn icon_label(&self, window: &Window, cx: &App) -> Option<String>;
+    fn icon_label(&self, window: &Window, cx: &App) -> Option<PanelButtonLabel>;
     fn panel_focus_handle(&self, cx: &App) -> FocusHandle;
     fn to_any(&self) -> AnyView;
     fn activation_priority(&self, cx: &App) -> u32;
@@ -229,7 +237,7 @@ where
         self.read(cx).toggle_action()
     }
 
-    fn icon_label(&self, window: &Window, cx: &App) -> Option<String> {
+    fn icon_label(&self, window: &Window, cx: &App) -> Option<PanelButtonLabel> {
         self.read(cx).icon_label(window, cx)
     }
 
@@ -1349,66 +1357,59 @@ impl Render for PanelButtons {
                         .trigger(move |is_active, _window, _cx| {
                             // Include active state in element ID to invalidate the cached
                             // tooltip when panel state changes (e.g., via keyboard shortcut)
-                            let numeric_icon_label = icon_label
-                                .clone()
-                                .and_then(|label| label.parse::<usize>().ok());
-                            let text_icon_label = icon_label
-                                .clone()
-                                .filter(|label| label.parse::<usize>().is_err());
-                            let icon_focus_handle = focus_handle.clone();
-                            let text_focus_handle = focus_handle.clone();
-                            let icon_tooltip = tooltip.clone();
-                            let text_tooltip = tooltip.clone();
-                            let icon_click_action = action.boxed_clone();
-                            let text_click_action = action.boxed_clone();
-                            let icon_tooltip_action = action.boxed_clone();
-                            let text_tooltip_action = action.boxed_clone();
-                            let button = text_icon_label.map_or_else(
-                                || {
-                                    IconButton::new((name, is_active_button as u64), icon)
-                                        .icon_size(IconSize::Small)
-                                        .toggle_state(is_active_button)
-                                        .on_click({
-                                            let action = icon_click_action.boxed_clone();
-                                            move |_, window, cx| {
-                                                window.focus(&icon_focus_handle, cx);
-                                                window.dispatch_action(action.boxed_clone(), cx)
-                                            }
+                            let text_label = match icon_label.as_ref() {
+                                Some(PanelButtonLabel::Text(label)) => Some(label.clone()),
+                                _ => None,
+                            };
+                            let count_label = match icon_label.as_ref() {
+                                Some(PanelButtonLabel::Count(count)) => Some(*count),
+                                _ => None,
+                            };
+                            let click_focus_handle = focus_handle.clone();
+                            let tooltip_action = action.boxed_clone();
+                            let click_action = action.boxed_clone();
+                            let tooltip_label = tooltip.clone();
+                            let button = if let Some(label) = text_label {
+                                Button::new((name, is_active_button as u64), label)
+                                    .start_icon(Icon::new(icon).size(IconSize::Small))
+                                    .label_size(LabelSize::Small)
+                                    .toggle_state(is_active_button)
+                                    .on_click(move |_, window, cx| {
+                                        window.focus(&click_focus_handle, cx);
+                                        window.dispatch_action(click_action.boxed_clone(), cx)
+                                    })
+                                    .when(!is_active, |this| {
+                                        this.tooltip(move |_window, cx| {
+                                            Tooltip::for_action(
+                                                tooltip_label.clone(),
+                                                &*tooltip_action,
+                                                cx,
+                                            )
                                         })
-                                        .when(!is_active, |this| {
-                                            let action = icon_tooltip_action.boxed_clone();
-                                            let tooltip = icon_tooltip.clone();
-                                            this.tooltip(move |_window, cx| {
-                                                Tooltip::for_action(tooltip.clone(), &*action, cx)
-                                            })
+                                    })
+                                    .into_any_element()
+                            } else {
+                                IconButton::new((name, is_active_button as u64), icon)
+                                    .icon_size(IconSize::Small)
+                                    .toggle_state(is_active_button)
+                                    .on_click(move |_, window, cx| {
+                                        window.focus(&click_focus_handle, cx);
+                                        window.dispatch_action(click_action.boxed_clone(), cx)
+                                    })
+                                    .when(!is_active, |this| {
+                                        this.tooltip(move |_window, cx| {
+                                            Tooltip::for_action(
+                                                tooltip_label.clone(),
+                                                &*tooltip_action,
+                                                cx,
+                                            )
                                         })
-                                        .into_any_element()
-                                },
-                                |label| {
-                                    Button::new((name, is_active_button as u64), label)
-                                        .start_icon(Icon::new(icon).size(IconSize::Small))
-                                        .label_size(LabelSize::Small)
-                                        .toggle_state(is_active_button)
-                                        .on_click({
-                                            let action = text_click_action.boxed_clone();
-                                            move |_, window, cx| {
-                                                window.focus(&text_focus_handle, cx);
-                                                window.dispatch_action(action.boxed_clone(), cx)
-                                            }
-                                        })
-                                        .when(!is_active, |this| {
-                                            let action = text_tooltip_action.boxed_clone();
-                                            let tooltip = text_tooltip.clone();
-                                            this.tooltip(move |_window, cx| {
-                                                Tooltip::for_action(tooltip.clone(), &*action, cx)
-                                            })
-                                        })
-                                        .into_any_element()
-                                },
-                            );
+                                    })
+                                    .into_any_element()
+                            };
 
                             div().relative().child(button).when_some(
-                                numeric_icon_label.filter(|_| !is_active_button),
+                                count_label.filter(|_| !is_active_button),
                                 |this, count| this.child(CountBadge::new(count)),
                             )
                         }),


### PR DESCRIPTION


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

— Added option to display branch name in status bar.

<img width="734" height="146" alt="tempImageoG4mxq" src="https://github.com/user-attachments/assets/35bbf953-6caf-4915-b3ac-6c38ed02c194" />
