### PR TITLE
Fix macOS system font fallback cascade append

### DIFF
--- a/crates/gpui_macos/src/open_type.rs
+++ b/crates/gpui_macos/src/open_type.rs
@@ -125,12 +125,12 @@ fn append_system_fallbacks(fallback_array: CFMutableArrayRef, font_ref: CTFontRe
         let default_fallbacks: CFArray<CTFontDescriptor> =
             CFArray::wrap_under_create_rule(default_fallbacks);
 
-        default_fallbacks
+        for desc in default_fallbacks
             .iter()
             .filter(|desc| desc.font_path().is_some())
-            .map(|desc| {
-                CFArrayAppendValue(fallback_array, desc.as_concrete_TypeRef() as _);
-            });
+        {
+            CFArrayAppendValue(fallback_array, desc.as_concrete_TypeRef() as _);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #57916.

`append_system_fallbacks` used `.map(...)` for the `CFArrayAppendValue` side effect, but the iterator was never consumed.

This changes it to a `for` loop so the fallback descriptors are actually appended.
