### PR TITLE
Escape seeded regex searches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15817,6 +15817,7 @@ dependencies = [
  "multi_buffer",
  "pretty_assertions",
  "project",
+ "regex",
  "serde",
  "serde_json",
  "settings",

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -34,6 +34,7 @@ language.workspace = true
 menu.workspace = true
 multi_buffer.workspace = true
 project.workspace = true
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1128,6 +1128,11 @@ impl BufferSearchBar {
         let search = self
             .query_suggestion(seed_query_override, window, cx)
             .map(|suggestion| {
+                let suggestion = if self.default_options.contains(SearchOptions::REGEX) {
+                    regex::escape(&suggestion)
+                } else {
+                    suggestion
+                };
                 self.search(&suggestion, Some(self.default_options), true, window, cx)
             });
 
@@ -3252,6 +3257,73 @@ mod tests {
             .unindent(),
         })
         .await;
+    }
+
+    #[gpui::test]
+    async fn test_regex_search_escapes_seeded_selection(cx: &mut TestAppContext) {
+        init_globals(cx);
+        let seeded_regex = r".\+*?()|[]{}^$#&-\~";
+        let buffer = cx.new(|cx| Buffer::local(format!("zed\nz.d\n{seeded_regex}\n"), cx));
+        let cx = cx.add_empty_window();
+        let editor =
+            cx.new_window_entity(|window, cx| Editor::for_buffer(buffer.clone(), None, window, cx));
+        let search_bar = cx.new_window_entity(|window, cx| {
+            let mut search_bar = BufferSearchBar::new(None, window, cx);
+            search_bar.set_active_pane_item(Some(&editor), window, cx);
+            search_bar.enable_search_option(SearchOptions::REGEX, window, cx);
+            search_bar.dismiss(&Dismiss, window, cx);
+            search_bar
+        });
+
+        for (selected_text, row, expected_range) in [
+            ("z.d", 1, Point::new(1, 0)..Point::new(1, 3)),
+            (
+                seeded_regex,
+                2,
+                Point::new(2, 0)..Point::new(2, seeded_regex.len() as u32),
+            ),
+        ] {
+            editor.update_in(cx, |editor, window, cx| {
+                editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selections| {
+                    selections.select_ranges([
+                        Point::new(row, 0)..Point::new(row, selected_text.len() as u32)
+                    ])
+                });
+            });
+
+            search_bar
+                .update_in(cx, |search_bar, window, cx| {
+                    search_bar.deploy(&Deploy::find(), None, window, cx);
+                    assert_eq!(search_bar.query(cx), regex::escape(selected_text));
+                    search_bar.update_matches(false, false, window, cx)
+                })
+                .await
+                .unwrap();
+
+            editor.update(cx, |editor, cx| {
+                assert_eq!(
+                    editor.search_background_highlights(cx),
+                    &[expected_range.clone()]
+                );
+            });
+        }
+
+        search_bar
+            .update_in(cx, |search_bar, window, cx| {
+                search_bar.search("z.d", Some(SearchOptions::REGEX), true, window, cx)
+            })
+            .await
+            .unwrap();
+
+        editor.update(cx, |editor, cx| {
+            assert_eq!(
+                editor.search_background_highlights(cx),
+                &[
+                    Point::new(0, 0)..Point::new(0, 3),
+                    Point::new(1, 0)..Point::new(1, 3)
+                ]
+            );
+        });
     }
 
     #[gpui::test]


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #57253

When regex search is enabled, opening search from a selection like `z.d` used to treat the `.` as part of the regex. This PR escapes selection-seeded searches first, so the selected text is searched literally. Typing a regex by hand still works the same as before.

Release Notes:

- Fixed seeded searches in regex mode so selected text is matched literally.
