### PR TITLE
vim: Fix `g i` and `g a` in Helix mode to match Helix semantics

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -503,6 +503,8 @@
       "g c": "vim::WindowMiddle",
       "g b": "vim::WindowBottom",
       "g r": "editor::FindAllReferences",
+      "g i": "editor::GoToImplementation",
+      "g a": "pane::AlternateFile",
       "g n": "pane::ActivateNextItem",
       "shift-l": "pane::ActivateNextItem", // not a helix default
       "g p": "pane::ActivatePreviousItem",


### PR DESCRIPTION
In Helix mode, `g i` and `g a` currently leak through from the catch-all
`VimControl && !menu` section:

- `g i` fires `vim::InsertAtPrevious` (Vim's "go to last insert"), but Helix's `goto_implementation` expects an LSP jump to the implementation site.
- `g a` fires `editor::SelectAllMatches`, but Helix's `goto_last_accessed_file` expects to jump to the alternate buffer.

This adds explicit overrides in the shared `(vim_mode == helix_normal || vim_mode == helix_select)` section so both keys behave per Helix's documented goto-mode bindings: https://docs.helix-editor.com/keymap.html

### Before
| Key | Helix expects (`goto_*`) | Zed actual (leaked from Vim) |
| --- | --- | --- |
| `g i` | `goto_implementation` (LSP) | `vim::InsertAtPrevious` |
| `g a` | `goto_last_accessed_file` | `editor::SelectAllMatches` |

### After
| Key | Action |
| --- | --- |
| `g i` | `editor::GoToImplementation` |
| `g a` | `pane::AlternateFile` |

Refs #4642

Bounty: https://app.opire.dev/issues/01J6HJZCK02FVD4XG900FY36EE

### Release Notes:

- vim: Fixed `g i` and `g a` in Helix mode to invoke `goto_implementation` and `goto_last_accessed_file` instead of leaking Vim-mode bindings.
