### PR TITLE
python: Fix Python type annotation highlighting

### DIFF
--- a/crates/grammars/src/python/highlights.scm
+++ b/crates/grammars/src/python/highlights.scm
@@ -4,6 +4,18 @@
 (attribute
   attribute: (identifier) @property)
 
+; Type
+[(type [
+    (identifier) @type
+    (_ [(identifier) (none)]? @type
+      (_ [(identifier) (none)]? @type
+        (_ [(identifier) (none)]? @type
+          (_ [(identifier) (none)]? @type))))
+  ])
+  (generic_type
+    (identifier) @type)
+]
+
 ; CamelCase for classes
 ((identifier) @type.class
   (#match? @type.class "^_*[A-Z][A-Za-z0-9_]*$"))
@@ -11,12 +23,6 @@
 ; ALL_CAPS for constants:
 ((identifier) @constant
   (#match? @constant "^_*[A-Z][A-Z0-9_]*$"))
-
-(type
-  (identifier) @type)
-
-(generic_type
-  (identifier) @type)
 
 (comment) @comment
 
@@ -329,18 +335,7 @@
   (#any-of? @attribute.builtin "classmethod" "staticmethod" "property"))
 
 ; Builtin types as identifiers
-[
-  (call
-    function: (identifier) @type.builtin)
-  (type
-    (identifier) @type.builtin)
-  (generic_type
-    (identifier) @type.builtin)
-  ; also check if type binary operator left identifier for union types
-  (type
-    (binary_operator
-      left: (identifier) @type.builtin))
+((identifier) @type.builtin
   (#any-of? @type.builtin
     "bool" "bytearray" "bytes" "complex" "dict" "float" "frozenset" "int" "list" "memoryview"
-    "object" "range" "set" "slice" "str" "tuple")
-]
+    "object" "range" "set" "slice" "str" "tuple"))


### PR DESCRIPTION
In the current Python Tree-sitter `highlights.scm`, union type annotations using `|` or `Union` are not properly highlighted.

This PR improves type annotation highlighting by:
- Moving the base `@type` capture earlier in the evaluation order to ensure more specific highlights (e.g., `@type.class`) are applied afterward without being overridden.
- Handling nested type annotations up to a fixed depth (4 levels), which covers complex cases such as i.e., `list[dict[str, list[int]]]`
- Broadening the built-in type matching rules to ensure all Python built-in types are correctly captured within type annotations.

|                                                               Before                                                                |                                                               After                                                                |
| :---------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------: |
| <img width="483" height="958" alt="image" src="https://github.com/user-attachments/assets/e4aa7434-e826-46c8-9673-1be5f476af66" /> | <img width="527" height="1022" alt="image" src="https://github.com/user-attachments/assets/0b47d214-5aa3-4461-aa76-70a56341b6cd" /> |

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed Python type annotation highlighting