### PR TITLE
Swap streaming_diff to f32s

### DIFF
--- a/crates/streaming_diff/src/streaming_diff.rs
+++ b/crates/streaming_diff/src/streaming_diff.rs
@@ -9,7 +9,7 @@ use std::{
 
 #[derive(Default)]
 struct Matrix {
-    cells: Vec<f64>,
+    cells: Vec<f32>,
     rows: usize,
     cols: usize,
 }
@@ -52,7 +52,7 @@ impl Matrix {
         }
     }
 
-    fn get(&self, row: usize, col: usize) -> f64 {
+    fn get(&self, row: usize, col: usize) -> f32 {
         if row >= self.rows {
             panic!("row out of bounds")
         }
@@ -63,7 +63,7 @@ impl Matrix {
         self.cells[col * self.rows + row]
     }
 
-    fn set(&mut self, row: usize, col: usize, value: f64) {
+    fn set(&mut self, row: usize, col: usize, value: f32) {
         if row >= self.rows {
             panic!("row out of bounds")
         }
@@ -75,7 +75,7 @@ impl Matrix {
         self.cells[col * self.rows + row] = value;
     }
 
-    fn adjacent_columns_mut(&mut self, current_col: usize) -> (&[f64], &mut [f64]) {
+    fn adjacent_columns_mut(&mut self, current_col: usize) -> (&[f32], &mut [f32]) {
         if current_col == 0 || current_col >= self.cols {
             panic!("column out of bounds");
         }
@@ -122,9 +122,9 @@ pub struct StreamingDiff {
 }
 
 impl StreamingDiff {
-    const INSERTION_SCORE: f64 = -1.;
-    const DELETION_SCORE: f64 = -20.;
-    const EQUALITY_BASE: f64 = 1.8;
+    const INSERTION_SCORE: f32 = -1.;
+    const DELETION_SCORE: f32 = -20.;
+    const EQUALITY_BASE: f32 = 1.8;
     const MAX_EQUALITY_EXPONENT: i32 = 16;
 
     pub fn new(old: String) -> Self {
@@ -133,7 +133,7 @@ impl StreamingDiff {
         let mut scores = Matrix::new();
         scores.resize(old_len + 1, 1);
         for i in 0..=old_len {
-            scores.set(i, 0, i as f64 * Self::DELETION_SCORE);
+            scores.set(i, 0, i as f32 * Self::DELETION_SCORE);
         }
         Self {
             old,
@@ -161,7 +161,7 @@ impl StreamingDiff {
             let current_equal_runs = &mut self.current_equal_runs;
             let (previous_scores, current_scores) = self.scores.adjacent_columns_mut(relative_j);
 
-            current_scores[0] = j as f64 * Self::INSERTION_SCORE;
+            current_scores[0] = j as f32 * Self::INSERTION_SCORE;
             for i in 1..=old.len() {
                 let insertion_score = previous_scores[i] + Self::INSERTION_SCORE;
                 let deletion_score = current_scores[i - 1] + Self::DELETION_SCORE;
@@ -172,7 +172,7 @@ impl StreamingDiff {
                     let exponent = cmp::min(equal_run as i32 / 4, Self::MAX_EQUALITY_EXPONENT);
                     previous_scores[i - 1] + Self::EQUALITY_BASE.powi(exponent)
                 } else {
-                    f64::NEG_INFINITY
+                    f32::NEG_INFINITY
                 };
 
                 current_scores[i] = insertion_score.max(deletion_score).max(equality_score);
@@ -181,7 +181,7 @@ impl StreamingDiff {
             std::mem::swap(&mut self.previous_equal_runs, &mut self.current_equal_runs);
         }
 
-        let mut max_score = f64::NEG_INFINITY;
+        let mut max_score = f32::NEG_INFINITY;
         let mut next_old_text_ix = self.old_text_ix;
         let next_new_text_ix = self.new.len();
         for i in self.old_text_ix..=self.old.len() {


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/57849

Rationale: 

We have way too much precision with `f64`, and halving the memory cost of the `Matrix` object has all sorts of knock-on performance effects. Tests for the crate pass locally, so might as well try it out.

Perf diff with nice colors

<img width="2556" height="474" alt="CleanShot 2026-05-29 at 00 20 36@2x" src="https://github.com/user-attachments/assets/1b6f8498-9351-41b2-8ee5-702bf1f5c411" />

In plain text:

<details>

```
==> Comparison
group                                                     main                                     streaming-edits-f32
-----                                                     ----                                     -------------------
streaming_diff_finish/medium_insertions/5077              1.35      4.3±1.08µs  1117.9 MB/sec      1.00      3.2±1.07µs  1504.1 MB/sec
streaming_diff_finish/medium_many_small_changes/5074      1.39      4.9±0.77µs  1049.6 MB/sec      1.00      3.6±0.57µs  1455.4 MB/sec
streaming_diff_finish/small_function_rewrite/3353         1.24      3.2±0.81µs  1100.6 MB/sec      1.00      2.6±0.64µs  1359.8 MB/sec
streaming_diff_finish/tiny_function_rewrite/1510          2.19  1926.9±2942.37ns   783.0 MB/sec    1.00  881.5±248.65ns  1711.5 MB/sec
streaming_diff_push_new/medium_insertions/5077            1.39    139.9±5.46ms    35.4 KB/sec      1.00    100.4±2.56ms    49.4 KB/sec
streaming_diff_push_new/medium_many_small_changes/5074    1.46    153.6±4.60ms    34.6 KB/sec      1.00    105.0±7.89ms    50.6 KB/sec
streaming_diff_push_new/small_function_rewrite/3353       1.31     62.3±3.17ms    57.0 KB/sec      1.00     47.6±1.84ms    74.6 KB/sec
streaming_diff_push_new/tiny_function_rewrite/1510        1.11      9.7±1.53ms   159.7 KB/sec      1.00      8.7±0.19ms   176.7 KB/sec
```
</details>

Numbers were obtained with 10s of `criterion` benchmarks, using a wrapper script ([upcoming PR](https://github.com/zed-industries/zed/pull/58040)) and [critcmp](https://github.com/BurntSushi/critcmp).

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


Release Notes:

- Improved performance of streaming_diff tool
