### PR TITLE
terminal: Show OSC 9 desktop notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "alacritty_terminal"
 version = "0.26.1-dev"
-source = "git+https://github.com/zed-industries/alacritty?rev=fcf32feacb367b75ec84dd40f041e4fd411d3cc1#fcf32feacb367b75ec84dd40f041e4fd411d3cc1"
+source = "git+https://github.com/ober37/alacritty?rev=41cdf3200f20b49b0db03f9da309b78fa593be52#41cdf3200f20b49b0db03f9da309b78fa593be52"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.10.0",
@@ -2748,7 +2748,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2777,7 +2777,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.2",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -5312,7 +5312,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6147,7 +6147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6570,7 +6570,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6964,7 +6964,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7603,7 +7603,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9480,7 +9480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9562,7 +9562,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11525,7 +11525,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11960,7 +11960,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -16172,7 +16172,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16185,7 +16185,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -16307,7 +16307,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -17656,7 +17656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -17977,6 +17977,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -18639,7 +18640,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix 0.38.44",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "winx",
 ]
 
@@ -18807,7 +18808,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -19732,7 +19733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb391ac70462b3097a755618fbf9c8f95ecc1eb379a414f7b46f202ed10db1f"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -20652,8 +20653,7 @@ dependencies = [
 [[package]]
 name = "vte"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+source = "git+https://github.com/ober37/vte?rev=6cc83558790b8c3c7e0e52d29bc10024e88cac21#6cc83558790b8c3c7e0e52d29bc10024e88cac21"
 dependencies = [
  "arrayvec",
  "bitflags 2.10.0",
@@ -21837,7 +21837,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -22667,7 +22667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.10.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -511,7 +511,7 @@ accesskit_unix = "0.21.0"
 accesskit_windows = "0.32.1"
 agent-client-protocol = { version = "=0.12.1", features = ["unstable"] }
 aho-corasick = "1.1"
-alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "fcf32feacb367b75ec84dd40f041e4fd411d3cc1" }
+alacritty_terminal = { git = "https://github.com/ober37/alacritty", rev = "41cdf3200f20b49b0db03f9da309b78fa593be52" }
 any_vec = "0.14"
 anyhow = "1.0.86"
 ashpd = { version = "0.13", default-features = false, features = [
@@ -890,6 +890,7 @@ features = [
 ]
 
 [patch.crates-io]
+vte = { git = "https://github.com/ober37/vte", rev = "6cc83558790b8c3c7e0e52d29bc10024e88cac21" }
 async-task = { git = "https://github.com/smol-rs/async-task.git", rev = "b4486cd71e4e94fbda54ce6302444de14f4d190e" }
 notify = { git = "https://github.com/zed-industries/notify.git", rev = "ce58c24cad542c28e04ced02e20325a4ec28a31d" }
 notify-types = { git = "https://github.com/zed-industries/notify.git", rev = "ce58c24cad542c28e04ced02e20325a4ec28a31d" }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1977,7 +1977,8 @@ impl AgentPanel {
                 TerminalEvent::BlinkChanged(_)
                 | TerminalEvent::SelectionsChanged
                 | TerminalEvent::NewNavigationTarget(_)
-                | TerminalEvent::Open(_) => {}
+                | TerminalEvent::Open(_)
+                | TerminalEvent::Notification(_) => {}
             },
         );
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -138,6 +138,7 @@ pub enum Event {
     BreadcrumbsChanged,
     CloseTerminal,
     Bell,
+    Notification(String),
     Wakeup,
     BlinkChanged(bool),
     SelectionsChanged,
@@ -992,6 +993,9 @@ impl Terminal {
             }
             AlacTermEvent::Bell => {
                 cx.emit(Event::Bell);
+            }
+            AlacTermEvent::Notification(message) => {
+                cx.emit(Event::Notification(message));
             }
             AlacTermEvent::Exit => self.register_task_finished(None, cx),
             AlacTermEvent::MouseCursorDirty => {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -11,8 +11,9 @@ use editor::{
 use gpui::{
     Action, AnyElement, App, ClipboardEntry, DismissEvent, Entity, EventEmitter, ExternalPaths,
     FocusHandle, Focusable, Font, KeyContext, KeyDownEvent, Keystroke, MouseButton, MouseDownEvent,
-    Pixels, Point, Render, ScrollWheelEvent, Styled, Subscription, Task, TaskExt, WeakEntity,
-    actions, anchored, deferred, div,
+    Pixels, PlatformDisplay, Point, Render, ScrollWheelEvent, Size, Styled, Subscription, Task,
+    TaskExt, WeakEntity, Window, WindowBackgroundAppearance, WindowBounds, WindowDecorations,
+    WindowHandle, WindowKind, WindowOptions, actions, anchored, deferred, div, point,
 };
 use itertools::Itertools;
 use menu;
@@ -147,6 +148,7 @@ pub struct TerminalView {
     self_handle: WeakEntity<Self>,
     rename_editor: Option<Entity<Editor>>,
     rename_editor_subscription: Option<Subscription>,
+    notification: Option<(WindowHandle<TerminalNotification>, Subscription)>,
     _subscriptions: Vec<Subscription>,
     _terminal_subscriptions: Vec<Subscription>,
 }
@@ -293,6 +295,7 @@ impl TerminalView {
             self_handle: cx.entity().downgrade(),
             rename_editor: None,
             rename_editor_subscription: None,
+            notification: None,
             _subscriptions: subscriptions,
             _terminal_subscriptions: terminal_subscriptions,
         }
@@ -1077,6 +1080,12 @@ fn subscribe_for_terminal_events(
                         window.play_system_bell();
                     }
                     cx.emit(Event::Wakeup);
+                }
+
+                Event::Notification(message) => {
+                    if !terminal_view.focus_handle.is_focused(window) {
+                        show_terminal_notification(terminal_view, message, window, cx);
+                    }
                 }
 
                 Event::BlinkChanged(blinking) => {
@@ -2092,6 +2101,171 @@ fn first_project_directory(workspace: &Workspace, cx: &App) -> Option<PathBuf> {
     } else {
         // If worktree is a file, return its parent directory
         worktree_path.parent().map(|p| p.to_path_buf())
+    }
+}
+
+pub enum TerminalNotificationEvent {
+    Accepted,
+    Dismissed,
+}
+
+pub struct TerminalNotification {
+    message: SharedString,
+}
+
+impl EventEmitter<TerminalNotificationEvent> for TerminalNotification {}
+
+impl TerminalNotification {
+    fn new(message: impl Into<SharedString>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    fn window_options(screen: Rc<dyn PlatformDisplay>, _cx: &App) -> WindowOptions {
+        let size = Size {
+            width: px(450.),
+            height: px(72.),
+        };
+        let notification_margin_width = px(16.);
+        let notification_margin_height = px(-48.);
+        let bounds = gpui::Bounds::<Pixels> {
+            origin: screen.bounds().top_right()
+                - point(
+                    size.width + notification_margin_width,
+                    notification_margin_height,
+                ),
+            size,
+        };
+        WindowOptions {
+            window_bounds: Some(WindowBounds::Windowed(bounds)),
+            titlebar: None,
+            focus: false,
+            show: true,
+            kind: WindowKind::PopUp,
+            is_movable: false,
+            display_id: Some(screen.id()),
+            window_background: WindowBackgroundAppearance::Transparent,
+            app_id: None,
+            window_min_size: None,
+            window_decorations: Some(WindowDecorations::Client),
+            tabbing_identifier: None,
+            ..Default::default()
+        }
+    }
+
+    fn accept(&mut self, cx: &mut Context<Self>) {
+        cx.emit(TerminalNotificationEvent::Accepted);
+    }
+
+    fn dismiss(&mut self, cx: &mut Context<Self>) {
+        cx.emit(TerminalNotificationEvent::Dismissed);
+    }
+}
+
+impl Render for TerminalNotification {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let ui_font = theme_settings::setup_ui_font(window, cx);
+        let line_height = window.line_height();
+
+        h_flex()
+            .id("terminal-notification")
+            .size_full()
+            .p_3()
+            .gap_4()
+            .justify_between()
+            .elevation_3(cx)
+            .text_ui(cx)
+            .font(ui_font)
+            .border_color(cx.theme().colors().border)
+            .rounded_xl()
+            .child(
+                h_flex()
+                    .items_start()
+                    .gap_2()
+                    .flex_1()
+                    .child(
+                        h_flex().h(line_height).justify_center().child(
+                            Icon::new(IconName::Terminal)
+                                .color(Color::Muted)
+                                .size(IconSize::Small),
+                        ),
+                    )
+                    .child(
+                        v_flex()
+                            .flex_1()
+                            .max_w(px(300.))
+                            .child(
+                                div()
+                                    .text_size(px(14.))
+                                    .text_color(cx.theme().colors().text)
+                                    .truncate()
+                                    .child(self.message.clone()),
+                            ),
+                    ),
+            )
+            .child(
+                v_flex()
+                    .gap_1()
+                    .items_center()
+                    .child(
+                        Button::new("open", "View")
+                            .style(ButtonStyle::Tinted(ui::TintColor::Accent))
+                            .full_width()
+                            .on_click(cx.listener(|this, _, _, cx| this.accept(cx))),
+                    )
+                    .child(Button::new("dismiss", "Dismiss").full_width().on_click(
+                        cx.listener(|this, _, _, cx| this.dismiss(cx)),
+                    )),
+            )
+    }
+}
+
+fn show_terminal_notification(
+    terminal_view: &mut TerminalView,
+    message: &String,
+    window: &mut Window,
+    cx: &mut Context<TerminalView>,
+) {
+    // Dismiss any existing notification before showing a new one.
+    if let Some((existing_window, _sub)) = terminal_view.notification.take() {
+        existing_window
+            .update(cx, |_, window, _| window.remove_window())
+            .ok();
+    }
+
+    let Some(screen) = window.display(cx) else {
+        return;
+    };
+    let options = TerminalNotification::window_options(screen, cx);
+
+    if let Some(notification_window) = cx
+        .open_window(options, |_, cx| {
+            cx.new(|_cx| TerminalNotification::new(message.clone()))
+        })
+        .log_err()
+        && let Some(notification_entity) = notification_window.entity(cx).log_err()
+    {
+        let subscription = cx.subscribe_in(
+            &notification_entity,
+            window,
+            |terminal_view, _, event, window, cx| match event {
+                TerminalNotificationEvent::Accepted => {
+                    cx.activate(true);
+                    window.activate_window();
+                    terminal_view.focus_handle.focus(window);
+                    if let Some((w, _)) = terminal_view.notification.take() {
+                        w.update(cx, |_, window, _| window.remove_window()).ok();
+                    }
+                }
+                TerminalNotificationEvent::Dismissed => {
+                    if let Some((w, _)) = terminal_view.notification.take() {
+                        w.update(cx, |_, window, _| window.remove_window()).ok();
+                    }
+                }
+            },
+        );
+        terminal_view.notification = Some((notification_window, subscription));
     }
 }
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -2253,7 +2253,7 @@ fn show_terminal_notification(
                 TerminalNotificationEvent::Accepted => {
                     cx.activate(true);
                     window.activate_window();
-                    terminal_view.focus_handle.focus(window);
+                    terminal_view.focus_handle.focus(window, cx);
                     if let Some((w, _)) = terminal_view.notification.take() {
                         w.update(cx, |_, window, _| window.remove_window()).ok();
                     }


### PR DESCRIPTION
Closes #58014

## Summary

When a program running in a terminal pane emits an OSC 9 sequence
(`ESC ] 9 ; message ST`) — which is what Claude Code uses for
Ghostty/Kitty-style notifications — Zed now shows a native floating
notification window, but only when the terminal pane is **not** currently
focused.

Clicking **View** activates the Zed window and focuses the terminal pane
that sent the notification. Clicking **Dismiss** closes the popup without
changing focus.

## Architecture

This change spans three repositories:

### 1. [`ober37/vte`](https://github.com/ober37/vte/tree/osc9-notification) (fork of `alacritty/vte`)
- Adds `fn terminal_notification(&mut self, message: String) {}` (default no-op) to the `ansi::Handler` trait
- Adds an OSC `b"9"` case in `Performer::osc_dispatch` that calls `handler.terminal_notification(message)`

### 2. [`ober37/alacritty`](https://github.com/ober37/alacritty/tree/osc9-notification-v2) (fork of `zed-industries/alacritty`)
- Adds `Event::Notification(String)` variant to `alacritty_terminal::event::Event`
- Implements `terminal_notification` on `Term<T>: Handler` to emit `Event::Notification`
- Patches `vte` to the `ober37/vte` fork

### 3. This repo (`crates/terminal` + `crates/terminal_view`)
- `terminal.rs`: adds `Event::Notification(String)` and handles `AlacTermEvent::Notification`
- `terminal_view.rs`: adds `TerminalNotification` popup widget and `show_terminal_notification` helper; handles `Event::Notification` in the terminal event subscription

The `TerminalNotification` widget is self-contained inside `terminal_view` (which already has all needed deps: `gpui`, `ui`, `theme_settings`) to avoid a circular dependency with `agent_ui`, which already depends on `terminal_view`.

## Testing

- [ ] Run Claude Code in a Zed terminal, switch focus away from the terminal, and verify the notification appears when Claude Code finishes its task
- [ ] Click "View" — Zed should come to front and focus the terminal pane
- [ ] Click "Dismiss" — popup closes, focus unchanged
- [ ] With terminal focused, verify no popup appears
- [ ] Send `printf '\033]9;Hello\a'` in a terminal pane while focused elsewhere

Release Notes:

- Added support for OSC 9 terminal notifications: programs running in a Zed terminal pane can now trigger a native notification popup when Zed is not focused on that pane.