### PR TITLE
anthropic: Fix serialized representation of `Effort::XHigh`

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -676,6 +676,8 @@ pub enum Effort {
     Low,
     Medium,
     High,
+    #[serde(rename = "xhigh")]
+    #[strum(serialize = "xhigh")]
     XHigh,
     Max,
 }


### PR DESCRIPTION
This PR fixes the serialized representation of the `Effort::XHigh` variant, as it should be `xhigh`, not `x_high`.

https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#adaptive-thinking-with-the-effort-parameter

Release Notes:

- Fixed using `xhigh` thinking effort with Anthropic models.
