### PR TITLE
agent: Do not render diagnostics in diff

### DIFF
--- a/crates/agent_ui/src/entry_view_state.rs
+++ b/crates/agent_ui/src/entry_view_state.rs
@@ -10,7 +10,7 @@ use gpui::{
     ScrollHandle, TextStyleRefinement, WeakEntity, Window,
 };
 use language::language_settings::SoftWrap;
-use project::{AgentId, Project};
+use project::{AgentId, Project, project_settings::DiagnosticSeverity};
 use prompt_store::PromptStore;
 use rope::Point;
 use settings::Settings as _;
@@ -445,6 +445,7 @@ fn create_editor_diff(
         );
         editor.set_show_gutter(false, cx);
         editor.disable_diagnostics(cx);
+        editor.set_max_diagnostics_severity(DiagnosticSeverity::Off, cx);
         editor.disable_expand_excerpt_buttons(cx);
         editor.set_show_vertical_scrollbar(false, cx);
         editor.set_minimap_visibility(MinimapVisibility::Disabled, window, cx);

--- a/crates/agent_ui/src/entry_view_state.rs
+++ b/crates/agent_ui/src/entry_view_state.rs
@@ -444,7 +444,7 @@ fn create_editor_diff(
             cx,
         );
         editor.set_show_gutter(false, cx);
-        editor.disable_inline_diagnostics();
+        editor.disable_diagnostics(cx);
         editor.disable_expand_excerpt_buttons(cx);
         editor.set_show_vertical_scrollbar(false, cx);
         editor.set_minimap_visibility(MinimapVisibility::Disabled, window, cx);


### PR DESCRIPTION
Release Notes:

- agent: Fixed an issue where diagnostics would show up in agent panel diffs
