### PR TITLE
Restore focus after tool confirmation prompt is dismissed

### DIFF
--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1551,6 +1551,14 @@ impl ConversationView {
             }
             AcpThreadEvent::ToolAuthorizationRequested(_) => {
                 self.notify_with_sound("Waiting for tool confirmation", IconName::Info, window, cx);
+                if let Some(active) = self.thread_view(&session_id) {
+                    active.update(cx, |active, cx| {
+                        // Only save focus the first time (when no prompt was already showing).
+                        if active.pre_confirmation_focus.is_none() {
+                            active.pre_confirmation_focus = window.focused(cx);
+                        }
+                    });
+                }
             }
             AcpThreadEvent::ToolAuthorizationReceived(_) => {}
             AcpThreadEvent::Retry(retry) => {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -585,6 +585,8 @@ pub struct ThreadView {
     pub new_server_version_available: Option<SharedString>,
     pub resumed_without_history: bool,
     pub(crate) permission_selections: HashMap<acp::ToolCallId, PermissionSelection>,
+    /// Focus handle saved when the first permission prompt appears, restored on dismiss.
+    pub(super) pre_confirmation_focus: Option<FocusHandle>,
     pub _cancel_task: Option<Task<()>>,
     _save_task: Option<Task<()>>,
     _draft_resolve_task: Option<Task<()>>,
@@ -890,6 +892,7 @@ impl ThreadView {
             is_loading_contents: false,
             new_server_version_available: None,
             permission_selections: HashMap::default(),
+            pre_confirmation_focus: None,
             _cancel_task: None,
             _save_task: None,
             _draft_resolve_task: None,
@@ -2139,6 +2142,7 @@ impl ThreadView {
                 .ok();
         }
         cx.notify();
+        self.restore_pre_confirmation_focus(window, cx);
         Some(())
     }
 
@@ -2283,7 +2287,22 @@ impl ThreadView {
                 .ok();
         }
         cx.notify();
+        self.restore_pre_confirmation_focus(window, cx);
         result
+    }
+
+    fn restore_pre_confirmation_focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let session_id = self.thread.read(cx).session_id().clone();
+        let has_pending = self
+            .conversation
+            .read(cx)
+            .pending_tool_call_for_session(&session_id, cx)
+            .is_some();
+        if !has_pending {
+            if let Some(handle) = self.pre_confirmation_focus.take() {
+                window.focus(&handle, cx);
+            }
+        }
     }
 
     // edits


### PR DESCRIPTION
## Summary

When a tool permission prompt appears, the previously focused handle is saved. Once the last pending prompt is authorized or rejected, focus is restored to that handle.

Previously, when the permission prompt was removed from the view tree, GPUI dropped focus back to the last active editor — causing focus to jump away from the agent panel, especially noticeable when following the agent as it navigated files.

## Changes

- On `ToolAuthorizationRequested`: capture `window.focused(cx)` into `ThreadView.pre_confirmation_focus` (only on the first prompt, so chained prompts don't overwrite it)
- On authorization/rejection: if no more pending prompts remain for the session, restore the saved handle via `restore_pre_confirmation_focus()`

Closes #56287