### PR TITLE
sidebar: Include archived threads in the thread switcher dropdown

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -5306,6 +5306,7 @@ impl Sidebar {
     fn mru_entries_for_switcher(&self, cx: &App) -> Vec<ThreadSwitcherEntry> {
         let mut current_header_label: Option<SharedString> = None;
         let mut current_header_key: Option<ProjectGroupKey> = None;
+        let mut seen_thread_ids: HashSet<ThreadId> = HashSet::new();
         let mut entries: Vec<ThreadSwitcherEntry> = self
             .contents
             .entries
@@ -5334,6 +5335,7 @@ impl Sidebar {
                             })
                         }
                     }?;
+                    seen_thread_ids.insert(thread.metadata.thread_id);
                     let notified = self.contents.is_thread_notified(&thread.metadata.thread_id);
                     let timestamp: SharedString =
                         format_history_entry_timestamp(Self::thread_display_time(&thread.metadata))
@@ -5386,6 +5388,68 @@ impl Sidebar {
                 }
             })
             .collect();
+
+        // Also include archived threads whose project is currently open, so the
+        // switcher can reach archived/closed agent threads, not just active
+        // ones. Without this they're invisible to the dropdown even though
+        // they're still real history.
+        if let Some(multi_workspace) = self.multi_workspace.upgrade() {
+            let open_workspaces: Vec<Entity<Workspace>> =
+                multi_workspace.read(cx).workspaces().cloned().collect();
+            let workspace_for_paths = |folder_paths: &PathList| -> Option<Entity<Workspace>> {
+                open_workspaces
+                    .iter()
+                    .find(|ws| workspace_path_list(ws, cx) == *folder_paths)
+                    .cloned()
+            };
+            for metadata in ThreadMetadataStore::global(cx).read(cx).archived_entries() {
+                if !seen_thread_ids.insert(metadata.thread_id) {
+                    continue;
+                }
+                let Some(workspace) = workspace_for_paths(metadata.folder_paths()) else {
+                    continue;
+                };
+                let project_name = workspace
+                    .read(cx)
+                    .project()
+                    .read(cx)
+                    .visible_worktrees(cx)
+                    .next()
+                    .map(|wt| SharedString::from(wt.read(cx).root_name_str().to_string()));
+                let timestamp: SharedString =
+                    format_history_entry_timestamp(Self::thread_display_time(metadata)).into();
+                // Inline icon resolution: the full `resolve_agent_icon` closure
+                // in `rebuild_contents` also surfaces custom-agent SVG icons via
+                // the agent_server_store, but that's only worth the plumbing if
+                // the archived-switcher rows visibly need it. Stick to a
+                // built-in icon by Agent kind.
+                let icon = match Agent::from(metadata.agent_id.clone()) {
+                    Agent::NativeAgent => IconName::ZedAgent,
+                    Agent::Custom { .. } => IconName::Terminal,
+                    _ => IconName::ZedAgent,
+                };
+                let icon_from_external_svg: Option<SharedString> = None;
+                let worktrees = worktree_info_from_thread_paths(
+                    &metadata.worktree_paths,
+                    &HashMap::new(),
+                );
+                entries.push(ThreadSwitcherEntry::Thread(ThreadSwitcherThreadEntry {
+                    title: metadata.display_title(),
+                    icon,
+                    icon_from_external_svg,
+                    status: AgentThreadStatus::Completed,
+                    metadata: metadata.clone(),
+                    workspace,
+                    project_name,
+                    worktrees,
+                    diff_stats: DiffStats::default(),
+                    is_draft: false,
+                    is_title_generating: false,
+                    notified: false,
+                    timestamp,
+                }));
+            }
+        }
 
         entries.sort_by(|a, b| self.switcher_entry_cmp(a, b));
 


### PR DESCRIPTION
Summary:

The thread switcher dropdown (the per-project popover triggered by
`ToggleThreadSwitcher`) sources its entries from the sidebar's
filtered list, which excludes archived threads. So archived agent
threads — even ones from the project you're currently in — are
unreachable from the dropdown. The only way back is to open the
Archive view.

This PR also pulls archived metadata from
`ThreadMetadataStore::archived_entries()`, scoped to currently-open
projects (so the entry has a valid `Workspace` to switch into), and
appends those to the switcher entries. They're de-duped against the
entries already sourced from `contents.entries`, then the existing
sort runs as before.

Implementation notes:
- A `seen_thread_ids: HashSet<ThreadId>` is built while iterating the
  sidebar contents and then consulted while iterating archived
  entries to avoid double-listing.
- Workspace resolution: each archived entry's `folder_paths()` is
  matched against the path lists of currently-open workspaces; if
  none matches, the archived entry is skipped (no workspace to switch
  to).
- The agent-icon resolution is inlined as a simple match on the Agent
  variant (NativeAgent / Custom) rather than reusing
  `resolve_agent_icon`, which is a closure local to
  `rebuild_contents` that captures `agent_server_store`; that closure
  would also surface custom-agent SVG icons via the store, but
  routing that here would require plumbing the store into
  `mru_entries_for_switcher` for what is, visually, a minor icon
  fallback. Happy to thread it through if reviewers prefer.

Related work:

This pairs nicely with a planned follow-up PR that surfaces archived
threads in the sidebar's "Search threads…" content search as well.
With both, archived threads are reachable from the two natural search
entry points — the per-project dropdown (this PR) and the
cross-project sidebar filter — without users having to bounce into
the Archive view.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — N/A
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior — extends an existing enumeration; manually verified.
- [x] Performance impact has been considered and is acceptable — one extra pass over the archived metadata, only when the switcher is built.

Release Notes:

- Improved the thread switcher dropdown so it also lists archived threads from currently-open projects, so they're reachable without opening the Archive view.