### PR TITLE
which_key: Add more discoverable bindings helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20774,9 +20774,12 @@ name = "which_key"
 version = "0.1.0"
 dependencies = [
  "command_palette",
+ "db",
  "gpui",
+ "project",
  "serde",
  "settings",
+ "theme",
  "theme_settings",
  "ui",
  "util",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -45,6 +45,8 @@
       "ctrl-alt-shift-i": "edit_prediction::ToggleMenu",
       "ctrl-alt-l": "lsp_tool::ToggleMenu",
       "ctrl-alt-shift-s": "workspace::ToggleWorktreeSecurity",
+      "ctrl-h k": "zed::DescribeKey",
+      "ctrl-h b": "zed::ToggleWhichKey",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -51,6 +51,8 @@
       "ctrl-cmd-l": "lsp_tool::ToggleMenu",
       "ctrl-cmd-c": "editor::DisplayCursorNames",
       "ctrl-cmd-s": "workspace::ToggleWorktreeSecurity",
+      "ctrl-h k": "zed::DescribeKey",
+      "ctrl-h b": "zed::ToggleWhichKey",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -43,6 +43,8 @@
       "shift-alt-l": "lsp_tool::ToggleMenu",
       "ctrl-shift-alt-c": "editor::DisplayCursorNames",
       "ctrl-shift-alt-s": "workspace::ToggleWorktreeSecurity",
+      "ctrl-h k": "zed::DescribeKey",
+      "ctrl-h b": "zed::ToggleWhichKey",
     },
   },
   {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -5085,6 +5085,23 @@ impl Window {
             .possible_next_bindings_for_input(input, &self.context_stack())
     }
 
+    /// Find the bindings that can follow the current input sequence for a specific focus handle's
+    /// context stack. Returns an empty `Vec` if the focus handle is not present in the most
+    /// recently rendered frame's dispatch tree (e.g. before the first render or if the handle
+    /// has gone stale).
+    pub fn possible_bindings_for_input_in(
+        &self,
+        input: &[Keystroke],
+        focus_handle: &FocusHandle,
+    ) -> Vec<KeyBinding> {
+        let Some(context_stack) = self.context_stack_for_focus_handle(focus_handle) else {
+            return Vec::new();
+        };
+        self.rendered_frame
+            .dispatch_tree
+            .possible_next_bindings_for_input(input, &context_stack)
+    }
+
     fn context_stack_for_focus_handle(
         &self,
         focus_handle: &FocusHandle,

--- a/crates/which_key/Cargo.toml
+++ b/crates/which_key/Cargo.toml
@@ -21,3 +21,11 @@ theme_settings.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true
+
+[dev-dependencies]
+db = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
+settings = { workspace = true, features = ["test-support"] }
+theme.workspace = true
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/which_key/src/describe_key_modal.rs
+++ b/crates/which_key/src/describe_key_modal.rs
@@ -1,0 +1,845 @@
+use command_palette::humanize_action_name;
+use gpui::{
+    App, Context, DismissEvent, EventEmitter, FocusHandle, Focusable, FontWeight, KeyBinding,
+    KeyContext, Keystroke, Subscription, WeakEntity, Window,
+};
+use std::collections::HashSet;
+use settings::Settings;
+use theme_settings::ThemeSettings;
+use ui::{prelude::*, text_for_keystrokes, DynamicSpacing, LabelSize};
+use workspace::{ModalView, Workspace};
+
+pub struct DescribeKeyModal {
+    workspace: WeakEntity<Workspace>,
+    focus_handle: FocusHandle,
+    state: DescribeKeyState,
+    intercept_subscription: Option<Subscription>,
+    _focus_out_subscription: Subscription,
+}
+
+enum DescribeKeyState {
+    WaitingForKey,
+    CollectingChord(CollectingChordState),
+    ShowingResults(DescribeKeyResults),
+}
+
+struct CollectingChordState {
+    keystrokes: Vec<Keystroke>,
+    context_stack: Vec<KeyContext>,
+    direct_binding: Option<BindingInfo>,
+    pending_bindings: Vec<(SharedString, SharedString)>,
+}
+
+struct DescribeKeyResults {
+    keystroke_label: SharedString,
+    active_binding: Option<BindingInfo>,
+    shadowed_bindings: Vec<BindingInfo>,
+    pending_bindings: Vec<(SharedString, SharedString)>,
+}
+
+struct BindingInfo {
+    action_name: SharedString,
+    context_predicate: Option<SharedString>,
+    documentation: Option<&'static str>,
+}
+
+impl BindingInfo {
+    fn from_binding(binding: &KeyBinding, cx: &App) -> Self {
+        let action_name = humanize_action_name(binding.action().name()).into();
+        let context_predicate = binding.predicate().map(|p| SharedString::from(p.to_string()));
+        let documentation = cx
+            .action_documentation()
+            .get(binding.action().name())
+            .copied();
+
+        Self {
+            action_name,
+            context_predicate,
+            documentation,
+        }
+    }
+}
+
+impl DescribeKeyModal {
+    pub fn new(
+        workspace: WeakEntity<Workspace>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let focus_handle = window.focused(cx).unwrap_or(cx.focus_handle());
+
+        let handle = cx.weak_entity();
+        let focus_out_subscription = window.on_focus_out(&focus_handle, cx, move |_, _, cx| {
+            handle.update(cx, |_, cx| cx.emit(DismissEvent)).ok();
+        });
+
+        let mut this = Self {
+            workspace,
+            focus_handle,
+            state: DescribeKeyState::WaitingForKey,
+            intercept_subscription: None,
+            _focus_out_subscription: focus_out_subscription,
+        };
+        this.start_intercepting(cx);
+        this
+    }
+
+    fn start_intercepting(&mut self, cx: &mut Context<Self>) {
+        let listener = cx.listener(
+            |this, event: &gpui::KeystrokeEvent, window, cx| {
+                let keystroke = &event.keystroke;
+
+                match &this.state {
+                    DescribeKeyState::WaitingForKey => {
+                        if keystroke.key == "escape" && keystroke.modifiers == gpui::Modifiers::default() {
+                            cx.emit(DismissEvent);
+                            return;
+                        }
+
+                        cx.stop_propagation();
+
+                        let context_stack = event.context_stack.clone();
+                        let continuations =
+                            Self::collect_continuations(std::slice::from_ref(keystroke), &this.focus_handle, window, cx);
+
+                        if continuations.is_empty() {
+                            this.intercept_subscription.take();
+                            let results = Self::resolve_bindings(
+                                std::slice::from_ref(keystroke),
+                                &context_stack,
+                                &this.focus_handle,
+                                window,
+                                cx,
+                            );
+                            this.state = DescribeKeyState::ShowingResults(results);
+                            this.start_dismiss_interception(cx);
+                        } else {
+                            let direct_binding = Self::find_direct_binding(
+                                std::slice::from_ref(keystroke),
+                                &context_stack,
+                                cx,
+                            );
+                            this.state =
+                                DescribeKeyState::CollectingChord(CollectingChordState {
+                                    keystrokes: vec![keystroke.clone()],
+                                    context_stack,
+                                    direct_binding,
+                                    pending_bindings: continuations,
+                                });
+                        }
+                        cx.notify();
+                    }
+                    DescribeKeyState::CollectingChord(chord) => {
+                        cx.stop_propagation();
+
+                        let mut keystrokes = chord.keystrokes.clone();
+                        let context_stack = chord.context_stack.clone();
+
+                        if keystroke.key == "escape" && keystroke.modifiers == gpui::Modifiers::default() {
+                            this.intercept_subscription.take();
+                            let results = Self::resolve_bindings(
+                                &keystrokes,
+                                &context_stack,
+                                &this.focus_handle,
+                                window,
+                                cx,
+                            );
+                            this.state = DescribeKeyState::ShowingResults(results);
+                            this.start_dismiss_interception(cx);
+                            cx.notify();
+                            return;
+                        }
+
+                        keystrokes.push(keystroke.clone());
+
+                        let continuations =
+                            Self::collect_continuations(&keystrokes, &this.focus_handle, window, cx);
+
+                        if continuations.is_empty() {
+                            this.intercept_subscription.take();
+                            let results = Self::resolve_bindings(
+                                &keystrokes,
+                                &context_stack,
+                                &this.focus_handle,
+                                window,
+                                cx,
+                            );
+                            this.state = DescribeKeyState::ShowingResults(results);
+                            this.start_dismiss_interception(cx);
+                        } else {
+                            let direct_binding =
+                                Self::find_direct_binding(&keystrokes, &context_stack, cx);
+                            this.state =
+                                DescribeKeyState::CollectingChord(CollectingChordState {
+                                    keystrokes,
+                                    context_stack,
+                                    direct_binding,
+                                    pending_bindings: continuations,
+                                });
+                        }
+                        cx.notify();
+                    }
+                    DescribeKeyState::ShowingResults(_) => {}
+                }
+            },
+        );
+        self.intercept_subscription = Some(cx.intercept_keystrokes(listener));
+    }
+
+    fn start_dismiss_interception(&mut self, cx: &mut Context<Self>) {
+        let listener = cx.listener(|_this, _event: &gpui::KeystrokeEvent, _window, cx| {
+            cx.stop_propagation();
+            cx.emit(DismissEvent);
+        });
+        self.intercept_subscription = Some(cx.intercept_keystrokes(listener));
+    }
+
+    fn collect_continuations(
+        keystrokes: &[Keystroke],
+        focus_handle: &gpui::FocusHandle,
+        window: &mut Window,
+        cx: &App,
+    ) -> Vec<(SharedString, SharedString)> {
+        let mut seen = HashSet::new();
+        window
+            .possible_bindings_for_input_in(keystrokes, focus_handle)
+            .iter()
+            .filter(|b| b.keystrokes().len() > keystrokes.len())
+            .map(|binding| {
+                let remaining_keystrokes: Vec<Keystroke> = binding
+                    .keystrokes()
+                    .iter()
+                    .skip(keystrokes.len())
+                    .map(|k| k.inner().to_owned())
+                    .collect();
+                let keystrokes_label: SharedString =
+                    format!("... {}", text_for_keystrokes(&remaining_keystrokes, cx)).into();
+                let action_name: SharedString =
+                    humanize_action_name(binding.action().name()).into();
+                (keystrokes_label, action_name)
+            })
+            .filter(|entry| seen.insert(entry.clone()))
+            .collect()
+    }
+
+    fn find_direct_binding(
+        keystrokes: &[Keystroke],
+        context_stack: &[KeyContext],
+        cx: &App,
+    ) -> Option<BindingInfo> {
+        cx.all_bindings_for_input(keystrokes)
+            .iter()
+            .find(|binding| {
+                binding
+                    .predicate()
+                    .map_or(true, |predicate| predicate.depth_of(context_stack).is_some())
+            })
+            .map(|binding| BindingInfo::from_binding(binding, cx))
+    }
+
+    fn resolve_bindings(
+        keystrokes: &[Keystroke],
+        context_stack: &[KeyContext],
+        focus_handle: &gpui::FocusHandle,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> DescribeKeyResults {
+        let all_bindings = cx.all_bindings_for_input(keystrokes);
+
+        let mut active_binding = None;
+        let mut shadowed_bindings = Vec::new();
+
+        let mut seen_actions = HashSet::new();
+        for binding in &all_bindings {
+            let matches_context = binding
+                .predicate()
+                .map_or(true, |predicate| predicate.depth_of(context_stack).is_some());
+
+            if !matches_context {
+                continue;
+            }
+
+            let action_key = (
+                SharedString::from(binding.action().name()),
+                binding.predicate().map(|p| p.to_string()),
+            );
+            if !seen_actions.insert(action_key) {
+                continue;
+            }
+
+            if active_binding.is_none() {
+                active_binding = Some(BindingInfo::from_binding(binding, cx));
+            } else {
+                shadowed_bindings.push(BindingInfo::from_binding(binding, cx));
+            }
+        }
+
+        let pending_bindings =
+            Self::collect_continuations(keystrokes, focus_handle, window, cx);
+
+        let keystroke_label: SharedString = text_for_keystrokes(keystrokes, cx).into();
+
+        DescribeKeyResults {
+            keystroke_label,
+            active_binding,
+            shadowed_bindings,
+            pending_bindings,
+        }
+    }
+
+    fn render_waiting(&self, _cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .gap(px(4.))
+            .child(
+                Label::new("Press any key to describe...")
+                    .size(LabelSize::Default)
+                    .weight(FontWeight::MEDIUM)
+                    .color(Color::Accent),
+            )
+            .child(
+                Label::new("Escape to cancel")
+                    .size(LabelSize::XSmall)
+                    .color(Color::Muted),
+            )
+    }
+
+    fn render_collecting(
+        &self,
+        chord_state: &CollectingChordState,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let keys_label = text_for_keystrokes(&chord_state.keystrokes, cx);
+
+        let mut content = v_flex().gap(px(8.));
+
+        content = content.child(
+            Label::new(format!("{} ...", keys_label))
+                .size(LabelSize::Large)
+                .weight(FontWeight::BOLD)
+                .color(Color::Accent),
+        );
+
+        if let Some(direct) = &chord_state.direct_binding {
+            content = content.child(
+                h_flex()
+                    .gap(px(8.))
+                    .child(
+                        Label::new("Alone:")
+                            .size(LabelSize::XSmall)
+                            .weight(FontWeight::MEDIUM)
+                            .color(Color::Muted),
+                    )
+                    .child(
+                        Label::new(direct.action_name.clone())
+                            .size(LabelSize::Small)
+                            .color(Color::Default),
+                    ),
+            );
+        }
+
+        content = content.child(
+            Label::new("Waiting for next key...")
+                .size(LabelSize::XSmall)
+                .color(Color::Muted),
+        );
+
+        if !chord_state.pending_bindings.is_empty() {
+            content = content
+                .child(
+                    Label::new("Possible continuations:")
+                        .size(LabelSize::XSmall)
+                        .weight(FontWeight::MEDIUM)
+                        .color(Color::Muted),
+                )
+                .child(
+                    v_flex().gap(px(2.)).children(
+                        chord_state.pending_bindings.iter().map(|(keys, action)| {
+                            h_flex()
+                                .gap(px(8.))
+                                .child(
+                                    Label::new(keys.clone())
+                                        .size(LabelSize::Small)
+                                        .color(Color::Accent),
+                                )
+                                .child(
+                                    Label::new(action.clone())
+                                        .size(LabelSize::Small)
+                                        .color(Color::Default),
+                                )
+                        }),
+                    ),
+                );
+        }
+
+        content
+    }
+
+    fn render_results(
+        &self,
+        results: &DescribeKeyResults,
+        _cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let mut content = v_flex().gap(px(8.));
+
+        content = content.child(
+            Label::new(results.keystroke_label.clone())
+                .size(LabelSize::Large)
+                .weight(FontWeight::BOLD)
+                .color(Color::Accent),
+        );
+
+        if let Some(active) = &results.active_binding {
+            content = content.child(Self::render_binding_info(active, false));
+        } else if results.pending_bindings.is_empty() {
+            content = content.child(
+                Label::new("No binding found")
+                    .size(LabelSize::Default)
+                    .color(Color::Muted),
+            );
+        }
+
+        if !results.shadowed_bindings.is_empty() {
+            content = content
+                .child(
+                    Label::new("Shadowed bindings:")
+                        .size(LabelSize::XSmall)
+                        .weight(FontWeight::MEDIUM)
+                        .color(Color::Muted),
+                )
+                .children(
+                    results
+                        .shadowed_bindings
+                        .iter()
+                        .map(|info| Self::render_binding_info(info, true)),
+                );
+        }
+
+        if !results.pending_bindings.is_empty() {
+            content = content
+                .child(
+                    Label::new("Multi-key continuations:")
+                        .size(LabelSize::XSmall)
+                        .weight(FontWeight::MEDIUM)
+                        .color(Color::Muted),
+                )
+                .child(
+                    v_flex().gap(px(2.)).children(
+                        results.pending_bindings.iter().map(|(keys, action)| {
+                            h_flex()
+                                .gap(px(8.))
+                                .child(
+                                    Label::new(keys.clone())
+                                        .size(LabelSize::Small)
+                                        .color(Color::Accent),
+                                )
+                                .child(
+                                    Label::new(action.clone())
+                                        .size(LabelSize::Small)
+                                        .color(Color::Default),
+                                )
+                        }),
+                    ),
+                );
+        }
+
+        content
+    }
+
+    fn render_binding_info(info: &BindingInfo, dimmed: bool) -> impl IntoElement {
+        let name_color = if dimmed {
+            Color::Muted
+        } else {
+            Color::Default
+        };
+
+        let mut row = v_flex().gap(px(2.)).child(
+            Label::new(info.action_name.clone())
+                .size(LabelSize::Default)
+                .weight(FontWeight::MEDIUM)
+                .color(name_color),
+        );
+
+        if let Some(context) = &info.context_predicate {
+            row = row.child(
+                Label::new(format!("context: {}", context))
+                    .size(LabelSize::XSmall)
+                    .color(Color::Muted),
+            );
+        }
+
+        if let Some(docs) = info.documentation {
+            row = row.child(
+                Label::new(docs.to_string())
+                    .size(LabelSize::XSmall)
+                    .color(Color::Muted),
+            );
+        }
+
+        row
+    }
+}
+
+impl Render for DescribeKeyModal {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let viewport_size = window.viewport_size();
+        let max_panel_width = px((f32::from(viewport_size.width) * 0.5).min(480.0));
+
+        let status_height = self
+            .workspace
+            .upgrade()
+            .and_then(|workspace| {
+                workspace.read_with(cx, |workspace, cx| {
+                    if workspace.status_bar_visible(cx) {
+                        Some(
+                            DynamicSpacing::Base04.px(cx) * 2.0
+                                + ThemeSettings::get_global(cx).ui_font_size(cx),
+                        )
+                    } else {
+                        None
+                    }
+                })
+            })
+            .unwrap_or(px(0.));
+
+        let margin_bottom = px(16.);
+        let bottom_offset = margin_bottom + status_height;
+
+        let body = match &self.state {
+            DescribeKeyState::WaitingForKey => self.render_waiting(cx).into_any_element(),
+            DescribeKeyState::CollectingChord(chord_state) => {
+                self.render_collecting(chord_state, cx).into_any_element()
+            }
+            DescribeKeyState::ShowingResults(results) => {
+                self.render_results(results, cx).into_any_element()
+            }
+        };
+
+        div()
+            .id("describe-key-modal")
+            .occlude()
+            .absolute()
+            .bottom(bottom_offset)
+            .right(px(16.))
+            .min_w(px(220.))
+            .max_w(max_panel_width)
+            .elevation_3(cx)
+            .px(px(12.))
+            .py(px(8.))
+            .child(body)
+    }
+}
+
+impl EventEmitter<DismissEvent> for DescribeKeyModal {}
+
+impl Focusable for DescribeKeyModal {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl ModalView for DescribeKeyModal {
+    fn render_bare(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{Entity, TestAppContext, VisualTestContext, actions};
+    use project::Project;
+    use settings::KeymapFile;
+    use workspace::{AppState, MultiWorkspace, Workspace};
+
+    actions!(
+        test_describe_key,
+        [
+            TestSingleKeyAction,
+            TestChordAction,
+            TestChordAction2,
+            TestThreeKeyAction,
+        ]
+    );
+
+    fn init_test(cx: &mut TestAppContext) -> std::sync::Arc<AppState> {
+        cx.update(|cx| {
+            let app_state = AppState::test(cx);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            workspace::init(app_state.clone(), cx);
+            crate::init(cx);
+            app_state
+        })
+    }
+
+    fn open_describe_key(
+        workspace: &Entity<Workspace>,
+        cx: &mut VisualTestContext,
+    ) -> Entity<DescribeKeyModal> {
+        workspace.update_in(cx, |workspace, window, cx| {
+            let workspace_handle = cx.weak_entity();
+            workspace.toggle_modal(window, cx, |window, cx| {
+                DescribeKeyModal::new(workspace_handle, window, cx)
+            });
+        });
+        cx.run_until_parked();
+        workspace
+            .read_with(cx, |workspace, cx| {
+                workspace.active_modal::<DescribeKeyModal>(cx)
+            })
+            .expect("DescribeKeyModal should be open")
+    }
+
+    #[gpui::test]
+    async fn test_single_key_binding_shows_results_immediately(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        cx.update(|_window, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": { "ctrl-c": "test_describe_key::TestSingleKeyAction" } }]"#,
+                cx,
+            ));
+        });
+
+        let modal = open_describe_key(&workspace, cx);
+
+        cx.simulate_keystrokes("ctrl-c");
+        cx.run_until_parked();
+
+        modal.read_with(cx, |modal, _| {
+            match &modal.state {
+                DescribeKeyState::ShowingResults(results) => {
+                    assert!(
+                        results.active_binding.is_some(),
+                        "should have an active binding"
+                    );
+                    assert_eq!(
+                        results.active_binding.as_ref().map(|b| b.action_name.as_ref()),
+                        Some("test describe key: test single key action"),
+                    );
+                }
+                other => panic!("expected ShowingResults, got {:?}", state_name(other)),
+            }
+        });
+    }
+
+    #[gpui::test]
+    async fn test_multi_key_chord_enters_collecting_state(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        cx.update(|_window, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": { "ctrl-k ctrl-d": "test_describe_key::TestChordAction" } }]"#,
+                cx,
+            ));
+        });
+
+        let modal = open_describe_key(&workspace, cx);
+
+        cx.simulate_keystrokes("ctrl-k");
+        cx.run_until_parked();
+
+        modal.read_with(cx, |modal, _| {
+            match &modal.state {
+                DescribeKeyState::CollectingChord(chord) => {
+                    assert_eq!(chord.keystrokes.len(), 1);
+                    assert!(!chord.pending_bindings.is_empty(), "should list continuations");
+                }
+                other => panic!("expected CollectingChord, got {:?}", state_name(other)),
+            }
+        });
+    }
+
+    #[gpui::test]
+    async fn test_multi_key_chord_resolves_after_full_sequence(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        cx.update(|_window, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": { "ctrl-k ctrl-d": "test_describe_key::TestChordAction" } }]"#,
+                cx,
+            ));
+        });
+
+        let modal = open_describe_key(&workspace, cx);
+
+        cx.simulate_keystrokes("ctrl-k");
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("ctrl-d");
+        cx.run_until_parked();
+
+        modal.read_with(cx, |modal, _| {
+            match &modal.state {
+                DescribeKeyState::ShowingResults(results) => {
+                    assert!(
+                        results.active_binding.is_some(),
+                        "should have resolved the chord to an action"
+                    );
+                    assert_eq!(
+                        results.active_binding.as_ref().map(|b| b.action_name.as_ref()),
+                        Some("test describe key: test chord action"),
+                    );
+                }
+                other => panic!("expected ShowingResults, got {:?}", state_name(other)),
+            }
+        });
+    }
+
+    #[gpui::test]
+    async fn test_escape_during_collecting_shows_results(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        cx.update(|_window, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": { "ctrl-k ctrl-d": "test_describe_key::TestChordAction" } }]"#,
+                cx,
+            ));
+        });
+
+        let modal = open_describe_key(&workspace, cx);
+
+        cx.simulate_keystrokes("ctrl-k");
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        modal.read_with(cx, |modal, _| {
+            match &modal.state {
+                DescribeKeyState::ShowingResults(results) => {
+                    assert!(
+                        results.active_binding.is_none(),
+                        "ctrl-k alone should have no binding"
+                    );
+                }
+                other => panic!("expected ShowingResults, got {:?}", state_name(other)),
+            }
+        });
+    }
+
+    #[gpui::test]
+    async fn test_escape_while_waiting_dismisses_modal(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        let _modal = open_describe_key(&workspace, cx);
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        workspace.read_with(cx, |workspace, cx| {
+            assert!(
+                workspace.active_modal::<DescribeKeyModal>(cx).is_none(),
+                "modal should be dismissed after escape"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_three_key_chord_accumulates(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        cx.update(|_window, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": { "ctrl-k ctrl-d ctrl-a": "test_describe_key::TestThreeKeyAction" } }]"#,
+                cx,
+            ));
+        });
+
+        let modal = open_describe_key(&workspace, cx);
+
+        cx.simulate_keystrokes("ctrl-k");
+        cx.run_until_parked();
+        modal.read_with(cx, |modal, _| {
+            assert!(matches!(modal.state, DescribeKeyState::CollectingChord(_)));
+        });
+
+        cx.simulate_keystrokes("ctrl-d");
+        cx.run_until_parked();
+        modal.read_with(cx, |modal, _| {
+            match &modal.state {
+                DescribeKeyState::CollectingChord(chord) => {
+                    assert_eq!(chord.keystrokes.len(), 2);
+                }
+                other => panic!("expected CollectingChord with 2 keys, got {:?}", state_name(other)),
+            }
+        });
+
+        cx.simulate_keystrokes("ctrl-a");
+        cx.run_until_parked();
+        modal.read_with(cx, |modal, _| {
+            match &modal.state {
+                DescribeKeyState::ShowingResults(results) => {
+                    assert_eq!(
+                        results.active_binding.as_ref().map(|b| b.action_name.as_ref()),
+                        Some("test describe key: test three key action"),
+                    );
+                }
+                other => panic!("expected ShowingResults, got {:?}", state_name(other)),
+            }
+        });
+    }
+
+    #[gpui::test]
+    async fn test_dismiss_after_results(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        cx.update(|_window, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": { "ctrl-c": "test_describe_key::TestSingleKeyAction" } }]"#,
+                cx,
+            ));
+        });
+
+        let _modal = open_describe_key(&workspace, cx);
+
+        cx.simulate_keystrokes("ctrl-c");
+        cx.run_until_parked();
+
+        // Any key should dismiss after showing results
+        cx.simulate_keystrokes("a");
+        cx.run_until_parked();
+
+        workspace.read_with(cx, |workspace, cx| {
+            assert!(
+                workspace.active_modal::<DescribeKeyModal>(cx).is_none(),
+                "modal should be dismissed after pressing a key while showing results"
+            );
+        });
+    }
+
+    fn state_name(state: &DescribeKeyState) -> &'static str {
+        match state {
+            DescribeKeyState::WaitingForKey => "WaitingForKey",
+            DescribeKeyState::CollectingChord(_) => "CollectingChord",
+            DescribeKeyState::ShowingResults(_) => "ShowingResults",
+        }
+    }
+}

--- a/crates/which_key/src/which_key.rs
+++ b/crates/which_key/src/which_key.rs
@@ -1,9 +1,11 @@
-//! Which-key support for Zed.
+//! Which-key and describe-key support for Zed.
 
+mod describe_key_modal;
 mod which_key_modal;
 mod which_key_settings;
 
-use gpui::{App, Keystroke};
+use describe_key_modal::DescribeKeyModal;
+use gpui::{App, Keystroke, actions};
 use settings::Settings;
 use std::{sync::LazyLock, time::Duration};
 use util::ResultExt;
@@ -11,13 +13,29 @@ use which_key_modal::WhichKeyModal;
 use which_key_settings::WhichKeySettings;
 use workspace::Workspace;
 
+actions!(
+    zed,
+    [
+        /// Captures the next keystroke and describes what action it would trigger.
+        DescribeKey
+    ]
+);
+
 pub fn init(cx: &mut App) {
     WhichKeySettings::register(cx);
 
-    cx.observe_new(|_: &mut Workspace, window, cx| {
+    cx.observe_new(|workspace: &mut Workspace, window, cx| {
         let Some(window) = window else {
             return;
         };
+
+        workspace.register_action(|workspace, _: &DescribeKey, window, cx| {
+            let workspace_handle = cx.weak_entity();
+            workspace.toggle_modal(window, cx, |window, cx| {
+                DescribeKeyModal::new(workspace_handle, window, cx)
+            });
+        });
+
         let mut timer = None;
         cx.observe_pending_input(window, move |workspace, window, cx| {
             if window.pending_input_keystrokes().is_none() {

--- a/crates/which_key/src/which_key.rs
+++ b/crates/which_key/src/which_key.rs
@@ -17,7 +17,9 @@ actions!(
     zed,
     [
         /// Captures the next keystroke and describes what action it would trigger.
-        DescribeKey
+        DescribeKey,
+        /// Shows all available keybindings for the current context.
+        ToggleWhichKey,
     ]
 );
 
@@ -36,11 +38,20 @@ pub fn init(cx: &mut App) {
             });
         });
 
+        workspace.register_action(|workspace, _: &ToggleWhichKey, window, cx| {
+            let workspace_handle = cx.weak_entity();
+            workspace.toggle_modal(window, cx, |window, cx| {
+                WhichKeyModal::new_manual(workspace_handle, window, cx)
+            });
+        });
+
         let mut timer = None;
         cx.observe_pending_input(window, move |workspace, window, cx| {
             if window.pending_input_keystrokes().is_none() {
                 if let Some(modal) = workspace.active_modal::<WhichKeyModal>(cx) {
-                    modal.update(cx, |modal, cx| modal.dismiss(cx));
+                    if !modal.read(cx).is_manual() {
+                        modal.update(cx, |modal, cx| modal.dismiss(cx));
+                    }
                 };
                 timer.take();
                 return;

--- a/crates/which_key/src/which_key_modal.rs
+++ b/crates/which_key/src/which_key_modal.rs
@@ -22,7 +22,10 @@ pub struct WhichKeyModal {
     scroll_handle: ScrollHandle,
     bindings: Vec<(SharedString, SharedString)>,
     pending_keys: SharedString,
+    manual: bool,
+    showing_continuations: bool,
     _pending_input_subscription: Subscription,
+    _keystroke_subscription: Option<Subscription>,
     _focus_out_subscription: Subscription,
 }
 
@@ -32,9 +35,18 @@ impl WhichKeyModal {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
+        let mut this = Self::new_inner(workspace, window, cx);
+        this.update_pending_keys(window, cx);
+        this
+    }
+
+    pub fn new_manual(
+        workspace: WeakEntity<Workspace>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
         // Keep focus where it currently is
         let focus_handle = window.focused(cx).unwrap_or(cx.focus_handle());
-
         let handle = cx.weak_entity();
         let mut this = Self {
             _workspace: workspace,
@@ -42,6 +54,60 @@ impl WhichKeyModal {
             scroll_handle: ScrollHandle::new(),
             bindings: Vec::new(),
             pending_keys: SharedString::new_static(""),
+            manual: true,
+            showing_continuations: false,
+            _pending_input_subscription: cx.observe_pending_input(
+                window,
+                |this: &mut Self, window, cx| {
+                    if window.pending_input_keystrokes().is_some() {
+                        this.showing_continuations = true;
+                        this.update_pending_keys(window, cx);
+                    } else if this.showing_continuations {
+                        cx.emit(DismissEvent);
+                    }
+                },
+            ),
+            _keystroke_subscription: None,
+            _focus_out_subscription: window.on_focus_out(&focus_handle, cx, move |_, _, cx| {
+                handle.update(cx, |_, cx| cx.emit(DismissEvent)).ok();
+            }),
+        };
+        this.update_all_bindings(window, cx);
+        // Defer the keystroke observer so it doesn't fire for the keystroke
+        // that triggered ToggleWhichKey.
+        cx.defer_in(window, |this, _window, cx| {
+            this._keystroke_subscription = Some(cx.observe_keystrokes(
+                |this, _event, _window, cx| {
+                    if !this.showing_continuations {
+                        this.dismiss(cx);
+                    }
+                },
+            ));
+        });
+        this
+    }
+
+    pub fn is_manual(&self) -> bool {
+        self.manual
+    }
+
+    fn new_inner(
+        workspace: WeakEntity<Workspace>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        // Keep focus where it currently is
+        let focus_handle = window.focused(cx).unwrap_or(cx.focus_handle());
+        let handle = cx.weak_entity();
+        Self {
+            _workspace: workspace,
+            focus_handle: focus_handle.clone(),
+            scroll_handle: ScrollHandle::new(),
+            bindings: Vec::new(),
+            pending_keys: SharedString::new_static(""),
+            manual: false,
+            showing_continuations: false,
+            _keystroke_subscription: None,
             _pending_input_subscription: cx.observe_pending_input(
                 window,
                 |this: &mut Self, window, cx| {
@@ -51,9 +117,7 @@ impl WhichKeyModal {
             _focus_out_subscription: window.on_focus_out(&focus_handle, cx, move |_, _, cx| {
                 handle.update(cx, |_, cx| cx.emit(DismissEvent)).ok();
             }),
-        };
-        this.update_pending_keys(window, cx);
-        this
+        }
     }
 
     pub fn dismiss(&self, cx: &mut Context<Self>) {
@@ -70,13 +134,18 @@ impl WhichKeyModal {
         let binding_data = bindings
             .into_iter()
             .map(|(keystrokes, action_name)| {
-                // Map to remaining keystrokes and action name
                 let remaining = keystrokes[pending_keys.len()..].to_vec();
                 (remaining, action_name)
             })
             .collect();
         let title = text_for_keystrokes(&pending_keys, cx).into();
         self.sort_and_finalize_bindings(binding_data, title, cx);
+    }
+
+    fn update_all_bindings(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let binding_data =
+            Self::collect_filtered_bindings(window, &[], Some(&self.focus_handle), false);
+        self.sort_and_finalize_bindings(binding_data, "Keybindings".into(), cx);
     }
 
     fn collect_filtered_bindings(
@@ -93,8 +162,8 @@ impl WhichKeyModal {
         };
         bindings
             .iter()
+            // Map to keystrokes
             .map(|binding| {
-                // Map to keystrokes
                 (
                     binding
                         .keystrokes()
@@ -104,13 +173,14 @@ impl WhichKeyModal {
                     binding.action(),
                 )
             })
+            // Check if this binding matches any filtered keystroke pattern
             .filter(|(keystrokes, _action)| {
-                // Check if this binding matches any filtered keystroke pattern
                 !FILTERED_KEYSTROKES.iter().any(|filtered| {
                     keystrokes.len() >= filtered.len()
                         && keystrokes[..filtered.len()] == filtered[..]
                 })
             })
+            // Map to remaining keystrokes and action name
             .map(|(keystrokes, action)| {
                 let action_name: SharedString =
                     command_palette::humanize_action_name(action.name()).into();
@@ -316,10 +386,10 @@ impl ModalView for WhichKeyModal {
 fn group_bindings(
     binding_data: Vec<(Vec<Keystroke>, SharedString)>,
 ) -> Vec<(Vec<Keystroke>, SharedString)> {
-    // Group bindings by the visible identity of their first keystroke
     type GroupKey = Option<(Modifiers, String)>;
     let mut groups: HashMap<GroupKey, Vec<(Vec<Keystroke>, SharedString)>> = HashMap::new();
 
+    // Group bindings by the visible identity of their first keystroke
     for (remaining_keystrokes, action_name) in binding_data {
         let first_key = remaining_keystrokes
             .first()
@@ -369,4 +439,426 @@ fn group_bindings(
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{Action, Entity, Keystroke, TestAppContext, VisualTestContext, actions};
+    use project::Project;
+    use settings::KeymapFile;
+    use workspace::{AppState, MultiWorkspace, Workspace};
+
+    actions!(
+        test_which_key,
+        [
+            TestActionA,
+            TestActionB,
+            TestChordAction,
+            TestChordAction2,
+        ]
+    );
+
+    fn init_test(cx: &mut TestAppContext) -> std::sync::Arc<AppState> {
+        cx.update(|cx| {
+            let app_state = AppState::test(cx);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            workspace::init(app_state.clone(), cx);
+            crate::init(cx);
+            app_state
+        })
+    }
+
+    fn open_which_key_manual(
+        workspace: &Entity<Workspace>,
+        cx: &mut VisualTestContext,
+    ) -> Entity<WhichKeyModal> {
+        workspace.update_in(cx, |workspace, window, cx| {
+            let workspace_handle = cx.weak_entity();
+            workspace.toggle_modal(window, cx, |window, cx| {
+                WhichKeyModal::new_manual(workspace_handle, window, cx)
+            });
+        });
+        cx.run_until_parked();
+        workspace
+            .read_with(cx, |workspace, cx| {
+                workspace.active_modal::<WhichKeyModal>(cx)
+            })
+            .expect("WhichKeyModal should be open")
+    }
+
+    fn open_which_key_pending(
+        workspace: &Entity<Workspace>,
+        cx: &mut VisualTestContext,
+    ) -> Entity<WhichKeyModal> {
+        workspace.update_in(cx, |workspace, window, cx| {
+            let workspace_handle = cx.weak_entity();
+            workspace.toggle_modal(window, cx, |window, cx| {
+                WhichKeyModal::new(workspace_handle, window, cx)
+            });
+        });
+        cx.run_until_parked();
+        workspace
+            .read_with(cx, |workspace, cx| {
+                workspace.active_modal::<WhichKeyModal>(cx)
+            })
+            .expect("WhichKeyModal should be open")
+    }
+
+    #[gpui::test]
+    async fn test_manual_modal_shows_keybindings_title(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        cx.update(|_window, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": { "ctrl-a": "test_which_key::TestActionA" } }]"#,
+                cx,
+            ));
+        });
+
+        let modal = open_which_key_manual(&workspace, cx);
+
+        modal.read_with(cx, |modal, _| {
+            assert_eq!(modal.pending_keys.as_ref(), "Keybindings");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_manual_modal_lists_bindings(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        cx.update(|_window, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": {
+                    "ctrl-a": "test_which_key::TestActionA",
+                    "ctrl-b": "test_which_key::TestActionB"
+                } }]"#,
+                cx,
+            ));
+        });
+
+        let modal = open_which_key_manual(&workspace, cx);
+
+        modal.read_with(cx, |modal, _| {
+            let action_names: Vec<&str> =
+                modal.bindings.iter().map(|(_, a)| a.as_ref()).collect();
+            assert!(
+                action_names.contains(&"test which key: test action a"),
+                "expected TestActionA in bindings, got: {:?}",
+                action_names
+            );
+            assert!(
+                action_names.contains(&"test which key: test action b"),
+                "expected TestActionB in bindings, got: {:?}",
+                action_names
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_toggle_which_key_action_opens_modal(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        workspace.update_in(cx, |_, window, cx| {
+            window.dispatch_action(
+                crate::ToggleWhichKey.boxed_clone(),
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        let modal = workspace
+            .read_with(cx, |workspace, cx| {
+                workspace.active_modal::<WhichKeyModal>(cx)
+            })
+            .expect("ToggleWhichKey should open the modal");
+
+        modal.read_with(cx, |modal, _| {
+            assert_eq!(modal.pending_keys.as_ref(), "Keybindings");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_pending_key_modal_shows_continuations(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        cx.update(|_window, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": { "ctrl-k ctrl-d": "test_which_key::TestChordAction" } }]"#,
+                cx,
+            ));
+        });
+
+        cx.simulate_keystrokes("ctrl-k");
+        cx.run_until_parked();
+
+        let modal = open_which_key_pending(&workspace, cx);
+
+        modal.read_with(cx, |modal, _| {
+            assert!(
+                !modal.bindings.is_empty(),
+                "pending key modal should list continuations"
+            );
+            let action_names: Vec<&str> =
+                modal.bindings.iter().map(|(_, a)| a.as_ref()).collect();
+            assert!(
+                action_names.contains(&"test which key: test chord action"),
+                "expected TestChordAction continuation, got: {:?}",
+                action_names
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_escape_dismisses_manual_modal(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        let _modal = open_which_key_manual(&workspace, cx);
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        workspace.read_with(cx, |workspace, cx| {
+            assert!(
+                workspace.active_modal::<WhichKeyModal>(cx).is_none(),
+                "modal should be dismissed after escape"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_toggle_which_key_closes_if_already_open(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        let _modal = open_which_key_manual(&workspace, cx);
+
+        workspace.update_in(cx, |_, window, cx| {
+            window.dispatch_action(crate::ToggleWhichKey.boxed_clone(), cx);
+        });
+        cx.run_until_parked();
+
+        workspace.read_with(cx, |workspace, cx| {
+            assert!(
+                workspace.active_modal::<WhichKeyModal>(cx).is_none(),
+                "second toggle should dismiss the modal"
+            );
+        });
+    }
+
+    #[test]
+    fn test_group_bindings_collapses_shared_prefix() {
+        let key_a = Keystroke::parse("a").unwrap();
+        let key_b = Keystroke::parse("b").unwrap();
+        let key_c = Keystroke::parse("c").unwrap();
+
+        let bindings = vec![
+            (vec![key_a.clone(), key_b], "Action One".into()),
+            (vec![key_a.clone(), key_c], "Action Two".into()),
+        ];
+
+        let grouped = group_bindings(bindings);
+
+        assert_eq!(grouped.len(), 1, "two bindings sharing first key should collapse into one group");
+        let (keystrokes, action) = &grouped[0];
+        assert_eq!(keystrokes.len(), 1);
+        assert_eq!(keystrokes[0], key_a);
+        assert_eq!(action.as_ref(), "+2 keybinds");
+    }
+
+    #[test]
+    fn test_group_bindings_preserves_direct_binding_with_chord_prefix() {
+        let key_h = Keystroke::parse("ctrl-h").unwrap();
+        let key_b = Keystroke::parse("b").unwrap();
+        let key_k = Keystroke::parse("k").unwrap();
+
+        let bindings = vec![
+            (vec![key_h.clone()], "Deploy Replace".into()),
+            (vec![key_h.clone(), key_b], "Toggle Which Key".into()),
+            (vec![key_h.clone(), key_k], "Describe Key".into()),
+        ];
+
+        let grouped = group_bindings(bindings);
+
+        let direct: Vec<_> = grouped
+            .iter()
+            .filter(|(_, a)| a.as_ref() == "Deploy Replace")
+            .collect();
+        assert_eq!(
+            direct.len(),
+            1,
+            "direct binding should appear individually, got: {:?}",
+            grouped.iter().map(|(_, a)| a.as_ref()).collect::<Vec<_>>()
+        );
+
+        let groups: Vec<_> = grouped
+            .iter()
+            .filter(|(_, a)| a.starts_with('+'))
+            .collect();
+        assert_eq!(
+            groups.len(),
+            1,
+            "chord bindings should be collapsed into one group"
+        );
+        assert_eq!(groups[0].1.as_ref(), "+2 keybinds");
+    }
+
+    #[test]
+    fn test_group_bindings_keeps_unique_prefixes() {
+        let key_a = Keystroke::parse("a").unwrap();
+        let key_b = Keystroke::parse("b").unwrap();
+
+        let bindings = vec![
+            (vec![key_a], "Action A".into()),
+            (vec![key_b], "Action B".into()),
+        ];
+
+        let grouped = group_bindings(bindings);
+
+        assert_eq!(grouped.len(), 2, "bindings with different first keys stay separate");
+    }
+
+    #[test]
+    fn test_group_bindings_handles_empty_keystrokes() {
+        let bindings: Vec<(Vec<Keystroke>, SharedString)> = vec![
+            (vec![], "Direct Action".into()),
+        ];
+
+        let grouped = group_bindings(bindings);
+
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[0].1.as_ref(), "Direct Action");
+    }
+
+    #[gpui::test]
+    async fn test_duplicate_bindings_are_deduped(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        cx.update(|_window, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": { "ctrl-k ctrl-d": "test_which_key::TestChordAction" } }]"#,
+                cx,
+            ));
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": { "ctrl-k ctrl-d": "test_which_key::TestChordAction" } }]"#,
+                cx,
+            ));
+        });
+
+        cx.simulate_keystrokes("ctrl-k");
+        cx.run_until_parked();
+
+        let modal = open_which_key_pending(&workspace, cx);
+
+        modal.read_with(cx, |modal, _| {
+            let matching: Vec<_> = modal
+                .bindings
+                .iter()
+                .filter(|(_, a)| a.as_ref() == "test which key: test chord action")
+                .collect();
+            assert_eq!(
+                matching.len(),
+                1,
+                "duplicate bindings should be deduped, got: {:?}",
+                modal.bindings
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_manual_modal_shows_continuations_on_chord_prefix(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        cx.update(|_window, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[{ "bindings": {
+                    "ctrl-k ctrl-d": "test_which_key::TestChordAction",
+                    "ctrl-k ctrl-e": "test_which_key::TestChordAction2"
+                } }]"#,
+                cx,
+            ));
+        });
+
+        let modal = open_which_key_manual(&workspace, cx);
+
+        // Initially shows all bindings with "Keybindings" title
+        modal.read_with(cx, |modal, _| {
+            assert_eq!(modal.pending_keys.as_ref(), "Keybindings");
+            assert!(!modal.showing_continuations);
+        });
+
+        // Press ctrl-k to enter pending input
+        cx.simulate_keystrokes("ctrl-k");
+        cx.run_until_parked();
+
+        // Modal should still be open, now showing continuations
+        let modal = workspace
+            .read_with(cx, |workspace, cx| {
+                workspace.active_modal::<WhichKeyModal>(cx)
+            })
+            .expect("modal should still be open after chord prefix");
+
+        modal.read_with(cx, |modal, _| {
+            assert!(modal.showing_continuations);
+            let action_names: Vec<&str> =
+                modal.bindings.iter().map(|(_, a)| a.as_ref()).collect();
+            assert!(
+                action_names.contains(&"test which key: test chord action"),
+                "expected continuations for ctrl-k, got: {:?}",
+                action_names
+            );
+        });
+    }
+
+    #[test]
+    fn test_group_bindings_dedupes_with_different_key_char() {
+        let key_a = Keystroke::parse("k").unwrap();
+        let mut key_a_with_char = key_a.clone();
+        key_a_with_char.key_char = Some("k".to_string());
+
+        let bindings = vec![
+            (vec![key_a], "zed: describe key".into()),
+            (vec![key_a_with_char], "zed: describe key".into()),
+        ];
+
+        let grouped = group_bindings(bindings);
+
+        assert_eq!(
+            grouped.len(),
+            1,
+            "bindings differing only in key_char should dedup, got: {:?}",
+            grouped.iter().map(|(_, a)| a.as_ref()).collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/which_key/src/which_key_modal.rs
+++ b/crates/which_key/src/which_key_modal.rs
@@ -3,7 +3,7 @@
 use gpui::prelude::FluentBuilder;
 use gpui::{
     App, Context, DismissEvent, EventEmitter, FocusHandle, Focusable, FontWeight, Keystroke,
-    ScrollHandle, Subscription, WeakEntity, Window,
+    Modifiers, ScrollHandle, Subscription, WeakEntity, Window,
 };
 use settings::Settings;
 use std::collections::{HashMap, HashSet};
@@ -316,12 +316,14 @@ impl ModalView for WhichKeyModal {
 fn group_bindings(
     binding_data: Vec<(Vec<Keystroke>, SharedString)>,
 ) -> Vec<(Vec<Keystroke>, SharedString)> {
-    let mut groups: HashMap<Option<Keystroke>, Vec<(Vec<Keystroke>, SharedString)>> =
-        HashMap::new();
+    // Group bindings by the visible identity of their first keystroke
+    type GroupKey = Option<(Modifiers, String)>;
+    let mut groups: HashMap<GroupKey, Vec<(Vec<Keystroke>, SharedString)>> = HashMap::new();
 
-    // Group bindings by their first keystroke
     for (remaining_keystrokes, action_name) in binding_data {
-        let first_key = remaining_keystrokes.first().cloned();
+        let first_key = remaining_keystrokes
+            .first()
+            .map(|k| (k.modifiers, k.key.clone()));
         groups
             .entry(first_key)
             .or_default()
@@ -331,16 +333,35 @@ fn group_bindings(
     let mut result = Vec::new();
 
     for (first_key, mut group_bindings) in groups {
-        // Remove duplicates within each group
-        group_bindings.dedup_by_key(|(keystrokes, _)| keystrokes.clone());
+        // Remove duplicates within each group (HashMap order is arbitrary,
+        // so dedup_by_key which only removes adjacent duplicates is insufficient)
+        let mut seen_keystrokes = HashSet::new();
+        group_bindings.retain(|(keystrokes, _)| seen_keystrokes.insert(keystrokes.clone()));
 
-        if let Some(first_key) = first_key
+        if first_key.is_some()
             && group_bindings.len() > 1
         {
-            // This is a group - create a single entry with just the first keystroke
-            let first_keystroke = vec![first_key];
-            let count = group_bindings.len();
-            result.push((first_keystroke, format!("+{} keybinds", count).into()));
+            // Separate direct (single-key) bindings from chord (multi-key) bindings
+            let (direct, chords): (Vec<_>, Vec<_>) = group_bindings
+                .into_iter()
+                .partition(|(keystrokes, _)| keystrokes.len() <= 1);
+
+            // Direct bindings are shown individually (dedup by action name for key_char variants)
+            let mut seen_actions = HashSet::new();
+            result.extend(
+                direct
+                    .into_iter()
+                    .filter(|(_, action)| seen_actions.insert(action.clone())),
+            );
+
+            // Chord bindings are collapsed into a group
+            if chords.len() > 1 {
+                let first_keystroke = vec![chords[0].0[0].clone()];
+                let count = chords.len();
+                result.push((first_keystroke, format!("+{} keybinds", count).into()));
+            } else {
+                result.extend(chords);
+            }
         } else {
             // Not a group or empty keystrokes - add all bindings as-is
             result.append(&mut group_bindings);

--- a/crates/which_key/src/which_key_modal.rs
+++ b/crates/which_key/src/which_key_modal.rs
@@ -6,7 +6,7 @@ use gpui::{
     ScrollHandle, Subscription, WeakEntity, Window,
 };
 use settings::Settings;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use theme_settings::ThemeSettings;
 use ui::{
     Divider, DividerColor, DynamicSpacing, LabelSize, WithScrollbar, prelude::*,
@@ -65,9 +65,33 @@ impl WhichKeyModal {
             cx.emit(DismissEvent);
             return;
         };
-        let bindings = window.possible_bindings_for_input(pending_keys);
+        let bindings =
+            Self::collect_filtered_bindings(window, pending_keys, Some(&self.focus_handle), true);
+        let binding_data = bindings
+            .into_iter()
+            .map(|(keystrokes, action_name)| {
+                // Map to remaining keystrokes and action name
+                let remaining = keystrokes[pending_keys.len()..].to_vec();
+                (remaining, action_name)
+            })
+            .collect();
+        let title = text_for_keystrokes(&pending_keys, cx).into();
+        self.sort_and_finalize_bindings(binding_data, title, cx);
+    }
 
-        let mut binding_data = bindings
+    fn collect_filtered_bindings(
+        window: &Window,
+        input: &[Keystroke],
+        focus_handle: Option<&gpui::FocusHandle>,
+        dedup_by_action: bool,
+    ) -> Vec<(Vec<Keystroke>, SharedString)> {
+        let mut seen = HashSet::new();
+        let bindings = if let Some(focus) = focus_handle {
+            window.possible_bindings_for_input_in(input, focus)
+        } else {
+            window.possible_bindings_for_input(input)
+        };
+        bindings
             .iter()
             .map(|binding| {
                 // Map to keystrokes
@@ -88,19 +112,33 @@ impl WhichKeyModal {
                 })
             })
             .map(|(keystrokes, action)| {
-                // Map to remaining keystrokes and action name
-                let remaining_keystrokes = keystrokes[pending_keys.len()..].to_vec();
                 let action_name: SharedString =
                     command_palette::humanize_action_name(action.name()).into();
-                (remaining_keystrokes, action_name)
+                (keystrokes, action_name)
+            })
+            .filter(|(_, action_name)| !dedup_by_action || seen.insert(action_name.clone()))
+            .collect()
+    }
+
+    fn sort_and_finalize_bindings(
+        &mut self,
+        binding_data: Vec<(Vec<Keystroke>, SharedString)>,
+        title: SharedString,
+        cx: &mut Context<Self>,
+    ) {
+        let binding_data = group_bindings(binding_data);
+
+        let mut entries: Vec<_> = binding_data
+            .into_iter()
+            .map(|(keystrokes, action)| {
+                let text: SharedString = text_for_keystrokes(&keystrokes, cx).into();
+                (keystrokes.len(), text, action)
             })
             .collect();
 
-        binding_data = group_bindings(binding_data);
-
         // Sort bindings from shortest to longest, with groups last
         // Using stable sort to preserve relative order of equal elements
-        binding_data.sort_by(|(keystrokes_a, action_a), (keystrokes_b, action_b)| {
+        entries.sort_by(|(len_a, text_a, action_a), (len_b, text_b, action_b)| {
             // Groups (actions starting with "+") should go last
             let is_group_a = action_a.starts_with('+');
             let is_group_b = action_b.starts_with('+');
@@ -112,25 +150,30 @@ impl WhichKeyModal {
             }
 
             // Then sort by keystroke count
-            let keystroke_cmp = keystrokes_a.len().cmp(&keystrokes_b.len());
+            let keystroke_cmp = len_a.cmp(len_b);
             if keystroke_cmp != std::cmp::Ordering::Equal {
                 return keystroke_cmp;
             }
 
             // Finally sort by text length, then lexicographically for full stability
-            let text_a = text_for_keystrokes(keystrokes_a, cx);
-            let text_b = text_for_keystrokes(keystrokes_b, cx);
             let text_len_cmp = text_a.len().cmp(&text_b.len());
             if text_len_cmp != std::cmp::Ordering::Equal {
                 return text_len_cmp;
             }
-            text_a.cmp(&text_b)
+            let text_cmp = text_a.cmp(text_b);
+            if text_cmp != std::cmp::Ordering::Equal {
+                return text_cmp;
+            }
+            action_a.cmp(action_b)
         });
-        binding_data.dedup();
-        self.pending_keys = text_for_keystrokes(&pending_keys, cx).into();
-        self.bindings = binding_data
+        entries.dedup();
+
+        self.pending_keys = title;
+        let mut seen = HashSet::new();
+        self.bindings = entries
             .into_iter()
-            .map(|(keystrokes, action)| (text_for_keystrokes(&keystrokes, cx).into(), action))
+            .map(|(_len, text, action)| (text, action))
+            .filter(|entry| seen.insert(entry.clone()))
             .collect();
     }
 }


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:
- Added a "Describe Key" command that captures a keystroke and shows what action it would trigger.
- Added a "Toggle Which Key" command that shows all available keybindings in the current context.

https://github.com/user-attachments/assets/56664b3d-ce20-4b73-b7a2-51b31641b4c6


