### PR TITLE
python: Fix Python exception highlighting

### DIFF
--- a/crates/grammars/src/python/highlights.scm
+++ b/crates/grammars/src/python/highlights.scm
@@ -344,3 +344,23 @@
     "bool" "bytearray" "bytes" "complex" "dict" "float" "frozenset" "int" "list" "memoryview"
     "object" "range" "set" "slice" "str" "tuple")
 ]
+
+((identifier) @type.builtin
+  (#any-of? @type.builtin
+    ; Exceptions
+    "BaseException" "Exception" "ArithmeticError" "BufferError" "LookupError" "AssertionError"
+    "AttributeError" "EOFError" "FloatingPointError" "GeneratorExit" "ImportError"
+    "ModuleNotFoundError" "IndexError" "KeyError" "KeyboardInterrupt" "MemoryError" "NameError"
+    "NotImplementedError" "OSError" "OverflowError" "RecursionError" "ReferenceError" "RuntimeError"
+    "StopIteration" "StopAsyncIteration" "SyntaxError" "IndentationError" "TabError" "SystemError"
+    "SystemExit" "TypeError" "UnboundLocalError" "UnicodeError" "UnicodeEncodeError"
+    "UnicodeDecodeError" "UnicodeTranslateError" "ValueError" "ZeroDivisionError" "EnvironmentError"
+    "IOError" "WindowsError" "BlockingIOError" "ChildProcessError" "ConnectionError"
+    "BrokenPipeError" "ConnectionAbortedError" "ConnectionRefusedError" "ConnectionResetError"
+    "FileExistsError" "FileNotFoundError" "InterruptedError" "IsADirectoryError"
+    "NotADirectoryError" "PermissionError" "ProcessLookupError" "TimeoutError" "ExceptionGroup"
+    "BaseExceptionGroup"
+    ; Warnings
+    "Warning" "UserWarning" "DeprecationWarning" "PendingDeprecationWarning"
+    "SyntaxWarning" "RuntimeWarning" "FutureWarning" "ImportWarning" "UnicodeWarning"
+    "EncodingWarning" "BytesWarning" "ResourceWarning"))

--- a/crates/grammars/src/python/highlights.scm
+++ b/crates/grammars/src/python/highlights.scm
@@ -345,8 +345,8 @@
     "object" "range" "set" "slice" "str" "tuple")
 ]
 
-((identifier) @type.builtin
-  (#any-of? @type.builtin
+((identifier) @type.class.builtin
+  (#any-of? @type.class.builtin
     ; Exceptions
     "BaseException" "Exception" "ArithmeticError" "BufferError" "LookupError" "AssertionError"
     "AttributeError" "EOFError" "FloatingPointError" "GeneratorExit" "ImportError"
@@ -361,6 +361,6 @@
     "NotADirectoryError" "PermissionError" "ProcessLookupError" "TimeoutError" "ExceptionGroup"
     "BaseExceptionGroup"
     ; Warnings
-    "Warning" "UserWarning" "DeprecationWarning" "PendingDeprecationWarning"
-    "SyntaxWarning" "RuntimeWarning" "FutureWarning" "ImportWarning" "UnicodeWarning"
-    "EncodingWarning" "BytesWarning" "ResourceWarning"))
+    "Warning" "UserWarning" "DeprecationWarning" "PendingDeprecationWarning" "SyntaxWarning"
+    "RuntimeWarning" "FutureWarning" "ImportWarning" "UnicodeWarning" "EncodingWarning"
+    "BytesWarning" "ResourceWarning"))


### PR DESCRIPTION
In the current Python Tree-sitter `highlights.scm`, exception (https://docs.python.org/3/library/exceptions.html) are highlighted under `@type.class` which is inconsistent compared to other editors (VS Code, Neovim, Helix).  

This PR adds `#any-of?` with a list of python's exceptions and highlight them under `@type.builtin`.

|                                                               Before                                                                |                                                               After                                                                |
| :---------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------: |
| <img width="1237" height="1160" alt="image" src="https://github.com/user-attachments/assets/05e1ae34-7637-413a-9785-ad696c2bf751" /> | <img width="1237" height="1154" alt="image" src="https://github.com/user-attachments/assets/105c61ca-b6a7-4c26-acc8-3e300f044510" /> |


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added the ability to stylize builtin python exceptions and warnings using the `type.class.builtin` syntax capture.
