### PR TITLE
git_ui: Create new worktree on latest origin main

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -9781,6 +9781,14 @@ mod tests {
             &NewWorktreeBranchTarget::CurrentBranch,
         );
         assert_eq!(resolved, None);
+
+        let resolved = git_ui::worktree_service::resolve_worktree_branch_target(
+            &NewWorktreeBranchTarget::RemoteBranch {
+                remote_name: "origin".to_string(),
+                branch_name: "main".to_string(),
+            },
+        );
+        assert_eq!(resolved, Some("origin/main".to_string()));
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -9788,7 +9788,7 @@ mod tests {
                 branch_name: "main".to_string(),
             },
         );
-        assert_eq!(resolved, Some("origin/main".to_string()));
+        assert_eq!(resolved, Some("refs/remotes/origin/main".to_string()));
     }
 
     #[gpui::test]

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -14,7 +14,7 @@ use git::{
         AskPassDelegate, Branch, CommitData, CommitDataReader, CommitDetails, CommitOptions,
         CreateWorktreeTarget, FetchOptions, GRAPH_CHUNK_SIZE, GitRepository,
         GitRepositoryCheckpoint, InitialGraphCommitData, LogOrder, LogSource, PushOptions, RefEdit,
-        Remote, RemoteCommandOutput, RepoPath, ResetMode, SearchCommitArgs, Worktree,
+        Remote, RepoPath, ResetMode, SearchCommitArgs, Worktree,
     },
     stash::GitStash,
     status::{
@@ -69,7 +69,6 @@ pub struct FakeGitRepositoryState {
     pub branches: HashSet<String>,
     /// List of remotes, keys are names and values are URLs
     pub remotes: HashMap<String, String>,
-    pub fetches: Vec<FetchOptions>,
     pub simulated_index_write_error_message: Option<String>,
     pub simulated_create_worktree_error: Option<String>,
     pub simulated_graph_error: Option<String>,
@@ -100,7 +99,6 @@ impl FakeGitRepositoryState {
             merge_base_contents: Default::default(),
             oids: Default::default(),
             remotes: HashMap::default(),
-            fetches: Vec::new(),
             graph_commits: Vec::new(),
             commit_data: Default::default(),
             commit_history: Vec::new(),
@@ -1089,18 +1087,12 @@ impl GitRepository for FakeGitRepository {
 
     fn fetch(
         &self,
-        fetch_options: FetchOptions,
+        _fetch_options: FetchOptions,
         _askpass: AskPassDelegate,
         _env: Arc<HashMap<String, String>>,
         _cx: AsyncApp,
-    ) -> BoxFuture<'_, Result<RemoteCommandOutput>> {
-        self.with_state_async(true, move |state| {
-            state.fetches.push(fetch_options);
-            Ok(RemoteCommandOutput {
-                stdout: String::new(),
-                stderr: String::new(),
-            })
-        })
+    ) -> BoxFuture<'_, Result<git::repository::RemoteCommandOutput>> {
+        unimplemented!()
     }
 
     fn get_all_remotes(&self) -> BoxFuture<'_, Result<Vec<Remote>>> {

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -14,7 +14,7 @@ use git::{
         AskPassDelegate, Branch, CommitData, CommitDataReader, CommitDetails, CommitOptions,
         CreateWorktreeTarget, FetchOptions, GRAPH_CHUNK_SIZE, GitRepository,
         GitRepositoryCheckpoint, InitialGraphCommitData, LogOrder, LogSource, PushOptions, RefEdit,
-        Remote, RepoPath, ResetMode, SearchCommitArgs, Worktree,
+        Remote, RemoteCommandOutput, RepoPath, ResetMode, SearchCommitArgs, Worktree,
     },
     stash::GitStash,
     status::{
@@ -69,6 +69,7 @@ pub struct FakeGitRepositoryState {
     pub branches: HashSet<String>,
     /// List of remotes, keys are names and values are URLs
     pub remotes: HashMap<String, String>,
+    pub fetches: Vec<FetchOptions>,
     pub simulated_index_write_error_message: Option<String>,
     pub simulated_create_worktree_error: Option<String>,
     pub simulated_graph_error: Option<String>,
@@ -99,6 +100,7 @@ impl FakeGitRepositoryState {
             merge_base_contents: Default::default(),
             oids: Default::default(),
             remotes: HashMap::default(),
+            fetches: Vec::new(),
             graph_commits: Vec::new(),
             commit_data: Default::default(),
             commit_history: Vec::new(),
@@ -1087,12 +1089,18 @@ impl GitRepository for FakeGitRepository {
 
     fn fetch(
         &self,
-        _fetch_options: FetchOptions,
+        fetch_options: FetchOptions,
         _askpass: AskPassDelegate,
         _env: Arc<HashMap<String, String>>,
         _cx: AsyncApp,
-    ) -> BoxFuture<'_, Result<git::repository::RemoteCommandOutput>> {
-        unimplemented!()
+    ) -> BoxFuture<'_, Result<RemoteCommandOutput>> {
+        self.with_state_async(true, move |state| {
+            state.fetches.push(fetch_options);
+            Ok(RemoteCommandOutput {
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        })
     }
 
     fn get_all_remotes(&self) -> BoxFuture<'_, Result<Vec<Remote>>> {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -7350,7 +7350,7 @@ impl Component for PanelRepoFooter {
     }
 }
 
-fn open_output(
+pub(crate) fn open_output(
     operation: impl Into<SharedString>,
     workspace: &mut Workspace,
     output: &str,

--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -422,14 +422,20 @@ impl WorktreePickerDelegate {
 
         if !self.has_multiple_repositories {
             if let Some(ref default_branch) = self.default_branch {
+                let is_different = self
+                    .current_branch_name
+                    .as_ref()
+                    .is_none_or(|current| current != &default_branch.branch_name);
                 entries.push(WorktreeEntry::CreateFromDefaultBranch {
                     default_branch: default_branch.clone(),
                 });
-                return entries;
+                if is_different {
+                    entries.push(WorktreeEntry::CreateFromCurrentBranch);
+                }
             }
+        } else {
+            entries.push(WorktreeEntry::CreateFromCurrentBranch);
         }
-
-        entries.push(WorktreeEntry::CreateFromCurrentBranch);
 
         entries
     }

--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -96,7 +96,7 @@ impl WorktreePicker {
             .map(|repository| repository.update(cx, |repository, _| repository.worktrees()));
 
         let default_branch_request = repository.clone().map(|repository| {
-            repository.update(cx, |repository, _| repository.default_branch(false))
+            repository.update(cx, |repository, _| repository.default_branch(true))
         });
 
         let initial_matches = vec![WorktreeEntry::CreateFromCurrentBranch];
@@ -110,7 +110,7 @@ impl WorktreePicker {
             workspace,
             focused_dock,
             current_branch_name,
-            default_branch_name: None,
+            default_branch: None,
             has_multiple_repositories,
             focus_handle: cx.focus_handle(),
             show_footer,
@@ -160,8 +160,8 @@ impl WorktreePicker {
 
                 picker_handle.update_in(cx, |picker, window, cx| {
                     picker.delegate.all_worktrees = all_worktrees;
-                    picker.delegate.default_branch_name =
-                        default_branch.map(|branch| branch.to_string());
+                    picker.delegate.default_branch =
+                        default_branch.and_then(|branch| RemoteBranchName::parse(&branch));
                     picker.refresh(window, cx);
                 })?;
 
@@ -260,7 +260,7 @@ impl Render for WorktreePicker {
 enum WorktreeEntry {
     CreateFromCurrentBranch,
     CreateFromDefaultBranch {
-        default_branch_name: String,
+        default_branch: RemoteBranchName,
     },
     Separator,
     Worktree {
@@ -269,9 +269,33 @@ enum WorktreeEntry {
     },
     CreateNamed {
         name: String,
-        from_branch: Option<String>,
+        from_branch: Option<RemoteBranchName>,
         disabled_reason: Option<String>,
     },
+}
+
+#[derive(Clone)]
+struct RemoteBranchName {
+    remote_name: String,
+    branch_name: String,
+}
+
+impl RemoteBranchName {
+    fn parse(name: &str) -> Option<Self> {
+        let name = name.strip_prefix("refs/remotes/").unwrap_or(name);
+        let (remote_name, branch_name) = name.split_once('/')?;
+        if remote_name.is_empty() || branch_name.is_empty() {
+            return None;
+        }
+        Some(Self {
+            remote_name: remote_name.to_string(),
+            branch_name: branch_name.to_string(),
+        })
+    }
+
+    fn display_name(&self) -> String {
+        format!("{}/{}", self.remote_name, self.branch_name)
+    }
 }
 
 struct WorktreePickerDelegate {
@@ -283,7 +307,7 @@ struct WorktreePickerDelegate {
     workspace: WeakEntity<Workspace>,
     focused_dock: Option<DockPosition>,
     current_branch_name: Option<String>,
-    default_branch_name: Option<String>,
+    default_branch: Option<RemoteBranchName>,
     has_multiple_repositories: bool,
     focus_handle: FocusHandle,
     show_footer: bool,
@@ -396,21 +420,16 @@ impl WorktreePickerDelegate {
     fn build_fixed_entries(&self) -> Vec<WorktreeEntry> {
         let mut entries = Vec::new();
 
-        entries.push(WorktreeEntry::CreateFromCurrentBranch);
-
         if !self.has_multiple_repositories {
-            if let Some(ref default_branch) = self.default_branch_name {
-                let is_different = self
-                    .current_branch_name
-                    .as_ref()
-                    .is_none_or(|current| current != default_branch);
-                if is_different {
-                    entries.push(WorktreeEntry::CreateFromDefaultBranch {
-                        default_branch_name: default_branch.clone(),
-                    });
-                }
+            if let Some(ref default_branch) = self.default_branch {
+                entries.push(WorktreeEntry::CreateFromDefaultBranch {
+                    default_branch: default_branch.clone(),
+                });
+                return entries;
             }
         }
+
+        entries.push(WorktreeEntry::CreateFromCurrentBranch);
 
         entries
     }
@@ -628,13 +647,9 @@ impl PickerDelegate for WorktreePickerDelegate {
             None
         };
 
-        let show_default_branch_create = !self.has_multiple_repositories
-            && self.default_branch_name.as_ref().is_some_and(|default| {
-                self.current_branch_name
-                    .as_ref()
-                    .is_none_or(|current| current != default)
-            });
-        let default_branch_name = self.default_branch_name.clone();
+        let show_default_branch_create =
+            !self.has_multiple_repositories && self.default_branch.is_some();
+        let default_branch = self.default_branch.clone();
 
         if query.is_empty() {
             let mut matches = self.build_fixed_entries();
@@ -719,19 +734,20 @@ impl PickerDelegate for WorktreePickerDelegate {
                     if !new_matches.is_empty() {
                         new_matches.push(WorktreeEntry::Separator);
                     }
-                    new_matches.push(WorktreeEntry::CreateNamed {
-                        name: normalized_query.clone(),
-                        from_branch: None,
-                        disabled_reason: create_named_disabled_reason.clone(),
-                    });
                     if show_default_branch_create {
-                        if let Some(ref default_branch) = default_branch_name {
+                        if let Some(ref default_branch) = default_branch {
                             new_matches.push(WorktreeEntry::CreateNamed {
                                 name: normalized_query.clone(),
                                 from_branch: Some(default_branch.clone()),
                                 disabled_reason: create_named_disabled_reason.clone(),
                             });
                         }
+                    } else {
+                        new_matches.push(WorktreeEntry::CreateNamed {
+                            name: normalized_query.clone(),
+                            from_branch: None,
+                            disabled_reason: create_named_disabled_reason.clone(),
+                        });
                     }
 
                     picker.delegate.matches = new_matches;
@@ -769,9 +785,7 @@ impl PickerDelegate for WorktreePickerDelegate {
                     });
                 }
             }
-            WorktreeEntry::CreateFromDefaultBranch {
-                default_branch_name,
-            } => {
+            WorktreeEntry::CreateFromDefaultBranch { default_branch } => {
                 if self.creation_blocked_reason(cx).is_some() {
                     return;
                 }
@@ -781,8 +795,9 @@ impl PickerDelegate for WorktreePickerDelegate {
                             workspace,
                             &CreateWorktree {
                                 worktree_name: None,
-                                branch_target: NewWorktreeBranchTarget::ExistingBranch {
-                                    name: default_branch_name.clone(),
+                                branch_target: NewWorktreeBranchTarget::RemoteBranch {
+                                    remote_name: default_branch.remote_name.clone(),
+                                    branch_name: default_branch.branch_name.clone(),
                                 },
                             },
                             window,
@@ -832,8 +847,9 @@ impl PickerDelegate for WorktreePickerDelegate {
                 disabled_reason: None,
             } => {
                 let branch_target = match from_branch {
-                    Some(branch) => NewWorktreeBranchTarget::ExistingBranch {
-                        name: branch.clone(),
+                    Some(branch) => NewWorktreeBranchTarget::RemoteBranch {
+                        remote_name: branch.remote_name.clone(),
+                        branch_name: branch.branch_name.clone(),
                     },
                     None => NewWorktreeBranchTarget::CurrentBranch,
                 };
@@ -901,9 +917,8 @@ impl PickerDelegate for WorktreePickerDelegate {
 
                 Some(item.into_any_element())
             }
-            WorktreeEntry::CreateFromDefaultBranch {
-                default_branch_name,
-            } => {
+            WorktreeEntry::CreateFromDefaultBranch { default_branch } => {
+                let default_branch_name = default_branch.display_name();
                 let label = format!("Create new worktree based on {default_branch_name}");
 
                 let item = create_new_list_item(
@@ -1088,11 +1103,16 @@ impl PickerDelegate for WorktreePickerDelegate {
                 disabled_reason,
             } => {
                 let branch_label = from_branch
-                    .as_deref()
-                    .unwrap_or(self.current_branch_name.as_deref().unwrap_or("HEAD"));
+                    .as_ref()
+                    .map(RemoteBranchName::display_name)
+                    .unwrap_or_else(|| {
+                        self.current_branch_name
+                            .clone()
+                            .unwrap_or_else(|| "HEAD".to_string())
+                    });
                 let label = format!("Create \"{name}\" based on {branch_label}");
                 let element_id = match from_branch {
-                    Some(branch) => format!("create-named-from-{branch}"),
+                    Some(branch) => format!("create-named-from-{}", branch.display_name()),
                     None => "create-named-from-current".to_string(),
                 };
 
@@ -1469,6 +1489,48 @@ mod tests {
         worktrees
             .iter()
             .any(|worktree| worktree.path == *worktree_path)
+    }
+
+    #[gpui::test]
+    async fn test_remote_default_branch_is_preferred_create_target(cx: &mut TestAppContext) {
+        let (_fs, worktree_picker, _repository, _worktree_path, mut cx) =
+            init_worktree_picker_test(cx).await;
+
+        worktree_picker.update(&mut cx, |worktree_picker, cx| {
+            worktree_picker.picker.update(cx, |picker, _| {
+                assert_eq!(picker.delegate.selected_index, 0);
+                match picker.delegate.matches.first() {
+                    Some(WorktreeEntry::CreateFromDefaultBranch { default_branch }) => {
+                        assert_eq!(default_branch.display_name(), "origin/main");
+                    }
+                    _ => panic!("remote default branch should be the first create target"),
+                }
+            })
+        });
+
+        let update_matches = worktree_picker.update_in(&mut cx, |worktree_picker, window, cx| {
+            worktree_picker.picker.update(cx, |picker, cx| {
+                picker
+                    .delegate
+                    .update_matches("feature".to_string(), window, cx)
+            })
+        });
+        update_matches.await;
+        cx.run_until_parked();
+
+        worktree_picker.update(&mut cx, |worktree_picker, cx| {
+            worktree_picker
+                .picker
+                .update(cx, |picker, _| match picker.delegate.matches.first() {
+                    Some(WorktreeEntry::CreateNamed {
+                        from_branch: Some(default_branch),
+                        ..
+                    }) => {
+                        assert_eq!(default_branch.display_name(), "origin/main");
+                    }
+                    _ => panic!("named worktree creation should prefer the remote default branch"),
+                })
+        });
     }
 
     #[gpui::test]

--- a/crates/git_ui/src/worktree_service.rs
+++ b/crates/git_ui/src/worktree_service.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -5,14 +7,20 @@ use anyhow::anyhow;
 use askpass::AskPassDelegate;
 use collections::HashSet;
 use fs::Fs;
-use gpui::{AsyncWindowContext, Entity, SharedString, TaskExt, WeakEntity};
+use gpui::{
+    AsyncWindowContext, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, SharedString,
+    TaskExt, WeakEntity,
+};
 use project::Project;
 use project::git_store::Repository;
 use project::project_settings::ProjectSettings;
 use project::trusted_worktrees::{PathTrust, TrustedWorktrees};
 use remote::RemoteConnectionOptions;
 use settings::Settings;
-use workspace::{MultiWorkspace, OpenMode, PreviousWorkspaceState, Workspace, dock::DockPosition};
+use ui::prelude::*;
+use workspace::{
+    MultiWorkspace, OpenMode, PreviousWorkspaceState, ToastView, Workspace, dock::DockPosition,
+};
 use zed_actions::NewWorktreeBranchTarget;
 
 use git::repository::{FetchOptions, Remote};
@@ -20,7 +28,7 @@ use git::repository::{FetchOptions, Remote};
 use util::ResultExt as _;
 
 use crate::askpass_modal::AskPassModal;
-use crate::git_panel::show_error_toast;
+use crate::git_panel::{open_output, show_error_toast};
 use crate::worktree_names;
 
 /// Whether a worktree operation is creating a new one or switching to an
@@ -29,6 +37,185 @@ use crate::worktree_names;
 enum WorktreeOperation {
     Create,
     Switch,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RemoteBranchFetchMode {
+    Fetch,
+    UseLocal,
+}
+
+impl RemoteBranchFetchMode {
+    fn should_fetch(self) -> bool {
+        matches!(self, Self::Fetch)
+    }
+}
+
+#[derive(Debug)]
+struct WorktreeFetchError {
+    remote_name: String,
+    branch_name: String,
+    source: anyhow::Error,
+}
+
+impl WorktreeFetchError {
+    fn remote_branch_name(&self) -> String {
+        format!("{}/{}", self.remote_name, self.branch_name)
+    }
+
+    fn output(&self) -> String {
+        format!("git fetch {} failed:\n{:#}", self.remote_name, self.source)
+    }
+}
+
+impl fmt::Display for WorktreeFetchError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "git fetch {} failed while creating worktree from {}: {}",
+            self.remote_name,
+            self.remote_branch_name(),
+            self.source
+        )
+    }
+}
+
+impl Error for WorktreeFetchError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+struct WorktreeFetchFailedToast {
+    workspace: WeakEntity<Workspace>,
+    worktree_name: Option<String>,
+    branch_target: NewWorktreeBranchTarget,
+    focused_dock: Option<DockPosition>,
+    remote_branch_name: String,
+    operation: SharedString,
+    output: String,
+    focus_handle: FocusHandle,
+}
+
+impl WorktreeFetchFailedToast {
+    fn new(
+        workspace: WeakEntity<Workspace>,
+        worktree_name: Option<String>,
+        branch_target: NewWorktreeBranchTarget,
+        focused_dock: Option<DockPosition>,
+        fetch_error: &WorktreeFetchError,
+        cx: &mut gpui::Context<Self>,
+    ) -> Self {
+        Self {
+            workspace,
+            worktree_name,
+            branch_target,
+            focused_dock,
+            remote_branch_name: fetch_error.remote_branch_name(),
+            operation: format!("fetch {}", fetch_error.remote_name).into(),
+            output: fetch_error.output(),
+            focus_handle: cx.focus_handle(),
+        }
+    }
+}
+
+impl Focusable for WorktreeFetchFailedToast {
+    fn focus_handle(&self, _cx: &gpui::App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl EventEmitter<DismissEvent> for WorktreeFetchFailedToast {}
+
+impl ToastView for WorktreeFetchFailedToast {
+    fn action(&self) -> Option<workspace::ToastAction> {
+        None
+    }
+
+    fn auto_dismiss(&self) -> bool {
+        false
+    }
+}
+
+impl Render for WorktreeFetchFailedToast {
+    fn render(&mut self, _window: &mut Window, cx: &mut gpui::Context<Self>) -> impl IntoElement {
+        let workspace_for_retry = self.workspace.clone();
+        let worktree_name = self.worktree_name.clone();
+        let branch_target = self.branch_target.clone();
+        let focused_dock = self.focused_dock;
+
+        let workspace_for_log = self.workspace.clone();
+        let operation = self.operation.clone();
+        let output = self.output.clone();
+
+        h_flex()
+            .id("worktree-fetch-failed-toast")
+            .elevation_3(cx)
+            .gap_2()
+            .py_1p5()
+            .pl_2p5()
+            .pr_1p5()
+            .flex_none()
+            .bg(cx.theme().colors().surface_background)
+            .shadow_lg()
+            .child(
+                Icon::new(IconName::XCircle)
+                    .size(IconSize::Small)
+                    .color(Color::Error),
+            )
+            .child(Label::new(format!(
+                "git fetch failed for {}",
+                self.remote_branch_name
+            )))
+            .child(
+                Button::new(
+                    "use-local-worktree-base",
+                    format!("Use local {}", self.remote_branch_name),
+                )
+                .color(Color::Muted)
+                .on_click(cx.listener(move |_, _event, window, cx| {
+                    cx.emit(DismissEvent);
+                    if let Some(workspace) = workspace_for_retry.upgrade() {
+                        workspace.update(cx, |workspace, cx| {
+                            handle_create_worktree_inner(
+                                workspace,
+                                &zed_actions::CreateWorktree {
+                                    worktree_name: worktree_name.clone(),
+                                    branch_target: branch_target.clone(),
+                                },
+                                window,
+                                focused_dock,
+                                RemoteBranchFetchMode::UseLocal,
+                                cx,
+                            );
+                        });
+                    }
+                })),
+            )
+            .child(
+                Button::new("view-worktree-fetch-log", "Show Error Logs")
+                    .color(Color::Muted)
+                    .on_click(cx.listener(move |_, _event, window, cx| {
+                        cx.emit(DismissEvent);
+                        let output = output.clone();
+                        let operation = operation.clone();
+                        workspace_for_log
+                            .update(cx, move |workspace, cx| {
+                                open_output(operation, workspace, &output, window, cx)
+                            })
+                            .ok();
+                    })),
+            )
+            .child(
+                IconButton::new("dismiss-worktree-fetch-failed-toast", IconName::Close)
+                    .shape(ui::IconButtonShape::Square)
+                    .icon_size(IconSize::Small)
+                    .icon_color(Color::Muted)
+                    .on_click(cx.listener(|_, _event, _window, cx| {
+                        cx.emit(DismissEvent);
+                    })),
+            )
+    }
 }
 
 /// Classifies the project's visible worktrees into git-managed repositories
@@ -381,6 +568,24 @@ pub fn handle_create_worktree(
     fallback_focused_dock: Option<DockPosition>,
     cx: &mut gpui::Context<Workspace>,
 ) {
+    handle_create_worktree_inner(
+        workspace,
+        action,
+        window,
+        fallback_focused_dock,
+        RemoteBranchFetchMode::Fetch,
+        cx,
+    );
+}
+
+fn handle_create_worktree_inner(
+    workspace: &mut Workspace,
+    action: &zed_actions::CreateWorktree,
+    window: &mut gpui::Window,
+    fallback_focused_dock: Option<DockPosition>,
+    remote_branch_fetch_mode: RemoteBranchFetchMode,
+    cx: &mut gpui::Context<Workspace>,
+) {
     let project = workspace.project().clone();
 
     if project.read(cx).repositories(cx).is_empty() {
@@ -433,21 +638,25 @@ pub fn handle_create_worktree(
 
     let worktree_name = action.worktree_name.clone();
     let branch_target = action.branch_target.clone();
-    let fetch_askpass_delegates = remote_branch_to_fetch(&branch_target)
-        .map(|(remote_name, _branch_name)| {
-            git_repos
-                .iter()
-                .map(|_| {
-                    create_worktree_askpass_delegate(
-                        workspace_handle.clone(),
-                        format!("git fetch {remote_name}"),
-                        window,
-                        cx,
-                    )
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+    let fetch_askpass_delegates = if remote_branch_fetch_mode.should_fetch() {
+        remote_branch_to_fetch(&branch_target)
+            .map(|(remote_name, _branch_name)| {
+                git_repos
+                    .iter()
+                    .map(|_| {
+                        create_worktree_askpass_delegate(
+                            workspace_handle.clone(),
+                            format!("git fetch {remote_name}"),
+                            window,
+                            cx,
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
     let display_name: SharedString = worktree_name
         .as_deref()
         .unwrap_or("worktree")
@@ -456,6 +665,9 @@ pub fn handle_create_worktree(
 
     workspace.set_active_worktree_creation(Some(display_name), false, cx);
 
+    let retry_worktree_name = worktree_name.clone();
+    let retry_branch_target = branch_target.clone();
+
     cx.spawn_in(window, async move |_workspace_entity, mut cx| {
         let result = do_create_worktree(
             git_repos,
@@ -463,6 +675,7 @@ pub fn handle_create_worktree(
             worktree_name,
             branch_target,
             fetch_askpass_delegates,
+            remote_branch_fetch_mode,
             previous_state,
             workspace_handle.clone(),
             window_handle,
@@ -476,7 +689,21 @@ pub fn handle_create_worktree(
             workspace_handle
                 .update(cx, |workspace, cx| {
                     workspace.set_active_worktree_creation(None, false, cx);
-                    show_error_toast(cx.entity(), "worktree create", anyhow!("{err:#}"), cx);
+                    if let Some(fetch_error) = err.downcast_ref::<WorktreeFetchError>() {
+                        let toast = cx.new(|cx| {
+                            WorktreeFetchFailedToast::new(
+                                workspace.weak_handle(),
+                                retry_worktree_name.clone(),
+                                retry_branch_target.clone(),
+                                fallback_focused_dock,
+                                fetch_error,
+                                cx,
+                            )
+                        });
+                        workspace.toggle_status_toast(toast, cx);
+                    } else {
+                        show_error_toast(cx.entity(), "worktree create", anyhow!("{err:#}"), cx);
+                    }
                 })
                 .ok();
         }
@@ -562,6 +789,7 @@ async fn do_create_worktree(
     worktree_name: Option<String>,
     branch_target: NewWorktreeBranchTarget,
     fetch_askpass_delegates: Vec<AskPassDelegate>,
+    remote_branch_fetch_mode: RemoteBranchFetchMode,
     previous_state: PreviousWorkspaceState,
     workspace: WeakEntity<Workspace>,
     window_handle: Option<gpui::WindowHandle<MultiWorkspace>>,
@@ -606,14 +834,26 @@ async fn do_create_worktree(
         }
     }
 
-    if let Some((remote_name, _branch_name)) = remote_branch_to_fetch(&branch_target) {
-        fetch_remote_for_worktree_base(
+    if remote_branch_fetch_mode.should_fetch()
+        && let Some((remote_name, branch_name)) = remote_branch_to_fetch(&branch_target)
+    {
+        let remote_name = remote_name.to_string();
+        let branch_name = branch_name.to_string();
+        if let Err(error) = fetch_remote_for_worktree_base(
             &git_repos,
-            remote_name.to_string(),
+            remote_name.clone(),
             fetch_askpass_delegates,
             cx,
         )
-        .await?;
+        .await
+        {
+            return Err(WorktreeFetchError {
+                remote_name,
+                branch_name,
+                source: error,
+            }
+            .into());
+        }
     }
 
     let mut rng = rand::rng();

--- a/crates/git_ui/src/worktree_service.rs
+++ b/crates/git_ui/src/worktree_service.rs
@@ -290,8 +290,8 @@ fn remote_branch_to_fetch(branch_target: &NewWorktreeBranchTarget) -> Option<(&s
 fn create_worktree_askpass_delegate(
     workspace: WeakEntity<Workspace>,
     operation: impl Into<SharedString>,
-    window: &mut gpui::Window,
-    cx: &mut gpui::Context<Workspace>,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
 ) -> AskPassDelegate {
     let operation = operation.into();
     let window = window.window_handle();

--- a/crates/git_ui/src/worktree_service.rs
+++ b/crates/git_ui/src/worktree_service.rs
@@ -84,7 +84,7 @@ pub fn resolve_worktree_branch_target(branch_target: &NewWorktreeBranchTarget) -
         NewWorktreeBranchTarget::RemoteBranch {
             remote_name,
             branch_name,
-        } => Some(format!("{remote_name}/{branch_name}")),
+        } => Some(format!("refs/remotes/{remote_name}/{branch_name}")),
     }
 }
 
@@ -434,13 +434,13 @@ pub fn handle_create_worktree(
     let worktree_name = action.worktree_name.clone();
     let branch_target = action.branch_target.clone();
     let fetch_askpass_delegates = remote_branch_to_fetch(&branch_target)
-        .map(|(remote_name, branch_name)| {
+        .map(|(remote_name, _branch_name)| {
             git_repos
                 .iter()
                 .map(|_| {
                     create_worktree_askpass_delegate(
                         workspace_handle.clone(),
-                        format!("git fetch {remote_name}/{branch_name}"),
+                        format!("git fetch {remote_name}"),
                         window,
                         cx,
                     )

--- a/crates/git_ui/src/worktree_service.rs
+++ b/crates/git_ui/src/worktree_service.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use askpass::AskPassDelegate;
 use collections::HashSet;
 use fs::Fs;
 use gpui::{AsyncWindowContext, Entity, SharedString, TaskExt, WeakEntity};
@@ -14,8 +15,11 @@ use settings::Settings;
 use workspace::{MultiWorkspace, OpenMode, PreviousWorkspaceState, Workspace, dock::DockPosition};
 use zed_actions::NewWorktreeBranchTarget;
 
+use git::repository::{FetchOptions, Remote};
+
 use util::ResultExt as _;
 
+use crate::askpass_modal::AskPassModal;
 use crate::git_panel::show_error_toast;
 use crate::worktree_names;
 
@@ -77,7 +81,82 @@ pub fn resolve_worktree_branch_target(branch_target: &NewWorktreeBranchTarget) -
     match branch_target {
         NewWorktreeBranchTarget::CurrentBranch => None,
         NewWorktreeBranchTarget::ExistingBranch { name } => Some(name.clone()),
+        NewWorktreeBranchTarget::RemoteBranch {
+            remote_name,
+            branch_name,
+        } => Some(format!("{remote_name}/{branch_name}")),
     }
+}
+
+fn remote_branch_to_fetch(branch_target: &NewWorktreeBranchTarget) -> Option<(&str, &str)> {
+    match branch_target {
+        NewWorktreeBranchTarget::RemoteBranch {
+            remote_name,
+            branch_name,
+        } => Some((remote_name, branch_name)),
+        NewWorktreeBranchTarget::CurrentBranch | NewWorktreeBranchTarget::ExistingBranch { .. } => {
+            None
+        }
+    }
+}
+
+fn create_worktree_askpass_delegate(
+    workspace: WeakEntity<Workspace>,
+    operation: impl Into<SharedString>,
+    window: &mut gpui::Window,
+    cx: &mut gpui::Context<Workspace>,
+) -> AskPassDelegate {
+    let operation = operation.into();
+    let window = window.window_handle();
+    AskPassDelegate::new(&mut cx.to_async(), move |prompt, tx, cx| {
+        window
+            .update(cx, |_, window, cx| {
+                workspace.update(cx, |workspace, cx| {
+                    workspace.toggle_modal(window, cx, |window, cx| {
+                        AskPassModal::new(operation.clone(), prompt.into(), tx, window, cx)
+                    });
+                })
+            })
+            .ok();
+    })
+}
+
+async fn fetch_remote_for_worktree_base(
+    git_repos: &[Entity<Repository>],
+    remote_name: String,
+    askpass_delegates: Vec<AskPassDelegate>,
+    cx: &mut AsyncWindowContext,
+) -> anyhow::Result<()> {
+    if askpass_delegates.len() != git_repos.len() {
+        return Err(anyhow!(
+            "Unable to fetch {remote_name}: missing credential prompt delegate"
+        ));
+    }
+
+    let fetches = cx.update(|_, cx| {
+        git_repos
+            .iter()
+            .cloned()
+            .zip(askpass_delegates)
+            .map(|(repo, askpass)| {
+                repo.update(cx, |repo, cx| {
+                    repo.fetch(
+                        FetchOptions::Remote(Remote {
+                            name: remote_name.clone().into(),
+                        }),
+                        askpass,
+                        cx,
+                    )
+                })
+            })
+            .collect::<Vec<_>>()
+    })?;
+
+    for fetch in futures::future::join_all(fetches).await {
+        fetch??;
+    }
+
+    Ok(())
 }
 
 /// Kicks off an async git-worktree creation for each repository. Returns:
@@ -354,6 +433,21 @@ pub fn handle_create_worktree(
 
     let worktree_name = action.worktree_name.clone();
     let branch_target = action.branch_target.clone();
+    let fetch_askpass_delegates = remote_branch_to_fetch(&branch_target)
+        .map(|(remote_name, branch_name)| {
+            git_repos
+                .iter()
+                .map(|_| {
+                    create_worktree_askpass_delegate(
+                        workspace_handle.clone(),
+                        format!("git fetch {remote_name}/{branch_name}"),
+                        window,
+                        cx,
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     let display_name: SharedString = worktree_name
         .as_deref()
         .unwrap_or("worktree")
@@ -368,6 +462,7 @@ pub fn handle_create_worktree(
             non_git_paths,
             worktree_name,
             branch_target,
+            fetch_askpass_delegates,
             previous_state,
             workspace_handle.clone(),
             window_handle,
@@ -466,6 +561,7 @@ async fn do_create_worktree(
     non_git_paths: Vec<PathBuf>,
     worktree_name: Option<String>,
     branch_target: NewWorktreeBranchTarget,
+    fetch_askpass_delegates: Vec<AskPassDelegate>,
     previous_state: PreviousWorkspaceState,
     workspace: WeakEntity<Workspace>,
     window_handle: Option<gpui::WindowHandle<MultiWorkspace>>,
@@ -508,6 +604,16 @@ async fn do_create_worktree(
             }
             Err(_) => {}
         }
+    }
+
+    if let Some((remote_name, _branch_name)) = remote_branch_to_fetch(&branch_target) {
+        fetch_remote_for_worktree_base(
+            &git_repos,
+            remote_name.to_string(),
+            fetch_askpass_delegates,
+            cx,
+        )
+        .await?;
     }
 
     let mut rng = rand::rng();

--- a/crates/git_ui/src/worktree_service.rs
+++ b/crates/git_ui/src/worktree_service.rs
@@ -665,15 +665,12 @@ fn handle_create_worktree_inner(
 
     workspace.set_active_worktree_creation(Some(display_name), false, cx);
 
-    let retry_worktree_name = worktree_name.clone();
-    let retry_branch_target = branch_target.clone();
-
     cx.spawn_in(window, async move |_workspace_entity, mut cx| {
         let result = do_create_worktree(
             git_repos,
             non_git_paths,
-            worktree_name,
-            branch_target,
+            worktree_name.clone(),
+            branch_target.clone(),
             fetch_askpass_delegates,
             remote_branch_fetch_mode,
             previous_state,
@@ -693,8 +690,8 @@ fn handle_create_worktree_inner(
                         let toast = cx.new(|cx| {
                             WorktreeFetchFailedToast::new(
                                 workspace.weak_handle(),
-                                retry_worktree_name.clone(),
-                                retry_branch_target.clone(),
+                                worktree_name,
+                                branch_target,
                                 fallback_focused_dock,
                                 fetch_error,
                                 cx,

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -262,6 +262,11 @@ pub enum NewWorktreeBranchTarget {
     CurrentBranch,
     /// Create a detached worktree at the tip of an existing branch.
     ExistingBranch { name: String },
+    /// Create a detached worktree at the tip of a remote-tracking branch.
+    RemoteBranch {
+        remote_name: String,
+        branch_name: String,
+    },
 }
 
 /// Creates a new git worktree and switches the workspace to it.


### PR DESCRIPTION
When creating a git worktree, we now always fetch latest `origin/main` and create the worktree based on that. If running `git fetch` fails, we show an error toast with the option to base the worktree of off local `origin/main`:

<img width="530" height="45" alt="image" src="https://github.com/user-attachments/assets/f9ae4c05-8c2c-44f3-9c14-3c291a9d82f6" />


Release Notes:

- git: Always create worktrees based on latest `origin/main`
