### PR TITLE
Log filesystem watcher lost sync only once per event

### DIFF
--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -423,7 +423,6 @@ fn push_notify_event(
         .collect::<Vec<_>>();
 
     if event.need_rescan() {
-        log::warn!("filesystem watcher lost sync for {watched_root:?}; scheduling rescan");
         path_events.retain(|path_event| path_event.path != watched_root);
         path_events.push(PathEvent {
             path: watched_root.to_path_buf(),
@@ -750,6 +749,12 @@ fn handle_event(mode: WatcherMode, event: Result<notify::Event, notify::Error>) 
 
     match event {
         Ok(event) => {
+            if event.need_rescan() {
+                log::warn!(
+                    "filesystem watcher lost sync for {mode:?}; scheduling rescans for {} registrations",
+                    callbacks.len()
+                );
+            }
             for callback in callbacks {
                 callback(&event);
             }


### PR DESCRIPTION
On Linux, we create a filesystem watcher recursively for every subdir. When we get "fs watcher lost sync" events, we used to log it for every child dir, which could results in thousands messages. This becomes problematic when we get into a state where we get those events repeatedly (this larger issue is to be addressed separately).

Now we log one message per parent.

Partially addresses #57422, #57042, FR-18

Release Notes:

- N/A
