### PR TITLE
python: Fix splat parameter highlighting

### DIFF
--- a/crates/grammars/src/python/highlights.scm
+++ b/crates/grammars/src/python/highlights.scm
@@ -90,6 +90,16 @@
         name: (identifier) @variable.parameter) ; Default parameters
       (typed_default_parameter
         name: (identifier) @variable.parameter) ; Typed default parameters
+      (list_splat_pattern
+        (identifier) @variable.parameter) ; List splat parameters (*args)
+      (dictionary_splat_pattern
+        (identifier) @variable.parameter) ; Dictionary splat parameters (**kwargs)
+      (typed_parameter
+        (list_splat_pattern
+          (identifier) @variable.parameter)) ; Typed list splat parameters
+      (typed_parameter
+        (dictionary_splat_pattern
+          (identifier) @variable.parameter)) ; Typed dictionary splat parameters
     ]))
 
 ; Keyword arguments


### PR DESCRIPTION
In the current Python Tree-sitter `highlights.scm`, splat parameters (e.g., `*args`, `**kwargs`) and typed splat parameters are not highlighted as `@variable.parameter` due to missing patterns. 

This PR adds  `list_splat_pattern` and `dictionary_splat_pattern`  to the function parameter rules so splat parameters are correctly colored.

|                                                               Before                                                                |                                                               After                                                                |
| :---------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------: |
| <img width="688" height="482" alt="image" src="https://github.com/user-attachments/assets/dbb04e09-51a2-401a-8239-d244a01a02f9" /> | <img width="686" height="480" alt="image" src="https://github.com/user-attachments/assets/f07518ec-30fd-4067-b59d-e090da8182c3" /> |


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed Python splat parameters highlighting
