### PR TITLE
markdown: Render soft breaks as line breaks in agent markdown

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -110,6 +110,10 @@ pub struct MarkdownStyle {
     pub height_is_multiple_of_line_height: bool,
     pub prevent_mouse_interaction: bool,
     pub table_columns_min_size: bool,
+    /// When true, soft breaks (single newlines within a paragraph) are rendered
+    /// as hard line breaks instead of spaces. This matches the behavior of
+    /// GitHub comments and Obsidian's default mode.
+    pub soft_break_as_hard_break: bool,
 }
 
 impl Default for MarkdownStyle {
@@ -133,6 +137,7 @@ impl Default for MarkdownStyle {
             height_is_multiple_of_line_height: false,
             prevent_mouse_interaction: false,
             table_columns_min_size: false,
+            soft_break_as_hard_break: false,
         }
     }
 }
@@ -270,6 +275,7 @@ impl MarkdownStyle {
                 }),
                 ..Default::default()
             },
+            soft_break_as_hard_break: matches!(font, MarkdownFont::Agent),
             heading_level_styles: matches!(font, MarkdownFont::Agent).then_some(
                 HeadingLevelStyles {
                     h1: Some(TextStyleRefinement {
@@ -2566,7 +2572,13 @@ impl Element for MarkdownElement {
                     );
                     builder.pop_div()
                 }
-                MarkdownEvent::SoftBreak => builder.push_text(" ", range.clone()),
+                MarkdownEvent::SoftBreak => {
+                    if self.style.soft_break_as_hard_break {
+                        builder.push_text("\n", range.clone())
+                    } else {
+                        builder.push_text(" ", range.clone())
+                    }
+                }
                 MarkdownEvent::HardBreak => builder.push_text("\n", range.clone()),
                 MarkdownEvent::TaskListMarker(_) => {
                     // handled inside the `MarkdownTag::Item` case

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -110,9 +110,6 @@ pub struct MarkdownStyle {
     pub height_is_multiple_of_line_height: bool,
     pub prevent_mouse_interaction: bool,
     pub table_columns_min_size: bool,
-    /// When true, soft breaks (single newlines within a paragraph) are rendered
-    /// as hard line breaks instead of spaces. This matches the behavior of
-    /// GitHub comments and Obsidian's default mode.
     pub soft_break_as_hard_break: bool,
 }
 


### PR DESCRIPTION
Agents sometimes output status lists with bullets represented by emojis - see #57372. These currently get rendered on one line, as opposed to bullet items like `-` or `*`, because single newlines within a paragraph are collapsed into spaces - standard CommonMark soft-break behavior *in prose* contexts (e.g. `README.md`). But in *comment/PR* contexts, GitHub preserves these newlines:

✅ Did A
✅ Did B
✅ Did C

Users reasonably expect agent output to be rendered following the comment-style convention.

## What this PR does

This PR adds a `soft_break_as_hard_break: bool` field on `MarkdownStyle` and enables it for `MarkdownFont::Agent`, so a single newline within a paragraph *in agent output* renders as a line break instead of a space. The field defaults to `false` to preserves CommonMark behavior everywhere else. In `themed_with_overrides`, sets it to `true` for `MarkdownFont::Agent`. The rendering switch in `MarkdownElement::request_layout` then emits `"\n"` instead of `" "` for `MarkdownEvent::SoftBreak` when the flag is set. This matches GitHub comments and Obsidian default behavior, and prevents emoji + trailing newline content from being collapsed onto a single line in agent responses.

Scoped strictly to `MarkdownFont::Agent`. Hover popovers, diagnostics, markdown preview, README rendering, etc. are all untouched.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior - visual tests completed: 
<img width="892" height="632" alt="image" src="https://github.com/user-attachments/assets/1aacb5da-edc8-49fd-bfe9-d37a22ae2d3f" />

- [x] Performance impact has been considered and is acceptable

Closes #57372

Release Notes:

- Improved agent panel markdown rendering: single newlines within agent responses now render as line breaks, matching the convention used by GitHub comments and Obsidian.