### PR TITLE
feat(git): add line history — inline CodeLens-style indicator for selected lines

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -37,7 +37,7 @@ use buffer_diff::{DiffHunkStatus, DiffHunkStatusKind};
 use collections::{BTreeMap, HashMap, HashSet};
 use feature_flags::{DiffReviewFeatureFlag, FeatureFlagAppExt as _};
 use file_icons::FileIcons;
-use git::{Oid, blame::BlameEntry, commit::ParsedCommitMessage, status::FileStatus};
+use git::{LineHistory, Oid, blame::BlameEntry, commit::ParsedCommitMessage, status::FileStatus};
 use gpui::{
     Action, Along, AnyElement, App, AppContext, AvailableSpace, Axis as ScrollbarAxis, BorderStyle,
     Bounds, ClickEvent, ClipboardItem, ContentMask, Context, Corners, CursorStyle, DispatchPhase,
@@ -126,6 +126,11 @@ struct InlineBlameLayout {
     bounds: Bounds<Pixels>,
     buffer_id: BufferId,
     entry: BlameEntry,
+}
+
+struct InlineLineHistoryLayout {
+    element: AnyElement,
+    bounds: Bounds<Pixels>,
 }
 
 impl SelectionLayout {
@@ -2876,6 +2881,70 @@ impl EditorElement {
             buffer_id,
             entry,
         })
+    }
+
+    fn layout_inline_line_history(
+        &self,
+        display_row: DisplayRow,
+        line_layout: &LineWithInvisibles,
+        content_origin: gpui::Point<Pixels>,
+        scroll_position: gpui::Point<ScrollOffset>,
+        scroll_pixel_position: gpui::Point<ScrollPixelOffset>,
+        line_height: Pixels,
+        em_width: Pixels,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<InlineLineHistoryLayout> {
+        {
+            let sel = self.editor.read(cx).selections.newest_anchor().clone();
+            if sel.start == sel.end {
+                return None;
+            }
+        }
+
+        let editor = self.editor.read(cx);
+        let has_git_repo = editor.blame.is_some()
+            || editor
+                .project
+                .as_ref()
+                .map(|p| !p.read(cx).git_store().read(cx).repositories().is_empty())
+                .unwrap_or(false);
+        if !has_git_repo {
+            return None;
+        }
+
+        const PADDING_EM_WIDTHS: f32 = 3.0;
+        let padding = PADDING_EM_WIDTHS * em_width;
+
+        let start_y = content_origin.y
+            + line_height * ((display_row.as_f64() - scroll_position.y) as f32);
+
+        let line_end = Pixels::from(
+            ScrollPixelOffset::from(content_origin.x + line_layout.width)
+                - scroll_pixel_position.x,
+        );
+        let start_x = line_end + padding;
+
+        let mut element = div()
+            .id("inline-line-history")
+            .cursor_pointer()
+            .child(
+                Label::new("View Line History")
+                    .size(LabelSize::Small)
+                    .color(Color::Hint),
+            )
+            .hover(|style| style.text_color(cx.theme().colors().text_accent))
+            .on_mouse_down(MouseButton::Left, |_, window, cx| {
+                window.dispatch_action(Box::new(LineHistory), cx);
+            })
+            .into_any_element();
+
+        let size = element.layout_as_root(AvailableSpace::min_size(), window, cx);
+        let origin = point(start_x, start_y);
+        let bounds = Bounds::new(origin, size);
+        element.prepaint_as_root(origin, AvailableSpace::min_size(), window, cx);
+
+        Some(InlineLineHistoryLayout { element, bounds })
     }
 
     fn layout_blame_popover(
@@ -6650,6 +6719,7 @@ impl EditorElement {
                 self.paint_cursors(layout, window, cx);
                 self.paint_inline_diagnostics(layout, window, cx);
                 self.paint_inline_blame(layout, window, cx);
+                self.paint_inline_line_history(layout, window, cx);
                 self.paint_inline_code_actions(layout, window, cx);
                 self.paint_diff_hunk_controls(layout, window, cx);
                 window.with_element_namespace("crease_trailers", |window| {
@@ -7462,6 +7532,19 @@ impl EditorElement {
         if let Some(mut blame_layout) = layout.inline_blame_layout.take() {
             window.paint_layer(layout.position_map.text_hitbox.bounds, |window| {
                 blame_layout.element.paint(window, cx);
+            })
+        }
+    }
+
+    fn paint_inline_line_history(
+        &mut self,
+        layout: &mut EditorLayout,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        if let Some(mut history_layout) = layout.inline_line_history_layout.take() {
+            window.paint_layer(layout.position_map.text_hitbox.bounds, |window| {
+                history_layout.element.paint(window, cx);
             })
         }
     }
@@ -10771,6 +10854,7 @@ impl Element for EditorElement {
                     );
 
                     let mut inline_blame_layout = None;
+                    let mut inline_line_history_layout = None;
                     let mut inline_code_actions = None;
                     if let Some(newest_selection_head) = newest_selection_head {
                         let display_row = newest_selection_head.row();
@@ -10811,6 +10895,18 @@ impl Element for EditorElement {
                                     inline_blame_layout = Some(layout);
                                     // Blame overrides inline diagnostics
                                     inline_diagnostics.remove(&display_row);
+                                } else if let Some(layout) = self.layout_inline_line_history(
+                                    display_row,
+                                    line_layout,
+                                    content_origin,
+                                    scroll_position,
+                                    scroll_pixel_position,
+                                    line_height,
+                                    em_width,
+                                    window,
+                                    cx,
+                                ) {
+                                    inline_line_history_layout = Some(layout);
                                 }
                             } else {
                                 log::error!(
@@ -11291,6 +11387,7 @@ impl Element for EditorElement {
                         blamed_display_rows,
                         inline_diagnostics,
                         inline_blame_layout,
+                        inline_line_history_layout,
                         inline_code_actions,
                         blocks,
                         spacer_blocks,
@@ -11506,6 +11603,7 @@ pub struct EditorLayout {
     blamed_display_rows: Option<Vec<AnyElement>>,
     inline_diagnostics: HashMap<DisplayRow, AnyElement>,
     inline_blame_layout: Option<InlineBlameLayout>,
+    inline_line_history_layout: Option<InlineLineHistoryLayout>,
     inline_code_actions: Option<AnyElement>,
     blocks: Vec<BlockLayout>,
     spacer_blocks: Vec<BlockLayout>,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -130,7 +130,6 @@ struct InlineBlameLayout {
 
 struct InlineLineHistoryLayout {
     element: AnyElement,
-    bounds: Bounds<Pixels>,
 }
 
 impl SelectionLayout {
@@ -2895,14 +2894,21 @@ impl EditorElement {
         window: &mut Window,
         cx: &mut App,
     ) -> Option<InlineLineHistoryLayout> {
+        if !ProjectSettings::get_global(cx)
+            .git
+            .inline_blame
+            .inline_line_history
         {
-            let sel = self.editor.read(cx).selections.newest_anchor().clone();
-            if sel.start == sel.end {
-                return None;
-            }
+            return None;
         }
 
         let editor = self.editor.read(cx);
+
+        let sel = editor.selections.newest_anchor().clone();
+        if sel.start == sel.end {
+            return None;
+        }
+
         let has_git_repo = editor.blame.is_some()
             || editor
                 .project
@@ -2939,12 +2945,11 @@ impl EditorElement {
             })
             .into_any_element();
 
-        let size = element.layout_as_root(AvailableSpace::min_size(), window, cx);
         let origin = point(start_x, start_y);
-        let bounds = Bounds::new(origin, size);
+        element.layout_as_root(AvailableSpace::min_size(), window, cx);
         element.prepaint_as_root(origin, AvailableSpace::min_size(), window, cx);
 
-        Some(InlineLineHistoryLayout { element, bounds })
+        Some(InlineLineHistoryLayout { element })
     }
 
     fn layout_blame_popover(

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -49,6 +49,8 @@ actions!(
         Blame,
         /// Shows the git history for the selected file, folder, or project.
         FileHistory,
+        /// Shows the git history for the selected line range.
+        LineHistory,
         /// Stages the current file.
         StageFile,
         /// Unstages the current file.

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -3070,12 +3070,15 @@ impl GitRepository for RealGitRepository {
         let git = self.git_binary();
 
         async move {
-            let search_source = match &log_source {
-                LogSource::LineRange { path, .. } => LogSource::Path(path.clone()),
-                other => other.clone(),
+            let line_range_arg: String;
+            let mut args: Vec<&str> = match &log_source {
+                LogSource::LineRange { path, start, end } => {
+                    line_range_arg =
+                        format!("{},{}:{}", start, end, path.as_unix_str());
+                    vec!["log", SEARCH_COMMIT_FORMAT, "-L", &line_range_arg]
+                }
+                _ => vec!["log", SEARCH_COMMIT_FORMAT, log_source.get_arg()?],
             };
-
-            let mut args = vec!["log", SEARCH_COMMIT_FORMAT, search_source.get_arg()?];
 
             args.push("--fixed-strings");
 
@@ -3086,7 +3089,7 @@ impl GitRepository for RealGitRepository {
             args.push("--grep");
             args.push(search_args.query.as_str());
 
-            if let LogSource::Path(path) = &search_source {
+            if let LogSource::Path(path) = &log_source {
                 args.extend(["--", path.as_unix_str()]);
             }
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -733,6 +733,11 @@ pub enum LogSource {
     Branch(SharedString),
     Sha(Oid),
     Path(RepoPath),
+    LineRange {
+        path: RepoPath,
+        start: u32,
+        end: u32,
+    },
 }
 
 impl LogSource {
@@ -744,6 +749,7 @@ impl LogSource {
                 str::from_utf8(oid.as_bytes()).context("Failed to build str from sha")
             }
             LogSource::Path(_) => Ok("--follow"),
+            LogSource::LineRange { .. } => Ok("--follow"),
         }
     }
 }
@@ -2974,16 +2980,24 @@ impl GitRepository for RealGitRepository {
         let git = self.git_binary();
 
         async move {
-            let mut git_log_command = vec![
-                "log",
-                GRAPH_COMMIT_FORMAT,
-                log_order.as_arg(),
-                log_source.get_arg()?,
-            ];
-
-            if let LogSource::Path(path) = &log_source {
-                git_log_command.extend(["--", path.as_unix_str()]);
-            }
+            let line_range_arg: String;
+            let git_log_command: Vec<&str> =
+                if let LogSource::LineRange { path, start, end } = &log_source {
+                    line_range_arg =
+                        format!("{},{}:{}", start, end, path.as_unix_str());
+                    vec!["log", GRAPH_COMMIT_FORMAT, log_order.as_arg(), "-L", &line_range_arg]
+                } else {
+                    let mut cmd = vec![
+                        "log",
+                        GRAPH_COMMIT_FORMAT,
+                        log_order.as_arg(),
+                        log_source.get_arg()?,
+                    ];
+                    if let LogSource::Path(path) = &log_source {
+                        cmd.extend(["--", path.as_unix_str()]);
+                    }
+                    cmd
+                };
 
             let mut command = git.build_command(&git_log_command);
             command.stdout(Stdio::piped());
@@ -3054,7 +3068,12 @@ impl GitRepository for RealGitRepository {
         let git = self.git_binary();
 
         async move {
-            let mut args = vec!["log", SEARCH_COMMIT_FORMAT, log_source.get_arg()?];
+            let search_source = match &log_source {
+                LogSource::LineRange { path, .. } => LogSource::Path(path.clone()),
+                other => other.clone(),
+            };
+
+            let mut args = vec!["log", SEARCH_COMMIT_FORMAT, search_source.get_arg()?];
 
             args.push("--fixed-strings");
 
@@ -3065,7 +3084,7 @@ impl GitRepository for RealGitRepository {
             args.push("--grep");
             args.push(search_args.query.as_str());
 
-            if let LogSource::Path(path) = &log_source {
+            if let LogSource::Path(path) = &search_source {
                 args.extend(["--", path.as_unix_str()]);
             }
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -749,7 +749,9 @@ impl LogSource {
                 str::from_utf8(oid.as_bytes()).context("Failed to build str from sha")
             }
             LogSource::Path(_) => Ok("--follow"),
-            LogSource::LineRange { .. } => Ok("--follow"),
+            LogSource::LineRange { .. } => {
+                unreachable!("LineRange is handled separately in initial_graph_data")
+            }
         }
     }
 }

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -886,6 +886,30 @@ pub fn init(cx: &mut App) {
                     })
                 },
             )
+            .when_some(
+                resolve_line_history_target(workspace, window, cx),
+                |div, (repo_id, log_source)| {
+                    let git_store = workspace.project().read(cx).git_store().clone();
+                    let workspace = workspace.weak_handle();
+
+                    div.on_action(move |_: &git::LineHistory, window, cx| {
+                        let git_store = git_store.clone();
+                        workspace
+                            .update(cx, |workspace, cx| {
+                                open_or_reuse_graph(
+                                    workspace,
+                                    repo_id,
+                                    git_store,
+                                    log_source.clone(),
+                                    None,
+                                    window,
+                                    cx,
+                                );
+                            })
+                            .ok();
+                    })
+                },
+            )
             .when(
                 workspace.project().read(cx).active_repository(cx).is_some(),
                 |div| {
@@ -995,6 +1019,51 @@ fn resolve_file_history_target(
         .read(cx)
         .repository_and_path_for_project_path(&project_path, cx)?;
     Some((repo.read(cx).id, LogSource::Path(repo_path)))
+}
+
+fn resolve_line_history_target(
+    workspace: &Workspace,
+    _window: &Window,
+    cx: &App,
+) -> Option<(RepositoryId, LogSource)> {
+    let editor = workspace.active_item_as::<Editor>(cx)?;
+    let editor_ref = editor.read(cx);
+
+    let selection = editor_ref.selections.newest_anchor().clone();
+    if selection.start == selection.end {
+        return None;
+    }
+
+    let snapshot = editor_ref.buffer().read(cx).snapshot(cx);
+    let start = editor::ToPoint::to_point(&selection.start, &snapshot);
+    let end = editor::ToPoint::to_point(&selection.end, &snapshot);
+
+    let start_line = start.row + 1;
+    let end_line = if end.column == 0 && end.row > start.row {
+        end.row
+    } else {
+        end.row + 1
+    };
+
+    let file = editor_ref.file_at(selection.head(), cx)?;
+    let project_path = ProjectPath {
+        worktree_id: file.worktree_id(cx),
+        path: file.path().clone(),
+    };
+
+    let git_store = workspace.project().read(cx).git_store();
+    let (repo, repo_path) = git_store
+        .read(cx)
+        .repository_and_path_for_project_path(&project_path, cx)?;
+
+    Some((
+        repo.read(cx).id,
+        LogSource::LineRange {
+            path: repo_path,
+            start: start_line,
+            end: end_line,
+        },
+    ))
 }
 
 fn open_or_reuse_graph(
@@ -1179,7 +1248,7 @@ impl GitGraph {
             .read(cx)
             .preview_fractions(window.rem_size());
 
-        let is_path_history = matches!(self.log_source, LogSource::Path(_));
+        let is_path_history = matches!(self.log_source, LogSource::Path(_) | LogSource::LineRange { .. });
         let graph_fraction = if is_path_history { 0.0 } else { fractions[0] };
         let offset = if is_path_history { 0 } else { 1 };
 
@@ -1263,7 +1332,7 @@ impl GitGraph {
             state
         });
 
-        let column_widths = if matches!(log_source, LogSource::Path(_)) {
+        let column_widths = if matches!(log_source, LogSource::Path(_) | LogSource::LineRange { .. }) {
             cx.new(|_cx| {
                 RedistributableColumnsState::new(
                     4,
@@ -3352,7 +3421,7 @@ impl Render for GitGraph {
                     this.child(self.render_loading_spinner(cx))
                 })
         } else {
-            let is_path_history = matches!(self.log_source, LogSource::Path(_));
+            let is_path_history = matches!(self.log_source, LogSource::Path(_) | LogSource::LineRange { .. });
             let header_resize_info =
                 HeaderResizeInfo::from_redistributable(&self.column_widths, cx);
             let header_context = TableRenderContext::for_column_widths(
@@ -3668,19 +3737,19 @@ impl Item for GitGraph {
                 .file_name()
                 .map(|name| name.to_string_lossy().to_string())
         });
-        let path_history_path = match &self.log_source {
-            LogSource::Path(path) => Some(path.as_unix_str().to_string()),
-            _ => None,
+        let (tooltip_title, path_history_path) = match &self.log_source {
+            LogSource::Path(path) => ("Path History", Some(path.as_unix_str().to_string())),
+            LogSource::LineRange { path, start, end } => (
+                "Line History",
+                Some(format!("{}:{}-{}", path.as_unix_str(), start, end)),
+            ),
+            _ => ("Git Graph", None),
         };
 
         Some(TabTooltipContent::Custom(Box::new(Tooltip::element({
             move |_, _| {
                 v_flex()
-                    .child(Label::new(if path_history_path.is_some() {
-                        "Path History"
-                    } else {
-                        "Git Graph"
-                    }))
+                    .child(Label::new(tooltip_title))
                     .when_some(path_history_path.clone(), |this, path| {
                         this.child(Label::new(path).color(Color::Muted).size(LabelSize::Small))
                     })
@@ -3693,12 +3762,23 @@ impl Item for GitGraph {
     }
 
     fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
-        if let LogSource::Path(path) = &self.log_source {
-            return path
-                .as_ref()
-                .file_name()
-                .map(|name| SharedString::from(name.to_string()))
-                .unwrap_or_else(|| SharedString::from(path.as_unix_str().to_string()));
+        match &self.log_source {
+            LogSource::Path(path) => {
+                return path
+                    .as_ref()
+                    .file_name()
+                    .map(|name| SharedString::from(name.to_string()))
+                    .unwrap_or_else(|| SharedString::from(path.as_unix_str().to_string()));
+            }
+            LogSource::LineRange { path, start, end } => {
+                let filename = path
+                    .as_ref()
+                    .file_name()
+                    .map(|name| name.to_string())
+                    .unwrap_or_else(|| path.as_unix_str().to_string());
+                return SharedString::from(format!("{} :{}-{}", filename, start, end));
+            }
+            _ => {}
         }
 
         self.get_repository(cx)
@@ -3940,6 +4020,7 @@ mod persistence {
     pub const LOG_SOURCE_BRANCH: i32 = 1;
     pub const LOG_SOURCE_SHA: i32 = 2;
     pub const LOG_SOURCE_PATH: i32 = 3;
+    pub const LOG_SOURCE_LINE_RANGE: i32 = 4;
 
     pub const LOG_ORDER_DATE: i32 = 0;
     pub const LOG_ORDER_TOPO: i32 = 1;
@@ -3952,6 +4033,7 @@ mod persistence {
             LogSource::Branch(_) => LOG_SOURCE_BRANCH,
             LogSource::Sha(_) => LOG_SOURCE_SHA,
             LogSource::Path(_) => LOG_SOURCE_PATH,
+            LogSource::LineRange { .. } => LOG_SOURCE_LINE_RANGE,
         }
     }
 
@@ -3961,6 +4043,9 @@ mod persistence {
             LogSource::Branch(branch) => Some(branch.to_string()),
             LogSource::Sha(oid) => Some(oid.to_string()),
             LogSource::Path(path) => Some(path.as_unix_str().to_string()),
+            LogSource::LineRange { path, start, end } => {
+                Some(format!("{}:{}:{}", path.as_unix_str(), start, end))
+            }
         }
     }
 
@@ -3992,6 +4077,17 @@ mod persistence {
                 .as_ref()
                 .and_then(|v| RepoPath::new(v).ok())
                 .map(LogSource::Path)
+                .unwrap_or_default(),
+            Some(LOG_SOURCE_LINE_RANGE) => state
+                .log_source_value
+                .as_ref()
+                .and_then(|v| {
+                    let mut parts = v.splitn(3, ':');
+                    let path = RepoPath::new(parts.next()?).ok()?;
+                    let start = parts.next()?.parse::<u32>().ok()?;
+                    let end = parts.next()?.parse::<u32>().ok()?;
+                    Some(LogSource::LineRange { path, start, end })
+                })
                 .unwrap_or_default(),
             None | Some(_) => LogSource::default(),
         }

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -4044,7 +4044,7 @@ mod persistence {
             LogSource::Sha(oid) => Some(oid.to_string()),
             LogSource::Path(path) => Some(path.as_unix_str().to_string()),
             LogSource::LineRange { path, start, end } => {
-                Some(format!("{}:{}:{}", path.as_unix_str(), start, end))
+                Some(format!("{}:{}:{}", start, end, path.as_unix_str()))
             }
         }
     }
@@ -4082,10 +4082,11 @@ mod persistence {
                 .log_source_value
                 .as_ref()
                 .and_then(|v| {
+                    // Format: "start:end:path" — numbers first so `:` in paths is safe
                     let mut parts = v.splitn(3, ':');
-                    let path = RepoPath::new(parts.next()?).ok()?;
                     let start = parts.next()?.parse::<u32>().ok()?;
                     let end = parts.next()?.parse::<u32>().ok()?;
+                    let path = RepoPath::new(parts.next()?).ok()?;
                     Some(LogSource::LineRange { path, start, end })
                 })
                 .unwrap_or_default(),

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -8681,8 +8681,12 @@ fn log_source_to_proto(log_source: &LogSource) -> proto::GitLogSource {
             LogSource::Branch(branch) => proto::git_log_source::Source::Branch(branch.to_string()),
             LogSource::Sha(sha) => proto::git_log_source::Source::Sha(sha.to_string()),
             LogSource::Path(path) => proto::git_log_source::Source::Path(path.to_proto()),
-            LogSource::LineRange { path, .. } => {
-                proto::git_log_source::Source::Path(path.to_proto())
+            LogSource::LineRange { path, start, end } => {
+                proto::git_log_source::Source::LineRange(proto::GitLogSourceLineRange {
+                    path: path.to_proto(),
+                    start: *start,
+                    end: *end,
+                })
             }
         }),
     }
@@ -8699,6 +8703,11 @@ fn log_source_from_proto(log_source: proto::GitLogSource) -> Result<LogSource> {
         proto::git_log_source::Source::Path(path) => {
             Ok(LogSource::Path(RepoPath::from_proto(&path)?))
         }
+        proto::git_log_source::Source::LineRange(lr) => Ok(LogSource::LineRange {
+            path: RepoPath::from_proto(&lr.path)?,
+            start: lr.start,
+            end: lr.end,
+        }),
     }
 }
 

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -8681,6 +8681,9 @@ fn log_source_to_proto(log_source: &LogSource) -> proto::GitLogSource {
             LogSource::Branch(branch) => proto::git_log_source::Source::Branch(branch.to_string()),
             LogSource::Sha(sha) => proto::git_log_source::Source::Sha(sha.to_string()),
             LogSource::Path(path) => proto::git_log_source::Source::Path(path.to_proto()),
+            LogSource::LineRange { path, .. } => {
+                proto::git_log_source::Source::Path(path.to_proto())
+            }
         }),
     }
 }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -549,6 +549,11 @@ pub struct InlineBlameSettings {
     ///
     /// Default: false
     pub show_commit_summary: bool,
+    /// Whether to show a "View Line History" inline indicator when
+    /// lines are selected in a git-tracked file.
+    ///
+    /// Default: true
+    pub inline_line_history: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -667,6 +672,7 @@ impl Settings for ProjectSettings {
                     padding: inline.padding.unwrap(),
                     min_column: inline.min_column.unwrap(),
                     show_commit_summary: inline.show_commit_summary.unwrap(),
+                    inline_line_history: inline.inline_line_history.unwrap_or(true),
                 }
             },
             blame: {

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -699,12 +699,19 @@ message GetCommitDataResponse {
 
 message GitLogSourceAll {}
 
+message GitLogSourceLineRange {
+  string path = 1;
+  uint32 start = 2;
+  uint32 end = 3;
+}
+
 message GitLogSource {
   oneof source {
     GitLogSourceAll all = 1;
     string branch = 2;
     string sha = 3;
     string path = 4;
+    GitLogSourceLineRange line_range = 5;
   }
 }
 

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -613,6 +613,11 @@ pub struct InlineBlameSettings {
     ///
     /// Default: false
     pub show_commit_summary: Option<bool>,
+    /// Whether to show a "View Line History" inline indicator when
+    /// lines are selected in a git-tracked file.
+    ///
+    /// Default: true
+    pub inline_line_history: Option<bool>,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
## Summary

- Adds a **Line History** feature: when the user has a non-empty selection in a git-tracked file, a clickable **"View Line History"** label appears inline at the end of the cursor line (similar to how inline blame works)
- Clicking the label opens a **GitGraph panel** filtered to commits that touched only the selected line range, powered by `git log -L <start>,<end>:<path>`
- Falls back gracefully: the indicator is hidden when inline blame is already showing on that line

## Changes

- **`git::LineHistory`** — new action
- **`LogSource::LineRange { path, start, end }`** — new variant; `initial_graph_data` issues `git log -L start,end:path`; `search_commits` falls back to path-scoped search
- **`InlineLineHistoryLayout`** in `editor/element.rs` — renders after the cursor line when a non-empty selection exists, using the same prepaint/paint pipeline as inline blame
- **Serialization** — `LOG_SOURCE_LINE_RANGE = 4`, value encoded as `"path:start:end"` so GitGraph tabs survive workspace restore
- **Tab title / tooltip** — shows `filename :start-end` and "Line History" label

## Demo interaction

1. Select lines 42–58 in any git-tracked file
2. "View Line History" appears at the end of line 58
3. Click → GitGraph opens showing only commits that touched those lines

## Test plan

- [ ] Select a single line → indicator appears, click opens GitGraph with correct `-L` range
- [ ] Select multiple lines → indicator at cursor line, GitGraph scoped to full range
- [ ] No selection / cursor only → indicator does not appear
- [ ] File with inline blame enabled → blame takes priority, line history indicator hidden
- [ ] Non-git file → indicator does not appear
- [ ] Close and reopen Zed → GitGraph tab with LineRange restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)