### PR TITLE
Fix task arguments with spaces

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1184,7 +1184,7 @@ pub fn prepare_task_for_spawn(
 ) -> SpawnInTerminal {
     let builder = ShellBuilder::new(shell, is_windows);
     let command_label = builder.command_label(task.command.as_deref().unwrap_or(""));
-    let (command, args) = builder.build_no_quote(task.command.clone(), &task.args);
+    let (command, args) = builder.build_for_task(task.command.clone(), &task.args);
 
     SpawnInTerminal {
         command_label,
@@ -1831,6 +1831,106 @@ mod tests {
                 interactive = if cfg!(windows) { "" } else { "-i " }
             ),
             "We want to show to the user the entire command spawned"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_prepare_task_preserves_args_with_spaces() {
+        let input = SpawnInTerminal {
+            command: Some("python".to_string()),
+            args: vec![
+                "main.py".to_string(),
+                "test1".to_string(),
+                "test2 test3".to_string(),
+            ],
+            ..SpawnInTerminal::default()
+        };
+        let shell = Shell::Program("sh".to_string());
+
+        let result = prepare_task_for_spawn(&input, &shell, false);
+
+        assert_eq!(result.command, Some("sh".to_string()));
+        assert_eq!(
+            result.args,
+            vec![
+                "-i".to_string(),
+                "-c".to_string(),
+                "python main.py test1 'test2 test3'".to_string(),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_prepare_task_keeps_command_as_shell_snippet() {
+        let input = SpawnInTerminal {
+            command: Some("echo first && echo second".to_string()),
+            args: vec!["test2 test3".to_string()],
+            ..SpawnInTerminal::default()
+        };
+        let shell = Shell::Program("sh".to_string());
+
+        let result = prepare_task_for_spawn(&input, &shell, false);
+
+        assert_eq!(
+            result.args,
+            vec![
+                "-i".to_string(),
+                "-c".to_string(),
+                "echo first && echo second 'test2 test3'".to_string(),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_prepare_task_preserves_quoted_and_shell_variable_args() {
+        let input = SpawnInTerminal {
+            command: Some("rspec".to_string()),
+            args: vec![
+                "\"test file.rb:10\"".to_string(),
+                "$PATH".to_string(),
+                "$ZED_RELATIVE_FILE".to_string(),
+            ],
+            ..SpawnInTerminal::default()
+        };
+        let shell = Shell::Program("sh".to_string());
+
+        let result = prepare_task_for_spawn(&input, &shell, false);
+
+        assert_eq!(
+            result.args,
+            vec![
+                "-i".to_string(),
+                "-c".to_string(),
+                "rspec \"test file.rb:10\" $PATH $ZED_RELATIVE_FILE".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_prepare_task_preserves_args_with_spaces_on_windows() {
+        let input = SpawnInTerminal {
+            command: Some("python".to_string()),
+            args: vec![
+                "main.py".to_string(),
+                "test1".to_string(),
+                "test2 test3".to_string(),
+            ],
+            ..SpawnInTerminal::default()
+        };
+        let shell = Shell::Program("powershell.exe".to_string());
+
+        let result = prepare_task_for_spawn(&input, &shell, true);
+
+        assert_eq!(result.command, Some("powershell.exe".to_string()));
+        assert_eq!(
+            result.args,
+            vec![
+                "-C".to_string(),
+                "python main.py test1 'test2 test3'".to_string(),
+            ]
         );
     }
 

--- a/crates/util/src/shell_builder.rs
+++ b/crates/util/src/shell_builder.rs
@@ -88,7 +88,7 @@ impl ShellBuilder {
             } else {
                 task_command
             };
-            let mut combined_command = task_args.iter().fold(task_command, |mut command, arg| {
+            let combined_command = task_args.iter().fold(task_command, |mut command, arg| {
                 command.push(' ');
                 let shell_variable = self.kind.to_shell_variable(arg);
                 command.push_str(&match self.kind.try_quote(&shell_variable) {
@@ -97,31 +97,7 @@ impl ShellBuilder {
                 });
                 command
             });
-            if self.redirect_stdin {
-                match self.kind {
-                    ShellKind::Fish => {
-                        combined_command.insert_str(0, "begin; ");
-                        combined_command.push_str("; end </dev/null");
-                    }
-                    ShellKind::Posix
-                    | ShellKind::Nushell
-                    | ShellKind::Csh
-                    | ShellKind::Tcsh
-                    | ShellKind::Rc
-                    | ShellKind::Xonsh
-                    | ShellKind::Elvish => {
-                        combined_command.insert(0, '(');
-                        combined_command.push_str("\n) </dev/null");
-                    }
-                    ShellKind::PowerShell | ShellKind::Pwsh => {
-                        combined_command.insert_str(0, "$null | & {");
-                        combined_command.push_str("}");
-                    }
-                    ShellKind::Cmd => {
-                        combined_command.push_str("< NUL");
-                    }
-                }
-            }
+            let combined_command = self.redirect_command_stdin(combined_command);
 
             self.args
                 .extend(self.kind.args_for_shell(self.interactive, combined_command));
@@ -138,42 +114,87 @@ impl ShellBuilder {
         task_args: &[String],
     ) -> (String, Vec<String>) {
         if let Some(task_command) = task_command {
-            let mut combined_command = task_args.iter().fold(task_command, |mut command, arg| {
+            let combined_command = task_args.iter().fold(task_command, |mut command, arg| {
                 command.push(' ');
                 command.push_str(&self.kind.to_shell_variable(arg));
                 command
             });
-            if self.redirect_stdin {
-                match self.kind {
-                    ShellKind::Fish => {
-                        combined_command.insert_str(0, "begin; ");
-                        combined_command.push_str("; end </dev/null");
-                    }
-                    ShellKind::Posix
-                    | ShellKind::Nushell
-                    | ShellKind::Csh
-                    | ShellKind::Tcsh
-                    | ShellKind::Rc
-                    | ShellKind::Xonsh
-                    | ShellKind::Elvish => {
-                        combined_command.insert(0, '(');
-                        combined_command.push_str("\n) </dev/null");
-                    }
-                    ShellKind::PowerShell | ShellKind::Pwsh => {
-                        combined_command.insert_str(0, "$null | & {");
-                        combined_command.push_str("}");
-                    }
-                    ShellKind::Cmd => {
-                        combined_command.push_str("< NUL");
-                    }
-                }
-            }
+            let combined_command = self.redirect_command_stdin(combined_command);
 
             self.args
                 .extend(self.kind.args_for_shell(self.interactive, combined_command));
         }
 
         (self.program, self.args)
+    }
+
+    pub fn build_for_task(
+        mut self,
+        task_command: Option<String>,
+        task_args: &[String],
+    ) -> (String, Vec<String>) {
+        if let Some(task_command) = task_command {
+            let combined_command = task_args.iter().fold(task_command, |mut command, arg| {
+                command.push(' ');
+                command.push_str(&self.quote_task_arg(arg));
+                command
+            });
+            let combined_command = self.redirect_command_stdin(combined_command);
+
+            self.args
+                .extend(self.kind.args_for_shell(self.interactive, combined_command));
+        }
+
+        (self.program, self.args)
+    }
+
+    fn quote_task_arg(&self, arg: &str) -> String {
+        let shell_variable = self.kind.to_shell_variable(arg);
+        if self.should_preserve_task_arg(arg, &shell_variable) {
+            shell_variable
+        } else {
+            match self.kind.try_quote(&shell_variable) {
+                Some(shell_variable) => shell_variable.into_owned(),
+                None => shell_variable,
+            }
+        }
+    }
+
+    fn should_preserve_task_arg(&self, arg: &str, shell_variable: &str) -> bool {
+        (arg.starts_with('"') && arg.ends_with('"'))
+            || (arg.starts_with('\'') && arg.ends_with('\''))
+            || arg.contains('$')
+            || matches!(self.kind, ShellKind::Cmd) && shell_variable.contains('%')
+    }
+
+    fn redirect_command_stdin(&self, mut combined_command: String) -> String {
+        if self.redirect_stdin {
+            match self.kind {
+                ShellKind::Fish => {
+                    combined_command.insert_str(0, "begin; ");
+                    combined_command.push_str("; end </dev/null");
+                }
+                ShellKind::Posix
+                | ShellKind::Nushell
+                | ShellKind::Csh
+                | ShellKind::Tcsh
+                | ShellKind::Rc
+                | ShellKind::Xonsh
+                | ShellKind::Elvish => {
+                    combined_command.insert(0, '(');
+                    combined_command.push_str("\n) </dev/null");
+                }
+                ShellKind::PowerShell | ShellKind::Pwsh => {
+                    combined_command.insert_str(0, "$null | & {");
+                    combined_command.push_str("}");
+                }
+                ShellKind::Cmd => {
+                    combined_command.push_str("< NUL");
+                }
+            }
+        }
+
+        combined_command
     }
 
     /// Builds a `smol::process::Command` with the given task command and arguments.


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #55482

This keeps task arguments with spaces together when Zed starts a task in the terminal. It only changes how task `args` are prepared, so script-style commands and existing manually quoted arguments keep working.

<img width="2398" height="1570" alt="image" src="https://github.com/user-attachments/assets/22032d62-2ece-4fcf-97a8-633af57da3b5" />

Release Notes:

- Fixed task arguments containing spaces being split into multiple arguments.

