### PR TITLE
crashes: Skip broken minidumper Server::drop on macOS quit

### DIFF
--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -532,4 +532,11 @@ pub fn crash_server(socket: &Path, logs_dir: PathBuf) {
             Some(CRASH_HANDLER_PING_TIMEOUT),
         )
         .expect("failed to run server");
+
+    // Workaround for upstream zed#57664: minidumper 0.9's Server::drop calls
+    // mach_port_deallocate on a kernel-guarded Mach port, terminating the
+    // crash-handler subprocess with EXC_GUARD/INVALID_RIGHT on quit. This
+    // subprocess is about to exit; let the kernel reclaim the port.
+    #[cfg(target_os = "macos")]
+    std::mem::forget(server);
 }


### PR DESCRIPTION
## Summary
Workaround for the long-standing `EXC_GUARD` / `INVALID_RIGHT` crash that fires inside `minidumper::Server::drop` whenever a user quits Zed on macOS. See the linked issue for full root-cause analysis.

On macOS only, leak the `Server` after `server.run(...)` returns. The crash-handler subprocess exits immediately afterwards, so the kernel reclaims the port — no real leak.

A proper fix belongs in the `minidumper` crate; this avoids the user-visible "Zed quit unexpectedly" dialog in the meantime.

Closes #57950
Fixes #57664

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — no unsafe blocks added
- [x] The content is consistent with the UI/UX checklist — no UI changes
- [x] Tests cover the new/changed behavior — manual verification only; this crash only occurs in the deployed crash-handler subprocess at quit time and cannot be reproduced in unit tests
- [x] Performance impact has been considered and is acceptable — runs once per quit, leaks one Mach port that the kernel reclaims a few microseconds later

Release Notes:

- Fixed a crash on quit ("Zed quit unexpectedly") caused by the crash-handler subprocess on macOS