### PR TITLE
editor: Fix completion menu height for single-line inputs

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -305,14 +305,14 @@
   //
   // 1. Show the scrollbar if there's important information or
   //    follow the system's configured behavior
-  //   "auto"
+  //   "auto" (default)
   // 2. Match the system's configured behavior:
   //    "system"
   // 3. Always show the scrollbar:
   //    "always"
   // 4. Never show the scrollbar:
-  //    "never" (default)
-  "completion_menu_scrollbar": "never",
+  //    "never"
+  "completion_menu_scrollbar": "auto",
   // Whether to align detail text in code completions context menus left or right.
   "completion_detail_alignment": "left",
   // How to display the LSP item kind (function, method, variable, etc.)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4813,8 +4813,7 @@ impl EditorElement {
     ) -> Option<ContextMenuLayout> {
         let mut min_menu_height = Pixels::ZERO;
         let mut max_menu_height = Pixels::ZERO;
-        let mut height_above_menu = Pixels::ZERO;
-        let height_below_menu = Pixels::ZERO;
+        let mut edit_prediction_height = Pixels::ZERO;
         let mut edit_prediction_popover_visible = false;
         let mut context_menu_visible = false;
         let context_menu_placement;
@@ -4824,7 +4823,7 @@ impl EditorElement {
             let editor = self.editor.read(cx);
             if editor.edit_prediction_visible_in_cursor_popover(editor.has_active_edit_prediction())
             {
-                height_above_menu +=
+                edit_prediction_height +=
                     editor.edit_prediction_cursor_popover_height() + POPOVER_Y_PADDING;
                 edit_prediction_popover_visible = true;
             }
@@ -4882,14 +4881,13 @@ impl EditorElement {
                 ..Default::default()
             });
 
-        // Account for the gap drawn between the two popovers when both are present.
         let popover_gap = if edit_prediction_popover_visible && context_menu_visible {
             MENU_GAP
         } else {
             Pixels::ZERO
         };
-        let min_height = height_above_menu + min_menu_height + height_below_menu + popover_gap;
-        let max_height = height_above_menu + max_menu_height + height_below_menu + popover_gap;
+        let min_height = edit_prediction_height + min_menu_height + popover_gap;
+        let max_height = edit_prediction_height + max_menu_height + popover_gap;
         let (laid_out_popovers, y_flipped) = self.layout_popovers_above_or_below_line(
             target_position,
             line_height,
@@ -4903,7 +4901,7 @@ impl EditorElement {
             |height, max_width_for_stable_x, y_flipped, window, cx| {
                 // First layout the menu to get its size - others can be at least this wide.
                 let context_menu = if context_menu_visible {
-                    let menu_height = height - height_above_menu - height_below_menu - popover_gap;
+                    let menu_height = height - edit_prediction_height - popover_gap;
                     let mut element = self
                         .render_context_menu(menu_line_height, menu_height, window, cx)
                         .expect("Visible context menu should always render.");

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5139,9 +5139,9 @@ impl EditorElement {
                     }
                     None => {
                         if available_below > min_height {
-                            (false, min_height)
+                            (false, cmp::min(max_height, available_below))
                         } else if available_above > min_height {
-                            (true, min_height)
+                            (true, cmp::min(max_height, available_above))
                         } else if available_above > available_below {
                             (true, available_above)
                         } else {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4898,7 +4898,7 @@ impl EditorElement {
             viewport_bounds,
             window,
             cx,
-            |height, max_width_for_stable_x, y_flipped, window, cx| {
+            |height, max_width_for_stable_x, _y_flipped, window, cx| {
                 // First layout the menu to get its size - others can be at least this wide.
                 let context_menu = if context_menu_visible {
                     let menu_height = height - edit_prediction_height - popover_gap;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4818,6 +4818,7 @@ impl EditorElement {
         let mut edit_prediction_popover_visible = false;
         let mut context_menu_visible = false;
         let context_menu_placement;
+        let menu_line_height = self.context_menu_line_height(window);
 
         {
             let editor = self.editor.read(cx);
@@ -4838,8 +4839,10 @@ impl EditorElement {
                         (options.min_entries_visible, options.max_entries_visible)
                     });
 
-                min_menu_height += line_height * min_height_in_lines as f32 + POPOVER_Y_PADDING;
-                max_menu_height += line_height * max_height_in_lines as f32 + POPOVER_Y_PADDING;
+                min_menu_height +=
+                    menu_line_height * min_height_in_lines as f32 + POPOVER_Y_PADDING;
+                max_menu_height +=
+                    menu_line_height * max_height_in_lines as f32 + POPOVER_Y_PADDING;
                 context_menu_visible = true;
             }
             context_menu_placement = editor
@@ -4879,8 +4882,14 @@ impl EditorElement {
                 ..Default::default()
             });
 
-        let min_height = height_above_menu + min_menu_height + height_below_menu;
-        let max_height = height_above_menu + max_menu_height + height_below_menu;
+        // Account for the gap drawn between the two popovers when both are present.
+        let popover_gap = if edit_prediction_popover_visible && context_menu_visible {
+            MENU_GAP
+        } else {
+            Pixels::ZERO
+        };
+        let min_height = height_above_menu + min_menu_height + height_below_menu + popover_gap;
+        let max_height = height_above_menu + max_menu_height + height_below_menu + popover_gap;
         let (laid_out_popovers, y_flipped) = self.layout_popovers_above_or_below_line(
             target_position,
             line_height,
@@ -4894,13 +4903,9 @@ impl EditorElement {
             |height, max_width_for_stable_x, y_flipped, window, cx| {
                 // First layout the menu to get its size - others can be at least this wide.
                 let context_menu = if context_menu_visible {
-                    let menu_height = if y_flipped {
-                        height - height_below_menu
-                    } else {
-                        height - height_above_menu
-                    };
+                    let menu_height = height - height_above_menu - height_below_menu - popover_gap;
                     let mut element = self
-                        .render_context_menu(line_height, menu_height, window, cx)
+                        .render_context_menu(menu_line_height, menu_height, window, cx)
                         .expect("Visible context menu should always render.");
                     let size = element.layout_as_root(AvailableSpace::min_size(), window, cx);
                     Some((CursorPopoverType::CodeContextMenu, element, size))
@@ -5051,8 +5056,9 @@ impl EditorElement {
                 (options.min_entries_visible, options.max_entries_visible)
             });
 
-        let min_height = line_height * min_height_in_lines as f32 + POPOVER_Y_PADDING;
-        let max_height = line_height * max_height_in_lines as f32 + POPOVER_Y_PADDING;
+        let menu_line_height = self.context_menu_line_height(window);
+        let min_height = menu_line_height * min_height_in_lines as f32 + POPOVER_Y_PADDING;
+        let max_height = menu_line_height * max_height_in_lines as f32 + POPOVER_Y_PADDING;
         let viewport_bounds =
             Bounds::new(Default::default(), window.viewport_size()).extend(Edges {
                 right: -right_margin - MENU_GAP,
@@ -5073,7 +5079,7 @@ impl EditorElement {
             cx,
             move |height, _max_width_for_stable_x, _, window, cx| {
                 let mut element = self
-                    .render_context_menu(line_height, height, window, cx)
+                    .render_context_menu(menu_line_height, height, window, cx)
                     .expect("Visible context menu should always render.");
                 let size = element.layout_as_root(AvailableSpace::min_size(), window, cx);
                 vec![(CursorPopoverType::CodeContextMenu, element, size)]
@@ -5297,6 +5303,14 @@ impl EditorElement {
         }
 
         None
+    }
+
+    // Menu rows render at Comfortable line height regardless of the editor's buffer_line_height
+    // (see the text-style override in layout_popovers_above_or_below_line). Budget calculations
+    // and the lines→pixels floor must use this same value so they stay consistent.
+    fn context_menu_line_height(&self, window: &Window) -> Pixels {
+        self.style.text.font_size.to_pixels(window.rem_size())
+            * BufferLineHeight::Comfortable.value()
     }
 
     fn render_context_menu(

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -231,13 +231,13 @@ pub struct EditorSettingsContent {
     ///
     /// 1. Show the scrollbar if there's important information or
     ///    follow the system's configured behavior
-    ///   "auto"
+    ///   "auto" (default)
     /// 2. Match the system's configured behavior:
     ///    "system"
     /// 3. Always show the scrollbar:
     ///    "always"
     /// 4. Never show the scrollbar:
-    ///    "never" (default)
+    ///    "never"
     pub completion_menu_scrollbar: Option<ShowScrollbar>,
 
     /// Whether to align detail text in code completions context menus left or right.


### PR DESCRIPTION
Single-line inputs, such as Keymap Editor > Edit Context, were showing only 3 completion entries without a scrollbar, even when there were more entries and there was plenty of screen space available.

This patch fixes that by:
1. Showing max 12 entries by default (previously 3) unless less space is available.
2. Changing "never" to "auto" for the completion menu scrollbar setting.

Here are some screenshots of what it looks like after the changes:

<img width="2184" height="1572" alt="CleanShot 2026-05-21 at 16 21 53@2x" src="https://github.com/user-attachments/assets/1446765c-00ab-4118-81c5-de2e7b43367f" />

<img width="2184" height="1572" alt="CleanShot 2026-05-21 at 16 21 29@2x" src="https://github.com/user-attachments/assets/a63dbf7f-2f17-4ba0-9946-43ff29f7236b" />

### Additional thoughts

I'm slightly hesistant to change the "completion_menu_scrollbar" setting from "never" to "auto" because I don't have a good grasp of what other surfaces will be impacted by this. This change for example introduces the scrollbar in the code completion menu too, which I think is a good thing but I would love to hear your thoughts on this.

<img width="2184" height="1572" alt="CleanShot 2026-05-21 at 16 26 24@2x" src="https://github.com/user-attachments/assets/ab3459a6-1b98-4603-aa43-dcfd77c4deb2" />


---

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #57348

Release Notes:

- Fixed completion menu height for single-line inputs, such as Keymap Editor > Edit Context.
