### PR TITLE
git_ui: Render commit message as markdown

### DIFF
--- a/assets/icons/fold_vertical.svg
+++ b/assets/icons/fold_vertical.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4419_37)">
+<path d="M7.99999 10.667V14.667M9.99999 12.667L7.99999 10.667L5.99999 12.667M7.99999 1.33301V5.33301M9.99999 3.33301L7.99999 5.33301L5.99999 3.33301M2.66699 8.00001H1.33299M6.66699 8.00001H5.33299M10.667 8.00001H9.33299M14.667 8.00001H13.333" stroke="#C6CAD0" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_4419_37">
+<rect width="16" height="16" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -557,6 +557,14 @@ impl CommitView {
             (IconName::Copy, Color::Muted)
         };
 
+        let has_more = self.commit.message.trim().contains('\n');
+        let is_expanded = self.message_expanded;
+        let expand_tooltip = if is_expanded {
+            "Fold Commit Description"
+        } else {
+            "Expand Commit Description"
+        };
+
         v_flex()
             .w_full()
             .py_2p5()
@@ -584,26 +592,45 @@ impl CommitView {
                                     )),
                             )
                             .child(
-                                v_flex().child(Label::new(author_name)).child(
-                                    h_flex()
-                                        .gap_1p5()
-                                        .child(
-                                            Label::new(date_string)
-                                                .color(Color::Muted)
-                                                .size(LabelSize::Small),
-                                        )
-                                        .child(
-                                            Label::new("•")
-                                                .size(LabelSize::Small)
-                                                .color(Color::Muted)
-                                                .alpha(0.5),
-                                        )
-                                        .child(
-                                            Label::new(author_email)
-                                                .color(Color::Muted)
-                                                .size(LabelSize::Small),
-                                        ),
-                                ),
+                                v_flex()
+                                    .child(h_flex().gap_1().child(Label::new(author_name)).when(
+                                        has_more,
+                                        |this| {
+                                            this.child(
+                                                Disclosure::new(
+                                                    "commit-message-disclosure",
+                                                    is_expanded,
+                                                )
+                                                .closed_icon(IconName::ExpandVertical)
+                                                .opened_icon(IconName::FoldVertical)
+                                                .tooltip(Tooltip::text(expand_tooltip))
+                                                .on_click(cx.listener(|this, _, _, cx| {
+                                                    this.message_expanded = !this.message_expanded;
+                                                    cx.notify();
+                                                })),
+                                            )
+                                        },
+                                    ))
+                                    .child(
+                                        h_flex()
+                                            .gap_1p5()
+                                            .child(
+                                                Label::new(date_string)
+                                                    .color(Color::Muted)
+                                                    .size(LabelSize::Small),
+                                            )
+                                            .child(
+                                                Label::new("•")
+                                                    .size(LabelSize::Small)
+                                                    .color(Color::Muted)
+                                                    .alpha(0.5),
+                                            )
+                                            .child(
+                                                Label::new(author_email)
+                                                    .color(Color::Muted)
+                                                    .size(LabelSize::Small),
+                                            ),
+                                    ),
                             ),
                     )
                     .when(self.stash.is_none(), |this| {
@@ -660,20 +687,7 @@ impl CommitView {
             h_flex()
                 .w_full()
                 .pr_2p5()
-                .items_start()
-                .child(h_flex().flex_none().w(avatar_spacer).justify_center().when(
-                    has_more,
-                    |this| {
-                        this.child(
-                            Disclosure::new("commit-message-disclosure", is_expanded)
-                                .closed_icon(IconName::ChevronRight)
-                                .on_click(cx.listener(|this, _, _, cx| {
-                                    this.message_expanded = !this.message_expanded;
-                                    cx.notify();
-                                })),
-                        )
-                    },
-                ))
+                .child(h_flex().flex_none().w(avatar_spacer))
                 .child(
                     div()
                         .relative()

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context as _, Result};
 use buffer_diff::BufferDiff;
 use collections::HashMap;
-use editor::display_map::{BlockPlacement, BlockProperties, BlockStyle};
-use editor::{Addon, Editor, EditorEvent, ExcerptRange, MultiBuffer, multibuffer_context_lines};
+use editor::{
+    Addon, Editor, EditorEvent, MultiBuffer, hover_markdown_style, multibuffer_context_lines,
+};
 use futures_lite::future::yield_now;
 use git::repository::{CommitDetails, CommitDiff, RepoPath, is_binary_content};
 use git::status::{FileStatus, StatusCode, TrackedStatus};
@@ -16,9 +17,10 @@ use gpui::{
     PromptLevel, Render, Styled, Task, WeakEntity, Window, actions,
 };
 use language::{
-    Anchor, Buffer, Capability, DiskState, File, LanguageRegistry, LineEnding, OffsetRangeExt as _,
-    Point, ReplicaId, Rope, TextBuffer,
+    Buffer, Capability, DiskState, File, LanguageRegistry, LineEnding, OffsetRangeExt as _,
+    ReplicaId, Rope, TextBuffer,
 };
+use markdown::{Markdown, MarkdownElement};
 use multi_buffer::PathKey;
 use project::{Project, ProjectPath, WorktreeId, git_store::Repository};
 use std::{
@@ -28,7 +30,7 @@ use std::{
     sync::Arc,
 };
 use theme::ActiveTheme;
-use ui::{ContextMenu, DiffStat, Divider, Tooltip, prelude::*};
+use ui::{ContextMenu, DiffStat, Disclosure, Divider, Tooltip, prelude::*};
 use util::{ResultExt, paths::PathStyle, rel_path::RelPath, truncate_and_trailoff};
 use workspace::item::TabTooltipContent;
 use workspace::{
@@ -71,6 +73,8 @@ pub fn init(cx: &mut App) {
 pub struct CommitView {
     commit: CommitDetails,
     editor: Entity<Editor>,
+    message: Entity<Markdown>,
+    message_expanded: bool,
     stash: Option<usize>,
     multibuffer: Entity<MultiBuffer>,
     repository: Entity<Repository>,
@@ -144,7 +148,6 @@ impl Addon for CommitDiffAddon {
     }
 }
 
-const COMMIT_MESSAGE_SORT_PREFIX: u64 = 0;
 const FILE_NAMESPACE_SORT_PREFIX: u64 = 1;
 
 impl CommitView {
@@ -240,27 +243,11 @@ impl CommitView {
         let language_registry = project.read(cx).languages().clone();
         let multibuffer = cx.new(|_| MultiBuffer::new(Capability::ReadOnly));
 
-        let message_buffer = cx.new(|cx| {
-            let mut buffer = Buffer::local(commit.message.clone(), cx);
-            buffer.set_capability(Capability::ReadOnly, cx);
-            buffer
-        });
-
-        multibuffer.update(cx, |multibuffer, cx| {
-            let snapshot = message_buffer.read(cx).snapshot();
-            let full_range = Point::zero()..snapshot.max_point();
-            let range = ExcerptRange {
-                context: full_range.clone(),
-                primary: full_range,
-            };
-            multibuffer.set_excerpt_ranges_for_path(
-                PathKey::with_sort_prefix(
-                    COMMIT_MESSAGE_SORT_PREFIX,
-                    RelPath::unix("commit message").unwrap().into(),
-                ),
-                message_buffer.clone(),
-                &snapshot,
-                vec![range],
+        let message = cx.new(|cx| {
+            Markdown::new(
+                commit.message.clone(),
+                Some(language_registry.clone()),
+                None,
                 cx,
             )
         });
@@ -274,37 +261,6 @@ impl CommitView {
             editor.set_show_breakpoints(false, cx);
             editor.set_show_diff_review_button(true, cx);
             editor.set_expand_all_diff_hunks(cx);
-            editor.disable_header_for_buffer(message_buffer.read(cx).remote_id(), cx);
-            editor.disable_indent_guides_for_buffer(message_buffer.read(cx).remote_id(), cx);
-
-            editor.insert_blocks(
-                [BlockProperties {
-                    placement: BlockPlacement::Above(editor::Anchor::Min),
-                    height: Some(1),
-                    style: BlockStyle::Sticky,
-                    render: Arc::new(|_| gpui::Empty.into_any_element()),
-                    priority: 0,
-                }]
-                .into_iter()
-                .chain(
-                    editor
-                        .buffer()
-                        .read(cx)
-                        .snapshot(cx)
-                        .anchor_in_buffer(Anchor::max_for_buffer(
-                            message_buffer.read(cx).remote_id(),
-                        ))
-                        .map(|anchor| BlockProperties {
-                            placement: BlockPlacement::Below(anchor),
-                            height: Some(1),
-                            style: BlockStyle::Sticky,
-                            render: Arc::new(|_| gpui::Empty.into_any_element()),
-                            priority: 0,
-                        }),
-                ),
-                None,
-                cx,
-            );
 
             editor
         });
@@ -484,6 +440,8 @@ impl CommitView {
         Self {
             commit,
             editor,
+            message,
+            message_expanded: false,
             multibuffer,
             stash,
             repository,
@@ -582,8 +540,8 @@ impl CommitView {
                 .gutter_dimensions(font_id, font_size, style, window, cx)
                 .full_width()
         });
-        let avatar_min_side_padding = rems_from_px(10.).to_pixels(window.rem_size());
-        let avatar_container_min = avatar_size_px + avatar_min_side_padding * 2.0;
+        let avatar_min_side_padding = rems_from_px(6.).to_pixels(window.rem_size());
+        let avatar_container_min = avatar_size_px + avatar_min_side_padding;
         let avatar_container_width = gutter_width.max(avatar_container_min);
 
         let clipboard_has_sha = cx
@@ -599,67 +557,133 @@ impl CommitView {
             (IconName::Copy, Color::Muted)
         };
 
-        h_flex()
-            .py_2()
-            .pr_2p5()
+        v_flex()
             .w_full()
-            .justify_between()
+            .py_2p5()
+            .gap_2()
             .border_b_1()
             .border_color(cx.theme().colors().border_variant)
             .child(
                 h_flex()
+                    .pr_2p5()
+                    .w_full()
+                    .flex_wrap()
+                    .justify_between()
                     .child(
                         h_flex()
-                            .flex_none()
-                            .w(avatar_container_width)
-                            .justify_center()
-                            .child(self.render_commit_avatar(&commit.sha, avatar_size, window, cx)),
-                    )
-                    .child(
-                        v_flex().child(Label::new(author_name)).child(
-                            h_flex()
-                                .gap_1p5()
-                                .child(
-                                    Label::new(date_string)
-                                        .color(Color::Muted)
-                                        .size(LabelSize::Small),
-                                )
-                                .child(
-                                    Label::new("•")
-                                        .size(LabelSize::Small)
-                                        .color(Color::Muted)
-                                        .alpha(0.5),
-                                )
-                                .child(
-                                    Label::new(author_email)
-                                        .color(Color::Muted)
-                                        .size(LabelSize::Small),
+                            .child(
+                                h_flex()
+                                    .flex_none()
+                                    .w(avatar_container_width)
+                                    .justify_center()
+                                    .child(self.render_commit_avatar(
+                                        &commit.sha,
+                                        avatar_size,
+                                        window,
+                                        cx,
+                                    )),
+                            )
+                            .child(
+                                v_flex().child(Label::new(author_name)).child(
+                                    h_flex()
+                                        .gap_1p5()
+                                        .child(
+                                            Label::new(date_string)
+                                                .color(Color::Muted)
+                                                .size(LabelSize::Small),
+                                        )
+                                        .child(
+                                            Label::new("•")
+                                                .size(LabelSize::Small)
+                                                .color(Color::Muted)
+                                                .alpha(0.5),
+                                        )
+                                        .child(
+                                            Label::new(author_email)
+                                                .color(Color::Muted)
+                                                .size(LabelSize::Small),
+                                        ),
                                 ),
-                        ),
-                    ),
-            )
-            .when(self.stash.is_none(), |this| {
-                this.child(
-                    Button::new("sha", "Commit SHA")
-                        .start_icon(
-                            Icon::new(copy_icon)
-                                .size(IconSize::Small)
-                                .color(copy_icon_color),
+                            ),
+                    )
+                    .when(self.stash.is_none(), |this| {
+                        this.child(
+                            Button::new("sha", "Commit SHA")
+                                .start_icon(
+                                    Icon::new(copy_icon)
+                                        .size(IconSize::Small)
+                                        .color(copy_icon_color),
+                                )
+                                .tooltip({
+                                    let commit_sha = commit_sha.clone();
+                                    move |_, cx| {
+                                        Tooltip::with_meta(
+                                            "Copy Commit SHA",
+                                            None,
+                                            commit_sha.clone(),
+                                            cx,
+                                        )
+                                    }
+                                })
+                                .on_click(move |_, _, cx| {
+                                    cx.stop_propagation();
+                                    cx.write_to_clipboard(ClipboardItem::new_string(
+                                        commit_sha.to_string(),
+                                    ));
+                                }),
                         )
-                        .tooltip({
-                            let commit_sha = commit_sha.clone();
-                            move |_, cx| {
-                                Tooltip::with_meta("Copy Commit SHA", None, commit_sha.clone(), cx)
-                            }
-                        })
-                        .on_click(move |_, _, cx| {
-                            cx.stop_propagation();
-                            cx.write_to_clipboard(ClipboardItem::new_string(
-                                commit_sha.to_string(),
-                            ));
-                        }),
-                )
-            })
+                    }),
+            )
+            .children(self.render_commit_message(avatar_container_width, window, cx))
+    }
+
+    fn render_commit_message(
+        &self,
+        avatar_spacer: Pixels,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<impl IntoElement> {
+        let message = self.commit.message.trim();
+        if message.is_empty() {
+            return None;
+        }
+
+        let markdown_style = hover_markdown_style(window, cx);
+
+        let is_expanded = self.message_expanded;
+
+        let has_more = message.contains('\n');
+        let collapsed = has_more && !is_expanded;
+        let collapsed_height = window.line_height();
+
+        Some(
+            h_flex()
+                .w_full()
+                .pr_2p5()
+                .items_start()
+                .child(h_flex().flex_none().w(avatar_spacer).justify_center().when(
+                    has_more,
+                    |this| {
+                        this.child(
+                            Disclosure::new("commit-message-disclosure", is_expanded)
+                                .closed_icon(IconName::ChevronRight)
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    this.message_expanded = !this.message_expanded;
+                                    cx.notify();
+                                })),
+                        )
+                    },
+                ))
+                .child(
+                    div()
+                        .relative()
+                        .flex_1()
+                        .min_w_0()
+                        .text_sm()
+                        .when(collapsed, |this| this.h(collapsed_height).overflow_hidden())
+                        .child(MarkdownElement::new(self.message.clone(), markdown_style)),
+                ),
+        )
     }
 
     fn apply_stash(workspace: &mut Workspace, window: &mut Window, cx: &mut App) {
@@ -1098,8 +1122,17 @@ impl Item for CommitView {
                 }
             });
             let multibuffer = editor.read(cx).buffer().clone();
+            let language_registry = self
+                .editor
+                .read(cx)
+                .project()
+                .map(|project| project.read(cx).languages().clone());
+            let message = cx
+                .new(|cx| Markdown::new(self.commit.message.clone(), language_registry, None, cx));
             Self {
                 editor,
+                message,
+                message_expanded: self.message_expanded,
                 multibuffer,
                 commit: self.commit.clone(),
                 stash: self.stash,

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -135,6 +135,7 @@ pub enum IconName {
     FileTree,
     Filter,
     Flame,
+    FoldVertical,
     Folder,
     FolderOpen,
     FolderOpenAdd,

--- a/crates/ui/src/components/disclosure.rs
+++ b/crates/ui/src/components/disclosure.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use gpui::{ClickEvent, CursorStyle, SharedString};
+use gpui::{AnyView, ClickEvent, CursorStyle, SharedString};
 
 use crate::prelude::*;
 
@@ -15,6 +15,7 @@ pub struct Disclosure {
     opened_icon: IconName,
     closed_icon: IconName,
     visible_on_hover: Option<SharedString>,
+    tooltip: Option<Box<dyn Fn(&mut Window, &mut App) -> AnyView + 'static>>,
 }
 
 impl Disclosure {
@@ -29,7 +30,13 @@ impl Disclosure {
             opened_icon: IconName::ChevronDown,
             closed_icon: IconName::ChevronRight,
             visible_on_hover: None,
+            tooltip: None,
         }
+    }
+
+    pub fn tooltip(mut self, tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static) -> Self {
+        self.tooltip = Some(Box::new(tooltip));
+        self
     }
 
     pub fn on_toggle_expanded(
@@ -98,6 +105,7 @@ impl RenderOnce for Disclosure {
         .when_some(self.visible_on_hover.clone(), |this, group_name| {
             this.visible_on_hover(group_name)
         })
+        .when_some(self.tooltip, |this, tooltip| this.tooltip(tooltip))
         .when_some(self.on_toggle_expanded, move |this, on_toggle| {
             this.on_click(move |event, window, cx| on_toggle(event, window, cx))
         })


### PR DESCRIPTION
This PR removes the commit message from the first excerpt of the multibuffer and renders it as markdown in the commit view's header. Effectively, this allows the commit view to use the split diff buffer, as done in https://github.com/zed-industries/zed/pull/58163. 

<img width="600" alt="Screenshot 2026-06-01 at 6  34@2x" src="https://github.com/user-attachments/assets/a763a04d-88ce-4d29-9cee-872a33ace6e4" />

Release Notes:

- N/A
