### PR TITLE
agent_ui: Allow expanding running MCP tool calls

### DIFF
--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -7046,6 +7046,130 @@ pub(crate) mod tests {
     }
 
     #[gpui::test]
+    async fn test_running_mcp_tool_call_with_raw_input_is_collapsible(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let tool_call_id = acp::ToolCallId::new("mcp-running-raw-input");
+        let tool_call = acp::ToolCall::new(tool_call_id.clone(), "Search docs")
+            .kind(acp::ToolKind::Other)
+            .status(acp::ToolCallStatus::InProgress)
+            .raw_input(json!({
+                "query": "gpui disclosure state"
+            }));
+
+        let connection = StubAgentConnection::new();
+        connection.set_next_prompt_updates(vec![acp::SessionUpdate::ToolCall(tool_call)]);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(connection), cx).await;
+
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("Search the docs", window, cx);
+        });
+
+        active_thread(&conversation_view, cx)
+            .update_in(cx, |view, window, cx| view.send(window, cx));
+
+        cx.run_until_parked();
+
+        conversation_view.read_with(cx, |view, cx| {
+            let active_thread = view.active_thread().expect("Thread should exist");
+            let thread_view = active_thread.read(cx);
+            let thread = thread_view.thread.read(cx);
+            let tool_call = thread
+                .entries()
+                .iter()
+                .find_map(|entry| match entry {
+                    AgentThreadEntry::ToolCall(tool_call) if tool_call.id == tool_call_id => {
+                        Some(tool_call)
+                    }
+                    _ => None,
+                })
+                .expect("Expected a running MCP tool call entry");
+
+            assert!(
+                tool_call.raw_input_markdown.is_some(),
+                "Raw input markdown should be built for running MCP calls"
+            );
+            assert_eq!(
+                thread_view.is_tool_call_collapsible(&tool_call_id, cx),
+                Some(true),
+                "Running MCP call with raw input should expose the top-level disclosure"
+            );
+        });
+
+        conversation_view.update(cx, |view, cx| {
+            view.expand_tool_call(tool_call_id.clone(), cx);
+        });
+
+        cx.run_until_parked();
+
+        conversation_view.read_with(cx, |view, cx| {
+            let active_thread = view.active_thread().expect("Thread should exist");
+            let thread_view = active_thread.read(cx);
+            assert!(
+                thread_view.expanded_tool_calls.contains(&tool_call_id),
+                "Expanded state should accept the running MCP tool call"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_running_mcp_tool_call_without_raw_input_is_not_collapsible(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let tool_call_id = acp::ToolCallId::new("mcp-running-empty");
+        let tool_call = acp::ToolCall::new(tool_call_id.clone(), "Search docs")
+            .kind(acp::ToolKind::Other)
+            .status(acp::ToolCallStatus::InProgress);
+
+        let connection = StubAgentConnection::new();
+        connection.set_next_prompt_updates(vec![acp::SessionUpdate::ToolCall(tool_call)]);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::new(connection), cx).await;
+
+        let message_editor = message_editor(&conversation_view, cx);
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("Search the docs", window, cx);
+        });
+
+        active_thread(&conversation_view, cx)
+            .update_in(cx, |view, window, cx| view.send(window, cx));
+
+        cx.run_until_parked();
+
+        conversation_view.read_with(cx, |view, cx| {
+            let active_thread = view.active_thread().expect("Thread should exist");
+            let thread_view = active_thread.read(cx);
+            let thread = thread_view.thread.read(cx);
+            let tool_call = thread
+                .entries()
+                .iter()
+                .find_map(|entry| match entry {
+                    AgentThreadEntry::ToolCall(tool_call) if tool_call.id == tool_call_id => {
+                        Some(tool_call)
+                    }
+                    _ => None,
+                })
+                .expect("Expected a running MCP tool call entry");
+
+            assert!(
+                tool_call.raw_input_markdown.is_none(),
+                "Control case should not have raw input markdown"
+            );
+            assert_eq!(
+                thread_view.is_tool_call_collapsible(&tool_call_id, cx),
+                Some(false),
+                "Running MCP call without raw input or output should stay non-collapsible"
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_authorize_tool_call_action_triggers_authorization(cx: &mut TestAppContext) {
         init_test(cx);
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -6729,13 +6729,12 @@ impl ThreadView {
 
         let use_card_layout = needs_confirmation || is_edit || is_terminal_tool;
 
-        let has_image_content = tool_call.content.iter().any(|c| c.image().is_some());
-        let is_collapsible = !tool_call.content.is_empty() && !needs_confirmation;
+        let should_show_raw_input = Self::tool_call_should_show_raw_input(tool_call, is_edit);
+        let is_collapsible =
+            Self::tool_call_is_collapsible(tool_call, needs_confirmation, should_show_raw_input);
         let mut is_open = self.expanded_tool_calls.contains(&tool_call.id);
 
         is_open |= needs_confirmation;
-
-        let should_show_raw_input = !is_terminal_tool && !is_edit && !has_image_content;
 
         let input_output_header = |label: SharedString| {
             Label::new(label)
@@ -6744,16 +6743,13 @@ impl ThreadView {
                 .buffer_font(cx)
         };
 
-        let tool_output_display = if is_open {
-            match &tool_call.status {
-                ToolCallStatus::WaitingForConfirmation { options, .. } => v_flex()
-                    .w_full()
-                    .children(
-                        tool_call
-                            .content
-                            .iter()
-                            .enumerate()
-                            .map(|(content_ix, content)| {
+        let tool_output_display =
+            if is_open {
+                match &tool_call.status {
+                    ToolCallStatus::WaitingForConfirmation { options, .. } => v_flex()
+                        .w_full()
+                        .children(tool_call.content.iter().enumerate().map(
+                            |(content_ix, content)| {
                                 div()
                                     .child(self.render_tool_call_content(
                                         active_session_id,
@@ -6768,123 +6764,134 @@ impl ThreadView {
                                         cx,
                                     ))
                                     .into_any_element()
-                            }),
-                    )
-                    .when(should_show_raw_input, |this| {
-                        let is_raw_input_expanded =
-                            self.expanded_tool_call_raw_inputs.contains(&tool_call.id);
+                            },
+                        ))
+                        .when(
+                            should_show_raw_input && tool_call.raw_input_markdown.is_some(),
+                            |this| {
+                                let is_raw_input_expanded =
+                                    self.expanded_tool_call_raw_inputs.contains(&tool_call.id);
 
-                        let input_header = if is_raw_input_expanded {
-                            "Raw Input:"
-                        } else {
-                            "View Raw Input"
-                        };
+                                let input_header = if is_raw_input_expanded {
+                                    "Raw Input:"
+                                } else {
+                                    "View Raw Input"
+                                };
 
-                        this.child(
-                            v_flex()
-                                .p_2()
-                                .gap_1()
-                                .border_t_1()
-                                .border_color(self.tool_card_border_color(cx))
-                                .child(
-                                    h_flex()
-                                        .id("disclosure_container")
-                                        .pl_0p5()
+                                this.child(
+                                    v_flex()
+                                        .p_2()
                                         .gap_1()
-                                        .justify_between()
-                                        .rounded_xs()
-                                        .hover(|s| s.bg(cx.theme().colors().element_hover))
-                                        .child(input_output_header(input_header.into()))
+                                        .border_t_1()
+                                        .border_color(self.tool_card_border_color(cx))
                                         .child(
-                                            Disclosure::new(
-                                                ("raw-input-disclosure", entry_ix),
-                                                is_raw_input_expanded,
-                                            )
-                                            .opened_icon(IconName::ChevronUp)
-                                            .closed_icon(IconName::ChevronDown),
-                                        )
-                                        .on_click(cx.listener({
-                                            let id = tool_call.id.clone();
+                                            h_flex()
+                                                .id("disclosure_container")
+                                                .pl_0p5()
+                                                .gap_1()
+                                                .justify_between()
+                                                .rounded_xs()
+                                                .hover(|s| s.bg(cx.theme().colors().element_hover))
+                                                .child(input_output_header(input_header.into()))
+                                                .child(
+                                                    Disclosure::new(
+                                                        ("raw-input-disclosure", entry_ix),
+                                                        is_raw_input_expanded,
+                                                    )
+                                                    .opened_icon(IconName::ChevronUp)
+                                                    .closed_icon(IconName::ChevronDown),
+                                                )
+                                                .on_click(cx.listener({
+                                                    let id = tool_call.id.clone();
 
-                                            move |this: &mut Self, _, _, cx| {
-                                                if this.expanded_tool_call_raw_inputs.contains(&id)
-                                                {
-                                                    this.expanded_tool_call_raw_inputs.remove(&id);
-                                                } else {
-                                                    this.expanded_tool_call_raw_inputs
-                                                        .insert(id.clone());
-                                                }
-                                                cx.notify();
-                                            }
-                                        })),
+                                                    move |this: &mut Self, _, _, cx| {
+                                                        if this
+                                                            .expanded_tool_call_raw_inputs
+                                                            .contains(&id)
+                                                        {
+                                                            this.expanded_tool_call_raw_inputs
+                                                                .remove(&id);
+                                                        } else {
+                                                            this.expanded_tool_call_raw_inputs
+                                                                .insert(id.clone());
+                                                        }
+                                                        cx.notify();
+                                                    }
+                                                })),
+                                        )
+                                        .when(is_raw_input_expanded, |this| {
+                                            this.children(tool_call.raw_input_markdown.clone().map(
+                                                |input| {
+                                                    self.render_markdown(
+                                                        input,
+                                                        MarkdownStyle::themed(
+                                                            MarkdownFont::Agent,
+                                                            window,
+                                                            cx,
+                                                        ),
+                                                        cx,
+                                                    )
+                                                },
+                                            ))
+                                        }),
                                 )
-                                .when(is_raw_input_expanded, |this| {
-                                    this.children(tool_call.raw_input_markdown.clone().map(
-                                        |input| {
-                                            self.render_markdown(
-                                                input,
-                                                MarkdownStyle::themed(
-                                                    MarkdownFont::Agent,
-                                                    window,
-                                                    cx,
-                                                ),
-                                                cx,
-                                            )
-                                        },
-                                    ))
-                                }),
+                            },
                         )
-                    })
-                    .child(self.render_permission_buttons(
-                        self.thread.read(cx).session_id().clone(),
-                        self.is_first_tool_call(active_session_id, &tool_call.id, cx),
-                        options,
-                        entry_ix,
-                        tool_call.id.clone(),
-                        focus_handle,
-                        cx,
-                    ))
-                    .into_any(),
-                ToolCallStatus::Pending | ToolCallStatus::InProgress
-                    if is_edit
-                        && tool_call.content.is_empty()
-                        && self.as_native_connection(cx).is_some() =>
-                {
-                    self.render_diff_loading(cx)
-                }
-                ToolCallStatus::Pending
-                | ToolCallStatus::InProgress
-                | ToolCallStatus::Completed
-                | ToolCallStatus::Failed
-                | ToolCallStatus::Canceled => v_flex()
-                    .when(should_show_raw_input, |this| {
-                        this.mt_1p5().w_full().child(
-                            v_flex()
-                                .ml(rems(0.4))
-                                .px_3p5()
-                                .pb_1()
-                                .gap_1()
-                                .border_l_1()
-                                .border_color(self.tool_card_border_color(cx))
-                                .child(input_output_header("Raw Input:".into()))
-                                .children(tool_call.raw_input_markdown.clone().map(|input| {
-                                    div().id(("tool-call-raw-input-markdown", entry_ix)).child(
-                                        self.render_markdown(
-                                            input,
-                                            MarkdownStyle::themed(MarkdownFont::Agent, window, cx),
-                                            cx,
-                                        ),
-                                    )
-                                }))
-                                .child(input_output_header("Output:".into())),
+                        .child(self.render_permission_buttons(
+                            self.thread.read(cx).session_id().clone(),
+                            self.is_first_tool_call(active_session_id, &tool_call.id, cx),
+                            options,
+                            entry_ix,
+                            tool_call.id.clone(),
+                            focus_handle,
+                            cx,
+                        ))
+                        .into_any(),
+                    ToolCallStatus::Pending | ToolCallStatus::InProgress
+                        if is_edit
+                            && tool_call.content.is_empty()
+                            && self.as_native_connection(cx).is_some() =>
+                    {
+                        self.render_diff_loading(cx)
+                    }
+                    ToolCallStatus::Pending
+                    | ToolCallStatus::InProgress
+                    | ToolCallStatus::Completed
+                    | ToolCallStatus::Failed
+                    | ToolCallStatus::Canceled => v_flex()
+                        .when(
+                            should_show_raw_input && tool_call.raw_input_markdown.is_some(),
+                            |this| {
+                                this.mt_1p5().w_full().child(
+                                    v_flex()
+                                        .ml(rems(0.4))
+                                        .px_3p5()
+                                        .pb_1()
+                                        .gap_1()
+                                        .border_l_1()
+                                        .border_color(self.tool_card_border_color(cx))
+                                        .child(input_output_header("Raw Input:".into()))
+                                        .children(tool_call.raw_input_markdown.clone().map(
+                                            |input| {
+                                                div()
+                                                    .id(("tool-call-raw-input-markdown", entry_ix))
+                                                    .child(self.render_markdown(
+                                                        input,
+                                                        MarkdownStyle::themed(
+                                                            MarkdownFont::Agent,
+                                                            window,
+                                                            cx,
+                                                        ),
+                                                        cx,
+                                                    ))
+                                            },
+                                        ))
+                                        .child(input_output_header("Output:".into())),
+                                )
+                            },
                         )
-                    })
-                    .children(
-                        tool_call
-                            .content
-                            .iter()
-                            .enumerate()
-                            .map(|(content_ix, content)| {
+                        .children(tool_call.content.iter().enumerate().map(
+                            |(content_ix, content)| {
                                 div().id(("tool-call-output", entry_ix)).child(
                                     self.render_tool_call_content(
                                         active_session_id,
@@ -6899,14 +6906,16 @@ impl ThreadView {
                                         cx,
                                     ),
                                 )
-                            }),
-                    )
-                    .when(!use_card_layout, |this| {
-                        let button_id =
-                            SharedString::from(format!("tool_output-collapse-{:?}", tool_call.id));
-                        let tool_call_id = tool_call.id.clone();
+                            },
+                        ))
+                        .when(!use_card_layout, |this| {
+                            let button_id = SharedString::from(format!(
+                                "tool_output-collapse-{:?}",
+                                tool_call.id
+                            ));
+                            let tool_call_id = tool_call.id.clone();
 
-                        this.child(
+                            this.child(
                             div()
                                 .ml(rems(0.4))
                                 .px_3p5()
@@ -6926,14 +6935,14 @@ impl ThreadView {
                                         })),
                                 ),
                         )
-                    })
-                    .into_any(),
-                ToolCallStatus::Rejected => Empty.into_any(),
-            }
-            .into()
-        } else {
-            None
-        };
+                        })
+                        .into_any(),
+                    ToolCallStatus::Rejected => Empty.into_any(),
+                }
+                .into()
+            } else {
+                None
+            };
 
         v_flex()
             .map(|this| {
@@ -7133,6 +7142,55 @@ impl ThreadView {
                 }
             })
             .children(tool_output_display)
+    }
+
+    fn tool_call_should_show_raw_input(tool_call: &ToolCall, is_edit: bool) -> bool {
+        !matches!(tool_call.kind, acp::ToolKind::Execute)
+            && !is_edit
+            && !tool_call
+                .content
+                .iter()
+                .any(|content| content.image().is_some())
+    }
+
+    fn tool_call_is_collapsible(
+        tool_call: &ToolCall,
+        needs_confirmation: bool,
+        should_show_raw_input: bool,
+    ) -> bool {
+        !needs_confirmation
+            && (!tool_call.content.is_empty()
+                || (should_show_raw_input && tool_call.raw_input_markdown.is_some()))
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn is_tool_call_collapsible(
+        &self,
+        tool_call_id: &acp::ToolCallId,
+        cx: &App,
+    ) -> Option<bool> {
+        self.thread
+            .read(cx)
+            .entries()
+            .iter()
+            .find_map(|entry| match entry {
+                AgentThreadEntry::ToolCall(tool_call) if &tool_call.id == tool_call_id => {
+                    let needs_confirmation = matches!(
+                        tool_call.status,
+                        ToolCallStatus::WaitingForConfirmation { .. }
+                    );
+                    let is_edit = matches!(tool_call.kind, acp::ToolKind::Edit)
+                        || tool_call.diffs().next().is_some();
+                    let should_show_raw_input =
+                        Self::tool_call_should_show_raw_input(tool_call, is_edit);
+                    Some(Self::tool_call_is_collapsible(
+                        tool_call,
+                        needs_confirmation,
+                        should_show_raw_input,
+                    ))
+                }
+                _ => None,
+            })
     }
 
     fn render_permission_buttons(


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #57144

Release Notes:

- Added ability to expand MCP tool calls and generic running tool calls when they have `raw_input_markdown` even if `content` is still empty.
