### PR TITLE
client: Refresh cloud models on websocket reconnect

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -333,6 +333,9 @@ impl Status {
 struct ClientState {
     credentials: Option<Credentials>,
     status: (watch::Sender<Status>, watch::Receiver<Status>),
+    /// Bumped each time the cloud websocket finishes its handshake. Starts at `0` so
+    /// subscribers can distinguish "no connection yet" from a real reconnect.
+    cloud_connection_id: (watch::Sender<u64>, watch::Receiver<u64>),
     _reconnect_task: Option<Task<()>>,
     _cloud_connection_task: Option<Task<()>>,
 }
@@ -435,6 +438,7 @@ impl Default for ClientState {
         Self {
             credentials: None,
             status: watch::channel_with(Status::SignedOut),
+            cloud_connection_id: watch::channel_with(0),
             _reconnect_task: None,
             _cloud_connection_task: None,
         }
@@ -666,6 +670,14 @@ impl Client {
 
     pub fn status(&self) -> watch::Receiver<Status> {
         self.state.read().status.1.clone()
+    }
+
+    /// Watches successful cloud websocket reconnections.
+    ///
+    /// The value is bumped each time the websocket handshake completes. The
+    /// initial `0` means no reconnection yet.
+    pub fn cloud_connection_id(&self) -> watch::Receiver<u64> {
+        self.state.read().cloud_connection_id.1.clone()
     }
 
     fn set_status(self: &Arc<Self>, status: Status, cx: &AsyncApp) {
@@ -1005,6 +1017,12 @@ impl Client {
         let connection = connect_task.await?;
 
         let (mut messages, _cloud_io_task) = cx.update(|cx| connection.spawn(cx));
+
+        {
+            let mut state = self.state.write();
+            let mut cloud_connection_id = state.cloud_connection_id.0.borrow_mut();
+            *cloud_connection_id = cloud_connection_id.saturating_add(1);
+        }
 
         while let Some(message) = messages.next().await {
             if let Some(message) = message.log_err() {

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -14,16 +14,19 @@ use language_model::{
     ZED_CLOUD_PROVIDER_NAME,
 };
 use language_models_cloud::{CloudLlmTokenProvider, CloudModelProvider};
+use rand::{Rng as _, SeedableRng as _, rngs::StdRng};
 use release_channel::AppVersion;
 
 use settings::SettingsStore;
 pub use settings::ZedDotDevAvailableModel as AvailableModel;
 pub use settings::ZedDotDevAvailableProvider as AvailableProvider;
 use std::sync::Arc;
+use std::time::Duration;
 use ui::{TintColor, prelude::*};
 
 const PROVIDER_ID: LanguageModelProviderId = ZED_CLOUD_PROVIDER_ID;
 const PROVIDER_NAME: LanguageModelProviderName = ZED_CLOUD_PROVIDER_NAME;
+const MODELS_REFRESH_DEBOUNCE: Duration = Duration::from_secs(5 * 60);
 
 struct ClientTokenProvider {
     client: Arc<Client>,
@@ -84,10 +87,12 @@ pub struct State {
     user_store: Entity<UserStore>,
     status: client::Status,
     provider: Entity<CloudModelProvider<ClientTokenProvider>>,
+    pending_models_refresh: Option<Task<()>>,
     _user_store_subscription: Subscription,
     _settings_subscription: Subscription,
     _llm_token_subscription: Subscription,
     _provider_subscription: Subscription,
+    _cloud_reconnect_task: Task<()>,
 }
 
 impl State {
@@ -112,10 +117,32 @@ impl State {
             )
         });
 
+        let cloud_reconnect_task = cx.spawn({
+            let client = client.clone();
+            async move |this, cx| {
+                let mut connection_id_rx = client.cloud_connection_id();
+                while let Some(connection_id) = connection_id_rx.next().await {
+                    // The initial value `0` means no connection has been
+                    // established since this `Client` was created; only real
+                    // reconnects trigger a refresh.
+                    if connection_id == 0 {
+                        continue;
+                    }
+                    if this
+                        .update(cx, |this, cx| this.schedule_debounced_models_refresh(cx))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            }
+        });
+
         Self {
             client: client.clone(),
             user_store: user_store.clone(),
             status,
+            pending_models_refresh: None,
             _provider_subscription: cx.observe(&provider, |_, _, cx| cx.notify()),
             provider,
             _user_store_subscription: cx.subscribe(
@@ -141,6 +168,7 @@ impl State {
                     this.refresh_models(cx);
                 },
             ),
+            _cloud_reconnect_task: cloud_reconnect_task,
         }
     }
 
@@ -166,6 +194,24 @@ impl State {
         self.provider.update(cx, |provider, cx| {
             provider.refresh_models(cx).detach_and_log_err(cx);
         });
+    }
+
+    /// Schedules a model list refresh, replacing any previously scheduled
+    /// refresh.
+    fn schedule_debounced_models_refresh(&mut self, cx: &mut Context<Self>) {
+        self.pending_models_refresh = Some(cx.spawn(async move |this, cx| {
+            #[cfg(any(test, feature = "test-support"))]
+            let mut rng = StdRng::seed_from_u64(0);
+            #[cfg(not(any(test, feature = "test-support")))]
+            let mut rng = StdRng::from_os_rng();
+            let jitter = Duration::from_millis(
+                rng.random_range(0..MODELS_REFRESH_DEBOUNCE.as_millis() as u64),
+            );
+            cx.background_executor()
+                .timer(MODELS_REFRESH_DEBOUNCE + jitter)
+                .await;
+            this.update(cx, |this, cx| this.refresh_models(cx)).ok();
+        }));
     }
 }
 


### PR DESCRIPTION
Until now, the cloud-hosted model list was only refreshed in response to events that exercise the LLM token (a `UserUpdated` push, an organization change, or `PrivateUserInfoUpdated`). If a user wasn't actively using AI features around the time we shipped new models, the list could stay stale until they restarted Zed.

This is the second step toward fixing that, after #57078 made the cloud websocket reconnect on its own. We now treat each successful (re)connect as a hint that the server state may have changed, so possibly new model definitions will be available, and trigger a model list refresh.

The trigger is a new `Client::cloud_connection_id()` watch that bumps a counter each time the websocket handshake completes. `CloudLanguageModelProvider::State` subscribes to it and, on every tick after the initial `0`, schedules a debounced refresh (with jitter, so we don't have all active clients trying to reconnect at the same time after we deploy in cloud).

Closes CLO-713.

Release Notes:

- The list of Zed hosted models is now refreshed automatically, without requiring a restart