### PR TITLE
Add Gerrit icon for Chromium hosting provider

### DIFF
--- a/assets/icons/gerrit.svg
+++ b/assets/icons/gerrit.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0" y="0" width="40" height="40" rx="4" ry="4" fill="none" stroke="#C6CAD0" stroke-width="3"/>
+<rect x="12" y="12" width="40" height="40" rx="4" ry="4" fill="none" stroke="#C6CAD0" stroke-width="3"/>
+<path d="M18 22h12v4H18z" fill="#C6CAD0"/>
+<path d="M34 22h12v4H34z" fill="#C6CAD0"/>
+<path d="M18 36h4v-4h4v4h4v4h-4v4h-4v-4h-4z" fill="#C6CAD0"/>
+<path d="M34 36h4v-4h4v4h4v4h-4v4h-4v-4h-4z" fill="#C6CAD0"/>
+</svg>

--- a/assets/icons/gerrit.svg
+++ b/assets/icons/gerrit.svg
@@ -1,8 +1,8 @@
-<svg width="16" height="16" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="0" y="0" width="40" height="40" rx="4" ry="4" fill="none" stroke="#C6CAD0" stroke-width="3"/>
-<rect x="12" y="12" width="40" height="40" rx="4" ry="4" fill="none" stroke="#C6CAD0" stroke-width="3"/>
-<path d="M18 22h12v4H18z" fill="#C6CAD0"/>
-<path d="M34 22h12v4H34z" fill="#C6CAD0"/>
-<path d="M18 36h4v-4h4v4h4v4h-4v4h-4v-4h-4z" fill="#C6CAD0"/>
-<path d="M34 36h4v-4h4v4h4v4h-4v4h-4v-4h-4z" fill="#C6CAD0"/>
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.2308 4.7609V2.92308C11.2308 2.41328 10.8175 2 10.3077 2H2.92308C2.41328 2 2 2.41328 2 2.92308V10.3077C2 10.8175 2.41328 11.2308 2.92308 11.2308H5" stroke="#C6CAD0" stroke-width="1.2"/>
+<path d="M13.0769 4.76926H5.6923C5.1825 4.76926 4.76923 5.18253 4.76923 5.69233V13.077C4.76923 13.5868 5.1825 14 5.6923 14H13.0769C13.5867 14 14 13.5868 14 13.077V5.69233C14 5.18253 13.5867 4.76926 13.0769 4.76926Z" stroke="#C6CAD0" stroke-width="1.2"/>
+<path d="M6.15385 7.07693H8.92308V8.00001H6.15385V7.07693Z" fill="#C6CAD0"/>
+<path d="M9.84615 7.07693H12.6154V8.00001H9.84615V7.07693Z" fill="#C6CAD0"/>
+<path d="M6.15385 10.3077H7.07692V9.38461H8V10.3077H8.92308V11.2308H8V12.1538H7.07692V11.2308H6.15385V10.3077Z" fill="#C6CAD0"/>
+<path d="M9.84615 10.3077H10.7692V9.38461H11.6923V10.3077H12.6154V11.2308H11.6923V12.1538H10.7692V11.2308H9.84615V10.3077Z" fill="#C6CAD0"/>
 </svg>

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -56,6 +56,7 @@ pub use conflict_view::MergeConflictIndicator;
 pub fn get_provider_icon(name: &str) -> IconName {
     match name {
         "Bitbucket" => IconName::Bitbucket,
+        "Chromium" => IconName::Gerrit,
         "Codeberg" => IconName::Codeberg,
         "Forgejo Self-Hosted" => IconName::Forgejo,
         "GitHub" => IconName::Github,

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -149,6 +149,7 @@ pub enum IconName {
     GenericMaximize,
     GenericMinimize,
     GenericRestore,
+    Gerrit,
     GitBranch,
     GitBranchPlus,
     GitCommit,


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Improves [#44738](https://github.com/zed-industries/zed/pull/57500) by including an icon for the Chromium code review remote. The Gerrit SVG icon was created by Claude, using https://commons.wikimedia.org/wiki/File:Gerrit_icon.svg#/media/File:Gerrit_icon.svg as source.

<img width="167" height="66" alt="Screenshot 2026-05-26 at 11 48 46" src="https://github.com/user-attachments/assets/d6a85751-3b86-4e30-a090-632f8b97d925" />

Release Notes:

- Added icon for the Chromium code review remote provider.