### PR TITLE
gpui: Support nearest-neighbor filtering for polychrome sprites

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -188,6 +188,10 @@ name = "image"
 path = "examples/image/image.rs"
 
 [[example]]
+name = "image_filter"
+path = "examples/image_filter.rs"
+
+[[example]]
 name = "input"
 path = "examples/input.rs"
 

--- a/crates/gpui/examples/image_filter.rs
+++ b/crates/gpui/examples/image_filter.rs
@@ -1,0 +1,116 @@
+#![cfg_attr(target_family = "wasm", no_main)]
+
+use std::sync::Arc;
+
+use gpui::{
+    App, AppContext, Bounds, Context, ImageFilter, RenderImage, SharedString, TitlebarOptions,
+    Window, WindowBounds, WindowOptions, div, img, prelude::*, px, size,
+};
+use image::Frame;
+use smallvec::SmallVec;
+
+const SOURCE_SIZE: u32 = 32;
+const CELL_SIZE: u32 = 4;
+
+fn checkerboard() -> Arc<RenderImage> {
+    let mut buffer =
+        image::RgbaImage::new(SOURCE_SIZE, SOURCE_SIZE);
+    for (x, y, pixel) in buffer.enumerate_pixels_mut() {
+        let dark = ((x / CELL_SIZE) + (y / CELL_SIZE)) % 2 == 0;
+        *pixel = if dark {
+            image::Rgba([0, 0, 0, 255])
+        } else {
+            image::Rgba([255, 255, 255, 255])
+        };
+    }
+    Arc::new(RenderImage::new(SmallVec::from_const([Frame::new(buffer)])))
+}
+
+struct ImageFilterDemo {
+    checker: Arc<RenderImage>,
+}
+
+impl Render for ImageFilterDemo {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let upscaled = px(SOURCE_SIZE as f32 * 8.0);
+        div()
+            .bg(gpui::white())
+            .size_full()
+            .p_8()
+            .flex()
+            .flex_col()
+            .gap_4()
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .gap_8()
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_2()
+                            .items_center()
+                            .child("Linear")
+                            .child(img(self.checker.clone()).w(upscaled).h(upscaled)),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_2()
+                            .items_center()
+                            .child("Nearest")
+                            .child(
+                                img(self.checker.clone())
+                                    .w(upscaled)
+                                    .h(upscaled)
+                                    .image_filter(ImageFilter::Nearest),
+                            ),
+                    ),
+            )
+    }
+}
+
+fn run_example() {
+    let checker = checkerboard();
+
+    #[cfg(not(target_family = "wasm"))]
+    let app = gpui_platform::application();
+    #[cfg(target_family = "wasm")]
+    let app = gpui_platform::single_threaded_web();
+
+    app.run(move |cx: &mut App| {
+        cx.activate(true);
+        let window_options = WindowOptions {
+            titlebar: Some(TitlebarOptions {
+                title: Some(SharedString::from("Image Filter")),
+                ..Default::default()
+            }),
+            window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
+                None,
+                size(px(720.0), px(420.0)),
+                cx,
+            ))),
+            ..Default::default()
+        };
+        cx.open_window(window_options, |_, cx| {
+            let checker = checker.clone();
+            cx.new(move |_| ImageFilterDemo { checker })
+        })
+        .unwrap();
+    });
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn main() {
+    env_logger::init();
+    run_example();
+}
+
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn start() {
+    gpui_platform::web_init();
+    run_example();
+}

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -1,8 +1,8 @@
 use crate::{
     AnyElement, AnyImageCache, App, Asset, AssetLogger, Bounds, DefiniteLength, Element, ElementId,
-    Entity, GlobalElementId, Hitbox, Image, ImageCache, InspectorElementId, InteractiveElement,
-    Interactivity, IntoElement, LayoutId, Length, ObjectFit, Pixels, RenderImage, Resource,
-    SharedString, SharedUri, StyleRefinement, Styled, Task, Window, px,
+    Entity, GlobalElementId, Hitbox, Image, ImageCache, ImageFilter, InspectorElementId,
+    InteractiveElement, Interactivity, IntoElement, LayoutId, Length, ObjectFit, Pixels,
+    RenderImage, Resource, SharedString, SharedUri, StyleRefinement, Styled, Task, Window, px,
 };
 use anyhow::Result;
 
@@ -127,6 +127,7 @@ where
 /// The style of an image element.
 pub struct ImageStyle {
     grayscale: bool,
+    filter: ImageFilter,
     object_fit: ObjectFit,
     loading: Option<Box<dyn Fn() -> AnyElement>>,
     fallback: Option<Box<dyn Fn() -> AnyElement>>,
@@ -136,6 +137,7 @@ impl Default for ImageStyle {
     fn default() -> Self {
         Self {
             grayscale: false,
+            filter: ImageFilter::default(),
             object_fit: ObjectFit::Contain,
             loading: None,
             fallback: None,
@@ -151,6 +153,12 @@ pub trait StyledImage: Sized {
     /// Set the image to be displayed in grayscale.
     fn grayscale(mut self, grayscale: bool) -> Self {
         self.image_style().grayscale = grayscale;
+        self
+    }
+
+    /// Pick the sampling filter used when the image is scaled.
+    fn image_filter(mut self, filter: ImageFilter) -> Self {
+        self.image_style().filter = filter;
         self
     }
 
@@ -497,6 +505,7 @@ impl Element for Img {
                             data,
                             layout_state.frame_index,
                             self.style.grayscale,
+                            self.style.filter,
                         )
                         .log_err();
                 } else if let Some(replacement) = &mut layout_state.replacement {

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -413,7 +413,9 @@ impl<'a> Iterator for BatchIterator<'a> {
                 })
             }
             PrimitiveKind::PolychromeSprite => {
-                let texture_id = self.polychrome_sprites_iter.peek().unwrap().tile.texture_id;
+                let first = self.polychrome_sprites_iter.peek().unwrap();
+                let texture_id = first.tile.texture_id;
+                let filter = first.filter;
                 let sprites_start = self.polychrome_sprites_start;
                 let mut sprites_end = sprites_start + 1;
                 self.polychrome_sprites_iter.next();
@@ -422,6 +424,7 @@ impl<'a> Iterator for BatchIterator<'a> {
                     .next_if(|sprite| {
                         (sprite.order, batch_kind) < max_order_and_kind
                             && sprite.tile.texture_id == texture_id
+                            && sprite.filter == filter
                     })
                     .is_some()
                 {
@@ -430,6 +433,7 @@ impl<'a> Iterator for BatchIterator<'a> {
                 self.polychrome_sprites_start = sprites_end;
                 Some(PrimitiveBatch::PolychromeSprites {
                     texture_id,
+                    filter,
                     range: sprites_start..sprites_end,
                 })
             }
@@ -476,9 +480,22 @@ pub enum PrimitiveBatch {
     },
     PolychromeSprites {
         texture_id: AtlasTextureId,
+        filter: ImageFilter,
         range: Range<usize>,
     },
     Surfaces(Range<usize>),
+}
+
+/// How an atlas texture is sampled when its source pixels don't map 1:1 to
+/// destination pixels.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+#[repr(C)]
+pub enum ImageFilter {
+    /// Bilinear filtering
+    #[default]
+    Linear = 0,
+    /// Nearest-neighbor sampling
+    Nearest = 1,
 }
 
 #[derive(Default, Debug, Copy, Clone)]
@@ -695,7 +712,7 @@ impl From<SubpixelSprite> for Primitive {
 #[expect(missing_docs)]
 pub struct PolychromeSprite {
     pub order: DrawOrder,
-    pub pad: u32,
+    pub filter: ImageFilter,
     pub grayscale: bool,
     pub opacity: f32,
     pub bounds: Bounds<ScaledPixels>,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6,9 +6,10 @@ use crate::{
     Context, Corners, CursorHideMode, CursorStyle, Decorations, DevicePixels,
     DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity,
     EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs,
-    Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke,
-    KeystrokeEvent, LayoutId, LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite,
-    MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas,
+    Hsla, ImageFilter, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent,
+    Keystroke, KeystrokeEvent, LayoutId, LineLayoutIndex, Modifiers, ModifiersChangedEvent,
+    MonochromeSprite, MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels,
+    PlatformAtlas,
     PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PolychromeSprite,
     Priority, PromptButton, PromptLevel, Quad, Render, RenderGlyphParams, RenderImage,
     RenderImageParams, RenderSvgParams, Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR,
@@ -3740,7 +3741,7 @@ impl Window {
 
             self.next_frame.scene.insert_primitive(PolychromeSprite {
                 order: 0,
-                pad: 0,
+                filter: ImageFilter::Linear,
                 grayscale: false,
                 bounds,
                 corner_radii: Default::default(),
@@ -3828,6 +3829,7 @@ impl Window {
         data: Arc<RenderImage>,
         frame_index: usize,
         grayscale: bool,
+        filter: ImageFilter,
     ) -> Result<()> {
         self.invalidator.debug_assert_paint();
 
@@ -3855,7 +3857,7 @@ impl Window {
 
         self.next_frame.scene.insert_primitive(PolychromeSprite {
             order: 0,
-            pad: 0,
+            filter,
             grayscale,
             bounds,
             content_mask,

--- a/crates/gpui_macos/build.rs
+++ b/crates/gpui_macos/build.rs
@@ -56,6 +56,8 @@ mod macos_build {
             "Quad".into(),
             "BorderStyle".into(),
             "SpriteInputIndex".into(),
+            "SpriteSamplerIndex".into(),
+            "ImageFilter".into(),
             "MonochromeSprite".into(),
             "PolychromeSprite".into(),
             "PathSprite".into(),

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -7,9 +7,9 @@ use cocoa::{
     quartzcore::AutoresizingMask,
 };
 use gpui::{
-    AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, MonochromeSprite, PaintSurface,
-    Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
-    Surface, Underline, point, size,
+    AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, ImageFilter, MonochromeSprite,
+    PaintSurface, Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow,
+    Size, Surface, Underline, point, size,
 };
 #[cfg(any(test, feature = "test-support"))]
 use image::RgbaImage;
@@ -124,6 +124,8 @@ pub(crate) struct MetalRenderer {
     underlines_pipeline_state: metal::RenderPipelineState,
     monochrome_sprites_pipeline_state: metal::RenderPipelineState,
     polychrome_sprites_pipeline_state: metal::RenderPipelineState,
+    polychrome_linear_sampler: metal::SamplerState,
+    polychrome_nearest_sampler: metal::SamplerState,
     surfaces_pipeline_state: metal::RenderPipelineState,
     unit_vertices: metal::Buffer,
     #[allow(clippy::arc_with_non_send_sync)]
@@ -310,6 +312,16 @@ impl MetalRenderer {
             "polychrome_sprite_fragment",
             MTLPixelFormat::BGRA8Unorm,
         );
+        let polychrome_linear_sampler = build_sampler_state(
+            &device,
+            metal::MTLSamplerMinMagFilter::Linear,
+            "polychrome_linear_sampler",
+        );
+        let polychrome_nearest_sampler = build_sampler_state(
+            &device,
+            metal::MTLSamplerMinMagFilter::Nearest,
+            "polychrome_nearest_sampler",
+        );
         let surfaces_pipeline_state = build_pipeline_state(
             &device,
             &library,
@@ -339,6 +351,8 @@ impl MetalRenderer {
             underlines_pipeline_state,
             monochrome_sprites_pipeline_state,
             polychrome_sprites_pipeline_state,
+            polychrome_linear_sampler,
+            polychrome_nearest_sampler,
             surfaces_pipeline_state,
             unit_vertices,
             instance_buffer_pool,
@@ -826,15 +840,19 @@ impl MetalRenderer {
                         viewport_size,
                         command_encoder,
                     ),
-                PrimitiveBatch::PolychromeSprites { texture_id, range } => self
-                    .draw_polychrome_sprites(
-                        texture_id,
-                        &scene.polychrome_sprites[range],
-                        instance_buffer,
-                        &mut instance_offset,
-                        viewport_size,
-                        command_encoder,
-                    ),
+                PrimitiveBatch::PolychromeSprites {
+                    texture_id,
+                    filter,
+                    range,
+                } => self.draw_polychrome_sprites(
+                    texture_id,
+                    filter,
+                    &scene.polychrome_sprites[range],
+                    instance_buffer,
+                    &mut instance_offset,
+                    viewport_size,
+                    command_encoder,
+                ),
                 PrimitiveBatch::Surfaces(range) => self.draw_surfaces(
                     &scene.surfaces[range],
                     instance_buffer,
@@ -1310,6 +1328,7 @@ impl MetalRenderer {
     fn draw_polychrome_sprites(
         &self,
         texture_id: AtlasTextureId,
+        filter: ImageFilter,
         sprites: &[PolychromeSprite],
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
@@ -1353,6 +1372,11 @@ impl MetalRenderer {
             *instance_offset as u64,
         );
         command_encoder.set_fragment_texture(SpriteInputIndex::AtlasTexture as u64, Some(&texture));
+        let sampler = match filter {
+            ImageFilter::Linear => &self.polychrome_linear_sampler,
+            ImageFilter::Nearest => &self.polychrome_nearest_sampler,
+        };
+        command_encoder.set_fragment_sampler_state(SpriteSamplerIndex::Atlas as u64, Some(sampler));
 
         let sprite_bytes_len = mem::size_of_val(sprites);
         let buffer_contents =
@@ -1542,6 +1566,18 @@ fn build_pipeline_state(
         .expect("could not create render pipeline state")
 }
 
+fn build_sampler_state(
+    device: &metal::DeviceRef,
+    filter: metal::MTLSamplerMinMagFilter,
+    label: &str,
+) -> metal::SamplerState {
+    let descriptor = metal::SamplerDescriptor::new();
+    descriptor.set_label(label);
+    descriptor.set_min_filter(filter);
+    descriptor.set_mag_filter(filter);
+    device.new_sampler(&descriptor)
+}
+
 fn build_path_sprite_pipeline_state(
     device: &metal::DeviceRef,
     library: &metal::LibraryRef,
@@ -1648,6 +1684,11 @@ enum SpriteInputIndex {
     ViewportSize = 2,
     AtlasTextureSize = 3,
     AtlasTexture = 4,
+}
+
+#[repr(C)]
+enum SpriteSamplerIndex {
+    Atlas = 0,
 }
 
 #[repr(C)]

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -698,10 +698,9 @@ vertex PolychromeSpriteVertexOutput polychrome_sprite_vertex(
 fragment float4 polychrome_sprite_fragment(
     PolychromeSpriteFragmentInput input [[stage_in]],
     constant PolychromeSprite *sprites [[buffer(SpriteInputIndex_Sprites)]],
-    texture2d<float> atlas_texture [[texture(SpriteInputIndex_AtlasTexture)]]) {
+    texture2d<float> atlas_texture [[texture(SpriteInputIndex_AtlasTexture)]],
+    sampler atlas_texture_sampler [[sampler(SpriteSamplerIndex_Atlas)]]) {
   PolychromeSprite sprite = sprites[input.sprite_id];
-  constexpr sampler atlas_texture_sampler(mag_filter::linear,
-                                          min_filter::linear);
   float4 sample =
       atlas_texture.sample(atlas_texture_sampler, input.tile_position);
   float distance =

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1235,7 +1235,7 @@ fn fs_mono_sprite(input: MonoSpriteVarying) -> @location(0) vec4<f32> {
 
 struct PolychromeSprite {
     order: u32,
-    pad: u32,
+    filter: u32,
     grayscale: u32,
     opacity: f32,
     bounds: Bounds,

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1,9 +1,9 @@
 use crate::{CompositorGpuHint, WgpuAtlas, WgpuContext};
 use bytemuck::{Pod, Zeroable};
 use gpui::{
-    AtlasTextureId, Background, Bounds, DevicePixels, GpuSpecs, MonochromeSprite, Path, Point,
-    PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size, SubpixelSprite,
-    Underline, get_gamma_correction_ratios,
+    AtlasTextureId, Background, Bounds, DevicePixels, GpuSpecs, ImageFilter, MonochromeSprite,
+    Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
+    SubpixelSprite, Underline, get_gamma_correction_ratios,
 };
 use log::warn;
 #[cfg(not(target_family = "wasm"))]
@@ -111,7 +111,8 @@ struct WgpuResources {
     surface: wgpu::Surface<'static>,
     pipelines: WgpuPipelines,
     bind_group_layouts: WgpuBindGroupLayouts,
-    atlas_sampler: wgpu::Sampler,
+    atlas_sampler_linear: wgpu::Sampler,
+    atlas_sampler_nearest: wgpu::Sampler,
     globals_buffer: wgpu::Buffer,
     globals_bind_group: wgpu::BindGroup,
     path_globals_bind_group: wgpu::BindGroup,
@@ -361,10 +362,16 @@ impl WgpuRenderer {
             dual_source_blending,
         );
 
-        let atlas_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            label: Some("atlas_sampler"),
+        let atlas_sampler_linear = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("atlas_sampler_linear"),
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+        let atlas_sampler_nearest = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("atlas_sampler_nearest"),
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
             ..Default::default()
         });
 
@@ -452,7 +459,8 @@ impl WgpuRenderer {
             surface,
             pipelines,
             bind_group_layouts,
-            atlas_sampler,
+            atlas_sampler_linear,
+            atlas_sampler_nearest,
             globals_buffer,
             globals_bind_group,
             path_globals_bind_group,
@@ -1293,13 +1301,17 @@ impl WgpuRenderer {
                                 &mut instance_offset,
                                 &mut pass,
                             ),
-                        PrimitiveBatch::PolychromeSprites { texture_id, range } => self
-                            .draw_polychrome_sprites(
-                                &scene.polychrome_sprites[range],
-                                texture_id,
-                                &mut instance_offset,
-                                &mut pass,
-                            ),
+                        PrimitiveBatch::PolychromeSprites {
+                            texture_id,
+                            filter,
+                            range,
+                        } => self.draw_polychrome_sprites(
+                            &scene.polychrome_sprites[range],
+                            texture_id,
+                            filter,
+                            &mut instance_offset,
+                            &mut pass,
+                        ),
                         PrimitiveBatch::Surfaces(_surfaces) => {
                             // Surfaces are macOS-only for video playback
                             // Not implemented for Linux/wgpu
@@ -1392,11 +1404,13 @@ impl WgpuRenderer {
     ) -> bool {
         let tex_info = self.atlas.get_texture_info(texture_id);
         let data = unsafe { Self::instance_bytes(sprites) };
+        let resources = self.resources();
         self.draw_instances_with_texture(
             data,
             sprites.len() as u32,
             &tex_info.view,
-            &self.resources().pipelines.mono_sprites,
+            &resources.atlas_sampler_linear,
+            &resources.pipelines.mono_sprites,
             instance_offset,
             pass,
         )
@@ -1421,6 +1435,7 @@ impl WgpuRenderer {
             data,
             sprites.len() as u32,
             &tex_info.view,
+            &resources.atlas_sampler_linear,
             pipeline,
             instance_offset,
             pass,
@@ -1431,16 +1446,23 @@ impl WgpuRenderer {
         &self,
         sprites: &[PolychromeSprite],
         texture_id: AtlasTextureId,
+        filter: ImageFilter,
         instance_offset: &mut u64,
         pass: &mut wgpu::RenderPass<'_>,
     ) -> bool {
         let tex_info = self.atlas.get_texture_info(texture_id);
         let data = unsafe { Self::instance_bytes(sprites) };
+        let resources = self.resources();
+        let sampler = match filter {
+            ImageFilter::Linear => &resources.atlas_sampler_linear,
+            ImageFilter::Nearest => &resources.atlas_sampler_nearest,
+        };
         self.draw_instances_with_texture(
             data,
             sprites.len() as u32,
             &tex_info.view,
-            &self.resources().pipelines.poly_sprites,
+            sampler,
+            &resources.pipelines.poly_sprites,
             instance_offset,
             pass,
         )
@@ -1483,6 +1505,7 @@ impl WgpuRenderer {
         data: &[u8],
         instance_count: u32,
         texture_view: &wgpu::TextureView,
+        sampler: &wgpu::Sampler,
         pipeline: &wgpu::RenderPipeline,
         instance_offset: &mut u64,
         pass: &mut wgpu::RenderPass<'_>,
@@ -1510,7 +1533,7 @@ impl WgpuRenderer {
                     },
                     wgpu::BindGroupEntry {
                         binding: 2,
-                        resource: wgpu::BindingResource::Sampler(&resources.atlas_sampler),
+                        resource: wgpu::BindingResource::Sampler(sampler),
                     },
                 ],
             });
@@ -1563,6 +1586,7 @@ impl WgpuRenderer {
             sprite_data,
             sprites.len() as u32,
             path_intermediate_view,
+            &resources.atlas_sampler_linear,
             &resources.pipelines.paths,
             instance_offset,
             pass,

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -94,7 +94,8 @@ struct DirectXRenderPipelines {
 
 struct DirectXGlobalElements {
     global_params_buffer: Option<ID3D11Buffer>,
-    sampler: Option<ID3D11SamplerState>,
+    sampler_linear: Option<ID3D11SamplerState>,
+    sampler_nearest: Option<ID3D11SamplerState>,
 }
 
 struct DirectComposition {
@@ -334,9 +335,11 @@ impl DirectXRenderer {
                 PrimitiveBatch::SubpixelSprites { texture_id, range } => {
                     self.draw_subpixel_sprites(texture_id, range.start, range.len())
                 }
-                PrimitiveBatch::PolychromeSprites { texture_id, range } => {
-                    self.draw_polychrome_sprites(texture_id, range.start, range.len())
-                }
+                PrimitiveBatch::PolychromeSprites {
+                    texture_id,
+                    filter,
+                    range,
+                } => self.draw_polychrome_sprites(texture_id, filter, range.start, range.len()),
                 PrimitiveBatch::Surfaces(range) => self.draw_surfaces(&scene.surfaces[range]),
             }
             .context(format!(
@@ -603,7 +606,7 @@ impl DirectXRenderer {
             slice::from_ref(&resources.path_intermediate_srv),
             slice::from_ref(&resources.viewport),
             slice::from_ref(&self.globals.global_params_buffer),
-            slice::from_ref(&self.globals.sampler),
+            slice::from_ref(&self.globals.sampler_linear),
             sprites.len() as u32,
         )
     }
@@ -643,7 +646,7 @@ impl DirectXRenderer {
             &texture_view,
             slice::from_ref(&resources.viewport),
             slice::from_ref(&self.globals.global_params_buffer),
-            slice::from_ref(&self.globals.sampler),
+            slice::from_ref(&self.globals.sampler_linear),
             start as u32,
             len as u32,
         )
@@ -667,7 +670,7 @@ impl DirectXRenderer {
             &texture_view,
             slice::from_ref(&resources.viewport),
             slice::from_ref(&self.globals.global_params_buffer),
-            slice::from_ref(&self.globals.sampler),
+            slice::from_ref(&self.globals.sampler_linear),
             start as u32,
             len as u32,
         )
@@ -676,6 +679,7 @@ impl DirectXRenderer {
     fn draw_polychrome_sprites(
         &mut self,
         texture_id: AtlasTextureId,
+        filter: ImageFilter,
         start: usize,
         len: usize,
     ) -> Result<()> {
@@ -685,13 +689,17 @@ impl DirectXRenderer {
         let devices = self.devices.as_ref().context("devices missing")?;
         let resources = self.resources.as_ref().context("resources missing")?;
         let texture_view = self.atlas.get_texture_view(texture_id);
+        let sampler = match filter {
+            ImageFilter::Linear => &self.globals.sampler_linear,
+            ImageFilter::Nearest => &self.globals.sampler_nearest,
+        };
         self.pipelines.poly_sprites.draw_range_with_texture(
             &devices.device,
             &devices.device_context,
             &texture_view,
             slice::from_ref(&resources.viewport),
             slice::from_ref(&self.globals.global_params_buffer),
-            slice::from_ref(&self.globals.sampler),
+            slice::from_ref(sampler),
             start as u32,
             len as u32,
         )
@@ -933,9 +941,26 @@ impl DirectXGlobalElements {
             buffer
         };
 
-        let sampler = unsafe {
+        let sampler_linear = unsafe {
             let desc = D3D11_SAMPLER_DESC {
                 Filter: D3D11_FILTER_MIN_MAG_MIP_LINEAR,
+                AddressU: D3D11_TEXTURE_ADDRESS_WRAP,
+                AddressV: D3D11_TEXTURE_ADDRESS_WRAP,
+                AddressW: D3D11_TEXTURE_ADDRESS_WRAP,
+                MipLODBias: 0.0,
+                MaxAnisotropy: 1,
+                ComparisonFunc: D3D11_COMPARISON_ALWAYS,
+                BorderColor: [0.0; 4],
+                MinLOD: 0.0,
+                MaxLOD: D3D11_FLOAT32_MAX,
+            };
+            let mut output = None;
+            device.CreateSamplerState(&desc, Some(&mut output))?;
+            output
+        };
+        let sampler_nearest = unsafe {
+            let desc = D3D11_SAMPLER_DESC {
+                Filter: D3D11_FILTER_MIN_MAG_MIP_POINT,
                 AddressU: D3D11_TEXTURE_ADDRESS_WRAP,
                 AddressV: D3D11_TEXTURE_ADDRESS_WRAP,
                 AddressW: D3D11_TEXTURE_ADDRESS_WRAP,
@@ -953,7 +978,8 @@ impl DirectXGlobalElements {
 
         Ok(Self {
             global_params_buffer,
-            sampler,
+            sampler_linear,
+            sampler_nearest,
         })
     }
 }

--- a/crates/gpui_windows/src/shaders.hlsl
+++ b/crates/gpui_windows/src/shaders.hlsl
@@ -1178,7 +1178,7 @@ SubpixelSpriteFragmentOutput subpixel_sprite_fragment(MonochromeSpriteFragmentIn
 
 struct PolychromeSprite {
     uint order;
-    uint pad;
+    uint filter;
     uint grayscale;
     float opacity;
     Bounds bounds;


### PR DESCRIPTION
This PR adds support for nearest-neighbor filtering in addition to the standard bilinear used everywhere in GPUI today. This allows for crisp/pixel-perfect upscaling as seen in the example picture below. Code written with assistance from Claude. I have manually reviewed all of it.

<img width="832" height="565" alt="image" src="https://github.com/user-attachments/assets/1f3e582c-6174-4dab-94ca-0d9481b3c55f" />

**Tests**: there doesn't appear to be any image snapshot testing or similar for GPU features like this one. Let me know what's expected here. I have manually verified that it works using the example (see crates/gpui/examples/image_filter.rs) and it runs as expected on macOS. I have not tested on Linux/Windows, but the actual GPU plumbing changes are mechanical and I don't expect there to be any issues.

**Performance**: This change splits the polychrome render batch only when the nearest neighbor filter is used. It also reuses a previous padding field to send the filter flag, so the GPU structs are the same size as before. For apps that don't use NN filtered sprites, performance impact should be effectively 0.

Release Notes:

- Added support for nearest-neighbor filtered polychrome sprites
