### PR TITLE
terminal_view: Use backslash escaping for dropped file paths for mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,7 @@ dependencies = [
  "serde_json",
  "serde_json_lenient",
  "settings",
+ "shlex",
  "streaming_diff",
  "task",
  "telemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18419,6 +18419,7 @@ dependencies = [
  "serde_json",
  "settings",
  "shellexpand",
+ "shlex",
  "task",
  "terminal",
  "theme",

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -143,6 +143,7 @@ remote_server = { workspace = true, features = ["test-support"] }
 
 search = { workspace = true, features = ["test-support"] }
 semver.workspace = true
+shlex.workspace = true
 reqwest_client.workspace = true
 tempfile.workspace = true
 vim.workspace = true

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -9038,7 +9038,7 @@ mod tests {
         let mut text = String::new();
         for path in paths {
             text.push(' ');
-            text.push_str(&format!("{path:?}"));
+            text.push_str(&shlex::try_quote(path.to_str().unwrap()).unwrap());
         }
         text.push(' ');
         text

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -32,13 +32,14 @@ menu.workspace = true
 pretty_assertions.workspace = true
 project.workspace = true
 regex.workspace = true
-task.workspace = true
 schemars.workspace = true
+task.workspace = true
 
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 shellexpand.workspace = true
+shlex.workspace = true
 terminal.workspace = true
 theme.workspace = true
 theme_settings.workspace = true

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -959,7 +959,7 @@ impl TerminalView {
     pub fn add_paths_to_terminal(&self, paths: &[PathBuf], window: &mut Window, cx: &mut App) {
         let mut text = paths
             .iter()
-            .map(|path| format!(" {}", shell_escape_path(path)))
+            .filter_map(|path| Some(format!(" {}", shlex::try_quote(path.to_str()?).ok()?)))
             .collect::<String>();
         text.push(' ');
         window.focus(&self.focus_handle(cx), cx);
@@ -1097,28 +1097,6 @@ impl TerminalView {
                 }),
         )
     }
-}
-
-#[cfg(unix)]
-fn shell_escape_path(path: &std::path::Path) -> String {
-    let s = path.to_string_lossy();
-    let mut result = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            ' ' | '!' | '"' | '#' | '$' | '&' | '\'' | '(' | ')' | '*' | ',' | ';' | '<' | '>'
-            | '?' | '[' | '\\' | ']' | '^' | '`' | '{' | '|' | '}' | '~' | '\t' | '\n' => {
-                result.push('\\');
-                result.push(c);
-            }
-            _ => result.push(c),
-        }
-    }
-    result
-}
-
-#[cfg(not(unix))]
-fn shell_escape_path(path: &std::path::Path) -> String {
-    format!("{path:?}")
 }
 
 fn terminal_rerun_override(task: &TaskId) -> zed_actions::Rerun {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -959,7 +959,7 @@ impl TerminalView {
     pub fn add_paths_to_terminal(&self, paths: &[PathBuf], window: &mut Window, cx: &mut App) {
         let mut text = paths
             .iter()
-            .map(|path| format!(" {path:?}"))
+            .map(|path| format!(" {}", shell_escape_path(path)))
             .collect::<String>();
         text.push(' ');
         window.focus(&self.focus_handle(cx), cx);
@@ -1097,6 +1097,28 @@ impl TerminalView {
                 }),
         )
     }
+}
+
+#[cfg(unix)]
+fn shell_escape_path(path: &std::path::Path) -> String {
+    let s = path.to_string_lossy();
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            ' ' | '!' | '"' | '#' | '$' | '&' | '\'' | '(' | ')' | '*' | ',' | ';' | '<' | '>'
+            | '?' | '[' | '\\' | ']' | '^' | '`' | '{' | '|' | '}' | '~' | '\t' | '\n' => {
+                result.push('\\');
+                result.push(c);
+            }
+            _ => result.push(c),
+        }
+    }
+    result
+}
+
+#[cfg(not(unix))]
+fn shell_escape_path(path: &std::path::Path) -> String {
+    format!("{path:?}")
 }
 
 fn terminal_rerun_override(task: &TaskId) -> zed_actions::Rerun {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -2176,7 +2176,7 @@ mod tests {
         let mut text = String::new();
         for path in paths {
             text.push(' ');
-            text.push_str(&format!("{path:?}"));
+            text.push_str(&shlex::try_quote(path.to_str().unwrap()).unwrap());
         }
         text.push(' ');
         text


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

When files are dragged into the terminal, paths were formatted using Rust's Debug format (`{path:?}`), which wraps them in double quotes. This caused issues with programs like Claude Code that parse bare paths from terminal input — quoted paths were treated as plain text instead of file references.

This change replaces double-quote wrapping with backslash escaping for special shell characters on Unix, which is both valid shell syntax and compatible with path-parsing tools running in the terminal. On non-Unix platforms the previous behavior is preserved.

Tested on macOS only. Unable to verify Windows behavior.

Fixes #57471

Release Notes:

  - Fixed/ file drag-and-drop into terminal inserting double-quoted paths, which prevented tools like Claude Code from recognizing them as file references.
