### PR TITLE
workspace: Use iterator `next` instead of `count` to check for empty

### DIFF
--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -114,8 +114,8 @@ impl Render for Toolbar {
 
         let secondary_items = self.secondary_items().map(|item| item.to_any());
 
-        let has_left_items = self.left_items().count() > 0;
-        let has_right_items = self.right_items().count() > 0;
+        let has_left_items = self.left_items().next().is_some();
+        let has_right_items = self.right_items().next().is_some();
 
         v_flex()
             .group("toolbar")


### PR DESCRIPTION
toolbar items

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A or Added/Fixed/Improved ...
