### PR TITLE
git_ui: Add setting for custom commit message instructions

### DIFF
--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -580,6 +580,7 @@ mod tests {
             inline_assistant_model: None,
             inline_assistant_use_streaming_tools: false,
             commit_message_model: None,
+            commit_message_instructions: None,
             thread_summary_model: None,
             inline_alternatives: vec![],
             favorite_models: vec![],

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -150,6 +150,7 @@ pub struct AgentSettings {
     pub inline_assistant_model: Option<LanguageModelSelection>,
     pub inline_assistant_use_streaming_tools: bool,
     pub commit_message_model: Option<LanguageModelSelection>,
+    pub commit_message_instructions: Option<String>,
     pub thread_summary_model: Option<LanguageModelSelection>,
     pub inline_alternatives: Vec<LanguageModelSelection>,
     pub favorite_models: Vec<LanguageModelSelection>,
@@ -649,6 +650,7 @@ impl Settings for AgentSettings {
                 .inline_assistant_use_streaming_tools
                 .unwrap_or(true),
             commit_message_model: agent.commit_message_model,
+            commit_message_instructions: agent.commit_message_instructions,
             thread_summary_model: agent.thread_summary_model,
             inline_alternatives: agent.inline_alternatives.unwrap_or_default(),
             favorite_models: agent.favorite_models,

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -860,6 +860,7 @@ mod tests {
             inline_assistant_model: None,
             inline_assistant_use_streaming_tools: false,
             commit_message_model: None,
+            commit_message_instructions: None,
             thread_summary_model: None,
             inline_alternatives: vec![],
             favorite_models: vec![],

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2644,6 +2644,7 @@ impl GitPanel {
         prompt: &str,
         user_agents_md: Option<&str>,
         rules_content: Option<&str>,
+        instructions: Option<&str>,
         subject: &str,
         diff_text: &str,
     ) -> String {
@@ -2663,6 +2664,14 @@ impl GitPanel {
             None => String::new(),
         };
 
+        let instructions_section = match instructions {
+            Some(instructions) if !instructions.trim().is_empty() => format!(
+                "\n\nThe user has provided the following instructions for writing commit messages that you should follow:\n\
+                <commit_message_instructions>\n{instructions}\n</commit_message_instructions>\n"
+            ),
+            _ => String::new(),
+        };
+
         let subject_section = if subject.trim().is_empty() {
             String::new()
         } else {
@@ -2670,7 +2679,7 @@ impl GitPanel {
         };
 
         format!(
-            "{prompt}{user_agents_md_section}{rules_section}{subject_section}\nHere are the changes in this commit:\n{diff_text}"
+            "{prompt}{user_agents_md_section}{rules_section}{instructions_section}{subject_section}\nHere are the changes in this commit:\n{diff_text}"
         )
     }
 
@@ -2701,6 +2710,9 @@ impl GitPanel {
         });
 
         let temperature = AgentSettings::temperature_for_model(&model, cx);
+        let instructions = AgentSettings::get_global(cx)
+            .commit_message_instructions
+            .clone();
         let project = self.project.clone();
         let repo_work_dir = repo.read(cx).work_directory_abs_path.clone();
 
@@ -2762,6 +2774,7 @@ impl GitPanel {
                     &prompt,
                     user_agents_md.as_deref(),
                     rules_content.as_deref(),
+                    instructions.as_deref(),
                     &subject,
                     &diff_text,
                 );
@@ -8721,18 +8734,36 @@ mod tests {
             "Write a commit message.",
             Some("Use terse commit messages."),
             Some("Use the git_ui prefix."),
+            Some("Follow the configured commit message format."),
             "Update generated message",
             "diff --git a/file b/file",
         );
 
         assert!(prompt.contains("Use terse commit messages."));
         assert!(prompt.contains("Use the git_ui prefix."));
+        assert!(prompt.contains("Follow the configured commit message format."));
         assert!(prompt.contains("Update generated message"));
         assert!(prompt.contains("diff --git a/file b/file"));
 
         let user_agents_md_index = prompt.find("<rules>").unwrap();
         let project_rules_index = prompt.find("<project_rules>").unwrap();
+        let instructions_index = prompt.find("<commit_message_instructions>").unwrap();
         assert!(user_agents_md_index < project_rules_index);
+        assert!(project_rules_index < instructions_index);
+    }
+
+    #[test]
+    fn test_commit_message_prompt_omits_blank_instructions() {
+        let prompt = GitPanel::build_commit_message_prompt(
+            "Write a commit message.",
+            None,
+            None,
+            Some("   \n  "),
+            "",
+            "diff --git a/file b/file",
+        );
+
+        assert!(!prompt.contains("<commit_message_instructions>"));
     }
 
     #[gpui::test]

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -131,6 +131,9 @@ pub struct AgentSettingsContent {
     pub inline_assistant_use_streaming_tools: Option<bool>,
     /// Model to use for generating git commit messages. Defaults to default_model when not specified.
     pub commit_message_model: Option<LanguageModelSelection>,
+    /// Custom instructions to include in the prompt when generating git commit messages.
+    /// Applied in addition to any project rules files (such as `.rules` or `AGENTS.md`).
+    pub commit_message_instructions: Option<String>,
     /// Model to use for generating thread summaries. Defaults to default_model when not specified.
     pub thread_summary_model: Option<LanguageModelSelection>,
     /// Additional models with which to generate alternatives when performing inline assists.

--- a/docs/src/ai/agent-settings.md
+++ b/docs/src/ai/agent-settings.md
@@ -62,6 +62,20 @@ You can assign distinct and specific models for the following AI-powered feature
 
 > If a custom model isn't set for one of these features, they automatically fall back to using the default model.
 
+### Commit Message Instructions {#commit-message-instructions}
+
+You can provide custom instructions that are included in the prompt whenever a Git commit message is generated. Unlike rules files (such as `.rules` or `AGENTS.md`), these instructions apply only to commit message generation:
+
+```json [settings]
+{
+  "agent": {
+    "commit_message_instructions": "Use the Conventional Commits format: <type>(<scope>): <description>."
+  }
+}
+```
+
+These instructions are sent in addition to any project rules files that are present.
+
 ### Alternative Models for Inline Assists {#alternative-assists}
 
 With the Inline Assistant in particular, you can send the same prompt to multiple models at once.

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -291,7 +291,17 @@ See [Feature-specific models](./ai/agent-settings.md#feature-specific-models) fo
 }
 ```
 
-To add custom commit instructions for the model, use the global `AGENTS.md` file located `~/.config/zed/AGENTS.md` on macOS and Linux, `%APPDATA%\Zed\AGENTS.md` on Windows.
+To add custom instructions that apply only to commit message generation, use the `commit_message_instructions` field in your agent settings:
+
+```json [settings]
+{
+  "agent": {
+    "commit_message_instructions": "Use the Conventional Commits format: <type>(<scope>): <description>."
+  }
+}
+```
+
+These instructions are sent to the model in addition to any project rules files (such as `.rules` or `AGENTS.md`). To add instructions that apply to both commit messages and the agent more broadly, use the global `AGENTS.md` file located `~/.config/zed/AGENTS.md` on macOS and Linux, `%APPDATA%\Zed\AGENTS.md` on Windows.
 
 > Before Zed v1.4.0, this was done through the Rules Library, which has been removed.
 > See [the "Migrating to Skills" docs](./ai/rules.md#migrating-to-skills) in the Rules page for more information.

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -291,6 +291,8 @@ See [Feature-specific models](./ai/agent-settings.md#feature-specific-models) fo
 }
 ```
 
+To add custom commit instructions for the model, use the global `AGENTS.md` file located `~/.config/zed/AGENTS.md` on macOS and Linux, `%APPDATA%\Zed\AGENTS.md` on Windows.
+
 To add custom instructions that apply only to commit message generation, use the `commit_message_instructions` field in your agent settings:
 
 ```json [settings]


### PR DESCRIPTION
There's currently no way to customize AI-generated commit messages on a per-commit basis. You can put instructions in AGENTS.md or a project rules file, but those get fed into every agent interaction, not just commit generation. The built-in "Commit message" prompt used to be editable in the Rules Library, but that was replaced by Skills, which aren't used when generating commit messages.

This PR adds an `agent.commit_message_instructions` setting. Its contents are added to the commit message prompt in their own section, alongside any project rules, so you can ask for a specific format (Conventional Commits, a ticket prefix, etc.) without changing how the agent behaves elsewhere:

```json
{
  "agent": {
    "commit_message_instructions": "Use the Conventional Commits format: <type>(<scope>): <description>."
  }
}
```

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Addresses #26503

Release Notes:

- Added an `agent.commit_message_instructions` setting to customize AI-generated git commit messages.