### PR TITLE
Update git2 to 0.21.0 and add support for SHA-256 object formatted repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7346,15 +7346,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -9950,9 +9949,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -592,7 +592,7 @@ futures = "0.3.32"
 futures-concurrency = "7.7.1"
 futures-lite = "1.13"
 gh-workflow = { git = "https://github.com/zed-industries/gh-workflow", rev = "37f3c0575d379c218a9c455ee67585184e40d43f" }
-git2 = { version = "0.20.1", default-features = false, features = ["vendored-libgit2"] }
+git2 = { version = "0.21.0", default-features = false, features = ["vendored-libgit2", "unstable-sha256"] }
 globset = "0.4"
 heapless = "0.9.2"
 handlebars = "4.3"

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -179,9 +179,12 @@ impl FromStr for Oid {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> std::prelude::v1::Result<Self, Self::Err> {
-        libgit::Oid::from_str(s)
-            .context("parsing git oid")
-            .map(Self)
+        let oid = if s.len() == 64 {
+            libgit::Oid::from_str_ext(s, libgit::ObjectFormat::Sha256)
+        } else {
+            libgit::Oid::from_str_ext(s, libgit::ObjectFormat::Sha1)
+        };
+        oid.context("parsing git oid").map(Self)
     }
 }
 
@@ -218,7 +221,7 @@ impl<'de> Deserialize<'de> for Oid {
 
 impl Default for Oid {
     fn default() -> Self {
-        Self(libgit::Oid::zero())
+        Self(libgit::Oid::ZERO_SHA1)
     }
 }
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1657,7 +1657,7 @@ impl GitRepository for RealGitRepository {
             .spawn(async move {
                 let repo = repo.lock();
                 let remote = repo.find_remote(&name).ok()?;
-                remote.url().map(|url| url.to_string())
+                remote.url().ok().map(|url| url.to_string())
             })
             .boxed()
     }

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -12734,7 +12734,7 @@ fn git_reset(offset: usize, repo: &git2::Repository) {
     let new_head = commit
         .parents()
         .inspect(|parnet| {
-            parnet.message();
+            let _ = parnet.message();
         })
         .nth(offset)
         .expect("Not enough history");


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] ~Unsafe blocks (if any) have justifying comments~ (N/A)
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior (didn't add new test for parsing SHA-256 - not sure if would be desired)
- [x] Performance impact has been considered and is acceptable

Closes #24070

Upgrades git2 from 0.20.1 to 0.21.0 with the `unstable-sha256` feature - adds ability to open and work with git repositories using the SHA-256 object format. `Oid::from_str` now detects 64-char hex strings to parse SHA-256 OIDs correctly.

Also adapts to breaking API changes in 0.21.0:
`Remote::url()` and `Commit::message()` both now return `Result`.

Release Notes:
- Added support for opening SHA-256 object format git repositories