### PR TITLE
agent_ui: Collapse message editor selection on focus loss

### DIFF
--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -15,7 +15,8 @@ use agent_client_protocol::schema as acp;
 use anyhow::{Result, anyhow};
 use editor::{
     Addon, AnchorRangeExt, ContextMenuOptions, Editor, EditorElement, EditorEvent, EditorMode,
-    EditorStyle, Inlay, MultiBuffer, MultiBufferOffset, MultiBufferSnapshot, ToOffset,
+    EditorStyle, Inlay, MultiBuffer, MultiBufferOffset, MultiBufferSnapshot, SelectionEffects,
+    ToOffset,
     actions::{Copy, Cut, Paste},
     code_context_menus::CodeContextMenu,
     display_map::{CreaseId, CreaseSnapshot},
@@ -526,7 +527,15 @@ impl MessageEditor {
             cx.emit(MessageEditorEvent::Focus)
         })
         .detach();
-        cx.on_focus_out(&editor.focus_handle(cx), window, |_, _, _, cx| {
+        cx.on_focus_out(&editor.focus_handle(cx), window, |this, _, window, cx| {
+            this.editor.update(cx, |editor, cx| {
+                if editor.has_non_empty_selection(&editor.display_snapshot(cx)) {
+                    let cursor = editor.selections.newest_anchor().head();
+                    editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                        s.select_anchor_ranges([cursor..cursor]);
+                    });
+                }
+            });
             cx.emit(MessageEditorEvent::LostFocus)
         })
         .detach();


### PR DESCRIPTION
When the message editor loses focus, collapse any non-empty selection to the latest cursor position before emitting the LostFocus event. This prevents stale selections from remaining active after focus moves away.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A or Added/Fixed/Improved ...
