### PR TITLE
workspace: Support relative search using `./` and `../` prefix

### DIFF
--- a/crates/open_path_prompt/src/open_path_prompt.rs
+++ b/crates/open_path_prompt/src/open_path_prompt.rs
@@ -44,6 +44,7 @@ pub struct OpenPathDelegate {
         Arc<dyn Fn(&mut Window, &mut Context<Picker<Self>>) -> Option<AnyElement> + 'static>,
     hidden_entries: bool,
     sort_mode: ProjectPanelSortMode,
+    relative_to: PathBuf,
 }
 
 impl OpenPathDelegate {
@@ -51,6 +52,7 @@ impl OpenPathDelegate {
         tx: oneshot::Sender<Option<Vec<PathBuf>>>,
         lister: DirectoryLister,
         creating_path: bool,
+        relative_to: PathBuf,
         cx: &App,
     ) -> Self {
         let path_style = lister.path_style(cx);
@@ -76,6 +78,7 @@ impl OpenPathDelegate {
             render_footer: Arc::new(|_, _| None),
             hidden_entries: false,
             sort_mode,
+            relative_to,
         }
     }
 
@@ -156,6 +159,26 @@ impl OpenPathDelegate {
         }
     }
 
+    fn resolve_path(&self, path: &str) -> String {
+        if path.starts_with("./") || path.starts_with(".\\") {
+            let stripped = &path[2..];
+            let resolved = self.relative_to.join(stripped);
+            resolved.to_string_lossy().into_owned()
+        } else if path.starts_with("../") || path.starts_with("..\\") {
+            let stripped = &path[3..];
+            let parent = self.relative_to.parent().unwrap_or(&self.relative_to);
+            let resolved = parent.join(stripped);
+            resolved.to_string_lossy().into_owned()
+        } else if path == "." {
+            self.relative_to.to_string_lossy().into_owned()
+        } else if path == ".." {
+            let parent = self.relative_to.parent().unwrap_or(&self.relative_to);
+            parent.to_string_lossy().into_owned()
+        } else {
+            path.to_string()
+        }
+    }
+
     fn current_dir(&self) -> &'static str {
         match self.path_style {
             PathStyle::Posix => "./",
@@ -230,9 +253,30 @@ impl OpenPathPrompt {
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
+        let relative_to = if creating_path {
+            workspace
+                .visible_worktrees(cx)
+                .next()
+                .map(|worktree| worktree.read(cx).abs_path().to_path_buf())
+        } else {
+            workspace
+                .active_item(cx)
+                .and_then(|item| item.project_path(cx))
+                .and_then(|project_path| {
+                    workspace
+                        .project()
+                        .read(cx)
+                        .absolute_path(&project_path, cx)
+                })
+                .and_then(|path| path.parent().map(|p| p.to_path_buf()))
+        };
+        let relative_to = relative_to
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+
         workspace.toggle_modal(window, cx, |window, cx| {
             let delegate =
-                OpenPathDelegate::new(tx, lister.clone(), creating_path, cx).show_hidden();
+                OpenPathDelegate::new(tx, lister.clone(), creating_path, relative_to, cx)
+                    .show_hidden();
             let picker =
                 Picker::uniform_list(delegate, window, cx).minimum_results_width(rems(34.));
             let mut query = lister.default_query(cx);
@@ -294,13 +338,13 @@ impl PickerDelegate for OpenPathDelegate {
         let lister = &self.lister;
         let input_is_empty = query.is_empty();
         let (dir, suffix) = get_dir_and_suffix(query, self.path_style);
-
+        let resolved_dir = self.resolve_path(&dir);
         let query = match &self.directory_state {
             DirectoryState::List { parent_path, .. } => {
                 if parent_path == &dir {
                     None
                 } else {
-                    Some(lister.list_directory(dir.clone(), cx))
+                    Some(lister.list_directory(resolved_dir, cx))
                 }
             }
             DirectoryState::Create {
@@ -313,10 +357,10 @@ impl PickerDelegate for OpenPathDelegate {
                 {
                     None
                 } else {
-                    Some(lister.list_directory(dir.clone(), cx))
+                    Some(lister.list_directory(resolved_dir, cx))
                 }
             }
-            DirectoryState::None { .. } => Some(lister.list_directory(dir.clone(), cx)),
+            DirectoryState::None { .. } => Some(lister.list_directory(resolved_dir, cx)),
         };
         self.cancel_flag.store(true, atomic::Ordering::Release);
         self.cancel_flag = Arc::new(AtomicBool::new(false));
@@ -629,11 +673,12 @@ impl PickerDelegate for OpenPathDelegate {
         match &self.directory_state {
             DirectoryState::None { .. } => return,
             DirectoryState::List { parent_path, .. } => {
+                let resolved_parent = self.resolve_path(parent_path);
                 let confirmed_path =
                     if parent_path == &self.prompt_root && candidate.path.string.is_empty() {
                         PathBuf::from(&self.prompt_root)
                     } else {
-                        Path::new(self.lister.resolve_tilde(parent_path, cx).as_ref())
+                        Path::new(self.lister.resolve_tilde(&resolved_parent, cx).as_ref())
                             .join(&candidate.path.string)
                     };
                 if let Some(tx) = self.tx.take() {
@@ -650,11 +695,12 @@ impl PickerDelegate for OpenPathDelegate {
                     if user_input.is_dir {
                         return;
                     }
+                    let resolved_parent = self.resolve_path(parent_path);
                     let prompted_path =
                         if parent_path == &self.prompt_root && user_input.file.string.is_empty() {
                             PathBuf::from(&self.prompt_root)
                         } else {
-                            Path::new(self.lister.resolve_tilde(parent_path, cx).as_ref())
+                            Path::new(self.lister.resolve_tilde(&resolved_parent, cx).as_ref())
                                 .join(&user_input.file.string)
                         };
                     if user_input.exists {

--- a/crates/open_path_prompt/src/open_path_prompt_tests.rs
+++ b/crates/open_path_prompt/src/open_path_prompt_tests.rs
@@ -501,8 +501,29 @@ fn build_open_path_prompt(
         cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
     let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
     (
-        workspace.update_in(cx, |_, window, cx| {
-            let delegate = OpenPathDelegate::new(tx, lister.clone(), creating_path, cx);
+        workspace.update_in(cx, |workspace, window, cx| {
+            let project_root = workspace
+                .visible_worktrees(cx)
+                .next()
+                .map(|worktree| worktree.read(cx).abs_path().to_path_buf());
+
+            let relative_to = workspace
+                .active_item(cx)
+                .and_then(|item| item.project_path(cx))
+                .and_then(|project_path| {
+                    workspace
+                        .project()
+                        .read(cx)
+                        .absolute_path(&project_path, cx)
+                })
+                .and_then(|path| path.parent().map(|p| p.to_path_buf()))
+                .or(project_root)
+                .unwrap_or_else(|| {
+                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+                });
+
+            let delegate =
+                OpenPathDelegate::new(tx, lister.clone(), creating_path, relative_to, cx);
             let delegate = if show_hidden {
                 delegate.show_hidden()
             } else {
@@ -552,4 +573,56 @@ fn collect_match_candidates(
     cx: &mut VisualTestContext,
 ) -> Vec<String> {
     picker.update(cx, |f, _| f.delegate.collect_match_candidates())
+}
+
+#[gpui::test]
+async fn test_open_path_prompt_relative_to(cx: &mut TestAppContext) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/root"),
+            json!({
+                "file_in_root": "Content",
+                "subdir": {
+                    "file_in_subdir": "Content",
+                }
+            }),
+        )
+        .await;
+
+    let project = Project::test(app_state.fs.clone(), [path!("/root").as_ref()], cx).await;
+    let (tx, _) = futures::channel::oneshot::channel();
+    let lister = project::DirectoryLister::Project(project.clone());
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+    let relative_to = std::path::PathBuf::from("/root/subdir");
+
+    let picker = workspace.update_in(cx, |_, window, cx| {
+        let delegate = OpenPathDelegate::new(tx, lister.clone(), false, relative_to, cx);
+        cx.new(|cx| {
+            let picker = Picker::uniform_list(delegate, window, cx)
+                .minimum_results_width(rems(34.))
+                .modal(false);
+            picker
+        })
+    });
+
+    let expected_separator = "./";
+
+    insert_query("./", &picker, cx).await;
+    assert_eq!(
+        collect_match_candidates(&picker, cx),
+        vec![expected_separator, "file_in_subdir"]
+    );
+
+    insert_query("../", &picker, cx).await;
+    assert_eq!(
+        collect_match_candidates(&picker, cx),
+        vec![expected_separator, "subdir", "file_in_root"]
+    );
 }

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -395,7 +395,14 @@ impl ProjectPicker {
     ) -> Entity<Self> {
         let (tx, rx) = oneshot::channel();
         let lister = project::DirectoryLister::Project(project.clone());
-        let delegate = open_path_prompt::OpenPathDelegate::new(tx, lister, false, cx).show_hidden();
+        let relative_to = project
+            .read(cx)
+            .visible_worktrees(cx)
+            .next()
+            .map(|worktree| worktree.read(cx).abs_path().to_path_buf())
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        let delegate = open_path_prompt::OpenPathDelegate::new(tx, lister, false, relative_to, cx)
+            .show_hidden();
 
         let picker = cx.new(|cx| {
             let picker = Picker::uniform_list(delegate, window, cx)

--- a/crates/remote_connection/src/remote_connection.rs
+++ b/crates/remote_connection/src/remote_connection.rs
@@ -245,6 +245,8 @@ impl RemoteConnectionModal {
             RemoteConnectionOptions::Mock(options) => {
                 (format!("mock-{}", options.id), None, false, false)
             }
+            #[allow(unreachable_patterns)]
+            _ => unreachable!(),
         };
         Self {
             prompt: cx.new(|cx| {

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -145,61 +145,73 @@ impl AddToolchainState {
     ) -> (OpenPathDelegate, oneshot::Receiver<Option<Vec<PathBuf>>>) {
         let (tx, rx) = oneshot::channel();
         let weak = cx.weak_entity();
-        let lister = OpenPathDelegate::new(tx, DirectoryLister::Project(project), false, cx)
-            .show_hidden()
-            .with_footer(Arc::new(move |_, cx| {
-                let error = weak
-                    .read_with(cx, |this, _| {
-                        if let AddState::Path { error, .. } = &this.state {
-                            error.clone()
-                        } else {
-                            None
+        let relative_to = project
+            .read(cx)
+            .visible_worktrees(cx)
+            .next()
+            .map(|worktree| worktree.read(cx).abs_path().to_path_buf())
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+        let lister = OpenPathDelegate::new(
+            tx,
+            DirectoryLister::Project(project),
+            false,
+            relative_to,
+            cx,
+        )
+        .show_hidden()
+        .with_footer(Arc::new(move |_, cx| {
+            let error = weak
+                .read_with(cx, |this, _| {
+                    if let AddState::Path { error, .. } = &this.state {
+                        error.clone()
+                    } else {
+                        None
+                    }
+                })
+                .ok()
+                .flatten();
+            let is_loading = weak
+                .read_with(cx, |this, _| {
+                    matches!(
+                        this.state,
+                        AddState::Path {
+                            input_state: PathInputState::Resolving(_),
+                            ..
                         }
-                    })
-                    .ok()
-                    .flatten();
-                let is_loading = weak
-                    .read_with(cx, |this, _| {
-                        matches!(
-                            this.state,
-                            AddState::Path {
-                                input_state: PathInputState::Resolving(_),
-                                ..
-                            }
-                        )
-                    })
-                    .unwrap_or_default();
-                Some(
-                    v_flex()
-                        .child(Divider::horizontal())
-                        .child(
-                            h_flex()
-                                .p_1()
-                                .justify_between()
-                                .gap_2()
-                                .child(Label::new("Select Toolchain Path").color(Color::Muted).map(
-                                    |this| {
-                                        if is_loading {
-                                            this.with_animation(
-                                                "select-toolchain-label",
-                                                Animation::new(Duration::from_secs(2))
-                                                    .repeat()
-                                                    .with_easing(pulsating_between(0.4, 0.8)),
-                                                |label, delta| label.alpha(delta),
-                                            )
-                                            .into_any()
-                                        } else {
-                                            this.into_any_element()
-                                        }
-                                    },
-                                ))
-                                .when_some(error, |this, error| {
-                                    this.child(Label::new(error).color(Color::Error))
-                                }),
-                        )
-                        .into_any(),
-                )
-            }));
+                    )
+                })
+                .unwrap_or_default();
+            Some(
+                v_flex()
+                    .child(Divider::horizontal())
+                    .child(
+                        h_flex()
+                            .p_1()
+                            .justify_between()
+                            .gap_2()
+                            .child(Label::new("Select Toolchain Path").color(Color::Muted).map(
+                                |this| {
+                                    if is_loading {
+                                        this.with_animation(
+                                            "select-toolchain-label",
+                                            Animation::new(Duration::from_secs(2))
+                                                .repeat()
+                                                .with_easing(pulsating_between(0.4, 0.8)),
+                                            |label, delta| label.alpha(delta),
+                                        )
+                                        .into_any()
+                                    } else {
+                                        this.into_any_element()
+                                    }
+                                },
+                            ))
+                            .when_some(error, |this, error| {
+                                this.child(Label::new(error).color(Color::Error))
+                            }),
+                    )
+                    .into_any(),
+            )
+        }));
 
         (lister, rx)
     }


### PR DESCRIPTION
Introduce support in `workspace: open files` to resolve relative path prefixes starting with `./` (or `.\` on Windows) and `../` to the current or parent directory of the currently opened buffer. If no file is associated with the active buffer or it cannot be detected, the path defaults to the workspace project root.

[workspace-open-dot-for-current-directory.webm](https://github.com/user-attachments/assets/e18828ab-8c91-4e8a-aef8-171a6ccbaa2b)

Release Notes:

- Added support for starting search from the active buffer's directory in the `workspace: open files` prompt by typing `./` or `../` for the parent directory.
