### PR TITLE
git: Fix `.git` directory being removed from watcher when excluded via `file_scan_exclusions`

### DIFF
--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -68,6 +68,8 @@ use project::{
 use rand::{Rng as _, rngs::StdRng};
 use serde_json::json;
 use settings::SettingsStore;
+#[cfg(target_os = "linux")]
+use settings::{LocalSettingsKind, LocalSettingsPath};
 #[cfg(not(windows))]
 use std::os;
 use std::{
@@ -10579,6 +10581,102 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
     });
 }
 
+#[cfg(target_os = "linux")]
+#[gpui::test(retries = 5)]
+async fn test_git_events_after_project_excludes_dot_git(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    cx.executor().allow_parking();
+
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.worktree.file_scan_exclusions = Some(vec!["foo".to_string()]);
+            });
+        });
+    });
+
+    let root = TempTree::new(json!({
+        "project": {
+            "a.txt": "a",
+        },
+    }));
+
+    let work_dir = root.path().join("project");
+    let repo = git_init(&work_dir);
+    git_add("a.txt", &repo);
+    git_commit("Initial commit", &repo);
+    git_branch("other-branch", &repo);
+
+    let project = Project::test(
+        Arc::new(RealFs::new(None, cx.executor())),
+        [work_dir.as_path()],
+        cx,
+    )
+    .await;
+
+    let tree = project.read_with(cx, |project, cx| project.worktrees(cx).next().unwrap());
+    tree.flush_fs_events(cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+    cx.executor().run_until_parked();
+
+    let repository = project.read_with(cx, |project, cx| {
+        project.repositories(cx).values().next().unwrap().clone()
+    });
+    let branch = repository.read_with(cx, |repository, _| {
+        repository
+            .snapshot()
+            .branch
+            .as_ref()
+            .map(|branch| branch.ref_name.to_string())
+    });
+    assert_eq!(branch.as_deref(), Some("refs/heads/main"));
+
+    let worktree_id = tree.read_with(cx, |tree, _| tree.id());
+    cx.update_global::<SettingsStore, _>(|store, cx| {
+        store
+            .set_local_settings(
+                worktree_id,
+                LocalSettingsPath::InWorktree(Arc::from(RelPath::empty())),
+                LocalSettingsKind::Settings,
+                Some(r#"{ "file_scan_exclusions": ["**/.git"] }"#),
+                cx,
+            )
+            .unwrap();
+    });
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+    cx.executor().run_until_parked();
+
+    cx.update(|cx| {
+        assert!(tree.read(cx).entry_for_path(rel_path(".git")).is_none());
+    });
+
+    git_checkout("other-branch", &repo);
+
+    let mut events = cx.events::<RepositoryEvent, _>(&repository);
+    let timeout = futures::FutureExt::fuse(cx.background_executor.timer(Duration::from_secs(5)));
+    futures::pin_mut!(timeout);
+    loop {
+        let branch = repository.read_with(cx, |repository, _| {
+            repository
+                .snapshot()
+                .branch
+                .as_ref()
+                .map(|branch| branch.ref_name.to_string())
+        });
+        if branch.as_deref() == Some("refs/heads/other-branch") {
+            break;
+        }
+
+        futures::select_biased! {
+            _ = events.next() => {}
+            _ = timeout => panic!("timed out waiting for repository HEAD update after .git was excluded"),
+        }
+    }
+}
+
 #[gpui::test]
 #[ignore]
 async fn test_git_status_postprocessing(cx: &mut gpui::TestAppContext) {
@@ -12923,7 +13021,7 @@ fn git_reset(offset: usize, work_dir: &Path) {
     );
 }
 
-#[cfg(any())]
+#[cfg(target_os = "linux")]
 #[allow(clippy::disallowed_methods)]
 #[track_caller]
 fn git_branch(name: &str, work_dir: &Path) {
@@ -12938,7 +13036,7 @@ fn git_branch(name: &str, work_dir: &Path) {
     );
 }
 
-#[cfg(any())]
+#[cfg(target_os = "linux")]
 #[allow(clippy::disallowed_methods)]
 #[track_caller]
 fn git_checkout(name: &str, work_dir: &Path) {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3142,9 +3142,19 @@ impl BackgroundScannerState {
         self.snapshot.check_invariants(false);
     }
 
-    fn remove_path_from_snapshot_and_unwatch(&mut self, path: &RelPath, watcher: &dyn Watcher) {
+    fn remove_path_from_snapshot_and_unwatch(
+        &mut self,
+        path: &RelPath,
+        watcher: &dyn Watcher,
+        preserve_repository_watches: bool,
+    ) {
         let removed_descendant_abs_paths = self.remove_path_from_snapshot(path);
-        self.unwatch_path(watcher, path, removed_descendant_abs_paths);
+        self.unwatch_path(
+            watcher,
+            path,
+            removed_descendant_abs_paths,
+            preserve_repository_watches,
+        );
     }
 
     fn unwatch_path(
@@ -3152,8 +3162,20 @@ impl BackgroundScannerState {
         watcher: &dyn Watcher,
         path: &RelPath,
         removed_descendant_abs_paths: Vec<PathBuf>,
+        preserve_repository_watches: bool,
     ) {
+        let mut repository_watches_to_preserve = HashSet::<Arc<Path>>::default();
+        if preserve_repository_watches {
+            for repository in self.snapshot.git_repositories.values() {
+                repository_watches_to_preserve.insert(repository.common_dir_abs_path.clone());
+                repository_watches_to_preserve.insert(repository.repository_dir_abs_path.clone());
+            }
+        }
+
         for removed_dir_abs_path in removed_descendant_abs_paths {
+            if repository_watches_to_preserve.contains(removed_dir_abs_path.as_path()) {
+                continue;
+            }
             watcher.remove(&removed_dir_abs_path).log_err();
         }
 
@@ -3161,7 +3183,9 @@ impl BackgroundScannerState {
             .external_canonical_to_relative
             .retain(|canonical, relative| {
                 if relative.starts_with(path) {
-                    watcher.remove(canonical.as_ref()).log_err();
+                    if !repository_watches_to_preserve.contains(canonical.as_ref()) {
+                        watcher.remove(canonical.as_ref()).log_err();
+                    }
                     false
                 } else {
                     true
@@ -3234,7 +3258,7 @@ impl BackgroundScannerState {
         #[cfg(feature = "test-support")]
         self.snapshot.check_invariants(false);
 
-        return removed_dir_abs_paths;
+        removed_dir_abs_paths
     }
 
     async fn insert_git_repository(
@@ -4927,7 +4951,11 @@ impl BackgroundScanner {
                 self.state
                     .lock()
                     .await
-                    .remove_path_from_snapshot_and_unwatch(&child_path, self.watcher.as_ref());
+                    .remove_path_from_snapshot_and_unwatch(
+                        &child_path,
+                        self.watcher.as_ref(),
+                        true,
+                    );
                 continue;
             }
 
@@ -5262,11 +5290,21 @@ impl BackgroundScanner {
                 }
                 Ok(None) => {
                     self.remove_repo_path(path.clone(), &mut state.snapshot);
-                    state.unwatch_path(self.watcher.as_ref(), path, removed_descendant_abs_paths);
+                    state.unwatch_path(
+                        self.watcher.as_ref(),
+                        path,
+                        removed_descendant_abs_paths,
+                        false,
+                    );
                 }
                 Err(err) => {
                     log::error!("error reading file {abs_path:?} on event: {err:#}");
-                    state.unwatch_path(self.watcher.as_ref(), path, removed_descendant_abs_paths);
+                    state.unwatch_path(
+                        self.watcher.as_ref(),
+                        path,
+                        removed_descendant_abs_paths,
+                        false,
+                    );
                 }
             }
         }


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #57888 

Commit `c19cc4c51e0f64eec42168943050f2deeccaa076` introduced the bug on #50412 . This change modified the `remove_path` function to also remove the path from the watcher: 

https://github.com/zed-industries/zed/blob/f0341c96a17630e5dfb441701441945dbb2a605a/crates/worktree/src/worktree.rs#L3218-L3220

And when a user modified the global setting and doesn't include `.git` in it, like: 

```jsonc
// ~/.config/zed/settings.json
{
  "file_scan_exclusions": ["foo"]
}
```

But then includes it on their local project settings: 

```jsonc
// ~/my/local/project/.zed/settings.json
{
  "file_scan_exclusions": ["**/.git"]
}
```

It causes zed to stop watching for changes on `.git` 

Release Notes:

- Fixed bug where zed stopped watching change on `.git` directory if it was added to the project local `file_scan_exclusions`