### PR TITLE
project: Include debug scenarios from all worktrees

### DIFF
--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -300,12 +300,11 @@ impl Inventory {
     )> {
         let mut scenarios = Vec::new();
 
-        if let Some(worktree_id) = task_contexts
+        for worktree_id in task_contexts
             .active_worktree_context
             .iter()
             .chain(task_contexts.other_worktree_contexts.iter())
             .map(|context| context.0)
-            .next()
         {
             scenarios.extend(self.worktree_scenarios_from_settings(worktree_id));
         }

--- a/crates/project/tests/integration/task_inventory.rs
+++ b/crates/project/tests/integration/task_inventory.rs
@@ -410,6 +410,72 @@ async fn test_reloading_debug_scenarios(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_debug_scenarios_include_all_worktrees(cx: &mut TestAppContext) {
+    init_test(cx);
+    let inventory = cx.update(|cx| Inventory::new(cx));
+    let worktree_1 = WorktreeId::from_usize(1);
+    let worktree_2 = WorktreeId::from_usize(2);
+
+    inventory.update(cx, |inventory, _| {
+        inventory
+            .update_file_based_scenarios(
+                TaskSettingsLocation::Worktree(SettingsLocation {
+                    worktree_id: worktree_1,
+                    path: rel_path(".zed"),
+                }),
+                Some(
+                    r#"
+                        [{
+                            "label": "worktree one",
+                            "adapter": "CodeLLDB",
+                            "request": "launch",
+                            "program": "one",
+                        }]
+                    "#,
+                ),
+            )
+            .unwrap();
+        inventory
+            .update_file_based_scenarios(
+                TaskSettingsLocation::Worktree(SettingsLocation {
+                    worktree_id: worktree_2,
+                    path: rel_path(".zed"),
+                }),
+                Some(
+                    r#"
+                        [{
+                            "label": "worktree two",
+                            "adapter": "CodeLLDB",
+                            "request": "launch",
+                            "program": "two",
+                        }]
+                    "#,
+                ),
+            )
+            .unwrap();
+    });
+
+    let task_contexts = TaskContexts {
+        active_worktree_context: Some((worktree_1, Default::default())),
+        other_worktree_contexts: vec![(worktree_2, Default::default())],
+        ..Default::default()
+    };
+
+    let labels = inventory
+        .update(cx, |this, cx| {
+            this.list_debug_scenarios(&task_contexts, vec![], vec![], false, cx)
+        })
+        .await
+        .1
+        .into_iter()
+        .map(|(_, scenario)| scenario.label)
+        .sorted()
+        .collect::<Vec<_>>();
+
+    assert_eq!(labels, ["worktree one", "worktree two"]);
+}
+
+#[gpui::test]
 async fn test_inventory_static_task_filters(cx: &mut TestAppContext) {
     init_test(cx);
     let inventory = cx.update(|cx| Inventory::new(cx));


### PR DESCRIPTION
Fixes debugger config discovery in multi-root projects by including debug scenarios from every worktree context instead of only the first worktree.

Previously, `Inventory::list_debug_scenarios` selected the first active/other worktree and loaded only that worktree's debug scenarios. In a multi-root project, this meant `.zed/debug.json` entries from other roots were not shown in the debugger start picker.

This updates the inventory to collect scenarios from all active and other worktree contexts, while preserving global debug scenario handling. It also adds a regression test covering two worktrees with separate debug scenario files.

Release Notes:

- Fixed debugger configuration discovery in multi-root projects to include scenarios from all worktrees.
