### PR TITLE
Add context compaction UI

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -180,6 +180,7 @@ pub enum AgentThreadEntry {
     AssistantMessage(AssistantMessage),
     ToolCall(ToolCall),
     CompletedPlan(Vec<PlanEntry>),
+    ContextCompaction,
 }
 
 impl AgentThreadEntry {
@@ -189,6 +190,7 @@ impl AgentThreadEntry {
             Self::AssistantMessage(message) => message.indented,
             Self::ToolCall(_) => false,
             Self::CompletedPlan(_) => false,
+            Self::ContextCompaction => false,
         }
     }
 
@@ -205,6 +207,7 @@ impl AgentThreadEntry {
                 }
                 md
             }
+            Self::ContextCompaction => "--- Context Compacted ---".to_string(),
         }
     }
 
@@ -1117,6 +1120,7 @@ pub struct AcpThread {
     shared_buffers: HashMap<Entity<Buffer>, BufferSnapshot>,
     turn_id: u32,
     running_turn: Option<RunningTurn>,
+    compacting_context: bool,
     connection: Rc<dyn AgentConnection>,
     token_usage: Option<TokenUsage>,
     cost: Option<SessionCost>,
@@ -1178,6 +1182,8 @@ pub enum AcpThreadEvent {
     ToolAuthorizationReceived(acp::ToolCallId),
     Retry(RetryStatus),
     SubagentSpawned(acp::SessionId),
+    CompactionStarted,
+    CompactionFinished,
     Stopped(acp::StopReason),
     Error,
     LoadError(LoadError),
@@ -1324,6 +1330,7 @@ impl AcpThread {
             provisional_title: None,
             project,
             running_turn: None,
+            compacting_context: false,
             turn_id: 0,
             connection,
             session_id,
@@ -1450,6 +1457,10 @@ impl AcpThread {
         }
     }
 
+    pub fn is_compacting_context(&self) -> bool {
+        self.compacting_context
+    }
+
     pub fn had_error(&self) -> bool {
         self.had_error
     }
@@ -1464,7 +1475,8 @@ impl AcpThread {
                 }) => return true,
                 AgentThreadEntry::ToolCall(_)
                 | AgentThreadEntry::AssistantMessage(_)
-                | AgentThreadEntry::CompletedPlan(_) => {}
+                | AgentThreadEntry::CompletedPlan(_)
+                | AgentThreadEntry::ContextCompaction => {}
             }
         }
         false
@@ -1492,7 +1504,8 @@ impl AcpThread {
                 }
                 AgentThreadEntry::ToolCall(_)
                 | AgentThreadEntry::AssistantMessage(_)
-                | AgentThreadEntry::CompletedPlan(_) => {}
+                | AgentThreadEntry::CompletedPlan(_)
+                | AgentThreadEntry::ContextCompaction => {}
             }
         }
 
@@ -1511,7 +1524,8 @@ impl AcpThread {
                 }
                 AgentThreadEntry::ToolCall(_)
                 | AgentThreadEntry::AssistantMessage(_)
-                | AgentThreadEntry::CompletedPlan(_) => {}
+                | AgentThreadEntry::CompletedPlan(_)
+                | AgentThreadEntry::ContextCompaction => {}
             }
         }
 
@@ -1522,9 +1536,9 @@ impl AcpThread {
         for entry in self.entries.iter().rev() {
             match entry {
                 AgentThreadEntry::UserMessage(..) => return false,
-                AgentThreadEntry::AssistantMessage(..) | AgentThreadEntry::CompletedPlan(..) => {
-                    continue;
-                }
+                AgentThreadEntry::AssistantMessage(..)
+                | AgentThreadEntry::CompletedPlan(..)
+                | AgentThreadEntry::ContextCompaction => continue,
                 AgentThreadEntry::ToolCall(..) => return true,
             }
         }
@@ -1866,6 +1880,25 @@ impl AcpThread {
         Self::flush_streaming_text(&mut self.streaming_text_buffer, cx);
         self.entries.push(entry);
         cx.emit(AcpThreadEvent::NewEntry);
+    }
+
+    pub fn context_compaction_started(&mut self, cx: &mut Context<Self>) {
+        if !self.compacting_context {
+            self.compacting_context = true;
+            cx.emit(AcpThreadEvent::CompactionStarted);
+        }
+    }
+
+    pub fn context_compaction_succeeded(&mut self, cx: &mut Context<Self>) {
+        self.push_entry(AgentThreadEntry::ContextCompaction, cx);
+        self.clear_context_compaction(cx);
+    }
+
+    pub fn clear_context_compaction(&mut self, cx: &mut Context<Self>) {
+        if self.compacting_context {
+            self.compacting_context = false;
+            cx.emit(AcpThreadEvent::CompactionFinished);
+        }
     }
 
     pub fn can_set_title(&mut self, cx: &mut Context<Self>) -> bool {
@@ -2433,6 +2466,7 @@ impl AcpThread {
 
                         if r.stop_reason == acp::StopReason::MaxTokens {
                             this.had_error = true;
+                            this.clear_context_compaction(cx);
                             cx.emit(AcpThreadEvent::Error);
                             log::error!("Max tokens reached. Usage: {:?}", this.token_usage);
 
@@ -2465,6 +2499,7 @@ impl AcpThread {
                         // Handle refusal - distinguish between user prompt and tool call refusals
                         if let acp::StopReason::Refusal = r.stop_reason {
                             this.had_error = true;
+                            this.clear_context_compaction(cx);
                             if let Some((user_msg_ix, _)) = this.last_user_message() {
                                 // Check if there's a completed tool call with results after the last user message
                                 // This indicates the refusal is in response to tool output, not the user's prompt
@@ -2507,6 +2542,7 @@ impl AcpThread {
                             cx.emit(AcpThreadEvent::TokenUsageUpdated);
                         }
 
+                        this.clear_context_compaction(cx);
                         cx.emit(AcpThreadEvent::Stopped(r.stop_reason));
                         Ok(Some(r))
                     }
@@ -2514,6 +2550,7 @@ impl AcpThread {
                         Self::flush_streaming_text(&mut this.streaming_text_buffer, cx);
 
                         this.had_error = true;
+                        this.clear_context_compaction(cx);
                         cx.emit(AcpThreadEvent::Error);
                         log::error!("Error in run turn: {:?}", e);
                         Err(e)
@@ -2531,6 +2568,7 @@ impl AcpThread {
         self.connection.cancel(&self.session_id, cx);
 
         Self::flush_streaming_text(&mut self.streaming_text_buffer, cx);
+        self.clear_context_compaction(cx);
         self.mark_pending_tools_as_canceled();
 
         // Wait for the send task to complete

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1912,9 +1912,21 @@ impl NativeAgentConnection {
                                     thread.update_retry_status(status, cx)
                                 })?;
                             }
-                            ThreadEvent::CompactionStarted(_)
-                            | ThreadEvent::CompactionSucceeded(_)
-                            | ThreadEvent::CompactionFailed(_) => {}
+                            ThreadEvent::CompactionStarted(_) => {
+                                acp_thread.update(cx, |thread, cx| {
+                                    thread.context_compaction_started(cx);
+                                })?;
+                            }
+                            ThreadEvent::CompactionSucceeded(_) => {
+                                acp_thread.update(cx, |thread, cx| {
+                                    thread.context_compaction_succeeded(cx);
+                                })?;
+                            }
+                            ThreadEvent::CompactionFailed(_) => {
+                                acp_thread.update(cx, |thread, cx| {
+                                    thread.clear_context_compaction(cx);
+                                })?;
+                            }
                             ThreadEvent::Stop(stop_reason) => {
                                 log::debug!("Assistant message complete: {:?}", stop_reason);
                                 return Ok(acp::PromptResponse::new(stop_reason));

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1326,6 +1326,12 @@ impl Thread {
         let (tx, rx) = mpsc::unbounded();
         let stream = ThreadEventStream(tx);
         for conversation in &self.conversations {
+            if cx.has_flag::<HandoffFeatureFlag>()
+                && let Some(marker) = &conversation.marker
+            {
+                stream.send_compaction_succeeded(marker.id.clone());
+            }
+
             for message in &conversation.messages {
                 match message {
                     Message::User(user_message) => stream.send_user_message(user_message),

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -3464,6 +3464,7 @@ mod tests {
                     acp_thread::AgentThreadEntry::AssistantMessage(_) => "assistant",
                     acp_thread::AgentThreadEntry::ToolCall(_) => "tool_call",
                     acp_thread::AgentThreadEntry::CompletedPlan(_) => "plan",
+                    acp_thread::AgentThreadEntry::ContextCompaction => "context_compaction",
                 })
                 .collect::<Vec<_>>()
         });

--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -1422,6 +1422,8 @@ impl AgentDiff {
             AcpThreadEvent::TitleUpdated
             | AcpThreadEvent::TokenUsageUpdated
             | AcpThreadEvent::SubagentSpawned(_)
+            | AcpThreadEvent::CompactionStarted
+            | AcpThreadEvent::CompactionFinished
             | AcpThreadEvent::EntriesRemoved(_)
             | AcpThreadEvent::ToolAuthorizationRequested(_)
             | AcpThreadEvent::ToolAuthorizationReceived(_)

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -25,6 +25,8 @@ use editor::{
     Editor, EditorEvent, EditorMode, MultiBuffer, PathKey, SelectionEffects, SizingBehavior,
 };
 use feature_flags::AgentSharingFeatureFlag;
+#[cfg(test)]
+use feature_flags::FeatureFlagAppExt as _;
 use file_icons::FileIcons;
 use fs::Fs;
 use futures::FutureExt as _;

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -24,7 +24,7 @@ use editor::scroll::Autoscroll;
 use editor::{
     Editor, EditorEvent, EditorMode, MultiBuffer, PathKey, SelectionEffects, SizingBehavior,
 };
-use feature_flags::{AgentSharingFeatureFlag, FeatureFlagAppExt as _};
+use feature_flags::AgentSharingFeatureFlag;
 use file_icons::FileIcons;
 use fs::Fs;
 use futures::FutureExt as _;
@@ -288,6 +288,8 @@ impl Conversation {
                     | AcpThreadEvent::EntriesRemoved(_)
                     | AcpThreadEvent::Retry(_)
                     | AcpThreadEvent::SubagentSpawned(_)
+                    | AcpThreadEvent::CompactionStarted
+                    | AcpThreadEvent::CompactionFinished
                     | AcpThreadEvent::Stopped(_)
                     | AcpThreadEvent::Error
                     | AcpThreadEvent::LoadError(_)
@@ -487,6 +489,8 @@ fn affects_thread_metadata(event: &AcpThreadEvent) -> bool {
         | AcpThreadEvent::ModeUpdated(_)
         | AcpThreadEvent::ConfigOptionsUpdated(_)
         | AcpThreadEvent::SubagentSpawned(_)
+        | AcpThreadEvent::CompactionStarted
+        | AcpThreadEvent::CompactionFinished
         | AcpThreadEvent::PromptUpdated => false,
     }
 }
@@ -1530,6 +1534,13 @@ impl ConversationView {
                 if let Some(active) = self.thread_view(&session_id) {
                     active.update(cx, |active, _cx| {
                         active.thread_retry_status = Some(retry.clone());
+                    });
+                }
+            }
+            AcpThreadEvent::CompactionStarted | AcpThreadEvent::CompactionFinished => {
+                if let Some(active) = self.thread_view(&session_id) {
+                    active.update(cx, |active, cx| {
+                        active.sync_generating_indicator(cx);
                     });
                 }
             }

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -11,7 +11,7 @@ use acp_thread::{ContentBlock, PlanEntry};
 use agent::{SkillLoadingError, SkillLoadingErrorsUpdated, UserAgentsMd};
 use cloud_api_types::{SubmitAgentThreadFeedbackBody, SubmitAgentThreadFeedbackCommentsBody};
 use editor::actions::OpenExcerpts;
-use feature_flags::AcpBetaFeatureFlag;
+use feature_flags::{AcpBetaFeatureFlag, FeatureFlagAppExt as _, HandoffFeatureFlag};
 
 use crate::completion_provider::AvailableSkill;
 use crate::message_editor::SharedSessionCapabilities;
@@ -5150,6 +5150,19 @@ impl ThreadView {
             AgentThreadEntry::CompletedPlan(entries) => {
                 self.render_completed_plan(entries, window, cx)
             }
+            AgentThreadEntry::ContextCompaction => h_flex()
+                .id(("context_compaction", entry_ix))
+                .px_5()
+                .py_1()
+                .gap_2()
+                .child(Divider::horizontal())
+                .child(
+                    Label::new("Context Compacted")
+                        .size(LabelSize::Custom(self.tool_name_font_size()))
+                        .color(Color::Muted),
+                )
+                .child(Divider::horizontal())
+                .into_any(),
         };
 
         let is_subagent_output = self.is_subagent()
@@ -5727,13 +5740,16 @@ impl ThreadView {
 
     /// Ensures the list item count includes (or excludes) an extra item for the generating indicator
     pub(crate) fn sync_generating_indicator(&mut self, cx: &App) {
-        let is_generating = matches!(self.thread.read(cx).status(), ThreadStatus::Generating);
+        let show_generating_indicator = {
+            let thread = self.thread.read(cx);
+            matches!(thread.status(), ThreadStatus::Generating) || thread.is_compacting_context()
+        };
 
-        if is_generating && !self.generating_indicator_in_list {
+        if show_generating_indicator && !self.generating_indicator_in_list {
             let entries_count = self.thread.read(cx).entries().len();
             self.list_state.splice(entries_count..entries_count, 1);
             self.generating_indicator_in_list = true;
-        } else if !is_generating && self.generating_indicator_in_list {
+        } else if !show_generating_indicator && self.generating_indicator_in_list {
             let entries_count = self.thread.read(cx).entries().len();
             self.list_state.splice(entries_count..entries_count + 1, 0);
             self.generating_indicator_in_list = false;
@@ -5764,6 +5780,7 @@ impl ThreadView {
                     .map(|tokens| crate::humanize_token_count(tokens))
             })
             .flatten();
+        let is_compacting_context = self.thread.read(cx).is_compacting_context();
 
         let arrow_icon = if is_waiting {
             IconName::ArrowUp
@@ -5777,7 +5794,21 @@ impl ThreadView {
             .px(rems_from_px(22.))
             .gap_2()
             .map(|this| {
-                if confirmation {
+                if is_compacting_context {
+                    this.child(
+                        h_flex()
+                            .w_2()
+                            .justify_center()
+                            .child(GeneratingSpinnerElement::new(SpinnerVariant::Sand)),
+                    )
+                    .child(
+                        div().min_w(rems(8.)).child(
+                            LoadingLabel::new("Compacting Context")
+                                .size(LabelSize::Small)
+                                .color(Color::Muted),
+                        ),
+                    )
+                } else if confirmation {
                     this.child(
                         h_flex()
                             .w_2()
@@ -6259,7 +6290,8 @@ impl ThreadView {
                 }
                 AgentThreadEntry::ToolCall(_)
                 | AgentThreadEntry::AssistantMessage(_)
-                | AgentThreadEntry::CompletedPlan(_) => {}
+                | AgentThreadEntry::CompletedPlan(_)
+                | AgentThreadEntry::ContextCompaction => {}
             }
         }
 
@@ -9286,7 +9318,10 @@ impl ThreadView {
     }
 
     fn render_token_limit_callout(&self, cx: &mut Context<Self>) -> Option<Callout> {
-        if self.token_limit_callout_dismissed || self.as_native_thread(cx).is_none() {
+        if cx.has_flag::<HandoffFeatureFlag>()
+            || self.token_limit_callout_dismissed
+            || self.as_native_thread(cx).is_none()
+        {
             return None;
         }
 

--- a/crates/agent_ui/src/entry_view_state.rs
+++ b/crates/agent_ui/src/entry_view_state.rs
@@ -237,6 +237,11 @@ impl EntryViewState {
                     self.set_entry(index, Entry::CompletedPlan);
                 }
             }
+            AgentThreadEntry::ContextCompaction => {
+                if !matches!(self.entries.get(index), Some(Entry::ContextCompaction)) {
+                    self.set_entry(index, Entry::ContextCompaction);
+                }
+            }
         };
     }
 
@@ -257,7 +262,8 @@ impl EntryViewState {
             match entry {
                 Entry::UserMessage { .. }
                 | Entry::AssistantMessage { .. }
-                | Entry::CompletedPlan => {}
+                | Entry::CompletedPlan
+                | Entry::ContextCompaction => {}
                 Entry::ToolCall(ToolCallEntry { content, .. }) => {
                     for view in content.values() {
                         if let Ok(diff_editor) = view.clone().downcast::<Editor>() {
@@ -326,6 +332,7 @@ pub enum Entry {
     AssistantMessage(AssistantMessageEntry),
     ToolCall(ToolCallEntry),
     CompletedPlan,
+    ContextCompaction,
 }
 
 impl Entry {
@@ -334,14 +341,17 @@ impl Entry {
             Self::UserMessage(editor) => Some(editor.read(cx).focus_handle(cx)),
             Self::AssistantMessage(message) => Some(message.focus_handle.clone()),
             Self::ToolCall(tool_call) => Some(tool_call.focus_handle.clone()),
-            Self::CompletedPlan => None,
+            Self::CompletedPlan | Self::ContextCompaction => None,
         }
     }
 
     pub fn message_editor(&self) -> Option<&Entity<MessageEditor>> {
         match self {
             Self::UserMessage(editor) => Some(editor),
-            Self::AssistantMessage(_) | Self::ToolCall(_) | Self::CompletedPlan => None,
+            Self::AssistantMessage(_)
+            | Self::ToolCall(_)
+            | Self::CompletedPlan
+            | Self::ContextCompaction => None,
         }
     }
 
@@ -368,7 +378,10 @@ impl Entry {
     ) -> Option<ScrollHandle> {
         match self {
             Self::AssistantMessage(message) => message.scroll_handle_for_chunk(chunk_ix),
-            Self::UserMessage(_) | Self::ToolCall(_) | Self::CompletedPlan => None,
+            Self::UserMessage(_)
+            | Self::ToolCall(_)
+            | Self::CompletedPlan
+            | Self::ContextCompaction => None,
         }
     }
 
@@ -383,7 +396,10 @@ impl Entry {
     pub fn has_content(&self) -> bool {
         match self {
             Self::ToolCall(ToolCallEntry { content, .. }) => !content.is_empty(),
-            Self::UserMessage(_) | Self::AssistantMessage(_) | Self::CompletedPlan => false,
+            Self::UserMessage(_)
+            | Self::AssistantMessage(_)
+            | Self::CompletedPlan
+            | Self::ContextCompaction => false,
         }
     }
 }
@@ -400,7 +416,7 @@ impl Focusable for Entry {
             Self::UserMessage(editor) => editor.read(cx).focus_handle(cx),
             Self::AssistantMessage(message) => message.focus_handle.clone(),
             Self::ToolCall(tool_call) => tool_call.focus_handle.clone(),
-            Self::CompletedPlan => cx.focus_handle(),
+            Self::CompletedPlan | Self::ContextCompaction => cx.focus_handle(),
         }
     }
 }


### PR DESCRIPTION
Adds UI plumbing for context handoff, including the transient compacting indicator, the durable Context Compacted divider, replay of persisted divider markers, and suppression of the old token-limit callout while handoff is enabled.

Release Notes:

- Improved agent threads by showing when context has been compacted.
