### PR TITLE
Prevent preview auto publish when no release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -745,6 +745,7 @@ jobs:
       run: |
         tag="$GITHUB_REF_NAME"
         release_published=false
+        auto_publish_skipped_reason=""
 
         if [[ ! "$tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)-pre$ ]]; then
             echo "::error::expected preview release tag in the form vMAJOR.MINOR.PATCH-pre, got $tag"
@@ -769,16 +770,25 @@ jobs:
             echo "Leaving $tag as a draft because it is the first preview release for v${major}.${minor}.x"
         fi
 
+        release_body="$(gh release view "$tag" --repo=zed-industries/zed --json body --jq .body)"
+        if [[ -z "${release_body//[[:space:]]/}" ]]; then
+            should_release=false
+            auto_publish_skipped_reason="empty_notes"
+            echo "Leaving $tag as a draft because the release notes are empty"
+        fi
+
         if [[ "$should_release" == "true" ]]; then
             gh release edit "$tag" --repo=zed-industries/zed --draft=false
             release_published=true
         fi
 
         echo "release_published=$release_published" >> "$GITHUB_OUTPUT"
+        echo "auto_publish_skipped_reason=$auto_publish_skipped_reason" >> "$GITHUB_OUTPUT"
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
     outputs:
       release_published: ${{ steps.auto-release-preview.outputs.release_published }}
+      auto_publish_skipped_reason: ${{ steps.auto-release-preview.outputs.auto_publish_skipped_reason }}
   push_release_update_notification:
     needs:
     - create_draft_release
@@ -849,6 +859,8 @@ jobs:
                 echo "❌ Auto release failed for $TAG: $RUN_URL"
             elif [ "$AUTO_RELEASE_RESULT" == "success" ] && [ "$AUTO_RELEASE_PUBLISHED" == "true" ]; then
                 echo "✅ Release $TAG was auto-released successfully: $RELEASE_URL"
+            elif [ "$AUTO_RELEASE_RESULT" == "success" ] && [ "$AUTO_PUBLISH_SKIPPED_REASON" == "empty_notes" ]; then
+                echo "📝 Release $TAG was left as a draft because the release notes are empty: $RELEASE_URL"
             else
                 echo "👀 Release $TAG sitting freshly baked in the oven and waiting to be published: $RELEASE_URL"
             fi
@@ -863,6 +875,7 @@ jobs:
         COMPLIANCE_RESULT: ${{ needs.release_compliance_check.result }}
         AUTO_RELEASE_RESULT: ${{ needs.auto_release_preview.result }}
         AUTO_RELEASE_PUBLISHED: ${{ needs.auto_release_preview.outputs.release_published }}
+        AUTO_PUBLISH_SKIPPED_REASON: ${{ needs.auto_release_preview.outputs.auto_publish_skipped_reason }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         TAG: ${{ github.ref_name }}
         RESULT_RUN_TESTS_MAC: ${{ needs.run_tests_mac.result }}

--- a/script/draft-release-notes
+++ b/script/draft-release-notes
@@ -77,10 +77,7 @@ async function main() {
     }
   }
 
-  if (releaseNotes.length === 0) {
-    const compareUrl = `https://github.com/zed-industries/zed/compare/${priorTag}...${tag}#commits_bucket`;
-    console.log(`No public-facing changes in this release. [View the commits](${compareUrl}).\n`);
-  } else {
+  if (releaseNotes.length > 0) {
     console.log(releaseNotes.join("\n") + "\n");
   }
 }

--- a/tooling/xtask/src/tasks/workflows/release.rs
+++ b/tooling/xtask/src/tasks/workflows/release.rs
@@ -67,7 +67,7 @@ pub(crate) fn release() -> Workflow {
         job_output,
     );
 
-    let (auto_release_preview, auto_release_published) =
+    let (auto_release_preview, auto_release_published, auto_publish_skipped_reason) =
         auto_release_preview(&[&validate_release_assets, &release_compliance]);
 
     let test_jobs = [
@@ -86,6 +86,7 @@ pub(crate) fn release() -> Workflow {
         &release_compliance,
         &auto_release_preview,
         &auto_release_published,
+        &auto_publish_skipped_reason,
         &test_jobs,
         &bundle,
     );
@@ -365,11 +366,12 @@ fn release_compliance_check(deps: &[&NamedJob], non_blocking_outcome: JobOutput)
     named::job(job)
 }
 
-fn auto_release_preview(deps: &[&NamedJob]) -> (NamedJob, JobOutput) {
+fn auto_release_preview(deps: &[&NamedJob]) -> (NamedJob, JobOutput, JobOutput) {
     fn auto_release_preview(token: &StepOutput) -> Step<Run> {
         named::bash(indoc::indoc! {r#"
             tag="$GITHUB_REF_NAME"
             release_published=false
+            auto_publish_skipped_reason=""
 
             if [[ ! "$tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)-pre$ ]]; then
                 echo "::error::expected preview release tag in the form vMAJOR.MINOR.PATCH-pre, got $tag"
@@ -394,12 +396,20 @@ fn auto_release_preview(deps: &[&NamedJob]) -> (NamedJob, JobOutput) {
                 echo "Leaving $tag as a draft because it is the first preview release for v${major}.${minor}.x"
             fi
 
+            release_body="$(gh release view "$tag" --repo=zed-industries/zed --json body --jq .body)"
+            if [[ -z "${release_body//[[:space:]]/}" ]]; then
+                should_release=false
+                auto_publish_skipped_reason="empty_notes"
+                echo "Leaving $tag as a draft because the release notes are empty"
+            fi
+
             if [[ "$should_release" == "true" ]]; then
                 gh release edit "$tag" --repo=zed-industries/zed --draft=false
                 release_published=true
             fi
 
             echo "release_published=$release_published" >> "$GITHUB_OUTPUT"
+            echo "auto_publish_skipped_reason=$auto_publish_skipped_reason" >> "$GITHUB_OUTPUT"
         "#})
         .id("auto-release-preview")
         .add_env(("GITHUB_TOKEN", token))
@@ -408,6 +418,8 @@ fn auto_release_preview(deps: &[&NamedJob]) -> (NamedJob, JobOutput) {
     let (authenticate, token) = steps::authenticate_as_zippy().into();
     let auto_release_preview_step = auto_release_preview(&token);
     let release_published = StepOutput::new(&auto_release_preview_step, "release_published");
+    let auto_publish_skipped_reason =
+        StepOutput::new(&auto_release_preview_step, "auto_publish_skipped_reason");
 
     let job = named::job(
         dependant_job(deps)
@@ -422,13 +434,20 @@ fn auto_release_preview(deps: &[&NamedJob]) -> (NamedJob, JobOutput) {
                     .with_ref(Context::github().ref_()),
             )
             .add_step(auto_release_preview_step)
-            .outputs([(
-                release_published.name.to_owned(),
-                release_published.to_string(),
-            )]),
+            .outputs([
+                (
+                    release_published.name.to_owned(),
+                    release_published.to_string(),
+                ),
+                (
+                    auto_publish_skipped_reason.name.to_owned(),
+                    auto_publish_skipped_reason.to_string(),
+                ),
+            ]),
     );
     let release_published = release_published.as_job_output(&job);
-    (job, release_published)
+    let auto_publish_skipped_reason = auto_publish_skipped_reason.as_job_output(&job);
+    (job, release_published, auto_publish_skipped_reason)
 }
 
 pub(crate) fn download_workflow_artifacts() -> DownloadArtifactStep {
@@ -505,6 +524,7 @@ pub(crate) fn push_release_update_notification(
     compliance_job: &NamedJob,
     auto_release_preview: &NamedJob,
     auto_release_published: &JobOutput,
+    auto_publish_skipped_reason: &JobOutput,
     test_jobs: &[&NamedJob],
     bundle_jobs: &ReleaseBundleJobs,
 ) -> NamedJob {
@@ -542,6 +562,10 @@ pub(crate) fn push_release_update_notification(
         (
             "AUTO_RELEASE_PUBLISHED".into(),
             auto_release_published.to_string(),
+        ),
+        (
+            "AUTO_PUBLISH_SKIPPED_REASON".into(),
+            auto_publish_skipped_reason.to_string(),
         ),
         ("RUN_URL".into(), CURRENT_ACTION_RUN_URL.to_string()),
         ("TAG".into(), Context::github().ref_name().to_string()),
@@ -597,6 +621,8 @@ pub(crate) fn push_release_update_notification(
                 echo "❌ Auto release failed for $TAG: $RUN_URL"
             elif [ "$AUTO_RELEASE_RESULT" == "success" ] && [ "$AUTO_RELEASE_PUBLISHED" == "true" ]; then
                 echo "✅ Release $TAG was auto-released successfully: $RELEASE_URL"
+            elif [ "$AUTO_RELEASE_RESULT" == "success" ] && [ "$AUTO_PUBLISH_SKIPPED_REASON" == "empty_notes" ]; then
+                echo "📝 Release $TAG was left as a draft because the release notes are empty: $RELEASE_URL"
             else
                 echo "👀 Release $TAG sitting freshly baked in the oven and waiting to be published: $RELEASE_URL"
             fi


### PR DESCRIPTION
If there are no release notes, we skip publishing and send a notification to Slack.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- N/A
