### PR TITLE
recent_projects: Improve label truncation

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -1258,6 +1258,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                             h_flex()
                                 .id("open_folder_item")
                                 .w_full()
+                                .min_w_0()
                                 .gap_2p5()
                                 .when(self.has_any_non_local_projects, |this| {
                                     this.child(Icon::new(icon).color(Color::Muted))
@@ -1412,6 +1413,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                             h_flex()
                                 .id("open_project_info_container")
                                 .w_full()
+                                .min_w_0()
                                 .gap_2p5()
                                 .when(self.has_any_non_local_projects, |this| {
                                     this.child(Icon::new(icon).color(Color::Muted))
@@ -1560,6 +1562,8 @@ impl PickerDelegate for RecentProjectsDelegate {
                         .child(
                             h_flex()
                                 .id("project_info_container")
+                                .w_full()
+                                .min_w_0()
                                 .gap_2p5()
                                 .flex_grow_1()
                                 .when(self.has_any_non_local_projects, |this| {

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -368,6 +368,8 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
                 .spacing(ListItemSpacing::Sparse)
                 .child(
                     h_flex()
+                        .w_full()
+                        .min_w_0()
                         .gap_3()
                         .flex_grow_1()
                         .when(self.has_any_non_local_projects, |this| {


### PR DESCRIPTION
Just a small tweak here making sure the recent project's list items truncate properly, instead of being hard cut off.

Release Notes:

- N/A
