### PR TITLE
Fix Helix append escape cursor restore

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -24,7 +24,8 @@ use workspace::searchable::{self, Direction, FilteredSearchRange};
 use crate::motion::{self, MotionKind};
 use crate::state::{HelixJumpBehaviour, HelixJumpLabel, Mode, Operator, SearchState};
 use crate::{
-    PushHelixSurroundAdd, PushHelixSurroundDelete, PushHelixSurroundReplace, Vim,
+    HelixAppendInsert, PushHelixSurroundAdd, PushHelixSurroundDelete, PushHelixSurroundReplace,
+    Vim,
     motion::{Motion, right},
 };
 use std::ops::Range;
@@ -642,6 +643,7 @@ impl Vim {
 
     fn helix_insert(&mut self, _: &HelixInsert, window: &mut Window, cx: &mut Context<Self>) {
         self.start_recording(cx);
+        self.helix_append_insert = None;
         self.update_editor(cx, |_, editor, cx| {
             editor.change_selections(Default::default(), window, cx, |s| {
                 s.move_with(&mut |_map, selection| {
@@ -718,7 +720,15 @@ impl Vim {
     fn helix_append(&mut self, _: &HelixAppend, window: &mut Window, cx: &mut Context<Self>) {
         self.start_recording(cx);
         self.switch_mode(Mode::Insert, false, window, cx);
-        self.update_editor(cx, |_, editor, cx| {
+        self.update_editor(cx, |vim, editor, cx| {
+            let snapshot = editor.display_snapshot(cx);
+            let original = editor
+                .selections
+                .all_anchors(&snapshot)
+                .iter()
+                .map(|selection| selection.tail()..selection.head())
+                .collect();
+
             editor.change_selections(Default::default(), window, cx, |s| {
                 s.move_with(&mut |map, selection| {
                     let point = if selection.is_empty() {
@@ -729,6 +739,15 @@ impl Vim {
                     selection.collapse_to(point, SelectionGoal::None);
                 });
             });
+
+            let snapshot = editor.display_snapshot(cx);
+            let inserted = editor
+                .selections
+                .all_anchors(&snapshot)
+                .iter()
+                .map(|selection| selection.range())
+                .collect();
+            vim.helix_append_insert = Some(HelixAppendInsert { original, inserted });
         });
     }
 
@@ -2479,6 +2498,23 @@ mod test {
     async fn test_append(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
         cx.enable_helix();
+
+        cx.set_state("Thˇe quick brown", Mode::HelixNormal);
+
+        cx.simulate_keystrokes("a");
+
+        cx.assert_state("Theˇ quick brown", Mode::Insert);
+
+        cx.simulate_keystrokes("escape");
+
+        cx.assert_state("Thˇe quick brown", Mode::HelixNormal);
+
+        cx.set_state("The quick brownˇ", Mode::HelixNormal);
+
+        cx.simulate_keystrokes("a escape");
+
+        cx.assert_state("The quick brownˇ", Mode::HelixNormal);
+
         // test from the end of the selection
         cx.set_state(
             indoc! {"
@@ -2498,6 +2534,16 @@ mod test {
             Mode::Insert,
         );
 
+        cx.simulate_keystrokes("escape");
+
+        cx.assert_state(
+            indoc! {"
+            «Theˇ» quick brown
+            fox jumps over
+            the lazy dog."},
+            Mode::HelixNormal,
+        );
+
         // test from the beginning of the selection
         cx.set_state(
             indoc! {"
@@ -2515,6 +2561,16 @@ mod test {
             fox jumps over
             the lazy dog."},
             Mode::Insert,
+        );
+
+        cx.simulate_keystrokes("escape");
+
+        cx.assert_state(
+            indoc! {"
+            «ˇThe» quick brown
+            fox jumps over
+            the lazy dog."},
+            Mode::HelixNormal,
         );
     }
 

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -24,8 +24,7 @@ use workspace::searchable::{self, Direction, FilteredSearchRange};
 use crate::motion::{self, MotionKind};
 use crate::state::{HelixJumpBehaviour, HelixJumpLabel, Mode, Operator, SearchState};
 use crate::{
-    HelixAppendInsert, PushHelixSurroundAdd, PushHelixSurroundDelete, PushHelixSurroundReplace,
-    Vim,
+    HelixAppendState, PushHelixSurroundAdd, PushHelixSurroundDelete, PushHelixSurroundReplace, Vim,
     motion::{Motion, right},
 };
 use std::ops::Range;
@@ -643,7 +642,6 @@ impl Vim {
 
     fn helix_insert(&mut self, _: &HelixInsert, window: &mut Window, cx: &mut Context<Self>) {
         self.start_recording(cx);
-        self.helix_append_insert = None;
         self.update_editor(cx, |_, editor, cx| {
             editor.change_selections(Default::default(), window, cx, |s| {
                 s.move_with(&mut |_map, selection| {
@@ -722,7 +720,7 @@ impl Vim {
         self.switch_mode(Mode::Insert, false, window, cx);
         self.update_editor(cx, |vim, editor, cx| {
             let snapshot = editor.display_snapshot(cx);
-            let original = editor
+            let selections_before_append = editor
                 .selections
                 .all_anchors(&snapshot)
                 .iter()
@@ -741,13 +739,16 @@ impl Vim {
             });
 
             let snapshot = editor.display_snapshot(cx);
-            let inserted = editor
+            let cursors_after_append = editor
                 .selections
                 .all_anchors(&snapshot)
                 .iter()
                 .map(|selection| selection.range())
                 .collect();
-            vim.helix_append_insert = Some(HelixAppendInsert { original, inserted });
+            vim.helix_append_state = Some(HelixAppendState {
+                selections_before_append,
+                cursors_after_append,
+            });
         });
     }
 
@@ -2572,6 +2573,27 @@ mod test {
             the lazy dog."},
             Mode::HelixNormal,
         );
+
+        // escape must not restore the selection once text was inserted
+        cx.set_state("Thˇe quick brown", Mode::HelixNormal);
+
+        cx.simulate_keystrokes("a x escape");
+
+        cx.assert_state("Thexˇ quick brown", Mode::HelixNormal);
+
+        // or when the cursor moved during insert mode
+        cx.set_state("Thˇe quick brown", Mode::HelixNormal);
+
+        cx.simulate_keystrokes("a left left escape");
+
+        cx.assert_state("Tˇhe quick brown", Mode::HelixNormal);
+
+        // all selections restore with multiple cursors
+        cx.set_state("ˇaaa bbb\nˇccc ddd", Mode::HelixNormal);
+
+        cx.simulate_keystrokes("a escape");
+
+        cx.assert_state("ˇaaa bbb\nˇccc ddd", Mode::HelixNormal);
     }
 
     #[gpui::test]

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -51,8 +51,28 @@ impl Vim {
             self.create_mark("^".into(), window, cx);
 
             if HelixModeSetting::get_global(cx).0 {
+                let append_insert = self.helix_append_insert.take();
+                let no_insert_transaction =
+                    self.current_tx.is_none() && self.current_anchor.is_none();
+                let restore_append_selection =
+                    no_insert_transaction.then_some(append_insert).flatten();
                 self.update_editor(cx, |_, editor, cx| {
                     editor.dismiss_menus_and_popups(false, window, cx);
+                    if let Some(append_insert) = restore_append_selection {
+                        let snapshot = editor.display_snapshot(cx);
+                        let current = editor
+                            .selections
+                            .all_anchors(&snapshot)
+                            .iter()
+                            .map(|selection| selection.range())
+                            .collect::<Vec<_>>();
+
+                        if current == append_insert.inserted {
+                            editor.change_selections(Default::default(), window, cx, |s| {
+                                s.select_anchor_ranges(append_insert.original);
+                            });
+                        }
+                    }
                 });
                 self.switch_mode(Mode::HelixNormal, false, window, cx);
                 return;

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -51,14 +51,18 @@ impl Vim {
             self.create_mark("^".into(), window, cx);
 
             if HelixModeSetting::get_global(cx).0 {
-                let append_insert = self.helix_append_insert.take();
+                // Restore the pre-append selections only if nothing happened in
+                // insert mode: no edits (tracked by current_tx/current_anchor)
+                // and the cursors are still where the append left them.
                 let no_insert_transaction =
                     self.current_tx.is_none() && self.current_anchor.is_none();
-                let restore_append_selection =
-                    no_insert_transaction.then_some(append_insert).flatten();
+                let restore_append_selection = self
+                    .helix_append_state
+                    .take()
+                    .filter(|_| no_insert_transaction);
                 self.update_editor(cx, |_, editor, cx| {
                     editor.dismiss_menus_and_popups(false, window, cx);
-                    if let Some(append_insert) = restore_append_selection {
+                    if let Some(append_state) = restore_append_selection {
                         let snapshot = editor.display_snapshot(cx);
                         let current = editor
                             .selections
@@ -67,9 +71,9 @@ impl Vim {
                             .map(|selection| selection.range())
                             .collect::<Vec<_>>();
 
-                        if current == append_insert.inserted {
+                        if current == append_state.cursors_after_append {
                             editor.change_selections(Default::default(), window, cx, |s| {
-                                s.select_anchor_ranges(append_insert.original);
+                                s.select_anchor_ranges(append_state.selections_before_append);
                             });
                         }
                     }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -527,6 +527,7 @@ pub(crate) struct Vim {
 
     pub(crate) current_tx: Option<TransactionId>,
     pub(crate) current_anchor: Option<Selection<Anchor>>,
+    pub(crate) helix_append_insert: Option<HelixAppendInsert>,
     pub(crate) undo_modes: HashMap<TransactionId, Mode>,
     pub(crate) undo_last_line_tx: Option<TransactionId>,
     extended_pending_selection_id: Option<usize>,
@@ -539,6 +540,11 @@ pub(crate) struct Vim {
     last_command: Option<String>,
     running_command: Option<Task<()>>,
     _subscriptions: Vec<Subscription>,
+}
+
+pub(crate) struct HelixAppendInsert {
+    pub(crate) original: Vec<Range<Anchor>>,
+    pub(crate) inserted: Vec<Range<Anchor>>,
 }
 
 // Hack: Vim intercepts events dispatched to a window and updates the view in response.
@@ -588,6 +594,7 @@ impl Vim {
             current_tx: None,
             undo_last_line_tx: None,
             current_anchor: None,
+            helix_append_insert: None,
             extended_pending_selection_id: None,
             undo_modes: HashMap::default(),
 
@@ -1210,6 +1217,9 @@ impl Vim {
         if mode == Mode::Normal || mode != last_mode {
             self.current_tx.take();
             self.current_anchor.take();
+            if mode != Mode::Insert {
+                self.helix_append_insert.take();
+            }
             self.update_editor(cx, |_, editor, _| {
                 editor.clear_selection_drag_state();
             });

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -527,7 +527,7 @@ pub(crate) struct Vim {
 
     pub(crate) current_tx: Option<TransactionId>,
     pub(crate) current_anchor: Option<Selection<Anchor>>,
-    pub(crate) helix_append_insert: Option<HelixAppendInsert>,
+    pub(crate) helix_append_state: Option<HelixAppendState>,
     pub(crate) undo_modes: HashMap<TransactionId, Mode>,
     pub(crate) undo_last_line_tx: Option<TransactionId>,
     extended_pending_selection_id: Option<usize>,
@@ -542,9 +542,11 @@ pub(crate) struct Vim {
     _subscriptions: Vec<Subscription>,
 }
 
-pub(crate) struct HelixAppendInsert {
-    pub(crate) original: Vec<Range<Anchor>>,
-    pub(crate) inserted: Vec<Range<Anchor>>,
+/// Captured by `helix_append` so that escape can restore the pre-append
+/// selections when nothing was inserted, matching Helix.
+pub(crate) struct HelixAppendState {
+    pub(crate) selections_before_append: Vec<Range<Anchor>>,
+    pub(crate) cursors_after_append: Vec<Range<Anchor>>,
 }
 
 // Hack: Vim intercepts events dispatched to a window and updates the view in response.
@@ -594,7 +596,7 @@ impl Vim {
             current_tx: None,
             undo_last_line_tx: None,
             current_anchor: None,
-            helix_append_insert: None,
+            helix_append_state: None,
             extended_pending_selection_id: None,
             undo_modes: HashMap::default(),
 
@@ -1218,7 +1220,7 @@ impl Vim {
             self.current_tx.take();
             self.current_anchor.take();
             if mode != Mode::Insert {
-                self.helix_append_insert.take();
+                self.helix_append_state.take();
             }
             self.update_editor(cx, |_, editor, _| {
                 editor.clear_selection_drag_state();


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54231

Related to the Opire Helix keymap bounty on #4642.
/claim #4642
Opire payout: @jamilahmadzai

Release Notes:

- Fixed Helix mode append so pressing Escape without inserting text restores the original cursor or selection instead of leaving it one character ahead.
