### PR TITLE
Include changed paths in remote UpdatedEntries events

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -346,6 +346,15 @@ static SKILLS_PREFIX: LazyLock<Option<Arc<RelPath>>> = LazyLock::new(|| {
         .map(|path| path.into_arc())
 });
 
+fn path_affects_project_context(path: &RelPath) -> bool {
+    RULES_FILE_REL_PATHS
+        .iter()
+        .any(|rules_path| path == rules_path.as_ref())
+        || SKILLS_PREFIX
+            .as_ref()
+            .is_some_and(|prefix| path.starts_with(prefix))
+}
+
 impl NativeAgent {
     pub fn new(
         thread_store: Entity<ThreadStore>,
@@ -1046,30 +1055,33 @@ impl NativeAgent {
         &mut self,
         project: Entity<Project>,
         event: &project::Event,
-        _cx: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
         let project_id = project.entity_id();
-        let Some(state) = self.projects.get_mut(&project_id) else {
+        if !self.projects.contains_key(&project_id) {
             return;
+        }
+
+        let should_refresh_project_context = match event {
+            project::Event::WorktreeAdded(_) | project::Event::WorktreeRemoved(_) => true,
+            project::Event::WorktreeUpdatedEntries(_, items) => items
+                .iter()
+                .any(|(path, _, _)| path_affects_project_context(path)),
+            project::Event::DeletedEntry(worktree_id, entry_id) => project
+                .read(cx)
+                .worktree_for_id(*worktree_id, cx)
+                .and_then(|worktree| {
+                    worktree
+                        .read(cx)
+                        .entry_for_id(*entry_id)
+                        .map(|entry| entry.path.clone())
+                })
+                .is_some_and(|path| path_affects_project_context(&path)),
+            _ => false,
         };
-        match event {
-            project::Event::WorktreeAdded(_) | project::Event::WorktreeRemoved(_) => {
-                state.project_context_needs_refresh.send(()).ok();
-            }
-            project::Event::WorktreeUpdatedEntries(_, items) => {
-                if items.iter().any(|(path, _, _)| {
-                    let path_ref = path.as_ref();
-                    RULES_FILE_REL_PATHS
-                        .iter()
-                        .any(|rules_path| path_ref == rules_path.as_ref())
-                        || SKILLS_PREFIX
-                            .as_ref()
-                            .is_some_and(|prefix| path_ref.starts_with(prefix))
-                }) {
-                    state.project_context_needs_refresh.send(()).ok();
-                }
-            }
-            _ => {}
+
+        if should_refresh_project_context && let Some(state) = self.projects.get_mut(&project_id) {
+            state.project_context_needs_refresh.send(()).ok();
         }
     }
 
@@ -3078,7 +3090,7 @@ mod internal_tests {
 
     use super::*;
     use acp_thread::{AgentConnection, AgentModelGroupName, AgentModelInfo, MentionUri};
-    use fs::FakeFs;
+    use fs::{FakeFs, RemoveOptions};
     use gpui::TestAppContext;
     use indoc::formatdoc;
     use language_model::fake_provider::{FakeLanguageModel, FakeLanguageModelProvider};
@@ -4149,6 +4161,98 @@ mod internal_tests {
             assert!(
                 skill_names.contains(&"my-skill"),
                 "trusted skill should appear in available skills: {skill_names:?}"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_deleted_project_skill_refreshes_available_skills(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/project",
+            json!({
+                ".agents": {
+                    "skills": {
+                        "test-skill": {
+                            "SKILL.md": "---\nname: test-skill\ndescription: A project skill\n---\n\nbody"
+                        }
+                    }
+                }
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        let agent =
+            cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), fs.clone(), cx));
+        let connection = NativeAgentConnection(agent.clone());
+        let acp_thread = cx
+            .update(|cx| {
+                Rc::new(connection.clone()).new_session(
+                    project.clone(),
+                    PathList::new(&[Path::new("/project")]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        let project_id = project.entity_id();
+        let session_id = acp_thread.read_with(cx, |thread, _cx| thread.session_id().clone());
+        cx.update(|cx| {
+            let skills = connection.available_skills(&session_id, cx);
+            let skill_names: Vec<&str> = skills.iter().map(|skill| skill.name.as_str()).collect();
+            assert!(
+                skill_names.contains(&"test-skill"),
+                "skill should be available before deletion: {skill_names:?}"
+            );
+        });
+
+        let (worktree_id, skill_dir_entry_id) = project.read_with(cx, |project, cx| {
+            let worktree = project.worktrees(cx).next().unwrap();
+            let worktree = worktree.read(cx);
+            let skill_dir = worktree
+                .entry_for_path(rel_path(".agents/skills/test-skill"))
+                .unwrap();
+            (worktree.id(), skill_dir.id)
+        });
+
+        fs.remove_dir(
+            Path::new("/project/.agents/skills/test-skill"),
+            RemoveOptions {
+                recursive: true,
+                ignore_if_not_exists: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        agent.update(cx, |agent, cx| {
+            agent.handle_project_event(
+                project.clone(),
+                &project::Event::DeletedEntry(worktree_id, skill_dir_entry_id),
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        agent.read_with(cx, |agent, _cx| {
+            let state = agent.projects.get(&project_id).unwrap();
+            assert!(
+                user_skills(&state.skills).is_empty(),
+                "deleted project skill should be removed from state: {:?}",
+                state.skills
+            );
+        });
+        cx.update(|cx| {
+            let skills = connection.available_skills(&session_id, cx);
+            let skill_names: Vec<&str> = skills.iter().map(|skill| skill.name.as_str()).collect();
+            assert!(
+                !skill_names.contains(&"test-skill"),
+                "deleted skill should be removed from available skills: {skill_names:?}"
             );
         });
     }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -595,21 +595,44 @@ impl Worktree {
                         }
 
                         let old_root_repo_common_dir = this.snapshot.root_repo_common_dir.clone();
-                        let mut entries_changed = false;
+                        let mut changed_entries: Vec<(Arc<RelPath>, ProjectEntryId, PathChange)> =
+                            Vec::new();
                         {
                             let mut lock = this.background_snapshot.lock();
-                            this.snapshot = lock.0.clone();
+                            // Replace the snapshot, keeping the previous one around so we can
+                            // resolve the paths of removed entries (the new snapshot no longer
+                            // contains them, and the wire format only carries their ids).
+                            let old_snapshot = mem::replace(&mut this.snapshot, lock.0.clone());
                             for update in lock.1.drain(..) {
-                                entries_changed |= !update.updated_entries.is_empty()
-                                    || !update.removed_entries.is_empty();
+                                for entry_id in &update.removed_entries {
+                                    let entry_id = ProjectEntryId::from_proto(*entry_id);
+                                    if let Some(entry) = old_snapshot.entry_for_id(entry_id) {
+                                        changed_entries.push((
+                                            entry.path.clone(),
+                                            entry_id,
+                                            PathChange::Removed,
+                                        ));
+                                    }
+                                }
+                                for entry in &update.updated_entries {
+                                    // Remote updates don't distinguish creation from
+                                    // modification, so report `AddedOrUpdated`.
+                                    if let Some(path) = RelPath::from_proto(&entry.path).log_err() {
+                                        changed_entries.push((
+                                            path,
+                                            ProjectEntryId::from_proto(entry.id),
+                                            PathChange::AddedOrUpdated,
+                                        ));
+                                    }
+                                }
                                 if let Some(tx) = &this.update_observer {
                                     tx.unbounded_send(update).ok();
                                 }
                             }
                         };
 
-                        if entries_changed {
-                            cx.emit(Event::UpdatedEntries(Arc::default()));
+                        if !changed_entries.is_empty() {
+                            cx.emit(Event::UpdatedEntries(changed_entries.into()));
                         }
                         let is_first_update = !this.received_initial_update;
                         this.received_initial_update = true;

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -4349,6 +4349,158 @@ async fn test_remote_worktree_with_git_emits_root_repo_event_when_repo_info_arri
     );
 }
 
+fn remote_proto_entry(id: u64, path: &str, is_dir: bool) -> proto::Entry {
+    proto::Entry {
+        id,
+        is_dir,
+        path: path.to_string(),
+        inode: id,
+        mtime: Some(proto::Timestamp {
+            seconds: 0,
+            nanos: 0,
+        }),
+        is_ignored: false,
+        is_hidden: false,
+        is_external: false,
+        is_fifo: false,
+        size: None,
+        canonical_path: None,
+    }
+}
+
+// Regression test: a remote worktree used to emit `UpdatedEntries` with an
+// empty changeset (`Arc::default()`), discarding the changed paths. Consumers
+// that key off those paths - notably the agent's `.agents/skills` refresh -
+// therefore never fired on remote projects, so skills pasted into an already
+// open project were never picked up. The changeset must carry the real paths.
+#[gpui::test]
+async fn test_remote_worktree_update_entries_carry_changed_paths(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        let store = SettingsStore::test(cx);
+        cx.set_global(store);
+    });
+
+    let client = AnyProtoClient::new(NoopProtoClient::new());
+
+    let worktree = cx.update(|cx| {
+        Worktree::remote(
+            1,
+            clock::ReplicaId::new(1),
+            proto::WorktreeMetadata {
+                id: 1,
+                root_name: "project".to_string(),
+                visible: true,
+                abs_path: "/home/user/project".to_string(),
+                root_repo_common_dir: None,
+            },
+            client,
+            PathStyle::Posix,
+            cx,
+        )
+    });
+
+    // Collect the (path, change) pairs from every `UpdatedEntries` event.
+    let changes: Arc<Mutex<Vec<(String, PathChange)>>> = Arc::new(Mutex::new(Vec::new()));
+    cx.update(|cx| {
+        let changes = changes.clone();
+        cx.subscribe(&worktree, move |_, event, _cx| {
+            if let Event::UpdatedEntries(updated) = event {
+                changes.lock().extend(
+                    updated
+                        .iter()
+                        .map(|(path, _, change)| (path.as_unix_str().to_string(), *change)),
+                );
+            }
+        })
+        .detach();
+    });
+
+    // Simulate pasting two skill folders into `.agents/skills`.
+    worktree.update(cx, |worktree, _cx| {
+        worktree
+            .as_remote()
+            .unwrap()
+            .update_from_remote(proto::UpdateWorktree {
+                project_id: 1,
+                worktree_id: 1,
+                abs_path: "/home/user/project".to_string(),
+                root_name: "project".to_string(),
+                updated_entries: vec![
+                    remote_proto_entry(1, "", true),
+                    remote_proto_entry(2, ".agents", true),
+                    remote_proto_entry(3, ".agents/skills", true),
+                    remote_proto_entry(4, ".agents/skills/skill-1", true),
+                    remote_proto_entry(5, ".agents/skills/skill-1/SKILL.md", false),
+                    remote_proto_entry(6, ".agents/skills/skill-2", true),
+                    remote_proto_entry(7, ".agents/skills/skill-2/SKILL.md", false),
+                ],
+                removed_entries: vec![],
+                scan_id: 1,
+                is_last_update: true,
+                updated_repositories: vec![],
+                removed_repositories: vec![],
+                root_repo_common_dir: None,
+            });
+    });
+
+    cx.run_until_parked();
+
+    {
+        let changes = changes.lock();
+        assert!(
+            changes
+                .iter()
+                .any(|(path, change)| path == ".agents/skills/skill-1/SKILL.md"
+                    && *change == PathChange::AddedOrUpdated),
+            "remote UpdatedEntries should carry the added skill paths, got {:?}",
+            changes
+        );
+        assert!(
+            changes
+                .iter()
+                .any(|(path, _)| path == ".agents/skills/skill-2/SKILL.md"),
+            "remote UpdatedEntries should carry every added path, got {:?}",
+            changes
+        );
+    }
+    changes.lock().clear();
+
+    // Now remove one skill folder. The wire format only carries entry ids for
+    // removals, so the worktree must resolve their paths against the previous
+    // snapshot before it is replaced.
+    worktree.update(cx, |worktree, _cx| {
+        worktree
+            .as_remote()
+            .unwrap()
+            .update_from_remote(proto::UpdateWorktree {
+                project_id: 1,
+                worktree_id: 1,
+                abs_path: "/home/user/project".to_string(),
+                root_name: "project".to_string(),
+                updated_entries: vec![],
+                removed_entries: vec![6, 7],
+                scan_id: 2,
+                is_last_update: true,
+                updated_repositories: vec![],
+                removed_repositories: vec![],
+                root_repo_common_dir: None,
+            });
+    });
+
+    cx.run_until_parked();
+
+    let changes = changes.lock();
+    assert!(
+        changes
+            .iter()
+            .any(|(path, change)| path == ".agents/skills/skill-2/SKILL.md"
+                && *change == PathChange::Removed),
+        "remote UpdatedEntries should carry removed paths resolved from the \
+         previous snapshot, got {:?}",
+        changes
+    );
+}
+
 #[gpui::test]
 async fn test_deferred_watch_repository_above_root(
     executor: BackgroundExecutor,


### PR DESCRIPTION
Skills added to `.agents/skills` in a remote project were never picked up by the agent's skill catalog, even though the same flow works locally.

## Root cause

When skills are added or changed under `.agents/skills`, the agent reloads its catalog in response to `WorktreeUpdatedEntries`, but only if a changed path under `.agents/skills` is present in the event payload.

For local worktrees, the payload contains the real changed paths, so the refresh fires. For remote worktrees, `Worktree::remote` collapsed all change information into a single boolean and emitted `Event::UpdatedEntries(Arc::default())` — an empty changeset. The actual paths were only forwarded to the raw proto `update_observer`, never placed in the event. As a result, the agent (and every other consumer that inspects these paths, e.g. git blame invalidation, telemetry project-type detection, and the `.rules`/`AGENTS.md` refresh) never saw any change on remote.

## Fix

Reconstruct the changed-entry set from the proto updates the remote worktree already drains:

- Updated entries carry their path on the wire, reported as `AddedOrUpdated`.
- Removed entries only carry ids, so their paths are resolved against the previous snapshot (captured before it is replaced) and reported as `Removed`.

The event is now emitted with the populated changeset, matching local behavior.

## Tests

Added `test_remote_worktree_update_entries_carry_changed_paths`, which drives a remote worktree update simulating pasted skill folders and asserts the emitted `UpdatedEntries` carries the added paths, plus a removal case that verifies paths are resolved from the previous snapshot.

Closes AI-329

Closes https://github.com/zed-industries/zed/issues/57877

Release Notes:

- Fixed skills in `.agents/skills` not appearing in the agent's skill catalog for remote projects.
