### PR TITLE
Fix grammatical errors throughout the documentation

### DIFF
--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -150,7 +150,7 @@ Copying an image and pasting it is also supported.
 Zed surfaces how many tokens you are consuming for your currently active thread near the profile selector in the panel's message editor.
 
 Once you approach the model's context window, a banner appears above the message editor suggesting to start a new thread with the current one summarized and added as context.
-You can also do this at any time with an ongoing thread via the "Agent Options" menu on the top right, where you'll see a "New from Summary" button, as well as simply @-mentioning a past thread in a new one..
+You can also do this at any time with an ongoing thread via the "Agent Options" menu on the top right, where you'll see a "New from Summary" button, as well as simply @-mentioning a past thread in a new one.
 
 ## Changing Models {#changing-models}
 

--- a/docs/src/ai/billing.md
+++ b/docs/src/ai/billing.md
@@ -48,7 +48,7 @@ Zed Business consolidates your team's costs. Seat licenses and AI usage for all 
 
 ### Billing dashboard {#dashboard}
 
-Owners and admins can access billing information at [dashboard.zed.dev](https://dashboard.zed.dev). The dashboard shows the plan you're currently on and offers jumping off points to update billing details, such as the billing name and address, as well as payment information. You can also access your invoices history, accessible through the Orb billing portal.
+Owners and admins can access billing information at [dashboard.zed.dev](https://dashboard.zed.dev). The dashboard shows the plan you're currently on and offers jumping off points to update billing details, such as the billing name and address, as well as payment information. You can also access your invoice history, accessible through the Orb billing portal.
 
 ### AI usage {#ai-usage}
 

--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -111,7 +111,7 @@ After that, `alt-tab` remains available for accepting edit predictions, and on L
 
 To move both default accept bindings to something else, unbind them and add your replacement:
 
-Open the keymap editor with {#action zed::OpenKeymap} ({#kb zed::OpenKeymap}), search for `AcceptEditPrediction`, right click on the binding for `tab` and delete it. Then right click on the binding for `alt-tab`, select "Edit", and record your desired keystrokes before hitting saving.
+Open the keymap editor with {#action zed::OpenKeymap} ({#kb zed::OpenKeymap}), search for `AcceptEditPrediction`, right click on the binding for `tab` and delete it. Then right click on the binding for `alt-tab`, select "Edit", and record your desired keystrokes before saving.
 
 Alternatively, you can put the following in your `keymap.json`:
 

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -237,7 +237,7 @@ It's also possible to customize environment variables for registry-installed age
 
 ## Debugging Agents
 
-When using external agents in Zed, you can access the debug view via with {#action dev::OpenAcpLogs} from the Command Palette.
+When using external agents in Zed, you can access the debug view via {#action dev::OpenAcpLogs} from the Command Palette.
 This lets you see the messages being sent and received between Zed and the agent.
 
 ![The debug view for ACP logs.](https://zed.dev/img/acp/acp-logs.webp)

--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -515,7 +515,7 @@ One such service is [Ollama Turbo](https://ollama.com/turbo). To configure Zed t
 4. Paste your API key and press enter.
 5. For the API URL enter `https://ollama.com`
 
-Zed will also use the `OLLAMA_API_KEY` environment variables if defined.
+Zed will also use the `OLLAMA_API_KEY` environment variable if defined.
 
 ### OpenAI {#openai}
 

--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -81,7 +81,7 @@ For example, the GitHub MCP extension requires you to add a [Personal Access Tok
 In the case of custom servers, make sure you check the provider documentation to determine what type of command, arguments, and environment variables need to be added to the JSON.
 
 To check if your MCP server is properly configured, go to the Agent Panel's settings view and watch the indicator dot next to its name.
-If they're running correctly, the indicator will be green and its tooltip will say "Server is active".
+If it's running correctly, the indicator will be green and its tooltip will say "Server is active".
 If not, other colors and tooltip messages will indicate what is happening.
 
 ### Agent Panel Usage
@@ -162,7 +162,7 @@ For details on what configuration is shared between Zed and external agents, see
 
 ### Error Handling
 
-When a MCP server encounters an error while processing a tool call, the agent receives the error message directly and the operation fails.
+When an MCP server encounters an error while processing a tool call, the agent receives the error message directly and the operation fails.
 Common error scenarios include:
 
 - Invalid parameters passed to the tool

--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -249,7 +249,7 @@ Most of the servers would rely on this way of configuring only.
 }
 ```
 
-Apart of the LSP-related server configuration options, certain servers in Zed allow configuring the way binary is launched by Zed.
+Apart from the LSP-related server configuration options, certain servers in Zed allow configuring the way binary is launched by Zed.
 
 Language servers are automatically downloaded or launched if found in your path, if you wish to specify an explicit alternate binary you can specify that in settings:
 

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -80,7 +80,7 @@ Which one you choose depends on what you are trying to achieve.
 When launching a new instance, Zed (and the underlying debug adapter) can often do a better job at picking up the debug information compared to attaching to an existing process, since it controls the lifetime of a whole program.
 Running unit tests or a debug build of your application is a good use case for launching.
 
-Compared to launching, attaching to an existing process might seem inferior, but that's far from truth; there are cases where you cannot afford to restart your program, because for example, the bug is not reproducible outside of a production environment or some other circumstances.
+Compared to launching, attaching to an existing process might seem inferior, but that's far from the truth; there are cases where you cannot afford to restart your program, because for example, the bug is not reproducible outside of a production environment or some other circumstances.
 
 ## Configuration
 

--- a/docs/src/extensions/languages.md
+++ b/docs/src/extensions/languages.md
@@ -528,7 +528,7 @@ Each rule in the `semantic_token_rules` array is defined as follows:
 - `foreground_color`: The foreground color to use for the token type, in hex format (e.g., `"#ff0000"`).
 - `background_color`: The background color to use for the token type, in hex format (e.g., `"#ff0000"`).
 - `underline`: A boolean or color to underline with, in hex format. If `true`, then the token will be underlined with the text color.
-- `strikethrough`: A boolean or color to strikethrough with, in hex format. If `true`, then the token have a strikethrough with the text color.
+- `strikethrough`: A boolean or color to strikethrough with, in hex format. If `true`, then the token will have a strikethrough with the text color.
 - `font_weight`: One of `"normal"`, `"bold"`.
 - `font_style`: One of `"normal"`, `"italic"`.
 

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -336,7 +336,7 @@ You can configure multiple custom providers if you work with several self-hosted
 Zed also has a Copy Permalink feature to create a permanent link to a code snippet on your Git hosting service.
 These links are useful for sharing a specific line or range of lines in a file at a specific commit.
 Trigger this action via the [Command Palette](./getting-started.md#command-palette) (search for `permalink`),
-by creating a [custom key bindings](key-bindings.md#custom-key-bindings) to the
+by creating [custom key bindings](key-bindings.md#custom-key-bindings) for the
 `editor::CopyPermalinkToLine` or `editor::OpenPermalinkToLine` actions
 or by simply right clicking and selecting `Copy Permalink` with line(s) selected in your editor.
 

--- a/docs/src/globs.md
+++ b/docs/src/globs.md
@@ -14,9 +14,9 @@ Zed uses two different rust crates for matching glob patterns:
 - [ignore crate](https://docs.rs/ignore/latest/ignore/) for matching glob patterns stored in `.gitignore` files
 - [glob crate](https://docs.rs/glob/latest/glob/) for matching file paths in Zed
 
-While simple expressions are portable across environments (e.g. running `ls *.py` or `*.tmp` in a gitignore) there is significant divergence in the support for and syntax of more advanced features varies (character classes, exclusions, `**`, etc) across implementations. For the rest of this document we will be describing globs as supported in Zed via the `glob` crate implementation. Please see [References](#references) below for documentation links for glob pattern syntax for `.gitignore`, shells and other programming languages.
+While simple expressions are portable across environments (e.g. running `ls *.py` or `*.tmp` in a gitignore) there is significant divergence in the support for and syntax of more advanced features (character classes, exclusions, `**`, etc) across implementations. For the rest of this document we will be describing globs as supported in Zed via the `glob` crate implementation. Please see [References](#references) below for documentation links for glob pattern syntax for `.gitignore`, shells and other programming languages.
 
-The `glob` crate is implemented entirely in rust and does not rely on the `glob` / `fnmatch` interfaces provided by your platforms libc. This means that globs in Zed should behave similarly with across platforms.
+The `glob` crate is implemented entirely in rust and does not rely on the `glob` / `fnmatch` interfaces provided by your platform's libc. This means that globs in Zed should behave similarly across platforms.
 
 ## Introduction
 
@@ -71,7 +71,7 @@ If instead you wanted to restrict yourself only to [Zed Language-Specific Docume
 
 When using the "Include" / "Exclude" filters on a Project Search each glob is wrapped in implicit wildcards. For example to exclude any files with license in the path or filename from your search just type `license` in the exclude box. Behind the scenes Zed transforms `license` to `**license**`. This means that files named `license.*`, `*.license` or inside a `license` subdirectory will all be filtered out. This enables users to easily filter for `*.ts` without having to remember to type `**/*.ts` every time.
 
-Alternatively, if in your Zed settings you wanted a [`file_types`](./reference/all-settings.md#file-types) override which only applied to a certain directory you must explicitly include the wildcard globs. For example, if you had a directory of template files with the `html` extension that you wanted to recognize as Jinja2 template you could use the following:
+Alternatively, if in your Zed settings you wanted a [`file_types`](./reference/all-settings.md#file-types) override which only applied to a certain directory you must explicitly include the wildcard globs. For example, if you had a directory of template files with the `html` extension that you wanted to recognize as a Jinja2 template you could use the following:
 
 ```json [settings]
 {

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -67,7 +67,7 @@ If this script is insufficient for your use case, you run into problems running 
 
 ### macOS
 
-Zed supports the follow macOS releases:
+Zed supports the following macOS releases:
 
 | Version       | Codename | Apple Status   | Zed Status          |
 | ------------- | -------- | -------------- | ------------------- |

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -28,7 +28,7 @@ For more information, see the documentation for [Vim mode](./vim.md) and [Helix 
 
 ## Keymap Editor
 
-You can access the keymap editor through the {#kb zed::OpenKeymap} action or by running {#action zed::OpenKeymap} action from the command palette. You can easily add or change a keybind for an action with the `Change Keybinding` or `Add Keybinding` button on the command pallets left bottom corner.
+You can access the keymap editor through the {#kb zed::OpenKeymap} action or by running {#action zed::OpenKeymap} action from the command palette. You can easily add or change a keybind for an action with the `Change Keybinding` or `Add Keybinding` button on the command palette's left bottom corner.
 
 In there, you can see all of the existing actions in Zed as well as the associated keybindings set to them by default.
 

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -6,7 +6,7 @@ description: "Overview of programming language support in Zed, including built-i
 # Language Support in Zed
 
 Zed supports hundreds of programming languages and text formats.
-Some work out-of-the box and others rely on 3rd party extensions.
+Some work out-of-the-box and others rely on 3rd party extensions.
 
 > The ones included out-of-the-box, natively built into Zed, are marked with \*.
 

--- a/docs/src/languages/cpp.md
+++ b/docs/src/languages/cpp.md
@@ -80,7 +80,7 @@ You can pass any number of arguments to clangd. To see a full set of available o
 
 ## Formatting
 
-By default Zed will use the `clangd` language server for formatting C++ code. The Clangd is the same as the `clang-format` CLI tool. To configure this you can add a `.clang-format` file. For example:
+By default Zed will use the `clangd` language server for formatting C++ code. Its formatter is the same as the `clang-format` CLI tool. To configure this you can add a `.clang-format` file. For example:
 
 ```yaml
 # yaml-language-server: $schema=https://json.schemastore.org/clang-format-21.x.json

--- a/docs/src/languages/lua.md
+++ b/docs/src/languages/lua.md
@@ -27,7 +27,7 @@ See [LuaLS Settings Documentation](https://luals.github.io/wiki/settings/) for a
 
 ### LuaCATS Definitions
 
-LuaLS can provide enhanced LSP autocompletion suggestions and type validation with the help of LuaCATS (Lua Comment and Type System) definitions. These definitions are available for many common Lua libraries, and local paths containing them can be specified via `workspace.library` in `luarc.json`. You can do this via relative paths if you checkout your definitions into the same partent directory of your project (`../playdate-luacats`, `../love2d`, etc). Alternatively you can create submodule(s) inside your project for each LuaCATS definition repo.
+LuaLS can provide enhanced LSP autocompletion suggestions and type validation with the help of LuaCATS (Lua Comment and Type System) definitions. These definitions are available for many common Lua libraries, and local paths containing them can be specified via `workspace.library` in `luarc.json`. You can do this via relative paths if you checkout your definitions into the same parent directory of your project (`../playdate-luacats`, `../love2d`, etc). Alternatively you can create submodule(s) inside your project for each LuaCATS definition repo.
 
 ### LÖVE (Love2D) {#love2d}
 

--- a/docs/src/languages/ocaml.md
+++ b/docs/src/languages/ocaml.md
@@ -12,13 +12,13 @@ OCaml support is available through the [OCaml extension](https://github.com/zed-
 
 ## Setup Instructions
 
-If you have the development environment already setup, you can skip to [Launching Zed](#launching-zed)
+If you have the development environment already set up, you can skip to [Launching Zed](#launching-zed)
 
 ### Using Opam
 
 Opam is the official package manager for OCaml and is highly recommended for getting started with OCaml. To get started using Opam, please follow the instructions provided [here](https://ocaml.org/install).
 
-Once you install opam and setup a switch with your development environment as per the instructions, you can proceed.
+Once you install opam and set up a switch with your development environment as per the instructions, you can proceed.
 
 ### Launching Zed
 

--- a/docs/src/languages/php.md
+++ b/docs/src/languages/php.md
@@ -157,7 +157,7 @@ These are common troubleshooting tips, in case you run into issues:
 - Ensure that you have Xdebug installed for the version of PHP you're running.
 - Ensure that Xdebug is configured to run in `debug` mode.
 - Ensure that Xdebug is actually starting a debugging session.
-- Ensure that the host and port matches between Xdebug and Zed.
+- Ensure that the host and port match between Xdebug and Zed.
 - Look at the diagnostics log by using the `xdebug_info()` function in the page you're trying to debug.
 
 ## Using the Tailwind CSS Language Server with PHP

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -106,7 +106,7 @@ See: [Working with Language Servers](https://zed.dev/docs/configuring-languages#
 
 [basedpyright](https://docs.basedpyright.com/latest/) is the primary Python language server in Zed beginning with Zed v0.204.0. It provides core language server functionality like navigation (go to definition/find all references) and type checking. Compared to Pyright, it adds support for additional language server features (like inlay hints) and checking rules.
 
-Note that while basedpyright in isolation defaults to the `recommended` [type-checking mode](https://docs.basedpyright.com/latest/benefits-over-pyright/better-defaults/#typecheckingmode), Zed configures it to use the less-strict `standard` mode by default, which matches the behavior of Pyright. You can set the type-checking mode for your project using the `typeCheckingMode` setting in `pyrightconfig.json` or `pyproject.toml`, which will override Zed's default. Read on more for more details about how to configure basedpyright.
+Note that while basedpyright in isolation defaults to the `recommended` [type-checking mode](https://docs.basedpyright.com/latest/benefits-over-pyright/better-defaults/#typecheckingmode), Zed configures it to use the less-strict `standard` mode by default, which matches the behavior of Pyright. You can set the type-checking mode for your project using the `typeCheckingMode` setting in `pyrightconfig.json` or `pyproject.toml`, which will override Zed's default. Read on for more details about how to configure basedpyright.
 
 #### Basedpyright Configuration
 

--- a/docs/src/languages/r.md
+++ b/docs/src/languages/r.md
@@ -142,7 +142,7 @@ TBD: R REPL Docs
 ### Ark Installation
 
 To use the Zed REPL with R you need to install [Ark](https://github.com/posit-dev/ark), an R Kernel for Jupyter applications.
-You can down the latest version from the [Ark GitHub Releases](https://github.com/posit-dev/ark/releases) and then extract the `ark` binary to a directory in your `PATH`.
+You can download the latest version from the [Ark GitHub Releases](https://github.com/posit-dev/ark/releases) and then extract the `ark` binary to a directory in your `PATH`.
 
 For example to install the latest non-debug build:
 

--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -30,7 +30,7 @@ They both have an overlapping feature set of autocomplete, diagnostics, code act
 
 In addition to these two language servers, Zed also supports:
 
-- [rubocop](https://github.com/rubocop/rubocop) which is a static code analyzer and linter for Ruby. Under the hood, it's also used by Zed as a language server, but its functionality is complimentary to that of solargraph and ruby-lsp.
+- [rubocop](https://github.com/rubocop/rubocop) which is a static code analyzer and linter for Ruby. Under the hood, it's also used by Zed as a language server, but its functionality is complementary to that of solargraph and ruby-lsp.
 - [sorbet](https://sorbet.org/) which is a static type checker for Ruby with a custom gradual type system.
 - [steep](https://github.com/soutaro/steep) which is a static type checker for Ruby that uses Ruby Signature (RBS).
 - [Herb](https://herb-tools.dev) which is a language server for ERB files.

--- a/docs/src/languages/scala.md
+++ b/docs/src/languages/scala.md
@@ -27,7 +27,7 @@ Behavior of the Metals language server can be controlled with:
 - `.scalafix.conf` file - See [Scalafix Configuration](https://scalacenter.github.io/scalafix/docs/users/configuration.html)
 - `.scalafmt.conf` file - See [Scalafmt Configuration](https://scalameta.org/scalafmt/docs/configuration.html)
 
-You can place these files in the root of your project or specifying their location in the Metals configuration. See [Metals User Configuration](https://scalameta.org/metals/docs/editors/user-configuration) for more.
+You can place these files in the root of your project or specify their location in the Metals configuration. See [Metals User Configuration](https://scalameta.org/metals/docs/editors/user-configuration) for more.
 
 <!--
 TBD: Provide LSP configuration example for metals in Zed settings.json. metals.{javaHome,excludedPackages,customProjectRoot} etc.

--- a/docs/src/languages/sml.md
+++ b/docs/src/languages/sml.md
@@ -25,4 +25,4 @@ version = 1
 root = "sources.mlb"
 ```
 
-The root must be either a [ML Basis (MLB)](http://mlton.org/MLBasis) file (`.mlb`, used with MLton) or a [SML/NJ Compilation Manager (CM)](https://www.smlnj.org/doc/CM/new.pdf) file (`.cm`, used with SML/NJ). Files not transitively reachable from the root are not analyzed. See the [Millet manual](https://github.com/azdavis/millet/blob/main/docs/manual.md) for more options.
+The root must be either an [ML Basis (MLB)](http://mlton.org/MLBasis) file (`.mlb`, used with MLton) or an [SML/NJ Compilation Manager (CM)](https://www.smlnj.org/doc/CM/new.pdf) file (`.cm`, used with SML/NJ). Files not transitively reachable from the root are not analyzed. See the [Millet manual](https://github.com/azdavis/millet/blob/main/docs/manual.md) for more options.

--- a/docs/src/languages/svelte.md
+++ b/docs/src/languages/svelte.md
@@ -29,7 +29,7 @@ You can modify how certain styles, such as directives and modifiers, appear in a
 
 ## Inlay Hints
 
-When inlay hints is enabled in Zed, to make the language server send them back, Zed sets the following initialization options:
+When inlay hints are enabled in Zed, to make the language server send them back, Zed sets the following initialization options:
 
 ```json
 "inlayHints": {

--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -147,7 +147,7 @@ If you see an error like "/lib64/libc.so.6: version 'GLIBC_2.29' not found" it m
 
 Zed requires a GPU to run effectively. Under the hood, we use [Vulkan](https://www.vulkan.org/) to communicate with your GPU. If you are seeing problems with performance, or Zed fails to load, it is possible that Vulkan is the culprit.
 
-If you see a notification saying `Zed failed to open a window: NoSupportedDeviceFound` this means that Vulkan cannot find a compatible GPU. you can try running [vkcube](https://github.com/krh/vkcube) (usually available as part of the `vulkaninfo` or `vulkan-tools` package on various distributions) to try to troubleshoot where the issue is coming from like so:
+If you see a notification saying `Zed failed to open a window: NoSupportedDeviceFound` this means that Vulkan cannot find a compatible GPU. You can try running [vkcube](https://github.com/krh/vkcube) (usually available as part of the `vulkaninfo` or `vulkan-tools` package on various distributions) to try to troubleshoot where the issue is coming from like so:
 
 ```
 vkcube
@@ -163,7 +163,7 @@ If you see errors like `ERROR_INITIALIZATION_FAILED` or `GPU Crashed` or `ERROR_
 
 On some systems the file `/etc/prime-discrete` can be used to enforce the use of a discrete GPU using [PRIME](https://wiki.archlinux.org/title/PRIME). Depending on the details of your setup, you may need to change the contents of this file to "on" (to force discrete graphics) or "off" (to force integrated graphics).
 
-On others, you may be able to the environment variable `DRI_PRIME=1` when running Zed to force the use of the discrete GPU.
+On others, you may be able to set the environment variable `DRI_PRIME=1` when running Zed to force the use of the discrete GPU.
 
 If you're using an AMD GPU, you might get a 'Broken Pipe' error. Try using the RADV or Mesa drivers. (See [#13880](https://github.com/zed-industries/zed/issues/13880))
 
@@ -262,7 +262,7 @@ Some window managers, such as `Hyprland`, don't provide a file picker by default
 
 ### Zed isn't remembering my login
 
-These feature also requires XDG desktop portals, specifically:
+This feature also requires XDG desktop portals, specifically:
 
 - `org.freedesktop.portal.Secret` or
 - `org.freedesktop.Secrets`

--- a/docs/src/multibuffers.md
+++ b/docs/src/multibuffers.md
@@ -20,7 +20,7 @@ One of the superpowers Zed gives you is the ability to edit multiple files simul
 
 Editing a multibuffer is the same as editing a normal file. Changes you make will be reflected in the open copies of that file in the rest of the editor, and you can save all files with {#action workspace::Save} (bound to `cmd-s` on macOS, `ctrl-s` on Windows/Linux, or `:w` in Vim mode).
 
-When in a multibuffer, it is often useful to use multiple cursors to edit every file simultaneously. If you want to edit a few instances, you can select them with the mouse (`option-click` on macOS, `alt-click` on Window/Linux) or the keyboard. `cmd-d` on macOS, `ctrl-d` on Windows/Linux, or `gl` in Vim mode will select the next match of the word under the cursor.
+When in a multibuffer, it is often useful to use multiple cursors to edit every file simultaneously. If you want to edit a few instances, you can select them with the mouse (`option-click` on macOS, `alt-click` on Windows/Linux) or the keyboard. `cmd-d` on macOS, `ctrl-d` on Windows/Linux, or `gl` in Vim mode will select the next match of the word under the cursor.
 
 When you want to edit all matches you can select them by running the {#action editor::SelectAllMatches} command (`cmd-shift-l` on macOS, `ctrl-shift-l` on Windows/Linux, or `g a` in Vim mode).
 
@@ -40,6 +40,6 @@ If you have a language server installed, the diagnostics pane can show you all e
 
 ## Find References
 
-If you have a language server installed, you can find all references to the symbol under the cursor with the {#action editor::FindAllReferences} command (`cmd-click` on macOS, `ctrl-click` on Windows/Linux, or `g A` in Vim mode.
+If you have a language server installed, you can find all references to the symbol under the cursor with the {#action editor::FindAllReferences} command (`cmd-click` on macOS, `ctrl-click` on Windows/Linux, or `g A` in Vim mode).
 
 Depending on your language server, commands like {#action editor::GoToDefinition} and {#action editor::GoToTypeDefinition} will also open a multibuffer if there are multiple possible definitions.

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -13,7 +13,7 @@ the browser (specifically a local instance of [firefox_profiler](https://profile
 
 See [samply](https://github.com/mstange/samply)'s README on how to install and run.
 
-The profile.json does not contain any symbols. Firefox profiler can add the local symbols to the profile for for. To do that hit the upload local profile button in the top right corner.
+The profile.json does not contain any symbols. Firefox profiler can add the local symbols to the profile. To do that hit the upload local profile button in the top right corner.
 
 <img width="851" height="auto" alt="image" src="https://github.com/user-attachments/assets/cbef2b51-0442-4ee9-bc5c-95f6ccf9be2c" style="display: block; margin: 0 auto;" />
 

--- a/docs/src/project-panel.md
+++ b/docs/src/project-panel.md
@@ -1,6 +1,6 @@
 ---
 title: Project Panel - Zed
-description: Navigate workspace files and directories with Zed's project panel. Create, rename, trash and delete file and directories.
+description: Navigate workspace files and directories with Zed's project panel. Create, rename, trash and delete files and directories.
 ---
 
 # Project Panel

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -558,7 +558,7 @@ See [Git documentation](../git.md#diff-view-styles) for more details.
 ## Direnv Integration
 
 - Description: Settings for [direnv](https://direnv.net/) integration. Requires `direnv` to be installed.
-  `direnv` integration make it possible to use the environment variables set by a `direnv` configuration to detect some language servers in `$PATH` instead of installing them.
+  `direnv` integration makes it possible to use the environment variables set by a `direnv` configuration to detect some language servers in `$PATH` instead of installing them.
   It also allows for those environment variables to be used in tasks.
 - Setting: `load_direnv`
 - Default: `"direct"`
@@ -771,7 +771,7 @@ List of `string` values
 }
 ```
 
-4. An box drawn around the following character:
+4. A box drawn around the following character:
 
 ```json [settings]
 {
@@ -1936,7 +1936,7 @@ While other options may be changed at a runtime and should be placed under `sett
 }
 ```
 
-3. External formatters may optionally include a `{buffer_path}` placeholder which at runtime will include the path of the buffer being formatted. Formatters operate by receiving file content via standard input, reformatting it and then outputting it to standard output and so normally don't know the filename of what they are formatting. Tools like Prettier support receiving the file path via a command line argument which can then used to impact formatting decisions.
+3. External formatters may optionally include a `{buffer_path}` placeholder which at runtime will include the path of the buffer being formatted. Formatters operate by receiving file content via standard input, reformatting it and then outputting it to standard output and so normally don't know the filename of what they are formatting. Tools like Prettier support receiving the file path via a command line argument which can then be used to impact formatting decisions.
 
 WARNING: `{buffer_path}` should not be used to direct your formatter to read from a filename. Your formatter should only read from standard input and should not read or write files directly.
 
@@ -2753,7 +2753,7 @@ Run the {#action icon_theme_selector::Toggle} action in the command palette to s
 **Options**
 
 Inlay hints querying consists of two parts: editor (client) and LSP server.
-With the inlay settings above are changed to enable the hints, editor will start to query certain types of hints and react on LSP hint refresh request from the server.
+When the inlay settings above are changed to enable the hints, the editor will start to query certain types of hints and react on LSP hint refresh request from the server.
 At this point, the server may or may not return hints depending on its implementation, further configuration might be needed, refer to the corresponding LSP server documentation.
 
 The following languages have inlay hints preconfigured by Zed:
@@ -2865,7 +2865,7 @@ Unspecified values have a `false` value, hints won't be toggled if all the modif
 
 **Options**
 
-To override settings for a language, add an entry for that languages name to the `languages` value. Example:
+To override settings for a language, add an entry for that language's name to the `languages` value. Example:
 
 ```json [settings]
 {
@@ -3026,7 +3026,7 @@ Positive `integer` values or `null` for unlimited tabs
 
 ## Multi Cursor Modifier
 
-- Description: Determines the modifier to be used to add multiple cursors with the mouse. The open hover link mouse gestures will adapt such that it do not conflict with the multicursor modifier.
+- Description: Determines the modifier to be used to add multiple cursors with the mouse. The open hover link mouse gestures will adapt such that it does not conflict with the multicursor modifier.
 - Setting: `multi_cursor_modifier`
 - Default: `alt`
 
@@ -3040,7 +3040,7 @@ Positive `integer` values or `null` for unlimited tabs
 }
 ```
 
-2. Maps `Control` on Linux and Windows and to `Command` on macOS:
+2. Maps to `Control` on Linux and Windows and to `Command` on macOS:
 
 ```json [settings]
 {
@@ -3656,7 +3656,7 @@ Non-negative `integer` values
 
 ## Search Wrap
 
-- Description: If `search_wrap` is disabled, search result do not wrap around the end of the file
+- Description: If `search_wrap` is disabled, search results do not wrap around the end of the file
 - Setting: `search_wrap`
 - Default: `true`
 
@@ -4060,7 +4060,7 @@ List of `integer` column numbers
 
 ### Metrics
 
-- Description: Setting for sending anonymized usage data, such what languages you're using Zed with.
+- Description: Setting for sending anonymized usage data, such as what languages you're using Zed with.
 - Setting: `metrics`
 - Default: `true`
 
@@ -4481,7 +4481,7 @@ See Buffer Font Features
 
 ## Terminal: Detect Virtual Environments {#terminal-detect_venv}
 
-- Description: Activate the [Python Virtual Environment](https://docs.python.org/3/library/venv.html), if one is found, in the terminal's working directory (as resolved by the working_directory and automatically activating the virtual environment.
+- Description: Activate the [Python Virtual Environment](https://docs.python.org/3/library/venv.html), if one is found, in the terminal's working directory (as resolved by the `working_directory` setting), automatically activating the virtual environment.
 - Setting: `detect_venv`
 - Default:
 

--- a/docs/src/remote-development.md
+++ b/docs/src/remote-development.md
@@ -16,7 +16,7 @@ Remote development requires two computers, your local machine that runs the Zed 
 
 ![Architectural overview of Zed Remote Development](https://zed.dev/img/remote-development/diagram.png)
 
-On your local machine, Zed runs its UI, talks to language models, uses Tree-sitter to parse and syntax-highlight code, and store unsaved changes and recent projects. The source code, language servers, tasks, and the terminal all run on the remote server. [AI features](./ai/overview.md) work in remote sessions, including the Agent Panel and Inline Assistant.
+On your local machine, Zed runs its UI, talks to language models, uses Tree-sitter to parse and syntax-highlight code, and stores unsaved changes and recent projects. The source code, language servers, tasks, and the terminal all run on the remote server. [AI features](./ai/overview.md) work in remote sessions, including the Agent Panel and Inline Assistant.
 
 > **Note:** The original version of remote development sent traffic via Zed's servers. As of Zed v0.157 you can no-longer use that mode.
 

--- a/docs/src/repl.md
+++ b/docs/src/repl.md
@@ -217,4 +217,4 @@ Available kernels:
   rust                  /Users/z/Library/Jupyter/kernels/rust
 ```
 
-> Note: Zed makes best effort usage of `sys.prefix` and `CONDA_PREFIX` to find kernels in Python environments. If you want explicitly control run `python -m ipykernel install --user --name myenv --display-name "Python (myenv)"` to install the kernel directly while in the environment.
+> Note: Zed makes best effort usage of `sys.prefix` and `CONDA_PREFIX` to find kernels in Python environments. If you want to explicitly control run `python -m ipykernel install --user --name myenv --display-name "Python (myenv)"` to install the kernel directly while in the environment.

--- a/docs/src/snippets.md
+++ b/docs/src/snippets.md
@@ -7,7 +7,7 @@ description: Create and use code snippets in Zed with tab stops, placeholders, v
 
 Use the {#action snippets::ConfigureSnippets} action to create a new snippets file or edit an existing snippets file for a specified [scope](#scopes).
 
-The snippets are located in `~/.config/zed/snippets` directory to which you can navigate to with the {#action snippets::OpenFolder} action.
+The snippets are located in `~/.config/zed/snippets` directory to which you can navigate with the {#action snippets::OpenFolder} action.
 
 ## Example configuration
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -76,7 +76,7 @@ If you would like to use distinct themes for light mode/dark mode that can be se
 
 ### Font ligatures
 
-By default Zed enable font ligatures which will visually combines certain adjacent characters.
+By default Zed enables font ligatures which will visually combine certain adjacent characters.
 
 For example `=>` will be displayed as `→` and `!=` will be `≠`.
 This is purely cosmetic and the individual characters remain unchanged.


### PR DESCRIPTION
Fixes a batch of grammatical mistakes found across the `docs/` folder: typos/misspellings, subject-verb agreement errors, missing and duplicated words, article errors (`a`/`an`), wrong word forms, and punctuation issues (doubled periods, unclosed parentheses).

Scope is limited to prose in `docs/src/**`; no behavior, settings, or code changes. 33 files updated, 49 lines changed.

Representative fixes:

- `globs.md`: "features varies" -> "features"; "platforms libc" -> "platform's libc".
- `installation.md`: "the follow macOS releases" -> "the following macOS releases".
- `key-bindings.md`: "command pallets" -> "command palette's".
- `linux.md`: capitalization after a period; "able to the environment variable" -> "able to set the environment variable"; "These feature also requires" -> "This feature also requires".
- `multibuffers.md`: "Window/Linux" -> "Windows/Linux"; added a missing closing parenthesis.
- `reference/all-settings.md`: several agreement/article/missing-word fixes plus an unclosed parenthesis.
- `languages/*`: "partent" -> "parent", "complimentary" -> "complementary", "setup" -> "set up", "is enabled" -> "are enabled", and similar.

Release Notes:

- N/A
