### PR TITLE
editor: Fix newline outdent when tab size is greater than current indent size

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1583,6 +1583,25 @@ pub struct RewrapOptions {
     pub line_length: Option<usize>,
 }
 
+fn outdent_len_for_indent(indent_size: IndentSize, tab_size: NonZeroU32) -> u32 {
+    if indent_size.len == 0 {
+        return 0;
+    }
+
+    match indent_size.kind {
+        IndentKind::Space => {
+            let tab_size = tab_size.get();
+            let columns_to_prev_tab_stop = indent_size.len % tab_size;
+            if columns_to_prev_tab_stop == 0 {
+                tab_size
+            } else {
+                columns_to_prev_tab_stop
+            }
+        }
+        IndentKind::Tab => 1,
+    }
+}
+
 impl Editor {
     pub fn single_line(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let buffer = cx.new(|cx| Buffer::local("", cx));
@@ -5106,7 +5125,7 @@ impl Editor {
             let snapshot = buffer.snapshot(cx);
             for selection in &selections {
                 let settings = buffer.language_settings_at(selection.start, cx);
-                let tab_size = settings.tab_size.get();
+                let tab_size = settings.tab_size;
                 let mut rows = selection.spanned_rows(false, &display_map);
 
                 // Avoid re-outdenting a row that has already been outdented by a
@@ -5120,17 +5139,7 @@ impl Editor {
                 for row in rows.iter_rows() {
                     let indent_size = snapshot.indent_size_for_line(row);
                     if indent_size.len > 0 {
-                        let deletion_len = match indent_size.kind {
-                            IndentKind::Space => {
-                                let columns_to_prev_tab_stop = indent_size.len % tab_size;
-                                if columns_to_prev_tab_stop == 0 {
-                                    tab_size
-                                } else {
-                                    columns_to_prev_tab_stop
-                                }
-                            }
-                            IndentKind::Tab => 1,
-                        };
+                        let deletion_len = outdent_len_for_indent(indent_size, tab_size);
                         let start = if has_multiple_rows
                             || deletion_len > selection.start.column
                             || indent_size.len < selection.start.column

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1583,25 +1583,6 @@ pub struct RewrapOptions {
     pub line_length: Option<usize>,
 }
 
-fn outdent_len_for_indent(indent_size: IndentSize, tab_size: NonZeroU32) -> u32 {
-    if indent_size.len == 0 {
-        return 0;
-    }
-
-    match indent_size.kind {
-        IndentKind::Space => {
-            let tab_size = tab_size.get();
-            let columns_to_prev_tab_stop = indent_size.len % tab_size;
-            if columns_to_prev_tab_stop == 0 {
-                tab_size
-            } else {
-                columns_to_prev_tab_stop
-            }
-        }
-        IndentKind::Tab => 1,
-    }
-}
-
 impl Editor {
     pub fn single_line(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let buffer = cx.new(|cx| Buffer::local("", cx));
@@ -5139,7 +5120,7 @@ impl Editor {
                 for row in rows.iter_rows() {
                     let indent_size = snapshot.indent_size_for_line(row);
                     if indent_size.len > 0 {
-                        let deletion_len = outdent_len_for_indent(indent_size, tab_size);
+                        let deletion_len = indent_size.outdent_len(tab_size);
                         let start = if has_multiple_rows
                             || deletion_len > selection.start.column
                             || indent_size.len < selection.start.column

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -34948,6 +34948,42 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
         -
         ˇitem
     "});
+
+    update_test_language_settings(&mut cx, &|settings| {
+        settings.defaults.tab_size = Some(4.try_into().unwrap());
+    });
+
+    // Case 9: Empty list item unindent works when tab size is larger than list indentation
+    cx.set_state(indoc! {"
+        - item
+          - sub item
+          - ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        - item
+          - sub item
+        - ˇ
+    "});
+
+    // Case 10: Empty list item unindent moves to the previous tab stop
+    cx.set_state(
+        indoc! {"
+        $$$$$$- ˇ
+    "}
+        .replace("$", " ")
+        .as_str(),
+    );
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(
+        indoc! {"
+        $$$$- ˇ
+    "}
+        .replace("$", " ")
+        .as_str(),
+    );
 }
 
 #[gpui::test]

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -648,11 +648,11 @@ impl Editor {
                                 let row_start =
                                     buffer.point_to_offset(Point::new(start_point.row, 0));
                                 let tab_size = buffer.language_settings_at(start, cx).tab_size;
-                                let tab_size_indent = IndentSize::spaces(tab_size.get());
-                                let reduced_indent =
-                                    existing_indent.with_delta(Ordering::Less, tab_size_indent);
+                                existing_indent.len = existing_indent.len.saturating_sub(
+                                    outdent_len_for_indent(existing_indent, tab_size),
+                                );
                                 let mut new_text = String::new();
-                                new_text.extend(reduced_indent.chars());
+                                new_text.extend(existing_indent.chars());
                                 new_text.push_str(continuation);
                                 (row_start, new_text, true)
                             }

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -648,9 +648,9 @@ impl Editor {
                                 let row_start =
                                     buffer.point_to_offset(Point::new(start_point.row, 0));
                                 let tab_size = buffer.language_settings_at(start, cx).tab_size;
-                                existing_indent.len = existing_indent.len.saturating_sub(
-                                    outdent_len_for_indent(existing_indent, tab_size),
-                                );
+                                existing_indent.len = existing_indent
+                                    .len
+                                    .saturating_sub(existing_indent.outdent_len(tab_size));
                                 let mut new_text = String::new();
                                 new_text.extend(existing_indent.chars());
                                 new_text.push_str(continuation);

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -5917,6 +5917,27 @@ impl IndentSize {
         self
     }
 
+    /// Returns the number of indentation characters to remove when outdenting to the
+    /// previous editor tab stop.
+    pub fn outdent_len(self, tab_size: NonZeroU32) -> u32 {
+        if self.len == 0 {
+            return 0;
+        }
+
+        match self.kind {
+            IndentKind::Space => {
+                let tab_size = tab_size.get();
+                let columns_to_prev_tab_stop = self.len % tab_size;
+                if columns_to_prev_tab_stop == 0 {
+                    tab_size
+                } else {
+                    columns_to_prev_tab_stop
+                }
+            }
+            IndentKind::Tab => 1,
+        }
+    }
+
     pub fn len_with_expanded_tabs(&self, tab_size: NonZeroU32) -> usize {
         match self.kind {
             IndentKind::Space => self.len as usize,


### PR DESCRIPTION
This fixes no-op on the newline outdent path when the settings tab size is greater than the current indent size.

Release Notes:

- Fixed pressing Enter on an empty nested Markdown list item when the tab size is larger than the list indentation.
