### PR TITLE
project_panel: Show agent-edit indicator on files with unreviewed changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14393,6 +14393,7 @@ dependencies = [
 name = "project_panel"
 version = "0.1.0"
 dependencies = [
+ "agent_ui",
  "anyhow",
  "client",
  "collections",

--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -1238,12 +1238,13 @@ struct WorkspaceThread {
     _workspace_subscription: Option<Subscription>,
 }
 
-struct AgentDiffGlobal(Entity<AgentDiff>);
+/// Global handle for [`AgentDiff`], used to observe agent edit state across the application.
+pub struct AgentDiffGlobal(pub(crate) Entity<AgentDiff>);
 
 impl Global for AgentDiffGlobal {}
 
 impl AgentDiff {
-    fn global(cx: &mut App) -> Entity<Self> {
+    pub fn global(cx: &mut App) -> Entity<Self> {
         cx.try_global::<AgentDiffGlobal>()
             .map(|global| global.0.clone())
             .unwrap_or_else(|| {
@@ -1252,6 +1253,41 @@ impl AgentDiff {
                 cx.set_global(global);
                 entity
             })
+    }
+
+    /// Project panel uses this to display agent-edit indicators on changed files and their parent directories.
+    pub fn agent_changed_project_paths(
+        workspace: &WeakEntity<Workspace>,
+        cx: &App,
+    ) -> HashSet<ProjectPath> {
+        let Some(agent_diff) = cx.try_global::<AgentDiffGlobal>() else {
+            return HashSet::default();
+        };
+        let agent_diff = agent_diff.0.read(cx);
+        let Some(workspace_thread) = agent_diff.workspace_threads.get(workspace) else {
+            return HashSet::default();
+        };
+        let Some(thread) = workspace_thread.thread.upgrade() else {
+            return HashSet::default();
+        };
+        let action_log = thread.read(cx).action_log();
+        let mut paths = HashSet::default();
+        for (buffer, _) in action_log.read(cx).changed_buffers(cx) {
+            let buffer = buffer.read(cx);
+            let Some(project_path) = buffer.project_path(cx) else {
+                continue;
+            };
+            // Include the file itself and all ancestor directories so folders
+            // containing agent-edited files also show the indicator.
+            for ancestor in project_path.path.ancestors() {
+                paths.insert(ProjectPath {
+                    worktree_id: project_path.worktree_id,
+                    path: ancestor.into(),
+                });
+            }
+            paths.insert(project_path);
+        }
+        paths
     }
 
     pub fn set_active_thread(
@@ -2302,5 +2338,106 @@ mod tests {
             })
         });
         cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    async fn test_agent_changed_project_paths(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            prompt_store::init(cx);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            language_model::init(cx);
+            workspace::register_project_item::<Editor>(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/test"),
+            json!({"subdir": {"file1": "original content"}}),
+        )
+        .await;
+
+        let project = Project::test(fs, [path!("/test").as_ref()], cx).await;
+        let buffer_path = project
+            .read_with(cx, |project, cx| {
+                project.find_project_path("test/subdir/file1", cx)
+            })
+            .unwrap();
+        let parent_dir_path = project
+            .read_with(cx, |project, cx| {
+                project.find_project_path("test/subdir", cx)
+            })
+            .unwrap();
+
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        let weak_workspace = workspace.downgrade();
+
+        let connection = Rc::new(acp_thread::StubAgentConnection::new());
+        let thread = cx
+            .update(|_, cx| {
+                connection.clone().new_session(
+                    project.clone(),
+                    PathList::new(&[Path::new(path!("/test"))]),
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
+
+        cx.update(|window, cx| {
+            AgentDiff::set_active_thread(&weak_workspace, thread.clone(), window, cx)
+        });
+        cx.run_until_parked();
+
+        // No edits yet — should be empty
+        assert!(
+            cx.update(|_, cx| AgentDiff::agent_changed_project_paths(&weak_workspace, cx))
+                .is_empty()
+        );
+
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_buffer(buffer_path.clone(), cx)
+            })
+            .await
+            .unwrap();
+
+        // buffer_read, edit, buffer_edited in one cx.update block so the
+        // Agent-authored diff update is queued before the User-authored BufferEvent dispatch.
+        cx.update(|_, cx| {
+            action_log.update(cx, |log, cx| log.buffer_read(buffer.clone(), cx));
+            buffer.update(cx, |buffer, cx| {
+                buffer
+                    .edit([(Point::new(0, 0)..Point::new(0, 0), "new ")], None, cx)
+                    .unwrap()
+            });
+            action_log.update(cx, |log, cx| log.buffer_edited(buffer.clone(), cx));
+        });
+        cx.run_until_parked();
+
+        let changed =
+            cx.update(|_, cx| AgentDiff::agent_changed_project_paths(&weak_workspace, cx));
+        assert!(
+            changed.contains(&buffer_path),
+            "should contain the edited file path: {changed:?}"
+        );
+        assert!(
+            changed.contains(&parent_dir_path),
+            "should contain the parent directory path: {changed:?}"
+        );
+
+        cx.update(|_, cx| {
+            action_log.update(cx, |log, cx| log.keep_all_edits(None, cx));
+        });
+        cx.run_until_parked();
+
+        assert!(
+            cx.update(|_, cx| AgentDiff::agent_changed_project_paths(&weak_workspace, cx))
+                .is_empty()
+        );
     }
 }

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -1,6 +1,6 @@
 mod agent_configuration;
 pub mod agent_connection_store;
-mod agent_diff;
+pub mod agent_diff;
 mod agent_model_selector;
 mod agent_panel;
 mod agent_registry_ui;

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
+agent_ui.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true
 editor.workspace = true

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2,9 +2,10 @@ pub mod project_panel_settings;
 mod undo;
 mod utils;
 
+use agent_ui::agent_diff::AgentDiff;
 use anyhow::{Context as _, Result};
 use client::{ErrorCode, ErrorExt};
-use collections::{BTreeSet, HashMap, hash_map};
+use collections::{BTreeSet, HashMap, HashSet, hash_map};
 use command_palette_hooks::CommandPaletteFilter;
 use editor::{
     Editor, EditorEvent, MultiBufferOffset,
@@ -51,7 +52,6 @@ use std::{
     any::TypeId,
     cell::OnceCell,
     cmp,
-    collections::HashSet,
     ops::Neg,
     ops::Range,
     path::{Path, PathBuf},
@@ -164,6 +164,8 @@ pub struct ProjectPanel {
     last_reported_update: Instant,
     update_visible_entries_task: UpdateVisibleEntriesTask,
     undo_manager: UndoManager,
+    agent_changed_paths: HashSet<ProjectPath>,
+    _agent_diff_subscription: Option<Subscription>,
     state: State,
 }
 
@@ -285,6 +287,7 @@ struct EntryDetails {
     diagnostic_count: Option<DiagnosticCount>,
     git_status: GitSummary,
     is_private: bool,
+    agent_changed: bool,
     worktree_id: WorktreeId,
     canonical_path: Option<Arc<Path>>,
 }
@@ -836,7 +839,20 @@ impl ProjectPanel {
                 },
                 update_visible_entries_task: Default::default(),
                 undo_manager: UndoManager::new(workspace.weak_handle(), weak_project_panel, &cx),
+                agent_changed_paths: HashSet::default(),
+                _agent_diff_subscription: None,
             };
+
+            // Subscribe to agent diff changes so we can update the agent-change indicators.
+            let agent_diff = AgentDiff::global(cx);
+            this._agent_diff_subscription =
+                Some(cx.observe(&agent_diff, |this, _agent_diff, cx| {
+                    let workspace = this.workspace.clone();
+                    this.agent_changed_paths =
+                        AgentDiff::agent_changed_project_paths(&workspace, cx);
+                    cx.notify();
+                }));
+
             this.update_visible_entries(None, false, false, window, cx);
 
             this
@@ -5304,6 +5320,7 @@ impl ProjectPanel {
         let filename_text_color = details.filename_text_color;
         let diagnostic_severity = details.diagnostic_severity;
         let diagnostic_count = details.diagnostic_count;
+        let agent_changed = details.agent_changed;
         let item_colors = get_item_color(is_sticky, cx);
 
         let canonical_path = details
@@ -5749,7 +5766,8 @@ impl ProjectPanel {
                     .when(
                         canonical_path.is_some()
                             || diagnostic_count.is_some()
-                            || git_indicator.is_some(),
+                            || git_indicator.is_some()
+                            || agent_changed,
                         |this| {
                             let symlink_element = canonical_path.map(|path| {
                                 div()
@@ -5768,6 +5786,20 @@ impl ProjectPanel {
                                             .color(filename_text_color),
                                     )
                             });
+                            let agent_indicator = if agent_changed {
+                                Some(
+                                    div()
+                                        .id("agent_edit_icon")
+                                        .tooltip(Tooltip::text("Edited by an Agent"))
+                                        .child(
+                                            Icon::new(IconName::AiEdit)
+                                                .size(IconSize::Indicator)
+                                                .color(Color::Modified),
+                                        ),
+                                )
+                            } else {
+                                None
+                            };
                             this.end_slot::<AnyElement>(
                                 h_flex()
                                     .gap_1()
@@ -5807,6 +5839,7 @@ impl ProjectPanel {
                                         this.child(git_indicator)
                                     })
                                     .when_some(symlink_element, |this, el| this.child(el))
+                                    .when_some(agent_indicator, |this, el| this.child(el))
                                     .into_any_element(),
                             )
                         },
@@ -6233,6 +6266,11 @@ impl ProjectPanel {
             .as_ref()
             .is_some_and(|e| e.is_cut() && e.items().contains(&selection));
 
+        let agent_changed = self.agent_changed_paths.contains(&ProjectPath {
+            worktree_id,
+            path: entry.path.clone(),
+        });
+
         EntryDetails {
             filename,
             icon,
@@ -6252,6 +6290,7 @@ impl ProjectPanel {
             diagnostic_count,
             git_status,
             is_private: entry.is_private,
+            agent_changed,
             worktree_id,
             canonical_path: entry.canonical_path.clone(),
         }


### PR DESCRIPTION
Adds a small AiEdit icon next to files and folders in the project panel that have unreviewed agent edits. The indicator disappears automatically when the user accepts the changes. Parent directories also show the icon, so users can spot agent-edited trees without expanding them. 

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes: 

- Added an agent-edit indicator in the project panel for files with unreviewed agent changes.

<img width="371" height="805" alt="ai_indicator_showcase2" src="https://github.com/user-attachments/assets/0f3dd7cd-1e07-4f1d-9cba-c46470e505e3" />