### PR TITLE
docs: add OrcaRouter setup guide under OpenAI API Compatible

### DIFF
--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -624,6 +624,63 @@ If a provider exposes models that only work with the Responses API, set `chat_co
 Note that LLM API keys aren't stored in your settings file.
 So, ensure you have it set in your environment variables (`<PROVIDER_NAME>_API_KEY=<your api key>`) so your settings can pick it up. In the example above, it would be `TOGETHER_AI_API_KEY=<your api key>`.
 
+#### OrcaRouter {#openai-api-compatible-orcarouter}
+
+[OrcaRouter](https://www.orcarouter.ai) is a meta-router that exposes 150+ upstream LLMs (OpenAI, Anthropic, Google, DeepSeek, xAI, Qwen, MiniMax, and others) through a single OpenAI-compatible endpoint at `https://api.orcarouter.ai/v1`.
+
+1. Sign in at the [OrcaRouter Console](https://www.orcarouter.ai/console) and generate an API key (keys start with `sk-orca-`)
+2. Set it as an environment variable: `ORCA_ROUTER_API_KEY=sk-orca-...` (Zed derives the env var name from the `openai_compatible` map key by converting it to UPPER_SNAKE_CASE)
+3. Add the following snippet under `language_models` in your [settings file](../configuring-zed.md#settings-files):
+
+```json [settings]
+{
+  "language_models": {
+    "openai_compatible": {
+      "OrcaRouter": {
+        "api_url": "https://api.orcarouter.ai/v1",
+        "available_models": [
+          {
+            "name": "orcarouter/auto",
+            "display_name": "OrcaRouter Auto",
+            "max_tokens": 200000,
+            "capabilities": {
+              "tools": true,
+              "images": true,
+              "parallel_tool_calls": false,
+              "prompt_cache_key": false
+            }
+          },
+          {
+            "name": "openai/gpt-5",
+            "display_name": "GPT-5 via OrcaRouter",
+            "max_tokens": 400000,
+            "capabilities": {
+              "tools": true,
+              "images": true,
+              "parallel_tool_calls": false,
+              "prompt_cache_key": false
+            }
+          },
+          {
+            "name": "anthropic/claude-opus-4.7",
+            "display_name": "Claude Opus 4.7 via OrcaRouter",
+            "max_tokens": 200000,
+            "capabilities": {
+              "tools": true,
+              "images": true,
+              "parallel_tool_calls": false,
+              "prompt_cache_key": false
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+The `orcarouter/auto` entry routes each request to an appropriate upstream model based on prompt characteristics. The full catalog of supported model IDs is at [orcarouter.ai/models](https://www.orcarouter.ai/models); any model listed there can be added to `available_models` using the same shape.
+
 ### OpenCode {#opencode}
 
 OpenCode offers multiple ways to access AI models:


### PR DESCRIPTION
## Summary

Adds a short setup guide showing how to use [OrcaRouter](https://www.orcarouter.ai) — a meta-router exposing 150+ upstream LLMs through a single OpenAI-compatible endpoint at `https://api.orcarouter.ai/v1` — through Zed's existing `openai_compatible` provider.

Follows the path @bennetbo recommended in #57234 ("Atomic Chat seems to be OpenAI compatible, so if you want to use it in Zed you can configure it manually") and @benbrandt in #53139 ("we'd suggest adding docs for people to add your provider as an OpenAI compatible provider in their settings"). No new code, no new maintenance surface — just a worked example in `docs/src/ai/llm-providers.md`.

Disclosure: I'm an engineer on the OrcaRouter team.

## Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — N/A (docs-only)
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior — N/A (docs-only)
- [x] Performance impact has been considered and is acceptable — N/A (docs-only)

## Release Notes:

- Added docs: configuring [OrcaRouter](https://www.orcarouter.ai) as an OpenAI-compatible provider