### PR TITLE
settings_ui: Display scope in the breadcrumb

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -3006,19 +3006,26 @@ impl SettingsWindow {
     }
 
     fn render_sub_page_breadcrumbs(&self) -> impl IntoElement {
+        let scope_name: SharedString = self
+            .display_name(&self.current_file)
+            .unwrap_or_else(|| self.current_file.setting_type().to_string())
+            .into();
+
         h_flex().min_w_0().gap_1().overflow_x_hidden().children(
             itertools::intersperse(
-                std::iter::once(self.current_page().title.into()).chain(
-                    self.sub_page_stack
-                        .iter()
-                        .enumerate()
-                        .flat_map(|(index, page)| {
-                            (index == 0)
-                                .then(|| page.section_header.clone())
-                                .into_iter()
-                                .chain(std::iter::once(page.link.title.clone()))
-                        }),
-                ),
+                std::iter::once(scope_name)
+                    .chain(std::iter::once(self.current_page().title.into()))
+                    .chain(
+                        self.sub_page_stack
+                            .iter()
+                            .enumerate()
+                            .flat_map(|(index, page)| {
+                                (index == 0)
+                                    .then(|| page.section_header.clone())
+                                    .into_iter()
+                                    .chain(std::iter::once(page.link.title.clone()))
+                            }),
+                    ),
                 "/".into(),
             )
             .map(|item| Label::new(item).color(Color::Muted)),


### PR DESCRIPTION
Whenever there are subpages in the settings UI, a breadcrumb is displayed. However, we weren't displaying the scope as part of the breadcrumb, which can be relevant if you're wondering why a certain information you expected to see here isn't being displayed. It might just be that it is displayed in the _project_ scope instead of in the _user_ scope. Therefore, this PR adds the scope in the breadcrumb:

| Before | After |
|--------|--------|
| <img width="1348" height="290" alt="Screenshot 2026-05-21 at 4  38 2@2x" src="https://github.com/user-attachments/assets/1b64ba98-8e7e-41a7-9b13-19722bdbe093" /> | <img width="1348" height="290" alt="Screenshot 2026-05-21 at 4  38@2x" src="https://github.com/user-attachments/assets/b5deb091-0617-42ac-bb4a-b8ba00ec386c" /> | 

Release Notes:

- Started to display the setting scope (user or project) in the Settings Editor for better contextualization of settings subpages.
