### PR TITLE
Reference-count atlas tiles to prevent use-after-free in renderer

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1021,8 +1021,49 @@ pub trait PlatformAtlas {
         &self,
         key: &AtlasKey,
         build: &mut dyn FnMut() -> Result<Option<(Size<DevicePixels>, Cow<'a, [u8]>)>>,
-    ) -> Result<Option<AtlasTile>>;
+    ) -> Result<Option<AtlasTileRef>>;
     fn remove(&self, key: &AtlasKey);
+}
+
+/// Type-erased keep-alive owned by an [`AtlasTileRef`]. Backends implement this
+/// to release the underlying atlas slot when the last [`AtlasTileRef`] holding
+/// it is dropped.
+#[doc(hidden)]
+pub trait AtlasTileKeepAlive: std::fmt::Debug + Send + Sync + 'static {}
+
+/// A reference-counted handle to an [`AtlasTile`].
+///
+/// The atlas hands out exactly one keep-alive per tile; the surrounding `Arc`
+/// is what makes the handle cloneable and what releases the slot when the last
+/// clone is dropped. Callers (the image cache, the scene, etc.) keep the slot
+/// alive simply by holding onto an `AtlasTileRef` clone.
+///
+/// `tile` is the raw `#[repr(C)]` data that the GPU consumes verbatim; copying
+/// it out via `Deref` or `.tile` is allowed and does not affect the refcount.
+/// What must not happen is using the raw `AtlasTile` after every `AtlasTileRef`
+/// for it has been dropped.
+#[derive(Clone, Debug)]
+pub struct AtlasTileRef {
+    /// Raw GPU-side tile data. Safe to copy into instance buffers as long as
+    /// at least one `AtlasTileRef` is kept alive for the duration of the use.
+    pub tile: AtlasTile,
+    #[allow(dead_code)]
+    keep_alive: std::sync::Arc<dyn AtlasTileKeepAlive>,
+}
+
+impl AtlasTileRef {
+    /// Wrap a raw tile together with the backend-provided keep-alive.
+    pub fn new(tile: AtlasTile, keep_alive: std::sync::Arc<dyn AtlasTileKeepAlive>) -> Self {
+        Self { tile, keep_alive }
+    }
+}
+
+impl ops::Deref for AtlasTileRef {
+    type Target = AtlasTile;
+
+    fn deref(&self) -> &AtlasTile {
+        &self.tile
+    }
 }
 
 #[doc(hidden)]

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -1,5 +1,6 @@
 use crate::{
-    AnyWindowHandle, AtlasKey, AtlasTextureId, AtlasTile, Bounds, DevicePixels,
+    AnyWindowHandle, AtlasKey, AtlasTextureId, AtlasTileKeepAlive, AtlasTileRef,
+    Bounds, DevicePixels,
     DispatchEventResult, GpuSpecs, Pixels, PlatformAtlas, PlatformDisplay,
     PlatformHeadlessRenderer, PlatformInput, PlatformInputHandler, PlatformWindow, Point,
     PromptButton, RequestFrameOptions, Scene, Size, TestPlatform, TileId, WindowAppearance,
@@ -336,8 +337,12 @@ impl PlatformWindow for TestWindow {
 
 pub(crate) struct TestAtlasState {
     next_id: u32,
-    tiles: HashMap<AtlasKey, AtlasTile>,
+    tiles: HashMap<AtlasKey, AtlasTileRef>,
 }
+
+#[derive(Debug)]
+struct TestTileKeepAlive;
+impl AtlasTileKeepAlive for TestTileKeepAlive {}
 
 pub(crate) struct TestAtlas(Mutex<TestAtlasState>);
 
@@ -357,10 +362,10 @@ impl PlatformAtlas for TestAtlas {
         build: &mut dyn FnMut() -> anyhow::Result<
             Option<(Size<crate::DevicePixels>, std::borrow::Cow<'a, [u8]>)>,
         >,
-    ) -> anyhow::Result<Option<crate::AtlasTile>> {
+    ) -> anyhow::Result<Option<crate::AtlasTileRef>> {
         let mut state = self.0.lock();
-        if let Some(&tile) = state.tiles.get(key) {
-            return Ok(Some(tile));
+        if let Some(tile_ref) = state.tiles.get(key) {
+            return Ok(Some(tile_ref.clone()));
         }
         drop(state);
 
@@ -374,23 +379,22 @@ impl PlatformAtlas for TestAtlas {
         state.next_id += 1;
         let tile_id = state.next_id;
 
-        state.tiles.insert(
-            key.clone(),
-            crate::AtlasTile {
-                texture_id: AtlasTextureId {
-                    index: texture_id,
-                    kind: crate::AtlasTextureKind::Monochrome,
-                },
-                tile_id: TileId(tile_id),
-                padding: 0,
-                bounds: crate::Bounds {
-                    origin: Point::default(),
-                    size,
-                },
+        let tile = crate::AtlasTile {
+            texture_id: AtlasTextureId {
+                index: texture_id,
+                kind: crate::AtlasTextureKind::Monochrome,
             },
-        );
+            tile_id: TileId(tile_id),
+            padding: 0,
+            bounds: crate::Bounds {
+                origin: Point::default(),
+                size,
+            },
+        };
+        let tile_ref = AtlasTileRef::new(tile, std::sync::Arc::new(TestTileKeepAlive));
+        state.tiles.insert(key.clone(), tile_ref.clone());
 
-        Ok(Some(state.tiles[key]))
+        Ok(Some(tile_ref))
     }
 
     fn remove(&self, key: &AtlasKey) {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -1,7 +1,6 @@
 use crate::{
-    AnyWindowHandle, AtlasKey, AtlasTextureId, AtlasTileKeepAlive, AtlasTileRef,
-    Bounds, DevicePixels,
-    DispatchEventResult, GpuSpecs, Pixels, PlatformAtlas, PlatformDisplay,
+    AnyWindowHandle, AtlasKey, AtlasTextureId, AtlasTileKeepAlive, AtlasTileRef, Bounds,
+    DevicePixels, DispatchEventResult, GpuSpecs, Pixels, PlatformAtlas, PlatformDisplay,
     PlatformHeadlessRenderer, PlatformInput, PlatformInputHandler, PlatformWindow, Point,
     PromptButton, RequestFrameOptions, Scene, Size, TestPlatform, TileId, WindowAppearance,
     WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowParams,

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -246,9 +246,9 @@ impl Primitive {
             Primitive::Quad(quad) => &quad.bounds,
             Primitive::Path(path) => &path.bounds,
             Primitive::Underline(underline) => &underline.bounds,
-            Primitive::MonochromeSprite { sprite, .. } => &sprite.bounds,
-            Primitive::SubpixelSprite { sprite, .. } => &sprite.bounds,
-            Primitive::PolychromeSprite { sprite, .. } => &sprite.bounds,
+            Primitive::MonochromeSprite { sprite, tile_ref: _ } => &sprite.bounds,
+            Primitive::SubpixelSprite { sprite, tile_ref: _ } => &sprite.bounds,
+            Primitive::PolychromeSprite { sprite, tile_ref: _ } => &sprite.bounds,
             Primitive::Surface(surface) => &surface.bounds,
         }
     }
@@ -259,9 +259,9 @@ impl Primitive {
             Primitive::Quad(quad) => &quad.content_mask,
             Primitive::Path(path) => &path.content_mask,
             Primitive::Underline(underline) => &underline.content_mask,
-            Primitive::MonochromeSprite { sprite, .. } => &sprite.content_mask,
-            Primitive::SubpixelSprite { sprite, .. } => &sprite.content_mask,
-            Primitive::PolychromeSprite { sprite, .. } => &sprite.content_mask,
+            Primitive::MonochromeSprite { sprite, tile_ref: _ } => &sprite.content_mask,
+            Primitive::SubpixelSprite { sprite, tile_ref: _ } => &sprite.content_mask,
+            Primitive::PolychromeSprite { sprite, tile_ref: _ } => &sprite.content_mask,
             Primitive::Surface(surface) => &surface.content_mask,
         }
     }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -5,8 +5,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AtlasTextureId, AtlasTile, AtlasTileRef, Background, Bounds, ContentMask, Corners, Edges,
-    Hsla, Pixels, Point, Radians, ScaledPixels, Size, bounds_tree::BoundsTree, point,
+    AtlasTextureId, AtlasTile, AtlasTileRef, Background, Bounds, ContentMask, Corners, Edges, Hsla,
+    Pixels, Point, Radians, ScaledPixels, Size, bounds_tree::BoundsTree, point,
 };
 use std::{
     fmt::Debug,
@@ -246,9 +246,18 @@ impl Primitive {
             Primitive::Quad(quad) => &quad.bounds,
             Primitive::Path(path) => &path.bounds,
             Primitive::Underline(underline) => &underline.bounds,
-            Primitive::MonochromeSprite { sprite, tile_ref: _ } => &sprite.bounds,
-            Primitive::SubpixelSprite { sprite, tile_ref: _ } => &sprite.bounds,
-            Primitive::PolychromeSprite { sprite, tile_ref: _ } => &sprite.bounds,
+            Primitive::MonochromeSprite {
+                sprite,
+                tile_ref: _,
+            } => &sprite.bounds,
+            Primitive::SubpixelSprite {
+                sprite,
+                tile_ref: _,
+            } => &sprite.bounds,
+            Primitive::PolychromeSprite {
+                sprite,
+                tile_ref: _,
+            } => &sprite.bounds,
             Primitive::Surface(surface) => &surface.bounds,
         }
     }
@@ -259,9 +268,18 @@ impl Primitive {
             Primitive::Quad(quad) => &quad.content_mask,
             Primitive::Path(path) => &path.content_mask,
             Primitive::Underline(underline) => &underline.content_mask,
-            Primitive::MonochromeSprite { sprite, tile_ref: _ } => &sprite.content_mask,
-            Primitive::SubpixelSprite { sprite, tile_ref: _ } => &sprite.content_mask,
-            Primitive::PolychromeSprite { sprite, tile_ref: _ } => &sprite.content_mask,
+            Primitive::MonochromeSprite {
+                sprite,
+                tile_ref: _,
+            } => &sprite.content_mask,
+            Primitive::SubpixelSprite {
+                sprite,
+                tile_ref: _,
+            } => &sprite.content_mask,
+            Primitive::PolychromeSprite {
+                sprite,
+                tile_ref: _,
+            } => &sprite.content_mask,
             Primitive::Surface(surface) => &surface.content_mask,
         }
     }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -5,8 +5,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AtlasTextureId, AtlasTile, Background, Bounds, ContentMask, Corners, Edges, Hsla, Pixels,
-    Point, Radians, ScaledPixels, Size, bounds_tree::BoundsTree, point,
+    AtlasTextureId, AtlasTile, AtlasTileRef, Background, Bounds, ContentMask, Corners, Edges,
+    Hsla, Pixels, Point, Radians, ScaledPixels, Size, bounds_tree::BoundsTree, point,
 };
 use std::{
     fmt::Debug,
@@ -36,6 +36,11 @@ pub struct Scene {
     pub subpixel_sprites: Vec<SubpixelSprite>,
     pub polychrome_sprites: Vec<PolychromeSprite>,
     pub surfaces: Vec<PaintSurface>,
+    /// Keep-alive handles for every atlas tile referenced by any sprite in
+    /// this scene. Holding these here ensures the underlying texture slots
+    /// stay alive until the scene is cleared (which happens after the
+    /// renderer has finished uploading the primitives to the GPU).
+    pub(crate) tile_refs: Vec<AtlasTileRef>,
 }
 
 #[expect(missing_docs)]
@@ -52,6 +57,7 @@ impl Scene {
         self.subpixel_sprites.clear();
         self.polychrome_sprites.clear();
         self.surfaces.clear();
+        self.tile_refs.clear();
     }
 
     pub fn len(&self) -> usize {
@@ -103,17 +109,20 @@ impl Scene {
                 underline.order = order;
                 self.underlines.push(*underline);
             }
-            Primitive::MonochromeSprite(sprite) => {
+            Primitive::MonochromeSprite { sprite, tile_ref } => {
                 sprite.order = order;
                 self.monochrome_sprites.push(*sprite);
+                self.tile_refs.push(tile_ref.clone());
             }
-            Primitive::SubpixelSprite(sprite) => {
+            Primitive::SubpixelSprite { sprite, tile_ref } => {
                 sprite.order = order;
                 self.subpixel_sprites.push(*sprite);
+                self.tile_refs.push(tile_ref.clone());
             }
-            Primitive::PolychromeSprite(sprite) => {
+            Primitive::PolychromeSprite { sprite, tile_ref } => {
                 sprite.order = order;
                 self.polychrome_sprites.push(*sprite);
+                self.tile_refs.push(tile_ref.clone());
             }
             Primitive::Surface(surface) => {
                 surface.order = order;
@@ -210,9 +219,22 @@ pub enum Primitive {
     Quad(Quad),
     Path(Path<ScaledPixels>),
     Underline(Underline),
-    MonochromeSprite(MonochromeSprite),
-    SubpixelSprite(SubpixelSprite),
-    PolychromeSprite(PolychromeSprite),
+    /// Sprite primitives carry the [`AtlasTileRef`] keep-alive alongside the
+    /// raw `#[repr(C)]` GPU data so the underlying atlas slot stays live for
+    /// as long as the primitive is part of any scene (including scenes
+    /// produced by `Scene::replay`).
+    MonochromeSprite {
+        sprite: MonochromeSprite,
+        tile_ref: AtlasTileRef,
+    },
+    SubpixelSprite {
+        sprite: SubpixelSprite,
+        tile_ref: AtlasTileRef,
+    },
+    PolychromeSprite {
+        sprite: PolychromeSprite,
+        tile_ref: AtlasTileRef,
+    },
     Surface(PaintSurface),
 }
 
@@ -224,9 +246,9 @@ impl Primitive {
             Primitive::Quad(quad) => &quad.bounds,
             Primitive::Path(path) => &path.bounds,
             Primitive::Underline(underline) => &underline.bounds,
-            Primitive::MonochromeSprite(sprite) => &sprite.bounds,
-            Primitive::SubpixelSprite(sprite) => &sprite.bounds,
-            Primitive::PolychromeSprite(sprite) => &sprite.bounds,
+            Primitive::MonochromeSprite { sprite, .. } => &sprite.bounds,
+            Primitive::SubpixelSprite { sprite, .. } => &sprite.bounds,
+            Primitive::PolychromeSprite { sprite, .. } => &sprite.bounds,
             Primitive::Surface(surface) => &surface.bounds,
         }
     }
@@ -237,9 +259,9 @@ impl Primitive {
             Primitive::Quad(quad) => &quad.content_mask,
             Primitive::Path(path) => &path.content_mask,
             Primitive::Underline(underline) => &underline.content_mask,
-            Primitive::MonochromeSprite(sprite) => &sprite.content_mask,
-            Primitive::SubpixelSprite(sprite) => &sprite.content_mask,
-            Primitive::PolychromeSprite(sprite) => &sprite.content_mask,
+            Primitive::MonochromeSprite { sprite, .. } => &sprite.content_mask,
+            Primitive::SubpixelSprite { sprite, .. } => &sprite.content_mask,
+            Primitive::PolychromeSprite { sprite, .. } => &sprite.content_mask,
             Primitive::Surface(surface) => &surface.content_mask,
         }
     }
@@ -652,6 +674,24 @@ impl Default for TransformationMatrix {
     }
 }
 
+impl From<(MonochromeSprite, AtlasTileRef)> for Primitive {
+    fn from((sprite, tile_ref): (MonochromeSprite, AtlasTileRef)) -> Self {
+        Primitive::MonochromeSprite { sprite, tile_ref }
+    }
+}
+
+impl From<(SubpixelSprite, AtlasTileRef)> for Primitive {
+    fn from((sprite, tile_ref): (SubpixelSprite, AtlasTileRef)) -> Self {
+        Primitive::SubpixelSprite { sprite, tile_ref }
+    }
+}
+
+impl From<(PolychromeSprite, AtlasTileRef)> for Primitive {
+    fn from((sprite, tile_ref): (PolychromeSprite, AtlasTileRef)) -> Self {
+        Primitive::PolychromeSprite { sprite, tile_ref }
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 #[expect(missing_docs)]
@@ -663,12 +703,6 @@ pub struct MonochromeSprite {
     pub color: Hsla,
     pub tile: AtlasTile,
     pub transformation: TransformationMatrix,
-}
-
-impl From<MonochromeSprite> for Primitive {
-    fn from(sprite: MonochromeSprite) -> Self {
-        Primitive::MonochromeSprite(sprite)
-    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -684,12 +718,6 @@ pub struct SubpixelSprite {
     pub transformation: TransformationMatrix,
 }
 
-impl From<SubpixelSprite> for Primitive {
-    fn from(sprite: SubpixelSprite) -> Self {
-        Primitive::SubpixelSprite(sprite)
-    }
-}
-
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 #[expect(missing_docs)]
@@ -702,12 +730,6 @@ pub struct PolychromeSprite {
     pub content_mask: ContentMask<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
     pub tile: AtlasTile,
-}
-
-impl From<PolychromeSprite> for Primitive {
-    fn from(sprite: PolychromeSprite) -> Self {
-        Primitive::PolychromeSprite(sprite)
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3647,25 +3647,31 @@ impl Window {
             let content_mask = self.snapped_content_mask();
 
             if subpixel_rendering {
-                self.next_frame.scene.insert_primitive(SubpixelSprite {
-                    order: 0,
-                    pad: 0,
-                    bounds,
-                    content_mask,
-                    color: color.opacity(element_opacity),
+                self.next_frame.scene.insert_primitive((
+                    SubpixelSprite {
+                        order: 0,
+                        pad: 0,
+                        bounds,
+                        content_mask,
+                        color: color.opacity(element_opacity),
+                        tile: tile.tile,
+                        transformation: TransformationMatrix::unit(),
+                    },
                     tile,
-                    transformation: TransformationMatrix::unit(),
-                });
+                ));
             } else {
-                self.next_frame.scene.insert_primitive(MonochromeSprite {
-                    order: 0,
-                    pad: 0,
-                    bounds,
-                    content_mask,
-                    color: color.opacity(element_opacity),
+                self.next_frame.scene.insert_primitive((
+                    MonochromeSprite {
+                        order: 0,
+                        pad: 0,
+                        bounds,
+                        content_mask,
+                        color: color.opacity(element_opacity),
+                        tile: tile.tile,
+                        transformation: TransformationMatrix::unit(),
+                    },
                     tile,
-                    transformation: TransformationMatrix::unit(),
-                });
+                ));
             }
         }
         Ok(())
@@ -3738,16 +3744,19 @@ impl Window {
             let content_mask = self.snapped_content_mask();
             let opacity = self.element_opacity();
 
-            self.next_frame.scene.insert_primitive(PolychromeSprite {
-                order: 0,
-                pad: 0,
-                grayscale: false,
-                bounds,
-                corner_radii: Default::default(),
-                content_mask,
+            self.next_frame.scene.insert_primitive((
+                PolychromeSprite {
+                    order: 0,
+                    pad: 0,
+                    grayscale: false,
+                    bounds,
+                    corner_radii: Default::default(),
+                    content_mask,
+                    tile: tile.tile,
+                    opacity,
+                },
                 tile,
-                opacity,
-            });
+            ));
         }
         Ok(())
     }
@@ -3804,15 +3813,18 @@ impl Window {
             .map_origin(|value| ScaledPixels(round_half_toward_zero(value.0)))
             .map_size(|size| size.ceil());
 
-        self.next_frame.scene.insert_primitive(MonochromeSprite {
-            order: 0,
-            pad: 0,
-            bounds: final_bounds,
-            content_mask,
-            color: color.opacity(element_opacity),
+        self.next_frame.scene.insert_primitive((
+            MonochromeSprite {
+                order: 0,
+                pad: 0,
+                bounds: final_bounds,
+                content_mask,
+                color: color.opacity(element_opacity),
+                tile: tile.tile,
+                transformation,
+            },
             tile,
-            transformation,
-        });
+        ));
 
         Ok(())
     }
@@ -3853,16 +3865,19 @@ impl Window {
         let corner_radii = corner_radii.scale(self.scale_factor());
         let opacity = self.element_opacity();
 
-        self.next_frame.scene.insert_primitive(PolychromeSprite {
-            order: 0,
-            pad: 0,
-            grayscale,
-            bounds,
-            content_mask,
-            corner_radii,
+        self.next_frame.scene.insert_primitive((
+            PolychromeSprite {
+                order: 0,
+                pad: 0,
+                grayscale,
+                bounds,
+                content_mask,
+                corner_radii,
+                tile: tile.tile,
+                opacity,
+            },
             tile,
-            opacity,
-        });
+        ));
         Ok(())
     }
 

--- a/crates/gpui_macos/src/metal_atlas.rs
+++ b/crates/gpui_macos/src/metal_atlas.rs
@@ -54,9 +54,9 @@ struct MetalAtlasState {
     tiles_by_key: FxHashMap<AtlasKey, AtlasTileRef>,
 }
 
-    /// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
-    /// tile in this atlas. When the last clone is dropped its `Drop` impl
-    /// releases the slot in the originating atlas (if it still exists).
+/// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
+/// tile in this atlas. When the last clone is dropped its `Drop` impl
+/// releases the slot in the originating atlas (if it still exists).
 #[derive(Debug)]
 struct MetalAtlasTileKeepAlive {
     state: Weak<Mutex<MetalAtlasState>>,

--- a/crates/gpui_macos/src/metal_atlas.rs
+++ b/crates/gpui_macos/src/metal_atlas.rs
@@ -3,28 +3,41 @@ use collections::FxHashMap;
 use derive_more::{Deref, DerefMut};
 use etagere::BucketedAtlasAllocator;
 use gpui::{
-    AtlasKey, AtlasTextureId, AtlasTextureKind, AtlasTextureList, AtlasTile, Bounds, DevicePixels,
-    PlatformAtlas, Point, Size,
+    AtlasKey, AtlasTextureId, AtlasTextureKind, AtlasTextureList, AtlasTile, AtlasTileKeepAlive,
+    AtlasTileRef, Bounds, DevicePixels, PlatformAtlas, Point, Size,
 };
 use metal::Device;
 use parking_lot::Mutex;
 use std::borrow::Cow;
+use std::sync::{Arc, Weak};
 
-pub(crate) struct MetalAtlas(Mutex<MetalAtlasState>);
+pub(crate) struct MetalAtlas {
+    state: Arc<Mutex<MetalAtlasState>>,
+}
 
 impl MetalAtlas {
     pub(crate) fn new(device: Device, is_apple_gpu: bool) -> Self {
-        MetalAtlas(Mutex::new(MetalAtlasState {
-            device: AssertSend(device),
-            is_apple_gpu,
-            monochrome_textures: Default::default(),
-            polychrome_textures: Default::default(),
-            tiles_by_key: Default::default(),
-        }))
+        MetalAtlas {
+            state: Arc::new(Mutex::new(MetalAtlasState {
+                device: AssertSend(device),
+                is_apple_gpu,
+                monochrome_textures: Default::default(),
+                polychrome_textures: Default::default(),
+                tiles_by_key: Default::default(),
+            })),
+        }
     }
 
     pub(crate) fn metal_texture(&self, id: AtlasTextureId) -> metal::Texture {
-        self.0.lock().texture(id).metal_texture.clone()
+        self.state.lock().texture(id).metal_texture.clone()
+    }
+
+    fn make_tile_ref(&self, tile: AtlasTile) -> AtlasTileRef {
+        let keep_alive: Arc<dyn AtlasTileKeepAlive> = Arc::new(MetalAtlasTileKeepAlive {
+            state: Arc::downgrade(&self.state),
+            texture_id: tile.texture_id,
+        });
+        AtlasTileRef::new(tile, keep_alive)
     }
 }
 
@@ -33,7 +46,30 @@ struct MetalAtlasState {
     is_apple_gpu: bool,
     monochrome_textures: AtlasTextureList<MetalAtlasTexture>,
     polychrome_textures: AtlasTextureList<MetalAtlasTexture>,
-    tiles_by_key: FxHashMap<AtlasKey, AtlasTile>,
+    /// Cache of currently-live tiles, keyed by their atlas key. Holding an
+    /// `AtlasTileRef` here is what keeps a cached slot alive between paints.
+    tiles_by_key: FxHashMap<AtlasKey, AtlasTileRef>,
+}
+
+#[derive(Debug)]
+struct MetalAtlasTileKeepAlive {
+    state: Weak<Mutex<MetalAtlasState>>,
+    texture_id: AtlasTextureId,
+}
+
+impl AtlasTileKeepAlive for MetalAtlasTileKeepAlive {}
+
+impl Drop for MetalAtlasTileKeepAlive {
+    fn drop(&mut self) {
+        // Slot release is driven entirely by the keep-alive Drop. By the time
+        // the last `AtlasTileRef` for this tile goes out of scope, no scene
+        // primitive or cache entry can still be referring to the slot, so it
+        // is safe to free.
+        let Some(state) = self.state.upgrade() else {
+            return;
+        };
+        state.lock().release_slot(self.texture_id);
+    }
 }
 
 impl PlatformAtlas for MetalAtlas {
@@ -41,33 +77,44 @@ impl PlatformAtlas for MetalAtlas {
         &self,
         key: &AtlasKey,
         build: &mut dyn FnMut() -> Result<Option<(Size<DevicePixels>, Cow<'a, [u8]>)>>,
-    ) -> Result<Option<AtlasTile>> {
-        let mut lock = self.0.lock();
-        if let Some(tile) = lock.tiles_by_key.get(key) {
-            Ok(Some(*tile))
-        } else {
-            let Some((size, bytes)) = build()? else {
-                return Ok(None);
-            };
-            let tile = lock
-                .allocate(size, key.texture_kind())
-                .context("failed to allocate")?;
-            let texture = lock.texture(tile.texture_id);
-            texture.upload(tile.bounds, &bytes);
-            lock.tiles_by_key.insert(key.clone(), tile);
-            Ok(Some(tile))
+    ) -> Result<Option<AtlasTileRef>> {
+        let mut lock = self.state.lock();
+        if let Some(tile_ref) = lock.tiles_by_key.get(key) {
+            return Ok(Some(tile_ref.clone()));
         }
+        let Some((size, bytes)) = build()? else {
+            return Ok(None);
+        };
+        let tile = lock
+            .allocate(size, key.texture_kind())
+            .context("failed to allocate")?;
+        let texture = lock.texture(tile.texture_id);
+        texture.upload(tile.bounds, &bytes);
+        // Drop the state lock before wrapping the tile, because constructing
+        // the keep-alive does not need the lock and we want to keep the
+        // critical section short.
+        drop(lock);
+        let tile_ref = self.make_tile_ref(tile);
+        self.state
+            .lock()
+            .tiles_by_key
+            .insert(key.clone(), tile_ref.clone());
+        Ok(Some(tile_ref))
     }
 
     fn remove(&self, key: &AtlasKey) {
-        let mut lock = self.0.lock();
-        let Some(id) = lock.tiles_by_key.remove(key).map(|v| v.texture_id) else {
-            return;
-        };
+        // Just drop the cache's reference. The underlying slot is released
+        // when (and only when) the last `AtlasTileRef` for the tile — held by
+        // the scene, the cache, or both — is dropped.
+        self.state.lock().tiles_by_key.remove(key);
+    }
+}
 
+impl MetalAtlasState {
+    fn release_slot(&mut self, id: AtlasTextureId) {
         let textures = match id.kind {
-            AtlasTextureKind::Monochrome => &mut lock.monochrome_textures,
-            AtlasTextureKind::Polychrome => &mut lock.polychrome_textures,
+            AtlasTextureKind::Monochrome => &mut self.monochrome_textures,
+            AtlasTextureKind::Polychrome => &mut self.polychrome_textures,
             AtlasTextureKind::Subpixel => unreachable!(),
         };
 
@@ -88,9 +135,7 @@ impl PlatformAtlas for MetalAtlas {
             }
         }
     }
-}
 
-impl MetalAtlasState {
     fn allocate(
         &mut self,
         size: Size<DevicePixels>,
@@ -288,7 +333,7 @@ mod tests {
         })
     }
 
-    fn insert_tile(atlas: &MetalAtlas, key: &AtlasKey, size: Size<DevicePixels>) -> AtlasTile {
+    fn insert_tile(atlas: &MetalAtlas, key: &AtlasKey, size: Size<DevicePixels>) -> AtlasTileRef {
         atlas
             .get_or_insert_with(key, &mut || {
                 let byte_count = (size.width.0 as usize) * (size.height.0 as usize) * 4;
@@ -336,6 +381,35 @@ mod tests {
 
         // The texture must actually exist — this would panic before the fix.
         let _texture = atlas.metal_texture(tile_a2.texture_id);
+    }
+
+    /// A tile handed out by `get_or_insert_with` and captured by a caller
+    /// (for example, baked into a scene's primitives) must remain resolvable
+    /// via `metal_texture` even if the corresponding key is removed before
+    /// the caller is done with it. The caller's `AtlasTileRef` is what keeps
+    /// the slot alive across the remove.
+    #[test]
+    fn test_metal_texture_lookup_after_remove_does_not_panic() {
+        let Some(atlas) = create_atlas() else {
+            return;
+        };
+
+        let small = Size {
+            width: DevicePixels(64),
+            height: DevicePixels(64),
+        };
+        let key = make_image_key(42, 0);
+
+        // Equivalent of `paint_image`: tile captured by the scene.
+        let tile = insert_tile(&atlas, &key, small);
+        let captured_id = tile.texture_id;
+
+        // Equivalent of `drop_image` mid-frame.
+        atlas.remove(&key);
+
+        // The scene's `AtlasTileRef` (`tile`) is still alive, so the slot
+        // must still be resolvable.
+        let _texture = atlas.metal_texture(captured_id);
     }
 
     #[test]

--- a/crates/gpui_macos/src/metal_atlas.rs
+++ b/crates/gpui_macos/src/metal_atlas.rs
@@ -32,6 +32,9 @@ impl MetalAtlas {
         self.state.lock().texture(id).metal_texture.clone()
     }
 
+    /// Wrap a freshly allocated tile in an [`AtlasTileRef`] backed by a
+    /// keep-alive that points back at this atlas. Dropping the last clone
+    /// will free the slot.
     fn make_tile_ref(&self, tile: AtlasTile) -> AtlasTileRef {
         let keep_alive: Arc<dyn AtlasTileKeepAlive> = Arc::new(MetalAtlasTileKeepAlive {
             state: Arc::downgrade(&self.state),
@@ -51,6 +54,9 @@ struct MetalAtlasState {
     tiles_by_key: FxHashMap<AtlasKey, AtlasTileRef>,
 }
 
+    /// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
+    /// tile in this atlas. When the last clone is dropped its `Drop` impl
+    /// releases the slot in the originating atlas (if it still exists).
 #[derive(Debug)]
 struct MetalAtlasTileKeepAlive {
     state: Weak<Mutex<MetalAtlasState>>,
@@ -111,6 +117,10 @@ impl PlatformAtlas for MetalAtlas {
 }
 
 impl MetalAtlasState {
+    /// Free a tile's slot. Called from the keep-alive's `Drop` once the last
+    /// [`AtlasTileRef`] for the tile is gone, so no scene primitive or cache
+    /// entry can still be referring to the slot. If the slot held the last
+    /// tile in its texture, the texture itself is returned to the free list.
     fn release_slot(&mut self, id: AtlasTextureId) {
         let textures = match id.kind {
             AtlasTextureKind::Monochrome => &mut self.monochrome_textures,

--- a/crates/gpui_macos/src/metal_atlas.rs
+++ b/crates/gpui_macos/src/metal_atlas.rs
@@ -32,9 +32,7 @@ impl MetalAtlas {
         self.state.lock().texture(id).metal_texture.clone()
     }
 
-    /// Wrap a freshly allocated tile in an [`AtlasTileRef`] backed by a
-    /// keep-alive that points back at this atlas. Dropping the last clone
-    /// will free the slot.
+    /// Wrap a freshly allocated tile in an [`AtlasTileRef`].
     fn make_tile_ref(&self, tile: AtlasTile) -> AtlasTileRef {
         let keep_alive: Arc<dyn AtlasTileKeepAlive> = Arc::new(MetalAtlasTileKeepAlive {
             state: Arc::downgrade(&self.state),
@@ -54,9 +52,8 @@ struct MetalAtlasState {
     tiles_by_key: FxHashMap<AtlasKey, AtlasTileRef>,
 }
 
-/// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
-/// tile in this atlas. When the last clone is dropped its `Drop` impl
-/// releases the slot in the originating atlas (if it still exists).
+/// Backend [`AtlasTileKeepAlive`] for this atlas; see [`AtlasTileRef`] for
+/// the contract.
 #[derive(Debug)]
 struct MetalAtlasTileKeepAlive {
     state: Weak<Mutex<MetalAtlasState>>,
@@ -67,10 +64,6 @@ impl AtlasTileKeepAlive for MetalAtlasTileKeepAlive {}
 
 impl Drop for MetalAtlasTileKeepAlive {
     fn drop(&mut self) {
-        // Slot release is driven entirely by the keep-alive Drop. By the time
-        // the last `AtlasTileRef` for this tile goes out of scope, no scene
-        // primitive or cache entry can still be referring to the slot, so it
-        // is safe to free.
         let Some(state) = self.state.upgrade() else {
             return;
         };
@@ -109,18 +102,16 @@ impl PlatformAtlas for MetalAtlas {
     }
 
     fn remove(&self, key: &AtlasKey) {
-        // Just drop the cache's reference. The underlying slot is released
-        // when (and only when) the last `AtlasTileRef` for the tile — held by
-        // the scene, the cache, or both — is dropped.
+        // Drop the cache's reference; the slot itself is released by the
+        // keep-alive's `Drop`. See [`AtlasTileRef`].
         self.state.lock().tiles_by_key.remove(key);
     }
 }
 
 impl MetalAtlasState {
-    /// Free a tile's slot. Called from the keep-alive's `Drop` once the last
-    /// [`AtlasTileRef`] for the tile is gone, so no scene primitive or cache
-    /// entry can still be referring to the slot. If the slot held the last
-    /// tile in its texture, the texture itself is returned to the free list.
+    /// Free a tile's slot. Called from the keep-alive's `Drop`. If the slot
+    /// held the last tile in its texture, the texture itself is returned to
+    /// the free list.
     fn release_slot(&mut self, id: AtlasTextureId) {
         let textures = match id.kind {
             AtlasTextureKind::Monochrome => &mut self.monochrome_textures,

--- a/crates/gpui_wgpu/src/wgpu_atlas.rs
+++ b/crates/gpui_wgpu/src/wgpu_atlas.rs
@@ -44,6 +44,9 @@ struct WgpuAtlasState {
     pending_uploads: Vec<PendingUpload>,
 }
 
+    /// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
+    /// tile in this atlas. When the last clone is dropped its `Drop` impl
+    /// releases the slot in the originating atlas (if it still exists).
 #[derive(Debug)]
 struct WgpuAtlasTileKeepAlive {
     state: Weak<Mutex<WgpuAtlasState>>,
@@ -85,6 +88,9 @@ impl WgpuAtlas {
         }
     }
 
+    /// Wrap a freshly allocated tile in an [`AtlasTileRef`] backed by a
+    /// keep-alive that points back at this atlas. Dropping the last clone
+    /// will free the slot.
     fn make_tile_ref(&self, tile: AtlasTile) -> AtlasTileRef {
         let keep_alive: Arc<dyn AtlasTileKeepAlive> = Arc::new(WgpuAtlasTileKeepAlive {
             state: Arc::downgrade(&self.state),
@@ -172,6 +178,10 @@ impl PlatformAtlas for WgpuAtlas {
 }
 
 impl WgpuAtlasState {
+    /// Free a tile's slot. Called from the keep-alive's `Drop` once the last
+    /// [`AtlasTileRef`] for the tile is gone, so no scene primitive or cache
+    /// entry can still be referring to the slot. If the slot held the last
+    /// tile in its texture, the texture itself is returned to the free list.
     fn release_slot(&mut self, id: AtlasTextureId) {
         let Some(texture_slot) = self.storage[id.kind].textures.get_mut(id.index as usize) else {
             return;

--- a/crates/gpui_wgpu/src/wgpu_atlas.rs
+++ b/crates/gpui_wgpu/src/wgpu_atlas.rs
@@ -45,9 +45,8 @@ struct WgpuAtlasState {
     pending_uploads: Vec<PendingUpload>,
 }
 
-/// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
-/// tile in this atlas. When the last clone is dropped its `Drop` impl
-/// releases the slot in the originating atlas (if it still exists).
+/// Backend [`AtlasTileKeepAlive`] for this atlas; see [`AtlasTileRef`] for
+/// the contract.
 #[derive(Debug)]
 struct WgpuAtlasTileKeepAlive {
     state: Weak<Mutex<WgpuAtlasState>>,
@@ -89,9 +88,7 @@ impl WgpuAtlas {
         }
     }
 
-    /// Wrap a freshly allocated tile in an [`AtlasTileRef`] backed by a
-    /// keep-alive that points back at this atlas. Dropping the last clone
-    /// will free the slot.
+    /// Wrap a freshly allocated tile in an [`AtlasTileRef`].
     fn make_tile_ref(&self, tile: AtlasTile) -> AtlasTileRef {
         let keep_alive: Arc<dyn AtlasTileKeepAlive> = Arc::new(WgpuAtlasTileKeepAlive {
             state: Arc::downgrade(&self.state),
@@ -171,18 +168,15 @@ impl PlatformAtlas for WgpuAtlas {
     }
 
     fn remove(&self, key: &AtlasKey) {
-        // Drop the cache's reference; the slot is freed only when the last
-        // `AtlasTileRef` for this tile (held by the cache and/or any scene)
-        // is dropped, via `WgpuAtlasTileKeepAlive::drop`.
+        // See `MetalAtlas::remove`.
         self.state.lock().tiles_by_key.remove(key);
     }
 }
 
 impl WgpuAtlasState {
-    /// Free a tile's slot. Called from the keep-alive's `Drop` once the last
-    /// [`AtlasTileRef`] for the tile is gone, so no scene primitive or cache
-    /// entry can still be referring to the slot. If the slot held the last
-    /// tile in its texture, the texture itself is returned to the free list.
+    /// Free a tile's slot. Called from the keep-alive's `Drop`. If the slot
+    /// held the last tile in its texture, the texture itself is returned to
+    /// the free list.
     fn release_slot(&mut self, id: AtlasTextureId) {
         let Some(texture_slot) = self.storage[id.kind].textures.get_mut(id.index as usize) else {
             return;

--- a/crates/gpui_wgpu/src/wgpu_atlas.rs
+++ b/crates/gpui_wgpu/src/wgpu_atlas.rs
@@ -7,7 +7,8 @@ use gpui::{
 };
 use parking_lot::Mutex;
 use std::{
-    borrow::Cow, ops,
+    borrow::Cow,
+    ops,
     sync::{Arc, Weak},
 };
 
@@ -44,9 +45,9 @@ struct WgpuAtlasState {
     pending_uploads: Vec<PendingUpload>,
 }
 
-    /// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
-    /// tile in this atlas. When the last clone is dropped its `Drop` impl
-    /// releases the slot in the originating atlas (if it still exists).
+/// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
+/// tile in this atlas. When the last clone is dropped its `Drop` impl
+/// releases the slot in the originating atlas (if it still exists).
 #[derive(Debug)]
 struct WgpuAtlasTileKeepAlive {
     state: Weak<Mutex<WgpuAtlasState>>,

--- a/crates/gpui_wgpu/src/wgpu_atlas.rs
+++ b/crates/gpui_wgpu/src/wgpu_atlas.rs
@@ -2,11 +2,14 @@ use anyhow::{Context as _, Result};
 use collections::FxHashMap;
 use etagere::{BucketedAtlasAllocator, size2};
 use gpui::{
-    AtlasKey, AtlasTextureId, AtlasTextureKind, AtlasTextureList, AtlasTile, Bounds, DevicePixels,
-    PlatformAtlas, Point, Size,
+    AtlasKey, AtlasTextureId, AtlasTextureKind, AtlasTextureList, AtlasTile, AtlasTileKeepAlive,
+    AtlasTileRef, Bounds, DevicePixels, PlatformAtlas, Point, Size,
 };
 use parking_lot::Mutex;
-use std::{borrow::Cow, ops, sync::Arc};
+use std::{
+    borrow::Cow, ops,
+    sync::{Arc, Weak},
+};
 
 use crate::WgpuContext;
 
@@ -21,7 +24,9 @@ fn etagere_point_to_device(point: etagere::Point) -> Point<DevicePixels> {
     }
 }
 
-pub struct WgpuAtlas(Mutex<WgpuAtlasState>);
+pub struct WgpuAtlas {
+    state: Arc<Mutex<WgpuAtlasState>>,
+}
 
 struct PendingUpload {
     id: AtlasTextureId,
@@ -35,8 +40,25 @@ struct WgpuAtlasState {
     max_texture_size: u32,
     color_texture_format: wgpu::TextureFormat,
     storage: WgpuAtlasStorage,
-    tiles_by_key: FxHashMap<AtlasKey, AtlasTile>,
+    tiles_by_key: FxHashMap<AtlasKey, AtlasTileRef>,
     pending_uploads: Vec<PendingUpload>,
+}
+
+#[derive(Debug)]
+struct WgpuAtlasTileKeepAlive {
+    state: Weak<Mutex<WgpuAtlasState>>,
+    texture_id: AtlasTextureId,
+}
+
+impl AtlasTileKeepAlive for WgpuAtlasTileKeepAlive {}
+
+impl Drop for WgpuAtlasTileKeepAlive {
+    fn drop(&mut self) {
+        let Some(state) = self.state.upgrade() else {
+            return;
+        };
+        state.lock().release_slot(self.texture_id);
+    }
 }
 
 pub struct WgpuTextureInfo {
@@ -50,15 +72,25 @@ impl WgpuAtlas {
         color_texture_format: wgpu::TextureFormat,
     ) -> Self {
         let max_texture_size = device.limits().max_texture_dimension_2d;
-        WgpuAtlas(Mutex::new(WgpuAtlasState {
-            device,
-            queue,
-            max_texture_size,
-            color_texture_format,
-            storage: WgpuAtlasStorage::default(),
-            tiles_by_key: Default::default(),
-            pending_uploads: Vec::new(),
-        }))
+        WgpuAtlas {
+            state: Arc::new(Mutex::new(WgpuAtlasState {
+                device,
+                queue,
+                max_texture_size,
+                color_texture_format,
+                storage: WgpuAtlasStorage::default(),
+                tiles_by_key: Default::default(),
+                pending_uploads: Vec::new(),
+            })),
+        }
+    }
+
+    fn make_tile_ref(&self, tile: AtlasTile) -> AtlasTileRef {
+        let keep_alive: Arc<dyn AtlasTileKeepAlive> = Arc::new(WgpuAtlasTileKeepAlive {
+            state: Arc::downgrade(&self.state),
+            texture_id: tile.texture_id,
+        });
+        AtlasTileRef::new(tile, keep_alive)
     }
 
     pub fn from_context(context: &WgpuContext) -> Self {
@@ -70,12 +102,12 @@ impl WgpuAtlas {
     }
 
     pub fn before_frame(&self) {
-        let mut lock = self.0.lock();
+        let mut lock = self.state.lock();
         lock.flush_uploads();
     }
 
     pub fn get_texture_info(&self, id: AtlasTextureId) -> WgpuTextureInfo {
-        let lock = self.0.lock();
+        let lock = self.state.lock();
         let texture = &lock.storage[id];
         WgpuTextureInfo {
             view: texture.view.clone(),
@@ -85,7 +117,7 @@ impl WgpuAtlas {
     /// Clears all cached textures and tiles, forcing them to be recreated.
     /// Use this for incremental recovery when the device is still valid.
     pub fn clear(&self) {
-        let mut lock = self.0.lock();
+        let mut lock = self.state.lock();
         lock.storage = WgpuAtlasStorage::default();
         lock.tiles_by_key.clear();
         lock.pending_uploads.clear();
@@ -94,7 +126,7 @@ impl WgpuAtlas {
     /// Handles device lost by clearing all textures and cached tiles.
     /// The atlas will lazily recreate textures as needed on subsequent frames.
     pub fn handle_device_lost(&self, context: &WgpuContext) {
-        let mut lock = self.0.lock();
+        let mut lock = self.state.lock();
         lock.device = context.device.clone();
         lock.queue = context.queue.clone();
         lock.color_texture_format = context.color_texture_format();
@@ -109,41 +141,48 @@ impl PlatformAtlas for WgpuAtlas {
         &self,
         key: &AtlasKey,
         build: &mut dyn FnMut() -> Result<Option<(Size<DevicePixels>, Cow<'a, [u8]>)>>,
-    ) -> Result<Option<AtlasTile>> {
-        let mut lock = self.0.lock();
-        if let Some(tile) = lock.tiles_by_key.get(key) {
-            Ok(Some(*tile))
-        } else {
-            profiling::scope!("new tile");
-            let Some((size, bytes)) = build()? else {
-                return Ok(None);
-            };
-            let tile = lock
-                .allocate(size, key.texture_kind())
-                .context("failed to allocate")?;
-            lock.upload_texture(tile.texture_id, tile.bounds, &bytes);
-            lock.tiles_by_key.insert(key.clone(), tile);
-            Ok(Some(tile))
+    ) -> Result<Option<AtlasTileRef>> {
+        let mut lock = self.state.lock();
+        if let Some(tile_ref) = lock.tiles_by_key.get(key) {
+            return Ok(Some(tile_ref.clone()));
         }
+        profiling::scope!("new tile");
+        let Some((size, bytes)) = build()? else {
+            return Ok(None);
+        };
+        let tile = lock
+            .allocate(size, key.texture_kind())
+            .context("failed to allocate")?;
+        lock.upload_texture(tile.texture_id, tile.bounds, &bytes);
+        drop(lock);
+        let tile_ref = self.make_tile_ref(tile);
+        self.state
+            .lock()
+            .tiles_by_key
+            .insert(key.clone(), tile_ref.clone());
+        Ok(Some(tile_ref))
     }
 
     fn remove(&self, key: &AtlasKey) {
-        let mut lock = self.0.lock();
+        // Drop the cache's reference; the slot is freed only when the last
+        // `AtlasTileRef` for this tile (held by the cache and/or any scene)
+        // is dropped, via `WgpuAtlasTileKeepAlive::drop`.
+        self.state.lock().tiles_by_key.remove(key);
+    }
+}
 
-        let Some(id) = lock.tiles_by_key.remove(key).map(|tile| tile.texture_id) else {
-            return;
-        };
-
-        let Some(texture_slot) = lock.storage[id.kind].textures.get_mut(id.index as usize) else {
+impl WgpuAtlasState {
+    fn release_slot(&mut self, id: AtlasTextureId) {
+        let Some(texture_slot) = self.storage[id.kind].textures.get_mut(id.index as usize) else {
             return;
         };
 
         if let Some(mut texture) = texture_slot.take() {
             texture.decrement_ref_count();
             if texture.is_unreferenced() {
-                lock.pending_uploads
+                self.pending_uploads
                     .retain(|upload| upload.id != texture.id);
-                lock.storage[id.kind]
+                self.storage[id.kind]
                     .free_list
                     .push(texture.id.index as usize);
             } else {
@@ -151,9 +190,7 @@ impl PlatformAtlas for WgpuAtlas {
             }
         }
     }
-}
 
-impl WgpuAtlasState {
     fn allocate(
         &mut self,
         size: Size<DevicePixels>,

--- a/crates/gpui_windows/src/directx_atlas.rs
+++ b/crates/gpui_windows/src/directx_atlas.rs
@@ -1,6 +1,7 @@
 use collections::FxHashMap;
 use etagere::BucketedAtlasAllocator;
 use parking_lot::Mutex;
+use std::sync::{Arc, Weak};
 use windows::Win32::Graphics::{
     Direct3D11::{
         D3D11_BIND_SHADER_RESOURCE, D3D11_BOX, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT,
@@ -10,11 +11,13 @@ use windows::Win32::Graphics::{
 };
 
 use gpui::{
-    AtlasKey, AtlasTextureId, AtlasTextureKind, AtlasTextureList, AtlasTile, Bounds, DevicePixels,
-    PlatformAtlas, Point, Size,
+    AtlasKey, AtlasTextureId, AtlasTextureKind, AtlasTextureList, AtlasTile, AtlasTileKeepAlive,
+    AtlasTileRef, Bounds, DevicePixels, PlatformAtlas, Point, Size,
 };
 
-pub(crate) struct DirectXAtlas(Mutex<DirectXAtlasState>);
+pub(crate) struct DirectXAtlas {
+    state: Arc<Mutex<DirectXAtlasState>>,
+}
 
 struct DirectXAtlasState {
     device: ID3D11Device,
@@ -22,7 +25,24 @@ struct DirectXAtlasState {
     monochrome_textures: AtlasTextureList<DirectXAtlasTexture>,
     polychrome_textures: AtlasTextureList<DirectXAtlasTexture>,
     subpixel_textures: AtlasTextureList<DirectXAtlasTexture>,
-    tiles_by_key: FxHashMap<AtlasKey, AtlasTile>,
+    tiles_by_key: FxHashMap<AtlasKey, AtlasTileRef>,
+}
+
+#[derive(Debug)]
+struct DirectXAtlasTileKeepAlive {
+    state: Weak<Mutex<DirectXAtlasState>>,
+    texture_id: AtlasTextureId,
+}
+
+impl AtlasTileKeepAlive for DirectXAtlasTileKeepAlive {}
+
+impl Drop for DirectXAtlasTileKeepAlive {
+    fn drop(&mut self) {
+        let Some(state) = self.state.upgrade() else {
+            return;
+        };
+        state.lock().release_slot(self.texture_id);
+    }
 }
 
 struct DirectXAtlasTexture {
@@ -36,21 +56,31 @@ struct DirectXAtlasTexture {
 
 impl DirectXAtlas {
     pub(crate) fn new(device: &ID3D11Device, device_context: &ID3D11DeviceContext) -> Self {
-        DirectXAtlas(Mutex::new(DirectXAtlasState {
-            device: device.clone(),
-            device_context: device_context.clone(),
-            monochrome_textures: Default::default(),
-            polychrome_textures: Default::default(),
-            subpixel_textures: Default::default(),
-            tiles_by_key: Default::default(),
-        }))
+        DirectXAtlas {
+            state: Arc::new(Mutex::new(DirectXAtlasState {
+                device: device.clone(),
+                device_context: device_context.clone(),
+                monochrome_textures: Default::default(),
+                polychrome_textures: Default::default(),
+                subpixel_textures: Default::default(),
+                tiles_by_key: Default::default(),
+            })),
+        }
+    }
+
+    fn make_tile_ref(&self, tile: AtlasTile) -> AtlasTileRef {
+        let keep_alive: Arc<dyn AtlasTileKeepAlive> = Arc::new(DirectXAtlasTileKeepAlive {
+            state: Arc::downgrade(&self.state),
+            texture_id: tile.texture_id,
+        });
+        AtlasTileRef::new(tile, keep_alive)
     }
 
     pub(crate) fn get_texture_view(
         &self,
         id: AtlasTextureId,
     ) -> [Option<ID3D11ShaderResourceView>; 1] {
-        let lock = self.0.lock();
+        let lock = self.state.lock();
         let tex = lock.texture(id);
         tex.view.clone()
     }
@@ -60,7 +90,7 @@ impl DirectXAtlas {
         device: &ID3D11Device,
         device_context: &ID3D11DeviceContext,
     ) {
-        let mut lock = self.0.lock();
+        let mut lock = self.state.lock();
         lock.device = device.clone();
         lock.device_context = device_context.clone();
         lock.monochrome_textures = AtlasTextureList::default();
@@ -77,35 +107,42 @@ impl PlatformAtlas for DirectXAtlas {
         build: &mut dyn FnMut() -> anyhow::Result<
             Option<(Size<DevicePixels>, std::borrow::Cow<'a, [u8]>)>,
         >,
-    ) -> anyhow::Result<Option<AtlasTile>> {
-        let mut lock = self.0.lock();
-        if let Some(tile) = lock.tiles_by_key.get(key) {
-            Ok(Some(*tile))
-        } else {
-            let Some((size, bytes)) = build()? else {
-                return Ok(None);
-            };
-            let tile = lock
-                .allocate(size, key.texture_kind())
-                .ok_or_else(|| anyhow::anyhow!("failed to allocate"))?;
-            let texture = lock.texture(tile.texture_id);
-            texture.upload(&lock.device_context, tile.bounds, &bytes);
-            lock.tiles_by_key.insert(key.clone(), tile);
-            Ok(Some(tile))
+    ) -> anyhow::Result<Option<AtlasTileRef>> {
+        let mut lock = self.state.lock();
+        if let Some(tile_ref) = lock.tiles_by_key.get(key) {
+            return Ok(Some(tile_ref.clone()));
         }
+        let Some((size, bytes)) = build()? else {
+            return Ok(None);
+        };
+        let tile = lock
+            .allocate(size, key.texture_kind())
+            .ok_or_else(|| anyhow::anyhow!("failed to allocate"))?;
+        let texture = lock.texture(tile.texture_id);
+        texture.upload(&lock.device_context, tile.bounds, &bytes);
+        drop(lock);
+        let tile_ref = self.make_tile_ref(tile);
+        self.state
+            .lock()
+            .tiles_by_key
+            .insert(key.clone(), tile_ref.clone());
+        Ok(Some(tile_ref))
     }
 
     fn remove(&self, key: &AtlasKey) {
-        let mut lock = self.0.lock();
+        // See `MetalAtlas::remove` — the actual slot release happens via the
+        // keep-alive's Drop once the last `AtlasTileRef` for the tile goes
+        // away.
+        self.state.lock().tiles_by_key.remove(key);
+    }
+}
 
-        let Some(id) = lock.tiles_by_key.remove(key).map(|tile| tile.texture_id) else {
-            return;
-        };
-
+impl DirectXAtlasState {
+    fn release_slot(&mut self, id: AtlasTextureId) {
         let textures = match id.kind {
-            AtlasTextureKind::Monochrome => &mut lock.monochrome_textures,
-            AtlasTextureKind::Polychrome => &mut lock.polychrome_textures,
-            AtlasTextureKind::Subpixel => &mut lock.subpixel_textures,
+            AtlasTextureKind::Monochrome => &mut self.monochrome_textures,
+            AtlasTextureKind::Polychrome => &mut self.polychrome_textures,
+            AtlasTextureKind::Subpixel => &mut self.subpixel_textures,
         };
 
         let Some(texture_slot) = textures.textures.get_mut(id.index as usize) else {
@@ -121,9 +158,7 @@ impl PlatformAtlas for DirectXAtlas {
             }
         }
     }
-}
 
-impl DirectXAtlasState {
     fn allocate(
         &mut self,
         size: Size<DevicePixels>,

--- a/crates/gpui_windows/src/directx_atlas.rs
+++ b/crates/gpui_windows/src/directx_atlas.rs
@@ -28,9 +28,8 @@ struct DirectXAtlasState {
     tiles_by_key: FxHashMap<AtlasKey, AtlasTileRef>,
 }
 
-/// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
-/// tile in this atlas. When the last clone is dropped its `Drop` impl
-/// releases the slot in the originating atlas (if it still exists).
+/// Backend [`AtlasTileKeepAlive`] for this atlas; see [`AtlasTileRef`] for
+/// the contract.
 #[derive(Debug)]
 struct DirectXAtlasTileKeepAlive {
     state: Weak<Mutex<DirectXAtlasState>>,
@@ -71,9 +70,7 @@ impl DirectXAtlas {
         }
     }
 
-    /// Wrap a freshly allocated tile in an [`AtlasTileRef`] backed by a
-    /// keep-alive that points back at this atlas. Dropping the last clone
-    /// will free the slot.
+    /// Wrap a freshly allocated tile in an [`AtlasTileRef`].
     fn make_tile_ref(&self, tile: AtlasTile) -> AtlasTileRef {
         let keep_alive: Arc<dyn AtlasTileKeepAlive> = Arc::new(DirectXAtlasTileKeepAlive {
             state: Arc::downgrade(&self.state),
@@ -136,18 +133,15 @@ impl PlatformAtlas for DirectXAtlas {
     }
 
     fn remove(&self, key: &AtlasKey) {
-        // See `MetalAtlas::remove` — the actual slot release happens via the
-        // keep-alive's Drop once the last `AtlasTileRef` for the tile goes
-        // away.
+        // See `MetalAtlas::remove`.
         self.state.lock().tiles_by_key.remove(key);
     }
 }
 
 impl DirectXAtlasState {
-    /// Free a tile's slot. Called from the keep-alive's `Drop` once the last
-    /// [`AtlasTileRef`] for the tile is gone, so no scene primitive or cache
-    /// entry can still be referring to the slot. If the slot held the last
-    /// tile in its texture, the texture itself is returned to the free list.
+    /// Free a tile's slot. Called from the keep-alive's `Drop`. If the slot
+    /// held the last tile in its texture, the texture itself is returned to
+    /// the free list.
     fn release_slot(&mut self, id: AtlasTextureId) {
         let textures = match id.kind {
             AtlasTextureKind::Monochrome => &mut self.monochrome_textures,

--- a/crates/gpui_windows/src/directx_atlas.rs
+++ b/crates/gpui_windows/src/directx_atlas.rs
@@ -28,9 +28,9 @@ struct DirectXAtlasState {
     tiles_by_key: FxHashMap<AtlasKey, AtlasTileRef>,
 }
 
-    /// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
-    /// tile in this atlas. When the last clone is dropped its `Drop` impl
-    /// releases the slot in the originating atlas (if it still exists).
+/// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
+/// tile in this atlas. When the last clone is dropped its `Drop` impl
+/// releases the slot in the originating atlas (if it still exists).
 #[derive(Debug)]
 struct DirectXAtlasTileKeepAlive {
     state: Weak<Mutex<DirectXAtlasState>>,

--- a/crates/gpui_windows/src/directx_atlas.rs
+++ b/crates/gpui_windows/src/directx_atlas.rs
@@ -28,6 +28,9 @@ struct DirectXAtlasState {
     tiles_by_key: FxHashMap<AtlasKey, AtlasTileRef>,
 }
 
+    /// Backend-specific keep-alive carried by every [`AtlasTileRef`] for a
+    /// tile in this atlas. When the last clone is dropped its `Drop` impl
+    /// releases the slot in the originating atlas (if it still exists).
 #[derive(Debug)]
 struct DirectXAtlasTileKeepAlive {
     state: Weak<Mutex<DirectXAtlasState>>,
@@ -68,6 +71,9 @@ impl DirectXAtlas {
         }
     }
 
+    /// Wrap a freshly allocated tile in an [`AtlasTileRef`] backed by a
+    /// keep-alive that points back at this atlas. Dropping the last clone
+    /// will free the slot.
     fn make_tile_ref(&self, tile: AtlasTile) -> AtlasTileRef {
         let keep_alive: Arc<dyn AtlasTileKeepAlive> = Arc::new(DirectXAtlasTileKeepAlive {
             state: Arc::downgrade(&self.state),
@@ -138,6 +144,10 @@ impl PlatformAtlas for DirectXAtlas {
 }
 
 impl DirectXAtlasState {
+    /// Free a tile's slot. Called from the keep-alive's `Drop` once the last
+    /// [`AtlasTileRef`] for the tile is gone, so no scene primitive or cache
+    /// entry can still be referring to the slot. If the slot held the last
+    /// tile in its texture, the texture itself is returned to the free list.
     fn release_slot(&mut self, id: AtlasTextureId) {
         let textures = match id.kind {
             AtlasTextureKind::Monochrome => &mut self.monochrome_textures,


### PR DESCRIPTION
Previously `AtlasTile` was a `Copy`, `#[repr(C)]` value type that carried only an opaque `AtlasTextureId` index, and the scene baked it into sprite primitives by value with no refcount back into the atlas. If `PlatformAtlas::remove` ran in the same frame that paint had committed the tile to the scene (for example when `RetainAllImageCache::clear` fires from inside the paint phase), the slot was freed immediately and the renderer would unwrap a `None` slot at present time, crashing in `MetalAtlas::metal_texture`. See #57509 for additional info.

`AtlasTileRef` is a cloneable RAII handle holding the raw `AtlasTile` alongside an `Arc<dyn AtlasTileKeepAlive>`. The atlas hands out exactly one keep-alive per tile; the backend's `Drop` impl releases the slot only when the last clone (held by the cache, by any scene primitive, or both) is dropped. `remove(key)` now just drops the cache's reference; the slot stays live as long as anyone still needs it.

Scene primitives store the raw `AtlasTile` for GPU upload as before and additionally hold an `AtlasTileRef` so the slot lives at least as long as the scene. The keep-alive flows through `Scene::replay` via the `Primitive::*Sprite { sprite, tile_ref }` variants.

Implemented for the Metal, wgpu, and DirectX atlases plus the test atlas. No per-frame ordering contract is required of the renderer.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable


Release Notes:

- Fixed a crash where a draw call could ask for a texture that was no longer present in the atlas, panicking editor window.