### PR TITLE
markdown_preview: Use editor font size for preview text

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -166,15 +166,19 @@ impl MarkdownStyle {
         let is_preview = matches!(font, MarkdownFont::Preview);
 
         let buffer_font_weight = theme_settings.buffer_font.weight;
-        let (buffer_font_size, ui_font_size) = match font {
+        let (buffer_font_size, body_font_size) = match font {
             MarkdownFont::Agent => (
                 theme_settings.agent_buffer_font_size(cx),
                 theme_settings.agent_ui_font_size(cx),
             ),
-            MarkdownFont::Editor | MarkdownFont::Preview => (
+            MarkdownFont::Editor => (
                 theme_settings.buffer_font_size(cx),
                 theme_settings.ui_font_size(cx),
             ),
+            MarkdownFont::Preview => {
+                let buffer_font_size = theme_settings.buffer_font_size(cx);
+                (buffer_font_size, buffer_font_size)
+            }
         };
 
         let body_font_family = if is_preview {
@@ -197,7 +201,7 @@ impl MarkdownStyle {
             font_family: Some(body_font_family),
             font_fallbacks: theme_settings.ui_font.fallbacks.clone(),
             font_features: Some(theme_settings.ui_font.features.clone()),
-            font_size: Some(ui_font_size.into()),
+            font_size: Some(body_font_size.into()),
             line_height: Some(line_height.into()),
             color: Some(text_color),
             ..Default::default()
@@ -4713,6 +4717,43 @@ mod tests {
             );
             row_top += line_height;
         }
+    }
+
+    #[gpui::test]
+    fn test_preview_body_font_size_tracks_buffer_font_size(cx: &mut TestAppContext) {
+        struct TestWindow;
+        impl Render for TestWindow {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                div()
+            }
+        }
+
+        ensure_theme_initialized(cx);
+        cx.update(|cx| {
+            cx.update_global::<settings::SettingsStore, _>(|settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.theme.buffer_font_size = Some(settings::FontSize(22.0));
+                    settings.theme.ui_font_size = Some(settings::FontSize(11.0));
+                });
+            });
+        });
+
+        let (_, cx) = cx.add_window_view(|_, _| TestWindow);
+        cx.update(|window, cx| {
+            let style = MarkdownStyle::themed(MarkdownFont::Preview, window, cx);
+
+            assert_eq!(
+                style.base_text_style.font_size.to_pixels(window.rem_size()),
+                px(22.0)
+            );
+            assert_eq!(
+                style
+                    .inline_code
+                    .font_size
+                    .map(|font_size| font_size.to_pixels(window.rem_size())),
+                Some(px(22.0))
+            );
+        });
     }
 
     #[gpui::test]

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -20,7 +20,7 @@ use markdown::{
 };
 use project::Project;
 use project::search::SearchQuery;
-use settings::{SeedQuerySetting, Settings};
+use settings::{SeedQuerySetting, Settings, SettingsStore};
 use theme::{SystemAppearance, Theme, ThemeRegistry};
 use theme_settings::ThemeSettings;
 use ui::{ContextMenu, WithScrollbar, prelude::*, right_click_menu};
@@ -45,6 +45,7 @@ pub struct MarkdownPreviewView {
     focus_handle: FocusHandle,
     markdown: Entity<Markdown>,
     _markdown_subscription: Subscription,
+    _settings_subscription: Subscription,
     active_source_index: Option<usize>,
     scroll_handle: ScrollHandle,
     image_cache: Entity<RetainAllImageCache>,
@@ -239,6 +240,8 @@ impl MarkdownPreviewView {
                         this.sync_active_root_block(cx);
                     },
                 ),
+                _settings_subscription: cx
+                    .observe_global::<SettingsStore>(|_: &mut Self, cx| cx.notify()),
                 markdown,
                 active_source_index: None,
                 scroll_handle: ScrollHandle::new(),


### PR DESCRIPTION
## Summary

- Use the buffer font size for Markdown preview body text, matching code blocks and line height.
- Refresh Markdown preview items when settings change so font settings apply without reopening the preview.
- Add coverage for Markdown preview body text following the buffer font size.

## Testing

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p markdown test_preview_body_font_size_tracks_buffer_font_size` did not complete locally because this Windows machine is missing the Visual Studio Spectre-mitigated MSVC libraries required by the workspace.

Release Notes:

- Fixed Markdown preview text not following the editor font size setting.