### PR TITLE
agent: Add setting to auto-approve external ACP agent tool calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "acp_thread",
  "action_log",
  "agent-client-protocol",
+ "agent_settings",
  "anyhow",
  "async-channel 2.5.0",
  "chrono",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1102,6 +1102,13 @@
         // },
       },
     },
+    // When `true`, automatically approve every `session/request_permission`
+    // request raised by external ACP agents (e.g. Cursor, Claude Code,
+    // Gemini CLI) without showing a confirmation prompt. The `tool_permissions`
+    // rules above only apply to Zed's native agent — external agents own their
+    // own permission decisions. Use with care: this is the equivalent of
+    // running the external agent in a "yolo" / "always allow" mode.
+    "always_allow_external_agent_tools": false,
     // When enabled, agent edits will be displayed in single-file editors for review
     "single_file_review": false,
     // When enabled, show voting thumbs for feedback on agent edits.

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -600,6 +600,7 @@ mod tests {
             show_merge_conflict_indicator: true,
             sidebar_side: Default::default(),
             thinking_display: Default::default(),
+            always_allow_external_agent_tools: false,
         }
     }
 

--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -21,6 +21,7 @@ acp_thread.workspace = true
 action_log.workspace = true
 async-channel.workspace = true
 agent-client-protocol.workspace = true
+agent_settings.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 client.workspace = true

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -3809,6 +3809,61 @@ mod tests {
             "session should be removed after final close"
         );
     }
+
+    fn permission_option(id: &str, kind: acp::PermissionOptionKind) -> acp::PermissionOption {
+        acp::PermissionOption::new(acp::PermissionOptionId::new(id), id.to_string(), kind)
+    }
+
+    #[test]
+    fn auto_approve_outcome_prefers_allow_always() {
+        let options = vec![
+            permission_option("once", acp::PermissionOptionKind::AllowOnce),
+            permission_option("always", acp::PermissionOptionKind::AllowAlways),
+            permission_option("reject", acp::PermissionOptionKind::RejectOnce),
+        ];
+        let outcome =
+            auto_approve_outcome(&options).expect("expected auto-approve outcome to be selected");
+        assert_eq!(outcome.option_id.0.as_ref(), "always");
+    }
+
+    #[test]
+    fn auto_approve_outcome_falls_back_to_allow_once() {
+        let options = vec![
+            permission_option("reject_always", acp::PermissionOptionKind::RejectAlways),
+            permission_option("once", acp::PermissionOptionKind::AllowOnce),
+            permission_option("reject", acp::PermissionOptionKind::RejectOnce),
+        ];
+        let outcome =
+            auto_approve_outcome(&options).expect("expected auto-approve outcome to be selected");
+        assert_eq!(outcome.option_id.0.as_ref(), "once");
+    }
+
+    #[test]
+    fn auto_approve_outcome_returns_none_when_only_reject_options() {
+        let options = vec![
+            permission_option("reject", acp::PermissionOptionKind::RejectOnce),
+            permission_option("reject_always", acp::PermissionOptionKind::RejectAlways),
+        ];
+        assert!(auto_approve_outcome(&options).is_none());
+    }
+
+    #[test]
+    fn auto_approve_outcome_returns_none_for_empty_options() {
+        let options: Vec<acp::PermissionOption> = vec![];
+        assert!(auto_approve_outcome(&options).is_none());
+    }
+
+    #[test]
+    fn auto_approve_outcome_picks_first_allow_always_when_multiple_present() {
+        let options = vec![
+            permission_option("once", acp::PermissionOptionKind::AllowOnce),
+            permission_option("always_a", acp::PermissionOptionKind::AllowAlways),
+            permission_option("always_b", acp::PermissionOptionKind::AllowAlways),
+        ];
+        let outcome =
+            auto_approve_outcome(&options).expect("expected auto-approve outcome to be selected");
+        assert_eq!(outcome.option_id.0.as_ref(), "always_a");
+    }
 }
 
 fn mcp_servers_for_project(project: &Entity<Project>, cx: &App) -> Vec<acp::McpServer> {
@@ -4061,6 +4116,23 @@ fn respond_err<T: JsonRpcResponse>(responder: Responder<T>, err: acp::Error) {
     responder.respond_with_error(err).log_err();
 }
 
+/// When `agent.always_allow_external_agent_tools` is enabled, picks an option
+/// to auto-approve from the set offered by the external agent. Prefers a
+/// remembered "allow always" choice, falling back to a one-shot allow when the
+/// agent only offers `allow_once`. Returns `None` if no allow-shaped option is
+/// available, in which case the normal confirmation UI is shown.
+fn auto_approve_outcome(
+    options: &[acp::PermissionOption],
+) -> Option<acp::SelectedPermissionOutcome> {
+    let pick = |kind: acp::PermissionOptionKind| {
+        options
+            .iter()
+            .find(|option| option.kind == kind)
+            .map(|option| acp::SelectedPermissionOutcome::new(option.option_id.clone()))
+    };
+    pick(acp::PermissionOptionKind::AllowAlways).or_else(|| pick(acp::PermissionOptionKind::AllowOnce))
+}
+
 fn handle_request_permission(
     args: acp::RequestPermissionRequest,
     responder: Responder<acp::RequestPermissionResponse>,
@@ -4071,6 +4143,28 @@ fn handle_request_permission(
         Ok(t) => t,
         Err(e) => return respond_err(responder, e),
     };
+
+    // Honor the global blanket-approve switch for external ACP agents. Read it
+    // synchronously here so the bypass doesn't race against later setting
+    // changes within the same prompt turn. `try_read_global` keeps us safe in
+    // the (unexpected) case where the settings store isn't installed yet.
+    let auto_approve = cx
+        .try_read_global::<settings::SettingsStore, _>(|_, cx| {
+            <agent_settings::AgentSettings as settings::Settings>::get_global(cx)
+                .always_allow_external_agent_tools
+        })
+        .unwrap_or(false);
+
+    if auto_approve
+        && let Some(outcome) = auto_approve_outcome(&args.options)
+    {
+        responder
+            .respond(acp::RequestPermissionResponse::new(
+                acp::RequestPermissionOutcome::Selected(outcome),
+            ))
+            .log_err();
+        return;
+    }
 
     cx.spawn(async move |cx| {
         let result: Result<_, acp::Error> = async {

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -168,6 +168,7 @@ pub struct AgentSettings {
     pub show_turn_stats: bool,
     pub show_merge_conflict_indicator: bool,
     pub tool_permissions: ToolPermissions,
+    pub always_allow_external_agent_tools: bool,
 }
 
 impl AgentSettings {
@@ -672,6 +673,9 @@ impl Settings for AgentSettings {
             show_turn_stats: agent.show_turn_stats.unwrap(),
             show_merge_conflict_indicator: agent.show_merge_conflict_indicator.unwrap(),
             tool_permissions: compile_tool_permissions(agent.tool_permissions),
+            always_allow_external_agent_tools: agent
+                .always_allow_external_agent_tools
+                .unwrap_or(false),
         }
     }
 }

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -833,6 +833,7 @@ mod tests {
             show_merge_conflict_indicator: true,
             sidebar_side: Default::default(),
             thinking_display: Default::default(),
+            always_allow_external_agent_tools: false,
         };
 
         cx.update(|cx| {

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -211,6 +211,18 @@ pub struct AgentSettingsContent {
     /// `always_confirm`) match against the tool's text input (command, path,
     /// URL, etc.).
     pub tool_permissions: Option<ToolPermissionsContent>,
+    /// When `true`, automatically approve every `session/request_permission`
+    /// request raised by external ACP agents (e.g. Cursor, Claude Code,
+    /// Gemini CLI) without showing a confirmation prompt.
+    ///
+    /// Zed's own `tool_permissions` rules do **not** apply to external ACP
+    /// agents — those agents own their own permission decisions and delegate
+    /// the prompt UI to Zed. This switch is a blanket "trust the agent" bypass
+    /// for that delegated prompt. Each external agent may also enforce its own
+    /// hardcoded refusals; this setting cannot override those.
+    ///
+    /// Default: false
+    pub always_allow_external_agent_tools: Option<bool>,
 }
 
 impl AgentSettingsContent {

--- a/docs/src/ai/tool-permissions.md
+++ b/docs/src/ai/tool-permissions.md
@@ -157,6 +157,33 @@ You can use the "Test Your Rules" checker, available in each individual tool pag
 
 </div>
 
+## External ACP Agents
+
+`tool_permissions` applies only to Zed's **native** agent tools. External
+agents that talk to Zed over the [Agent Client Protocol](https://agentclientprotocol.com)
+(e.g. Cursor, Claude Code, Gemini CLI) own their own permission decisions and
+ask Zed to display the confirmation UI for every tool call. Because the agent
+controls when to ask, the per-tool patterns above cannot match against them.
+
+If you want a single switch that auto-approves every external-agent prompt:
+
+```json [settings]
+{
+  "agent": {
+    "always_allow_external_agent_tools": true
+  }
+}
+```
+
+When enabled, Zed responds to every `session/request_permission` request with
+the agent's `allow_always` option (or `allow_once` if no `allow_always` is
+offered) and never shows the prompt UI. This is equivalent to running the
+external agent in a "yolo" / "always allow" mode, so use it only with agents
+you fully trust.
+
+This setting has no effect on Zed's native agent — use `tool_permissions`
+above for that.
+
 ## Built-in Security Rules
 
 Zed includes a small set of hardcoded security rules that **cannot be overridden** by any setting.


### PR DESCRIPTION
Closes #57355.

## Summary

- Adds an opt-in `agent.always_allow_external_agent_tools` setting for external ACP agents.
- When enabled, permission requests from external agents are auto-approved by preferring `AllowAlways` and falling back to `AllowOnce`.
- Preserves current behavior by default (`false`).

## Changes

- Added `always_allow_external_agent_tools` to agent settings and settings content.
- Updated ACP permission handling to auto-approve when the setting is enabled.
- Added unit tests for auto-approval option selection.

## Test plan

- `cargo test -p agent_servers auto_approve_outcome -- --nocapture`

Release Notes:

- Added an opt-in `agent.always_allow_external_agent_tools` setting that auto-approves tool-call permission requests from external ACP agents.
