### PR TITLE
workspace: Add no-project last-tab close setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -178,6 +178,8 @@
   //  3. Never close the window
   //         "when_closing_with_no_tabs": "keep_window_open",
   "when_closing_with_no_tabs": "platform_default",
+  // Whether closing the last tab should also close the window when no project is open.
+  "on_last_tab_closed_if_no_project": false,
   // What to do when the last window is closed.
   // May take 2 values:
   //  1. Use the current platform's convention

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1028,6 +1028,7 @@ impl VsCodeSettings {
             } else {
                 None
             },
+            on_last_tab_closed_if_no_project: None,
             on_last_window_closed: None,
             pane_split_direction_horizontal: None,
             pane_split_direction_vertical: None,

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -73,6 +73,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: auto ("on" on macOS, "off" otherwise)
     pub when_closing_with_no_tabs: Option<CloseWindowWhenNoItems>,
+    /// Whether to close the window when the last tab is closed in a workspace with no project.
+    ///
+    /// Default: false
+    pub on_last_tab_closed_if_no_project: Option<bool>,
     /// Whether to use the system provided dialogs for Open and Save As.
     /// When set to false, Zed will use the built-in keyboard-first pickers.
     ///

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -157,6 +157,25 @@ fn general_page(cx: &App) -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
+                title: "Close Window When Last Tab Is Closed If No Project",
+                description: "Whether closing the last tab should also close the window when no project is open.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("on_last_tab_closed_if_no_project"),
+                    pick: |settings_content| {
+                        settings_content
+                            .workspace
+                            .on_last_tab_closed_if_no_project
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content.workspace.on_last_tab_closed_if_no_project = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
                 title: "On Last Window Closed",
                 description: "What to do when the last window is closed.",
                 field: Box::new(SettingField {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5654,6 +5654,11 @@ impl Workspace {
                 cx.emit(Event::ItemRemoved {
                     item_id: item.item_id(),
                 });
+                if self.should_close_window_after_last_item_closed(cx) {
+                    cx.defer_in(window, |_, window, _| {
+                        window.remove_window();
+                    });
+                }
             }
             pane::Event::Focus => {
                 window.invalidate_character_coordinates();
@@ -7165,6 +7170,30 @@ impl Workspace {
 
     fn has_any_items_open(&self, cx: &App) -> bool {
         self.panes.iter().any(|pane| pane.read(cx).items_len() > 0)
+    }
+
+    fn has_project_open(&self, cx: &App) -> bool {
+        self.visible_worktrees(cx)
+            .any(|worktree| !worktree.read(cx).is_single_file())
+    }
+
+    fn should_close_window_after_last_item_closed(&self, cx: &App) -> bool {
+        let settings = WorkspaceSettings::get_global(cx);
+        if !settings.on_last_tab_closed_if_no_project
+            || self.has_any_items_open(cx)
+            || self.has_project_open(cx)
+        {
+            return false;
+        }
+
+        match self.multi_workspace() {
+            Some(multi_workspace) => multi_workspace
+                .read_with(cx, |multi_workspace, _| {
+                    multi_workspace.workspaces().count() == 1
+                })
+                .unwrap_or(false),
+            None => true,
+        }
     }
 
     fn workspace_location(&self, cx: &App) -> WorkspaceLocation {
@@ -15772,6 +15801,166 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_close_window_after_last_tab_closed_in_workspace_without_project(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        set_on_last_tab_closed_if_no_project(cx, true);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, None, cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.add_item(
+                Box::new(cx.new(TestItem::new)),
+                true,
+                true,
+                None,
+                window,
+                cx,
+            );
+        });
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.close_active_item(&pane::CloseActiveItem::default(), window, cx)
+        })
+        .await
+        .unwrap();
+        cx.run_until_parked();
+
+        assert_eq!(cx.read(|cx| cx.windows().len()), 0);
+    }
+
+    #[gpui::test]
+    async fn test_close_window_after_last_tab_closed_in_single_file_workspace(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        set_on_last_tab_closed_if_no_project(cx, true);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/root"), json!({ "file.txt": "" }))
+            .await;
+
+        let project = Project::test(fs, [path!("/root/file.txt").as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.add_item(
+                Box::new(cx.new(TestItem::new)),
+                true,
+                true,
+                None,
+                window,
+                cx,
+            );
+        });
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.close_active_item(&pane::CloseActiveItem::default(), window, cx)
+        })
+        .await
+        .unwrap();
+        cx.run_until_parked();
+
+        assert_eq!(cx.read(|cx| cx.windows().len()), 0);
+    }
+
+    #[gpui::test]
+    async fn test_close_window_after_last_tab_closed_keeps_project_workspace_open(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        set_on_last_tab_closed_if_no_project(cx, true);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/root", json!({ "file.txt": "" })).await;
+
+        let project = Project::test(fs, ["/root".as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.add_item(
+                Box::new(cx.new(TestItem::new)),
+                true,
+                true,
+                None,
+                window,
+                cx,
+            );
+        });
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.close_active_item(&pane::CloseActiveItem::default(), window, cx)
+        })
+        .await
+        .unwrap();
+        cx.run_until_parked();
+
+        assert_eq!(cx.read(|cx| cx.windows().len()), 1);
+        pane.read_with(cx, |pane, _| {
+            assert_eq!(pane.items_len(), 0);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_close_window_after_last_tab_closed_keeps_multi_workspace_window_open(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        set_on_last_tab_closed_if_no_project(cx, true);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/root", json!({ "file.txt": "" })).await;
+
+        let scratch_project = Project::test(fs.clone(), None, cx).await;
+        let project = Project::test(fs, ["/root".as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(scratch_project, window, cx));
+        let scratch_workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        multi_workspace.update_in(cx, |multi_workspace, window, cx| {
+            multi_workspace.open_sidebar(cx);
+            multi_workspace.test_add_workspace(project, window, cx);
+            multi_workspace.activate(scratch_workspace.clone(), window, cx);
+        });
+
+        let pane = scratch_workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+        pane.update_in(cx, |pane, window, cx| {
+            pane.add_item(
+                Box::new(cx.new(TestItem::new)),
+                true,
+                true,
+                None,
+                window,
+                cx,
+            );
+        });
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.close_active_item(&pane::CloseActiveItem::default(), window, cx)
+        })
+        .await
+        .unwrap();
+        cx.run_until_parked();
+
+        assert_eq!(cx.read(|cx| cx.windows().len()), 1);
+        multi_workspace.read_with(cx, |multi_workspace, _| {
+            assert_eq!(multi_workspace.workspaces().count(), 2);
+        });
+    }
+
+    #[gpui::test]
     async fn test_panel_zoom_preserved_across_workspace_switch(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.executor());
@@ -16072,6 +16261,14 @@ mod tests {
             }
         });
         item
+    }
+
+    fn set_on_last_tab_closed_if_no_project(cx: &mut TestAppContext, enabled: bool) {
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.workspace.on_last_tab_closed_if_no_project = Some(enabled);
+            });
+        });
     }
 
     #[gpui::test]

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -28,6 +28,7 @@ pub struct WorkspaceSettings {
     pub command_aliases: HashMap<String, ActionName>,
     pub max_tabs: Option<NonZeroUsize>,
     pub when_closing_with_no_tabs: settings::CloseWindowWhenNoItems,
+    pub on_last_tab_closed_if_no_project: bool,
     pub on_last_window_closed: settings::OnLastWindowClosed,
     pub text_rendering_mode: settings::TextRenderingMode,
     pub resize_all_panels_in_dock: Vec<DockPosition>,
@@ -108,6 +109,7 @@ impl Settings for WorkspaceSettings {
             command_aliases: workspace.command_aliases.clone(),
             max_tabs: workspace.max_tabs,
             when_closing_with_no_tabs: workspace.when_closing_with_no_tabs.unwrap(),
+            on_last_tab_closed_if_no_project: workspace.on_last_tab_closed_if_no_project.unwrap(),
             on_last_window_closed: workspace.on_last_window_closed.unwrap(),
             text_rendering_mode: workspace.text_rendering_mode.unwrap(),
             resize_all_panels_in_dock: workspace

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3153,6 +3153,20 @@ Or to set a `socks5` proxy:
 
 If you wish to exclude certain hosts from using the proxy, set the `NO_PROXY` environment variable. This accepts a comma-separated list of hostnames, host suffixes, IPv4/IPv6 addresses or blocks that should not use the proxy. For example if your environment included `NO_PROXY="google.com, 192.168.1.0/24"` all hosts in `192.168.1.*`, `google.com` and `*.google.com` would bypass the proxy. See [reqwest NoProxy docs](https://docs.rs/reqwest/latest/reqwest/struct.NoProxy.html#method.from_string) for more.
 
+## When Last Tab Closed If No Project
+
+- Description: Whether closing the last tab should also close the window when no project is open.
+- Setting: `on_last_tab_closed_if_no_project`
+- Default: `false`
+
+**Options**
+
+```json [settings]
+{
+  "on_last_tab_closed_if_no_project": true
+}
+```
+
 ## On Last Window Closed
 
 - Description: What to do when the last window is closed


### PR DESCRIPTION
## Summary

- add `on_last_tab_closed_if_no_project` to workspace settings and settings UI
- close a no-project window when its last tab is closed when the setting is enabled
- document the setting in the generated settings reference

See discussion #45705

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes pending

Release Notes:

- Added an option to close a no-project window when its last tab is closed.
