### PR TITLE
ep: Make `tree-sitter` dependency optional in  `edit_prediction_metrics`

### DIFF
--- a/crates/edit_prediction/Cargo.toml
+++ b/crates/edit_prediction/Cargo.toml
@@ -31,7 +31,7 @@ credentials_provider.workspace = true
 db.workspace = true
 edit_prediction_types.workspace = true
 edit_prediction_context.workspace = true
-edit_prediction_metrics.workspace = true
+edit_prediction_metrics = { workspace = true, features = ["tree-sitter"] }
 feature_flags.workspace = true
 fs.workspace = true
 futures.workspace = true

--- a/crates/edit_prediction_cli/Cargo.toml
+++ b/crates/edit_prediction_cli/Cargo.toml
@@ -61,7 +61,7 @@ terminal_view.workspace = true
 util.workspace = true
 watch.workspace = true
 edit_prediction = { workspace = true, features = ["cli-support"] }
-edit_prediction_metrics.workspace = true
+edit_prediction_metrics = { workspace = true, features = ["tree-sitter"] }
 telemetry_events.workspace = true
 wasmtime.workspace = true
 zeta_prompt.workspace = true

--- a/crates/edit_prediction_metrics/Cargo.toml
+++ b/crates/edit_prediction_metrics/Cargo.toml
@@ -11,12 +11,15 @@ workspace = true
 [lib]
 path = "src/edit_prediction_metrics.rs"
 
+[features]
+tree-sitter = ["dep:tree-sitter"]
+
 [dependencies]
 imara-diff.workspace = true
 serde.workspace = true
 serde_json = "1.0"
 similar = "2.7.0"
-tree-sitter.workspace = true
+tree-sitter = { workspace = true, optional = true }
 zeta_prompt.workspace = true
 
 [dev-dependencies]

--- a/crates/edit_prediction_metrics/src/edit_prediction_metrics.rs
+++ b/crates/edit_prediction_metrics/src/edit_prediction_metrics.rs
@@ -4,6 +4,7 @@ mod prediction_score;
 mod reversal;
 mod summary;
 mod tokenize;
+#[cfg(feature = "tree-sitter")]
 mod tree_sitter;
 
 pub use kept_rate::AnnotatedToken;
@@ -30,4 +31,5 @@ pub use prediction_score::{
 };
 pub use reversal::compute_prediction_reversal_ratio_from_history;
 pub use summary::{PredictionSummaryInput, QaSummaryData, SummaryJson, compute_summary};
+#[cfg(feature = "tree-sitter")]
 pub use tree_sitter::count_tree_sitter_errors;


### PR DESCRIPTION
Needed for use in cloud

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A or Added/Fixed/Improved ...
