### PR TITLE
agent_ui: Add right-click context menu to sidebar threads

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -28,8 +28,9 @@ use feature_flags::{
 };
 use gpui::{
     Action as _, AnyElement, App, ClickEvent, Context, DismissEvent, Entity, EntityId, FocusHandle,
-    Focusable, KeyContext, ListState, Modifiers, Pixels, Render, SharedString, Task, TaskExt,
-    WeakEntity, Window, WindowHandle, linear_color_stop, linear_gradient, list, prelude::*, px,
+    Focusable, KeyContext, ListState, Modifiers, MouseDownEvent, Pixels, Point, Render,
+    SharedString, Subscription, Task, TaskExt, WeakEntity, Window, WindowHandle, anchored,
+    deferred, linear_color_stop, linear_gradient, list, prelude::*, px,
 };
 use itertools::Itertools;
 use menu::{
@@ -700,6 +701,9 @@ pub struct Sidebar {
     recent_projects_popover_handle: PopoverMenuHandle<SidebarRecentProjects>,
     project_header_menu_handles: HashMap<usize, PopoverMenuHandle<ContextMenu>>,
     project_header_menu_ix: Option<usize>,
+    /// Right-click context menu shown for a thread entry. The `Point` is the
+    /// screen position to anchor the menu at (the click location).
+    thread_context_menu: Option<(Entity<ContextMenu>, Point<Pixels>, Subscription)>,
     _subscriptions: Vec<gpui::Subscription>,
     _draft_editor_observations: Vec<gpui::Subscription>,
     /// For the thread import banners, if there is just one we show "Import
@@ -822,6 +826,7 @@ impl Sidebar {
             recent_projects_popover_handle: PopoverMenuHandle::default(),
             project_header_menu_handles: HashMap::new(),
             project_header_menu_ix: None,
+            thread_context_menu: None,
             _subscriptions: Vec::new(),
             _draft_editor_observations: Vec::new(),
             import_banners_use_verbose_labels: None,
@@ -2930,6 +2935,52 @@ impl Sidebar {
 
     fn has_filter_query(&self, cx: &App) -> bool {
         !self.filter_editor.read(cx).text(cx).is_empty()
+    }
+
+    /// Opens a right-click context menu for the thread at `ix`, anchored at
+    /// `position` (the screen-space location of the click). The menu contains
+    /// the same actions exposed via the hover buttons (Rename, plus
+    /// Archive/Discard Draft as appropriate) so a user who reaches for a
+    /// right-click gets the same affordances without having to hover.
+    fn deploy_thread_context_menu(
+        &mut self,
+        ix: usize,
+        position: Point<Pixels>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(ListEntry::Thread(thread)) = self.contents.entries.get(ix) else {
+            return;
+        };
+        let is_running = matches!(
+            thread.status,
+            AgentThreadStatus::Running | AgentThreadStatus::WaitingForConfirmation
+        );
+        let is_draft = thread.is_draft;
+
+        self.selection = Some(ix);
+
+        let focus_handle = self.focus_handle.clone();
+        let context_menu = ContextMenu::build(window, cx, |menu, _, _| {
+            menu.context(focus_handle)
+                .action("Rename", Box::new(RenameSelectedThread))
+                .when(!is_running, |menu| {
+                    let label = if is_draft {
+                        "Discard Draft"
+                    } else {
+                        "Archive"
+                    };
+                    menu.action(label, Box::new(ArchiveSelectedThread))
+                })
+        });
+
+        window.focus(&context_menu.focus_handle(cx), cx);
+        let subscription = cx.subscribe(&context_menu, |this, _, _: &DismissEvent, cx| {
+            this.thread_context_menu.take();
+            cx.notify();
+        });
+        self.thread_context_menu = Some((context_menu, position, subscription));
+        cx.notify();
     }
 
     fn start_renaming_thread(
@@ -5728,6 +5779,15 @@ impl Sidebar {
                 }
                 cx.notify();
             }))
+            .on_secondary_mouse_down(cx.listener(
+                move |this, event: &MouseDownEvent, window, cx| {
+                    if this.renaming_thread_id.is_some() {
+                        return;
+                    }
+                    cx.stop_propagation();
+                    this.deploy_thread_context_menu(ix, event.position, window, cx);
+                },
+            ))
             .when(is_renaming, |this| {
                 this.is_truncated(false).title_slot(
                     div()
@@ -7341,6 +7401,15 @@ impl Render for Sidebar {
                 })
             })
             .child(self.render_sidebar_bottom_bar(cx))
+            .children(self.thread_context_menu.as_ref().map(|(menu, position, _)| {
+                deferred(
+                    anchored()
+                        .position(*position)
+                        .anchor(gpui::Anchor::TopLeft)
+                        .child(menu.clone()),
+                )
+                .with_priority(3)
+            }))
     }
 }
 

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -5026,6 +5026,77 @@ async fn test_rename_thread_from_sidebar_updates_title_override(cx: &mut TestApp
 }
 
 #[gpui::test]
+async fn test_right_click_deploys_thread_context_menu(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let (sidebar, panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+
+    let connection = StubAgentConnection::new();
+    connection.set_next_prompt_updates(vec![acp::SessionUpdate::AgentMessageChunk(
+        acp::ContentChunk::new("Hi there!".into()),
+    )]);
+    open_thread_with_connection(&panel, connection, cx);
+    send_message(&panel, cx);
+
+    let session_id = active_session_id(&panel, cx);
+    save_test_thread_metadata(&session_id, &project, cx).await;
+    cx.run_until_parked();
+
+    let entry_ix = sidebar.read_with(cx, |sidebar, _cx| {
+        sidebar
+            .contents
+            .entries
+            .iter()
+            .position(|entry| matches!(entry, ListEntry::Thread(_)))
+            .expect("sidebar should have a thread entry")
+    });
+
+    // Right-click a thread entry: the context menu should be installed and the
+    // entry should become the current selection so the menu's Rename/Archive
+    // actions know which thread to act on.
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        sidebar.deploy_thread_context_menu(entry_ix, gpui::Point::default(), window, cx);
+    });
+    cx.run_until_parked();
+
+    sidebar.read_with(cx, |sidebar, _cx| {
+        assert!(
+            sidebar.thread_context_menu.is_some(),
+            "right-click should deploy a thread context menu"
+        );
+        assert_eq!(
+            sidebar.selection,
+            Some(entry_ix),
+            "right-click should select the clicked thread so menu actions target it"
+        );
+    });
+
+    // Dismissing the menu (Esc, click outside, etc.) emits a DismissEvent on
+    // the menu, which the sidebar subscribes to in order to drop its reference.
+    let menu = sidebar.read_with(cx, |sidebar, _cx| {
+        sidebar
+            .thread_context_menu
+            .as_ref()
+            .map(|(menu, _, _)| menu.clone())
+            .expect("menu should be present")
+    });
+    cx.update(|_, cx| {
+        menu.update(cx, |_, cx| {
+            cx.emit(gpui::DismissEvent);
+        });
+    });
+    cx.run_until_parked();
+
+    sidebar.read_with(cx, |sidebar, _cx| {
+        assert!(
+            sidebar.thread_context_menu.is_none(),
+            "dismissing the menu should clear the sidebar's reference"
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_rename_selected_thread_action_renames_selected_thread(cx: &mut TestAppContext) {
     let project = init_test_project_with_agent_panel("/my-project", cx).await;
     let (multi_workspace, cx) =

--- a/crates/ui/src/components/ai/thread_item.rs
+++ b/crates/ui/src/components/ai/thread_item.rs
@@ -1,7 +1,8 @@
 use crate::{CommonAnimationExt, DiffStat, GradientFade, HighlightedLabel, Tooltip, prelude::*};
 
 use gpui::{
-    Animation, AnimationExt, ClickEvent, Hsla, MouseButton, SharedString, pulsating_between,
+    Animation, AnimationExt, ClickEvent, Hsla, MouseButton, MouseDownEvent, SharedString,
+    pulsating_between,
 };
 use itertools::Itertools as _;
 use std::{path::PathBuf, sync::Arc, time::Duration};
@@ -60,6 +61,8 @@ pub struct ThreadItem {
     archived: bool,
     on_click: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
     on_hover: Box<dyn Fn(&bool, &mut Window, &mut App) + 'static>,
+    on_secondary_mouse_down:
+        Option<Box<dyn Fn(&MouseDownEvent, &mut Window, &mut App) + 'static>>,
     action_slot: Option<AnyElement>,
     base_bg: Option<Hsla>,
 }
@@ -94,6 +97,7 @@ impl ThreadItem {
             archived: false,
             on_click: None,
             on_hover: Box::new(|_, _, _| {}),
+            on_secondary_mouse_down: None,
             action_slot: None,
             base_bg: None,
         }
@@ -224,6 +228,14 @@ impl ThreadItem {
 
     pub fn on_hover(mut self, on_hover: impl Fn(&bool, &mut Window, &mut App) + 'static) -> Self {
         self.on_hover = Box::new(on_hover);
+        self
+    }
+
+    pub fn on_secondary_mouse_down(
+        mut self,
+        handler: impl Fn(&MouseDownEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_secondary_mouse_down = Some(Box::new(handler));
         self
     }
 
@@ -602,6 +614,14 @@ impl RenderOnce for ThreadItem {
                 }))
             })
             .when_some(self.on_click, |this, on_click| this.on_click(on_click))
+            .when_some(
+                self.on_secondary_mouse_down,
+                |this, on_secondary_mouse_down| {
+                    this.on_mouse_down(MouseButton::Right, move |event, window, cx| {
+                        (on_secondary_mouse_down)(event, window, cx)
+                    })
+                },
+            )
     }
 }
 


### PR DESCRIPTION
Summary:

PR #57656 added inline rename for agent threads via a pencil hover-button
and the shift-r keybinding. This PR adds the third conventional entry
point: right-click a thread entry to open a context menu containing
Rename and Archive (or Discard Draft for drafts), so the same actions
are reachable without having to hover.

Implementation:

- Adds an `on_secondary_mouse_down` builder method to `ui::ThreadItem`,
  mirroring the existing pattern on `tree_view_item`.
- Adds `Sidebar::deploy_thread_context_menu` which sets the selection to
  the right-clicked entry (so the dispatched `RenameSelectedThread` /
  `ArchiveSelectedThread` actions target it) and renders a `ContextMenu`
  anchored at the click position.
- Suppresses right-click while an inline rename is in progress.

Tests:

- `test_right_click_deploys_thread_context_menu` covers deploy + the
  dismiss path that clears the sidebar's reference to the menu.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — N/A
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Improved agent threads by adding a right-click context menu to rename or archive threads directly from the sidebar.