### PR TITLE
Stop populating root_repo_common_dir from ancestor .git

### DIFF
--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -1738,6 +1738,68 @@ async fn test_remote_root_repo_common_dir(cx: &mut TestAppContext, server_cx: &m
 }
 
 #[gpui::test]
+async fn test_remote_root_repo_common_dir_not_polluted_by_ancestor_git(
+    cx: &mut TestAppContext,
+    server_cx: &mut TestAppContext,
+) {
+    // Regression test (remote): when a remote worktree is rooted at a
+    // subdirectory of a monorepo (no `.git` at the worktree root, but an
+    // ancestor has one), the value carried over the wire must be `None`.
+    // Otherwise sibling subdirectories collapse into one entry in recent
+    // projects. See PR #55715.
+    let fs = FakeFs::new(server_cx.executor());
+    fs.insert_tree(
+        "/code",
+        json!({
+            "monorepo": {
+                ".git": {},
+                "frontend": {
+                    "file.txt": "content",
+                },
+                "backend": {
+                    "file.txt": "content",
+                },
+            },
+        }),
+    )
+    .await;
+
+    let (project, _headless) = init_test(&fs, cx, server_cx).await;
+
+    let (worktree_frontend, _) = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree("/code/monorepo/frontend", true, cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    let (worktree_backend, _) = project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree("/code/monorepo/backend", true, cx)
+        })
+        .await
+        .unwrap();
+    cx.executor().run_until_parked();
+
+    let frontend_common_dir = worktree_frontend.read_with(cx, |worktree, _| {
+        worktree.snapshot().root_repo_common_dir().cloned()
+    });
+    assert_eq!(
+        frontend_common_dir, None,
+        "remote monorepo subdirectory must not inherit ancestor .git",
+    );
+
+    let backend_common_dir = worktree_backend.read_with(cx, |worktree, _| {
+        worktree.snapshot().root_repo_common_dir().cloned()
+    });
+    assert_eq!(
+        backend_common_dir, None,
+        "remote monorepo subdirectory must not inherit ancestor .git",
+    );
+}
+
+#[gpui::test]
 async fn test_remote_search_commits_streams_proto_chunks(
     cx: &mut TestAppContext,
     server_cx: &mut TestAppContext,

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1274,8 +1274,17 @@ impl LocalWorktree {
     ) {
         let repo_changes = self.changed_repos(&self.snapshot, &mut new_snapshot);
 
+        // Only treat the worktree root as a "repo root" when its own `.git` lives
+        // at the worktree root (either a normal repo or a linked worktree gitfile).
+        // An `AboveProject` repository — discovered by walking ancestors of the
+        // worktree root — must NOT populate `root_repo_common_dir`, otherwise
+        // multiple sibling subdirectories of the same monorepo would be grouped
+        // together as a single project in recent projects. See PR #55715.
         new_snapshot.root_repo_common_dir = new_snapshot
             .local_repo_for_work_directory_path(RelPath::empty())
+            .filter(|repo| {
+                !matches!(repo.work_directory, WorkDirectory::AboveProject { .. })
+            })
             .map(|repo| SanitizedPath::from_arc(repo.common_dir_abs_path.clone()));
 
         let old_root_repo_common_dir = (self.snapshot.root_repo_common_dir

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1282,9 +1282,7 @@ impl LocalWorktree {
         // together as a single project in recent projects. See PR #55715.
         new_snapshot.root_repo_common_dir = new_snapshot
             .local_repo_for_work_directory_path(RelPath::empty())
-            .filter(|repo| {
-                !matches!(repo.work_directory, WorkDirectory::AboveProject { .. })
-            })
+            .filter(|repo| !matches!(repo.work_directory, WorkDirectory::AboveProject { .. }))
             .map(|repo| SanitizedPath::from_arc(repo.common_dir_abs_path.clone()));
 
         let old_root_repo_common_dir = (self.snapshot.root_repo_common_dir

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -3996,6 +3996,81 @@ async fn test_root_repo_common_dir(executor: BackgroundExecutor, cx: &mut TestAp
 }
 
 #[gpui::test]
+async fn test_root_repo_common_dir_not_polluted_by_ancestor_git(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    // Regression test: subdirectories of a monorepo (where `.git` lives on an
+    // ancestor, but the worktree root itself has no `.git`) must NOT report
+    // the ancestor `.git` as `root_repo_common_dir`. Otherwise sibling
+    // subdirectories of the same monorepo would be merged into a single entry
+    // in recent projects. See PR #55715.
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/monorepo"),
+        json!({
+            ".git": {},
+            "frontend": {
+                "file.txt": "content",
+            },
+            "backend": {
+                "file.txt": "content",
+            },
+        }),
+    )
+    .await;
+
+    let frontend_tree = Worktree::local(
+        path!("/monorepo/frontend").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    frontend_tree
+        .update(cx, |tree, _| tree.as_local().unwrap().scan_complete())
+        .await;
+    cx.run_until_parked();
+
+    let backend_tree = Worktree::local(
+        path!("/monorepo/backend").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(1),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    backend_tree
+        .update(cx, |tree, _| tree.as_local().unwrap().scan_complete())
+        .await;
+    cx.run_until_parked();
+
+    frontend_tree.read_with(cx, |tree, _| {
+        assert_eq!(
+            tree.snapshot().root_repo_common_dir(),
+            None,
+            "monorepo subdirectory must not inherit ancestor .git as root_repo_common_dir",
+        );
+    });
+    backend_tree.read_with(cx, |tree, _| {
+        assert_eq!(
+            tree.snapshot().root_repo_common_dir(),
+            None,
+            "monorepo subdirectory must not inherit ancestor .git as root_repo_common_dir",
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_invisible_worktree_does_not_track_ancestor_git_repository(
     executor: BackgroundExecutor,
     cx: &mut TestAppContext,


### PR DESCRIPTION
A worktree's root_repo_common_dir was overwritten by an ancestor .git repository discovered via WorkDirectory::AboveProject. As a result, two sibling subdirectories of the same monorepo reported identical root_repo_common_dirs and were collapsed into a single entry in the recent projects list.

Skip AboveProject repositories when recomputing root_repo_common_dir in set_snapshot so only repositories located at or inside the worktree contribute to its identity.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #56346

Release Notes:

- Fixed subdirectories of the same monorepo being merged into a single entry in recent projects
