### PR TITLE
terminal: Add terminal hints overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17944,6 +17944,7 @@ dependencies = [
  "settings",
  "shellexpand",
  "task",
+ "tempfile",
  "terminal",
  "theme",
  "theme_settings",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1245,6 +1245,7 @@
       "alt-t": "terminal::RerunTask",
       "ctrl-shift-5": "pane::SplitRight",
       "ctrl->": "agent::AddSelectionToThread",
+      "ctrl-shift-o": "terminal::ActivateHints",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1314,6 +1314,7 @@
       "cmd-d": "pane::SplitRight",
       "cmd-alt-r": "terminal::RerunTask",
       "cmd->": "agent::AddSelectionToThread",
+      "ctrl-shift-o": "terminal::ActivateHints",
     },
   },
   {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -4,6 +4,7 @@ pub use alacritty_terminal;
 
 mod pty_info;
 mod terminal_hyperlinks;
+pub use terminal_hyperlinks::TerminalHyperlink;
 pub mod terminal_settings;
 
 use alacritty_terminal::{
@@ -51,7 +52,10 @@ use terminal_hyperlinks::RegexSearches;
 use terminal_settings::{AlternateScroll, CursorShape, TerminalSettings};
 use theme::{ActiveTheme, Theme};
 use urlencoding;
-use util::{paths::PathStyle, truncate_and_trailoff};
+use util::{
+    paths::{PathStyle, PathWithPosition},
+    truncate_and_trailoff,
+};
 
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
@@ -426,6 +430,7 @@ impl TerminalBuilder {
             path_style,
             #[cfg(any(test, feature = "test-support"))]
             input_log: Vec::new(),
+            hint_state: None,
         };
 
         Ok(TerminalBuilder {
@@ -660,6 +665,7 @@ impl TerminalBuilder {
                 path_style,
                 #[cfg(any(test, feature = "test-support"))]
                 input_log: Vec::new(),
+                hint_state: None,
             };
 
             if !activation_script.is_empty() && no_task {
@@ -844,6 +850,87 @@ pub enum SelectionPhase {
     Ended,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum HintLabel {
+    Single(char),
+    Double(char, char),
+}
+
+/// Characters used for hint labels, ordered by ergonomics (home-row first).
+const HINT_CHARS: &[char] = &[
+    'j', 'f', 'k', 'd', 'l', 's', 'a', 'h', 'g', 'u', 'r', 'i', 'e', 'o', 'w', 'p', 'q', 't', 'y',
+    'z', 'n', 'v', 'm', 'c', 'x', 'b',
+];
+
+pub fn assign_hint_labels(count: usize) -> Vec<HintLabel> {
+    let n = HINT_CHARS.len();
+    if count <= n {
+        HINT_CHARS[..count]
+            .iter()
+            .map(|&c| HintLabel::Single(c))
+            .collect()
+    } else {
+        let cap = count.min(n * n);
+        // Column-major order: vary the first letter first so small sets of hints get
+        // maximally distinct first chars (e.g. 4 hints → jj, fj, kj, dj rather than
+        // all starting with 'j').
+        (0..cap)
+            .map(|i| HintLabel::Double(HINT_CHARS[i % n], HINT_CHARS[i / n]))
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerminalHint {
+    pub label: HintLabel,
+    pub hyperlink: TerminalHyperlink,
+}
+
+impl TerminalHint {
+    pub fn position(&self) -> AlacPoint {
+        *self.hyperlink.match_range.start()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerminalHintState {
+    pub hints: Vec<TerminalHint>,
+    pub input: String,
+    pub display_offset: usize,
+}
+
+impl TerminalHintState {
+    /// Returns hints that are still visible given the current typed input.
+    pub fn visible_hints(&self) -> Vec<&TerminalHint> {
+        match self.input.len() {
+            0 => self.hints.iter().collect(),
+            1 => {
+                let first = self.input.chars().next().unwrap();
+                self.hints
+                    .iter()
+                    .filter(|h| matches!(&h.label, HintLabel::Double(f, _) if *f == first))
+                    .collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    /// Returns the hint whose label exactly matches `input`, if any.
+    pub fn find_match(&self, input: &str) -> Option<&TerminalHint> {
+        let mut chars = input.chars();
+        let first = chars.next()?;
+        match chars.next() {
+            None => self
+                .hints
+                .iter()
+                .find(|h| matches!(&h.label, HintLabel::Single(c) if *c == first)),
+            Some(second) => self.hints.iter().find(
+                |h| matches!(&h.label, HintLabel::Double(f, s) if *f == first && *s == second),
+            ),
+        }
+    }
+}
+
 enum TerminalType {
     Pty {
         pty_tx: Notifier,
@@ -887,6 +974,7 @@ pub struct Terminal {
     path_style: PathStyle,
     #[cfg(any(test, feature = "test-support"))]
     input_log: Vec<Vec<u8>>,
+    hint_state: Option<TerminalHintState>,
 }
 
 struct CopyTemplate {
@@ -1040,6 +1128,7 @@ impl Terminal {
                 }
 
                 term.resize(new_bounds);
+                self.hint_state = None;
                 // If there are matches we need to emit a wake up event to
                 // invalidate the matches and recalculate their locations
                 // in the new terminal layout
@@ -1592,7 +1681,58 @@ impl Terminal {
         }
     }
 
-    pub fn try_keystroke(&mut self, keystroke: &Keystroke, option_as_meta: bool) -> bool {
+    fn hint_mode_keystroke(&mut self, keystroke: &Keystroke, cx: &mut Context<Self>) {
+        if !self.hint_mode_enabled() {
+            return;
+        }
+        if keystroke.modifiers.control || keystroke.modifiers.alt || keystroke.modifiers.platform {
+            return;
+        }
+
+        match keystroke.key.as_str() {
+            "escape" => self.set_hint_state(None),
+            "backspace" => {
+                if let Some(state) = self.hint_state_mut() {
+                    state.input.pop();
+                }
+            }
+            _ => {
+                if keystroke.key.chars().count() != 1 {
+                    return;
+                }
+                let ch = keystroke.key.chars().next().expect("must be just one char");
+                let state = self.hint_state_mut().expect("hint mode must be active");
+
+                state.input.push(ch);
+                if let Some(matched) = state.find_match(&state.input).cloned() {
+                    self.set_hint_state(None);
+                    let hyperlink = (
+                        matched.hyperlink.text,
+                        matched.hyperlink.is_url,
+                        matched.hyperlink.match_range,
+                    );
+                    self.process_hyperlink(hyperlink, true, cx);
+                    return;
+                }
+                if state.input.len() >= 2 || state.visible_hints().is_empty() {
+                    self.set_hint_state(None);
+                }
+            }
+        }
+        return;
+    }
+
+    pub fn try_keystroke(
+        &mut self,
+        keystroke: &Keystroke,
+        option_as_meta: bool,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.hint_mode_enabled() {
+            self.hint_mode_keystroke(keystroke, cx);
+            return true;
+        }
+
         if self.vi_mode_enabled {
             self.vi_motion(keystroke);
             return true;
@@ -1648,7 +1788,9 @@ impl Terminal {
             self.process_terminal_event(&e, &mut terminal, window, cx)
         }
 
-        self.last_content = Self::make_content(&terminal, &self.last_content);
+        if !self.hint_mode_enabled() {
+            self.last_content = Self::make_content(&terminal, &self.last_content);
+        }
     }
 
     fn make_content(term: &Term<ZedListener>, last_content: &TerminalContent) -> TerminalContent {
@@ -1682,6 +1824,38 @@ impl Terminal {
             scrolled_to_top: content.display_offset == term.history_size(),
             scrolled_to_bottom: content.display_offset == 0,
         }
+    }
+
+    /// Collects hint targets (URLs and paths) visible in the current viewport.
+    pub fn collect_visible_hint_targets(&mut self) -> Vec<TerminalHyperlink> {
+        let term = self.term.lock_unfair();
+        let terminal_dir = self.working_directory();
+        let raw = terminal_hyperlinks::find_visible_hint_targets(
+            &term,
+            &mut self.hyperlink_regex_searches,
+            self.path_style,
+        );
+        drop(term);
+        raw.into_iter()
+            .filter_map(|hyperlink| {
+                if hyperlink.is_url {
+                    Some(hyperlink)
+                } else {
+                    let base_path = PathWithPosition::parse_str(&hyperlink.text).path;
+                    let resolved = if base_path.is_absolute() {
+                        base_path
+                    } else if let Some(dir) = &terminal_dir {
+                        dir.join(base_path)
+                    } else {
+                        return None;
+                    };
+                    if !resolved.exists() {
+                        return None;
+                    }
+                    Some(hyperlink)
+                }
+            })
+            .collect()
     }
 
     pub fn get_content(&self) -> String {
@@ -2333,6 +2507,22 @@ impl Terminal {
         self.vi_mode_enabled
     }
 
+    pub fn hint_mode_enabled(&self) -> bool {
+        self.hint_state().is_some()
+    }
+
+    pub fn hint_state(&self) -> Option<&TerminalHintState> {
+        self.hint_state.as_ref()
+    }
+
+    fn hint_state_mut(&mut self) -> Option<&mut TerminalHintState> {
+        self.hint_state.as_mut()
+    }
+
+    pub fn set_hint_state(&mut self, state: Option<TerminalHintState>) {
+        self.hint_state = state;
+    }
+
     pub fn clone_builder(&self, cx: &App, cwd: Option<PathBuf>) -> Task<Result<TerminalBuilder>> {
         let working_directory = self.working_directory().or_else(|| cwd);
         TerminalBuilder::new(
@@ -2807,12 +2997,12 @@ mod tests {
 
         let first_event = event_rx.recv().await.expect("No wakeup event received");
 
-        terminal.update(cx, |terminal, _| {
-            let success = terminal.try_keystroke(&Keystroke::parse("ctrl-c").unwrap(), false);
+        terminal.update(cx, |terminal, cx| {
+            let success = terminal.try_keystroke(&Keystroke::parse("ctrl-c").unwrap(), false, cx);
             assert!(success, "Should have registered ctrl-c sequence");
         });
-        terminal.update(cx, |terminal, _| {
-            let success = terminal.try_keystroke(&Keystroke::parse("ctrl-d").unwrap(), false);
+        terminal.update(cx, |terminal, cx| {
+            let success = terminal.try_keystroke(&Keystroke::parse("ctrl-d").unwrap(), false, cx);
             assert!(success, "Should have registered ctrl-d sequence");
         });
 

--- a/crates/terminal/src/terminal_hyperlinks.rs
+++ b/crates/terminal/src/terminal_hyperlinks.rs
@@ -421,6 +421,121 @@ fn path_match<T>(
     None
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerminalHyperlink {
+    pub text: String,
+    pub is_url: bool,
+    pub match_range: Match,
+}
+
+/// Scans the currently visible viewport for URLs and path-like strings.
+/// Returns `TerminalHyperlink` elements with precise text, URL flag, and match bounds.
+pub(super) fn find_visible_hint_targets<T: EventListener>(
+    term: &Term<T>,
+    regex_searches: &mut RegexSearches,
+    path_style: PathStyle,
+) -> Vec<TerminalHyperlink> {
+    let mut results: Vec<TerminalHyperlink> = Vec::new();
+
+    let display_offset = term.grid().display_offset();
+    let screen_lines = term.screen_lines();
+    let last_column = term.last_column();
+
+    // Only search lines that are currently visible in the viewport.
+    // In Alacritty grid coordinates: viewport_line = grid_line + display_offset,
+    // so visible lines run from -(display_offset) to (screen_lines - 1 - display_offset).
+    let first_visible = alacritty_terminal::index::Line(-(display_offset as i32));
+    let last_visible =
+        alacritty_terminal::index::Line(screen_lines as i32 - 1 - display_offset as i32);
+
+    for line in first_visible.0..=last_visible.0 {
+        let line = alacritty_terminal::index::Line(line);
+        let line_start = AlacPoint::new(line, Column(0));
+        let line_end = AlacPoint::new(line, last_column);
+
+        // Scan for URLs on this line.
+        let url_iter = RegexIter::new(
+            line_start,
+            line_end,
+            AlacDirection::Right,
+            term,
+            &mut regex_searches.url_regex,
+        );
+        for url_match in url_iter {
+            let url_text = term.bounds_to_string(*url_match.start(), *url_match.end());
+            let (url_text, sanitized_match) = sanitize_url_punctuation(url_text, url_match, term);
+            if url_text.is_empty() {
+                continue;
+            }
+            // Convert file:// URLs to paths.
+            let (final_text, is_url) = if url_text.starts_with("file://") {
+                if let Ok(url) = Url::parse(&url_text) {
+                    if let Ok(path) = url.to_file_path_ext(path_style) {
+                        (path.to_string_lossy().into_owned(), false)
+                    } else if let Some(path) = try_osc8_url_to_path(url)
+                        && path_style.is_posix()
+                    {
+                        (path, false)
+                    } else {
+                        let path = url_text
+                            .strip_prefix("file://")
+                            .unwrap_or(&url_text)
+                            .to_string();
+                        (path, false)
+                    }
+                } else {
+                    (url_text, true)
+                }
+            } else {
+                (url_text, true)
+            };
+            results.push(TerminalHyperlink {
+                text: final_text,
+                is_url,
+                match_range: sanitized_match,
+            });
+        }
+
+        // Scan for path-like strings on this line using configured regexes.
+        if regex_searches.path_hyperlink_regexes.is_empty() {
+            continue;
+        }
+        let line_text = term.bounds_to_string(line_start, line_end);
+        let line_text = line_text.trim_ascii_end();
+        if line_text.is_empty() {
+            continue;
+        }
+        for regex in &regex_searches.path_hyperlink_regexes {
+            for m in regex.find_iter(line_text) {
+                let trimmed_start = m.as_str().trim_start();
+                let leading_whitespace_chars =
+                    m.as_str().chars().count() - trimmed_start.chars().count();
+                let trimmed = trimmed_start.trim_end();
+                let path_text = trimmed.to_string();
+                if path_text.is_empty() {
+                    continue;
+                }
+                // Count Unicode scalar values before the match start to get the terminal
+                // column. Using byte offset directly would miscount multi-byte chars (e.g.
+                // the fish prompt '❯' is 3 bytes but occupies 1 column).
+                // Wide chars (2 columns each) are still approximated as 1 here.
+                let start_col =
+                    Column(line_text[..m.start()].chars().count() + leading_whitespace_chars);
+                let len = path_text.chars().count();
+                let end_col = Column(start_col.0 + len.saturating_sub(1));
+                let match_range = AlacPoint::new(line, start_col)..=AlacPoint::new(line, end_col);
+                results.push(TerminalHyperlink {
+                    text: path_text,
+                    is_url: false,
+                    match_range,
+                });
+            }
+        }
+    }
+
+    results
+}
+
 #[cfg(test)]
 mod tests {
     use crate::terminal_settings::TerminalSettings;

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -55,6 +55,7 @@ remote = { workspace = true, features = ["test-support"] }
 release_channel.workspace = true
 rpc = { workspace = true, features = ["test-support"] }
 semver.workspace = true
+tempfile.workspace = true
 terminal = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }
 

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -6,7 +6,7 @@ use gpui::{
     IntoElement, LayoutId, Length, ModifiersChangedEvent, MouseButton, MouseMoveEvent, Pixels,
     Point, StatefulInteractiveElement, StrikethroughStyle, Styled, TextRun, TextStyle,
     UTF16Selection, UnderlineStyle, WeakEntity, WhiteSpace, Window, div, fill, point, px, relative,
-    size,
+    rgb, size,
 };
 use itertools::Itertools;
 use language::CursorShape;
@@ -35,7 +35,10 @@ use workspace::Workspace;
 use std::mem;
 use std::{fmt::Debug, ops::RangeInclusive, rc::Rc};
 
-use crate::{BlockContext, BlockProperties, ContentMode, TerminalMode, TerminalView};
+use crate::{
+    BlockContext, BlockProperties, ContentMode, HintLabel, TerminalHintState, TerminalMode,
+    TerminalView,
+};
 
 /// The information generated during layout that is necessary for painting.
 pub struct LayoutState {
@@ -53,6 +56,7 @@ pub struct LayoutState {
     block_below_cursor_element: Option<AnyElement>,
     base_text_style: TextStyle,
     content_mode: ContentMode,
+    hint_state: Option<TerminalHintState>,
 }
 
 /// Helper struct for converting data between Alacritty's cursor points, and displayed cursor points.
@@ -746,8 +750,9 @@ impl TerminalElement {
                 move |e, window, cx| {
                     terminal_view
                         .update(cx, |terminal_view, cx| {
-                            if matches!(terminal_view.mode, TerminalMode::Standalone)
-                                || terminal_view.focus_handle.is_focused(window)
+                            if (matches!(terminal_view.mode, TerminalMode::Standalone)
+                                || terminal_view.focus_handle.is_focused(window))
+                                && !terminal_view.terminal.read(cx).hint_mode_enabled()
                             {
                                 terminal_view.scroll_wheel(e, cx);
                                 cx.notify();
@@ -1263,6 +1268,17 @@ impl Element for TerminalElement {
                     None
                 };
 
+                let view = self.terminal_view.read(cx);
+                let hint_state =
+                    view.terminal
+                        .read(cx)
+                        .hint_state()
+                        .map(|s| crate::TerminalHintState {
+                            hints: s.hints.clone(),
+                            input: s.input.clone(),
+                            display_offset: s.display_offset,
+                        });
+
                 LayoutState {
                     hitbox,
                     batched_text_runs,
@@ -1278,6 +1294,7 @@ impl Element for TerminalElement {
                     block_below_cursor_element,
                     base_text_style: text_style,
                     content_mode,
+                    hint_state,
                 }
             },
         )
@@ -1390,6 +1407,10 @@ impl Element for TerminalElement {
                     }
                     let text_paint_time = text_paint_start.elapsed();
 
+                    if let Some(hint_state) = &layout.hint_state {
+                        paint_hint_overlays(hint_state, &layout, origin, window, cx);
+                    }
+
                     if let Some(text_to_mark) = &marked_text_cloned
                         && !text_to_mark.is_empty()
                         && let Some(ime_bounds) = layout.ime_cursor_bounds
@@ -1468,6 +1489,143 @@ impl IntoElement for TerminalElement {
 
     fn into_element(self) -> Self::Element {
         self
+    }
+}
+
+fn paint_hint_overlays(
+    hint_state: &TerminalHintState,
+    layout: &LayoutState,
+    origin: gpui::Point<Pixels>,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let yellow = Hsla::from(rgb(0xffe167));
+    let red = Hsla::from(rgb(0xac4242));
+    let black = Hsla::from(rgb(0x000000));
+    let font_size = layout
+        .base_text_style
+        .font_size
+        .to_pixels(window.rem_size());
+    let font = layout.base_text_style.font();
+    let cell_width = layout.dimensions.cell_width;
+    let line_height = layout.dimensions.line_height;
+
+    let visible = hint_state.visible_hints();
+    for hint in visible {
+        let position = hint.position();
+        let viewport_line = position.line.0 + hint_state.display_offset as i32;
+        if viewport_line < 0 || viewport_line as usize >= layout.dimensions.num_lines() {
+            continue;
+        }
+        let col = position.column.0;
+        let box_x = origin.x + col as f32 * cell_width;
+        let box_y = origin.y + viewport_line as f32 * line_height;
+
+        match (&hint.label, hint_state.input.len()) {
+            (HintLabel::Single(ch), _) => {
+                let bounds = gpui::Bounds::new(
+                    gpui::point(box_x, box_y),
+                    gpui::size(cell_width, line_height),
+                );
+                window.paint_quad(fill(bounds, yellow));
+                let text_runs = &[TextRun {
+                    len: ch.len_utf8(),
+                    font: font.clone(),
+                    color: black,
+                    ..TextRun::default()
+                }];
+                let shaped = window.text_system().shape_line(
+                    ch.to_string().into(),
+                    font_size,
+                    text_runs,
+                    None,
+                );
+                shaped
+                    .paint(
+                        gpui::point(box_x, box_y),
+                        line_height,
+                        gpui::TextAlign::Left,
+                        None,
+                        window,
+                        cx,
+                    )
+                    .log_err();
+            }
+            (HintLabel::Double(first, second), 0) => {
+                // First cell: yellow background.
+                let first_bounds = gpui::Bounds::new(
+                    gpui::point(box_x, box_y),
+                    gpui::size(cell_width, line_height),
+                );
+                window.paint_quad(fill(first_bounds, yellow));
+                // Second cell: red background.
+                let second_bounds = gpui::Bounds::new(
+                    gpui::point(box_x + cell_width, box_y),
+                    gpui::size(cell_width, line_height),
+                );
+                window.paint_quad(fill(second_bounds, red));
+                let label: String = [*first, *second].iter().collect();
+                let text_runs = &[
+                    TextRun {
+                        len: first.len_utf8(),
+                        font: font.clone(),
+                        color: black,
+                        ..TextRun::default()
+                    },
+                    TextRun {
+                        len: second.len_utf8(),
+                        font: font.clone(),
+                        color: black,
+                        ..TextRun::default()
+                    },
+                ];
+                let shaped =
+                    window
+                        .text_system()
+                        .shape_line(label.into(), font_size, text_runs, None);
+                shaped
+                    .paint(
+                        gpui::point(box_x, box_y),
+                        line_height,
+                        gpui::TextAlign::Left,
+                        None,
+                        window,
+                        cx,
+                    )
+                    .log_err();
+            }
+            (HintLabel::Double(_, second), 1) => {
+                // First char matched — show only second char with yellow background at hint position.
+                let bounds = gpui::Bounds::new(
+                    gpui::point(box_x, box_y),
+                    gpui::size(cell_width, line_height),
+                );
+                window.paint_quad(fill(bounds, yellow));
+                let text_runs = &[TextRun {
+                    len: second.len_utf8(),
+                    font: font.clone(),
+                    color: black,
+                    ..TextRun::default()
+                }];
+                let shaped = window.text_system().shape_line(
+                    second.to_string().into(),
+                    font_size,
+                    text_runs,
+                    None,
+                );
+                shaped
+                    .paint(
+                        gpui::point(box_x, box_y),
+                        line_height,
+                        gpui::TextAlign::Left,
+                        None,
+                        window,
+                        cx,
+                    )
+                    .log_err();
+            }
+            (HintLabel::Double(_, _), _) => {}
+        }
     }
 }
 

--- a/crates/terminal_view/src/terminal_path_like_target.rs
+++ b/crates/terminal_view/src/terminal_path_like_target.rs
@@ -78,22 +78,20 @@ fn possible_hover_target(
 
 pub(super) fn open_path_like_target(
     workspace: &WeakEntity<Workspace>,
-    terminal_view: &mut TerminalView,
     path_like_target: &PathLikeTarget,
     window: &mut Window,
     cx: &mut Context<TerminalView>,
 ) {
     #[cfg(not(test))]
     {
-        possibly_open_target(workspace, terminal_view, path_like_target, window, cx)
-            .detach_and_log_err(cx)
+        possibly_open_target(workspace, path_like_target.clone(), window, cx).detach_and_log_err(cx)
     }
+
     #[cfg(test)]
     {
         possibly_open_target(
             workspace,
-            terminal_view,
-            path_like_target,
+            path_like_target.clone(),
             window,
             cx,
             BackgroundFsChecks::Enabled,
@@ -102,19 +100,14 @@ pub(super) fn open_path_like_target(
     }
 }
 
-fn possibly_open_target(
+pub(super) fn possibly_open_target(
     workspace: &WeakEntity<Workspace>,
-    terminal_view: &mut TerminalView,
-    path_like_target: &PathLikeTarget,
+    path_like_target: PathLikeTarget,
     window: &mut Window,
     cx: &mut Context<TerminalView>,
     #[cfg(test)] background_fs_checks: BackgroundFsChecks,
 ) -> Task<Result<Option<OpenTarget>>> {
-    if terminal_view.hover.is_none() {
-        return Task::ready(Ok(None));
-    }
     let workspace = workspace.clone();
-    let path_like_target = path_like_target.clone();
     cx.spawn_in(window, async move |terminal_view, cx| {
         let Some(open_target) = terminal_view
             .update(cx, |_, cx| {
@@ -295,18 +288,16 @@ mod tests {
                 terminal_view.read_with(cx, |terminal_view, _| terminal_view.hover.clone());
 
             let open_target = terminal_view
-                .update_in(cx, |terminal_view, window, cx| {
-                    possibly_open_target(
+                .update(cx, |_, cx| {
+                    possible_open_target_with_fs_checks(
                         &workspace.downgrade(),
-                        terminal_view,
-                        &path_like_target,
-                        window,
+                        &path_like_target.maybe_path,
+                        path_like_target.terminal_dir.as_deref(),
                         cx,
                         background_fs_checks,
                     )
                 })
-                .await
-                .expect("Failed to possibly open target");
+                .await;
 
             (hover_target, open_target)
         }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -34,13 +34,15 @@ use std::{
 };
 use task::TaskId;
 use terminal::{
-    Clear, Copy, Event, HoveredWord, MaybeNavigationTarget, Paste, PasteText, ScrollLineDown,
-    ScrollLineUp, ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop, ShowCharacterPalette,
-    TaskState, TaskStatus, Terminal, TerminalBounds, ToggleViMode,
+    Clear, Copy, Event, HintLabel, HoveredWord, MaybeNavigationTarget, Paste, PasteText,
+    ScrollLineDown, ScrollLineUp, ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop,
+    ShowCharacterPalette, TaskState, TaskStatus, Terminal, TerminalBounds, TerminalHint,
+    TerminalHintState, ToggleViMode,
     alacritty_terminal::{
         index::Point as AlacPoint,
         term::{TermMode, point_to_viewport, search::RegexSearch},
     },
+    assign_hint_labels,
     terminal_settings::{CursorShape, TerminalSettings},
 };
 use terminal_element::TerminalElement;
@@ -91,6 +93,9 @@ actions!(
     [
         /// Reruns the last executed task in the terminal.
         RerunTask,
+        /// Activates hint mode: labels all visible URLs and paths with two-letter overlays.
+        /// Typing a label opens the target; Escape exits the mode.
+        ActivateHints,
     ]
 );
 
@@ -602,6 +607,7 @@ impl TerminalView {
                 term.try_keystroke(
                     &Keystroke::parse("ctrl-cmd-space").unwrap(),
                     TerminalSettings::get_global(cx).option_as_meta,
+                    cx,
                 )
             });
         } else {
@@ -622,6 +628,64 @@ impl TerminalView {
             .map(|task| terminal_rerun_override(&task.spawned_task.id))
             .unwrap_or_default();
         window.dispatch_action(Box::new(task), cx);
+    }
+
+    fn activate_hints(&mut self, _: &ActivateHints, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.terminal.read(cx).hint_mode_enabled() {
+            return;
+        }
+
+        self.set_hint_state(
+            Some(TerminalHintState {
+                hints: Vec::new(),
+                input: String::new(),
+                display_offset: 0,
+            }),
+            cx,
+        );
+        self.refresh_hints(cx);
+    }
+
+    fn refresh_hints(&mut self, cx: &mut Context<Self>) {
+        if !self.terminal.read(cx).hint_mode_enabled() {
+            return;
+        }
+
+        let raw = self
+            .terminal
+            .update(cx, |term, _| term.collect_visible_hint_targets());
+        if raw.is_empty() {
+            self.set_hint_state(None, cx);
+            cx.notify();
+            return;
+        }
+        let display_offset = self.terminal.read(cx).last_content().display_offset;
+        let labels = assign_hint_labels(raw.len());
+        let hints = labels
+            .into_iter()
+            .zip(raw)
+            .map(|(label, hyperlink)| TerminalHint { label, hyperlink })
+            .collect();
+        let input = self
+            .terminal
+            .read(cx)
+            .hint_state()
+            .map(|s| s.input.clone())
+            .unwrap_or_default();
+        self.set_hint_state(
+            Some(TerminalHintState {
+                hints,
+                input,
+                display_offset,
+            }),
+            cx,
+        );
+        cx.notify();
+    }
+
+    fn set_hint_state(&mut self, state: Option<TerminalHintState>, cx: &mut Context<Self>) {
+        self.terminal
+            .update(cx, |term, _| term.set_hint_state(state));
     }
 
     fn clear(&mut self, _: &Clear, _: &mut Window, cx: &mut Context<Self>) {
@@ -652,7 +716,6 @@ impl TerminalView {
 
     fn scroll_wheel(&mut self, event: &ScrollWheelEvent, cx: &mut Context<Self>) {
         let terminal_content = self.terminal.read(cx).last_content();
-
         if self.block_below_cursor.is_some() && terminal_content.display_offset == 0 {
             let line_height = terminal_content.terminal_bounds.line_height;
             let y_delta = event.delta.pixel_delta(line_height).y;
@@ -875,7 +938,12 @@ impl TerminalView {
         });
     }
 
-    fn send_keystroke(&mut self, text: &SendKeystroke, _: &mut Window, cx: &mut Context<Self>) {
+    fn send_keystroke(
+        &mut self,
+        text: &SendKeystroke,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(keystroke) = Keystroke::parse(&text.0).log_err() {
             self.clear_bell(cx);
             self.blink_manager.update(cx, BlinkManager::pause_blinking);
@@ -889,6 +957,10 @@ impl TerminalView {
 
         if self.terminal.read(cx).vi_mode_enabled() {
             dispatch_context.add("vi_mode");
+        }
+
+        if self.terminal.read(cx).hint_mode_enabled() {
+            dispatch_context.add("hint_mode");
         }
 
         let mode = self.terminal.read(cx).last_content.mode;
@@ -1111,13 +1183,9 @@ fn subscribe_for_terminal_events(
 
                 Event::Open(maybe_navigation_target) => match maybe_navigation_target {
                     MaybeNavigationTarget::Url(url) => cx.open_url(url),
-                    MaybeNavigationTarget::PathLike(path_like_target) => open_path_like_target(
-                        &workspace,
-                        terminal_view,
-                        path_like_target,
-                        window,
-                        cx,
-                    ),
+                    MaybeNavigationTarget::PathLike(path_like_target) => {
+                        open_path_like_target(&workspace, path_like_target, window, cx)
+                    }
                 },
                 Event::BreadcrumbsChanged => cx.emit(ItemEvent::UpdateBreadcrumbs),
                 Event::CloseTerminal => cx.emit(ItemEvent::CloseItem),
@@ -1163,24 +1231,26 @@ impl TerminalView {
     /// updates the cursor locally without sending data to the shell, so there's no
     /// shell output to automatically trigger a re-render.
     fn process_keystroke(&mut self, keystroke: &Keystroke, cx: &mut Context<Self>) -> bool {
-        let (handled, vi_mode_enabled) = self.terminal.update(cx, |term, cx| {
-            (
-                term.try_keystroke(keystroke, TerminalSettings::get_global(cx).option_as_meta),
-                term.vi_mode_enabled(),
-            )
+        let (handled, needs_refresh) = self.terminal.update(cx, |term, cx| {
+            let was_hint_mode = term.hint_mode_enabled();
+            let handled = term.try_keystroke(
+                keystroke,
+                TerminalSettings::get_global(cx).option_as_meta,
+                cx,
+            );
+            let needs_refresh = term.vi_mode_enabled() || was_hint_mode;
+            (handled, needs_refresh)
         });
 
-        if handled && vi_mode_enabled {
+        if handled && needs_refresh {
             cx.notify();
         }
-
         handled
     }
 
     fn key_down(&mut self, event: &KeyDownEvent, window: &mut Window, cx: &mut Context<Self>) {
         self.clear_bell(cx);
         self.pause_cursor_blinking(window, cx);
-
         if self.process_keystroke(&event.keystroke, cx) {
             cx.stop_propagation();
         }
@@ -1236,6 +1306,7 @@ impl Render for TerminalView {
         let terminal_view_handle = cx.entity();
 
         let focused = self.focus_handle.is_focused(window);
+        let hint_state = self.terminal.read(cx).hint_state().cloned();
 
         div()
             .id("terminal-view")
@@ -1243,23 +1314,36 @@ impl Render for TerminalView {
             .relative()
             .track_focus(&self.focus_handle(cx))
             .key_context(self.dispatch_context(cx))
-            .on_action(cx.listener(TerminalView::send_text))
-            .on_action(cx.listener(TerminalView::send_keystroke))
             .on_action(cx.listener(TerminalView::copy))
-            .on_action(cx.listener(TerminalView::paste))
-            .on_action(cx.listener(TerminalView::paste_text))
-            .on_action(cx.listener(TerminalView::clear))
-            .on_action(cx.listener(TerminalView::scroll_line_up))
-            .on_action(cx.listener(TerminalView::scroll_line_down))
-            .on_action(cx.listener(TerminalView::scroll_page_up))
-            .on_action(cx.listener(TerminalView::scroll_page_down))
-            .on_action(cx.listener(TerminalView::scroll_to_top))
-            .on_action(cx.listener(TerminalView::scroll_to_bottom))
-            .on_action(cx.listener(TerminalView::toggle_vi_mode))
             .on_action(cx.listener(TerminalView::show_character_palette))
             .on_action(cx.listener(TerminalView::select_all))
             .on_action(cx.listener(TerminalView::rerun_task))
             .on_action(cx.listener(TerminalView::rename_terminal))
+            .on_action(cx.listener(TerminalView::send_keystroke))
+            .when_else(
+                hint_state.is_some(),
+                |div| {
+                    div.on_action(cx.listener(|_, _: &zed_actions::buffer_search::Deploy, _, _| {}))
+                        .on_action(cx.listener(|this, _: &menu::Cancel, _, cx| {
+                            this.set_hint_state(None, cx);
+                            cx.notify();
+                        }))
+                },
+                |div| {
+                    div.on_action(cx.listener(TerminalView::activate_hints))
+                        .on_action(cx.listener(TerminalView::scroll_line_up))
+                        .on_action(cx.listener(TerminalView::scroll_line_down))
+                        .on_action(cx.listener(TerminalView::scroll_page_up))
+                        .on_action(cx.listener(TerminalView::scroll_page_down))
+                        .on_action(cx.listener(TerminalView::scroll_to_top))
+                        .on_action(cx.listener(TerminalView::scroll_to_bottom))
+                        .on_action(cx.listener(TerminalView::toggle_vi_mode))
+                        .on_action(cx.listener(TerminalView::paste))
+                        .on_action(cx.listener(TerminalView::paste_text))
+                        .on_action(cx.listener(TerminalView::clear))
+                        .on_action(cx.listener(TerminalView::send_text))
+                },
+            )
             .on_key_down(cx.listener(Self::key_down))
             .on_mouse_down(
                 MouseButton::Right,
@@ -1315,6 +1399,33 @@ impl Render for TerminalView {
                         )
                     }),
             )
+            .when_some(hint_state.as_ref(), |el, state| {
+                let label = format!("Hints Mode [{} targets]", state.hints.len());
+                el.child(
+                    div()
+                        .absolute()
+                        .top_0()
+                        .right(
+                            ui::ScrollbarStyle::Regular.to_pixels()
+                                + 2. * ui::SCROLLBAR_PADDING
+                                + px(4.),
+                        )
+                        .child(
+                            h_flex()
+                                .gap_1()
+                                .px_0p5()
+                                .border_x_1()
+                                .border_b_1()
+                                .border_color(cx.theme().colors().border_variant)
+                                .rounded_b_lg()
+                                .bg(cx.theme().colors().element_background)
+                                .shadow_md()
+                                .child(
+                                    Label::new(label).color(Color::Muted).size(LabelSize::Small),
+                                ),
+                        ),
+                )
+            })
             .children(self.context_menu.as_ref().map(|(menu, position, _)| {
                 deferred(
                     anchored()
@@ -2064,9 +2175,36 @@ mod tests {
     use project::{Entry, Project, ProjectPath, Worktree};
     use remote::RemoteClient;
     use std::path::{Path, PathBuf};
+    use terminal::TerminalHyperlink;
     use util::paths::PathStyle;
     use util::rel_path::RelPath;
     use workspace::item::test::{TestItem, TestProjectItem};
+
+    fn terminal_hint_sample_double(first: char, second: char) -> TerminalHint {
+        use terminal::alacritty_terminal::index::{Column, Line};
+        TerminalHint {
+            label: HintLabel::Double(first, second),
+            hyperlink: TerminalHyperlink {
+                text: "https://example.com".to_string(),
+                is_url: true,
+                match_range: AlacPoint::new(Line(0), Column(0))
+                    ..=AlacPoint::new(Line(0), Column(0)),
+            },
+        }
+    }
+
+    fn terminal_hint_sample_single(ch: char) -> TerminalHint {
+        use terminal::alacritty_terminal::index::{Column, Line};
+        TerminalHint {
+            label: HintLabel::Single(ch),
+            hyperlink: TerminalHyperlink {
+                text: "https://example.com".to_string(),
+                is_url: true,
+                match_range: AlacPoint::new(Line(0), Column(0))
+                    ..=AlacPoint::new(Line(0), Column(0)),
+            },
+        }
+    }
     use workspace::{AppState, MultiWorkspace, SelectedEntry};
 
     fn expected_drop_text(paths: &[PathBuf]) -> String {
@@ -2833,6 +2971,498 @@ mod tests {
                 !text.is_empty() && text.as_ref() != "   ",
                 "Tab should show terminal title, not whitespace; got: '{}'",
                 text
+            );
+        });
+    }
+
+    async fn setup_test_terminal_and_view(
+        cx: &mut TestAppContext,
+    ) -> (
+        gpui::WindowHandle<MultiWorkspace>,
+        gpui::Entity<terminal::Terminal>,
+        gpui::Entity<TerminalView>,
+    ) {
+        let (project, _workspace, window_handle) = init_test_with_window(cx).await;
+        let (terminal, terminal_view) = window_handle
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                let terminal = cx.new(|cx| {
+                    terminal::TerminalBuilder::new_display_only(
+                        CursorShape::default(),
+                        terminal::terminal_settings::AlternateScroll::On,
+                        None,
+                        0,
+                        cx.background_executor(),
+                        PathStyle::local(),
+                    )
+                    .unwrap()
+                    .subscribe(cx)
+                });
+                let terminal_view = cx.new(|cx| {
+                    TerminalView::new(
+                        terminal.clone(),
+                        workspace.downgrade(),
+                        None,
+                        project.downgrade(),
+                        window,
+                        cx,
+                    )
+                });
+                workspace.update(cx, |workspace, cx| {
+                    workspace.add_item_to_active_pane(
+                        Box::new(terminal_view.clone()),
+                        None,
+                        true,
+                        window,
+                        cx,
+                    );
+                });
+                (terminal, terminal_view)
+            })
+            .unwrap();
+        cx.run_until_parked();
+        (window_handle, terminal, terminal_view)
+    }
+
+    #[test]
+    fn test_hint_mode_label_assignment() {
+        assert_eq!(assign_hint_labels(0).len(), 0);
+        assert_eq!(assign_hint_labels(1).len(), 1);
+
+        let small = assign_hint_labels(26);
+        assert_eq!(small.len(), 26);
+        assert!(small.iter().all(|l| matches!(l, HintLabel::Single(_))));
+
+        let large = assign_hint_labels(27);
+        assert_eq!(large.len(), 27);
+        assert!(large.iter().all(|l| matches!(l, HintLabel::Double(_, _))));
+
+        let max_possible = assign_hint_labels(676);
+        assert_eq!(max_possible.len(), 676);
+        assert_eq!(assign_hint_labels(677).len(), 676);
+
+        let mut seen = std::collections::HashSet::new();
+        for label in &max_possible {
+            assert!(seen.insert(label), "duplicate label: {:?}", label);
+        }
+    }
+
+    #[test]
+    fn test_hint_mode_input_matching_and_visibility() {
+        let hints = vec![
+            terminal_hint_sample_double('j', 'j'),
+            terminal_hint_sample_double('j', 'f'),
+            terminal_hint_sample_double('f', 'j'),
+        ];
+        let mut state = TerminalHintState {
+            hints,
+            input: String::new(),
+            display_offset: 0,
+        };
+
+        // No input: all hints are visible
+        assert_eq!(state.visible_hints().len(), 3);
+
+        // Type 'j': only hints matching 'j' prefix are visible
+        state.input = "j".to_string();
+        let visible = state.visible_hints();
+        assert_eq!(visible.len(), 2);
+        assert!(
+            visible
+                .iter()
+                .all(|h| matches!(&h.label, HintLabel::Double(f, _) if *f == 'j'))
+        );
+
+        // Type 'jj': full match shows no pending hints (input is complete)
+        state.input = "jj".to_string();
+        assert_eq!(state.visible_hints().len(), 0);
+
+        // Backspace clears the input: all hints visible again
+        state.input.pop();
+        assert_eq!(state.input, "j");
+        assert_eq!(state.visible_hints().len(), 2);
+
+        state.input.pop();
+        assert_eq!(state.input, "");
+        assert_eq!(state.visible_hints().len(), 3);
+    }
+
+    #[test]
+    fn test_hint_mode_find_match() {
+        // Test matching with double-character labels
+        let double_hints = vec![
+            terminal_hint_sample_double('j', 'j'),
+            terminal_hint_sample_double('j', 'f'),
+            terminal_hint_sample_double('f', 'j'),
+        ];
+        let double_state = TerminalHintState {
+            hints: double_hints,
+            input: String::new(),
+            display_offset: 0,
+        };
+        assert!(double_state.find_match("jf").is_some());
+        assert!(double_state.find_match("jj").is_some());
+        assert!(double_state.find_match("zz").is_none());
+
+        // Test matching with single-character labels
+        let single_hints = vec![
+            terminal_hint_sample_single('j'),
+            terminal_hint_sample_single('f'),
+        ];
+        let single_state = TerminalHintState {
+            hints: single_hints,
+            input: String::new(),
+            display_offset: 0,
+        };
+        assert!(single_state.find_match("j").is_some());
+        assert!(single_state.find_match("f").is_some());
+        assert!(single_state.find_match("z").is_none());
+        assert!(
+            single_state.find_match("jf").is_none(),
+            "two chars must not match single-char label"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_hint_mode_open_url(cx: &mut TestAppContext) {
+        use std::cell::RefCell;
+
+        let (window_handle, terminal, terminal_view) = setup_test_terminal_and_view(cx).await;
+
+        terminal.update(cx, |term, cx| {
+            term.write_output(b"https://example.com", cx);
+        });
+        cx.run_until_parked();
+
+        let opened_url: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+        let _subscription = cx.update(|cx| {
+            cx.subscribe(&terminal, {
+                let opened_url = opened_url.clone();
+                move |_, event: &Event, _| {
+                    if let Event::Open(MaybeNavigationTarget::Url(url)) = event {
+                        *opened_url.borrow_mut() = Some(url.clone());
+                    }
+                }
+            })
+        });
+
+        cx.dispatch_action(window_handle.into(), ActivateHints);
+
+        let hint_char = terminal_view.read_with(cx, |view, cx| {
+            let state = view
+                .terminal
+                .read(cx)
+                .hint_state()
+                .expect("hint_state should be Some after ActivateHints");
+            assert_eq!(state.hints.len(), 1, "one URL should produce one hint");
+            match state.hints[0].label {
+                HintLabel::Single(ch) => ch,
+                HintLabel::Double(_, _) => panic!("one URL must produce a single-char label"),
+            }
+        });
+
+        // Single-char label: typing it should immediately match and emit Event::Open.
+        cx.simulate_keystrokes(window_handle.into(), &hint_char.to_string());
+
+        terminal_view.read_with(cx, |view, cx| {
+            assert!(
+                view.terminal.read(cx).hint_state().is_none(),
+                "hint_state should be cleared after typing single-char label"
+            );
+        });
+
+        assert_eq!(
+            *opened_url.borrow(),
+            Some("https://example.com".to_string()),
+            "URL should be opened via Event::Open"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_hint_mode_open_file(cx: &mut TestAppContext) {
+        use std::cell::RefCell;
+        use std::io::Write;
+
+        let (window_handle, terminal, terminal_view) = setup_test_terminal_and_view(cx).await;
+
+        // Create a real file so collect_visible_navigation_targets can verify it exists.
+        let mut temp_file = tempfile::NamedTempFile::new().unwrap();
+        temp_file.write_all(b"// hint test").unwrap();
+
+        // file:// URLs are matched by the URL regex and converted to PathLike by
+        // collect_visible_navigation_targets when the file exists on disk.
+        let file_url = format!("file://{}", temp_file.path().display());
+        terminal.update(cx, |term, cx| {
+            term.write_output(file_url.as_bytes(), cx);
+        });
+        cx.run_until_parked();
+
+        let opened_target: Rc<RefCell<Option<MaybeNavigationTarget>>> = Rc::new(RefCell::new(None));
+        let _subscription = cx.update(|cx| {
+            cx.subscribe(&terminal, {
+                let opened_target = opened_target.clone();
+                move |_, event: &Event, _| {
+                    if let Event::Open(target) = event {
+                        *opened_target.borrow_mut() = Some(target.clone());
+                    }
+                }
+            })
+        });
+
+        cx.dispatch_action(window_handle.into(), ActivateHints);
+
+        let hint_char = terminal_view.read_with(cx, |view, cx| {
+            let state = view
+                .terminal
+                .read(cx)
+                .hint_state()
+                .expect("hint_state should be Some after ActivateHints");
+            assert_eq!(
+                state.hints.len(),
+                1,
+                "one file path should produce one hint"
+            );
+            match state.hints[0].label {
+                HintLabel::Single(ch) => ch,
+                HintLabel::Double(_, _) => panic!("one file must produce a single-char label"),
+            }
+        });
+
+        // Single-char label: typing it should immediately match and emit Event::Open.
+        cx.simulate_keystrokes(window_handle.into(), &hint_char.to_string());
+
+        terminal_view.read_with(cx, |view, cx| {
+            assert!(
+                view.terminal.read(cx).hint_state().is_none(),
+                "hint_state should be cleared after typing the single-char label"
+            );
+        });
+
+        let expected_path = temp_file.path().to_string_lossy().into_owned();
+        let target = opened_target.borrow();
+        match target.as_ref().expect("Event::Open should be emitted") {
+            MaybeNavigationTarget::PathLike(path_like) => {
+                assert_eq!(path_like.maybe_path, expected_path);
+            }
+            MaybeNavigationTarget::Url(url) => {
+                panic!("expected PathLike target, got Url: {url}");
+            }
+        }
+    }
+
+    #[gpui::test]
+    async fn test_hint_mode_keyboard_controls(cx: &mut TestAppContext) {
+        use gpui::{Modifiers, ScrollDelta};
+
+        let (_window_handle, _terminal, terminal_view) = setup_test_terminal_and_view(cx).await;
+
+        // Inject 27 double-char hints directly so the test doesn't depend on URL detection
+        // or viewport size. assign_hint_labels(27) produces Double variants since 27 > 26.
+        let (first_char, hint_count) = terminal_view.update(cx, |view, cx| {
+            let labels = assign_hint_labels(27);
+            assert!(
+                labels.iter().all(|l| matches!(l, HintLabel::Double(_, _))),
+                "assign_hint_labels(27) must produce double-char labels"
+            );
+            let first_char = match labels[0] {
+                HintLabel::Double(f, _) => f,
+                HintLabel::Single(_) => unreachable!(),
+            };
+            let hint_count = labels.len();
+            view.set_hint_state(
+                Some(TerminalHintState {
+                    hints: labels
+                        .into_iter()
+                        .map(|label| {
+                            use terminal::alacritty_terminal::index::{Column, Line};
+                            TerminalHint {
+                                label,
+                                hyperlink: TerminalHyperlink {
+                                    text: "https://example.com".to_string(),
+                                    is_url: true,
+                                    match_range: AlacPoint::new(Line(0), Column(0))
+                                        ..=AlacPoint::new(Line(0), Column(0)),
+                                },
+                            }
+                        })
+                        .collect(),
+                    input: String::new(),
+                    display_offset: 0,
+                }),
+                cx,
+            );
+            (first_char, hint_count)
+        });
+
+        // Type the first char: hint mode must stay active, only matching hints visible.
+        terminal_view.update(cx, |view, cx| {
+            view.process_keystroke(
+                &Keystroke {
+                    key: first_char.to_string(),
+                    ..Default::default()
+                },
+                cx,
+            );
+        });
+        terminal_view.read_with(cx, |view, cx| {
+            let state = view.terminal.read(cx).hint_state().unwrap();
+            assert_eq!(state.input.len(), 1, "one char should be recorded in input");
+            let visible_count = state.visible_hints().len();
+            assert!(
+                visible_count > 0 && visible_count < hint_count,
+                "visible hints should be a filtered subset after typing first char"
+            );
+        });
+
+        // ctrl-f must be consumed (returns true) without exiting hint mode or advancing input.
+        let ctrl_f_handled = terminal_view.update(cx, |view, cx| {
+            view.process_keystroke(
+                &Keystroke {
+                    key: "f".to_string(),
+                    modifiers: Modifiers {
+                        control: true,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                cx,
+            )
+        });
+        assert!(ctrl_f_handled, "ctrl-f must be blocked in hint mode");
+        terminal_view.read_with(cx, |view, cx| {
+            assert!(
+                view.terminal.read(cx).hint_state().is_some(),
+                "hint mode must survive ctrl-f"
+            );
+            assert_eq!(
+                view.terminal.read(cx).hint_state().unwrap().input.len(),
+                1,
+                "ctrl-f must not advance input"
+            );
+        });
+
+        // shift+pageup must be consumed without scrolling or exiting hint mode.
+        let shift_pageup_handled = terminal_view.update(cx, |view, cx| {
+            view.process_keystroke(
+                &Keystroke {
+                    key: "pageup".to_string(),
+                    modifiers: Modifiers {
+                        shift: true,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                cx,
+            )
+        });
+        assert!(
+            shift_pageup_handled,
+            "shift+pageup must be blocked in hint mode"
+        );
+        terminal_view.read_with(cx, |view, cx| {
+            assert!(
+                view.terminal.read(cx).hint_state().is_some(),
+                "hint mode must survive shift+pageup"
+            );
+        });
+
+        // Mouse scroll must not change terminal state while in hint mode.
+        terminal_view.update(cx, |view, cx| {
+            view.scroll_wheel(
+                &ScrollWheelEvent {
+                    delta: ScrollDelta::Lines(Point::new(0.0, -3.0)),
+                    ..Default::default()
+                },
+                cx,
+            );
+        });
+        terminal_view.read_with(cx, |view, cx| {
+            assert!(
+                view.terminal.read(cx).hint_state().is_some(),
+                "hint mode must survive mouse scroll"
+            );
+        });
+
+        // Backspace clears the last typed char; all hints become visible again.
+        terminal_view.update(cx, |view, cx| {
+            view.process_keystroke(
+                &Keystroke {
+                    key: "backspace".to_string(),
+                    ..Default::default()
+                },
+                cx,
+            );
+        });
+        terminal_view.read_with(cx, |view, cx| {
+            let state = view.terminal.read(cx).hint_state().unwrap();
+            assert!(
+                state.input.is_empty(),
+                "backspace should clear the recorded input"
+            );
+            assert_eq!(
+                state.visible_hints().len(),
+                state.hints.len(),
+                "all hints should be visible after input is cleared"
+            );
+        });
+
+        // Escape exits hint mode entirely.
+        terminal_view.update(cx, |view, cx| {
+            view.process_keystroke(
+                &Keystroke {
+                    key: "escape".to_string(),
+                    ..Default::default()
+                },
+                cx,
+            );
+        });
+        assert!(
+            terminal_view.read_with(cx, |v, cx| v.terminal.read(cx).hint_state().is_none()),
+            "escape should exit hint mode"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_hint_mode_clears_on_resize(cx: &mut TestAppContext) {
+        let (window_handle, terminal, terminal_view) = setup_test_terminal_and_view(cx).await;
+
+        terminal.update(cx, |term, cx| {
+            term.write_output(b"https://example.com", cx);
+        });
+        cx.run_until_parked();
+
+        cx.dispatch_action(window_handle.into(), ActivateHints);
+
+        // 1. Verify hints state is active and has 1 hint.
+        terminal_view.read_with(cx, |view, cx| {
+            let state = view
+                .terminal
+                .read(cx)
+                .hint_state()
+                .expect("hint_state should be Some after ActivateHints");
+            assert_eq!(state.hints.len(), 1, "one URL should produce one hint");
+        });
+
+        // 2. Perform a grid resize.
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal.update(cx, |term, cx| {
+                    let mut new_bounds = term.last_content().terminal_bounds;
+                    new_bounds.bounds.size.height += Pixels::from(100.);
+                    new_bounds.bounds.size.width += Pixels::from(100.);
+                    term.set_size(new_bounds);
+                    term.sync(window, cx);
+                });
+            })
+            .unwrap();
+
+        cx.run_until_parked();
+
+        // 3. Hint state should be cleared after resize so stale typed input doesn't hide hints.
+        terminal_view.read_with(cx, |view, cx| {
+            assert!(
+                view.terminal.read(cx).hint_state().is_none(),
+                "hint_state should be cleared after resize"
             );
         });
     }

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -28,7 +28,7 @@ const SCROLLBAR_HIDE_DURATION: Duration = Duration::from_millis(400);
 const SCROLLBAR_SHOW_DURATION: Duration = Duration::from_millis(50);
 
 pub const EDITOR_SCROLLBAR_WIDTH: Pixels = ScrollbarStyle::Editor.to_pixels();
-const SCROLLBAR_PADDING: Pixels = px(4.);
+pub const SCROLLBAR_PADDING: Pixels = px(4.);
 const BORDER_WIDTH: Pixels = px(1.);
 
 pub mod scrollbars {


### PR DESCRIPTION
`ctrl-shift-o` shows an overlay with terminal hints for paths and urls found in current terminal. Each hint has two letter code attached which can be typed to open the file in active pane at exact file locaton (:lin:col) if available. URLs are opened via external system handlers.

Basically, this is the same functionality as HINTS in Alacritty (https://man.archlinux.org/man/extra/alacritty/alacritty.5.en#HINTS).

There is related discussion about this topic: https://github.com/zed-industries/zed/discussions/24853

[zed-terminal-hints.webm](https://github.com/user-attachments/assets/dfe02e5f-2819-405f-b2f9-6663c7ff0990)


Release Notes:

- Added hints mode for terminal (allows to open a link via keyboard, `ctrl-shift-o` by default)
