### PR TITLE
sidebar: Improved search — content, archived, closed-ACP, scope alignment, ranking, collapse during search

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3083,6 +3083,39 @@ impl AcpThread {
         self.entries.iter().map(|e| e.to_markdown(cx)).collect()
     }
 
+    /// Concatenated text of the thread's *visible, searchable* content: user
+    /// messages, assistant message chunks (excluding collapsed thinking
+    /// blocks), and tool-call labels (excluding tool output). This deliberately
+    /// mirrors the scope of the in-thread search bar, so a cross-thread content
+    /// match (e.g. the sidebar's "Search threads") always corresponds to text
+    /// the user can actually navigate to in-thread — unlike [`Self::to_markdown`],
+    /// which also includes thinking and tool output.
+    pub fn searchable_text(&self, cx: &App) -> String {
+        let mut text = String::new();
+        for entry in &self.entries {
+            match entry {
+                AgentThreadEntry::UserMessage(message) => {
+                    text.push_str(&message.to_markdown(cx));
+                    text.push('\n');
+                }
+                AgentThreadEntry::AssistantMessage(message) => {
+                    for chunk in &message.chunks {
+                        if let AssistantMessageChunk::Message { block } = chunk {
+                            text.push_str(&block.to_markdown(cx).to_string());
+                            text.push('\n');
+                        }
+                    }
+                }
+                AgentThreadEntry::ToolCall(tool_call) => {
+                    text.push_str(tool_call.label.read(cx).source());
+                    text.push('\n');
+                }
+                AgentThreadEntry::CompletedPlan(_) => {}
+            }
+        }
+        text
+    }
+
     pub fn emit_load_error(&mut self, error: LoadError, cx: &mut Context<Self>) {
         cx.emit(AcpThreadEvent::LoadError(error));
     }

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -165,6 +165,18 @@ impl Message {
         }
     }
 
+    /// Visible, searchable text only — user text, assistant text, and tool-use
+    /// names. Excludes thinking blocks, tool-use input JSON, and tool results,
+    /// so cross-thread content search (the sidebar) matches the same scope as
+    /// the in-thread search bar rather than incidental hidden content.
+    pub fn searchable_markdown(&self) -> String {
+        match self {
+            Message::User(message) => message.to_markdown(),
+            Message::Agent(message) => message.searchable_markdown(),
+            Message::Resume => String::new(),
+        }
+    }
+
     pub fn role(&self) -> Role {
         match self {
             Message::User(_) | Message::Resume => Role::User,
@@ -484,6 +496,28 @@ fn codeblock_tag(full_path: &Path, line_range: Option<&RangeInclusive<u32>>) -> 
 }
 
 impl AgentMessage {
+    /// Visible, searchable text only: assistant text and tool-use names.
+    /// Excludes thinking, tool-use input JSON, and tool results — see
+    /// [`Message::searchable_markdown`].
+    pub fn searchable_markdown(&self) -> String {
+        let mut markdown = String::new();
+        for content in &self.content {
+            match content {
+                AgentMessageContent::Text(text) => {
+                    markdown.push_str(text);
+                    markdown.push('\n');
+                }
+                AgentMessageContent::ToolUse(tool_use) => {
+                    markdown.push_str(tool_use.name.as_ref());
+                    markdown.push('\n');
+                }
+                AgentMessageContent::Thinking { .. }
+                | AgentMessageContent::RedactedThinking(_) => {}
+            }
+        }
+        markdown
+    }
+
     pub fn to_markdown(&self) -> String {
         let mut markdown = String::new();
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1542,6 +1542,43 @@ impl AgentPanel {
         &self.connection_store
     }
 
+    /// Loads an existing agent session's content *headlessly* — without opening
+    /// it as the active view — so its messages can be searched (e.g. the
+    /// sidebar's "Search more" pass over closed external/ACP threads). Reuses
+    /// or establishes the per-agent connection, then replays the session and
+    /// returns the resulting `AcpThread` whose entries can be read via
+    /// `to_markdown`. Errors if the agent can't load sessions or the connection
+    /// fails.
+    pub fn load_session_content_for_search(
+        &mut self,
+        agent: Agent,
+        session_id: acp::SessionId,
+        work_dirs: PathList,
+        title: Option<SharedString>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<AcpThread>>> {
+        let server = agent.server(self.fs.clone(), self.thread_store.clone());
+        let entry = self
+            .connection_store
+            .update(cx, |store, cx| store.request_connection(agent, server, cx));
+        let connect = entry.read(cx).wait_for_connection();
+        let project = self.project.clone();
+        cx.spawn(async move |_this, cx| {
+            let connected = connect.await.map_err(|err| anyhow::anyhow!(err))?;
+            let connection = connected.connection;
+            anyhow::ensure!(
+                connection.supports_load_session(),
+                "agent does not support loading sessions"
+            );
+            let load = cx.update(|cx| {
+                connection
+                    .clone()
+                    .load_session(session_id, project, work_dirs, title, cx)
+            });
+            load.await
+        })
+    }
+
     pub fn selected_agent(&self, cx: &App) -> Agent {
         if self.project.read(cx).is_via_collab() {
             Agent::NativeAgent

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -654,6 +654,23 @@ impl ThreadMetadataStore {
             .filter(move |s| s.matches_remote_connection(remote_connection))
     }
 
+    /// Like [`Self::entries_for_main_worktree_path`], but returns only
+    /// *archived* threads. Used by the sidebar to surface archived threads
+    /// inline (visually demoted) when a content search matches them.
+    pub fn archived_entries_for_main_worktree_path<'a>(
+        &'a self,
+        path_list: &PathList,
+        remote_connection: Option<&'a RemoteConnectionOptions>,
+    ) -> impl Iterator<Item = &'a ThreadMetadata> + 'a {
+        self.threads_by_main_paths
+            .get(path_list)
+            .into_iter()
+            .flatten()
+            .filter_map(|s| self.threads.get(s))
+            .filter(|s| s.archived)
+            .filter(move |s| s.matches_remote_connection(remote_connection))
+    }
+
     fn reload(&mut self, cx: &mut Context<Self>) -> Shared<Task<()>> {
         let db = self.db.clone();
         self.reload_task.take();

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1652,7 +1652,10 @@ impl Sidebar {
                             group_key.path_list(),
                             group_host.as_ref(),
                         )
-                        .filter(|metadata| self.content_matches.contains(&metadata.thread_id))
+                        .filter(|metadata| {
+                            self.content_matches.contains(&metadata.thread_id)
+                                || self.closed_search_matches.contains(&metadata.thread_id)
+                        })
                         .cloned()
                         .collect::<Vec<_>>()
                     {
@@ -3265,7 +3268,6 @@ impl Sidebar {
             .entries()
             .any(|metadata| {
                 metadata.agent_id.as_ref() != agent::ZED_AGENT_ID.as_ref()
-                    && !metadata.archived
                     && metadata.session_id.is_some()
                     && !self.content_matches.contains(&metadata.thread_id)
                     && !self.closed_search_matches.contains(&metadata.thread_id)
@@ -3308,11 +3310,14 @@ impl Sidebar {
             }
         }
 
+        // Includes archived threads: archived external/ACP threads have no
+        // locally-readable content either, so the "Search more" pass is their
+        // only way to be content-searched. Matches render demoted via the
+        // archived-injection in `rebuild_contents`.
         let candidates: Vec<ClosedAcpCandidate> = ThreadMetadataStore::global(cx)
             .read(cx)
             .entries()
             .filter(|m| m.agent_id.as_ref() != agent::ZED_AGENT_ID.as_ref())
-            .filter(|m| !m.archived)
             .filter_map(|m| {
                 let session_id = m.session_id.clone()?;
                 let thread_id = m.thread_id;

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1514,7 +1514,11 @@ impl Sidebar {
             let label = group_key.display_name(&path_detail_map);
 
             let is_collapsed = self.is_group_collapsed(group_key, cx);
-            let should_load_threads = !is_collapsed || !query.is_empty();
+            // Respect the user's collapsed state even while a query is active,
+            // so the project chevron actually toggles search results. Groups
+            // whose threads contain matches still surface a header below
+            // (via has_content_match_in_group), so the user can expand them.
+            let should_load_threads = !is_collapsed;
 
             let is_active = active_workspace
                 .as_ref()
@@ -1873,7 +1877,34 @@ impl Sidebar {
                     }
                 }
 
-                if matched_threads.is_empty() && matched_terminals.is_empty() && !workspace_matched
+                // When the group is collapsed, its threads weren't loaded, so
+                // `matched_threads` can't surface them. Still keep the header
+                // visible if any of the group's threads match by title or
+                // content — so the user knows where the hits live and can
+                // expand the group to reveal them. Without this, a collapsed
+                // project would silently vanish from search results.
+                let has_collapsed_match = is_collapsed && {
+                    let store = ThreadMetadataStore::global(cx).read(cx);
+                    store
+                        .entries_for_main_worktree_path(
+                            group_key.path_list(),
+                            group_host.as_ref(),
+                        )
+                        .chain(
+                            store.entries_for_path(group_key.path_list(), group_host.as_ref()),
+                        )
+                        .any(|m| {
+                            self.content_matches.contains(&m.thread_id)
+                                || self.closed_search_matches.contains(&m.thread_id)
+                                || fuzzy_match_positions(&query, m.display_title().as_ref())
+                                    .is_some()
+                        })
+                };
+
+                if matched_threads.is_empty()
+                    && matched_terminals.is_empty()
+                    && !workspace_matched
+                    && !has_collapsed_match
                 {
                     continue;
                 }

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1599,6 +1599,28 @@ impl Sidebar {
                     }
                 }
 
+                // Surface archived threads whose *content* matches the active
+                // query. They're excluded from every query above, so we add
+                // them here; `render_thread` renders them demoted via
+                // `ThreadItem::archived`. Only runs while filtering.
+                if !query.is_empty() {
+                    for row in thread_store
+                        .read(cx)
+                        .archived_entries_for_main_worktree_path(
+                            group_key.path_list(),
+                            group_host.as_ref(),
+                        )
+                        .filter(|metadata| self.content_matches.contains(&metadata.thread_id))
+                        .cloned()
+                        .collect::<Vec<_>>()
+                    {
+                        if !seen_thread_ids.insert(row.thread_id) {
+                            continue;
+                        }
+                        let workspace = resolve_workspace(row.folder_paths());
+                        threads.push(make_thread_entry(row, workspace));
+                    }
+                }
                 for thread in &mut threads {
                     if thread.draft.is_none() {
                         continue;
@@ -5902,6 +5924,7 @@ impl Sidebar {
         ThreadItem::new(id, title.clone())
             .base_bg(sidebar_bg)
             .icon(icon)
+            .archived(thread.metadata.archived)
             .when(is_draft, |this| {
                 this.icon_color(Color::Custom(cx.theme().colors().icon_muted.opacity(0.2)))
             })

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1,7 +1,8 @@
 mod thread_switcher;
 
-use acp_thread::ThreadStatus;
+use acp_thread::{AcpThread, ThreadStatus};
 use action_log::DiffStats;
+use agent::ThreadStore;
 use agent_client_protocol::schema as acp;
 use agent_settings::AgentSettings;
 use agent_ui::terminal_thread_metadata_store::{
@@ -40,6 +41,7 @@ use recent_projects::sidebar_recent_projects::SidebarRecentProjects;
 use remote::{RemoteConnectionOptions, same_remote_connection_identity};
 use ui::utils::platform_title_bar_height;
 
+use project::search::SearchQuery;
 use serde::{Deserialize, Serialize};
 use settings::Settings as _;
 use std::cmp::Ordering;
@@ -48,6 +50,7 @@ use std::mem;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
 use theme::ActiveTheme;
 use ui::{
     AgentThreadStatus, CommonAnimationExt, ContextMenu, ContextMenuEntry, Divider, GradientFade,
@@ -57,6 +60,7 @@ use ui::{
 };
 use util::ResultExt as _;
 use util::path_list::PathList;
+use util::paths::PathMatcher;
 use workspace::{
     CloseWindow, FocusWorkspaceSidebar, MultiWorkspace, MultiWorkspaceEvent, NextProject,
     NextThread, Open, OpenMode, PreviousProject, PreviousThread, ProjectGroupKey, SaveIntent,
@@ -700,6 +704,23 @@ pub struct Sidebar {
     recent_projects_popover_handle: PopoverMenuHandle<SidebarRecentProjects>,
     project_header_menu_handles: HashMap<usize, PopoverMenuHandle<ContextMenu>>,
     project_header_menu_ix: Option<usize>,
+    /// Thread IDs whose *message content* (not just title) matches the current
+    /// filter query. Populated asynchronously by [`Self::update_content_search`]
+    /// and OR-ed into the title/worktree match in [`Self::rebuild_contents`] so
+    /// that a thread surfaces in the filtered list when the query appears in the
+    /// conversation, not only in its title.
+    content_matches: HashSet<ThreadId>,
+    /// Bumped on every filter-query change. The background content search
+    /// captures the value at spawn time and bails if it no longer matches,
+    /// so results from a stale query never overwrite a newer one.
+    content_search_generation: usize,
+    /// Cache of extracted, searchable thread text keyed by session, invalidated
+    /// when the thread's `updated_at` changes. Avoids re-loading and
+    /// re-deserializing every thread blob on each keystroke.
+    thread_text_cache: HashMap<acp::SessionId, (DateTime<Utc>, Arc<str>)>,
+    /// The in-flight content search. Holding the handle here cancels the
+    /// previous search when a new query replaces it.
+    _content_search_task: Task<()>,
     _subscriptions: Vec<gpui::Subscription>,
     _draft_editor_observations: Vec<gpui::Subscription>,
     /// For the thread import banners, if there is just one we show "Import
@@ -756,6 +777,7 @@ impl Sidebar {
                 if !query.is_empty() {
                     this.selection.take();
                 }
+                this.update_content_search(cx);
                 this.update_entries(cx);
                 if !query.is_empty() {
                     this.select_first_entry();
@@ -822,6 +844,10 @@ impl Sidebar {
             recent_projects_popover_handle: PopoverMenuHandle::default(),
             project_header_menu_handles: HashMap::new(),
             project_header_menu_ix: None,
+            content_matches: HashSet::new(),
+            content_search_generation: 0,
+            thread_text_cache: HashMap::new(),
+            _content_search_task: Task::ready(()),
             _subscriptions: Vec::new(),
             _draft_editor_observations: Vec::new(),
             import_banners_use_verbose_labels: None,
@@ -1725,6 +1751,8 @@ impl Sidebar {
                 let mut matched_threads: Vec<Arc<ThreadEntry>> = Vec::new();
                 for mut thread in threads {
                     let mut worktree_matched = false;
+                    let content_matched =
+                        self.content_matches.contains(&thread.metadata.thread_id);
                     {
                         let thread = Arc::make_mut(&mut thread);
                         let title = thread.metadata.display_title();
@@ -1744,6 +1772,7 @@ impl Sidebar {
                     if workspace_matched
                         || !thread.highlight_positions.is_empty()
                         || worktree_matched
+                        || content_matched
                     {
                         matched_threads.push(thread);
                     }
@@ -2930,6 +2959,181 @@ impl Sidebar {
 
     fn has_filter_query(&self, cx: &App) -> bool {
         !self.filter_editor.read(cx).text(cx).is_empty()
+    }
+
+    /// Kicks off an asynchronous search of every (non-draft) thread's message
+    /// content for the current filter query. This is the cross-thread analogue
+    /// of the in-thread search bar: the query is broadcast to every thread,
+    /// each thread's persisted content is searched (loading it on demand when
+    /// it isn't already in memory), and the set of matching threads is gathered
+    /// back into `content_matches`, which `rebuild_contents` ORs into the title
+    /// match so a thread surfaces when the query appears in the conversation,
+    /// not just in its title.
+    ///
+    /// The work runs off the main thread, is debounced, caches extracted thread
+    /// text by `updated_at`, and is cancelled when a newer query supersedes it.
+    /// The caller is responsible for calling `update_entries` afterwards; the
+    /// async completion path calls it itself once results land.
+    fn update_content_search(&mut self, cx: &mut Context<Self>) {
+        let query_text = self.filter_editor.read(cx).text(cx);
+        self.content_search_generation = self.content_search_generation.wrapping_add(1);
+        let generation = self.content_search_generation;
+
+        if query_text.trim().is_empty() {
+            self._content_search_task = Task::ready(());
+            self.content_matches.clear();
+            return;
+        }
+
+        let query = match SearchQuery::text(
+            query_text,
+            false,
+            false,
+            false,
+            PathMatcher::default(),
+            PathMatcher::default(),
+            false,
+            None,
+        ) {
+            Ok(query) => Arc::new(query),
+            Err(_) => {
+                self.content_matches.clear();
+                return;
+            }
+        };
+
+        let thread_store = ThreadStore::try_global(cx);
+
+        // Cheap, main-thread step: snapshot the candidate threads from
+        // metadata, plus a map of every thread currently *loaded* in an agent
+        // panel to its live `AcpThread`. The loaded map is what makes search
+        // work for external/ACP agent threads (and for unsaved, in-flight
+        // content): their messages live in memory, not in the native-agent
+        // SQLite DB that `load_thread` reads.
+        let candidates: Vec<(ThreadId, Option<acp::SessionId>, DateTime<Utc>)> =
+            ThreadMetadataStore::global(cx)
+                .read(cx)
+                .entries()
+                .map(|metadata| {
+                    (
+                        metadata.thread_id,
+                        metadata.session_id.clone(),
+                        metadata.updated_at,
+                    )
+                })
+                .collect();
+
+        let mut loaded_threads: HashMap<ThreadId, Entity<AcpThread>> = HashMap::new();
+        if let Some(multi_workspace) = self.multi_workspace.upgrade() {
+            let workspaces: Vec<_> = multi_workspace.read(cx).workspaces().cloned().collect();
+            for workspace in workspaces {
+                let Some(agent_panel) = workspace.read(cx).panel::<AgentPanel>(cx) else {
+                    continue;
+                };
+                for view in agent_panel.read(cx).conversation_views() {
+                    let view = view.read(cx);
+                    let thread_id = view.parent_id();
+                    if let Some(thread_view) = view.root_thread_view() {
+                        loaded_threads
+                            .insert(thread_id, thread_view.read(cx).thread.clone());
+                    }
+                }
+            }
+        }
+
+        self._content_search_task = cx.spawn(async move |this, cx| {
+            // Debounce: a fresh keystroke bumps the generation, so when this
+            // timer fires we bail unless we are still the latest query.
+            cx.background_executor()
+                .timer(Duration::from_millis(150))
+                .await;
+            if this
+                .update(cx, |this, _| this.content_search_generation)
+                .ok()
+                != Some(generation)
+            {
+                return;
+            }
+
+            let mut matched: HashSet<ThreadId> = HashSet::new();
+            for (thread_id, session_id, updated_at) in candidates {
+                // Abandon a stale search as soon as a newer query arrives.
+                if this
+                    .update(cx, |this, _| this.content_search_generation)
+                    .ok()
+                    != Some(generation)
+                {
+                    return;
+                }
+
+                // Tier 1: loaded threads search their own in-memory content.
+                // This covers external/ACP threads and live, unsaved messages.
+                let text: Option<Arc<str>> = if let Some(thread) =
+                    loaded_threads.get(&thread_id)
+                {
+                    this.update(cx, |_, cx| Arc::<str>::from(thread.read(cx).to_markdown(cx)))
+                        .ok()
+                } else if let Some(session_id) = session_id {
+                    // Tier 2: unloaded threads are loaded from the native-agent
+                    // DB on demand, cached by `updated_at`.
+                    let cached = this
+                        .update(cx, |this, _| {
+                            this.thread_text_cache
+                                .get(&session_id)
+                                .filter(|(ts, _)| *ts == updated_at)
+                                .map(|(_, text)| text.clone())
+                        })
+                        .ok()
+                        .flatten();
+                    match cached {
+                        Some(text) => Some(text),
+                        None => {
+                            let Some(thread_store) = thread_store.as_ref() else {
+                                continue;
+                            };
+                            let load = thread_store
+                                .update(cx, |store, cx| store.load_thread(session_id.clone(), cx));
+                            let Ok(Some(db_thread)) = load.await else {
+                                continue;
+                            };
+                            let mut text = String::new();
+                            for message in &db_thread.messages {
+                                text.push_str(&message.to_markdown());
+                                text.push('\n');
+                            }
+                            let text: Arc<str> = Arc::from(text);
+                            this.update(cx, |this, _| {
+                                this.thread_text_cache
+                                    .insert(session_id.clone(), (updated_at, text.clone()));
+                            })
+                            .ok();
+                            Some(text)
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                let Some(text) = text else {
+                    continue;
+                };
+
+                if !query.search_str(&text).is_empty() {
+                    matched.insert(thread_id);
+                }
+            }
+
+            this.update(cx, |this, cx| {
+                if this.content_search_generation != generation {
+                    return;
+                }
+                if this.content_matches != matched {
+                    this.content_matches = matched;
+                    this.update_entries(cx);
+                }
+            })
+            .ok();
+        });
     }
 
     fn start_renaming_thread(

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -754,6 +754,10 @@ pub struct Sidebar {
     closed_search_generation: usize,
     /// Holds the in-flight "Search more" task; dropping it cancels the pass.
     _closed_search_task: Task<()>,
+    /// Number of content matches per thread (from both the cheap content search
+    /// and the "Search more" pass). Used to rank content matches by relevance —
+    /// more hits sort higher. Cleared when the query changes.
+    match_counts: HashMap<ThreadId, usize>,
     _subscriptions: Vec<gpui::Subscription>,
     _draft_editor_observations: Vec<gpui::Subscription>,
     /// For the thread import banners, if there is just one we show "Import
@@ -885,6 +889,7 @@ impl Sidebar {
             closed_search: ClosedSearch::Idle,
             closed_search_generation: 0,
             _closed_search_task: Task::ready(()),
+            match_counts: HashMap::new(),
             _subscriptions: Vec::new(),
             _draft_editor_observations: Vec::new(),
             import_banners_use_verbose_labels: None,
@@ -1890,12 +1895,41 @@ impl Sidebar {
                     has_threads,
                 });
 
+                // Rank search results: title/worktree matches first, then
+                // content matches by relevance (more hits first), then recency.
+                matched_threads.sort_by(|a, b| {
+                    let a_named = !a.highlight_positions.is_empty()
+                        || a.worktrees.iter().any(|w| !w.highlight_positions.is_empty());
+                    let b_named = !b.highlight_positions.is_empty()
+                        || b.worktrees.iter().any(|w| !w.highlight_positions.is_empty());
+                    b_named
+                        .cmp(&a_named)
+                        .then_with(|| {
+                            let a_count = self
+                                .match_counts
+                                .get(&a.metadata.thread_id)
+                                .copied()
+                                .unwrap_or(0);
+                            let b_count = self
+                                .match_counts
+                                .get(&b.metadata.thread_id)
+                                .copied()
+                                .unwrap_or(0);
+                            b_count.cmp(&a_count)
+                        })
+                        .then_with(|| {
+                            Self::thread_display_time(&b.metadata)
+                                .cmp(&Self::thread_display_time(&a.metadata))
+                        })
+                });
+
                 Self::push_entries_by_display_time(
                     &mut entries,
                     matched_terminals,
                     matched_threads,
                     &mut current_session_ids,
                     &mut current_thread_ids,
+                    true,
                 );
             } else {
                 let has_terminal_notifications = terminals
@@ -1946,6 +1980,7 @@ impl Sidebar {
                     threads,
                     &mut current_session_ids,
                     &mut current_thread_ids,
+                    false,
                 );
             }
         }
@@ -3048,6 +3083,7 @@ impl Sidebar {
         self.closed_search = ClosedSearch::Idle;
         self.closed_search_matches.clear();
         self._closed_search_task = Task::ready(());
+        self.match_counts.clear();
 
         if query_text.trim().is_empty() {
             self._content_search_task = Task::ready(());
@@ -3126,6 +3162,7 @@ impl Sidebar {
             }
 
             let mut matched: HashSet<ThreadId> = HashSet::new();
+            let mut matched_counts: HashMap<ThreadId, usize> = HashMap::new();
             for (thread_id, session_id, updated_at) in candidates {
                 // Abandon a stale search as soon as a newer query arrives.
                 if this
@@ -3141,7 +3178,7 @@ impl Sidebar {
                 let text: Option<Arc<str>> = if let Some(thread) =
                     loaded_threads.get(&thread_id)
                 {
-                    this.update(cx, |_, cx| Arc::<str>::from(thread.read(cx).to_markdown(cx)))
+                    this.update(cx, |_, cx| Arc::<str>::from(thread.read(cx).searchable_text(cx)))
                         .ok()
                 } else if let Some(session_id) = session_id {
                     // Tier 2: unloaded threads are loaded from the native-agent
@@ -3168,7 +3205,7 @@ impl Sidebar {
                             };
                             let mut text = String::new();
                             for message in &db_thread.messages {
-                                text.push_str(&message.to_markdown());
+                                text.push_str(&message.searchable_markdown());
                                 text.push('\n');
                             }
                             let text: Arc<str> = Arc::from(text);
@@ -3188,8 +3225,10 @@ impl Sidebar {
                     continue;
                 };
 
-                if !query.search_str(&text).is_empty() {
+                let count = query.search_str(&text).len();
+                if count > 0 {
                     matched.insert(thread_id);
+                    matched_counts.insert(thread_id, count);
                 }
             }
 
@@ -3197,10 +3236,9 @@ impl Sidebar {
                 if this.content_search_generation != generation {
                     return;
                 }
-                if this.content_matches != matched {
-                    this.content_matches = matched;
-                    this.update_entries(cx);
-                }
+                this.content_matches = matched;
+                this.match_counts = matched_counts;
+                this.update_entries(cx);
             })
             .ok();
         });
@@ -3326,22 +3364,23 @@ impl Sidebar {
                         cx,
                     )
                 });
-                let matched = match load.await {
+                let match_count = match load.await {
                     Ok(acp_thread) => this
                         .update(cx, |_, cx| {
-                            let text = acp_thread.read(cx).to_markdown(cx);
-                            !query.search_str(&text).is_empty()
+                            let text = acp_thread.read(cx).searchable_text(cx);
+                            query.search_str(&text).len()
                         })
-                        .unwrap_or(false),
-                    Err(_) => false,
+                        .unwrap_or(0),
+                    Err(_) => 0,
                 };
 
                 this.update(cx, |this, cx| {
                     if this.closed_search_generation != generation {
                         return;
                     }
-                    if matched {
+                    if match_count > 0 {
                         this.closed_search_matches.insert(candidate.thread_id);
+                        this.match_counts.insert(candidate.thread_id, match_count);
                     }
                     if let ClosedSearch::Running { done, .. } = &mut this.closed_search {
                         *done += 1;
@@ -5744,6 +5783,10 @@ impl Sidebar {
         threads: Vec<Arc<ThreadEntry>>,
         current_session_ids: &mut HashSet<acp::SessionId>,
         current_thread_ids: &mut HashSet<agent_ui::ThreadId>,
+        // When true, keep the caller's thread order (used for ranked search
+        // results) and append terminals after, sorted by recency. When false,
+        // interleave threads and terminals purely by recency.
+        preserve_thread_order: bool,
     ) {
         fn display_time(entry: &ListEntry) -> DateTime<Utc> {
             match entry {
@@ -5756,11 +5799,22 @@ impl Sidebar {
             }
         }
 
-        let row_entries = terminals
-            .into_iter()
-            .map(ListEntry::Terminal)
-            .chain(threads.into_iter().map(ListEntry::Thread))
-            .sorted_by_key(|right| std::cmp::Reverse(display_time(right)));
+        let row_entries: Vec<ListEntry> = if preserve_thread_order {
+            let mut terminals = terminals;
+            terminals.sort_by_key(|terminal| std::cmp::Reverse(terminal.metadata.created_at));
+            threads
+                .into_iter()
+                .map(ListEntry::Thread)
+                .chain(terminals.into_iter().map(ListEntry::Terminal))
+                .collect()
+        } else {
+            terminals
+                .into_iter()
+                .map(ListEntry::Terminal)
+                .chain(threads.into_iter().map(ListEntry::Thread))
+                .sorted_by_key(|right| std::cmp::Reverse(display_time(right)))
+                .collect()
+        };
 
         for entry in row_entries {
             if let ListEntry::Thread(thread) = &entry {

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -663,6 +663,26 @@ fn connect_remote(
     remote_connection::connect_with_modal(&modal_workspace, connection_options, window, cx)
 }
 
+/// Progress of the on-demand "Search more" pass that loads closed external/ACP
+/// threads from their agents to search their content.
+#[derive(Clone, Copy, PartialEq)]
+enum ClosedSearch {
+    Idle,
+    Running { done: usize, total: usize },
+}
+
+/// A closed external/ACP thread eligible for the on-demand "Search more" pass:
+/// it isn't loaded, its project is open (so we have a panel + project to load
+/// it through), and it hasn't already matched the cheap content search.
+struct ClosedAcpCandidate {
+    thread_id: ThreadId,
+    session_id: acp::SessionId,
+    agent: Agent,
+    work_dirs: PathList,
+    title: Option<SharedString>,
+    panel: Entity<AgentPanel>,
+}
+
 /// The sidebar re-derives its entire entry list from scratch on every
 /// change via `update_entries` → `rebuild_contents`. Avoid adding
 /// incremental or inter-event coordination state — if something can
@@ -721,6 +741,19 @@ pub struct Sidebar {
     /// The in-flight content search. Holding the handle here cancels the
     /// previous search when a new query replaces it.
     _content_search_task: Task<()>,
+    /// Closed external/ACP threads whose content matched, found via the
+    /// explicit "Search more" pass (which loads each thread from its agent on
+    /// demand). Kept separate from `content_matches` since it's only populated
+    /// on user request, and ORed into the filter the same way.
+    closed_search_matches: HashSet<ThreadId>,
+    /// Progress state of the on-demand "Search more" pass over closed ACP
+    /// threads. Drives the button / progress row in the sidebar footer.
+    closed_search: ClosedSearch,
+    /// Bumped when a "Search more" pass starts or is stopped, so an in-flight
+    /// pass bails if superseded or cancelled.
+    closed_search_generation: usize,
+    /// Holds the in-flight "Search more" task; dropping it cancels the pass.
+    _closed_search_task: Task<()>,
     _subscriptions: Vec<gpui::Subscription>,
     _draft_editor_observations: Vec<gpui::Subscription>,
     /// For the thread import banners, if there is just one we show "Import
@@ -848,6 +881,10 @@ impl Sidebar {
             content_search_generation: 0,
             thread_text_cache: HashMap::new(),
             _content_search_task: Task::ready(()),
+            closed_search_matches: HashSet::new(),
+            closed_search: ClosedSearch::Idle,
+            closed_search_generation: 0,
+            _closed_search_task: Task::ready(()),
             _subscriptions: Vec::new(),
             _draft_editor_observations: Vec::new(),
             import_banners_use_verbose_labels: None,
@@ -1773,8 +1810,12 @@ impl Sidebar {
                 let mut matched_threads: Vec<Arc<ThreadEntry>> = Vec::new();
                 for mut thread in threads {
                     let mut worktree_matched = false;
-                    let content_matched =
-                        self.content_matches.contains(&thread.metadata.thread_id);
+                    let content_matched = self
+                        .content_matches
+                        .contains(&thread.metadata.thread_id)
+                        || self
+                            .closed_search_matches
+                            .contains(&thread.metadata.thread_id);
                     {
                         let thread = Arc::make_mut(&mut thread);
                         let title = thread.metadata.display_title();
@@ -3001,6 +3042,13 @@ impl Sidebar {
         self.content_search_generation = self.content_search_generation.wrapping_add(1);
         let generation = self.content_search_generation;
 
+        // A changed query invalidates any prior "Search more" (closed ACP)
+        // results and cancels an in-flight pass.
+        self.closed_search_generation = self.closed_search_generation.wrapping_add(1);
+        self.closed_search = ClosedSearch::Idle;
+        self.closed_search_matches.clear();
+        self._closed_search_task = Task::ready(());
+
         if query_text.trim().is_empty() {
             self._content_search_task = Task::ready(());
             self.content_matches.clear();
@@ -3156,6 +3204,226 @@ impl Sidebar {
             })
             .ok();
         });
+    }
+
+    /// True when there is at least one closed external/ACP thread (in an open
+    /// project) that the cheap content search couldn't cover, so the "Search
+    /// more" affordance is worth showing for the current query.
+    fn has_searchable_closed_acp_threads(&self, cx: &App) -> bool {
+        let Some(multi_workspace) = self.multi_workspace.upgrade() else {
+            return false;
+        };
+        let open_paths: HashSet<PathList> = multi_workspace
+            .read(cx)
+            .workspaces()
+            .filter(|ws| ws.read(cx).panel::<AgentPanel>(cx).is_some())
+            .map(|ws| workspace_path_list(ws, cx))
+            .collect();
+        if open_paths.is_empty() {
+            return false;
+        }
+        ThreadMetadataStore::global(cx)
+            .read(cx)
+            .entries()
+            .any(|metadata| {
+                metadata.agent_id.as_ref() != agent::ZED_AGENT_ID.as_ref()
+                    && !metadata.archived
+                    && metadata.session_id.is_some()
+                    && !self.content_matches.contains(&metadata.thread_id)
+                    && !self.closed_search_matches.contains(&metadata.thread_id)
+                    && open_paths.contains(metadata.folder_paths())
+            })
+    }
+
+    /// Runs the on-demand "Search more" pass: loads each closed external/ACP
+    /// thread (in an open project) from its agent, searches its content, and
+    /// surfaces matches. Progressive and cancelable — each thread is loaded one
+    /// at a time, results appear as they're found, and [`Self::stop_closed_acp_search`]
+    /// (or a new query) aborts it.
+    fn start_closed_acp_search(&mut self, cx: &mut Context<Self>) {
+        let query_text = self.filter_editor.read(cx).text(cx);
+        if query_text.trim().is_empty() {
+            return;
+        }
+        let Ok(query) = SearchQuery::text(
+            query_text,
+            false,
+            false,
+            false,
+            PathMatcher::default(),
+            PathMatcher::default(),
+            false,
+            None,
+        ) else {
+            return;
+        };
+        let query = Arc::new(query);
+
+        let Some(multi_workspace) = self.multi_workspace.upgrade() else {
+            return;
+        };
+        let workspaces: Vec<_> = multi_workspace.read(cx).workspaces().cloned().collect();
+        let mut panel_by_paths: HashMap<PathList, Entity<AgentPanel>> = HashMap::new();
+        for ws in &workspaces {
+            if let Some(panel) = ws.read(cx).panel::<AgentPanel>(cx) {
+                panel_by_paths.insert(workspace_path_list(ws, cx), panel);
+            }
+        }
+
+        let candidates: Vec<ClosedAcpCandidate> = ThreadMetadataStore::global(cx)
+            .read(cx)
+            .entries()
+            .filter(|m| m.agent_id.as_ref() != agent::ZED_AGENT_ID.as_ref())
+            .filter(|m| !m.archived)
+            .filter_map(|m| {
+                let session_id = m.session_id.clone()?;
+                let thread_id = m.thread_id;
+                if self.content_matches.contains(&thread_id)
+                    || self.closed_search_matches.contains(&thread_id)
+                {
+                    return None;
+                }
+                let panel = panel_by_paths.get(m.folder_paths())?.clone();
+                Some(ClosedAcpCandidate {
+                    thread_id,
+                    session_id,
+                    agent: Agent::Custom {
+                        id: m.agent_id.clone(),
+                    },
+                    work_dirs: m.folder_paths().clone(),
+                    title: m.title(),
+                    panel,
+                })
+            })
+            .collect();
+
+        if candidates.is_empty() {
+            return;
+        }
+
+        self.closed_search_generation = self.closed_search_generation.wrapping_add(1);
+        let generation = self.closed_search_generation;
+        let total = candidates.len();
+        self.closed_search = ClosedSearch::Running { done: 0, total };
+        cx.notify();
+
+        self._closed_search_task = cx.spawn(async move |this, cx| {
+            for candidate in candidates {
+                if this
+                    .update(cx, |this, _| this.closed_search_generation)
+                    .ok()
+                    != Some(generation)
+                {
+                    return;
+                }
+
+                let load = candidate.panel.update(cx, |panel, cx| {
+                    panel.load_session_content_for_search(
+                        candidate.agent.clone(),
+                        candidate.session_id.clone(),
+                        candidate.work_dirs.clone(),
+                        candidate.title.clone(),
+                        cx,
+                    )
+                });
+                let matched = match load.await {
+                    Ok(acp_thread) => this
+                        .update(cx, |_, cx| {
+                            let text = acp_thread.read(cx).to_markdown(cx);
+                            !query.search_str(&text).is_empty()
+                        })
+                        .unwrap_or(false),
+                    Err(_) => false,
+                };
+
+                this.update(cx, |this, cx| {
+                    if this.closed_search_generation != generation {
+                        return;
+                    }
+                    if matched {
+                        this.closed_search_matches.insert(candidate.thread_id);
+                    }
+                    if let ClosedSearch::Running { done, .. } = &mut this.closed_search {
+                        *done += 1;
+                    }
+                    this.update_entries(cx);
+                })
+                .ok();
+            }
+
+            this.update(cx, |this, cx| {
+                if this.closed_search_generation == generation {
+                    this.closed_search = ClosedSearch::Idle;
+                    this.update_entries(cx);
+                }
+            })
+            .ok();
+        });
+    }
+
+    fn stop_closed_acp_search(&mut self, cx: &mut Context<Self>) {
+        self.closed_search_generation = self.closed_search_generation.wrapping_add(1);
+        self.closed_search = ClosedSearch::Idle;
+        self._closed_search_task = Task::ready(());
+        cx.notify();
+    }
+
+    /// Footer row offering the on-demand "Search more" pass over closed
+    /// external/ACP threads, or its live progress + a stop control while
+    /// running. Only shown in the thread list while a query is active.
+    fn render_search_more_row(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        if !matches!(self.view, SidebarView::ThreadList) || !self.has_filter_query(cx) {
+            return None;
+        }
+        match self.closed_search {
+            ClosedSearch::Running { done, total } => Some(
+                h_flex()
+                    .w_full()
+                    .px_2()
+                    .py_1()
+                    .gap_2()
+                    .justify_between()
+                    .border_t_1()
+                    .border_color(cx.theme().colors().border_variant)
+                    .child(
+                        Label::new(format!("Searching agent histories… {done}/{total}"))
+                            .size(LabelSize::Small)
+                            .color(Color::Muted),
+                    )
+                    .child(
+                        Button::new("stop-closed-acp-search", "Stop")
+                            .label_size(LabelSize::Small)
+                            .on_click(cx.listener(|this, _, _window, cx| {
+                                this.stop_closed_acp_search(cx);
+                            })),
+                    )
+                    .into_any_element(),
+            ),
+            ClosedSearch::Idle => {
+                if !self.has_searchable_closed_acp_threads(cx) {
+                    return None;
+                }
+                Some(
+                    h_flex()
+                        .w_full()
+                        .px_2()
+                        .py_1()
+                        .border_t_1()
+                        .border_color(cx.theme().colors().border_variant)
+                        .child(
+                            Button::new(
+                                "search-closed-acp",
+                                "Search more (closed agent threads)",
+                            )
+                            .label_size(LabelSize::Small)
+                            .on_click(cx.listener(|this, _, _window, cx| {
+                                this.start_closed_acp_search(cx);
+                            })),
+                        )
+                        .into_any_element(),
+                )
+            }
+        }
     }
 
     fn start_renaming_thread(
@@ -7567,6 +7835,7 @@ impl Render for Sidebar {
                     this.child(self.render_cross_channel_import_onboarding(verbose, cx))
                 })
             })
+            .children(self.render_search_more_row(cx))
             .child(self.render_sidebar_bottom_bar(cx))
     }
 }

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -4037,6 +4037,38 @@ async fn test_search_narrows_visible_threads_to_matches(cx: &mut TestAppContext)
 }
 
 #[gpui::test]
+async fn test_search_by_project_name_shows_its_threads(cx: &mut TestAppContext) {
+    // Typing a project name should surface that project's threads, even when
+    // the query matches neither their titles nor their content.
+    let project = init_test_project("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    for (id, title, hour) in [("t-1", "Fix crash", 3), ("t-2", "Add diff view", 2)] {
+        save_thread_metadata(
+            acp::SessionId::new(Arc::from(id)),
+            Some(title.into()),
+            chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, hour, 0, 0).unwrap(),
+            None,
+            None,
+            &project,
+            cx,
+        );
+    }
+    cx.run_until_parked();
+
+    type_in_search(&sidebar, "my-project", cx);
+    let visible = visible_entries_as_strings(&sidebar, cx);
+    assert!(
+        visible.iter().any(|row| row.contains("Fix crash"))
+            && visible.iter().any(|row| row.contains("Add diff view")),
+        "typing the project name should surface its threads, got: {:?}",
+        visible
+    );
+}
+
+#[gpui::test]
 async fn test_search_matches_thread_message_content(cx: &mut TestAppContext) {
     // Scenario: the user remembers something they *said* in a thread, but not
     // the thread's title. Searching for that phrase should surface the thread

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -4037,6 +4037,103 @@ async fn test_search_narrows_visible_threads_to_matches(cx: &mut TestAppContext)
 }
 
 #[gpui::test]
+async fn test_search_matches_thread_message_content(cx: &mut TestAppContext) {
+    // Scenario: the user remembers something they *said* in a thread, but not
+    // the thread's title. Searching for that phrase should surface the thread
+    // even though the title doesn't contain it — the sidebar loads the thread's
+    // persisted content on demand and matches against it.
+    let project = init_test_project("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    let session_id = acp::SessionId::new(Arc::from("content-thread"));
+
+    // Persist a thread whose message content contains "watermelon" while its
+    // title deliberately does not.
+    let db_thread = agent::DbThread {
+        title: "Daily standup notes".into(),
+        messages: vec![Arc::new(agent::Message::User(agent::UserMessage {
+            id: acp_thread::UserMessageId::new(),
+            content: Arc::from(vec![agent::UserMessageContent::Text(
+                "please summarize the watermelon harvest report".into(),
+            )]),
+        }))],
+        updated_at: chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+        detailed_summary: None,
+        initial_project_snapshot: None,
+        cumulative_token_usage: Default::default(),
+        request_token_usage: Default::default(),
+        model: None,
+        profile: None,
+        imported: false,
+        subagent_context: None,
+        speed: None,
+        thinking_enabled: false,
+        thinking_effort: None,
+        draft_prompt: None,
+        ui_scroll_position: None,
+        sandboxed_terminal_temp_dir: None,
+    };
+    let save_task = cx.update(|_, cx| {
+        ThreadStore::global(cx).update(cx, |store, cx| {
+            store.save_thread(session_id.clone(), db_thread, PathList::default(), cx)
+        })
+    });
+    save_task.await.unwrap();
+    cx.run_until_parked();
+
+    // Lightweight sidebar metadata, same session id, title without "watermelon".
+    save_thread_metadata(
+        session_id.clone(),
+        Some("Daily standup notes".into()),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+        None,
+        None,
+        &project,
+        cx,
+    );
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            //
+            "v [my-project]",
+            "  Daily standup notes",
+        ]
+    );
+
+    // Title search for "watermelon" alone would hide the thread; content search
+    // brings it back once the async load + match completes.
+    type_in_search(&sidebar, "watermelon", cx);
+    cx.executor().advance_clock(Duration::from_millis(250));
+    cx.run_until_parked();
+
+    // No `<== selected` marker: selection is set synchronously while typing
+    // (when the list is still empty, since the title doesn't match), and the
+    // content match arrives asynchronously afterwards without re-selecting.
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec![
+            //
+            "v [my-project]",
+            "  Daily standup notes",
+        ],
+        "thread should surface because its message content matches the query"
+    );
+
+    // A query that matches neither title nor content hides it again.
+    type_in_search(&sidebar, "pineapple", cx);
+    cx.executor().advance_clock(Duration::from_millis(250));
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        Vec::<String>::new()
+    );
+}
+
+#[gpui::test]
 async fn test_search_matches_regardless_of_case(cx: &mut TestAppContext) {
     // Scenario: A user remembers a thread title but not the exact casing.
     // Search should match case-insensitively so they can still find it.

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -4571,7 +4571,10 @@ async fn test_search_matches_workspace_name(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_search_finds_threads_inside_collapsed_groups(cx: &mut TestAppContext) {
+async fn test_search_keeps_collapsed_group_header_visible_for_matches(cx: &mut TestAppContext) {
+    // Project chevron must work *during* search: a collapsed group stays
+    // collapsed when a query matches inside it, but its header is kept visible
+    // so the user knows results live there and can expand to see them.
     let project = init_test_project("/my-project", cx).await;
     let (multi_workspace, cx) =
         cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
@@ -4588,8 +4591,7 @@ async fn test_search_finds_threads_inside_collapsed_groups(cx: &mut TestAppConte
     );
     cx.run_until_parked();
 
-    // User focuses the sidebar and collapses the group using keyboard:
-    // manually select the header, then press SelectParent to collapse.
+    // Collapse the group via keyboard.
     focus_sidebar(&sidebar, cx);
     sidebar.update_in(cx, |sidebar, _window, _cx| {
         sidebar.selection = Some(0);
@@ -4605,14 +4607,15 @@ async fn test_search_finds_threads_inside_collapsed_groups(cx: &mut TestAppConte
         ]
     );
 
-    // User types a search — the thread appears even though its group is collapsed.
+    // Type a search that matches a thread in the collapsed group. The header
+    // remains (so the user knows there's a match in there) and the chevron
+    // stays in its collapsed state — the user must expand to reveal the hits.
     type_in_search(&sidebar, "important", cx);
     assert_eq!(
         visible_entries_as_strings(&sidebar, cx),
         vec![
             //
-            "> [my-project]",
-            "  Important thread  <== selected",
+            "> [my-project]  <== selected",
         ]
     );
 }

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -4134,6 +4134,90 @@ async fn test_search_matches_thread_message_content(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_search_surfaces_archived_thread_by_content(cx: &mut TestAppContext) {
+    // Scenario: a thread the user archived still matches a content search. It's
+    // normally hidden from the list, but should surface (rendered demoted) when
+    // the query appears in its conversation.
+    let project = init_test_project("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    let session_id = acp::SessionId::new(Arc::from("archived-thread"));
+
+    let db_thread = agent::DbThread {
+        title: "Archived standup notes".into(),
+        messages: vec![Arc::new(agent::Message::User(agent::UserMessage {
+            id: acp_thread::UserMessageId::new(),
+            content: Arc::from(vec![agent::UserMessageContent::Text(
+                "the kumquat migration is finally done".into(),
+            )]),
+        }))],
+        updated_at: chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+        detailed_summary: None,
+        initial_project_snapshot: None,
+        cumulative_token_usage: Default::default(),
+        request_token_usage: Default::default(),
+        model: None,
+        profile: None,
+        imported: false,
+        subagent_context: None,
+        speed: None,
+        thinking_enabled: false,
+        thinking_effort: None,
+        draft_prompt: None,
+        ui_scroll_position: None,
+        sandboxed_terminal_temp_dir: None,
+    };
+    let save_task = cx.update(|_, cx| {
+        ThreadStore::global(cx).update(cx, |store, cx| {
+            store.save_thread(session_id.clone(), db_thread, PathList::default(), cx)
+        })
+    });
+    save_task.await.unwrap();
+    cx.run_until_parked();
+
+    // Seed *archived* metadata for the same session, with the project's
+    // worktree paths so it indexes under the `[my-project]` group.
+    let worktree_paths = cx.update(|_, cx| project.read(cx).worktree_paths(cx));
+    let metadata = ThreadMetadata {
+        thread_id: ThreadId::new(),
+        session_id: Some(session_id.clone()),
+        agent_id: agent::ZED_AGENT_ID.clone(),
+        title: Some("Archived standup notes".into()),
+        title_override: None,
+        updated_at: chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+        created_at: None,
+        interacted_at: None,
+        worktree_paths,
+        remote_connection: None,
+        archived: true,
+    };
+    seed_thread_metadata(metadata, cx);
+
+    // Archived threads don't show in the normal (unfiltered) list.
+    assert!(
+        !visible_entries_as_strings(&sidebar, cx)
+            .iter()
+            .any(|row| row.contains("Archived standup notes")),
+        "archived thread should be hidden before searching"
+    );
+
+    // Content search surfaces it (title has no "kumquat").
+    type_in_search(&sidebar, "kumquat", cx);
+    cx.executor().advance_clock(Duration::from_millis(250));
+    cx.run_until_parked();
+
+    assert!(
+        visible_entries_as_strings(&sidebar, cx)
+            .iter()
+            .any(|row| row.contains("Archived standup notes")),
+        "archived thread should surface when its content matches the query, got: {:?}",
+        visible_entries_as_strings(&sidebar, cx)
+    );
+}
+
+#[gpui::test]
 async fn test_search_matches_regardless_of_case(cx: &mut TestAppContext) {
     // Scenario: A user remembers a thread title but not the exact casing.
     // Search should match case-insensitively so they can still find it.


### PR DESCRIPTION
Summary:

A bundle of improvements to the agent thread sidebar's "Search threads…"
filter. Previously it only matched titles. With this PR a query matches
the actual conversation content too, archived threads are reachable from
the same search box, and the result ordering and collapse behaviour
match what you'd expect coming from any cross-document search.

Builds on @dandv's in-thread search bar work in #57231 conceptually:
that PR added search *inside* a single open thread; this PR adds search
*across* threads, designed to match the same visible scope so a sidebar
match is always findable in dandv's bar once #57231 lands. See "Credit"
below.

What's in the PR:

1. **Content search** — typing in the sidebar filter now also matches
   thread message content, not just titles. Loaded threads are searched
   in memory; unloaded native threads are read from the local thread DB
   on demand. Debounced + cached + cancelable.

2. **Archived in content search** — archived threads (normally hidden
   from the sidebar) surface in results when their content matches the
   query, rendered demoted via `ThreadItem::archived`. New helper
   `ThreadMetadataStore::archived_entries_for_main_worktree_path` and
   per-group injection in `rebuild_contents`.

3. **"Search more (closed agent threads)" footer** — closed
   external/ACP threads can't be searched from local storage (their
   history lives in the agent). An explicit "Search more" button runs
   a progressive pass: load each one through its agent, search its
   content, and surface matches as they're found, with a live N/M
   progress and a Stop control. Per-agent connections are reused, so
   one connection per agent (not per thread). New
   `AgentPanel::load_session_content_for_search` performs the headless
   load.

4. **Scope alignment + ranking** — the sidebar matched the thread's
   full markdown (including thinking blocks and tool output), but the
   in-thread search bar (#57231) deliberately scans only the visible
   text. A sidebar match in hidden content would open to "0/0" in the
   bar. Now both paths use the same scope via new
   `AcpThread::searchable_text` and `agent::Message::searchable_markdown`
   helpers, so cross-thread results are always navigable in-thread.
   Results are also ranked: title/worktree matches first, then content
   matches by hit count, then recency.

5. **"Search more" includes archived** — archived external/ACP threads
   are also covered by the on-demand pass, and matches surface through
   the archived injection.

6. **Respect collapse during search** — typing a query no longer force-
   loads every group's threads. Clicking the project chevron during a
   search actually folds/unfolds results. Groups whose threads match by
   title or content still show their header so the user can expand to
   reveal the hits.

Credit:

This work builds directly on @dandv's open PR #57231 ("agent_ui: Add
in-thread search bar"):

- **Scope alignment**: @dandv's PR defines which thread content is
  "visible / searchable" for the in-thread Find bar (user messages,
  assistant message chunks, tool-call labels; excluding thinking blocks
  and tool output). This PR's `AcpThread::searchable_text` and
  `agent::Message::searchable_markdown` mirror that exact scope, so a
  sidebar match is guaranteed to be reachable in his bar once #57231
  lands.
- **Click-through (held back)**: Clicking a sidebar result and having
  it open his Find bar pre-filled with the same query is a tiny
  follow-up we built but are holding back until #57231 merges (it
  modifies `thread_search_bar.rs` / `thread_view.rs` directly). Will
  open it as a small standalone PR after his lands.

Related PRs in this bundle:

- #57231 — @dandv — in-thread search bar (the foundation this PR aligns with).
- #58212 — Right-click context menu on sidebar threads.
- #58213 — Retry button for failed agent launch.
- #58214 — Match project name in archive-view search.
- #58215 — Include archived threads in the thread switcher dropdown.

Tests:

- 142 sidebar tests pass (incl. new tests for content search, archived surfacing, project-name match, and collapse-during-search).

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — N/A
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable — content search is debounced, cached, and run off the main thread; "Search more" is gated behind explicit user action and reuses one connection per agent.

Release Notes:

- Improved agent thread sidebar search: now matches thread message content (not just titles), surfaces archived threads, ranks results by relevance, makes project folding work during search, and adds a "Search more" footer button that loads closed external/ACP threads on demand for content search.