### PR TITLE
agent_ui: Fix crash when opening built-in skill mention in remote projects

### DIFF
--- a/crates/agent_ui/src/ui/mention_crease.rs
+++ b/crates/agent_ui/src/ui/mention_crease.rs
@@ -7,6 +7,7 @@ use gpui::{
     Animation, AnimationExt, AnyView, Context, IntoElement, TaskExt, WeakEntity, Window,
     pulsating_between,
 };
+use language::Buffer;
 use prompt_store::PromptId;
 use rope::Point;
 use settings::Settings;
@@ -205,12 +206,15 @@ fn open_skill_file(
 ) {
     // Built-in skills have synthetic paths that don't exist on disk.
     // Open a read-only buffer with the embedded content instead.
+    //
+    // The buffer is intentionally not registered with the project's buffer
+    // store: it has no on-disk backing, isn't searchable, and `Project::
+    // create_local_buffer` panics for remote projects (SSH/collab), which
+    // would crash Zed if a user clicked a built-in skill mention while
+    // connected to a remote project.
     if let Some(content) = agent_skills::builtin_skill_content(&skill_file_path) {
-        let project = workspace.project().clone();
-        let languages = project.read(cx).languages().clone();
-        let buffer = project.update(cx, |project, cx| {
-            project.create_local_buffer(content, None, false, cx)
-        });
+        let languages = workspace.project().read(cx).languages().clone();
+        let buffer = cx.new(|cx| Buffer::local(content, cx));
         // Set markdown highlighting asynchronously — the buffer
         // opens instantly and the highlighting appears once loaded.
         cx.spawn({


### PR DESCRIPTION
Clicking a built-in skill mention while connected to a remote project (SSH or collab) caused Zed to abort with `called create_local_buffer on a remote project`.

## Root cause

`agent_ui::ui::mention_crease::open_skill_file` was calling `Project::create_local_buffer` to display the embedded read-only content of a built-in skill:

```rust
let buffer = project.update(cx, |project, cx| {
    project.create_local_buffer(content, None, false, cx)
});
```

`Project::create_local_buffer` has an explicit panic guard for remote projects, so any user who clicked a built-in skill mention while in an SSH or collab project would crash Zed.

## Fix

The buffer is purely a display surface for binary-embedded skill content — it has no on-disk backing, isn't searchable, and never needs to be tracked by the project's buffer store. Build it directly with `language::Buffer::local(content, cx)` instead, matching the pattern used elsewhere in `agent_ui` (`thread_view.rs`, `message_editor.rs`, `inline_assistant.rs`, etc.). This works for both local and remote projects.

## Repro (before fix)

1. Connect Zed to a remote (SSH) project.
2. In the agent panel, click on a built-in skill mention (e.g. one referencing `create-skill`).
3. Zed aborts with SIGABRT.

After the fix, the mention opens a read-only editor with the embedded markdown content, identical behavior to local projects.

Release Notes:

- Fixed a crash when clicking a built-in skill mention in the agent panel while connected to a remote project (Preview only).
