### PR TITLE
worktree: Fix linked worktree git dir event handling

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5490,8 +5490,7 @@ impl BackgroundScanner {
                         if SanitizedPath::new(repo.common_dir_abs_path.as_ref()) == dot_git_dir
                             || SanitizedPath::new(repo.repository_dir_abs_path.as_ref())
                                 == dot_git_dir
-                            || SanitizedPath::new(repo.dot_git_abs_path.as_ref())
-                                == dot_git_dir
+                            || SanitizedPath::new(repo.dot_git_abs_path.as_ref()) == dot_git_dir
                         {
                             Some(repo.clone())
                         } else {
@@ -5547,10 +5546,7 @@ impl BackgroundScanner {
                     });
 
             if exists_in_snapshot
-                || matches!(
-                    self.fs.metadata(&entry.dot_git_abs_path).await,
-                    Ok(Some(_))
-                )
+                || matches!(self.fs.metadata(&entry.dot_git_abs_path).await, Ok(Some(_)))
             {
                 ids_to_preserve.insert(work_directory_id);
             }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5490,6 +5490,8 @@ impl BackgroundScanner {
                         if SanitizedPath::new(repo.common_dir_abs_path.as_ref()) == dot_git_dir
                             || SanitizedPath::new(repo.repository_dir_abs_path.as_ref())
                                 == dot_git_dir
+                            || SanitizedPath::new(repo.dot_git_abs_path.as_ref())
+                                == dot_git_dir
                         {
                             Some(repo.clone())
                         } else {
@@ -5546,7 +5548,7 @@ impl BackgroundScanner {
 
             if exists_in_snapshot
                 || matches!(
-                    self.fs.metadata(&entry.common_dir_abs_path).await,
+                    self.fs.metadata(&entry.dot_git_abs_path).await,
                     Ok(Some(_))
                 )
             {

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -3328,7 +3328,7 @@ async fn test_invisible_worktree_does_not_track_ancestor_git_repository(
 }
 
 #[gpui::test]
-async fn test_linked_worktree_git_file_event_does_not_panic(
+async fn test_linked_worktree_gitfile_event_preserves_repo(
     executor: BackgroundExecutor,
     cx: &mut TestAppContext,
 ) {
@@ -3342,19 +3342,11 @@ async fn test_linked_worktree_git_file_event_does_not_panic(
     // and `update_git_repositories` panics because the path is outside the
     // worktree root.
     init_test(cx);
-
     use git::repository::Worktree as GitWorktree;
 
     let fs = FakeFs::new(executor);
-
-    fs.insert_tree(
-        path!("/main_repo"),
-        json!({
-            ".git": {},
-            "file.txt": "content",
-        }),
-    )
-    .await;
+    fs.insert_tree(path!("/main_repo"), json!({ ".git": {}, "file.txt": "" }))
+        .await;
     fs.add_linked_worktree_for_repo(
         Path::new(path!("/main_repo/.git")),
         false,
@@ -3367,12 +3359,9 @@ async fn test_linked_worktree_git_file_event_does_not_panic(
         },
     )
     .await;
-    fs.write(
-        path!("/linked_worktree/file.txt").as_ref(),
-        "content".as_bytes(),
-    )
-    .await
-    .unwrap();
+    fs.write(path!("/linked_worktree/file.txt").as_ref(), b"content")
+        .await
+        .unwrap();
 
     let tree = Worktree::local(
         path!("/linked_worktree").as_ref(),
@@ -3389,17 +3378,19 @@ async fn test_linked_worktree_git_file_event_does_not_panic(
         .await;
     cx.run_until_parked();
 
-    // Trigger a filesystem event inside the main repo's .git directory
-    // (which the linked worktree scanner watches via the commondir). This
-    // uses the sentinel-file helper to ensure the event goes through the
-    // real watcher path, exactly as it would in production.
-    tree.flush_fs_events_in_root_git_repository(cx).await;
+    // Overwrite the .git gitfile with garbage to trigger an event for the
+    // gitfile path itself, which only matches `dot_git_abs_path`.
+    fs.write(path!("/linked_worktree/.git").as_ref(), b"garbage")
+        .await
+        .unwrap();
+    tree.flush_fs_events(cx).await;
 
     // The worktree should still be intact.
     tree.read_with(cx, |tree, _| {
         assert_eq!(
             tree.snapshot().root_repo_common_dir().map(|p| p.as_ref()),
             Some(Path::new(path!("/main_repo/.git"))),
+            "linked worktree repo should survive a gitfile change event"
         );
     });
 }


### PR DESCRIPTION
When a linked worktree receives fs events for its .git directory, the event path resolves to the per-worktree git dir (e.g. main_repo/.git/worktrees/<name>), not the .git directory itself or the common dir. The existing match only checked common_dir_abs_path and repository_dir_abs_path, causing the repository entry to be missed and then removed as stale.

Add dot_git_abs_path to the match, and fix the staleness metadata check to use dot_git_abs_path (the actual .git entry) rather than common_dir_abs_path (which may be outside the worktree root).

Extracted from https://github.com/zed-industries/zed/pull/53453

Release Notes:

- N/A or Added/Fixed/Improved ...
