### PR TITLE
Limit editor rendering to visible clipped rows

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7997,12 +7997,14 @@ impl Element for EditorElement {
 
                     // Calculate how much of the editor is clipped by parent containers (e.g., List).
                     // This allows us to only render lines that are actually visible, which is
-                    // critical for performance when large AutoHeight editors are inside Lists.
+                    // critical for performance when large content-sized editors are inside Lists.
                     let visible_bounds = window.content_mask().bounds;
-                    let clipped_top = (visible_bounds.origin.y - bounds.origin.y).max(px(0.));
+                    let visible_top = bounds.top().max(visible_bounds.top());
+                    let visible_bottom = bounds.bottom().min(visible_bounds.bottom());
+                    let clipped_top = (visible_top - bounds.top()).max(px(0.));
+                    let visible_height = (visible_bottom - visible_top).max(px(0.));
                     let clipped_top_in_lines = f64::from(clipped_top / line_height);
-                    let visible_height_in_lines =
-                        f64::from(visible_bounds.size.height / line_height);
+                    let visible_height_in_lines = f64::from(visible_height / line_height);
 
                     // The max scroll position for the top of the window
                     let scroll_beyond_last_line = self.editor.read(cx).scroll_beyond_last_line(cx);


### PR DESCRIPTION
Editor prepaint previously used the full parent content mask height when deciding which rows to lay out, while only accounting for top clipping. Embedded, content-sized editors in agent tool cards could therefore ask the display map to highlight rows below the editor's visible intersection with the list viewport. Compute the vertical intersection between the editor bounds and the content mask instead, so highlighted chunks and custom highlight endpoints are built only for rows that can actually be painted.

Release Notes:

- N/A or Added/Fixed/Improved ...
