### PR TITLE
sidebar: Show main worktree branch in thread items

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -8153,12 +8153,12 @@ mod tests {
         cx.run_until_parked();
 
         assert!(
-            cx.debug_bounds("MENU_ITEM-Skills").is_some(),
-            "Skills menu item should be visible"
+            cx.debug_bounds("MENU_ITEM-Create a Skill").is_some(),
+            "Create a Skill menu item should be visible"
         );
         assert!(
             cx.debug_bounds("KEY_BINDING-l").is_some(),
-            "Skills menu item should show the OpenRulesLibrary shortcut"
+            "Create a Skill menu item should show the OpenRulesLibrary shortcut"
         );
     }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -8153,12 +8153,12 @@ mod tests {
         cx.run_until_parked();
 
         assert!(
-            cx.debug_bounds("MENU_ITEM-Create a Skill").is_some(),
-            "Create a Skill menu item should be visible"
+            cx.debug_bounds("MENU_ITEM-Skills").is_some(),
+            "Skills menu item should be visible"
         );
         assert!(
             cx.debug_bounds("KEY_BINDING-l").is_some(),
-            "Create a Skill menu item should show the OpenRulesLibrary shortcut"
+            "Skills menu item should show the OpenRulesLibrary shortcut"
         );
     }
 

--- a/crates/ui/src/components/ai/thread_item.rs
+++ b/crates/ui/src/components/ai/thread_item.rs
@@ -367,14 +367,19 @@ impl RenderOnce for ThreadItem {
             AgentThreadStatus::Error | AgentThreadStatus::WaitingForConfirmation
         );
 
-        let linked_worktrees: Vec<ThreadItemWorktreeInfo> = self
+        let visible_worktrees: Vec<ThreadItemWorktreeInfo> = self
             .worktrees
             .into_iter()
-            .filter(|wt| wt.kind == WorktreeKind::Linked)
+            .map(|mut wt| {
+                if wt.kind == WorktreeKind::Main {
+                    wt.worktree_name = None
+                }
+                wt
+            })
             .filter(|wt| wt.worktree_name.is_some() || wt.branch_name.is_some())
             .collect();
 
-        let has_worktree = !linked_worktrees.is_empty();
+        let has_worktree = !visible_worktrees.is_empty();
 
         let has_metadata = has_project_name
             || has_project_paths
@@ -472,7 +477,7 @@ impl RenderOnce for ThreadItem {
                                     this.child(dot_separator())
                                 })
                                 .children(
-                                    linked_worktrees.into_iter().map(|wt| {
+                                    visible_worktrees.into_iter().map(|wt| {
                                         let worktree_label = wt.worktree_name.clone().map(|name| {
                                             if wt.highlight_positions.is_empty() {
                                                 Label::new(name)
@@ -736,7 +741,7 @@ impl Component for ThreadItem {
                     .into_any_element(),
             ),
             single_example(
-                "Main Worktree (hidden) + Changes + Timestamp",
+                "Main Worktree Branch + Changes + Timestamp",
                 container()
                     .child(
                         ThreadItem::new("ti-5e", "Main worktree branch with diff stats")


### PR DESCRIPTION
I find the lack of context on the main worktree difficult. I want at
least the branch name (possibly the worktree too if there's more than
one?) but figured starting with this would already help.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
