### PR TITLE
open_router: Add prompt caching for Anthropic models

### DIFF
--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -30,6 +30,7 @@ const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new(
 const API_KEY_ENV_VAR_NAME: &str = "OPENROUTER_API_KEY";
 static API_KEY_ENV_VAR: LazyLock<EnvVar> = env_var!(API_KEY_ENV_VAR_NAME);
 pub(crate) const RESERVED_HEADER_NAMES: &[&str] = &["HTTP-Referer", "X-Title"];
+const MAX_OPEN_ROUTER_SESSION_ID_LENGTH: usize = 256;
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct OpenRouterSettings {
@@ -449,15 +450,14 @@ pub fn into_open_router(
     // If we ever have a more formal distionction between the models in the future,
     // we should revise this to use that instead.
     let is_anthropic_model = model.id().starts_with("anthropic/");
+    let session_id = open_router_session_id(request.thread_id);
 
     let mut messages = Vec::new();
     let mut any_message_wants_cache = false;
-    // Index into `messages` of the last built message that originated from a
-    // source message with `cache == true`. Used after the loop to stamp the
-    // 5-minute conversation-tail breakpoint.
     let mut last_cache_message_index: Option<usize> = None;
 
     for message in request.messages {
+        let mut message_added_content = false;
         let reasoning_details_for_message = if is_anthropic_model {
             None
         } else {
@@ -471,15 +471,18 @@ pub fn into_open_router(
 
         for content in message.content {
             match content {
-                MessageContent::Text(text) => add_message_content_part(
-                    open_router::MessagePart::Text {
-                        text,
-                        cache_control: None,
-                    },
-                    message.role,
-                    &mut messages,
-                    reasoning_details_for_message.clone(),
-                ),
+                MessageContent::Text(text) => {
+                    add_message_content_part(
+                        open_router::MessagePart::Text {
+                            text,
+                            cache_control: None,
+                        },
+                        message.role,
+                        &mut messages,
+                        reasoning_details_for_message.clone(),
+                    );
+                    message_added_content = true;
+                }
                 MessageContent::Thinking { .. } => {}
                 MessageContent::RedactedThinking(_) => {}
                 MessageContent::Compaction(_) => {}
@@ -492,6 +495,7 @@ pub fn into_open_router(
                         &mut messages,
                         reasoning_details_for_message.clone(),
                     );
+                    message_added_content = true;
                 }
                 MessageContent::ToolUse(tool_use) => {
                     let tool_call = open_router::ToolCall {
@@ -517,6 +521,7 @@ pub fn into_open_router(
                             reasoning_details: reasoning_details_for_message.clone(),
                         });
                     }
+                    message_added_content = true;
                 }
                 MessageContent::ToolResult(tool_result) => {
                     let content: Vec<open_router::MessagePart> = tool_result
@@ -541,62 +546,34 @@ pub fn into_open_router(
                         content: content.into(),
                         tool_call_id: tool_result.tool_use_id.to_string(),
                     });
+                    message_added_content = true;
                 }
             }
         }
 
-        if message_wants_cache && !messages.is_empty() {
-            last_cache_message_index = Some(messages.len() - 1);
+        if message_wants_cache && message_added_content {
+            last_cache_message_index = messages.len().checked_sub(1);
         }
     }
 
-    // Apply prompt caching for Anthropic models. We use explicit per-block
-    // cache_control breakpoints (not the top-level automatic caching field)
-    // so that OpenRouter can route to any Anthropic-compatible provider
-    // including Bedrock and Vertex AI — top-level automatic caching restricts
-    // routing to Anthropic direct only.
-    //
-    // Two-tier strategy mirrors the direct Anthropic provider:
-    //   Tier 1 (static prefix, 1h TTL): stamp the system message's last text
-    //     block. Because the prefix order is tools → system → messages, this
-    //     breakpoint covers the tools list as well even though the OpenAI-compat
-    //     format has no per-tool cache_control field.
-    //   Tier 2 (conversation tail, 5min TTL): stamp the last text block of the
-    //     last message built from a source message with cache == true.
     if is_anthropic_model && any_message_wants_cache {
-        // Tier 1: system message gets 1-hour TTL breakpoint.
-        let long_lived = open_router::CacheControl {
-            cache_type: open_router::CacheControlType::Ephemeral,
-            ttl: Some(open_router::CacheTtl::OneHour),
-        };
-        for message in &mut messages {
-            if let open_router::RequestMessage::System { content } = message {
-                set_last_text_cache_control(content, long_lived);
-                break;
-            }
+        // OpenRouter's top-level automatic cache_control restricts routing to
+        // Anthropic direct; explicit block breakpoints also work on Bedrock and Vertex.
+        if let Some(content) = last_cache_message_index
+            .and_then(|index| messages.get_mut(index))
+            .and_then(request_message_content_mut)
+        {
+            set_last_text_cache_control(content, cache_control(None));
         }
 
-        // Tier 2: conversation tail gets 5-minute TTL breakpoint.
-        if let Some(index) = last_cache_message_index {
-            let short_lived = open_router::CacheControl {
-                cache_type: open_router::CacheControlType::Ephemeral,
-                ttl: None,
-            };
-            if let Some(message) = messages.get_mut(index) {
-                let content = match message {
-                    open_router::RequestMessage::User { content } => Some(content),
-                    open_router::RequestMessage::System { content } => Some(content),
-                    open_router::RequestMessage::Assistant {
-                        content: Some(content),
-                        ..
-                    } => Some(content),
-                    open_router::RequestMessage::Tool { content, .. } => Some(content),
-                    _ => None,
-                };
-                if let Some(content) = content {
-                    set_last_text_cache_control(content, short_lived);
-                }
-            }
+        if let Some(content) = messages.iter_mut().find_map(|message| match message {
+            open_router::RequestMessage::System { content } => Some(content),
+            _ => None,
+        }) {
+            set_last_text_cache_control(
+                content,
+                cache_control(Some(open_router::CacheTtl::OneHour)),
+            );
         }
     }
 
@@ -604,6 +581,7 @@ pub fn into_open_router(
         model: model.id().into(),
         messages,
         stream: true,
+        session_id,
         stop: request.stop,
         temperature: request.temperature.unwrap_or(0.4),
         max_tokens: max_output_tokens,
@@ -645,8 +623,37 @@ pub fn into_open_router(
     }
 }
 
-/// Stamps `cache_control` on the last `MessagePart::Text` within `content`,
-/// converting `Plain` to `Multipart` first if necessary.
+fn open_router_session_id(thread_id: Option<String>) -> Option<String> {
+    thread_id.map(|thread_id| {
+        thread_id
+            .chars()
+            .take(MAX_OPEN_ROUTER_SESSION_ID_LENGTH)
+            .collect()
+    })
+}
+
+fn cache_control(ttl: Option<open_router::CacheTtl>) -> open_router::CacheControl {
+    open_router::CacheControl {
+        cache_type: open_router::CacheControlType::Ephemeral,
+        ttl,
+    }
+}
+
+fn request_message_content_mut(
+    message: &mut open_router::RequestMessage,
+) -> Option<&mut open_router::MessageContent> {
+    match message {
+        open_router::RequestMessage::User { content }
+        | open_router::RequestMessage::System { content }
+        | open_router::RequestMessage::Tool { content, .. } => Some(content),
+        open_router::RequestMessage::Assistant {
+            content: Some(content),
+            ..
+        } => Some(content),
+        open_router::RequestMessage::Assistant { content: None, .. } => None,
+    }
+}
+
 fn set_last_text_cache_control(
     content: &mut open_router::MessageContent,
     cache_control: open_router::CacheControl,
@@ -654,14 +661,19 @@ fn set_last_text_cache_control(
     match content {
         open_router::MessageContent::Plain(text) => {
             let text = std::mem::take(text);
-            *content = open_router::MessageContent::Multipart(vec![open_router::MessagePart::Text {
-                text,
-                cache_control: Some(cache_control),
-            }]);
+            *content =
+                open_router::MessageContent::Multipart(vec![open_router::MessagePart::Text {
+                    text,
+                    cache_control: Some(cache_control),
+                }]);
         }
         open_router::MessageContent::Multipart(parts) => {
             for part in parts.iter_mut().rev() {
-                if let open_router::MessagePart::Text { cache_control: target, .. } = part {
+                if let open_router::MessagePart::Text {
+                    cache_control: target,
+                    ..
+                } = part
+                {
                     *target = Some(cache_control);
                     break;
                 }
@@ -751,11 +763,11 @@ impl OpenRouterEventMapper {
                 cache_creation_input_tokens: usage
                     .prompt_tokens_details
                     .as_ref()
-                    .map_or(0, |d| d.cache_write_tokens),
+                    .map_or(0, |details| details.cache_write_tokens),
                 cache_read_input_tokens: usage
                     .prompt_tokens_details
                     .as_ref()
-                    .map_or(0, |d| d.cached_tokens),
+                    .map_or(0, |details| details.cached_tokens),
             })));
         }
 
@@ -1214,18 +1226,54 @@ mod tests {
                 prompt_tokens: 12,
                 completion_tokens: 7,
                 total_tokens: 19,
-                prompt_tokens_details: None,
+                prompt_tokens_details: Some(open_router::PromptTokensDetails {
+                    cached_tokens: 5,
+                    cache_write_tokens: 3,
+                }),
             }),
         });
 
         assert_eq!(events.len(), 1);
-        match events.into_iter().next().unwrap() {
-            Ok(LanguageModelCompletionEvent::UsageUpdate(usage)) => {
+        match events.into_iter().next() {
+            Some(Ok(LanguageModelCompletionEvent::UsageUpdate(usage))) => {
                 assert_eq!(usage.input_tokens, 12);
                 assert_eq!(usage.output_tokens, 7);
+                assert_eq!(usage.cache_creation_input_tokens, 3);
+                assert_eq!(usage.cache_read_input_tokens, 5);
             }
             other => panic!("Expected usage update event, got: {other:?}"),
         }
+    }
+
+    #[gpui::test]
+    async fn test_session_id_uses_thread_id() {
+        let model = open_router::Model::new(
+            "openai/gpt-4o",
+            Some("GPT-4o"),
+            Some(128000),
+            Some(true),
+            Some(false),
+            None,
+            None,
+        );
+        let expected_session_id = "a".repeat(MAX_OPEN_ROUTER_SESSION_ID_LENGTH);
+        let request = LanguageModelRequest {
+            thread_id: Some(format!("{expected_session_id}extra")),
+            messages: vec![language_model::LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![MessageContent::Text("Hello".to_string())],
+                cache: false,
+                reasoning_details: None,
+            }],
+            ..Default::default()
+        };
+
+        let result = into_open_router(request, &model, None);
+
+        assert_eq!(
+            result.session_id.as_deref(),
+            Some(expected_session_id.as_str())
+        );
     }
 
     #[gpui::test]
@@ -1272,8 +1320,6 @@ mod tests {
 
     #[gpui::test]
     async fn test_anthropic_model_caching_two_tier() {
-        // Anthropic model: system message gets 1h breakpoint, last cache:true
-        // message gets 5min breakpoint, all other blocks remain unmarked.
         let model = open_router::Model::new(
             "anthropic/claude-sonnet-4-5",
             Some("Claude Sonnet"),
@@ -1321,11 +1367,11 @@ mod tests {
             thread_id: None,
             prompt_id: None,
             intent: None,
+            compact_at_tokens: None,
         };
 
         let result = into_open_router(request, &model, None);
 
-        // System message must have 1h breakpoint on its last text block.
         let system_cache = result.messages.iter().find_map(|m| {
             if let open_router::RequestMessage::System { content } = m {
                 if let open_router::MessageContent::Multipart(parts) = content {
@@ -1354,23 +1400,23 @@ mod tests {
             "System message should have 1h cache_control, got: {system_cache:?}"
         );
 
-        // The last user message must have 5min breakpoint on its last text block.
-        let last_user = result.messages.last().unwrap();
-        let tail_cache = if let open_router::RequestMessage::User { content } = last_user {
-            if let open_router::MessageContent::Multipart(parts) = content {
-                parts.iter().last().and_then(|p| {
-                    if let open_router::MessagePart::Text { cache_control, .. } = p {
-                        *cache_control
-                    } else {
-                        None
-                    }
-                })
+        let tail_cache = result.messages.last().and_then(|last_message| {
+            if let open_router::RequestMessage::User { content } = last_message {
+                if let open_router::MessageContent::Multipart(parts) = content {
+                    parts.iter().last().and_then(|part| {
+                        if let open_router::MessagePart::Text { cache_control, .. } = part {
+                            *cache_control
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                }
             } else {
                 None
             }
-        } else {
-            None
-        };
+        });
         assert!(
             matches!(
                 tail_cache,
@@ -1382,7 +1428,6 @@ mod tests {
             "Last cache:true message should have 5min cache_control, got: {tail_cache:?}"
         );
 
-        // No other message content blocks should be marked.
         for (i, message) in result.messages.iter().enumerate() {
             let is_system = matches!(message, open_router::RequestMessage::System { .. });
             let is_last = i == result.messages.len() - 1;
@@ -1426,7 +1471,6 @@ mod tests {
 
     #[gpui::test]
     async fn test_anthropic_model_no_cache_when_no_cache_flag() {
-        // Anthropic model with no cache:true messages: nothing gets marked.
         let model = open_router::Model::new(
             "anthropic/claude-sonnet-4-5",
             Some("Claude Sonnet"),
@@ -1462,6 +1506,7 @@ mod tests {
             thread_id: None,
             prompt_id: None,
             intent: None,
+            compact_at_tokens: None,
         };
 
         let result = into_open_router(request, &model, None);
@@ -1489,7 +1534,6 @@ mod tests {
 
     #[gpui::test]
     async fn test_non_anthropic_model_no_cache_control() {
-        // Non-Anthropic model: no cache_control regardless of message.cache.
         let model = open_router::Model::new(
             "openai/gpt-4o",
             Some("GPT-4o"),
@@ -1525,6 +1569,7 @@ mod tests {
             thread_id: None,
             prompt_id: None,
             intent: None,
+            compact_at_tokens: None,
         };
 
         let result = into_open_router(request, &model, None);

--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -451,6 +451,12 @@ pub fn into_open_router(
     let is_anthropic_model = model.id().starts_with("anthropic/");
 
     let mut messages = Vec::new();
+    let mut any_message_wants_cache = false;
+    // Index into `messages` of the last built message that originated from a
+    // source message with `cache == true`. Used after the loop to stamp the
+    // 5-minute conversation-tail breakpoint.
+    let mut last_cache_message_index: Option<usize> = None;
+
     for message in request.messages {
         let reasoning_details_for_message = if is_anthropic_model {
             None
@@ -458,10 +464,18 @@ pub fn into_open_router(
             message.reasoning_details.clone()
         };
 
+        let message_wants_cache = message.cache;
+        if message_wants_cache {
+            any_message_wants_cache = true;
+        }
+
         for content in message.content {
             match content {
                 MessageContent::Text(text) => add_message_content_part(
-                    open_router::MessagePart::Text { text },
+                    open_router::MessagePart::Text {
+                        text,
+                        cache_control: None,
+                    },
                     message.role,
                     &mut messages,
                     reasoning_details_for_message.clone(),
@@ -512,6 +526,7 @@ pub fn into_open_router(
                             LanguageModelToolResultContent::Text(text) => {
                                 open_router::MessagePart::Text {
                                     text: text.to_string(),
+                                    cache_control: None,
                                 }
                             }
                             LanguageModelToolResultContent::Image(image) => {
@@ -526,6 +541,60 @@ pub fn into_open_router(
                         content: content.into(),
                         tool_call_id: tool_result.tool_use_id.to_string(),
                     });
+                }
+            }
+        }
+
+        if message_wants_cache && !messages.is_empty() {
+            last_cache_message_index = Some(messages.len() - 1);
+        }
+    }
+
+    // Apply prompt caching for Anthropic models. We use explicit per-block
+    // cache_control breakpoints (not the top-level automatic caching field)
+    // so that OpenRouter can route to any Anthropic-compatible provider
+    // including Bedrock and Vertex AI — top-level automatic caching restricts
+    // routing to Anthropic direct only.
+    //
+    // Two-tier strategy mirrors the direct Anthropic provider:
+    //   Tier 1 (static prefix, 1h TTL): stamp the system message's last text
+    //     block. Because the prefix order is tools → system → messages, this
+    //     breakpoint covers the tools list as well even though the OpenAI-compat
+    //     format has no per-tool cache_control field.
+    //   Tier 2 (conversation tail, 5min TTL): stamp the last text block of the
+    //     last message built from a source message with cache == true.
+    if is_anthropic_model && any_message_wants_cache {
+        // Tier 1: system message gets 1-hour TTL breakpoint.
+        let long_lived = open_router::CacheControl {
+            cache_type: open_router::CacheControlType::Ephemeral,
+            ttl: Some(open_router::CacheTtl::OneHour),
+        };
+        for message in &mut messages {
+            if let open_router::RequestMessage::System { content } = message {
+                set_last_text_cache_control(content, long_lived);
+                break;
+            }
+        }
+
+        // Tier 2: conversation tail gets 5-minute TTL breakpoint.
+        if let Some(index) = last_cache_message_index {
+            let short_lived = open_router::CacheControl {
+                cache_type: open_router::CacheControlType::Ephemeral,
+                ttl: None,
+            };
+            if let Some(message) = messages.get_mut(index) {
+                let content = match message {
+                    open_router::RequestMessage::User { content } => Some(content),
+                    open_router::RequestMessage::System { content } => Some(content),
+                    open_router::RequestMessage::Assistant {
+                        content: Some(content),
+                        ..
+                    } => Some(content),
+                    open_router::RequestMessage::Tool { content, .. } => Some(content),
+                    _ => None,
+                };
+                if let Some(content) = content {
+                    set_last_text_cache_control(content, short_lived);
                 }
             }
         }
@@ -573,6 +642,31 @@ pub fn into_open_router(
             LanguageModelToolChoice::None => open_router::ToolChoice::None,
         }),
         provider: model.provider.clone(),
+    }
+}
+
+/// Stamps `cache_control` on the last `MessagePart::Text` within `content`,
+/// converting `Plain` to `Multipart` first if necessary.
+fn set_last_text_cache_control(
+    content: &mut open_router::MessageContent,
+    cache_control: open_router::CacheControl,
+) {
+    match content {
+        open_router::MessageContent::Plain(text) => {
+            let text = std::mem::take(text);
+            *content = open_router::MessageContent::Multipart(vec![open_router::MessagePart::Text {
+                text,
+                cache_control: Some(cache_control),
+            }]);
+        }
+        open_router::MessageContent::Multipart(parts) => {
+            for part in parts.iter_mut().rev() {
+                if let open_router::MessagePart::Text { cache_control: target, .. } = part {
+                    *target = Some(cache_control);
+                    break;
+                }
+            }
+        }
     }
 }
 
@@ -654,8 +748,14 @@ impl OpenRouterEventMapper {
             events.push(Ok(LanguageModelCompletionEvent::UsageUpdate(TokenUsage {
                 input_tokens: usage.prompt_tokens,
                 output_tokens: usage.completion_tokens,
-                cache_creation_input_tokens: 0,
-                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: usage
+                    .prompt_tokens_details
+                    .as_ref()
+                    .map_or(0, |d| d.cache_write_tokens),
+                cache_read_input_tokens: usage
+                    .prompt_tokens_details
+                    .as_ref()
+                    .map_or(0, |d| d.cached_tokens),
             })));
         }
 
@@ -1114,6 +1214,7 @@ mod tests {
                 prompt_tokens: 12,
                 completion_tokens: 7,
                 total_tokens: 19,
+                prompt_tokens_details: None,
             }),
         });
 
@@ -1166,6 +1267,286 @@ mod tests {
             assert_eq!(arr[0]["data"], "real_data_here");
         } else {
             panic!("Expected array");
+        }
+    }
+
+    #[gpui::test]
+    async fn test_anthropic_model_caching_two_tier() {
+        // Anthropic model: system message gets 1h breakpoint, last cache:true
+        // message gets 5min breakpoint, all other blocks remain unmarked.
+        let model = open_router::Model::new(
+            "anthropic/claude-sonnet-4-5",
+            Some("Claude Sonnet"),
+            Some(200000),
+            Some(true),
+            Some(false),
+            None,
+            None,
+        );
+
+        let request = LanguageModelRequest {
+            messages: vec![
+                language_model::LanguageModelRequestMessage {
+                    role: Role::System,
+                    content: vec![MessageContent::Text("You are helpful.".to_string())],
+                    cache: false,
+                    reasoning_details: None,
+                },
+                language_model::LanguageModelRequestMessage {
+                    role: Role::User,
+                    content: vec![MessageContent::Text("Hello".to_string())],
+                    cache: false,
+                    reasoning_details: None,
+                },
+                language_model::LanguageModelRequestMessage {
+                    role: Role::Assistant,
+                    content: vec![MessageContent::Text("Hi there!".to_string())],
+                    cache: false,
+                    reasoning_details: None,
+                },
+                language_model::LanguageModelRequestMessage {
+                    role: Role::User,
+                    content: vec![MessageContent::Text("What is 2+2?".to_string())],
+                    cache: true,
+                    reasoning_details: None,
+                },
+            ],
+            stop: vec![],
+            temperature: None,
+            tools: vec![],
+            tool_choice: None,
+            thinking_allowed: false,
+            thinking_effort: None,
+            speed: None,
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+        };
+
+        let result = into_open_router(request, &model, None);
+
+        // System message must have 1h breakpoint on its last text block.
+        let system_cache = result.messages.iter().find_map(|m| {
+            if let open_router::RequestMessage::System { content } = m {
+                if let open_router::MessageContent::Multipart(parts) = content {
+                    parts.iter().last().and_then(|p| {
+                        if let open_router::MessagePart::Text { cache_control, .. } = p {
+                            *cache_control
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        });
+        assert!(
+            matches!(
+                system_cache,
+                Some(open_router::CacheControl {
+                    cache_type: open_router::CacheControlType::Ephemeral,
+                    ttl: Some(open_router::CacheTtl::OneHour),
+                })
+            ),
+            "System message should have 1h cache_control, got: {system_cache:?}"
+        );
+
+        // The last user message must have 5min breakpoint on its last text block.
+        let last_user = result.messages.last().unwrap();
+        let tail_cache = if let open_router::RequestMessage::User { content } = last_user {
+            if let open_router::MessageContent::Multipart(parts) = content {
+                parts.iter().last().and_then(|p| {
+                    if let open_router::MessagePart::Text { cache_control, .. } = p {
+                        *cache_control
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        assert!(
+            matches!(
+                tail_cache,
+                Some(open_router::CacheControl {
+                    cache_type: open_router::CacheControlType::Ephemeral,
+                    ttl: None,
+                })
+            ),
+            "Last cache:true message should have 5min cache_control, got: {tail_cache:?}"
+        );
+
+        // No other message content blocks should be marked.
+        for (i, message) in result.messages.iter().enumerate() {
+            let is_system = matches!(message, open_router::RequestMessage::System { .. });
+            let is_last = i == result.messages.len() - 1;
+            if is_system || is_last {
+                continue;
+            }
+            let parts: Option<&Vec<open_router::MessagePart>> = match message {
+                open_router::RequestMessage::User { content }
+                | open_router::RequestMessage::System { content }
+                | open_router::RequestMessage::Tool { content, .. } => {
+                    if let open_router::MessageContent::Multipart(parts) = content {
+                        Some(parts)
+                    } else {
+                        None
+                    }
+                }
+                open_router::RequestMessage::Assistant {
+                    content: Some(content),
+                    ..
+                } => {
+                    if let open_router::MessageContent::Multipart(parts) = content {
+                        Some(parts)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+            if let Some(parts) = parts {
+                for part in parts {
+                    if let open_router::MessagePart::Text { cache_control, .. } = part {
+                        assert!(
+                            cache_control.is_none(),
+                            "Message {i} should not have cache_control"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[gpui::test]
+    async fn test_anthropic_model_no_cache_when_no_cache_flag() {
+        // Anthropic model with no cache:true messages: nothing gets marked.
+        let model = open_router::Model::new(
+            "anthropic/claude-sonnet-4-5",
+            Some("Claude Sonnet"),
+            Some(200000),
+            Some(true),
+            Some(false),
+            None,
+            None,
+        );
+
+        let request = LanguageModelRequest {
+            messages: vec![
+                language_model::LanguageModelRequestMessage {
+                    role: Role::System,
+                    content: vec![MessageContent::Text("You are helpful.".to_string())],
+                    cache: false,
+                    reasoning_details: None,
+                },
+                language_model::LanguageModelRequestMessage {
+                    role: Role::User,
+                    content: vec![MessageContent::Text("Hello".to_string())],
+                    cache: false,
+                    reasoning_details: None,
+                },
+            ],
+            stop: vec![],
+            temperature: None,
+            tools: vec![],
+            tool_choice: None,
+            thinking_allowed: false,
+            thinking_effort: None,
+            speed: None,
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+        };
+
+        let result = into_open_router(request, &model, None);
+
+        for message in &result.messages {
+            let content = match message {
+                open_router::RequestMessage::User { content }
+                | open_router::RequestMessage::System { content } => Some(content),
+                _ => None,
+            };
+            if let Some(content) = content {
+                if let open_router::MessageContent::Multipart(parts) = content {
+                    for part in parts {
+                        if let open_router::MessagePart::Text { cache_control, .. } = part {
+                            assert!(
+                                cache_control.is_none(),
+                                "No message should have cache_control when no cache:true flags"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[gpui::test]
+    async fn test_non_anthropic_model_no_cache_control() {
+        // Non-Anthropic model: no cache_control regardless of message.cache.
+        let model = open_router::Model::new(
+            "openai/gpt-4o",
+            Some("GPT-4o"),
+            Some(128000),
+            Some(true),
+            Some(false),
+            None,
+            None,
+        );
+
+        let request = LanguageModelRequest {
+            messages: vec![
+                language_model::LanguageModelRequestMessage {
+                    role: Role::System,
+                    content: vec![MessageContent::Text("You are helpful.".to_string())],
+                    cache: false,
+                    reasoning_details: None,
+                },
+                language_model::LanguageModelRequestMessage {
+                    role: Role::User,
+                    content: vec![MessageContent::Text("Hello".to_string())],
+                    cache: true,
+                    reasoning_details: None,
+                },
+            ],
+            stop: vec![],
+            temperature: None,
+            tools: vec![],
+            tool_choice: None,
+            thinking_allowed: false,
+            thinking_effort: None,
+            speed: None,
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+        };
+
+        let result = into_open_router(request, &model, None);
+
+        for message in &result.messages {
+            let content = match message {
+                open_router::RequestMessage::User { content }
+                | open_router::RequestMessage::System { content } => Some(content),
+                _ => None,
+            };
+            if let Some(content) = content {
+                if let open_router::MessageContent::Multipart(parts) = content {
+                    for part in parts {
+                        if let open_router::MessagePart::Text { cache_control, .. } = part {
+                            assert!(
+                                cache_control.is_none(),
+                                "Non-Anthropic model should never have cache_control"
+                            );
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -757,17 +757,23 @@ impl OpenRouterEventMapper {
         let mut events = Vec::new();
 
         if let Some(usage) = event.usage {
+            let cache_creation_input_tokens = usage
+                .prompt_tokens_details
+                .as_ref()
+                .map_or(0, |details| details.cache_write_tokens);
+            let cache_read_input_tokens = usage
+                .prompt_tokens_details
+                .as_ref()
+                .map_or(0, |details| details.cached_tokens);
+            let input_tokens = usage.prompt_tokens.saturating_sub(
+                cache_creation_input_tokens.saturating_add(cache_read_input_tokens),
+            );
+
             events.push(Ok(LanguageModelCompletionEvent::UsageUpdate(TokenUsage {
-                input_tokens: usage.prompt_tokens,
+                input_tokens,
                 output_tokens: usage.completion_tokens,
-                cache_creation_input_tokens: usage
-                    .prompt_tokens_details
-                    .as_ref()
-                    .map_or(0, |details| details.cache_write_tokens),
-                cache_read_input_tokens: usage
-                    .prompt_tokens_details
-                    .as_ref()
-                    .map_or(0, |details| details.cached_tokens),
+                cache_creation_input_tokens,
+                cache_read_input_tokens,
             })));
         }
 
@@ -1236,10 +1242,11 @@ mod tests {
         assert_eq!(events.len(), 1);
         match events.into_iter().next() {
             Some(Ok(LanguageModelCompletionEvent::UsageUpdate(usage))) => {
-                assert_eq!(usage.input_tokens, 12);
+                assert_eq!(usage.input_tokens, 4);
                 assert_eq!(usage.output_tokens, 7);
                 assert_eq!(usage.cache_creation_input_tokens, 3);
                 assert_eq!(usage.cache_read_input_tokens, 5);
+                assert_eq!(usage.total_tokens(), 19);
             }
             other => panic!("Expected usage update event, got: {other:?}"),
         }

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -147,6 +147,8 @@ pub struct Request {
     pub messages: Vec<RequestMessage>,
     pub stream: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub stop: Vec<String>,
@@ -260,7 +262,11 @@ impl MessageContent {
 impl From<Vec<MessagePart>> for MessageContent {
     fn from(parts: Vec<MessagePart>) -> Self {
         if parts.len() == 1
-            && let MessagePart::Text { text, .. } = &parts[0]
+            && let MessagePart::Text {
+                text,
+                cache_control,
+            } = &parts[0]
+            && cache_control.is_none()
         {
             return Self::Plain(text.clone());
         }
@@ -349,9 +355,7 @@ pub enum MessagePart {
         cache_control: Option<CacheControl>,
     },
     #[serde(rename = "image_url")]
-    Image {
-        image_url: String,
-    },
+    Image { image_url: String },
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -248,6 +248,7 @@ impl MessageContent {
             Self::Plain(text) => {
                 let text_part = MessagePart::Text {
                     text: std::mem::take(text),
+                    cache_control: None,
                 };
                 *self = Self::Multipart(vec![text_part, part]);
             }
@@ -259,7 +260,7 @@ impl MessageContent {
 impl From<Vec<MessagePart>> for MessageContent {
     fn from(parts: Vec<MessagePart>) -> Self {
         if parts.len() == 1
-            && let MessagePart::Text { text } = &parts[0]
+            && let MessagePart::Text { text, .. } = &parts[0]
         {
             return Self::Plain(text.clone());
         }
@@ -284,7 +285,7 @@ impl MessageContent {
         match self {
             Self::Plain(text) => Some(text),
             Self::Multipart(parts) if parts.len() == 1 => {
-                if let MessagePart::Text { text } = &parts[0] {
+                if let MessagePart::Text { text, .. } = &parts[0] {
                     Some(text)
                 } else {
                     None
@@ -300,7 +301,7 @@ impl MessageContent {
             Self::Multipart(parts) => parts
                 .iter()
                 .filter_map(|part| {
-                    if let MessagePart::Text { text } = part {
+                    if let MessagePart::Text { text, .. } = part {
                         Some(text.as_str())
                     } else {
                         None
@@ -312,11 +313,40 @@ impl MessageContent {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CacheControlType {
+    Ephemeral,
+}
+
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
+pub enum CacheTtl {
+    /// Anthropic's default ephemeral TTL (currently 5 minutes). Refreshes for
+    /// free on every cache hit.
+    #[serde(rename = "5m")]
+    FiveMinutes,
+    /// Anthropic's extended ephemeral TTL (currently 1 hour). Costs 2x base
+    /// input tokens to write, but persists across longer idle gaps.
+    #[serde(rename = "1h")]
+    OneHour,
+}
+
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
+pub struct CacheControl {
+    #[serde(rename = "type")]
+    pub cache_type: CacheControlType,
+    /// Omitting this field uses the API's default 5-minute TTL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<CacheTtl>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum MessagePart {
     Text {
         text: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
     },
     #[serde(rename = "image_url")]
     Image {
@@ -371,11 +401,21 @@ pub struct FunctionChunk {
     pub thought_signature: Option<String>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct PromptTokensDetails {
+    #[serde(default)]
+    pub cached_tokens: u64,
+    #[serde(default)]
+    pub cache_write_tokens: u64,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Usage {
     pub prompt_tokens: u64,
     pub completion_tokens: u64,
     pub total_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/52576

## Overview

Adds prompt caching support for Anthropic Claude models when accessed via OpenRouter.

This mirrors Zed's native Anthropic provider by using explicit per-block `cache_control` breakpoints:

- A long-lived 1-hour breakpoint on the system message's last text block, covering the tools and system prefix.
- A default 5-minute breakpoint on the last `cache: true` conversation message.

The implementation intentionally avoids OpenRouter's top-level automatic `cache_control` field so routing remains available across Anthropic-compatible providers including Anthropic, Bedrock, and Vertex AI. It also adds `session_id` sticky routing from the request thread ID and maps OpenRouter cache usage fields into Zed's token usage accounting.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed Anthropic prompt caching when using OpenRouter.
