### PR TITLE
vim: Swap q/Q in Helix mode to match Helix macro semantics

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -494,6 +494,10 @@
       "n": "vim::HelixSelectNext",
       "shift-n": "vim::HelixSelectPrevious",
 
+      // Macros — Helix swaps Vim's q/Q: Q records, q replays
+      "q": "vim::ReplayLastRecording",
+      "shift-q": "vim::ToggleRecord",
+
       // Goto mode
       "g e": "vim::EndOfDocument",
       "g h": "vim::StartOfLine",


### PR DESCRIPTION
Helix inverts Vim's macro keys: **`Q`** starts/stops recording, **`q`** replays. Currently both leak through to Helix mode from the catch-all `VimControl && !menu` section using Vim's mapping, so Helix users hitting `Q` to record a macro instead get playback, and vice versa.

Helix's default keymap explicitly chooses this inversion — the Vim mapping is even present as a commented-out alternative in [helix-term/src/keymap/default.rs](https://github.com/helix-editor/helix/blob/master/helix-term/src/keymap/default.rs):

```rust
"Q" => record_macro,
"q" => replay_macro,
// "q" => record_macro,
// "Q" => replay_macro,
```

### Before
| Key | Helix expects | Zed actual (leaked from Vim) |
| --- | --- | --- |
| `q` | `replay_macro` | `vim::ToggleRecord` |
| `Q` | `record_macro` (start/stop) | `vim::ReplayLastRecording` |

### After
| Key | Action |
| --- | --- |
| `q` | `vim::ReplayLastRecording` |
| `shift-q` | `vim::ToggleRecord` |

Refs https://docs.helix-editor.com/keymap.html
Refs #4642

Bounty: https://app.opire.dev/issues/01J6HJZCK02FVD4XG900FY36EE

### Release Notes:

- vim: Swapped `q` and `Q` in Helix mode so they record / replay macros per Helix defaults instead of leaking Vim bindings.
