### PR TITLE
python: Add dunder variables highlighting

### DIFF
--- a/crates/grammars/src/python/highlights.scm
+++ b/crates/grammars/src/python/highlights.scm
@@ -4,6 +4,10 @@
 (attribute
   attribute: (identifier) @property)
 
+; Dunder variables
+((identifier) @variable.special
+  (#match? @variable.special "^__[a-zA-Z0-9_]+__$"))
+
 ; CamelCase for classes
 ((identifier) @type.class
   (#match? @type.class "^_*[A-Z][A-Za-z0-9_]*$"))

--- a/crates/grammars/src/python/highlights.scm
+++ b/crates/grammars/src/python/highlights.scm
@@ -4,10 +4,6 @@
 (attribute
   attribute: (identifier) @property)
 
-; Dunder variables
-((identifier) @variable.special
-  (#match? @variable.special "^__[a-zA-Z0-9_]+__$"))
-
 ; CamelCase for classes
 ((identifier) @type.class
   (#match? @type.class "^_*[A-Z][A-Za-z0-9_]*$"))
@@ -331,6 +327,16 @@
 (decorator
   (identifier) @attribute.builtin
   (#any-of? @attribute.builtin "classmethod" "staticmethod" "property"))
+
+(attribute
+  attribute: (identifier) @attribute.special
+  (#any-of? @attribute.special
+    "__all__" "__annotations__" "__bases__" "__builtins__" "__class__" "__closure__" "__code__"
+    "__debug__" "__defaults__" "__dict__" "__doc__" "__file__" "__func__" "__globals__"
+    "__kwdefaults__" "__match_args__" "__members__" "__metaclass__" "__methods__" "__module__"
+    "__mro__" "__mro_entries__" "__name__" "__qualname__" "__post_init__" "__self__" "__signature__"
+    "__slots__" "__subclasses__" "__version__" "__weakref__" "__wrapped__" "__classcell__"
+    "__spec__" "__path__" "__package__" "__future__" "__traceback__"))
 
 ; Builtin types as identifiers
 [


### PR DESCRIPTION
In the current Python Tree-sitter `highlights.scm`,  dunder variables (e.g., `__name__`, `__file__`)  are not highlighted. 

This PR adds a regex `#match?` so all dunder variables are highlighted under `@attribute.special`.

An alternative solution would be to use `#any-of?` and list all dunder variables.


|                                                               Before                                                                |                                                               After                                                                |
| :---------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------: |
|<img width="623" height="895" alt="image" src="https://github.com/user-attachments/assets/ad7b67ba-541c-40ac-a38a-cc863e417fcc" /> | <img width="612" height="903" alt="image" src="https://github.com/user-attachments/assets/a91f5efb-230a-4214-b16b-04278b3ef9ee" />|


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added Python dunder variables highlighting via `attribute.special` in themes.
