### PR TITLE
Add .agents folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .blob_store
 .build
 .claude/settings.local.json
+.agents/*
 .envrc
 .flatpak-builder
 .idea


### PR DESCRIPTION
This PR adds .agents to zed's .gitignore file to allow people to have to have local only skills

We can still manually add skills to Zed when people want to share them. This should make it easier for people have their own custom skills while still being able to run `git add .`

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
