### PR TITLE
file_finder: Open absolute paths outside worktrees

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1373,7 +1373,9 @@ impl FileFinderDelegate {
     ///
     /// If the query path resolves to an absolute file that exists in the project,
     /// this method will find the corresponding worktree and relative path, create a
-    /// match for it, and update the picker's search results.
+    /// match for it, and update the picker's search results. If the file exists on
+    /// disk but lies outside any of the project's worktrees, a synthetic match is
+    /// pushed so that pressing Enter opens it via `workspace.open_abs_path`.
     ///
     /// Returns `true` if the absolute path exists, otherwise returns `false`.
     fn lookup_absolute_path(
@@ -1393,15 +1395,16 @@ impl FileFinderDelegate {
             let query_path = Path::new(query.path_query());
             let mut path_matches = Vec::new();
 
-            let abs_file_exists = project
+            let resolved_path = project
                 .update(cx, |this, cx| {
                     this.resolve_abs_file_path(query.path_query(), cx)
                 })
-                .await
-                .is_some();
+                .await;
+            let abs_file_exists = resolved_path.is_some();
+            let mut external_abs_path = None;
 
-            if abs_file_exists {
-                project.update(cx, |project, cx| {
+            if let Some(resolved) = resolved_path {
+                let found_in_worktree = project.update(cx, |project, cx| {
                     if let Some((worktree, relative_path)) = project.find_worktree(query_path, cx) {
                         path_matches.push(ProjectPanelOrdMatch(PathMatch {
                             score: 1.0,
@@ -1412,8 +1415,17 @@ impl FileFinderDelegate {
                             is_dir: false, // File finder doesn't support directories
                             distance_to_relative_ancestor: usize::MAX,
                         }));
+                        true
+                    } else {
+                        false
                     }
                 });
+
+                if !found_in_worktree
+                    && let Some(abs_path) = resolved.into_abs_path()
+                {
+                    external_abs_path = Some(PathBuf::from(abs_path));
+                }
             }
 
             picker
@@ -1421,6 +1433,26 @@ impl FileFinderDelegate {
                     let picker_delegate = &mut picker.delegate;
                     let search_id = util::post_inc(&mut picker_delegate.search_count);
                     picker_delegate.set_search_matches(search_id, false, query, path_matches, cx);
+
+                    if let Some(absolute) = external_abs_path {
+                        picker_delegate.matches.matches.insert(
+                            0,
+                            Match::History {
+                                path: FoundPath::new(
+                                    ProjectPath {
+                                        // A sentinel id that won't resolve to any worktree, so
+                                        // rendering falls back to the absolute path and `confirm`
+                                        // opens via `workspace.open_abs_path`.
+                                        worktree_id: WorktreeId::from_usize(usize::MAX),
+                                        path: RelPath::empty().into(),
+                                    },
+                                    absolute,
+                                ),
+                                panel_match: None,
+                            },
+                        );
+                        picker_delegate.selected_index = 0;
+                    }
 
                     anyhow::Ok(())
                 })

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -398,6 +398,63 @@ async fn test_absolute_paths(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_absolute_path_outside_worktrees(cx: &mut TestAppContext) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/project"),
+            json!({
+                "src": {
+                    "lib.rs": "",
+                },
+            }),
+        )
+        .await;
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/outside"),
+            json!({
+                "elsewhere.rs": "",
+            }),
+        )
+        .await;
+
+    let project = Project::test(app_state.fs.clone(), [path!("/project").as_ref()], cx).await;
+
+    let (picker, workspace, cx) = build_find_picker(project, cx);
+
+    let outside_path = path!("/outside/elsewhere.rs").to_string();
+    picker
+        .update_in(cx, |picker, window, cx| {
+            picker.delegate.update_matches(outside_path.clone(), window, cx)
+        })
+        .await;
+    picker.update(cx, |picker, _| {
+        assert_eq!(
+            picker.delegate.matches.matches.len(),
+            1,
+            "Existing absolute path outside any worktree should produce one synthetic match"
+        );
+        match &picker.delegate.matches.matches[0] {
+            Match::History { path, panel_match } => {
+                assert!(panel_match.is_none(), "Synthetic match should have no panel_match");
+                assert_eq!(path.absolute, PathBuf::from(path!("/outside/elsewhere.rs")));
+            }
+            other => panic!("Expected History match, got {other:?}"),
+        }
+    });
+    cx.dispatch_action(Confirm);
+    cx.read(|cx| {
+        let active_editor = workspace.read(cx).active_item_as::<Editor>(cx).unwrap();
+        assert_eq!(active_editor.read(cx).title(cx), "elsewhere.rs");
+    });
+}
+
+#[gpui::test]
 async fn test_complex_path(cx: &mut TestAppContext) {
     let app_state = init_test(cx);
 


### PR DESCRIPTION
Closes #23740 (closed by automation, never implemented — ConradIrwin replied "This is a great idea!" on the original issue).
Picks up where #48273 left off (closed as stale; @SomeoneToIgnore reviewed and said "the new approach seems ok and the feature too, thank you for an attempt to work on this").

Related but different in scope:
- #55371 — broader "Support opening files outside workspace" effort by @Daucloud (also touches command palette).
- #39695 — `workspace: open` showing the local file picker in remote projects; this PR does not address that.

---

When pasting an absolute path into Ctrl+P, the file finder would silently show an empty result if the file existed on disk but was not inside any of the project's worktrees. This made it impossible to jump to files copied from terminal output, error messages, or other tools unless the target file happened to live under an open worktree.

`lookup_absolute_path` now keeps the resolved path and pushes a synthetic `Match::History` entry when the file exists outside all worktrees. The existing render and confirm paths already handle History matches whose `worktree_id` doesn't resolve — render falls back to displaying the absolute path, and confirm opens via `workspace.open_abs_path`.

Introduced in dd6e2df2a1 by Kirill Bulatov, Jan 11 2024 ("Show abs path matches in file finder"), which added the feature with the in-worktree-only limitation from day one.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [-] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

williamdes: I remember a time where I could paste full paths into CTRL+P and open my files.
williamdes: Claude did most of the work here, I hope it is good. I have reviewed the diff and test and they look okay

Release Notes:

  - Improved file finder to open files via pasted absolute path even when they live outside any of the project's worktrees