### PR TITLE
sidebar: Remove pending indicator from header when visiting project again

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1632,6 +1632,12 @@ impl Sidebar {
                         }
                     }
                 }
+
+                if is_active
+                    && let Some(ActiveEntry::Thread { thread_id, .. }) = self.active_entry.as_ref()
+                {
+                    notified_threads.remove(thread_id);
+                }
             }
 
             let has_visible_rows = !threads.is_empty() || !terminals.is_empty();


### PR DESCRIPTION
Quick follow-up to https://github.com/zed-industries/zed/pull/57322. We weren't removing the pending notification when re-visiting the project that contains the pending thread (only while the project is still collapsed, though).

Release Notes:

- N/A
