### PR TITLE
Handle bracketed ellipsis title prefixes

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -271,11 +271,6 @@ fn pick_icon_glyph(prefix: &str) -> Option<SharedString> {
         return None;
     }
 
-    // Condense a leading run of dots (`...`) into a single ellipsis.
-    if prefix.starts_with("..") {
-        return Some("\u{2026}".into());
-    }
-
     // Strip a single pair of surrounding ASCII brackets, e.g. `[!]` -> `!`.
     let unwrapped = match prefix.chars().next() {
         Some('[') => prefix.strip_prefix('[').and_then(|s| s.strip_suffix(']')),
@@ -288,6 +283,11 @@ fn pick_icon_glyph(prefix: &str) -> Option<SharedString> {
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .unwrap_or(prefix);
+
+    // Condense a leading run of dots (`...`) into a single ellipsis.
+    if prefix.starts_with("..") {
+        return Some("\u{2026}".into());
+    }
 
     // Take the first grapheme cluster so multi-codepoint emoji stay intact.
     let first_grapheme = prefix.graphemes(true).next()?;

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -14771,6 +14771,14 @@ fn test_split_leading_icon_char() {
     assert_eq!(icon.as_ref(), "\u{2026}");
     assert_eq!(title.as_ref(), "working");
 
+    let (icon, title, _) = split_leading_icon_char(&"[...] working".into(), &[]).unwrap();
+    assert_eq!(icon.as_ref(), "\u{2026}");
+    assert_eq!(title.as_ref(), "working");
+
+    let (icon, title, _) = split_leading_icon_char(&"[…] working".into(), &[]).unwrap();
+    assert_eq!(icon.as_ref(), "\u{2026}");
+    assert_eq!(title.as_ref(), "working");
+
     // Multi-codepoint emoji are kept intact rather than sliced mid-cluster.
     let (icon, title, _) = split_leading_icon_char(&"🇺🇸 flag".into(), &[]).unwrap();
     assert_eq!(icon.as_ref(), "🇺🇸");


### PR DESCRIPTION
Terminal thread title prefixes now strip surrounding brackets before condensing leading dots, so bracketed ellipsis prefixes render with the same ellipsis icon as unbracketed prefixes.

Release Notes:

- Improved terminal thread icons for bracketed ellipsis title prefixes