### PR TITLE
Fix traffic light padding on macOS SDK 26+ builds

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -659,7 +659,7 @@ impl TitleBar {
                 })
             });
 
-        if cfg!(macos_sdk_26) {
+        if ui::utils::MACOS_SDK_26_OR_LATER {
             // Make up for Tahoe's traffic light buttons having less spacing around them
             Some(div().child(button).ml_0p5().into_any_element())
         } else {

--- a/crates/ui/build.rs
+++ b/crates/ui/build.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::disallowed_methods, reason = "build scripts are exempt")]
 
 fn main() {
-    println!("cargo::rustc-check-cfg=cfg(macos_sdk_26)");
+    println!("cargo::rustc-check-cfg=cfg(macos_sdk_26_or_later)");
 
     #[cfg(target_os = "macos")]
     {
@@ -22,7 +22,7 @@ fn main() {
         if let Some(major) = major_version
             && major >= 26
         {
-            println!("cargo:rustc-cfg=macos_sdk_26");
+            println!("cargo:rustc-cfg=macos_sdk_26_or_later");
         }
     }
 }

--- a/crates/ui/src/utils/constants.rs
+++ b/crates/ui/src/utils/constants.rs
@@ -7,11 +7,7 @@ pub const MACOS_SDK_26_OR_LATER: bool = cfg!(macos_sdk_26_or_later);
 //
 // Magic number: There is one extra pixel of padding on the left side due to
 // the 1px border around the window on macOS apps.
-pub const TRAFFIC_LIGHT_PADDING: f32 = if MACOS_SDK_26_OR_LATER {
-    78.
-} else {
-    71.
-};
+pub const TRAFFIC_LIGHT_PADDING: f32 = if MACOS_SDK_26_OR_LATER { 78. } else { 71. };
 
 /// Returns the platform-appropriate title bar height.
 ///

--- a/crates/ui/src/utils/constants.rs
+++ b/crates/ui/src/utils/constants.rs
@@ -1,15 +1,17 @@
 use gpui::{Pixels, Window, px};
 
+pub const MACOS_SDK_26_OR_LATER: bool = cfg!(macos_sdk_26_or_later);
+
 // Use pixels here instead of a rem-based size because the macOS traffic
 // lights are a static size, and don't scale with the rest of the UI.
 //
 // Magic number: There is one extra pixel of padding on the left side due to
 // the 1px border around the window on macOS apps.
-#[cfg(macos_sdk_26)]
-pub const TRAFFIC_LIGHT_PADDING: f32 = 78.;
-
-#[cfg(not(macos_sdk_26))]
-pub const TRAFFIC_LIGHT_PADDING: f32 = 71.;
+pub const TRAFFIC_LIGHT_PADDING: f32 = if MACOS_SDK_26_OR_LATER {
+    78.
+} else {
+    71.
+};
 
 /// Returns the platform-appropriate title bar height.
 ///


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] ~~Unsafe blocks (if any) have justifying comments~~ (N/A)
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Corrects the value used for traffic light clearance/padding when building with the macOS 26 SDK (or later). This was originally fixed in #45351 but regressed in #48800 where `TRAFFIC_LIGHT_PADDING` was moved to `ui/src/utils/constants.rs` but the local `build.rs` in `title_bar` did not apply to the `ui` crate.

Release Notes:

- N/A
