### PR TITLE
copilot_chat: Support SDK auth.db and reload via LSP didChangeStatus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3704,6 +3704,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
+ "sqlez",
 ]
 
 [[package]]

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1259,6 +1259,7 @@ impl Copilot {
                 | request::SignInStatus::AlreadySignedIn { .. } => {
                     server.sign_in_status = SignInStatus::Authorized;
                     cx.emit(Event::CopilotAuthSignedIn);
+                    notify_copilot_chat_auth_changed(cx);
                     for buffer in self.buffers.iter().cloned().collect::<Vec<_>>() {
                         if let Some(buffer) = buffer.upgrade() {
                             self.register_buffer(&buffer, cx);
@@ -1278,6 +1279,7 @@ impl Copilot {
                         };
                     }
                     cx.emit(Event::CopilotAuthSignedOut);
+                    notify_copilot_chat_auth_changed(cx);
                     for buffer in self.buffers.iter().cloned().collect::<Vec<_>>() {
                         self.unregister_buffer(&buffer);
                     }
@@ -1379,6 +1381,17 @@ fn notify_did_change_config_to_server(
         })
         .ok();
     Ok(())
+}
+
+/// Notify the `copilot_chat` global that the Copilot auth state may have
+/// changed (sign-in, sign-out, account switch). This is the LSP's
+/// `didChangeStatus` notification turned into a cross-crate poke: it
+/// replaces a previous filesystem watcher on the Copilot SDK's config
+/// directory, which was unreliable for SQLite writes on Windows.
+fn notify_copilot_chat_auth_changed(cx: &mut Context<Copilot>) {
+    if let Some(copilot_chat) = copilot_chat::CopilotChat::global(cx) {
+        copilot_chat.update(cx, |chat, cx| chat.reload_auth(cx));
+    }
 }
 
 async fn clear_copilot_dir() {

--- a/crates/copilot_chat/Cargo.toml
+++ b/crates/copilot_chat/Cargo.toml
@@ -34,6 +34,7 @@ paths.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
+sqlez.workspace = true
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -17,8 +17,6 @@ use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
 use paths::home_dir;
 use serde::{Deserialize, Serialize};
 
-use settings::watch_config_dir;
-
 pub const COPILOT_OAUTH_ENV_VAR: &str = "GH_COPILOT_TOKEN";
 const DEFAULT_COPILOT_API_ENDPOINT: &str = "https://api.githubcopilot.com";
 
@@ -501,6 +499,7 @@ pub struct CopilotChat {
     configuration: CopilotChatConfiguration,
     models: Option<Vec<Model>>,
     client: Arc<dyn HttpClient>,
+    fs: Arc<dyn Fs>,
 }
 
 pub fn init(
@@ -529,6 +528,18 @@ pub fn copilot_chat_config_dir() -> &'static PathBuf {
     })
 }
 
+/// Legacy JSON token-storage paths used by older Copilot SDK builds.
+/// Current SDK builds write `auth.db` instead (see
+/// `extract_oauth_token_from_db`). This helper, `extract_oauth_token`,
+/// and the JSON branch of `read_oauth_token` exist purely for backwards
+/// compatibility with users who authenticated before the SDK migration
+/// and still have a valid `apps.json` / `hosts.json` on disk.
+///
+/// TODO: once the GitHub Copilot SDK officially deprecates the JSON
+/// stores, drop this function, `extract_oauth_token`, and the JSON loop
+/// in `read_oauth_token`. At that point `read_oauth_token` collapses to
+/// just `extract_oauth_token_from_db` and the `config_paths` /
+/// `HashSet<PathBuf>` plumbing can go too.
 fn copilot_chat_config_paths() -> [PathBuf; 2] {
     let base_dir = copilot_chat_config_dir();
     [base_dir.join("hosts.json"), base_dir.join("apps.json")]
@@ -546,40 +557,51 @@ impl CopilotChat {
         configuration: CopilotChatConfiguration,
         cx: &mut Context<Self>,
     ) -> Self {
-        let config_paths: HashSet<PathBuf> = copilot_chat_config_paths().into_iter().collect();
-        let dir_path = copilot_chat_config_dir();
-
+        // Initial async scan of token sources (JSON files + auth.db).
+        // Live reload is driven by `reload_auth()`, called from the
+        // `copilot` crate when its LSP fires `didChangeStatus`. We do
+        // not watch the filesystem directly: SQLite writes its WAL
+        // alongside the main file and finalises with rename/replace
+        // operations whose ordering and visibility differ across
+        // platforms, so a `fs.watch` loop over the config dir is racy
+        // (we observed it firing before the token row is committed,
+        // and missing later commits on Windows). The LSP already knows
+        // when auth state changes and gives us a clean, semantic
+        // signal that works the same way on every platform.
+        let fs_for_scan = fs.clone();
         cx.spawn(async move |this, cx| {
-            let mut parent_watch_rx = watch_config_dir(
-                cx.background_executor(),
-                fs.clone(),
-                dir_path.clone(),
-                config_paths,
-            );
-            while let Some(contents) = parent_watch_rx.next().await {
-                let oauth_domain =
-                    this.read_with(cx, |this, _| this.configuration.oauth_domain())?;
-                let oauth_token = extract_oauth_token(contents, &oauth_domain);
+            let oauth_domain =
+                this.read_with(cx, |this, _| this.configuration.oauth_domain())?;
+            let config_paths: HashSet<PathBuf> =
+                copilot_chat_config_paths().into_iter().collect();
+            let auth_db_path = copilot_chat_config_dir().join("auth.db");
 
+            let oauth_token =
+                read_oauth_token(&fs_for_scan, &config_paths, &oauth_domain, &auth_db_path).await;
+            if oauth_token.is_some() {
                 this.update(cx, |this, cx| {
-                    this.oauth_token = oauth_token.clone();
+                    this.oauth_token = oauth_token;
                     cx.notify();
                 })?;
-
-                if oauth_token.is_some() {
-                    Self::update_models(&this, cx).await?;
-                }
+                Self::update_models(&this, cx).await?;
             }
             anyhow::Ok(())
         })
         .detach_and_log_err(cx);
 
         let this = Self {
-            oauth_token: std::env::var(COPILOT_OAUTH_ENV_VAR).ok(),
+            oauth_token: std::env::var(COPILOT_OAUTH_ENV_VAR)
+                .ok()
+                .or_else(|| {
+                    // Fallback: newer Copilot SDK stores tokens in auth.db
+                    let db_path = copilot_chat_config_dir().join("auth.db");
+                    extract_oauth_token_from_db(&db_path)
+                }),
             api_endpoint: None,
             models: None,
             configuration,
             client,
+            fs,
         };
 
         if this.oauth_token.is_some() {
@@ -764,6 +786,43 @@ impl CopilotChat {
             .detach();
         }
     }
+
+    /// Re-read the OAuth token from disk and refresh the model catalog
+    /// if the token changed. Called from the `copilot` crate when its
+    /// LSP fires `didChangeStatus` (sign-in, sign-out, account switch).
+    pub fn reload_auth(&mut self, cx: &mut Context<Self>) {
+        let fs = self.fs.clone();
+        let oauth_domain = self.configuration.oauth_domain();
+        cx.spawn(async move |this, cx| {
+            let config_paths: HashSet<PathBuf> =
+                copilot_chat_config_paths().into_iter().collect();
+            let auth_db_path = copilot_chat_config_dir().join("auth.db");
+
+            let new_token =
+                read_oauth_token(&fs, &config_paths, &oauth_domain, &auth_db_path).await;
+
+            let token_present = this.update(cx, |this, cx| {
+                let changed = this.oauth_token != new_token;
+                if changed {
+                    this.oauth_token = new_token.clone();
+                    if new_token.is_none() {
+                        // Sign-out: drop derived state so a future sign-in
+                        // re-discovers the endpoint and re-fetches models.
+                        this.api_endpoint = None;
+                        this.models = None;
+                    }
+                    cx.notify();
+                }
+                new_token.is_some()
+            })?;
+
+            if token_present {
+                Self::update_models(&this, cx).await?;
+            }
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
+    }
 }
 
 async fn get_models(
@@ -917,6 +976,25 @@ async fn request_models(
     Ok(models)
 }
 
+/// Read the OAuth token from any available source, in order:
+/// legacy JSON files (`hosts.json`, `apps.json`) first, then the
+/// newer `auth.db` SQLite database written by the Copilot SDK.
+async fn read_oauth_token(
+    fs: &Arc<dyn Fs>,
+    config_paths: &HashSet<PathBuf>,
+    oauth_domain: &str,
+    auth_db_path: &std::path::Path,
+) -> Option<String> {
+    for file_path in config_paths {
+        if let Ok(contents) = fs.load(file_path).await {
+            if let Some(token) = extract_oauth_token(contents, oauth_domain) {
+                return Some(token);
+            }
+        }
+    }
+    extract_oauth_token_from_db(auth_db_path)
+}
+
 fn extract_oauth_token(contents: String, domain: &str) -> Option<String> {
     serde_json::from_str::<serde_json::Value>(&contents)
         .map(|v| {
@@ -932,6 +1010,33 @@ fn extract_oauth_token(contents: String, domain: &str) -> Option<String> {
         })
         .ok()
         .flatten()
+}
+
+/// Extract OAuth token from the newer Copilot SDK's SQLite auth.db.
+///
+/// The Copilot SDK migrated token storage from `apps.json` to a SQLite
+/// database (`auth.db`). The schema has an `oauth_tokens` table with a
+/// `token_ciphertext` column containing the raw `ghu_...` token as text.
+fn extract_oauth_token_from_db(db_path: &std::path::Path) -> Option<String> {
+    if !db_path.exists() {
+        return None;
+    }
+
+    let db = sqlez::connection::Connection::open_file(db_path.to_str()?);
+
+    let mut select = db
+        .select_row::<String>("SELECT token_ciphertext FROM oauth_tokens LIMIT 1")
+        .ok()?;
+
+    let token = select().ok().flatten()?;
+
+    if token.starts_with("ghu_") && token.len() >= 36 && token.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        log::debug!("Copilot OAuth token loaded from auth.db");
+        Some(token)
+    } else {
+        log::warn!("Copilot auth.db: token does not match expected GitHub OAuth format (ghu_<alphanumeric>)");
+        None
+    }
 }
 
 async fn stream_completion(


### PR DESCRIPTION
### Summary

The GitHub Copilot SDK migrated its OAuth token storage from JSON files (`apps.json` / `hosts.json`) to a SQLite database (`auth.db`) under the same `github-copilot` config directory. Zed only knew about the JSON files, so users on a fresh SDK install saw an **empty Copilot Chat model dropdown** even though they were signed in via the LSP (edit predictions worked fine, since those go through the LSP directly).

This PR teaches `copilot_chat` to read `auth.db`, and replaces the previous filesystem watcher with an LSP-driven reload triggered by `didChangeStatus` from the `copilot` crate.

Related: #57219 (same user-visible symptom; different root cause from #57738 — both fixes are needed depending on which SDK build the user has).

### Changes

- **`extract_oauth_token_from_db()`** reads `token_ciphertext` from the `oauth_tokens` table via the existing `sqlez` dependency. The column stores the raw `ghu_...` OAuth token as text on current SDK builds. Format is validated (prefix + length ≥ 36 + ASCII alphanumeric/underscore) so we fail closed if the SDK changes the schema again.
- **`CopilotChat::reload_auth(cx)`** is a small public method that re-reads the token. On sign-out it also clears `api_endpoint` and `models` so a subsequent sign-in re-discovers them rather than reusing stale state.
- **`notify_copilot_chat_auth_changed()`** in `copilot.rs` calls `reload_auth` whenever `update_sign_in_status` would emit `CopilotAuthSignedIn` / `CopilotAuthSignedOut`. The `copilot` crate already depends on `copilot_chat`, so this is the clean direction of the cross-crate poke.
- **Removed** the previous `fs.watch()` loop on the config directory.

### Why not just keep the filesystem watcher?

It was flaky on Windows specifically because of how SQLite finalises writes:
- The WAL is written alongside the main file and finalised with rename/replace; some commits surfaced as multiple watcher events, others as none.
- The watcher sometimes fired *before* the new token row was committed — we read `None`, then the LSP told us we were signed in.
- A 100 ms debounce papered over the symptom but not the cause.

### Why not `sqlite3_update_hook` / `commit_hook`?

Investigated and rejected. SQLite update/commit hooks are **per-connection, in-process** callbacks: they fire only when *your own* connection writes the DB. They're not an IPC mechanism. The Copilot LSP writes `auth.db` from a different process — our connection would never see those writes regardless of how many hooks we register. SQLite has no `LISTEN/NOTIFY` equivalent; that's a deliberate library-not-server design choice.

### Why the LSP signal?

The Copilot LSP already has the ground-truth event — `didChangeStatus`. It's the same notification VS Code's Copilot extension subscribes to internally. Tapping the producer's semantic signal beats watching its incidental filesystem side-effects: it works the same way on Windows / macOS / Linux, and it fires *after* the token is durably written.

### Testing

Tested on Windows 11 with the official Copilot SDK build that ships `auth.db`:
- Cold sign-in: model dropdown populates within a couple of seconds of the LSP reporting `Authorized`, no restart needed.
- Sign-out: model list clears; subsequent sign-in re-fetches endpoint + models.
- Legacy `apps.json` / `hosts.json` users: unaffected (JSON path is tried first).

### Notes for reviewers

- The token-format check (`ghu_` prefix, length ≥ 36, ASCII alnum/`_`) is intentional defence-in-depth in case the SDK eventually starts storing actually-ciphertext in `token_ciphertext`. If that happens, we log a warning and return `None` rather than passing garbage to the API.
- No new dependencies — `sqlez` is already a workspace member.

Release Notes:

- Fixed GitHub Copilot Chat showing an empty model dropdown for users on newer Copilot SDK builds that store the OAuth token in `auth.db` instead of `apps.json`/`hosts.json`, and made the model list refresh automatically after signing in or out without requiring a restart.