### PR TITLE
Show linked worktree labels for workspace subfolders

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -544,6 +544,38 @@ impl WorkspaceMenuWorktreeLabel {
     }
 }
 
+fn repository_snapshot_for_root_path<'a>(
+    root_path: &Path,
+    repository_snapshots: &'a [project::git_store::RepositorySnapshot],
+) -> Option<(&'a project::git_store::RepositorySnapshot, &'a Path)> {
+    if let Some(snapshot) = repository_snapshots
+        .iter()
+        .find(|snapshot| snapshot.work_directory_abs_path.as_ref() == root_path)
+    {
+        return Some((snapshot, snapshot.work_directory_abs_path.as_ref()));
+    }
+
+    if let Some((snapshot, worktree_path)) = repository_snapshots
+        .iter()
+        .flat_map(|snapshot| {
+            snapshot
+                .linked_worktrees()
+                .iter()
+                .filter(|linked_worktree| root_path.starts_with(&linked_worktree.path))
+                .map(move |linked_worktree| (snapshot, linked_worktree.path.as_path()))
+        })
+        .max_by_key(|(_, worktree_path)| worktree_path.components().count())
+    {
+        return Some((snapshot, worktree_path));
+    }
+
+    repository_snapshots
+        .iter()
+        .filter(|snapshot| root_path.starts_with(snapshot.work_directory_abs_path.as_ref()))
+        .max_by_key(|snapshot| snapshot.work_directory_abs_path.components().count())
+        .map(|snapshot| (snapshot, snapshot.work_directory_abs_path.as_ref()))
+}
+
 fn workspace_menu_worktree_labels(
     workspace: &Entity<Workspace>,
     cx: &App,
@@ -566,20 +598,31 @@ fn workspace_menu_worktree_labels(
                 .file_name()
                 .map(|name| SharedString::from(name.to_string_lossy().to_string()))
                 .unwrap_or_default();
-            let repository_snapshot = repository_snapshots
-                .iter()
-                .find(|snapshot| snapshot.work_directory_abs_path.as_ref() == root_path);
 
-            if let Some(snapshot) = repository_snapshot {
-                let worktree_name = if snapshot.is_linked_worktree() {
+            if let Some((snapshot, worktree_path)) =
+                repository_snapshot_for_root_path(root_path, &repository_snapshots)
+            {
+                let worktree_name = if snapshot.work_directory_abs_path.as_ref() == worktree_path {
+                    if snapshot.is_linked_worktree() {
+                        snapshot
+                            .main_worktree_abs_path()
+                            .and_then(|main_worktree_path| {
+                                project::linked_worktree_short_name(
+                                    main_worktree_path,
+                                    worktree_path,
+                                )
+                            })
+                            .unwrap_or_else(|| folder_name.clone())
+                    } else {
+                        "main".into()
+                    }
+                } else {
                     snapshot
                         .main_worktree_abs_path()
                         .and_then(|main_worktree_path| {
-                            project::linked_worktree_short_name(main_worktree_path, root_path)
+                            project::linked_worktree_short_name(main_worktree_path, worktree_path)
                         })
                         .unwrap_or_else(|| folder_name.clone())
-                } else {
-                    "main".into()
                 };
 
                 if show_folder_name {

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -2001,6 +2001,56 @@ async fn test_agent_panel_terminal_shows_project_and_linked_worktree(cx: &mut Te
 }
 
 #[gpui::test]
+async fn test_workspace_menu_labels_linked_worktree_subdirectory(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project",
+        serde_json::json!({
+            ".git": {},
+            "example": {},
+        }),
+    )
+    .await;
+    fs.insert_tree("/worktrees/sedge-beacon/example", serde_json::json!({}))
+        .await;
+    fs.add_linked_worktree_for_repo(
+        Path::new("/project/.git"),
+        false,
+        git::repository::Worktree {
+            path: PathBuf::from("/worktrees/sedge-beacon"),
+            ref_name: Some("refs/heads/sedge-beacon".into()),
+            sha: "aaa".into(),
+            is_main: false,
+            is_bare: false,
+        },
+    )
+    .await;
+    cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+
+    let worktree_project =
+        project::Project::test(fs.clone(), ["/worktrees/sedge-beacon/example".as_ref()], cx).await;
+    worktree_project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (_multi_workspace, cx) = cx.add_window_view(|window, cx| {
+        MultiWorkspace::test_new(worktree_project.clone(), window, cx)
+    });
+    let workspace = _multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+    let labels = workspace_menu_worktree_labels(&workspace, cx);
+
+    assert_eq!(labels.len(), 1);
+    assert_eq!(labels[0].primary_name.as_ref(), "example");
+    assert_eq!(
+        labels[0].secondary_name.as_ref().map(|name| name.as_ref()),
+        Some("sedge-beacon")
+    );
+}
+
+#[gpui::test]
 async fn test_terminal_close_event_on_archived_linked_worktree_removes_workspace(
     cx: &mut TestAppContext,
 ) {


### PR DESCRIPTION
Closes #58091

1. Failure mechanism

The workspace switcher currently finds a repository snapshot only when the opened workspace root exactly equals `work_directory_abs_path`.

When the opened root is a subdirectory inside a linked worktree, that exact match misses the repository. The label then falls back to the folder name only, so two opened `example` folders from different linked worktrees both look like `example`.

2. Change

This teaches the workspace switcher to resolve the repository snapshot for a root path that sits under a linked worktree. It matches exact repository roots first, then the longest linked worktree prefix, then the existing repository-root prefix fallback.

For a linked worktree subdirectory, the UI keeps the opened folder as the primary label and uses the linked worktree root to compute the secondary label. That gives labels like `example: sedge-beacon` instead of just `example`.

3. Testing

Added a sidebar regression test that opens `/worktrees/sedge-beacon/example` for a repository whose main checkout contains an `example` folder, then verifies the workspace menu label is:

primary: `example`
secondary: `sedge-beacon`

I also ran:

rustfmt crates/sidebar/src/sidebar.rs crates/sidebar/src/sidebar_tests.rs
git diff --check -- crates/sidebar/src/sidebar.rs crates/sidebar/src/sidebar_tests.rs
