### PR TITLE
gpui: Don't panic when a Metal atlas texture is missing

### DIFF
--- a/crates/gpui/src/platform/mac/metal_atlas.rs
+++ b/crates/gpui/src/platform/mac/metal_atlas.rs
@@ -23,8 +23,11 @@ impl MetalAtlas {
         }))
     }
 
-    pub(crate) fn metal_texture(&self, id: AtlasTextureId) -> metal::Texture {
-        self.0.lock().texture(id).metal_texture.clone()
+    pub(crate) fn metal_texture(&self, id: AtlasTextureId) -> Option<metal::Texture> {
+        self.0
+            .lock()
+            .texture(id)
+            .map(|texture| texture.metal_texture.clone())
     }
 
     pub(crate) fn allocate(
@@ -68,7 +71,12 @@ impl PlatformAtlas for MetalAtlas {
         } else {
             let (size, bytes) = build()?;
             let tile = lock.allocate(size, key.texture_kind());
-            let texture = lock.texture(tile.texture_id);
+            let texture = lock.texture(tile.texture_id).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "failed to find atlas texture {:?} immediately after allocation",
+                    tile.texture_id
+                )
+            })?;
             texture.upload(tile.bounds, &bytes);
             lock.tiles_by_key.insert(key.clone(), tile.clone());
             Ok(tile)
@@ -144,13 +152,13 @@ impl MetalAtlasState {
         textures.last_mut().unwrap()
     }
 
-    fn texture(&self, id: AtlasTextureId) -> &MetalAtlasTexture {
+    fn texture(&self, id: AtlasTextureId) -> Option<&MetalAtlasTexture> {
         let textures = match id.kind {
             crate::AtlasTextureKind::Monochrome => &self.monochrome_textures,
             crate::AtlasTextureKind::Polychrome => &self.polychrome_textures,
             crate::AtlasTextureKind::Path => &self.path_textures,
         };
-        &textures[id.index as usize]
+        textures.get(id.index as usize)
     }
 }
 

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -441,7 +441,12 @@ impl MetalRenderer {
                 .object_at(0)
                 .unwrap();
 
-            let texture = self.sprite_atlas.metal_texture(texture_id);
+            let Some(texture) = self.sprite_atlas.metal_texture(texture_id) else {
+                log::warn!(
+                    "skipping path rasterization for missing atlas texture {texture_id:?}"
+                );
+                continue;
+            };
             color_attachment.set_texture(Some(&texture));
             color_attachment.set_load_action(metal::MTLLoadAction::Clear);
             color_attachment.set_store_action(metal::MTLStoreAction::Store);
@@ -662,7 +667,13 @@ impl MetalRenderer {
             } else {
                 align_offset(instance_offset);
                 let texture_id = prev_texture_id.take().unwrap();
-                let texture: metal::Texture = self.sprite_atlas.metal_texture(texture_id);
+                let Some(texture) = self.sprite_atlas.metal_texture(texture_id) else {
+                    log::warn!(
+                        "skipping path draw for missing atlas texture {texture_id:?}"
+                    );
+                    sprites.clear();
+                    continue;
+                };
                 let texture_size = size(
                     DevicePixels(texture.width() as i32),
                     DevicePixels(texture.height() as i32),
@@ -793,7 +804,12 @@ impl MetalRenderer {
         }
         align_offset(instance_offset);
 
-        let texture = self.sprite_atlas.metal_texture(texture_id);
+        let Some(texture) = self.sprite_atlas.metal_texture(texture_id) else {
+            log::warn!(
+                "skipping monochrome sprites for missing atlas texture {texture_id:?}"
+            );
+            return true;
+        };
         let texture_size = size(
             DevicePixels(texture.width() as i32),
             DevicePixels(texture.height() as i32),
@@ -867,7 +883,12 @@ impl MetalRenderer {
         }
         align_offset(instance_offset);
 
-        let texture = self.sprite_atlas.metal_texture(texture_id);
+        let Some(texture) = self.sprite_atlas.metal_texture(texture_id) else {
+            log::warn!(
+                "skipping polychrome sprites for missing atlas texture {texture_id:?}"
+            );
+            return true;
+        };
         let texture_size = size(
             DevicePixels(texture.width() as i32),
             DevicePixels(texture.height() as i32),


### PR DESCRIPTION
I encountered a crash where Zed aborts with `Option::unwrap()` on `None` inside `MetalAtlas::metal_texture` during `MacWindow::draw`. The panic occured while viewing an image file.

Here are the relevant frames from the crash:

```rust
core::option::unwrap_failed
gpui_macos::metal_atlas::MetalAtlas::metal_texture
gpui_macos::window::MacWindow::draw
```

## Root cause

`MetalAtlas::metal_texture` indexed straight into the per-kind texture `Vec` (`&textures[id.index as usize]`) and returned the inner `metal::Texture` unconditionally. If a draw call ever asked for a texture that was no longer present in the atlas (e.g. because the relevant atlas was cleared between tile allocation and the draw, or the `AtlasTextureId` outlived its texture), the indexing would panic and abort the process. There was no fallback path, so a single missing tile would take the whole window down.

## Fix / Change Proposal

I decided to fix this conservatively. 

`MetalAtlas::metal_texture` now returns `Option<metal::Texture>` and uses `Vec::get` to avoid panicking on out-of-bounds access. The caller is responsible for handling the `None` case, which indicates a missing texture.

All call sites in `metal_renderer.rs` (`rasterize_paths`, `draw_paths`, `draw_monochrome_sprites`, `draw_polychrome_sprites`) now log a warning and skip that batch instead of crashing. The rest of the frame should continue to render normally this way.
Let me know if you'd like me to fix this any other way. (I'm not an expert in gpui/Metal and don't know much about Zed's error handling conventions yet.)

For context, this patch treats the symptom: it stops the crash and keeps the app alive. It does not investigate *why* the texture goes missing in the first place. 
I don't know enough about the atlas internals to speculate on the root cause of the missing texture. If you can give me any pointer on where to look, I can try to investigate further and maybe attempt a more robust fix that prevents the texture from going missing in the first place. But either way, the `unwrap` should be removed and the `None` case be handled gracefully, so I think this patch is an improvement regardless.

## Reported environment

- Zed 1.3.6 (20260521.222851), ARM-64
- macOS 15.7.1 (24G231)
