### PR TITLE
Restore Rules Library and add Summarization prompt to BuiltInPrompt

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -16,7 +16,7 @@ use feature_flags::{
 
 use agent_client_protocol::schema as acp;
 use agent_settings::{
-    AgentProfileId, AgentSettings, SUMMARIZE_THREAD_DETAILED_PROMPT, SUMMARIZE_THREAD_PROMPT,
+    AgentProfileId, AgentSettings, SUMMARIZE_THREAD_PROMPT,
 };
 use anyhow::{Context as _, Result, anyhow};
 use chrono::{DateTime, Local, Utc};
@@ -44,7 +44,7 @@ use language_model::{
     TokenUsage, ZED_CLOUD_PROVIDER_ID,
 };
 use project::Project;
-use prompt_store::ProjectContext;
+use prompt_store::{self, BuiltInPrompt, ProjectContext};
 use schemars::{JsonSchema, Schema};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -2756,27 +2756,37 @@ impl Thread {
             log::error!("No summarization model available");
             return Task::ready(None).shared();
         };
-        let mut request = LanguageModelRequest {
-            intent: Some(CompletionIntent::ThreadContextSummarization),
-            temperature: AgentSettings::temperature_for_model(&model, cx),
-            ..Default::default()
-        };
+        let temperature = AgentSettings::temperature_for_model(&model, cx);
 
+        let mut messages = Vec::new();
         for message in &self.messages {
-            request.messages.extend(message.to_request());
+            messages.extend(message.to_request());
         }
 
-        request.messages.push(LanguageModelRequestMessage {
-            role: Role::User,
-            content: vec![SUMMARIZE_THREAD_DETAILED_PROMPT.into()],
-            cache: false,
-            reasoning_details: None,
-        });
-
         let task = cx
-            .spawn(async move |this, cx| {
+            .spawn(async move |this, mut cx| {
+                let prompt = Self::load_builtin_prompt(
+                    BuiltInPrompt::SummarizeThreadDetailed,
+                    &mut cx,
+                )
+                .await;
+
+                messages.push(LanguageModelRequestMessage {
+                    role: Role::User,
+                    content: vec![prompt.into()],
+                    cache: false,
+                    reasoning_details: None,
+                });
+
+                let request = LanguageModelRequest {
+                    intent: Some(CompletionIntent::ThreadContextSummarization),
+                    temperature,
+                    messages,
+                    ..Default::default()
+                };
+
                 let mut summary = String::new();
-                let mut messages = model.stream_completion(request, cx).await.log_err()?;
+                let mut messages = model.stream_completion(request, &mut cx).await.log_err()?;
                 while let Some(event) = messages.next().await {
                     let event = event.log_err()?;
                     let text = match event {
@@ -2874,6 +2884,25 @@ impl Thread {
                 }
             });
         }));
+    }
+
+    async fn load_builtin_prompt(
+        builtin: BuiltInPrompt,
+        cx: &mut AsyncApp,
+    ) -> String {
+        let load = async {
+            let store = cx
+                .update(|cx| prompt_store::PromptStore::global(cx))
+                .await
+                .ok()?;
+            store
+                .update(cx, |s, cx| {
+                    s.load(prompt_store::PromptId::BuiltIn(builtin), cx)
+                })
+                .await
+                .ok()
+        };
+        load.await.unwrap_or_else(|| builtin.default_content().to_string())
     }
 
     pub fn set_title(&mut self, title: SharedString, cx: &mut Context<Self>) {

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -22,8 +22,6 @@ use settings::{
 pub use crate::agent_profile::*;
 
 pub const SUMMARIZE_THREAD_PROMPT: &str = include_str!("prompts/summarize_thread_prompt.txt");
-pub const SUMMARIZE_THREAD_DETAILED_PROMPT: &str =
-    include_str!("prompts/summarize_thread_detailed_prompt.txt");
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PanelLayout {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -72,6 +72,7 @@ use language::LanguageRegistry;
 use language_model::LanguageModelRegistry;
 use project::{Project, ProjectPath, Worktree};
 use prompt_store::PromptStore;
+use rules_library;
 use settings::TerminalDockPosition;
 use settings::{NotifyWhenAgentWaiting, Settings, update_settings_file};
 use skill_creator::open_skill_creator;
@@ -3053,15 +3054,21 @@ impl AgentPanel {
 
     fn deploy_rules_library(
         &mut self,
-        _action: &OpenRulesLibrary,
-        window: &mut Window,
+        action: &OpenRulesLibrary,
+        _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // The legacy Rules action is rerouted to the skill creator so the
-        // existing keyboard shortcut (still bound to `OpenRulesLibrary` in
-        // the default keymaps) and any persisted user keymap entries keep
-        // working.
-        self.deploy_skill_creator(&OpenSkillCreator, window, cx);
+        let delegate = AgentPanelRulesDelegate;
+
+        rules_library::open_rules_library(
+            self.language_registry.clone(),
+            Box::new(delegate),
+            action.prompt_to_select.map(|uuid| prompt_store::PromptId::User {
+                uuid: prompt_store::UserPromptId::from(uuid),
+            }),
+            cx,
+        )
+        .detach_and_log_err(cx);
     }
 
     fn deploy_skill_creator(
@@ -4889,7 +4896,7 @@ impl AgentPanel {
                                 .header("Skills")
                                 .entry(
                                     "Create Skill…",
-                                    Some(Box::new(OpenRulesLibrary::default())),
+                                    Some(Box::new(OpenSkillCreator)),
                                     |window, cx| {
                                         window.dispatch_action(Box::new(OpenSkillCreator), cx);
                                     },
@@ -4902,6 +4909,17 @@ impl AgentPanel {
                                         cx,
                                     );
                                 })
+                                .separator()
+                                .entry(
+                                    "Rules Library…",
+                                    Some(Box::new(OpenRulesLibrary::default())),
+                                    |window, cx| {
+                                        window.dispatch_action(
+                                            Box::new(OpenRulesLibrary::default()),
+                                            cx,
+                                        );
+                                    },
+                                )
                                 .separator();
 
                             if project_agents_md_path.is_some() || global_agents_md_loaded {
@@ -8302,6 +8320,60 @@ mod tests {
         assert!(
             cx.debug_bounds("KEY_BINDING-l").is_some(),
             "Create Skill… menu item should show the OpenRulesLibrary shortcut"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_rules_library_menu_entry_shows_shortcut(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            let default_key_bindings = settings::KeymapFile::load_asset_allow_partial_failure(
+                "keymaps/default-macos.json",
+                cx,
+            )
+            .unwrap();
+            cx.bind_keys(default_key_bindings);
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+        fs.insert_tree("/project", json!({ "file.txt": "" })).await;
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        let mut cx = VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        let panel = workspace.update_in(&mut cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, None, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+        open_thread_with_connection(&panel, StubAgentConnection::new(), &mut cx);
+        workspace.update_in(&mut cx, |workspace, window, cx| {
+            workspace.focus_panel::<AgentPanel>(window, cx);
+        });
+        cx.run_until_parked();
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.toggle_options_menu(&ToggleOptionsMenu, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert!(
+            cx.debug_bounds("MENU_ITEM-Rules Library…").is_some(),
+            "Rules Library… menu item should be visible"
+        );
+        assert!(
+            cx.debug_bounds("KEY_BINDING-l").is_some(),
+            "Rules Library… menu item should show the OpenRulesLibrary shortcut"
         );
     }
 
@@ -11975,5 +12047,50 @@ mod tests {
                 "panel should have an active, connected agent thread"
             );
         });
+    }
+}
+
+/// Bridges the Rules Library window to the Agent Panel.
+struct AgentPanelRulesDelegate;
+
+impl rules_library::InlineAssistDelegate for AgentPanelRulesDelegate {
+    fn assist(
+        &self,
+        prompt_editor: &Entity<Editor>,
+        initial_prompt: Option<String>,
+        _window: &mut Window,
+        cx: &mut Context<rules_library::RulesLibrary>,
+    ) {
+        let mut text = prompt_editor.read(cx).text(cx);
+        if let Some(prompt) = initial_prompt {
+            text = prompt;
+        }
+
+        // Copy to clipboard and focus the agent panel so the user can
+        // paste the rule text into a new thread without cross-window plumbing.
+        cx.write_to_clipboard(ClipboardItem::new_string(text));
+
+        for handle in cx.windows() {
+            if let Some(multi_workspace) = handle.downcast::<MultiWorkspace>() {
+                multi_workspace
+                    .update(cx, |multi_workspace, window, cx| {
+                        multi_workspace.workspace().update(cx, |workspace, cx| {
+                            workspace.focus_panel::<AgentPanel>(window, cx);
+                        })
+                    })
+                    .log_err();
+                break;
+            }
+        }
+    }
+
+    fn focus_agent_panel(
+        &self,
+        workspace: &mut Workspace,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> bool {
+        workspace.focus_panel::<AgentPanel>(window, cx);
+        true
     }
 }

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -743,13 +743,9 @@ fn update_command_palette_filter(cx: &mut App) {
             filter.show_namespace("multi_workspace");
         }
 
-        // Hide `assistant: open rules library` — Rules are surfaced
-        // through the Skills UI now. Applied after the disable-ai /
-        // agent-enabled branches so it overrides the
-        // `show_namespace("assistant")` call above without affecting the
-        // rest of that namespace's actions.
+        // Both the Rules Library and Skill Creator are surfaced.
         if !disable_ai {
-            filter.hide_action_types(&open_rules_library_action);
+            filter.show_action_types(open_rules_library_action.iter());
             filter.show_action_types(open_skill_creator_action.iter());
         } else {
             filter.show_action_types(open_rules_library_action.iter());

--- a/crates/prompt_store/src/prompt_store.rs
+++ b/crates/prompt_store/src/prompt_store.rs
@@ -68,12 +68,14 @@ impl PromptMetadata {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, EnumIter)]
 pub enum BuiltInPrompt {
     CommitMessage,
+    SummarizeThreadDetailed,
 }
 
 impl BuiltInPrompt {
     pub fn title(&self) -> &'static str {
         match self {
             Self::CommitMessage => "Commit message",
+            Self::SummarizeThreadDetailed => "Summarize thread (detailed)",
         }
     }
 
@@ -81,6 +83,9 @@ impl BuiltInPrompt {
     pub fn default_content(&self) -> &'static str {
         match self {
             Self::CommitMessage => include_str!("../../git_ui/src/commit_message_prompt.txt"),
+            Self::SummarizeThreadDetailed => {
+                include_str!("../../agent_settings/src/prompts/summarize_thread_detailed_prompt.txt")
+            }
         }
     }
 }
@@ -89,6 +94,7 @@ impl std::fmt::Display for BuiltInPrompt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::CommitMessage => write!(f, "Commit message"),
+            Self::SummarizeThreadDetailed => write!(f, "Summarize thread (detailed)"),
         }
     }
 }
@@ -126,9 +132,7 @@ impl PromptId {
     pub fn can_edit(&self) -> bool {
         match self {
             Self::User { .. } => true,
-            Self::BuiltIn(builtin) => match builtin {
-                BuiltInPrompt::CommitMessage => true,
-            },
+            Self::BuiltIn(_) => true,
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced in v1.4.0 where the Rules Library window was redirected to the Skill Creator, making built-in prompts (Commit Message) uneditable. It restores the Rules Library window for editing `BuiltInPrompt` entries and adds **Summarize thread (detailed)** as a new customizable built-in prompt.

## Motivation

- **Regression (v1.4.0):** The `agent: open rules library` action was silently redirecting to `agent: open skill creator`. While user-created rules were intentionally migrated to Skills, the built-in prompt editor (used for Commit Message customization) was lost with no replacement. Users who customized their Commit Message prompt before v1.4.0 still have their customization stored in `PromptStore`, but can no longer edit it.
- **Missing feature:** The thread summarization prompt was hardcoded at compile time. Users had no way to customize it, unlike the Commit Message prompt.

## Changes

### 1. Restore Rules Library window

**`crates/agent_ui/src/agent_panel.rs`**
- `deploy_rules_library()` now opens the actual Rules Library window via `rules_library::open_rules_library()` instead of redirecting to `deploy_skill_creator()`.
- Added `AgentPanelRulesDelegate` — a minimal `InlineAssistDelegate` implementation that bridges the Rules Library window to the Agent Panel. When the user clicks "Test", the rule text is copied to clipboard and the agent panel is focused.
- Menu: added separate "Rules Library…" entry (dispatches `OpenRulesLibrary`), "Create Skill…" now dispatches `OpenSkillCreator` directly.

**`crates/agent_ui/src/agent_ui.rs`**
- Command palette: both `agent: open rules library` and `agent: open skill creator` are now visible (previously `OpenRulesLibrary` was hidden).

### 2. Add Summarization prompt to PromptStore

**`crates/prompt_store/src/prompt_store.rs`**
- Added `BuiltInPrompt::SummarizeThreadDetailed` variant.
- `default_content()` includes the prompt text from the existing `summarize_thread_detailed_prompt.txt`.
- `title()` and `Display` implementations updated.
- `can_edit()` now returns `true` for all `BuiltIn` variants.

### 3. Thread loads the detailed summarization prompt from PromptStore

**`crates/agent/src/thread.rs`**
- Added `Thread::load_builtin_prompt()` — an async helper that loads a prompt from `PromptStore`, falling back to `BuiltInPrompt::default_content()` if no custom version exists (same pattern as `GitPanel::load_commit_message_prompt`).
- `Thread::summary()` now loads `SummarizeThreadDetailed` from PromptStore inside the spawned async task.
- `Thread::generate_title()` keeps using the hardcoded `SUMMARIZE_THREAD_PROMPT` constant (title prompt is intentionally not customizable).

### 4. Remove dead code

**`crates/agent_settings/src/agent_settings.rs`**
- Removed `SUMMARIZE_THREAD_DETAILED_PROMPT` constant (no longer referenced; prompt text is now provided by `BuiltInPrompt::default_content()`).
- Kept `SUMMARIZE_THREAD_PROMPT` for title generation.

## How it works

1. User opens **Rules Library** via `agent: open rules library` (`shift-alt-l` on Windows, `cmd-alt-l` on macOS, `ctrl-alt-l` on Linux).
2. The Rules Library window shows all `BuiltInPrompt` entries under "Built-in Rules": **Commit message** and **Summarize thread (detailed)**.
3. Each can be edited — changes are saved to the `PromptStore` (LMDB database).
4. When `Thread::summary()` runs, it loads the user's custom prompt from `PromptStore`. If none exists, it falls back to the default content.

## Files changed

| File | Change |
|---|---|
| `crates/agent_ui/src/agent_panel.rs` | Restore `deploy_rules_library`, add `AgentPanelRulesDelegate`, fix menu |
| `crates/agent_ui/src/agent_ui.rs` | Show both `OpenRulesLibrary` and `OpenSkillCreator` in command palette |
| `crates/agent/src/thread.rs` | Load summarization prompt from `PromptStore` via `load_builtin_prompt()` |
| `crates/prompt_store/src/prompt_store.rs` | Add `SummarizeThreadDetailed` to `BuiltInPrompt`, make all builtins editable |
| `crates/agent_settings/src/agent_settings.rs` | Remove dead `SUMMARIZE_THREAD_DETAILED_PROMPT` constant |

## Testing

- [x] `cargo check` — passes
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] `cargo test -p prompt_store` — 25 passed
- [x] `cargo test -p agent_ui` — 316/317 passed (1 pre-existing flaky test: `test_new_workspace_load_uses_global_terminal_entry_kind`)
- [x] `cargo test -p agent_ui -- test_skills_menu_entry_shows_rules_shortcut test_rules_library_menu_entry_shows_shortcut` — 2 passed
- [x] `cargo build -p zed` — debug binary produced
- [x] Manual: Rules Library opens, both built-in prompts visible and editable
- [x] Manual: Summarize thread (detailed) edited, custom prompt used for thread summarization
- [x] Manual: Commit Message editing still works in Rules Library
- [x] Manual: Skill Creator opens correctly from menu and command palette

Release Notes:

- Fixed: Restored the Rules Library window for editing built-in prompts (Commit Message, Thread Summarization). This fixes a regression from v1.4.0 where the `agent: open rules library` action was redirected to the Skill Creator, making Commit Message customization inaccessible.
- Added Summarize thread (detailed) as an editable built-in prompt. Users can now customize the prompt used for thread summarization via the Rules Library.
