### PR TITLE
Threads sidebar UX improvements - reordering, renaming projects

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -7,6 +7,7 @@ mod ssh_config;
 
 use std::{
     path::{Path, PathBuf},
+    rc::Rc,
     sync::Arc,
 };
 
@@ -22,6 +23,7 @@ pub use remote_connection::{RemoteConnectionModal, connect};
 pub use remote_connections::{navigate_to_positions, open_remote_project};
 
 use disconnected_overlay::DisconnectedOverlay;
+use editor::Editor;
 use fuzzy_nucleo::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{
     Action, AnyElement, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
@@ -54,7 +56,12 @@ use zed_actions::{OpenDevContainer, OpenRecent, OpenRemote};
 
 actions!(
     recent_projects,
-    [ToggleActionsMenu, RemoveSelected, AddToWorkspace,]
+    [
+        ToggleActionsMenu,
+        RemoveSelected,
+        AddToWorkspace,
+        RenameSelected,
+    ]
 );
 
 #[derive(Clone, Debug)]
@@ -64,6 +71,130 @@ pub struct RecentProjectEntry {
     pub paths: Vec<PathBuf>,
     pub workspace_id: WorkspaceId,
     pub timestamp: DateTime<Utc>,
+}
+
+type ProjectRenamedCallback = Rc<dyn Fn(&ProjectGroupKey, &mut Window, &mut App)>;
+
+pub struct RenameProjectModal {
+    key: ProjectGroupKey,
+    editor: Entity<Editor>,
+    on_renamed: Option<ProjectRenamedCallback>,
+    is_saving: bool,
+}
+
+impl ModalView for RenameProjectModal {}
+
+impl EventEmitter<DismissEvent> for RenameProjectModal {}
+
+impl Focusable for RenameProjectModal {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.editor.focus_handle(cx)
+    }
+}
+
+impl RenameProjectModal {
+    pub fn new(
+        key: ProjectGroupKey,
+        current_name: SharedString,
+        on_renamed: Option<ProjectRenamedCallback>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            editor.set_placeholder_text("Use folder name", window, cx);
+            editor.set_text(current_name.to_string(), window, cx);
+            editor
+        });
+
+        Self {
+            key,
+            editor,
+            on_renamed,
+            is_saving: false,
+        }
+    }
+
+    fn cancel(&mut self, _: &menu::Cancel, _window: &mut Window, cx: &mut Context<Self>) {
+        cx.emit(DismissEvent);
+    }
+
+    fn confirm(&mut self, _: &menu::Confirm, window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_saving {
+            return;
+        }
+
+        let name = self.editor.read(cx).text(cx);
+        let name = name.trim();
+        let name = (!name.is_empty()).then(|| name.to_string());
+        let key = self.key.clone();
+        let save = workspace::set_project_name_for_key(&key, name, cx);
+        let on_renamed = self.on_renamed.clone();
+
+        self.is_saving = true;
+        cx.notify();
+
+        cx.spawn_in(window, async move |this, cx| {
+            save.await.log_err();
+            this.update_in(cx, move |this, window, cx| {
+                this.is_saving = false;
+                if let Some(on_renamed) = on_renamed {
+                    on_renamed(&key, window, cx);
+                }
+                cx.emit(DismissEvent);
+            })
+            .ok();
+        })
+        .detach();
+    }
+}
+
+impl Render for RenameProjectModal {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .key_context("RenameProjectModal")
+            .on_action(cx.listener(Self::cancel))
+            .on_action(cx.listener(Self::confirm))
+            .elevation_3(cx)
+            .w_96()
+            .overflow_hidden()
+            .child(
+                v_flex()
+                    .p_3()
+                    .gap_2()
+                    .border_b_1()
+                    .border_color(cx.theme().colors().border_variant)
+                    .child(Label::new("Rename Project"))
+                    .child(self.editor.clone()),
+            )
+            .child(
+                h_flex()
+                    .p_2()
+                    .gap_1()
+                    .justify_between()
+                    .child(
+                        Label::new("Leave blank to use the folder name.")
+                            .size(LabelSize::Small)
+                            .color(Color::Muted),
+                    )
+                    .child(
+                        h_flex()
+                            .gap_1()
+                            .child(Button::new("cancel", "Cancel").on_click(cx.listener(
+                                |this, _, window, cx| {
+                                    this.cancel(&menu::Cancel, window, cx);
+                                },
+                            )))
+                            .child(
+                                Button::new("save", "Save")
+                                    .disabled(self.is_saving)
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.confirm(&menu::Confirm, window, cx);
+                                    })),
+                            ),
+                    ),
+            )
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -251,6 +382,30 @@ fn get_open_folders(workspace: &Workspace, cx: &App) -> Vec<OpenFolderEntry> {
 
     entries.sort_by_key(|entry| entry.name.to_lowercase());
     entries
+}
+
+fn default_project_name(key: &ProjectGroupKey) -> SharedString {
+    let names = key
+        .path_list()
+        .ordered_paths()
+        .filter_map(|path| {
+            let display_path = if path.extension() == Some(std::ffi::OsStr::new("git")) {
+                std::borrow::Cow::Owned(path.with_extension(""))
+            } else {
+                std::borrow::Cow::Borrowed(path.as_path())
+            };
+            display_path
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .filter(|name| !name.is_empty())
+        .collect::<Vec<_>>();
+
+    if names.is_empty() {
+        "Empty Workspace".into()
+    } else {
+        names.join(", ").into()
+    }
 }
 
 fn get_branch_for_worktree(
@@ -812,6 +967,17 @@ impl RecentProjects {
             }
         });
     }
+
+    fn handle_rename_selected(
+        &mut self,
+        _: &RenameSelected,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.picker.update(cx, |picker, cx| {
+            picker.delegate.rename_selected_project(window, cx);
+        });
+    }
 }
 
 impl EventEmitter<DismissEvent> for RecentProjects {}
@@ -829,6 +995,7 @@ impl Render for RecentProjects {
             .on_action(cx.listener(Self::handle_toggle_open_menu))
             .on_action(cx.listener(Self::handle_remove_selected))
             .on_action(cx.listener(Self::handle_add_to_workspace))
+            .on_action(cx.listener(Self::handle_rename_selected))
             .w(rems(self.rem_width))
             .child(self.picker.clone())
     }
@@ -976,12 +1143,18 @@ impl PickerDelegate for RecentProjectsDelegate {
             .iter()
             .enumerate()
             .map(|(id, key)| {
-                let combined_string = key
-                    .path_list()
-                    .ordered_paths()
-                    .map(|path| path.compact().to_string_lossy().into_owned())
-                    .collect::<Vec<_>>()
-                    .join("");
+                let mut parts = Vec::new();
+                if let Some(name) = workspace::project_name_for_key(key, cx) {
+                    parts.push(name.to_string());
+                }
+                parts.push(
+                    key.path_list()
+                        .ordered_paths()
+                        .map(|path| path.compact().to_string_lossy().into_owned())
+                        .collect::<Vec<_>>()
+                        .join(""),
+                );
+                let combined_string = parts.join(" ");
                 StringMatchCandidate::new(id, &combined_string)
             })
             .collect();
@@ -999,15 +1172,25 @@ impl PickerDelegate for RecentProjectsDelegate {
             .workspaces
             .iter()
             .enumerate()
-            .filter(|(_, workspace)| self.is_valid_recent_candidate(workspace, cx))
-            .map(|(id, workspace)| {
-                let combined_string = workspace
-                    .identity_paths
-                    .ordered_paths()
-                    .map(|path| path.compact().to_string_lossy().into_owned())
-                    .collect::<Vec<_>>()
-                    .join("");
-                StringMatchCandidate::new(id, &combined_string)
+            .filter_map(|(id, workspace)| {
+                if !self.is_valid_recent_candidate(workspace, cx) {
+                    return None;
+                }
+                let key = workspace.project_group_key();
+                let mut parts = Vec::new();
+                if let Some(name) = workspace::project_name_for_key(&key, cx) {
+                    parts.push(name.to_string());
+                }
+                parts.push(
+                    workspace
+                        .identity_paths
+                        .ordered_paths()
+                        .map(|path| path.compact().to_string_lossy().into_owned())
+                        .collect::<Vec<_>>()
+                        .join(""),
+                );
+                let combined_string = parts.join(" ");
+                Some(StringMatchCandidate::new(id, &combined_string))
             })
             .collect();
 
@@ -1319,6 +1502,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                 let key = self.window_project_groups.get(hit.candidate_id)?;
                 let is_active = self.is_active_project_group(key, cx);
                 let paths = key.path_list();
+                let custom_name = workspace::project_name_for_key(key, cx);
                 let ordered_paths: Vec<_> = paths
                     .ordered_paths()
                     .map(|p| p.compact().to_string_lossy().to_string())
@@ -1327,7 +1511,38 @@ impl PickerDelegate for RecentProjectsDelegate {
                 let icon = icon_for_remote_connection(self.project_connection_options.as_ref());
 
                 let mut path_start_offset = 0;
-                let (match_labels, path_highlights): (Vec<_>, Vec<_>) = paths
+                let match_label = if let Some(custom_name) = custom_name.as_ref() {
+                    let name = custom_name.to_string();
+                    path_start_offset = name.len() + 1;
+                    let name_len = name.len();
+                    HighlightedMatch {
+                        text: name,
+                        highlight_positions: hit
+                            .positions
+                            .iter()
+                            .copied()
+                            .filter(|position| *position < name_len)
+                            .collect(),
+                        color: Color::Default,
+                    }
+                } else {
+                    let (match_labels, _): (Vec<_>, Vec<_>) = paths
+                        .ordered_paths()
+                        .map(|p| p.compact())
+                        .map(|path| {
+                            let highlighted_text = highlights_for_path(
+                                path.as_ref(),
+                                &hit.positions,
+                                path_start_offset,
+                            );
+                            path_start_offset += highlighted_text.1.text.len();
+                            highlighted_text
+                        })
+                        .unzip();
+                    path_start_offset = 0;
+                    HighlightedMatch::join(match_labels.into_iter().flatten(), ", ")
+                };
+                let (_, path_highlights): (Vec<_>, Vec<_>) = paths
                     .ordered_paths()
                     .map(|p| p.compact())
                     .map(|path| {
@@ -1340,7 +1555,7 @@ impl PickerDelegate for RecentProjectsDelegate {
 
                 let highlighted_match = HighlightedMatchWithPaths {
                     prefix: None,
-                    match_label: HighlightedMatch::join(match_labels.into_iter().flatten(), ", "),
+                    match_label,
                     paths: path_highlights,
                     active: is_active,
                 };
@@ -1435,6 +1650,8 @@ impl PickerDelegate for RecentProjectsDelegate {
                 let location = &workspace.location;
                 let raw_paths = &workspace.paths;
                 let identity_paths = &workspace.identity_paths;
+                let project_group_key = workspace.project_group_key();
+                let custom_name = workspace::project_name_for_key(&project_group_key, cx);
                 let is_local = matches!(location, SerializedWorkspaceLocation::Local);
                 let paths_to_add = raw_paths.paths().to_vec();
                 let ordered_paths: Vec<_> = identity_paths
@@ -1454,7 +1671,38 @@ impl PickerDelegate for RecentProjectsDelegate {
                 };
 
                 let mut path_start_offset = 0;
-                let (match_labels, paths): (Vec<_>, Vec<_>) = identity_paths
+                let match_label = if let Some(custom_name) = custom_name.as_ref() {
+                    let name = custom_name.to_string();
+                    path_start_offset = name.len() + 1;
+                    let name_len = name.len();
+                    HighlightedMatch {
+                        text: name,
+                        highlight_positions: hit
+                            .positions
+                            .iter()
+                            .copied()
+                            .filter(|position| *position < name_len)
+                            .collect(),
+                        color: Color::Default,
+                    }
+                } else {
+                    let (match_labels, _): (Vec<_>, Vec<_>) = identity_paths
+                        .ordered_paths()
+                        .map(|p| p.compact())
+                        .map(|path| {
+                            let highlighted_text = highlights_for_path(
+                                path.as_ref(),
+                                &hit.positions,
+                                path_start_offset,
+                            );
+                            path_start_offset += highlighted_text.1.text.len();
+                            highlighted_text
+                        })
+                        .unzip();
+                    path_start_offset = 0;
+                    HighlightedMatch::join(match_labels.into_iter().flatten(), ", ")
+                };
+                let (_, paths): (Vec<_>, Vec<_>) = identity_paths
                     .ordered_paths()
                     .map(|p| p.compact())
                     .map(|path| {
@@ -1480,7 +1728,7 @@ impl PickerDelegate for RecentProjectsDelegate {
 
                 let highlighted_match = HighlightedMatchWithPaths {
                     prefix,
-                    match_label: HighlightedMatch::join(match_labels.into_iter().flatten(), ", "),
+                    match_label,
                     paths,
                     active: false,
                 };
@@ -1837,6 +2085,13 @@ impl PickerDelegate for RecentProjectsDelegate {
                                     .unwrap_or(false),
                                 _ => false,
                             };
+                            let show_rename_project = matches!(
+                                selected_entry,
+                                Some(
+                                    ProjectPickerEntry::ProjectGroup(_)
+                                        | ProjectPickerEntry::RecentProject(_)
+                                )
+                            );
 
                             move |window, cx| {
                                 Some(ContextMenu::build(window, cx, {
@@ -1849,6 +2104,13 @@ impl PickerDelegate for RecentProjectsDelegate {
                                                 menu.action(
                                                     "Add Folder to this Project",
                                                     AddToWorkspace.boxed_clone(),
+                                                )
+                                                .separator()
+                                            })
+                                            .when(show_rename_project, |menu| {
+                                                menu.action(
+                                                    "Rename Project",
+                                                    RenameSelected.boxed_clone(),
                                                 )
                                                 .separator()
                                             })
@@ -2023,6 +2285,50 @@ fn open_local_project(
 }
 
 impl RecentProjectsDelegate {
+    fn selected_project_key(&self) -> Option<ProjectGroupKey> {
+        match self.filtered_entries.get(self.selected_index)? {
+            ProjectPickerEntry::ProjectGroup(hit) => {
+                self.window_project_groups.get(hit.candidate_id).cloned()
+            }
+            ProjectPickerEntry::RecentProject(hit) => self
+                .workspaces
+                .get(hit.candidate_id)
+                .map(RecentWorkspace::project_group_key),
+            _ => None,
+        }
+    }
+
+    fn rename_selected_project(&mut self, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        let Some(key) = self.selected_project_key() else {
+            return;
+        };
+        let current_name =
+            workspace::project_name_for_key(&key, cx).unwrap_or_else(|| default_project_name(&key));
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+        let picker = cx.entity().downgrade();
+
+        workspace.update(cx, |workspace, cx| {
+            workspace.toggle_modal(window, cx, |window, cx| {
+                RenameProjectModal::new(
+                    key,
+                    current_name,
+                    Some(Rc::new(move |_, window, cx| {
+                        if let Some(picker) = picker.upgrade() {
+                            picker.update(cx, |picker, cx| {
+                                let query = picker.query(cx);
+                                picker.update_matches(query, window, cx);
+                            });
+                        }
+                    })),
+                    window,
+                    cx,
+                )
+            });
+        });
+    }
+
     fn open_recent_projects(
         &mut self,
         candidate_id: usize,

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -2812,6 +2812,76 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn renamed_project_group_is_searchable_in_picker(cx: &mut TestAppContext) {
+        let (picker, cx) = build_picker(cx);
+        let key = project_group(0);
+
+        let save_name = cx.update(|_, cx| {
+            workspace::set_project_name_for_key(&key, Some("Customer API".to_string()), cx)
+        });
+        save_name.await.expect("custom project name should save");
+
+        picker
+            .update_in(cx, |picker, window, cx| {
+                picker
+                    .delegate
+                    .update_matches("Customer".to_string(), window, cx)
+            })
+            .await;
+
+        picker.update(cx, |picker, _| {
+            assert!(matches!(
+                picker.delegate.filtered_entries.as_slice(),
+                [
+                    ProjectPickerEntry::Header(title),
+                    ProjectPickerEntry::ProjectGroup(hit),
+                ] if title.as_ref() == "This Window" && hit.candidate_id == 0
+            ));
+        });
+
+        let save_name = cx.update(|_, cx| {
+            workspace::set_project_name_for_key(&key, Some("Billing API".to_string()), cx)
+        });
+        save_name.await.expect("renamed project name should save");
+
+        picker
+            .update_in(cx, |picker, window, cx| {
+                picker
+                    .delegate
+                    .update_matches("Customer".to_string(), window, cx)
+            })
+            .await;
+
+        picker.update(cx, |picker, _| {
+            assert!(
+                picker.delegate.filtered_entries.is_empty(),
+                "old project name should not match after rename"
+            );
+        });
+
+        picker
+            .update_in(cx, |picker, window, cx| {
+                picker
+                    .delegate
+                    .update_matches("Billing".to_string(), window, cx)
+            })
+            .await;
+
+        picker.update(cx, |picker, _| {
+            assert!(matches!(
+                picker.delegate.filtered_entries.as_slice(),
+                [
+                    ProjectPickerEntry::Header(title),
+                    ProjectPickerEntry::ProjectGroup(hit),
+                ] if title.as_ref() == "This Window" && hit.candidate_id == 0
+            ));
+        });
+
+        let clear_name = cx.update(|_, cx| workspace::set_project_name_for_key(&key, None, cx));
+        clear_name.await.expect("custom project name should clear");
+    }
+
+    #[gpui::test]
     fn deleting_top_recent_project_preserves_scroll_position(cx: &mut TestAppContext) {
         let target = FIRST_RECENT_PROJECT;
         let (picker, cx) = build_picker(cx);

--- a/crates/remote/src/remote_identity.rs
+++ b/crates/remote/src/remote_identity.rs
@@ -6,7 +6,7 @@ use crate::RemoteConnectionOptions;
 /// This mirrors workspace persistence identity semantics rather than full
 /// `RemoteConnectionOptions` equality, so runtime-only fields like SSH
 /// nicknames or Docker environment overrides do not affect matching.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
 pub enum RemoteConnectionIdentity {
     Ssh {
         host: String,

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1447,7 +1447,7 @@ impl Sidebar {
                 continue;
             }
 
-            let label = group_key.display_name(&path_detail_map);
+            let label = workspace::project_display_name(group_key, &path_detail_map, cx);
 
             let is_collapsed = self.is_group_collapsed(group_key, cx);
             let should_load_threads = !is_collapsed || !query.is_empty();
@@ -2200,18 +2200,32 @@ impl Sidebar {
                     .child(
                         div()
                             .id(format!("{id_prefix}project-header-disclosure-{ix}"))
+                            .flex_1()
+                            .min_w(px(24.))
                             .when(!is_focused, |this| this.visible_on_hover(&group_name))
                             .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| {
                                 cx.stop_propagation();
                             })
-                            .on_click(cx.listener(move |this, _, window, cx| {
-                                cx.stop_propagation();
-                                this.toggle_collapse(&key_for_disclosure, window, cx);
-                            }))
                             .child(
-                                Icon::new(disclosure_icon)
-                                    .size(IconSize::Small)
-                                    .color(Color::Muted),
+                                IconButton::new(
+                                    format!("{id_prefix}project-header-disclosure-button-{ix}"),
+                                    disclosure_icon,
+                                )
+                                .full_width()
+                                .icon_size(IconSize::Small)
+                                .icon_color(Color::Muted)
+                                .selected_style(ButtonStyle::Tinted(TintColor::Accent))
+                                .tooltip(Tooltip::text(if is_collapsed {
+                                    "Expand Project"
+                                } else {
+                                    "Collapse Project"
+                                }))
+                                .on_click(cx.listener(
+                                    move |this, _, window, cx| {
+                                        cx.stop_propagation();
+                                        this.toggle_collapse(&key_for_disclosure, window, cx);
+                                    },
+                                )),
                             ),
                     ),
             )
@@ -2262,6 +2276,7 @@ impl Sidebar {
                         ix,
                         id_prefix,
                         key,
+                        &label_text,
                         is_active,
                         has_threads,
                         &group_name,
@@ -2350,6 +2365,7 @@ impl Sidebar {
         ix: usize,
         id_prefix: &str,
         project_group_key: &ProjectGroupKey,
+        project_label: &SharedString,
         is_active: bool,
         has_threads: bool,
         group_name: &SharedString,
@@ -2357,6 +2373,7 @@ impl Sidebar {
     ) -> AnyElement {
         let multi_workspace = self.multi_workspace.clone();
         let project_group_key = project_group_key.clone();
+        let project_label = project_label.clone();
 
         let show_multi_project_entries = multi_workspace
             .read_with(cx, |mw, _| {
@@ -2432,10 +2449,51 @@ impl Sidebar {
                     .map(|workspace| active_workspace.as_ref() == Some(workspace))
                     .collect();
 
+                let project_label_for_menu = project_label.clone();
                 let menu =
                     ContextMenu::build_persistent(window, cx, move |menu, _window, menu_cx| {
                         let menu = menu.end_slot_action(Box::new(menu::SecondaryConfirm));
                         let weak_menu = menu_cx.weak_entity();
+
+                        let rename_key = project_group_key.clone();
+                        let rename_label = project_label_for_menu.clone();
+                        let rename_multi_workspace = multi_workspace.clone();
+                        let rename_weak_menu = weak_menu.clone();
+                        let rename_sidebar = this_for_menu.clone();
+                        let menu = menu.entry("Rename Project", None, move |window, cx| {
+                            let rename_key = rename_key.clone();
+                            let rename_label = rename_label.clone();
+                            let rename_sidebar = rename_sidebar.clone();
+                            rename_multi_workspace
+                                .update(cx, |multi_workspace, cx| {
+                                    multi_workspace.toggle_modal(window, cx, {
+                                        let rename_key = rename_key.clone();
+                                        let rename_label = rename_label.clone();
+                                        move |window, cx| {
+                                            recent_projects::RenameProjectModal::new(
+                                                rename_key.clone(),
+                                                rename_label.clone(),
+                                                Some(Rc::new({
+                                                    let rename_sidebar = rename_sidebar.clone();
+                                                    move |_, _, cx| {
+                                                        rename_sidebar
+                                                            .update(cx, |sidebar, cx| {
+                                                                sidebar.update_entries(cx);
+                                                            })
+                                                            .ok();
+                                                    }
+                                                })),
+                                                window,
+                                                cx,
+                                            )
+                                        }
+                                    });
+                                })
+                                .ok();
+                            rename_weak_menu
+                                .update(cx, |_, cx| cx.emit(DismissEvent))
+                                .ok();
+                        });
 
                         let menu = menu.when(show_multi_project_entries, |this| {
                             this.entry(

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -27,9 +27,10 @@ use feature_flags::{
     AgentThreadWorktreeLabel, AgentThreadWorktreeLabelFlag, FeatureFlag, FeatureFlagAppExt as _,
 };
 use gpui::{
-    Action as _, AnyElement, App, ClickEvent, Context, DismissEvent, Entity, EntityId, FocusHandle,
-    Focusable, KeyContext, ListState, Modifiers, Pixels, Render, SharedString, Task, TaskExt,
-    WeakEntity, Window, WindowHandle, linear_color_stop, linear_gradient, list, prelude::*, px,
+    Action as _, AnyElement, App, ClickEvent, Context, DismissEvent, DragMoveEvent, Entity,
+    EntityId, FocusHandle, Focusable, KeyContext, ListState, Modifiers, Pixels, Render,
+    SharedString, Task, TaskExt, WeakEntity, Window, WindowHandle, linear_color_stop,
+    linear_gradient, list, prelude::*, px,
 };
 use itertools::Itertools;
 use menu::{
@@ -49,8 +50,9 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
 use theme::ActiveTheme;
+use theme_settings::ThemeSettings;
 use ui::{
-    AgentThreadStatus, CommonAnimationExt, ContextMenu, ContextMenuEntry, Divider, GradientFade,
+    AgentThreadStatus, CommonAnimationExt, ContextMenu, ContextMenuEntry, Divider,
     HighlightedLabel, KeyBinding, PopoverMenu, PopoverMenuHandle, ProjectEmptyState, ScrollAxes,
     Scrollbars, Tab, ThreadItem, ThreadItemWorktreeInfo, TintColor, Tooltip, WithScrollbar,
     prelude::*, render_modifiers,
@@ -309,6 +311,55 @@ enum ListEntry {
     },
     Thread(ThreadEntry),
     Terminal(TerminalEntry),
+}
+
+#[derive(Clone)]
+struct DraggedProjectGroup {
+    key: ProjectGroupKey,
+    label: SharedString,
+}
+
+struct DraggedProjectGroupView {
+    label: SharedString,
+    click_offset: gpui::Point<Pixels>,
+}
+
+impl Render for DraggedProjectGroupView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let ui_font = ThemeSettings::get_global(cx).ui_font.clone();
+        h_flex()
+            .font(ui_font)
+            .pl(self.click_offset.x + px(12.))
+            .pt(self.click_offset.y + px(12.))
+            .child(
+                h_flex()
+                    .gap_1()
+                    .items_center()
+                    .py_1()
+                    .px_2()
+                    .rounded_lg()
+                    .bg(cx.theme().colors().background)
+                    .child(
+                        Icon::new(IconName::Folder)
+                            .size(IconSize::Small)
+                            .color(Color::Muted),
+                    )
+                    .child(Label::new(self.label.clone()).truncate()),
+            )
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProjectGroupDropPlacement {
+    Before,
+    After,
+}
+
+#[derive(Clone)]
+struct ProjectGroupDropTarget {
+    dragged_key: ProjectGroupKey,
+    target_key: ProjectGroupKey,
+    placement: ProjectGroupDropPlacement,
 }
 
 #[derive(Clone)]
@@ -664,6 +715,7 @@ pub struct Sidebar {
     recent_projects_popover_handle: PopoverMenuHandle<SidebarRecentProjects>,
     project_header_menu_handles: HashMap<usize, PopoverMenuHandle<ContextMenu>>,
     project_header_menu_ix: Option<usize>,
+    project_group_drop_target: Option<ProjectGroupDropTarget>,
     _subscriptions: Vec<gpui::Subscription>,
     _draft_editor_observations: Vec<gpui::Subscription>,
     /// For the thread import banners, if there is just one we show "Import
@@ -773,6 +825,7 @@ impl Sidebar {
             recent_projects_popover_handle: PopoverMenuHandle::default(),
             project_header_menu_handles: HashMap::new(),
             project_header_menu_ix: None,
+            project_group_drop_target: None,
             _subscriptions: Vec::new(),
             _draft_editor_observations: Vec::new(),
             import_banners_use_verbose_labels: None,
@@ -2037,12 +2090,13 @@ impl Sidebar {
         let key_for_disclosure = key.clone();
         let key_for_focus = key.clone();
 
+        let label_text = label.clone();
         let label = if highlight_positions.is_empty() {
-            Label::new(label.clone())
+            Label::new(label_text.clone())
                 .when(!is_active, |this| this.color(Color::Muted))
                 .into_any_element()
         } else {
-            HighlightedLabel::new(label.clone(), highlight_positions.to_vec())
+            HighlightedLabel::new(label_text.clone(), highlight_positions.to_vec())
                 .when(!is_active, |this| this.color(Color::Muted))
                 .into_any_element()
         };
@@ -2059,14 +2113,11 @@ impl Sidebar {
             .blend(color.element_background.opacity(0.2));
         let hover_solid = base_bg.blend(hover_base);
 
-        let group_name_for_gradient = group_name.clone();
-        let gradient_overlay = move || {
-            GradientFade::new(base_bg, hover_solid, hover_solid)
-                .width(px(64.0))
-                .right(px(-2.0))
-                .gradient_stop(0.75)
-                .group_name(group_name_for_gradient.clone())
-        };
+        let drop_placement = self
+            .project_group_drop_target
+            .as_ref()
+            .filter(|target| target.target_key == *key)
+            .map(|target| target.placement);
 
         let header = h_flex()
             .id(id)
@@ -2084,6 +2135,15 @@ impl Sidebar {
                     this.border_color(color.border_focused)
                 } else {
                     this.border_color(gpui::transparent_black())
+                }
+            })
+            .when_some(drop_placement, |this, placement| {
+                let this = this
+                    .border_color(color.drop_target_border)
+                    .bg(color.drop_target_background);
+                match placement {
+                    ProjectGroupDropPlacement::Before => this.border_t_2(),
+                    ProjectGroupDropPlacement::After => this.border_b_2(),
                 }
             })
             .hover(|s| s.bg(hover_solid))
@@ -2155,10 +2215,8 @@ impl Sidebar {
                             ),
                     ),
             )
-            .child(gradient_overlay())
             .child(
                 h_flex()
-                    .child(gradient_overlay())
                     .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| {
                         cx.stop_propagation();
                     })
@@ -2225,7 +2283,42 @@ impl Sidebar {
                 cx.listener(move |this, _event: &gpui::ClickEvent, window, cx| {
                     this.activate_or_open_workspace_for_group(&key_for_focus, window, cx);
                 }),
-            );
+            )
+            .when(!is_sticky, |this| {
+                let dragged_project_group = DraggedProjectGroup {
+                    key: key.clone(),
+                    label: label_text.clone(),
+                };
+                let target_key_for_move = key.clone();
+                let target_key_for_drop = key.clone();
+
+                this.on_drag(
+                    dragged_project_group,
+                    |dragged, click_offset, _window, cx| {
+                        cx.new(|_| DraggedProjectGroupView {
+                            label: dragged.label.clone(),
+                            click_offset,
+                        })
+                    },
+                )
+                .on_drag_move::<DraggedProjectGroup>(cx.listener(
+                    move |this, event: &DragMoveEvent<DraggedProjectGroup>, _window, cx| {
+                        let dragged = event.drag(cx).clone();
+                        this.update_project_group_drop_target(
+                            &dragged,
+                            &target_key_for_move,
+                            event,
+                            cx,
+                        );
+                    },
+                ))
+                .on_drop(cx.listener(
+                    move |this, dragged: &DraggedProjectGroup, _window, cx| {
+                        this.drop_project_group(dragged, &target_key_for_drop, cx);
+                        cx.stop_propagation();
+                    },
+                ))
+            });
 
         if !is_collapsed && !has_threads {
             v_flex()
@@ -2726,6 +2819,108 @@ impl Sidebar {
     ) {
         let is_collapsed = self.is_group_collapsed(project_group_key, cx);
         self.set_group_expanded(project_group_key, is_collapsed, cx);
+        self.update_entries(cx);
+    }
+
+    fn update_project_group_drop_target(
+        &mut self,
+        dragged: &DraggedProjectGroup,
+        target_key: &ProjectGroupKey,
+        event: &DragMoveEvent<DraggedProjectGroup>,
+        cx: &mut Context<Self>,
+    ) {
+        if dragged.key == *target_key || !event.bounds.contains(&event.event.position) {
+            if self
+                .project_group_drop_target
+                .as_ref()
+                .is_some_and(|target| target.target_key == *target_key)
+            {
+                self.project_group_drop_target = None;
+                cx.notify();
+            }
+            return;
+        }
+
+        let midpoint_y = event.bounds.origin.y + event.bounds.size.height / 2.0;
+        let placement = if event.event.position.y < midpoint_y {
+            ProjectGroupDropPlacement::Before
+        } else {
+            ProjectGroupDropPlacement::After
+        };
+
+        let is_unchanged = self
+            .project_group_drop_target
+            .as_ref()
+            .is_some_and(|target| {
+                target.dragged_key == dragged.key
+                    && target.target_key == *target_key
+                    && target.placement == placement
+            });
+        if is_unchanged {
+            return;
+        }
+
+        self.project_group_drop_target = Some(ProjectGroupDropTarget {
+            dragged_key: dragged.key.clone(),
+            target_key: target_key.clone(),
+            placement,
+        });
+        cx.notify();
+    }
+
+    fn drop_project_group(
+        &mut self,
+        dragged: &DraggedProjectGroup,
+        target_key: &ProjectGroupKey,
+        cx: &mut Context<Self>,
+    ) {
+        let drop_target = self.project_group_drop_target.take();
+        let placement = drop_target
+            .as_ref()
+            .filter(|target| target.dragged_key == dragged.key && target.target_key == *target_key)
+            .map_or(ProjectGroupDropPlacement::Before, |target| target.placement);
+
+        let Some(multi_workspace) = self.multi_workspace.upgrade() else {
+            cx.notify();
+            return;
+        };
+
+        multi_workspace.update(cx, |multi_workspace, cx| {
+            let keys = multi_workspace.project_group_keys();
+            let Some(source_index) = keys.iter().position(|key| key == &dragged.key) else {
+                return;
+            };
+            let Some(target_index) = keys.iter().position(|key| key == target_key) else {
+                return;
+            };
+            if source_index == target_index {
+                return;
+            }
+
+            let target_index_after_removal = match placement {
+                ProjectGroupDropPlacement::Before => {
+                    if source_index < target_index {
+                        target_index.saturating_sub(1)
+                    } else {
+                        target_index
+                    }
+                }
+                ProjectGroupDropPlacement::After => {
+                    if source_index < target_index {
+                        target_index
+                    } else {
+                        target_index + 1
+                    }
+                }
+            };
+
+            multi_workspace.move_project_group_to_index(
+                &dragged.key,
+                target_index_after_removal,
+                cx,
+            );
+        });
+
         self.update_entries(cx);
     }
 

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -2034,7 +2034,7 @@ impl Sidebar {
             IconName::ChevronDown
         };
 
-        let key_for_toggle = key.clone();
+        let key_for_disclosure = key.clone();
         let key_for_focus = key.clone();
 
         let label = if highlight_positions.is_empty() {
@@ -2139,7 +2139,15 @@ impl Sidebar {
                     })
                     .child(
                         div()
+                            .id(format!("{id_prefix}project-header-disclosure-{ix}"))
                             .when(!is_focused, |this| this.visible_on_hover(&group_name))
+                            .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| {
+                                cx.stop_propagation();
+                            })
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                cx.stop_propagation();
+                                this.toggle_collapse(&key_for_disclosure, window, cx);
+                            }))
                             .child(
                                 Icon::new(disclosure_icon)
                                     .size(IconSize::Small)
@@ -2214,12 +2222,8 @@ impl Sidebar {
                 }
             })
             .on_click(
-                cx.listener(move |this, event: &gpui::ClickEvent, window, cx| {
-                    if event.modifiers().secondary() {
-                        this.activate_or_open_workspace_for_group(&key_for_focus, window, cx);
-                    } else {
-                        this.toggle_collapse(&key_for_toggle, window, cx);
-                    }
+                cx.listener(move |this, _event: &gpui::ClickEvent, window, cx| {
+                    this.activate_or_open_workspace_for_group(&key_for_focus, window, cx);
                 }),
             );
 
@@ -2902,7 +2906,7 @@ impl Sidebar {
         match entry {
             ListEntry::ProjectHeader { key, .. } => {
                 let key = key.clone();
-                self.toggle_collapse(&key, window, cx);
+                self.activate_or_open_workspace_for_group(&key, window, cx);
             }
             ListEntry::Thread(thread) => {
                 let metadata = thread.metadata.clone();

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -1346,6 +1346,34 @@ async fn test_project_header_drop_reorders_project_groups(cx: &mut TestAppContex
 }
 
 #[gpui::test]
+async fn test_project_header_uses_custom_project_name(cx: &mut TestAppContext) {
+    let project = init_test_project("/custom-name-project", cx).await;
+    let project_group_key = project.read_with(cx, |project, cx| project.project_group_key(cx));
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    let save_name = cx.update(|_, cx| {
+        workspace::set_project_name_for_key(
+            &project_group_key,
+            Some("Customer API".to_string()),
+            cx,
+        )
+    });
+    save_name.await.expect("custom project name should save");
+
+    sidebar.update_in(cx, |sidebar, _window, cx| {
+        sidebar.update_entries(cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec!["v [Customer API]"]
+    );
+}
+
+#[gpui::test]
 async fn test_keyboard_expand_and_collapse_selected_entry(cx: &mut TestAppContext) {
     let project = init_test_project("/my-project", cx).await;
     let (multi_workspace, cx) =

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -1303,6 +1303,49 @@ async fn test_keyboard_confirm_on_project_header_activates_project(cx: &mut Test
 }
 
 #[gpui::test]
+async fn test_project_header_drop_reorders_project_groups(cx: &mut TestAppContext) {
+    let (fs, project_a) =
+        init_multi_project_test(&["/project-a", "/project-b", "/project-c"], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project_a, window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    add_test_project("/project-b", &fs, &multi_workspace, cx).await;
+    add_test_project("/project-c", &fs, &multi_workspace, cx).await;
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec!["v [project-c]", "v [project-b]", "v [project-a]",]
+    );
+
+    let keys = multi_workspace.read_with(cx, |multi_workspace, _cx| {
+        multi_workspace.project_group_keys()
+    });
+    let project_c_key = keys[0].clone();
+    let project_a_key = keys[2].clone();
+
+    sidebar.update_in(cx, |sidebar, _window, cx| {
+        let dragged = DraggedProjectGroup {
+            key: project_a_key.clone(),
+            label: "project-a".into(),
+        };
+        sidebar.project_group_drop_target = Some(ProjectGroupDropTarget {
+            dragged_key: project_a_key.clone(),
+            target_key: project_c_key.clone(),
+            placement: ProjectGroupDropPlacement::Before,
+        });
+        sidebar.drop_project_group(&dragged, &project_c_key, cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec!["v [project-a]", "v [project-c]", "v [project-b]",]
+    );
+}
+
+#[gpui::test]
 async fn test_keyboard_expand_and_collapse_selected_entry(cx: &mut TestAppContext) {
     let project = init_test_project("/my-project", cx).await;
     let (multi_workspace, cx) =

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -1249,54 +1249,56 @@ async fn test_keyboard_focus_in_does_not_set_selection(cx: &mut TestAppContext) 
 }
 
 #[gpui::test]
-async fn test_keyboard_confirm_on_project_header_toggles_collapse(cx: &mut TestAppContext) {
-    let project = init_test_project("/my-project", cx).await;
+async fn test_keyboard_confirm_on_project_header_activates_project(cx: &mut TestAppContext) {
+    let (fs, project) = init_multi_project_test(&["/project-a", "/project-b"], cx).await;
     let (multi_workspace, cx) =
         cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
     let sidebar = setup_sidebar(&multi_workspace, cx);
 
     save_n_test_threads(1, &project, cx).await;
+    let workspace_a = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+    let workspace_b = add_test_project("/project-b", &fs, &multi_workspace, cx).await;
+    multi_workspace.update_in(cx, |mw, window, cx| {
+        mw.activate(workspace_b.clone(), None, window, cx);
+    });
     multi_workspace.update_in(cx, |_, _window, cx| cx.notify());
     cx.run_until_parked();
 
     assert_eq!(
+        multi_workspace.read_with(cx, |mw, _| mw.workspace().clone()),
+        workspace_b
+    );
+    assert_eq!(
         visible_entries_as_strings(&sidebar, cx),
-        vec![
-            //
-            "v [my-project]",
-            "  Thread 1",
-        ]
+        vec!["v [project-b]", "v [project-a]", "  Thread 1",]
     );
 
-    // Focus the sidebar and select the header
-    focus_sidebar(&sidebar, cx);
-    sidebar.update_in(cx, |sidebar, _window, _cx| {
-        sidebar.selection = Some(0);
+    let project_a_header_index = sidebar.read_with(cx, |sidebar, _cx| {
+        sidebar
+            .contents
+            .entries
+            .iter()
+            .position(|entry| {
+                matches!(entry, ListEntry::ProjectHeader { label, .. } if label.as_ref() == "project-a")
+            })
+            .expect("project-a header should exist")
     });
 
-    // Confirm on project header collapses the group
+    focus_sidebar(&sidebar, cx);
+    sidebar.update_in(cx, |sidebar, _window, _cx| {
+        sidebar.selection = Some(project_a_header_index);
+    });
+
     cx.dispatch_action(Confirm);
     cx.run_until_parked();
 
     assert_eq!(
-        visible_entries_as_strings(&sidebar, cx),
-        vec![
-            //
-            "> [my-project]  <== selected",
-        ]
+        multi_workspace.read_with(cx, |mw, _| mw.workspace().clone()),
+        workspace_a
     );
-
-    // Confirm again expands the group
-    cx.dispatch_action(Confirm);
-    cx.run_until_parked();
-
     assert_eq!(
         visible_entries_as_strings(&sidebar, cx),
-        vec![
-            //
-            "v [my-project]  <== selected",
-            "  Thread 1",
-        ]
+        vec!["v [project-b]", "v [project-a]", "  Thread 1",]
     );
 }
 
@@ -14151,12 +14153,12 @@ async fn test_collab_guest_move_thread_paths_is_noop(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_cmd_click_project_header_returns_to_last_active_linked_worktree_workspace(
+async fn test_project_header_activation_returns_to_last_active_linked_worktree_workspace(
     cx: &mut TestAppContext,
 ) {
-    // Regression test for: cmd-clicking a project group header should return
-    // the user to the workspace they most recently had active in that group,
-    // including workspaces rooted at a linked worktree.
+    // Activating a project group header should return the user to the
+    // workspace they most recently had active in that group, including
+    // workspaces rooted at a linked worktree.
     init_test(cx);
     let fs = FakeFs::new(cx.executor());
 
@@ -14251,8 +14253,8 @@ async fn test_cmd_click_project_header_returns_to_last_active_linked_worktree_wo
         "group B's workspace should be active after step 2"
     );
 
-    // Step 3: simulate cmd-click on group A's header. The project group key
-    // for group A is derived from the *main-paths* workspace (linked-worktree
+    // Step 3: simulate activating group A's header. The project group key for
+    // group A is derived from the *main-paths* workspace (linked-worktree
     // workspaces share the same key because it normalizes to main-worktree
     // paths).
     let group_a_key = main_workspace_a.read_with(cx, |ws, cx| ws.project_group_key(cx));
@@ -14263,15 +14265,16 @@ async fn test_cmd_click_project_header_returns_to_last_active_linked_worktree_wo
 
     // Expected: we're back in the linked-worktree workspace, not the
     // main-paths one.
-    let active_after_cmd_click = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+    let active_after_header_activation =
+        multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
     assert_eq!(
-        active_after_cmd_click, worktree_workspace_a,
-        "cmd-click on group A's header should return to the last-active \
+        active_after_header_activation, worktree_workspace_a,
+        "activating group A's header should return to the last-active \
          linked-worktree workspace, not the main-paths workspace"
     );
     assert_ne!(
-        active_after_cmd_click, main_workspace_a,
-        "cmd-click must not fall back to the main-paths workspace when a \
+        active_after_header_activation, main_workspace_a,
+        "header activation must not fall back to the main-paths workspace when a \
          linked-worktree workspace was the last-active one for the group"
     );
 }

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -237,6 +237,12 @@ impl Render for TitleBar {
                 }
             }
         }
+        if let Some(workspace) = self.workspace.upgrade() {
+            let key = workspace.read(cx).project_group_key(cx);
+            if let Some(name) = workspace::project_name_for_key(&key, cx) {
+                project_name = Some(name);
+            }
+        }
 
         children.push(
             h_flex()

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -892,6 +892,34 @@ impl MultiWorkspace {
         true
     }
 
+    pub fn move_project_group_to_index(
+        &mut self,
+        key: &ProjectGroupKey,
+        target_index: usize,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(index) = self
+            .project_groups
+            .iter()
+            .position(|group| group.key == *key)
+        else {
+            return false;
+        };
+
+        let group = self.project_groups.remove(index);
+        let target_index = target_index.min(self.project_groups.len());
+        if index == target_index {
+            self.project_groups.insert(index, group);
+            return false;
+        }
+
+        self.project_groups.insert(target_index, group);
+        cx.emit(MultiWorkspaceEvent::ProjectGroupsChanged);
+        self.serialize(cx);
+        cx.notify();
+        true
+    }
+
     pub fn workspaces_for_project_group(
         &self,
         key: &ProjectGroupKey,

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -19,7 +19,7 @@ use db::{
     sqlez::{connection::Connection, domain::Domain},
     sqlez_macros::sql,
 };
-use gpui::{Axis, Bounds, Task, WindowBounds, WindowId, point, size};
+use gpui::{AppContext as _, Axis, Bounds, Task, WindowBounds, WindowId, point, size};
 use project::{
     ProjectGroupKey,
     bookmark_store::SerializedBookmark,
@@ -184,6 +184,62 @@ impl Column for SerializedWindowBounds {
 }
 
 const DEFAULT_WINDOW_BOUNDS_KEY: &str = "default_window_bounds";
+const PROJECT_NAMES_NAMESPACE: &str = "project_names";
+
+#[derive(Serialize)]
+struct SerializedProjectNameKey {
+    path_list: SerializedPathList,
+    host: Option<RemoteConnectionIdentity>,
+}
+
+fn project_name_key(project_group_key: &ProjectGroupKey) -> Result<String> {
+    serde_json::to_string(&SerializedProjectNameKey {
+        path_list: project_group_key.path_list().serialize(),
+        host: project_group_key
+            .host()
+            .as_ref()
+            .map(remote_connection_identity),
+    })
+    .context("serializing project name key")
+}
+
+pub fn project_name_for_key(project_group_key: &ProjectGroupKey, cx: &App) -> Option<SharedString> {
+    let key = project_name_key(project_group_key).log_err()?;
+    KeyValueStore::global(cx)
+        .scoped(PROJECT_NAMES_NAMESPACE)
+        .read(&key)
+        .log_err()
+        .flatten()
+        .map(SharedString::from)
+}
+
+pub fn project_display_name(
+    project_group_key: &ProjectGroupKey,
+    path_detail_map: &std::collections::HashMap<PathBuf, usize>,
+    cx: &App,
+) -> SharedString {
+    project_name_for_key(project_group_key, cx)
+        .unwrap_or_else(|| project_group_key.display_name(path_detail_map))
+}
+
+pub fn set_project_name_for_key(
+    project_group_key: &ProjectGroupKey,
+    name: Option<String>,
+    cx: &mut App,
+) -> Task<Result<()>> {
+    let key = match project_name_key(project_group_key) {
+        Ok(key) => key,
+        Err(error) => return Task::ready(Err(error)),
+    };
+    let store = KeyValueStore::global(cx);
+    cx.background_spawn(async move {
+        let names = store.scoped(PROJECT_NAMES_NAMESPACE);
+        match name {
+            Some(name) => names.write(key, name).await,
+            None => names.delete(key).await,
+        }
+    })
+}
 
 pub fn read_default_window_bounds(kvp: &KeyValueStore) -> Option<(Uuid, WindowBounds)> {
     let json_str = kvp

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -91,7 +91,8 @@ pub use persistence::{
         DockData, DockStructure, ItemId, MultiWorkspaceState, SerializedMultiWorkspace,
         SerializedProjectGroup, SerializedWorkspaceLocation, SessionWorkspace,
     },
-    read_serialized_multi_workspaces,
+    project_display_name, project_name_for_key, read_serialized_multi_workspaces,
+    set_project_name_for_key,
 };
 use persistence::{SerializedWindowBounds, model::SerializedWorkspace};
 use postage::stream::Stream;
@@ -262,6 +263,8 @@ actions!(
         ActivatePreviousWindow,
         /// Adds a folder to the current project.
         AddFolderToProject,
+        /// Rebuilds the current project by rescanning its worktrees.
+        RebuildProject,
         /// Clears all bookmarks in the project.
         ClearBookmarks,
         /// Clears all notifications.
@@ -7377,6 +7380,25 @@ impl Workspace {
                     workspace.toggle_dock(DockPosition::Bottom, window, cx);
                 },
             ))
+            .on_action(
+                cx.listener(|workspace: &mut Workspace, _: &RebuildProject, _, cx| {
+                    let refreshes = workspace
+                        .visible_worktrees(cx)
+                        .filter_map(|worktree| {
+                            worktree.read(cx).as_local().map(|worktree| {
+                                worktree.refresh_entries_for_paths(vec![RelPath::empty().into()])
+                            })
+                        })
+                        .collect::<Vec<_>>();
+
+                    cx.spawn(async move |_, _| {
+                        for mut refresh in refreshes {
+                            refresh.next().await;
+                        }
+                    })
+                    .detach();
+                }),
+            )
             .on_action(cx.listener(
                 |workspace: &mut Workspace, _: &CloseActiveDock, window, cx| {
                     if !workspace.close_active_dock(window, cx) {


### PR DESCRIPTION
- **Selectable projects in threads sidebar #57504**
- **Drag & drop projects in thread sidebar #57504**
- **Allow renaming of projects #57504**

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #57504

Release Notes:

- Added renaming of projects
- Added drag & drop of projects in threads sidebar
- Improved UX of selecting a project in threads sidebar
