### PR TITLE
Git 3-way merge editor

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1000,6 +1000,12 @@
     //
     // Default: 72
     "commit_title_max_length": 72,
+    // Whether opening a conflicted file from the git panel uses the dedicated
+    // 3-way merge editor (Ours / Result / Theirs side panes). When disabled,
+    // conflicted files open in the regular project diff view.
+    //
+    // Default: false
+    "merge_editor": false,
   },
   "message_editor": {
     // Whether to automatically replace emoji shortcodes with emoji characters.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -323,6 +323,7 @@ pub enum DebugStackFrameLine {}
 pub enum ConflictsOuter {}
 pub enum ConflictsOurs {}
 pub enum ConflictsTheirs {}
+pub enum ConflictsBase {}
 pub enum ConflictsOursMarker {}
 pub enum ConflictsTheirsMarker {}
 

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -14,7 +14,7 @@ use git::{
         AskPassDelegate, Branch, CommitData, CommitDataReader, CommitDetails, CommitOptions,
         CreateWorktreeTarget, FetchOptions, GRAPH_CHUNK_SIZE, GitRepository,
         GitRepositoryCheckpoint, InitialGraphCommitData, LogOrder, LogSource, PushOptions, RefEdit,
-        Remote, RepoPath, ResetMode, SearchCommitArgs, Worktree,
+        Remote, RepoPath, ResetMode, SearchCommitArgs, UnmergedStages, Worktree,
     },
     stash::GitStash,
     status::{
@@ -59,6 +59,9 @@ pub struct FakeGitRepositoryState {
     pub commit_history: Vec<FakeCommitSnapshot>,
     pub event_emitter: async_channel::Sender<PathBuf>,
     pub unmerged_paths: HashMap<RepoPath, UnmergedStatus>,
+    /// Per-path stage 1/2/3 contents for unmerged paths. Mirrors what
+    /// `git2::Index` exposes for real repositories.
+    pub unmerged_stages: HashMap<RepoPath, git::repository::UnmergedStages>,
     pub head_contents: HashMap<RepoPath, String>,
     pub index_contents: HashMap<RepoPath, String>,
     // everything in commit contents is in oids
@@ -87,6 +90,7 @@ impl FakeGitRepositoryState {
             head_contents: Default::default(),
             index_contents: Default::default(),
             unmerged_paths: Default::default(),
+            unmerged_stages: Default::default(),
             blames: Default::default(),
             current_branch_name: Default::default(),
             branches: Default::default(),
@@ -172,6 +176,36 @@ impl GitRepository for FakeGitRepository {
                 .cloned()
         });
         self.executor.spawn(async move { fut.await.ok() }).boxed()
+    }
+
+    fn load_unmerged_stages(&self, path: RepoPath) -> BoxFuture<'_, UnmergedStages> {
+        let fut = self.with_state_async(false, move |state| {
+            Ok(state.unmerged_stages.get(&path).cloned().unwrap_or_default())
+        });
+        self.executor
+            .spawn(async move { fut.await.unwrap_or_default() })
+            .boxed()
+    }
+
+    fn merge_file_diff3(&self, path: RepoPath) -> BoxFuture<'_, Result<String>> {
+        // Fake repos don't run the merge algorithm; they synthesize a
+        // canonical diff3-style file from the stored stage contents so tests
+        // can exercise the auto-rewrite path without a real libgit2.
+        let fut = self.with_state_async(false, move |state| {
+            let stages = state
+                .unmerged_stages
+                .get(&path)
+                .cloned()
+                .context("path has no unmerged stages")?;
+            let base = stages.base.context("path has no base stage")?;
+            let ours = stages.ours.context("path has no ours stage")?;
+            let theirs = stages.theirs.context("path has no theirs stage")?;
+            Ok(format!(
+                "<<<<<<< ours\n{}||||||| base\n{}=======\n{}>>>>>>> theirs\n",
+                ours, base, theirs,
+            ))
+        });
+        self.executor.spawn(fut).boxed()
     }
 
     fn load_committed_text(&self, path: RepoPath) -> BoxFuture<'_, Option<String>> {

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -57,7 +57,7 @@ use collections::{BTreeMap, btree_map};
 use fake_git_repo::{FakeCommitDataEntry, FakeGitRepositoryState};
 #[cfg(feature = "test-support")]
 use git::{
-    repository::{CommitData, InitialGraphCommitData, RepoPath, Worktree, repo_path},
+    repository::{CommitData, InitialGraphCommitData, RepoPath, UnmergedStages, Worktree, repo_path},
     status::{FileStatus, StatusCode, TrackedStatus, UnmergedStatus},
 };
 #[cfg(feature = "test-support")]
@@ -2140,6 +2140,24 @@ impl FakeFs {
                 unmerged_state
                     .iter()
                     .map(|(path, content)| (path.clone(), *content)),
+            );
+        })
+        .unwrap();
+    }
+
+    /// Sets the base/ours/theirs (index stages 1/2/3) for unmerged paths in
+    /// the fake repository. Mirrors what `git2::Index` exposes for real repos.
+    pub fn set_unmerged_stages_for_repo(
+        &self,
+        dot_git: &Path,
+        stages: &[(RepoPath, UnmergedStages)],
+    ) {
+        self.with_git_state(dot_git, true, |state| {
+            state.unmerged_stages.clear();
+            state.unmerged_stages.extend(
+                stages
+                    .iter()
+                    .map(|(path, stages)| (path.clone(), stages.clone())),
             );
         })
         .unwrap();

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -76,6 +76,21 @@ pub fn original_repo_path_from_common_dir(common_dir: &Path) -> Option<PathBuf> 
     }
 }
 
+/// Picks the incoming branch name out of `.git/MERGE_MSG`. Git writes the
+/// first line as `Merge branch 'foo' into bar` (or `Merge branches 'foo',
+/// 'baz'`); we just want `foo`. Returns `None` if the message doesn't match
+/// the standard shape — caller falls back to a generic label.
+fn parse_merge_msg_branch(msg: &str) -> Option<String> {
+    let first_line = msg.lines().next()?;
+    let after_quote = first_line.split_once('\'')?.1;
+    let branch = after_quote.split_once('\'')?.0;
+    if branch.is_empty() {
+        None
+    } else {
+        Some(branch.to_owned())
+    }
+}
+
 /// Commit data needed for the git graph visualization.
 #[derive(Debug, Clone)]
 pub struct CommitData {
@@ -761,6 +776,21 @@ pub trait GitRepository: Send + Sync {
     fn load_committed_text(&self, path: RepoPath) -> BoxFuture<'_, Option<String>>;
     fn load_blob_content(&self, oid: Oid) -> BoxFuture<'_, Result<String>>;
 
+    /// Returns the base/ours/theirs (index stages 1/2/3) for an unmerged path.
+    /// Each side is `None` when that stage is absent (e.g. a modify/delete
+    /// conflict has no `theirs`) or when the blob is not valid UTF-8.
+    /// Returns a fully-`None` `UnmergedStages` for paths that are not unmerged.
+    fn load_unmerged_stages(&self, path: RepoPath) -> BoxFuture<'_, UnmergedStages>;
+
+    /// Re-runs git's 3-way merge for an unmerged path and returns the
+    /// resulting working-tree content with diff3-style markers (i.e.
+    /// `<<<<<<<`, `|||||||` base section, `=======`, `>>>>>>>`). Lets the
+    /// merge editor present a base section even when the user's config has
+    /// `merge.conflictStyle = merge` (the 2-way default) and the working
+    /// tree on disk was written without `|||||||` markers. Returns `Err`
+    /// when the path isn't unmerged or its stages aren't UTF-8.
+    fn merge_file_diff3(&self, path: RepoPath) -> BoxFuture<'_, Result<String>>;
+
     fn set_index_text(
         &self,
         path: RepoPath,
@@ -1177,6 +1207,25 @@ pub struct GitRepositoryCheckpoint {
     pub commit_sha: Oid,
 }
 
+/// libgit2 index stage numbers for an unmerged path.
+/// See: https://git-scm.com/docs/git-merge#_how_conflicts_are_presented
+pub const STAGE_NORMAL: i32 = 0;
+pub const STAGE_BASE: i32 = 1;
+pub const STAGE_OURS: i32 = 2;
+pub const STAGE_THEIRS: i32 = 3;
+
+/// The three sides of a 3-way merge for a single path, as recorded by git in
+/// the index when a path is unmerged. Each side is `None` when that stage is
+/// absent (e.g., file added on both branches has no base; a modify/delete
+/// conflict has no `ours` or no `theirs`) or when the content is not valid
+/// UTF-8 (binary blob).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct UnmergedStages {
+    pub base: Option<String>,
+    pub ours: Option<String>,
+    pub theirs: Option<String>,
+}
+
 #[derive(Debug)]
 pub struct GitCommitter {
     pub name: Option<String>,
@@ -1475,7 +1524,6 @@ impl GitRepository for RealGitRepository {
                     let mut index = repo.index()?;
                     index.read(false)?;
 
-                    const STAGE_NORMAL: i32 = 0;
                     // git2 unwraps internally on empty paths or `.`
                     if path.is_empty() {
                         bail!("empty path has no index text");
@@ -1495,6 +1543,102 @@ impl GitRepository for RealGitRepository {
                     .context("loading index text")
                     .log_err()
                     .flatten()
+            })
+            .boxed()
+    }
+
+    fn load_unmerged_stages(&self, path: RepoPath) -> BoxFuture<'_, UnmergedStages> {
+        // https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
+        const GIT_MODE_SYMLINK: u32 = 0o120000;
+
+        let repo = self.repository.clone();
+        self.executor
+            .spawn(async move {
+                fn read_stage(
+                    repo: &git2::Repository,
+                    index: &git2::Index,
+                    path: &RepoPath,
+                    stage: i32,
+                ) -> Result<Option<String>> {
+                    let Some(entry) = index.get_path(path.as_std_path(), stage) else {
+                        return Ok(None);
+                    };
+                    if entry.mode == GIT_MODE_SYMLINK {
+                        return Ok(None);
+                    }
+                    let content = repo.find_blob(entry.id)?.content().to_owned();
+                    Ok(String::from_utf8(content).ok())
+                }
+
+                fn logic(repo: &git2::Repository, path: &RepoPath) -> Result<UnmergedStages> {
+                    if path.is_empty() {
+                        bail!("empty path has no unmerged stages");
+                    }
+                    let mut index = repo.index()?;
+                    // Force re-read so a concurrent terminal `git add` is observed.
+                    index.read(true)?;
+                    Ok(UnmergedStages {
+                        base: read_stage(repo, &index, path, STAGE_BASE)?,
+                        ours: read_stage(repo, &index, path, STAGE_OURS)?,
+                        theirs: read_stage(repo, &index, path, STAGE_THEIRS)?,
+                    })
+                }
+
+                logic(&repo.lock(), &path)
+                    .context("loading unmerged stages")
+                    .log_err()
+                    .unwrap_or_default()
+            })
+            .boxed()
+    }
+
+    fn merge_file_diff3(&self, path: RepoPath) -> BoxFuture<'_, Result<String>> {
+        let repo = self.repository.clone();
+        self.executor
+            .spawn(async move {
+                if path.is_empty() {
+                    bail!("empty path has no merge file");
+                }
+                let repo = repo.lock();
+                let mut index = repo.index()?;
+                index.read(true)?;
+                let ancestor = index
+                    .get_path(path.as_std_path(), STAGE_BASE)
+                    .context("path has no base stage (added on both sides?)")?;
+                let ours = index
+                    .get_path(path.as_std_path(), STAGE_OURS)
+                    .context("path has no ours stage")?;
+                let theirs = index
+                    .get_path(path.as_std_path(), STAGE_THEIRS)
+                    .context("path has no theirs stage")?;
+
+                // Use git's own marker labels — `HEAD` for ours, the
+                // incoming branch name for theirs (parsed from
+                // `.git/MERGE_MSG`'s `Merge branch 'foo'` line), and
+                // `merged common ancestors` for base — so the rewritten
+                // markers are indistinguishable from what git itself would
+                // produce with `merge.conflictStyle = diff3`. The inline
+                // conflict view (which exists outside the merge editor too)
+                // reads these labels back into its `Use HEAD` / `Use foo`
+                // buttons, so this preserves the pre-merge-editor UX for
+                // anyone looking at the buffer through a regular editor.
+                // The 3-way merge editor's own pane headers ("Ours · main",
+                // "Theirs · Incoming") supply the friendly framing on top.
+                let their_label = std::fs::read_to_string(repo.path().join("MERGE_MSG"))
+                    .ok()
+                    .as_deref()
+                    .and_then(parse_merge_msg_branch)
+                    .unwrap_or_else(|| "theirs".to_owned());
+
+                let mut opts = git2::MergeFileOptions::new();
+                opts.style_diff3(true)
+                    .ancestor_label("merged common ancestors")
+                    .our_label("HEAD")
+                    .their_label(&their_label);
+                let result =
+                    repo.merge_file_from_index(&ancestor, &ours, &theirs, Some(&mut opts))?;
+                let content = result.content().to_owned();
+                String::from_utf8(content).context("merge file content is not UTF-8")
             })
             .boxed()
     }
@@ -3419,6 +3563,14 @@ impl GitBinary {
         command.args(["-c", "core.fsmonitor=false"]);
         // Prepended signature lines would corrupt our --format parsers.
         command.args(["-c", "log.showSignature=false"]);
+        // Force diff3 conflict markers so the 3-way merge editor's "Use Base" path
+        // and any side panes that depend on a parsed base section always have it.
+        // Scoped to subcommands that can actually create merge conflicts so we don't
+        // silently override the user's `merge.conflictStyle` for unrelated operations
+        // (e.g., they configured `zdiff3` globally and we'd downgrade to `diff3`).
+        if first_subcommand(args).is_some_and(is_merge_creating_subcommand) {
+            command.args(["-c", "merge.conflictStyle=diff3"]);
+        }
         command.arg("--no-optional-locks");
         // Internal commands must be non-interactive so background tasks never block on user input.
         command.arg("--no-pager");
@@ -3445,6 +3597,25 @@ impl GitBinary {
         command.envs(&self.envs);
         command
     }
+}
+
+/// Returns the first positional (non-option) argument in `args`, which for a
+/// well-formed git invocation is the subcommand name.
+fn first_subcommand<S: AsRef<OsStr>>(args: &[S]) -> Option<&str> {
+    args.iter().find_map(|arg| {
+        let s = arg.as_ref().to_str()?;
+        (!s.starts_with('-')).then_some(s)
+    })
+}
+
+/// True for git subcommands that can produce conflict markers in the working
+/// tree. `stash` covers both `stash apply` and `stash pop` (the other
+/// `stash` variants don't merge, but the flag is a no-op for them).
+fn is_merge_creating_subcommand(subcommand: &str) -> bool {
+    matches!(
+        subcommand,
+        "merge" | "pull" | "rebase" | "cherry-pick" | "revert" | "am" | "stash"
+    )
 }
 
 #[derive(Error, Debug)]
@@ -3861,6 +4032,71 @@ mod tests {
             "false",
             "log.showSignature should be disabled for untrusted repos"
         );
+    }
+
+    #[gpui::test]
+    async fn test_build_command_scopes_diff3_to_merge_commands(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        // Set a per-repo `merge.conflictStyle = merge` so we can observe whether
+        // the build_command flag overrode it for a given invocation.
+        repo.config()
+            .unwrap()
+            .set_str("merge.conflictStyle", "merge")
+            .unwrap();
+
+        let git = GitBinary::new(
+            PathBuf::from("git"),
+            dir.path().to_path_buf(),
+            dir.path().join(".git"),
+            cx.executor(),
+            true,
+        );
+
+        // Non-merge subcommand: the per-invocation `-c merge.conflictStyle=diff3`
+        // must NOT be applied, so the user's local `merge` setting wins.
+        let output = git
+            .build_command(&["config", "--get", "merge.conflictStyle"])
+            .output()
+            .await
+            .expect("git config should run");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(
+            stdout.trim(),
+            "merge",
+            "merge.conflictStyle should be left alone for non-merge commands"
+        );
+    }
+
+    #[test]
+    fn test_first_subcommand_skips_leading_flags() {
+        // Callers of `build_command` pass the subcommand as the first positional
+        // arg; safety/config `-c` flags are added inside `build_command` itself.
+        // Still, be defensive in case a caller starts with a long flag.
+        assert_eq!(first_subcommand::<&str>(&[]), None);
+        assert_eq!(first_subcommand(&["status"]), Some("status"));
+        assert_eq!(first_subcommand(&["--no-pager", "log"]), Some("log"));
+        assert_eq!(first_subcommand(&["stash", "apply"]), Some("stash"));
+    }
+
+    #[test]
+    fn test_is_merge_creating_subcommand() {
+        for sub in [
+            "merge",
+            "pull",
+            "rebase",
+            "cherry-pick",
+            "revert",
+            "am",
+            "stash",
+        ] {
+            assert!(is_merge_creating_subcommand(sub), "{sub} should match");
+        }
+        for sub in ["status", "log", "diff", "show", "config", "commit", "push"] {
+            assert!(!is_merge_creating_subcommand(sub), "{sub} should not match");
+        }
     }
 
     #[gpui::test]

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -410,6 +410,35 @@ fn render_conflict_buttons(
                     }
                 }),
         )
+        .when_some(
+            conflict
+                .base
+                .clone()
+                .filter(|_| crate::git_panel_settings::GitPanelSettings::get_global(cx).merge_editor),
+            |this, base| {
+                this.child(
+                    Button::new("base", "Use Base")
+                        .label_size(LabelSize::Small)
+                        .tooltip(Tooltip::text(
+                            "Discard both sides and keep the common ancestor",
+                        ))
+                        .on_click({
+                            let editor = editor.clone();
+                            let conflict = conflict.clone();
+                            move |_, window, cx| {
+                                resolve_conflict(
+                                    editor.clone(),
+                                    conflict.clone(),
+                                    vec![base.clone()],
+                                    window,
+                                    cx,
+                                )
+                                .detach()
+                            }
+                        }),
+                )
+            },
+        )
         .when(is_ai_enabled, |this| {
             this.child(Divider::vertical()).child(
                 Button::new("resolve-with-agent", "Resolve with Agent")

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -1,12 +1,12 @@
 use agent_settings::AgentSettings;
 use collections::{HashMap, HashSet};
 use editor::{
-    ConflictsOurs, ConflictsOursMarker, ConflictsOuter, ConflictsTheirs, ConflictsTheirsMarker,
-    Editor, EditorEvent, MultiBuffer, RowHighlightOptions,
+    ConflictsBase, ConflictsOurs, ConflictsOursMarker, ConflictsOuter, ConflictsTheirs,
+    ConflictsTheirsMarker, Editor, EditorEvent, MultiBuffer, RowHighlightOptions,
     display_map::{BlockContext, BlockPlacement, BlockProperties, BlockStyle, CustomBlockId},
 };
 use gpui::{
-    App, ClickEvent, Context, Empty, Entity, InteractiveElement as _, ParentElement as _,
+    App, ClickEvent, Context, Empty, Entity, Hsla, InteractiveElement as _, ParentElement as _,
     Subscription, Task, WeakEntity,
 };
 use language::{Anchor, Buffer, BufferId};
@@ -17,11 +17,29 @@ use project::{
 use settings::Settings;
 use std::{ops::Range, sync::Arc};
 use ui::{ButtonLike, Divider, Tooltip, prelude::*};
-use util::{ResultExt as _, debug_panic, maybe};
+use util::{ResultExt as _, maybe};
 use workspace::{HideStatusItem, StatusItemView, Workspace, item::ItemHandle};
 use zed_actions::agent::{
     ConflictContent, ResolveConflictedFilesWithAgent, ResolveConflictsWithAgent,
 };
+
+/// Optional addon registered on an editor by the 3-way merge editor to
+/// override the default conflict-region row colors. When present, the
+/// inline conflict view uses these instead of the theme's
+/// `version_control_conflict_marker_*` tokens, and additionally paints
+/// the base section if the conflict carries one.
+#[derive(Clone, Copy)]
+pub struct ConflictHighlightPalette {
+    pub ours: Hsla,
+    pub theirs: Hsla,
+    pub base: Hsla,
+}
+
+impl editor::Addon for ConflictHighlightPalette {
+    fn to_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
 
 pub(crate) struct ConflictAddon {
     buffers: HashMap<BufferId, BufferConflicts>,
@@ -154,7 +172,14 @@ fn conflicts_updated(
         match buffer_conflicts.block_ids.get(event.old_range.clone()) {
             Some(_) => Some(event.old_range.clone()),
             None => {
-                debug_panic!(
+                // The update's `old_range` indexes into the conflict set, not
+                // this editor's `block_ids`; an editor that opened mid-stream
+                // (after a buffer rewrite, a tab reuse, or a `set_text`)
+                // legitimately ends up with a `block_ids` len that doesn't
+                // match the conflict set's prior snapshot. Clamp instead of
+                // panicking — the splice below will treat the truncated
+                // range as a no-op for the missing entries and proceed.
+                log::warn!(
                     "conflicts updated event old range is invalid for buffer conflicts view (block_ids len is {:?}, old_range is {:?})",
                     buffer_conflicts.block_ids.len(),
                     event.old_range,
@@ -195,6 +220,7 @@ fn conflicts_updated(
         editor.remove_highlighted_rows::<ConflictsOurs>(removed_highlighted_ranges.clone(), cx);
         editor
             .remove_highlighted_rows::<ConflictsOursMarker>(removed_highlighted_ranges.clone(), cx);
+        editor.remove_highlighted_rows::<ConflictsBase>(removed_highlighted_ranges.clone(), cx);
         editor.remove_highlighted_rows::<ConflictsTheirs>(removed_highlighted_ranges.clone(), cx);
         editor.remove_highlighted_rows::<ConflictsTheirsMarker>(
             removed_highlighted_ranges.clone(),
@@ -254,9 +280,28 @@ fn update_conflict_highlighting(
     let outer = buffer.buffer_anchor_range_to_anchor_range(conflict.range.clone())?;
     let ours = buffer.buffer_anchor_range_to_anchor_range(conflict.ours.clone())?;
     let theirs = buffer.buffer_anchor_range_to_anchor_range(conflict.theirs.clone())?;
+    let base = conflict
+        .base
+        .as_ref()
+        .and_then(|range| buffer.buffer_anchor_range_to_anchor_range(range.clone()));
 
-    let ours_background = cx.theme().colors().version_control_conflict_marker_ours;
-    let theirs_background = cx.theme().colors().version_control_conflict_marker_theirs;
+    let palette = editor.addon::<ConflictHighlightPalette>().copied();
+    let ours_background = palette
+        .map(|p| p.ours)
+        .unwrap_or_else(|| cx.theme().colors().version_control_conflict_marker_ours);
+    let theirs_background = palette
+        .map(|p| p.theirs)
+        .unwrap_or_else(|| cx.theme().colors().version_control_conflict_marker_theirs);
+    // Fill color for the "outer" row band that backgrounds the entire
+    // conflict region. With a palette, use the editor background so the
+    // explicit ours / base / theirs highlights stand on their own; without,
+    // keep the historical behavior of bleeding the theirs color across the
+    // whole region.
+    let outer_background = if palette.is_some() {
+        cx.theme().colors().editor_background
+    } else {
+        theirs_background
+    };
 
     let options = RowHighlightOptions {
         include_gutter: true,
@@ -270,7 +315,7 @@ fn update_conflict_highlighting(
     );
 
     // Prevent diff hunk highlighting within the entire conflict region.
-    editor.highlight_rows::<ConflictsOuter>(outer.clone(), theirs_background, options, cx);
+    editor.highlight_rows::<ConflictsOuter>(outer.clone(), outer_background, options, cx);
     editor.highlight_rows::<ConflictsOurs>(ours.clone(), ours_background, options, cx);
     editor.highlight_rows::<ConflictsOursMarker>(
         outer.start..ours.start,
@@ -278,6 +323,11 @@ fn update_conflict_highlighting(
         options,
         cx,
     );
+    if let Some(base_range) = base
+        && let Some(base_color) = palette.map(|p| p.base)
+    {
+        editor.highlight_rows::<ConflictsBase>(base_range, base_color, options, cx);
+    }
     editor.highlight_rows::<ConflictsTheirs>(theirs.clone(), theirs_background, options, cx);
     editor.highlight_rows::<ConflictsTheirsMarker>(
         theirs.end..outer.end,
@@ -477,6 +527,7 @@ pub(crate) fn resolve_conflict(
 
                 editor.remove_highlighted_rows::<ConflictsOuter>(vec![range.clone()], cx);
                 editor.remove_highlighted_rows::<ConflictsOurs>(vec![range.clone()], cx);
+                editor.remove_highlighted_rows::<ConflictsBase>(vec![range.clone()], cx);
                 editor.remove_highlighted_rows::<ConflictsTheirs>(vec![range.clone()], cx);
                 editor.remove_highlighted_rows::<ConflictsOursMarker>(vec![range.clone()], cx);
                 editor.remove_highlighted_rows::<ConflictsTheirsMarker>(vec![range], cx);

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1361,6 +1361,19 @@ impl GitPanel {
             let workspace = self.workspace.upgrade()?;
             let git_repo = self.active_repository.as_ref()?;
 
+            // Unmerged paths get the dedicated 3-way merge editor in place of
+            // the project-wide diff view, regardless of click vs. alt-click —
+            // but only when the user has opted in via `git_panel.merge_editor`.
+            if entry.status.is_conflicted()
+                && GitPanelSettings::get_global(cx).merge_editor
+            {
+                let path = git_repo
+                    .read(cx)
+                    .repo_path_to_project_path(&entry.repo_path, cx)?;
+                self.open_merge_editor_for(path, window, cx);
+                return Some(());
+            }
+
             if let Some(project_diff) = workspace.read(cx).active_item_as::<ProjectDiff>(cx)
                 && let Some(project_path) = project_diff.read(cx).active_path(cx)
                 && Some(&entry.repo_path)
@@ -1385,6 +1398,24 @@ impl GitPanel {
         });
     }
 
+    fn open_merge_editor_for(
+        &self,
+        path: project::ProjectPath,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let workspace = self.workspace.clone();
+        let open_workspace = workspace.clone();
+        cx.spawn_in(window, async move |_, mut cx| {
+            let task = cx.update(|window, cx| {
+                crate::merge_editor::MergeEditor::open(path, open_workspace, window, cx)
+            })?;
+            task.await.notify_workspace_async_err(workspace, &mut cx);
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
+    }
+
     fn open_file(
         &mut self,
         _: &menu::SecondaryConfirm,
@@ -1399,6 +1430,16 @@ impl GitPanel {
                 .repo_path_to_project_path(&entry.repo_path, cx)?;
             if entry.status.is_deleted() {
                 return None;
+            }
+
+            // Unmerged paths get the 3-way merge editor instead of a plain
+            // editor, but only when the user has opted in via the
+            // `git_panel.merge_editor` setting.
+            if entry.status.is_conflicted()
+                && GitPanelSettings::get_global(cx).merge_editor
+            {
+                self.open_merge_editor_for(path, window, cx);
+                return Some(());
             }
 
             let open_task = self

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -31,6 +31,7 @@ pub struct GitPanelSettings {
     pub show_count_badge: bool,
     pub starts_open: bool,
     pub commit_title_max_length: usize,
+    pub merge_editor: bool,
 }
 
 #[derive(Default)]
@@ -78,6 +79,7 @@ impl Settings for GitPanelSettings {
             show_count_badge: git_panel.show_count_badge.unwrap(),
             starts_open: git_panel.starts_open.unwrap(),
             commit_title_max_length: git_panel.commit_title_max_length.unwrap(),
+            merge_editor: git_panel.merge_editor.unwrap(),
         }
     }
 }

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -24,7 +24,10 @@ use project::git_store::Repository;
 use project_diff::ProjectDiff;
 use time::OffsetDateTime;
 use ui::prelude::*;
-use workspace::{ModalView, OpenMode, Workspace, notifications::DetachAndPromptErr};
+use workspace::{
+    ModalView, OpenMode, Workspace,
+    notifications::{DetachAndPromptErr, NotifyResultExt},
+};
 use zed_actions;
 
 use crate::{commit_view::CommitView, git_panel::GitPanel, text_diff_view::TextDiffView};
@@ -37,6 +40,7 @@ pub mod commit_view;
 mod conflict_view;
 pub mod file_diff_view;
 pub mod git_panel;
+pub mod merge_editor;
 mod git_panel_settings;
 pub mod git_picker;
 mod git_runtime_diagnostics;
@@ -198,6 +202,37 @@ pub fn init(cx: &mut App) {
                 });
             });
         }
+        workspace.register_action(
+            |workspace, _: &zed_actions::git::OpenMergeEditor, window, cx| {
+                use settings::Settings as _;
+                if !git_panel_settings::GitPanelSettings::get_global(cx).merge_editor {
+                    return;
+                }
+                let Some(project_path) = workspace
+                    .active_item(cx)
+                    .and_then(|item| item.project_path(cx))
+                else {
+                    return;
+                };
+                let workspace_weak = workspace.weak_handle();
+                let open_workspace = workspace_weak.clone();
+                cx.spawn_in(window, async move |_, mut cx| {
+                    let task = cx.update(|window, cx| {
+                        crate::merge_editor::MergeEditor::open(
+                            project_path,
+                            open_workspace,
+                            window,
+                            cx,
+                        )
+                    })?;
+                    task.await
+                        .notify_workspace_async_err(workspace_weak, &mut cx);
+                    anyhow::Ok(())
+                })
+                .detach_and_log_err(cx);
+            },
+        );
+
         workspace.register_action(|workspace, action: &git::StashAll, window, cx| {
             let Some(panel) = workspace.panel::<git_panel::GitPanel>(cx) else {
                 return;

--- a/crates/git_ui/src/merge_editor.rs
+++ b/crates/git_ui/src/merge_editor.rs
@@ -2,22 +2,26 @@
 //!
 //! Renders a conflicted file alongside the `ours` and `theirs` index stages
 //! (and optionally the common ancestor `base`) so the user can resolve the
-//! conflict with full side-by-side context.
+//! conflict with full side-by-side context. Side panes show per-stage diffs
+//! against the common ancestor when one is available.
 //!
-//! This module ships the skeleton: three (or four, with Base) read-only side
-//! panes around the working-tree buffer. Diff highlights between the stages
-//! and per-conflict accept buttons are added in a later step.
+//! The Result pane keeps Zed's existing inline conflict resolution buttons
+//! (registered globally via `git_ui::init`'s `observe_new(Editor)` hook) and
+//! gains the "Use Base" button alongside the existing Use Ours / Use Theirs /
+//! Use Both buttons whenever the conflict has a base section.
 
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, anyhow};
+use buffer_diff::BufferDiff;
 use editor::{Editor, EditorEvent, MultiBuffer};
 use git::repository::UnmergedStages;
 use gpui::{
-    AnyElement, App, AppContext as _, Context, Entity, EventEmitter, FocusHandle, Focusable,
-    IntoElement, Render, Subscription, Task, WeakEntity, Window,
+    AnyElement, App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, FocusHandle,
+    Focusable, IntoElement, Render, Subscription, Task, WeakEntity, Window,
 };
 use language::{Buffer, Capability};
 use project::{ConflictRegion, ConflictSetUpdate, Project, ProjectItem as _, ProjectPath};
 use std::any::{Any, TypeId};
+use std::sync::Arc;
 use ui::prelude::*;
 use ui::{IconButtonShape, Tooltip};
 use util::paths::PathExt as _;
@@ -130,6 +134,16 @@ impl MergeEditor {
                 .update(cx, |repo, cx| repo.load_unmerged_stages(repo_path.clone(), cx))
                 .await?;
 
+            // No stages at all = file isn't actually unmerged in the index, or
+            // every stage is binary/non-UTF8. A 3-pane view with three empty
+            // editors would be misleading; better to surface the issue.
+            if stages == UnmergedStages::default() {
+                return Err(anyhow!(
+                    "Cannot open 3-way merge editor: no text stages in git index \
+                     (file may be binary, a submodule, or not actually conflicted)"
+                ));
+            }
+
             // If the working tree was written with 2-way markers (user's
             // `merge.conflictStyle` is `merge`), fetch the diff3-style merge
             // output now; we'll apply it to the buffer AFTER the result
@@ -169,13 +183,28 @@ impl MergeEditor {
                 )
             });
 
+            // Build the transient stage buffers and base↔ours / base↔theirs
+            // diffs up front (off the workspace update), so the editor
+            // construction itself stays synchronous.
+            let StageBuffers {
+                base_buffer,
+                ours_buffer,
+                theirs_buffer,
+                ours_diff,
+                theirs_diff,
+            } = build_stage_buffers(&result_buffer, &stages, cx).await?;
+
             workspace.update_in(cx, |workspace, window, cx| {
                 let project = workspace.project().clone();
                 let result_buffer_for_rewrite = result_buffer.clone();
                 let merge_editor = cx.new(|cx| {
                     MergeEditor::new(
                         result_buffer,
-                        stages,
+                        base_buffer,
+                        ours_buffer,
+                        theirs_buffer,
+                        ours_diff,
+                        theirs_diff,
                         ours_branch_label,
                         theirs_branch_label,
                         project,
@@ -206,9 +235,14 @@ impl MergeEditor {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new(
         result_buffer: Entity<Buffer>,
-        stages: UnmergedStages,
+        base_buffer: Option<Entity<Buffer>>,
+        ours_buffer: Entity<Buffer>,
+        theirs_buffer: Entity<Buffer>,
+        ours_diff: Option<Entity<BufferDiff>>,
+        theirs_diff: Option<Entity<BufferDiff>>,
         ours_branch_label: SharedString,
         theirs_branch_label: SharedString,
         project: Entity<Project>,
@@ -238,23 +272,11 @@ impl MergeEditor {
             editor
         });
 
-        let ours_editor = build_stage_pane(
-            stages.ours.unwrap_or_default(),
-            result_buffer.clone(),
-            project.clone(),
-            window,
-            cx,
-        );
-        let theirs_editor = build_stage_pane(
-            stages.theirs.unwrap_or_default(),
-            result_buffer.clone(),
-            project.clone(),
-            window,
-            cx,
-        );
-        let base_editor = stages.base.map(|base_text| {
-            build_stage_pane(base_text, result_buffer.clone(), project.clone(), window, cx)
-        });
+        let ours_editor = build_stage_editor(ours_buffer, ours_diff, project.clone(), window, cx);
+        let theirs_editor =
+            build_stage_editor(theirs_buffer, theirs_diff, project.clone(), window, cx);
+        let base_editor =
+            base_buffer.map(|buffer| build_stage_editor(buffer, None, project.clone(), window, cx));
 
         let mut subscriptions = Vec::new();
         // Re-emit the inner editor's events as our own so the workspace's Item
@@ -414,6 +436,19 @@ impl MergeEditor {
             );
             *stored_blocks = new_blocks;
         }
+    }
+
+    /// Returns the underlying single buffer behind a side-pane editor.
+    /// Side-pane editors wrap their stage buffer in a `MultiBuffer::singleton`
+    /// so `as_singleton()` always succeeds.
+    #[cfg(test)]
+    fn stage_buffer(editor: &Entity<Editor>, cx: &App) -> Entity<Buffer> {
+        editor
+            .read(cx)
+            .buffer()
+            .read(cx)
+            .as_singleton()
+            .expect("side-pane multibuffer is a singleton")
     }
 
     fn toggle_base(&mut self, _: &mut Window, cx: &mut Context<Self>) {
@@ -631,34 +666,118 @@ fn build_side_pane_button_blocks(
     editor.update(cx, |editor, cx| editor.insert_blocks(block_properties, None, cx))
 }
 
-fn build_stage_pane(
-    content: String,
-    sibling: Entity<Buffer>,
+/// Builds an editor for one of the read-only side panes. If a `BufferDiff` is
+/// provided (i.e. we have a common ancestor to diff against), it's attached so
+/// the pane shows red/green hunks for what that stage changed vs. base.
+fn build_stage_editor(
+    stage_buffer: Entity<Buffer>,
+    diff: Option<Entity<BufferDiff>>,
     project: Entity<Project>,
     window: &mut Window,
     cx: &mut Context<MergeEditor>,
 ) -> Entity<Editor> {
-    // Transient in-memory buffer (no `ProjectPath`), so language servers don't
-    // get a phantom `didOpen` for a file that isn't on disk.
-    let language = sibling.read(cx).language().cloned();
-    let language_registry = sibling.read(cx).language_registry();
-
-    let stage_buffer = cx.new(|cx| {
-        let mut buffer = Buffer::local(content, cx);
-        buffer.set_language(language, cx);
-        if let Some(registry) = language_registry {
-            buffer.set_language_registry(registry);
-        }
-        buffer.set_capability(Capability::ReadOnly, cx);
-        buffer
-    });
-
     cx.new(|cx| {
-        let multibuffer = cx.new(|cx| MultiBuffer::singleton(stage_buffer, cx));
+        let multibuffer = cx.new(|cx| {
+            let mut multibuffer = MultiBuffer::singleton(stage_buffer, cx);
+            if let Some(diff) = diff {
+                multibuffer.add_diff(diff, cx);
+            }
+            multibuffer
+        });
         let mut editor = Editor::for_multibuffer(multibuffer, Some(project), window, cx);
         editor.set_read_only(true);
+        // Show all hunks expanded since the user is here to review every change.
+        editor.set_expand_all_diff_hunks(cx);
         editor
     })
+}
+
+struct StageBuffers {
+    base_buffer: Option<Entity<Buffer>>,
+    ours_buffer: Entity<Buffer>,
+    theirs_buffer: Entity<Buffer>,
+    /// `BufferDiff` of Ours against Base, attached to the Ours pane. `None`
+    /// when there's no base section to compare against.
+    ours_diff: Option<Entity<BufferDiff>>,
+    /// `BufferDiff` of Theirs against Base, attached to the Theirs pane.
+    theirs_diff: Option<Entity<BufferDiff>>,
+}
+
+async fn build_stage_buffers(
+    result_buffer: &Entity<Buffer>,
+    stages: &UnmergedStages,
+    cx: &mut AsyncApp,
+) -> Result<StageBuffers> {
+    let (language, language_registry) = result_buffer.read_with(cx, |buffer, _| {
+        (buffer.language().cloned(), buffer.language_registry())
+    });
+
+    // Transient in-memory buffers (no `ProjectPath`) so language servers don't
+    // see phantom `didOpen`s for files that don't exist on disk.
+    let make_buffer = |text: String, cx: &mut AsyncApp| -> Entity<Buffer> {
+        let language = language.clone();
+        let language_registry = language_registry.clone();
+        cx.new(|cx| {
+            let mut buffer = Buffer::local(text, cx);
+            buffer.set_language(language, cx);
+            if let Some(registry) = language_registry {
+                buffer.set_language_registry(registry);
+            }
+            buffer.set_capability(Capability::ReadOnly, cx);
+            buffer
+        })
+    };
+
+    let base_buffer = stages.base.clone().map(|text| make_buffer(text, cx));
+    let ours_buffer = make_buffer(stages.ours.clone().unwrap_or_default(), cx);
+    let theirs_buffer = make_buffer(stages.theirs.clone().unwrap_or_default(), cx);
+
+    let base_text: Option<Arc<str>> = stages.base.as_deref().map(Arc::from);
+
+    let ours_diff = match (&base_text, stages.ours.as_ref()) {
+        (Some(base), Some(_)) => Some(build_diff(&ours_buffer, base.clone(), cx).await?),
+        _ => None,
+    };
+    let theirs_diff = match (&base_text, stages.theirs.as_ref()) {
+        (Some(base), Some(_)) => Some(build_diff(&theirs_buffer, base.clone(), cx).await?),
+        _ => None,
+    };
+
+    Ok(StageBuffers {
+        base_buffer,
+        ours_buffer,
+        theirs_buffer,
+        ours_diff,
+        theirs_diff,
+    })
+}
+
+/// Builds a `BufferDiff` that compares `buffer`'s text against `base_text`.
+/// Highlights in the resulting diff are "what this side changed from base".
+async fn build_diff(
+    buffer: &Entity<Buffer>,
+    base_text: Arc<str>,
+    cx: &mut AsyncApp,
+) -> Result<Entity<BufferDiff>> {
+    let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot());
+    let diff = cx.new(|cx| BufferDiff::new(&snapshot.text, cx));
+
+    let update = diff
+        .update(cx, |diff, cx| {
+            diff.update_diff(
+                snapshot.text.clone(),
+                Some(base_text),
+                Some(true),
+                snapshot.language().cloned(),
+                cx,
+            )
+        })
+        .await;
+
+    diff.update(cx, |diff, cx| diff.set_snapshot(update, &snapshot.text, cx))
+        .await;
+
+    Ok(diff)
 }
 
 impl EventEmitter<EditorEvent> for MergeEditor {}
@@ -947,22 +1066,16 @@ mod tests {
 
         merge_editor.read_with(cx, |merge_editor, cx| {
             assert_eq!(
-                merge_editor
-                    .ours_editor
+                MergeEditor::stage_buffer(&merge_editor.ours_editor, cx)
                     .read(cx)
-                    .buffer()
-                    .read(cx)
-                    .snapshot(cx)
+                    .snapshot()
                     .text(),
                 "our line\n",
             );
             assert_eq!(
-                merge_editor
-                    .theirs_editor
+                MergeEditor::stage_buffer(&merge_editor.theirs_editor, cx)
                     .read(cx)
-                    .buffer()
-                    .read(cx)
-                    .snapshot(cx)
+                    .snapshot()
                     .text(),
                 "their line\n",
             );
@@ -971,7 +1084,10 @@ mod tests {
                 .as_ref()
                 .expect("base editor should be created when stage 1 is present");
             assert_eq!(
-                base_editor.read(cx).buffer().read(cx).snapshot(cx).text(),
+                MergeEditor::stage_buffer(base_editor, cx)
+                    .read(cx)
+                    .snapshot()
+                    .text(),
                 "base line\n",
             );
             assert!(!merge_editor.base_visible, "Base hidden by default");
@@ -1003,5 +1119,62 @@ mod tests {
                 "focused_inner_editor should track on_focus_in subscriptions"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_refuses_to_open_when_no_stages(
+        _: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "binary.bin": "ignored",
+            }),
+        )
+        .await;
+
+        // Mark as unmerged but provide no stage contents — emulates a binary
+        // conflict where `load_unmerged_stages` returns all-`None`.
+        fs.set_unmerged_paths_for_repo(
+            path!("/project/.git").as_ref(),
+            &[(
+                repo_path("binary.bin"),
+                UnmergedStatus {
+                    first_head: UnmergedStatusCode::Updated,
+                    second_head: UnmergedStatusCode::Updated,
+                },
+            )],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let (multi_workspace, cx) = cx.add_window_view(|window, cx| {
+            MultiWorkspace::test_new(project.clone(), window, cx)
+        });
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        cx.executor().run_until_parked();
+
+        let worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+        let project_path = ProjectPath {
+            worktree_id,
+            path: util::rel_path::rel_path("binary.bin").into(),
+        };
+
+        let err = workspace
+            .update_in(cx, |workspace, window, cx| {
+                MergeEditor::open(project_path, workspace.weak_handle(), window, cx)
+            })
+            .await
+            .expect_err("opening a stage-less unmerged path should error");
+        assert!(
+            err.to_string().contains("no text stages"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/git_ui/src/merge_editor.rs
+++ b/crates/git_ui/src/merge_editor.rs
@@ -1,0 +1,1007 @@
+//! 3-way merge editor.
+//!
+//! Renders a conflicted file alongside the `ours` and `theirs` index stages
+//! (and optionally the common ancestor `base`) so the user can resolve the
+//! conflict with full side-by-side context.
+//!
+//! This module ships the skeleton: three (or four, with Base) read-only side
+//! panes around the working-tree buffer. Diff highlights between the stages
+//! and per-conflict accept buttons are added in a later step.
+
+use anyhow::{Context as _, Result};
+use editor::{Editor, EditorEvent, MultiBuffer};
+use git::repository::UnmergedStages;
+use gpui::{
+    AnyElement, App, AppContext as _, Context, Entity, EventEmitter, FocusHandle, Focusable,
+    IntoElement, Render, Subscription, Task, WeakEntity, Window,
+};
+use language::{Buffer, Capability};
+use project::{ConflictRegion, ConflictSetUpdate, Project, ProjectItem as _, ProjectPath};
+use std::any::{Any, TypeId};
+use ui::prelude::*;
+use ui::{IconButtonShape, Tooltip};
+use util::paths::PathExt as _;
+use workspace::{
+    Item, ItemHandle as _, Workspace,
+    item::{ItemEvent, SaveOptions, TabContentParams},
+};
+
+/// Which side of a conflict a button accepts.
+#[derive(Clone, Copy)]
+enum AcceptSide {
+    Ours,
+    Theirs,
+}
+
+impl AcceptSide {
+    fn range(self, conflict: &project::ConflictRegion) -> Option<std::ops::Range<language::Anchor>> {
+        match self {
+            AcceptSide::Ours => Some(conflict.ours.clone()),
+            AcceptSide::Theirs => Some(conflict.theirs.clone()),
+        }
+    }
+}
+
+pub struct MergeEditor {
+    result_buffer: Entity<Buffer>,
+    result_editor: Entity<Editor>,
+    ours_editor: Entity<Editor>,
+    theirs_editor: Entity<Editor>,
+    /// Base/common-ancestor editor. Present even when hidden so toggling is
+    /// cheap; when `base_visible` is false it's simply not rendered.
+    base_editor: Option<Entity<Editor>>,
+    base_visible: bool,
+    ours_branch_label: SharedString,
+    theirs_branch_label: SharedString,
+    /// Which inner editor most recently received focus. Drives
+    /// [`Focusable::focus_handle`] and [`Item::act_as_type`] so that workspace
+    /// systems (focus tracking, vim, inline assist, etc.) see the editor the
+    /// user is actually interacting with, not just the Result pane.
+    last_focused_pane: FocusedPane,
+    /// Per-conflict accept-button block IDs that we own in the Ours and
+    /// Theirs side panes, so we can remove and re-insert them when the
+    /// underlying conflict set changes.
+    ours_side_blocks: Vec<editor::display_map::CustomBlockId>,
+    theirs_side_blocks: Vec<editor::display_map::CustomBlockId>,
+    _subscriptions: Vec<Subscription>,
+}
+
+#[derive(Copy, Clone, Default)]
+enum FocusedPane {
+    Ours,
+    #[default]
+    Result,
+    Theirs,
+    Base,
+}
+
+impl MergeEditor {
+    pub fn open(
+        project_path: ProjectPath,
+        workspace: WeakEntity<Workspace>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Task<Result<Entity<Self>>> {
+        window.spawn(cx, async move |cx| {
+            // Reuse an existing merge editor for this path if one is already
+            // open in the workspace; clicking the same conflicted file in the
+            // git panel shouldn't proliferate tabs. The check is done inside
+            // the spawned future to avoid nesting workspace.update calls when
+            // the caller is itself running inside one.
+            let existing = workspace.update_in(cx, |workspace, window, cx| {
+                let existing = workspace
+                    .items_of_type::<MergeEditor>(cx)
+                    .find(|item| {
+                        item.read(cx)
+                            .result_buffer
+                            .read(cx)
+                            .project_path(cx)
+                            .as_ref()
+                            == Some(&project_path)
+                    });
+                if let Some(existing) = existing {
+                    workspace.activate_item(&existing, true, true, window, cx);
+                    Some(existing)
+                } else {
+                    None
+                }
+            })?;
+            if let Some(existing) = existing {
+                return Ok(existing);
+            }
+
+            let project = workspace.update(cx, |workspace, _| workspace.project().clone())?;
+
+            let (repository, repo_path) = project.read_with(cx, |project, cx| {
+                project
+                    .git_store()
+                    .read(cx)
+                    .repository_and_path_for_project_path(&project_path, cx)
+                    .context("path is not in a git repository")
+            })?;
+
+            let result_buffer = project
+                .update(cx, |project, cx| {
+                    project.open_buffer(project_path.clone(), cx)
+                })
+                .await?;
+
+            let stages = repository
+                .update(cx, |repo, cx| repo.load_unmerged_stages(repo_path.clone(), cx))
+                .await?;
+
+            // If the working tree was written with 2-way markers (user's
+            // `merge.conflictStyle` is `merge`), fetch the diff3-style merge
+            // output now; we'll apply it to the buffer AFTER the result
+            // editor is fully constructed, to avoid a race where the
+            // `ConflictAddon`'s subscription on the conflict set fires before
+            // its own initial-state sync has populated `block_ids` and trips
+            // the addon's `debug_panic!` in conflict_view.rs. Skipped if the
+            // buffer is already dirty (preserves in-progress edits) or if
+            // the base stage isn't available.
+            let needs_diff3_rewrite = result_buffer.read_with(cx, |buffer, _| {
+                if buffer.is_dirty() {
+                    return false;
+                }
+                let snapshot = buffer.snapshot();
+                let conflicts = project::ConflictSet::parse(&snapshot);
+                !conflicts.conflicts.is_empty()
+                    && conflicts.conflicts.iter().all(|c| c.base.is_none())
+            });
+            let pending_diff3_rewrite = if needs_diff3_rewrite && stages.base.is_some() {
+                repository
+                    .update(cx, |repo, cx| repo.merge_file_diff3(repo_path.clone(), cx))
+                    .await
+                    .ok()
+            } else {
+                None
+            };
+
+            let (ours_branch_label, theirs_branch_label) = repository.read_with(cx, |repo, _| {
+                let branch = repo
+                    .branch
+                    .as_ref()
+                    .map(|b| b.name().to_string())
+                    .unwrap_or_else(|| "HEAD".to_string());
+                (
+                    SharedString::from(branch),
+                    SharedString::new_static("Incoming"),
+                )
+            });
+
+            workspace.update_in(cx, |workspace, window, cx| {
+                let project = workspace.project().clone();
+                let result_buffer_for_rewrite = result_buffer.clone();
+                let merge_editor = cx.new(|cx| {
+                    MergeEditor::new(
+                        result_buffer,
+                        stages,
+                        ours_branch_label,
+                        theirs_branch_label,
+                        project,
+                        window,
+                        cx,
+                    )
+                });
+
+                // Now that the result editor + `ConflictAddon` are fully
+                // initialized (the addon's `block_ids` matches the conflict
+                // set's current snapshot), apply the diff3 rewrite. The
+                // subsequent `ConflictSetUpdate` event arrives at a
+                // consistent addon state and can be processed without
+                // tripping the `block_ids` invariant in conflict_view.rs.
+                if let Some(diff3_text) = pending_diff3_rewrite {
+                    result_buffer_for_rewrite.update(cx, |buffer, cx| {
+                        buffer.set_text(diff3_text, cx);
+                    });
+                }
+
+                let pane = workspace.active_pane().clone();
+                pane.update(cx, |pane, cx| {
+                    pane.add_item(Box::new(merge_editor.clone()), true, true, None, window, cx);
+                });
+
+                merge_editor
+            })
+        })
+    }
+
+    fn new(
+        result_buffer: Entity<Buffer>,
+        stages: UnmergedStages,
+        ours_branch_label: SharedString,
+        theirs_branch_label: SharedString,
+        project: Entity<Project>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let result_editor = cx.new(|cx| {
+            let multibuffer = cx.new(|cx| MultiBuffer::singleton(result_buffer.clone(), cx));
+            let mut editor = Editor::for_multibuffer(multibuffer, Some(project.clone()), window, cx);
+            // Suppress the regular working-tree-vs-HEAD diff overlay. The
+            // merge editor's Result pane should show conflict highlights only,
+            // not the ambient git diff that paints `import sys` and the
+            // conflict marker lines red.
+            editor.start_temporary_diff_override();
+            // Override the default conflict marker colors with the same
+            // row-background palette the side panes use for their
+            // additions/deletions hunks, so the Result pane reads as a
+            // continuation of those rather than its own visual language.
+            // Base gets a subdued accent tint (no editor-level base color
+            // exists; the side panes don't render base directly).
+            let theme_colors = cx.theme().colors();
+            editor.register_addon(crate::conflict_view::ConflictHighlightPalette {
+                ours: theme_colors.editor_diff_hunk_added_background,
+                theirs: theme_colors.editor_diff_hunk_deleted_background,
+                base: theme_colors.text_accent.opacity(0.18),
+            });
+            editor
+        });
+
+        let ours_editor = build_stage_pane(
+            stages.ours.unwrap_or_default(),
+            result_buffer.clone(),
+            project.clone(),
+            window,
+            cx,
+        );
+        let theirs_editor = build_stage_pane(
+            stages.theirs.unwrap_or_default(),
+            result_buffer.clone(),
+            project.clone(),
+            window,
+            cx,
+        );
+        let base_editor = stages.base.map(|base_text| {
+            build_stage_pane(base_text, result_buffer.clone(), project.clone(), window, cx)
+        });
+
+        let mut subscriptions = Vec::new();
+        // Re-emit the inner editor's events as our own so the workspace's Item
+        // machinery sees dirty/saved/title-changed transitions on this tab.
+        // GPUI events don't bubble through `Render`; the workspace subscribes
+        // to events on the Item entity itself.
+        subscriptions.push(cx.subscribe(&result_editor, |_, _, event: &EditorEvent, cx| {
+            cx.emit(event.clone());
+        }));
+        // Track focus across all panes so `focus_handle` and `act_as_type`
+        // can return the editor the user is actually interacting with.
+        // Without this, clicking into Ours/Theirs/Base leaves vim and the
+        // workspace's `contains_focused` check pointing at Result.
+        for (pane, editor) in [
+            (FocusedPane::Result, &result_editor),
+            (FocusedPane::Ours, &ours_editor),
+            (FocusedPane::Theirs, &theirs_editor),
+        ]
+        .into_iter()
+        .chain(base_editor.as_ref().map(|e| (FocusedPane::Base, e)))
+        {
+            let focus_handle = editor.read(cx).focus_handle(cx);
+            subscriptions.push(cx.on_focus_in(&focus_handle, window, move |this, _, cx| {
+                this.last_focused_pane = pane;
+                cx.notify();
+            }));
+        }
+        // Subscribe to the conflict set so per-conflict accept buttons in
+        // the side panes are kept in sync as conflicts are added, removed,
+        // or resolved. The set is opened by `ConflictAddon` (registered on
+        // the result editor via `git_ui::init`); we go through the project's
+        // git store to get a handle to the same one.
+        let git_store = project.read(cx).git_store().clone();
+        let conflict_set = git_store.update(cx, |git_store, cx| {
+            git_store.open_conflict_set(result_buffer.clone(), cx)
+        });
+        subscriptions.push(cx.subscribe(
+            &conflict_set,
+            |this, _, _: &ConflictSetUpdate, cx| {
+                this.refresh_side_pane_buttons(cx);
+            },
+        ));
+
+        Self {
+            result_buffer,
+            result_editor,
+            ours_editor,
+            theirs_editor,
+            base_editor,
+            base_visible: false,
+            ours_branch_label,
+            theirs_branch_label,
+            last_focused_pane: FocusedPane::default(),
+            ours_side_blocks: Vec::new(),
+            theirs_side_blocks: Vec::new(),
+            _subscriptions: subscriptions,
+        }
+    }
+
+    /// The inner editor the user is currently interacting with, or
+    /// `result_editor` when no pane has been focused yet (the initial state).
+    /// Falls back to `result_editor` if the recorded pane is `Base` but no
+    /// base editor exists.
+    fn focused_inner_editor(&self) -> &Entity<Editor> {
+        match self.last_focused_pane {
+            FocusedPane::Ours => &self.ours_editor,
+            FocusedPane::Theirs => &self.theirs_editor,
+            FocusedPane::Base => self.base_editor.as_ref().unwrap_or(&self.result_editor),
+            FocusedPane::Result => &self.result_editor,
+        }
+    }
+
+    /// Whether the working-tree buffer currently has any parsed conflicts.
+    /// Drives the enabled state of the per-pane "Accept all" buttons.
+    fn has_conflicts(&self, cx: &App) -> bool {
+        !self.conflict_regions(cx).is_empty()
+    }
+
+    /// Returns every parsed conflict region in the result buffer, in document
+    /// order. Pulled from the `ConflictAddon` that `git_ui::init` registers on
+    /// every editor; if it isn't there yet (e.g., the first paint), the result
+    /// is empty.
+    fn conflict_regions(&self, cx: &App) -> Vec<project::ConflictRegion> {
+        let editor = self.result_editor.read(cx);
+        let Some(addon) = editor.addon::<crate::conflict_view::ConflictAddon>() else {
+            return Vec::new();
+        };
+        let buffer_id = self.result_buffer.read(cx).remote_id();
+        let Some(conflict_set) = addon.conflict_set(buffer_id) else {
+            return Vec::new();
+        };
+        conflict_set.read(cx).snapshot.conflicts.to_vec()
+    }
+
+    /// Accepts the given side for every conflict in the result buffer.
+    fn accept_all(
+        &mut self,
+        side: AcceptSide,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let conflicts = self.conflict_regions(cx);
+        for conflict in conflicts {
+            let Some(range) = side.range(&conflict) else {
+                continue;
+            };
+            crate::conflict_view::resolve_conflict(
+                self.result_editor.downgrade(),
+                conflict,
+                vec![range],
+                window,
+                cx,
+            )
+            .detach();
+        }
+    }
+
+    /// Refreshes the per-conflict "Use this" buttons in the Ours and Theirs
+    /// side panes, mirroring the inline buttons the result editor already
+    /// shows above each conflict. Each button is anchored to the first text
+    /// match of that conflict's side content within the side pane's buffer —
+    /// a cheap text-search rather than a full 3-way alignment, which suffices
+    /// when conflict payloads are reasonably distinctive (the common case).
+    fn refresh_side_pane_buttons(&mut self, cx: &mut Context<Self>) {
+        let conflicts = self.conflict_regions(cx);
+        let result_snapshot = self.result_buffer.read(cx).snapshot();
+        let result_handle = self.result_editor.downgrade();
+
+        for (editor, side, stored_blocks) in [
+            (
+                self.ours_editor.clone(),
+                AcceptSide::Ours,
+                &mut self.ours_side_blocks,
+            ),
+            (
+                self.theirs_editor.clone(),
+                AcceptSide::Theirs,
+                &mut self.theirs_side_blocks,
+            ),
+        ] {
+            // Tear down the previous batch before recomputing positions
+            // against the (possibly changed) conflict set.
+            editor.update(cx, |editor, cx| {
+                let stale = std::mem::take(stored_blocks);
+                if !stale.is_empty() {
+                    editor.remove_blocks(stale.into_iter().collect(), None, cx);
+                }
+            });
+
+            let new_blocks = build_side_pane_button_blocks(
+                &editor,
+                &result_snapshot,
+                &conflicts,
+                side,
+                result_handle.clone(),
+                cx,
+            );
+            *stored_blocks = new_blocks;
+        }
+    }
+
+    fn toggle_base(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+        if self.base_editor.is_some() {
+            self.base_visible = !self.base_visible;
+            cx.notify();
+        }
+    }
+
+    fn render_header(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let base_available = self.base_editor.is_some();
+        let base_visible = self.base_visible;
+        h_flex()
+            .px_2()
+            .py_1()
+            .gap_2()
+            .bg(cx.theme().colors().editor_background)
+            .border_b_1()
+            .border_color(cx.theme().colors().border)
+            .child(
+                Label::new(SharedString::new_static("3-way merge"))
+                    .size(ui::LabelSize::Small)
+                    .color(Color::Muted),
+            )
+            .child(div().flex_grow())
+            .child(
+                IconButton::new(
+                    "toggle-merge-base",
+                    if base_visible {
+                        IconName::EyeOff
+                    } else {
+                        IconName::Eye
+                    },
+                )
+                .shape(IconButtonShape::Square)
+                .icon_size(ui::IconSize::Small)
+                .disabled(!base_available)
+                .tooltip(move |_window, cx| {
+                    let text = if !base_available {
+                        "No common ancestor available (file added on both sides)"
+                    } else if base_visible {
+                        "Hide common ancestor"
+                    } else {
+                        "Show common ancestor"
+                    };
+                    Tooltip::simple(text, cx)
+                })
+                .on_click(cx.listener(|this, _, window, cx| this.toggle_base(window, cx))),
+            )
+    }
+
+    fn render_pane_header(
+        &self,
+        label: SharedString,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        h_flex()
+            .px_2()
+            .py_1()
+            .bg(cx.theme().colors().tab_bar_background)
+            .border_b_1()
+            .border_color(cx.theme().colors().border)
+            .child(
+                Label::new(label)
+                    .size(ui::LabelSize::Small)
+                    .color(Color::Muted),
+            )
+    }
+
+    /// Side-pane header with an "Accept all" button that resolves every
+    /// conflict in the result buffer with this side. The button is disabled
+    /// when there are no remaining conflicts to apply.
+    fn render_side_pane_header(
+        &self,
+        label: SharedString,
+        side: AcceptSide,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let has_conflicts = self.has_conflicts(cx);
+        let (button_id, button_label, tooltip): (&'static str, &'static str, &'static str) =
+            match side {
+                AcceptSide::Ours => (
+                    "accept-all-ours",
+                    "Accept all",
+                    "Accept this side for every conflict in the file",
+                ),
+                AcceptSide::Theirs => (
+                    "accept-all-theirs",
+                    "Accept all",
+                    "Accept this side for every conflict in the file",
+                ),
+            };
+        h_flex()
+            .px_2()
+            .py_1()
+            .gap_2()
+            .bg(cx.theme().colors().tab_bar_background)
+            .border_b_1()
+            .border_color(cx.theme().colors().border)
+            .child(
+                Label::new(label)
+                    .size(ui::LabelSize::Small)
+                    .color(Color::Muted),
+            )
+            .child(div().flex_grow())
+            .child(
+                Button::new(button_id, button_label)
+                    .label_size(LabelSize::Small)
+                    .disabled(!has_conflicts)
+                    .tooltip(move |_window, cx| Tooltip::simple(tooltip, cx))
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        this.accept_all(side, window, cx)
+                    })),
+            )
+    }
+}
+
+/// Inserts a "Use this" accept button block above each conflict's region in
+/// the given side-pane editor and returns the resulting block IDs. Each
+/// button locates its anchor by searching the side pane's text for the
+/// conflict's payload (the text between the markers in the working tree);
+/// if the payload isn't found (e.g. it's empty or duplicated elsewhere with
+/// no unique prefix), that conflict simply doesn't get a side-pane button —
+/// the inline buttons in the Result pane still work as the fallback.
+fn build_side_pane_button_blocks(
+    editor: &Entity<Editor>,
+    result_snapshot: &language::BufferSnapshot,
+    conflicts: &[ConflictRegion],
+    side: AcceptSide,
+    result_handle: WeakEntity<Editor>,
+    cx: &mut Context<MergeEditor>,
+) -> Vec<editor::display_map::CustomBlockId> {
+    use editor::display_map::{BlockPlacement, BlockProperties, BlockStyle};
+    use language::OffsetRangeExt as _;
+
+    let pane_buffer = editor
+        .read(cx)
+        .buffer()
+        .read(cx)
+        .as_singleton()
+        .expect("side-pane multibuffer is a singleton");
+    let pane_snapshot = pane_buffer.read(cx).snapshot();
+    let pane_text = pane_snapshot.text();
+
+    let label: SharedString = match side {
+        AcceptSide::Ours => "Use this".into(),
+        AcceptSide::Theirs => "Use this".into(),
+    };
+
+    let mut block_properties = Vec::new();
+    for conflict in conflicts {
+        let Some(range) = side.range(conflict) else {
+            continue;
+        };
+        let offset_range = range.to_offset(result_snapshot);
+        if offset_range.is_empty() {
+            continue;
+        }
+        let conflict_text: String = result_snapshot
+            .text_for_range(offset_range.clone())
+            .collect();
+        let Some(byte_pos) = pane_text.find(&conflict_text) else {
+            continue;
+        };
+        let buffer_anchor = pane_snapshot.anchor_before(byte_pos);
+        let multibuffer_snapshot = editor.read(cx).buffer().read(cx).snapshot(cx);
+        let Some(anchor) = multibuffer_snapshot.anchor_in_excerpt(buffer_anchor) else {
+            continue;
+        };
+        let conflict_for_click = conflict.clone();
+        let result_handle = result_handle.clone();
+        let label = label.clone();
+        block_properties.push(BlockProperties {
+            placement: BlockPlacement::Above(anchor),
+            height: Some(1),
+            style: BlockStyle::Sticky,
+            render: std::sync::Arc::new(move |cx| {
+                let conflict = conflict_for_click.clone();
+                let result_handle = result_handle.clone();
+                let label = label.clone();
+                let resolve_range = side.range(&conflict).expect("side range present");
+                h_flex()
+                    .id(cx.block_id)
+                    .h(cx.line_height)
+                    .ml(cx.margins.gutter.width)
+                    .bg(cx.theme().colors().editor_background)
+                    .child(
+                        Button::new(
+                            gpui::ElementId::Name(
+                                format!("merge-side-accept-{:?}", cx.block_id).into(),
+                            ),
+                            label,
+                        )
+                            .label_size(LabelSize::Small)
+                            .on_click(move |_, window, cx| {
+                                crate::conflict_view::resolve_conflict(
+                                    result_handle.clone(),
+                                    conflict.clone(),
+                                    vec![resolve_range.clone()],
+                                    window,
+                                    cx,
+                                )
+                                .detach();
+                            }),
+                    )
+                    .into_any()
+            }),
+            priority: 0,
+        });
+    }
+
+    if block_properties.is_empty() {
+        return Vec::new();
+    }
+    editor.update(cx, |editor, cx| editor.insert_blocks(block_properties, None, cx))
+}
+
+fn build_stage_pane(
+    content: String,
+    sibling: Entity<Buffer>,
+    project: Entity<Project>,
+    window: &mut Window,
+    cx: &mut Context<MergeEditor>,
+) -> Entity<Editor> {
+    // Transient in-memory buffer (no `ProjectPath`), so language servers don't
+    // get a phantom `didOpen` for a file that isn't on disk.
+    let language = sibling.read(cx).language().cloned();
+    let language_registry = sibling.read(cx).language_registry();
+
+    let stage_buffer = cx.new(|cx| {
+        let mut buffer = Buffer::local(content, cx);
+        buffer.set_language(language, cx);
+        if let Some(registry) = language_registry {
+            buffer.set_language_registry(registry);
+        }
+        buffer.set_capability(Capability::ReadOnly, cx);
+        buffer
+    });
+
+    cx.new(|cx| {
+        let multibuffer = cx.new(|cx| MultiBuffer::singleton(stage_buffer, cx));
+        let mut editor = Editor::for_multibuffer(multibuffer, Some(project), window, cx);
+        editor.set_read_only(true);
+        editor
+    })
+}
+
+impl EventEmitter<EditorEvent> for MergeEditor {}
+
+impl Focusable for MergeEditor {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.focused_inner_editor().focus_handle(cx)
+    }
+}
+
+impl Render for MergeEditor {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let ours_label = self.ours_branch_label.clone();
+        let theirs_label = self.theirs_branch_label.clone();
+
+        let ours_pane = v_flex()
+            .flex_1()
+            .size_full()
+            .border_r_1()
+            .border_color(cx.theme().colors().border)
+            .child(self.render_side_pane_header(
+                format!("Ours · {ours_label}").into(),
+                AcceptSide::Ours,
+                cx,
+            ))
+            .child(div().flex_1().size_full().child(self.ours_editor.clone()));
+
+        let base_pane = self
+            .base_visible
+            .then(|| self.base_editor.clone())
+            .flatten()
+            .map(|editor| {
+                v_flex()
+                    .flex_1()
+                    .size_full()
+                    .border_r_1()
+                    .border_color(cx.theme().colors().border)
+                    .child(self.render_pane_header(SharedString::new_static("Base"), cx))
+                    .child(div().flex_1().size_full().child(editor))
+            });
+
+        let result_pane = v_flex()
+            .flex_1()
+            .size_full()
+            .border_r_1()
+            .border_color(cx.theme().colors().border)
+            .child(self.render_pane_header(SharedString::new_static("Result"), cx))
+            .child(div().flex_1().size_full().child(self.result_editor.clone()));
+
+        let theirs_pane = v_flex()
+            .flex_1()
+            .size_full()
+            .child(self.render_side_pane_header(
+                format!("Theirs · {theirs_label}").into(),
+                AcceptSide::Theirs,
+                cx,
+            ))
+            .child(div().flex_1().size_full().child(self.theirs_editor.clone()));
+
+        v_flex()
+            .size_full()
+            .bg(cx.theme().colors().editor_background)
+            .child(self.render_header(cx))
+            .child(
+                h_flex()
+                    .flex_1()
+                    .size_full()
+                    .child(ours_pane)
+                    .when_some(base_pane, |this, base| this.child(base))
+                    .child(result_pane)
+                    .child(theirs_pane),
+            )
+    }
+}
+
+impl Item for MergeEditor {
+    type Event = EditorEvent;
+
+    fn tab_icon(&self, _window: &Window, _cx: &App) -> Option<Icon> {
+        Some(Icon::new(IconName::GitBranch).color(Color::Muted))
+    }
+
+    fn tab_content(&self, params: TabContentParams, _window: &Window, cx: &App) -> AnyElement {
+        Label::new(self.tab_content_text(params.detail.unwrap_or_default(), cx))
+            .color(if params.selected {
+                Color::Default
+            } else {
+                Color::Muted
+            })
+            .into_any_element()
+    }
+
+    fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
+        let name = self
+            .result_buffer
+            .read(cx)
+            .file()
+            .and_then(|file| {
+                file.full_path(cx)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+            })
+            .unwrap_or_else(|| "untitled".into());
+        format!("Merge: {name}").into()
+    }
+
+    fn tab_tooltip_text(&self, cx: &App) -> Option<ui::SharedString> {
+        let path = self
+            .result_buffer
+            .read(cx)
+            .file()
+            .map(|file| file.full_path(cx).compact().to_string_lossy().into_owned())
+            .unwrap_or_else(|| "untitled".into());
+        Some(format!("Merge: {path}").into())
+    }
+
+    fn to_item_events(event: &EditorEvent, f: &mut dyn FnMut(ItemEvent)) {
+        Editor::to_item_events(event, f)
+    }
+
+    fn telemetry_event_text(&self) -> Option<&'static str> {
+        Some("Merge Editor Opened")
+    }
+
+    fn act_as_type<'a>(
+        &'a self,
+        type_id: TypeId,
+        self_handle: &'a Entity<Self>,
+        cx: &'a App,
+    ) -> Option<gpui::AnyEntity> {
+        if type_id == TypeId::of::<Self>() {
+            Some(self_handle.clone().into())
+        } else {
+            // Route to whichever pane the user most recently focused so vim,
+            // inline assist, completion provider, and agent diff act on the
+            // editor the user is actually looking at — not just the Result
+            // pane.
+            self.focused_inner_editor().act_as_type(type_id, cx)
+        }
+    }
+
+    fn for_each_project_item(
+        &self,
+        cx: &App,
+        f: &mut dyn FnMut(gpui::EntityId, &dyn project::ProjectItem),
+    ) {
+        self.result_editor.for_each_project_item(cx, f)
+    }
+
+    fn deactivated(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.result_editor.deactivated(window, cx);
+    }
+
+    fn added_to_workspace(
+        &mut self,
+        workspace: &mut Workspace,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // The inline conflict resolver's `Use Ours` / `Use Theirs` / etc.
+        // buttons require the editor's `workspace` handle to be populated —
+        // `conflict_view::resolve_conflict` short-circuits when it's `None`.
+        // Without this delegation, the result editor's workspace handle
+        // never gets set and the buttons silently do nothing.
+        self.result_editor.update(cx, |editor, cx| {
+            editor.added_to_workspace(workspace, window, cx);
+        });
+    }
+
+    fn navigate(
+        &mut self,
+        data: std::sync::Arc<dyn Any + Send>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        self.result_editor
+            .update(cx, |editor, cx| editor.navigate(data, window, cx))
+    }
+
+    fn can_save(&self, cx: &App) -> bool {
+        self.result_editor.read(cx).can_save(cx)
+    }
+
+    fn save(
+        &mut self,
+        options: SaveOptions,
+        project: Entity<Project>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        self.result_editor.save(options, project, window, cx)
+    }
+
+    fn is_dirty(&self, cx: &App) -> bool {
+        self.result_editor.read(cx).is_dirty(cx)
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fs::FakeFs;
+    use git::{
+        repository::{UnmergedStages, repo_path},
+        status::{UnmergedStatus, UnmergedStatusCode},
+    };
+    use gpui::{BackgroundExecutor, TestAppContext};
+    use project::Project;
+    use serde_json::json;
+    use settings::SettingsStore;
+    use util::path;
+    use workspace::MultiWorkspace;
+
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_open_merge_editor(_: BackgroundExecutor, cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "conflict.txt": "<<<<<<< HEAD\nour line\n=======\ntheir line\n>>>>>>> branch\n",
+            }),
+        )
+        .await;
+
+        fs.set_unmerged_paths_for_repo(
+            path!("/project/.git").as_ref(),
+            &[(
+                repo_path("conflict.txt"),
+                UnmergedStatus {
+                    first_head: UnmergedStatusCode::Updated,
+                    second_head: UnmergedStatusCode::Updated,
+                },
+            )],
+        );
+
+        fs.set_unmerged_stages_for_repo(
+            path!("/project/.git").as_ref(),
+            &[(
+                repo_path("conflict.txt"),
+                UnmergedStages {
+                    base: Some("base line\n".into()),
+                    ours: Some("our line\n".into()),
+                    theirs: Some("their line\n".into()),
+                },
+            )],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let (multi_workspace, cx) = cx.add_window_view(|window, cx| {
+            MultiWorkspace::test_new(project.clone(), window, cx)
+        });
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        cx.executor().run_until_parked();
+
+        let worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+        let project_path = ProjectPath {
+            worktree_id,
+            path: util::rel_path::rel_path("conflict.txt").into(),
+        };
+
+        let merge_editor = workspace
+            .update_in(cx, |workspace, window, cx| {
+                MergeEditor::open(
+                    project_path,
+                    workspace.weak_handle(),
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+
+        merge_editor.read_with(cx, |merge_editor, cx| {
+            assert_eq!(
+                merge_editor
+                    .ours_editor
+                    .read(cx)
+                    .buffer()
+                    .read(cx)
+                    .snapshot(cx)
+                    .text(),
+                "our line\n",
+            );
+            assert_eq!(
+                merge_editor
+                    .theirs_editor
+                    .read(cx)
+                    .buffer()
+                    .read(cx)
+                    .snapshot(cx)
+                    .text(),
+                "their line\n",
+            );
+            let base_editor = merge_editor
+                .base_editor
+                .as_ref()
+                .expect("base editor should be created when stage 1 is present");
+            assert_eq!(
+                base_editor.read(cx).buffer().read(cx).snapshot(cx).text(),
+                "base line\n",
+            );
+            assert!(!merge_editor.base_visible, "Base hidden by default");
+            assert_eq!(
+                merge_editor.tab_content_text(0, cx).as_ref(),
+                "Merge: conflict.txt"
+            );
+        });
+
+        // Focus routing: clicking into a side pane must redirect `focus_handle`
+        // and `act_as_type::<Editor>()` so vim / inline-assist / contains_focused
+        // operate on the editor the user is actually interacting with.
+        merge_editor.update_in(cx, |this, window, cx| {
+            let ours_focus = this.ours_editor.read(cx).focus_handle(cx);
+            window.focus(&ours_focus, cx);
+        });
+        cx.executor().run_until_parked();
+
+        merge_editor.read_with(cx, |merge_editor, cx| {
+            let focused = merge_editor.focus_handle(cx);
+            assert_eq!(
+                focused,
+                merge_editor.ours_editor.read(cx).focus_handle(cx),
+                "focus_handle should redirect to the most recently focused inner editor"
+            );
+            assert_eq!(
+                merge_editor.focused_inner_editor().entity_id(),
+                merge_editor.ours_editor.entity_id(),
+                "focused_inner_editor should track on_focus_in subscriptions"
+            );
+        });
+    }
+}

--- a/crates/git_ui/src/merge_editor.rs
+++ b/crates/git_ui/src/merge_editor.rs
@@ -9,17 +9,26 @@
 //! (registered globally via `git_ui::init`'s `observe_new(Editor)` hook) and
 //! gains the "Use Base" button alongside the existing Use Ours / Use Theirs /
 //! Use Both buttons whenever the conflict has a base section.
+//!
+//! A "Mark as Resolved" button in the editor header runs `git add` once
+//! all conflict markers are gone from the buffer. If the path leaves the
+//! unmerged state externally (e.g., the user runs `git add` from a terminal),
+//! a banner appears informing them rather than the merge editor silently
+//! becoming meaningless.
 
 use anyhow::{Context as _, Result, anyhow};
 use buffer_diff::BufferDiff;
 use editor::{Editor, EditorEvent, MultiBuffer};
-use git::repository::UnmergedStages;
+use git::repository::{RepoPath, UnmergedStages};
 use gpui::{
     AnyElement, App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, FocusHandle,
     Focusable, IntoElement, Render, Subscription, Task, WeakEntity, Window,
 };
 use language::{Buffer, Capability};
-use project::{ConflictRegion, ConflictSetUpdate, Project, ProjectItem as _, ProjectPath};
+use project::{
+    ConflictRegion, ConflictSetUpdate, Project, ProjectItem as _, ProjectPath,
+    git_store::{Repository, RepositoryEvent},
+};
 use std::any::{Any, TypeId};
 use std::sync::Arc;
 use ui::prelude::*;
@@ -57,6 +66,19 @@ pub struct MergeEditor {
     base_visible: bool,
     ours_branch_label: SharedString,
     theirs_branch_label: SharedString,
+    repository: Entity<Repository>,
+    repo_path: RepoPath,
+    /// Set to true when the path leaves the unmerged state without the user
+    /// using this editor's "Mark as Resolved" button — i.e., resolved by an
+    /// external `git add`. Drives a banner; doesn't auto-close the editor so
+    /// the user keeps their cursor and scroll position.
+    externally_resolved: bool,
+    /// Sticky once the user clicks "Mark as Resolved": suppresses the
+    /// external-resolution banner for the status change our own `git add`
+    /// triggers, as well as any subsequent status changes (the file's
+    /// conflict is already resolved from this editor's point of view, so the
+    /// banner would be redundant).
+    internally_resolved: bool,
     /// Which inner editor most recently received focus. Drives
     /// [`Focusable::focus_handle`] and [`Item::act_as_type`] so that workspace
     /// systems (focus tracking, vim, inline assist, etc.) see the editor the
@@ -208,6 +230,8 @@ impl MergeEditor {
                         ours_branch_label,
                         theirs_branch_label,
                         project,
+                        repository,
+                        repo_path,
                         window,
                         cx,
                     )
@@ -246,6 +270,8 @@ impl MergeEditor {
         ours_branch_label: SharedString,
         theirs_branch_label: SharedString,
         project: Entity<Project>,
+        repository: Entity<Repository>,
+        repo_path: RepoPath,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -304,6 +330,24 @@ impl MergeEditor {
                 cx.notify();
             }));
         }
+        // Re-render when the result buffer is edited so the "Mark as Resolved"
+        // button's enabled state stays current.
+        subscriptions.push(cx.subscribe(&result_buffer, |this, _, event, cx| {
+            if let language::BufferEvent::Edited { .. } = event {
+                this.refresh_resolution_state(cx);
+            }
+        }));
+        // Watch for external resolution: when statuses change, re-check
+        // whether our path is still unmerged.
+        let repo_path_clone = repo_path.clone();
+        subscriptions.push(cx.subscribe(
+            &repository,
+            move |this, repo, event: &RepositoryEvent, cx| {
+                if matches!(event, RepositoryEvent::StatusesChanged) {
+                    this.on_statuses_changed(&repo, &repo_path_clone, cx);
+                }
+            },
+        ));
         // Subscribe to the conflict set so per-conflict accept buttons in
         // the side panes are kept in sync as conflicts are added, removed,
         // or resolved. The set is opened by `ConflictAddon` (registered on
@@ -329,6 +373,10 @@ impl MergeEditor {
             base_visible: false,
             ours_branch_label,
             theirs_branch_label,
+            repository,
+            repo_path,
+            externally_resolved: false,
+            internally_resolved: false,
             last_focused_pane: FocusedPane::default(),
             ours_side_blocks: Vec::new(),
             theirs_side_blocks: Vec::new(),
@@ -438,6 +486,79 @@ impl MergeEditor {
         }
     }
 
+    fn refresh_resolution_state(&self, cx: &mut Context<Self>) {
+        // Currently just notifies; the render path recomputes the marker scan.
+        // Centralized here so future caching (e.g., debounced text scans for
+        // very large files) has one entry point.
+        cx.notify();
+    }
+
+    fn on_statuses_changed(
+        &mut self,
+        repository: &Entity<Repository>,
+        repo_path: &RepoPath,
+        cx: &mut Context<Self>,
+    ) {
+        let still_conflicted = repository
+            .read(cx)
+            .status_for_path(repo_path)
+            .map(|entry| entry.status.is_conflicted())
+            .unwrap_or(false);
+        if !still_conflicted && !self.externally_resolved && !self.internally_resolved {
+            self.externally_resolved = true;
+        }
+        // Always notify so the header button picks up index-level changes
+        // (e.g., transitions between staged ↔ unstaged after the user
+        // clicks `Mark as Resolved` or `Unstage`).
+        cx.notify();
+    }
+
+    /// True when the working-tree buffer no longer contains any parseable
+    /// conflict region. Uses the same parser the inline conflict view drives
+    /// from, so a legitimate `=======` line in a Markdown/RST/banner-comment
+    /// file isn't mistaken for an unresolved marker.
+    fn all_markers_cleared(&self, cx: &App) -> bool {
+        let snapshot = self.result_buffer.read(cx).snapshot();
+        project::ConflictSet::parse(&snapshot).conflicts.is_empty()
+    }
+
+    fn mark_as_resolved(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        if !self.all_markers_cleared(cx) {
+            return;
+        }
+        // `Repository::stage_entries` already saves any dirty buffer for the
+        // path before invoking `git add`, so the working tree on disk
+        // matches what the user sees here. Mark the resolution as internal
+        // ONLY after staging succeeds — otherwise a failed `git add` would
+        // permanently latch the flag, suppressing the external-resolution
+        // banner forever even if the file is later resolved from a terminal.
+        let stage = self
+            .repository
+            .update(cx, |repo, cx| repo.stage_entries(vec![self.repo_path.clone()], cx));
+        cx.spawn(async move |this, cx| {
+            stage.await?;
+            this.update(cx, |this, cx| {
+                this.internally_resolved = true;
+                cx.notify();
+            })
+        })
+        .detach_and_log_err(cx);
+    }
+
+    /// Inverse of `mark_as_resolved`: runs `git reset HEAD <path>` so the
+    /// file leaves the staged area. Lets the user undo a too-eager
+    /// resolution without dropping to a terminal. The path doesn't go back
+    /// to being unmerged in git (that's a one-way state transition you'd
+    /// need `git checkout --conflict` for), but the staged-vs-working-tree
+    /// distinction does, which is the bit the button toggles.
+    fn unstage_resolution(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        let unstage = self
+            .repository
+            .update(cx, |repo, cx| repo.unstage_entries(vec![self.repo_path.clone()], cx));
+        cx.spawn(async move |_, _cx| unstage.await)
+            .detach_and_log_err(cx);
+    }
+
     /// Returns the underlying single buffer behind a side-pane editor.
     /// Side-pane editors wrap their stage buffer in a `MultiBuffer::singleton`
     /// so `as_singleton()` always succeeds.
@@ -461,6 +582,43 @@ impl MergeEditor {
     fn render_header(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let base_available = self.base_editor.is_some();
         let base_visible = self.base_visible;
+        // Derive button state from the live repository status rather than the
+        // sticky `externally_resolved` flag: when the path currently has
+        // anything staged in the index, show "Unstage" so the user can undo
+        // a `git add` they (or someone else) ran. Otherwise show "Mark as
+        // Resolved".
+        let is_staged = self
+            .repository
+            .read(cx)
+            .status_for_path(&self.repo_path)
+            .map(|entry| entry.status.staging().has_staged())
+            .unwrap_or(false);
+        let resolved_enabled = self.all_markers_cleared(cx);
+        let resolution_button = if is_staged {
+            Button::new("unstage-resolution", "Unstage")
+                .label_size(LabelSize::Small)
+                .tooltip(|_window, cx| {
+                    Tooltip::simple("Undo `git add` for this file", cx)
+                })
+                .on_click(
+                    cx.listener(|this, _, window, cx| this.unstage_resolution(window, cx)),
+                )
+        } else {
+            Button::new("mark-as-resolved", "Mark as Resolved")
+                .label_size(LabelSize::Small)
+                .disabled(!resolved_enabled)
+                .tooltip(move |_window, cx| {
+                    let text = if resolved_enabled {
+                        "Stage this file with `git add` to mark the conflict resolved"
+                    } else {
+                        "Remove all conflict markers from the buffer first"
+                    };
+                    Tooltip::simple(text, cx)
+                })
+                .on_click(
+                    cx.listener(|this, _, window, cx| this.mark_as_resolved(window, cx)),
+                )
+        };
         h_flex()
             .px_2()
             .py_1()
@@ -474,6 +632,7 @@ impl MergeEditor {
                     .color(Color::Muted),
             )
             .child(div().flex_grow())
+            .child(resolution_button)
             .child(
                 IconButton::new(
                     "toggle-merge-base",
@@ -498,6 +657,32 @@ impl MergeEditor {
                 })
                 .on_click(cx.listener(|this, _, window, cx| this.toggle_base(window, cx))),
             )
+    }
+
+    fn render_external_resolution_banner(&self, cx: &mut Context<Self>) -> AnyElement {
+        if !self.externally_resolved {
+            return gpui::Empty.into_any_element();
+        }
+        h_flex()
+            .px_2()
+            .py_1()
+            .gap_2()
+            .bg(cx.theme().colors().element_background)
+            .border_b_1()
+            .border_color(cx.theme().colors().border)
+            .child(
+                Icon::new(IconName::Info)
+                    .size(ui::IconSize::Small)
+                    .color(Color::Info),
+            )
+            .child(
+                Label::new(SharedString::new_static(
+                    "This file is no longer in conflict. The merge editor remains open so you don't lose your place.",
+                ))
+                .size(LabelSize::Small)
+                .color(Color::Muted),
+            )
+            .into_any_element()
     }
 
     fn render_pane_header(
@@ -841,6 +1026,7 @@ impl Render for MergeEditor {
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .child(self.render_header(cx))
+            .child(self.render_external_resolution_banner(cx))
             .child(
                 h_flex()
                     .flex_1()
@@ -1176,5 +1362,219 @@ mod tests {
             err.to_string().contains("no text stages"),
             "unexpected error: {err}"
         );
+    }
+
+    /// Opens a merge editor for `/project/conflict.txt` with realistic stages
+    /// and returns the project, workspace, merge editor, and cx for further
+    /// assertions. Used by the Mark-as-Resolved and external-resolution tests.
+    async fn open_for_test(
+        cx: &mut TestAppContext,
+    ) -> (
+        Arc<FakeFs>,
+        Entity<Project>,
+        Entity<MergeEditor>,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "conflict.txt": "<<<<<<< HEAD\nour line\n=======\ntheir line\n>>>>>>> branch\n",
+            }),
+        )
+        .await;
+
+        fs.set_unmerged_paths_for_repo(
+            path!("/project/.git").as_ref(),
+            &[(
+                repo_path("conflict.txt"),
+                UnmergedStatus {
+                    first_head: UnmergedStatusCode::Updated,
+                    second_head: UnmergedStatusCode::Updated,
+                },
+            )],
+        );
+        fs.set_unmerged_stages_for_repo(
+            path!("/project/.git").as_ref(),
+            &[(
+                repo_path("conflict.txt"),
+                UnmergedStages {
+                    base: Some("base line\n".into()),
+                    ours: Some("our line\n".into()),
+                    theirs: Some("their line\n".into()),
+                },
+            )],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let (multi_workspace, view_cx) = cx.add_window_view(|window, cx| {
+            MultiWorkspace::test_new(project.clone(), window, cx)
+        });
+        let workspace = multi_workspace.read_with(view_cx, |mw, _| mw.workspace().clone());
+        view_cx.executor().run_until_parked();
+
+        let worktree_id = project.read_with(view_cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+        let project_path = ProjectPath {
+            worktree_id,
+            path: util::rel_path::rel_path("conflict.txt").into(),
+        };
+        let merge_editor = workspace
+            .update_in(view_cx, |workspace, window, cx| {
+                MergeEditor::open(project_path, workspace.weak_handle(), window, cx)
+            })
+            .await
+            .unwrap();
+
+        (fs, project, merge_editor)
+    }
+
+    #[gpui::test]
+    async fn test_external_resolution_sets_banner_flag(
+        _: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        let (fs, _project, merge_editor) = open_for_test(cx).await;
+
+        merge_editor.read_with(cx, |this, _| {
+            assert!(
+                !this.externally_resolved,
+                "fresh merge editor must not have the banner flag set"
+            );
+        });
+
+        // Externally resolve: remove the unmerged path from the repo state.
+        // This mirrors what a terminal `git add` would do.
+        fs.set_unmerged_paths_for_repo(path!("/project/.git").as_ref(), &[]);
+        cx.executor().run_until_parked();
+
+        merge_editor.read_with(cx, |this, _| {
+            assert!(
+                this.externally_resolved,
+                "merge editor should detect external resolution via RepositoryEvent"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_internal_resolution_suppresses_banner(
+        _: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        let (fs, _project, merge_editor) = open_for_test(cx).await;
+
+        // Set the flag the way `mark_as_resolved` would. We do this directly
+        // rather than via the button-handler closure because the latter takes
+        // a `&mut Window` which the existing test fixture doesn't surface.
+        // The behavior under test is `on_statuses_changed` honoring the flag.
+        merge_editor.update(cx, |this, _| {
+            this.internally_resolved = true;
+        });
+
+        // Simulate `git add` completing: the path leaves the unmerged set.
+        fs.set_unmerged_paths_for_repo(path!("/project/.git").as_ref(), &[]);
+        cx.executor().run_until_parked();
+
+        merge_editor.read_with(cx, |this, _| {
+            assert!(
+                !this.externally_resolved,
+                "banner must not fire when the user resolved via this editor's button"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_mark_as_resolved_disabled_when_markers_present(
+        _: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        let (_fs, _project, merge_editor) = open_for_test(cx).await;
+
+        merge_editor.read_with(cx, |this, cx| {
+            assert!(
+                !this.all_markers_cleared(cx),
+                "freshly opened conflict file still contains markers"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_mark_as_resolved_when_markers_cleared(
+        _: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        let (_fs, _project, merge_editor) = open_for_test(cx).await;
+
+        // Simulate the user resolving every conflict by replacing the buffer
+        // contents with marker-free text.
+        merge_editor.update(cx, |this, cx| {
+            this.result_buffer.update(cx, |buffer, cx| {
+                buffer.set_text("our line\n", cx);
+            });
+        });
+        cx.executor().run_until_parked();
+
+        merge_editor.read_with(cx, |this, cx| {
+            assert!(
+                this.all_markers_cleared(cx),
+                "marker scan should report clean once <<<< etc. are removed"
+            );
+        });
+    }
+
+    /// Regression test for the `=======` substring false-positive: legitimate
+    /// content (Markdown H1 underlines, RST headings, ASCII banner comments)
+    /// frequently contains a bare line of equals signs. Using `ConflictSet::parse`
+    /// rather than `str::contains` keeps Mark-as-Resolved enabled for those files.
+    #[gpui::test]
+    async fn test_all_markers_cleared_ignores_legitimate_equals_lines(
+        _: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        let (_fs, _project, merge_editor) = open_for_test(cx).await;
+
+        // Resolved content that legitimately contains a Markdown H1 underline
+        // / RST section divider made of equals signs.
+        merge_editor.update(cx, |this, cx| {
+            this.result_buffer.update(cx, |buffer, cx| {
+                buffer.set_text("# Heading\n=======\n\nthe resolved body\n", cx);
+            });
+        });
+        cx.executor().run_until_parked();
+
+        merge_editor.read_with(cx, |this, cx| {
+            assert!(
+                this.all_markers_cleared(cx),
+                "bare `=======` lines outside a conflict block must not block Mark-as-Resolved"
+            );
+        });
+    }
+
+    /// Side-pane buffers must not be attached to any `ProjectPath`. The merge
+    /// editor builds them via `Buffer::local`, so language servers don't get
+    /// phantom `didOpen` notifications for files that don't exist on disk.
+    #[gpui::test]
+    async fn test_side_pane_buffers_have_no_project_path(
+        _: BackgroundExecutor,
+        cx: &mut TestAppContext,
+    ) {
+        let (_fs, _project, merge_editor) = open_for_test(cx).await;
+
+        merge_editor.read_with(cx, |this, cx| {
+            for editor in [&this.ours_editor, &this.theirs_editor]
+                .into_iter()
+                .chain(this.base_editor.as_ref())
+            {
+                let buffer = MergeEditor::stage_buffer(editor, cx);
+                assert!(
+                    buffer.read(cx).file().is_none(),
+                    "side-pane buffer must have no on-disk file (otherwise LSPs \
+                     would see a phantom didOpen)"
+                );
+            }
+        });
     }
 }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -37,8 +37,8 @@ use git::{
         Branch, CommitData, CommitDetails, CommitDiff, CommitFile, CommitOptions,
         CreateWorktreeTarget, DiffType, FetchOptions, GitCommitTemplate, GitRepository,
         GitRepositoryCheckpoint, InitialGraphCommitData, LogOrder, LogSource, PushOptions, Remote,
-        RemoteCommandOutput, RepoPath, ResetMode, SearchCommitArgs, UpstreamTrackingStatus,
-        Worktree as GitWorktree, delete_branch_flag,
+        RemoteCommandOutput, RepoPath, ResetMode, SearchCommitArgs, UnmergedStages,
+        UpstreamTrackingStatus, Worktree as GitWorktree, delete_branch_flag,
     },
     stash::{GitStash, StashEntry},
     status::{
@@ -7994,6 +7994,51 @@ impl Repository {
                         .await?;
                     Ok(response.content)
                 }
+            }
+        });
+        cx.spawn(|_: &mut AsyncApp| async move { rx.await? })
+    }
+
+    /// Returns the base / ours / theirs (index stages 1/2/3) for an unmerged
+    /// path. Each side is `None` for a missing stage (e.g. a modify/delete
+    /// conflict) or non-UTF-8 blob. Returns a fully-`None` value for paths
+    /// that are not unmerged.
+    ///
+    /// Remote repositories are not yet supported and will return a fully-`None`
+    /// value; the 3-way merge editor only opens local files for now.
+    pub fn load_unmerged_stages(
+        &mut self,
+        repo_path: RepoPath,
+        cx: &App,
+    ) -> Task<Result<UnmergedStages>> {
+        let rx = self.send_job("load_unmerged_stages", None, move |state, _| async move {
+            match state {
+                RepositoryState::Local(LocalRepositoryState { backend, .. }) => {
+                    anyhow::Ok(backend.load_unmerged_stages(repo_path).await)
+                }
+                RepositoryState::Remote(_) => Ok(UnmergedStages::default()),
+            }
+        });
+        cx.spawn(|_: &mut AsyncApp| async move { rx.await? })
+    }
+
+    /// Re-runs git's 3-way merge for an unmerged path and returns the file
+    /// content with diff3-style markers, regardless of the user's
+    /// `merge.conflictStyle` config. Used by the merge editor to present a
+    /// base section when the working tree was written with 2-way markers.
+    pub fn merge_file_diff3(
+        &mut self,
+        repo_path: RepoPath,
+        cx: &App,
+    ) -> Task<Result<String>> {
+        let rx = self.send_job("merge_file_diff3", None, move |state, _| async move {
+            match state {
+                RepositoryState::Local(LocalRepositoryState { backend, .. }) => {
+                    backend.merge_file_diff3(repo_path).await
+                }
+                RepositoryState::Remote(_) => Err(anyhow!(
+                    "merge_file_diff3 is not supported on remote repositories"
+                )),
             }
         });
         cx.spawn(|_: &mut AsyncApp| async move { rx.await? })

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -5,7 +5,7 @@ mod conflict_set_tests {
 
     use fs::FakeFs;
     use git::{
-        repository::{RepoPath, repo_path},
+        repository::{RepoPath, UnmergedStages, repo_path},
         status::{UnmergedStatus, UnmergedStatusCode},
     };
     use gpui::{BackgroundExecutor, TestAppContext};
@@ -622,6 +622,109 @@ mod conflict_set_tests {
             assert!(!conflict_set.has_conflict);
             assert_eq!(conflict_set.snapshot.conflicts.len(), 0);
         });
+    }
+
+    #[gpui::test]
+    async fn test_load_unmerged_stages(executor: BackgroundExecutor, cx: &mut TestAppContext) {
+        zlog::init_test();
+        cx.update(|cx| {
+            settings::init(cx);
+        });
+
+        let fs = FakeFs::new(executor);
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "conflict.txt": "<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n",
+                "deleted_by_them.txt": "kept by us\n",
+                "clean.txt": "no conflict here\n",
+            }),
+        )
+        .await;
+
+        fs.set_unmerged_paths_for_repo(
+            path!("/project/.git").as_ref(),
+            &[
+                (
+                    repo_path("conflict.txt"),
+                    UnmergedStatus {
+                        first_head: UnmergedStatusCode::Updated,
+                        second_head: UnmergedStatusCode::Updated,
+                    },
+                ),
+                (
+                    repo_path("deleted_by_them.txt"),
+                    UnmergedStatus {
+                        first_head: UnmergedStatusCode::Updated,
+                        second_head: UnmergedStatusCode::Deleted,
+                    },
+                ),
+            ],
+        );
+
+        fs.set_unmerged_stages_for_repo(
+            path!("/project/.git").as_ref(),
+            &[
+                (
+                    repo_path("conflict.txt"),
+                    UnmergedStages {
+                        base: Some("base\n".into()),
+                        ours: Some("ours\n".into()),
+                        theirs: Some("theirs\n".into()),
+                    },
+                ),
+                (
+                    repo_path("deleted_by_them.txt"),
+                    UnmergedStages {
+                        base: Some("base\n".into()),
+                        ours: Some("kept by us\n".into()),
+                        theirs: None,
+                    },
+                ),
+            ],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        cx.executor().run_until_parked();
+
+        let repository = project.read_with(cx, |project, cx| {
+            project.repositories(cx).values().next().unwrap().clone()
+        });
+
+        let stages = cx
+            .update(|cx| {
+                repository.update(cx, |repository, cx| {
+                    repository.load_unmerged_stages(repo_path("conflict.txt"), cx)
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(stages.base.as_deref(), Some("base\n"));
+        assert_eq!(stages.ours.as_deref(), Some("ours\n"));
+        assert_eq!(stages.theirs.as_deref(), Some("theirs\n"));
+
+        let stages = cx
+            .update(|cx| {
+                repository.update(cx, |repository, cx| {
+                    repository.load_unmerged_stages(repo_path("deleted_by_them.txt"), cx)
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(stages.base.as_deref(), Some("base\n"));
+        assert_eq!(stages.ours.as_deref(), Some("kept by us\n"));
+        assert!(stages.theirs.is_none());
+
+        let stages = cx
+            .update(|cx| {
+                repository.update(cx, |repository, cx| {
+                    repository.load_unmerged_stages(repo_path("clean.txt"), cx)
+                })
+            })
+            .await
+            .unwrap();
+        assert_eq!(stages, UnmergedStages::default());
     }
 }
 

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -716,6 +716,14 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: 72
     pub commit_title_max_length: Option<usize>,
+
+    /// Whether opening a conflicted file from the git panel uses the
+    /// dedicated 3-way merge editor (Ours / Result / Theirs side panes).
+    /// When disabled, conflicted files open in the regular project diff
+    /// view, matching Zed's behavior before the merge editor existed.
+    ///
+    /// Default: false
+    pub merge_editor: Option<bool>,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7334,6 +7334,30 @@ fn version_control_page() -> SettingsPage {
         ]
     }
 
+    fn merge_editor_section() -> [SettingsPageItem; 2] {
+        [
+            SettingsPageItem::SectionHeader("Merge Editor"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "3-Way Merge Editor",
+                description: "Open conflicted files in a dedicated 3-way merge editor (Ours / Result / Theirs side panes). When disabled, conflicted files open in the regular project diff view.",
+                field: Box::new(SettingField {
+                    json_path: Some("git_panel.merge_editor"),
+                    pick: |settings_content| {
+                        settings_content.git_panel.as_ref()?.merge_editor.as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .git_panel
+                            .get_or_insert_default()
+                            .merge_editor = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+        ]
+    }
+
     SettingsPage {
         title: "Version Control",
         items: concat_sections![
@@ -7343,6 +7367,7 @@ fn version_control_page() -> SettingsPage {
             git_blame_view_section(),
             branch_picker_section(),
             git_hunks_section(),
+            merge_editor_section(),
         ],
     }
 }

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -318,7 +318,9 @@ pub mod git {
             /// Opens the git worktree selector.
             Worktree,
             /// Creates a pull request for the current branch.
-            CreatePullRequest
+            CreatePullRequest,
+            /// Opens the active conflicted file in a 3-way merge editor.
+            OpenMergeEditor,
         ]
     );
 }


### PR DESCRIPTION
# Add a 3-way merge editor for git conflicts

Feature preview:
<img width="1508" height="611" alt="Screenshot 2026-05-27 at 11 32 13" src="https://github.com/user-attachments/assets/d3731534-519a-44d7-b5c1-2a2913a9c4e2" />

Adds a dedicated workspace item that renders a conflicted file alongside its
`ours` and `theirs` index stages, with the common ancestor available behind a
toggle. Closes the loop on conflict resolution with a "Mark as Resolved"
button, side-pane diffs against the base, and a banner that detects external
resolution (e.g. `git add` from a terminal) without losing the user's place.

The existing inline conflict view is unchanged: this is gated behind a new
setting (default off), and when the setting is off every code path falls back
to current behavior.

The feature is reachable from **Settings → Version Control → Merge Editor →
3-Way Merge Editor** (or `"git_panel": { "merge_editor": true }` in settings
JSON).

## Notes for reviewers

- **Behavior when the setting is off**: identical to current behavior. The
  inline conflict view continues to work; the `Use Base` button is hidden;
  the merge editor is unreachable from the Git panel and the
  `OpenMergeEditor` action is a no-op.
- **diff3 marker scope**: users with `merge.conflictStyle = zdiff3` globally
  are still overridden to plain `diff3` for the matched subcommands; we can
  refine this later if it becomes a real complaint.

Release Notes:

- Added an optional 3-way merge editor for git conflicts (Ours / Result / Theirs side panes, Use Base button, Mark as Resolved), gated by the `git_panel.merge_editor` setting (default off)

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Resolves #34813