### PR TITLE
[DRAFT] Add Cursor-like planning mode for agentic systems

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1165,6 +1165,29 @@
         "enable_all_context_servers": false,
         "tools": {},
       },
+      "plan": {
+        "name": "Plan",
+        // Read-only mode: research the codebase and produce a markdown plan
+        // at .zed/plans/<slug>.md, but do not modify any source files. Use the
+        // "Build" button in the message editor footer to execute the plan.
+        "enable_all_context_servers": false,
+        "tools": {
+          "diagnostics": true,
+          "fetch": true,
+          "find_path": true,
+          "find_references": true,
+          "go_to_definition": true,
+          "grep": true,
+          "list_directory": true,
+          "read_file": true,
+          "search_web": true,
+          "skill": true,
+          "spawn_agent": true,
+          "update_plan": true,
+          "update_title": true,
+          "write_plan_file": true,
+        },
+      },
     },
     // Where to show notifications when the agent has either completed
     // its response, or else needs confirmation before it can run a

--- a/crates/agent/src/templates.rs
+++ b/crates/agent/src/templates.rs
@@ -96,6 +96,30 @@ mod tests {
         assert!(rendered.contains("## Planning"));
         assert!(rendered.contains("## Session Title"));
         assert!(rendered.contains("test-model"));
+        // The Plan Mode section is only injected when `write_plan_file` is available.
+        assert!(!rendered.contains("## Plan Mode"));
+    }
+
+    #[test]
+    fn test_system_prompt_template_with_plan_mode() {
+        let project = prompt_store::ProjectContext::default();
+        let template = SystemPromptTemplate {
+            project: &project,
+            available_tools: vec![
+                "read_file".into(),
+                "grep".into(),
+                "update_plan".into(),
+                "write_plan_file".into(),
+            ],
+            model_name: Some("test-model".to_string()),
+            date: "2026-01-01".to_string(),
+            user_agents_md: None,
+        };
+        let templates = Templates::new();
+        let rendered = template.render(&templates).unwrap();
+        assert!(rendered.contains("## Plan Mode"));
+        assert!(rendered.contains("`.zed/plans/<slug>.md`"));
+        assert!(rendered.contains("## Decisions Log"));
     }
 
     #[test]

--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -75,6 +75,56 @@ Use a plan when:
 - You discover additional steps while working and intend to complete them before yielding to the user.
 
 {{/if}}
+{{#if (contains available_tools 'write_plan_file') }}
+## Plan Mode
+
+You are in Plan Mode. Your job is NOT to modify project source files. You will produce a written implementation plan that the user can review and then ask another agent to execute.
+
+Workflow:
+
+1. Research first. Read relevant files with `read_file`, `grep`, `find_path`, `list_directory`, `find_references`, and `go_to_definition`. Resolve ambiguity before writing the plan.
+2. If important requirements are unclear, ask the user one short, batched set of clarifying questions before producing the plan. Do not ask about details you can determine yourself by reading the code.
+3. Use `update_plan` to mirror your high-level TODOs in the UI as you work.
+4. Call `write_plan_file` once per turn (unless the user explicitly asks for revisions in the same turn), passing the full updated plan body. On follow-up turns, re-read the existing `.zed/plans/<slug>.md` first with `read_file` — the user may have edited it between turns, and that on-disk version is the source of truth.
+5. Keep the `slug` stable across turns within the same conversation so revisions update the same file. Choose a short kebab-case slug derived from the feature name.
+
+The plan file MUST use this structure:
+
+```markdown
+# <Concise feature title>
+
+## Goal
+<2-4 sentences describing the user-facing outcome.>
+
+## Context & Assumptions
+- <Notable existing code references, e.g. `crate/path/file.rs:LINE`.>
+- <Assumptions the user should confirm.>
+
+## Architecture
+<Optional Mermaid diagram or short prose for non-trivial designs.>
+
+## Files Touched
+- `path/to/file.rs` — <what changes>
+- ...
+
+## TODO
+- [ ] Step 1 — <imperative, verifiable>
+- [ ] Step 2 — ...
+- [ ] Add or extend tests for ...
+- [ ] Manual validation: <command or steps>
+
+## Open Questions
+- <Anything still uncertain. Leave the section empty if none.>
+
+## Decisions Log
+<Append-only. Add a new bullet whenever the user requests a change of direction so the rationale stays visible.>
+```
+
+The following tools are NOT available to you in Plan Mode and will fail if called: `edit_file`, `write_file`, `create_directory`, `delete_path`, `move_path`, `copy_path`, `apply_code_action`, `rename_symbol`, `terminal`. If the user asks you to "just do it" or skip planning, tell them to press the "Build" button below the message editor to switch out of Plan Mode.
+
+After calling `write_plan_file`, do not paste the plan body back into your reply — the user can already see it. Briefly summarize the key decisions and any open questions.
+
+{{/if}}
 {{#if (contains available_tools 'update_title') }}
 ## Session Title
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4,7 +4,7 @@ use crate::{
     FindPathTool, FindReferencesTool, GetCodeActionsTool, GoToDefinitionTool, GrepTool,
     ListDirectoryTool, MovePathTool, ProjectSnapshot, ReadFileTool, RenameTool, SpawnAgentTool,
     SystemPromptTemplate, Template, Templates, TerminalTool, ToolPermissionDecision,
-    UpdatePlanTool, UpdateTitleTool, UserAgentsMd, WebSearchTool, WriteFileTool,
+    UpdatePlanTool, UpdateTitleTool, UserAgentsMd, WebSearchTool, WriteFileTool, WritePlanFileTool,
     decide_permission_from_settings,
 };
 use acp_thread::{MentionUri, UserMessageId};
@@ -1673,6 +1673,12 @@ impl Thread {
             language_registry.clone(),
         ));
         self.add_tool(WriteFileTool::new(
+            self.project.clone(),
+            cx.weak_entity(),
+            self.action_log.clone(),
+            language_registry.clone(),
+        ));
+        self.add_tool(WritePlanFileTool::new(
             self.project.clone(),
             cx.weak_entity(),
             self.action_log.clone(),

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -27,6 +27,7 @@ mod update_plan_tool;
 mod update_title_tool;
 mod web_search_tool;
 mod write_file_tool;
+mod write_plan_file_tool;
 
 use crate::AgentTool;
 use language_model::{LanguageModelRequestTool, LanguageModelToolSchemaFormat};
@@ -84,6 +85,7 @@ pub use update_plan_tool::*;
 pub use update_title_tool::*;
 pub use web_search_tool::*;
 pub use write_file_tool::*;
+pub use write_plan_file_tool::*;
 
 macro_rules! tools {
     ($($tool:ty),* $(,)?) => {
@@ -177,4 +179,5 @@ tools! {
     UpdateTitleTool,
     WebSearchTool,
     WriteFileTool,
+    WritePlanFileTool,
 }

--- a/crates/agent/src/tools/edit_session.rs
+++ b/crates/agent/src/tools/edit_session.rs
@@ -36,6 +36,22 @@ use util::{Deferred, ResultExt};
 pub(crate) enum EditSessionMode {
     Write,
     Edit,
+    /// Like `Write`, but for files the agent maintains as part of its own workflow
+    /// (e.g. Plan Mode's `.zed/plans/<slug>.md`). User-facing edit authorization
+    /// is bypassed and the file is not tracked in the action log's review tray.
+    AgentInternalWrite,
+}
+
+impl EditSessionMode {
+    /// Returns whether this mode writes the full file contents (as opposed to
+    /// applying granular edits). Used by code paths that share write semantics
+    /// between the user-facing `write_file` tool and agent-internal writes.
+    pub(crate) fn is_write_like(self) -> bool {
+        matches!(
+            self,
+            EditSessionMode::Write | EditSessionMode::AgentInternalWrite
+        )
+    }
 }
 
 /// A single edit operation that replaces old text with new text
@@ -380,14 +396,15 @@ enum EditPipelineEntry {
 
 impl Pipeline {
     fn new(mode: EditSessionMode, file_changed_since_last_read: bool) -> Self {
-        match mode {
-            EditSessionMode::Write => Self::Write(WritePipeline {
+        if mode.is_write_like() {
+            Self::Write(WritePipeline {
                 content_written: false,
-            }),
-            EditSessionMode::Edit => Self::Edit(EditPipeline {
+            })
+        } else {
+            Self::Edit(EditPipeline {
                 current_edit: None,
                 file_changed_since_last_read,
-            }),
+            })
         }
     }
 }
@@ -654,9 +671,14 @@ impl EditSession {
             ToolCallUpdateFields::new().locations(vec![ToolCallLocation::new(abs_path.clone())]),
         );
 
-        cx.update(|cx| context.authorize(tool_name, &path, event_stream, cx))
-            .await
-            .map_err(|e| e.to_string())?;
+        // Agent-internal writes (e.g. Plan Mode's `.zed/plans/`) bypass the
+        // user-facing edit authorization prompt: the file is the agent's own
+        // working area, not a user source file.
+        if !matches!(mode, EditSessionMode::AgentInternalWrite) {
+            cx.update(|cx| context.authorize(tool_name, &path, event_stream, cx))
+                .await
+                .map_err(|e| e.to_string())?;
+        }
 
         let buffer = context
             .project
@@ -677,10 +699,16 @@ impl EditSession {
             }
         }) as Box<dyn FnOnce()>);
 
-        context.action_log.update(cx, |log, cx| match mode {
-            EditSessionMode::Write => log.buffer_created(buffer.clone(), cx),
-            EditSessionMode::Edit => log.buffer_read(buffer.clone(), cx),
-        });
+        // Agent-internal writes don't appear in the conversation's edits
+        // review tray. The user reviews the plan by opening the markdown
+        // file in an editor pane, not by Reject/Keep on a diff.
+        if !matches!(mode, EditSessionMode::AgentInternalWrite) {
+            context.action_log.update(cx, |log, cx| match mode {
+                EditSessionMode::Write => log.buffer_created(buffer.clone(), cx),
+                EditSessionMode::Edit => log.buffer_read(buffer.clone(), cx),
+                EditSessionMode::AgentInternalWrite => unreachable!(),
+            });
+        }
 
         let old_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
         let old_text = cx
@@ -992,9 +1020,10 @@ async fn resolve_dirty_buffer(
         })
     });
 
-    let prompt_kind = match mode {
-        EditSessionMode::Edit => super::tool_permissions::DirtyBufferPromptKind::Edit,
-        EditSessionMode::Write => super::tool_permissions::DirtyBufferPromptKind::Overwrite,
+    let prompt_kind = if mode.is_write_like() {
+        super::tool_permissions::DirtyBufferPromptKind::Overwrite
+    } else {
+        super::tool_permissions::DirtyBufferPromptKind::Edit
     };
     let prompt = cx.update(|cx| {
         super::tool_permissions::authorize_dirty_buffer(prompt_kind, event_stream, cx)
@@ -1013,14 +1042,15 @@ async fn resolve_dirty_buffer(
         event_stream.update_fields(
             acp::ToolCallUpdateFields::new().status(acp::ToolCallStatus::InProgress),
         );
-        return match mode {
-            EditSessionMode::Edit => Ok(()),
-            EditSessionMode::Write => Err(
+        return if mode.is_write_like() {
+            Err(
                 "The user saved their unsaved changes while the prompt was visible; \
                  the file overwrite was cancelled to preserve them. Ask the user how \
                  they'd like to proceed before retrying."
                     .to_string(),
-            ),
+            )
+        } else {
+            Ok(())
         };
     };
 
@@ -1063,62 +1093,60 @@ fn resolve_path(
 ) -> Result<ProjectPath, String> {
     let project = project.read(cx);
 
-    match mode {
-        EditSessionMode::Edit => {
-            let path = project
-                .find_project_path(&path, cx)
-                .ok_or_else(|| "Can't edit file: path not found".to_string())?;
+    if matches!(mode, EditSessionMode::Edit) {
+        let path = project
+            .find_project_path(&path, cx)
+            .ok_or_else(|| "Can't edit file: path not found".to_string())?;
 
-            let entry = project
-                .entry_for_path(&path, cx)
-                .ok_or_else(|| "Can't edit file: path not found".to_string())?;
+        let entry = project
+            .entry_for_path(&path, cx)
+            .ok_or_else(|| "Can't edit file: path not found".to_string())?;
 
-            if entry.is_file() {
-                Ok(path)
-            } else {
-                Err("Can't edit file: path is a directory".to_string())
-            }
-        }
-        EditSessionMode::Write => {
-            if let Some(path) = project.find_project_path(&path, cx)
-                && let Some(entry) = project.entry_for_path(&path, cx)
-            {
-                if entry.is_file() {
-                    return Ok(path);
-                } else {
-                    return Err("Can't write to file: path is a directory".to_string());
-                }
-            }
-
-            let parent_path = path
-                .parent()
-                .ok_or_else(|| "Can't create file: incorrect path".to_string())?;
-
-            let parent_project_path = project.find_project_path(&parent_path, cx);
-
-            let parent_entry = parent_project_path
-                .as_ref()
-                .and_then(|path| project.entry_for_path(path, cx))
-                .ok_or_else(|| "Can't create file: parent directory doesn't exist")?;
-
-            if !parent_entry.is_dir() {
-                return Err("Can't create file: parent is not a directory".to_string());
-            }
-
-            let file_name = path
-                .file_name()
-                .and_then(|file_name| file_name.to_str())
-                .and_then(|file_name| RelPath::unix(file_name).ok())
-                .ok_or_else(|| "Can't create file: invalid filename".to_string())?;
-
-            let new_file_path = parent_project_path.map(|parent| ProjectPath {
-                path: parent.path.join(file_name),
-                ..parent
-            });
-
-            new_file_path.ok_or_else(|| "Can't create file".to_string())
-        }
+        return if entry.is_file() {
+            Ok(path)
+        } else {
+            Err("Can't edit file: path is a directory".to_string())
+        };
     }
+
+    // Write-like: locate the file, or create it under an existing parent directory.
+    if let Some(path) = project.find_project_path(&path, cx)
+        && let Some(entry) = project.entry_for_path(&path, cx)
+    {
+        return if entry.is_file() {
+            Ok(path)
+        } else {
+            Err("Can't write to file: path is a directory".to_string())
+        };
+    }
+
+    let parent_path = path
+        .parent()
+        .ok_or_else(|| "Can't create file: incorrect path".to_string())?;
+
+    let parent_project_path = project.find_project_path(&parent_path, cx);
+
+    let parent_entry = parent_project_path
+        .as_ref()
+        .and_then(|path| project.entry_for_path(path, cx))
+        .ok_or_else(|| "Can't create file: parent directory doesn't exist")?;
+
+    if !parent_entry.is_dir() {
+        return Err("Can't create file: parent is not a directory".to_string());
+    }
+
+    let file_name = path
+        .file_name()
+        .and_then(|file_name| file_name.to_str())
+        .and_then(|file_name| RelPath::unix(file_name).ok())
+        .ok_or_else(|| "Can't create file: invalid filename".to_string())?;
+
+    let new_file_path = parent_project_path.map(|parent| ProjectPath {
+        path: parent.path.join(file_name),
+        ..parent
+    });
+
+    new_file_path.ok_or_else(|| "Can't create file".to_string())
 }
 
 #[cfg(test)]

--- a/crates/agent/src/tools/write_plan_file_tool.rs
+++ b/crates/agent/src/tools/write_plan_file_tool.rs
@@ -1,0 +1,259 @@
+use super::edit_session::{
+    EditSession, EditSessionContext, EditSessionMode, EditSessionOutput, EditSessionResult,
+    run_session,
+};
+use crate::{AgentTool, Thread, ToolCallEventStream, ToolInput};
+use action_log::ActionLog;
+use agent_client_protocol::schema as acp;
+use gpui::{App, AsyncApp, Entity, SharedString, Task, WeakEntity};
+use language::LanguageRegistry;
+use project::{Project, ProjectPath};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+use util::rel_path::RelPath;
+
+const PLANS_DIR: &str = ".zed/plans";
+
+/// Writes (or overwrites) the implementation plan for the current task.
+///
+/// This tool is only available in Plan Mode. It saves a Markdown plan to
+/// `.zed/plans/<slug>.md` inside the first project worktree, opens it in a
+/// buffer so the user can edit it inline, and shows the diff in the agent
+/// panel. Use it once per turn, providing the full updated plan body each
+/// time. On follow-up turns, re-read the existing file first so user edits
+/// are preserved.
+///
+/// The plan file is the source of truth. When the user clicks "Build", a
+/// new agent in Write mode will read this file and execute the TODOs.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct WritePlanFileToolInput {
+    /// Kebab-case slug used as the filename (without extension). Example: "add-auth-flow".
+    /// Must not contain path separators or leading dots. Should be descriptive but short.
+    pub slug: String,
+    /// The full Markdown body of the plan. Replaces the previous content entirely.
+    pub content: String,
+}
+
+pub struct WritePlanFileTool {
+    project: Entity<Project>,
+    session_context: Arc<EditSessionContext>,
+}
+
+impl WritePlanFileTool {
+    pub fn new(
+        project: Entity<Project>,
+        thread: WeakEntity<Thread>,
+        action_log: Entity<ActionLog>,
+        language_registry: Arc<LanguageRegistry>,
+    ) -> Self {
+        Self {
+            project: project.clone(),
+            session_context: Arc::new(EditSessionContext::new(
+                project,
+                thread,
+                action_log,
+                language_registry,
+            )),
+        }
+    }
+}
+
+fn sanitize_slug(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("Plan slug cannot be empty".to_string());
+    }
+    if trimmed.starts_with('.') {
+        return Err("Plan slug cannot start with '.'".to_string());
+    }
+    if trimmed
+        .chars()
+        .any(|c| matches!(c, '/' | '\\' | ':' | '\0') || c.is_control())
+    {
+        return Err(format!(
+            "Plan slug '{trimmed}' contains an invalid character. \
+             Use only letters, digits, '-', and '_'."
+        ));
+    }
+    // Strip a trailing ".md" if the model included it.
+    let without_ext = trimmed
+        .strip_suffix(".md")
+        .or_else(|| trimmed.strip_suffix(".markdown"))
+        .unwrap_or(trimmed);
+    if without_ext.is_empty() {
+        return Err("Plan slug cannot be just an extension".to_string());
+    }
+    Ok(without_ext.to_string())
+}
+
+impl AgentTool for WritePlanFileTool {
+    type Input = WritePlanFileToolInput;
+    type Output = EditSessionOutput;
+
+    const NAME: &'static str = "write_plan_file";
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Edit
+    }
+
+    fn initial_title(
+        &self,
+        input: Result<Self::Input, serde_json::Value>,
+        _cx: &mut App,
+    ) -> SharedString {
+        match input {
+            Ok(input) => match sanitize_slug(&input.slug) {
+                Ok(slug) => format!("Write plan `{}/{}.md`", PLANS_DIR, slug).into(),
+                Err(_) => "Write plan".into(),
+            },
+            Err(_) => "Write plan".into(),
+        }
+    }
+
+    fn run(
+        self: Arc<Self>,
+        input: ToolInput<Self::Input>,
+        event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<Self::Output, Self::Output>> {
+        let project = self.project.clone();
+        cx.spawn(async move |cx: &mut AsyncApp| {
+            let input = input
+                .recv()
+                .await
+                .map_err(|e| EditSessionOutput::error(e.to_string()))?;
+            let slug = sanitize_slug(&input.slug).map_err(EditSessionOutput::error)?;
+
+            let worktree_info = cx.update(|cx| {
+                project
+                    .read(cx)
+                    .visible_worktrees(cx)
+                    .next()
+                    .map(|worktree| {
+                        let worktree = worktree.read(cx);
+                        (
+                            worktree.id(),
+                            worktree.root_name().as_unix_str().to_string(),
+                        )
+                    })
+            });
+
+            let (worktree_id, worktree_root_name) = worktree_info.ok_or_else(|| {
+                EditSessionOutput::error(
+                    "Cannot create plan file: project has no visible worktree.".to_string(),
+                )
+            })?;
+
+            // Ensure `.zed/plans/` exists in the worktree so EditSession's
+            // resolve_path can find the parent directory.
+            let plans_dir_rel = RelPath::unix(PLANS_DIR)
+                .map_err(|e| EditSessionOutput::error(e.to_string()))?
+                .into_arc();
+            let plans_dir_project_path = ProjectPath {
+                worktree_id,
+                path: plans_dir_rel,
+            };
+
+            let already_exists = cx.update(|cx| {
+                project
+                    .read(cx)
+                    .entry_for_path(&plans_dir_project_path, cx)
+                    .is_some_and(|entry| entry.is_dir())
+            });
+
+            if !already_exists {
+                let create_task = project.update(cx, |project, cx| {
+                    project.create_entry(plans_dir_project_path.clone(), true, cx)
+                });
+                create_task
+                    .await
+                    .map_err(|e| EditSessionOutput::error(e.to_string()))?;
+            }
+
+            // Compose the worktree-prefixed path the EditSession API expects.
+            let plan_file_path =
+                PathBuf::from(format!("{}/{}/{}.md", worktree_root_name, PLANS_DIR, slug));
+
+            let session_context = self.session_context.clone();
+            let session_result = match EditSession::new(
+                plan_file_path,
+                EditSessionMode::AgentInternalWrite,
+                Self::NAME,
+                session_context,
+                &event_stream,
+                cx,
+            )
+            .await
+            {
+                Ok(mut session) => match session.finalize_write(&input.content, cx).await {
+                    Ok(()) => EditSessionResult::Completed(session),
+                    Err(error) => EditSessionResult::Failed {
+                        error,
+                        session: Some(session),
+                    },
+                },
+                Err(error) => EditSessionResult::Failed {
+                    error,
+                    session: None,
+                },
+            };
+
+            run_session(session_result, cx).await
+        })
+    }
+
+    fn replay(
+        &self,
+        _input: Self::Input,
+        output: Self::Output,
+        event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> anyhow::Result<()> {
+        self.session_context.replay_output(output, event_stream, cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_sanitization_accepts_kebab() {
+        assert_eq!(sanitize_slug("add-auth-flow").unwrap(), "add-auth-flow");
+    }
+
+    #[test]
+    fn slug_sanitization_strips_md_suffix() {
+        assert_eq!(sanitize_slug("add-auth-flow.md").unwrap(), "add-auth-flow");
+        assert_eq!(
+            sanitize_slug("add-auth-flow.markdown").unwrap(),
+            "add-auth-flow"
+        );
+    }
+
+    #[test]
+    fn slug_sanitization_rejects_path_separators() {
+        assert!(sanitize_slug("foo/bar").is_err());
+        assert!(sanitize_slug("foo\\bar").is_err());
+        assert!(sanitize_slug("../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn slug_sanitization_rejects_leading_dot() {
+        assert!(sanitize_slug(".hidden").is_err());
+    }
+
+    #[test]
+    fn slug_sanitization_rejects_empty() {
+        assert!(sanitize_slug("").is_err());
+        assert!(sanitize_slug("   ").is_err());
+        assert!(sanitize_slug(".md").is_err());
+    }
+
+    #[test]
+    fn slug_sanitization_trims_whitespace() {
+        assert_eq!(sanitize_slug("  plan-one  ").unwrap(), "plan-one");
+    }
+}

--- a/crates/agent_settings/src/agent_profile.rs
+++ b/crates/agent_settings/src/agent_profile.rs
@@ -19,9 +19,10 @@ pub mod builtin_profiles {
     pub const WRITE: &str = "write";
     pub const ASK: &str = "ask";
     pub const MINIMAL: &str = "minimal";
+    pub const PLAN: &str = "plan";
 
     pub fn is_builtin(profile_id: &AgentProfileId) -> bool {
-        profile_id.as_str() == WRITE || profile_id.as_str() == ASK || profile_id.as_str() == MINIMAL
+        matches!(profile_id.as_str(), WRITE | ASK | MINIMAL | PLAN)
     }
 }
 

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -23,6 +23,7 @@ mod message_editor;
 mod mode_selector;
 mod model_selector;
 mod model_selector_popover;
+mod plan_file_toolbar;
 mod profile_selector;
 mod terminal_codegen;
 mod terminal_inline_assistant;
@@ -81,6 +82,7 @@ pub use external_source_prompt::ExternalSourcePrompt;
 pub(crate) use mode_selector::ModeSelector;
 pub(crate) use model_selector::ModelSelector;
 pub(crate) use model_selector_popover::ModelSelectorPopover;
+pub use plan_file_toolbar::PlanFileToolbar;
 pub use thread_import::{
     AcpThreadImportOnboarding, CrossChannelImportOnboarding, ThreadImportModal,
     channels_with_threads, import_threads_from_other_channels,

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -298,6 +298,9 @@ pub struct ThreadView {
     /// Used for showing/hiding tool call results, terminal output, etc.
     pub expanded_tool_calls: HashSet<acp::ToolCallId>,
     pub expanded_tool_call_raw_inputs: HashSet<acp::ToolCallId>,
+    /// Paths of plan files we've already revealed in the workspace this
+    /// session, so repeated `write_plan_file` calls don't keep re-opening.
+    opened_plan_files: HashSet<PathBuf>,
     pub expanded_thinking_blocks: HashSet<(usize, usize)>,
     auto_expanded_thinking_block: Option<(usize, usize)>,
     user_toggled_thinking_blocks: HashSet<(usize, usize)>,
@@ -593,6 +596,7 @@ impl ThreadView {
             thread_feedback: Default::default(),
             expanded_tool_calls: HashSet::default(),
             expanded_tool_call_raw_inputs: HashSet::default(),
+            opened_plan_files: HashSet::default(),
             expanded_thinking_blocks: HashSet::default(),
             auto_expanded_thinking_block: None,
             user_toggled_thinking_blocks: HashSet::default(),
@@ -811,6 +815,7 @@ impl ThreadView {
                 if AgentSettings::get_global(cx).expand_edit_card {
                     self.expanded_tool_calls.insert(tool_call_id.clone());
                 }
+                self.maybe_reveal_plan_file(tool_call_id, window, cx);
             }
             ViewEvent::NewTerminal(tool_call_id) => {
                 if AgentSettings::get_global(cx).expand_terminal_card {
@@ -3394,6 +3399,7 @@ impl ThreadView {
                                             .children(self.mode_selector.clone())
                                             .children(self.model_selector.clone()),
                                     })
+                                    .children(self.render_build_button(cx))
                                     .child(self.render_send_button(cx)),
                             ),
                     ),
@@ -4133,6 +4139,255 @@ impl ThreadView {
                 }))
                 .into_any_element()
         }
+    }
+
+    /// When `tool_call_id` references a `write_plan_file` tool call, open the
+    /// plan file in the workspace so the user can read/edit it inline.
+    /// Called once per `NewDiff` event; subsequent updates to the same file
+    /// are no-ops because the workspace already has the buffer open.
+    fn maybe_reveal_plan_file(
+        &mut self,
+        tool_call_id: &acp::ToolCallId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let thread = self.thread.read(cx);
+        let plan_path = thread.entries().iter().find_map(|entry| {
+            let acp_thread::AgentThreadEntry::ToolCall(call) = entry else {
+                return None;
+            };
+            if &call.id != tool_call_id {
+                return None;
+            }
+            // Tool name matches the `NAME` const on `agent::WritePlanFileTool`.
+            // We use the literal here to avoid bringing the `AgentTool` trait
+            // into scope just for this one comparison.
+            if call.tool_name.as_deref() != Some("write_plan_file") {
+                return None;
+            }
+            call.locations.first().map(|loc| loc.path.clone())
+        });
+        let Some(plan_path) = plan_path else {
+            return;
+        };
+        if !self.opened_plan_files.insert(plan_path.clone()) {
+            return;
+        }
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+        workspace.update(cx, |workspace, cx| {
+            workspace
+                .open_abs_path(plan_path, workspace::OpenOptions::default(), window, cx)
+                .detach_and_log_err(cx);
+        });
+    }
+
+    /// Returns true when the active thread is using the built-in "Plan" profile.
+    fn is_in_plan_mode(&self, cx: &App) -> bool {
+        self.as_native_thread(cx).is_some_and(|thread| {
+            thread.read(cx).profile().as_str() == agent_settings::builtin_profiles::PLAN
+        })
+    }
+
+    /// Scans every visible worktree's `.zed/plans/` directory for `.md` files
+    /// and returns the absolute path of the most recently modified one. This
+    /// is what "Build" will execute against.
+    fn latest_plan_file(&self, cx: &App) -> Option<PathBuf> {
+        let plans_rel = RelPath::unix(".zed/plans").ok()?;
+        let project = self.thread.read(cx).project().read(cx);
+        let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+        for worktree in project.visible_worktrees(cx) {
+            let worktree = worktree.read(cx);
+            let snapshot = worktree.snapshot();
+            if snapshot
+                .entry_for_path(plans_rel)
+                .is_none_or(|e| !e.is_dir())
+            {
+                continue;
+            }
+            for entry in snapshot.child_entries(plans_rel) {
+                if !entry.is_file() {
+                    continue;
+                }
+                let path_str = entry.path.as_unix_str();
+                if !path_str.ends_with(".md") {
+                    continue;
+                }
+                let mtime = entry
+                    .mtime
+                    .map(|m| m.timestamp_for_user())
+                    .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+                let abs = worktree.abs_path().join(entry.path.as_std_path());
+                match &best {
+                    Some((best_mtime, _)) if *best_mtime >= mtime => {}
+                    _ => best = Some((mtime, abs)),
+                }
+            }
+        }
+        best.map(|(_, path)| path)
+    }
+
+    /// Switches the thread out of Plan mode and asks the agent to implement
+    /// the given plan file. If `model` is provided, the thread is switched to
+    /// that model before sending; otherwise the current model is used.
+    pub(crate) fn build_plan(
+        &mut self,
+        plan_path: PathBuf,
+        model: Option<Arc<dyn language_model::LanguageModel>>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(native_thread) = self.as_native_thread(cx) else {
+            return;
+        };
+
+        native_thread.update(cx, |thread, cx| {
+            thread.set_profile(
+                AgentProfileId(agent_settings::builtin_profiles::WRITE.into()),
+                cx,
+            );
+            if let Some(model) = model {
+                thread.set_model(model, cx);
+            }
+        });
+
+        // Display the plan path the same way users see it in the project panel:
+        // worktree-prefixed when there are multiple worktrees, otherwise just the relative path.
+        let project = self.thread.read(cx).project().clone();
+        let display_path = project
+            .read(cx)
+            .project_path_for_absolute_path(&plan_path, cx)
+            .and_then(|pp| project.read(cx).short_full_path_for_project_path(&pp, cx))
+            .unwrap_or_else(|| plan_path.to_string_lossy().into_owned());
+
+        let prompt = format!(
+            "Implement the plan in `{display_path}`.\n\n\
+             Workflow:\n\
+             1. Read the plan file fully with `read_file`.\n\
+             2. Use `update_plan` to mirror its TODO list, then work through it in order.\n\
+             3. After completing each TODO, update the plan file to mark that item as `[x]` so it stays in sync with reality.\n\
+             4. If you need to deviate from the plan, append a bullet under `## Decisions Log` in the plan file before changing course.\n\
+             5. When all TODOs are done, run validation and produce a final summary."
+        );
+
+        // Reveal the plan file in the workspace so the user can see it while the agent works.
+        if let Some(workspace) = self.workspace.upgrade() {
+            workspace.update(cx, |workspace, cx| {
+                workspace
+                    .open_abs_path(
+                        plan_path,
+                        workspace::OpenOptions {
+                            visible: Some(workspace::OpenVisible::None),
+                            ..Default::default()
+                        },
+                        window,
+                        cx,
+                    )
+                    .detach_and_log_err(cx);
+            });
+        }
+
+        self.message_editor.update(cx, |editor, cx| {
+            editor.clear(window, cx);
+            editor.insert_text(&prompt, window, cx);
+        });
+        self.send(window, cx);
+    }
+
+    fn render_build_button(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        if !self.is_in_plan_mode(cx) {
+            return None;
+        }
+        let plan_path = self.latest_plan_file(cx)?;
+        let is_generating = self.thread.read(cx).status() != ThreadStatus::Idle;
+
+        let current_model_name = self
+            .as_native_thread(cx)
+            .and_then(|thread| thread.read(cx).model().map(|m| m.name().0.to_string()));
+
+        let plan_for_left = plan_path.clone();
+        let weak_self = cx.weak_entity();
+
+        let left = ButtonLike::new("build-plan-button")
+            .style(ButtonStyle::Tinted(TintColor::Accent))
+            .disabled(is_generating)
+            .child(Icon::new(IconName::PlayFilled).size(IconSize::Small))
+            .child(Label::new("Build").size(LabelSize::Small))
+            .tooltip({
+                let model_name = current_model_name.clone();
+                move |_window, cx| {
+                    let body = match &model_name {
+                        Some(name) => {
+                            format!("Switch to Write mode and execute the plan with {name}")
+                        }
+                        None => "Switch to Write mode and execute the plan".to_string(),
+                    };
+                    Tooltip::simple(body, cx)
+                }
+            })
+            .on_click(cx.listener(move |this, _, window, cx| {
+                this.build_plan(plan_for_left.clone(), None, window, cx);
+            }));
+
+        // Right half: a chevron that opens a context menu listing every
+        // configured language model. Clicking a model builds the plan with it.
+        let plan_for_menu = plan_path.clone();
+        let menu_weak = weak_self.clone();
+        let right = PopoverMenu::new("build-plan-model-menu")
+            .trigger(
+                IconButton::new("build-plan-model-trigger", IconName::ChevronDown)
+                    .icon_size(IconSize::XSmall)
+                    .icon_color(Color::Muted)
+                    .disabled(is_generating),
+            )
+            .anchor(gpui::Anchor::BottomRight)
+            .offset(gpui::Point {
+                x: px(0.0),
+                y: px(-2.0),
+            })
+            .menu(move |window, cx| {
+                let plan_path = plan_for_menu.clone();
+                let weak_self = menu_weak.clone();
+                Some(ContextMenu::build(
+                    window,
+                    cx,
+                    move |mut menu, _window, cx| {
+                        let models: Vec<Arc<dyn language_model::LanguageModel>> =
+                            LanguageModelRegistry::read_global(cx)
+                                .available_models(cx)
+                                .collect();
+                        if models.is_empty() {
+                            menu = menu.label("No models configured");
+                        } else {
+                            menu = menu.header("Build with model");
+                            for model in models {
+                                let label =
+                                    format!("{} · {}", model.provider_name().0, model.name().0);
+                                let plan_path = plan_path.clone();
+                                let weak_self = weak_self.clone();
+                                let model = model.clone();
+                                menu = menu.entry(label, None, move |window, cx| {
+                                    let plan_path = plan_path.clone();
+                                    let model = model.clone();
+                                    weak_self
+                                        .update(cx, |this, cx| {
+                                            this.build_plan(plan_path, Some(model), window, cx);
+                                        })
+                                        .ok();
+                                });
+                            }
+                        }
+                        menu
+                    },
+                ))
+            });
+
+        Some(
+            SplitButton::new(left, right.into_any_element())
+                .style(SplitButtonStyle::Filled)
+                .into_any_element(),
+        )
     }
 
     fn render_add_context_button(&mut self, cx: &mut Context<Self>) -> impl IntoElement {

--- a/crates/agent_ui/src/plan_file_toolbar.rs
+++ b/crates/agent_ui/src/plan_file_toolbar.rs
@@ -1,0 +1,267 @@
+//! Editor-toolbar Build button for Plan Mode markdown files.
+//!
+//! When the active editor item is a file under `.zed/plans/` with an `.md`
+//! extension, this toolbar shows a `Build` split-button on the right side of
+//! the editor's primary toolbar. Clicking the button asks the active agent
+//! thread (in the workspace's `AgentPanel`) to switch out of Plan Mode and
+//! implement the plan; the chevron opens a model picker so the user can
+//! choose which model performs the build.
+
+use crate::{AgentPanel, conversation_view::ThreadView};
+use editor::Editor;
+use gpui::{
+    App, Context, EventEmitter, IntoElement, ParentElement, Render, SharedString, Subscription,
+    WeakEntity, Window, px,
+};
+use language_model::{LanguageModel, LanguageModelRegistry};
+use settings::SettingsStore;
+use std::path::PathBuf;
+use std::sync::Arc;
+use ui::{
+    ButtonLike, ButtonStyle, Color, ContextMenu, Icon, IconButton, IconName, IconSize, Label,
+    LabelSize, PopoverMenu, SplitButton, SplitButtonStyle, TintColor, Tooltip, prelude::*,
+};
+use workspace::{ItemHandle, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace};
+
+pub struct PlanFileToolbar {
+    /// Absolute path of the plan file currently shown in the active editor, if
+    /// any. `None` when the toolbar is hidden.
+    active_plan: Option<PathBuf>,
+    workspace: WeakEntity<Workspace>,
+    _settings_subscription: Subscription,
+}
+
+impl PlanFileToolbar {
+    pub fn new(workspace: WeakEntity<Workspace>, cx: &mut Context<Self>) -> Self {
+        Self {
+            active_plan: None,
+            workspace,
+            _settings_subscription: cx
+                .observe_global::<SettingsStore>(|this, cx| this.update_location(cx)),
+        }
+    }
+
+    fn update_location(&mut self, cx: &mut Context<Self>) {
+        let location = self.location();
+        cx.emit(ToolbarItemEvent::ChangeLocation(location));
+    }
+
+    fn location(&self) -> ToolbarItemLocation {
+        if self.active_plan.is_some() {
+            ToolbarItemLocation::PrimaryRight
+        } else {
+            ToolbarItemLocation::Hidden
+        }
+    }
+
+    /// Returns the absolute path of a plan file (i.e. an `.md` file under a
+    /// worktree's `.zed/plans/` directory) if the given item is an editor on
+    /// such a file. Returns `None` otherwise.
+    fn plan_path_for_item(item: &dyn ItemHandle, cx: &App) -> Option<PathBuf> {
+        let editor = item.act_as::<Editor>(cx)?;
+        if !editor.read(cx).mode().is_full() {
+            return None;
+        }
+        let buffer = editor.read(cx).buffer().read(cx).as_singleton()?;
+        let buffer = buffer.read(cx);
+        let file = buffer.file()?;
+        let abs_path = file.as_local()?.abs_path(cx);
+        if !is_plan_file_path(&abs_path) {
+            return None;
+        }
+        Some(abs_path)
+    }
+
+    fn build_with_model(
+        &mut self,
+        model: Option<Arc<dyn LanguageModel>>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(plan_path) = self.active_plan.clone() else {
+            return;
+        };
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+        let Some(thread_view) = workspace
+            .read(cx)
+            .panel::<AgentPanel>(cx)
+            .and_then(|panel| panel.read(cx).active_thread_view(cx))
+        else {
+            // Surface a friendly message via a workspace toast in the future;
+            // for now we no-op so the toolbar click doesn't crash.
+            log::warn!("PlanFileToolbar: cannot Build — agent panel has no active thread");
+            return;
+        };
+        thread_view.update(cx, |view: &mut ThreadView, cx| {
+            view.build_plan(plan_path, model, window, cx);
+        });
+    }
+}
+
+/// Returns true for absolute paths that look like a plan file maintained by
+/// Plan Mode: an `.md` file whose path contains a `.zed/plans/` segment.
+fn is_plan_file_path(path: &std::path::Path) -> bool {
+    let Some(ext) = path.extension() else {
+        return false;
+    };
+    if !ext.eq_ignore_ascii_case("md") {
+        return false;
+    }
+    let mut components = path.components();
+    while let Some(component) = components.next() {
+        if component.as_os_str() == ".zed" {
+            // The very next component must be `plans`.
+            if let Some(next) = components.next()
+                && next.as_os_str() == "plans"
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+impl EventEmitter<ToolbarItemEvent> for PlanFileToolbar {}
+
+impl ToolbarItemView for PlanFileToolbar {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> ToolbarItemLocation {
+        self.active_plan = active_pane_item.and_then(|item| Self::plan_path_for_item(item, cx));
+        self.location()
+    }
+
+    fn pane_focus_update(
+        &mut self,
+        _pane_focused: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
+}
+
+impl Render for PlanFileToolbar {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if self.active_plan.is_none() {
+            return gpui::Empty.into_any_element();
+        }
+
+        let current_model_name: Option<SharedString> = LanguageModelRegistry::read_global(cx)
+            .default_model()
+            .map(|m| m.model.name().0);
+
+        let weak_self = cx.weak_entity();
+
+        let left = ButtonLike::new("plan-toolbar-build")
+            .style(ButtonStyle::Tinted(TintColor::Accent))
+            .child(Icon::new(IconName::PlayFilled).size(IconSize::Small))
+            .child(Label::new("Build").size(LabelSize::Small))
+            .tooltip({
+                let model_name = current_model_name.clone();
+                move |_window, cx| {
+                    let body = match model_name.as_ref() {
+                        Some(name) => format!(
+                            "Switch the active thread to Write mode and implement this plan with {name}"
+                        ),
+                        None => "Switch the active thread to Write mode and implement this plan"
+                            .to_string(),
+                    };
+                    Tooltip::simple(body, cx)
+                }
+            })
+            .on_click({
+                let weak_self = weak_self.clone();
+                move |_, window, cx| {
+                    weak_self
+                        .update(cx, |this, cx| this.build_with_model(None, window, cx))
+                        .ok();
+                }
+            });
+
+        let menu_weak = weak_self.clone();
+        let right = PopoverMenu::new("plan-toolbar-build-model")
+            .trigger(
+                IconButton::new("plan-toolbar-build-model-trigger", IconName::ChevronDown)
+                    .icon_size(IconSize::XSmall)
+                    .icon_color(Color::Muted),
+            )
+            .anchor(gpui::Anchor::BottomRight)
+            .offset(gpui::Point {
+                x: px(0.0),
+                y: px(-2.0),
+            })
+            .menu(move |window, cx| {
+                let weak_self = menu_weak.clone();
+                Some(ContextMenu::build(
+                    window,
+                    cx,
+                    move |mut menu, _window, cx| {
+                        let models: Vec<Arc<dyn LanguageModel>> =
+                            LanguageModelRegistry::read_global(cx)
+                                .available_models(cx)
+                                .collect();
+                        if models.is_empty() {
+                            menu = menu.label("No models configured");
+                        } else {
+                            menu = menu.header("Build with model");
+                            for model in models {
+                                let label =
+                                    format!("{} · {}", model.provider_name().0, model.name().0);
+                                let weak_self = weak_self.clone();
+                                let model = model.clone();
+                                menu = menu.entry(label, None, move |window, cx| {
+                                    let model = model.clone();
+                                    weak_self
+                                        .update(cx, |this, cx| {
+                                            this.build_with_model(Some(model), window, cx);
+                                        })
+                                        .ok();
+                                });
+                            }
+                        }
+                        menu
+                    },
+                ))
+            });
+
+        SplitButton::new(left, right.into_any_element())
+            .style(SplitButtonStyle::Filled)
+            .into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_plan_file_path;
+    use std::path::Path;
+
+    #[test]
+    fn matches_md_under_dot_zed_plans() {
+        assert!(is_plan_file_path(Path::new(
+            "/work/zed/.zed/plans/add-auth.md"
+        )));
+        assert!(is_plan_file_path(Path::new(
+            "C:\\work\\zed\\.zed\\plans\\add-auth.md"
+        )));
+    }
+
+    #[test]
+    fn rejects_md_outside_plans_dir() {
+        assert!(!is_plan_file_path(Path::new("/work/zed/.zed/settings.md")));
+        assert!(!is_plan_file_path(Path::new("/work/zed/README.md")));
+        assert!(!is_plan_file_path(Path::new("/work/zed/docs/plans/foo.md")));
+    }
+
+    #[test]
+    fn rejects_non_md_under_plans() {
+        assert!(!is_plan_file_path(Path::new(
+            "/work/zed/.zed/plans/notes.txt"
+        )));
+        assert!(!is_plan_file_path(Path::new("/work/zed/.zed/plans/README")));
+    }
+}

--- a/crates/agent_ui/src/profile_selector.rs
+++ b/crates/agent_ui/src/profile_selector.rs
@@ -345,6 +345,9 @@ impl ProfilePickerDelegate {
             builtin_profiles::WRITE => Some("Get help to write anything."),
             builtin_profiles::ASK => Some("Chat about your codebase."),
             builtin_profiles::MINIMAL => Some("Chat about anything with no tools."),
+            builtin_profiles::PLAN => Some(
+                "Research and write an implementation plan to `.zed/plans/`. Source files are not modified — press Build to execute the plan.",
+            ),
             _ => None,
         }
     }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -16,7 +16,7 @@ pub mod visual_tests;
 pub(crate) mod windows_only_instance;
 
 use agent::{UserAgentsMdState, init_user_agents_md};
-use agent_ui::AgentDiffToolbar;
+use agent_ui::{AgentDiffToolbar, PlanFileToolbar};
 use anyhow::Context as _;
 pub use app_menus::*;
 use assets::Assets;
@@ -1344,6 +1344,8 @@ fn initialize_pane(
             toolbar.add_item(commit_view_toolbar, window, cx);
             let agent_diff_toolbar = cx.new(AgentDiffToolbar::new);
             toolbar.add_item(agent_diff_toolbar, window, cx);
+            let plan_file_toolbar = cx.new(|cx| PlanFileToolbar::new(workspace_handle.clone(), cx));
+            toolbar.add_item(plan_file_toolbar, window, cx);
             let basedpyright_banner = cx.new(|cx| BasedPyrightBanner::new(workspace, cx));
             toolbar.add_item(basedpyright_banner, window, cx);
             let image_view_toolbar = cx.new(|_| image_viewer::ImageViewToolbarControls::new());

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -288,7 +288,7 @@ You can also extend the set of available tools via [MCP Servers](./mcp.md).
 ### Profiles {#profiles}
 
 Profiles act as a way to group tools.
-Zed offers three built-in profiles and you can create as many custom ones as you want.
+Zed offers four built-in profiles and you can create as many custom ones as you want.
 
 #### Built-in Profiles {#built-in-profiles}
 
@@ -298,6 +298,21 @@ Zed offers three built-in profiles and you can create as many custom ones as you
   Best for asking questions about your code base without the concern of the agent making changes.
 - `Minimal`: A profile with no tools.
   Best for general conversations with the LLM where no knowledge of your code base is necessary.
+- `Plan`: A read-only profile that researches the codebase and writes an implementation plan to `.zed/plans/<slug>.md`.
+  Source files are not modified. See [Plan Mode](#plan-mode) below.
+
+#### Plan Mode {#plan-mode}
+
+Plan Mode is designed for kicking off non-trivial work. The agent researches your codebase, asks clarifying questions when needed, and produces a Markdown plan with goals, file references, a TODO list, and a decisions log. You can edit the plan inline like any other file in the editor — it is the source of truth for the implementation that follows.
+
+The typical workflow is:
+
+1. Select the `Plan` profile (or press {#kb agent::CycleModeSelector} to cycle to it) and describe the feature.
+2. Answer any clarifying questions the agent asks, then review the plan it writes to `.zed/plans/<slug>.md`. Edit it directly if anything is off.
+3. Iterate by sending follow-up prompts — they update the same plan file.
+4. When you're happy with it, click the **Build** button next to the send button. The agent switches to the `Write` profile and executes the plan. The chevron next to Build lets you pick which model performs the build.
+
+Plans live in `.zed/plans/` in your first worktree. They are plain Markdown, so you can commit them to share design intent with reviewers, or gitignore the directory if you prefer to keep them local.
 
 You can explore the exact tools enabled in each profile by clicking on the profile selector button > `Configure` button > the one you want to check out.
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:
Adds Plan Mode to the agent. New built-in `Plan` profile alongside Write/Ask/Minimal. Read-only. agent researches the codebase and writes a markdown plan to `.zed/plans/<slug>.md` instead of touching source files.

System prompt enforces a fixed plan structure: Goal, Context, Architecture, Files Touched, TODO checklist, Open Questions, Decisions Log. Follow-up prompts iterate on the same file. User can hand-edit the markdown between turns.

New `write_plan_file` tool. Skips the normal edit authorization prompt and doesn't show up in the Reject/Keep edits review tray. It's the agent's own working file, not a user source file. Plan auto-opens in an editor tab when first written.

Build button in two places. Split-button next to Send in the agent panel footer, and a second one in the editor toolbar whenever a `.zed/plans/*.md` file is open. Left side builds with the active model. Chevron opens a model picker so you can build with a different one. Build switches the thread to Write mode and sends a canned "implement this plan" prompt.

Docs updated under `docs/src/ai/agent-panel.md`.

This mirrors the cursor functionality of the same name. Anecdotally I find the quality of code implementations increases when using plan mode in some situations as it forces a lot of the same behavior as reasoning mode / chain of thought. The additional plan artifact is useful for human-in-the-middle review, approval, and adjustment periods before work.

This serves as a basic proof of concept in that same space. Could be improved further with the addition of guided generation after the build step to produce TODO inline steps. Something I'd like to do.

AI was used in the composition of this feature but was reviewed and audited by human hands and brainmeats, as flawed as that goes.