### PR TITLE
Filter out remote HEAD refs from branch switcher/picker

### DIFF
--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -773,6 +773,9 @@ fn process_branches(
     let mut result: Vec<Branch> = branches
         .iter()
         .filter(|branch| {
+            if branch.is_remote() && branch.name().ends_with("/HEAD") {
+                return false;
+            }
             !remote_upstreams.contains(&branch.ref_name)
                 || preserved_branch
                     .as_ref()


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] ~Unsafe blocks (if any) have justifying comments~ (N/A)
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

I was unable to find an issue directly mentioning this behaviour.

`origin/HEAD` (and any other remote `/HEAD` ref) is a symbolic ref that points to the remote's default branch and cannot be checked out. Attempting to do so via the branch switcher produces an error: `'HEAD' is not a valid branch name; class=Reference (4).` - which I feel is an avoidable error that can be solved just by filtering the listing out.

Below shows the branch switcher/picker with the ability to switch to `origin/HEAD` (this change removes it being listed here):

![Branch Switcher](https://github.com/user-attachments/assets/f9091e5c-3b8b-463a-a14d-284f9d019c21)

Below shows the popup with the error:

![Error Popup](https://github.com/user-attachments/assets/c3b46a97-2c5c-4ab3-beda-9383cce4a3fd)

Release Notes:

- Fixed remote HEAD symbolic refs appearing in the branch picker

