### PR TITLE
Remove leftover test a11y label

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -238,8 +238,6 @@ impl Render for TitleBar {
             }
         }
 
-        children.push(gpui::text!("Hello from a11y").into_any_element());
-
         children.push(
             h_flex()
                 .h_full()


### PR DESCRIPTION
Removes a leftover test label added by #56065 

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
