### PR TITLE
agent_ui: Fix crash when filtering tools in the agent profile tool picker

### DIFF
--- a/crates/agent_ui/src/agent_configuration/tool_picker.rs
+++ b/crates/agent_ui/src/agent_configuration/tool_picker.rs
@@ -173,11 +173,7 @@ impl PickerDelegate for ToolPickerDelegate {
     }
 
     fn can_select(&self, ix: usize, _window: &mut Window, _cx: &mut Context<Picker<Self>>) -> bool {
-        let item = &self.filtered_items[ix];
-        match item {
-            PickerItem::Tool { .. } => true,
-            PickerItem::ContextServer { .. } => false,
-        }
+        matches!(self.filtered_items.get(ix), Some(PickerItem::Tool { .. }))
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
@@ -245,7 +241,9 @@ impl PickerDelegate for ToolPickerDelegate {
             return;
         }
 
-        let item = &self.filtered_items[self.selected_index];
+        let Some(item) = self.filtered_items.get(self.selected_index) else {
+            return;
+        };
 
         let PickerItem::Tool {
             name: tool_name,

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -803,7 +803,8 @@ impl<D: PickerDelegate> Picker<D> {
         ix: usize,
     ) -> impl IntoElement + use<D> {
         let item_bounds = self.item_bounds.clone();
-        let selectable = self.delegate.can_select(ix, window, cx);
+        let selectable =
+            ix < self.delegate.match_count() && self.delegate.can_select(ix, window, cx);
 
         div()
             .id(("item", ix))


### PR DESCRIPTION
Closes FR-40

This PR uses the same pattern for `can_select` as other delegates and also guards `can_select` call in `Picker::render_element` which was regressed in #50705.

Release Notes:

- Fixed a crash that could occur when searching or configuring tools in agent profile settings.
