### PR TITLE
Add macOS file drag-out from project panel

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2814,6 +2814,9 @@ pub struct AnyDrag {
 
     /// The cursor style to use while dragging
     pub cursor_style: Option<CursorStyle>,
+
+    /// Real on-disk paths that can be handed to the platform as an outbound file drag.
+    pub external_paths: Option<crate::ExternalPaths>,
 }
 
 /// Contains state associated with a tooltip. You'll only need this struct if you're implementing

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2815,8 +2815,8 @@ pub struct AnyDrag {
     /// The cursor style to use while dragging
     pub cursor_style: Option<CursorStyle>,
 
-    /// Real on-disk paths that can be handed to the platform as an outbound file drag.
-    pub external_paths: Option<crate::FileDragPaths>,
+    /// Payload to offer the platform if the drag leaves the window.
+    pub external_payload: Option<crate::ExternalDragPayload>,
 }
 
 /// Contains state associated with a tooltip. You'll only need this struct if you're implementing

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2816,7 +2816,7 @@ pub struct AnyDrag {
     pub cursor_style: Option<CursorStyle>,
 
     /// Real on-disk paths that can be handed to the platform as an outbound file drag.
-    pub external_paths: Option<crate::ExternalPaths>,
+    pub external_paths: Option<crate::FileDragPaths>,
 }
 
 /// Contains state associated with a tooltip. You'll only need this struct if you're implementing

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2815,9 +2815,15 @@ pub struct AnyDrag {
     /// The cursor style to use while dragging
     pub cursor_style: Option<CursorStyle>,
 
-    /// Payload to offer the platform if the drag leaves the window.
-    pub external_payload: Option<crate::ExternalDragPayload>,
+    /// Resolves the payload to offer the platform if the drag leaves the window.
+    /// Invoked at most once per drag gesture, at promotion time.
+    pub external_payload_source: Option<ExternalDragPayloadSource>,
 }
+
+/// Lazily resolves the payload handed to the platform when an internal drag is
+/// promoted to a native drag session.
+pub type ExternalDragPayloadSource =
+    Box<dyn FnOnce(&mut Window, &mut App) -> Option<crate::ExternalDragPayload> + 'static>;
 
 /// Contains state associated with a tooltip. You'll only need this struct if you're implementing
 /// tooltip behavior on a custom element. Otherwise, use [Div::tooltip](crate::Interactivity::tooltip).

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -45,14 +45,15 @@ use crate::InspectorElementRegistry;
 use crate::{
     Action, ActionBuildError, ActionRegistry, Any, AnyView, AnyWindowHandle, AppContext, Arena,
     ArenaBox, Asset, AssetSource, BackgroundExecutor, Bounds, ClipboardItem, CursorStyle,
-    DispatchPhase, DisplayId, EventEmitter, FocusHandle, FocusMap, ForegroundExecutor, Global,
-    KeyBinding, KeyContext, Keymap, Keystroke, LayoutId, Menu, MenuItem, OwnedMenu,
-    PathPromptOptions, Pixels, Platform, PlatformDisplay, PlatformKeyboardLayout,
-    PlatformKeyboardMapper, Point, Priority, PromptBuilder, PromptButton, PromptHandle,
-    PromptLevel, Render, RenderImage, RenderablePromptHandle, Reservation, ScreenCaptureSource,
-    SharedString, SubscriberSet, Subscription, SvgRenderer, SystemNotification,
-    SystemNotificationResponse, Task, TextRenderingMode, TextSystem, ThermalState, Window,
-    WindowAppearance, WindowButtonLayout, WindowHandle, WindowId, WindowInvalidator,
+    DispatchPhase, DisplayId, EventEmitter, ExternalDragPayload, FocusHandle, FocusMap,
+    ForegroundExecutor, Global, KeyBinding, KeyContext, Keymap, Keystroke, LayoutId, Menu,
+    MenuItem, OwnedMenu, PathPromptOptions, Pixels, Platform, PlatformDisplay,
+    PlatformKeyboardLayout, PlatformKeyboardMapper, Point, Priority, PromptBuilder, PromptButton,
+    PromptHandle, PromptLevel, Render, RenderImage, RenderablePromptHandle, Reservation,
+    ScreenCaptureSource, SharedString, SubscriberSet, Subscription, SvgRenderer,
+    SystemNotification, SystemNotificationResponse, Task, TextRenderingMode, TextSystem,
+    ThermalState, Window, WindowAppearance, WindowButtonLayout, WindowHandle, WindowId,
+    WindowInvalidator,
     colors::{Colors, GlobalColors},
     hash, init_app_menus,
 };
@@ -2823,7 +2824,7 @@ pub struct AnyDrag {
 /// Lazily resolves the payload handed to the platform when an internal drag is
 /// promoted to a native drag session.
 pub type ExternalDragPayloadSource =
-    Box<dyn FnOnce(&mut Window, &mut App) -> Option<crate::ExternalDragPayload> + 'static>;
+    Box<dyn FnOnce(&mut Window, &mut App) -> Option<ExternalDragPayload> + 'static>;
 
 /// Contains state associated with a tooltip. You'll only need this struct if you're implementing
 /// tooltip behavior on a custom element. Otherwise, use [Div::tooltip](crate::Interactivity::tooltip).

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -2838,22 +2838,6 @@ impl Interactivity {
                                 cursor_style: drag_cursor_style,
                                 external_paths,
                             });
-                            // Set `active_drag` first, then hand the paths to the OS: the
-                            // session-end cleanup clears `active_drag`, so it must already be set.
-                            if let Some(paths) = cx
-                                .active_drag
-                                .as_ref()
-                                .and_then(|drag| drag.external_paths.as_ref())
-                            {
-                                log::info!(
-                                    "[DEBUG-file-drag-event] requesting platform file drag: path_count={}, trigger={event:?}",
-                                    paths.paths().len()
-                                );
-                                let started = window.platform_window.start_file_drag(paths);
-                                log::info!(
-                                    "[DEBUG-file-drag-event] platform file drag request completed: started={started}"
-                                );
-                            }
                             pending_mouse_down.take();
                             window.refresh();
                             cx.stop_propagation();

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -2845,7 +2845,14 @@ impl Interactivity {
                                 .as_ref()
                                 .and_then(|drag| drag.external_paths.as_ref())
                             {
-                                window.platform_window.start_file_drag(paths);
+                                log::info!(
+                                    "[DEBUG-file-drag-event] requesting platform file drag: path_count={}, trigger={event:?}",
+                                    paths.paths().len()
+                                );
+                                let started = window.platform_window.start_file_drag(paths);
+                                log::info!(
+                                    "[DEBUG-file-drag-event] platform file drag request completed: started={started}"
+                                );
                             }
                             pending_mouse_down.take();
                             window.refresh();

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -18,13 +18,13 @@
 use crate::PinchEvent;
 use crate::{
     Action, AnyDrag, AnyElement, AnyTooltip, AnyView, App, Bounds, ClickEvent, DispatchPhase,
-    Display, Element, ElementId, Entity, EntityId, FocusHandle, Global, GlobalElementId, Hitbox,
-    HitboxBehavior, HitboxId, InspectorElementId, IntoElement, IsZero, KeyContext, KeyDownEvent,
-    KeyUpEvent, KeyboardButton, KeyboardClickEvent, LayoutId, ModifiersChangedEvent, MouseButton,
-    MouseClickEvent, MouseDownEvent, MouseExitEvent, MouseMoveEvent, MousePressureEvent,
-    MouseUpEvent, Overflow, ParentElement, Pixels, Point, Render, ScrollWheelEvent, SharedString,
-    Size, Style, StyleRefinement, Styled, Task, TooltipId, Visibility, Window, WindowControlArea,
-    point, px, size,
+    Display, Element, ElementId, Entity, EntityId, ExternalPaths, FocusHandle, Global,
+    GlobalElementId, Hitbox, HitboxBehavior, HitboxId, InspectorElementId, IntoElement, IsZero,
+    KeyContext, KeyDownEvent, KeyUpEvent, KeyboardButton, KeyboardClickEvent, LayoutId,
+    ModifiersChangedEvent, MouseButton, MouseClickEvent, MouseDownEvent, MouseExitEvent,
+    MouseMoveEvent, MousePressureEvent, MouseUpEvent, Overflow, ParentElement, Pixels, Point,
+    Render, ScrollWheelEvent, SharedString, Size, Style, StyleRefinement, Styled, Task, TooltipId,
+    Visibility, Window, WindowControlArea, point, px, size,
 };
 use collections::HashMap;
 use gpui_util::ResultExt;
@@ -610,6 +610,33 @@ impl Interactivity {
             Box::new(move |value, offset, window, cx| {
                 constructor(value.downcast_ref().unwrap(), offset, window, cx).into()
             }),
+            None,
+        ));
+    }
+
+    /// On drag initiation, resolve real on-disk paths to expose this drag to the platform.
+    pub fn on_drag_with_external_paths<T, W>(
+        &mut self,
+        value: T,
+        external_paths: impl Fn(&T, &mut Window, &mut App) -> Option<ExternalPaths> + 'static,
+        constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
+    ) where
+        Self: Sized,
+        T: 'static,
+        W: 'static + Render,
+    {
+        debug_assert!(
+            self.drag_listener.is_none(),
+            "calling on_drag more than once on the same element is not supported"
+        );
+        self.drag_listener = Some((
+            Arc::new(value),
+            Box::new(move |value, offset, window, cx| {
+                constructor(value.downcast_ref().unwrap(), offset, window, cx).into()
+            }),
+            Some(Box::new(move |value, window, cx| {
+                external_paths(value.downcast_ref::<T>()?, window, cx)
+            })),
         ));
     }
 
@@ -1519,6 +1546,23 @@ pub trait StatefulInteractiveElement: InteractiveElement {
         self
     }
 
+    /// On drag initiation, resolve real on-disk paths to expose this drag to the platform.
+    fn on_drag_with_external_paths<T, W>(
+        mut self,
+        value: T,
+        external_paths: impl Fn(&T, &mut Window, &mut App) -> Option<ExternalPaths> + 'static,
+        constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
+    ) -> Self
+    where
+        Self: Sized,
+        T: 'static,
+        W: 'static + Render,
+    {
+        self.interactivity()
+            .on_drag_with_external_paths(value, external_paths, constructor);
+        self
+    }
+
     /// Bind the given callback on the hover start and end events of this element. Note that the boolean
     /// passed to the callback is true when the hover starts and false when it ends.
     /// The fluent API equivalent to [`Interactivity::on_hover`].
@@ -1588,6 +1632,9 @@ pub(crate) type ClickListener = Rc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 
 
 pub(crate) type DragListener =
     Box<dyn Fn(&dyn Any, Point<Pixels>, &mut Window, &mut App) -> AnyView + 'static>;
+
+pub(crate) type ExternalPathsExtractor =
+    Box<dyn Fn(&dyn Any, &mut Window, &mut App) -> Option<ExternalPaths> + 'static>;
 
 type DropListener = Box<dyn Fn(&dyn Any, &mut Window, &mut App) + 'static>;
 
@@ -1994,7 +2041,7 @@ pub struct Interactivity {
     pub(crate) can_drop_predicate: Option<CanDropPredicate>,
     pub(crate) click_listeners: Vec<ClickListener>,
     pub(crate) aux_click_listeners: Vec<ClickListener>,
-    pub(crate) drag_listener: Option<(Arc<dyn Any>, DragListener)>,
+    pub(crate) drag_listener: Option<(Arc<dyn Any>, DragListener, Option<ExternalPathsExtractor>)>,
     pub(crate) hover_listener: Option<Box<dyn Fn(&bool, &mut Window, &mut App)>>,
     pub(crate) tooltip_builder: Option<TooltipBuilder>,
     pub(crate) tooltip_show_delay: Option<Duration>,
@@ -2767,19 +2814,29 @@ impl Interactivity {
                         if let Some(mouse_down) = pending_mouse_down.clone()
                             && !cx.has_active_drag()
                             && (event.position - mouse_down.position).magnitude() > DRAG_THRESHOLD
-                            && let Some((drag_value, drag_listener)) = drag_listener.take()
+                            && let Some((drag_value, drag_listener, external_paths_extractor)) =
+                                drag_listener.take()
                             && mouse_down.button == MouseButton::Left
                         {
                             *clicked_state.borrow_mut() = ElementClickedState::default();
                             let cursor_offset = event.position - hitbox.origin;
                             let drag =
                                 (drag_listener)(drag_value.as_ref(), cursor_offset, window, cx);
+                            let external_paths = external_paths_extractor
+                                .and_then(|extractor| extractor(drag_value.as_ref(), window, cx));
                             cx.active_drag = Some(AnyDrag {
                                 view: drag,
                                 value: drag_value,
                                 cursor_offset,
                                 cursor_style: drag_cursor_style,
+                                external_paths,
                             });
+                            let _ = cx
+                                .active_drag
+                                .as_ref()
+                                .and_then(|drag| drag.external_paths.as_ref())
+                                .map(|paths| window.platform_window.start_file_drag(paths))
+                                .unwrap_or(false);
                             pending_mouse_down.take();
                             window.refresh();
                             cx.stop_propagation();

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -601,17 +601,7 @@ impl Interactivity {
         T: 'static,
         W: 'static + Render,
     {
-        debug_assert!(
-            self.drag_listener.is_none(),
-            "calling on_drag more than once on the same element is not supported"
-        );
-        self.drag_listener = Some((
-            Arc::new(value),
-            Box::new(move |value, offset, window, cx| {
-                constructor(value.downcast_ref().unwrap(), offset, window, cx).into()
-            }),
-            None,
-        ));
+        self.set_drag_listener(value, constructor, None);
     }
 
     /// On drag initiation, resolve real on-disk paths to expose this drag to the platform.
@@ -620,6 +610,25 @@ impl Interactivity {
         value: T,
         external_paths: impl Fn(&T, &mut Window, &mut App) -> Option<ExternalPaths> + 'static,
         constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
+    ) where
+        Self: Sized,
+        T: 'static,
+        W: 'static + Render,
+    {
+        self.set_drag_listener(
+            value,
+            constructor,
+            Some(Box::new(move |value, window, cx| {
+                external_paths(value.downcast_ref::<T>()?, window, cx)
+            })),
+        );
+    }
+
+    fn set_drag_listener<T, W>(
+        &mut self,
+        value: T,
+        constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
+        external_paths: Option<ExternalPathsExtractor>,
     ) where
         Self: Sized,
         T: 'static,
@@ -634,9 +643,7 @@ impl Interactivity {
             Box::new(move |value, offset, window, cx| {
                 constructor(value.downcast_ref().unwrap(), offset, window, cx).into()
             }),
-            Some(Box::new(move |value, window, cx| {
-                external_paths(value.downcast_ref::<T>()?, window, cx)
-            })),
+            external_paths,
         ));
     }
 
@@ -2831,12 +2838,15 @@ impl Interactivity {
                                 cursor_style: drag_cursor_style,
                                 external_paths,
                             });
-                            let _ = cx
+                            // Set `active_drag` first, then hand the paths to the OS: the
+                            // session-end cleanup clears `active_drag`, so it must already be set.
+                            if let Some(paths) = cx
                                 .active_drag
                                 .as_ref()
                                 .and_then(|drag| drag.external_paths.as_ref())
-                                .map(|paths| window.platform_window.start_file_drag(paths))
-                                .unwrap_or(false);
+                            {
+                                window.platform_window.start_file_drag(paths);
+                            }
                             pending_mouse_down.take();
                             window.refresh();
                             cx.stop_propagation();

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -604,7 +604,8 @@ impl Interactivity {
         self.set_drag_listener(value, constructor, None);
     }
 
-    /// On drag initiation, resolve a payload to offer the platform if the drag leaves the window.
+    /// Registers a callback resolving a payload to offer the platform if the drag leaves the
+    /// window. It is invoked at most once per drag gesture, when the pointer exits the viewport.
     pub fn on_drag_with_external_payload<T, W>(
         &mut self,
         value: T,
@@ -1553,7 +1554,8 @@ pub trait StatefulInteractiveElement: InteractiveElement {
         self
     }
 
-    /// On drag initiation, resolve a payload to offer the platform if the drag leaves the window.
+    /// Registers a callback resolving a payload to offer the platform if the drag leaves the
+    /// window. It is invoked at most once per drag gesture, when the pointer exits the viewport.
     fn on_drag_with_external_payload<T, W>(
         mut self,
         value: T,
@@ -2830,14 +2832,20 @@ impl Interactivity {
                             let cursor_offset = event.position - hitbox.origin;
                             let drag =
                                 (drag_listener)(drag_value.as_ref(), cursor_offset, window, cx);
-                            let external_payload = external_payload_extractor
-                                .and_then(|extractor| extractor(drag_value.as_ref(), window, cx));
+                            let external_payload_source =
+                                external_payload_extractor.map(|extractor| {
+                                    let value = drag_value.clone();
+                                    Box::new(move |window: &mut Window, cx: &mut App| {
+                                        extractor(value.as_ref(), window, cx)
+                                    })
+                                        as crate::ExternalDragPayloadSource
+                                });
                             cx.active_drag = Some(AnyDrag {
                                 view: drag,
                                 value: drag_value,
                                 cursor_offset,
                                 cursor_style: drag_cursor_style,
-                                external_payload,
+                                external_payload_source,
                             });
                             pending_mouse_down.take();
                             window.refresh();

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -18,10 +18,10 @@
 use crate::PinchEvent;
 use crate::{
     Action, AnyDrag, AnyElement, AnyTooltip, AnyView, App, Bounds, ClickEvent, DispatchPhase,
-    Display, Element, ElementId, Entity, EntityId, ExternalDragPayload, FocusHandle, Global,
-    GlobalElementId, Hitbox, HitboxBehavior, HitboxId, InspectorElementId, IntoElement, IsZero,
-    KeyContext, KeyDownEvent, KeyUpEvent, KeyboardButton, KeyboardClickEvent, LayoutId,
-    ModifiersChangedEvent, MouseButton, MouseClickEvent, MouseDownEvent, MouseExitEvent,
+    Display, Element, ElementId, Entity, EntityId, ExternalDragPayload, ExternalDragPayloadSource,
+    FocusHandle, Global, GlobalElementId, Hitbox, HitboxBehavior, HitboxId, InspectorElementId,
+    IntoElement, IsZero, KeyContext, KeyDownEvent, KeyUpEvent, KeyboardButton, KeyboardClickEvent,
+    LayoutId, ModifiersChangedEvent, MouseButton, MouseClickEvent, MouseDownEvent, MouseExitEvent,
     MouseMoveEvent, MousePressureEvent, MouseUpEvent, Overflow, ParentElement, Pixels, Point,
     Render, ScrollWheelEvent, SharedString, Size, Style, StyleRefinement, Styled, Task, TooltipId,
     Visibility, Window, WindowControlArea, point, px, size,
@@ -629,7 +629,7 @@ impl Interactivity {
         &mut self,
         value: T,
         constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
-        external_payload: Option<ExternalPayloadExtractor>,
+        external_payload: Option<ExternalDragPayloadResolver>,
     ) where
         Self: Sized,
         T: 'static,
@@ -639,13 +639,13 @@ impl Interactivity {
             self.drag_listener.is_none(),
             "calling on_drag more than once on the same element is not supported"
         );
-        self.drag_listener = Some((
-            Arc::new(value),
-            Box::new(move |value, offset, window, cx| {
+        self.drag_listener = Some(DragListener {
+            value: Arc::new(value),
+            render: Box::new(move |value, offset, window, cx| {
                 constructor(value.downcast_ref().unwrap(), offset, window, cx).into()
             }),
             external_payload,
-        ));
+        });
     }
 
     /// Bind the given callback on the hover start and end events of this element. Note that the boolean
@@ -1639,10 +1639,13 @@ pub(crate) type PinchListener =
 
 pub(crate) type ClickListener = Rc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
 
-pub(crate) type DragListener =
-    Box<dyn Fn(&dyn Any, Point<Pixels>, &mut Window, &mut App) -> AnyView + 'static>;
+pub(crate) struct DragListener {
+    value: Arc<dyn Any>,
+    render: Box<dyn Fn(&dyn Any, Point<Pixels>, &mut Window, &mut App) -> AnyView + 'static>,
+    external_payload: Option<ExternalDragPayloadResolver>,
+}
 
-pub(crate) type ExternalPayloadExtractor =
+type ExternalDragPayloadResolver =
     Box<dyn Fn(&dyn Any, &mut Window, &mut App) -> Option<ExternalDragPayload> + 'static>;
 
 type DropListener = Box<dyn Fn(&dyn Any, &mut Window, &mut App) + 'static>;
@@ -2050,8 +2053,7 @@ pub struct Interactivity {
     pub(crate) can_drop_predicate: Option<CanDropPredicate>,
     pub(crate) click_listeners: Vec<ClickListener>,
     pub(crate) aux_click_listeners: Vec<ClickListener>,
-    pub(crate) drag_listener:
-        Option<(Arc<dyn Any>, DragListener, Option<ExternalPayloadExtractor>)>,
+    pub(crate) drag_listener: Option<DragListener>,
     pub(crate) hover_listener: Option<Box<dyn Fn(&bool, &mut Window, &mut App)>>,
     pub(crate) tooltip_builder: Option<TooltipBuilder>,
     pub(crate) tooltip_show_delay: Option<Duration>,
@@ -2824,25 +2826,28 @@ impl Interactivity {
                         if let Some(mouse_down) = pending_mouse_down.clone()
                             && !cx.has_active_drag()
                             && (event.position - mouse_down.position).magnitude() > DRAG_THRESHOLD
-                            && let Some((drag_value, drag_listener, external_payload_extractor)) =
-                                drag_listener.take()
+                            && let Some(listener) = drag_listener.take()
                             && mouse_down.button == MouseButton::Left
                         {
                             *clicked_state.borrow_mut() = ElementClickedState::default();
                             let cursor_offset = event.position - hitbox.origin;
-                            let drag =
-                                (drag_listener)(drag_value.as_ref(), cursor_offset, window, cx);
+                            let drag = (listener.render)(
+                                listener.value.as_ref(),
+                                cursor_offset,
+                                window,
+                                cx,
+                            );
                             let external_payload_source =
-                                external_payload_extractor.map(|extractor| {
-                                    let value = drag_value.clone();
+                                listener.external_payload.map(|external_payload| {
+                                    let value = listener.value.clone();
                                     Box::new(move |window: &mut Window, cx: &mut App| {
-                                        extractor(value.as_ref(), window, cx)
+                                        external_payload(value.as_ref(), window, cx)
                                     })
-                                        as crate::ExternalDragPayloadSource
+                                        as ExternalDragPayloadSource
                                 });
                             cx.active_drag = Some(AnyDrag {
                                 view: drag,
-                                value: drag_value,
+                                value: listener.value,
                                 cursor_offset,
                                 cursor_style: drag_cursor_style,
                                 external_payload_source,

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -18,7 +18,7 @@
 use crate::PinchEvent;
 use crate::{
     Action, AnyDrag, AnyElement, AnyTooltip, AnyView, App, Bounds, ClickEvent, DispatchPhase,
-    Display, Element, ElementId, Entity, EntityId, FileDragPaths, FocusHandle, Global,
+    Display, Element, ElementId, Entity, EntityId, ExternalDragPayload, FocusHandle, Global,
     GlobalElementId, Hitbox, HitboxBehavior, HitboxId, InspectorElementId, IntoElement, IsZero,
     KeyContext, KeyDownEvent, KeyUpEvent, KeyboardButton, KeyboardClickEvent, LayoutId,
     ModifiersChangedEvent, MouseButton, MouseClickEvent, MouseDownEvent, MouseExitEvent,
@@ -604,11 +604,11 @@ impl Interactivity {
         self.set_drag_listener(value, constructor, None);
     }
 
-    /// On drag initiation, resolve real on-disk paths to expose this drag to the platform.
-    pub fn on_drag_with_external_paths<T, W>(
+    /// On drag initiation, resolve a payload to offer the platform if the drag leaves the window.
+    pub fn on_drag_with_external_payload<T, W>(
         &mut self,
         value: T,
-        external_paths: impl Fn(&T, &mut Window, &mut App) -> Option<FileDragPaths> + 'static,
+        external_payload: impl Fn(&T, &mut Window, &mut App) -> Option<ExternalDragPayload> + 'static,
         constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
     ) where
         Self: Sized,
@@ -619,7 +619,7 @@ impl Interactivity {
             value,
             constructor,
             Some(Box::new(move |value, window, cx| {
-                external_paths(value.downcast_ref::<T>()?, window, cx)
+                external_payload(value.downcast_ref::<T>()?, window, cx)
             })),
         );
     }
@@ -628,7 +628,7 @@ impl Interactivity {
         &mut self,
         value: T,
         constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
-        external_paths: Option<ExternalPathsExtractor>,
+        external_payload: Option<ExternalPayloadExtractor>,
     ) where
         Self: Sized,
         T: 'static,
@@ -643,7 +643,7 @@ impl Interactivity {
             Box::new(move |value, offset, window, cx| {
                 constructor(value.downcast_ref().unwrap(), offset, window, cx).into()
             }),
-            external_paths,
+            external_payload,
         ));
     }
 
@@ -1553,11 +1553,11 @@ pub trait StatefulInteractiveElement: InteractiveElement {
         self
     }
 
-    /// On drag initiation, resolve real on-disk paths to expose this drag to the platform.
-    fn on_drag_with_external_paths<T, W>(
+    /// On drag initiation, resolve a payload to offer the platform if the drag leaves the window.
+    fn on_drag_with_external_payload<T, W>(
         mut self,
         value: T,
-        external_paths: impl Fn(&T, &mut Window, &mut App) -> Option<FileDragPaths> + 'static,
+        external_payload: impl Fn(&T, &mut Window, &mut App) -> Option<ExternalDragPayload> + 'static,
         constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
     ) -> Self
     where
@@ -1566,7 +1566,7 @@ pub trait StatefulInteractiveElement: InteractiveElement {
         W: 'static + Render,
     {
         self.interactivity()
-            .on_drag_with_external_paths(value, external_paths, constructor);
+            .on_drag_with_external_payload(value, external_payload, constructor);
         self
     }
 
@@ -1640,8 +1640,8 @@ pub(crate) type ClickListener = Rc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 
 pub(crate) type DragListener =
     Box<dyn Fn(&dyn Any, Point<Pixels>, &mut Window, &mut App) -> AnyView + 'static>;
 
-pub(crate) type ExternalPathsExtractor =
-    Box<dyn Fn(&dyn Any, &mut Window, &mut App) -> Option<FileDragPaths> + 'static>;
+pub(crate) type ExternalPayloadExtractor =
+    Box<dyn Fn(&dyn Any, &mut Window, &mut App) -> Option<ExternalDragPayload> + 'static>;
 
 type DropListener = Box<dyn Fn(&dyn Any, &mut Window, &mut App) + 'static>;
 
@@ -2048,7 +2048,8 @@ pub struct Interactivity {
     pub(crate) can_drop_predicate: Option<CanDropPredicate>,
     pub(crate) click_listeners: Vec<ClickListener>,
     pub(crate) aux_click_listeners: Vec<ClickListener>,
-    pub(crate) drag_listener: Option<(Arc<dyn Any>, DragListener, Option<ExternalPathsExtractor>)>,
+    pub(crate) drag_listener:
+        Option<(Arc<dyn Any>, DragListener, Option<ExternalPayloadExtractor>)>,
     pub(crate) hover_listener: Option<Box<dyn Fn(&bool, &mut Window, &mut App)>>,
     pub(crate) tooltip_builder: Option<TooltipBuilder>,
     pub(crate) tooltip_show_delay: Option<Duration>,
@@ -2821,7 +2822,7 @@ impl Interactivity {
                         if let Some(mouse_down) = pending_mouse_down.clone()
                             && !cx.has_active_drag()
                             && (event.position - mouse_down.position).magnitude() > DRAG_THRESHOLD
-                            && let Some((drag_value, drag_listener, external_paths_extractor)) =
+                            && let Some((drag_value, drag_listener, external_payload_extractor)) =
                                 drag_listener.take()
                             && mouse_down.button == MouseButton::Left
                         {
@@ -2829,14 +2830,14 @@ impl Interactivity {
                             let cursor_offset = event.position - hitbox.origin;
                             let drag =
                                 (drag_listener)(drag_value.as_ref(), cursor_offset, window, cx);
-                            let external_paths = external_paths_extractor
+                            let external_payload = external_payload_extractor
                                 .and_then(|extractor| extractor(drag_value.as_ref(), window, cx));
                             cx.active_drag = Some(AnyDrag {
                                 view: drag,
                                 value: drag_value,
                                 cursor_offset,
                                 cursor_style: drag_cursor_style,
-                                external_paths,
+                                external_payload,
                             });
                             pending_mouse_down.take();
                             window.refresh();

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -601,40 +601,6 @@ impl Interactivity {
         T: 'static,
         W: 'static + Render,
     {
-        self.set_drag_listener(value, constructor, None);
-    }
-
-    /// Registers a callback resolving a payload to offer the platform if the drag leaves the
-    /// window. It is invoked at most once per drag gesture, when the pointer exits the viewport.
-    pub fn on_drag_with_external_payload<T, W>(
-        &mut self,
-        value: T,
-        external_payload: impl Fn(&T, &mut Window, &mut App) -> Option<ExternalDragPayload> + 'static,
-        constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
-    ) where
-        Self: Sized,
-        T: 'static,
-        W: 'static + Render,
-    {
-        self.set_drag_listener(
-            value,
-            constructor,
-            Some(Box::new(move |value, window, cx| {
-                external_payload(value.downcast_ref::<T>()?, window, cx)
-            })),
-        );
-    }
-
-    fn set_drag_listener<T, W>(
-        &mut self,
-        value: T,
-        constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
-        external_payload: Option<ExternalDragPayloadResolver>,
-    ) where
-        Self: Sized,
-        T: 'static,
-        W: 'static + Render,
-    {
         debug_assert!(
             self.drag_listener.is_none(),
             "calling on_drag more than once on the same element is not supported"
@@ -644,8 +610,36 @@ impl Interactivity {
             render: Box::new(move |value, offset, window, cx| {
                 constructor(value.downcast_ref().unwrap(), offset, window, cx).into()
             }),
-            external_payload,
+            external_payload: None,
         });
+    }
+
+    /// Registers a callback resolving a payload to offer the platform if a drag started by this
+    /// element leaves the window. It is invoked at most once per drag gesture, when the pointer
+    /// exits the viewport. Must be called after [`Self::on_drag`], with the same dragged value
+    /// type `T`.
+    pub fn external_drag_payload<T>(
+        &mut self,
+        resolver: impl Fn(&T, &mut Window, &mut App) -> Option<ExternalDragPayload> + 'static,
+    ) where
+        Self: Sized,
+        T: 'static,
+    {
+        let Some(drag_listener) = self.drag_listener.as_mut() else {
+            debug_assert!(false, "external_drag_payload must be called after on_drag");
+            return;
+        };
+        debug_assert!(
+            drag_listener.value.as_ref().type_id() == TypeId::of::<T>(),
+            "external_drag_payload must use the same dragged value type as on_drag"
+        );
+        debug_assert!(
+            drag_listener.external_payload.is_none(),
+            "calling external_drag_payload more than once on the same element is not supported"
+        );
+        drag_listener.external_payload = Some(Box::new(move |value, window, cx| {
+            resolver(value.downcast_ref::<T>()?, window, cx)
+        }));
     }
 
     /// Bind the given callback on the hover start and end events of this element. Note that the boolean
@@ -1554,21 +1548,20 @@ pub trait StatefulInteractiveElement: InteractiveElement {
         self
     }
 
-    /// Registers a callback resolving a payload to offer the platform if the drag leaves the
-    /// window. It is invoked at most once per drag gesture, when the pointer exits the viewport.
-    fn on_drag_with_external_payload<T, W>(
+    /// Registers a callback resolving a payload to offer the platform if a drag started by this
+    /// element leaves the window. It is invoked at most once per drag gesture, when the pointer
+    /// exits the viewport. Must be called after [`Self::on_drag`], with the same dragged value
+    /// type `T`.
+    /// The fluent API equivalent to [`Interactivity::external_drag_payload`].
+    fn external_drag_payload<T>(
         mut self,
-        value: T,
-        external_payload: impl Fn(&T, &mut Window, &mut App) -> Option<ExternalDragPayload> + 'static,
-        constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
+        resolver: impl Fn(&T, &mut Window, &mut App) -> Option<ExternalDragPayload> + 'static,
     ) -> Self
     where
         Self: Sized,
         T: 'static,
-        W: 'static + Render,
     {
-        self.interactivity()
-            .on_drag_with_external_payload(value, external_payload, constructor);
+        self.interactivity().external_drag_payload(resolver);
         self
     }
 

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -18,7 +18,7 @@
 use crate::PinchEvent;
 use crate::{
     Action, AnyDrag, AnyElement, AnyTooltip, AnyView, App, Bounds, ClickEvent, DispatchPhase,
-    Display, Element, ElementId, Entity, EntityId, ExternalPaths, FocusHandle, Global,
+    Display, Element, ElementId, Entity, EntityId, FileDragPaths, FocusHandle, Global,
     GlobalElementId, Hitbox, HitboxBehavior, HitboxId, InspectorElementId, IntoElement, IsZero,
     KeyContext, KeyDownEvent, KeyUpEvent, KeyboardButton, KeyboardClickEvent, LayoutId,
     ModifiersChangedEvent, MouseButton, MouseClickEvent, MouseDownEvent, MouseExitEvent,
@@ -608,7 +608,7 @@ impl Interactivity {
     pub fn on_drag_with_external_paths<T, W>(
         &mut self,
         value: T,
-        external_paths: impl Fn(&T, &mut Window, &mut App) -> Option<ExternalPaths> + 'static,
+        external_paths: impl Fn(&T, &mut Window, &mut App) -> Option<FileDragPaths> + 'static,
         constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
     ) where
         Self: Sized,
@@ -1557,7 +1557,7 @@ pub trait StatefulInteractiveElement: InteractiveElement {
     fn on_drag_with_external_paths<T, W>(
         mut self,
         value: T,
-        external_paths: impl Fn(&T, &mut Window, &mut App) -> Option<ExternalPaths> + 'static,
+        external_paths: impl Fn(&T, &mut Window, &mut App) -> Option<FileDragPaths> + 'static,
         constructor: impl Fn(&T, Point<Pixels>, &mut Window, &mut App) -> Entity<W> + 'static,
     ) -> Self
     where
@@ -1641,7 +1641,7 @@ pub(crate) type DragListener =
     Box<dyn Fn(&dyn Any, Point<Pixels>, &mut Window, &mut App) -> AnyView + 'static>;
 
 pub(crate) type ExternalPathsExtractor =
-    Box<dyn Fn(&dyn Any, &mut Window, &mut App) -> Option<ExternalPaths> + 'static>;
+    Box<dyn Fn(&dyn Any, &mut Window, &mut App) -> Option<FileDragPaths> + 'static>;
 
 type DropListener = Box<dyn Fn(&dyn Any, &mut Window, &mut App) + 'static>;
 

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -757,6 +757,8 @@ pub enum PlatformInput {
     FileDrop(FileDropEvent),
     /// A raw touch event on a touch screen.
     Touch(TouchEvent),
+    /// An OS-level drag session that originated in this app has ended.
+    DragSessionEnded,
 }
 
 impl PlatformInput {
@@ -774,6 +776,7 @@ impl PlatformInput {
             PlatformInput::Pinch(event) => Some(event),
             PlatformInput::FileDrop(event) => Some(event),
             PlatformInput::Touch(_) => None,
+            PlatformInput::DragSessionEnded => None,
         }
     }
 
@@ -791,6 +794,7 @@ impl PlatformInput {
             PlatformInput::Pinch(_) => None,
             PlatformInput::FileDrop(_) => None,
             PlatformInput::Touch(_) => None,
+            PlatformInput::DragSessionEnded => None,
         }
     }
 
@@ -807,9 +811,11 @@ impl PlatformInput {
 mod test {
 
     use crate::{
-        self as gpui, AppContext as _, Context, FocusHandle, InteractiveElement, IntoElement,
-        KeyBinding, Keystroke, ParentElement, Render, TestAppContext, Window, div,
+        self as gpui, AnyDrag, AppContext as _, Context, Empty, FocusHandle, InteractiveElement,
+        IntoElement, KeyBinding, Keystroke, ParentElement, PlatformInput, Render, TestAppContext,
+        Window, div, point, px,
     };
+    use std::sync::Arc;
 
     struct TestView {
         saw_key_down: bool,
@@ -872,6 +878,37 @@ mod test {
                 assert!(test_view.saw_key_down || test_view.saw_action);
                 assert!(test_view.saw_key_down);
                 assert!(test_view.saw_action);
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn drag_session_ended_is_not_mouse_or_keyboard_input() {
+        let event = PlatformInput::DragSessionEnded;
+        assert!(event.mouse_event().is_none());
+        assert!(event.keyboard_event().is_none());
+    }
+
+    #[gpui::test]
+    fn drag_session_ended_clears_active_drag(cx: &mut TestAppContext) {
+        let window = cx.update(|cx| {
+            cx.open_window(Default::default(), |_, cx| cx.new(|_| Empty))
+                .unwrap()
+        });
+
+        window
+            .update(cx, |_, window, cx| {
+                cx.active_drag = Some(AnyDrag {
+                    view: cx.new(|_| Empty).into(),
+                    value: Arc::new(()),
+                    cursor_offset: point(px(0.), px(0.)),
+                    cursor_style: None,
+                    external_paths: None,
+                });
+
+                window.dispatch_event(PlatformInput::DragSessionEnded, cx);
+
+                assert!(cx.active_drag.is_none());
             })
             .unwrap();
     }

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -757,8 +757,6 @@ pub enum PlatformInput {
     FileDrop(FileDropEvent),
     /// A raw touch event on a touch screen.
     Touch(TouchEvent),
-    /// An OS-level drag session that originated in this app has ended.
-    DragSessionEnded,
 }
 
 impl PlatformInput {
@@ -776,7 +774,6 @@ impl PlatformInput {
             PlatformInput::Pinch(event) => Some(event),
             PlatformInput::FileDrop(event) => Some(event),
             PlatformInput::Touch(_) => None,
-            PlatformInput::DragSessionEnded => None,
         }
     }
 
@@ -794,7 +791,6 @@ impl PlatformInput {
             PlatformInput::Pinch(_) => None,
             PlatformInput::FileDrop(_) => None,
             PlatformInput::Touch(_) => None,
-            PlatformInput::DragSessionEnded => None,
         }
     }
 
@@ -811,11 +807,9 @@ impl PlatformInput {
 mod test {
 
     use crate::{
-        self as gpui, AnyDrag, AppContext as _, Context, Empty, FocusHandle, InteractiveElement,
-        IntoElement, KeyBinding, Keystroke, ParentElement, PlatformInput, Render, TestAppContext,
-        Window, div, point, px,
+        self as gpui, AppContext as _, Context, FocusHandle, InteractiveElement, IntoElement,
+        KeyBinding, Keystroke, ParentElement, Render, TestAppContext, Window, div,
     };
-    use std::sync::Arc;
 
     struct TestView {
         saw_key_down: bool,
@@ -878,37 +872,6 @@ mod test {
                 assert!(test_view.saw_key_down || test_view.saw_action);
                 assert!(test_view.saw_key_down);
                 assert!(test_view.saw_action);
-            })
-            .unwrap();
-    }
-
-    #[test]
-    fn drag_session_ended_is_not_mouse_or_keyboard_input() {
-        let event = PlatformInput::DragSessionEnded;
-        assert!(event.mouse_event().is_none());
-        assert!(event.keyboard_event().is_none());
-    }
-
-    #[gpui::test]
-    fn drag_session_ended_clears_active_drag(cx: &mut TestAppContext) {
-        let window = cx.update(|cx| {
-            cx.open_window(Default::default(), |_, cx| cx.new(|_| Empty))
-                .unwrap()
-        });
-
-        window
-            .update(cx, |_, window, cx| {
-                cx.active_drag = Some(AnyDrag {
-                    view: cx.new(|_| Empty).into(),
-                    value: Arc::new(()),
-                    cursor_offset: point(px(0.), px(0.)),
-                    cursor_style: None,
-                    external_paths: None,
-                });
-
-                window.dispatch_event(PlatformInput::DragSessionEnded, cx);
-
-                assert!(cx.active_drag.is_none());
             })
             .unwrap();
     }

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -702,9 +702,14 @@ pub enum ExternalDragPayload {
 /// Paths handed to the platform for a native file drag. Directory metadata is
 /// provided by the caller to avoid querying it when the platform drag starts.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
-pub struct FileDragPaths(pub SmallVec<[(PathBuf, bool); 2]>);
+pub struct FileDragPaths(SmallVec<[(PathBuf, bool); 2]>);
 
 impl FileDragPaths {
+    /// Creates a native file-drag payload from paths paired with whether each path is a directory.
+    pub fn new(entries: impl IntoIterator<Item = (PathBuf, bool)>) -> Self {
+        Self(entries.into_iter().collect())
+    }
+
     /// The dragged paths, each paired with whether it is a directory.
     pub fn entries(&self) -> &[(PathBuf, bool)] {
         &self.0

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -691,6 +691,18 @@ impl ExternalPaths {
     }
 }
 
+/// Paths handed to the platform for a native file drag. Directory metadata is
+/// provided by the caller to avoid querying it when the platform drag starts.
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct FileDragPaths(pub SmallVec<[(PathBuf, bool); 2]>);
+
+impl FileDragPaths {
+    /// The dragged paths, each paired with whether it is a directory.
+    pub fn entries(&self) -> &[(PathBuf, bool)] {
+        &self.0
+    }
+}
+
 impl Render for ExternalPaths {
     fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
         // the platform will render icons for the dragged files

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -691,6 +691,14 @@ impl ExternalPaths {
     }
 }
 
+/// Data offered to the platform when an internal drag leaves the window and is
+/// promoted to a native drag session.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ExternalDragPayload {
+    /// Real on-disk paths, handed to the platform as an outbound file drag.
+    Files(FileDragPaths),
+}
+
 /// Paths handed to the platform for a native file drag. Directory metadata is
 /// provided by the caller to avoid querying it when the platform drag starts.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -36,8 +36,8 @@ pub(crate) type PlatformScreenCaptureFrame = core_video::image_buffer::CVImageBu
 
 use crate::{
     Action, AnyWindowHandle, App, AsyncWindowContext, BackgroundExecutor, Bounds,
-    DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Edges, FileDragPaths, Font, FontId,
-    FontMetrics, FontRun, ForegroundExecutor, GlyphId, GpuSpecs, Hsla, ImageSource, Keymap,
+    DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Edges, ExternalDragPayload, Font,
+    FontId, FontMetrics, FontRun, ForegroundExecutor, GlyphId, GpuSpecs, Hsla, ImageSource, Keymap,
     LineLayout, Pixels, PlatformGestures, PlatformInput, Point, Priority, RenderGlyphParams,
     RenderImage, RenderImageParams, RenderSvgParams, Scene, ShapedGlyph, ShapedRun, SharedString,
     Size, SvgRenderer, SystemWindowTab, Task, Window, WindowControlArea, hash, point, px, size,
@@ -886,7 +886,7 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn request_decorations(&self, _decorations: WindowDecorations) {}
     fn show_window_menu(&self, _position: Point<Pixels>) {}
     fn start_window_move(&self) {}
-    fn start_file_drag(&self, _paths: &FileDragPaths) -> bool {
+    fn start_external_drag(&self, _payload: &ExternalDragPayload) -> bool {
         false
     }
     fn start_window_resize(&self, _edge: ResizeEdge) {}

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -886,6 +886,9 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn request_decorations(&self, _decorations: WindowDecorations) {}
     fn show_window_menu(&self, _position: Point<Pixels>) {}
     fn start_window_move(&self) {}
+    fn can_start_external_drag(&self) -> bool {
+        false
+    }
     fn start_external_drag(&self, _payload: &ExternalDragPayload) -> bool {
         false
     }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -36,7 +36,7 @@ pub(crate) type PlatformScreenCaptureFrame = core_video::image_buffer::CVImageBu
 
 use crate::{
     Action, AnyWindowHandle, App, AsyncWindowContext, BackgroundExecutor, Bounds,
-    DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Edges, ExternalPaths, Font, FontId,
+    DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Edges, FileDragPaths, Font, FontId,
     FontMetrics, FontRun, ForegroundExecutor, GlyphId, GpuSpecs, Hsla, ImageSource, Keymap,
     LineLayout, Pixels, PlatformGestures, PlatformInput, Point, Priority, RenderGlyphParams,
     RenderImage, RenderImageParams, RenderSvgParams, Scene, ShapedGlyph, ShapedRun, SharedString,
@@ -886,7 +886,7 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn request_decorations(&self, _decorations: WindowDecorations) {}
     fn show_window_menu(&self, _position: Point<Pixels>) {}
     fn start_window_move(&self) {}
-    fn start_file_drag(&self, _paths: &ExternalPaths) -> bool {
+    fn start_file_drag(&self, _paths: &FileDragPaths) -> bool {
         false
     }
     fn start_window_resize(&self, _edge: ResizeEdge) {}

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -36,11 +36,11 @@ pub(crate) type PlatformScreenCaptureFrame = core_video::image_buffer::CVImageBu
 
 use crate::{
     Action, AnyWindowHandle, App, AsyncWindowContext, BackgroundExecutor, Bounds,
-    DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Edges, Font, FontId, FontMetrics,
-    FontRun, ForegroundExecutor, GlyphId, GpuSpecs, Hsla, ImageSource, Keymap, LineLayout, Pixels,
-    PlatformGestures, PlatformInput, Point, Priority, RenderGlyphParams, RenderImage,
-    RenderImageParams, RenderSvgParams, Scene, ShapedGlyph, ShapedRun, SharedString, Size,
-    SvgRenderer, SystemWindowTab, Task, Window, WindowControlArea, hash, point, px, size,
+    DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Edges, ExternalPaths, Font, FontId,
+    FontMetrics, FontRun, ForegroundExecutor, GlyphId, GpuSpecs, Hsla, ImageSource, Keymap,
+    LineLayout, Pixels, PlatformGestures, PlatformInput, Point, Priority, RenderGlyphParams,
+    RenderImage, RenderImageParams, RenderSvgParams, Scene, ShapedGlyph, ShapedRun, SharedString,
+    Size, SvgRenderer, SystemWindowTab, Task, Window, WindowControlArea, hash, point, px, size,
 };
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use anyhow::bail;
@@ -886,6 +886,9 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn request_decorations(&self, _decorations: WindowDecorations) {}
     fn show_window_menu(&self, _position: Point<Pixels>) {}
     fn start_window_move(&self) {}
+    fn start_file_drag(&self, _paths: &ExternalPaths) -> bool {
+        false
+    }
     fn start_window_resize(&self, _edge: ResizeEdge) {}
     fn set_exclusive_zone(&self, _zone: Pixels) {}
     #[cfg(all(target_os = "linux", feature = "wayland"))]

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -38,7 +38,7 @@ pub(crate) struct TestWindowState {
     input_handler: Option<PlatformInputHandler>,
     is_fullscreen: bool,
     appearance: WindowAppearance,
-    file_drag_paths: Vec<PathBuf>,
+    file_drag_paths: Vec<(PathBuf, bool)>,
     start_file_drag_result: bool,
 }
 
@@ -144,7 +144,7 @@ impl TestWindow {
         !result.propagate
     }
 
-    pub fn file_drag_paths(&self) -> Vec<PathBuf> {
+    pub fn file_drag_paths(&self) -> Vec<(PathBuf, bool)> {
         self.0.lock().file_drag_paths.clone()
     }
 
@@ -365,9 +365,9 @@ impl PlatformWindow for TestWindow {
         unimplemented!()
     }
 
-    fn start_file_drag(&self, paths: &crate::ExternalPaths) -> bool {
+    fn start_file_drag(&self, paths: &crate::FileDragPaths) -> bool {
         let mut state = self.0.lock();
-        state.file_drag_paths.extend_from_slice(paths.paths());
+        state.file_drag_paths.extend_from_slice(paths.entries());
         state.start_file_drag_result
     }
 

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -11,6 +11,7 @@ use image::RgbaImage;
 use parking_lot::Mutex;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use std::{
+    path::PathBuf,
     rc::{Rc, Weak},
     sync::{self, Arc},
 };
@@ -37,6 +38,8 @@ pub(crate) struct TestWindowState {
     input_handler: Option<PlatformInputHandler>,
     is_fullscreen: bool,
     appearance: WindowAppearance,
+    file_drag_paths: Vec<PathBuf>,
+    start_file_drag_result: bool,
 }
 
 #[derive(Clone)]
@@ -91,6 +94,8 @@ impl TestWindow {
             input_handler: None,
             is_fullscreen: false,
             appearance: WindowAppearance::Light,
+            file_drag_paths: Vec::new(),
+            start_file_drag_result: false,
         })))
     }
 
@@ -137,6 +142,14 @@ impl TestWindow {
         let result = callback(event);
         self.0.lock().input_callback = Some(callback);
         !result.propagate
+    }
+
+    pub fn file_drag_paths(&self) -> Vec<PathBuf> {
+        self.0.lock().file_drag_paths.clone()
+    }
+
+    pub fn set_start_file_drag_result(&self, result: bool) {
+        self.0.lock().start_file_drag_result = result;
     }
 }
 
@@ -350,6 +363,12 @@ impl PlatformWindow for TestWindow {
 
     fn start_window_move(&self) {
         unimplemented!()
+    }
+
+    fn start_file_drag(&self, paths: &crate::ExternalPaths) -> bool {
+        let mut state = self.0.lock();
+        state.file_drag_paths.extend_from_slice(paths.paths());
+        state.start_file_drag_result
     }
 
     fn update_ime_position(&self, _bounds: Bounds<Pixels>) {}

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -365,6 +365,10 @@ impl PlatformWindow for TestWindow {
         unimplemented!()
     }
 
+    fn can_start_external_drag(&self) -> bool {
+        true
+    }
+
     fn start_external_drag(&self, payload: &crate::ExternalDragPayload) -> bool {
         let mut state = self.0.lock();
         match payload {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -38,8 +38,8 @@ pub(crate) struct TestWindowState {
     input_handler: Option<PlatformInputHandler>,
     is_fullscreen: bool,
     appearance: WindowAppearance,
-    file_drag_paths: Vec<(PathBuf, bool)>,
-    start_file_drag_result: bool,
+    external_drag_files: Vec<(PathBuf, bool)>,
+    start_external_drag_result: bool,
 }
 
 #[derive(Clone)]
@@ -94,8 +94,8 @@ impl TestWindow {
             input_handler: None,
             is_fullscreen: false,
             appearance: WindowAppearance::Light,
-            file_drag_paths: Vec::new(),
-            start_file_drag_result: false,
+            external_drag_files: Vec::new(),
+            start_external_drag_result: false,
         })))
     }
 
@@ -144,12 +144,12 @@ impl TestWindow {
         !result.propagate
     }
 
-    pub fn file_drag_paths(&self) -> Vec<(PathBuf, bool)> {
-        self.0.lock().file_drag_paths.clone()
+    pub fn external_drag_files(&self) -> Vec<(PathBuf, bool)> {
+        self.0.lock().external_drag_files.clone()
     }
 
-    pub fn set_start_file_drag_result(&self, result: bool) {
-        self.0.lock().start_file_drag_result = result;
+    pub fn set_start_external_drag_result(&self, result: bool) {
+        self.0.lock().start_external_drag_result = result;
     }
 }
 
@@ -365,10 +365,14 @@ impl PlatformWindow for TestWindow {
         unimplemented!()
     }
 
-    fn start_file_drag(&self, paths: &crate::FileDragPaths) -> bool {
+    fn start_external_drag(&self, payload: &crate::ExternalDragPayload) -> bool {
         let mut state = self.0.lock();
-        state.file_drag_paths.extend_from_slice(paths.entries());
-        state.start_file_drag_result
+        match payload {
+            crate::ExternalDragPayload::Files(paths) => {
+                state.external_drag_files.extend_from_slice(paths.entries());
+            }
+        }
+        state.start_external_drag_result
     }
 
     fn update_ime_position(&self, _bounds: Bounds<Pixels>) {}

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4947,6 +4947,7 @@ impl Window {
                             view: cx.new(|_| paths).into(),
                             cursor_offset: position,
                             cursor_style: None,
+                            external_paths: None,
                         });
                     }
                     PlatformInput::MouseMove(MouseMoveEvent {
@@ -4979,6 +4980,10 @@ impl Window {
                 }
             },
             PlatformInput::Touch(touch) => PlatformInput::Touch(touch),
+            PlatformInput::DragSessionEnded => {
+                cx.stop_active_drag(self);
+                PlatformInput::DragSessionEnded
+            }
             PlatformInput::KeyDown(_) | PlatformInput::KeyUp(_) => event,
         };
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6893,9 +6893,10 @@ mod tests {
                 .on_drag_with_external_payload(
                     self.path.clone(),
                     |path, _, _| {
-                        Some(ExternalDragPayload::Files(FileDragPaths(
-                            vec![(path.clone(), true)].into(),
-                        )))
+                        Some(ExternalDragPayload::Files(FileDragPaths::new([(
+                            path.clone(),
+                            true,
+                        )])))
                     },
                     |_, _, _, cx| cx.new(|_| Empty),
                 )

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -5019,8 +5019,9 @@ impl Window {
         if Bounds::new(Point::default(), self.viewport_size).contains(&mouse_move.position) {
             return;
         }
-        // Taking the source latches the attempt to once per gesture: synthetic drag moves would
-        // otherwise replay this same out-of-bounds position every 16ms.
+        if !self.platform_window.can_start_external_drag() {
+            return;
+        }
         let Some(payload_source) = cx
             .active_drag
             .as_mut()

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4947,7 +4947,7 @@ impl Window {
                             view: cx.new(|_| paths).into(),
                             cursor_offset: position,
                             cursor_style: None,
-                            external_paths: None,
+                            external_payload: None,
                         });
                     }
                     PlatformInput::MouseMove(MouseMoveEvent {
@@ -4991,7 +4991,7 @@ impl Window {
 
         // Must run after the move is dispatched: the platform owns the gesture afterwards, so this
         // is the last chance for drag listeners to see the pointer leave and reset their state.
-        self.promote_file_drag_to_platform(&event, cx);
+        self.promote_external_drag_to_platform(&event, cx);
 
         if self.invalidator.update_count() > update_count_before {
             self.input_rate_tracker.borrow_mut().record_input();
@@ -5009,7 +5009,7 @@ impl Window {
         }
     }
 
-    fn promote_file_drag_to_platform(&mut self, event: &PlatformInput, cx: &mut App) {
+    fn promote_external_drag_to_platform(&mut self, event: &PlatformInput, cx: &mut App) {
         let PlatformInput::MouseMove(mouse_move) = event else {
             return;
         };
@@ -5019,16 +5019,16 @@ impl Window {
         if Bounds::new(Point::default(), self.viewport_size).contains(&mouse_move.position) {
             return;
         }
-        // Taking the paths latches the attempt to once per gesture: synthetic drag moves would
+        // Taking the payload latches the attempt to once per gesture: synthetic drag moves would
         // otherwise replay this same out-of-bounds position every 16ms.
-        let Some(paths) = cx
+        let Some(payload) = cx
             .active_drag
             .as_mut()
-            .and_then(|drag| drag.external_paths.take())
+            .and_then(|drag| drag.external_payload.take())
         else {
             return;
         };
-        if self.platform_window.start_file_drag(&paths) {
+        if self.platform_window.start_external_drag(&payload) {
             cx.stop_active_drag(self);
         }
     }
@@ -6721,10 +6721,10 @@ mod tests {
     };
 
     use crate::{
-        AnyWindowHandle, AppContext as _, Bounds, Context, DragMoveEvent, Empty, FileDragPaths,
-        FocusHandle, InputEvent as _, InteractiveElement as _, IntoElement, MouseButton,
-        MouseDownEvent, MouseMoveEvent, ParentElement, Pixels, Point, Render,
-        StatefulInteractiveElement as _, Styled, TestAppContext, Window, WindowAppearance,
+        AnyWindowHandle, AppContext as _, Bounds, Context, DragMoveEvent, Empty,
+        ExternalDragPayload, FileDragPaths, FocusHandle, InputEvent as _, InteractiveElement as _,
+        IntoElement, MouseButton, MouseDownEvent, MouseMoveEvent, ParentElement, Pixels, Point,
+        Render, StatefulInteractiveElement as _, Styled, TestAppContext, Window, WindowAppearance,
         WindowOptions, canvas, div, point, px, size,
     };
 
@@ -6886,9 +6886,13 @@ mod tests {
             div()
                 .id("file-drag")
                 .size_full()
-                .on_drag_with_external_paths(
+                .on_drag_with_external_payload(
                     self.path.clone(),
-                    |path, _, _| Some(FileDragPaths(vec![(path.clone(), true)].into())),
+                    |path, _, _| {
+                        Some(ExternalDragPayload::Files(FileDragPaths(
+                            vec![(path.clone(), true)].into(),
+                        )))
+                    },
                     |_, _, _, cx| cx.new(|_| Empty),
                 )
                 .on_drag_move({
@@ -6919,7 +6923,7 @@ mod tests {
                 })
                 .into();
             cx.test_window(window)
-                .set_start_file_drag_result(platform_result);
+                .set_start_external_drag_result(platform_result);
 
             let update_result = cx.update_window(window, |_, window, cx| {
                 window.draw(cx).clear();
@@ -6950,7 +6954,7 @@ mod tests {
                 "failed to start drag: {update_result:?}"
             );
 
-            assert!(cx.test_window(window).file_drag_paths().is_empty());
+            assert!(cx.test_window(window).external_drag_files().is_empty());
             Drag {
                 window,
                 observed_drag_moves,
@@ -6977,7 +6981,7 @@ mod tests {
             "failed to promote drag: {update_result:?}"
         );
         assert_eq!(
-            cx.test_window(successful.window).file_drag_paths(),
+            cx.test_window(successful.window).external_drag_files(),
             [(successful_path, true)]
         );
         // Views must still see the move that leaves the window, otherwise they never learn to tear
@@ -7008,7 +7012,7 @@ mod tests {
             "failed to retain drag after platform failure: {update_result:?}"
         );
         assert_eq!(
-            cx.test_window(failed.window).file_drag_paths(),
+            cx.test_window(failed.window).external_drag_files(),
             [(failed_path, true)]
         );
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6721,7 +6721,7 @@ mod tests {
     };
 
     use crate::{
-        AnyWindowHandle, AppContext as _, Bounds, Context, DragMoveEvent, Empty, ExternalPaths,
+        AnyWindowHandle, AppContext as _, Bounds, Context, DragMoveEvent, Empty, FileDragPaths,
         FocusHandle, InputEvent as _, InteractiveElement as _, IntoElement, MouseButton,
         MouseDownEvent, MouseMoveEvent, ParentElement, Pixels, Point, Render,
         StatefulInteractiveElement as _, Styled, TestAppContext, Window, WindowAppearance,
@@ -6888,7 +6888,7 @@ mod tests {
                 .size_full()
                 .on_drag_with_external_paths(
                     self.path.clone(),
-                    |path, _, _| Some(ExternalPaths(vec![path.clone()].into())),
+                    |path, _, _| Some(FileDragPaths(vec![(path.clone(), true)].into())),
                     |_, _, _, cx| cx.new(|_| Empty),
                 )
                 .on_drag_move({
@@ -6978,7 +6978,7 @@ mod tests {
         );
         assert_eq!(
             cx.test_window(successful.window).file_drag_paths(),
-            [successful_path]
+            [(successful_path, true)]
         );
         // Views must still see the move that leaves the window, otherwise they never learn to tear
         // down the drag state they built up while the pointer was inside.
@@ -7009,7 +7009,7 @@ mod tests {
         );
         assert_eq!(
             cx.test_window(failed.window).file_drag_paths(),
-            [failed_path]
+            [(failed_path, true)]
         );
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6928,7 +6928,7 @@ mod tests {
                 .set_start_external_drag_result(platform_result);
 
             let update_result = cx.update_window(window, |_, window, cx| {
-                window.draw(cx).clear();
+                window.draw(cx).clear(cx);
                 window.dispatch_event(
                     MouseDownEvent {
                         position: point(px(10.), px(10.)),

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6890,16 +6890,13 @@ mod tests {
             div()
                 .id("file-drag")
                 .size_full()
-                .on_drag_with_external_payload(
-                    self.path.clone(),
-                    |path, _, _| {
-                        Some(ExternalDragPayload::Files(FileDragPaths::new([(
-                            path.clone(),
-                            true,
-                        )])))
-                    },
-                    |_, _, _, cx| cx.new(|_| Empty),
-                )
+                .on_drag(self.path.clone(), |_, _, _, cx| cx.new(|_| Empty))
+                .external_drag_payload(|path: &PathBuf, _, _| {
+                    Some(ExternalDragPayload::Files(FileDragPaths::new([(
+                        path.clone(),
+                        true,
+                    )])))
+                })
                 .on_drag_move({
                     let observed_drag_moves = self.observed_drag_moves.clone();
                     move |event: &DragMoveEvent<PathBuf>, _, _| {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4980,10 +4980,6 @@ impl Window {
                 }
             },
             PlatformInput::Touch(touch) => PlatformInput::Touch(touch),
-            PlatformInput::DragSessionEnded => {
-                cx.stop_active_drag(self);
-                PlatformInput::DragSessionEnded
-            }
             PlatformInput::KeyDown(_) | PlatformInput::KeyUp(_) => event,
         };
 
@@ -4992,6 +4988,10 @@ impl Window {
         } else if let Some(any_key_event) = event.keyboard_event() {
             self.dispatch_key_event(any_key_event, cx);
         }
+
+        // Must run after the move is dispatched: the platform owns the gesture afterwards, so this
+        // is the last chance for drag listeners to see the pointer leave and reset their state.
+        self.promote_file_drag_to_platform(&event, cx);
 
         if self.invalidator.update_count() > update_count_before {
             self.input_rate_tracker.borrow_mut().record_input();
@@ -5006,6 +5006,30 @@ impl Window {
         DispatchEventResult {
             propagate: cx.propagate_event,
             default_prevented: self.default_prevented,
+        }
+    }
+
+    fn promote_file_drag_to_platform(&mut self, event: &PlatformInput, cx: &mut App) {
+        let PlatformInput::MouseMove(mouse_move) = event else {
+            return;
+        };
+        if mouse_move.pressed_button != Some(MouseButton::Left) {
+            return;
+        }
+        if Bounds::new(Point::default(), self.viewport_size).contains(&mouse_move.position) {
+            return;
+        }
+        // Taking the paths latches the attempt to once per gesture: synthetic drag moves would
+        // otherwise replay this same out-of-bounds position every 16ms.
+        let Some(paths) = cx
+            .active_drag
+            .as_mut()
+            .and_then(|drag| drag.external_paths.take())
+        else {
+            return;
+        };
+        if self.platform_window.start_file_drag(&paths) {
+            cx.stop_active_drag(self);
         }
     }
 
@@ -6690,12 +6714,18 @@ pub fn outline(
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::Cell, rc::Rc};
+    use std::{
+        cell::{Cell, RefCell},
+        path::PathBuf,
+        rc::Rc,
+    };
 
     use crate::{
-        AppContext as _, Bounds, Context, FocusHandle, InteractiveElement as _, IntoElement,
-        ParentElement, Pixels, Render, Styled, TestAppContext, Window, WindowAppearance,
-        WindowOptions, canvas, div, px, size,
+        AnyWindowHandle, AppContext as _, Bounds, Context, DragMoveEvent, Empty, ExternalPaths,
+        FocusHandle, InputEvent as _, InteractiveElement as _, IntoElement, MouseButton,
+        MouseDownEvent, MouseMoveEvent, ParentElement, Pixels, Point, Render,
+        StatefulInteractiveElement as _, Styled, TestAppContext, Window, WindowAppearance,
+        WindowOptions, canvas, div, point, px, size,
     };
 
     struct EmptyView;
@@ -6844,6 +6874,143 @@ mod tests {
         .unwrap();
 
         assert_eq!(child_bounds.get().size, size(px(300.), px(200.)));
+    }
+
+    struct FileDragView {
+        path: PathBuf,
+        observed_drag_moves: Rc<RefCell<Vec<Point<Pixels>>>>,
+    }
+
+    impl Render for FileDragView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .id("file-drag")
+                .size_full()
+                .on_drag_with_external_paths(
+                    self.path.clone(),
+                    |path, _, _| Some(ExternalPaths(vec![path.clone()].into())),
+                    |_, _, _, cx| cx.new(|_| Empty),
+                )
+                .on_drag_move({
+                    let observed_drag_moves = self.observed_drag_moves.clone();
+                    move |event: &DragMoveEvent<PathBuf>, _, _| {
+                        observed_drag_moves.borrow_mut().push(event.event.position);
+                    }
+                })
+        }
+    }
+
+    #[gpui::test]
+    fn file_drag_is_promoted_once_after_leaving_the_viewport(cx: &mut TestAppContext) {
+        struct Drag {
+            window: AnyWindowHandle,
+            observed_drag_moves: Rc<RefCell<Vec<Point<Pixels>>>>,
+        }
+
+        fn start_drag(cx: &mut TestAppContext, path: PathBuf, platform_result: bool) -> Drag {
+            let observed_drag_moves = Rc::new(RefCell::new(Vec::new()));
+            let window: AnyWindowHandle = cx
+                .add_window({
+                    let observed_drag_moves = observed_drag_moves.clone();
+                    move |_, _| FileDragView {
+                        path,
+                        observed_drag_moves,
+                    }
+                })
+                .into();
+            cx.test_window(window)
+                .set_start_file_drag_result(platform_result);
+
+            let update_result = cx.update_window(window, |_, window, cx| {
+                window.draw(cx).clear();
+                window.dispatch_event(
+                    MouseDownEvent {
+                        position: point(px(10.), px(10.)),
+                        button: MouseButton::Left,
+                        modifiers: Default::default(),
+                        click_count: 1,
+                        first_mouse: false,
+                    }
+                    .to_platform_input(),
+                    cx,
+                );
+                window.dispatch_event(
+                    MouseMoveEvent {
+                        position: point(px(20.), px(20.)),
+                        pressed_button: Some(MouseButton::Left),
+                        modifiers: Default::default(),
+                    }
+                    .to_platform_input(),
+                    cx,
+                );
+                assert!(cx.active_drag.is_some());
+            });
+            assert!(
+                update_result.is_ok(),
+                "failed to start drag: {update_result:?}"
+            );
+
+            assert!(cx.test_window(window).file_drag_paths().is_empty());
+            Drag {
+                window,
+                observed_drag_moves,
+            }
+        }
+
+        let successful_path = PathBuf::from("/tmp/successful-drag");
+        let successful = start_drag(cx, successful_path.clone(), true);
+        let outside_position = point(px(-1.), px(20.));
+        let update_result = cx.update_window(successful.window, |_, window, cx| {
+            window.dispatch_event(
+                MouseMoveEvent {
+                    position: outside_position,
+                    pressed_button: Some(MouseButton::Left),
+                    modifiers: Default::default(),
+                }
+                .to_platform_input(),
+                cx,
+            );
+            assert!(cx.active_drag.is_none());
+        });
+        assert!(
+            update_result.is_ok(),
+            "failed to promote drag: {update_result:?}"
+        );
+        assert_eq!(
+            cx.test_window(successful.window).file_drag_paths(),
+            [successful_path]
+        );
+        // Views must still see the move that leaves the window, otherwise they never learn to tear
+        // down the drag state they built up while the pointer was inside.
+        assert_eq!(
+            successful.observed_drag_moves.borrow().last(),
+            Some(&outside_position)
+        );
+
+        let failed_path = PathBuf::from("/tmp/failed-drag");
+        let failed = start_drag(cx, failed_path.clone(), false);
+        let update_result = cx.update_window(failed.window, |_, window, cx| {
+            for x_position in [-1., -2.] {
+                window.dispatch_event(
+                    MouseMoveEvent {
+                        position: point(px(x_position), px(20.)),
+                        pressed_button: Some(MouseButton::Left),
+                        modifiers: Default::default(),
+                    }
+                    .to_platform_input(),
+                    cx,
+                );
+            }
+            assert!(cx.active_drag.is_some());
+        });
+        assert!(
+            update_result.is_ok(),
+            "failed to retain drag after platform failure: {update_result:?}"
+        );
+        assert_eq!(
+            cx.test_window(failed.window).file_drag_paths(),
+            [failed_path]
+        );
     }
 
     struct FocusForwarder {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4947,7 +4947,7 @@ impl Window {
                             view: cx.new(|_| paths).into(),
                             cursor_offset: position,
                             cursor_style: None,
-                            external_payload: None,
+                            external_payload_source: None,
                         });
                     }
                     PlatformInput::MouseMove(MouseMoveEvent {
@@ -5019,13 +5019,16 @@ impl Window {
         if Bounds::new(Point::default(), self.viewport_size).contains(&mouse_move.position) {
             return;
         }
-        // Taking the payload latches the attempt to once per gesture: synthetic drag moves would
+        // Taking the source latches the attempt to once per gesture: synthetic drag moves would
         // otherwise replay this same out-of-bounds position every 16ms.
-        let Some(payload) = cx
+        let Some(payload_source) = cx
             .active_drag
             .as_mut()
-            .and_then(|drag| drag.external_payload.take())
+            .and_then(|drag| drag.external_payload_source.take())
         else {
+            return;
+        };
+        let Some(payload) = payload_source(self, cx) else {
             return;
         };
         if self.platform_window.start_external_drag(&payload) {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -24,8 +24,8 @@ use cocoa::{
 };
 use dispatch2::DispatchQueue;
 use gpui::{
-    AnyWindowHandle, BackgroundExecutor, Bounds, Capslock, CursorStyle, ExternalPaths,
-    FileDragPaths, FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke, Modifiers,
+    AnyWindowHandle, BackgroundExecutor, Bounds, Capslock, CursorStyle, ExternalDragPayload,
+    ExternalPaths, FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke, Modifiers,
     ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels,
     PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point,
     PromptButton, PromptLevel, RequestFrameOptions, SharedString, Size, SystemWindowTab,
@@ -1838,9 +1838,10 @@ impl PlatformWindow for MacWindow {
         }
     }
 
-    fn start_file_drag(&self, paths: &FileDragPaths) -> bool {
+    fn start_external_drag(&self, payload: &ExternalDragPayload) -> bool {
+        let ExternalDragPayload::Files(paths) = payload;
         if paths.entries().is_empty() {
-            log::warn!("start_file_drag declined: no paths");
+            log::warn!("start_external_drag declined: no paths");
             return false;
         }
 
@@ -1854,7 +1855,7 @@ impl PlatformWindow for MacWindow {
         };
 
         let Some(last_left_mouse_down_event) = last_left_mouse_down_event else {
-            log::warn!("start_file_drag declined: no retained left mouse down event");
+            log::warn!("start_external_drag declined: no retained left mouse down event");
             return false;
         };
 
@@ -1878,7 +1879,7 @@ impl PlatformWindow for MacWindow {
             for (path, is_directory) in paths.entries() {
                 // Preserve non-UTF-8 paths
                 let Ok(path_bytes) = CString::new(path.as_os_str().as_bytes()) else {
-                    log::warn!("start_file_drag skipped path containing an interior nul byte");
+                    log::warn!("start_external_drag skipped path containing an interior nul byte");
                     continue;
                 };
 
@@ -1890,14 +1891,14 @@ impl PlatformWindow for MacWindow {
                 ];
 
                 if url.is_null() {
-                    log::warn!("start_file_drag skipped path with nil NSURL");
+                    log::warn!("start_external_drag skipped path with nil NSURL");
                     continue;
                 }
 
                 let item: id = msg_send![class!(NSDraggingItem), alloc];
                 let item: id = msg_send![item, initWithPasteboardWriter: url];
                 if item.is_null() {
-                    log::warn!("start_file_drag declined: NSDraggingItem allocation failed");
+                    log::warn!("start_external_drag declined: NSDraggingItem allocation failed");
                     continue;
                 }
 
@@ -1910,7 +1911,7 @@ impl PlatformWindow for MacWindow {
 
             let count: NSUInteger = msg_send![dragging_items, count];
             if count == 0 {
-                log::warn!("start_file_drag declined: no dragging items");
+                log::warn!("start_external_drag declined: no dragging items");
                 return false;
             }
 
@@ -1926,7 +1927,7 @@ impl PlatformWindow for MacWindow {
                 self.0.lock().synthetic_drag_counter += 1;
             }
             log::debug!(
-                "start_file_drag completed: started={}, item_count={}",
+                "start_external_drag completed: started={}, item_count={}",
                 started,
                 count
             );

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1861,18 +1861,6 @@ impl PlatformWindow for MacWindow {
             let current_event: id = msg_send![app, currentEvent];
             let pressed_mouse_buttons = NSEvent::pressedMouseButtons(nil);
             let current_event_type = (!current_event.is_null()).then(|| current_event.eventType());
-            if current_event_type == Some(NSEventType::NSEventTypePressure) {
-                log::info!(
-                    "[DEBUG-file-drag-event] start_file_drag: current_event_type={current_event_type:?}, pressed_mouse_buttons={pressed_mouse_buttons:#x}, pressure={}, stage={}",
-                    current_event.pressure(),
-                    current_event.stage(),
-                );
-            } else {
-                log::info!(
-                    "[DEBUG-file-drag-event] start_file_drag: current_event_type={current_event_type:?}, pressed_mouse_buttons={pressed_mouse_buttons:#x}"
-                );
-            }
-
             let event = if matches!(
                 current_event_type,
                 Some(
@@ -1885,9 +1873,6 @@ impl PlatformWindow for MacWindow {
             } else if pressed_mouse_buttons & NS_LEFT_MOUSE_BUTTON_MASK != 0
                 && let Some(last_left_mouse_dragged_event) = &last_left_mouse_dragged_event
             {
-                log::info!(
-                    "[DEBUG-file-drag-event] start_file_drag: using cached left-mouse-dragged event for current_event_type={current_event_type:?}"
-                );
                 Retained::as_ptr(last_left_mouse_dragged_event).cast()
             } else {
                 log::warn!(
@@ -1957,6 +1942,9 @@ impl PlatformWindow for MacWindow {
             ];
 
             let started = !session.is_null();
+            if started {
+                self.0.lock().synthetic_drag_counter += 1;
+            }
             log::debug!(
                 "start_file_drag completed: started={}, item_count={}",
                 started,
@@ -2397,23 +2385,6 @@ extern "C" fn handle_view_event(this: &Object, _: Sel, native_event: id) {
     let event = unsafe { platform_input_from_native(native_event, Some(window_height)) };
 
     if let Some(mut event) = event {
-        if matches!(
-            &event,
-            PlatformInput::MouseDown(MouseDownEvent {
-                button: MouseButton::Left,
-                ..
-            }) | PlatformInput::MouseMove(MouseMoveEvent {
-                pressed_button: Some(MouseButton::Left),
-                ..
-            }) | PlatformInput::MousePressure(_)
-                | PlatformInput::MouseUp(MouseUpEvent {
-                    button: MouseButton::Left,
-                    ..
-                })
-        ) {
-            log::info!("[DEBUG-file-drag-event] handle_view_event: translated={event:?}");
-        }
-
         // AppKit unhides the cursor on the next mouse movement; mirror that here.
         if matches!(
             event,
@@ -3074,7 +3045,17 @@ fn screen_point_to_gpui_point(this: &Object, position: NSPoint) -> Point<Pixels>
     point(px(window_x as f32), px(window_y as f32))
 }
 
+/// AppKit delivers a drag back to the window it started from, where accepting it would drop the
+/// files onto themselves. `draggingSource` is nil only for drags from another application.
+fn is_self_originated_drag(dragging_info: id) -> bool {
+    let source: id = unsafe { msg_send![dragging_info, draggingSource] };
+    !source.is_null()
+}
+
 extern "C" fn dragging_entered(this: &Object, _: Sel, dragging_info: id) -> NSDragOperation {
+    if is_self_originated_drag(dragging_info) {
+        return NSDragOperationNone;
+    }
     let window_state = unsafe { get_window_state(this) };
     let position = drag_event_position(&window_state, dragging_info);
     let paths = external_paths_from_event(dragging_info);
@@ -3087,6 +3068,9 @@ extern "C" fn dragging_entered(this: &Object, _: Sel, dragging_info: id) -> NSDr
 }
 
 extern "C" fn dragging_updated(this: &Object, _: Sel, dragging_info: id) -> NSDragOperation {
+    if is_self_originated_drag(dragging_info) {
+        return NSDragOperationNone;
+    }
     let window_state = unsafe { get_window_state(this) };
     let position = drag_event_position(&window_state, dragging_info);
     if send_file_drop_event(window_state, FileDropEvent::Pending { position }) {
@@ -3096,12 +3080,18 @@ extern "C" fn dragging_updated(this: &Object, _: Sel, dragging_info: id) -> NSDr
     }
 }
 
-extern "C" fn dragging_exited(this: &Object, _: Sel, _: id) {
+extern "C" fn dragging_exited(this: &Object, _: Sel, dragging_info: id) {
+    if is_self_originated_drag(dragging_info) {
+        return;
+    }
     let window_state = unsafe { get_window_state(this) };
     send_file_drop_event(window_state, FileDropEvent::Exited);
 }
 
 extern "C" fn perform_drag_operation(this: &Object, _: Sel, dragging_info: id) -> BOOL {
+    if is_self_originated_drag(dragging_info) {
+        return NO;
+    }
     let window_state = unsafe { get_window_state(this) };
     let position = drag_event_position(&window_state, dragging_info);
     send_file_drop_event(window_state, FileDropEvent::Submit { position }).to_objc()
@@ -3159,25 +3149,9 @@ extern "C" fn dragging_session_ended(
     // SAFETY: AppKit invokes this selector on the GPUIWindow instance registered in build_classes,
     // which always has WINDOW_STATE_IVAR initialized to the owning MacWindowState.
     let window_state = unsafe { get_window_state(this) };
-    send_drag_session_ended_event(window_state);
-}
-
-fn send_drag_session_ended_event(window_state: Arc<Mutex<MacWindowState>>) -> bool {
     let mut lock = window_state.lock();
     lock.synthetic_drag_counter += 1;
     lock.last_left_mouse_dragged_event = None;
-    log::info!(
-        "[DEBUG-file-drag-event] drag session ended: cancelled_synthetic_drag_id={}",
-        lock.synthetic_drag_counter
-    );
-    if let Some(mut callback) = lock.event_callback.take() {
-        drop(lock);
-        callback(PlatformInput::DragSessionEnded);
-        window_state.lock().event_callback = Some(callback);
-        true
-    } else {
-        false
-    }
 }
 
 async fn synthetic_drag(

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1838,6 +1838,10 @@ impl PlatformWindow for MacWindow {
         }
     }
 
+    fn can_start_external_drag(&self) -> bool {
+        true
+    }
+
     fn start_external_drag(&self, payload: &ExternalDragPayload) -> bool {
         let ExternalDragPayload::Files(paths) = payload;
         if paths.entries().is_empty() {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use block::ConcreteBlock;
 use cocoa::{
     appkit::{
-        NSApplication, NSBackingStoreBuffered, NSColor, NSEventModifierFlags,
+        NSApplication, NSBackingStoreBuffered, NSColor, NSEvent, NSEventModifierFlags, NSEventType,
         NSFilenamesPboardType, NSPasteboard, NSRequestUserAttentionType, NSScreen, NSView,
         NSViewHeightSizable, NSViewWidthSizable, NSVisualEffectMaterial, NSVisualEffectState,
         NSVisualEffectView, NSWindow, NSWindowCollectionBehavior, NSWindowOcclusionState,
@@ -108,6 +108,10 @@ type NSDragOperation = NSUInteger;
 const NSDragOperationNone: NSDragOperation = 0;
 #[allow(non_upper_case_globals)]
 const NSDragOperationCopy: NSDragOperation = 1;
+#[allow(non_upper_case_globals)]
+const NSDragOperationMove: NSDragOperation = 16;
+const NSDRAGGING_CONTEXT_OUTSIDE_APPLICATION: NSInteger = 0;
+const NSDRAGGING_CONTEXT_WITHIN_APPLICATION: NSInteger = 1;
 #[derive(PartialEq)]
 pub enum UserTabbingPreference {
     Never,
@@ -426,6 +430,17 @@ unsafe fn build_window_class(name: &'static str, superclass: &Class) -> *const C
         decl.add_method(
             sel!(concludeDragOperation:),
             conclude_drag_operation as extern "C" fn(&Object, Sel, id),
+        );
+
+        decl.add_protocol(Protocol::get("NSDraggingSource").unwrap());
+        decl.add_method(
+            sel!(draggingSession:sourceOperationMaskForDraggingContext:),
+            dragging_session_source_operation_mask
+                as extern "C" fn(&Object, Sel, id, NSInteger) -> NSDragOperation,
+        );
+        decl.add_method(
+            sel!(draggingSession:endedAtPoint:operation:),
+            dragging_session_ended as extern "C" fn(&Object, Sel, id, NSPoint, NSDragOperation),
         );
 
         decl.add_method(
@@ -1820,6 +1835,111 @@ impl PlatformWindow for MacWindow {
         }
     }
 
+    fn start_file_drag(&self, paths: &ExternalPaths) -> bool {
+        if paths.paths().is_empty() {
+            log::warn!("start_file_drag declined: no paths");
+            return false;
+        }
+
+        let (native_view, native_window) = {
+            let state = self.0.lock();
+            (state.native_view.as_ptr(), state.native_window)
+        };
+
+        // SAFETY: This method runs on the AppKit/foreground path during drag initiation. The
+        // native view/window are retained by MacWindowState, copied out under a short lock above,
+        // and Objective-C results that may be nil are checked before use.
+        unsafe {
+            let app = NSApplication::sharedApplication(nil);
+            let event: id = msg_send![app, currentEvent];
+            if event.is_null() {
+                log::warn!("start_file_drag declined: currentEvent is nil");
+                return false;
+            }
+
+            let event_type = event.eventType();
+            if !matches!(
+                event_type,
+                NSEventType::NSLeftMouseDragged
+                    | NSEventType::NSRightMouseDragged
+                    | NSEventType::NSOtherMouseDragged
+            ) {
+                log::warn!(
+                    "start_file_drag declined: currentEvent is not a mouse dragged event: {:?}",
+                    event_type
+                );
+                return false;
+            }
+
+            let dragging_items: id = msg_send![class!(NSMutableArray), array];
+            let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
+            let location: NSPoint = msg_send![event, locationInWindow];
+            let frame = NSRect::new(
+                NSPoint::new(location.x - 16., location.y - 16.),
+                NSSize::new(32., 32.),
+            );
+
+            for path in paths.paths() {
+                let path = ns_string(&path.to_string_lossy());
+                let url: id = msg_send![class!(NSURL), fileURLWithPath: path];
+                if url.is_null() {
+                    log::warn!("start_file_drag skipped path with nil NSURL");
+                    continue;
+                }
+
+                let pasteboard_item: id = msg_send![class!(NSPasteboardItem), alloc];
+                let pasteboard_item: id = msg_send![pasteboard_item, init];
+                if pasteboard_item.is_null() {
+                    log::warn!("start_file_drag skipped path with nil NSPasteboardItem");
+                    continue;
+                }
+
+                let file_url_type = ns_string("public.file-url");
+                let absolute_url_string: id = msg_send![url, absoluteString];
+                let wrote_file_url: BOOL = msg_send![pasteboard_item, setString: absolute_url_string forType: file_url_type];
+                if wrote_file_url == NO {
+                    log::warn!("start_file_drag skipped path after failing to write file URL");
+                    let _: () = msg_send![pasteboard_item, release];
+                    continue;
+                }
+
+                let item: id = msg_send![class!(NSDraggingItem), alloc];
+                let item: id = msg_send![item, initWithPasteboardWriter: pasteboard_item];
+                let _: () = msg_send![pasteboard_item, release];
+                if item.is_null() {
+                    log::warn!("start_file_drag declined: NSDraggingItem allocation failed");
+                    continue;
+                }
+
+                let icon: id = msg_send![workspace, iconForFile: path];
+                let _: () = msg_send![item, setDraggingFrame: frame contents: icon];
+                let _: () = msg_send![dragging_items, addObject: item];
+                let _: () = msg_send![item, release];
+            }
+
+            let count: NSUInteger = msg_send![dragging_items, count];
+            if count == 0 {
+                log::warn!("start_file_drag declined: no dragging items");
+                return false;
+            }
+
+            let session: id = msg_send![
+                native_view,
+                beginDraggingSessionWithItems: dragging_items
+                event: event
+                source: native_window
+            ];
+
+            let started = !session.is_null();
+            log::info!(
+                "start_file_drag completed: started={}, item_count={}",
+                started,
+                count
+            );
+            started
+        }
+    }
+
     fn play_system_bell(&self) {
         NSBeep()
     }
@@ -2951,6 +3071,51 @@ fn external_paths_from_event(dragging_info: *mut Object) -> Option<ExternalPaths
 extern "C" fn conclude_drag_operation(this: &Object, _: Sel, _: id) {
     let window_state = unsafe { get_window_state(this) };
     send_file_drop_event(window_state, FileDropEvent::Exited);
+}
+
+extern "C" fn dragging_session_source_operation_mask(
+    _: &Object,
+    _: Sel,
+    _: id,
+    context: NSInteger,
+) -> NSDragOperation {
+    let operation = match context {
+        NSDRAGGING_CONTEXT_OUTSIDE_APPLICATION => NSDragOperationCopy | NSDragOperationMove,
+        NSDRAGGING_CONTEXT_WITHIN_APPLICATION => NSDragOperationNone,
+        _ => NSDragOperationNone,
+    };
+    log::info!(
+        "dragging_session_source_operation_mask: context={}, operation={}",
+        context,
+        operation
+    );
+    operation
+}
+
+extern "C" fn dragging_session_ended(
+    this: &Object,
+    _: Sel,
+    _: id,
+    _: NSPoint,
+    operation: NSDragOperation,
+) {
+    log::info!("dragging_session_ended operation={operation}");
+    // SAFETY: AppKit invokes this selector on the GPUIWindow instance registered in build_classes,
+    // which always has WINDOW_STATE_IVAR initialized to the owning MacWindowState.
+    let window_state = unsafe { get_window_state(this) };
+    send_drag_session_ended_event(window_state);
+}
+
+fn send_drag_session_ended_event(window_state: Arc<Mutex<MacWindowState>>) -> bool {
+    let mut lock = window_state.lock();
+    if let Some(mut callback) = lock.event_callback.take() {
+        drop(lock);
+        callback(PlatformInput::DragSessionEnded);
+        window_state.lock().event_callback = Some(callback);
+        true
+    } else {
+        false
+    }
 }
 
 async fn synthetic_drag(

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -3030,15 +3030,13 @@ fn screen_point_to_gpui_point(this: &Object, position: NSPoint) -> Point<Pixels>
     point(px(window_x as f32), px(window_y as f32))
 }
 
-/// AppKit delivers a drag back to the window it started from, where accepting it would drop the
-/// files onto themselves. `draggingSource` is nil only for drags from another application.
-fn is_self_originated_drag(dragging_info: id) -> bool {
+fn is_drag_from_this_window(this: &Object, dragging_info: id) -> bool {
     let source: id = unsafe { msg_send![dragging_info, draggingSource] };
-    !source.is_null()
+    std::ptr::eq(source as *const Object, this as *const Object)
 }
 
 extern "C" fn dragging_entered(this: &Object, _: Sel, dragging_info: id) -> NSDragOperation {
-    if is_self_originated_drag(dragging_info) {
+    if is_drag_from_this_window(this, dragging_info) {
         return NSDragOperationNone;
     }
     let window_state = unsafe { get_window_state(this) };
@@ -3053,7 +3051,7 @@ extern "C" fn dragging_entered(this: &Object, _: Sel, dragging_info: id) -> NSDr
 }
 
 extern "C" fn dragging_updated(this: &Object, _: Sel, dragging_info: id) -> NSDragOperation {
-    if is_self_originated_drag(dragging_info) {
+    if is_drag_from_this_window(this, dragging_info) {
         return NSDragOperationNone;
     }
     let window_state = unsafe { get_window_state(this) };
@@ -3066,7 +3064,7 @@ extern "C" fn dragging_updated(this: &Object, _: Sel, dragging_info: id) -> NSDr
 }
 
 extern "C" fn dragging_exited(this: &Object, _: Sel, dragging_info: id) {
-    if is_self_originated_drag(dragging_info) {
+    if is_drag_from_this_window(this, dragging_info) {
         return;
     }
     let window_state = unsafe { get_window_state(this) };
@@ -3074,7 +3072,7 @@ extern "C" fn dragging_exited(this: &Object, _: Sel, dragging_info: id) {
 }
 
 extern "C" fn perform_drag_operation(this: &Object, _: Sel, dragging_info: id) -> BOOL {
-    if is_self_originated_drag(dragging_info) {
+    if is_drag_from_this_window(this, dragging_info) {
         return NO;
     }
     let window_state = unsafe { get_window_state(this) };
@@ -3112,7 +3110,7 @@ extern "C" fn dragging_session_source_operation_mask(
 ) -> NSDragOperation {
     let operation = match context {
         NSDRAGGING_CONTEXT_OUTSIDE_APPLICATION => NSDragOperationCopy | NSDragOperationMove,
-        NSDRAGGING_CONTEXT_WITHIN_APPLICATION => NSDragOperationNone,
+        NSDRAGGING_CONTEXT_WITHIN_APPLICATION => NSDragOperationCopy,
         _ => NSDragOperationNone,
     };
     log::debug!(

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1931,7 +1931,7 @@ impl PlatformWindow for MacWindow {
             ];
 
             let started = !session.is_null();
-            log::info!(
+            log::debug!(
                 "start_file_drag completed: started={}, item_count={}",
                 started,
                 count
@@ -3084,7 +3084,7 @@ extern "C" fn dragging_session_source_operation_mask(
         NSDRAGGING_CONTEXT_WITHIN_APPLICATION => NSDragOperationNone,
         _ => NSDragOperationNone,
     };
-    log::info!(
+    log::debug!(
         "dragging_session_source_operation_mask: context={}, operation={}",
         context,
         operation
@@ -3099,7 +3099,7 @@ extern "C" fn dragging_session_ended(
     _: NSPoint,
     operation: NSDragOperation,
 ) {
-    log::info!("dragging_session_ended operation={operation}");
+    log::debug!("dragging_session_ended operation={operation}");
     // SAFETY: AppKit invokes this selector on the GPUIWindow instance registered in build_classes,
     // which always has WINDOW_STATE_IVAR initialized to the owning MacWindowState.
     let window_state = unsafe { get_window_state(this) };

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -113,7 +113,6 @@ const NSDragOperationCopy: NSDragOperation = 1;
 const NSDragOperationMove: NSDragOperation = 16;
 const NSDRAGGING_CONTEXT_OUTSIDE_APPLICATION: NSInteger = 0;
 const NSDRAGGING_CONTEXT_WITHIN_APPLICATION: NSInteger = 1;
-const NS_LEFT_MOUSE_BUTTON_MASK: NSUInteger = 1;
 #[derive(PartialEq)]
 pub enum UserTabbingPreference {
     Never,
@@ -514,7 +513,7 @@ struct MacWindowState {
     appearance_changed_callback: Option<Box<dyn FnMut()>>,
     input_handler: Option<PlatformInputHandler>,
     last_key_equivalent: Option<KeyDownEvent>,
-    last_left_mouse_dragged_event: Option<Retained<Objc2Object>>,
+    last_left_mouse_down_event: Option<Retained<Objc2Object>>,
     synthetic_drag_counter: usize,
     traffic_light_position: Option<Point<Pixels>>,
     traffic_light_frames: Option<TrafficLightFrames>,
@@ -916,7 +915,7 @@ impl MacWindow {
                 appearance_changed_callback: None,
                 input_handler: None,
                 last_key_equivalent: None,
-                last_left_mouse_dragged_event: None,
+                last_left_mouse_down_event: None,
                 synthetic_drag_counter: 0,
                 traffic_light_position: titlebar
                     .as_ref()
@@ -1845,46 +1844,31 @@ impl PlatformWindow for MacWindow {
             return false;
         }
 
-        let (native_view, native_window, last_left_mouse_dragged_event) = {
+        let (native_view, native_window, last_left_mouse_down_event) = {
             let state = self.0.lock();
             (
                 state.native_view.as_ptr(),
                 state.native_window,
-                state.last_left_mouse_dragged_event.clone(),
+                state.last_left_mouse_down_event.clone(),
             )
+        };
+
+        let Some(last_left_mouse_down_event) = last_left_mouse_down_event else {
+            log::warn!("start_file_drag declined: no retained left mouse down event");
+            return false;
         };
 
         // SAFETY: This method runs on the AppKit/foreground path during drag initiation. The
         // native view/window are retained by MacWindowState, copied out under a short lock above,
         // and Objective-C results that may be nil are checked before use.
         unsafe {
-            let app = NSApplication::sharedApplication(nil);
-            let current_event: id = msg_send![app, currentEvent];
-            let pressed_mouse_buttons = NSEvent::pressedMouseButtons(nil);
-            let current_event_type = (!current_event.is_null()).then(|| current_event.eventType());
-            let event = if matches!(
-                current_event_type,
-                Some(
-                    NSEventType::NSLeftMouseDragged
-                        | NSEventType::NSRightMouseDragged
-                        | NSEventType::NSOtherMouseDragged
-                )
-            ) {
-                current_event
-            } else if pressed_mouse_buttons & NS_LEFT_MOUSE_BUTTON_MASK != 0
-                && let Some(last_left_mouse_dragged_event) = &last_left_mouse_dragged_event
-            {
-                Retained::as_ptr(last_left_mouse_dragged_event).cast()
-            } else {
-                log::warn!(
-                    "start_file_drag declined: no usable mouse dragged event: current_event_type={current_event_type:?}, pressed_mouse_buttons={pressed_mouse_buttons:#x}, cached_left_drag_event={}",
-                    last_left_mouse_dragged_event.is_some()
-                );
-                return false;
-            };
-
+            let event: id = Retained::as_ptr(&last_left_mouse_down_event)
+                .cast_mut()
+                .cast();
             let dragging_items: id = msg_send![class!(NSMutableArray), array];
             let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
+            // AppKit keeps this frame's distance from the event's location as the drag image's
+            // offset from the cursor, so it has to stay anchored on `event`.
             let location: NSPoint = msg_send![event, locationInWindow];
             let frame = NSRect::new(
                 NSPoint::new(location.x - 16., location.y - 16.),
@@ -2368,14 +2352,14 @@ extern "C" fn handle_view_event(this: &Object, _: Sel, native_event: id) {
     let window_height = lock.content_size().height;
     let native_event_type = unsafe { native_event.eventType() };
     match native_event_type {
-        NSEventType::NSLeftMouseDown | NSEventType::NSLeftMouseUp => {
-            lock.last_left_mouse_dragged_event = None;
-        }
-        NSEventType::NSLeftMouseDragged => {
-            // AppKit owns `native_event` for the callback; retain it so a later pressure or
-            // tracking event can still initiate the same drag gesture.
-            lock.last_left_mouse_dragged_event =
+        NSEventType::NSLeftMouseDown => {
+            // AppKit owns `native_event` for the callback; retain it so the drag session can still
+            // be started later, once the pointer leaves the window.
+            lock.last_left_mouse_down_event =
                 unsafe { Retained::retain(native_event.cast::<Objc2Object>()) };
+        }
+        NSEventType::NSLeftMouseUp => {
+            lock.last_left_mouse_down_event = None;
         }
         _ => {}
     }
@@ -3148,7 +3132,7 @@ extern "C" fn dragging_session_ended(
     let window_state = unsafe { get_window_state(this) };
     let mut lock = window_state.lock();
     lock.synthetic_drag_counter += 1;
-    lock.last_left_mouse_dragged_event = None;
+    lock.last_left_mouse_down_event = None;
 }
 
 async fn synthetic_drag(

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -60,9 +60,10 @@ use raw_window_handle as rwh;
 use smallvec::SmallVec;
 use std::{
     cell::Cell,
-    ffi::{CStr, c_void},
+    ffi::{CStr, CString, c_void},
     mem,
     ops::Range,
+    os::unix::ffi::OsStrExt,
     path::PathBuf,
     ptr::{self, NonNull},
     rc::Rc,
@@ -1891,38 +1892,34 @@ impl PlatformWindow for MacWindow {
             );
 
             for path in paths.paths() {
-                let path = ns_string(&path.to_string_lossy());
-                let url: id = msg_send![class!(NSURL), fileURLWithPath: path];
+                // Preserve non-UTF-8 paths
+                let Ok(path_bytes) = CString::new(path.as_os_str().as_bytes()) else {
+                    log::warn!("start_file_drag skipped path containing an interior nul byte");
+                    continue;
+                };
+
+                let is_directory: BOOL = if path.is_dir() {YES } else { NO };
+                let url: id = msg_send![
+                    class!(NSURL),
+                    fileURLWithFileSystemRepresentation: path_bytes.as_ptr()
+                    isDirectory: is_directory
+                    relativeToURL: nil
+                ];
+
                 if url.is_null() {
                     log::warn!("start_file_drag skipped path with nil NSURL");
                     continue;
                 }
 
-                let pasteboard_item: id = msg_send![class!(NSPasteboardItem), alloc];
-                let pasteboard_item: id = msg_send![pasteboard_item, init];
-                if pasteboard_item.is_null() {
-                    log::warn!("start_file_drag skipped path with nil NSPasteboardItem");
-                    continue;
-                }
-
-                let file_url_type = ns_string("public.file-url");
-                let absolute_url_string: id = msg_send![url, absoluteString];
-                let wrote_file_url: BOOL = msg_send![pasteboard_item, setString: absolute_url_string forType: file_url_type];
-                if wrote_file_url == NO {
-                    log::warn!("start_file_drag skipped path after failing to write file URL");
-                    let _: () = msg_send![pasteboard_item, release];
-                    continue;
-                }
-
                 let item: id = msg_send![class!(NSDraggingItem), alloc];
-                let item: id = msg_send![item, initWithPasteboardWriter: pasteboard_item];
-                let _: () = msg_send![pasteboard_item, release];
+                let item: id = msg_send![item, initWithPasteboardWriter: url];
                 if item.is_null() {
                     log::warn!("start_file_drag declined: NSDraggingItem allocation failed");
                     continue;
                 }
 
-                let icon: id = msg_send![workspace, iconForFile: path];
+                let url_path: id = msg_send![url, path];
+                let icon: id = msg_send![workspace, iconForFile: url_path];
                 let _: () = msg_send![item, setDraggingFrame: frame contents: icon];
                 let _: () = msg_send![dragging_items, addObject: item];
                 let _: () = msg_send![item, release];

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -3109,9 +3109,9 @@ extern "C" fn dragging_session_source_operation_mask(
     context: NSInteger,
 ) -> NSDragOperation {
     let operation = match context {
-        NSDRAGGING_CONTEXT_OUTSIDE_APPLICATION => NSDragOperationCopy | NSDragOperationMove,
-        NSDRAGGING_CONTEXT_WITHIN_APPLICATION => NSDragOperationCopy,
-        _ => NSDragOperationNone,
+        NSDRAGGING_CONTEXT_OUTSIDE_APPLICATION => NSDragOperationCopy,
+        NSDRAGGING_CONTEXT_WITHIN_APPLICATION => NSDragOperationCopy | NSDragOperationMove,
+        _ => NSDragOperationCopy | NSDragOperationMove,
     };
     log::debug!(
         "dragging_session_source_operation_mask: context={}, operation={}",

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -25,12 +25,12 @@ use cocoa::{
 use dispatch2::DispatchQueue;
 use gpui::{
     AnyWindowHandle, BackgroundExecutor, Bounds, Capslock, CursorStyle, ExternalPaths,
-    FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke, Modifiers, ModifiersChangedEvent,
-    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformAtlas,
-    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptButton,
-    PromptLevel, RequestFrameOptions, SharedString, Size, SystemWindowTab, WindowAppearance,
-    WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowKind, WindowParams, point,
-    px, size,
+    FileDragPaths, FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke, Modifiers,
+    ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels,
+    PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point,
+    PromptButton, PromptLevel, RequestFrameOptions, SharedString, Size, SystemWindowTab,
+    WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowKind,
+    WindowParams, point, px, size,
 };
 #[cfg(any(test, feature = "test-support"))]
 use image::RgbaImage;
@@ -1838,8 +1838,8 @@ impl PlatformWindow for MacWindow {
         }
     }
 
-    fn start_file_drag(&self, paths: &ExternalPaths) -> bool {
-        if paths.paths().is_empty() {
+    fn start_file_drag(&self, paths: &FileDragPaths) -> bool {
+        if paths.entries().is_empty() {
             log::warn!("start_file_drag declined: no paths");
             return false;
         }
@@ -1875,18 +1875,17 @@ impl PlatformWindow for MacWindow {
                 NSSize::new(32., 32.),
             );
 
-            for path in paths.paths() {
+            for (path, is_directory) in paths.entries() {
                 // Preserve non-UTF-8 paths
                 let Ok(path_bytes) = CString::new(path.as_os_str().as_bytes()) else {
                     log::warn!("start_file_drag skipped path containing an interior nul byte");
                     continue;
                 };
 
-                let is_directory: BOOL = if path.is_dir() {YES } else { NO };
                 let url: id = msg_send![
                     class!(NSURL),
                     fileURLWithFileSystemRepresentation: path_bytes.as_ptr()
-                    isDirectory: is_directory
+                    isDirectory: is_directory.to_objc()
                     relativeToURL: nil
                 ];
 

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -49,7 +49,7 @@ use objc::{
     runtime::{BOOL, Class, NO, Object, Protocol, Sel, YES},
     sel, sel_impl,
 };
-use objc2::rc::Retained;
+use objc2::{rc::Retained, runtime::AnyObject as Objc2Object};
 use objc2_app_kit::{
     NSBeep, NSButton as Objc2NSButton, NSView as Objc2NSView, NSWindow as Objc2NSWindow,
     NSWindowButton as Objc2NSWindowButton,
@@ -112,6 +112,7 @@ const NSDragOperationCopy: NSDragOperation = 1;
 const NSDragOperationMove: NSDragOperation = 16;
 const NSDRAGGING_CONTEXT_OUTSIDE_APPLICATION: NSInteger = 0;
 const NSDRAGGING_CONTEXT_WITHIN_APPLICATION: NSInteger = 1;
+const NS_LEFT_MOUSE_BUTTON_MASK: NSUInteger = 1;
 #[derive(PartialEq)]
 pub enum UserTabbingPreference {
     Never,
@@ -512,6 +513,7 @@ struct MacWindowState {
     appearance_changed_callback: Option<Box<dyn FnMut()>>,
     input_handler: Option<PlatformInputHandler>,
     last_key_equivalent: Option<KeyDownEvent>,
+    last_left_mouse_dragged_event: Option<Retained<Objc2Object>>,
     synthetic_drag_counter: usize,
     traffic_light_position: Option<Point<Pixels>>,
     traffic_light_frames: Option<TrafficLightFrames>,
@@ -913,6 +915,7 @@ impl MacWindow {
                 appearance_changed_callback: None,
                 input_handler: None,
                 last_key_equivalent: None,
+                last_left_mouse_dragged_event: None,
                 synthetic_drag_counter: 0,
                 traffic_light_position: titlebar
                     .as_ref()
@@ -1841,9 +1844,13 @@ impl PlatformWindow for MacWindow {
             return false;
         }
 
-        let (native_view, native_window) = {
+        let (native_view, native_window, last_left_mouse_dragged_event) = {
             let state = self.0.lock();
-            (state.native_view.as_ptr(), state.native_window)
+            (
+                state.native_view.as_ptr(),
+                state.native_window,
+                state.last_left_mouse_dragged_event.clone(),
+            )
         };
 
         // SAFETY: This method runs on the AppKit/foreground path during drag initiation. The
@@ -1851,25 +1858,44 @@ impl PlatformWindow for MacWindow {
         // and Objective-C results that may be nil are checked before use.
         unsafe {
             let app = NSApplication::sharedApplication(nil);
-            let event: id = msg_send![app, currentEvent];
-            if event.is_null() {
-                log::warn!("start_file_drag declined: currentEvent is nil");
-                return false;
+            let current_event: id = msg_send![app, currentEvent];
+            let pressed_mouse_buttons = NSEvent::pressedMouseButtons(nil);
+            let current_event_type = (!current_event.is_null()).then(|| current_event.eventType());
+            if current_event_type == Some(NSEventType::NSEventTypePressure) {
+                log::info!(
+                    "[DEBUG-file-drag-event] start_file_drag: current_event_type={current_event_type:?}, pressed_mouse_buttons={pressed_mouse_buttons:#x}, pressure={}, stage={}",
+                    current_event.pressure(),
+                    current_event.stage(),
+                );
+            } else {
+                log::info!(
+                    "[DEBUG-file-drag-event] start_file_drag: current_event_type={current_event_type:?}, pressed_mouse_buttons={pressed_mouse_buttons:#x}"
+                );
             }
 
-            let event_type = event.eventType();
-            if !matches!(
-                event_type,
-                NSEventType::NSLeftMouseDragged
-                    | NSEventType::NSRightMouseDragged
-                    | NSEventType::NSOtherMouseDragged
+            let event = if matches!(
+                current_event_type,
+                Some(
+                    NSEventType::NSLeftMouseDragged
+                        | NSEventType::NSRightMouseDragged
+                        | NSEventType::NSOtherMouseDragged
+                )
             ) {
+                current_event
+            } else if pressed_mouse_buttons & NS_LEFT_MOUSE_BUTTON_MASK != 0
+                && let Some(last_left_mouse_dragged_event) = &last_left_mouse_dragged_event
+            {
+                log::info!(
+                    "[DEBUG-file-drag-event] start_file_drag: using cached left-mouse-dragged event for current_event_type={current_event_type:?}"
+                );
+                Retained::as_ptr(last_left_mouse_dragged_event).cast()
+            } else {
                 log::warn!(
-                    "start_file_drag declined: currentEvent is not a mouse dragged event: {:?}",
-                    event_type
+                    "start_file_drag declined: no usable mouse dragged event: current_event_type={current_event_type:?}, pressed_mouse_buttons={pressed_mouse_buttons:#x}, cached_left_drag_event={}",
+                    last_left_mouse_dragged_event.is_some()
                 );
                 return false;
-            }
+            };
 
             let dragging_items: id = msg_send![class!(NSMutableArray), array];
             let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
@@ -2355,9 +2381,39 @@ extern "C" fn handle_view_event(this: &Object, _: Sel, native_event: id) {
     let weak_window_state = Arc::downgrade(&window_state);
     let mut lock = window_state.as_ref().lock();
     let window_height = lock.content_size().height;
+    let native_event_type = unsafe { native_event.eventType() };
+    match native_event_type {
+        NSEventType::NSLeftMouseDown | NSEventType::NSLeftMouseUp => {
+            lock.last_left_mouse_dragged_event = None;
+        }
+        NSEventType::NSLeftMouseDragged => {
+            // AppKit owns `native_event` for the callback; retain it so a later pressure or
+            // tracking event can still initiate the same drag gesture.
+            lock.last_left_mouse_dragged_event =
+                unsafe { Retained::retain(native_event.cast::<Objc2Object>()) };
+        }
+        _ => {}
+    }
     let event = unsafe { platform_input_from_native(native_event, Some(window_height)) };
 
     if let Some(mut event) = event {
+        if matches!(
+            &event,
+            PlatformInput::MouseDown(MouseDownEvent {
+                button: MouseButton::Left,
+                ..
+            }) | PlatformInput::MouseMove(MouseMoveEvent {
+                pressed_button: Some(MouseButton::Left),
+                ..
+            }) | PlatformInput::MousePressure(_)
+                | PlatformInput::MouseUp(MouseUpEvent {
+                    button: MouseButton::Left,
+                    ..
+                })
+        ) {
+            log::info!("[DEBUG-file-drag-event] handle_view_event: translated={event:?}");
+        }
+
         // AppKit unhides the cursor on the next mouse movement; mirror that here.
         if matches!(
             event,
@@ -3108,6 +3164,12 @@ extern "C" fn dragging_session_ended(
 
 fn send_drag_session_ended_event(window_state: Arc<Mutex<MacWindowState>>) -> bool {
     let mut lock = window_state.lock();
+    lock.synthetic_drag_counter += 1;
+    lock.last_left_mouse_dragged_event = None;
+    log::info!(
+        "[DEBUG-file-drag-event] drag session ended: cancelled_synthetic_drag_id={}",
+        lock.synthetic_drag_counter
+    );
     if let Some(mut callback) = lock.event_callback.take() {
         drop(lock);
         callback(PlatformInput::DragSessionEnded);

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -120,6 +120,12 @@ pub enum UserTabbingPreference {
     InFullScreen,
 }
 
+#[link(name = "AppKit", kind = "framework")]
+unsafe extern "C" {
+    // AppKit constant naming the icon component of an NSDraggingImageComponent.
+    #[allow(non_upper_case_globals)]
+    static NSDraggingImageComponentIconKey: id;
+}
 #[ctor(unsafe)]
 unsafe fn build_classes() {
     unsafe {
@@ -1871,7 +1877,6 @@ impl PlatformWindow for MacWindow {
                 .cast_mut()
                 .cast();
             let dragging_items: id = msg_send![class!(NSMutableArray), array];
-            let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
             // AppKit keeps this frame's distance from the event's location as the drag image's
             // offset from the cursor, so it has to stay anchored on `event`.
             let location: NSPoint = msg_send![event, locationInWindow];
@@ -1906,9 +1911,38 @@ impl PlatformWindow for MacWindow {
                     continue;
                 }
 
-                let url_path: id = msg_send![url, path];
-                let icon: id = msg_send![workspace, iconForFile: url_path];
-                let _: () = msg_send![item, setDraggingFrame: frame contents: icon];
+                // Resolve drag images lazily via `imageComponentsProvider` (Apple's
+                // recommendation for large item counts), and by file *type* rather than
+                // `iconForFile:`, which can synchronously hit LaunchServices, network
+                // mounts, or iCloud for every selected path and beachball drag startup.
+                // `iconForFileType:` is deprecated in favor of `iconForContentType:`,
+                // but the replacement requires macOS 11 and we target 10.15.
+                let file_type = if *is_directory {
+                    "public.folder".to_string()
+                } else {
+                    path.extension()
+                        .and_then(|extension| extension.to_str())
+                        .map(|extension| extension.to_string())
+                        .unwrap_or_else(|| "public.data".to_string())
+                };
+                let provider = ConcreteBlock::new(move || -> id {
+                    let component: id = msg_send![
+                        class!(NSDraggingImageComponent),
+                        draggingImageComponentWithKey: NSDraggingImageComponentIconKey
+                    ];
+                    let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
+                    let icon: id = msg_send![workspace, iconForFileType: ns_string(&file_type)];
+                    let _: () = msg_send![component, setContents: icon];
+                    // Component frames are relative to the item's dragging frame.
+                    let _: () = msg_send![
+                        component,
+                        setFrame: NSRect::new(NSPoint::new(0., 0.), NSSize::new(32., 32.))
+                    ];
+                    msg_send![class!(NSArray), arrayWithObject: component]
+                });
+                let provider = provider.copy();
+                let _: () = msg_send![item, setDraggingFrame: frame];
+                let _: () = msg_send![item, setImageComponentsProvider: provider];
                 let _: () = msg_send![dragging_items, addObject: item];
                 let _: () = msg_send![item, release];
             }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4787,11 +4787,15 @@ impl ProjectPanel {
         selections: &DraggedSelection,
         cx: &App,
     ) -> Option<FileDragPaths> {
-        let selections = selections.items().map(|selection| SelectedEntry {
-            worktree_id: selection.worktree_id,
-            entry_id: self.resolve_entry(selection.entry_id),
-        });
-        Self::file_drag_paths_for_selections(&self.project, selections, cx)
+        let resolved_selections = selections
+            .items()
+            .map(|selection| SelectedEntry {
+                worktree_id: selection.worktree_id,
+                entry_id: self.resolve_entry(selection.entry_id),
+            })
+            .collect::<BTreeSet<SelectedEntry>>();
+        let entries = self.disjoint_entries(resolved_selections, cx);
+        Self::file_drag_paths_for_selections(&self.project, entries, cx)
     }
 
     fn drag_onto(

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4765,24 +4765,18 @@ impl ProjectPanel {
         selections: &DraggedSelection,
         cx: &App,
     ) -> Option<ExternalPaths> {
-        let candidate_paths = {
-            let project = project.read(cx);
-            selections
-                .items()
-                .filter_map(|selection| {
-                    let worktree = project.worktree_for_id(selection.worktree_id, cx)?.read(cx);
-                    if !worktree.is_local() {
-                        return None;
-                    }
-                    let project_path = project.path_for_entry(selection.entry_id, cx)?.path;
-                    Some(worktree.absolutize(&project_path))
-                })
-                .collect::<SmallVec<[_; 2]>>()
-        };
-
-        let paths = candidate_paths
-            .into_iter()
-            .filter(|absolute_path| absolute_path.exists())
+        let project = project.read(cx);
+        let paths = selections
+            .items()
+            .filter_map(|selection| {
+                let worktree = project.worktree_for_id(selection.worktree_id, cx)?.read(cx);
+                if !worktree.is_local() {
+                    return None;
+                }
+                let project_path = project.path_for_entry(selection.entry_id, cx)?.path;
+                let absolute_path = worktree.absolutize(&project_path);
+                absolute_path.exists().then_some(absolute_path)
+            })
             .collect::<SmallVec<[_; 2]>>();
 
         (!paths.is_empty()).then_some(ExternalPaths(paths))

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -22,8 +22,8 @@ use git_ui::file_diff_view::FileDiffView;
 use gpui::{
     Action, AnyElement, App, AsyncWindowContext, Bounds, ClipboardEntry as GpuiClipboardEntry,
     ClipboardItem, Context, CursorStyle, DismissEvent, Div, DragMoveEvent, Entity, EventEmitter,
-    ExternalPaths, FocusHandle, Focusable, FontWeight, Hsla, InteractiveElement, KeyContext,
-    ListHorizontalSizingBehavior, ListSizingBehavior, Modifiers, ModifiersChangedEvent,
+    ExternalPaths, FileDragPaths, FocusHandle, Focusable, FontWeight, Hsla, InteractiveElement,
+    KeyContext, ListHorizontalSizingBehavior, ListSizingBehavior, Modifiers, ModifiersChangedEvent,
     MouseButton, MouseDownEvent, MouseExitEvent, ParentElement, PathPromptOptions, Pixels, Point,
     PromptLevel, Render, ScrollStrategy, Stateful, Styled, Subscription, Task,
     UniformListScrollHandle, WeakEntity, Window, actions, anchored, deferred, div, hsla,
@@ -4764,7 +4764,7 @@ impl ProjectPanel {
         project: &Entity<Project>,
         selections: &DraggedSelection,
         cx: &App,
-    ) -> Option<ExternalPaths> {
+    ) -> Option<FileDragPaths> {
         let project = project.read(cx);
         let paths = selections
             .items()
@@ -4773,12 +4773,12 @@ impl ProjectPanel {
                 if !worktree.is_local() {
                     return None;
                 }
-                let project_path = project.path_for_entry(selection.entry_id, cx)?.path;
-                Some(worktree.absolutize(&project_path))
+                let entry = worktree.entry_for_id(selection.entry_id)?;
+                Some((worktree.absolutize(&entry.path), entry.is_dir()))
             })
             .collect::<SmallVec<[_; 2]>>();
 
-        (!paths.is_empty()).then_some(ExternalPaths(paths))
+        (!paths.is_empty()).then_some(FileDragPaths(paths))
     }
 
     fn drag_onto(

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4761,14 +4761,14 @@ impl ProjectPanel {
             || cfg!(not(target_os = "macos")) && modifiers.control
     }
 
-    fn external_paths_for_dragged_selection(
+    fn file_drag_paths_for_selections(
         project: &Entity<Project>,
-        selections: &DraggedSelection,
+        selections: impl IntoIterator<Item = SelectedEntry>,
         cx: &App,
     ) -> Option<FileDragPaths> {
         let project = project.read(cx);
         let paths = selections
-            .items()
+            .into_iter()
             .filter_map(|selection| {
                 let worktree = project.worktree_for_id(selection.worktree_id, cx)?.read(cx);
                 if !worktree.is_local() {
@@ -4779,7 +4779,19 @@ impl ProjectPanel {
             })
             .collect::<SmallVec<[_; 2]>>();
 
-        (!paths.is_empty()).then_some(FileDragPaths(paths))
+        (!paths.is_empty()).then(|| FileDragPaths::new(paths))
+    }
+
+    fn external_paths_for_dragged_selection(
+        &self,
+        selections: &DraggedSelection,
+        cx: &App,
+    ) -> Option<FileDragPaths> {
+        let selections = selections.items().map(|selection| SelectedEntry {
+            worktree_id: selection.worktree_id,
+            entry_id: self.resolve_entry(selection.entry_id),
+        });
+        Self::file_drag_paths_for_selections(&self.project, selections, cx)
     }
 
     fn drag_onto(
@@ -5951,9 +5963,11 @@ impl ProjectPanel {
                     .on_drag_with_external_payload(
                         dragged_selection,
                         {
-                            let project = self.project.clone();
+                            let project_panel = cx.entity();
                             move |selection, _window, cx| {
-                                Self::external_paths_for_dragged_selection(&project, selection, cx)
+                                project_panel
+                                    .read(cx)
+                                    .external_paths_for_dragged_selection(selection, cx)
                                     .map(ExternalDragPayload::Files)
                             }
                         },

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -22,12 +22,13 @@ use git_ui::file_diff_view::FileDiffView;
 use gpui::{
     Action, AnyElement, App, AsyncWindowContext, Bounds, ClipboardEntry as GpuiClipboardEntry,
     ClipboardItem, Context, CursorStyle, DismissEvent, Div, DragMoveEvent, Entity, EventEmitter,
-    ExternalPaths, FileDragPaths, FocusHandle, Focusable, FontWeight, Hsla, InteractiveElement,
-    KeyContext, ListHorizontalSizingBehavior, ListSizingBehavior, Modifiers, ModifiersChangedEvent,
-    MouseButton, MouseDownEvent, MouseExitEvent, ParentElement, PathPromptOptions, Pixels, Point,
-    PromptLevel, Render, ScrollStrategy, Stateful, Styled, Subscription, Task,
-    UniformListScrollHandle, WeakEntity, Window, actions, anchored, deferred, div, hsla,
-    linear_color_stop, linear_gradient, point, px, size, transparent_white, uniform_list,
+    ExternalDragPayload, ExternalPaths, FileDragPaths, FocusHandle, Focusable, FontWeight, Hsla,
+    InteractiveElement, KeyContext, ListHorizontalSizingBehavior, ListSizingBehavior, Modifiers,
+    ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseExitEvent, ParentElement,
+    PathPromptOptions, Pixels, Point, PromptLevel, Render, ScrollStrategy, Stateful, Styled,
+    Subscription, Task, UniformListScrollHandle, WeakEntity, Window, actions, anchored, deferred,
+    div, hsla, linear_color_stop, linear_gradient, point, px, size, transparent_white,
+    uniform_list,
 };
 use language::DiagnosticSeverity;
 use markdown_preview::markdown_preview_view::MarkdownPreviewView;
@@ -5947,12 +5948,13 @@ impl ProjectPanel {
                                 }));
                         },
                     ))
-                    .on_drag_with_external_paths(
+                    .on_drag_with_external_payload(
                         dragged_selection,
                         {
                             let project = self.project.clone();
                             move |selection, _window, cx| {
                                 Self::external_paths_for_dragged_selection(&project, selection, cx)
+                                    .map(ExternalDragPayload::Files)
                             }
                         },
                         {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4760,6 +4760,34 @@ impl ProjectPanel {
             || cfg!(not(target_os = "macos")) && modifiers.control
     }
 
+    fn external_paths_for_dragged_selection(
+        project: &Entity<Project>,
+        selections: &DraggedSelection,
+        cx: &App,
+    ) -> Option<ExternalPaths> {
+        let candidate_paths = {
+            let project = project.read(cx);
+            selections
+                .items()
+                .filter_map(|selection| {
+                    let worktree = project.worktree_for_id(selection.worktree_id, cx)?.read(cx);
+                    if !worktree.is_local() {
+                        return None;
+                    }
+                    let project_path = project.path_for_entry(selection.entry_id, cx)?.path;
+                    Some(worktree.absolutize(&project_path))
+                })
+                .collect::<SmallVec<[_; 2]>>()
+        };
+
+        let paths = candidate_paths
+            .into_iter()
+            .filter(|absolute_path| absolute_path.exists())
+            .collect::<SmallVec<[_; 2]>>();
+
+        (!paths.is_empty()).then_some(ExternalPaths(paths))
+    }
+
     fn drag_onto(
         &mut self,
         selections: &DraggedSelection,
@@ -5926,24 +5954,33 @@ impl ProjectPanel {
                                 }));
                         },
                     ))
-                    .on_drag(dragged_selection, {
-                        let active_component =
-                            self.state.ancestors.get(&entry_id).and_then(|ancestors| {
-                                ancestors.active_component(&details.filename)
-                            });
-                        move |selection, click_offset, _window, cx| {
-                            let filename = active_component
-                                .as_ref()
-                                .unwrap_or_else(|| &details.filename);
-                            cx.new(|_| DraggedProjectEntryView {
-                                icon: details.icon.clone(),
-                                filename: filename.clone(),
-                                click_offset,
-                                selection: selection.active_selection,
-                                selections: selection.marked_selections.clone(),
-                            })
-                        }
-                    })
+                    .on_drag_with_external_paths(
+                        dragged_selection,
+                        {
+                            let project = self.project.clone();
+                            move |selection, _window, cx| {
+                                Self::external_paths_for_dragged_selection(&project, selection, cx)
+                            }
+                        },
+                        {
+                            let active_component =
+                                self.state.ancestors.get(&entry_id).and_then(|ancestors| {
+                                    ancestors.active_component(&details.filename)
+                                });
+                            move |selection, click_offset, _window, cx| {
+                                let filename = active_component
+                                    .as_ref()
+                                    .unwrap_or_else(|| &details.filename);
+                                cx.new(|_| DraggedProjectEntryView {
+                                    icon: details.icon.clone(),
+                                    filename: filename.clone(),
+                                    click_offset,
+                                    selection: selection.active_selection,
+                                    selections: selection.marked_selections.clone(),
+                                })
+                            }
+                        },
+                    )
                     .on_drop(cx.listener(
                         move |this, selections: &DraggedSelection, window, cx| {
                             this.clear_drag_state(cx);

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4774,8 +4774,7 @@ impl ProjectPanel {
                     return None;
                 }
                 let project_path = project.path_for_entry(selection.entry_id, cx)?.path;
-                let absolute_path = worktree.absolutize(&project_path);
-                absolute_path.exists().then_some(absolute_path)
+                Some(worktree.absolutize(&project_path))
             })
             .collect::<SmallVec<[_; 2]>>();
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5960,36 +5960,33 @@ impl ProjectPanel {
                                 }));
                         },
                     ))
-                    .on_drag_with_external_payload(
-                        dragged_selection,
-                        {
-                            let project_panel = cx.entity();
-                            move |selection, _window, cx| {
-                                project_panel
-                                    .read(cx)
-                                    .external_paths_for_dragged_selection(selection, cx)
-                                    .map(ExternalDragPayload::Files)
-                            }
-                        },
-                        {
-                            let active_component =
-                                self.state.ancestors.get(&entry_id).and_then(|ancestors| {
-                                    ancestors.active_component(&details.filename)
-                                });
-                            move |selection, click_offset, _window, cx| {
-                                let filename = active_component
-                                    .as_ref()
-                                    .unwrap_or_else(|| &details.filename);
-                                cx.new(|_| DraggedProjectEntryView {
-                                    icon: details.icon.clone(),
-                                    filename: filename.clone(),
-                                    click_offset,
-                                    selection: selection.active_selection,
-                                    selections: selection.marked_selections.clone(),
-                                })
-                            }
-                        },
-                    )
+                    .on_drag(dragged_selection, {
+                        let active_component =
+                            self.state.ancestors.get(&entry_id).and_then(|ancestors| {
+                                ancestors.active_component(&details.filename)
+                            });
+                        move |selection, click_offset, _window, cx| {
+                            let filename = active_component
+                                .as_ref()
+                                .unwrap_or_else(|| &details.filename);
+                            cx.new(|_| DraggedProjectEntryView {
+                                icon: details.icon.clone(),
+                                filename: filename.clone(),
+                                click_offset,
+                                selection: selection.active_selection,
+                                selections: selection.marked_selections.clone(),
+                            })
+                        }
+                    })
+                    .external_drag_payload({
+                        let project_panel = cx.entity();
+                        move |selection: &DraggedSelection, _window, cx| {
+                            project_panel
+                                .read(cx)
+                                .external_paths_for_dragged_selection(selection, cx)
+                                .map(ExternalDragPayload::Files)
+                        }
+                    })
                     .on_drop(cx.listener(
                         move |this, selections: &DraggedSelection, window, cx| {
                             this.clear_drag_state(cx);

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -4596,26 +4596,25 @@ async fn test_rename_survives_window_deactivation(cx: &mut gpui::TestAppContext)
 }
 
 #[gpui::test]
-async fn test_external_paths_for_dragged_selection_filters_missing_paths(
-    cx: &mut gpui::TestAppContext,
-) {
+async fn test_file_drag_paths_use_worktree_snapshot(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 
     let temp_dir = tempfile::tempdir().unwrap();
     let root_path = temp_dir.path();
     let existing_a = root_path.join("existing_a.txt");
     let existing_b = root_path.join("existing_b.txt");
-    let deleted = root_path.join("deleted.txt");
+    let deleted_directory = root_path.join("deleted_dir");
     std::fs::write(&existing_a, "a").unwrap();
     std::fs::write(&existing_b, "b").unwrap();
-    std::fs::write(&deleted, "deleted").unwrap();
+    std::fs::create_dir(&deleted_directory).unwrap();
+    std::fs::write(deleted_directory.join("nested.txt"), "nested").unwrap();
 
     let fs = FakeFs::new(cx.executor());
     fs.insert_tree_from_real_fs(root_path, root_path).await;
-    std::fs::remove_file(&deleted).unwrap();
+    std::fs::remove_dir_all(&deleted_directory).unwrap();
 
     let project = Project::test(fs.clone(), [root_path], cx).await;
-    let (worktree_id, existing_a_id, existing_b_id, deleted_id) = cx.update(|cx| {
+    let (worktree_id, existing_a_id, existing_b_id, deleted_directory_id) = cx.update(|cx| {
         let project = project.read(cx);
         let worktree = project.worktrees(cx).next().unwrap();
         let worktree = worktree.read(cx);
@@ -4629,7 +4628,7 @@ async fn test_external_paths_for_dragged_selection_filters_missing_paths(
                 .entry_for_path(rel_path("existing_b.txt"))
                 .unwrap()
                 .id,
-            worktree.entry_for_path(rel_path("deleted.txt")).unwrap().id,
+            worktree.entry_for_path(rel_path("deleted_dir")).unwrap().id,
         )
     });
 
@@ -4649,7 +4648,7 @@ async fn test_external_paths_for_dragged_selection_filters_missing_paths(
             },
             SelectedEntry {
                 worktree_id,
-                entry_id: deleted_id,
+                entry_id: deleted_directory_id,
             },
         ]),
     };
@@ -4660,7 +4659,14 @@ async fn test_external_paths_for_dragged_selection_filters_missing_paths(
         })
         .unwrap();
 
-    assert_eq!(paths.paths(), &[existing_a, existing_b]);
+    assert_eq!(
+        paths.entries(),
+        &[
+            (existing_a, false),
+            (existing_b, false),
+            (deleted_directory, true),
+        ]
+    );
 }
 
 #[gpui::test]
@@ -4708,7 +4714,7 @@ async fn test_external_paths_for_dragged_selection_uses_active_selection_unless_
         })
         .unwrap();
 
-    assert_eq!(paths.paths(), &[active_path]);
+    assert_eq!(paths.entries(), &[(active_path, false)]);
 }
 
 #[gpui::test]

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -4655,7 +4655,11 @@ async fn test_file_drag_paths_use_worktree_snapshot(cx: &mut gpui::TestAppContex
 
     let paths = cx
         .update(|cx| {
-            ProjectPanel::external_paths_for_dragged_selection(&project, &dragged_selection, cx)
+            ProjectPanel::file_drag_paths_for_selections(
+                &project,
+                dragged_selection.items().copied(),
+                cx,
+            )
         })
         .unwrap();
 
@@ -4710,11 +4714,73 @@ async fn test_external_paths_for_dragged_selection_uses_active_selection_unless_
 
     let paths = cx
         .update(|cx| {
-            ProjectPanel::external_paths_for_dragged_selection(&project, &dragged_selection, cx)
+            ProjectPanel::file_drag_paths_for_selections(
+                &project,
+                dragged_selection.items().copied(),
+                cx,
+            )
         })
         .unwrap();
 
     assert_eq!(paths.entries(), &[(active_path, false)]);
+}
+
+#[gpui::test]
+async fn test_external_paths_for_dragged_selection_resolves_folded_directory(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root",
+        json!({
+            "a": {
+                "b": {
+                    "c": {
+                        "d": {}
+                    }
+                }
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+
+    cx.update(|_, cx| {
+        let settings = *ProjectPanelSettings::get_global(cx);
+        ProjectPanelSettings::override_global(
+            ProjectPanelSettings {
+                auto_fold_dirs: true,
+                ..settings
+            },
+            cx,
+        );
+    });
+
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+    select_folded_path_with_mark(&panel, "root/a/b/c/d", "root/a/b", cx);
+
+    let dragged_selection = panel.read_with(cx, |panel, _| DraggedSelection {
+        active_selection: panel.selection.unwrap(),
+        marked_selections: Arc::from(panel.marked_entries.clone()),
+    });
+    let paths = cx
+        .update(|_, cx| {
+            panel.read_with(cx, |panel, cx| {
+                panel.external_paths_for_dragged_selection(&dragged_selection, cx)
+            })
+        })
+        .unwrap();
+
+    assert_eq!(paths.entries(), &[(PathBuf::from("/root/a/b"), true)]);
 }
 
 #[gpui::test]
@@ -4744,7 +4810,11 @@ async fn test_external_paths_for_dragged_selection_skips_remote_worktrees(
     };
 
     let paths = cx.update(|cx| {
-        ProjectPanel::external_paths_for_dragged_selection(&project, &dragged_selection, cx)
+        ProjectPanel::file_drag_paths_for_selections(
+            &project,
+            dragged_selection.items().copied(),
+            cx,
+        )
     });
 
     assert!(paths.is_none());

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -4596,6 +4596,155 @@ async fn test_rename_survives_window_deactivation(cx: &mut gpui::TestAppContext)
 }
 
 #[gpui::test]
+async fn test_external_paths_for_dragged_selection_filters_missing_paths(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root_path = temp_dir.path();
+    let existing_a = root_path.join("existing_a.txt");
+    let existing_b = root_path.join("existing_b.txt");
+    let deleted = root_path.join("deleted.txt");
+    std::fs::write(&existing_a, "a").unwrap();
+    std::fs::write(&existing_b, "b").unwrap();
+    std::fs::write(&deleted, "deleted").unwrap();
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree_from_real_fs(root_path, root_path).await;
+    std::fs::remove_file(&deleted).unwrap();
+
+    let project = Project::test(fs.clone(), [root_path], cx).await;
+    let (worktree_id, existing_a_id, existing_b_id, deleted_id) = cx.update(|cx| {
+        let project = project.read(cx);
+        let worktree = project.worktrees(cx).next().unwrap();
+        let worktree = worktree.read(cx);
+        (
+            worktree.id(),
+            worktree
+                .entry_for_path(rel_path("existing_a.txt"))
+                .unwrap()
+                .id,
+            worktree
+                .entry_for_path(rel_path("existing_b.txt"))
+                .unwrap()
+                .id,
+            worktree.entry_for_path(rel_path("deleted.txt")).unwrap().id,
+        )
+    });
+
+    let dragged_selection = DraggedSelection {
+        active_selection: SelectedEntry {
+            worktree_id,
+            entry_id: existing_a_id,
+        },
+        marked_selections: Arc::from(vec![
+            SelectedEntry {
+                worktree_id,
+                entry_id: existing_a_id,
+            },
+            SelectedEntry {
+                worktree_id,
+                entry_id: existing_b_id,
+            },
+            SelectedEntry {
+                worktree_id,
+                entry_id: deleted_id,
+            },
+        ]),
+    };
+
+    let paths = cx
+        .update(|cx| {
+            ProjectPanel::external_paths_for_dragged_selection(&project, &dragged_selection, cx)
+        })
+        .unwrap();
+
+    assert_eq!(paths.paths(), &[existing_a, existing_b]);
+}
+
+#[gpui::test]
+async fn test_external_paths_for_dragged_selection_uses_active_selection_unless_marked(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root_path = temp_dir.path();
+    let active_path = root_path.join("active.txt");
+    let marked_path = root_path.join("marked.txt");
+    std::fs::write(&active_path, "active").unwrap();
+    std::fs::write(&marked_path, "marked").unwrap();
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree_from_real_fs(root_path, root_path).await;
+
+    let project = Project::test(fs.clone(), [root_path], cx).await;
+    let (worktree_id, active_id, marked_id) = cx.update(|cx| {
+        let project = project.read(cx);
+        let worktree = project.worktrees(cx).next().unwrap();
+        let worktree = worktree.read(cx);
+        (
+            worktree.id(),
+            worktree.entry_for_path(rel_path("active.txt")).unwrap().id,
+            worktree.entry_for_path(rel_path("marked.txt")).unwrap().id,
+        )
+    });
+
+    let dragged_selection = DraggedSelection {
+        active_selection: SelectedEntry {
+            worktree_id,
+            entry_id: active_id,
+        },
+        marked_selections: Arc::from(vec![SelectedEntry {
+            worktree_id,
+            entry_id: marked_id,
+        }]),
+    };
+
+    let paths = cx
+        .update(|cx| {
+            ProjectPanel::external_paths_for_dragged_selection(&project, &dragged_selection, cx)
+        })
+        .unwrap();
+
+    assert_eq!(paths.paths(), &[active_path]);
+}
+
+#[gpui::test]
+async fn test_external_paths_for_dragged_selection_skips_remote_worktrees(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/local", json!({})).await;
+    let project = Project::test(fs.clone(), ["/local".as_ref()], cx).await;
+
+    let remote_worktree = project.update(cx, |project, cx| {
+        project.add_test_remote_worktree("/remote/project", cx)
+    });
+    let remote_worktree_id = remote_worktree.read_with(cx, |worktree, _| worktree.id());
+
+    let dragged_selection = DraggedSelection {
+        active_selection: SelectedEntry {
+            worktree_id: remote_worktree_id,
+            entry_id: ProjectEntryId::from_usize(1),
+        },
+        marked_selections: Arc::from(vec![SelectedEntry {
+            worktree_id: remote_worktree_id,
+            entry_id: ProjectEntryId::from_usize(1),
+        }]),
+    };
+
+    let paths = cx.update(|cx| {
+        ProjectPanel::external_paths_for_dragged_selection(&project, &dragged_selection, cx)
+    });
+
+    assert!(paths.is_none());
+}
+
+#[gpui::test]
 async fn test_multiple_marked_entries(cx: &mut gpui::TestAppContext) {
     init_test_with_editor(cx);
     let fs = FakeFs::new(cx.executor());


### PR DESCRIPTION
## Description

Adds native macOS file drag out support for Project Panel entries. Local file paths are resolved only when a drag gesture starts, remote or missing paths are skipped, and unsupported platforms keep the default no-op behavior.

The macOS implementation starts an AppKit drag session with file URL pasteboard items, allows Finder and other external apps to choose copy or move, keeps in-app GPUI drag/drop behavior in control for internal drags, and clears the active drag state when the native session ends.

https://github.com/user-attachments/assets/42909389-1a32-4574-a200-9a14b913f55f

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #55370

Release Notes:

- Added support for dragging files from the Project Panel to external macOS apps.
