### PR TITLE
grammars: Highlight markdown code spans in tables

### DIFF
--- a/crates/grammars/src/markdown/injections.scm
+++ b/crates/grammars/src/markdown/injections.scm
@@ -6,6 +6,9 @@
 ((inline) @injection.content
   (#set! injection.language "markdown-inline"))
 
+((pipe_table_cell) @injection.content
+  (#set! injection.language "markdown-inline"))
+
 ((html_block) @injection.content
   (#set! injection.language "html"))
 


### PR DESCRIPTION
Resolves https://github.com/zed-industries/zed/issues/57501

This diff fixes Markdown inline syntax highlighting inside pipe table cells. The block Markdown parser represents table content as `pipe_table_cell` nodes rather than `inline` nodes, so Zed’s existing `markdown-inline` injection ran for paragraph text but skipped code spans inside tables.

With this change, table cells also inject `markdown-inline`, allowing existing inline highlighting to handle code spans consistently between paragraph text and table cells.

| Before | After |
| --- | --- |
| <img width="500" alt="Before screenshot" src="https://github.com/user-attachments/assets/bdb75c18-9f20-4f3c-bea6-946194098db6" /> | <img width="500" alt="After screenshot" src="https://github.com/user-attachments/assets/23ae7bc5-5208-4dc7-ab6f-d07404aeae06" /> |

Release Notes:

- Fixed Markdown inline code highlighting in table cells.