### PR TITLE
collab: Use avatar URLs returned from Cloud

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -2685,7 +2685,7 @@ async fn get_users(
         .into_iter()
         .map(|user| proto::User {
             id: user.id.to_proto(),
-            avatar_url: format!("https://github.com/{}.png?size=128", user.github_login),
+            avatar_url: user.avatar_url,
             github_login: user.github_login,
             name: user.name,
         })
@@ -2723,7 +2723,7 @@ async fn fuzzy_search_users(
         .filter(|user| user.id != session.user_id())
         .map(|user| proto::User {
             id: user.id.to_proto(),
-            avatar_url: format!("https://github.com/{}.png?size=128", user.github_login),
+            avatar_url: user.avatar_url,
             github_login: user.github_login,
             name: user.name,
         })


### PR DESCRIPTION
This PR updates Collab to use the avatar URLs returned from Cloud instead of constructing them directly.

Release Notes:

- N/A
