### PR TITLE
docs: Simplify theme toggle

### DIFF
--- a/docs/theme/css/chrome.css
+++ b/docs/theme/css/chrome.css
@@ -659,57 +659,6 @@ ul#searchresults span.teaser em {
   gap: 0.6em;
 }
 
-.theme-popup {
-  position: absolute;
-  right: 155px;
-  top: calc(var(--menu-bar-height) - 18px);
-  z-index: 1000;
-  border-radius: 4px;
-  font-size: 1.4rem;
-  color: var(--fg);
-  background: var(--popover-bg);
-  border: 1px solid var(--popover-border);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: none;
-  overflow: hidden;
-}
-
-[dir="rtl"] .theme-popup {
-  left: unset;
-  right: 10px;
-}
-.theme-popup .default {
-  color: var(--icons);
-}
-.theme-popup .theme {
-  width: 100%;
-  border: 0;
-  margin: 0;
-  padding: 2px 24px;
-  line-height: 25px;
-  white-space: nowrap;
-  text-align: start;
-  cursor: pointer;
-  color: inherit;
-  background: inherit;
-  font-size: inherit;
-  font-family: inherit;
-}
-.theme-popup .theme:hover {
-  background-color: var(--theme-hover);
-}
-
-.theme-selected::before {
-  font-family: Arial, Helvetica, sans-serif;
-  text-align: center;
-  display: inline-block;
-  content: "✓";
-  margin-inline-start: -20px;
-  width: 20px;
-}
-
 .download-button {
   max-height: 28px;
   margin-left: 8px;
@@ -859,9 +808,5 @@ ul#searchresults span.teaser em {
 
   .search-content-mobile {
     display: flex;
-  }
-
-  .theme-popup {
-    right: 15px;
   }
 }

--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -109,14 +109,9 @@
             </button>
             {{/if}}
             <div class="right-container">
-                <button id="theme-toggle" class="icon-button" type="button" title="Change Theme" aria-label="Change Theme" aria-haspopup="true" aria-expanded="false" aria-controls="theme-list">
-                    <i class="fa fa-paint-brush"></i>
+                <button id="color-scheme-toggle" class="icon-button" type="button" title="Switch to dark theme" aria-label="Switch to dark theme">
+                    <i class="fa fa-moon-o"></i>
                 </button>
-
-                <ul id="theme-list" class="theme-popup" aria-label="Themes" role="menu">
-                    <li role="none"><button role="menuitem" class="theme" id="light">Light</button></li>
-                    <li role="none"><button role="menuitem" class="theme" id="dark">Dark</button></li>
-                </ul>
 
                 <button id="copy-markdown-toggle" class="icon-button ib-hidden-mobile" type="button" title="Copy Page as Markdown" aria-label="Copy page as markdown">
                     <i class="fa fa-copy"></i>

--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -113,6 +113,15 @@
                     <i class="fa fa-moon-o"></i>
                 </button>
 
+                <!-- mdBook 0.4.40's bundled book.js requires these elements even though plugins.js handles theme switching. -->
+                <div hidden aria-hidden="true">
+                    <button id="theme-toggle" type="button" aria-expanded="false"></button>
+                    <ul id="theme-list">
+                        <li><button type="button" class="theme" id="light">Light</button></li>
+                        <li><button type="button" class="theme" id="dark">Dark</button></li>
+                    </ul>
+                </div>
+
                 <button id="copy-markdown-toggle" class="icon-button ib-hidden-mobile" type="button" title="Copy Page as Markdown" aria-label="Copy page as markdown">
                     <i class="fa fa-copy"></i>
                 </button>

--- a/docs/theme/plugins.js
+++ b/docs/theme/plugins.js
@@ -49,34 +49,60 @@ if (typeof requestIdleCallback === "function") {
 
 function darkModeToggle() {
   var html = document.documentElement;
+  var themeToggleButton = document.getElementById("color-scheme-toggle");
+  var themeToggleIcon = themeToggleButton
+    ? themeToggleButton.querySelector(".fa")
+    : null;
 
-  function setTheme(theme) {
+  function setTheme(theme, persist) {
     html.setAttribute("data-theme", theme);
     html.setAttribute("data-color-scheme", theme);
     html.className = theme;
-    localStorage.setItem("mdbook-theme", theme);
+
+    if (persist) {
+      localStorage.setItem("mdbook-theme", theme);
+    }
+
+    if (themeToggleButton) {
+      var nextTheme = theme === "dark" ? "light" : "dark";
+      var label =
+        nextTheme === "dark" ? "Switch to dark theme" : "Switch to light theme";
+      themeToggleButton.setAttribute("aria-label", label);
+      themeToggleButton.setAttribute("title", label);
+    }
+
+    if (themeToggleIcon) {
+      themeToggleIcon.className =
+        theme === "dark" ? "fa fa-sun-o" : "fa fa-moon-o";
+    }
   }
 
   // Set initial theme
   var currentTheme = localStorage.getItem("mdbook-theme");
   if (currentTheme) {
-    setTheme(currentTheme);
+    setTheme(currentTheme, false);
   } else {
     // If no theme is set, use the system's preference
     var systemPreference = window.matchMedia("(prefers-color-scheme: dark)")
       .matches
       ? "dark"
       : "light";
-    setTheme(systemPreference);
+    setTheme(systemPreference, false);
   }
 
   // Listen for system's preference changes
   const darkModeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   darkModeMediaQuery.addEventListener("change", function (e) {
     if (!localStorage.getItem("mdbook-theme")) {
-      setTheme(e.matches ? "dark" : "light");
+      setTheme(e.matches ? "dark" : "light", false);
     }
   });
+
+  if (themeToggleButton) {
+    themeToggleButton.addEventListener("click", function () {
+      setTheme(html.classList.contains("dark") ? "light" : "dark", true);
+    });
+  }
 }
 
 const copyMarkdown = () => {

--- a/docs/theme/plugins.js
+++ b/docs/theme/plugins.js
@@ -49,18 +49,39 @@ if (typeof requestIdleCallback === "function") {
 
 function darkModeToggle() {
   var html = document.documentElement;
+  var themeColorMetaTag = document.querySelector('meta[name="theme-color"]');
   var themeToggleButton = document.getElementById("color-scheme-toggle");
   var themeToggleIcon = themeToggleButton
     ? themeToggleButton.querySelector(".fa")
     : null;
+
+  function getStoredTheme() {
+    try {
+      return localStorage.getItem("mdbook-theme");
+    } catch {
+      return null;
+    }
+  }
+
+  function persistTheme(theme) {
+    try {
+      localStorage.setItem("mdbook-theme", theme);
+    } catch {}
+  }
 
   function setTheme(theme, persist) {
     html.setAttribute("data-theme", theme);
     html.setAttribute("data-color-scheme", theme);
     html.className = theme;
 
+    if (themeColorMetaTag) {
+      setTimeout(function () {
+        themeColorMetaTag.content = getComputedStyle(html).backgroundColor;
+      }, 0);
+    }
+
     if (persist) {
-      localStorage.setItem("mdbook-theme", theme);
+      persistTheme(theme);
     }
 
     if (themeToggleButton) {
@@ -78,7 +99,7 @@ function darkModeToggle() {
   }
 
   // Set initial theme
-  var currentTheme = localStorage.getItem("mdbook-theme");
+  var currentTheme = getStoredTheme();
   if (currentTheme) {
     setTheme(currentTheme, false);
   } else {
@@ -93,7 +114,7 @@ function darkModeToggle() {
   // Listen for system's preference changes
   const darkModeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   darkModeMediaQuery.addEventListener("change", function (e) {
-    if (!localStorage.getItem("mdbook-theme")) {
+    if (!getStoredTheme()) {
       setTheme(e.matches ? "dark" : "light", false);
     }
   });


### PR DESCRIPTION
Instead of a dropdown, it is now just a one-click icon.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Improved theme toggle for the documentation website
