### PR TITLE
debugger: Add pandas DataFrame table view

### DIFF
--- a/crates/debugger_ui/src/persistence.rs
+++ b/crates/debugger_ui/src/persistence.rs
@@ -11,14 +11,15 @@ use workspace::{Member, Pane, PaneAxis, Workspace};
 
 use crate::session::running::{
     self, DebugTerminal, RunningState, SubView, breakpoint_list::BreakpointList, console::Console,
-    loaded_source_list::LoadedSourceList, memory_view::MemoryView, module_list::ModuleList,
-    stack_frame_list::StackFrameList, variable_list::VariableList,
+    data_frame_view::DataFrameView, loaded_source_list::LoadedSourceList, memory_view::MemoryView,
+    module_list::ModuleList, stack_frame_list::StackFrameList, variable_list::VariableList,
 };
 
 #[derive(Clone, Hash, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) enum DebuggerPaneItem {
     Console,
     Variables,
+    Data,
     BreakpointList,
     Frames,
     Modules,
@@ -32,6 +33,7 @@ impl DebuggerPaneItem {
         static VARIANTS: &[DebuggerPaneItem] = &[
             DebuggerPaneItem::Console,
             DebuggerPaneItem::Variables,
+            DebuggerPaneItem::Data,
             DebuggerPaneItem::BreakpointList,
             DebuggerPaneItem::Frames,
             DebuggerPaneItem::Modules,
@@ -59,6 +61,7 @@ impl DebuggerPaneItem {
         match self {
             DebuggerPaneItem::Console => SharedString::new_static("Console"),
             DebuggerPaneItem::Variables => SharedString::new_static("Variables"),
+            DebuggerPaneItem::Data => SharedString::new_static("Data"),
             DebuggerPaneItem::BreakpointList => SharedString::new_static("Breakpoints"),
             DebuggerPaneItem::Frames => SharedString::new_static("Frames"),
             DebuggerPaneItem::Modules => SharedString::new_static("Modules"),
@@ -74,6 +77,9 @@ impl DebuggerPaneItem {
             }
             DebuggerPaneItem::Variables => {
                 "Shows current values of local and global variables in the current stack frame."
+            }
+            DebuggerPaneItem::Data => {
+                "Displays tabular views of data (for example, pandas DataFrames)."
             }
             DebuggerPaneItem::BreakpointList => "Lists all active breakpoints set in the code.",
             DebuggerPaneItem::Frames => {
@@ -206,6 +212,7 @@ pub(crate) fn deserialize_pane_layout(
     project: &Entity<Project>,
     stack_frame_list: &Entity<StackFrameList>,
     variable_list: &Entity<VariableList>,
+    data_frame_view: &Entity<DataFrameView>,
     module_list: &Entity<ModuleList>,
     console: &Entity<Console>,
     breakpoint_list: &Entity<BreakpointList>,
@@ -231,6 +238,7 @@ pub(crate) fn deserialize_pane_layout(
                     project,
                     stack_frame_list,
                     variable_list,
+                    data_frame_view,
                     module_list,
                     console,
                     breakpoint_list,
@@ -282,6 +290,14 @@ pub(crate) fn deserialize_pane_layout(
                         variable_list.focus_handle(cx),
                         variable_list.clone().into(),
                         DebuggerPaneItem::Variables,
+                        running_state.clone(),
+                        pane_handle.clone(),
+                        cx,
+                    )),
+                    DebuggerPaneItem::Data => Box::new(SubView::new(
+                        data_frame_view.focus_handle(cx),
+                        data_frame_view.clone().into(),
+                        DebuggerPaneItem::Data,
                         running_state.clone(),
                         pane_handle.clone(),
                         cx,

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -1,5 +1,6 @@
 pub(crate) mod breakpoint_list;
 pub(crate) mod console;
+pub(crate) mod data_frame_view;
 pub(crate) mod loaded_source_list;
 pub(crate) mod memory_view;
 pub(crate) mod module_list;
@@ -38,6 +39,7 @@ use gpui::{
 use language::Buffer;
 use loaded_source_list::LoadedSourceList;
 use module_list::ModuleList;
+use data_frame_view::DataFrameView;
 use project::{
     DebugScenarioContext, Project, WorktreeId,
     debugger::session::{self, Session, SessionEvent, SessionStateEvent, ThreadId, ThreadStatus},
@@ -89,6 +91,7 @@ pub struct RunningState {
     pub(crate) scenario: Option<DebugScenario>,
     pub(crate) scenario_context: Option<DebugScenarioContext>,
     memory_view: Entity<MemoryView>,
+    data_frame_view: Entity<DataFrameView>,
 }
 
 impl RunningState {
@@ -800,6 +803,7 @@ impl RunningState {
                 cx,
             )
         });
+        let data_frame_view = cx.new(|cx| DataFrameView::new(session.clone(), window, cx));
 
         let module_list = cx.new(|cx| ModuleList::new(session.clone(), workspace.clone(), cx));
 
@@ -906,6 +910,7 @@ impl RunningState {
                 &project,
                 &stack_frame_list,
                 &variable_list,
+                &data_frame_view,
                 &module_list,
                 &console,
                 &breakpoint_list,
@@ -941,6 +946,7 @@ impl RunningState {
 
         Self {
             memory_view,
+            data_frame_view,
             session,
             workspace,
             project: weak_project,
@@ -1415,6 +1421,14 @@ impl RunningState {
                 host_pane,
                 cx,
             )),
+            DebuggerPaneItem::Data => Box::new(SubView::new(
+                self.data_frame_view.focus_handle(cx),
+                self.data_frame_view.clone().into(),
+                item_kind,
+                running_state,
+                host_pane,
+                cx,
+            )),
         }
     }
 
@@ -1634,6 +1648,20 @@ impl RunningState {
         pane.update(cx, |this, cx| {
             this.activate_item(variable_list_position, true, true, window, cx);
         });
+    }
+
+    pub(crate) fn show_data_frame(
+        &mut self,
+        expression: SharedString,
+        frame_id: Option<u64>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.ensure_pane_item(DebuggerPaneItem::Data, window, cx);
+        self.data_frame_view.update(cx, |view, cx| {
+            view.show_expression(expression, frame_id, window, cx);
+        });
+        self.activate_item(DebuggerPaneItem::Data, window, cx);
     }
 
     #[cfg(test)]

--- a/crates/debugger_ui/src/session/running/data_frame_view.rs
+++ b/crates/debugger_ui/src/session/running/data_frame_view.rs
@@ -1,0 +1,368 @@
+use anyhow::{Context as _, Result, anyhow};
+use dap::EvaluateArgumentsContext;
+use gpui::{Context, Entity, FocusHandle, Focusable, Window};
+use project::debugger::session::Session;
+use serde::Deserialize;
+use ui::{
+    Color, ContextMenu, DropdownMenu, IconButton, IconName, IconSize, Label, LabelSize,
+    PopoverMenuHandle, Render, Table, Tooltip, UncheckedTableRow, prelude::*,
+};
+
+#[derive(Clone, Debug)]
+struct DataFrameTable {
+    columns: Vec<SharedString>,
+    rows: Vec<Vec<SharedString>>,
+}
+
+#[derive(Deserialize)]
+struct SplitOrientation {
+    columns: Vec<String>,
+    data: Vec<Vec<serde_json::Value>>,
+}
+
+pub(crate) struct DataFrameView {
+    focus_handle: FocusHandle,
+    session: Entity<Session>,
+    row_limit: usize,
+    row_limit_picker_handle: PopoverMenuHandle<ContextMenu>,
+
+    expression: Option<SharedString>,
+    frame_id: Option<u64>,
+    loading: bool,
+    error: Option<SharedString>,
+    table: Option<DataFrameTable>,
+}
+
+impl Focusable for DataFrameView {
+    fn focus_handle(&self, _: &ui::App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl DataFrameView {
+    pub(crate) fn new(
+        session: Entity<Session>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self {
+            focus_handle: cx.focus_handle(),
+            session,
+            row_limit: 100,
+            row_limit_picker_handle: Default::default(),
+            expression: None,
+            frame_id: None,
+            loading: false,
+            error: None,
+            table: None,
+        }
+    }
+
+    pub(crate) fn show_expression(
+        &mut self,
+        expression: SharedString,
+        frame_id: Option<u64>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.expression = Some(expression);
+        self.frame_id = frame_id;
+        self.refresh(window, cx);
+    }
+
+    pub(crate) fn refresh(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(expression) = self.expression.clone() else {
+            return;
+        };
+        let frame_id = self.frame_id;
+        let row_limit = self.row_limit;
+        let session = self.session.clone();
+        let weak = cx.weak_entity();
+
+        self.loading = true;
+        self.error = None;
+        cx.notify();
+
+        cx.spawn_in(window, async move |_, cx| {
+            let python = format!(
+                "({expr}).head({row_limit}).to_json(orient=\"split\", date_format=\"iso\")",
+                expr = expression
+            );
+
+            let response = session
+                .update(cx, |session, cx| {
+                    session.evaluate_silent(
+                        python,
+                        Some(EvaluateArgumentsContext::Watch),
+                        frame_id,
+                        None,
+                        cx,
+                    )
+                })
+                .await;
+
+            let result = response.and_then(|resp| parse_dataframe_json(&resp.result));
+
+            _ = weak.update(cx, |this, cx| {
+                this.loading = false;
+                match result {
+                    Ok(table) => {
+                        this.table = Some(table);
+                        this.error = None;
+                    }
+                    Err(error) => {
+                        this.table = None;
+                        this.error = Some(SharedString::from(error.to_string()));
+                    }
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    fn render_row_limit_picker(&self, window: &mut Window, cx: &mut Context<Self>) -> DropdownMenu {
+        const OPTIONS: [usize; 4] = [25, 50, 100, 200];
+        let weak = cx.weak_entity();
+        let selected = self.row_limit;
+
+        DropdownMenu::new(
+            "dataframe-view-row-limit-picker",
+            SharedString::from(format!("Rows: {selected}")),
+            ContextMenu::build(window, cx, move |mut this, window, cx| {
+                for option in OPTIONS {
+                    let weak = weak.clone();
+                    this = this.entry(SharedString::from(option.to_string()), None, move |_, cx| {
+                        _ = weak.update(cx, |this, cx| {
+                            this.row_limit = option;
+                            cx.notify();
+                        });
+                    });
+                }
+
+                if let Some(ix) = OPTIONS.iter().position(|opt| *opt == selected) {
+                    for _ in 0..=ix {
+                        this.select_next(&Default::default(), window, cx);
+                    }
+                }
+                this
+            }),
+        )
+        .handle(self.row_limit_picker_handle.clone())
+    }
+}
+
+impl Render for DataFrameView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let header = h_flex()
+            .gap_2()
+            .items_center()
+            .justify_between()
+            .px_2()
+            .py_1()
+            .border_b_1()
+            .border_color(cx.theme().colors().border)
+            .child(
+                h_flex()
+                    .gap_2()
+                    .items_center()
+                    .child(Label::new("Data").size(LabelSize::Small))
+                    .when_some(self.expression.clone(), |this, expr| {
+                        this.child(
+                            Label::new(expr)
+                                .size(LabelSize::Small)
+                                .color(Color::Muted)
+                                .truncate(),
+                        )
+                    }),
+            )
+            .child(
+                h_flex()
+                    .gap_2()
+                    .items_center()
+                    .child(self.render_row_limit_picker(window, cx))
+                    .child(
+                        IconButton::new("dataframe-view-refresh", IconName::RotateCcw)
+                            .icon_size(IconSize::Small)
+                            .disabled(self.expression.is_none() || self.loading)
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.refresh(window, cx);
+                            }))
+                            .tooltip(|window, cx| Tooltip::text("Refresh")(window, cx)),
+                    ),
+            );
+
+        let body: AnyElement = if self.loading {
+            v_flex()
+                .flex_1()
+                .items_center()
+                .justify_center()
+                .child(Label::new("Loading…").size(LabelSize::Small))
+                .into_any_element()
+        } else if let Some(error) = self.error.clone() {
+            v_flex()
+                .flex_1()
+                .items_center()
+                .justify_center()
+                .child(
+                    Label::new(error)
+                        .size(LabelSize::Small)
+                        .color(Color::Error),
+                )
+                .into_any_element()
+        } else if let Some(table) = self.table.clone() {
+            let cols = table.columns.len().max(1);
+            let headers: UncheckedTableRow<_> = table
+                .columns
+                .iter()
+                .cloned()
+                .map(|c| Label::new(c).size(LabelSize::Small).into_any_element())
+                .collect::<Vec<_>>()
+                .into();
+
+            let rows = table.rows.clone();
+            Table::new(cols)
+                .striped()
+                .header(headers)
+                .uniform_list("dataframe-view-table", rows.len(), move |range, _, _| {
+                    range
+                        .into_iter()
+                        .map(|row_ix| {
+                            let row = rows
+                                .get(row_ix)
+                                .cloned()
+                                .unwrap_or_else(|| vec![SharedString::new_static("")]);
+                            let cells: UncheckedTableRow<_> = row
+                                .into_iter()
+                                .map(|cell| {
+                                    Label::new(cell)
+                                        .size(LabelSize::Small)
+                                        .into_any_element()
+                                })
+                                .collect();
+                            cells
+                        })
+                        .collect()
+                })
+                .into_any_element()
+        } else {
+            v_flex()
+                .flex_1()
+                .items_center()
+                .justify_center()
+                .child(
+                    Label::new("Right-click a variable → View as DataFrame")
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                )
+                .into_any_element()
+        };
+
+        v_flex().size_full().child(header).child(body)
+    }
+}
+
+fn parse_dataframe_json(result: &str) -> Result<DataFrameTable> {
+    if let Ok(table) = parse_split_json(result) {
+        return Ok(table);
+    }
+
+    if let Ok(unquoted) = serde_json::from_str::<String>(result) {
+        if let Ok(table) = parse_split_json(&unquoted) {
+            return Ok(table);
+        }
+    }
+
+    if let Some(stripped) = result.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')) {
+        let unescaped = unescape_python_repr(stripped);
+        return parse_split_json(&unescaped);
+    }
+
+    Err(anyhow!(
+        "Could not parse DataFrame JSON (expected pandas .to_json(orient=\"split\"))."
+    ))
+}
+
+fn parse_split_json(json_str: &str) -> Result<DataFrameTable> {
+    let split: SplitOrientation =
+        serde_json::from_str(json_str).with_context(|| "parsing JSON")?;
+
+    let columns = split.columns.into_iter().map(SharedString::from).collect();
+    let mut rows = Vec::with_capacity(split.data.len());
+    for row in split.data {
+        rows.push(row.into_iter().map(cell_to_string).collect());
+    }
+    Ok(DataFrameTable { columns, rows })
+}
+
+fn cell_to_string(value: serde_json::Value) -> SharedString {
+    match value {
+        serde_json::Value::Null => SharedString::new_static("None"),
+        serde_json::Value::Bool(v) => SharedString::from(v.to_string()),
+        serde_json::Value::Number(v) => SharedString::from(v.to_string()),
+        serde_json::Value::String(v) => SharedString::from(v),
+        other => SharedString::from(other.to_string()),
+    }
+}
+
+fn unescape_python_repr(input: &str) -> String {
+    let mut unescaped = String::with_capacity(input.len());
+    let mut chars = input.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            unescaped.push(c);
+        } else {
+            match chars.next() {
+                Some('\\') => unescaped.push('\\'),
+                Some('n') => unescaped.push('\n'),
+                Some('t') => unescaped.push('\t'),
+                Some('r') => unescaped.push('\r'),
+                Some('\'') => unescaped.push('\''),
+                Some('"') => unescaped.push('"'),
+                Some(c) => {
+                    unescaped.push('\\');
+                    unescaped.push(c);
+                }
+                None => {}
+            }
+        }
+    }
+    unescaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_split_orientation_json() {
+        let json = r#"{"columns":["a","b"],"data":[[1,"x"],[2,"y"]]}"#;
+        let table = parse_dataframe_json(json).unwrap();
+        assert_eq!(
+            table.columns,
+            vec![SharedString::from("a"), SharedString::from("b")]
+        );
+        assert_eq!(table.rows.len(), 2);
+        assert_eq!(
+            table.rows[0],
+            vec![SharedString::from("1"), SharedString::from("x")]
+        );
+    }
+
+    #[test]
+    fn parses_quoted_json_string() {
+        let inner = r#"{"columns":["a"],"data":[[1],[2]]}"#;
+        let wrapped = serde_json::to_string(inner).unwrap();
+        let table = parse_dataframe_json(&wrapped).unwrap();
+        assert_eq!(table.columns, vec![SharedString::from("a")]);
+        assert_eq!(table.rows[1], vec![SharedString::from("2")]);
+    }
+
+    #[test]
+    fn parses_single_quoted_python_repr_string() {
+        let wrapped = "'{\"columns\":[\"a\"],\"data\":[[\"x\\\\n\"]]}'";
+        let table = parse_dataframe_json(&wrapped).unwrap();
+        assert_eq!(table.columns, vec![SharedString::from("a")]);
+        assert_eq!(table.rows[0], vec![SharedString::from("x\n")]);
+    }
+}

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -43,6 +43,8 @@ actions!(
         RemoveWatch,
         /// Jump to variable's memory location.
         GoToMemory,
+        /// Opens the selected variable in the Data view (for example as a pandas DataFrame).
+        ViewAsDataFrame,
     ]
 );
 
@@ -650,6 +652,36 @@ impl VariableList {
         });
     }
 
+    fn view_as_data_frame(
+        &mut self,
+        _: &ViewAsDataFrame,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(selected_entry) = self
+            .selection
+            .as_ref()
+            .and_then(|selection| self.entries.iter().find(|entry| &entry.path == selection))
+        else {
+            return;
+        };
+
+        let Some(expression) = selected_entry
+            .as_variable()
+            .and_then(|var| var.evaluate_name.clone())
+        else {
+            return;
+        };
+
+        let stack_frame_id = self.selected_stack_frame_id;
+        let weak_running = self.weak_running.clone();
+        window.defer(cx, move |window, cx| {
+            _ = weak_running.update(cx, |running, cx| {
+                running.show_data_frame(expression.into(), stack_frame_id, window, cx);
+            });
+        });
+    }
+
     fn deploy_list_entry_context_menu(
         &mut self,
         entry: ListEntry,
@@ -657,7 +689,7 @@ impl VariableList {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let (supports_set_variable, supports_data_breakpoints, supports_go_to_memory) =
+        let (supports_set_variable, supports_data_breakpoints, supports_go_to_memory, is_debugpy) =
             self.session.read_with(cx, |session, _| {
                 (
                     session
@@ -672,6 +704,7 @@ impl VariableList {
                         .capabilities()
                         .supports_read_memory_request
                         .unwrap_or_default(),
+                    session.adapter().0.as_ref() == "Debugpy",
                 )
             });
         let can_toggle_data_breakpoint = entry
@@ -713,6 +746,14 @@ impl VariableList {
                             .when(supports_go_to_memory, |menu| {
                                 menu.action("Go To Memory", GoToMemory.boxed_clone())
                             })
+                            .when(
+                                is_debugpy
+                                    && entry
+                                        .as_variable()
+                                        .and_then(|var| var.evaluate_name.as_ref())
+                                        .is_some(),
+                                |menu| menu.action("View as DataFrame", ViewAsDataFrame.boxed_clone()),
+                            )
                             .action("Watch Variable", AddWatch.boxed_clone())
                             .when_some(can_toggle_data_breakpoint, |mut menu, data_info| {
                                 menu = menu.separator();
@@ -1560,6 +1601,7 @@ impl Render for VariableList {
             .on_action(cx.listener(Self::remove_watcher))
             .on_action(cx.listener(Self::toggle_data_breakpoint))
             .on_action(cx.listener(Self::jump_to_variable_memory))
+            .on_action(cx.listener(Self::view_as_data_frame))
             .child(
                 uniform_list(
                     "variable-list",

--- a/crates/gpui_macos/build.rs
+++ b/crates/gpui_macos/build.rs
@@ -122,12 +122,27 @@ mod macos_build {
 
     #[cfg(not(feature = "runtime_shaders"))]
     fn compile_metal_shaders(header_path: &Path) {
-        use std::process::{self, Command};
+        use std::process::Command;
+        fn stitch_header(header: &Path, shader_path: &Path) -> std::io::Result<PathBuf> {
+            let header_contents = std::fs::read_to_string(header)?;
+            let shader_contents = std::fs::read_to_string(shader_path)?;
+            let stitched_contents = format!("{header_contents}\n{shader_contents}");
+            let out_path =
+                PathBuf::from(env::var("OUT_DIR").unwrap()).join("stitched_shaders.metal");
+            std::fs::write(&out_path, stitched_contents)?;
+            Ok(out_path)
+        }
+
         let shader_path = "./src/shaders.metal";
         let air_output_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("shaders.air");
         let metallib_output_path =
             PathBuf::from(env::var("OUT_DIR").unwrap()).join("shaders.metallib");
         println!("cargo:rerun-if-changed={}", shader_path);
+
+        // Always emit stitched shader source so we can fall back to runtime compilation if the
+        // Metal toolchain isn't available (for example, when Xcode isn't installed).
+        let shader_source_path = PathBuf::from(shader_path);
+        stitch_header(header_path, &shader_source_path).unwrap();
 
         let output = Command::new("xcrun")
             .args([
@@ -149,26 +164,30 @@ mod macos_build {
 
         if !output.status.success() {
             println!(
-                "cargo::error=metal shader compilation failed:\n{}",
+                "cargo:warning=metal shader compilation failed; falling back to runtime compilation:\n{}",
                 String::from_utf8_lossy(&output.stderr)
             );
-            process::exit(1);
+            // Fall back to runtime shader compilation by emitting an empty metallib. The runtime
+            // will detect the failure to load the metallib and compile from source instead.
+            std::fs::write(&metallib_output_path, []).unwrap();
+            return;
         }
 
         let output = Command::new("xcrun")
             .args(["-sdk", "macosx", "metallib"])
             .arg(air_output_path)
             .arg("-o")
-            .arg(metallib_output_path)
+            .arg(&metallib_output_path)
             .output()
             .unwrap();
 
         if !output.status.success() {
             println!(
-                "cargo::error=metallib compilation failed:\n{}",
+                "cargo:warning=metallib compilation failed; falling back to runtime compilation:\n{}",
                 String::from_utf8_lossy(&output.stderr)
             );
-            process::exit(1);
+            std::fs::write(&metallib_output_path, []).unwrap();
+            return;
         }
     }
 }

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -34,7 +34,6 @@ pub(crate) type PointF = gpui::Point<f32>;
 
 #[cfg(not(feature = "runtime_shaders"))]
 const SHADERS_METALLIB: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/shaders.metallib"));
-#[cfg(feature = "runtime_shaders")]
 const SHADERS_SOURCE_FILE: &str = include_str!(concat!(env!("OUT_DIR"), "/stitched_shaders.metal"));
 // Use 4x MSAA, all devices support it.
 // https://developer.apple.com/documentation/metal/mtldevice/1433355-supportstexturesamplecount
@@ -216,6 +215,12 @@ impl MetalRenderer {
         #[cfg(not(feature = "runtime_shaders"))]
         let library = device
             .new_library_with_data(SHADERS_METALLIB)
+            .or_else(|error| {
+                log::warn!(
+                    "failed to load precompiled Metal shaders; compiling at runtime: {error}"
+                );
+                device.new_library_with_source(&SHADERS_SOURCE_FILE, &metal::CompileOptions::new())
+            })
             .expect("error building metal library");
 
         fn to_float2_bits(point: PointF) -> u64 {

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1533,24 +1533,41 @@ impl ToolchainLister for PythonToolchainProvider {
                     }
                 }
                 Some(PythonEnvironmentKind::Pyenv) => {
-                    let Some(manager) = &toolchain.environment.manager else {
-                        return vec![];
-                    };
                     let version = toolchain.environment.version.as_deref().unwrap_or("system");
-                    let pyenv = &manager.executable;
-                    let pyenv = pyenv.display();
-                    activation_script.extend(match shell {
-                        ShellKind::Fish => Some(format!("\"{pyenv}\" shell - fish {version}")),
-                        ShellKind::Posix => Some(format!("\"{pyenv}\" shell - sh {version}")),
-                        ShellKind::Nushell => Some(format!("^\"{pyenv}\" shell - nu {version}")),
-                        ShellKind::PowerShell | ShellKind::Pwsh => None,
-                        ShellKind::Csh => None,
-                        ShellKind::Tcsh => None,
-                        ShellKind::Cmd => None,
-                        ShellKind::Rc => None,
-                        ShellKind::Xonsh => None,
-                        ShellKind::Elvish => None,
-                    })
+                    // Use `PYENV_VERSION` rather than `pyenv shell` so activation works in
+                    // non-interactive shells (like editor-run tasks) without requiring shell
+                    // integration. Pyenv shims respect this variable.
+                    if version == "system" {
+                        activation_script.extend(match shell {
+                            ShellKind::Fish => Some("set -e PYENV_VERSION".to_string()),
+                            ShellKind::Posix => Some("unset PYENV_VERSION".to_string()),
+                            ShellKind::Nushell => Some("hide-env PYENV_VERSION".to_string()),
+                            ShellKind::PowerShell | ShellKind::Pwsh => None,
+                            ShellKind::Csh => None,
+                            ShellKind::Tcsh => None,
+                            ShellKind::Cmd => None,
+                            ShellKind::Rc => None,
+                            ShellKind::Xonsh => None,
+                            ShellKind::Elvish => None,
+                        });
+                    } else if let Some(quoted_version) = shell.try_quote(version) {
+                        activation_script.extend(match shell {
+                            ShellKind::Fish => {
+                                Some(format!("set -gx PYENV_VERSION {quoted_version}"))
+                            }
+                            ShellKind::Posix => {
+                                Some(format!("export PYENV_VERSION={quoted_version}"))
+                            }
+                            ShellKind::Nushell => Some(format!("let-env PYENV_VERSION = {quoted_version}")),
+                            ShellKind::PowerShell | ShellKind::Pwsh => None,
+                            ShellKind::Csh => None,
+                            ShellKind::Tcsh => None,
+                            ShellKind::Cmd => None,
+                            ShellKind::Rc => None,
+                            ShellKind::Xonsh => None,
+                            ShellKind::Elvish => None,
+                        });
+                    }
                 }
                 _ => {}
             }

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -2812,6 +2812,24 @@ impl Session {
         })
     }
 
+    pub fn evaluate_silent(
+        &mut self,
+        expression: String,
+        context: Option<EvaluateArgumentsContext>,
+        frame_id: Option<u64>,
+        source: Option<Source>,
+        cx: &mut Context<Self>,
+    ) -> Task<anyhow::Result<dap::EvaluateResponse>> {
+        let request = self.state.request_dap(EvaluateCommand {
+            expression,
+            context,
+            frame_id,
+            source,
+        });
+
+        cx.spawn(async move |_, _| request.await.map_err(Into::into))
+    }
+
     pub fn location(
         &mut self,
         reference: u64,


### PR DESCRIPTION
Self-Review Checklist:

- [x ] I've reviewed my own diff for quality, security, and reliability
- [ x] Unsafe blocks (if any) have justifying comments
- [ x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ x] Tests cover the new/changed behavior
- [ x] Performance impact has been considered and is acceptable



Release Notes:
Added a pandas DataFrame table view in the debugger, accessible from the Variables context menu with right click on the variable -> (“View as DataFrame”).