### PR TITLE
Keep inline code pipes inside markdown table cells

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -5125,6 +5125,21 @@ mod tests {
     }
 
     #[gpui::test]
+    fn test_code_span_link_receives_raw_pipe_inline_code(cx: &mut TestAppContext) {
+        let source = r"| Pattern |
+| --- |
+| `a|b` |";
+        let rendered = render_markdown_with_code_span_link(
+            source,
+            |text, _cx| (text == "a|b").then(|| "file:///tmp/a-or-b".into()),
+            cx,
+        );
+
+        assert_eq!(rendered.links.len(), 1);
+        assert_eq!(rendered.links[0].destination_url, "file:///tmp/a-or-b");
+    }
+
+    #[gpui::test]
     fn test_code_span_link_ignores_code_when_mouse_interaction_is_prevented(
         cx: &mut TestAppContext,
     ) {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -2604,6 +2604,9 @@ impl Element for MarkdownElement {
                         cx,
                     );
                 }
+                MarkdownEvent::SubstitutedCode(text) => {
+                    self.push_markdown_code_span(&mut builder, text, range.clone(), cx);
+                }
                 MarkdownEvent::Html => {
                     let html = &parsed_markdown.source[range.clone()];
                     if html.starts_with("<!--") {
@@ -4712,6 +4715,25 @@ mod tests {
         }
     }
 
+    #[gpui::test]
+    fn test_escaped_pipes_in_inline_code_inside_tables(cx: &mut TestAppContext) {
+        let markdown = "\
+| Pattern | What it does |
+| --- | --- |
+| `^echo(\\s\\|$)` | command pattern |
+| `a\\|b` | alternation |
+| `(a\\|b)` | grouped alternation |
+| `a\\|\\|b` | empty middle alternative |";
+        let rendered = render_markdown(markdown, cx);
+        let text = rendered.text_for_range(0..markdown.len());
+
+        assert!(text.contains("^echo(\\s|$)"));
+        assert!(text.contains("a|b"));
+        assert!(text.contains("(a|b)"));
+        assert!(text.contains("a||b"));
+        assert!(!text.contains("\\|"));
+    }
+
     #[test]
     fn test_source_range_for_rendered_handles_split_chunks() {
         let mappings = vec![
@@ -5085,6 +5107,21 @@ mod tests {
                 .link_for_source_index(source.find("see").unwrap())
                 .is_none()
         );
+    }
+
+    #[gpui::test]
+    fn test_code_span_link_receives_decoded_inline_code(cx: &mut TestAppContext) {
+        let source = r"| Pattern |
+| --- |
+| `a\|b` |";
+        let rendered = render_markdown_with_code_span_link(
+            source,
+            |text, _cx| (text == "a|b").then(|| "file:///tmp/a-or-b".into()),
+            cx,
+        );
+
+        assert_eq!(rendered.links.len(), 1);
+        assert_eq!(rendered.links[0].destination_url, "file:///tmp/a-or-b");
     }
 
     #[gpui::test]

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -4734,6 +4734,25 @@ mod tests {
         assert!(!text.contains("\\|"));
     }
 
+    #[gpui::test]
+    fn test_raw_pipes_in_inline_code_inside_tables(cx: &mut TestAppContext) {
+        let markdown = "\
+| Pattern | What it does |
+| --- | --- |
+| ``^echo(\\s|$)`` | command pattern |
+| `a|b` | alternation |
+| `(a|b)` | grouped alternation |
+| `a||b` | empty middle alternative |";
+        let rendered = render_markdown(markdown, cx);
+        let text = rendered.text_for_range(0..markdown.len());
+
+        assert!(text.contains("^echo(\\s|$)"));
+        assert!(text.contains("a|b"));
+        assert!(text.contains("(a|b)"));
+        assert!(text.contains("a||b"));
+        assert!(!text.contains("``^echo"));
+    }
+
     #[test]
     fn test_source_range_for_rendered_handles_split_chunks() {
         let mappings = vec![

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -4727,30 +4727,19 @@ mod tests {
         let rendered = render_markdown(markdown, cx);
         let text = rendered.text_for_range(0..markdown.len());
 
-        assert!(text.contains("^echo(\\s|$)"));
-        assert!(text.contains("a|b"));
-        assert!(text.contains("(a|b)"));
-        assert!(text.contains("a||b"));
-        assert!(!text.contains("\\|"));
-    }
-
-    #[gpui::test]
-    fn test_raw_pipes_in_inline_code_inside_tables(cx: &mut TestAppContext) {
-        let markdown = "\
-| Pattern | What it does |
-| --- | --- |
-| ``^echo(\\s|$)`` | command pattern |
-| `a|b` | alternation |
-| `(a|b)` | grouped alternation |
-| `a||b` | empty middle alternative |";
-        let rendered = render_markdown(markdown, cx);
-        let text = rendered.text_for_range(0..markdown.len());
-
-        assert!(text.contains("^echo(\\s|$)"));
-        assert!(text.contains("a|b"));
-        assert!(text.contains("(a|b)"));
-        assert!(text.contains("a||b"));
-        assert!(!text.contains("``^echo"));
+        assert_eq!(
+            text,
+            "Pattern\n\
+             What it does\n\
+             ^echo(\\s|$)\n\
+             command pattern\n\
+             a|b\n\
+             alternation\n\
+             (a|b)\n\
+             grouped alternation\n\
+             a||b\n\
+             empty middle alternative"
+        );
     }
 
     #[test]
@@ -5133,21 +5122,6 @@ mod tests {
         let source = r"| Pattern |
 | --- |
 | `a\|b` |";
-        let rendered = render_markdown_with_code_span_link(
-            source,
-            |text, _cx| (text == "a|b").then(|| "file:///tmp/a-or-b".into()),
-            cx,
-        );
-
-        assert_eq!(rendered.links.len(), 1);
-        assert_eq!(rendered.links[0].destination_url, "file:///tmp/a-or-b");
-    }
-
-    #[gpui::test]
-    fn test_code_span_link_receives_raw_pipe_inline_code(cx: &mut TestAppContext) {
-        let source = r"| Pattern |
-| --- |
-| `a|b` |";
         let rendered = render_markdown_with_code_span_link(
             source,
             |text, _cx| (text == "a|b").then(|| "file:///tmp/a-or-b".into()),

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -1012,7 +1012,6 @@ fn mask_raw_pipes_in_inline_code_spans(
 ) {
     let bytes = line.as_bytes();
     let mut index = 0;
-    let mut code_span_ticks = None;
 
     while index < bytes.len() {
         if bytes[index] == b'`' && !is_backslash_escaped(bytes, index) {
@@ -1020,28 +1019,57 @@ fn mask_raw_pipes_in_inline_code_spans(
                 .iter()
                 .take_while(|byte| **byte == b'`')
                 .count();
-            match code_span_ticks {
-                Some(opening_ticks) if opening_ticks == tick_count => {
-                    code_span_ticks = None;
-                }
-                None => {
-                    code_span_ticks = Some(tick_count);
-                }
-                _ => {}
+            let content_start = index + tick_count;
+            if let Some(content_end) = find_closing_code_span(bytes, content_start, tick_count) {
+                mask_raw_pipes_in_range(
+                    original,
+                    bytes,
+                    line_start,
+                    content_start..content_end,
+                    masked,
+                );
+                index = content_end + tick_count;
+            } else {
+                index = content_start;
+            }
+        } else {
+            index += 1;
+        }
+    }
+}
+
+fn find_closing_code_span(bytes: &[u8], mut index: usize, opening_ticks: usize) -> Option<usize> {
+    while index < bytes.len() {
+        if bytes[index] == b'`' && !is_backslash_escaped(bytes, index) {
+            let tick_count = bytes[index..]
+                .iter()
+                .take_while(|byte| **byte == b'`')
+                .count();
+            if tick_count == opening_ticks {
+                return Some(index);
             }
             index += tick_count;
         } else {
-            if code_span_ticks.is_some()
-                && bytes[index] == b'|'
-                && !is_backslash_escaped(bytes, index)
-            {
-                let masked = masked.get_or_insert_with(|| original.to_owned());
-                masked.replace_range(
-                    line_start + index..line_start + index + 1,
-                    MASKED_RAW_PIPE_IN_CODE,
-                );
-            }
             index += 1;
+        }
+    }
+    None
+}
+
+fn mask_raw_pipes_in_range(
+    original: &str,
+    line_bytes: &[u8],
+    line_start: usize,
+    range: Range<usize>,
+    masked: &mut Option<String>,
+) {
+    for index in range {
+        if line_bytes[index] == b'|' && !is_backslash_escaped(line_bytes, index) {
+            let masked = masked.get_or_insert_with(|| original.to_owned());
+            masked.replace_range(
+                line_start + index..line_start + index + 1,
+                MASKED_RAW_PIPE_IN_CODE,
+            );
         }
     }
 }
@@ -1653,14 +1681,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_inline_code_preserves_raw_pipes_in_tables() {
-        let markdown = r"| Pattern | Meaning |
-| --- | --- |
-| ``^echo(\s|$)`` | command pattern |
-| `a|b` | alternation |
-| `(a|b)` | grouped alternation |
-| `a||b` | empty middle alternative |";
+    fn table_rows(markdown: &str) -> Vec<Vec<String>> {
         let parsed = parse_markdown_with_options(markdown, false, false, false);
         let mut rows = Vec::new();
         let mut current_row: Option<Vec<String>> = None;
@@ -1698,14 +1719,63 @@ mod tests {
             }
         }
 
+        rows
+    }
+
+    #[test]
+    fn test_inline_code_substitutes_escaped_pipes() {
+        let markdown = r"| Pattern |
+| --- |
+| `a\|b` |";
+        let parsed = parse_markdown_with_options(markdown, false, false);
+        let code_range = {
+            let start = markdown.find(r"a\|b").expect("inline code source");
+            start..start + r"a\|b".len()
+        };
+
+        assert!(
+            parsed
+                .events
+                .iter()
+                .any(|(range, event)| range == &code_range
+                    && event == &SubstitutedCode("a|b".into())),
+            "expected escaped pipe in table inline code to render as decoded inline code: {:?}",
+            parsed.events
+        );
+    }
+
+    #[test]
+    fn test_inline_code_preserves_raw_pipes_in_tables() {
+        let markdown = r"| Pattern | Meaning |
+| --- | --- |
+| ``^echo(\s|$)`` | command pattern |
+| `a|b` | alternation |
+| `(a|b)` | grouped alternation |
+| `a||b` | empty middle alternative |";
+
         assert_eq!(
-            rows,
+            table_rows(markdown),
             vec![
                 vec!["Pattern".to_string(), "Meaning".to_string()],
                 vec!["^echo(\\s|$)".to_string(), "command pattern".to_string()],
                 vec!["a|b".to_string(), "alternation".to_string()],
                 vec!["(a|b)".to_string(), "grouped alternation".to_string()],
                 vec!["a||b".to_string(), "empty middle alternative".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn test_unclosed_inline_code_does_not_mask_table_pipes() {
+        let markdown = r"| Pattern | Meaning |
+| --- | --- |
+| `a|b | broken |";
+
+        assert_eq!(
+            table_rows(markdown),
+            vec![
+                vec!["Pattern".to_string(), "Meaning".to_string()],
+                vec!["`a".to_string(), "b".to_string()],
             ]
         );
     }

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -10,6 +10,9 @@ use util::markdown::generate_heading_slug;
 
 use crate::{html, path_range::PathWithRange};
 
+// Keep masked parser input byte-aligned with the original markdown source.
+const MASKED_RAW_PIPE_IN_CODE: &str = "\u{1f}";
+
 pub const PARSE_OPTIONS: Options = Options::ENABLE_TABLES
     .union(Options::ENABLE_FOOTNOTES)
     .union(Options::ENABLE_STRIKETHROUGH)
@@ -250,7 +253,9 @@ pub(crate) fn parse_markdown_with_options(
     } else {
         PARSE_OPTIONS
     };
-    let mut parser = Parser::new_ext(text, parse_options)
+    let parser_text = mask_raw_pipes_in_inline_code(text);
+    let parser_text = parser_text.as_deref().unwrap_or(text);
+    let mut parser = Parser::new_ext(parser_text, parse_options)
         .into_offset_iter()
         .peekable();
     while let Some((pulldown_event, range)) = parser.next() {
@@ -922,6 +927,135 @@ fn unescape_table_pipes_in_code(text: &str) -> String {
     text.replace(r"\|", "|")
 }
 
+fn mask_raw_pipes_in_inline_code(text: &str) -> Option<String> {
+    let mut masked = None;
+    let mut line_start = 0;
+    let mut fenced_code_block: Option<(u8, usize)> = None;
+
+    while line_start < text.len() {
+        let line_end = text[line_start..]
+            .find('\n')
+            .map(|newline| line_start + newline)
+            .unwrap_or(text.len());
+        let line = &text[line_start..line_end];
+
+        if let Some((marker, minimum_len)) = fenced_code_block {
+            if let Some((closing_marker, closing_len)) = code_fence_marker(line)
+                && closing_marker == marker
+                && closing_len >= minimum_len
+            {
+                fenced_code_block = None;
+            }
+        } else if let Some(fence) = code_fence_marker(line) {
+            fenced_code_block = Some(fence);
+        } else if !is_indented_code_line(line) {
+            mask_raw_pipes_in_inline_code_spans(text, line, line_start, &mut masked);
+        }
+
+        if line_end == text.len() {
+            break;
+        }
+        line_start = line_end + 1;
+    }
+
+    masked
+}
+
+fn code_fence_marker(line: &str) -> Option<(u8, usize)> {
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    let mut leading_spaces = 0;
+
+    while index < bytes.len() && bytes[index] == b' ' && leading_spaces < 4 {
+        leading_spaces += 1;
+        index += 1;
+    }
+
+    if leading_spaces > 3 || index >= bytes.len() {
+        return None;
+    }
+
+    let marker = bytes[index];
+    if marker != b'`' && marker != b'~' {
+        return None;
+    }
+
+    let len = bytes[index..]
+        .iter()
+        .take_while(|byte| **byte == marker)
+        .count();
+    (len >= 3).then_some((marker, len))
+}
+
+fn is_indented_code_line(line: &str) -> bool {
+    let mut spaces = 0;
+    for byte in line.bytes() {
+        match byte {
+            b' ' => {
+                spaces += 1;
+                if spaces >= 4 {
+                    return true;
+                }
+            }
+            b'\t' => return true,
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn mask_raw_pipes_in_inline_code_spans(
+    original: &str,
+    line: &str,
+    line_start: usize,
+    masked: &mut Option<String>,
+) {
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    let mut code_span_ticks = None;
+
+    while index < bytes.len() {
+        if bytes[index] == b'`' && !is_backslash_escaped(bytes, index) {
+            let tick_count = bytes[index..]
+                .iter()
+                .take_while(|byte| **byte == b'`')
+                .count();
+            match code_span_ticks {
+                Some(opening_ticks) if opening_ticks == tick_count => {
+                    code_span_ticks = None;
+                }
+                None => {
+                    code_span_ticks = Some(tick_count);
+                }
+                _ => {}
+            }
+            index += tick_count;
+        } else {
+            if code_span_ticks.is_some()
+                && bytes[index] == b'|'
+                && !is_backslash_escaped(bytes, index)
+            {
+                let masked = masked.get_or_insert_with(|| original.to_owned());
+                masked.replace_range(
+                    line_start + index..line_start + index + 1,
+                    MASKED_RAW_PIPE_IN_CODE,
+                );
+            }
+            index += 1;
+        }
+    }
+}
+
+fn is_backslash_escaped(bytes: &[u8], index: usize) -> bool {
+    let mut backslash_count = 0;
+    let mut index = index;
+    while index > 0 && bytes[index - 1] == b'\\' {
+        backslash_count += 1;
+        index -= 1;
+    }
+    backslash_count % 2 == 1
+}
+
 pub(crate) fn extract_code_block_content_range(text: &str) -> Range<usize> {
     let mut range = 0..text.len();
     if text.starts_with("```") {
@@ -1516,6 +1650,61 @@ mod tests {
                     && event == &SubstitutedCode("a|b".into())),
             "expected escaped pipe in table inline code to render as decoded inline code: {:?}",
             parsed.events
+        );
+    }
+
+    #[test]
+    fn test_inline_code_preserves_raw_pipes_in_tables() {
+        let markdown = r"| Pattern | Meaning |
+| --- | --- |
+| `a|b` | alternation |
+| `(a|b)` | grouped alternation |
+| `a||b` | empty middle alternative |";
+        let parsed = parse_markdown_with_options(markdown, false, false, false);
+        let mut rows = Vec::new();
+        let mut current_row: Option<Vec<String>> = None;
+        let mut current_cell: Option<String> = None;
+
+        for (range, event) in &parsed.events {
+            match event {
+                Start(TableHead) | Start(TableRow) => {
+                    current_row = Some(Vec::new());
+                }
+                End(MarkdownTagEnd::TableHead) | End(MarkdownTagEnd::TableRow) => {
+                    if let Some(row) = current_row.take() {
+                        rows.push(row);
+                    }
+                }
+                Start(TableCell) => {
+                    current_cell = Some(String::new());
+                }
+                End(MarkdownTagEnd::TableCell) => {
+                    if let (Some(row), Some(cell)) = (&mut current_row, current_cell.take()) {
+                        row.push(cell.trim().to_string());
+                    }
+                }
+                Text | Code => {
+                    if let Some(cell) = &mut current_cell {
+                        cell.push_str(&markdown[range.clone()]);
+                    }
+                }
+                SubstitutedText(text) | SubstitutedCode(text) => {
+                    if let Some(cell) = &mut current_cell {
+                        cell.push_str(text);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        assert_eq!(
+            rows,
+            vec![
+                vec!["Pattern".to_string(), "Meaning".to_string()],
+                vec!["a|b".to_string(), "alternation".to_string()],
+                vec!["(a|b)".to_string(), "grouped alternation".to_string()],
+                vec!["a||b".to_string(), "empty middle alternative".to_string()],
+            ]
         );
     }
 

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -10,9 +10,6 @@ use util::markdown::generate_heading_slug;
 
 use crate::{html, path_range::PathWithRange};
 
-// Keep masked parser input byte-aligned with the original markdown source.
-const MASKED_RAW_PIPE_IN_CODE: &str = "\u{1f}";
-
 pub const PARSE_OPTIONS: Options = Options::ENABLE_TABLES
     .union(Options::ENABLE_FOOTNOTES)
     .union(Options::ENABLE_STRIKETHROUGH)
@@ -253,9 +250,7 @@ pub(crate) fn parse_markdown_with_options(
     } else {
         PARSE_OPTIONS
     };
-    let parser_text = mask_raw_pipes_in_inline_code(text);
-    let parser_text = parser_text.as_deref().unwrap_or(text);
-    let mut parser = Parser::new_ext(parser_text, parse_options)
+    let mut parser = Parser::new_ext(text, parse_options)
         .into_offset_iter()
         .peekable();
     while let Some((pulldown_event, range)) = parser.next() {
@@ -641,13 +636,13 @@ pub(crate) fn parse_markdown_with_options(
                     state.push_event(range, event);
                 }
             }
-            pulldown_cmark::Event::Code(_) => {
+            pulldown_cmark::Event::Code(parsed) => {
                 let content_range = extract_code_content_range(&text[range.clone()]);
                 let content_range =
                     content_range.start + range.start..content_range.end + range.start;
                 let source = &text[content_range.clone()];
                 let event = if within_table && source.contains(r"\|") {
-                    MarkdownEvent::SubstitutedCode(unescape_table_pipes_in_code(source))
+                    MarkdownEvent::SubstitutedCode(parsed.to_string())
                 } else {
                     MarkdownEvent::Code
                 };
@@ -921,183 +916,6 @@ fn extract_code_content_range(text: &str) -> Range<usize> {
     }
 
     start_ticks..text_len - end_ticks
-}
-
-fn unescape_table_pipes_in_code(text: &str) -> String {
-    text.replace(r"\|", "|")
-}
-
-fn mask_raw_pipes_in_inline_code(text: &str) -> Option<String> {
-    let mut masked = None;
-    let mut line_start = 0;
-    let mut fenced_code_block: Option<(u8, usize)> = None;
-
-    while line_start < text.len() {
-        let line_end = text[line_start..]
-            .find('\n')
-            .map(|newline| line_start + newline)
-            .unwrap_or(text.len());
-        let line = &text[line_start..line_end];
-
-        if let Some((marker, minimum_len)) = fenced_code_block {
-            if is_closing_code_fence(line, marker, minimum_len) {
-                fenced_code_block = None;
-            }
-        } else if let Some(fence) = opening_code_fence_marker(line) {
-            fenced_code_block = Some(fence);
-        } else if !is_indented_code_line(line) {
-            mask_raw_pipes_in_inline_code_spans(text, line, line_start, &mut masked);
-        }
-
-        if line_end == text.len() {
-            break;
-        }
-        line_start = line_end + 1;
-    }
-
-    masked
-}
-
-fn opening_code_fence_marker(line: &str) -> Option<(u8, usize)> {
-    let bytes = line.as_bytes();
-    let (index, marker, len) = code_fence_marker_start(bytes)?;
-    if marker == b'`' && bytes[index + len..].contains(&b'`') {
-        return None;
-    }
-    Some((marker, len))
-}
-
-fn is_closing_code_fence(line: &str, marker: u8, minimum_len: usize) -> bool {
-    let bytes = line.as_bytes();
-    let Some((index, closing_marker, len)) = code_fence_marker_start(bytes) else {
-        return false;
-    };
-    closing_marker == marker
-        && len >= minimum_len
-        && bytes[index + len..]
-            .iter()
-            .all(|byte| *byte == b' ' || *byte == b'\t')
-}
-
-fn code_fence_marker_start(bytes: &[u8]) -> Option<(usize, u8, usize)> {
-    let mut index = 0;
-    let mut leading_spaces = 0;
-    while index < bytes.len() && bytes[index] == b' ' && leading_spaces < 4 {
-        leading_spaces += 1;
-        index += 1;
-    }
-
-    if leading_spaces > 3 || index >= bytes.len() {
-        return None;
-    }
-
-    let marker = bytes[index];
-    if marker != b'`' && marker != b'~' {
-        return None;
-    }
-
-    let len = bytes[index..]
-        .iter()
-        .take_while(|byte| **byte == marker)
-        .count();
-    (len >= 3).then_some((index, marker, len))
-}
-
-fn is_indented_code_line(line: &str) -> bool {
-    let mut spaces = 0;
-    for byte in line.bytes() {
-        match byte {
-            b' ' => {
-                spaces += 1;
-                if spaces >= 4 {
-                    return true;
-                }
-            }
-            b'\t' => return true,
-            _ => return false,
-        }
-    }
-    false
-}
-
-fn mask_raw_pipes_in_inline_code_spans(
-    original: &str,
-    line: &str,
-    line_start: usize,
-    masked: &mut Option<String>,
-) {
-    let bytes = line.as_bytes();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        if bytes[index] == b'`' && !is_backslash_escaped(bytes, index) {
-            let tick_count = bytes[index..]
-                .iter()
-                .take_while(|byte| **byte == b'`')
-                .count();
-            let content_start = index + tick_count;
-            if let Some(content_end) = find_closing_code_span(bytes, content_start, tick_count) {
-                mask_raw_pipes_in_range(
-                    original,
-                    bytes,
-                    line_start,
-                    content_start..content_end,
-                    masked,
-                );
-                index = content_end + tick_count;
-            } else {
-                index = content_start;
-            }
-        } else {
-            index += 1;
-        }
-    }
-}
-
-fn find_closing_code_span(bytes: &[u8], mut index: usize, opening_ticks: usize) -> Option<usize> {
-    while index < bytes.len() {
-        if bytes[index] == b'`' && !is_backslash_escaped(bytes, index) {
-            let tick_count = bytes[index..]
-                .iter()
-                .take_while(|byte| **byte == b'`')
-                .count();
-            if tick_count == opening_ticks {
-                return Some(index);
-            }
-            index += tick_count;
-        } else {
-            index += 1;
-        }
-    }
-    None
-}
-
-fn mask_raw_pipes_in_range(
-    original: &str,
-    line_bytes: &[u8],
-    line_start: usize,
-    range: Range<usize>,
-    masked: &mut Option<String>,
-) {
-    for index in range {
-        if line_bytes[index] == b'|' && !is_backslash_escaped(line_bytes, index) {
-            let masked = masked.get_or_insert_with(|| original.to_owned());
-            masked.replace_range(
-                line_start + index..line_start + index + 1,
-                MASKED_RAW_PIPE_IN_CODE,
-            );
-        }
-    }
-}
-
-fn is_backslash_escaped(bytes: &[u8], index: usize) -> bool {
-    let mut backslash_count = 0;
-    let mut index = index;
-    while index > 0 && bytes[index - 1] == b'\\' {
-        backslash_count += 1;
-        index -= 1;
-    }
-    backslash_count % 2 == 1
 }
 
 pub(crate) fn extract_code_block_content_range(text: &str) -> Range<usize> {
@@ -1551,27 +1369,6 @@ mod tests {
         );
     }
 
-    fn test_invalid_closing_fence_keeps_table_pipes_unmasked() {
-        let markdown = "```text\n``` not a closing fence\n| `a|b` | still code |\n```\n";
-        let parsed = parse_markdown_with_options(markdown, false, false);
-
-        assert!(
-            parsed.events.iter().all(|(_, event)| !matches!(
-                event,
-                SubstitutedText(text) if text.contains(MASKED_RAW_PIPE_IN_CODE)
-            )),
-            "fenced code block contents should not be masked: {:?}",
-            parsed.events
-        );
-        assert!(
-            parsed.events.iter().any(|(range, event)| {
-                event == &Text && markdown[range.clone()].contains("| `a|b` | still code |")
-            }),
-            "expected fenced code block text to retain raw pipes: {:?}",
-            parsed.events
-        );
-    }
-
     #[test]
     fn test_metadata_blocks_are_root_blocks() {
         assert_eq!(
@@ -1696,47 +1493,6 @@ mod tests {
         assert_eq!(extract_code_content_range(input), 0..13);
     }
 
-    fn table_rows(markdown: &str) -> Vec<Vec<String>> {
-        let parsed = parse_markdown_with_options(markdown, false, false, false);
-        let mut rows = Vec::new();
-        let mut current_row: Option<Vec<String>> = None;
-        let mut current_cell: Option<String> = None;
-
-        for (range, event) in &parsed.events {
-            match event {
-                Start(TableHead) | Start(TableRow) => {
-                    current_row = Some(Vec::new());
-                }
-                End(MarkdownTagEnd::TableHead) | End(MarkdownTagEnd::TableRow) => {
-                    if let Some(row) = current_row.take() {
-                        rows.push(row);
-                    }
-                }
-                Start(TableCell) => {
-                    current_cell = Some(String::new());
-                }
-                End(MarkdownTagEnd::TableCell) => {
-                    if let (Some(row), Some(cell)) = (&mut current_row, current_cell.take()) {
-                        row.push(cell.trim().to_string());
-                    }
-                }
-                Text | Code => {
-                    if let Some(cell) = &mut current_cell {
-                        cell.push_str(&markdown[range.clone()]);
-                    }
-                }
-                SubstitutedText(text) | SubstitutedCode(text) => {
-                    if let Some(cell) = &mut current_cell {
-                        cell.push_str(text);
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        rows
-    }
-
     #[test]
     fn test_inline_code_substitutes_escaped_pipes() {
         let markdown = r"| Pattern |
@@ -1756,42 +1512,6 @@ mod tests {
                     && event == &SubstitutedCode("a|b".into())),
             "expected escaped pipe in table inline code to render as decoded inline code: {:?}",
             parsed.events
-        );
-    }
-
-    #[test]
-    fn test_inline_code_preserves_raw_pipes_in_tables() {
-        let markdown = r"| Pattern | Meaning |
-| --- | --- |
-| ``^echo(\s|$)`` | command pattern |
-| `a|b` | alternation |
-| `(a|b)` | grouped alternation |
-| `a||b` | empty middle alternative |";
-
-        assert_eq!(
-            table_rows(markdown),
-            vec![
-                vec!["Pattern".to_string(), "Meaning".to_string()],
-                vec!["^echo(\\s|$)".to_string(), "command pattern".to_string()],
-                vec!["a|b".to_string(), "alternation".to_string()],
-                vec!["(a|b)".to_string(), "grouped alternation".to_string()],
-                vec!["a||b".to_string(), "empty middle alternative".to_string()],
-            ]
-        );
-    }
-
-    #[test]
-    fn test_unclosed_inline_code_does_not_mask_table_pipes() {
-        let markdown = r"| Pattern | Meaning |
-| --- | --- |
-| `a|b | broken |";
-
-        assert_eq!(
-            table_rows(markdown),
-            vec![
-                vec!["Pattern".to_string(), "Meaning".to_string()],
-                vec!["`a".to_string(), "b".to_string()],
-            ]
         );
     }
 

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -940,13 +940,10 @@ fn mask_raw_pipes_in_inline_code(text: &str) -> Option<String> {
         let line = &text[line_start..line_end];
 
         if let Some((marker, minimum_len)) = fenced_code_block {
-            if let Some((closing_marker, closing_len)) = code_fence_marker(line)
-                && closing_marker == marker
-                && closing_len >= minimum_len
-            {
+            if is_closing_code_fence(line, marker, minimum_len) {
                 fenced_code_block = None;
             }
-        } else if let Some(fence) = code_fence_marker(line) {
+        } else if let Some(fence) = opening_code_fence_marker(line) {
             fenced_code_block = Some(fence);
         } else if !is_indented_code_line(line) {
             mask_raw_pipes_in_inline_code_spans(text, line, line_start, &mut masked);
@@ -961,11 +958,30 @@ fn mask_raw_pipes_in_inline_code(text: &str) -> Option<String> {
     masked
 }
 
-fn code_fence_marker(line: &str) -> Option<(u8, usize)> {
+fn opening_code_fence_marker(line: &str) -> Option<(u8, usize)> {
     let bytes = line.as_bytes();
+    let (index, marker, len) = code_fence_marker_start(bytes)?;
+    if marker == b'`' && bytes[index + len..].contains(&b'`') {
+        return None;
+    }
+    Some((marker, len))
+}
+
+fn is_closing_code_fence(line: &str, marker: u8, minimum_len: usize) -> bool {
+    let bytes = line.as_bytes();
+    let Some((index, closing_marker, len)) = code_fence_marker_start(bytes) else {
+        return false;
+    };
+    closing_marker == marker
+        && len >= minimum_len
+        && bytes[index + len..]
+            .iter()
+            .all(|byte| *byte == b' ' || *byte == b'\t')
+}
+
+fn code_fence_marker_start(bytes: &[u8]) -> Option<(usize, u8, usize)> {
     let mut index = 0;
     let mut leading_spaces = 0;
-
     while index < bytes.len() && bytes[index] == b' ' && leading_spaces < 4 {
         leading_spaces += 1;
         index += 1;
@@ -984,7 +1000,7 @@ fn code_fence_marker(line: &str) -> Option<(u8, usize)> {
         .iter()
         .take_while(|byte| **byte == marker)
         .count();
-    (len >= 3).then_some((marker, len))
+    (len >= 3).then_some((index, marker, len))
 }
 
 fn is_indented_code_line(line: &str) -> bool {
@@ -1535,6 +1551,27 @@ mod tests {
         );
     }
 
+    fn test_invalid_closing_fence_keeps_table_pipes_unmasked() {
+        let markdown = "```text\n``` not a closing fence\n| `a|b` | still code |\n```\n";
+        let parsed = parse_markdown_with_options(markdown, false, false);
+
+        assert!(
+            parsed.events.iter().all(|(_, event)| !matches!(
+                event,
+                SubstitutedText(text) if text.contains(MASKED_RAW_PIPE_IN_CODE)
+            )),
+            "fenced code block contents should not be masked: {:?}",
+            parsed.events
+        );
+        assert!(
+            parsed.events.iter().any(|(range, event)| {
+                event == &Text && markdown[range.clone()].contains("| `a|b` | still code |")
+            }),
+            "expected fenced code block text to retain raw pipes: {:?}",
+            parsed.events
+        );
+    }
+
     #[test]
     fn test_metadata_blocks_are_root_blocks() {
         assert_eq!(
@@ -1659,28 +1696,6 @@ mod tests {
         assert_eq!(extract_code_content_range(input), 0..13);
     }
 
-    #[test]
-    fn test_inline_code_substitutes_escaped_pipes() {
-        let markdown = r"| Pattern |
-| --- |
-| `a\|b` |";
-        let parsed = parse_markdown_with_options(markdown, false, false, false);
-        let code_range = {
-            let start = markdown.find(r"a\|b").expect("inline code source");
-            start..start + r"a\|b".len()
-        };
-
-        assert!(
-            parsed
-                .events
-                .iter()
-                .any(|(range, event)| range == &code_range
-                    && event == &SubstitutedCode("a|b".into())),
-            "expected escaped pipe in table inline code to render as decoded inline code: {:?}",
-            parsed.events
-        );
-    }
-
     fn table_rows(markdown: &str) -> Vec<Vec<String>> {
         let parsed = parse_markdown_with_options(markdown, false, false, false);
         let mut rows = Vec::new();
@@ -1727,7 +1742,7 @@ mod tests {
         let markdown = r"| Pattern |
 | --- |
 | `a\|b` |";
-        let parsed = parse_markdown_with_options(markdown, false, false);
+        let parsed = parse_markdown_with_options(markdown, false, false, false);
         let code_range = {
             let start = markdown.find(r"a\|b").expect("inline code source");
             start..start + r"a\|b".len()

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -1709,6 +1709,57 @@ mod tests {
     }
 
     #[test]
+    fn test_double_tick_inline_code_preserves_raw_pipes_in_tables() {
+        let markdown = r"| Pattern | Meaning |
+| --- | --- |
+| ``^echo(\s|$)`` | command pattern |";
+        let parsed = parse_markdown_with_options(markdown, false, false);
+        let mut rows = Vec::new();
+        let mut current_row: Option<Vec<String>> = None;
+        let mut current_cell: Option<String> = None;
+
+        for (range, event) in &parsed.events {
+            match event {
+                Start(TableHead) | Start(TableRow) => {
+                    current_row = Some(Vec::new());
+                }
+                End(MarkdownTagEnd::TableHead) | End(MarkdownTagEnd::TableRow) => {
+                    if let Some(row) = current_row.take() {
+                        rows.push(row);
+                    }
+                }
+                Start(TableCell) => {
+                    current_cell = Some(String::new());
+                }
+                End(MarkdownTagEnd::TableCell) => {
+                    if let (Some(row), Some(cell)) = (&mut current_row, current_cell.take()) {
+                        row.push(cell.trim().to_string());
+                    }
+                }
+                Text | Code => {
+                    if let Some(cell) = &mut current_cell {
+                        cell.push_str(&markdown[range.clone()]);
+                    }
+                }
+                SubstitutedText(text) | SubstitutedCode(text) => {
+                    if let Some(cell) = &mut current_cell {
+                        cell.push_str(text);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        assert_eq!(
+            rows,
+            vec![
+                vec!["Pattern".to_string(), "Meaning".to_string()],
+                vec!["^echo(\\s|$)".to_string(), "command pattern".to_string()],
+            ]
+        );
+    }
+
+    #[test]
     fn test_inline_code_keeps_escaped_pipes_outside_tables() {
         let markdown = r"`a\|b`";
         let parsed = parse_markdown_with_options(markdown, false, false, false);

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -149,6 +149,12 @@ fn build_heading_slugs(
                 }
                 heading_text.push_str(&source[range.clone()]);
             }
+            MarkdownEvent::SubstitutedCode(substituted) if inside_heading => {
+                if heading_source_start.is_none() {
+                    heading_source_start = Some(range.start);
+                }
+                heading_text.push_str(substituted);
+            }
             MarkdownEvent::SubstitutedText(substituted) if inside_heading => {
                 if heading_source_start.is_none() {
                     heading_source_start = Some(range.start);
@@ -236,6 +242,7 @@ pub(crate) fn parse_markdown_with_options(
     let mut within_link = false;
     let mut within_code_block = false;
     let mut within_metadata = false;
+    let mut within_table = false;
     let mut current_metadata_block_start = None;
     let mut metadata_block_content_range: Option<Range<usize>> = None;
     let parse_options = if parse_metadata_blocks {
@@ -402,7 +409,10 @@ pub(crate) fn parse_markdown_with_options(
                     pulldown_cmark::Tag::FootnoteDefinition(label) => {
                         MarkdownTag::FootnoteDefinition(SharedString::from(label.to_string()))
                     }
-                    pulldown_cmark::Tag::Table(alignments) => MarkdownTag::Table(alignments),
+                    pulldown_cmark::Tag::Table(alignments) => {
+                        within_table = true;
+                        MarkdownTag::Table(alignments)
+                    }
                     pulldown_cmark::Tag::TableHead => MarkdownTag::TableHead,
                     pulldown_cmark::Tag::TableRow => MarkdownTag::TableRow,
                     pulldown_cmark::Tag::TableCell => MarkdownTag::TableCell,
@@ -455,6 +465,8 @@ pub(crate) fn parse_markdown_with_options(
                     if !parse_metadata_blocks {
                         continue;
                     }
+                } else if let pulldown_cmark::TagEnd::Table = tag {
+                    within_table = false;
                 }
                 state.push_event(range, MarkdownEvent::End(tag));
             }
@@ -628,7 +640,13 @@ pub(crate) fn parse_markdown_with_options(
                 let content_range = extract_code_content_range(&text[range.clone()]);
                 let content_range =
                     content_range.start + range.start..content_range.end + range.start;
-                state.push_event(content_range, MarkdownEvent::Code)
+                let source = &text[content_range.clone()];
+                let event = if within_table && source.contains(r"\|") {
+                    MarkdownEvent::SubstitutedCode(unescape_table_pipes_in_code(source))
+                } else {
+                    MarkdownEvent::Code
+                };
+                state.push_event(content_range, event)
             }
             pulldown_cmark::Event::Html(_) => state.push_event(range, MarkdownEvent::Html),
             pulldown_cmark::Event::InlineHtml(html) => {
@@ -751,6 +769,8 @@ pub enum MarkdownEvent {
     SubstitutedText(String),
     /// An inline code node.
     Code,
+    /// An inline code node that differs from the markdown source due to escape decoding.
+    SubstitutedCode(String),
     /// An HTML node.
     Html,
     /// An inline HTML node.
@@ -896,6 +916,10 @@ fn extract_code_content_range(text: &str) -> Range<usize> {
     }
 
     start_ticks..text_len - end_ticks
+}
+
+fn unescape_table_pipes_in_code(text: &str) -> String {
+    text.replace(r"\|", "|")
 }
 
 pub(crate) fn extract_code_block_content_range(text: &str) -> Range<usize> {
@@ -1471,6 +1495,43 @@ mod tests {
 
         let input = "``let x = 5;`";
         assert_eq!(extract_code_content_range(input), 0..13);
+    }
+
+    #[test]
+    fn test_inline_code_substitutes_escaped_pipes() {
+        let markdown = r"| Pattern |
+| --- |
+| `a\|b` |";
+        let parsed = parse_markdown_with_options(markdown, false, false, false);
+        let code_range = {
+            let start = markdown.find(r"a\|b").expect("inline code source");
+            start..start + r"a\|b".len()
+        };
+
+        assert!(
+            parsed
+                .events
+                .iter()
+                .any(|(range, event)| range == &code_range
+                    && event == &SubstitutedCode("a|b".into())),
+            "expected escaped pipe in table inline code to render as decoded inline code: {:?}",
+            parsed.events
+        );
+    }
+
+    #[test]
+    fn test_inline_code_keeps_escaped_pipes_outside_tables() {
+        let markdown = r"`a\|b`";
+        let parsed = parse_markdown_with_options(markdown, false, false, false);
+
+        assert!(
+            parsed
+                .events
+                .iter()
+                .any(|(range, event)| range == &(1..5) && event == &Code),
+            "expected escaped pipe outside a table to remain normal inline code: {:?}",
+            parsed.events
+        );
     }
 
     #[test]

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -1657,6 +1657,7 @@ mod tests {
     fn test_inline_code_preserves_raw_pipes_in_tables() {
         let markdown = r"| Pattern | Meaning |
 | --- | --- |
+| ``^echo(\s|$)`` | command pattern |
 | `a|b` | alternation |
 | `(a|b)` | grouped alternation |
 | `a||b` | empty middle alternative |";
@@ -1701,60 +1702,10 @@ mod tests {
             rows,
             vec![
                 vec!["Pattern".to_string(), "Meaning".to_string()],
+                vec!["^echo(\\s|$)".to_string(), "command pattern".to_string()],
                 vec!["a|b".to_string(), "alternation".to_string()],
                 vec!["(a|b)".to_string(), "grouped alternation".to_string()],
                 vec!["a||b".to_string(), "empty middle alternative".to_string()],
-            ]
-        );
-    }
-
-    #[test]
-    fn test_double_tick_inline_code_preserves_raw_pipes_in_tables() {
-        let markdown = r"| Pattern | Meaning |
-| --- | --- |
-| ``^echo(\s|$)`` | command pattern |";
-        let parsed = parse_markdown_with_options(markdown, false, false);
-        let mut rows = Vec::new();
-        let mut current_row: Option<Vec<String>> = None;
-        let mut current_cell: Option<String> = None;
-
-        for (range, event) in &parsed.events {
-            match event {
-                Start(TableHead) | Start(TableRow) => {
-                    current_row = Some(Vec::new());
-                }
-                End(MarkdownTagEnd::TableHead) | End(MarkdownTagEnd::TableRow) => {
-                    if let Some(row) = current_row.take() {
-                        rows.push(row);
-                    }
-                }
-                Start(TableCell) => {
-                    current_cell = Some(String::new());
-                }
-                End(MarkdownTagEnd::TableCell) => {
-                    if let (Some(row), Some(cell)) = (&mut current_row, current_cell.take()) {
-                        row.push(cell.trim().to_string());
-                    }
-                }
-                Text | Code => {
-                    if let Some(cell) = &mut current_cell {
-                        cell.push_str(&markdown[range.clone()]);
-                    }
-                }
-                SubstitutedText(text) | SubstitutedCode(text) => {
-                    if let Some(cell) = &mut current_cell {
-                        cell.push_str(text);
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        assert_eq!(
-            rows,
-            vec![
-                vec!["Pattern".to_string(), "Meaning".to_string()],
-                vec!["^echo(\\s|$)".to_string(), "command pattern".to_string()],
             ]
         );
     }


### PR DESCRIPTION
## Summary

Fixes markdown table rendering when inline code spans contain pipe characters. Code such as `` `a|b` `` and `` `a||b` `` now stays in one table cell instead of being split into extra columns.

## Why

Agent output and markdown previews can include regexes, shell snippets, and other code spans with `|` characters inside tables. Before this change, those pipes could be parsed as table delimiters even though they were part of inline code.

## Changes

- Masks raw pipes only inside matched inline code spans before `pulldown-cmark` parses tables.
- Restores rendered code-span text from the original source range, including escaped table pipes.
- Avoids masking unmatched backticks, fenced code blocks, indented code blocks, and invalid fence closers.
- Adds parser and renderer coverage for raw pipes, escaped pipes, unmatched inline code, invalid fences, and code-span link callbacks.

Manual check: generated agent responses across multiple models render tables containing `` `a|b` ``, `` `(a|b)` ``, and `` `a||b` `` as single code-span cells rather than split columns.

## Screenshots / Recordings

| Before | After |
| --- | --- |
| <img width="702" height="532" alt="Before" src="https://github.com/user-attachments/assets/f9b7606f-15d5-41bc-980c-5e26337f9be4"> | <img width="846" height="536" alt="After" src="https://github.com/user-attachments/assets/60a7a9bf-8417-4146-ac37-0725dd8b4e3c"> |

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #57683

Release Notes:

- Fixed markdown table rendering for inline code spans that contain pipe characters.