### PR TITLE
Allow symlinked global skill directories

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -3624,6 +3624,113 @@ mod internal_tests {
     }
 
     #[gpui::test]
+    async fn test_symlinked_global_skills_load_and_reload(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let skills_dir = global_skills_dir();
+        let external_skill_dir = PathBuf::from(path!("/external/my-skill"));
+        let skill_link_dir = skills_dir.join("my-skill");
+        let skill_link_path = skill_link_dir.join("SKILL.md");
+
+        fs.insert_tree(
+            &external_skill_dir,
+            json!({
+                "SKILL.md": "---\nname: my-skill\ndescription: First symlinked version\n---\n\nbody-v1"
+            }),
+        )
+        .await;
+        fs.create_dir(&skills_dir).await.unwrap();
+        fs.create_symlink(&skill_link_dir, external_skill_dir)
+            .await
+            .unwrap();
+
+        let project = Project::test(fs.clone(), [], cx).await;
+        let project_id = project.entity_id();
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        let agent =
+            cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), fs.clone(), cx));
+
+        cx.update(|cx| {
+            agent.update(cx, |agent, cx| agent.ensure_skills_scan_started(cx));
+        });
+
+        let connection = NativeAgentConnection(agent.clone());
+        let _acp_thread = cx
+            .update(|cx| {
+                Rc::new(connection).new_session(
+                    project.clone(),
+                    PathList::new(&[Path::new("/")]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        let loaded_skill = agent.read_with(cx, |agent, cx| {
+            let state = agent.projects.get(&project_id).unwrap();
+            let user = user_skills(&state.skills);
+            assert_eq!(user.len(), 1);
+            assert_eq!(user[0].name, "my-skill");
+            assert_eq!(user[0].description, "First symlinked version");
+            assert_eq!(user[0].source, SkillSource::Global);
+            assert_eq!(user[0].skill_file_path, skill_link_path);
+
+            let catalog_skills = state.project_context.read(cx).skills();
+            let catalog_skill = catalog_skills
+                .iter()
+                .find(|skill| skill.name == "my-skill")
+                .expect("symlinked skill should be included in the model-facing catalog");
+            assert_eq!(catalog_skill.description, "First symlinked version");
+            assert_eq!(
+                catalog_skill.location,
+                skill_link_path.to_string_lossy().as_ref()
+            );
+
+            (*user[0]).clone()
+        });
+        let body = agent_skills::read_skill_body(fs.as_ref(), &loaded_skill.skill_file_path)
+            .await
+            .unwrap();
+        assert_eq!(body, "body-v1");
+
+        fs.write(
+            &skill_link_path,
+            b"---\nname: my-skill\ndescription: Second symlinked version\n---\n\nbody-v2",
+        )
+        .await
+        .unwrap();
+        cx.run_until_parked();
+
+        let reloaded_skill = agent.read_with(cx, |agent, cx| {
+            let state = agent.projects.get(&project_id).unwrap();
+            let user = user_skills(&state.skills);
+            assert_eq!(user.len(), 1);
+            assert_eq!(user[0].name, "my-skill");
+            assert_eq!(user[0].description, "Second symlinked version");
+            assert_eq!(user[0].source, SkillSource::Global);
+            assert_eq!(user[0].skill_file_path, skill_link_path);
+
+            let catalog_skills = state.project_context.read(cx).skills();
+            let catalog_skill = catalog_skills
+                .iter()
+                .find(|skill| skill.name == "my-skill")
+                .expect("reloaded symlinked skill should be included in the model-facing catalog");
+            assert_eq!(catalog_skill.description, "Second symlinked version");
+            assert_eq!(
+                catalog_skill.location,
+                skill_link_path.to_string_lossy().as_ref()
+            );
+
+            (*user[0]).clone()
+        });
+        let body = agent_skills::read_skill_body(fs.as_ref(), &reloaded_skill.skill_file_path)
+            .await
+            .unwrap();
+        assert_eq!(body, "body-v2");
+    }
+
+    #[gpui::test]
     async fn test_global_skills_dir_created_after_startup(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.executor());

--- a/crates/agent/src/tools/tool_permissions.rs
+++ b/crates/agent/src/tools/tool_permissions.rs
@@ -132,15 +132,42 @@ pub async fn resolve_global_skill_path(path: &Path, fs: &dyn Fs) -> Option<PathB
     // skills tree (and so different but equivalent path representations
     // match). The lexical check above intentionally runs first, so a
     // symlinked `~/.agents/skills` root can't broaden the allowlist to every
-    // path under the symlink target.
+    // path under the symlink target. A symlinked immediate skill directory is
+    // allowed separately, but only for paths that stay under that skill target.
     let canonical_path = fs.canonicalize(&normalized_path).await.ok()?;
     let canonical_skills_dir = canonical_global_skills_dir(fs).await?;
 
-    if canonical_path.starts_with(&canonical_skills_dir) {
+    if canonical_path.starts_with(&canonical_skills_dir)
+        || is_in_symlinked_global_skill_dir(&normalized_path, &canonical_path, fs).await
+    {
         Some(canonical_path)
     } else {
         None
     }
+}
+
+async fn is_in_symlinked_global_skill_dir(path: &Path, canonical_path: &Path, fs: &dyn Fs) -> bool {
+    let skills_dir = normalize_path(&agent_skills::global_skills_dir());
+    let Ok(relative_path) = path.strip_prefix(&skills_dir) else {
+        return false;
+    };
+    let Some(Component::Normal(skill_dir_name)) = relative_path.components().next() else {
+        return false;
+    };
+
+    let skill_dir = skills_dir.join(skill_dir_name);
+    let Ok(Some(metadata)) = fs.metadata(&skill_dir).await else {
+        return false;
+    };
+    metadata.is_symlink
+        && metadata.is_dir
+        && fs
+            .canonicalize(&skill_dir)
+            .await
+            .is_ok_and(|canonical_skill_dir| canonical_path.starts_with(canonical_skill_dir))
+        && fs
+            .is_file(&skill_dir.join(agent_skills::SKILL_FILE_NAME))
+            .await
 }
 
 fn expand_home_prefix(path: &Path) -> Option<PathBuf> {
@@ -922,6 +949,94 @@ mod tests {
             .expect("global skill file should resolve");
 
         assert_eq!(resolved, skill_file);
+    }
+
+    #[gpui::test]
+    async fn test_resolve_global_skill_path_allows_symlinked_skill_dir(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let skills_dir = agent_skills::global_skills_dir();
+        fs.insert_tree(
+            path!("/external/my-skill"),
+            json!({
+                "SKILL.md": "---\nname: my-skill\ndescription: test\n---",
+                "references": { "guide.md": "details" }
+            }),
+        )
+        .await;
+        fs.create_dir(&skills_dir)
+            .await
+            .expect("global skills directory should be created");
+        fs.create_symlink(
+            &skills_dir.join("my-skill"),
+            PathBuf::from(path!("/external/my-skill")),
+        )
+        .await
+        .expect("skill directory should be symlinked");
+
+        let input_path = PathBuf::from("~")
+            .join(".agents")
+            .join("skills")
+            .join("my-skill")
+            .join("references")
+            .join("guide.md");
+        let resolved = resolve_global_skill_path(&input_path, fs.as_ref())
+            .await
+            .expect("symlinked global skill resource should resolve");
+
+        assert_eq!(
+            resolved,
+            PathBuf::from(path!("/external/my-skill/references/guide.md"))
+        );
+    }
+
+    #[gpui::test]
+    async fn test_resolve_global_skill_path_rejects_escape_from_symlinked_skill_dir(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let skills_dir = agent_skills::global_skills_dir();
+        fs.insert_tree(
+            path!("/external/my-skill"),
+            json!({
+                "SKILL.md": "---\nname: my-skill\ndescription: test\n---",
+            }),
+        )
+        .await;
+        fs.insert_tree(path!("/private"), json!({ "secret.txt": "secret" }))
+            .await;
+        fs.create_symlink(
+            &PathBuf::from(path!("/external/my-skill/secret")),
+            PathBuf::from(path!("/private")),
+        )
+        .await
+        .expect("nested symlink should be created");
+        fs.create_dir(&skills_dir)
+            .await
+            .expect("global skills directory should be created");
+        fs.create_symlink(
+            &skills_dir.join("my-skill"),
+            PathBuf::from(path!("/external/my-skill")),
+        )
+        .await
+        .expect("skill directory should be symlinked");
+
+        let input_path = PathBuf::from("~")
+            .join(".agents")
+            .join("skills")
+            .join("my-skill")
+            .join("secret")
+            .join("secret.txt");
+
+        assert!(
+            resolve_global_skill_path(&input_path, fs.as_ref())
+                .await
+                .is_none(),
+            "nested symlinks inside a symlinked skill must not broaden global skill access",
+        );
     }
 
     #[gpui::test]

--- a/crates/agent/src/tools/tool_permissions.rs
+++ b/crates/agent/src/tools/tool_permissions.rs
@@ -132,13 +132,19 @@ pub async fn resolve_global_skill_path(path: &Path, fs: &dyn Fs) -> Option<PathB
     // skills tree (and so different but equivalent path representations
     // match). The lexical check above intentionally runs first, so a
     // symlinked `~/.agents/skills` root can't broaden the allowlist to every
-    // path under the symlink target. A symlinked immediate skill directory is
+    // path under the symlink target. A linked immediate skill directory is
     // allowed separately, but only for paths that stay under that skill target.
     let canonical_path = fs.canonicalize(&normalized_path).await.ok()?;
     let canonical_skills_dir = canonical_global_skills_dir(fs).await?;
 
     if canonical_path.starts_with(&canonical_skills_dir)
-        || is_in_symlinked_global_skill_dir(&normalized_path, &canonical_path, fs).await
+        || is_in_linked_global_skill_dir(
+            &normalized_path,
+            &canonical_path,
+            &canonical_skills_dir,
+            fs,
+        )
+        .await
     {
         Some(canonical_path)
     } else {
@@ -146,7 +152,12 @@ pub async fn resolve_global_skill_path(path: &Path, fs: &dyn Fs) -> Option<PathB
     }
 }
 
-async fn is_in_symlinked_global_skill_dir(path: &Path, canonical_path: &Path, fs: &dyn Fs) -> bool {
+async fn is_in_linked_global_skill_dir(
+    path: &Path,
+    canonical_path: &Path,
+    canonical_skills_dir: &Path,
+    fs: &dyn Fs,
+) -> bool {
     let skills_dir = normalize_path(&agent_skills::global_skills_dir());
     let Ok(relative_path) = path.strip_prefix(&skills_dir) else {
         return false;
@@ -156,15 +167,12 @@ async fn is_in_symlinked_global_skill_dir(path: &Path, canonical_path: &Path, fs
     };
 
     let skill_dir = skills_dir.join(skill_dir_name);
-    let Ok(Some(metadata)) = fs.metadata(&skill_dir).await else {
+    let Ok(canonical_skill_dir) = fs.canonicalize(&skill_dir).await else {
         return false;
     };
-    metadata.is_symlink
-        && metadata.is_dir
-        && fs
-            .canonicalize(&skill_dir)
-            .await
-            .is_ok_and(|canonical_skill_dir| canonical_path.starts_with(canonical_skill_dir))
+
+    !canonical_skill_dir.starts_with(canonical_skills_dir)
+        && canonical_path.starts_with(&canonical_skill_dir)
         && fs
             .is_file(&skill_dir.join(agent_skills::SKILL_FILE_NAME))
             .await

--- a/crates/agent_skills/agent_skills.rs
+++ b/crates/agent_skills/agent_skills.rs
@@ -1531,6 +1531,41 @@ description: A skill with no body content
     }
 
     #[gpui::test]
+    async fn test_load_symlinked_skill_directory(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/external/my-skill",
+            serde_json::json!({
+                "SKILL.md": "---\nname: my-skill\ndescription: Symlinked skill\n---\n\n# Instructions"
+            }),
+        )
+        .await;
+        fs.create_dir(Path::new("/skills")).await.unwrap();
+        fs.create_symlink(
+            Path::new("/skills/my-skill"),
+            PathBuf::from("/external/my-skill"),
+        )
+        .await
+        .unwrap();
+
+        let results = load_skills_from_directory(
+            &(fs as Arc<dyn Fs>),
+            Path::new("/skills"),
+            SkillSource::Global,
+        )
+        .await;
+
+        assert_eq!(results.len(), 1);
+        let skill = results[0].as_ref().expect("Should load successfully");
+        assert_eq!(skill.name, "my-skill");
+        assert_eq!(skill.description, "Symlinked skill");
+        assert_eq!(
+            skill.skill_file_path,
+            Path::new("/skills/my-skill/SKILL.md")
+        );
+    }
+
+    #[gpui::test]
     async fn test_load_nested_skills(cx: &mut TestAppContext) {
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #58088

Release Notes:
- Allows for symlinked global skill directories
