### PR TITLE
Auto-scroll hover popup while selecting text

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1041,6 +1041,7 @@ impl InfoPopover {
                         .track_scroll(&self.scroll_handle)
                         .child(
                             MarkdownElement::new(markdown, hover_markdown_style(window, cx))
+                                .scroll_handle(self.scroll_handle.clone())
                                 .code_block_renderer(markdown::CodeBlockRenderer::Default {
                                     copy_button_visibility: CopyButtonVisibility::Hidden,
                                     wrap_button_visibility: markdown::WrapButtonVisibility::Hidden,

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -238,7 +238,11 @@ impl BlameRenderer for GitBlameRenderer {
 
         let message = details
             .as_ref()
-            .map(|_| MarkdownElement::new(markdown.clone(), markdown_style).into_any())
+            .map(|_| {
+                MarkdownElement::new(markdown.clone(), markdown_style)
+                    .scroll_handle(scroll_handle.clone())
+                    .into_any()
+            })
             .unwrap_or("<no commit message>".into_any());
 
         let pull_request = details

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -258,7 +258,11 @@ impl Render for CommitTooltip {
             .commit
             .message
             .as_ref()
-            .map(|_| MarkdownElement::new(self.markdown.clone(), markdown_style).into_any())
+            .map(|_| {
+                MarkdownElement::new(self.markdown.clone(), markdown_style)
+                    .scroll_handle(self.scroll_handle.clone())
+                    .into_any()
+            })
             .unwrap_or("<no commit message>".into_any());
 
         let pull_request = self


### PR DESCRIPTION
Selecting text inside the hover documentation or git popups did not scroll the popup when the drag passed the visible area, so any text below the area could not be selected with the mouse.

The popup's container already had a `ScrollHandle` wired to its scrollbar and wheel scrolling, but the inner `MarkdownElement` was constructed without one. That left it in the default `AutoscrollBehavior::Propagate` mode, which routes drag-autoscroll requests to the editor-wide autoscroll listener, which is a listener that does not exist inside a floating popover, so the requests were silently dropped.

Passing the popup's existing `ScrollHandle` into the `MarkdownElement` switches it to `AutoscrollBehavior::Controlled`, which scrolls the popup's own container directly during a drag. The markdown preview view already uses this same pattern.

Release Notes:

- Fixed hover documentation and git popups not scrolling while selecting text with the mouse

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable
