### PR TITLE
gpui_macos: Use nearest filter for monochrome glyph atlas sprite sampling

### DIFF
--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -663,8 +663,10 @@ fragment float4 monochrome_sprite_fragment(
     return float4(0.0);
   }
 
-  constexpr sampler atlas_texture_sampler(mag_filter::linear,
-                                          min_filter::linear);
+  // Monochrome glyphs already bake subpixel variants into atlas tiles, so
+  // nearest avoids redundant blur; polychrome sprites keep linear sampling.
+  constexpr sampler atlas_texture_sampler(mag_filter::nearest,
+                                          min_filter::nearest);
   float4 sample =
       atlas_texture.sample(atlas_texture_sampler, input.tile_position);
   float4 color = input.color;

--- a/crates/gpui_macos/tests/glyph_atlas_sampler.rs
+++ b/crates/gpui_macos/tests/glyph_atlas_sampler.rs
@@ -1,0 +1,111 @@
+use gpui::{SUBPIXEL_VARIANTS_X, SUBPIXEL_VARIANTS_Y};
+
+const SHADER_SOURCE: &str = include_str!("../src/shaders.metal");
+
+#[derive(Debug, PartialEq)]
+struct QuantizedGlyphOrigin {
+    integer_origin_x: f32,
+    integer_origin_y: f32,
+    subpixel_variant_x: f32,
+    subpixel_variant_y: f32,
+}
+
+fn shader_section(start_marker: &str, end_marker: &str) -> &'static str {
+    let (_, after_start) = SHADER_SOURCE
+        .split_once(start_marker)
+        .expect("shader source should contain the requested fragment start marker");
+    let (section, _) = after_start
+        .split_once(end_marker)
+        .expect("shader source should contain the requested fragment end marker");
+    section
+}
+
+fn round_half_toward_zero(value: f32) -> f32 {
+    (value.abs() - 0.5).ceil().copysign(value)
+}
+
+fn quantize_glyph_origin(device_x: f32, device_y: f32) -> QuantizedGlyphOrigin {
+    let variants_x = f32::from(SUBPIXEL_VARIANTS_X);
+    let variants_y = f32::from(SUBPIXEL_VARIANTS_Y);
+    let quantized_x = round_half_toward_zero(device_x * variants_x) / variants_x;
+    let quantized_y = round_half_toward_zero(device_y * variants_y) / variants_y;
+
+    QuantizedGlyphOrigin {
+        integer_origin_x: quantized_x.trunc(),
+        integer_origin_y: quantized_y.trunc(),
+        subpixel_variant_x: quantized_x.fract() * variants_x,
+        subpixel_variant_y: quantized_y.fract() * variants_y,
+    }
+}
+
+#[test]
+fn monochrome_sprite_fragment_uses_nearest_filtering() {
+    let monochrome_fragment = shader_section(
+        "fragment float4 monochrome_sprite_fragment",
+        "struct PolychromeSpriteVertexOutput",
+    );
+
+    assert!(
+        monochrome_fragment.contains("mag_filter::nearest"),
+        "monochrome glyph atlas sampler should use nearest mag_filter because subpixel variants already bake fractional glyph origins",
+    );
+    assert!(
+        monochrome_fragment.contains("min_filter::nearest"),
+        "monochrome glyph atlas sampler should use nearest min_filter because glyph atlas texels are already rasterized at the selected subpixel variant",
+    );
+    assert!(
+        !monochrome_fragment.contains("mag_filter::linear"),
+        "monochrome glyph atlas sampler should not use linear mag_filter; bilinear filtering adds redundant blur",
+    );
+}
+
+#[test]
+fn fractional_device_pixel_origins_select_expected_subpixel_variants() {
+    for (device_x, expected_variant_x, expected_integer_x) in [
+        (10.0, 0.0, 10.0),
+        (10.25, 1.0, 10.0),
+        (10.5, 2.0, 10.0),
+        (10.75, 3.0, 10.0),
+        (11.0, 0.0, 11.0),
+    ] {
+        let quantized = quantize_glyph_origin(device_x, 20.0);
+
+        assert_eq!(
+            quantized.subpixel_variant_x, expected_variant_x,
+            "fractional device-pixel origin {device_x} should map to the pre-rasterized x subpixel variant {expected_variant_x}",
+        );
+        assert_eq!(
+            quantized.integer_origin_x, expected_integer_x,
+            "fractional device-pixel origin {device_x} should still place the sprite at an integer texel-aligned x origin",
+        );
+        assert_eq!(
+            quantized.subpixel_variant_y, 0.0,
+            "monochrome glyph y subpixel variant should remain zero because SUBPIXEL_VARIANTS_Y is one",
+        );
+        assert_eq!(
+            quantized.integer_origin_y, 20.0,
+            "integer y origin should remain texel-aligned when no vertical subpixel variants are enabled",
+        );
+    }
+}
+
+#[test]
+fn polychrome_sprite_fragment_keeps_linear_filtering() {
+    let polychrome_fragment = shader_section(
+        "fragment float4 polychrome_sprite_fragment",
+        "struct PathRasterizationVertexOutput",
+    );
+
+    assert!(
+        polychrome_fragment.contains("mag_filter::linear"),
+        "polychrome sprite sampler should keep linear mag_filter for color emoji/image atlas sampling",
+    );
+    assert!(
+        polychrome_fragment.contains("min_filter::linear"),
+        "polychrome sprite sampler should keep linear min_filter for color emoji/image atlas sampling",
+    );
+    assert!(
+        !polychrome_fragment.contains("mag_filter::nearest"),
+        "polychrome sprite sampler should not be changed when fixing monochrome glyph atlas filtering",
+    );
+}


### PR DESCRIPTION
Closes #57777

## Summary

This switches the macOS monochrome glyph atlas sampler from linear to nearest filtering and adds focused coverage for the sampler choice, subpixel variant math, and the polychrome regression boundary.

## Why nearest is correct

Monochrome glyphs already bake fractional glyph origins into atlas tiles through `SUBPIXEL_VARIANTS_X = 4`. `Window::paint_glyph` quantizes the glyph origin, selects the matching `RenderGlyphParams::subpixel_variant`, and places the sprite at an integer device-pixel origin. Sampling those pre-rasterized atlas texels with linear filtering adds a second interpolation step, which softens dense strokes such as CJK glyphs. Nearest filtering preserves the selected subpixel variant without adding that redundant blur.

## Polychrome path

`polychrome_sprite_fragment` is intentionally unchanged and keeps linear filtering. Color emoji and image-like atlas content do not use the monochrome subpixel-variant glyph pipeline, so changing that sampler would be a separate visual behavior change. The shader comment and regression test both document this asymmetry.

## Tests

Added `crates/gpui_macos/tests/glyph_atlas_sampler.rs`:

- `monochrome_sprite_fragment_uses_nearest_filtering`
- `fractional_device_pixel_origins_select_expected_subpixel_variants`
- `polychrome_sprite_fragment_keeps_linear_filtering`

## Manual verification

- RED: `cargo test -p gpui_macos --features runtime_shaders --test glyph_atlas_sampler` failed before the shader change with `monochrome glyph atlas sampler should use nearest mag_filter because subpixel variants already bake fractional glyph origins`.
- GREEN: `cargo test -p gpui_macos --features runtime_shaders --test glyph_atlas_sampler` passed after the shader change.
- GREEN crate run: `cargo test -p gpui_macos --features runtime_shaders` passed.
- Formatting: `cargo fmt -p gpui_macos -- --check` passed.
- Build: `cargo build -p gpui_macos --release --features runtime_shaders` passed.
- Default build attempt: `cargo build -p gpui_macos --release` was attempted locally but the local toolchain cannot find the offline Metal compiler: `xcrun: error: unable to find utility "metal", not a developer tool or in PATH`.
- `lsp_diagnostics` on the Rust integration test reported no diagnostics; `.metal` has no configured LSP server in this environment.

Release Notes:

- Improved macOS monochrome glyph sharpness by avoiding redundant linear filtering in the glyph atlas sampler.
