### PR TITLE
sidebar: Add `enabled` setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1006,6 +1006,10 @@
     // For example: typing `:wave:` gets replaced with `👋`.
     "auto_replace_emoji_shortcode": true,
   },
+  "sidebar": {
+    // Whether the threads sidebar is enabled.
+    "enabled": true,
+  },
   "agent": {
     // Whether the inline assistant should use streaming tools, when available
     "inline_assistant_use_streaming_tools": true,

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -85,7 +85,7 @@ use ui::{
 use util::ResultExt as _;
 use workspace::{
     CollaboratorId, DraggedSelection, DraggedTab, MultiWorkspace, PathList, SerializedPathList,
-    ToggleWorkspaceSidebar, ToggleZoom, Workspace, WorkspaceId,
+    SidebarSettings, ToggleWorkspaceSidebar, ToggleZoom, Workspace, WorkspaceId,
     dock::{DockPosition, Panel, PanelEvent},
     item::ItemEvent,
 };
@@ -4851,7 +4851,7 @@ impl AgentPanel {
             .with_handle(self.agent_panel_menu_handle.clone())
             .menu({
                 move |window, cx| {
-                    Some(ContextMenu::build(window, cx, |mut menu, _window, _| {
+                    Some(ContextMenu::build(window, cx, |mut menu, _window, cx| {
                         menu = menu.context(menu_action_context.clone());
 
                         if can_regenerate_thread_title {
@@ -4964,10 +4964,13 @@ impl AgentPanel {
                             menu = menu.action("Profiles", Box::new(ManageProfiles::default()));
                         }
 
-                        menu = menu
-                            .action("Settings", Box::new(OpenSettings))
-                            .separator()
-                            .action("Toggle Threads Sidebar", Box::new(ToggleWorkspaceSidebar));
+                        menu = menu.action("Settings", Box::new(OpenSettings));
+
+                        if SidebarSettings::get_global(cx).enabled {
+                            menu = menu
+                                .separator()
+                                .action("Toggle Threads Sidebar", Box::new(ToggleWorkspaceSidebar));
+                        }
 
                         if has_auth_methods || supports_logout {
                             menu = menu.separator()

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -65,7 +65,7 @@ use serde::{Deserialize, Serialize};
 use settings::{LanguageModelSelection, Settings as _, SettingsStore, SidebarSide};
 use std::any::TypeId;
 use std::path::{Path, PathBuf};
-use workspace::Workspace;
+use workspace::{SidebarSettings, Workspace};
 
 use crate::agent_configuration::{ConfigureContextServerModal, ManageProfilesModal};
 pub use crate::agent_connection_store::{ActiveAcpConnection, AgentConnectionStore};
@@ -670,6 +670,7 @@ fn maybe_backfill_editor_layout(fs: Arc<dyn Fs>, is_new_install: bool, cx: &mut 
 fn update_command_palette_filter(cx: &mut App) {
     let disable_ai = DisableAiSettings::get_global(cx).disable_ai;
     let agent_enabled = AgentSettings::get_global(cx).enabled;
+    let sidebar_enabled = SidebarSettings::get_global(cx).enabled;
 
     let edit_prediction_provider = AllLanguageSettings::get_global(cx)
         .edit_predictions
@@ -739,8 +740,12 @@ fn update_command_palette_filter(cx: &mut App) {
 
             filter.show_namespace("zed_predict_onboarding");
             filter.show_action_types(&[TypeId::of::<zed_actions::OpenZedPredictOnboarding>()]);
+        }
 
+        if !disable_ai && agent_enabled && sidebar_enabled {
             filter.show_namespace("multi_workspace");
+        } else {
+            filter.hide_namespace("multi_workspace");
         }
 
         // Hide `assistant: open rules library` — Rules are surfaced
@@ -828,6 +833,7 @@ mod tests {
     use settings::{
         DockPosition, NotifyWhenAgentWaiting, PlaySoundWhenAgentDone, Settings, SettingsStore,
     };
+    use workspace::ToggleWorkspaceSidebar;
 
     #[gpui::test]
     fn test_agent_command_palette_visibility(cx: &mut TestAppContext) {
@@ -837,6 +843,7 @@ mod tests {
             cx.set_global(store);
             command_palette_hooks::init(cx);
             AgentSettings::register(cx);
+            SidebarSettings::register(cx);
             DisableAiSettings::register(cx);
             AllLanguageSettings::register(cx);
         });
@@ -878,6 +885,7 @@ mod tests {
 
         cx.update(|cx| {
             AgentSettings::override_global(agent_settings.clone(), cx);
+            SidebarSettings::override_global(SidebarSettings { enabled: true }, cx);
             DisableAiSettings::override_global(DisableAiSettings { disable_ai: false }, cx);
 
             // Initial update
@@ -894,6 +902,10 @@ mod tests {
             assert!(
                 !filter.is_hidden(&NewTerminalThread),
                 "NewTerminalThread should be visible by default"
+            );
+            assert!(
+                !filter.is_hidden(&ToggleWorkspaceSidebar),
+                "ToggleWorkspaceSidebar should be visible by default"
             );
         });
 
@@ -918,6 +930,36 @@ mod tests {
                 filter.is_hidden(&NewTerminalThread),
                 "NewTerminalThread should be hidden when agent is disabled"
             );
+            assert!(
+                filter.is_hidden(&ToggleWorkspaceSidebar),
+                "ToggleWorkspaceSidebar should be hidden when agent is disabled"
+            );
+        });
+
+        // Re-enable agent and disable sidebar
+        cx.update(|cx| {
+            AgentSettings::override_global(agent_settings.clone(), cx);
+            SidebarSettings::override_global(SidebarSettings { enabled: false }, cx);
+
+            update_command_palette_filter(cx);
+        });
+
+        cx.update(|cx| {
+            let filter = CommandPaletteFilter::try_global(cx).unwrap();
+            assert!(
+                filter.is_hidden(&ToggleWorkspaceSidebar),
+                "ToggleWorkspaceSidebar should be hidden when sidebar is disabled"
+            );
+            assert!(
+                !filter.is_hidden(&NewThread),
+                "NewThread should remain visible when only sidebar is disabled"
+            );
+        });
+
+        // Restore sidebar before testing edit predictions.
+        cx.update(|cx| {
+            SidebarSettings::override_global(SidebarSettings { enabled: true }, cx);
+            update_command_palette_filter(cx);
         });
 
         // Test EditPredictionProvider

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -742,7 +742,7 @@ fn update_command_palette_filter(cx: &mut App) {
             filter.show_action_types(&[TypeId::of::<zed_actions::OpenZedPredictOnboarding>()]);
         }
 
-        if !disable_ai && agent_enabled && sidebar_enabled {
+        if !disable_ai && sidebar_enabled {
             filter.show_namespace("multi_workspace");
         } else {
             filter.hide_namespace("multi_workspace");

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -210,6 +210,7 @@ impl VsCodeSettings {
             repl: None,
             server_url: None,
             session: None,
+            sidebar: None,
             status_bar: self.status_bar_settings_content(),
             tab_bar: self.tab_bar_settings_content(),
             tabs: self.item_settings_content(),

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -40,6 +40,15 @@ pub enum SidebarSide {
     Right,
 }
 
+#[with_fallible_options]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct SidebarSettingsContent {
+    /// Whether the threads sidebar is enabled.
+    ///
+    /// Default: true
+    pub enabled: Option<bool>,
+}
+
 /// How thinking blocks should be displayed by default in the agent panel.
 #[derive(
     Clone,

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -146,6 +146,9 @@ pub struct SettingsContent {
     pub agent: Option<AgentSettingsContent>,
     pub agent_servers: Option<AllAgentServersSettings>,
 
+    /// Configuration for the threads sidebar.
+    pub sidebar: Option<SidebarSettingsContent>,
+
     /// Configuration of audio in Zed.
     pub audio: Option<AudioSettingsContent>,
 

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7449,7 +7449,7 @@ fn collaboration_page() -> SettingsPage {
 }
 
 fn ai_page(cx: &App) -> SettingsPage {
-    fn general_section() -> [SettingsPageItem; 3] {
+    fn general_section() -> [SettingsPageItem; 4] {
         [
             SettingsPageItem::SectionHeader("General"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -7464,6 +7464,19 @@ fn ai_page(cx: &App) -> SettingsPage {
                 }),
                 metadata: None,
                 files: USER | PROJECT,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Threads Sidebar",
+                description: "Whether the threads sidebar is enabled.",
+                field: Box::new(SettingField {
+                    json_path: Some("sidebar.enabled"),
+                    pick: |settings_content| settings_content.sidebar.as_ref()?.enabled.as_ref(),
+                    write: |settings_content, value, _| {
+                        settings_content.sidebar.get_or_insert_default().enabled = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Threads Sidebar Side",

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1832,7 +1832,7 @@ impl Sidebar {
         let Some(multi_workspace) = self.multi_workspace.upgrade() else {
             return;
         };
-        if !multi_workspace.read(cx).multi_workspace_enabled(cx) {
+        if !multi_workspace.read(cx).enabled(cx) {
             return;
         }
 

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -736,9 +736,8 @@ impl TitleBar {
             .multi_workspace
             .as_ref()
             .and_then(|mw| mw.upgrade())
-            .map(|mw| mw.read(cx).sidebar_open())
-            .unwrap_or(false)
-            && PlatformTitleBar::is_multi_workspace_enabled(cx);
+            .map(|mw| mw.read(cx).sidebar_render_state(cx).open)
+            .unwrap_or(false);
 
         let is_threads_list_view_active = self
             .multi_workspace

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -2056,11 +2056,11 @@ impl MultiWorkspace {
 
 impl Render for MultiWorkspace {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let multi_workspace_enabled = self.enabled(cx);
+        let enabled = self.enabled(cx);
         let sidebar_side = self.sidebar_side(cx);
         let sidebar_on_right = sidebar_side == SidebarSide::Right;
 
-        let sidebar: Option<AnyElement> = if multi_workspace_enabled && self.sidebar_open() {
+        let sidebar: Option<AnyElement> = if enabled && self.sidebar_open() {
             self.sidebar.as_ref().map(|sidebar_handle| {
                 let weak = cx.weak_entity();
 
@@ -2239,8 +2239,8 @@ impl Render for MultiWorkspace {
             window,
             cx,
             Tiling {
-                left: !sidebar_on_right && multi_workspace_enabled && self.sidebar_open(),
-                right: sidebar_on_right && multi_workspace_enabled && self.sidebar_open(),
+                left: !sidebar_on_right && enabled && self.sidebar_open(),
+                right: sidebar_on_right && enabled && self.sidebar_open(),
                 ..Tiling::default()
             },
         )

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -28,7 +28,7 @@ const SIDEBAR_RESIZE_HANDLE_SIZE: Pixels = px(6.0);
 use crate::open_remote_project_with_existing_connection;
 use crate::{
     CloseIntent, CloseWindow, DockPosition, Event as WorkspaceEvent, Item, ModalView, OpenMode,
-    Panel, Workspace, WorkspaceId, client_side_decorations,
+    Panel, SidebarSettings, Workspace, WorkspaceId, client_side_decorations,
     persistence::model::MultiWorkspaceState,
 };
 
@@ -308,7 +308,7 @@ impl MultiWorkspace {
 
     pub fn sidebar_render_state(&self, cx: &App) -> SidebarRenderState {
         SidebarRenderState {
-            open: self.sidebar_open() && self.multi_workspace_enabled(cx),
+            open: self.sidebar_open() && self.enabled(cx),
             side: self.sidebar_side(cx),
         }
     }
@@ -324,15 +324,13 @@ impl MultiWorkspace {
         });
         let quit_subscription = cx.on_app_quit(Self::app_will_quit);
         let settings_subscription = cx.observe_global_in::<settings::SettingsStore>(window, {
-            let mut previous_multi_workspace_enabled = !DisableAiSettings::get_global(cx)
-                .disable_ai
-                && AgentSettings::get_global(cx).enabled;
+            let mut previous_enabled = Self::enabled_from_settings(cx);
             move |this, window, cx| {
-                let multi_workspace_enabled = this.multi_workspace_enabled(cx);
-                if previous_multi_workspace_enabled && !multi_workspace_enabled {
+                let enabled = this.enabled(cx);
+                if previous_enabled && !enabled {
                     this.collapse_to_single_workspace(window, cx);
                 }
-                previous_multi_workspace_enabled = multi_workspace_enabled;
+                previous_enabled = enabled;
             }
         });
         Self::subscribe_to_workspace(&workspace, window, cx);
@@ -398,12 +396,18 @@ impl MultiWorkspace {
             .map_or(false, |s| s.is_threads_list_view_active(cx))
     }
 
-    pub fn multi_workspace_enabled(&self, cx: &App) -> bool {
-        !DisableAiSettings::get_global(cx).disable_ai && AgentSettings::get_global(cx).enabled
+    fn enabled_from_settings(cx: &App) -> bool {
+        !DisableAiSettings::get_global(cx).disable_ai
+            && AgentSettings::get_global(cx).enabled
+            && SidebarSettings::get_global(cx).enabled
+    }
+
+    pub fn enabled(&self, cx: &App) -> bool {
+        Self::enabled_from_settings(cx)
     }
 
     pub fn toggle_sidebar(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.multi_workspace_enabled(cx) {
+        if !self.enabled(cx) {
             return;
         }
 
@@ -420,7 +424,7 @@ impl MultiWorkspace {
     }
 
     pub fn close_sidebar_action(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.multi_workspace_enabled(cx) {
+        if !self.enabled(cx) {
             return;
         }
 
@@ -430,7 +434,7 @@ impl MultiWorkspace {
     }
 
     pub fn focus_sidebar(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.multi_workspace_enabled(cx) {
+        if !self.enabled(cx) {
             return;
         }
 
@@ -1471,7 +1475,7 @@ impl MultiWorkspace {
         let old_active_workspace = self.active_workspace.clone();
         let old_active_was_retained = self.active_workspace_is_retained();
         let workspace_was_retained = self.is_workspace_retained(&workspace);
-        let should_retain_workspaces = self.multi_workspace_enabled(cx);
+        let should_retain_workspaces = self.enabled(cx);
 
         if should_retain_workspaces && !old_active_was_retained {
             let key = old_active_workspace.read(cx).project_group_key(cx);
@@ -1978,7 +1982,7 @@ impl MultiWorkspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Workspace>>> {
-        if self.multi_workspace_enabled(cx) {
+        if self.enabled(cx) {
             let empty_workspace = if self
                 .active_workspace
                 .read(cx)
@@ -2052,7 +2056,7 @@ impl MultiWorkspace {
 
 impl Render for MultiWorkspace {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let multi_workspace_enabled = self.multi_workspace_enabled(cx);
+        let multi_workspace_enabled = self.enabled(cx);
         let sidebar_side = self.sidebar_side(cx);
         let sidebar_on_right = sidebar_side == SidebarSide::Right;
 
@@ -2136,7 +2140,7 @@ impl Render for MultiWorkspace {
                 .font(ui_font)
                 .text_color(text_color)
                 .on_action(cx.listener(Self::close_window))
-                .when(self.multi_workspace_enabled(cx), |this| {
+                .when(self.enabled(cx), |this| {
                     this.on_action(cx.listener(
                         |this: &mut Self, _: &ToggleWorkspaceSidebar, window, cx| {
                             this.toggle_sidebar(window, cx);
@@ -2194,26 +2198,20 @@ impl Render for MultiWorkspace {
                         ))
                     })
                 })
-                .when(
-                    self.sidebar_open() && self.multi_workspace_enabled(cx),
-                    |this| {
-                        this.on_drag_move(cx.listener(
-                            move |this: &mut Self,
-                                  e: &DragMoveEvent<DraggedSidebar>,
-                                  window,
-                                  cx| {
-                                if let Some(sidebar) = &this.sidebar {
-                                    let new_width = if sidebar_on_right {
-                                        window.bounds().size.width - e.event.position.x
-                                    } else {
-                                        e.event.position.x
-                                    };
-                                    sidebar.set_width(Some(new_width), cx);
-                                }
-                            },
-                        ))
-                    },
-                )
+                .when(self.sidebar_open() && self.enabled(cx), |this| {
+                    this.on_drag_move(cx.listener(
+                        move |this: &mut Self, e: &DragMoveEvent<DraggedSidebar>, window, cx| {
+                            if let Some(sidebar) = &this.sidebar {
+                                let new_width = if sidebar_on_right {
+                                    window.bounds().size.width - e.event.position.x
+                                } else {
+                                    e.event.position.x
+                                };
+                                sidebar.set_width(Some(new_width), cx);
+                            }
+                        },
+                    ))
+                })
                 .children(left_sidebar)
                 .child(
                     div()

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -30,7 +30,7 @@ async fn test_sidebar_disabled_when_disable_ai_is_enabled(cx: &mut TestAppContex
         cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
 
     multi_workspace.read_with(cx, |mw, cx| {
-        assert!(mw.multi_workspace_enabled(cx));
+        assert!(mw.enabled(cx));
     });
 
     multi_workspace.update_in(cx, |mw, _window, cx| {
@@ -49,7 +49,7 @@ async fn test_sidebar_disabled_when_disable_ai_is_enabled(cx: &mut TestAppContex
             "Sidebar should be closed when disable_ai is true"
         );
         assert!(
-            !mw.multi_workspace_enabled(cx),
+            !mw.enabled(cx),
             "Multi-workspace should be disabled when disable_ai is true"
         );
     });
@@ -71,7 +71,7 @@ async fn test_sidebar_disabled_when_disable_ai_is_enabled(cx: &mut TestAppContex
 
     multi_workspace.read_with(cx, |mw, cx| {
         assert!(
-            mw.multi_workspace_enabled(cx),
+            mw.enabled(cx),
             "Multi-workspace should be enabled after re-enabling AI"
         );
         assert!(
@@ -109,7 +109,7 @@ async fn test_multi_workspace_collapses_when_agent_is_disabled(cx: &mut TestAppC
     cx.run_until_parked();
 
     multi_workspace.read_with(cx, |multi_workspace, cx| {
-        assert!(multi_workspace.multi_workspace_enabled(cx));
+        assert!(multi_workspace.enabled(cx));
         assert_eq!(multi_workspace.workspaces().count(), 2);
     });
 
@@ -121,7 +121,44 @@ async fn test_multi_workspace_collapses_when_agent_is_disabled(cx: &mut TestAppC
     cx.run_until_parked();
 
     multi_workspace.read_with(cx, |multi_workspace, cx| {
-        assert!(!multi_workspace.multi_workspace_enabled(cx));
+        assert!(!multi_workspace.enabled(cx));
+        assert!(!multi_workspace.sidebar_open());
+        assert_eq!(multi_workspace.workspaces().count(), 1);
+        assert!(multi_workspace.project_group_keys().is_empty());
+    });
+}
+
+#[gpui::test]
+async fn test_multi_workspace_collapses_when_sidebar_is_disabled(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root_a", json!({ "file.txt": "" })).await;
+    fs.insert_tree("/root_b", json!({ "file.txt": "" })).await;
+    let project_a = Project::test(fs.clone(), ["/root_a".as_ref()], cx).await;
+    let project_b = Project::test(fs, ["/root_b".as_ref()], cx).await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project_a, window, cx));
+
+    multi_workspace.update_in(cx, |multi_workspace, window, cx| {
+        multi_workspace.open_sidebar(cx);
+        multi_workspace.test_add_workspace(project_b, window, cx);
+    });
+    cx.run_until_parked();
+
+    multi_workspace.read_with(cx, |multi_workspace, cx| {
+        assert!(multi_workspace.enabled(cx));
+        assert!(multi_workspace.sidebar_open());
+        assert_eq!(multi_workspace.workspaces().count(), 2);
+    });
+
+    cx.update(|_window, cx| {
+        SidebarSettings::override_global(SidebarSettings { enabled: false }, cx);
+    });
+    cx.run_until_parked();
+
+    multi_workspace.read_with(cx, |multi_workspace, cx| {
+        assert!(!multi_workspace.enabled(cx));
         assert!(!multi_workspace.sidebar_open());
         assert_eq!(multi_workspace.workspaces().count(), 1);
         assert!(multi_workspace.project_group_keys().is_empty());

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -85,7 +85,7 @@ impl SidebarStatus {
             .and_then(|mw| mw.upgrade())
             .map(|mw| {
                 let mw = mw.read(cx);
-                let enabled = mw.multi_workspace_enabled(cx);
+                let enabled = mw.enabled(cx);
                 Self {
                     open: mw.sidebar_open() && enabled,
                     side: mw.sidebar_side(cx),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -154,7 +154,8 @@ use util::{
 use uuid::Uuid;
 pub use workspace_settings::{
     AutosaveSetting, BottomDockLayout, EncodingDisplayOptions, FocusFollowsMouse,
-    RestoreOnStartupBehavior, StatusBarSettings, TabBarSettings, WorkspaceSettings,
+    RestoreOnStartupBehavior, SidebarSettings, StatusBarSettings, TabBarSettings,
+    WorkspaceSettings,
 };
 use zed_actions::{Spawn, feedback::FileBugReport, theme::ToggleMode};
 
@@ -9899,7 +9900,7 @@ pub fn open_paths(
                     window.filter(|window| {
                         window
                             .read(cx)
-                            .is_ok_and(|mw| mw.multi_workspace_enabled(cx))
+                            .is_ok_and(|mw| mw.enabled(cx))
                     })
                 });
 

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -72,6 +72,11 @@ pub struct TabBarSettings {
     pub show_pinned_tabs_in_separate_row: bool,
 }
 
+#[derive(Clone, Debug, RegisterSetting)]
+pub struct SidebarSettings {
+    pub enabled: bool,
+}
+
 impl Settings for WorkspaceSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let workspace = &content.workspace;
@@ -148,6 +153,15 @@ impl Settings for TabBarSettings {
             show_nav_history_buttons: tab_bar.show_nav_history_buttons.unwrap(),
             show_tab_bar_buttons: tab_bar.show_tab_bar_buttons.unwrap(),
             show_pinned_tabs_in_separate_row: tab_bar.show_pinned_tabs_in_separate_row.unwrap(),
+        }
+    }
+}
+
+impl Settings for SidebarSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        let sidebar = content.sidebar.clone().unwrap();
+        Self {
+            enabled: sidebar.enabled.unwrap(),
         }
     }
 }


### PR DESCRIPTION
This allows the sidebar to be disabled separately so that you can still use the agent panel without the sidebar

Planning to follow up with:
- Migrating the sidebar_side setting (currently under `agent`) to `sidebar.side`
- Adding a way to access the thread history via the agent panel when the sidebar is disabled

Release Notes:

- Allow disabling the sidebar without disabling the agent panel (`sidebar > enabled`)
