### PR TITLE
Make notebook cells follow global font and markdown styling

### DIFF
--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -8,7 +8,7 @@ use gpui::{
     StatefulInteractiveElement, Task, prelude::*,
 };
 use language::{Buffer, Language, LanguageRegistry};
-use markdown::{Markdown, MarkdownElement, MarkdownStyle};
+use markdown::{Markdown, MarkdownElement, MarkdownFont, MarkdownStyle};
 use nbformat::v4::{CellId, CellMetadata, CellType};
 use runtimelib::{JupyterMessage, JupyterMessageContent};
 use settings::Settings as _;
@@ -595,10 +595,7 @@ impl Render for MarkdownCell {
 
         // Preview mode - show rendered markdown
 
-        let style = MarkdownStyle {
-            base_text_style: window.text_style(),
-            ..Default::default()
-        };
+        let style = MarkdownStyle::themed(MarkdownFont::Preview, window, cx);
 
         v_flex()
             .size_full()

--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -5,14 +5,13 @@ use editor::{Editor, EditorMode, MultiBuffer, SizingBehavior};
 use futures::future::Shared;
 use gpui::{
     App, Entity, EventEmitter, Focusable, Hsla, InteractiveElement, RetainAllImageCache,
-    StatefulInteractiveElement, Task, TextStyleRefinement, prelude::*,
+    StatefulInteractiveElement, Task, prelude::*,
 };
 use language::{Buffer, Language, LanguageRegistry};
 use markdown::{Markdown, MarkdownElement, MarkdownStyle};
 use nbformat::v4::{CellId, CellMetadata, CellType};
 use runtimelib::{JupyterMessage, JupyterMessageContent};
 use settings::Settings as _;
-use theme_settings::ThemeSettings;
 use ui::{CommonAnimationExt, IconButtonShape, prelude::*};
 use util::ResultExt;
 
@@ -419,17 +418,7 @@ impl MarkdownCell {
                 cx,
             );
 
-            let theme = ThemeSettings::get_global(cx);
-            let refinement = TextStyleRefinement {
-                font_family: Some(theme.buffer_font.family.clone()),
-                font_size: Some(theme.buffer_font_size(cx).into()),
-                color: Some(cx.theme().colors().editor_foreground),
-                background_color: Some(gpui::transparent_black()),
-                ..Default::default()
-            };
-
             editor.set_show_gutter(false, cx);
-            editor.set_text_style_refinement(refinement);
             editor.set_use_modal_editing(true);
             editor.disable_mouse_wheel_zoom();
             editor.disable_scrollbars_and_minimap(window, cx);
@@ -710,20 +699,10 @@ impl CodeCell {
                 cx,
             );
 
-            let theme = ThemeSettings::get_global(cx);
-            let refinement = TextStyleRefinement {
-                font_family: Some(theme.buffer_font.family.clone()),
-                font_size: Some(theme.buffer_font_size(cx).into()),
-                color: Some(cx.theme().colors().editor_foreground),
-                background_color: Some(gpui::transparent_black()),
-                ..Default::default()
-            };
-
             editor.disable_mouse_wheel_zoom();
             editor.disable_scrollbars_and_minimap(window, cx);
             editor.set_text(source.clone(), window, cx);
             editor.set_show_gutter(false, cx);
-            editor.set_text_style_refinement(refinement);
             editor.set_use_modal_editing(true);
             editor
         });


### PR DESCRIPTION
Notebook cells are currently not responding to changes in font-family (`zed://settings/buffer_font_family`) and font-size (`zed://settings/buffer_font_size`). 

Currently, `MarkdownCell` and `CodeCell` create and set a `TextStyleRefinement` on their `Editor`, creating copies of font-family and font-size in the process. As a result, these do not get updated when the global font-family or font-size change.  
By not setting the refinement manually and letting the editor handle these value instead, these values get updated when the global settings change.

This behaviour is consistent with how the inline repl already behaves and in my opinion is according to the users expectations.


After Review: this PR changes the rendered preview of MarkdownCells to use the themed MarkdownStyle instead of an empty Markdown Style



Before:

https://github.com/user-attachments/assets/e70b9346-8fa1-4d66-aa85-07e987c56ff2

After:

https://github.com/user-attachments/assets/4957e20e-9b5b-4cb9-a9df-3b33538bc686



Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
  - not sure if this needs test or how they should look like...
- [x] Performance impact has been considered and is acceptable

~~Closes #ISSUE~~

Release Notes:

- Fixed notebook cells not responding to appearance settings changes
