### PR TITLE
vim: Fix dot repeat after replaying a macro

### DIFF
--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -177,7 +177,12 @@ impl Replayer {
                 };
                 editor.update(cx, |editor, cx| {
                     editor.replay_insert_event(&text, utf16_range_to_replace.clone(), window, cx)
-                })
+                });
+                // `replay_insert_event` doesn't emit `InputHandled`, so feed
+                // the text into dot-recording explicitly.
+                cx.defer(move |cx| {
+                    Vim::globals(cx).observe_replayed_insertion(text, utf16_range_to_replace);
+                });
             }
         }
         window.defer(cx, move |window, cx| self.next(window, cx));
@@ -1116,6 +1121,25 @@ mod test {
         cx.shared_state().await.assert_eq("aaaaaaabˇrld");
         cx.simulate_shared_keystrokes("@ b").await;
         cx.shared_state().await.assert_eq("aaaaaaabbbˇd");
+    }
+
+    #[gpui::test]
+    async fn test_record_replay_then_dot(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        // `.` repeats the macro's single change.
+        cx.set_shared_state("ˇhello world").await;
+        cx.simulate_shared_keystrokes("q a i X escape q").await;
+        cx.simulate_shared_keystrokes("@ a").await;
+        cx.simulate_shared_keystrokes(".").await;
+        cx.shared_state().await.assert_eq("ˇXXXhello world");
+
+        // For a multi-change macro, `.` repeats only the last change.
+        cx.set_shared_state("ˇhello world").await;
+        cx.simulate_shared_keystrokes("q b r a l r b q").await;
+        cx.simulate_shared_keystrokes("@ b").await;
+        cx.simulate_shared_keystrokes(".").await;
+        cx.shared_state().await.assert_eq("aaˇblo world");
     }
 
     #[gpui::test]

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1016,6 +1016,29 @@ impl VimGlobals {
         }
     }
 
+    // Like `observe_insertion`, but skips the macro-register branch so that
+    // replaying a macro doesn't recursively capture its own text.
+    pub fn observe_replayed_insertion(
+        &mut self,
+        text: Arc<str>,
+        range_to_replace: Option<Range<isize>>,
+    ) {
+        if !self.dot_recording {
+            return;
+        }
+        self.recording_actions.push(ReplayableAction::Insertion {
+            text,
+            utf16_range_to_replace: range_to_replace,
+        });
+        if self.stop_recording_after_next_action {
+            self.dot_recording = false;
+            self.recorded_actions = std::mem::take(&mut self.recording_actions);
+            self.recorded_count = self.recording_count.take();
+            self.recorded_register_for_dot = self.recording_register_for_dot.take();
+            self.stop_recording_after_next_action = false;
+        }
+    }
+
     pub fn focused_vim(&self) -> Option<Entity<Vim>> {
         self.focused_vim.as_ref().and_then(|vim| vim.upgrade())
     }

--- a/crates/vim/test_data/test_record_replay_then_dot.json
+++ b/crates/vim/test_data/test_record_replay_then_dot.json
@@ -1,0 +1,24 @@
+{"Put":{"state":"ˇhello world"}}
+{"Key":"q"}
+{"Key":"a"}
+{"Key":"i"}
+{"Key":"X"}
+{"Key":"escape"}
+{"Key":"q"}
+{"Key":"@"}
+{"Key":"a"}
+{"Key":"."}
+{"Get":{"state":"ˇXXXhello world","mode":"Normal"}}
+{"Put":{"state":"ˇhello world"}}
+{"Key":"q"}
+{"Key":"b"}
+{"Key":"r"}
+{"Key":"a"}
+{"Key":"l"}
+{"Key":"r"}
+{"Key":"b"}
+{"Key":"q"}
+{"Key":"@"}
+{"Key":"b"}
+{"Key":"."}
+{"Get":{"state":"aaˇblo world","mode":"Normal"}}


### PR DESCRIPTION
Replaying a macro via `@<reg>` dispatches actions through `Replayer`, but its `Insertion` branch writes the buffer with `replay_insert_event`, which bypasses the `InputHandled` event that feeds `observe_insertion`. The dot-recording started by the replayed `InsertBefore` therefore sealed an empty insertion into `recorded_actions`, so pressing `.` after `@<reg>` only re-entered and exited insert mode without inserting any text.

Add `observe_replayed_insertion` that feeds the dot-recording stream only, and call it from `Replayer::next` after each replayed insertion. The existing dot-recording machinery then captures the last change inside the macro, matching Vim's `.` semantics for both single- and multi-change macros.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #47251

Release Notes:

- Fixed `.` not repeating after replaying a macro with `@<reg>` in vim mode

examples :

https://github.com/user-attachments/assets/cbf87e52-13a5-4b5b-a3c8-cf2a6a389195


