### PR TITLE
bedrock: Add support for Service Tiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "zeroize",
 ]
 
@@ -1398,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.12"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26bbf46abc608f2dc61fd6cb3b7b0665497cc259a21520151ed98f8b37d2c79"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1433,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.0"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f92058d22a46adf53ec57a6a96f34447daf02bff52e8fb956c66bcd5c6ac12"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1461,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.125.0"
+version = "1.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e9a808701bdc7c6e27dfbc284f5b40c30ac0392a2e58e3bc855b243a7c967"
+checksum = "e494025b4c578bfefd025aada69c51ab1db6b7589f61cb78ae681f3115269209"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1534,14 +1534,14 @@ dependencies = [
  "bytes 1.11.1",
  "fastrand 2.3.0",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -1621,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.0"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f6ae9b71597dc5fd115d52849d7a5556ad9265885ad3492ea8d73b93bbc46e"
+checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -1631,16 +1631,15 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes 1.11.1",
- "crypto-bigint 0.5.5",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.3.1",
  "p256",
  "percent-encoding",
- "ring",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "time",
  "tracing",
@@ -1675,7 +1674,7 @@ dependencies = [
  "md-5",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -1692,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.63.4"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4a8a5fe3e4ac7ee871237c340bbce13e982d37543b65700f4419e039f5d78e"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -1714,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.10"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0709f0083aa19b704132684bc26d3c868e06bd428ccc4373b0b55c3e8748a58b"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1744,18 +1743,20 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -1772,15 +1773,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd3dfc18c1ce097cf81fced7192731e63809829c6cbf933c1ec47452d08e1aa"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes 1.11.1",
  "fastrand 2.3.0",
@@ -1797,11 +1799,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.4"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c55e0837e9b8526f49e0b9bfa9ee18ddee70e853f5bc09c5d11ebceddcb0fec"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes 1.11.1",
  "http 0.2.12",
@@ -1813,10 +1816,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
 dependencies = [
  "base64-simd",
  "bytes 1.11.1",
@@ -1849,13 +1874,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.12"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c50f3cdf47caa8d01f2be4a6663ea02418e892f9bbfd82c7b9a3a37eaccdd3a"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -1940,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -1980,6 +2006,8 @@ dependencies = [
  "aws-sdk-bedrockruntime",
  "aws-smithy-types",
  "futures 0.3.32",
+ "language_model_core",
+ "log",
  "schemars 1.0.4",
  "serde",
  "serde_json",
@@ -2133,6 +2161,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2891,7 +2928,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
  "zeroize",
 ]
@@ -3031,7 +3068,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "settings",
- "sha2",
+ "sha2 0.10.9",
  "smol",
  "telemetry",
  "telemetry_events",
@@ -3110,6 +3147,12 @@ checksum = "b042e5d8a74ae91bb0961acd039822472ec99f8ab0948cbf6d1369588f8be586"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "cobs"
@@ -3287,7 +3330,7 @@ dependencies = [
  "serde_json",
  "session",
  "settings",
- "sha2",
+ "sha2 0.10.9",
  "smol",
  "sqlx",
  "strum 0.27.2",
@@ -3548,6 +3591,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3617,7 +3666,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
- "sha2",
+ "sha2 0.10.9",
  "slotmap",
  "tempfile",
  "url",
@@ -3985,6 +4034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cranelift-assembler-x64"
 version = "0.123.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4045,7 +4103,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasmtime-internal-math",
@@ -4188,7 +4246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rustversion",
  "spin 0.10.0",
 ]
@@ -4311,24 +4369,14 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -4339,6 +4387,15 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -4403,6 +4460,15 @@ dependencies = [
  "dispatch",
  "nix 0.30.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -4842,21 +4908,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -5024,10 +5080,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -5252,14 +5320,16 @@ checksum = "3b31a881d38439026e3d5dd938ab20328d36e23caca8fd5981c42e4b677f5842"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.6.1",
+ "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature 1.6.4",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -5617,18 +5687,18 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest",
+ "crypto-bigint",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "pkcs8 0.9.0",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -6330,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -7183,6 +7253,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -8026,9 +8097,9 @@ checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand_core 0.6.4",
@@ -8333,7 +8404,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -8342,7 +8413,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -8477,7 +8557,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "url",
  "util",
@@ -8514,6 +8594,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -9376,7 +9465,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "signature 2.2.0",
+ "signature",
  "simple_asn1",
 ]
 
@@ -9714,7 +9803,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
- "sha2",
+ "sha2 0.10.9",
  "smol",
  "strum 0.27.2",
  "tokio",
@@ -10151,7 +10240,7 @@ dependencies = [
  "rustls-native-certs 0.6.3",
  "scopeguard",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -10598,7 +10687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -11845,20 +11934,20 @@ dependencies = [
  "blocking",
  "cbc",
  "cipher",
- "digest",
+ "digest 0.10.7",
  "endi",
  "futures-lite 2.6.1",
  "futures-util",
  "getrandom 0.4.1",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "md-5",
  "num",
  "num-bigint-dig 0.9.1",
  "pbkdf2 0.12.2",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zbus",
  "zbus_macros",
@@ -12155,13 +12244,14 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -12357,10 +12447,10 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
  "password-hash",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -12369,8 +12459,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -12480,7 +12570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -12728,7 +12818,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "toml 0.8.23",
 ]
 
@@ -12764,7 +12854,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -13080,19 +13170,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -13101,8 +13181,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -13385,6 +13465,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13441,9 +13530,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -13547,7 +13636,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
- "sha2",
+ "sha2 0.10.9",
  "shellexpand",
  "smallvec",
  "smol",
@@ -14106,9 +14195,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -14922,13 +15011,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -15107,7 +15195,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "strum 0.27.2",
  "tracing",
  "util",
@@ -15121,16 +15209,16 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig 0.8.6",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
  "subtle",
  "zeroize",
 ]
@@ -15235,7 +15323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "globset",
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -15834,14 +15922,14 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.6.1",
+ "der",
  "generic-array",
- "pkcs8 0.9.0",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -16287,8 +16375,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -16298,8 +16386,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -16315,8 +16403,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -16444,21 +16543,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -16764,22 +16853,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
-
-[[package]]
-name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -16861,7 +16940,7 @@ dependencies = [
  "rustls 0.23.40",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.17",
  "time",
@@ -16901,7 +16980,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -16925,7 +17004,7 @@ dependencies = [
  "bytes 1.11.1",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -16935,7 +17014,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -16947,7 +17026,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -16978,7 +17057,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -16990,7 +17069,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -17786,7 +17865,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_lenient",
- "sha2",
+ "sha2 0.10.9",
  "shellexpand",
  "util",
  "zed_actions",
@@ -18659,9 +18738,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -18682,9 +18761,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -19134,9 +19213,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -22996,7 +23075,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "flate2",
- "hmac",
+ "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "sha1",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -534,7 +534,7 @@ aws-config = { version = "1.8.10", features = ["behavior-version-latest"] }
 aws-credential-types = { version = "1.2.8", features = [
     "hardcoded-credentials",
 ] }
-aws-sdk-bedrockruntime = { version = "1.112.0", features = [
+aws-sdk-bedrockruntime = { version = "1.131.0", features = [
     "behavior-version-latest",
 ] }
 aws-smithy-runtime-api = { version = "1.9.2", features = ["http-1x", "client"] }

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -326,6 +326,8 @@
       "ctrl-alt-'": "agent::ToggleThinkingEffortMenu",
       "ctrl-'": "agent::CycleThinkingEffort",
       "ctrl-alt-.": "agent::ToggleFastMode",
+      "ctrl-alt-,": "agent::ToggleServiceTierMenu",
+      "ctrl-,": "agent::CycleServiceTier",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -367,6 +367,8 @@
       "cmd-alt-'": "agent::ToggleThinkingEffortMenu",
       "ctrl-'": "agent::CycleThinkingEffort",
       "cmd-alt-.": "agent::ToggleFastMode",
+      "cmd-alt-,": "agent::ToggleServiceTierMenu",
+      "cmd-,": "agent::CycleServiceTier",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -327,6 +327,8 @@
       "ctrl-alt-'": "agent::ToggleThinkingEffortMenu",
       "ctrl-'": "agent::CycleThinkingEffort",
       "ctrl-alt-.": "agent::ToggleFastMode",
+      "ctrl-alt-,": "agent::ToggleServiceTierMenu",
+      "ctrl-,": "agent::CycleServiceTier",
     },
   },
   {

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -576,12 +576,15 @@ impl NativeAgent {
         });
 
         let registry = LanguageModelRegistry::read_global(cx);
-        let summarization_model = registry.thread_summary_model(cx).map(|c| c.model);
+        let summarization = registry.thread_summary_model(cx);
+        let summarization_model = summarization.as_ref().map(|c| c.model.clone());
+        let summarization_service_tier =
+            summarization.as_ref().and_then(|c| c.service_tier.clone());
 
         let weak = cx.weak_entity();
         let weak_thread = thread_handle.downgrade();
         thread_handle.update(cx, |thread, cx| {
-            thread.set_summarization_model(summarization_model, cx);
+            thread.set_summarization_model(summarization_model, summarization_service_tier, cx);
             thread.add_default_tools(
                 Rc::new(NativeThreadEnvironment {
                     acp_thread: acp_thread.downgrade(),
@@ -1142,7 +1145,10 @@ impl NativeAgent {
 
         let registry = LanguageModelRegistry::read_global(cx);
         let default_model = registry.default_model().map(|m| m.model);
-        let summarization_model = registry.thread_summary_model(cx).map(|m| m.model);
+        let summarization = registry.thread_summary_model(cx);
+        let summarization_model = summarization.as_ref().map(|m| m.model.clone());
+        let summarization_service_tier =
+            summarization.as_ref().and_then(|c| c.service_tier.clone());
 
         for session in self.sessions.values_mut() {
             session.thread.update(cx, |thread, cx| {
@@ -1156,7 +1162,11 @@ impl NativeAgent {
                     if thread.summarization_model().is_none()
                         || matches!(event, language_model::Event::ThreadSummaryModelChanged)
                     {
-                        thread.set_summarization_model(Some(model), cx);
+                        thread.set_summarization_model(
+                            Some(model),
+                            summarization_service_tier.clone(),
+                            cx,
+                        );
                     }
                 }
             });
@@ -1343,9 +1353,10 @@ impl NativeAgent {
                     .projects
                     .get(&project_id)
                     .context("project state not found")?;
-                let summarization_model = LanguageModelRegistry::read_global(cx)
-                    .thread_summary_model(cx)
-                    .map(|c| c.model);
+                let summarization = LanguageModelRegistry::read_global(cx).thread_summary_model(cx);
+                let summarization_model = summarization.as_ref().map(|c| c.model.clone());
+                let summarization_service_tier =
+                    summarization.as_ref().and_then(|c| c.service_tier.clone());
 
                 Ok(cx.new(|cx| {
                     let mut thread = Thread::from_db(
@@ -1357,7 +1368,11 @@ impl NativeAgent {
                         this.templates.clone(),
                         cx,
                     );
-                    thread.set_summarization_model(summarization_model, cx);
+                    thread.set_summarization_model(
+                        summarization_model,
+                        summarization_service_tier,
+                        cx,
+                    );
                     thread
                 }))
             })?
@@ -4738,7 +4753,7 @@ mod internal_tests {
         let summary_model = Arc::new(FakeLanguageModel::default());
         thread.update(cx, |thread, cx| {
             thread.set_model(model.clone(), cx);
-            thread.set_summarization_model(Some(summary_model.clone()), cx);
+            thread.set_summarization_model(Some(summary_model.clone()), None, cx);
         });
         cx.run_until_parked();
         assert_eq!(thread_entries(&thread_store, cx), vec![]);
@@ -5000,7 +5015,7 @@ mod internal_tests {
         let summary_model = Arc::new(FakeLanguageModel::default());
         thread.update(cx, |thread, cx| {
             thread.set_model(model.clone(), cx);
-            thread.set_summarization_model(Some(summary_model.clone()), cx);
+            thread.set_summarization_model(Some(summary_model.clone()), None, cx);
         });
 
         let send = acp_thread.update(cx, |thread, cx| thread.send(vec!["hello".into()], cx));

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -2068,12 +2068,14 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
             enable_thinking,
             effort,
             speed,
+            service_tier,
             ..
         } = agent_settings::language_model_to_selection(&model, favorite.as_ref());
 
         thread.update(cx, |thread, cx| {
             thread.set_model(model.clone(), cx);
             thread.set_thinking_effort(effort.clone(), cx);
+            thread.set_service_tier(service_tier.clone(), cx);
             thread.set_thinking_enabled(enable_thinking, cx);
             if let Some(speed) = speed {
                 thread.set_speed(speed, cx);
@@ -2096,6 +2098,7 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
                         model,
                         enable_thinking,
                         effort,
+                        service_tier,
                         speed,
                     });
             },

--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -78,6 +78,8 @@ pub struct DbThread {
     #[serde(default)]
     pub thinking_effort: Option<String>,
     #[serde(default)]
+    pub service_tier: Option<String>,
+    #[serde(default)]
     pub draft_prompt: Option<Vec<acp::ContentBlock>>,
     #[serde(default)]
     pub ui_scroll_position: Option<SerializedScrollPosition>,
@@ -128,6 +130,7 @@ impl SharedThread {
             speed: None,
             thinking_enabled: false,
             thinking_effort: None,
+            service_tier: None,
             draft_prompt: None,
             ui_scroll_position: None,
         }
@@ -307,6 +310,7 @@ impl DbThread {
             speed: None,
             thinking_enabled: false,
             thinking_effort: None,
+            service_tier: None,
             draft_prompt: None,
             ui_scroll_position: None,
         })
@@ -692,6 +696,7 @@ mod tests {
             speed: None,
             thinking_enabled: false,
             thinking_effort: None,
+            service_tier: None,
             draft_prompt: None,
             ui_scroll_position: None,
         }

--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -158,6 +158,7 @@ mod tests {
                         Some(&language_model::SelectedModel {
                             provider: language_model::ANTHROPIC_PROVIDER_ID,
                             model: language_model::LanguageModelId("claude-sonnet-4-latest".into()),
+                            service_tier: None,
                         }),
                         cx,
                     );

--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -112,6 +112,7 @@ fn model_id_to_selection(model_id: &acp::ModelId, cx: &App) -> LanguageModelSele
             model: model.to_owned(),
             enable_thinking: false,
             effort: None,
+            service_tier: None,
             speed: None,
         };
     };

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -3309,7 +3309,7 @@ async fn test_title_generation(cx: &mut TestAppContext) {
 
     let summary_model = Arc::new(FakeLanguageModel::default());
     thread.update(cx, |thread, cx| {
-        thread.set_summarization_model(Some(summary_model.clone()), cx)
+        thread.set_summarization_model(Some(summary_model.clone()), None, cx)
     });
 
     let send = thread
@@ -3360,7 +3360,7 @@ async fn test_title_generation_failure_allows_retry(cx: &mut TestAppContext) {
     let summary_model = Arc::new(FakeLanguageModel::default());
     let fake_summary_model = summary_model.as_fake();
     thread.update(cx, |thread, cx| {
-        thread.set_summarization_model(Some(summary_model.clone()), cx)
+        thread.set_summarization_model(Some(summary_model.clone()), None, cx)
     });
 
     let send = thread
@@ -3818,7 +3818,7 @@ async fn test_update_title_tool_sets_thread_title(cx: &mut TestAppContext) {
     });
     thread.update(cx, |thread, cx| {
         thread.add_tool(UpdateTitleTool::new(cx.weak_entity()));
-        thread.set_summarization_model(Some(summary_model.clone()), cx);
+        thread.set_summarization_model(Some(summary_model.clone()), None, cx);
     });
 
     let mut events = thread
@@ -3897,7 +3897,7 @@ async fn test_update_title_availability_suppresses_summary_title_generation(
     });
     thread.update(cx, |thread, cx| {
         thread.add_tool(UpdateTitleTool::new(cx.weak_entity()));
-        thread.set_summarization_model(Some(summary_model.clone()), cx);
+        thread.set_summarization_model(Some(summary_model.clone()), None, cx);
     });
 
     let send = thread
@@ -3930,7 +3930,7 @@ async fn test_update_title_flag_without_available_tool_falls_back_to_summary_tit
         cx.update_flags(true, vec!["update-title-tool".to_string()]);
     });
     thread.update(cx, |thread, cx| {
-        thread.set_summarization_model(Some(summary_model.clone()), cx);
+        thread.set_summarization_model(Some(summary_model.clone()), None, cx)
     });
 
     let send = thread

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -5749,6 +5749,7 @@ async fn test_subagent_thread_uses_configured_subagent_model(cx: &mut TestAppCon
             model: "subagent-model".to_string(),
             enable_thinking: true,
             effort: Some("high".to_string()),
+            service_tier: None,
             speed: None,
         });
         agent_settings::AgentSettings::override_global(settings, cx);

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -987,6 +987,7 @@ pub struct Thread {
     summarization_model: Option<Arc<dyn LanguageModel>>,
     thinking_enabled: bool,
     thinking_effort: Option<String>,
+    service_tier: Option<String>,
     speed: Option<Speed>,
     prompt_capabilities_tx: watch::Sender<acp::PromptCapabilities>,
     pub(crate) prompt_capabilities_rx: watch::Receiver<acp::PromptCapabilities>,
@@ -1084,6 +1085,10 @@ impl Thread {
             .default_model
             .as_ref()
             .and_then(|model| model.speed);
+        let service_tier = settings
+            .default_model
+            .as_ref()
+            .and_then(|model| model.service_tier.clone());
         let (prompt_capabilities_tx, prompt_capabilities_rx) =
             watch::channel(Self::prompt_capabilities(model.as_deref()));
         Self {
@@ -1118,6 +1123,7 @@ impl Thread {
             thinking_enabled: enable_thinking,
             speed,
             thinking_effort,
+            service_tier,
             prompt_capabilities_tx,
             prompt_capabilities_rx,
             project,
@@ -1138,6 +1144,7 @@ impl Thread {
     fn inherit_parent_settings(&mut self, parent_thread: &Entity<Thread>, cx: &mut Context<Self>) {
         let parent = parent_thread.read(cx);
         self.speed = parent.speed;
+        self.service_tier = parent.service_tier.clone();
         self.thinking_enabled = parent.thinking_enabled;
         self.thinking_effort = parent.thinking_effort.clone();
         self.summarization_model = parent.summarization_model.clone();
@@ -1162,6 +1169,20 @@ impl Thread {
         self.thinking_enabled = selection.enable_thinking && model.supports_thinking();
         self.thinking_effort = selection.effort.clone();
         self.speed = selection.speed.filter(|_| model.supports_fast_mode());
+        self.service_tier = selection
+            .service_tier
+            .clone()
+            .filter(|value| {
+                model
+                    .supported_service_tiers()
+                    .iter()
+                    .any(|tier| tier.value.as_ref() == value.as_str())
+            })
+            .or_else(|| {
+                model
+                    .default_service_tier()
+                    .map(|tier| tier.value.to_string())
+            });
         self.prompt_capabilities_tx
             .send(Self::prompt_capabilities(self.model.as_deref()))
             .log_err();
@@ -1431,6 +1452,7 @@ impl Thread {
             summarization_model: None,
             thinking_enabled: db_thread.thinking_enabled,
             thinking_effort: db_thread.thinking_effort,
+            service_tier: db_thread.service_tier,
             speed: db_thread.speed,
             project,
             action_log,
@@ -1469,6 +1491,7 @@ impl Thread {
             speed: self.speed,
             thinking_enabled: self.thinking_enabled,
             thinking_effort: self.thinking_effort.clone(),
+            service_tier: self.service_tier.clone(),
             draft_prompt: self.draft_prompt.clone(),
             ui_scroll_position: self.ui_scroll_position.map(|lo| {
                 crate::db::SerializedScrollPosition {
@@ -1631,6 +1654,25 @@ impl Thread {
                 .update(cx, |thread, cx| {
                     if thread.inherits_parent_model_settings {
                         thread.set_speed(speed, cx);
+                    }
+                })
+                .ok();
+        }
+        cx.notify();
+    }
+
+    pub fn service_tier(&self) -> Option<&String> {
+        self.service_tier.as_ref()
+    }
+
+    pub fn set_service_tier(&mut self, service_tier: Option<String>, cx: &mut Context<Self>) {
+        self.service_tier = service_tier.clone();
+
+        for subagent in &self.running_subagents {
+            subagent
+                .update(cx, |thread, cx| {
+                    if thread.inherits_parent_model_settings {
+                        thread.set_service_tier(service_tier.clone(), cx)
                     }
                 })
                 .ok();
@@ -2998,6 +3040,7 @@ impl Thread {
             temperature: AgentSettings::temperature_for_model(model, cx),
             thinking_allowed: self.thinking_enabled,
             thinking_effort: self.thinking_effort.clone(),
+            service_tier: self.service_tier().cloned(),
             speed: self.speed(),
         };
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -985,6 +985,7 @@ pub struct Thread {
     pub(crate) templates: Arc<Templates>,
     model: Option<Arc<dyn LanguageModel>>,
     summarization_model: Option<Arc<dyn LanguageModel>>,
+    summarization_service_tier: Option<String>,
     thinking_enabled: bool,
     thinking_effort: Option<String>,
     service_tier: Option<String>,
@@ -1120,6 +1121,7 @@ impl Thread {
             templates,
             model,
             summarization_model: None,
+            summarization_service_tier: None,
             thinking_enabled: enable_thinking,
             speed,
             thinking_effort,
@@ -1148,6 +1150,7 @@ impl Thread {
         self.thinking_enabled = parent.thinking_enabled;
         self.thinking_effort = parent.thinking_effort.clone();
         self.summarization_model = parent.summarization_model.clone();
+        self.summarization_service_tier = parent.summarization_service_tier.clone();
         self.profile_id = parent.profile_id.clone();
     }
 
@@ -1402,6 +1405,7 @@ impl Thread {
                     let model = SelectedModel {
                         provider: model.provider.clone().into(),
                         model: model.model.into(),
+                        service_tier: db_thread.service_tier.clone(),
                     };
                     registry.select_model(&model, cx)
                 })
@@ -1450,6 +1454,7 @@ impl Thread {
             templates,
             model,
             summarization_model: None,
+            summarization_service_tier: None,
             thinking_enabled: db_thread.thinking_enabled,
             thinking_effort: db_thread.thinking_effort,
             service_tier: db_thread.service_tier,
@@ -1590,14 +1595,16 @@ impl Thread {
     pub fn set_summarization_model(
         &mut self,
         model: Option<Arc<dyn LanguageModel>>,
+        service_tier: Option<String>,
         cx: &mut Context<Self>,
     ) {
         self.summarization_model = model.clone();
+        self.summarization_service_tier = service_tier.clone();
 
         for subagent in &self.running_subagents {
             subagent
                 .update(cx, |thread, cx| {
-                    thread.set_summarization_model(model.clone(), cx)
+                    thread.set_summarization_model(model.clone(), service_tier.clone(), cx)
                 })
                 .ok();
         }
@@ -1925,6 +1932,7 @@ impl Thread {
         let selected = SelectedModel {
             provider: LanguageModelProviderId::from(selection.provider.0.clone()),
             model: LanguageModelId::from(selection.model.clone()),
+            service_tier: selection.service_tier.clone(),
         };
         LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
             registry
@@ -2801,6 +2809,8 @@ impl Thread {
         let mut request = LanguageModelRequest {
             intent: Some(CompletionIntent::ThreadContextSummarization),
             temperature: AgentSettings::temperature_for_model(&model, cx),
+            service_tier: AgentSettings::service_tier_for_model(&model, cx)
+                .or_else(|| self.summarization_service_tier.clone()),
             ..Default::default()
         };
 
@@ -2864,6 +2874,8 @@ impl Thread {
         let mut request = LanguageModelRequest {
             intent: Some(CompletionIntent::ThreadSummarization),
             temperature: AgentSettings::temperature_for_model(&model, cx),
+            service_tier: AgentSettings::service_tier_for_model(&model, cx)
+                .or_else(|| self.summarization_service_tier.clone()),
             ..Default::default()
         };
 
@@ -3040,7 +3052,8 @@ impl Thread {
             temperature: AgentSettings::temperature_for_model(model, cx),
             thinking_allowed: self.thinking_enabled,
             thinking_effort: self.thinking_effort.clone(),
-            service_tier: self.service_tier().cloned(),
+            service_tier: AgentSettings::service_tier_for_model(model, cx)
+                .or_else(|| self.service_tier().cloned()),
             speed: self.speed(),
         };
 
@@ -4877,7 +4890,7 @@ mod tests {
 
         cx.update(|cx| {
             parent.update(cx, |thread, cx| {
-                thread.set_summarization_model(Some(summary_model), cx);
+                thread.set_summarization_model(Some(summary_model), None, cx);
             });
 
             for subagent in &subagents {
@@ -4954,6 +4967,38 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_set_service_tier_propagates_to_subagents(cx: &mut TestAppContext) {
+        let (parent, _event_stream) = setup_thread_for_test(cx).await;
+        let subagents = setup_parent_with_subagents(cx, &parent, 2);
+
+        cx.update(|cx| {
+            parent.update(cx, |thread, cx| {
+                thread.set_service_tier(Some("priority".to_string()), cx);
+            });
+
+            for subagent in &subagents {
+                assert_eq!(
+                    subagent.read(cx).service_tier().map(|s| s.as_str()),
+                    Some("priority"),
+                    "Subagent service tier should match parent after set_service_tier"
+                );
+            }
+
+            parent.update(cx, |thread, cx| {
+                thread.set_service_tier(None, cx);
+            });
+
+            for subagent in &subagents {
+                assert_eq!(
+                    subagent.read(cx).service_tier(),
+                    None,
+                    "Subagent service tier should be None after parent clears it"
+                );
+            }
+        });
+    }
+
+    #[gpui::test]
     async fn test_subagent_inherits_settings_at_creation(cx: &mut TestAppContext) {
         let (parent, _event_stream) = setup_thread_for_test(cx).await;
 
@@ -4962,6 +5007,7 @@ mod tests {
                 thread.set_speed(Speed::Fast, cx);
                 thread.set_thinking_enabled(true, cx);
                 thread.set_thinking_effort(Some("high".to_string()), cx);
+                thread.set_service_tier(Some("flex".to_string()), cx);
                 thread.set_profile(AgentProfileId("custom-profile".into()), cx);
             });
         });
@@ -4973,6 +5019,11 @@ mod tests {
             assert_eq!(sub.speed(), Some(Speed::Fast));
             assert!(sub.thinking_enabled());
             assert_eq!(sub.thinking_effort().map(|s| s.as_str()), Some("high"));
+            assert_eq!(
+                sub.service_tier().map(|s| s.as_str()),
+                Some("flex"),
+                "Subagent should inherit service tier at creation"
+            );
             assert_eq!(sub.profile(), &AgentProfileId("custom-profile".into()));
         });
     }
@@ -4994,6 +5045,38 @@ mod tests {
                     "Subagent speed should match parent after set_speed"
                 );
             }
+        });
+    }
+
+    #[gpui::test]
+    async fn test_service_tier_includes_in_completion_request(cx: &mut TestAppContext) {
+        let (thread, _event_stream) = setup_thread_for_test(cx).await;
+
+        let model = Arc::new(FakeLanguageModel::default());
+        model.set_service_tiers(vec![
+            language_model::ServiceTierInfo {
+                name: SharedString::new_static("Standard"),
+                value: SharedString::new_static("default"),
+                is_default: true,
+            },
+            language_model::ServiceTierInfo {
+                name: SharedString::new_static("Priority"),
+                value: SharedString::new_static("priority"),
+                is_default: false,
+            },
+        ]);
+
+        cx.update(|cx| {
+            thread.update(cx, |thread, cx| {
+                thread.set_model(model.clone(), cx);
+                thread.set_service_tier(Some("priority".to_string()), cx);
+            });
+
+            let request = thread
+                .read(cx)
+                .build_completion_request(CompletionIntent::UserPrompt, cx)
+                .unwrap();
+            assert_eq!(request.service_tier, Some("priority".to_string()));
         });
     }
 

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -165,6 +165,7 @@ mod tests {
             speed: None,
             thinking_enabled: false,
             thinking_effort: None,
+            service_tier: None,
             draft_prompt: None,
             ui_scroll_position: None,
         }

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -193,6 +193,26 @@ impl AgentSettings {
         return None;
     }
 
+    pub fn service_tier_for_model(model: &Arc<dyn LanguageModel>, cx: &App) -> Option<String> {
+        let settings = Self::get_global(cx);
+        for setting in settings.model_parameters.iter().rev() {
+            if let Some(provider) = &setting.provider
+                && provider.0 != model.provider_id().0
+            {
+                continue;
+            }
+            if let Some(setting_model) = &setting.model
+                && *setting_model != model.id().0
+            {
+                continue;
+            }
+            if let Some(service_tier) = &setting.service_tier {
+                return Some(service_tier.clone());
+            }
+        }
+        return None;
+    }
+
     pub fn sidebar_side(&self) -> SidebarSide {
         match self.sidebar_side {
             SidebarDockPosition::Left => SidebarSide::Left,

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -237,6 +237,20 @@ pub fn language_model_to_selection(
                         .default_effort_level()
                         .map(|effort| effort.value.to_string())
                 }),
+            service_tier: current
+                .service_tier
+                .clone()
+                .filter(|value| {
+                    model
+                        .supported_service_tiers()
+                        .iter()
+                        .any(|tier| tier.value.as_ref() == value.as_str())
+                })
+                .or_else(|| {
+                    model
+                        .default_service_tier()
+                        .map(|tier| tier.value.to_string())
+                }),
             speed: current.speed.filter(|_| model.supports_fast_mode()),
         },
         None => LanguageModelSelection {
@@ -246,6 +260,9 @@ pub fn language_model_to_selection(
             effort: model
                 .default_effort_level()
                 .map(|effort| effort.value.to_string()),
+            service_tier: model
+                .default_service_tier()
+                .map(|tier| tier.value.to_string()),
             speed: None,
         },
     }

--- a/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
@@ -272,6 +272,7 @@ impl ManageProfilesModal {
                                         effort: model
                                             .default_effort_level()
                                             .map(|effort| effort.value.to_string()),
+                                        service_tier: None,
                                         speed: None,
                                     });
                                 }

--- a/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
@@ -250,7 +250,11 @@ impl ManageProfilesModal {
                                     .iter()
                                     .find(|m| m.id().0 == selection.model.as_str())?
                                     .clone();
-                                Some(language_model::ConfiguredModel { provider, model })
+                                Some(language_model::ConfiguredModel {
+                                    provider,
+                                    model,
+                                    service_tier: None,
+                                })
                             })
                     }
                 },

--- a/crates/agent_ui/src/agent_model_selector.rs
+++ b/crates/agent_ui/src/agent_model_selector.rs
@@ -37,13 +37,31 @@ impl AgentModelSelector {
                         move |model, cx| {
                             let provider = model.provider_id().0.to_string();
                             let model_id = model.id().0.to_string();
+                            let model = model.clone();
                             match &model_usage_context {
                                 ModelUsageContext::InlineAssistant => {
                                     update_settings_file(fs.clone(), cx, move |settings, _cx| {
-                                        settings
-                                            .agent
-                                            .get_or_insert_default()
-                                            .set_inline_assistant_model(provider.clone(), model_id);
+                                        let agent = settings.agent.get_or_insert_default();
+                                        let current_selection =
+                                            agent.inline_assistant_model.as_ref();
+                                        let service_tier = current_selection
+                                            .and_then(|s| s.service_tier.clone())
+                                            .filter(|tier| {
+                                                model
+                                                    .supported_service_tiers()
+                                                    .iter()
+                                                    .any(|t| t.value.as_ref() == tier.as_str())
+                                            })
+                                            .or_else(|| {
+                                                model
+                                                    .default_service_tier()
+                                                    .map(|t| t.value.to_string())
+                                            });
+                                        agent.set_inline_assistant_model(
+                                            provider.clone(),
+                                            model_id,
+                                            service_tier,
+                                        );
                                     });
                                 }
                             }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3576,6 +3576,7 @@ impl AgentPanel {
                                 model,
                                 enable_thinking,
                                 effort,
+                                service_tier: None,
                                 speed: None,
                             })
                     });
@@ -9645,6 +9646,7 @@ mod tests {
             speed: None,
             thinking_enabled: false,
             thinking_effort: None,
+            service_tier: None,
             draft_prompt: None,
             ui_scroll_position: None,
         };

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3562,21 +3562,39 @@ impl AgentPanel {
                     && let Some(model) = provider.default_model(cx)
                 {
                     update_settings_file(self.fs.clone(), cx, move |settings, _| {
+                        let language_model = model.clone();
                         let provider = model.provider_id().0.to_string();
                         let enable_thinking = model.supports_thinking();
                         let effort = model
                             .default_effort_level()
                             .map(|effort| effort.value.to_string());
-                        let model = model.id().0.to_string();
+                        let model_name = model.id().0.to_string();
+                        let current_selection = settings
+                            .agent
+                            .as_ref()
+                            .and_then(|a| a.default_model.as_ref());
+                        let service_tier = current_selection
+                            .and_then(|s| s.service_tier.clone())
+                            .filter(|tier| {
+                                language_model
+                                    .supported_service_tiers()
+                                    .iter()
+                                    .any(|t| t.value.as_ref() == tier.as_str())
+                            })
+                            .or_else(|| {
+                                language_model
+                                    .default_service_tier()
+                                    .map(|t| t.value.to_string())
+                            });
                         settings
                             .agent
                             .get_or_insert_default()
                             .set_model(LanguageModelSelection {
                                 provider: LanguageModelProviderSetting(provider),
-                                model,
+                                model: model_name,
                                 enable_thinking,
                                 effort,
-                                service_tier: None,
+                                service_tier,
                                 speed: None,
                             })
                     });

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -263,6 +263,10 @@ actions!(
         CycleThinkingEffort,
         /// Toggles the thinking effort selector menu open or closed.
         ToggleThinkingEffortMenu,
+        /// Cycles through available service tiers for the current model.
+        CycleServiceTier,
+        /// Toggles the service tier selector menu open or closed.
+        ToggleServiceTierMenu,
         /// Toggles fast mode for models that support it.
         ToggleFastMode,
         /// Scroll the output by one page up.

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -789,6 +789,7 @@ fn update_active_language_model_from_settings(cx: &mut App) {
         language_model::SelectedModel {
             provider: LanguageModelProviderId::from(selection.provider.0.clone()),
             model: LanguageModelId::from(selection.model.clone()),
+            service_tier: selection.service_tier.clone(),
         }
     }
 

--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -548,6 +548,7 @@ impl CodegenAlternative {
                 messages,
                 thinking_allowed: false,
                 thinking_effort: None,
+                service_tier: None,
                 speed: None,
             }
         }))
@@ -628,6 +629,7 @@ impl CodegenAlternative {
                 messages: vec![request_message],
                 thinking_allowed: false,
                 thinking_effort: None,
+                service_tier: None,
                 speed: None,
             }
         }))

--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -173,6 +173,7 @@ impl BufferCodegen {
     pub fn start(
         &mut self,
         primary_model: Arc<dyn LanguageModel>,
+        service_tier: Option<String>,
         user_prompt: String,
         context_task: Shared<Task<Option<LoadedContext>>>,
         cx: &mut Context<Self>,
@@ -203,8 +204,15 @@ impl BufferCodegen {
             .chain(alternative_models)
             .zip(&self.alternatives)
         {
+            let service_tier = service_tier.clone();
             alternative.update(cx, |alternative, cx| {
-                alternative.start(user_prompt.clone(), context_task.clone(), model.clone(), cx)
+                alternative.start(
+                    user_prompt.clone(),
+                    context_task.clone(),
+                    model.clone(),
+                    service_tier,
+                    cx,
+                )
             })?;
         }
 
@@ -287,6 +295,7 @@ pub struct CodegenAlternative {
     session_id: Uuid,
     pub description: Option<String>,
     pub failure: Option<String>,
+    service_tier: Option<String>,
 }
 
 impl EventEmitter<CodegenEvent> for CodegenAlternative {}
@@ -347,6 +356,7 @@ impl CodegenAlternative {
             session_id,
             description: None,
             failure: None,
+            service_tier: None,
             _subscription: cx.subscribe(&buffer, Self::handle_buffer_event),
         }
     }
@@ -409,8 +419,11 @@ impl CodegenAlternative {
         user_prompt: String,
         context_task: Shared<Task<Option<LoadedContext>>>,
         model: Arc<dyn LanguageModel>,
+        service_tier: Option<String>,
         cx: &mut Context<Self>,
     ) -> Result<()> {
+        self.service_tier = service_tier;
+
         // Clear the model explanation since the user has started a new generation.
         self.description = None;
 
@@ -494,6 +507,8 @@ impl CodegenAlternative {
             .context("generating content prompt")?;
 
         let temperature = AgentSettings::temperature_for_model(model, cx);
+        let service_tier =
+            AgentSettings::service_tier_for_model(model, cx).or_else(|| self.service_tier.clone());
 
         let tool_input_format = model.tool_input_format();
         let tool_choice = model
@@ -548,7 +563,7 @@ impl CodegenAlternative {
                 messages,
                 thinking_allowed: false,
                 thinking_effort: None,
-                service_tier: None,
+                service_tier,
                 speed: None,
             }
         }))
@@ -603,6 +618,8 @@ impl CodegenAlternative {
             .context("generating content prompt")?;
 
         let temperature = AgentSettings::temperature_for_model(model, cx);
+        let service_tier =
+            AgentSettings::service_tier_for_model(model, cx).or_else(|| self.service_tier.clone());
 
         Ok(cx.spawn(async move |_cx| {
             let mut request_message = LanguageModelRequestMessage {
@@ -629,7 +646,7 @@ impl CodegenAlternative {
                 messages: vec![request_message],
                 thinking_allowed: false,
                 thinking_effort: None,
-                service_tier: None,
+                service_tier,
                 speed: None,
             }
         }))

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -95,13 +95,14 @@ use crate::thread_metadata_store::{ThreadId, ThreadMetadataStore};
 use crate::ui::{AgentNotification, AgentNotificationEvent};
 use crate::{
     Agent, AgentDiffPane, AgentInitialContent, AgentPanel, AgentPanelEvent, AllowAlways, AllowOnce,
-    AuthorizeToolCall, ClearMessageQueue, CycleFavoriteModels, CycleModeSelector,
+    AuthorizeToolCall, ClearMessageQueue, CycleFavoriteModels, CycleModeSelector, CycleServiceTier,
     CycleThinkingEffort, EditFirstQueuedMessage, ExpandMessageEditor, Follow, KeepAll, NewThread,
     OpenAddContextMenu, OpenAgentDiff, RejectAll, RejectOnce, RemoveFirstQueuedMessage,
     ScrollOutputLineDown, ScrollOutputLineUp, ScrollOutputPageDown, ScrollOutputPageUp,
     ScrollOutputToBottom, ScrollOutputToNextMessage, ScrollOutputToPreviousMessage,
     ScrollOutputToTop, SendImmediately, SendNextQueuedMessage, ToggleFastMode,
-    ToggleProfileSelector, ToggleThinkingEffortMenu, ToggleThinkingMode, UndoLastReject,
+    ToggleProfileSelector, ToggleServiceTierMenu, ToggleThinkingEffortMenu, ToggleThinkingMode,
+    UndoLastReject,
 };
 
 const STOPWATCH_THRESHOLD: Duration = Duration::from_secs(30);

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -597,6 +597,7 @@ pub struct ThreadView {
     pub message_editor: Entity<MessageEditor>,
     pub add_context_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub thinking_effort_menu_handle: PopoverMenuHandle<ContextMenu>,
+    pub service_tier_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub project: WeakEntity<Project>,
     /// Cache + worktree snapshot for resolving paths in markdown code spans.
     /// Cloned from the parent `ConversationView` so the cache is shared and the
@@ -890,6 +891,7 @@ impl ThreadView {
             message_editor,
             add_context_menu_handle: PopoverMenuHandle::default(),
             thinking_effort_menu_handle: PopoverMenuHandle::default(),
+            service_tier_menu_handle: PopoverMenuHandle::default(),
             project,
             code_span_resolver,
             show_external_source_prompt_warning,
@@ -3647,7 +3649,8 @@ impl ThreadView {
                                     .child(self.render_add_context_button(cx))
                                     .child(self.render_follow_toggle(cx))
                                     .children(self.render_fast_mode_control(cx))
-                                    .children(self.render_thinking_control(cx)),
+                                    .children(self.render_thinking_control(cx))
+                                    .children(self.render_service_tier_control(cx)),
                             )
                             .child(
                                 h_flex()
@@ -4319,6 +4322,186 @@ impl ThreadView {
                 y: px(-2.0),
             })
             .anchor(gpui::Anchor::BottomLeft)
+    }
+
+    fn service_tier_available(&self, cx: &Context<Self>) -> bool {
+        self.as_native_thread(cx)
+            .and_then(|thread| thread.read(cx).model())
+            .is_some_and(|model| model.supported_service_tiers().len() > 1)
+    }
+
+    fn render_service_tier_control(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        if !self.service_tier_available(cx) {
+            return None;
+        }
+
+        let thread = self.as_native_thread(cx)?;
+        let thread_ref = thread.read(cx);
+        let model = thread_ref.model()?;
+        let supported_tiers = model.supported_service_tiers();
+        let selected_tier = thread_ref.service_tier().cloned();
+        let weak_self = cx.weak_entity();
+
+        let selected = selected_tier
+            .as_ref()
+            .and_then(|tier| {
+                supported_tiers
+                    .iter()
+                    .find(|t| t.value.as_ref() == tier.as_str())
+            })
+            .cloned();
+
+        let default_tier = model.default_service_tier();
+
+        let label = selected
+            .clone()
+            .or(default_tier)
+            .map_or("Service Tier".into(), |tier| tier.name);
+
+        let (label_color, icon) = if self.service_tier_menu_handle.is_deployed() {
+            (Color::Accent, IconName::ChevronUp)
+        } else {
+            (Color::Muted, IconName::ChevronDown)
+        };
+
+        let focus_handle = self.message_editor.focus_handle(cx);
+        let show_cycle_row = supported_tiers.len() > 1;
+
+        let tooltip = Tooltip::element({
+            move |_, cx| {
+                let mut content = v_flex().gap_1().child(
+                    h_flex()
+                        .gap_2()
+                        .justify_between()
+                        .child(Label::new("Change Service Tier"))
+                        .child(KeyBinding::for_action_in(
+                            &ToggleServiceTierMenu,
+                            &focus_handle,
+                            cx,
+                        )),
+                );
+
+                if show_cycle_row {
+                    content = content.child(
+                        h_flex()
+                            .pt_1()
+                            .gap_2()
+                            .justify_between()
+                            .border_t_1()
+                            .border_color(cx.theme().colors().border_variant)
+                            .child(Label::new("Cycle Service Tier"))
+                            .child(KeyBinding::for_action_in(
+                                &CycleServiceTier,
+                                &focus_handle,
+                                cx,
+                            )),
+                    );
+                }
+
+                content.into_any_element()
+            }
+        });
+
+        Some(
+            PopoverMenu::new("service-tier-selector")
+                .trigger_with_tooltip(
+                    ButtonLike::new_rounded_right("service-tier-selector-trigger")
+                        .selected_style(ButtonStyle::Tinted(TintColor::Accent))
+                        .child(Label::new(label).size(LabelSize::Small).color(label_color))
+                        .child(Icon::new(icon).size(IconSize::XSmall).color(Color::Muted)),
+                    tooltip,
+                )
+                .menu(move |window, cx| {
+                    let supported_tiers = supported_tiers.clone();
+                    let selected = selected.clone();
+                    let weak_self = weak_self.clone();
+                    Some(ContextMenu::build(window, cx, |mut menu, _window, _cx| {
+                        menu = menu.header("Change Service Tier");
+
+                        for tier in &supported_tiers {
+                            let is_selected =
+                                selected.as_ref().is_some_and(|s| s.value == tier.value);
+                            let entry = ContextMenuEntry::new(tier.name.clone())
+                                .toggleable(IconPosition::End, is_selected);
+
+                            let tier_value = tier.value.clone();
+                            menu.push_item(entry.handler({
+                                let weak_self = weak_self.clone();
+                                let tier_value = tier_value.clone();
+                                move |_window, cx| {
+                                    let tier_value = tier_value.clone();
+                                    weak_self
+                                        .update(cx, |this, cx| {
+                                            if let Some(thread) = this.as_native_thread(cx) {
+                                                thread.update(cx, |thread, cx| {
+                                                    thread.set_service_tier(
+                                                        Some(tier_value.to_string()),
+                                                        cx,
+                                                    );
+
+                                                    let favorite_key =
+                                                        thread.model().map(|model| {
+                                                            (
+                                                                model.provider_id().0.to_string(),
+                                                                model.id().0.to_string(),
+                                                            )
+                                                        });
+                                                    let fs = thread.project().read(cx).fs().clone();
+                                                    update_settings_file(
+                                                        fs,
+                                                        cx,
+                                                        move |settings, _| {
+                                                            if let Some(agent) =
+                                                                settings.agent.as_mut()
+                                                            {
+                                                                if let Some(default_model) =
+                                                                    agent.default_model.as_mut()
+                                                                {
+                                                                    default_model.service_tier =
+                                                                        Some(
+                                                                            tier_value.to_string(),
+                                                                        );
+                                                                }
+                                                                if let Some((
+                                                                    provider_id,
+                                                                    model_id,
+                                                                )) = &favorite_key
+                                                                {
+                                                                    agent.update_favorite_model(
+                                                                        provider_id,
+                                                                        model_id,
+                                                                        |favorite| {
+                                                                            favorite.service_tier =
+                                                                                Some(
+                                                                                    tier_value
+                                                                                        .to_string(
+                                                                                        ),
+                                                                                )
+                                                                        },
+                                                                    );
+                                                                }
+                                                            }
+                                                        },
+                                                    );
+                                                });
+                                            }
+                                        })
+                                        .ok();
+                                }
+                            }));
+                        }
+
+                        menu
+                    }))
+                })
+                .with_handle(self.service_tier_menu_handle.clone())
+                .offset(gpui::Point {
+                    x: px(0.0),
+                    y: px(-2.0),
+                })
+                .anchor(gpui::Anchor::BottomLeft)
+                .into_any_element(),
+        )
     }
 
     fn render_send_button(&self, cx: &mut Context<Self>) -> AnyElement {
@@ -9457,6 +9640,66 @@ impl ThreadView {
             menu_handle.toggle(window, cx);
         });
     }
+
+    fn cycle_service_tier(&mut self, cx: &mut Context<Self>) {
+        let Some(thread) = self.as_native_thread(cx) else {
+            return;
+        };
+
+        let (tiers, current_tier) = {
+            let thread_ref = thread.read(cx);
+            let Some(model) = thread_ref.model() else {
+                return;
+            };
+            let tiers = model.supported_service_tiers();
+            if tiers.is_empty() {
+                return;
+            }
+            let current_tier = thread_ref.service_tier().cloned();
+            (tiers, current_tier)
+        };
+
+        let current_index =
+            current_tier.and_then(|current| tiers.iter().position(|tier| tier.value == current));
+        let next_index = match current_index {
+            Some(index) => (index + 1) % tiers.len(),
+            None => 0,
+        };
+        let next_tier = tiers[next_index].value.to_string();
+
+        thread.update(cx, |thread, cx| {
+            thread.set_service_tier(Some(next_tier.clone()), cx);
+
+            let favorite_key = thread
+                .model()
+                .map(|model| (model.provider_id().0.to_string(), model.id().0.to_string()));
+            let fs = thread.project().read(cx).fs().clone();
+            update_settings_file(fs, cx, move |settings, _| {
+                if let Some(agent) = settings.agent.as_mut() {
+                    if let Some(default_model) = agent.default_model.as_mut() {
+                        default_model.service_tier = Some(next_tier.clone());
+                    }
+                    if let Some((provider_id, model_id)) = &favorite_key {
+                        agent.update_favorite_model(provider_id, model_id, |favorite| {
+                            favorite.service_tier = Some(next_tier)
+                        });
+                    }
+                }
+            });
+        });
+    }
+
+    fn toggle_service_tier_menu(
+        &mut self,
+        _action: &ToggleServiceTierMenu,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let menu_handle = self.service_tier_menu_handle.clone();
+        window.defer(cx, move |window, cx| {
+            menu_handle.toggle(window, cx);
+        });
+    }
 }
 
 impl Render for ThreadView {
@@ -9541,6 +9784,20 @@ impl Render for ThreadView {
                         return;
                     }
                     this.toggle_thinking_effort_menu(action, window, cx);
+                }),
+            )
+            .on_action(cx.listener(|this, _: &CycleServiceTier, _window, cx| {
+                if this.thread.read(cx).status() != ThreadStatus::Idle {
+                    return;
+                }
+                this.cycle_service_tier(cx);
+            }))
+            .on_action(
+                cx.listener(|this, action: &ToggleServiceTierMenu, window, cx| {
+                    if this.thread.read(cx).status() != ThreadStatus::Idle {
+                        return;
+                    }
+                    this.toggle_service_tier_menu(action, window, cx);
                 }),
             )
             .on_action(cx.listener(|this, _: &SendNextQueuedMessage, window, cx| {

--- a/crates/agent_ui/src/inline_assistant.rs
+++ b/crates/agent_ui/src/inline_assistant.rs
@@ -1252,8 +1252,11 @@ impl InlineAssistant {
             self.prompt_history.pop_front();
         }
 
-        let Some(ConfiguredModel { model, .. }) =
-            LanguageModelRegistry::read_global(cx).inline_assistant_model()
+        let Some(ConfiguredModel {
+            model,
+            service_tier,
+            ..
+        }) = LanguageModelRegistry::read_global(cx).inline_assistant_model()
         else {
             return;
         };
@@ -1262,7 +1265,7 @@ impl InlineAssistant {
         assist
             .codegen
             .update(cx, |codegen, cx| {
-                codegen.start(model, user_prompt, context_task, cx)
+                codegen.start(model, service_tier, user_prompt, context_task, cx)
             })
             .log_err();
     }

--- a/crates/agent_ui/src/terminal_inline_assistant.rs
+++ b/crates/agent_ui/src/terminal_inline_assistant.rs
@@ -216,7 +216,11 @@ impl TerminalInlineAssistant {
         assist_id: TerminalInlineAssistId,
         cx: &mut App,
     ) -> Result<Task<LanguageModelRequest>> {
-        let ConfiguredModel { model, .. } = LanguageModelRegistry::read_global(cx)
+        let ConfiguredModel {
+            model,
+            service_tier,
+            ..
+        } = LanguageModelRegistry::read_global(cx)
             .inline_assistant_model()
             .context("No inline assistant model")?;
 
@@ -246,6 +250,7 @@ impl TerminalInlineAssistant {
         )?;
 
         let temperature = AgentSettings::temperature_for_model(&model, cx);
+        let service_tier = AgentSettings::service_tier_for_model(&model, cx).or(service_tier);
 
         let mention_set = prompt_editor.read(cx).mention_set().clone();
         let load_context_task = load_context(&mention_set, cx);
@@ -275,7 +280,7 @@ impl TerminalInlineAssistant {
                 temperature,
                 thinking_allowed: false,
                 thinking_effort: None,
-                service_tier: None,
+                service_tier,
                 speed: None,
             }
         }))

--- a/crates/agent_ui/src/terminal_inline_assistant.rs
+++ b/crates/agent_ui/src/terminal_inline_assistant.rs
@@ -275,6 +275,7 @@ impl TerminalInlineAssistant {
                 temperature,
                 thinking_allowed: false,
                 thinking_effort: None,
+                service_tier: None,
                 speed: None,
             }
         }))

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -1829,6 +1829,7 @@ mod tests {
             speed: None,
             thinking_enabled: false,
             thinking_effort: None,
+            service_tier: None,
             draft_prompt: None,
             ui_scroll_position: None,
         }

--- a/crates/anthropic/src/completion.rs
+++ b/crates/anthropic/src/completion.rs
@@ -562,6 +562,7 @@ mod tests {
             tool_choice: None,
             thinking_allowed: true,
             thinking_effort: None,
+            service_tier: None,
             speed: None,
         };
 
@@ -666,6 +667,7 @@ mod tests {
             tool_choice: None,
             thinking_allowed: true,
             thinking_effort: None,
+            service_tier: None,
             speed: None,
         };
 
@@ -736,6 +738,7 @@ mod tests {
             tool_choice: None,
             thinking_allowed: true,
             thinking_effort: None,
+            service_tier: None,
             speed: None,
         };
 
@@ -773,6 +776,7 @@ mod tests {
             tools: vec![],
             tool_choice: None,
             thinking_allowed: true,
+            service_tier: None,
             speed: None,
         };
         request.messages.push(LanguageModelRequestMessage {

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -20,6 +20,8 @@ anyhow.workspace = true
 aws-sdk-bedrockruntime = { workspace = true, features = ["behavior-version-latest"] }
 aws-smithy-types = {workspace = true}
 futures.workspace = true
+language_model_core.workspace = true
+log.workspace = true
 schemars = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bedrock/src/bedrock.rs
+++ b/crates/bedrock/src/bedrock.rs
@@ -10,6 +10,9 @@ pub use aws_sdk_bedrockruntime::types::{
     ToolSpecification as BedrockToolSpec,
 };
 use aws_sdk_bedrockruntime::types::{GuardrailStreamConfiguration, InferenceConfiguration};
+pub use aws_sdk_bedrockruntime::types::{
+    ServiceTier as BedrockServiceTier, ServiceTierType as BedrockServiceTierType,
+};
 pub use aws_smithy_types::Blob as BedrockBlob;
 use aws_smithy_types::{Document, Number as AwsNumber};
 pub use bedrock::operation::converse_stream::ConverseStreamInput as BedrockStreamingRequest;
@@ -70,6 +73,25 @@ pub async fn stream_completion(
 
     if !additional_fields.is_empty() {
         response = response.additional_model_request_fields(Document::Object(additional_fields));
+    }
+
+    if let Some(ref service_tier) = request.service_tier {
+        let tier_type = match service_tier.as_str() {
+            "default" => Some(BedrockServiceTierType::Default),
+            "flex" => Some(BedrockServiceTierType::Flex),
+            "priority" => Some(BedrockServiceTierType::Priority),
+            "reserved" => Some(BedrockServiceTierType::Reserved),
+            _ => {
+                log::warn!("Unrecognized Bedrock service tier: {service_tier}");
+                None
+            }
+        };
+        if let Some(tier_type) = tier_type {
+            match BedrockServiceTier::builder().r#type(tier_type).build() {
+                Ok(tier) => response = response.service_tier(tier),
+                Err(error) => log::error!("Failed to build Bedrock service tier: {error}"),
+            }
+        }
     }
 
     if request.tools.as_ref().is_some_and(|t| !t.tools.is_empty()) {
@@ -217,6 +239,7 @@ pub struct Request {
     pub top_p: Option<f32>,
     pub guardrail_identifier: Option<String>,
     pub guardrail_version: Option<String>,
+    pub service_tier: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -1,3 +1,4 @@
+use language_model_core::{ServiceTierInfo, SharedString};
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
 
@@ -201,6 +202,7 @@ pub enum Model {
         max_output_tokens: Option<u64>,
         default_temperature: Option<f32>,
         cache_configuration: Option<BedrockModelCacheConfiguration>,
+        service_tiers: Option<Vec<String>>,
     },
 }
 
@@ -575,6 +577,122 @@ impl Model {
         }
     }
 
+    pub fn supported_service_tiers(&self) -> Vec<ServiceTierInfo> {
+        match self {
+            Self::Custom { service_tiers, .. } => service_tiers
+                .as_ref()
+                .map(|tiers| {
+                    tiers
+                        .iter()
+                        .filter_map(|tier| match tier.as_str() {
+                            "default" => Some(ServiceTierInfo {
+                                name: SharedString::new_static("Standard"),
+                                value: SharedString::new_static("default"),
+                                is_default: true,
+                            }),
+                            "flex" => Some(ServiceTierInfo {
+                                name: SharedString::new_static("Flex"),
+                                value: SharedString::new_static("flex"),
+                                is_default: false,
+                            }),
+                            "priority" => Some(ServiceTierInfo {
+                                name: SharedString::new_static("Priority"),
+                                value: SharedString::new_static("priority"),
+                                is_default: false,
+                            }),
+                            "reserved" => Some(ServiceTierInfo {
+                                name: SharedString::new_static("Reserved"),
+                                value: SharedString::new_static("reserved"),
+                                is_default: false,
+                            }),
+                            _ => None,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+
+            Self::ClaudeSonnet4
+            | Self::ClaudeOpus4_1
+            | Self::ClaudeOpus4_7
+            | Self::DeepSeekV3_1
+            | Self::DeepSeekR1
+            | Self::Llama4Scout17B
+            | Self::Llama4Maverick17B
+            | Self::NovaLite => vec![ServiceTierInfo {
+                name: SharedString::new_static("Standard"),
+                value: SharedString::new_static("default"),
+                is_default: true,
+            }],
+
+            Self::ClaudeHaiku4_5
+            | Self::ClaudeSonnet4_5
+            | Self::ClaudeOpus4_5
+            | Self::ClaudeOpus4_6
+            | Self::ClaudeSonnet4_6 => vec![
+                ServiceTierInfo {
+                    name: SharedString::new_static("Standard"),
+                    value: SharedString::new_static("default"),
+                    is_default: true,
+                },
+                ServiceTierInfo {
+                    name: SharedString::new_static("Reserved"),
+                    value: SharedString::new_static("reserved"),
+                    is_default: false,
+                },
+            ],
+
+            Self::DeepSeekV3_2
+            | Self::Gemma3_4B
+            | Self::Gemma3_12B
+            | Self::Gemma3_27B
+            | Self::MiniMaxM2
+            | Self::MiniMaxM2_1
+            | Self::MiniMaxM2_5
+            | Self::MagistralSmall
+            | Self::MistralLarge3
+            | Self::PixtralLarge
+            | Self::Devstral2_123B
+            | Self::Ministral14B
+            | Self::KimiK2_5
+            | Self::KimiK2Thinking
+            | Self::GLM5
+            | Self::GLM4_7
+            | Self::GLM4_7Flash
+            | Self::NemotronSuper3_120B
+            | Self::NemotronNano3_30B
+            | Self::GptOss120B
+            | Self::GptOss20B
+            | Self::Qwen3VL235B
+            | Self::Qwen3_32B
+            | Self::Qwen3_235B
+            | Self::Qwen3Next80B
+            | Self::Qwen3Coder30B
+            | Self::Qwen3CoderNext
+            | Self::Qwen3Coder480B
+            | Self::Nova2Lite
+            | Self::NovaPro
+            | Self::NovaPremier => {
+                vec![
+                    ServiceTierInfo {
+                        name: SharedString::new_static("Standard"),
+                        value: SharedString::new_static("default"),
+                        is_default: true,
+                    },
+                    ServiceTierInfo {
+                        name: SharedString::new_static("Priority"),
+                        value: SharedString::new_static("priority"),
+                        is_default: false,
+                    },
+                    ServiceTierInfo {
+                        name: SharedString::new_static("Flex"),
+                        value: SharedString::new_static("flex"),
+                        is_default: false,
+                    },
+                ]
+            }
+        }
+    }
+
     pub fn cross_region_inference_id(
         &self,
         region: &str,
@@ -929,6 +1047,7 @@ mod tests {
             max_output_tokens: Some(8192),
             default_temperature: Some(0.7),
             cache_configuration: None,
+            service_tiers: None,
         };
 
         assert_eq!(

--- a/crates/edit_prediction/src/mercury.rs
+++ b/crates/edit_prediction/src/mercury.rs
@@ -147,6 +147,7 @@ impl Mercury {
                 tools: vec![],
                 prompt_cache_key: None,
                 reasoning_effort: None,
+                service_tier: None,
             };
 
             let buf = serde_json::to_vec(&request_body)?;

--- a/crates/edit_prediction_cli/src/openai_client.rs
+++ b/crates/edit_prediction_cli/src/openai_client.rs
@@ -49,6 +49,7 @@ impl PlainOpenAiClient {
             tools: Vec::new(),
             prompt_cache_key: None,
             reasoning_effort: None,
+            service_tier: None,
         };
 
         let response = non_streaming_completion(
@@ -509,6 +510,7 @@ impl BatchingOpenAiClient {
                     tools: Vec::new(),
                     prompt_cache_key: None,
                     reasoning_effort: None,
+                    service_tier: None,
                 };
 
                 let custom_id = format!("req_hash_{}", hash);

--- a/crates/eval_cli/src/main.rs
+++ b/crates/eval_cli/src/main.rs
@@ -483,7 +483,11 @@ async fn run_agent(
 
         registry.update(cx, |registry, cx| {
             registry.set_default_model(
-                Some(language_model::ConfiguredModel { provider, model }),
+                Some(language_model::ConfiguredModel {
+                    provider,
+                    model,
+                    service_tier: None,
+                }),
                 cx,
             );
         });

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2705,8 +2705,11 @@ impl GitPanel {
             return;
         }
 
-        let Some(ConfiguredModel { provider, model }) =
-            LanguageModelRegistry::read_global(cx).commit_message_model(cx)
+        let Some(ConfiguredModel {
+            provider,
+            model,
+            service_tier,
+        }) = LanguageModelRegistry::read_global(cx).commit_message_model(cx)
         else {
             return;
         };
@@ -2726,6 +2729,7 @@ impl GitPanel {
         });
 
         let temperature = AgentSettings::temperature_for_model(&model, cx);
+        let service_tier = AgentSettings::service_tier_for_model(&model, cx).or(service_tier);
         let project = self.project.clone();
         let repo_work_dir = repo.read(cx).work_directory_abs_path.clone();
 
@@ -2806,7 +2810,7 @@ impl GitPanel {
                     temperature,
                     thinking_allowed: false,
                     thinking_effort: None,
-                    service_tier: None,
+                    service_tier,
                     speed: None,
                 };
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2806,6 +2806,7 @@ impl GitPanel {
                     temperature,
                     thinking_allowed: false,
                     thinking_effort: None,
+                    service_tier: None,
                     speed: None,
                 };
 

--- a/crates/language_model/src/fake_provider.rs
+++ b/crates/language_model/src/fake_provider.rs
@@ -126,6 +126,7 @@ pub struct FakeLanguageModel {
     supports_thinking: AtomicBool,
     supports_streaming_tools: AtomicBool,
     supports_images: AtomicBool,
+    service_tiers: Mutex<Vec<language_model_core::ServiceTierInfo>>,
 }
 
 impl Default for FakeLanguageModel {
@@ -140,6 +141,7 @@ impl Default for FakeLanguageModel {
             supports_thinking: AtomicBool::new(false),
             supports_streaming_tools: AtomicBool::new(false),
             supports_images: AtomicBool::new(false),
+            service_tiers: Mutex::new(Vec::new()),
         }
     }
 }
@@ -178,6 +180,10 @@ impl FakeLanguageModel {
 
     pub fn set_supports_images(&self, supports: bool) {
         self.supports_images.store(supports, SeqCst);
+    }
+
+    pub fn set_service_tiers(&self, tiers: Vec<language_model_core::ServiceTierInfo>) {
+        *self.service_tiers.lock() = tiers;
     }
 
     pub fn pending_completions(&self) -> Vec<LanguageModelRequest> {
@@ -295,6 +301,10 @@ impl LanguageModel for FakeLanguageModel {
 
     fn supports_streaming_tools(&self) -> bool {
         self.supports_streaming_tools.load(SeqCst)
+    }
+
+    fn supported_service_tiers(&self) -> Vec<language_model_core::ServiceTierInfo> {
+        self.service_tiers.lock().clone()
     }
 
     fn telemetry_id(&self) -> String {

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -92,6 +92,18 @@ pub trait LanguageModel: Send + Sync {
             .find(|effort_level| effort_level.is_default)
     }
 
+    /// Returns the list of supported service tiers for this model.
+    fn supported_service_tiers(&self) -> Vec<ServiceTierInfo> {
+        Vec::new()
+    }
+
+    /// Returns the default service tier for this model.
+    fn default_service_tier(&self) -> Option<ServiceTierInfo> {
+        self.supported_service_tiers()
+            .into_iter()
+            .find(|tier| tier.is_default)
+    }
+
     /// Whether this model supports images
     fn supports_images(&self) -> bool;
 

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -64,6 +64,7 @@ pub struct LanguageModelRegistry {
 pub struct SelectedModel {
     pub provider: LanguageModelProviderId,
     pub model: LanguageModelId,
+    pub service_tier: Option<String>,
 }
 
 impl FromStr for SelectedModel {
@@ -86,6 +87,7 @@ impl FromStr for SelectedModel {
         Ok(SelectedModel {
             provider: LanguageModelProviderId(provider_id.to_string().into()),
             model: LanguageModelId(model_id.to_string().into()),
+            service_tier: None,
         })
     }
 }
@@ -94,6 +96,7 @@ impl FromStr for SelectedModel {
 pub struct ConfiguredModel {
     pub provider: Arc<dyn LanguageModelProvider>,
     pub model: Arc<dyn LanguageModel>,
+    pub service_tier: Option<String>,
 }
 
 impl ConfiguredModel {
@@ -139,6 +142,7 @@ impl LanguageModelRegistry {
             let configured_model = ConfiguredModel {
                 provider: fake_provider.clone(),
                 model,
+                service_tier: None,
             };
             registry.set_default_model(Some(configured_model), cx);
             registry
@@ -346,7 +350,11 @@ impl LanguageModelRegistry {
             .iter()
             .find(|model| model.id() == selected_model.model)?
             .clone();
-        Some(ConfiguredModel { provider, model })
+        Some(ConfiguredModel {
+            provider,
+            model,
+            service_tier: selected_model.service_tier.clone(),
+        })
     }
 
     pub fn set_default_model(&mut self, model: Option<ConfiguredModel>, cx: &mut Context<Self>) {
@@ -426,9 +434,16 @@ impl LanguageModelRegistry {
     pub fn default_fast_model(&self, cx: &App) -> Option<ConfiguredModel> {
         let configured = self.default_model()?;
         let fast_model = configured.provider.default_fast_model(cx)?;
+        let service_tier = configured.service_tier.clone().filter(|tier| {
+            fast_model
+                .supported_service_tiers()
+                .iter()
+                .any(|t| t.value.as_ref() == tier.as_str())
+        });
         Some(ConfiguredModel {
-            provider: configured.provider,
+            provider: configured.provider.clone(),
             model: fast_model,
+            service_tier,
         })
     }
 
@@ -614,6 +629,7 @@ mod tests {
                 Some(ConfiguredModel {
                     provider: provider.clone(),
                     model: model.clone(),
+                    service_tier: None,
                 }),
                 cx,
             );

--- a/crates/language_model_core/src/language_model_core.rs
+++ b/crates/language_model_core/src/language_model_core.rs
@@ -354,6 +354,13 @@ pub struct LanguageModelEffortLevel {
     pub is_default: bool,
 }
 
+#[derive(Debug, Clone)]
+pub struct ServiceTierInfo {
+    pub name: SharedString,
+    pub value: SharedString,
+    pub is_default: bool,
+}
+
 /// An error that occurred when trying to authenticate the language model provider.
 #[derive(Debug, Error)]
 pub enum AuthenticateError {

--- a/crates/language_model_core/src/request.rs
+++ b/crates/language_model_core/src/request.rs
@@ -369,6 +369,7 @@ pub struct LanguageModelRequest {
     pub temperature: Option<f32>,
     pub thinking_allowed: bool,
     pub thinking_effort: Option<String>,
+    pub service_tier: Option<String>,
     pub speed: Option<Speed>,
 }
 

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -167,7 +167,11 @@ pub fn update_environment_fallback_model(cx: &mut App) {
                 let model = provider
                     .default_model(cx)
                     .or_else(|| provider.recommended_models(cx).first().cloned())?;
-                Some(ConfiguredModel { provider, model })
+                Some(ConfiguredModel {
+                    provider,
+                    model,
+                    service_tier: None,
+                })
             })
         } else {
             registry
@@ -181,6 +185,7 @@ pub fn update_environment_fallback_model(cx: &mut App) {
                     Some(ConfiguredModel {
                         provider: provider.clone(),
                         model,
+                        service_tier: None,
                     })
                 })
         }

--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -488,6 +488,7 @@ impl LanguageModelProvider for BedrockLanguageModelProvider {
                             min_total_token: config.min_total_token,
                         }
                     }),
+                    service_tiers: model.service_tiers.clone(),
                 },
             );
         }
@@ -679,6 +680,10 @@ impl LanguageModel for BedrockModel {
         } else {
             Vec::new()
         }
+    }
+
+    fn supported_service_tiers(&self) -> Vec<language_model::ServiceTierInfo> {
+        self.model.supported_service_tiers()
     }
 
     fn supports_tool_choice(&self, choice: LanguageModelToolChoice) -> bool {
@@ -1146,6 +1151,7 @@ pub fn into_bedrock(
         top_p: None,
         guardrail_identifier,
         guardrail_version,
+        service_tier: request.service_tier,
     })
 }
 

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -1212,6 +1212,7 @@ fn into_copilot_responses(
         temperature,
         thinking_allowed,
         thinking_effort,
+        service_tier: _,
         speed: _,
     } = request;
 

--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -981,6 +981,7 @@ mod tests {
             stop: vec![],
             thinking_allowed: true,
             thinking_effort: None,
+            service_tier: None,
             speed: Default::default(),
         };
 
@@ -1017,6 +1018,7 @@ mod tests {
             stop: vec![],
             thinking_allowed: true,
             thinking_effort: None,
+            service_tier: None,
             speed: None,
         };
 

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -173,6 +173,7 @@ pub fn into_open_ai(
             LanguageModelToolChoice::None => crate::ToolChoice::None,
         }),
         reasoning_effort,
+        service_tier: request.service_tier,
     }
 }
 
@@ -198,6 +199,7 @@ pub fn into_open_ai_response(
         temperature,
         thinking_allowed,
         thinking_effort,
+        service_tier,
         speed: _,
     } = request;
 
@@ -284,6 +286,7 @@ pub fn into_open_ai_response(
             None
         },
         reasoning,
+        service_tier,
     }
 }
 
@@ -1390,6 +1393,7 @@ mod tests {
             temperature: None,
             thinking_allowed: true,
             thinking_effort: Some("high".into()),
+            service_tier: None,
             speed: None,
         };
 
@@ -1511,6 +1515,7 @@ mod tests {
             temperature: None,
             thinking_allowed: false,
             thinking_effort: None,
+            service_tier: None,
             speed: None,
         };
 
@@ -1593,6 +1598,7 @@ mod tests {
             temperature: None,
             thinking_allowed: false,
             thinking_effort: None,
+            service_tier: None,
             speed: None,
         };
 
@@ -1649,6 +1655,7 @@ mod tests {
             temperature: None,
             thinking_allowed: false,
             thinking_effort: Some("high".into()),
+            service_tier: None,
             speed: None,
         };
 
@@ -1684,6 +1691,7 @@ mod tests {
             temperature: None,
             thinking_allowed: false,
             thinking_effort: Some("high".into()),
+            service_tier: None,
             speed: None,
         };
 
@@ -1722,6 +1730,7 @@ mod tests {
             temperature: None,
             thinking_allowed: true,
             thinking_effort: Some("none".into()),
+            service_tier: None,
             speed: None,
         };
 
@@ -1772,6 +1781,7 @@ mod tests {
             temperature: None,
             thinking_allowed: true,
             thinking_effort: None,
+            service_tier: None,
             speed: None,
         };
 
@@ -1861,6 +1871,7 @@ mod tests {
             temperature: None,
             thinking_allowed: true,
             thinking_effort: None,
+            service_tier: None,
             speed: None,
         };
 
@@ -1948,6 +1959,7 @@ mod tests {
             temperature: None,
             thinking_allowed: false,
             thinking_effort: None,
+            service_tier: None,
             speed: None,
         };
 
@@ -2976,6 +2988,7 @@ mod tests {
             temperature: None,
             thinking_allowed: true,
             thinking_effort: None,
+            service_tier: None,
             speed: None,
         };
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -456,6 +456,8 @@ pub struct Request {
     pub prompt_cache_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<ReasoningEffort>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/open_ai/src/responses.rs
+++ b/crates/open_ai/src/responses.rs
@@ -35,6 +35,8 @@ pub struct Request {
     pub reasoning: Option<ReasoningConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub store: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -230,13 +230,18 @@ impl AgentSettingsContent {
         self.default_model = Some(language_model)
     }
 
-    pub fn set_inline_assistant_model(&mut self, provider: String, model: String) {
+    pub fn set_inline_assistant_model(
+        &mut self,
+        provider: String,
+        model: String,
+        service_tier: Option<String>,
+    ) {
         self.inline_assistant_model = Some(LanguageModelSelection {
             provider: provider.into(),
             model,
             enable_thinking: false,
             effort: None,
-            service_tier: None,
+            service_tier,
             speed: None,
         });
     }
@@ -407,6 +412,7 @@ pub struct LanguageModelParameters {
     pub model: Option<String>,
     #[serde(serialize_with = "crate::serialize_optional_f32_with_two_decimal_places")]
     pub temperature: Option<f32>,
+    pub service_tier: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, MergeFrom)]

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -236,6 +236,7 @@ impl AgentSettingsContent {
             model,
             enable_thinking: false,
             effort: None,
+            service_tier: None,
             speed: None,
         });
     }
@@ -246,7 +247,7 @@ impl AgentSettingsContent {
 
     pub fn add_favorite_model(&mut self, model: LanguageModelSelection) {
         // Note: this is intentional to not compare using `PartialEq`here.
-        // Full equality would treat entries that differ just in thinking/effort/speed
+        // Full equality would treat entries that differ just in thinking/effort/speed/service_tier
         // as distinct and silently produce duplicates.
         if !self
             .favorite_models
@@ -395,6 +396,7 @@ pub struct LanguageModelSelection {
     #[serde(default)]
     pub enable_thinking: bool,
     pub effort: Option<String>,
+    pub service_tier: Option<String>,
     pub speed: Option<language_model_core::Speed>,
 }
 

--- a/crates/settings_content/src/language_model.rs
+++ b/crates/settings_content/src/language_model.rs
@@ -82,6 +82,7 @@ pub struct BedrockAvailableModel {
     #[serde(serialize_with = "crate::serialize_optional_f32_with_two_decimal_places")]
     pub default_temperature: Option<f32>,
     pub mode: Option<ModelMode>,
+    pub service_tiers: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -2732,6 +2732,7 @@ fn run_multi_workspace_sidebar_visual_tests(
                             speed: None,
                             thinking_enabled: false,
                             thinking_effort: None,
+                            service_tier: None,
                             ui_scroll_position: None,
                             draft_prompt: None,
                         },


### PR DESCRIPTION
**TL;DR**: some inference providers support different **_tiers_** for that inference: in addition to the `default` that everybody uses, there are usually also some other tiers like a `flex` tier that is cheaper and slower (say 50% cheaper for extra 1-2s in latency), a `priority` tier (say double the price for faster responses), and fancy enterprise tiers (for example, think of things like reserved capacity, custom SLAs, etc). This PR adds support for that, using the same pattern as `thinking_effort`.

-----

## Background

Being a very financially responsible person, I wanted to optimize my LLM cost when using Zed Agent. I was thinking about implementing support for Bedrock service tiers [for a while now](https://github.com/zed-industries/zed/issues/49617#issuecomment-4092295196), but when doing that I discovered that 1) Zed already kinda supported this though its staff-only Claude Fast Mode and 2) non-Bedrock providers support this too.

Some quick research showed several options available for multiple inference providers with built-in support in Zed:
- **Bedrock** supports [several service tiers today](https://aws.amazon.com/bedrock/service-tiers/) ([docs here](https://docs.aws.amazon.com/bedrock/latest/userguide/service-tiers-inference.html)) with presumably(?) another service tier coming for the [AWS](https://www.aboutamazon.com/news/aws/aws-cerebras-ai-inference) <> [Cerebras](https://www.cerebras.ai/blog/cerebras-is-coming-to-aws) collaboration
  - `flex` is 50% cheaper and has higher latency ([benchmark 1](https://blog.serverworks.co.jp/bedrock-service-tier))
  - `standard`, which is already used by Zed, and which is the Bedrock everybody knows and uses
  - `priority` is 75% more expensive and has lower latency ([benchmark 2](https://github.com/gilinachum/bedrock-latency/blob/main/SERVICE_TIER_TESTING.md
))
  - `reserved` which requires a 1-3 months contract for fancy companies and offers is guaranteed capacity and throughput and other fancy stuff

- **Google** [supports 3 service tiers](https://ai.google.dev/gemini-api/docs/pricing):
  - `flex` is 50% cheaper _"in exchange for variable latency and best-effort availability"_ ([docs](https://ai.google.dev/gemini-api/docs/flex-inference))
  - `standard`
  - `priority` is more ~80% more expensive for _"lower latency and the highest reliability"_ and is available to [Tier 2 & Tier 3](https://ai.google.dev/gemini-api/docs/billing#about-billing) users ([docs](https://ai.google.dev/gemini-api/docs/priority-inference))

- **OpenRouter** [supports 3 service tiers](https://openrouter.ai/docs/guides/features/service-tiers) for OpenAI, Google Vertex, and Google AI Studio providers:
  - `flex`
  - `default`
  - `priority`

- **Anthropic** is a bit messy and [supports `standard` and `priority` service tiers](https://platform.claude.com/docs/en/api/service-tiers), an `auto` service tier [that "_automatically use Priority Tier when available, fallback to standard_"](https://platform.claude.com/docs/en/api/service-tiers#using-service-tiers), and a [seemingly(?) separate Fast mode](https://platform.claude.com/docs/en/build-with-claude/fast-mode)

- **OpenAI** supports [several service tiers](https://developers.openai.com/api/docs/pricing?latest-pricing=priority) and a [Codex-only Fast mode](https://developers.openai.com/codex/speed) (that [may or may not be mapped to `priority`](https://github.com/router-for-me/CLIProxyAPI/issues/3411) but that is [definitely a service tier](https://github.com/openai/codex/issues/15853#issuecomment-4135613878)) :
  - `flex` ([docs](https://developers.openai.com/api/docs/guides/flex-processing))
  - `standard`
  - `priority` ([docs](https://developers.openai.com/api/docs/guides/priority-processing))
  - `scale` for fancy companies ([docs](https://openai.com/api-scale-tier/))

It's all messy and chaotic and several of the things above are in beta/preview and may or may not change soon 😅

## Implementation

> [!TIP]
> This pull request is **best reviewed commit-by-commit**!

With all this chaos, I decided to implement support only for Bedrock as I could easily test its `flex` and `priority` options.

The implementation is heavily based on how `thinking_effort` is currently implemented in Zed: an optional list of fields for some models/providers that is optionally shown in the UI. 

Example Bedrock model with service tier selection:
<img width="401" height="136" alt="Screenshot of Nova 2 Lite with the service tier drop-down" src="https://github.com/user-attachments/assets/7acd42a9-6344-4285-ac67-c2cc85cc5d23" />

Bedrock models that only support the `standard` tier show no tier drop-down:
<img width="416" height="115" alt="Screenshot of Opus 4.7 without any tier selection shown" src="https://github.com/user-attachments/assets/5c70c513-8ba4-4605-822c-efd1312b83d6" />

Bedrock models that support both service tiers and thinking show 2 drop-downs:
<img width="439" height="120" alt="Screenshot of Opus 4.6" src="https://github.com/user-attachments/assets/c0028bb7-4170-4f1d-bdd9-9fa497b82fd6" />

-----

**Open question**: _drop-down_ versus _icon_. It is unclear what's best to use for the UI: an icon like Fast Mode or a drop-down? On the one hand, an icon would not take as much space — the above screenshot is a bit crowded. On the other hand, an icon is less clear and not at all discoverable.  
Currently there's a ⏩ icon used for Fast Mode (glowing icon when enabled, crossed-out gray icon when disabled). If icons want to be used for service tiers too, I imagine something like a stack of coins could be used for `flex`, 💲 for `default`, 💰 for `priority`, and 💎 or 🪎 for `reserved`/`scale`? Based on data from work, I am strongly advising against using any Copilot-like multipliers — the amount of developers that used Opus because _"I thought 3x meant it's 3 times faster"_ is surprisingly large.

-----

CC @5herlocked since this is a Bedrock change. Model details were taken from https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.html and I hope the Bedrock docs weren't wrong 😅 

CC @tomhoule as this conflicts a bit with https://github.com/zed-industries/zed/pull/57412 and as we chatted a bit there

> [!TIP]
> This pull request is **best reviewed commit-by-commit**!

-----

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Bedrock: Added support for Service Tiers
