### PR TITLE
Add handoff feature flag

### DIFF
--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -35,6 +35,18 @@ impl FeatureFlag for AgentSharingFeatureFlag {
 }
 register_feature_flag!(AgentSharingFeatureFlag);
 
+pub struct HandoffFeatureFlag;
+
+impl FeatureFlag for HandoffFeatureFlag {
+    const NAME: &'static str = "handoff";
+    type Value = PresenceFlag;
+
+    fn enabled_for_staff() -> bool {
+        false
+    }
+}
+register_feature_flag!(HandoffFeatureFlag);
+
 pub struct DiffReviewFeatureFlag;
 
 impl FeatureFlag for DiffReviewFeatureFlag {


### PR DESCRIPTION
Adds the handoff feature flag with staff disabled by default, giving the rest of the auto-compaction stack a rollout gate without changing behavior for users outside the flag.

Release Notes:

- N/A
