### PR TITLE
scheduler: Add the ability to suppress `Running seed` output

### DIFF
--- a/crates/scheduler/src/test_scheduler.rs
+++ b/crates/scheduler/src/test_scheduler.rs
@@ -57,10 +57,12 @@ impl TestScheduler {
             .map(|seed| seed.parse().unwrap())
             .unwrap_or(0);
 
+        let interactive = !std::env::var("SCHEDULER_NONINTERACTIVE").is_ok();
+
         (seed..seed + num_iterations as u64)
             .map(|seed| {
                 let mut unwind_safe_f = AssertUnwindSafe(&mut f);
-                if !std::env::var("SCHEDULER_NONINTERACTIVE").is_ok() {
+                if interactive {
                     eprintln!("Running seed: {seed}");
                 }
                 match panic::catch_unwind(move || Self::with_seed(seed, &mut *unwind_safe_f)) {

--- a/crates/scheduler/src/test_scheduler.rs
+++ b/crates/scheduler/src/test_scheduler.rs
@@ -60,7 +60,9 @@ impl TestScheduler {
         (seed..seed + num_iterations as u64)
             .map(|seed| {
                 let mut unwind_safe_f = AssertUnwindSafe(&mut f);
-                eprintln!("Running seed: {seed}");
+                if !std::env::var("SCHEDULER_NONINTERACTIVE").is_ok() {
+                    eprintln!("Running seed: {seed}");
+                }
                 match panic::catch_unwind(move || Self::with_seed(seed, &mut *unwind_safe_f)) {
                     Ok(result) => result,
                     Err(error) => {


### PR DESCRIPTION
This is useful when running tests for a large number of iterations noninteractively

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A