### PR TITLE
gpui: Allow chaining `flex_grow()` and `flex_shrink()` with custom factors

### DIFF
--- a/crates/acp_tools/src/acp_tools.rs
+++ b/crates/acp_tools/src/acp_tools.rs
@@ -767,7 +767,7 @@ impl Render for AcpTools {
                     } else {
                         div()
                             .size_full()
-                            .flex_grow()
+                            .flex_grow_1()
                             .child(
                                 list(
                                     connection.list_state.clone(),

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -4948,7 +4948,7 @@ impl AgentPanel {
         h_flex()
             .key_context("TitleEditor")
             .group("title_editor")
-            .flex_grow()
+            .flex_grow_1()
             .w_full()
             .min_w_0()
             .max_w_full()

--- a/crates/agent_ui/src/agent_registry_ui.rs
+++ b/crates/agent_ui/src/agent_registry_ui.rs
@@ -650,7 +650,7 @@ impl Render for AgentRegistryPage {
                     let scroll_handle = &self.list;
                     this.child(
                         uniform_list("registry-entries", count, cx.processor(Self::render_agents))
-                            .flex_grow()
+                            .flex_grow_1()
                             .pb_4()
                             .track_scroll(scroll_handle),
                     )

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2624,7 +2624,7 @@ impl ThreadView {
                 v_flex()
                     .when_some(max_content_width, |this, max_w| this.flex_basis(max_w))
                     .when(max_content_width.is_none(), |this| this.w_full())
-                    .flex_shrink()
+                    .flex_shrink_1()
                     .flex_grow_0()
                     .max_w_full()
                     .bg(self.activity_bar_bg(cx))
@@ -3726,7 +3726,7 @@ impl ThreadView {
                     .when_some(max_content_width, |this, max_w| this.flex_basis(max_w))
                     .when(max_content_width.is_none(), |this| this.w_full())
                     .when(fills_container, |this| this.h_full())
-                    .flex_shrink()
+                    .flex_shrink_1()
                     .flex_grow_0()
                     .justify_between()
                     .gap_2()
@@ -5100,7 +5100,7 @@ impl ThreadView {
             }),
         )
         .with_sizing_behavior(gpui::ListSizingBehavior::Auto)
-        .flex_grow()
+        .flex_grow_1()
     }
 
     fn render_entry(

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -1580,7 +1580,7 @@ impl PickerDelegate for ProjectPickerDelegate {
                         .child(
                             h_flex()
                                 .gap_3()
-                                .flex_grow()
+                                .flex_grow_1()
                                 .child(highlighted_match.render(window, cx)),
                         )
                         .tooltip(Tooltip::text(tooltip_path))

--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -49,7 +49,7 @@ impl Render for Breadcrumbs {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let element = h_flex()
             .id("breadcrumb-container")
-            .flex_grow()
+            .flex_grow_1()
             .h_8()
             .overflow_x_scroll()
             .text_ui(cx);

--- a/crates/component_preview/src/component_preview.rs
+++ b/crates/component_preview/src/component_preview.rs
@@ -520,7 +520,7 @@ impl ComponentPreview {
                             }
                         }),
                     )
-                    .flex_grow()
+                    .flex_grow_1()
                     .with_sizing_behavior(gpui::ListSizingBehavior::Auto)
                     .into_any_element()
                 },

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -1574,7 +1574,7 @@ impl Render for VariableList {
                 .with_horizontal_sizing_behavior(gpui::ListHorizontalSizingBehavior::Unconstrained)
                 .gap_1_5()
                 .size_full()
-                .flex_grow(),
+                .flex_grow_1(),
             )
             .children(self.open_context_menu.as_ref().map(|(menu, position, _)| {
                 deferred(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6655,7 +6655,7 @@ pub fn render_breadcrumb_text(
 ) -> gpui::AnyElement {
     const MAX_SEGMENTS: usize = 12;
 
-    let element = h_flex().flex_grow().text_ui(cx);
+    let element = h_flex().flex_grow_1().text_ui(cx);
 
     let prefix_end_ix = cmp::min(segments.len(), MAX_SEGMENTS / 2);
     let suffix_start_ix = cmp::max(

--- a/crates/editor/src/split_editor_view.rs
+++ b/crates/editor/src/split_editor_view.rs
@@ -210,7 +210,7 @@ impl RenderOnce for SplitEditorView {
                     .child(
                         div()
                             .id("split-editor-left")
-                            .flex_shrink()
+                            .flex_shrink_1()
                             .min_w_0()
                             .h_full()
                             .flex_basis(DefiniteLength::Fraction(left_ratio))
@@ -221,7 +221,7 @@ impl RenderOnce for SplitEditorView {
                     .child(
                         div()
                             .id("split-editor-right")
-                            .flex_shrink()
+                            .flex_shrink_1()
                             .min_w_0()
                             .h_full()
                             .flex_basis(DefiniteLength::Fraction(right_ratio))

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -1772,7 +1772,7 @@ impl Render for ExtensionsPage {
                     let scroll_handle = &self.list;
                     this.child(
                         uniform_list("entries", count, cx.processor(Self::render_extensions))
-                            .flex_grow()
+                            .flex_grow_1()
                             .pb_4()
                             .track_scroll(scroll_handle),
                     )

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -1526,7 +1526,7 @@ impl PickerDelegate for BranchListDelegate {
                     h_flex()
                         .w_full()
                         .gap_2p5()
-                        .flex_grow()
+                        .flex_grow_1()
                         .child(
                             Icon::new(entry_icon)
                                 .color(if is_checked_branch {

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -419,11 +419,11 @@ impl CommitModal {
             .child(
                 h_flex()
                     .gap_1()
-                    .flex_shrink()
+                    .flex_shrink_1()
                     .overflow_x_hidden()
                     .child(
                         h_flex()
-                            .flex_shrink()
+                            .flex_shrink_1()
                             .overflow_x_hidden()
                             .child(branch_picker),
                     )

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -1113,7 +1113,7 @@ impl Render for CommitView {
             .bg(cx.theme().colors().editor_background)
             .child(self.render_header(window, cx))
             .when(!self.editor.read(cx).is_empty(cx), |this| {
-                this.child(div().flex_grow().child(self.editor.clone()))
+                this.child(div().flex_grow_1().child(self.editor.clone()))
             })
     }
 }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4876,7 +4876,7 @@ impl GitPanel {
             .border_color(cx.theme().colors().border.opacity(0.8))
             .child(
                 div()
-                    .flex_grow()
+                    .flex_grow_1()
                     .overflow_hidden()
                     .max_w(relative(0.85))
                     .child(
@@ -5792,7 +5792,7 @@ impl GitPanel {
                         })
                         .group("entries")
                         .size_full()
-                        .flex_grow()
+                        .flex_grow_1()
                         .with_width_from_item(self.max_width_item_index)
                         .track_scroll(&self.scroll_handle),
                     )

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -200,6 +200,7 @@ pub trait Styled: Sized {
     fn flex_none(mut self) -> Self {
         self.style().flex_grow = Some(0.);
         self.style().flex_shrink = Some(0.);
+        self.style().flex_basis = Some(Length::Auto);
         self
     }
 
@@ -210,31 +211,45 @@ pub trait Styled: Sized {
         self
     }
 
-    /// Sets the element to allow a flex item to grow to fill any available space.
+    /// Sets the flex item's grow factor.
     /// [Docs](https://tailwindcss.com/docs/flex-grow)
-    fn flex_grow(mut self) -> Self {
-        self.style().flex_grow = Some(1.);
+    fn flex_grow(mut self, grow: f32) -> Self {
+        self.style().flex_grow = Some(grow);
         self
     }
 
-    /// Sets the element to prevent a flex item from growing.
+    /// Disables flex item growth (flex-grow: 0).
     /// [Docs](https://tailwindcss.com/docs/flex-grow#dont-grow)
     fn flex_grow_0(mut self) -> Self {
         self.style().flex_grow = Some(0.);
         self
     }
 
-    /// Sets the element to allow a flex item to shrink if needed.
-    /// [Docs](https://tailwindcss.com/docs/flex-shrink)
-    fn flex_shrink(mut self) -> Self {
-        self.style().flex_shrink = Some(1.);
+    /// Enables flex item growth (flex-grow: 1).
+    /// [Docs](https://tailwindcss.com/docs/flex-grow#grow-1)
+    fn flex_grow_1(mut self) -> Self {
+        self.style().flex_grow = Some(1.);
         self
     }
 
-    /// Sets the element to prevent a flex item from shrinking.
+    /// Sets the flex item's shrink factor.
+    /// [Docs](https://tailwindcss.com/docs/flex-shrink)
+    fn flex_shrink(mut self, shrink: f32) -> Self {
+        self.style().flex_shrink = Some(shrink);
+        self
+    }
+
+    /// Disables flex item shrinking (flex-shrink: 0).
     /// [Docs](https://tailwindcss.com/docs/flex-shrink#dont-shrink)
     fn flex_shrink_0(mut self) -> Self {
         self.style().flex_shrink = Some(0.);
+        self
+    }
+
+    /// Enables flex item shrinking (flex-shrink: 1).
+    /// [Docs](https://tailwindcss.com/docs/flex-shrink#shrink-1)
+    fn flex_shrink_1(mut self) -> Self {
+        self.style().flex_shrink = Some(1.);
         self
     }
 

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -3468,7 +3468,7 @@ impl Render for ActionArgumentsEditor {
             .min_h_8()
             .min_w_48()
             .px_2()
-            .flex_grow()
+            .flex_grow_1()
             .rounded_md()
             .bg(cx.theme().colors().editor_background)
             .border_1()

--- a/crates/livekit_client/examples/test_app.rs
+++ b/crates/livekit_client/examples/test_app.rs
@@ -350,7 +350,7 @@ impl Render for LivekitWindow {
                     .overflow_y_scroll()
                     .flex()
                     .flex_col()
-                    .flex_grow()
+                    .flex_grow_1()
                     .children(self.remote_participants.iter().map(|(identity, state)| {
                         div()
                             .h(px(1080.0))

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4786,9 +4786,9 @@ impl OutlinePanel {
             };
 
             v_flex()
-                .flex_shrink()
+                .flex_shrink_1()
                 .size_full()
-                .child(list_contents.size_full().flex_shrink())
+                .child(list_contents.size_full().flex_shrink_1())
                 .custom_scrollbars(
                     Scrollbars::for_settings::<OutlinePanelSettingsScrollbarProxy>()
                         .tracked_scroll_handle(&self.scroll_handle.clone())

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -881,7 +881,7 @@ impl<D: PickerDelegate> Picker<D> {
             .when_some(self.widest_item, |el, widest_item| {
                 el.with_width_from_item(Some(widest_item))
             })
-            .flex_grow()
+            .flex_grow_1()
             .py(DynamicSpacing::Base04.rems(cx))
             .track_scroll(&scroll_handle)
             .into_any_element(),
@@ -892,7 +892,7 @@ impl<D: PickerDelegate> Picker<D> {
                 }),
             )
             .with_sizing_behavior(sizing_behavior)
-            .flex_grow()
+            .flex_grow_1()
             .py(DynamicSpacing::Base04.rems(cx))
             .into_any_element(),
         }
@@ -1140,7 +1140,7 @@ impl<D: PickerDelegate> Render for Picker<D> {
                     v_flex()
                         .id("element-container")
                         .relative()
-                        .flex_grow()
+                        .flex_grow_1()
                         .when_some(self.max_height, |div, max_h| div.max_h(max_h))
                         .overflow_hidden()
                         .children(self.delegate.render_header(window, cx))
@@ -1167,7 +1167,7 @@ impl<D: PickerDelegate> Render for Picker<D> {
                 el.when_some(self.delegate.no_matches_text(window, cx), |el, text| {
                     el.child(
                         v_flex()
-                            .flex_grow()
+                            .flex_grow_1()
                             .py(DynamicSpacing::Base04.rems(cx))
                             .child(
                                 ListItem::new("empty_state")

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -6932,7 +6932,7 @@ impl Render for ProjectPanel {
                             div()
                                 .id("project-panel-blank-area")
                                 .block_mouse_except_scroll()
-                                .flex_grow()
+                                .flex_grow_1()
                                 .on_scroll_wheel({
                                     let scroll_handle = self.scroll_handle.clone();
                                     let entity_id = cx.entity().entity_id();

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -1561,7 +1561,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                             h_flex()
                                 .id("project_info_container")
                                 .gap_2p5()
-                                .flex_grow()
+                                .flex_grow_1()
                                 .when(self.has_any_non_local_projects, |this| {
                                     this.child(Icon::new(icon).color(Color::Muted))
                                 })

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -369,7 +369,7 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                 .child(
                     h_flex()
                         .gap_3()
-                        .flex_grow()
+                        .flex_grow_1()
                         .when(self.has_any_non_local_projects, |this| {
                             this.child(Icon::new(icon).color(Color::Muted))
                         })

--- a/crates/recent_projects/src/wsl_picker.rs
+++ b/crates/recent_projects/src/wsl_picker.rs
@@ -172,7 +172,7 @@ impl picker::PickerDelegate for WslPickerDelegate {
                 .spacing(ui::ListItemSpacing::Sparse)
                 .child(
                     h_flex()
-                        .flex_grow()
+                        .flex_grow_1()
                         .gap_3()
                         .child(Icon::new(IconName::Linux))
                         .child(v_flex().child(HighlightedLabel::new(

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -362,7 +362,7 @@ impl PickerDelegate for KernelPickerDelegate {
                                 .child(icon.color(Color::Default).size(IconSize::Medium))
                                 .child(
                                     v_flex()
-                                        .flex_grow()
+                                        .flex_grow_1()
                                         .overflow_x_hidden()
                                         .gap_0p5()
                                         .child(
@@ -371,7 +371,7 @@ impl PickerDelegate for KernelPickerDelegate {
                                                 .child(
                                                     div()
                                                         .overflow_x_hidden()
-                                                        .flex_shrink()
+                                                        .flex_shrink_1()
                                                         .text_ellipsis()
                                                         .child(
                                                             Label::new(spec.name())

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2199,7 +2199,7 @@ impl Render for ProjectSearchBar {
         let input_base_styles = |panel: InputPanel| {
             input_base_styles(search.border_color_for(panel, cx), |div| match panel {
                 InputPanel::Query | InputPanel::Replacement => div.w(input_width),
-                InputPanel::Include | InputPanel::Exclude => div.flex_grow(),
+                InputPanel::Include | InputPanel::Exclude => div.flex_grow_1(),
             })
         };
         let theme_colors = cx.theme().colors();

--- a/crates/skill_creator/src/skill_creator.rs
+++ b/crates/skill_creator/src/skill_creator.rs
@@ -898,7 +898,7 @@ impl SkillCreator {
         // than squeezing the body editor below its minimum height.
         v_flex()
             .id("skill-creator-form-fields")
-            .flex_grow()
+            .flex_grow_1()
             .flex_shrink_0()
             .gap_4()
             .child(
@@ -914,7 +914,7 @@ impl SkillCreator {
             .child(Divider::horizontal())
             .child(
                 v_flex()
-                    .flex_grow()
+                    .flex_grow_1()
                     .flex_shrink_0()
                     .gap_2()
                     .child(Label::new("Skill Content"))

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1378,7 +1378,7 @@ impl Item for TerminalView {
                 v_flex()
                     .gap_1()
                     .child(Label::new(title.clone()))
-                    .child(h_flex().flex_grow().child(Divider::horizontal()))
+                    .child(h_flex().flex_grow_1().child(Divider::horizontal()))
                     .child(
                         Label::new(format!("Process ID (PID): {}", pid))
                             .color(Color::Muted)

--- a/crates/ui/src/components/button/split_button.rs
+++ b/crates/ui/src/components/button/split_button.rs
@@ -76,7 +76,7 @@ impl RenderOnce for SplitButton {
             .when(self.style == SplitButtonStyle::Transparent, |this| {
                 this.gap_px()
             })
-            .child(div().flex_grow().child(match self.left {
+            .child(div().flex_grow_1().child(match self.left {
                 SplitButtonKind::ButtonLike(button) => button.into_any_element(),
                 SplitButtonKind::IconButton(icon) => icon.into_any_element(),
             }))

--- a/crates/ui/src/components/data_table.rs
+++ b/crates/ui/src/components/data_table.rs
@@ -652,7 +652,7 @@ pub fn render_table_row(
         // restrict_scroll_to_axis lets vertical scroll events pass through to the list.
         let mut scrollable_section = div()
             .id(("table-row-scrollable", row_index as u64))
-            .flex_grow()
+            .flex_grow_1()
             .overflow_x_scroll()
             .flex()
             .child(
@@ -769,7 +769,7 @@ pub fn render_table_header(
         );
         let mut scrollable_section = div()
             .id("table-header-scrollable")
-            .flex_grow()
+            .flex_grow_1()
             .overflow_x_scroll()
             .flex()
             .child(inner);
@@ -1136,7 +1136,7 @@ impl RenderOnce for Table {
             })
             .child({
                 let content = div()
-                    .flex_grow()
+                    .flex_grow_1()
                     .w_full()
                     .relative()
                     .overflow_hidden()
@@ -1180,7 +1180,7 @@ impl RenderOnce for Table {
                                 },
                             )
                             .size_full()
-                            .flex_grow()
+                            .flex_grow_1()
                             .with_sizing_behavior(ListSizingBehavior::Auto)
                             .with_horizontal_sizing_behavior(horizontal_sizing)
                             .when_some(
@@ -1208,7 +1208,7 @@ impl RenderOnce for Table {
                                 }
                             })
                             .size_full()
-                            .flex_grow()
+                            .flex_grow_1()
                             .with_sizing_behavior(ListSizingBehavior::Auto),
                         ),
                     })
@@ -1237,7 +1237,7 @@ impl RenderOnce for Table {
                 let mut h_scroll_container = div()
                     .id("table-h-scroll")
                     .overflow_x_scroll()
-                    .flex_grow()
+                    .flex_grow_1()
                     .h_full()
                     .track_scroll(&state.read(cx).horizontal_scroll_handle)
                     .child(table);

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -336,7 +336,7 @@ impl RenderOnce for ListItem {
                     }))
                     .child(
                         h_flex()
-                            .flex_grow()
+                            .flex_grow_1()
                             .flex_shrink_0()
                             .flex_basis(relative(0.25))
                             .gap(DynamicSpacing::Base06.rems(cx))
@@ -354,16 +354,16 @@ impl RenderOnce for ListItem {
                     .when_some(self.end_slot, |this, end_slot| {
                         this.child(match self.end_slot_visibility {
                             EndSlotVisibility::Always => {
-                                h_flex().flex_shrink().overflow_hidden().child(end_slot)
+                                h_flex().flex_shrink_1().overflow_hidden().child(end_slot)
                             }
                             EndSlotVisibility::OnHover => h_flex()
-                                .flex_shrink()
+                                .flex_shrink_1()
                                 .overflow_hidden()
                                 .visible_on_hover("list_item")
                                 .child(end_slot),
                             EndSlotVisibility::SwapOnHover(hover_slot) => h_flex()
                                 .relative()
-                                .flex_shrink()
+                                .flex_shrink_1()
                                 .child(h_flex().visible_on_hover("list_item").child(hover_slot))
                                 .child(
                                     h_flex()

--- a/crates/ui/src/components/tab_bar.rs
+++ b/crates/ui/src/components/tab_bar.rs
@@ -129,7 +129,7 @@ impl RenderOnce for TabBar {
                     .child(
                         h_flex()
                             .id("tabs")
-                            .flex_grow()
+                            .flex_grow_1()
                             .overflow_x_scroll()
                             .when_some(self.scroll_handle, |cx, scroll_handle| {
                                 cx.track_scroll(&scroll_handle)

--- a/crates/ui/src/components/tree_view_item.rs
+++ b/crates/ui/src/components/tree_view_item.rs
@@ -193,7 +193,7 @@ impl RenderOnce for TreeViewItem {
                                 h_flex()
                                     .id("nested_inner_tree_view_item")
                                     .w_full()
-                                    .flex_grow()
+                                    .flex_grow_1()
                                     .child(
                                         Label::new(label)
                                             .when(!self.selected, |this| this.color(Color::Muted)),

--- a/crates/ui_input/src/input_field.rs
+++ b/crates/ui_input/src/input_field.rs
@@ -176,7 +176,7 @@ impl Render for InputField {
                     .w_full()
                     .px_2()
                     .py_1p5()
-                    .flex_grow()
+                    .flex_grow_1()
                     .text_color(style.text_color)
                     .rounded_md()
                     .bg(style.background_color)

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3630,7 +3630,7 @@ impl Pane {
             .id("tab_bar_drop_target")
             .min_w_6()
             .h(Tab::container_height(cx))
-            .flex_grow()
+            .flex_grow_1()
             // HACK: This empty child is currently necessary to force the drop target to appear
             // despite us setting a min width above.
             .child("")
@@ -3674,7 +3674,7 @@ impl Pane {
             .debug_selector(|| "pinned_tabs_border".into())
             .min_w_6()
             .h(Tab::container_height(cx))
-            .flex_grow()
+            .flex_grow_1()
             .border_l_1()
             .border_color(cx.theme().colors().border)
             // HACK: This empty child is currently necessary to force the drop target to appear

--- a/crates/zed/src/zed/quick_action_bar/repl_menu.rs
+++ b/crates/zed/src/zed/quick_action_bar/repl_menu.rs
@@ -344,7 +344,7 @@ impl QuickActionBar {
                         .child(
                             div()
                                 .overflow_x_hidden()
-                                .flex_grow()
+                                .flex_grow_1()
                                 .whitespace_nowrap()
                                 .child(
                                     Label::new(if let Some(name) = current_kernel_name {

--- a/crates/zed/src/zed/telemetry_log.rs
+++ b/crates/zed/src/zed/telemetry_log.rs
@@ -518,7 +518,7 @@ impl Render for TelemetryLogView {
             } else {
                 div()
                     .size_full()
-                    .flex_grow()
+                    .flex_grow_1()
                     .child(
                         list(self.list_state.clone(), cx.processor(Self::render_entry))
                             .with_sizing_behavior(gpui::ListSizingBehavior::Auto)


### PR DESCRIPTION
Allow chaining of `flex_grow()` and `flex_shrink()` with custom factors, following Tailwind CSS conventions.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A


_For example:_

<img width="509" height="308" alt="aaa" src="https://github.com/user-attachments/assets/02094fb2-d762-4ac9-a1d9-ef06e2fb047f" />

Before:

``` rust
div()
        .flex()
        .flex_row()
        .size_full()
        .bg(gpui::white())
        .child(
            div()
                .map(|mut this| {
                    this.style().flex_grow = Some(1.);
                    this
                })
                .bg(gpui::blue()),
        )
        .child(
            div()
                .map(|mut this| {
                    this.style().flex_grow = Some(2.);
                    this
                })
                .bg(gpui::green()),
        )
        .child(
            div()
                .map(|mut this| {
                    this.style().flex_grow = Some(3.);
                    this
                })
                .bg(gpui::red()),
        )
```

After:

``` rust
div()
        .flex()
        .flex_row()
        .size_full()
        .bg(gpui::white())
        .child(div().flex_grow(1.).bg(gpui::blue()))
        .child(div().flex_grow(2.).bg(gpui::green()))
        .child(div().flex_grow(3.).bg(gpui::red()))
```