### PR TITLE
Fix error prompt darkened background exceeding window boundaries on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19236,6 +19236,7 @@ dependencies = [
  "markdown",
  "menu",
  "settings",
+ "theme",
  "theme_settings",
  "ui",
  "workspace",

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -51,7 +51,7 @@ pub const CLIENT_SIDE_DECORATION_ROUNDING: Pixels = px(10.0);
 pub const CLIENT_SIDE_DECORATION_SHADOW: Pixels = px(10.0);
 
 /// Styling helpers for elements that follow client-side window decorations.
-pub trait ClientDecorations: Styled + Sized {
+pub trait ClientDecorationsExt: Styled {
     /// Rounds each corner whose two adjacent edges are both untiled.
     fn rounded_client_corners(mut self, tiling: Tiling) -> Self {
         if !tiling.top && !tiling.left {
@@ -70,7 +70,7 @@ pub trait ClientDecorations: Styled + Sized {
     }
 }
 
-impl<T: Styled + Sized> ClientDecorations for T {}
+impl<T: Styled> ClientDecorationsExt for T {}
 
 /// The appearance of the theme.
 #[derive(Debug, PartialEq, Clone, Copy, Deserialize)]

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -25,7 +25,8 @@ use std::sync::Arc;
 use gpui::BorrowAppContext;
 use gpui::Global;
 use gpui::{
-    App, AssetSource, Hsla, Pixels, SharedString, WindowAppearance, WindowBackgroundAppearance, px,
+    App, AssetSource, Hsla, Pixels, SharedString, Styled, Tiling, WindowAppearance,
+    WindowBackgroundAppearance, px,
 };
 use serde::Deserialize;
 
@@ -48,6 +49,28 @@ pub const DEFAULT_DARK_THEME: &str = "One Dark";
 pub const CLIENT_SIDE_DECORATION_ROUNDING: Pixels = px(10.0);
 /// Defines window shadow size for platforms that use client side decorations.
 pub const CLIENT_SIDE_DECORATION_SHADOW: Pixels = px(10.0);
+
+/// Styling helpers for elements that follow client-side window decorations.
+pub trait ClientDecorations: Styled + Sized {
+    /// Rounds each corner whose two adjacent edges are both untiled.
+    fn rounded_client_corners(mut self, tiling: Tiling) -> Self {
+        if !tiling.top && !tiling.left {
+            self = self.rounded_tl(CLIENT_SIDE_DECORATION_ROUNDING);
+        }
+        if !tiling.top && !tiling.right {
+            self = self.rounded_tr(CLIENT_SIDE_DECORATION_ROUNDING);
+        }
+        if !tiling.bottom && !tiling.left {
+            self = self.rounded_bl(CLIENT_SIDE_DECORATION_ROUNDING);
+        }
+        if !tiling.bottom && !tiling.right {
+            self = self.rounded_br(CLIENT_SIDE_DECORATION_ROUNDING);
+        }
+        self
+    }
+}
+
+impl<T: Styled + Sized> ClientDecorations for T {}
 
 /// The appearance of the theme.
 #[derive(Debug, PartialEq, Clone, Copy, Deserialize)]

--- a/crates/ui_prompt/Cargo.toml
+++ b/crates/ui_prompt/Cargo.toml
@@ -19,6 +19,7 @@ gpui.workspace = true
 markdown.workspace = true
 menu.workspace = true
 settings.workspace = true
+theme.workspace = true
 theme_settings.workspace = true
 ui.workspace = true
 workspace.workspace = true

--- a/crates/ui_prompt/src/ui_prompt.rs
+++ b/crates/ui_prompt/src/ui_prompt.rs
@@ -160,7 +160,7 @@ impl Render for ZedPromptRenderer {
         };
         let inset = window.client_inset().unwrap_or(Pixels::ZERO);
         let inset_for_edge = |is_tiled| if is_tiled { Pixels::ZERO } else { inset };
-        let rounding = px(10.0);
+        let rounding = theme::CLIENT_SIDE_DECORATION_ROUNDING;
 
         div().size_full().occlude().child(
             v_flex()

--- a/crates/ui_prompt/src/ui_prompt.rs
+++ b/crates/ui_prompt/src/ui_prompt.rs
@@ -1,7 +1,7 @@
 use gpui::{
-    App, Entity, EventEmitter, FocusHandle, Focusable, PromptButton, PromptHandle, PromptLevel,
-    PromptResponse, RenderablePromptHandle, SharedString, TextStyleRefinement, Window, div,
-    prelude::*,
+    App, Decorations, Entity, EventEmitter, FocusHandle, Focusable, PromptButton, PromptHandle,
+    PromptLevel, PromptResponse, RenderablePromptHandle, SharedString, TextStyleRefinement, Window,
+    div, prelude::*,
 };
 use markdown::{Markdown, MarkdownElement, MarkdownStyle};
 use settings::{Settings, SettingsStore};
@@ -154,20 +154,41 @@ impl Render for ZedPromptRenderer {
                     })),
             );
 
-        div()
-            .size_full()
-            .occlude()
-            .bg(gpui::black().opacity(0.2))
-            .child(
-                v_flex()
-                    .size_full()
-                    .absolute()
-                    .top_0()
-                    .left_0()
-                    .items_center()
-                    .justify_center()
-                    .child(dialog),
-            )
+        let tiling = match window.window_decorations() {
+            Decorations::Server => gpui::Tiling::tiled(),
+            Decorations::Client { tiling } => tiling,
+        };
+        let inset = window.client_inset().unwrap_or(Pixels::ZERO);
+        let inset_for_edge = |is_tiled| if is_tiled { Pixels::ZERO } else { inset };
+        let rounding = px(10.0);
+
+        div().size_full().occlude().child(
+            v_flex()
+                .absolute()
+                .bg(gpui::black().opacity(0.2))
+                .top(inset_for_edge(tiling.top))
+                .right(inset_for_edge(tiling.right))
+                .bottom(inset_for_edge(tiling.bottom))
+                .left(inset_for_edge(tiling.left))
+                .map(|mut div| {
+                    if !tiling.top && !tiling.left {
+                        div = div.rounded_tl(rounding);
+                    }
+                    if !tiling.top && !tiling.right {
+                        div = div.rounded_tr(rounding);
+                    }
+                    if !tiling.bottom && !tiling.left {
+                        div = div.rounded_bl(rounding);
+                    }
+                    if !tiling.bottom && !tiling.right {
+                        div = div.rounded_br(rounding);
+                    }
+                    div
+                })
+                .items_center()
+                .justify_center()
+                .child(dialog),
+        )
     }
 }
 

--- a/crates/ui_prompt/src/ui_prompt.rs
+++ b/crates/ui_prompt/src/ui_prompt.rs
@@ -170,20 +170,17 @@ impl Render for ZedPromptRenderer {
                 .right(inset_for_edge(tiling.right))
                 .bottom(inset_for_edge(tiling.bottom))
                 .left(inset_for_edge(tiling.left))
-                .map(|mut div| {
-                    if !tiling.top && !tiling.left {
-                        div = div.rounded_tl(rounding);
-                    }
-                    if !tiling.top && !tiling.right {
-                        div = div.rounded_tr(rounding);
-                    }
-                    if !tiling.bottom && !tiling.left {
-                        div = div.rounded_bl(rounding);
-                    }
-                    if !tiling.bottom && !tiling.right {
-                        div = div.rounded_br(rounding);
-                    }
-                    div
+                .when(!tiling.top && !tiling.left, |this| {
+                    this.rounded_tl(rounding)
+                })
+                .when(!tiling.top && !tiling.right, |this| {
+                    this.rounded_tr(rounding)
+                })
+                .when(!tiling.bottom && !tiling.left, |this| {
+                    this.rounded_bl(rounding)
+                })
+                .when(!tiling.bottom && !tiling.right, |this| {
+                    this.rounded_br(rounding)
                 })
                 .items_center()
                 .justify_center()

--- a/crates/ui_prompt/src/ui_prompt.rs
+++ b/crates/ui_prompt/src/ui_prompt.rs
@@ -5,7 +5,7 @@ use gpui::{
 };
 use markdown::{Markdown, MarkdownElement, MarkdownStyle};
 use settings::{Settings, SettingsStore};
-use theme::ClientDecorations;
+use theme::ClientDecorationsExt;
 use theme_settings::ThemeSettings;
 use ui::{FluentBuilder, TintColor, prelude::*};
 use workspace::WorkspaceSettings;
@@ -158,8 +158,9 @@ impl Render for ZedPromptRenderer {
         let decorations = window.window_decorations();
         let inset = window.client_inset().unwrap_or(Pixels::ZERO);
 
-        div().size_full().occlude().child(
+        div().size_full().child(
             v_flex()
+                .occlude()
                 .absolute()
                 .inset_0()
                 .bg(gpui::black().opacity(0.2))

--- a/crates/ui_prompt/src/ui_prompt.rs
+++ b/crates/ui_prompt/src/ui_prompt.rs
@@ -5,6 +5,7 @@ use gpui::{
 };
 use markdown::{Markdown, MarkdownElement, MarkdownStyle};
 use settings::{Settings, SettingsStore};
+use theme::ClientDecorations;
 use theme_settings::ThemeSettings;
 use ui::{FluentBuilder, TintColor, prelude::*};
 use workspace::WorkspaceSettings;
@@ -154,33 +155,22 @@ impl Render for ZedPromptRenderer {
                     })),
             );
 
-        let tiling = match window.window_decorations() {
-            Decorations::Server => gpui::Tiling::tiled(),
-            Decorations::Client { tiling } => tiling,
-        };
+        let decorations = window.window_decorations();
         let inset = window.client_inset().unwrap_or(Pixels::ZERO);
-        let inset_for_edge = |is_tiled| if is_tiled { Pixels::ZERO } else { inset };
-        let rounding = theme::CLIENT_SIDE_DECORATION_ROUNDING;
 
         div().size_full().occlude().child(
             v_flex()
                 .absolute()
+                .inset_0()
                 .bg(gpui::black().opacity(0.2))
-                .top(inset_for_edge(tiling.top))
-                .right(inset_for_edge(tiling.right))
-                .bottom(inset_for_edge(tiling.bottom))
-                .left(inset_for_edge(tiling.left))
-                .when(!tiling.top && !tiling.left, |this| {
-                    this.rounded_tl(rounding)
-                })
-                .when(!tiling.top && !tiling.right, |this| {
-                    this.rounded_tr(rounding)
-                })
-                .when(!tiling.bottom && !tiling.left, |this| {
-                    this.rounded_bl(rounding)
-                })
-                .when(!tiling.bottom && !tiling.right, |this| {
-                    this.rounded_br(rounding)
+                .map(|this| match decorations {
+                    Decorations::Server => this,
+                    Decorations::Client { tiling } => this
+                        .when(!tiling.top, |this| this.top(inset))
+                        .when(!tiling.bottom, |this| this.bottom(inset))
+                        .when(!tiling.left, |this| this.left(inset))
+                        .when(!tiling.right, |this| this.right(inset))
+                        .rounded_client_corners(tiling),
                 })
                 .items_center()
                 .justify_center()

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -138,7 +138,7 @@ use std::{
     time::Duration,
 };
 use task::{DebugScenario, SharedTaskContext, SpawnInTerminal};
-use theme::{ActiveTheme, SystemAppearance};
+use theme::{ActiveTheme, ClientDecorations, SystemAppearance};
 use theme_settings::ThemeSettings;
 pub use toolbar::{
     PaneSearchBarCallbacks, Toolbar, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView,
@@ -10498,6 +10498,12 @@ pub fn client_side_decorations(
         Decorations::Server => Tiling::default(),
         Decorations::Client { tiling } => tiling,
     };
+    let corner_tiling = Tiling {
+        top: tiling.top || border_radius_tiling.top,
+        bottom: tiling.bottom || border_radius_tiling.bottom,
+        left: tiling.left || border_radius_tiling.left,
+        right: tiling.right || border_radius_tiling.right,
+    };
 
     match decorations {
         Decorations::Client { .. } => window.set_client_inset(theme::CLIENT_SIDE_DECORATION_SHADOW),
@@ -10513,34 +10519,7 @@ pub fn client_side_decorations(
         .map(|div| match decorations {
             Decorations::Server => div,
             Decorations::Client { .. } => div
-                .when(
-                    !(tiling.top
-                        || tiling.right
-                        || border_radius_tiling.top
-                        || border_radius_tiling.right),
-                    |div| div.rounded_tr(theme::CLIENT_SIDE_DECORATION_ROUNDING),
-                )
-                .when(
-                    !(tiling.top
-                        || tiling.left
-                        || border_radius_tiling.top
-                        || border_radius_tiling.left),
-                    |div| div.rounded_tl(theme::CLIENT_SIDE_DECORATION_ROUNDING),
-                )
-                .when(
-                    !(tiling.bottom
-                        || tiling.right
-                        || border_radius_tiling.bottom
-                        || border_radius_tiling.right),
-                    |div| div.rounded_br(theme::CLIENT_SIDE_DECORATION_ROUNDING),
-                )
-                .when(
-                    !(tiling.bottom
-                        || tiling.left
-                        || border_radius_tiling.bottom
-                        || border_radius_tiling.left),
-                    |div| div.rounded_bl(theme::CLIENT_SIDE_DECORATION_ROUNDING),
-                )
+                .rounded_client_corners(corner_tiling)
                 .when(!tiling.top, |div| {
                     div.pt(theme::CLIENT_SIDE_DECORATION_SHADOW)
                 })
@@ -10595,34 +10574,7 @@ pub fn client_side_decorations(
                     Decorations::Server => div,
                     Decorations::Client { .. } => div
                         .border_color(cx.theme().colors().border)
-                        .when(
-                            !(tiling.top
-                                || tiling.right
-                                || border_radius_tiling.top
-                                || border_radius_tiling.right),
-                            |div| div.rounded_tr(theme::CLIENT_SIDE_DECORATION_ROUNDING),
-                        )
-                        .when(
-                            !(tiling.top
-                                || tiling.left
-                                || border_radius_tiling.top
-                                || border_radius_tiling.left),
-                            |div| div.rounded_tl(theme::CLIENT_SIDE_DECORATION_ROUNDING),
-                        )
-                        .when(
-                            !(tiling.bottom
-                                || tiling.right
-                                || border_radius_tiling.bottom
-                                || border_radius_tiling.right),
-                            |div| div.rounded_br(theme::CLIENT_SIDE_DECORATION_ROUNDING),
-                        )
-                        .when(
-                            !(tiling.bottom
-                                || tiling.left
-                                || border_radius_tiling.bottom
-                                || border_radius_tiling.left),
-                            |div| div.rounded_bl(theme::CLIENT_SIDE_DECORATION_ROUNDING),
-                        )
+                        .rounded_client_corners(corner_tiling)
                         .when(!tiling.top, |div| div.border_t(BORDER_SIZE))
                         .when(!tiling.bottom, |div| div.border_b(BORDER_SIZE))
                         .when(!tiling.left, |div| div.border_l(BORDER_SIZE))

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -138,7 +138,7 @@ use std::{
     time::Duration,
 };
 use task::{DebugScenario, SharedTaskContext, SpawnInTerminal};
-use theme::{ActiveTheme, ClientDecorations, SystemAppearance};
+use theme::{ActiveTheme, ClientDecorationsExt, SystemAppearance};
 use theme_settings::ThemeSettings;
 pub use toolbar::{
     PaneSearchBarCallbacks, Toolbar, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView,


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior (visual difference only)
- [x] Performance impact has been considered and is acceptable

I was unable to find a specific issue or PR that mentions this.

As Linux installations always use built-in prompts and ignore the `Use System Prompts` setting (as far as I'm aware) all users using Zed (with client-side decorations) are affected. The darkened prompt backdrop was drawn across the full window boundary, including the transparent decoration/shadow inset, causing it to overlap.

This PR fixes the backdrop to respect the client-side decoration inset and only applies rounded corners on non-tiled edges. Tiled edges remain flush, matching the rest of the client-side window decoration behavior. I've verified it works on Wayland, X11 and causes no regressions on macOS or Windows (with `Use System Prompts` off).

Notice the screenshots below on a white background showing the before and after, where the faint overlap is shown broken and fixed (sorry if you have to squint).

Before:

![Before](https://github.com/user-attachments/assets/be12fbe9-1ad9-4282-a333-0d9d6ae162d5)

After:

![After](https://github.com/user-attachments/assets/75988dc8-2e45-4214-bf14-e999d7b9e996)

Release Notes:

- Fixed prompt darkened backdrop/background rendering outside client-decorated window boundaries on Linux.