### PR TITLE
Prevent terminal from stealing modal focus

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -317,7 +317,8 @@ impl TerminalPanel {
         if let Some(workspace) = workspace.upgrade() {
             let should_focus = workspace
                 .update_in(&mut cx, |workspace, window, cx| {
-                    workspace.active_item(cx).is_none()
+                    !workspace.has_active_modal(window, cx)
+                        && workspace.active_item(cx).is_none()
                         && workspace
                             .is_dock_at_position_open(terminal_panel.position(window, cx), cx)
                 })
@@ -904,6 +905,14 @@ impl TerminalPanel {
                                 cx,
                             )
                         }));
+
+                        let reveal_strategy = if workspace.has_active_modal(window, cx)
+                            && matches!(reveal_strategy, RevealStrategy::Always)
+                        {
+                            RevealStrategy::NoFocus
+                        } else {
+                            reveal_strategy
+                        };
 
                         match reveal_strategy {
                             RevealStrategy::Always => {


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #43297

Release Notes:

- Fixed terminal from stealing modal focus
