### PR TITLE
lsp: Handle dynamic registration of textDocument/documentLink

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -13076,6 +13076,18 @@ impl LspStore {
                     });
                     notify_server_capabilities_updated(&server, cx);
                 }
+                "textDocument/documentLink" => {
+                    if let Some(caps) = reg
+                        .register_options
+                        .map(serde_json::from_value)
+                        .transpose()?
+                    {
+                        server.update_capabilities(|capabilities| {
+                            capabilities.document_link_provider = Some(caps);
+                        });
+                        notify_server_capabilities_updated(&server, cx);
+                    }
+                }
                 _ => log::warn!("unhandled capability registration: {reg:?}"),
             }
         }
@@ -13276,6 +13288,12 @@ impl LspStore {
                 "textDocument/foldingRange" => {
                     server.update_capabilities(|capabilities| {
                         capabilities.folding_range_provider = None;
+                    });
+                    notify_server_capabilities_updated(&server, cx);
+                }
+                "textDocument/documentLink" => {
+                    server.update_capabilities(|capabilities| {
+                        capabilities.document_link_provider = None;
                     });
                     notify_server_capabilities_updated(&server, cx);
                 }


### PR DESCRIPTION
`register_server_capabilities` / `unregister_server_capabilities` had no arm for `textDocument/documentLink`, so when a server saw our `documentLink.dynamicRegistration` capability and chose to register the provider dynamically, the registration silently fell into the `unhandled capability registration` warning. `document_link_provider` stayed `None`, `GetDocumentLinks::check_capabilities` returned false, and no `textDocument/documentLink` request was ever sent.

Follow-up to https://github.com/zed-industries/zed/pull/56011

Release Notes:

- N/A