### PR TITLE
Avoid linkifying non-interactive code spans

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1213,7 +1213,10 @@ impl MarkdownElement {
         range: Range<usize>,
         cx: &App,
     ) {
-        let link_url = if builder.code_block_stack.is_empty() && builder.link_depth == 0 {
+        let link_url = if builder.code_block_stack.is_empty()
+            && builder.link_depth == 0
+            && !self.style.prevent_mouse_interaction
+        {
             self.code_span_link
                 .as_ref()
                 .and_then(|callback| callback(text, cx))
@@ -3490,7 +3493,10 @@ mod tests {
     use super::*;
     use gpui::{TestAppContext, size};
     use language::{Language, LanguageConfig, LanguageMatcher};
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     fn ensure_theme_initialized(cx: &mut TestAppContext) {
         cx.update(|cx| {
@@ -3563,6 +3569,15 @@ mod tests {
         callback: impl Fn(&str, &App) -> Option<SharedString> + 'static,
         cx: &mut TestAppContext,
     ) -> RenderedText {
+        render_markdown_with_code_span_link_style(markdown, MarkdownStyle::default(), callback, cx)
+    }
+
+    fn render_markdown_with_code_span_link_style(
+        markdown: &str,
+        style: MarkdownStyle,
+        callback: impl Fn(&str, &App) -> Option<SharedString> + 'static,
+        cx: &mut TestAppContext,
+    ) -> RenderedText {
         struct TestWindow;
 
         impl Render for TestWindow {
@@ -3580,7 +3595,7 @@ mod tests {
             Default::default(),
             size(px(600.0), px(600.0)),
             |_window, _cx| {
-                MarkdownElement::new(markdown, MarkdownStyle::default())
+                MarkdownElement::new(markdown, style)
                     .on_code_span_link(callback)
                     .code_block_renderer(CodeBlockRenderer::Default {
                         copy_button_visibility: CopyButtonVisibility::Hidden,
@@ -4249,6 +4264,31 @@ mod tests {
                 .link_for_source_index(source.find("see").unwrap())
                 .is_none()
         );
+    }
+
+    #[gpui::test]
+    fn test_code_span_link_ignores_code_when_mouse_interaction_is_prevented(
+        cx: &mut TestAppContext,
+    ) {
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let rendered = render_markdown_with_code_span_link_style(
+            "see `foo.rs` for details",
+            MarkdownStyle {
+                prevent_mouse_interaction: true,
+                ..MarkdownStyle::default()
+            },
+            {
+                let callback_count = callback_count.clone();
+                move |text, _cx| {
+                    callback_count.fetch_add(1, Ordering::Relaxed);
+                    (text == "foo.rs").then(|| "file:///tmp/foo.rs".into())
+                }
+            },
+            cx,
+        );
+
+        assert!(rendered.links.is_empty());
+        assert_eq!(callback_count.load(Ordering::Relaxed), 0);
     }
 
     #[gpui::test]


### PR DESCRIPTION
## Summary

- Skip code-span link resolution when markdown prevents mouse interaction
- Add regression coverage for non-interactive code spans

## Tests

- cargo test -p markdown test_code_span_link_ignores_code_when_mouse_interaction_is_prevented

Release Notes:

- Fixed extra link styling on file paths in agent tool call labels.
