### PR TITLE
git_ui: Fix commit view avatar being squished when gutter line numbers are disabled

### DIFF
--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -571,6 +571,8 @@ impl CommitView {
             time_format::TimestampFormat::MediumAbsolute,
         );
 
+        let avatar_size = rems_from_px(40.);
+        let avatar_size_px = avatar_size.to_pixels(window.rem_size());
         let gutter_width = self.editor.update(cx, |editor, cx| {
             let snapshot = editor.snapshot(window, cx);
             let style = editor.style(cx);
@@ -580,6 +582,9 @@ impl CommitView {
                 .gutter_dimensions(font_id, font_size, style, window, cx)
                 .full_width()
         });
+        let avatar_min_side_padding = rems_from_px(10.).to_pixels(window.rem_size());
+        let avatar_container_min = avatar_size_px + avatar_min_side_padding * 2.0;
+        let avatar_container_width = gutter_width.max(avatar_container_min);
 
         let clipboard_has_sha = cx
             .read_from_clipboard()
@@ -603,9 +608,13 @@ impl CommitView {
             .border_color(cx.theme().colors().border_variant)
             .child(
                 h_flex()
-                    .child(h_flex().w(gutter_width).justify_center().child(
-                        self.render_commit_avatar(&commit.sha, rems_from_px(40.), window, cx),
-                    ))
+                    .child(
+                        h_flex()
+                            .flex_none()
+                            .w(avatar_container_width)
+                            .justify_center()
+                            .child(self.render_commit_avatar(&commit.sha, avatar_size, window, cx)),
+                    )
                     .child(
                         v_flex().child(Label::new(author_name)).child(
                             h_flex()


### PR DESCRIPTION
## Self-Review Checklist:

- [ *] I've reviewed my own diff for quality, security, and reliability
- [ *] Unsafe blocks (if any) have justifying comments
- [ *] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ *] Tests cover the new/changed behavior
- [ *] Performance impact has been considered and is acceptable

## Summary

  Fixes an issue where the commit author avatar in the commit view could be horizontally
  compressed when editor gutter settings made the gutter unusually narrow.

  The avatar column now keeps a minimum width based on the avatar size plus horizontal
  breathing room, while still using the editor gutter width when it is larger. The spacing
  scales with the UI rem size so the layout remains proportional under UI scaling.

## Screenshots / Recording

- Before (default gutter)
<img width="686" height="336" alt="image" src="https://github.com/user-attachments/assets/3474fd0b-fdfc-409d-a440-7bb54b28b42c" />

- Before (gutter disabled)
<img width="680" height="337" alt="image" src="https://github.com/user-attachments/assets/66f873a2-1c98-4029-a65c-687171d2aebd" />

- After (default gutter)
<img width="687" height="532" alt="image" src="https://github.com/user-attachments/assets/94ea04e2-644c-491f-8f70-9353af7003d8" />

- After (min_line_number_digits: 1)
<img width="685" height="535" alt="image" src="https://github.com/user-attachments/assets/7080409c-dfa6-4ea6-8255-6de2a59f87fa" />

- After (gutter disabled)
<img width="683" height="529" alt="image" src="https://github.com/user-attachments/assets/e3a5ec33-36a0-4581-8421-2676df59c859" />


## Testing

  - Ran `cargo check -p git_ui`

## Release Notes:

- Fixed commit author avatars being compressed in the commit view when editor gutters are narrow.

