### PR TITLE
languages: Respect `devEngines` package manager for package scripts

### DIFF
--- a/crates/languages/src/package_json.rs
+++ b/crates/languages/src/package_json.rs
@@ -80,22 +80,7 @@ impl PackageJsonData {
             }
         }
 
-        let package_manager = package_json
-            .get("packageManager")
-            .and_then(|value| value.as_str())
-            .and_then(|value| {
-                if value.starts_with("pnpm") {
-                    Some("pnpm")
-                } else if value.starts_with("yarn") {
-                    Some("yarn")
-                } else if value.starts_with("npm") {
-                    Some("npm")
-                } else if value.starts_with("bun") {
-                    Some("bun")
-                } else {
-                    None
-                }
-            });
+        let package_manager = package_manager_from_package_json(&package_json);
 
         Self {
             jest_package_path,
@@ -124,5 +109,89 @@ impl PackageJsonData {
         self.node_package_path = self.node_package_path.take().or(other.node_package_path);
         self.scripts.extend(other.scripts);
         self.package_manager = self.package_manager.or(other.package_manager);
+    }
+}
+
+fn package_manager_from_package_json(
+    package_json: &HashMap<String, Value>,
+) -> Option<&'static str> {
+    package_json
+        .get("packageManager")
+        .and_then(|value| value.as_str())
+        .and_then(package_manager_name)
+        .or_else(|| {
+            package_json
+                .get("devEngines")
+                .and_then(|value| value.as_object())
+                .and_then(|dev_engines| dev_engines.get("packageManager"))
+                .and_then(package_manager_from_dev_engine)
+        })
+}
+
+fn package_manager_from_dev_engine(value: &Value) -> Option<&'static str> {
+    match value {
+        Value::Object(package_manager) => package_manager
+            .get("name")
+            .and_then(|name| name.as_str())
+            .and_then(package_manager_name),
+        Value::Array(package_managers) => package_managers
+            .iter()
+            .find_map(package_manager_from_dev_engine),
+        _ => None,
+    }
+}
+
+fn package_manager_name(value: &str) -> Option<&'static str> {
+    let value = value.split_once('@').map(|(name, _)| name).unwrap_or(value);
+    match value {
+        "pnpm" => Some("pnpm"),
+        "yarn" => Some("yarn"),
+        "npm" => Some("npm"),
+        "bun" => Some("bun"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use collections::HashMap;
+    use serde_json_lenient::Value;
+
+    use super::PackageJsonData;
+
+    #[test]
+    fn package_manager_detection() -> anyhow::Result<()> {
+        #[track_caller]
+        fn case(source: &str, expected: Option<&'static str>) -> anyhow::Result<()> {
+            let package_json = serde_json_lenient::from_str::<HashMap<String, Value>>(source)?;
+            let package_json =
+                PackageJsonData::new(Path::new("/root/package.json").into(), package_json);
+
+            assert_eq!(package_json.package_manager, expected);
+
+            Ok(())
+        }
+
+        case(r#"{"packageManager": "pnpm@11.1.3"}"#, Some("pnpm"))?;
+        case(
+            r#"{"devEngines": {"packageManager": {"name": "pnpm", "version": "^11.1.3", "onFail": "download"}}}"#,
+            Some("pnpm"),
+        )?;
+        case(
+            r#"{"devEngines": {"packageManager": [{"name": "foo"}, {"name": "yarn", "version": "^4.0.0"}]}}"#,
+            Some("yarn"),
+        )?;
+        case(
+            r#"{"packageManager": "npm@10.0.0", "devEngines": {"packageManager": {"name": "pnpm"}}}"#,
+            Some("npm"),
+        )?;
+        case(
+            r#"{"devEngines": {"packageManager": {"version": "^11.1.3"}}}"#,
+            None,
+        )?;
+
+        Ok(())
     }
 }

--- a/crates/languages/src/package_json.rs
+++ b/crates/languages/src/package_json.rs
@@ -156,9 +156,6 @@ fn package_manager_name(value: &str) -> Option<&'static str> {
 mod tests {
     use std::path::Path;
 
-    use collections::HashMap;
-    use serde_json_lenient::Value;
-
     use super::PackageJsonData;
 
     #[test]

--- a/crates/languages/src/package_json.rs
+++ b/crates/languages/src/package_json.rs
@@ -162,36 +162,44 @@ mod tests {
     use super::PackageJsonData;
 
     #[test]
-    fn package_manager_detection() -> anyhow::Result<()> {
-        #[track_caller]
-        fn case(source: &str, expected: Option<&'static str>) -> anyhow::Result<()> {
-            let package_json = serde_json_lenient::from_str::<HashMap<String, Value>>(source)?;
-            let package_json =
-                PackageJsonData::new(Path::new("/root/package.json").into(), package_json);
-
-            assert_eq!(package_json.package_manager, expected);
-
-            Ok(())
+    fn package_manager_detection() {
+        fn package_manager(source: &str) -> Option<&'static str> {
+            PackageJsonData::new(
+                Path::new("/root/package.json").into(),
+                serde_json_lenient::from_str(source).expect("provided source should be valid JSON"),
+            )
+            .package_manager
         }
 
-        case(r#"{"packageManager": "pnpm@11.1.3"}"#, Some("pnpm"))?;
-        case(
-            r#"{"devEngines": {"packageManager": {"name": "pnpm", "version": "^11.1.3", "onFail": "download"}}}"#,
-            Some("pnpm"),
-        )?;
-        case(
-            r#"{"devEngines": {"packageManager": [{"name": "foo"}, {"name": "yarn", "version": "^4.0.0"}]}}"#,
-            Some("yarn"),
-        )?;
-        case(
-            r#"{"packageManager": "npm@10.0.0", "devEngines": {"packageManager": {"name": "pnpm"}}}"#,
-            Some("npm"),
-        )?;
-        case(
-            r#"{"devEngines": {"packageManager": {"version": "^11.1.3"}}}"#,
-            None,
-        )?;
+        assert_eq!(
+            package_manager(r#"{"packageManager": "pnpm@11.1.3"}"#),
+            Some("pnpm")
+        );
 
-        Ok(())
+        assert_eq!(
+            package_manager(
+                r#"{"devEngines": {"packageManager": {"name": "pnpm", "version": "^11.1.3", "onFail": "download"}}}"#
+            ),
+            Some("pnpm"),
+        );
+
+        assert_eq!(
+            package_manager(
+                r#"{"devEngines": {"packageManager": [{"name": "foo"}, {"name": "yarn", "version": "^4.0.0"}]}}"#
+            ),
+            Some("yarn"),
+        );
+
+        assert_eq!(
+            package_manager(
+                r#"{"packageManager": "npm@10.0.0", "devEngines": {"packageManager": {"name": "pnpm"}}}"#
+            ),
+            Some("npm"),
+        );
+
+        assert_eq!(
+            package_manager(r#"{"devEngines": {"packageManager": {"version": "^11.1.3"}}}"#),
+            None,
+        );
     }
 }


### PR DESCRIPTION
Resolves https://github.com/zed-industries/zed/issues/58086

This diff fixes `package.json` runnables using npm for projects that declare their package manager through
`devEngines.packageManager`. The `package.json` parser only looked at the top-level `packageManager` field, so projects using the newer `devEngines` shape fell back to `npm` even when they specified `pnpm`, `yarn`, or `bun`.

With this change, package manager detection also reads `devEngines.packageManager` in both object and array forms. The top-level `packageManager` field still takes precedence when both are present, and the shared parser means the fix applies to `package.json` gutter runnables as well as TypeScript package-script tasks.

Release Notes:
- Fixed `package.json` runnables ignoring package managers declared via `devEngines.packageManager`.
