### PR TITLE
gpui_windows: Fix reversed linear/sRGB transfer functions in shader

### DIFF
--- a/crates/gpui_windows/src/shaders.hlsl
+++ b/crates/gpui_windows/src/shaders.hlsl
@@ -122,12 +122,12 @@ float4 distance_from_clip_rect_transformed(float2 unit_vertex, Bounds bounds, Bo
 
 // Convert linear RGB to sRGB
 float3 linear_to_srgb(float3 color) {
-    return pow(color, float3(2.2, 2.2, 2.2));
+    return pow(color, float3(1.0 / 2.2, 1.0 / 2.2, 1.0 / 2.2));
 }
 
 // Convert sRGB to linear RGB
 float3 srgb_to_linear(float3 color) {
-    return pow(color, float3(1.0 / 2.2, 1.0 / 2.2, 1.0 / 2.2));
+    return pow(color, float3(2.2, 2.2, 2.2));
 }
 
 /// Hsla to linear RGBA conversion.


### PR DESCRIPTION
## Summary
- swap the Windows HLSL exponents for `linear_to_srgb` and `srgb_to_linear`
- align the Windows Oklab gradient path with the existing Metal and WGSL implementations

## Testing
- not run (shader-only change)

Fixes #57542

Release Notes:

- [GPUI] Fix reversed linear/sRGB transfer functions