### PR TITLE
project: Re-resolve recent tasks against current editor context

### DIFF
--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -496,11 +496,47 @@ impl Inventory {
                 }
             })
             .map(|(task_source_kind, resolved_task)| {
-                (
-                    task_source_kind.clone(),
-                    resolved_task.clone(),
-                    post_inc(&mut lru_score),
-                )
+                let kind = task_source_kind.clone();
+                let id_base = kind.to_id_base();
+                let task = &resolved_task.original_task();
+                let reresolved = if let TaskSourceKind::Worktree { id, .. } = &kind {
+                    None.or_else(|| {
+                        let (_, _, item_context) =
+                            task_contexts.active_item_context.as_ref().filter(
+                                |(worktree_id, _, _)| Some(id) == worktree_id.as_ref(),
+                            )?;
+                        task.resolve_task(&id_base, item_context)
+                    })
+                    .or_else(|| {
+                        let (_, worktree_context) = task_contexts
+                            .active_worktree_context
+                            .as_ref()
+                            .filter(|(worktree_id, _)| id == worktree_id)?;
+                        task.resolve_task(&id_base, worktree_context)
+                    })
+                    .or_else(|| {
+                        let worktree_context = task_contexts
+                            .other_worktree_contexts
+                            .iter()
+                            .find(|(worktree_id, _)| worktree_id == id)
+                            .map(|(_, context)| context)?;
+                        task.resolve_task(&id_base, worktree_context)
+                    })
+                } else {
+                    None.or_else(|| {
+                        let (_, _, item_context) =
+                            task_contexts.active_item_context.as_ref()?;
+                        task.resolve_task(&id_base, item_context)
+                    })
+                    .or_else(|| {
+                        let (_, worktree_context) =
+                            task_contexts.active_worktree_context.as_ref()?;
+                        task.resolve_task(&id_base, worktree_context)
+                    })
+                }
+                .or_else(|| task.resolve_task(&id_base, &TaskContext::default()))
+                .unwrap_or_else(|| resolved_task.clone());
+                (kind, reresolved, post_inc(&mut lru_score))
             })
             .sorted_unstable_by(task_lru_comparator)
             .map(|(kind, task, _)| (kind, task))

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -528,10 +528,15 @@ impl Inventory {
             })
             .map(|(task_source_kind, resolved_task)| {
                 let reresolved = task_contexts.reresolve_task(task_source_kind, resolved_task);
-                (task_source_kind.clone(), reresolved)
+                let task = if reresolved.resolved_label == resolved_task.resolved_label {
+                    reresolved
+                } else {
+                    resolved_task.clone()
+                };
+                (task_source_kind.clone(), task)
             })
-            .filter_map(|(task_source_kind, resolved_task)| {
-                let keep = match task_labels_to_ids.entry(resolved_task.resolved_label.clone()) {
+            .filter(|(_, resolved_task)| {
+                match task_labels_to_ids.entry(resolved_task.resolved_label.clone()) {
                     hash_map::Entry::Occupied(mut o) => {
                         // Allow distinct re-resolved tasks that share a label but differ by context.
                         o.get_mut().insert(resolved_task.id.clone())
@@ -540,9 +545,9 @@ impl Inventory {
                         v.insert(HashSet::from_iter(Some(resolved_task.id.clone())));
                         true
                     }
-                };
-                keep.then(|| (task_source_kind, resolved_task, post_inc(&mut lru_score)))
+                }
             })
+            .map(|(kind, task)| (kind, task, post_inc(&mut lru_score)))
             .sorted_unstable_by(task_lru_comparator)
             .map(|(kind, task, _)| (kind, task))
             .collect::<Vec<_>>();

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -238,8 +238,8 @@ impl TaskContexts {
         let id_base = kind.to_id_base();
         let task = resolved_task.original_task();
 
-        let candidate_contexts: Vec<&TaskContext> = match kind {
-            TaskSourceKind::Worktree { id, .. } => [
+        let candidate_contexts: Vec<Option<&TaskContext>> = match kind {
+            TaskSourceKind::Worktree { id, .. } => vec![
                 self.active_item_context
                     .as_ref()
                     .filter(|(worktree_id, _, _)| worktree_id.as_ref() == Some(id))
@@ -252,25 +252,20 @@ impl TaskContexts {
                     .iter()
                     .find(|(worktree_id, _)| worktree_id == id)
                     .map(|(_, context)| context),
-            ]
-            .into_iter()
-            .flatten()
-            .collect(),
-            _ => [
+            ],
+            _ => vec![
                 self.active_item_context
                     .as_ref()
                     .map(|(_, _, context)| context),
                 self.active_worktree_context
                     .as_ref()
                     .map(|(_, context)| context),
-            ]
-            .into_iter()
-            .flatten()
-            .collect(),
+            ],
         };
 
         candidate_contexts
             .into_iter()
+            .flatten()
             .find_map(|context| task.resolve_task(&id_base, context))
             .or_else(|| task.resolve_task(&id_base, &TaskContext::default()))
             .unwrap_or_else(|| resolved_task.clone())
@@ -531,26 +526,22 @@ impl Inventory {
                     true
                 }
             })
-            .filter(|(_, resolved_task)| {
-                match task_labels_to_ids.entry(resolved_task.resolved_label.clone()) {
+            .map(|(task_source_kind, resolved_task)| {
+                let reresolved = task_contexts.reresolve_task(task_source_kind, resolved_task);
+                (task_source_kind.clone(), reresolved)
+            })
+            .filter_map(|(task_source_kind, resolved_task)| {
+                let keep = match task_labels_to_ids.entry(resolved_task.resolved_label.clone()) {
                     hash_map::Entry::Occupied(mut o) => {
-                        o.get_mut().insert(resolved_task.id.clone());
-                        // Neber allow duplicate reused tasks with the same labels
-                        false
+                        // Allow distinct re-resolved tasks that share a label but differ by context.
+                        o.get_mut().insert(resolved_task.id.clone())
                     }
                     hash_map::Entry::Vacant(v) => {
                         v.insert(HashSet::from_iter(Some(resolved_task.id.clone())));
                         true
                     }
-                }
-            })
-            .map(|(task_source_kind, resolved_task)| {
-                let reresolved = task_contexts.reresolve_task(task_source_kind, resolved_task);
-                (
-                    task_source_kind.clone(),
-                    reresolved,
-                    post_inc(&mut lru_score),
-                )
+                };
+                keep.then(|| (task_source_kind, resolved_task, post_inc(&mut lru_score)))
             })
             .sorted_unstable_by(task_lru_comparator)
             .map(|(kind, task, _)| (kind, task))

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -226,6 +226,55 @@ impl TaskContexts {
             .find(|(id, _)| *id == worktree_id)
             .map(|(_, context)| context)
     }
+
+    /// Re-resolves a previously resolved task against the current contexts, so that
+    /// any context-dependent variables (e.g. the active file or selection) reflect the
+    /// editor's current state rather than the state from when the task was first run.
+    ///
+    /// For worktree tasks the search is scoped to the task's own worktree; other tasks
+    /// fall back through the active item, active worktree, and finally an empty context.
+    /// If none of the contexts resolve, the original `resolved_task` is returned unchanged.
+    fn reresolve_task(&self, kind: &TaskSourceKind, resolved_task: &ResolvedTask) -> ResolvedTask {
+        let id_base = kind.to_id_base();
+        let task = resolved_task.original_task();
+
+        let candidate_contexts: Vec<&TaskContext> = match kind {
+            TaskSourceKind::Worktree { id, .. } => [
+                self.active_item_context
+                    .as_ref()
+                    .filter(|(worktree_id, _, _)| worktree_id.as_ref() == Some(id))
+                    .map(|(_, _, context)| context),
+                self.active_worktree_context
+                    .as_ref()
+                    .filter(|(worktree_id, _)| worktree_id == id)
+                    .map(|(_, context)| context),
+                self.other_worktree_contexts
+                    .iter()
+                    .find(|(worktree_id, _)| worktree_id == id)
+                    .map(|(_, context)| context),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+            _ => [
+                self.active_item_context
+                    .as_ref()
+                    .map(|(_, _, context)| context),
+                self.active_worktree_context
+                    .as_ref()
+                    .map(|(_, context)| context),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+        };
+
+        candidate_contexts
+            .into_iter()
+            .find_map(|context| task.resolve_task(&id_base, context))
+            .or_else(|| task.resolve_task(&id_base, &TaskContext::default()))
+            .unwrap_or_else(|| resolved_task.clone())
+    }
 }
 
 impl TaskSourceKind {
@@ -496,47 +545,12 @@ impl Inventory {
                 }
             })
             .map(|(task_source_kind, resolved_task)| {
-                let kind = task_source_kind.clone();
-                let id_base = kind.to_id_base();
-                let task = &resolved_task.original_task();
-                let reresolved = if let TaskSourceKind::Worktree { id, .. } = &kind {
-                    None.or_else(|| {
-                        let (_, _, item_context) =
-                            task_contexts.active_item_context.as_ref().filter(
-                                |(worktree_id, _, _)| Some(id) == worktree_id.as_ref(),
-                            )?;
-                        task.resolve_task(&id_base, item_context)
-                    })
-                    .or_else(|| {
-                        let (_, worktree_context) = task_contexts
-                            .active_worktree_context
-                            .as_ref()
-                            .filter(|(worktree_id, _)| id == worktree_id)?;
-                        task.resolve_task(&id_base, worktree_context)
-                    })
-                    .or_else(|| {
-                        let worktree_context = task_contexts
-                            .other_worktree_contexts
-                            .iter()
-                            .find(|(worktree_id, _)| worktree_id == id)
-                            .map(|(_, context)| context)?;
-                        task.resolve_task(&id_base, worktree_context)
-                    })
-                } else {
-                    None.or_else(|| {
-                        let (_, _, item_context) =
-                            task_contexts.active_item_context.as_ref()?;
-                        task.resolve_task(&id_base, item_context)
-                    })
-                    .or_else(|| {
-                        let (_, worktree_context) =
-                            task_contexts.active_worktree_context.as_ref()?;
-                        task.resolve_task(&id_base, worktree_context)
-                    })
-                }
-                .or_else(|| task.resolve_task(&id_base, &TaskContext::default()))
-                .unwrap_or_else(|| resolved_task.clone());
-                (kind, reresolved, post_inc(&mut lru_score))
+                let reresolved = task_contexts.reresolve_task(task_source_kind, resolved_task);
+                (
+                    task_source_kind.clone(),
+                    reresolved,
+                    post_inc(&mut lru_score),
+                )
             })
             .sorted_unstable_by(task_lru_comparator)
             .map(|(kind, task, _)| (kind, task))
@@ -1135,5 +1149,118 @@ impl ContextProviderWithTasks {
 impl ContextProvider for ContextProviderWithTasks {
     fn associated_tasks(&self, _: Option<Entity<Buffer>>, _: &App) -> Task<Option<TaskTemplates>> {
         Task::ready(Some(self.templates.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context_with_greeting(value: &str) -> TaskContext {
+        TaskContext {
+            task_variables: TaskVariables::from_iter([(
+                VariableName::Custom(Cow::Owned("GREETING".to_string())),
+                value.to_string(),
+            )]),
+            ..TaskContext::default()
+        }
+    }
+
+    fn greeting_template() -> TaskTemplate {
+        TaskTemplate {
+            label: "echo $ZED_CUSTOM_GREETING".to_string(),
+            command: "echo".to_string(),
+            args: vec!["$ZED_CUSTOM_GREETING".to_string()],
+            ..TaskTemplate::default()
+        }
+    }
+
+    #[test]
+    fn reresolve_task_uses_current_active_item_context() {
+        let template = greeting_template();
+        let stale = template
+            .resolve_task("oneshot", &context_with_greeting("stale"))
+            .expect("template should resolve against the stale context");
+        assert_eq!(stale.resolved_label, "echo stale");
+
+        let task_contexts = TaskContexts {
+            active_item_context: Some((None, None, context_with_greeting("fresh"))),
+            ..TaskContexts::default()
+        };
+
+        let reresolved = task_contexts.reresolve_task(&TaskSourceKind::UserInput, &stale);
+        assert_eq!(
+            reresolved.resolved_label, "echo fresh",
+            "re-resolution should pick up the current active item context"
+        );
+    }
+
+    #[test]
+    fn reresolve_task_scopes_worktree_tasks_to_their_worktree() {
+        let template = greeting_template();
+        let stale = template
+            .resolve_task("worktree", &context_with_greeting("stale"))
+            .expect("template should resolve against the stale context");
+
+        let task_worktree = WorktreeId::from_usize(1);
+        let other_worktree = WorktreeId::from_usize(2);
+        let kind = TaskSourceKind::Worktree {
+            id: task_worktree,
+            directory_in_worktree: RelPath::empty().into_arc(),
+            id_base: Cow::Borrowed("worktree"),
+        };
+
+        // The active item belongs to a different worktree, so it must not be used; the
+        // task's own worktree context should win instead.
+        let task_contexts = TaskContexts {
+            active_item_context: Some((Some(other_worktree), None, context_with_greeting("other"))),
+            active_worktree_context: Some((task_worktree, context_with_greeting("fresh"))),
+            ..TaskContexts::default()
+        };
+
+        let reresolved = task_contexts.reresolve_task(&kind, &stale);
+        assert_eq!(
+            reresolved.resolved_label, "echo fresh",
+            "worktree tasks should only re-resolve against their own worktree's context"
+        );
+    }
+
+    #[test]
+    fn reresolve_task_prefers_active_item_over_worktree_context() {
+        let template = greeting_template();
+        let stale = template
+            .resolve_task("oneshot", &context_with_greeting("stale"))
+            .expect("template should resolve against the stale context");
+
+        // Both contexts can resolve the task; the active item context is more specific
+        // and must take precedence over the active worktree context.
+        let task_contexts = TaskContexts {
+            active_item_context: Some((None, None, context_with_greeting("item"))),
+            active_worktree_context: Some((
+                WorktreeId::from_usize(1),
+                context_with_greeting("worktree"),
+            )),
+            ..TaskContexts::default()
+        };
+
+        let reresolved = task_contexts.reresolve_task(&TaskSourceKind::UserInput, &stale);
+        assert_eq!(
+            reresolved.resolved_label, "echo item",
+            "the active item context should take precedence over the worktree context"
+        );
+    }
+
+    #[test]
+    fn reresolve_task_falls_back_to_original_when_no_context_resolves() {
+        let template = greeting_template();
+        let stale = template
+            .resolve_task("oneshot", &context_with_greeting("stale"))
+            .expect("template should resolve against the stale context");
+
+        // No contexts provide the variable, and the empty default context cannot resolve
+        // a template that requires it, so the original resolved task is returned unchanged.
+        let task_contexts = TaskContexts::default();
+        let reresolved = task_contexts.reresolve_task(&TaskSourceKind::UserInput, &stale);
+        assert_eq!(reresolved, stale);
     }
 }


### PR DESCRIPTION
## Summary

Closes #55879.

When a task is run, its fully-resolved form (`ResolvedTask`, with `$ZED_FILE`/`$ZED_STEM`/`$ZED_COLUMN`/etc. already substituted) is cached in `Inventory::last_scheduled_tasks`. The next time the task picker is opened, `used_and_current_resolved_tasks` returns those cached entries as-is for the "recent" section. The "current" section *is* re-resolved against the active editor, but the label-based dedup keeps the stale recent entry.

The result is that `$ZED_FILE` keeps pointing at the file that was active the first time the task ran, even after switching editors and re-running from the picker.

This fix re-resolves each entry in the recent-tasks list against the current `TaskContexts` using the same context-pick chain the "current" branch already uses (item context → active worktree → other worktree → default). If re-resolution fails for any reason, we fall back to the cached `ResolvedTask` so behavior never regresses.

The change is localized to `previously_spawned_tasks` inside `used_and_current_resolved_tasks`. List order, dedup, and LRU scoring are unchanged — only the variable substitutions inside each `ResolvedTask` are refreshed.

## Test plan

- [x] Open a project with two source files (e.g. `1.cpp`, `2.cpp`) and a task that uses `$ZED_FILE` (e.g. `g++ $ZED_FILE -o $ZED_STEM && ./$ZED_STEM`).
- [x] Open `1.cpp`, run the task from the picker, confirm it compiles `1.cpp`.
- [x] Click `2.cpp`, open the task picker, pick the same task from the "recent" section, confirm it now compiles `2.cpp` (previously: still `1.cpp`).
- [x] Confirm the recent-task ordering and divider in the picker are unchanged.

Release Notes:

- Fixed task variables like `$ZED_FILE` not updating when re-running a recently used task after switching the active editor (#55879).