### PR TITLE
editor: Fix completion menu height clipped to minimum in single-line editors

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5139,9 +5139,9 @@ impl EditorElement {
                     }
                     None => {
                         if available_below > min_height {
-                            (false, min_height)
+                            (false, cmp::min(max_height, available_below))
                         } else if available_above > min_height {
-                            (true, min_height)
+                            (true, cmp::min(max_height, available_above))
                         } else if available_above > available_below {
                             (true, available_above)
                         } else {


### PR DESCRIPTION
## Summary

Fixes the "Edit Context" dropdown in the keymap editor being misleadingly short (only 3 entries visible, no scrollbar) when many matches exist.

**Root cause:** In `layout_popovers_above_or_below_line`, when the editor's text hitbox is too small to fit the minimum menu height (as happens with single-line editors in modals), a fallback path measures available viewport space but then used `min_height` as the target height — capping the menu at 3 entries even when the viewport had room for 12.

**Fix:** Use `cmp::min(max_height, available_space)` in the fallback so the menu grows up to the configured maximum.

Fixes #57348

Release Notes:

- Fixed completion menu in single-line editors (e.g. keymap "Edit Context" field) being clipped to the minimum height instead of expanding to show more entries.