### PR TITLE
vim: Fix replace in helix select mode

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -2478,6 +2478,12 @@ mod test {
         cx.simulate_keystrokes("r x");
 
         cx.assert_state("«xxˇ»", Mode::HelixNormal);
+
+        cx.set_state("«aaˇ»", Mode::HelixSelect);
+
+        cx.simulate_keystrokes("r x");
+
+        cx.assert_state("«xxˇ»", Mode::HelixNormal);
     }
 
     #[gpui::test]

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -2066,7 +2066,7 @@ impl Vim {
                 Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
                     self.visual_replace(text, window, cx)
                 }
-                Mode::HelixNormal => self.helix_replace(&text, window, cx),
+                Mode::HelixNormal | Mode::HelixSelect => self.helix_replace(&text, window, cx),
                 _ => self.clear_operator(window, cx),
             },
             Some(Operator::Digraph { first_char }) => {


### PR DESCRIPTION
Resolves https://github.com/zed-industries/zed/issues/57522

This diff fixes `r` in Helix select mode. The keybinding already pushed the replace operator in `helix_select`, but when the replacement character was typed, the operator dispatch only handled `HelixNormal`, so selected text in `HelixSelect` fell through and cleared the operator without editing the buffer.

With this change, Helix select mode uses the same `helix_replace` path as Helix normal mode. Multi-character selections now replace each selected grapheme with the typed character and return to Helix normal mode, matching the existing behaviour for Helix normal selections.

Release Notes:
- Fixed `r` not replacing multi-character selections in Helix select mode.
