### PR TITLE
git_ui: Update unsafe repo UI elements to be centered

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -5577,6 +5577,8 @@ impl GitPanel {
         v_flex()
                 .px_4()
                 .gap_1()
+                .items_center()
+                .text_center()
                 .child(Label::new(message).color(Color::Muted))
                 .child(
                     h_flex()


### PR DESCRIPTION
When this feature landed with https://github.com/zed-industries/zed/pull/43693 the text and buttons in this UI were centered. I'm not entirely sure when this changed, might have been when we introduced the "Changes" and "History" tabs to the Git Panel, but it seems to have been an accident, so this Pull Request fixes it.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
