### PR TITLE
agent: Fix clipping in fixed-width

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1046,8 +1046,14 @@ impl Dock {
         dispatch_context
     }
 
-    pub fn clamp_panel_size(&mut self, max_size: Pixels, window: &Window, cx: &mut App) {
+    pub fn clamp_panel_size(
+        &mut self,
+        max_size: Pixels,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) {
         let max_size = (max_size - RESIZE_HANDLE_SIZE).abs();
+        let mut clamped = false;
         for entry in &mut self.panel_entries {
             let use_flexible = entry.panel.has_flexible_size(window, cx);
             if use_flexible {
@@ -1060,7 +1066,11 @@ impl Dock {
                 .unwrap_or_else(|| entry.panel.default_size(window, cx));
             if size > max_size {
                 entry.size_state.size = Some(max_size.max(RESIZE_HANDLE_SIZE));
+                clamped = true;
             }
+        }
+        if clamped {
+            cx.notify();
         }
     }
 

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1046,12 +1046,7 @@ impl Dock {
         dispatch_context
     }
 
-    pub fn clamp_panel_size(
-        &mut self,
-        max_size: Pixels,
-        window: &Window,
-        cx: &mut Context<Self>,
-    ) {
+    pub fn clamp_panel_size(&mut self, max_size: Pixels, window: &Window, cx: &mut Context<Self>) {
         let max_size = (max_size - RESIZE_HANDLE_SIZE).abs();
         let mut clamped = false;
         for entry in &mut self.panel_entries {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7817,6 +7817,12 @@ impl Workspace {
                         .and_then(|state| state.size)
                         .unwrap_or_else(|| panel.default_size(window, cx));
                     container = container.w(size);
+                    // Allow the fixed-width dock to shrink when there isn't
+                    // enough space (e.g. when the sidebar is open). The
+                    // stored size is preserved so the dock expands back
+                    // when space becomes available.
+                    let style = container.style();
+                    style.flex_shrink = Some(1.0);
                 }
                 if let Some(min) = min_size {
                     container = container.min_w(min);


### PR DESCRIPTION
Fixed width mode wouldn't reliably take the sidebar width into account when laying out the content of the agent panel. This fixes it
 
Release Notes:

- N/A or Added/Fixed/Improved ...
