### PR TITLE
vim: Fix helix selection duplication with softwrap

### DIFF
--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -147,6 +147,8 @@ fn display_point_range_to_offset_range(
 #[cfg(test)]
 mod tests {
     use db::indoc;
+    use gpui::{AppContext, UpdateGlobal};
+    use settings::SettingsStore;
 
     use crate::{state::Mode, test::VimTestContext};
 
@@ -307,6 +309,52 @@ mod tests {
             indoc! {"
             H«äˇ»llo
             H«aˇ»llo"},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_selection_duplication_softwrap(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.enable_helix();
+        cx.update_global(|settings: &mut SettingsStore, cx| {
+            settings.update_user_settings(cx, |settings| {
+                settings.project.all_languages.defaults.soft_wrap =
+                    Some(settings::SoftWrap::Bounded);
+                settings
+                    .project
+                    .all_languages
+                    .defaults
+                    .preferred_line_length = Some(8);
+            });
+        });
+
+        cx.set_state(
+            indoc! {"
+            The quick brown
+            foˇx jumps over the
+            lazy dog."},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("C");
+
+        cx.assert_state(
+            indoc! {"
+            The quick brown
+            foˇx jumps over the
+            laˇzy dog."},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("alt-C");
+
+        cx.assert_state(
+            indoc! {"
+            Thˇe quick brown
+            foˇx jumps over the
+            laˇzy dog."},
             Mode::HelixNormal,
         );
     }

--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -1,6 +1,9 @@
 use std::ops::Range;
 
-use editor::{DisplayPoint, MultiBufferOffset, display_map::DisplaySnapshot};
+use editor::{
+    DisplayPoint, MultiBufferOffset, ToPoint,
+    display_map::{DisplayRow, DisplaySnapshot, ToDisplayPoint},
+};
 use gpui::Context;
 use language::PointUtf16;
 use multi_buffer::MultiBufferRow;
@@ -89,51 +92,47 @@ fn find_next_valid_duplicate_space(
         .column;
     let end_col_utf16 = buffer.point_to_point_utf16(origin.end.to_point(map)).column;
 
-    let mut candidate = origin;
+    let mut candidate_start_row = origin.start.to_point(map).row;
+    let mut candidate_end_row = origin.end.to_point(map).row;
+
     loop {
         match direction {
             Direction::Below => {
-                if candidate.end.row() >= map.max_point().row() {
+                if candidate_end_row >= map.max_row().0 {
                     return None;
                 }
-                *candidate.start.row_mut() += 1;
-                *candidate.end.row_mut() += 1;
+                candidate_start_row += 1;
+                candidate_end_row += 1;
             }
             Direction::Above => {
-                if candidate.start.row() == DisplayPoint::zero().row() {
+                if candidate_start_row == 0 {
                     return None;
                 }
-                *candidate.start.row_mut() = candidate.start.row().0.saturating_sub(1);
-                *candidate.end.row_mut() = candidate.end.row().0.saturating_sub(1);
+                candidate_start_row = candidate_start_row.saturating_sub(1);
+                candidate_end_row = candidate_end_row.saturating_sub(1);
             }
         }
 
-        let start_row = DisplayPoint::new(candidate.start.row(), 0)
-            .to_point(map)
-            .row;
-        let end_row = DisplayPoint::new(candidate.end.row(), 0).to_point(map).row;
-
-        if start_col_utf16 > buffer.line_len_utf16(MultiBufferRow(start_row))
-            || end_col_utf16 > buffer.line_len_utf16(MultiBufferRow(end_row))
+        if map.is_line_folded(MultiBufferRow(candidate_start_row))
+            || map.is_line_folded(MultiBufferRow(candidate_end_row))
         {
             continue;
         }
 
-        let start_col = buffer
-            .point_utf16_to_point(PointUtf16::new(start_row, start_col_utf16))
-            .column;
-        let end_col = buffer
-            .point_utf16_to_point(PointUtf16::new(end_row, end_col_utf16))
-            .column;
-
-        let candidate_start = DisplayPoint::new(candidate.start.row(), start_col);
-        let candidate_end = DisplayPoint::new(candidate.end.row(), end_col);
-
-        if map.clip_point(candidate_start, Bias::Left) == candidate_start
-            && map.clip_point(candidate_end, Bias::Right) == candidate_end
+        if start_col_utf16 > buffer.line_len_utf16(MultiBufferRow(candidate_start_row))
+            || end_col_utf16 > buffer.line_len_utf16(MultiBufferRow(candidate_end_row))
         {
-            return Some(candidate_start..candidate_end);
+            continue;
         }
+
+        let candidate_start = buffer
+            .point_utf16_to_point(PointUtf16::new(candidate_start_row, start_col_utf16))
+            .to_display_point(map);
+        let candidate_end = buffer
+            .point_utf16_to_point(PointUtf16::new(candidate_end_row, end_col_utf16))
+            .to_display_point(map);
+
+        return Some(candidate_start..candidate_end);
     }
 }
 


### PR DESCRIPTION
When softwrap is enabled the Helix selection duplication behaves strangely:

[Kooha-2026-05-25-16-44-21.webm](https://github.com/user-attachments/assets/688bd154-206d-45b8-be92-d34cab1c3e65)

In that recording I keep pressing `shift-c` after the third cursor appeared, but no more selections happen.
The issue is that the `DisplayPoint` gets converted to a UTF-16 column, but then the `start_col`, which is the UTF-16 column converted back to a normal column gets passed to `DisplayPoint::new`.
This effectively means that the non-wrapped column is interpreted as a wrapped column, which leads to there not being any selectable cells after a softwrapped line.

The UTF-16 usage here seems a bit suspect to me and it seems to behave incorrectly when using multi codepoint grapheme clusters such as flag emojis.
I spoke with @kubkon (I hope I'm remembering the right username) about this at the RustWeek hackaton and we agreed that it makes sense to first fix the duplication issue and leave the UTF-16 in for now.

My fix makes it such that the selection duplication ignores the softwrap, like it does in Helix itself:

[Kooha-2026-05-25-17-08-30.webm](https://github.com/user-attachments/assets/4bb694fd-3153-49cf-bbf9-c24445763fca)

Because we're no longer operating on display rows I had to add handling for skipping folded lines.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed helix selection duplication when softwrap is enabled
