### PR TITLE
Reword global rules section in agent system prompts

### DIFF
--- a/crates/agent/src/templates.rs
+++ b/crates/agent/src/templates.rs
@@ -131,12 +131,14 @@ mod tests {
         let templates = Templates::new();
         let rendered = template.render(&templates).unwrap();
 
-        assert!(rendered.contains("### Personal `AGENTS.md`"));
+        assert!(rendered.contains("These instructions apply to every project this user opens"));
         assert!(rendered.contains("always be concise"));
         assert!(rendered.contains("### Project Rules"));
         assert!(rendered.contains("project-specific guidance"));
 
-        let personal_idx = rendered.find("### Personal `AGENTS.md`").unwrap();
+        let personal_idx = rendered
+            .find("These instructions apply to every project this user opens")
+            .unwrap();
         let project_idx = rendered.find("### Project Rules").unwrap();
         assert!(
             personal_idx < project_idx,
@@ -231,7 +233,7 @@ mod tests {
         };
         let templates = Templates::new();
         let rendered = template.render(&templates).unwrap();
-        assert!(!rendered.contains("### Personal `AGENTS.md`"));
+        assert!(!rendered.contains("These instructions apply to every project this user opens"));
     }
 
     #[test]

--- a/crates/agent/src/templates.rs
+++ b/crates/agent/src/templates.rs
@@ -131,14 +131,12 @@ mod tests {
         let templates = Templates::new();
         let rendered = template.render(&templates).unwrap();
 
-        assert!(rendered.contains("These instructions apply to every project this user opens"));
+        assert!(rendered.contains("### Personal `AGENTS.md`"));
         assert!(rendered.contains("always be concise"));
         assert!(rendered.contains("### Project Rules"));
         assert!(rendered.contains("project-specific guidance"));
 
-        let personal_idx = rendered
-            .find("These instructions apply to every project this user opens")
-            .unwrap();
+        let personal_idx = rendered.find("### Personal `AGENTS.md`").unwrap();
         let project_idx = rendered.find("### Project Rules").unwrap();
         assert!(
             personal_idx < project_idx,
@@ -233,7 +231,7 @@ mod tests {
         };
         let templates = Templates::new();
         let rendered = template.render(&templates).unwrap();
-        assert!(!rendered.contains("These instructions apply to every project this user opens"));
+        assert!(!rendered.contains("### Personal `AGENTS.md`"));
     }
 
     #[test]

--- a/crates/agent/src/templates/experimental_system_prompt.hbs
+++ b/crates/agent/src/templates/experimental_system_prompt.hbs
@@ -179,6 +179,8 @@ You are powered by the model named {{model_name}}.
 The following additional instructions are provided by the user and should be followed to the best of your ability{{#if (gt (len available_tools) 0)}} without interfering with the tool use guidelines{{/if}}.
 
 {{#if user_agents_md}}
+### Personal `AGENTS.md`
+
 These instructions apply to every project this user opens. The user has specified the following rules that should be applied:
 
 ``````

--- a/crates/agent/src/templates/experimental_system_prompt.hbs
+++ b/crates/agent/src/templates/experimental_system_prompt.hbs
@@ -173,10 +173,23 @@ The current project contains the following root directories:
 You are powered by the model named {{model_name}}.
 
 {{/if}}
-{{#if has_rules}}
+{{#if (or user_agents_md has_rules)}}
 ## User's Custom Instructions
 
 The following additional instructions are provided by the user and should be followed to the best of your ability{{#if (gt (len available_tools) 0)}} without interfering with the tool use guidelines{{/if}}.
+
+{{#if user_agents_md}}
+These instructions apply to every project this user opens. The user has specified the following rules that should be applied:
+
+``````
+{{{user_agents_md}}}
+``````
+
+{{/if}}
+{{#if has_rules}}
+### Project Rules
+
+These instructions are scoped to the current project. They take precedence over the personal `AGENTS.md` above when they conflict.
 
 There are project rules that apply to these root directories:
 {{#each worktrees}}
@@ -187,4 +200,5 @@ There are project rules that apply to these root directories:
 ``````
 {{/if}}
 {{/each}}
+{{/if}}
 {{/if}}

--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -245,6 +245,8 @@ To use a Skill:
 The following additional instructions are provided by the user and should be followed to the best of your ability{{#if (gt (len available_tools) 0)}} without interfering with the tool use guidelines{{/if}}.
 
 {{#if user_agents_md}}
+### Personal `AGENTS.md`
+
 These instructions apply to every project this user opens. The user has specified the following rules that should be applied:
 
 ``````

--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -245,9 +245,7 @@ To use a Skill:
 The following additional instructions are provided by the user and should be followed to the best of your ability{{#if (gt (len available_tools) 0)}} without interfering with the tool use guidelines{{/if}}.
 
 {{#if user_agents_md}}
-### Personal `AGENTS.md`
-
-These instructions apply to every project this user opens. Project-specific rules below may override them.
+These instructions apply to every project this user opens. The user has specified the following rules that should be applied:
 
 ``````
 {{{user_agents_md}}}


### PR DESCRIPTION
Reword the global rules portion of the agent system prompts so the personal `AGENTS.md` instructions are introduced as rules the user wants applied, and drop the now-redundant "Personal `AGENTS.md`" subheading. The experimental system prompt is brought to parity so it also renders the global instructions.

Closes AI-328

Closes https://github.com/zed-industries/zed/issues/57866

Release Notes:

- Improved how globally-defined agent rules (`~/.config/zed/AGENTS.md`) are presented to the agent so they are followed more reliably.
