### PR TITLE
agent_ui: Remove the staff-only gate on fast mode toggle

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4190,9 +4190,6 @@ impl ThreadView {
     }
 
     fn fast_mode_available(&self, cx: &Context<Self>) -> bool {
-        if !cx.is_staff() {
-            return false;
-        }
         self.as_native_thread(cx)
             .and_then(|thread| thread.read(cx).model())
             .map(|model| model.supports_fast_mode())


### PR DESCRIPTION
This releases fast mode to everyone. Will cherry pick to preview.

Release Notes:

- Added "Fast mode" support in the agent panel for Anthropic and OpenAI models that support a toggle to get faster responses (fast mode for Anthropic and priority service tier for OpenAI) at increased per-token cost.
