### PR TITLE
gpui: Add builder API for BoxShadow

### DIFF
--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -33,7 +33,7 @@ use gpui::{
     ElementId, Empty, Entity, EventEmitter, FocusHandle, Focusable, Hsla, ListOffset, ListState,
     ObjectFit, PlatformDisplay, ScrollHandle, SharedString, StyledText, Subscription, Task,
     TaskExt, TextRun, TextStyle, WeakEntity, Window, WindowHandle, div, ease_in_out, img,
-    linear_color_stop, linear_gradient, list, point, pulsating_between,
+    linear_color_stop, linear_gradient, list, pulsating_between,
 };
 use language::{Buffer, Language, Rope};
 use language_model::{LanguageModelCompletionError, LanguageModelRegistry};
@@ -3428,7 +3428,7 @@ pub(crate) mod tests {
     use editor::MultiBufferOffset;
     use editor::actions::Paste;
     use fs::FakeFs;
-    use gpui::{ClipboardItem, EventEmitter, TestAppContext, VisualTestContext, size};
+    use gpui::{ClipboardItem, EventEmitter, TestAppContext, VisualTestContext, point, size};
     use parking_lot::Mutex;
     use project::Project;
     use serde_json::json;

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2853,13 +2853,10 @@ impl ThreadView {
                     .border_color(cx.theme().colors().border)
                     .rounded_t_md()
                     .when(opaque_window, |this| {
-                        this.shadow(vec![gpui::BoxShadow {
-                            color: gpui::black().opacity(0.12),
-                            offset: point(px(1.), px(-1.)),
-                            blur_radius: px(2.),
-                            spread_radius: px(0.),
-                            inset: false,
-                        }])
+                        this.shadow(vec![
+                            gpui::BoxShadow::new(px(1.), px(-1.), gpui::black().opacity(0.12))
+                                .blur_radius(px(2.)),
+                        ])
                     })
                     .when_some(awaiting_permission, |this, element| this.child(element))
                     .when(

--- a/crates/ai_onboarding/src/agent_api_keys_onboarding.rs
+++ b/crates/ai_onboarding/src/agent_api_keys_onboarding.rs
@@ -1,4 +1,4 @@
-use gpui::{Action, IntoElement, ParentElement, RenderOnce, point};
+use gpui::{Action, IntoElement, ParentElement, RenderOnce};
 use language_model::{IconOrSvg, LanguageModelRegistry, ZED_CLOUD_PROVIDER_ID};
 use ui::{Divider, List, ListBulletItem, prelude::*};
 
@@ -68,13 +68,9 @@ impl Render for ApiKeysWithProviders {
             .border_x_1()
             .border_color(cx.theme().colors().border.opacity(0.5))
             .bg(cx.theme().colors().background.alpha(0.5))
-            .shadow(vec![gpui::BoxShadow {
-                color: gpui::black().opacity(0.15),
-                offset: point(px(1.), px(-1.)),
-                blur_radius: px(3.),
-                spread_radius: px(0.),
-                inset: false,
-            }])
+            .shadow(vec![
+                gpui::BoxShadow::new(px(1.), px(-1.), gpui::black().opacity(0.15)).blur_radius(px(3.)),
+            ])
             .child(
                 h_flex()
                     .px_2p5()

--- a/crates/editor/src/edit_prediction.rs
+++ b/crates/editor/src/edit_prediction.rs
@@ -2017,13 +2017,10 @@ impl Editor {
                     .gap_1()
                     // Workaround: For some reason, there's a gap if we don't do this
                     .ml(-BORDER_WIDTH)
-                    .shadow(vec![gpui::BoxShadow {
-                        color: gpui::black().opacity(0.05),
-                        offset: point(px(1.), px(1.)),
-                        blur_radius: px(2.),
-                        spread_radius: px(0.),
-                        inset: false,
-                    }])
+                    .shadow(vec![
+                        gpui::BoxShadow::new(px(1.), px(1.), gpui::black().opacity(0.05))
+                            .blur_radius(px(2.)),
+                    ])
                     .bg(Editor::edit_prediction_line_popover_bg_color(cx))
                     .border(BORDER_WIDTH)
                     .border_color(cx.theme().colors().border)

--- a/crates/gpui/examples/opacity.rs
+++ b/crates/gpui/examples/opacity.rs
@@ -5,7 +5,7 @@ use std::{fs, path::PathBuf};
 use anyhow::Result;
 use gpui::{
     App, AssetSource, Bounds, BoxShadow, ClickEvent, Context, SharedString, Task, Window,
-    WindowBounds, WindowOptions, div, hsla, img, point, prelude::*, px, rgb, size, svg,
+    WindowBounds, WindowOptions, div, hsla, img, prelude::*, px, rgb, size, svg,
 };
 use gpui_platform::application;
 
@@ -114,13 +114,11 @@ impl Render for HelloWorld {
                             .bg(gpui::blue())
                             .border_3()
                             .border_color(gpui::black())
-                            .shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.5),
-                                blur_radius: px(1.0),
-                                spread_radius: px(5.0),
-                                offset: point(px(10.0), px(10.0)),
-                                inset: false,
-                            }])
+                            .shadow(vec![
+                                BoxShadow::new(px(10.0), px(10.0), hsla(0.0, 0.0, 0.0, 0.5))
+                                    .blur_radius(px(1.0))
+                                    .spread_radius(px(5.0)),
+                            ])
                             .child(img("image/app-icon.png").size_8())
                             .child("Opacity Panel (Click to test)")
                             .child(

--- a/crates/gpui/examples/shadow.rs
+++ b/crates/gpui/examples/shadow.rs
@@ -2,7 +2,7 @@
 
 use gpui::{
     App, Bounds, BoxShadow, Context, Div, SharedString, Window, WindowBounds, WindowOptions, div,
-    hsla, point, prelude::*, px, relative, rgb, size,
+    hsla, prelude::*, px, relative, rgb, size,
 };
 use gpui_platform::application;
 
@@ -95,609 +95,495 @@ impl Render for Shadow {
             .size_full()
             .text_xs()
             .child(div().flex().flex_col().w_full().children(vec![
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .flex_row()
-                    .children(vec![
-                        example(
-                            "Square",
-                            Shadow::square()
-                                .shadow(vec![BoxShadow {
-                                    color: hsla(0.0, 0.5, 0.5, 0.3),
-                                    offset: point(px(0.), px(8.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(0.),
-                                    inset: false,
-                                }]),
-                        ),
-                        example(
-                            "Rounded 4",
-                            Shadow::rounded_small()
-                                .shadow(vec![BoxShadow {
-                                    color: hsla(0.0, 0.5, 0.5, 0.3),
-                                    offset: point(px(0.), px(8.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(0.),
-                                    inset: false,
-                                }]),
-                        ),
-                        example(
-                            "Rounded 8",
-                            Shadow::rounded_medium()
-                                .shadow(vec![BoxShadow {
-                                    color: hsla(0.0, 0.5, 0.5, 0.3),
-                                    offset: point(px(0.), px(8.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(0.),
-                                    inset: false,
-                                }]),
-                        ),
-                        example(
-                            "Rounded 16",
-                            Shadow::rounded_large()
-                                .shadow(vec![BoxShadow {
-                                    color: hsla(0.0, 0.5, 0.5, 0.3),
-                                    offset: point(px(0.), px(8.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(0.),
-                                    inset: false,
-                                }]),
-                        ),
-                        example(
-                            "Circle",
-                            Shadow::base()
-                                .shadow(vec![BoxShadow {
-                                    color: hsla(0.0, 0.5, 0.5, 0.3),
-                                    offset: point(px(0.), px(8.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(0.),
-                                    inset: false,
-                                }]),
-                        ),
-                    ]),
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .w_full()
-                    .children(vec![
-                        example("None", Shadow::base()),
-                        // 2Xsmall shadow
-                        example("2X Small", Shadow::base().shadow_2xs()),
-                        // Xsmall shadow
-                        example("Extra Small", Shadow::base().shadow_xs()),
-                        // Small shadow
-                        example("Small", Shadow::base().shadow_sm()),
-                        // Medium shadow
-                        example("Medium", Shadow::base().shadow_md()),
-                        // Large shadow
-                        example("Large", Shadow::base().shadow_lg()),
-                        example("Extra Large", Shadow::base().shadow_xl()),
-                        example("2X Large", Shadow::base().shadow_2xl()),
-                    ]),
-                // Horizontal list of increasing blur radii
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .children(vec![
-                        example(
-                            "Blur 0",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(0.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Blur 2",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(2.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Blur 4",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(4.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Blur 8",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Blur 16",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(16.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                    ]),
-                // Horizontal list of increasing spread radii
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .children(vec![
-                        example(
-                            "Spread 0",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Spread 2",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(2.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Spread 4",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(4.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Spread 8",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(8.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Spread 16",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(16.),
-                                inset: false,
-                            }]),
-                        ),
-                    ]),
-                // Square spread examples
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .children(vec![
-                        example(
-                            "Square Spread 0",
-                            Shadow::square().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Square Spread 8",
-                            Shadow::square().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(8.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Square Spread 16",
-                            Shadow::square().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(16.),
-                                inset: false,
-                            }]),
-                        ),
-                    ]),
-                // Rounded large spread examples
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .children(vec![
-                        example(
-                            "Rounded Large Spread 0",
-                            Shadow::rounded_large().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Rounded Large Spread 8",
-                            Shadow::rounded_large().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(8.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Rounded Large Spread 16",
-                            Shadow::rounded_large().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(16.),
-                                inset: false,
-                            }]),
-                        ),
-                    ]),
-                // Directional shadows
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .children(vec![
-                        example(
-                            "Left",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(-8.), px(0.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Right",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(8.), px(0.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Top",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(0.), px(-8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Bottom",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                    ]),
-                // Square directional shadows
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .children(vec![
-                        example(
-                            "Square Left",
-                            Shadow::square().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(-8.), px(0.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Square Right",
-                            Shadow::square().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(8.), px(0.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Square Top",
-                            Shadow::square().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(0.), px(-8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Square Bottom",
-                            Shadow::square().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                    ]),
-                // Rounded large directional shadows
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .children(vec![
-                        example(
-                            "Rounded Large Left",
-                            Shadow::rounded_large().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(-8.), px(0.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Rounded Large Right",
-                            Shadow::rounded_large().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(8.), px(0.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Rounded Large Top",
-                            Shadow::rounded_large().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(0.), px(-8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                        example(
-                            "Rounded Large Bottom",
-                            Shadow::rounded_large().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.5, 0.5, 0.3),
-                                offset: point(px(0.), px(8.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: false,
-                            }]),
-                        ),
-                    ]),
-                // Multiple shadows for different shapes
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .children(vec![
-                        example(
-                            "Circle Multiple",
-                            Shadow::base().shadow(vec![
-                                BoxShadow {
-                                    color: hsla(0.0 / 360., 1.0, 0.5, 0.3), // Red
-                                    offset: point(px(0.), px(-12.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                                BoxShadow {
-                                    color: hsla(60.0 / 360., 1.0, 0.5, 0.3), // Yellow
-                                    offset: point(px(12.), px(0.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                                BoxShadow {
-                                    color: hsla(120.0 / 360., 1.0, 0.5, 0.3), // Green
-                                    offset: point(px(0.), px(12.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                                BoxShadow {
-                                    color: hsla(240.0 / 360., 1.0, 0.5, 0.3), // Blue
-                                    offset: point(px(-12.), px(0.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                            ]),
-                        ),
-                        example(
-                            "Square Multiple",
-                            Shadow::square().shadow(vec![
-                                BoxShadow {
-                                    color: hsla(0.0 / 360., 1.0, 0.5, 0.3), // Red
-                                    offset: point(px(0.), px(-12.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                                BoxShadow {
-                                    color: hsla(60.0 / 360., 1.0, 0.5, 0.3), // Yellow
-                                    offset: point(px(12.), px(0.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                                BoxShadow {
-                                    color: hsla(120.0 / 360., 1.0, 0.5, 0.3), // Green
-                                    offset: point(px(0.), px(12.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                                BoxShadow {
-                                    color: hsla(240.0 / 360., 1.0, 0.5, 0.3), // Blue
-                                    offset: point(px(-12.), px(0.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                            ]),
-                        ),
-                        example(
-                            "Rounded Large Multiple",
-                            Shadow::rounded_large().shadow(vec![
-                                BoxShadow {
-                                    color: hsla(0.0 / 360., 1.0, 0.5, 0.3), // Red
-                                    offset: point(px(0.), px(-12.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                                BoxShadow {
-                                    color: hsla(60.0 / 360., 1.0, 0.5, 0.3), // Yellow
-                                    offset: point(px(12.), px(0.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                                BoxShadow {
-                                    color: hsla(120.0 / 360., 1.0, 0.5, 0.3), // Green
-                                    offset: point(px(0.), px(12.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                                BoxShadow {
-                                    color: hsla(240.0 / 360., 1.0, 0.5, 0.3), // Blue
-                                    offset: point(px(-12.), px(0.)),
-                                    blur_radius: px(8.),
-                                    spread_radius: px(2.),
-                                    inset: false,
-                                },
-                            ]),
-                        ),
-                    ]),
-                // Inset shadows (CSS `box-shadow: inset ...`).
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .w_full()
-                    .children(vec![
-                        example(
-                            "Inset basic",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.5),
-                                offset: point(px(0.), px(0.)),
-                                blur_radius: px(12.),
-                                spread_radius: px(0.),
-                                inset: true,
-                            }]),
-                        ),
-                        example(
-                            "Inset offset",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.5),
-                                offset: point(px(6.), px(6.)),
-                                blur_radius: px(8.),
-                                spread_radius: px(0.),
-                                inset: true,
-                            }]),
-                        ),
-                        example(
-                            "Inset spread",
-                            Shadow::base().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.5),
-                                offset: point(px(0.), px(0.)),
-                                blur_radius: px(4.),
-                                spread_radius: px(8.),
-                                inset: true,
-                            }]),
-                        ),
-                        example(
-                            "Inset rounded",
-                            Shadow::rounded_large().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.5),
-                                offset: point(px(0.), px(4.)),
-                                blur_radius: px(10.),
-                                spread_radius: px(2.),
-                                inset: true,
-                            }]),
-                        ),
-                        example(
-                            "Inset sharp",
-                            Shadow::square().shadow(vec![BoxShadow {
-                                color: hsla(0.0, 0.0, 0.0, 0.6),
-                                offset: point(px(0.), px(0.)),
-                                blur_radius: px(0.),
-                                spread_radius: px(6.),
-                                inset: true,
-                            }]),
-                        ),
-                    ]),
-                // Combined: drop + inset shadows on the same element.
-                div()
-                    .border_b_1()
-                    .border_color(hsla(0.0, 0.0, 0.0, 1.0))
-                    .flex()
-                    .w_full()
-                    .children(vec![
-                        example(
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .flex_row()
+                        .children(vec![
+                            example(
+                                "Square",
+                                Shadow::square().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Rounded 4",
+                                Shadow::rounded_small().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Rounded 8",
+                                Shadow::rounded_medium().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Rounded 16",
+                                Shadow::rounded_large().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Circle",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                        ]),
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .w_full()
+                        .children(vec![
+                            example("None", Shadow::base()),
+                            // 2Xsmall shadow
+                            example("2X Small", Shadow::base().shadow_2xs()),
+                            // Xsmall shadow
+                            example("Extra Small", Shadow::base().shadow_xs()),
+                            // Small shadow
+                            example("Small", Shadow::base().shadow_sm()),
+                            // Medium shadow
+                            example("Medium", Shadow::base().shadow_md()),
+                            // Large shadow
+                            example("Large", Shadow::base().shadow_lg()),
+                            example("Extra Large", Shadow::base().shadow_xl()),
+                            example("2X Large", Shadow::base().shadow_2xl()),
+                        ]),
+                    // Horizontal list of increasing blur radii
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .children(vec![
+                            example(
+                                "Blur 0",
+                                Shadow::base().shadow(vec![BoxShadow::new(
+                                    px(0.),
+                                    px(8.),
+                                    hsla(0.0, 0.0, 0.0, 0.3),
+                                )]),
+                            ),
+                            example(
+                                "Blur 2",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(2.)),
+                                ]),
+                            ),
+                            example(
+                                "Blur 4",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(4.)),
+                                ]),
+                            ),
+                            example(
+                                "Blur 8",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Blur 16",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(16.)),
+                                ]),
+                            ),
+                        ]),
+                    // Horizontal list of increasing spread radii
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .children(vec![
+                            example(
+                                "Spread 0",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Spread 2",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.))
+                                        .spread_radius(px(2.)),
+                                ]),
+                            ),
+                            example(
+                                "Spread 4",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.))
+                                        .spread_radius(px(4.)),
+                                ]),
+                            ),
+                            example(
+                                "Spread 8",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.))
+                                        .spread_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Spread 16",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.))
+                                        .spread_radius(px(16.)),
+                                ]),
+                            ),
+                        ]),
+                    // Square spread examples
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .children(vec![
+                            example(
+                                "Square Spread 0",
+                                Shadow::square().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Square Spread 8",
+                                Shadow::square().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.))
+                                        .spread_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Square Spread 16",
+                                Shadow::square().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.))
+                                        .spread_radius(px(16.)),
+                                ]),
+                            ),
+                        ]),
+                    // Rounded large spread examples
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .children(vec![
+                            example(
+                                "Rounded Large Spread 0",
+                                Shadow::rounded_large().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Rounded Large Spread 8",
+                                Shadow::rounded_large().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.))
+                                        .spread_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Rounded Large Spread 16",
+                                Shadow::rounded_large().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.3))
+                                        .blur_radius(px(8.))
+                                        .spread_radius(px(16.)),
+                                ]),
+                            ),
+                        ]),
+                    // Directional shadows
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .children(vec![
+                            example(
+                                "Left",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(-8.), px(0.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Right",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(8.), px(0.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Top",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(-8.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Bottom",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                        ]),
+                    // Square directional shadows
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .children(vec![
+                            example(
+                                "Square Left",
+                                Shadow::square().shadow(vec![
+                                    BoxShadow::new(px(-8.), px(0.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Square Right",
+                                Shadow::square().shadow(vec![
+                                    BoxShadow::new(px(8.), px(0.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Square Top",
+                                Shadow::square().shadow(vec![
+                                    BoxShadow::new(px(0.), px(-8.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Square Bottom",
+                                Shadow::square().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                        ]),
+                    // Rounded large directional shadows
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .children(vec![
+                            example(
+                                "Rounded Large Left",
+                                Shadow::rounded_large().shadow(vec![
+                                    BoxShadow::new(px(-8.), px(0.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Rounded Large Right",
+                                Shadow::rounded_large().shadow(vec![
+                                    BoxShadow::new(px(8.), px(0.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Rounded Large Top",
+                                Shadow::rounded_large().shadow(vec![
+                                    BoxShadow::new(px(0.), px(-8.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                            example(
+                                "Rounded Large Bottom",
+                                Shadow::rounded_large().shadow(vec![
+                                    BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.5, 0.5, 0.3))
+                                        .blur_radius(px(8.)),
+                                ]),
+                            ),
+                        ]),
+                    // Multiple shadows for different shapes
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .children(vec![
+                            example(
+                                "Circle Multiple",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(
+                                        px(0.),
+                                        px(-12.),
+                                        hsla(0.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                    BoxShadow::new(
+                                        px(12.),
+                                        px(0.),
+                                        hsla(60.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                    BoxShadow::new(
+                                        px(0.),
+                                        px(12.),
+                                        hsla(120.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                    BoxShadow::new(
+                                        px(-12.),
+                                        px(0.),
+                                        hsla(240.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                ]),
+                            ),
+                            example(
+                                "Square Multiple",
+                                Shadow::square().shadow(vec![
+                                    BoxShadow::new(
+                                        px(0.),
+                                        px(-12.),
+                                        hsla(0.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                    BoxShadow::new(
+                                        px(12.),
+                                        px(0.),
+                                        hsla(60.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                    BoxShadow::new(
+                                        px(0.),
+                                        px(12.),
+                                        hsla(120.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                    BoxShadow::new(
+                                        px(-12.),
+                                        px(0.),
+                                        hsla(240.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                ]),
+                            ),
+                            example(
+                                "Rounded Large Multiple",
+                                Shadow::rounded_large().shadow(vec![
+                                    BoxShadow::new(
+                                        px(0.),
+                                        px(-12.),
+                                        hsla(0.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                    BoxShadow::new(
+                                        px(12.),
+                                        px(0.),
+                                        hsla(60.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                    BoxShadow::new(
+                                        px(0.),
+                                        px(12.),
+                                        hsla(120.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                    BoxShadow::new(
+                                        px(-12.),
+                                        px(0.),
+                                        hsla(240.0 / 360., 1.0, 0.5, 0.3),
+                                    )
+                                    .blur_radius(px(8.))
+                                    .spread_radius(px(2.)),
+                                ]),
+                            ),
+                        ]),
+                    // Inset shadows (CSS `box-shadow: inset ...`).
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .w_full()
+                        .children(vec![
+                            example(
+                                "Inset basic",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(0.), hsla(0.0, 0.0, 0.0, 0.5))
+                                        .blur_radius(px(12.))
+                                        .inset(),
+                                ]),
+                            ),
+                            example(
+                                "Inset offset",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(6.), px(6.), hsla(0.0, 0.0, 0.0, 0.5))
+                                        .blur_radius(px(8.))
+                                        .inset(),
+                                ]),
+                            ),
+                            example(
+                                "Inset spread",
+                                Shadow::base().shadow(vec![
+                                    BoxShadow::new(px(0.), px(0.), hsla(0.0, 0.0, 0.0, 0.5))
+                                        .blur_radius(px(4.))
+                                        .spread_radius(px(8.))
+                                        .inset(),
+                                ]),
+                            ),
+                            example(
+                                "Inset rounded",
+                                Shadow::rounded_large().shadow(vec![
+                                    BoxShadow::new(px(0.), px(4.), hsla(0.0, 0.0, 0.0, 0.5))
+                                        .blur_radius(px(10.))
+                                        .spread_radius(px(2.))
+                                        .inset(),
+                                ]),
+                            ),
+                            example(
+                                "Inset sharp",
+                                Shadow::square().shadow(vec![
+                                    BoxShadow::new(px(0.), px(0.), hsla(0.0, 0.0, 0.0, 0.6))
+                                        .spread_radius(px(6.))
+                                        .inset(),
+                                ]),
+                            ),
+                        ]),
+                    // Combined: drop + inset shadows on the same element.
+                    div()
+                        .border_b_1()
+                        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                        .flex()
+                        .w_full()
+                        .children(vec![example(
                             "Drop + Inset",
                             Shadow::rounded_medium().shadow(vec![
-                                BoxShadow {
-                                    color: hsla(0.0, 0.0, 0.0, 0.25),
-                                    offset: point(px(0.), px(8.)),
-                                    blur_radius: px(12.),
-                                    spread_radius: px(0.),
-                                    inset: false,
-                                },
-                                BoxShadow {
-                                    color: hsla(0.0, 0.0, 0.0, 0.4),
-                                    offset: point(px(0.), px(2.)),
-                                    blur_radius: px(4.),
-                                    spread_radius: px(0.),
-                                    inset: true,
-                                },
+                                BoxShadow::new(px(0.), px(8.), hsla(0.0, 0.0, 0.0, 0.25))
+                                    .blur_radius(px(12.)),
+                                BoxShadow::new(px(0.), px(2.), hsla(0.0, 0.0, 0.0, 0.4))
+                                    .blur_radius(px(4.))
+                                    .inset(),
                             ]),
-                        ),
-                    ]),
-            ]))
+                        )]),
+                ]))
     }
 }
 

--- a/crates/gpui/examples/window_shadow.rs
+++ b/crates/gpui/examples/window_shadow.rs
@@ -107,18 +107,19 @@ impl Render for WindowShadow {
                             .when(!tiling.left, |div| div.border_l(border_size))
                             .when(!tiling.right, |div| div.border_r(border_size))
                             .when(!tiling.is_tiled(), |div| {
-                                div.shadow(vec![gpui::BoxShadow {
-                                    color: Hsla {
-                                        h: 0.,
-                                        s: 0.,
-                                        l: 0.,
-                                        a: 0.4,
-                                    },
-                                    blur_radius: shadow_size / 2.,
-                                    spread_radius: px(0.),
-                                    inset: false,
-                                    offset: point(px(0.0), px(0.0)),
-                                }])
+                                div.shadow(vec![
+                                    gpui::BoxShadow::new(
+                                        px(0.),
+                                        px(0.),
+                                        Hsla {
+                                            h: 0.,
+                                            s: 0.,
+                                            l: 0.,
+                                            a: 0.4,
+                                        },
+                                    )
+                                    .blur_radius(shadow_size / 2.),
+                                ])
                             }),
                     })
                     .on_mouse_move(|_e, _, cx| {
@@ -148,18 +149,19 @@ impl Render for WindowShadow {
                                         .w(px(200.0))
                                         .h(px(100.0))
                                         .bg(green())
-                                        .shadow(vec![gpui::BoxShadow {
-                                            color: Hsla {
-                                                h: 0.,
-                                                s: 0.,
-                                                l: 0.,
-                                                a: 1.0,
-                                            },
-                                            blur_radius: px(20.0),
-                                            spread_radius: px(0.0),
-                                            inset: false,
-                                            offset: point(px(0.0), px(0.0)),
-                                        }])
+                                        .shadow(vec![
+                                            gpui::BoxShadow::new(
+                                                px(0.),
+                                                px(0.),
+                                                Hsla {
+                                                    h: 0.,
+                                                    s: 0.,
+                                                    l: 0.,
+                                                    a: 1.0,
+                                                },
+                                            )
+                                            .blur_radius(px(20.0)),
+                                        ])
                                         .map(|div| match decorations {
                                             Decorations::Server => div,
                                             Decorations::Client { .. } => div

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -9,7 +9,7 @@ use crate::{
     CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
     FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, Pixels, Point,
     PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window, black, phi,
-    point, quad, rems, size,
+    point, px, quad, rems, size,
 };
 use collections::HashSet;
 use refineable::Refineable;
@@ -353,6 +353,39 @@ pub struct BoxShadow {
     pub spread_radius: Pixels,
     /// Whether this is an inset shadow (drawn inside the element's bounds).
     pub inset: bool,
+}
+
+impl BoxShadow {
+    /// Creates a new [`BoxShadow`] with the given offset and color, matching the order
+    /// of the CSS `box-shadow` property. Use the builder methods to set blur radius,
+    /// spread radius, and inset.
+    pub fn new(offset_x: Pixels, offset_y: Pixels, color: Hsla) -> Self {
+        Self {
+            color,
+            offset: point(offset_x, offset_y),
+            blur_radius: px(0.),
+            spread_radius: px(0.),
+            inset: false,
+        }
+    }
+
+    /// Sets the shadow blur radius.
+    pub fn blur_radius(mut self, blur_radius: Pixels) -> Self {
+        self.blur_radius = blur_radius;
+        self
+    }
+
+    /// Sets the shadow spread radius.
+    pub fn spread_radius(mut self, spread_radius: Pixels) -> Self {
+        self.spread_radius = spread_radius;
+        self
+    }
+
+    /// Marks the shadow as inset (drawn inside the element's bounds).
+    pub fn inset(mut self) -> Self {
+        self.inset = true;
+        self
+    }
 }
 
 /// How to handle whitespace in text

--- a/crates/gpui_macros/src/styles.rs
+++ b/crates/gpui_macros/src/styles.rs
@@ -402,56 +402,36 @@ pub fn box_shadow_style_methods(input: TokenStream) -> TokenStream {
         /// Sets the box shadow of the element.
         /// [Docs](https://tailwindcss.com/docs/box-shadow)
         #visibility fn shadow_2xs(mut self) -> Self {
-            use gpui::{BoxShadow, hsla, point, px};
+            use gpui::{BoxShadow, hsla, px};
             use std::vec;
 
-            self.style().box_shadow = Some(vec![BoxShadow {
-                color: hsla(0., 0., 0., 0.05),
-                offset: point(px(0.), px(1.)),
-                blur_radius: px(0.),
-                spread_radius: px(0.),
-                inset: false,
-            }]);
+            self.style().box_shadow = Some(vec![
+                BoxShadow::new(px(0.), px(1.), hsla(0., 0., 0., 0.05))
+            ]);
             self
         }
 
         /// Sets the box shadow of the element.
         /// [Docs](https://tailwindcss.com/docs/box-shadow)
         #visibility fn shadow_xs(mut self) -> Self {
-            use gpui::{BoxShadow, hsla, point, px};
+            use gpui::{BoxShadow, hsla, px};
             use std::vec;
 
-            self.style().box_shadow = Some(vec![BoxShadow {
-                color: hsla(0., 0., 0., 0.05),
-                offset: point(px(0.), px(1.)),
-                blur_radius: px(2.),
-                spread_radius: px(0.),
-                inset: false,
-            }]);
+            self.style().box_shadow = Some(vec![
+                BoxShadow::new(px(0.), px(1.), hsla(0., 0., 0., 0.05)).blur_radius(px(2.))
+            ]);
             self
         }
 
         /// Sets the box shadow of the element.
         /// [Docs](https://tailwindcss.com/docs/box-shadow)
         #visibility fn shadow_sm(mut self) -> Self {
-            use gpui::{BoxShadow, hsla, point, px};
+            use gpui::{BoxShadow, hsla, px};
             use std::vec;
 
             self.style().box_shadow = Some(vec![
-                BoxShadow {
-                    color: hsla(0., 0., 0., 0.1),
-                    offset: point(px(0.), px(1.)),
-                    blur_radius: px(3.),
-                    spread_radius: px(0.),
-                    inset: false,
-                },
-                BoxShadow {
-                    color: hsla(0., 0., 0., 0.1),
-                    offset: point(px(0.), px(1.)),
-                    blur_radius: px(2.),
-                    spread_radius: px(-1.),
-                    inset: false,
-                }
+                BoxShadow::new(px(0.), px(1.), hsla(0., 0., 0., 0.1)).blur_radius(px(3.)),
+                BoxShadow::new(px(0.), px(1.), hsla(0., 0., 0., 0.1)).blur_radius(px(2.)).spread_radius(px(-1.)),
             ]);
             self
         }
@@ -459,24 +439,12 @@ pub fn box_shadow_style_methods(input: TokenStream) -> TokenStream {
         /// Sets the box shadow of the element.
         /// [Docs](https://tailwindcss.com/docs/box-shadow)
         #visibility fn shadow_md(mut self) -> Self {
-            use gpui::{BoxShadow, hsla, point, px};
+            use gpui::{BoxShadow, hsla, px};
             use std::vec;
 
             self.style().box_shadow = Some(vec![
-                BoxShadow {
-                    color: hsla(0., 0., 0., 0.1),
-                    offset: point(px(0.), px(4.)),
-                    blur_radius: px(6.),
-                    spread_radius: px(-1.),
-                    inset: false,
-                },
-                BoxShadow {
-                    color: hsla(0., 0., 0., 0.1),
-                    offset: point(px(0.), px(2.)),
-                    blur_radius: px(4.),
-                    spread_radius: px(-2.),
-                    inset: false,
-                }
+                BoxShadow::new(px(0.), px(4.), hsla(0., 0., 0., 0.1)).blur_radius(px(6.)).spread_radius(px(-1.)),
+                BoxShadow::new(px(0.), px(2.), hsla(0., 0., 0., 0.1)).blur_radius(px(4.)).spread_radius(px(-2.)),
             ]);
             self
         }
@@ -484,24 +452,12 @@ pub fn box_shadow_style_methods(input: TokenStream) -> TokenStream {
         /// Sets the box shadow of the element.
         /// [Docs](https://tailwindcss.com/docs/box-shadow)
         #visibility fn shadow_lg(mut self) -> Self {
-            use gpui::{BoxShadow, hsla, point, px};
+            use gpui::{BoxShadow, hsla, px};
             use std::vec;
 
             self.style().box_shadow = Some(vec![
-                BoxShadow {
-                    color: hsla(0., 0., 0., 0.1),
-                    offset: point(px(0.), px(10.)),
-                    blur_radius: px(15.),
-                    spread_radius: px(-3.),
-                    inset: false,
-                },
-                BoxShadow {
-                    color: hsla(0., 0., 0., 0.1),
-                    offset: point(px(0.), px(4.)),
-                    blur_radius: px(6.),
-                    spread_radius: px(-4.),
-                    inset: false,
-                }
+                BoxShadow::new(px(0.), px(10.), hsla(0., 0., 0., 0.1)).blur_radius(px(15.)).spread_radius(px(-3.)),
+                BoxShadow::new(px(0.), px(4.), hsla(0., 0., 0., 0.1)).blur_radius(px(6.)).spread_radius(px(-4.)),
             ]);
             self
         }
@@ -509,24 +465,12 @@ pub fn box_shadow_style_methods(input: TokenStream) -> TokenStream {
         /// Sets the box shadow of the element.
         /// [Docs](https://tailwindcss.com/docs/box-shadow)
         #visibility fn shadow_xl(mut self) -> Self {
-            use gpui::{BoxShadow, hsla, point, px};
+            use gpui::{BoxShadow, hsla, px};
             use std::vec;
 
             self.style().box_shadow = Some(vec![
-                BoxShadow {
-                    color: hsla(0., 0., 0., 0.1),
-                    offset: point(px(0.), px(20.)),
-                    blur_radius: px(25.),
-                    spread_radius: px(-5.),
-                    inset: false,
-                },
-                BoxShadow {
-                    color: hsla(0., 0., 0., 0.1),
-                    offset: point(px(0.), px(8.)),
-                    blur_radius: px(10.),
-                    spread_radius: px(-6.),
-                    inset: false,
-                }
+                BoxShadow::new(px(0.), px(20.), hsla(0., 0., 0., 0.1)).blur_radius(px(25.)).spread_radius(px(-5.)),
+                BoxShadow::new(px(0.), px(8.), hsla(0., 0., 0., 0.1)).blur_radius(px(10.)).spread_radius(px(-6.)),
             ]);
             self
         }
@@ -534,16 +478,12 @@ pub fn box_shadow_style_methods(input: TokenStream) -> TokenStream {
         /// Sets the box shadow of the element.
         /// [Docs](https://tailwindcss.com/docs/box-shadow)
         #visibility fn shadow_2xl(mut self) -> Self {
-            use gpui::{BoxShadow, hsla, point, px};
+            use gpui::{BoxShadow, hsla, px};
             use std::vec;
 
-            self.style().box_shadow = Some(vec![BoxShadow {
-                color: hsla(0., 0., 0., 0.25),
-                offset: point(px(0.), px(25.)),
-                blur_radius: px(50.),
-                spread_radius: px(-12.),
-                inset: false,
-            }]);
+            self.style().box_shadow = Some(vec![
+                BoxShadow::new(px(0.), px(25.), hsla(0., 0., 0., 0.25)).blur_radius(px(50.)).spread_radius(px(-12.))
+            ]);
             self
         }
     };

--- a/crates/ui/src/components/button/split_button.rs
+++ b/crates/ui/src/components/button/split_button.rs
@@ -1,6 +1,6 @@
 use gpui::{
     AnyElement, App, BoxShadow, IntoElement, ParentElement, RenderOnce, Styled, Window, div, hsla,
-    point, prelude::FluentBuilder, px, relative,
+    prelude::FluentBuilder, px, relative,
 };
 use theme::ActiveTheme;
 
@@ -89,13 +89,11 @@ impl RenderOnce for SplitButton {
             .child(self.right)
             .when(self.style == SplitButtonStyle::Filled, |this| {
                 this.bg(ElevationIndex::Surface.on_elevation_bg(cx))
-                    .shadow(vec![BoxShadow {
-                        color: hsla(0.0, 0.0, 0.0, 0.16),
-                        offset: point(px(0.), px(1.)),
-                        blur_radius: px(0.),
-                        spread_radius: px(0.),
-                        inset: false,
-                    }])
+                    .shadow(vec![BoxShadow::new(
+                        px(0.),
+                        px(1.),
+                        hsla(0.0, 0.0, 0.0, 0.16),
+                    )])
             })
     }
 }

--- a/crates/ui/src/components/keybinding_hint.rs
+++ b/crates/ui/src/components/keybinding_hint.rs
@@ -1,6 +1,6 @@
 use crate::KeyBinding;
 use crate::prelude::*;
-use gpui::{AnyElement, App, BoxShadow, FontStyle, Hsla, IntoElement, Window, point};
+use gpui::{AnyElement, App, BoxShadow, FontStyle, Hsla, IntoElement, Window};
 use theme::Appearance;
 
 /// Represents a hint for a keybinding, optionally with a prefix and suffix.
@@ -242,13 +242,7 @@ impl RenderOnce for KeybindingHint {
                     .border_1()
                     .border_color(border_color)
                     .bg(bg_color)
-                    .shadow(vec![BoxShadow {
-                        color: shadow_color,
-                        offset: point(px(0.), px(1.)),
-                        blur_radius: px(0.),
-                        spread_radius: px(0.),
-                        inset: false,
-                    }])
+                    .shadow(vec![BoxShadow::new(px(0.), px(1.), shadow_color)])
                     .child(self.keybinding.size(rems_from_px(kb_size))),
             )
             .children(self.suffix)

--- a/crates/ui/src/components/progress/progress_bar.rs
+++ b/crates/ui/src/components/progress/progress_bar.rs
@@ -1,5 +1,5 @@
 use documented::Documented;
-use gpui::{Hsla, point};
+use gpui::Hsla;
 
 use crate::components::Label;
 use crate::prelude::*;
@@ -71,13 +71,11 @@ impl RenderOnce for ProgressBar {
             .p_0p5()
             .rounded_full()
             .bg(self.bg_color)
-            .shadow(vec![gpui::BoxShadow {
-                color: gpui::black().opacity(0.08),
-                offset: point(px(0.), px(1.)),
-                blur_radius: px(0.),
-                spread_radius: px(0.),
-                inset: false,
-            }])
+            .shadow(vec![gpui::BoxShadow::new(
+                px(0.),
+                px(1.),
+                gpui::black().opacity(0.08),
+            )])
             .child(
                 div()
                     .h_full()

--- a/crates/ui/src/styles/elevation.rs
+++ b/crates/ui/src/styles/elevation.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 
-use gpui::{App, BoxShadow, Hsla, hsla, point, px};
+use gpui::{App, BoxShadow, Hsla, hsla, px};
 use theme::{ActiveTheme, Appearance};
 
 /// Today, elevation is primarily used to add shadows to elements, and set the correct background for elements like buttons.
@@ -47,51 +47,33 @@ impl ElevationIndex {
             ElevationIndex::EditorSurface => vec![],
 
             ElevationIndex::ElevatedSurface => vec![
-                BoxShadow {
-                    color: hsla(0., 0., 0., 0.12),
-                    offset: point(px(0.), px(2.)),
-                    blur_radius: px(3.),
-                    spread_radius: px(0.),
-                    inset: false,
-                },
-                BoxShadow {
-                    color: hsla(0., 0., 0., if is_light { 0.03 } else { 0.06 }),
-                    offset: point(px(0.), px(1.)),
-                    blur_radius: px(0.),
-                    spread_radius: px(0.),
-                    inset: false,
-                },
+                BoxShadow::new(px(0.), px(2.), hsla(0., 0., 0., 0.12)).blur_radius(px(3.)),
+                BoxShadow::new(
+                    px(0.),
+                    px(1.),
+                    hsla(0., 0., 0., if is_light { 0.03 } else { 0.06 }),
+                ),
             ],
 
             ElevationIndex::ModalSurface => vec![
-                BoxShadow {
-                    color: hsla(0., 0., 0., if is_light { 0.06 } else { 0.12 }),
-                    offset: point(px(0.), px(2.)),
-                    blur_radius: px(3.),
-                    spread_radius: px(0.),
-                    inset: false,
-                },
-                BoxShadow {
-                    color: hsla(0., 0., 0., if is_light { 0.06 } else { 0.08 }),
-                    offset: point(px(0.), px(3.)),
-                    blur_radius: px(6.),
-                    spread_radius: px(0.),
-                    inset: false,
-                },
-                BoxShadow {
-                    color: hsla(0., 0., 0., 0.04),
-                    offset: point(px(0.), px(6.)),
-                    blur_radius: px(12.),
-                    spread_radius: px(0.),
-                    inset: false,
-                },
-                BoxShadow {
-                    color: hsla(0., 0., 0., if is_light { 0.04 } else { 0.12 }),
-                    offset: point(px(0.), px(1.)),
-                    blur_radius: px(0.),
-                    spread_radius: px(0.),
-                    inset: false,
-                },
+                BoxShadow::new(
+                    px(0.),
+                    px(2.),
+                    hsla(0., 0., 0., if is_light { 0.06 } else { 0.12 }),
+                )
+                .blur_radius(px(3.)),
+                BoxShadow::new(
+                    px(0.),
+                    px(3.),
+                    hsla(0., 0., 0., if is_light { 0.06 } else { 0.08 }),
+                )
+                .blur_radius(px(6.)),
+                BoxShadow::new(px(0.), px(6.), hsla(0., 0., 0., 0.04)).blur_radius(px(12.)),
+                BoxShadow::new(
+                    px(0.),
+                    px(1.),
+                    hsla(0., 0., 0., if is_light { 0.04 } else { 0.12 }),
+                ),
             ],
 
             _ => vec![],

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -10776,18 +10776,19 @@ pub fn client_side_decorations(
                         .when(!tiling.left, |div| div.border_l(BORDER_SIZE))
                         .when(!tiling.right, |div| div.border_r(BORDER_SIZE))
                         .when(!tiling.is_tiled(), |div| {
-                            div.shadow(vec![gpui::BoxShadow {
-                                color: Hsla {
-                                    h: 0.,
-                                    s: 0.,
-                                    l: 0.,
-                                    a: 0.4,
-                                },
-                                blur_radius: theme::CLIENT_SIDE_DECORATION_SHADOW / 2.,
-                                spread_radius: px(0.),
-                                inset: false,
-                                offset: point(px(0.0), px(0.0)),
-                            }])
+                            div.shadow(vec![
+                                gpui::BoxShadow::new(
+                                    px(0.),
+                                    px(0.),
+                                    Hsla {
+                                        h: 0.,
+                                        s: 0.,
+                                        l: 0.,
+                                        a: 0.4,
+                                    },
+                                )
+                                .blur_radius(theme::CLIENT_SIDE_DECORATION_SHADOW / 2.),
+                            ])
                         }),
                 })
                 .on_mouse_move(|_e, _, cx| {


### PR DESCRIPTION
Replaces the verbose struct-literal construction of `gpui::BoxShadow` with a builder API:

- `BoxShadow::new(offset_x, offset_y, color)` takes the required fields, with arguments ordered to match the CSS `box-shadow` property.
- `.blur_radius(_)`, `.spread_radius(_)`, and `.inset()` set the optional fields.

All in-tree call sites are migrated, including the Tailwind-style `shadow_xs`..`shadow_2xl` helpers in `gpui_macros`, the `ElevationIndex` shadows in `ui`, and various widgets across `editor`, `workspace`, `agent_ui`, and `ai_onboarding`. The fields on `BoxShadow` remain public, so external code using struct-literal construction continues to work.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
