### PR TITLE
Include changed paths in remote UpdatedEntries events

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -595,21 +595,44 @@ impl Worktree {
                         }
 
                         let old_root_repo_common_dir = this.snapshot.root_repo_common_dir.clone();
-                        let mut entries_changed = false;
+                        let mut changed_entries: Vec<(Arc<RelPath>, ProjectEntryId, PathChange)> =
+                            Vec::new();
                         {
                             let mut lock = this.background_snapshot.lock();
-                            this.snapshot = lock.0.clone();
+                            // Replace the snapshot, keeping the previous one around so we can
+                            // resolve the paths of removed entries (the new snapshot no longer
+                            // contains them, and the wire format only carries their ids).
+                            let old_snapshot = mem::replace(&mut this.snapshot, lock.0.clone());
                             for update in lock.1.drain(..) {
-                                entries_changed |= !update.updated_entries.is_empty()
-                                    || !update.removed_entries.is_empty();
+                                for entry_id in &update.removed_entries {
+                                    let entry_id = ProjectEntryId::from_proto(*entry_id);
+                                    if let Some(entry) = old_snapshot.entry_for_id(entry_id) {
+                                        changed_entries.push((
+                                            entry.path.clone(),
+                                            entry_id,
+                                            PathChange::Removed,
+                                        ));
+                                    }
+                                }
+                                for entry in &update.updated_entries {
+                                    // Remote updates don't distinguish creation from
+                                    // modification, so report `AddedOrUpdated`.
+                                    if let Some(path) = RelPath::from_proto(&entry.path).log_err() {
+                                        changed_entries.push((
+                                            path,
+                                            ProjectEntryId::from_proto(entry.id),
+                                            PathChange::AddedOrUpdated,
+                                        ));
+                                    }
+                                }
                                 if let Some(tx) = &this.update_observer {
                                     tx.unbounded_send(update).ok();
                                 }
                             }
                         };
 
-                        if entries_changed {
-                            cx.emit(Event::UpdatedEntries(Arc::default()));
+                        if !changed_entries.is_empty() {
+                            cx.emit(Event::UpdatedEntries(changed_entries.into()));
                         }
                         let is_first_update = !this.received_initial_update;
                         this.received_initial_update = true;

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -4349,6 +4349,164 @@ async fn test_remote_worktree_with_git_emits_root_repo_event_when_repo_info_arri
     );
 }
 
+// Regression test: a remote worktree used to emit `UpdatedEntries` with an
+// empty changeset (`Arc::default()`), discarding the changed paths. Consumers
+// that key off those paths - notably the agent's `.agents/skills` refresh -
+// therefore never fired on remote projects, so skills pasted into an already
+// open project were never picked up. The changeset must carry the real paths.
+//
+// This drives the real host -> remote pipeline: a `FakeFs`-backed local
+// worktree scans the filesystem and produces `UpdateWorktree` messages via
+// `observe_updates`, which we relay into a remote worktree exactly as the
+// collab server does.
+#[gpui::test]
+async fn test_remote_worktree_update_entries_carry_changed_paths(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".agents": {
+                "skills": {}
+            }
+        }),
+    )
+    .await;
+
+    // The host worktree scans the fake filesystem and broadcasts updates.
+    let host = Worktree::local(
+        path!("/root").as_ref(),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(1),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    cx.read(|cx| host.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    // The remote worktree receives those updates over a simulated connection.
+    let remote = cx.update(|cx| {
+        Worktree::remote(
+            1,
+            clock::ReplicaId::new(1),
+            proto::WorktreeMetadata {
+                id: 1,
+                root_name: "root".to_string(),
+                visible: true,
+                abs_path: path!("/root").to_string(),
+                root_repo_common_dir: None,
+            },
+            AnyProtoClient::new(NoopProtoClient::new()),
+            PathStyle::local(),
+            cx,
+        )
+    });
+
+    // Relay every `UpdateWorktree` the host emits into the remote worktree,
+    // mirroring how the collab server forwards them. The callback only buffers
+    // the messages; we apply them on the foreground via `relay`.
+    let pending: Arc<Mutex<Vec<proto::UpdateWorktree>>> = Arc::new(Mutex::new(Vec::new()));
+    host.update(cx, |host, cx| {
+        let pending = pending.clone();
+        host.as_local_mut()
+            .unwrap()
+            .observe_updates(1, cx, move |update| {
+                pending.lock().push(update);
+                async { true }
+            });
+    });
+    let relay = {
+        let remote = remote.clone();
+        move |cx: &mut TestAppContext| {
+            let updates = std::mem::take(&mut *pending.lock());
+            remote.update(cx, |remote, _| {
+                let remote = remote.as_remote().unwrap();
+                for update in updates {
+                    remote.update_from_remote(update);
+                }
+            });
+        }
+    };
+
+    // Record the (path, change) pairs from every `UpdatedEntries` event the
+    // remote worktree emits.
+    let changes: Arc<Mutex<Vec<(String, PathChange)>>> = Arc::new(Mutex::new(Vec::new()));
+    cx.update(|cx| {
+        let changes = changes.clone();
+        cx.subscribe(&remote, move |_, event, _cx| {
+            if let Event::UpdatedEntries(updated) = event {
+                changes.lock().extend(
+                    updated
+                        .iter()
+                        .map(|(path, _, change)| (path.as_unix_str().to_string(), *change)),
+                );
+            }
+        })
+        .detach();
+    });
+
+    // Flush the initial sync (root + existing dirs) and ignore those paths.
+    cx.run_until_parked();
+    relay(cx);
+    cx.run_until_parked();
+    changes.lock().clear();
+
+    // Paste a skill folder into `.agents/skills` on the host.
+    fs.insert_tree(
+        path!("/root/.agents/skills/skill-1"),
+        json!({ "SKILL.md": "skill" }),
+    )
+    .await;
+    cx.run_until_parked();
+    relay(cx);
+    cx.run_until_parked();
+
+    {
+        let changes = changes.lock();
+        assert!(
+            changes
+                .iter()
+                .any(|(path, change)| path == ".agents/skills/skill-1/SKILL.md"
+                    && *change == PathChange::AddedOrUpdated),
+            "remote UpdatedEntries should carry the added skill path, got {:?}",
+            changes
+        );
+    }
+    changes.lock().clear();
+
+    // Remove the skill folder. The wire format only carries entry ids for
+    // removals, so the remote worktree must resolve their paths against the
+    // previous snapshot before it is replaced.
+    fs.remove_dir(
+        path!("/root/.agents/skills/skill-1").as_ref(),
+        RemoveOptions {
+            recursive: true,
+            ignore_if_not_exists: false,
+        },
+    )
+    .await
+    .unwrap();
+    cx.run_until_parked();
+    relay(cx);
+    cx.run_until_parked();
+
+    let changes = changes.lock();
+    assert!(
+        changes
+            .iter()
+            .any(|(path, change)| path == ".agents/skills/skill-1/SKILL.md"
+                && *change == PathChange::Removed),
+        "remote UpdatedEntries should carry removed paths resolved from the \
+         previous snapshot, got {:?}",
+        changes
+    );
+}
+
 #[gpui::test]
 async fn test_deferred_watch_repository_above_root(
     executor: BackgroundExecutor,


### PR DESCRIPTION
Include the changed paths in `UpdatedEntries` events emitted by remote worktrees.

Previously a remote worktree emitted `Event::UpdatedEntries` with an empty changeset (`Arc::default()`), discarding the changed paths. The changeset now carries the real added/updated/removed paths, resolving removed entries against the previous snapshot.

Release Notes:

- Fixed file change events not reporting changed paths in remote projects

