### PR TITLE
notebook: Add several smaller UX quality of life changes

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1481,6 +1481,8 @@
       "enter": "notebook::EnterEditMode",
       "down": "menu::SelectNext",
       "up": "menu::SelectPrevious",
+      "d d": "notebook::DeleteCell",
+      "delete": "notebook::DeleteCell",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1619,6 +1619,8 @@
       "enter": "notebook::EnterEditMode",
       "down": "menu::SelectNext",
       "up": "menu::SelectPrevious",
+      "d d": "notebook::DeleteCell",
+      "delete": "notebook::DeleteCell",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1544,6 +1544,8 @@
       "enter": "notebook::EnterEditMode",
       "down": "menu::SelectNext",
       "up": "menu::SelectPrevious",
+      "d d": "notebook::DeleteCell",
+      "delete": "notebook::DeleteCell",
     },
   },
   {

--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -455,7 +455,6 @@ impl MarkdownCell {
                 _ => {}
             });
 
-        let start_editing = source.is_empty();
         Self {
             id,
             metadata,
@@ -463,7 +462,7 @@ impl MarkdownCell {
             source,
             editor,
             markdown,
-            editing: start_editing,
+            editing: false,
             selected: false,
             cell_position: None,
             _editor_subscription: editor_subscription,
@@ -678,7 +677,15 @@ impl Render for MarkdownCell {
                                     cx.emit(MarkdownCellEvent::Clicked(this.id.clone()));
                                 }
                             }))
-                            .child(MarkdownElement::new(self.markdown.clone(), style)),
+                            .when(self.source.is_empty(), |this| {
+                                this.child(
+                                    Label::new("Empty markdown block. Double-click to edit.")
+                                        .color(Color::Placeholder),
+                                )
+                            })
+                            .when(!self.source.is_empty(), |this| {
+                                this.child(MarkdownElement::new(self.markdown.clone(), style))
+                            }),
                     ),
             )
             .children(self.cell_position_spacer(false, window, cx))

--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -42,11 +42,13 @@ pub enum CellControlType {
 pub enum CellEvent {
     Run(CellId),
     FocusedIn(CellId),
+    Clicked(CellId),
 }
 
 pub enum MarkdownCellEvent {
     FinishedEditing,
     Run(CellId),
+    Clicked(CellId),
 }
 
 impl CellControlType {
@@ -571,6 +573,36 @@ impl RenderableCell for MarkdownCell {
         self.cell_position = Some(cell_position);
         self
     }
+
+    fn gutter(&self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let is_selected = self.selected();
+        let gutter_id = ElementId::from(format!("{}-gutter", self.id));
+
+        div()
+            .relative()
+            .h_full()
+            .w(px(GUTTER_WIDTH))
+            .id(gutter_id)
+            .on_click(cx.listener(|this, _, _, cx| {
+                cx.emit(MarkdownCellEvent::Clicked(this.id.clone()));
+            }))
+            .child(
+                div()
+                    .w(px(GUTTER_WIDTH))
+                    .flex()
+                    .flex_none()
+                    .justify_center()
+                    .h_full()
+                    .child(
+                        div()
+                            .flex_none()
+                            .w(px(1.))
+                            .h_full()
+                            .when(is_selected, |this| this.bg(cx.theme().colors().icon_accent))
+                            .when(!is_selected, |this| this.bg(cx.theme().colors().border)),
+                    ),
+            )
+    }
 }
 
 impl Render for MarkdownCell {
@@ -633,10 +665,18 @@ impl Render for MarkdownCell {
                             .font_ui(cx)
                             .text_size(TextSize::Default.rems(cx))
                             .cursor_pointer()
-                            .on_click(cx.listener(|this, _event, window, cx| {
-                                this.editing = true;
-                                window.focus(&this.editor.focus_handle(cx), cx);
-                                cx.notify();
+                            .on_click(cx.listener(|this, event, window, cx| {
+                                let is_double_click = matches!(
+                                    event,
+                                    gpui::ClickEvent::Mouse(e) if e.down.click_count >= 2
+                                );
+                                if is_double_click {
+                                    this.editing = true;
+                                    window.focus(&this.editor.focus_handle(cx), cx);
+                                    cx.notify();
+                                } else {
+                                    cx.emit(MarkdownCellEvent::Clicked(this.id.clone()));
+                                }
                             }))
                             .child(MarkdownElement::new(self.markdown.clone(), style)),
                     ),
@@ -1002,11 +1042,16 @@ impl RenderableCell for CodeCell {
     fn gutter(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let is_selected = self.selected();
         let execution_count = self.execution_count;
+        let gutter_id = ElementId::from(format!("{}-gutter", self.id));
 
         div()
             .relative()
             .h_full()
             .w(px(GUTTER_WIDTH))
+            .id(gutter_id)
+            .on_click(cx.listener(|this, _, _, cx| {
+                cx.emit(CellEvent::Clicked(this.id().clone()));
+            }))
             .child(
                 div()
                     .w(px(GUTTER_WIDTH))
@@ -1146,6 +1191,10 @@ impl Render for CodeCell {
                             .items_start()
                             .gap(DynamicSpacing::Base08.rems(cx))
                             .bg(self.selected_bg_color(window, cx))
+                            .id(ElementId::from(format!("{}-output", self.id)))
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                cx.emit(CellEvent::Clicked(this.id().clone()));
+                            }))
                             .child(self.gutter_output(window, cx))
                             .child(
                                 div().py_1p5().w_full().child(

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -146,6 +146,9 @@ impl NotebookEditor {
                             CellEvent::FocusedIn(_) => {
                                 this.select_cell_by_id(&cell_id_for_focus, cx)
                             }
+                            CellEvent::Clicked(_) => {
+                                this.select_cell_in_command_mode(&cell_id_for_focus, cx)
+                            }
                         }
                     })
                     .detach();
@@ -160,9 +163,10 @@ impl NotebookEditor {
                     .detach();
                 }
                 Cell::Markdown(markdown_cell) => {
+                    let cell_id_for_click = cell_id.clone();
                     cx.subscribe(
                         markdown_cell,
-                        move |_this, cell, event: &MarkdownCellEvent, cx| {
+                        move |this, cell, event: &MarkdownCellEvent, cx| {
                             match event {
                                 MarkdownCellEvent::FinishedEditing => {
                                     cell.update(cx, |cell, cx| {
@@ -175,6 +179,9 @@ impl NotebookEditor {
                                     cell.update(cx, |cell, cx| {
                                         cell.reparse_markdown(cx);
                                     });
+                                }
+                                MarkdownCellEvent::Clicked(_) => {
+                                    this.select_cell_in_command_mode(&cell_id_for_click, cx);
                                 }
                             }
                         },
@@ -802,13 +809,17 @@ impl NotebookEditor {
             )
         });
 
+        let cell_id_for_click = new_cell_id.clone();
         cx.subscribe(
             &markdown_cell,
-            move |_this, cell, event: &MarkdownCellEvent, cx| match event {
+            move |this, cell, event: &MarkdownCellEvent, cx| match event {
                 MarkdownCellEvent::FinishedEditing | MarkdownCellEvent::Run(_) => {
                     cell.update(cx, |cell, cx| {
                         cell.reparse_markdown(cx);
                     });
+                }
+                MarkdownCellEvent::Clicked(_) => {
+                    this.select_cell_in_command_mode(&cell_id_for_click, cx);
                 }
             },
         )
@@ -859,6 +870,7 @@ impl NotebookEditor {
             move |this, _cell, event, window, cx| match event {
                 CellEvent::Run(cell_id) => this.execute_cell(cell_id.clone(), window, cx),
                 CellEvent::FocusedIn(_) => this.select_cell_by_id(&cell_id_for_run, cx),
+                CellEvent::Clicked(_) => this.select_cell_in_command_mode(&cell_id_for_run, cx),
             },
         )
         .detach();
@@ -891,6 +903,15 @@ impl NotebookEditor {
         if let Some(index) = self.cell_order.iter().position(|id| id == cell_id) {
             self.selected_cell_index = index;
             self.notebook_mode = NotebookMode::Edit;
+            cx.notify();
+        }
+    }
+
+    fn select_cell_in_command_mode(&mut self, cell_id: &CellId, cx: &mut Context<Self>) {
+        if let Some(index) = self.cell_order.iter().position(|id| id == cell_id) {
+            self.selected_cell_index = index;
+            self.notebook_mode = NotebookMode::Command;
+            self.cell_list.scroll_to_reveal_item(index);
             cx.notify();
         }
     }
@@ -1339,11 +1360,19 @@ impl NotebookEditor {
                 cell.clone().into_any_element()
             }
             Cell::Raw(cell) => {
+                let cell_id = cell.read(cx).id().clone();
                 cell.update(cx, |cell, _cx| {
                     cell.set_selected(is_selected)
                         .set_cell_position(cell_position);
                 });
-                cell.clone().into_any_element()
+                let wrapper_id = ElementId::from(format!("{}-raw-wrapper", cell_id));
+                div()
+                    .id(wrapper_id)
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.select_cell_in_command_mode(&cell_id, cx);
+                    }))
+                    .child(cell.clone())
+                    .into_any_element()
             }
         }
     }

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -43,9 +43,9 @@ use runtimelib::{ExecuteRequest, JupyterMessage, JupyterMessageContent};
 use ui::PopoverMenuHandle;
 use zed_actions::editor::{MoveDown, MoveUp};
 use zed_actions::notebook::{
-    AddCodeBlock, AddMarkdownBlock, ClearOutputs, EnterCommandMode, EnterEditMode, InterruptKernel,
-    MoveCellDown, MoveCellUp, NotebookMoveDown, NotebookMoveUp, OpenNotebook, RestartKernel, Run,
-    RunAll, RunAndAdvance,
+    AddCodeBlock, AddMarkdownBlock, ClearOutputs, DeleteCell, EnterCommandMode, EnterEditMode,
+    InterruptKernel, MoveCellDown, MoveCellUp, NotebookMoveDown, NotebookMoveUp, OpenNotebook,
+    RestartKernel, Run, RunAll, RunAndAdvance,
 };
 
 /// Whether the notebook is in command mode (navigating cells) or edit mode (editing a cell).
@@ -760,6 +760,18 @@ impl NotebookEditor {
         }
     }
 
+    fn delete_cell(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        let index = self.selected_cell_index;
+        let Some(cell_id) = self.cell_order.get(index).cloned() else {
+            return;
+        };
+        self.cell_order.remove(index);
+        self.cell_map.remove(&cell_id);
+        self.cell_list.splice(index..index + 1, 0);
+        self.selected_cell_index = index.min(self.cell_order.len().saturating_sub(1));
+        cx.notify();
+    }
+
     fn insert_cell_at_current_position(&mut self, cell_id: CellId, cell: Cell) {
         let insert_index = if self.cell_order.is_empty() {
             0
@@ -1086,6 +1098,22 @@ impl NotebookEditor {
                             ),
                     )
                     .child(
+                        Self::button_group(window, cx).child(
+                            Self::render_notebook_control(
+                                "delete-cell",
+                                IconName::Trash,
+                                window,
+                                cx,
+                            )
+                            .tooltip(move |window, cx| {
+                                Tooltip::for_action("Delete cell", &DeleteCell, cx)
+                            })
+                            .on_click(|_, window, cx| {
+                                window.dispatch_action(Box::new(DeleteCell), cx);
+                            }),
+                        ),
+                    )
+                    .child(
                         Self::button_group(window, cx)
                             .child(
                                 Self::render_notebook_control(
@@ -1355,6 +1383,9 @@ impl Render for NotebookEditor {
             )
             .on_action(
                 cx.listener(|this, _: &MoveCellDown, window, cx| this.move_cell_down(window, cx)),
+            )
+            .on_action(
+                cx.listener(|this, _: &DeleteCell, window, cx| this.delete_cell(window, cx)),
             )
             .on_action(cx.listener(|this, _: &AddMarkdownBlock, window, cx| {
                 this.add_markdown_block(window, cx)

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -897,6 +897,8 @@ pub mod notebook {
             EnterEditMode,
             /// Exits the cell editor and returns to cell command mode.
             EnterCommandMode,
+            /// Deletes the currently selected cell.
+            DeleteCell,
         ]
     );
 }


### PR DESCRIPTION
This pull request contains 3 commits which contain small improvements to the user experience when working with notebooks.

1. Cell deletion. ([view commit](https://github.com/zed-industries/zed/pull/58179/changes/a860b4e5012303663013d74a6ef69263c8289a4f))
There is currently no way to delete cells, only to insert some. This commit adds an action together with a button and a shortcut to delete the currenlty selected cell (in command mode). The default keybinds are "q q" (default in Jupyter Lab) and "delete". These are the same as in vscode and PyCharm.
<img width="1124" height="764" alt="delete" src="https://github.com/user-attachments/assets/e7deda85-0c79-4659-8539-aca47c4d6558" />

---

2. Add additional ways to enter notebook command mode. ([view commit](https://github.com/zed-industries/zed/pull/58179/changes/ef30e63fac633c4c4b3911cbdca37a14b86d3e2b))
I was irritated that I could only enter command mode by first entering a cell and pressing "escape". This adds click handlers to cells to allow users to select cells by clicking on the part of the cells that are not the editable area. Jupyter Lab, vscode and PyCharm behave similarly.  
Note that a markdown cell in preview mode does not have an editable area. The only way to edit a markdown cell in preview mode would be to enter edit mode using the "enter" keybind, which is why this also adds logic to enter edit mode using double-click.

<img width="1124" height="764" alt="command-mode" src="https://github.com/user-attachments/assets/43e1752d-3915-42ac-819c-579dab58a5fe" />

---

3. Start cells as non editable; Display hint on empty markdown cell preview. ([view commit](https://github.com/zed-industries/zed/commit/7866c63123cc256627839bdd5d65964170ddb673))
Fist, this changes markdown cell construction to always construct them with `editing: false`. This has the effect that when first opening a notebook file, markdown cells are rendered in preview mode instead of edit mode. This again mirrors the behaviour of editors like Jupyter Lab, vscode and PyCharm.  
Note that when markdown cells are added to notebooks, their `editing` state is already being updated by the caller, so this behaviour is unchanged.

---

Self-Review Checklist:

- I have tested all of these changes on Linux, I could not find unexpected side effects.
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


~~Closes #ISSUE~~

Release Notes:

- Improved notebook UX: added delete action, minor quality of life changes.