### PR TITLE
agent_ui: Match project name in archive-view search

### DIFF
--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -299,16 +299,29 @@ impl ThreadsArchiveView {
 
         for session in sessions {
             let highlight_positions = if !query.is_empty() {
-                match fuzzy_match_positions(
-                    &query,
-                    session
-                        .title
-                        .as_ref()
-                        .map(|t| t.as_ref())
-                        .unwrap_or(DEFAULT_THREAD_TITLE),
-                ) {
-                    Some(positions) => positions,
-                    None => continue,
+                let title = session
+                    .title
+                    .as_ref()
+                    .map(|t| t.as_ref())
+                    .unwrap_or(DEFAULT_THREAD_TITLE);
+                if let Some(positions) = fuzzy_match_positions(&query, title) {
+                    positions
+                } else {
+                    // Title didn't match — also try matching the project name
+                    // (the basename of any of the thread's worktree paths), so
+                    // typing a project name surfaces its threads here too.
+                    let worktree_matched = session.folder_paths().paths().iter().any(|p| {
+                        p.as_path()
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .is_some_and(|name| {
+                                fuzzy_match_positions(&query, name).is_some()
+                            })
+                    });
+                    if !worktree_matched {
+                        continue;
+                    }
+                    Vec::new()
                 }
             } else {
                 Vec::new()

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -307,16 +307,14 @@ impl ThreadsArchiveView {
                 if let Some(positions) = fuzzy_match_positions(&query, title) {
                     positions
                 } else {
-                    // Title didn't match — also try matching the project name
+                    // If title didn't match, also try matching the project name
                     // (the basename of any of the thread's worktree paths), so
                     // typing a project name surfaces its threads here too.
                     let worktree_matched = session.folder_paths().paths().iter().any(|p| {
                         p.as_path()
                             .file_name()
                             .and_then(|name| name.to_str())
-                            .is_some_and(|name| {
-                                fuzzy_match_positions(&query, name).is_some()
-                            })
+                            .is_some_and(|name| fuzzy_match_positions(&query, name).is_some())
                     });
                     if !worktree_matched {
                         continue;


### PR DESCRIPTION
Summary:

When you have a lot of projects open, finding a thread from a specific
project in the archive ("Search all threads") view is slower than it
should be — the filter only matches the thread title, so you have to
remember or scan titles to find what belongs to which project. Folder
names are a quicker mental handle than thread titles, especially across
many projects.

This PR makes the archive filter also try matching the basename of each
of the thread's worktree paths. Title matches still take precedence and
get the highlight positions; project-name matches just include the row.
Same `fuzzy_match_positions` contiguous substring matcher already used
for titles, so the matching feel is consistent.

Example: typing `my-laravel-project` now surfaces every thread that lives
under a project named `my-laravel-project`, regardless of title.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — N/A
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior — small extension to an existing filter branch; manually verified.
- [x] Performance impact has been considered and is acceptable — per-row path-basename check only runs when the title didn't match.

Release Notes:

- Improved the archive "Search all threads" view so you can filter by project name, not just by thread title — handy when many projects are open.