### PR TITLE
extension_api: Add support for downloading bzip2 files

### DIFF
--- a/crates/extension_api/wit/since_v0.8.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.8.0/extension.wit
@@ -29,6 +29,10 @@ world extension {
         zip,
         /// An uncompressed file.
         uncompressed,
+        /// A bzip2 file (`.bz2`).
+        bzip2,
+        /// A bzip2 tar archive (`.tar.bz2`).
+        bzip2-tar,
     }
 
     /// The installation status for a language server.

--- a/crates/extension_api/wit/since_v0.8.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.8.0/extension.wit
@@ -21,6 +21,10 @@ world extension {
 
     /// The type of a downloaded file.
     enum downloaded-file-type {
+        /// A bzip2 file (`.bz2`).
+        bzip2,
+        /// A bzip2 tar archive (`.tar.bz2`).
+        bzip2-tar,
         /// A gzipped file (`.gz`).
         gzip,
         /// A gzipped tar archive (`.tar.gz`).
@@ -29,10 +33,6 @@ world extension {
         zip,
         /// An uncompressed file.
         uncompressed,
-        /// A bzip2 file (`.bz2`).
-        bzip2,
-        /// A bzip2 tar archive (`.tar.bz2`).
-        bzip2-tar,
     }
 
     /// The installation status for a language server.

--- a/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
@@ -4,7 +4,7 @@ use crate::wasm_host::{WasmState, wit::ToWasmtimeResult};
 use ::http_client::{AsyncBody, HttpRequestExt};
 use ::settings::{Settings, WorktreeId};
 use anyhow::{Context as _, Result, bail};
-use async_compression::futures::bufread::GzipDecoder;
+use async_compression::futures::bufread::{BzDecoder, GzipDecoder};
 use async_tar::Archive;
 use async_trait::async_trait;
 use extension::{
@@ -1126,6 +1126,25 @@ impl ExtensionImports for WasmState {
                     extract_zip(&destination_path, body)
                         .await
                         .with_context(|| format!("unzipping {path:?} archive"))?;
+                }
+                DownloadedFileType::Bzip2 => {
+                    let body = BzDecoder::new(body);
+                    futures::pin_mut!(body);
+                    self.host
+                        .fs
+                        .create_file_with(&destination_path, body)
+                        .await?;
+                }
+                DownloadedFileType::Bzip2Tar => {
+                    let mut tar_bz2_bytes = Vec::new();
+                    body.read_to_end(&mut tar_bz2_bytes).await?;
+                    let decompressed_bytes =
+                        BzDecoder::new(BufReader::new(tar_bz2_bytes.as_slice()));
+                    futures::pin_mut!(decompressed_bytes);
+                    self.host
+                        .fs
+                        .extract_tar_file(&destination_path, Archive::new(decompressed_bytes))
+                        .await?;
                 }
             }
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
~- [ ] Tests cover the new/changed behavior~
- [x] Performance impact has been considered and is acceptable

Release Notes:

- feat(extension_api): add support to bzip2 downloads
