### PR TITLE
Fix new windows not showing the launchpad when restore_on_startup is set to "launchpad"

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1269,6 +1269,11 @@ fn register_actions(
                     app_state.clone(),
                     cx,
                     |workspace, window, cx| {
+                        if WorkspaceSettings::get_global(cx).restore_on_startup
+                            == workspace::RestoreOnStartupBehavior::Launchpad
+                        {
+                            return;
+                        }
                         cx.activate(true);
                         // Create buffer synchronously to avoid flicker
                         let project = workspace.project().clone();


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

This is a tiny change to make the `workspace::NewWindow` action show the launchpad instead of an empty untitled buffer when the `restore_on_startup` setting is set to "launchpad" as I feel this action should be consistent with the user's configured startup behaviour.

Alternative PR to #60711, would close #60720.

Release Notes:

- Fixed new windows not showing the launchpad when restore_on_startup is set to "launchpad".