### PR TITLE
acp: Handle reasoning effort shortcuts

### DIFF
--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -342,6 +342,14 @@ impl ConfigOptionSelector {
         }
     }
 
+    fn handles_category_keybindings(&self, category: &acp::SessionConfigOptionCategory) -> bool {
+        self.config_options
+            .config_options()
+            .into_iter()
+            .find(|option| option.category.as_ref() == Some(category))
+            .is_some_and(|option| option.id == self.config_id)
+    }
+
     fn render_trigger_button(&self, _window: &mut Window, _cx: &mut Context<Self>) -> Button {
         let Some(option) = self.current_option() else {
             return Button::new("config-option-trigger", "Unknown")
@@ -375,6 +383,11 @@ impl Render for ConfigOptionSelector {
 
         let trigger_button = self.render_trigger_button(window, cx);
 
+        let show_category_keybindings = option
+            .category
+            .as_ref()
+            .is_some_and(|category| self.handles_category_keybindings(category));
+        let option_category = option.category.clone();
         let option_name = option.name.clone();
         let option_description: Option<SharedString> = option.description.map(Into::into);
 
@@ -399,7 +412,7 @@ impl Render for ConfigOptionSelector {
                     .child(keybinding)
             };
 
-            if let Some(category) = &option.category {
+            if show_category_keybindings && let Some(category) = &option_category {
                 match category {
                     acp::SessionConfigOptionCategory::Mode => {
                         content = content

--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -419,7 +419,7 @@ impl Render for ConfigOptionSelector {
                                 KeyBinding::for_action(&ToggleModelSelector, cx),
                             ))
                             .child(action_tooltip_container(
-                                "Cycle Favorite Model",
+                                "Cycle Favorite Models",
                                 KeyBinding::for_action(&CycleFavoriteModels, cx),
                             ));
                     }

--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -15,11 +15,17 @@ use picker::popover_menu::PickerPopoverMenu;
 use picker::{Picker, PickerDelegate};
 use settings::SettingsStore;
 use ui::{
-    ElevationIndex, IconButton, ListItem, ListItemSpacing, PopoverMenuHandle, Tooltip, prelude::*,
+    ElevationIndex, IconButton, KeyBinding, ListItem, ListItemSpacing, PopoverMenuHandle, Tooltip,
+    prelude::*,
 };
 use util::ResultExt as _;
+use zed_actions::agent::ToggleModelSelector;
 
 use crate::ui::documentation_aside_side;
+use crate::{
+    CycleFavoriteModels, CycleModeSelector, CycleThinkingEffort, ToggleProfileSelector,
+    ToggleThinkingEffortMenu,
+};
 
 const PICKER_THRESHOLD: usize = 5;
 
@@ -372,7 +378,7 @@ impl Render for ConfigOptionSelector {
         let option_name = option.name.clone();
         let option_description: Option<SharedString> = option.description.map(Into::into);
 
-        let tooltip = Tooltip::element(move |_window, _cx| {
+        let tooltip = Tooltip::element(move |_window, cx| {
             let mut content = v_flex().gap_1().child(Label::new(option_name.clone()));
             if let Some(desc) = option_description.as_ref() {
                 content = content.child(
@@ -380,6 +386,56 @@ impl Render for ConfigOptionSelector {
                         .size(LabelSize::Small)
                         .color(Color::Muted),
                 );
+            }
+
+            let action_tooltip_container = |label: &str, keybinding: KeyBinding| {
+                h_flex()
+                    .pt_1()
+                    .gap_2()
+                    .justify_between()
+                    .border_t_1()
+                    .border_color(cx.theme().colors().border_variant)
+                    .child(Label::new(label))
+                    .child(keybinding)
+            };
+
+            if let Some(category) = &option.category {
+                match category {
+                    acp::SessionConfigOptionCategory::Mode => {
+                        content = content
+                            .child(action_tooltip_container(
+                                "Change Mode",
+                                KeyBinding::for_action(&ToggleProfileSelector, cx),
+                            ))
+                            .child(action_tooltip_container(
+                                "Cycle Through Modes",
+                                KeyBinding::for_action(&CycleModeSelector, cx),
+                            ));
+                    }
+                    acp::SessionConfigOptionCategory::Model => {
+                        content = content
+                            .child(action_tooltip_container(
+                                "Change Model",
+                                KeyBinding::for_action(&ToggleModelSelector, cx),
+                            ))
+                            .child(action_tooltip_container(
+                                "Cycle Favorite Model",
+                                KeyBinding::for_action(&CycleFavoriteModels, cx),
+                            ));
+                    }
+                    acp::SessionConfigOptionCategory::ThoughtLevel => {
+                        content = content
+                            .child(action_tooltip_container(
+                                "Change Thinking Effort",
+                                KeyBinding::for_action(&ToggleThinkingEffortMenu, cx),
+                            ))
+                            .child(action_tooltip_container(
+                                "Cycle Thinking Effort",
+                                KeyBinding::for_action(&CycleThinkingEffort, cx),
+                            ));
+                    }
+                    _ => {}
+                }
             }
             content.into_any()
         });

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -9649,7 +9649,7 @@ impl ThreadView {
         });
     }
 
-    fn cycle_thinking_effort(&mut self, cx: &mut Context<Self>) {
+    fn cycle_native_agent_thinking_effort(&mut self, cx: &mut Context<Self>) {
         let Some(thread) = self.as_native_thread(cx) else {
             return;
         };
@@ -9700,18 +9700,6 @@ impl ThreadView {
                     }
                 }
             });
-        });
-    }
-
-    fn toggle_thinking_effort_menu(
-        &mut self,
-        _action: &ToggleThinkingEffortMenu,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let menu_handle = self.thinking_effort_menu_handle.clone();
-        window.defer(cx, move |window, cx| {
-            menu_handle.toggle(window, cx);
         });
     }
 }
@@ -9790,14 +9778,41 @@ impl Render for ThreadView {
                 if this.thread.read(cx).status() != ThreadStatus::Idle {
                     return;
                 }
-                this.cycle_thinking_effort(cx);
+                if let Some(config_options_view) = this.config_options_view.clone() {
+                    let handled = config_options_view.update(cx, |view, cx| {
+                        view.cycle_category_option(
+                            acp::SessionConfigOptionCategory::ThoughtLevel,
+                            false,
+                            cx,
+                        )
+                    });
+                    if handled {
+                        return;
+                    }
+                }
+                this.cycle_native_agent_thinking_effort(cx);
             }))
             .on_action(
-                cx.listener(|this, action: &ToggleThinkingEffortMenu, window, cx| {
+                cx.listener(|this, _: &ToggleThinkingEffortMenu, window, cx| {
                     if this.thread.read(cx).status() != ThreadStatus::Idle {
                         return;
                     }
-                    this.toggle_thinking_effort_menu(action, window, cx);
+                    if let Some(config_options_view) = this.config_options_view.clone() {
+                        let handled = config_options_view.update(cx, |view, cx| {
+                            view.toggle_category_picker(
+                                acp::SessionConfigOptionCategory::ThoughtLevel,
+                                window,
+                                cx,
+                            )
+                        });
+                        if handled {
+                            return;
+                        }
+                    }
+                    let menu_handle = this.thinking_effort_menu_handle.clone();
+                    window.defer(cx, move |window, cx| {
+                        menu_handle.toggle(window, cx);
+                    });
                 }),
             )
             .on_action(cx.listener(|this, _: &SendNextQueuedMessage, window, cx| {

--- a/crates/agent_ui/src/ui/model_selector_components.rs
+++ b/crates/agent_ui/src/ui/model_selector_components.rs
@@ -257,7 +257,7 @@ impl RenderOnce for ModelSelectorTooltip {
                         .border_t_1()
                         .border_color(cx.theme().colors().border_variant)
                         .justify_between()
-                        .child(Label::new("Cycle Favorited Models"))
+                        .child(Label::new("Cycle Favorite Models"))
                         .child(KeyBinding::for_action(&CycleFavoriteModels, cx)),
                 )
             })


### PR DESCRIPTION
Makes sure that the reasoning effort levels picker can be controlled with the same shortcuts that are used in the native agent.

Also adds the keyboard shortcuts to the tooltips for all pickers that support them

Closes #56074

Release Notes:

- Fixed an issue where reasoning effort selector could not be controlled via keyboard shortcuts for ACP agents
