### PR TITLE
acp: Update agent-client-protocol sdk to 0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361ba6627e51de955b10f3c77fb9eb959c85191a236c1c2c84e32f4ff240faf"
+checksum = "8d197653697b91b3a2cfb579d061a3388cda9fdc79cb6f9393da65cbad46baf8"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -317,23 +317,20 @@ dependencies = [
  "futures 0.3.32",
  "futures-concurrency",
  "jsonrpcmsg",
- "rmcp",
  "rustc-hash 2.1.1",
  "schemars 1.0.4",
  "serde",
  "serde_json",
  "shell-words",
- "tokio",
- "tokio-util",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.11.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
+checksum = "b9e4fbf6733a900814fb921b2aac06612e15b42020b76a356fbc1192e725cebc"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -341,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b957d8391ac3933e2a940446171c508d2b8ffc386d8fa7d0b9c936a2575b463e"
+checksum = "0d419a87e28240978e4bfdf2a5b91bccb95ae8d5b06e10721bb07c449b9f43dd"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -402,7 +399,6 @@ dependencies = [
 name = "agent_settings"
 version = "0.1.0"
 dependencies = [
- "agent-client-protocol",
  "anyhow",
  "collections",
  "convert_case 0.11.0",
@@ -1473,7 +1469,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey 0.1.1",
+ "pastey",
  "rayon",
  "thiserror 2.0.17",
  "v_frame",
@@ -2162,7 +2158,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2182,7 +2178,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -5312,7 +5308,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6147,7 +6143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7603,7 +7599,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8818,7 +8814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e815d50d9e411ba2690d730e6ec139c08260dddb756df315dbd16d01a587226"
 dependencies = [
  "memchr",
- "pastey 0.1.1",
+ "pastey",
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "serde_json",
@@ -9064,7 +9060,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -9082,7 +9078,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.56.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -9336,7 +9332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -11950,7 +11946,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13002,12 +12998,6 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
-
-[[package]]
-name = "pastey"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pathdiff"
@@ -14587,7 +14577,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes 1.11.1",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -14620,7 +14610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -14882,7 +14872,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -14919,9 +14909,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15823,41 +15813,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmcp"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "chrono",
- "futures 0.3.32",
- "pastey 0.2.1",
- "pin-project-lite",
- "rmcp-macros",
- "schemars 1.0.4",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "rmcp-macros"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16147,7 +16102,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16456,7 +16411,6 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
- "chrono",
  "dyn-clone",
  "indexmap 2.11.4",
  "ref-cast",
@@ -18769,7 +18723,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -19695,7 +19649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb391ac70462b3097a755618fbf9c8f95ecc1eb379a414f7b46f202ed10db1f"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -21800,7 +21754,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -505,7 +505,7 @@ accesskit = "0.24.0"
 accesskit_macos = "0.26.0"
 accesskit_unix = "0.21.0"
 accesskit_windows = "0.32.1"
-agent-client-protocol = { version = "=0.12.1", features = ["unstable"] }
+agent-client-protocol = { version = "=0.13.1", features = ["unstable"] }
 aho-corasick = "1.1"
 alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "fcf32feacb367b75ec84dd40f041e4fd411d3cc1" }
 any_vec = "0.14"

--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -2,7 +2,7 @@ use crate::AcpThread;
 use agent_client_protocol::schema as acp;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use collections::{HashMap, IndexMap};
+use collections::{HashMap, HashSet, IndexMap};
 use gpui::{Entity, SharedString, Task};
 use language_model::LanguageModelProviderId;
 use project::{AgentId, Project};
@@ -19,6 +19,49 @@ pub struct UserMessageId(SharedString);
 impl UserMessageId {
     pub fn new() -> Self {
         Self(Uuid::new_v4().to_string().into())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub struct AgentModelId(SharedString);
+
+impl AgentModelId {
+    pub fn new(id: impl Into<Self>) -> Self {
+        id.into()
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<str> for AgentModelId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for AgentModelId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<SharedString> for AgentModelId {
+    fn from(id: SharedString) -> Self {
+        Self(id)
+    }
+}
+
+impl From<String> for AgentModelId {
+    fn from(id: String) -> Self {
+        Self(SharedString::from(id))
+    }
+}
+
+impl From<&str> for AgentModelId {
+    fn from(id: &str) -> Self {
+        Self(SharedString::from(id.to_owned()))
     }
 }
 
@@ -397,16 +440,13 @@ pub trait AgentModelSelector: 'static {
 
     /// Selects a model for a specific session (thread).
     ///
-    /// This sets the default model for future interactions in the session.
-    /// If the session doesn't exist or the model is invalid, it returns an error.
-    ///
     /// # Parameters
-    /// - `model`: The model to select (should be one from [list_models]).
+    /// - `model_id`: The model to select (should be one from [list_models]).
     /// - `cx`: The GPUI app context.
     ///
     /// # Returns
     /// A task resolving to `Ok(())` on success or an error.
-    fn select_model(&self, model_id: acp::ModelId, cx: &mut App) -> Task<Result<()>>;
+    fn select_model(&self, model_id: AgentModelId, cx: &mut App) -> Task<Result<()>>;
 
     /// Retrieves the currently selected model for a specific session (thread).
     ///
@@ -416,6 +456,13 @@ pub trait AgentModelSelector: 'static {
     /// # Returns
     /// A task resolving to the selected model (always set) or an error (e.g., session not found).
     fn selected_model(&self, cx: &mut App) -> Task<Result<AgentModelInfo>>;
+
+    fn favorite_model_ids(&self, _cx: &mut App) -> HashSet<AgentModelId> {
+        HashSet::default()
+    }
+
+    fn toggle_favorite_model(&self, _model_id: AgentModelId, _should_be_favorite: bool, _cx: &App) {
+    }
 
     /// Whenever the model list is updated the receiver will be notified.
     /// Optional for agents that don't update their model list.
@@ -440,25 +487,12 @@ pub enum AgentModelIcon {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentModelInfo {
-    pub id: acp::ModelId,
+    pub id: AgentModelId,
     pub name: SharedString,
     pub description: Option<SharedString>,
     pub icon: Option<AgentModelIcon>,
     pub is_latest: bool,
     pub cost: Option<SharedString>,
-}
-
-impl From<acp::ModelInfo> for AgentModelInfo {
-    fn from(info: acp::ModelInfo) -> Self {
-        Self {
-            id: info.model_id,
-            name: info.name.into(),
-            description: info.description.map(|desc| desc.into()),
-            icon: None,
-            is_latest: false,
-            cost: None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1024,7 +1058,7 @@ mod test_support {
         fn new() -> Self {
             Self {
                 selected_model: Arc::new(Mutex::new(AgentModelInfo {
-                    id: acp::ModelId::new("visual-test-model"),
+                    id: AgentModelId::new("visual-test-model"),
                     name: "Visual Test Model".into(),
                     description: Some("A stub model for visual testing".into()),
                     icon: Some(AgentModelIcon::Named(ui::IconName::ZedAssistant)),
@@ -1041,7 +1075,7 @@ mod test_support {
             Task::ready(Ok(AgentModelList::Flat(vec![model])))
         }
 
-        fn select_model(&self, model_id: acp::ModelId, _cx: &mut App) -> Task<Result<()>> {
+        fn select_model(&self, model_id: AgentModelId, _cx: &mut App) -> Task<Result<()>> {
             self.selected_model.lock().id = model_id;
             Task::ready(Ok(()))
         }

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -25,8 +25,8 @@ pub use tool_permissions::*;
 pub use tools::*;
 
 use acp_thread::{
-    AcpThread, AgentModelSelector, AgentSessionInfo, AgentSessionList, AgentSessionListRequest,
-    AgentSessionListResponse, TokenUsageRatio, UserMessageId,
+    AcpThread, AgentModelId, AgentModelSelector, AgentSessionInfo, AgentSessionList,
+    AgentSessionListRequest, AgentSessionListResponse, TokenUsageRatio, UserMessageId,
 };
 use agent_client_protocol::schema as acp;
 use agent_skills::{
@@ -47,7 +47,10 @@ use gpui::{
     App, AppContext, AsyncApp, Context, Entity, EntityId, SharedString, Subscription, Task,
     TaskExt, WeakEntity,
 };
-use language_model::{IconOrSvg, LanguageModel, LanguageModelProvider, LanguageModelRegistry};
+use language_model::{
+    IconOrSvg, LanguageModel, LanguageModelId, LanguageModelProvider, LanguageModelProviderId,
+    LanguageModelRegistry,
+};
 use project::{
     AgentId, Project, ProjectItem, ProjectPath, Worktree, WorktreeId,
     trusted_worktrees::TrustedWorktrees,
@@ -139,7 +142,7 @@ struct PendingSession {
 
 pub struct LanguageModels {
     /// Access language model by ID
-    models: HashMap<acp::ModelId, Arc<dyn LanguageModel>>,
+    models: HashMap<AgentModelId, Arc<dyn LanguageModel>>,
     /// Cached list for returning language model information
     model_list: acp_thread::AgentModelList,
     refresh_models_rx: watch::Receiver<()>,
@@ -213,7 +216,7 @@ impl LanguageModels {
         self.refresh_models_rx.clone()
     }
 
-    pub fn model_from_id(&self, model_id: &acp::ModelId) -> Option<Arc<dyn LanguageModel>> {
+    pub fn model_from_id(&self, model_id: &AgentModelId) -> Option<Arc<dyn LanguageModel>> {
         self.models.get(model_id).cloned()
     }
 
@@ -234,8 +237,8 @@ impl LanguageModels {
         }
     }
 
-    fn model_id(model: &Arc<dyn LanguageModel>) -> acp::ModelId {
-        acp::ModelId::new(format!("{}/{}", model.provider_id().0, model.id().0))
+    fn model_id(model: &Arc<dyn LanguageModel>) -> AgentModelId {
+        AgentModelId::new(format!("{}/{}", model.provider_id().0, model.id().0))
     }
 
     fn authenticate_all_language_model_providers(cx: &mut App) -> Task<()> {
@@ -2134,7 +2137,7 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
         })
     }
 
-    fn select_model(&self, model_id: acp::ModelId, cx: &mut App) -> Task<Result<()>> {
+    fn select_model(&self, model_id: AgentModelId, cx: &mut App) -> Task<Result<()>> {
         log::debug!(
             "Setting model for session {}: {}",
             self.session_id,
@@ -2227,6 +2230,27 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
         )))
     }
 
+    fn favorite_model_ids(&self, cx: &mut App) -> HashSet<AgentModelId> {
+        agent_settings::AgentSettings::get_global(cx)
+            .favorite_model_ids()
+            .into_iter()
+            .map(AgentModelId::from)
+            .collect()
+    }
+
+    fn toggle_favorite_model(&self, model_id: AgentModelId, should_be_favorite: bool, cx: &App) {
+        let selection = model_id_to_selection(&model_id, cx);
+        let fs = self.connection.0.read(cx).fs.clone();
+        update_settings_file(fs, cx, move |settings, _| {
+            let agent = settings.agent.get_or_insert_default();
+            if should_be_favorite {
+                agent.add_favorite_model(selection.clone());
+            } else {
+                agent.remove_favorite_model(&selection);
+            }
+        });
+    }
+
     fn watch(&self, cx: &mut App) -> Option<watch::Receiver<()>> {
         Some(self.connection.0.read(cx).models.watch())
     }
@@ -2234,6 +2258,44 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
     fn should_render_footer(&self) -> bool {
         true
     }
+}
+
+fn model_id_to_selection(model_id: &AgentModelId, cx: &App) -> LanguageModelSelection {
+    let id = model_id.as_ref();
+    let (provider, model) = id.split_once('/').unwrap_or(("", id));
+
+    let provider_id = LanguageModelProviderId(provider.to_string().into());
+    let model_id = LanguageModelId(model.to_string().into());
+    let resolved = LanguageModelRegistry::global(cx)
+        .read(cx)
+        .provider(&provider_id)
+        .and_then(|provider| {
+            provider
+                .provided_models(cx)
+                .into_iter()
+                .find(|model| model.id() == model_id)
+        });
+
+    let Some(resolved) = resolved else {
+        return LanguageModelSelection {
+            provider: provider.to_owned().into(),
+            model: model.to_owned(),
+            enable_thinking: false,
+            effort: None,
+            speed: None,
+        };
+    };
+
+    let current_user_selection = agent_settings::AgentSettings::get_global(cx)
+        .default_model
+        .as_ref()
+        .filter(|selection| {
+            selection.provider.0 == resolved.provider_id().0.as_ref()
+                && selection.model == resolved.id().0.as_ref()
+        })
+        .cloned();
+
+    agent_settings::language_model_to_selection(&resolved, current_user_selection.as_ref())
 }
 
 pub static ZED_AGENT_ID: LazyLock<AgentId> = LazyLock::new(|| AgentId::new("Zed Agent"));
@@ -4803,7 +4865,7 @@ mod internal_tests {
             IndexMap::from_iter([(
                 AgentModelGroupName("Fake".into()),
                 vec![AgentModelInfo {
-                    id: acp::ModelId::new("fake/fake"),
+                    id: AgentModelId::new("fake/fake"),
                     name: "Fake".into(),
                     description: None,
                     icon: Some(acp_thread::AgentModelIcon::Named(
@@ -4862,7 +4924,7 @@ mod internal_tests {
 
         // Select a model
         let selector = connection.model_selector(&session_id).unwrap();
-        let model_id = acp::ModelId::new("fake/fake");
+        let model_id = AgentModelId::new("fake/fake");
         cx.update(|cx| selector.select_model(model_id.clone(), cx))
             .await
             .unwrap();
@@ -4913,7 +4975,7 @@ mod internal_tests {
         agent.update(cx, |agent, cx| agent.models.refresh_list(cx));
 
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(acp::ModelId::new("fake-corp/fake-thinking"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/fake-thinking"), cx))
             .await
             .unwrap();
         cx.run_until_parked();
@@ -4987,7 +5049,7 @@ mod internal_tests {
 
         // Select the thinking model via select_model.
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(acp::ModelId::new("fake-corp/fake-thinking"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/fake-thinking"), cx))
             .await
             .unwrap();
 
@@ -5004,7 +5066,7 @@ mod internal_tests {
 
         // Switch back to the non-thinking model.
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(acp::ModelId::new("fake/fake"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("fake/fake"), cx))
             .await
             .unwrap();
 
@@ -5121,7 +5183,7 @@ mod internal_tests {
         let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
 
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(acp::ModelId::new("fake-corp/fake-thinking"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/fake-thinking"), cx))
             .await
             .unwrap();
 
@@ -5224,7 +5286,7 @@ mod internal_tests {
         let session_id = acp_thread.read_with(cx, |thread, _| thread.session_id().clone());
 
         let selector = connection.model_selector(&session_id).unwrap();
-        cx.update(|cx| selector.select_model(acp::ModelId::new("fake-corp/custom-model-id"), cx))
+        cx.update(|cx| selector.select_model(AgentModelId::new("fake-corp/custom-model-id"), cx))
             .await
             .unwrap();
 

--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -1,15 +1,10 @@
 use std::{any::Any, rc::Rc, sync::Arc};
 
-use agent_client_protocol::schema as acp;
 use agent_servers::{AgentServer, AgentServerDelegate};
-use agent_settings::{AgentSettings, language_model_to_selection};
 use anyhow::Result;
-use collections::HashSet;
 use fs::Fs;
 use gpui::{App, Entity, Task};
-use language_model::{LanguageModelId, LanguageModelProviderId, LanguageModelRegistry};
 use project::{AgentId, Project};
-use settings::{LanguageModelSelection, Settings as _, update_settings_file};
 
 use crate::{NativeAgent, NativeAgentConnection, ThreadStore, templates::Templates};
 
@@ -61,66 +56,6 @@ impl AgentServer for NativeAgentServer {
     fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
         self
     }
-
-    fn favorite_model_ids(&self, cx: &mut App) -> HashSet<acp::ModelId> {
-        AgentSettings::get_global(cx).favorite_model_ids()
-    }
-
-    fn toggle_favorite_model(
-        &self,
-        model_id: acp::ModelId,
-        should_be_favorite: bool,
-        fs: Arc<dyn Fs>,
-        cx: &App,
-    ) {
-        let selection = model_id_to_selection(&model_id, cx);
-        update_settings_file(fs, cx, move |settings, _| {
-            let agent = settings.agent.get_or_insert_default();
-            if should_be_favorite {
-                agent.add_favorite_model(selection.clone());
-            } else {
-                agent.remove_favorite_model(&selection);
-            }
-        });
-    }
-}
-
-/// Convert a ModelId (e.g. "anthropic/claude-3-5-sonnet") to a LanguageModelSelection.
-fn model_id_to_selection(model_id: &acp::ModelId, cx: &App) -> LanguageModelSelection {
-    let id = model_id.0.as_ref();
-    let (provider, model) = id.split_once('/').unwrap_or(("", id));
-
-    let provider_id = LanguageModelProviderId(provider.to_string().into());
-    let model_id_typed = LanguageModelId(model.to_string().into());
-    let resolved = LanguageModelRegistry::global(cx)
-        .read(cx)
-        .provider(&provider_id)
-        .and_then(|p| {
-            p.provided_models(cx)
-                .into_iter()
-                .find(|m| m.id() == model_id_typed)
-        });
-
-    let Some(resolved) = resolved else {
-        return LanguageModelSelection {
-            provider: provider.to_owned().into(),
-            model: model.to_owned(),
-            enable_thinking: false,
-            effort: None,
-            speed: None,
-        };
-    };
-
-    let current_user_selection = AgentSettings::get_global(cx)
-        .default_model
-        .as_ref()
-        .filter(|selection| {
-            selection.provider.0 == resolved.provider_id().0.as_ref()
-                && selection.model == resolved.id().0.as_ref()
-        })
-        .cloned();
-
-    language_model_to_selection(&resolved, current_user_selection.as_ref())
 }
 
 #[cfg(test)]

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -3560,7 +3560,6 @@ async fn test_agent_connection(cx: &mut TestAppContext) {
     assert_eq!(
         listed_models[&AgentModelGroupName("Fake".into())][0]
             .id
-            .0
             .as_ref(),
         "fake/fake"
     );

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -438,19 +438,13 @@ pub struct AcpConnection {
 #[derive(Clone, Default)]
 struct AcpConnectionDefaults {
     mode: Rc<RefCell<Option<acp::SessionModeId>>>,
-    model: Rc<RefCell<Option<acp::ModelId>>>,
     config_options: Rc<RefCell<HashMap<String, String>>>,
 }
 
 impl AcpConnectionDefaults {
-    fn new(
-        mode: Option<acp::SessionModeId>,
-        model: Option<acp::ModelId>,
-        config_options: HashMap<String, String>,
-    ) -> Self {
+    fn new(mode: Option<acp::SessionModeId>, config_options: HashMap<String, String>) -> Self {
         Self {
             mode: Rc::new(RefCell::new(mode)),
-            model: Rc::new(RefCell::new(model)),
             config_options: Rc::new(RefCell::new(config_options)),
         }
     }
@@ -459,33 +453,23 @@ impl AcpConnectionDefaults {
         self.mode.borrow().clone()
     }
 
-    fn model(&self) -> Option<acp::ModelId> {
-        self.model.borrow().clone()
-    }
-
     fn config_option(&self, config_id: &str) -> Option<String> {
         self.config_options.borrow().get(config_id).cloned()
     }
 
-    fn set(
-        &self,
-        mode: Option<acp::SessionModeId>,
-        model: Option<acp::ModelId>,
-        config_options: HashMap<String, String>,
-    ) {
+    fn set(&self, mode: Option<acp::SessionModeId>, config_options: HashMap<String, String>) {
         *self.mode.borrow_mut() = mode;
-        *self.model.borrow_mut() = model;
         *self.config_options.borrow_mut() = config_options;
     }
 
     fn refresh_from_settings(&self, agent_id: &AgentId, cx: &App) {
         let Some(settings_store) = cx.try_global::<SettingsStore>() else {
-            self.set(None, None, HashMap::default());
+            self.set(None, HashMap::default());
             return;
         };
         let settings = settings_store.get::<AllAgentServersSettings>(None);
         let Some(agent_settings) = settings.get(agent_id.as_ref()) else {
-            self.set(None, None, HashMap::default());
+            self.set(None, HashMap::default());
             return;
         };
 
@@ -501,7 +485,6 @@ impl AcpConnectionDefaults {
         };
         self.set(
             agent_settings.default_mode().map(acp::SessionModeId::new),
-            agent_settings.default_model().map(acp::ModelId::new),
             default_config_options,
         );
     }
@@ -526,7 +509,6 @@ struct PendingAcpSession {
 
 struct SessionConfigResponse {
     modes: Option<acp::SessionModeState>,
-    models: Option<acp::SessionModelState>,
     config_options: Option<Vec<acp::SessionConfigOption>>,
 }
 
@@ -551,7 +533,6 @@ impl ConfigOptions {
 pub struct AcpSession {
     thread: WeakEntity<AcpThread>,
     suppress_abort_err: bool,
-    models: Option<Rc<RefCell<acp::SessionModelState>>>,
     session_modes: Option<Rc<RefCell<acp::SessionModeState>>>,
     config_options: Option<ConfigOptions>,
     ref_count: usize,
@@ -673,7 +654,6 @@ pub async fn connect(
     command: AgentServerCommand,
     agent_server_store: WeakEntity<AgentServerStore>,
     default_mode: Option<acp::SessionModeId>,
-    default_model: Option<acp::ModelId>,
     default_config_options: HashMap<String, String>,
     cx: &mut AsyncApp,
 ) -> Result<Rc<dyn AgentConnection>> {
@@ -683,7 +663,6 @@ pub async fn connect(
         command.clone(),
         agent_server_store,
         default_mode,
-        default_model,
         default_config_options,
         cx,
     )
@@ -800,7 +779,6 @@ impl AcpConnection {
         command: AgentServerCommand,
         agent_server_store: WeakEntity<AgentServerStore>,
         default_mode: Option<acp::SessionModeId>,
-        default_model: Option<acp::ModelId>,
         default_config_options: HashMap<String, String>,
         cx: &mut AsyncApp,
     ) -> Result<Self> {
@@ -1082,8 +1060,7 @@ impl AcpConnection {
         } else {
             response.auth_methods
         };
-        let defaults =
-            AcpConnectionDefaults::new(default_mode, default_model, default_config_options);
+        let defaults = AcpConnectionDefaults::new(default_mode, default_config_options);
         let settings_subscription = cx.update({
             let agent_id = agent_id.clone();
             let defaults = defaults.clone();
@@ -1226,14 +1203,13 @@ impl AcpConnection {
                     // Register the session before awaiting the RPC so that any
                     // `session/update` notifications that arrive during the call
                     // (e.g. history replay during `session/load`) can find the thread.
-                    // Modes/models/config are filled in once the response arrives.
+                    // Modes/config are filled in once the response arrives.
                     this.sessions.borrow_mut().insert(
                         session_id.clone(),
                         AcpSession {
                             thread: thread.downgrade(),
                             suppress_abort_err: false,
                             session_modes: None,
-                            models: None,
                             config_options: None,
                             ref_count: 1,
                         },
@@ -1251,8 +1227,8 @@ impl AcpConnection {
                             }
                         };
 
-                    let (modes, models, config_options) =
-                        config_state(response.modes, response.models, response.config_options);
+                    let (modes, config_options) =
+                        config_state(response.modes, response.config_options);
 
                     if let Some(config_opts) = config_options.as_ref() {
                         this.apply_default_config_options(&session_id, config_opts, cx);
@@ -1277,7 +1253,6 @@ impl AcpConnection {
                             )));
                         };
                         session.session_modes = modes;
-                        session.models = models;
                         session.config_options = config_options.map(ConfigOptions::new);
                         session.ref_count = ref_count;
                     }
@@ -1577,8 +1552,7 @@ impl AgentConnection for AcpConnection {
             .await
             .map_err(map_acp_error)?;
 
-            let (modes, models, config_options) =
-                config_state(response.modes, response.models, response.config_options);
+            let (modes, config_options) = config_state(response.modes, response.config_options);
 
             let default_mode = self.defaults.mode();
             if let Some(default_mode) = default_mode {
@@ -1630,56 +1604,6 @@ impl AgentConnection for AcpConnection {
                 }
             }
 
-            let default_model = self.defaults.model();
-            if let Some(default_model) = default_model {
-                if let Some(models) = models.as_ref() {
-                    let mut models_ref = models.borrow_mut();
-                    let has_model = models_ref
-                        .available_models
-                        .iter()
-                        .any(|model| model.model_id == default_model);
-
-                    if has_model {
-                        let initial_model_id = models_ref.current_model_id.clone();
-
-                        cx.spawn({
-                            let default_model = default_model.clone();
-                            let session_id = response.session_id.clone();
-                            let models = models.clone();
-                            let conn = self.connection.clone();
-                            async move |_| {
-                                let result = into_foreground_future(
-                                    conn.send_request(acp::SetSessionModelRequest::new(
-                                        session_id,
-                                        default_model,
-                                    )),
-                                )
-                                .await
-                                .log_err();
-
-                                if result.is_none() {
-                                    models.borrow_mut().current_model_id = initial_model_id;
-                                }
-                            }
-                        })
-                        .detach();
-
-                        models_ref.current_model_id = default_model;
-                    } else {
-                        let available_models = models_ref
-                            .available_models
-                            .iter()
-                            .map(|model| format!("- `{}`: {}", model.model_id, model.name))
-                            .collect::<Vec<_>>()
-                            .join("\n");
-
-                        log::warn!(
-                            "`{default_model}` is not a valid {name} model. Available options:\n{available_models}",
-                        );
-                    }
-                }
-            }
-
             if let Some(config_opts) = config_options.as_ref() {
                 self.apply_default_config_options(&response.session_id, config_opts, cx);
             }
@@ -1708,7 +1632,6 @@ impl AgentConnection for AcpConnection {
                     thread: thread.downgrade(),
                     suppress_abort_err: false,
                     session_modes: modes,
-                    models,
                     config_options: config_options.map(ConfigOptions::new),
                     ref_count: 1,
                 },
@@ -1765,7 +1688,6 @@ impl AgentConnection for AcpConnection {
                     .map_err(map_acp_error)?;
                     Ok(SessionConfigResponse {
                         modes: response.modes,
-                        models: response.models,
                         config_options: response.config_options,
                     })
                 })
@@ -1808,7 +1730,6 @@ impl AgentConnection for AcpConnection {
                     .map_err(map_acp_error)?;
                     Ok(SessionConfigResponse {
                         modes: response.modes,
-                        models: response.models,
                         config_options: response.config_options,
                     })
                 })
@@ -2046,27 +1967,6 @@ impl AgentConnection for AcpConnection {
         }
     }
 
-    fn model_selector(
-        &self,
-        session_id: &acp::SessionId,
-    ) -> Option<Rc<dyn acp_thread::AgentModelSelector>> {
-        let sessions = self.sessions.clone();
-        let sessions_ref = sessions.borrow();
-        let Some(session) = sessions_ref.get(session_id) else {
-            return None;
-        };
-
-        if let Some(models) = session.models.as_ref() {
-            Some(Rc::new(AcpModelSelector::new(
-                session_id.clone(),
-                self.connection.clone(),
-                models.clone(),
-            )) as _)
-        } else {
-            None
-        }
-    }
-
     fn session_config_options(
         &self,
         session_id: &acp::SessionId,
@@ -2114,8 +2014,8 @@ pub mod test_support {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use acp_thread::{
-        AgentModelSelector, AgentSessionConfigOptions, AgentSessionModes, AgentSessionRetry,
-        AgentSessionSetTitle, AgentSessionTruncate, AgentTelemetry, UserMessageId,
+        AgentSessionConfigOptions, AgentSessionModes, AgentSessionRetry, AgentSessionSetTitle,
+        AgentSessionTruncate, AgentTelemetry, UserMessageId,
     };
 
     use super::*;
@@ -2363,13 +2263,6 @@ pub mod test_support {
             cx: &App,
         ) -> Option<Rc<dyn AgentSessionSetTitle>> {
             self.inner.set_title(session_id, cx)
-        }
-
-        fn model_selector(
-            &self,
-            session_id: &acp::SessionId,
-        ) -> Option<Rc<dyn AgentModelSelector>> {
-            self.inner.model_selector(session_id)
         }
 
         fn telemetry(&self) -> Option<Rc<dyn AgentTelemetry>> {
@@ -3086,8 +2979,6 @@ mod tests {
                         args: Vec::new(),
                         env: HashMap::default(),
                         default_mode: Some("manual".to_string()),
-                        default_model: Some("claude-sonnet-4".to_string()),
-                        favorite_models: Vec::new(),
                         default_config_options: HashMap::from_iter([(
                             "mode".to_string(),
                             "manual".to_string(),
@@ -3106,10 +2997,6 @@ mod tests {
             Some(acp::SessionModeId::new("manual"))
         );
         assert_eq!(
-            harness.connection.defaults.model(),
-            Some(acp::ModelId::new("claude-sonnet-4"))
-        );
-        assert_eq!(
             harness.connection.defaults.config_option("mode").as_deref(),
             Some("manual")
         );
@@ -3123,7 +3010,6 @@ mod tests {
         cx.run_until_parked();
 
         assert_eq!(harness.connection.defaults.mode(), None);
-        assert_eq!(harness.connection.defaults.model(), None);
         assert_eq!(harness.connection.defaults.config_option("mode"), None);
     }
 
@@ -3242,7 +3128,6 @@ mod tests {
             project,
             command,
             agent_server_store,
-            None,
             None,
             HashMap::default(),
             &mut async_cx,
@@ -3888,20 +3773,17 @@ fn mcp_servers_for_project(project: &Entity<Project>, cx: &App) -> Vec<acp::McpS
 
 fn config_state(
     modes: Option<acp::SessionModeState>,
-    models: Option<acp::SessionModelState>,
     config_options: Option<Vec<acp::SessionConfigOption>>,
 ) -> (
     Option<Rc<RefCell<acp::SessionModeState>>>,
-    Option<Rc<RefCell<acp::SessionModelState>>>,
     Option<Rc<RefCell<Vec<acp::SessionConfigOption>>>>,
 ) {
     if let Some(opts) = config_options {
-        return (None, None, Some(Rc::new(RefCell::new(opts))));
+        return (None, Some(Rc::new(RefCell::new(opts))));
     }
 
     let modes = modes.map(|modes| Rc::new(RefCell::new(modes)));
-    let models = models.map(|models| Rc::new(RefCell::new(models)));
-    (modes, models, None)
+    (modes, None)
 }
 
 struct AcpSessionModes {
@@ -3943,79 +3825,6 @@ impl acp_thread::AgentSessionModes for AcpSessionModes {
 
             Ok(())
         })
-    }
-}
-
-struct AcpModelSelector {
-    session_id: acp::SessionId,
-    connection: ConnectionTo<Agent>,
-    state: Rc<RefCell<acp::SessionModelState>>,
-}
-
-impl AcpModelSelector {
-    fn new(
-        session_id: acp::SessionId,
-        connection: ConnectionTo<Agent>,
-        state: Rc<RefCell<acp::SessionModelState>>,
-    ) -> Self {
-        Self {
-            session_id,
-            connection,
-            state,
-        }
-    }
-}
-
-impl acp_thread::AgentModelSelector for AcpModelSelector {
-    fn list_models(&self, _cx: &mut App) -> Task<Result<acp_thread::AgentModelList>> {
-        Task::ready(Ok(acp_thread::AgentModelList::Flat(
-            self.state
-                .borrow()
-                .available_models
-                .clone()
-                .into_iter()
-                .map(acp_thread::AgentModelInfo::from)
-                .collect(),
-        )))
-    }
-
-    fn select_model(&self, model_id: acp::ModelId, cx: &mut App) -> Task<Result<()>> {
-        let connection = self.connection.clone();
-        let session_id = self.session_id.clone();
-        let old_model_id;
-        {
-            let mut state = self.state.borrow_mut();
-            old_model_id = state.current_model_id.clone();
-            state.current_model_id = model_id.clone();
-        };
-        let state = self.state.clone();
-        cx.foreground_executor().spawn(async move {
-            let result = into_foreground_future(
-                connection.send_request(acp::SetSessionModelRequest::new(session_id, model_id)),
-            )
-            .await;
-
-            if result.is_err() {
-                state.borrow_mut().current_model_id = old_model_id;
-            }
-
-            result?;
-
-            Ok(())
-        })
-    }
-
-    fn selected_model(&self, _cx: &mut App) -> Task<Result<acp_thread::AgentModelInfo>> {
-        let state = self.state.borrow();
-        Task::ready(
-            state
-                .available_models
-                .iter()
-                .find(|m| m.model_id == state.current_model_id)
-                .cloned()
-                .map(acp_thread::AgentModelInfo::from)
-                .ok_or_else(|| anyhow::anyhow!("Model not found")),
-        )
     }
 }
 

--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -68,22 +68,6 @@ pub trait AgentServer: Send {
     ) {
     }
 
-    fn default_model(&self, _cx: &App) -> Option<acp_schema::ModelId> {
-        None
-    }
-
-    fn set_default_model(
-        &self,
-        _model_id: Option<acp_schema::ModelId>,
-        _fs: Arc<dyn Fs>,
-        _cx: &mut App,
-    ) {
-    }
-
-    fn favorite_model_ids(&self, _cx: &mut App) -> HashSet<acp_schema::ModelId> {
-        HashSet::default()
-    }
-
     fn default_config_option(&self, _config_id: &str, _cx: &App) -> Option<String> {
         None
     }
@@ -109,15 +93,6 @@ pub trait AgentServer: Send {
         &self,
         _config_id: acp_schema::SessionConfigId,
         _value_id: acp_schema::SessionConfigValueId,
-        _should_be_favorite: bool,
-        _fs: Arc<dyn Fs>,
-        _cx: &App,
-    ) {
-    }
-
-    fn toggle_favorite_model(
-        &self,
-        _model_id: acp_schema::ModelId,
         _should_be_favorite: bool,
         _fs: Arc<dyn Fs>,
         _cx: &App,

--- a/crates/agent_servers/src/custom.rs
+++ b/crates/agent_servers/src/custom.rs
@@ -141,91 +141,6 @@ impl AgentServer for CustomAgentServer {
         });
     }
 
-    fn default_model(&self, cx: &App) -> Option<acp::ModelId> {
-        let settings = cx.read_global(|settings: &SettingsStore, _| {
-            settings
-                .get::<AllAgentServersSettings>(None)
-                .get(self.agent_id().as_ref())
-                .cloned()
-        });
-
-        settings
-            .as_ref()
-            .and_then(|s| s.default_model().map(acp::ModelId::new))
-    }
-
-    fn set_default_model(&self, model_id: Option<acp::ModelId>, fs: Arc<dyn Fs>, cx: &mut App) {
-        let agent_id = self.agent_id();
-        update_settings_file(fs, cx, move |settings, _cx| {
-            let settings = settings
-                .agent_servers
-                .get_or_insert_default()
-                .entry(agent_id.0.to_string())
-                .or_insert_with(default_settings_for_agent);
-
-            match settings {
-                settings::CustomAgentServerSettings::Custom { default_model, .. }
-                | settings::CustomAgentServerSettings::Registry { default_model, .. } => {
-                    *default_model = model_id.map(|m| m.to_string());
-                }
-            }
-        });
-    }
-
-    fn favorite_model_ids(&self, cx: &mut App) -> HashSet<acp::ModelId> {
-        let settings = cx.read_global(|settings: &SettingsStore, _| {
-            settings
-                .get::<AllAgentServersSettings>(None)
-                .get(self.agent_id().as_ref())
-                .cloned()
-        });
-
-        settings
-            .as_ref()
-            .map(|s| {
-                s.favorite_models()
-                    .iter()
-                    .map(|id| acp::ModelId::new(id.clone()))
-                    .collect()
-            })
-            .unwrap_or_default()
-    }
-
-    fn toggle_favorite_model(
-        &self,
-        model_id: acp::ModelId,
-        should_be_favorite: bool,
-        fs: Arc<dyn Fs>,
-        cx: &App,
-    ) {
-        let agent_id = self.agent_id();
-        update_settings_file(fs, cx, move |settings, _cx| {
-            let settings = settings
-                .agent_servers
-                .get_or_insert_default()
-                .entry(agent_id.0.to_string())
-                .or_insert_with(default_settings_for_agent);
-
-            let favorite_models = match settings {
-                settings::CustomAgentServerSettings::Custom {
-                    favorite_models, ..
-                }
-                | settings::CustomAgentServerSettings::Registry {
-                    favorite_models, ..
-                } => favorite_models,
-            };
-
-            let model_id_str = model_id.to_string();
-            if should_be_favorite {
-                if !favorite_models.contains(&model_id_str) {
-                    favorite_models.push(model_id_str);
-                }
-            } else {
-                favorite_models.retain(|id| id != &model_id_str);
-            }
-        });
-    }
-
     fn default_config_option(&self, config_id: &str, cx: &App) -> Option<String> {
         let settings = cx.read_global(|settings: &SettingsStore, _| {
             settings
@@ -283,7 +198,6 @@ impl AgentServer for CustomAgentServer {
     ) -> Task<Result<Rc<dyn AgentConnection>>> {
         let agent_id = self.agent_id();
         let default_mode = self.default_mode(cx);
-        let default_model = self.default_model(cx);
         let is_registry_agent = is_registry_agent(agent_id.clone(), cx);
         let default_config_options = cx.read_global(|settings: &SettingsStore, _| {
             settings
@@ -355,7 +269,6 @@ impl AgentServer for CustomAgentServer {
                 command,
                 store.clone(),
                 default_mode,
-                default_model,
                 default_config_options,
                 cx,
             )
@@ -407,10 +320,8 @@ fn is_registry_agent(agent_id: impl Into<AgentId>, cx: &App) -> bool {
 
 fn default_settings_for_agent() -> settings::CustomAgentServerSettings {
     settings::CustomAgentServerSettings::Registry {
-        default_model: None,
         default_mode: None,
         env: Default::default(),
-        favorite_models: Vec::new(),
         default_config_options: Default::default(),
         favorite_config_option_values: Default::default(),
     }
@@ -505,8 +416,6 @@ mod tests {
                 settings::CustomAgentServerSettings::Registry {
                     env: HashMap::default(),
                     default_mode: None,
-                    default_model: None,
-                    favorite_models: Vec::new(),
                     default_config_options: HashMap::default(),
                     favorite_config_option_values: HashMap::default(),
                 },

--- a/crates/agent_settings/Cargo.toml
+++ b/crates/agent_settings/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 path = "src/agent_settings.rs"
 
 [dependencies]
-agent-client-protocol.workspace = true
 anyhow.workspace = true
 collections.workspace = true
 convert_case.workspace = true

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -4,11 +4,10 @@ mod user_agents_md;
 use std::path::{Component, Path};
 use std::sync::{Arc, LazyLock};
 
-use agent_client_protocol::schema as acp;
 use collections::{HashSet, IndexMap};
 use fs::Fs;
 use futures::channel::oneshot;
-use gpui::{App, Pixels, px};
+use gpui::{App, Pixels, SharedString, px};
 use language_model::LanguageModel;
 use project::DisableAiSettings;
 use schemars::JsonSchema;
@@ -207,10 +206,10 @@ impl AgentSettings {
         self.message_editor_min_lines * 2
     }
 
-    pub fn favorite_model_ids(&self) -> HashSet<acp::ModelId> {
+    pub fn favorite_model_ids(&self) -> HashSet<SharedString> {
         self.favorite_models
             .iter()
-            .map(|sel| acp::ModelId::new(format!("{}/{}", sel.provider.0, sel.model)))
+            .map(|sel| SharedString::from(format!("{}/{}", sel.provider.0, sel.model)))
             .collect()
     }
 }

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -1455,8 +1455,6 @@ async fn open_new_agent_servers_entry_in_settings_editor(
                                 args: vec![],
                                 env: HashMap::default(),
                                 default_mode: None,
-                                default_model: None,
-                                favorite_models: vec![],
                                 default_config_options: Default::default(),
                                 favorite_config_option_values: Default::default(),
                             },

--- a/crates/agent_ui/src/agent_registry_ui.rs
+++ b/crates/agent_ui/src/agent_registry_ui.rs
@@ -521,9 +521,7 @@ impl AgentRegistryPage {
                             agent_servers.entry(agent_id).or_insert_with(|| {
                                 settings::CustomAgentServerSettings::Registry {
                                     default_mode: None,
-                                    default_model: None,
                                     env: Default::default(),
-                                    favorite_models: Vec::new(),
                                     default_config_options: HashMap::default(),
                                     favorite_config_option_values: HashMap::default(),
                                 }

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1148,16 +1148,12 @@ impl ConversationView {
             model_selector = None;
             mode_selector = None;
         } else {
-            // Fall back to legacy mode/model selectors
+            // Fall back to dedicated mode/model selectors
             config_options_view = None;
             model_selector = connection.model_selector(&session_id).map(|selector| {
-                let agent_server = self.agent.clone();
-                let fs = self.project.read(cx).fs().clone();
                 cx.new(|cx| {
                     ModelSelectorPopover::new(
                         selector,
-                        agent_server,
-                        fs,
                         PopoverMenuHandle::default(),
                         self.focus_handle(cx),
                         window,

--- a/crates/agent_ui/src/model_selector.rs
+++ b/crates/agent_ui/src/model_selector.rs
@@ -1,12 +1,11 @@
 use std::{cmp::Reverse, rc::Rc, sync::Arc};
 
-use acp_thread::{AgentModelIcon, AgentModelInfo, AgentModelList, AgentModelSelector};
-use agent_client_protocol::schema as acp;
-use agent_servers::AgentServer;
+use acp_thread::{
+    AgentModelIcon, AgentModelId, AgentModelInfo, AgentModelList, AgentModelSelector,
+};
 
 use anyhow::Result;
 use collections::{HashSet, IndexMap};
-use fs::Fs;
 use futures::FutureExt;
 use fuzzy::{StringMatchCandidate, match_strings};
 use gpui::{
@@ -29,13 +28,11 @@ pub type ModelSelector = Picker<ModelPickerDelegate>;
 
 pub fn acp_model_selector(
     selector: Rc<dyn AgentModelSelector>,
-    agent_server: Rc<dyn AgentServer>,
-    fs: Arc<dyn Fs>,
     focus_handle: FocusHandle,
     window: &mut Window,
     cx: &mut Context<ModelSelector>,
 ) -> ModelSelector {
-    let delegate = ModelPickerDelegate::new(selector, agent_server, fs, focus_handle, window, cx);
+    let delegate = ModelPickerDelegate::new(selector, focus_handle, window, cx);
     Picker::list(delegate, window, cx)
         .show_scrollbar(true)
         .width(rems(20.))
@@ -49,14 +46,12 @@ enum ModelPickerEntry {
 
 pub struct ModelPickerDelegate {
     selector: Rc<dyn AgentModelSelector>,
-    agent_server: Rc<dyn AgentServer>,
-    fs: Arc<dyn Fs>,
     filtered_entries: Vec<ModelPickerEntry>,
     models: Option<AgentModelList>,
     selected_index: usize,
     selected_description: Option<(usize, SharedString)>,
     selected_model: Option<AgentModelInfo>,
-    favorites: HashSet<acp::ModelId>,
+    favorites: HashSet<AgentModelId>,
     _refresh_models_task: Task<()>,
     _settings_subscription: Subscription,
     focus_handle: FocusHandle,
@@ -65,8 +60,6 @@ pub struct ModelPickerDelegate {
 impl ModelPickerDelegate {
     fn new(
         selector: Rc<dyn AgentModelSelector>,
-        agent_server: Rc<dyn AgentServer>,
-        fs: Arc<dyn Fs>,
         focus_handle: FocusHandle,
         window: &mut Window,
         cx: &mut Context<ModelSelector>,
@@ -106,23 +99,21 @@ impl ModelPickerDelegate {
             })
         };
 
-        let agent_server_for_subscription = agent_server.clone();
+        let selector_for_subscription = selector.clone();
         let settings_subscription =
             cx.observe_global_in::<SettingsStore>(window, move |picker, window, cx| {
                 // Only refresh if the favorites actually changed to avoid redundant work
                 // when other settings are modified (e.g., user editing settings.json)
-                let new_favorites = agent_server_for_subscription.favorite_model_ids(cx);
+                let new_favorites = selector_for_subscription.favorite_model_ids(cx);
                 if new_favorites != picker.delegate.favorites {
                     picker.delegate.favorites = new_favorites;
                     picker.refresh(window, cx);
                 }
             });
-        let favorites = agent_server.favorite_model_ids(cx);
+        let favorites = selector.favorite_model_ids(cx);
 
         Self {
             selector,
-            agent_server,
-            fs,
             filtered_entries: Vec::new(),
             models: None,
             selected_model: None,
@@ -180,9 +171,6 @@ impl ModelPickerDelegate {
         };
 
         let next_model = favorite_models[next_index].clone();
-
-        self.agent_server
-            .set_default_model(Some(next_model.id.clone()), self.fs.clone(), cx);
 
         self.selector
             .select_model(next_model.id.clone(), cx)
@@ -279,9 +267,6 @@ impl PickerDelegate for ModelPickerDelegate {
         if let Some(ModelPickerEntry::Model(model_info, _)) =
             self.filtered_entries.get(self.selected_index)
         {
-            self.agent_server
-                .set_default_model(Some(model_info.id.clone()), self.fs.clone(), cx);
-
             self.selector
                 .select_model(model_info.id.clone(), cx)
                 .detach_and_log_err(cx);
@@ -316,16 +301,10 @@ impl PickerDelegate for ModelPickerDelegate {
                 let is_favorite = *is_favorite;
                 let handle_action_click = {
                     let model_id = model_info.id.clone();
-                    let fs = self.fs.clone();
-                    let agent_server = self.agent_server.clone();
+                    let selector = self.selector.clone();
 
                     cx.listener(move |_, _, _, cx| {
-                        agent_server.toggle_favorite_model(
-                            model_id.clone(),
-                            !is_favorite,
-                            fs.clone(),
-                            cx,
-                        );
+                        selector.toggle_favorite_model(model_id.clone(), !is_favorite, cx);
                     })
                 };
 
@@ -403,7 +382,7 @@ impl PickerDelegate for ModelPickerDelegate {
 
 fn info_list_to_picker_entries(
     model_list: AgentModelList,
-    favorites: &HashSet<acp::ModelId>,
+    favorites: &HashSet<AgentModelId>,
 ) -> Vec<ModelPickerEntry> {
     let mut entries = Vec::new();
 
@@ -509,12 +488,8 @@ async fn fuzzy_search(
 
 #[cfg(test)]
 mod tests {
-    use acp_thread::AgentConnection;
-    use fs::FakeFs;
-    use gpui::{App, Entity, TestAppContext, VisualTestContext};
-    use parking_lot::Mutex;
-    use project::{AgentId, Project};
-    use std::{any::Any, cell::RefCell};
+    use gpui::{App, TestAppContext, VisualTestContext};
+    use std::cell::RefCell;
 
     use super::*;
 
@@ -526,7 +501,7 @@ mod tests {
                     models
                         .into_iter()
                         .map(|model| acp_thread::AgentModelInfo {
-                            id: acp::ModelId::new(model.to_string()),
+                            id: AgentModelId::new(model),
                             name: model.to_string().into(),
                             description: None,
                             icon: None,
@@ -575,25 +550,22 @@ mod tests {
         }
     }
 
-    fn create_favorites(models: Vec<&str>) -> HashSet<acp::ModelId> {
-        models
-            .into_iter()
-            .map(|m| acp::ModelId::new(m.to_string()))
-            .collect()
+    fn create_favorites(models: Vec<&str>) -> HashSet<AgentModelId> {
+        models.into_iter().map(AgentModelId::new).collect()
     }
 
     fn get_entry_model_ids(entries: &[ModelPickerEntry]) -> Vec<&str> {
         entries
             .iter()
             .filter_map(|entry| match entry {
-                ModelPickerEntry::Model(info, _) => Some(info.id.0.as_ref()),
+                ModelPickerEntry::Model(info, _) => Some(info.id.as_ref()),
                 _ => None,
             })
             .collect()
     }
 
     #[gpui::test]
-    fn confirming_model_saves_selected_model_as_default(cx: &mut TestAppContext) {
+    fn confirming_model_selects_model(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let settings_store = settings::SettingsStore::test(cx);
             cx.set_global(settings_store);
@@ -601,17 +573,13 @@ mod tests {
             editor::init(cx);
         });
 
-        let agent_server = Rc::new(TestAgentServer::default());
         let model_selector = Rc::new(TestModelSelector::new());
-        let fs: Arc<dyn Fs> = FakeFs::new(cx.executor());
 
         let window_handle = cx.add_window({
-            let agent_server = agent_server.clone();
             let model_selector = model_selector.clone();
             move |window, cx| {
-                let selector: Rc<dyn AgentModelSelector> = model_selector.clone();
-                let agent_server: Rc<dyn AgentServer> = agent_server.clone();
-                acp_model_selector(selector, agent_server, fs, cx.focus_handle(), window, cx)
+                let selector: Rc<dyn AgentModelSelector> = model_selector;
+                acp_model_selector(selector, cx.focus_handle(), window, cx)
             }
         });
         cx.run_until_parked();
@@ -625,63 +593,22 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            agent_server.saved_defaults.lock().as_slice(),
-            &[Some(acp::ModelId::new("manual"))]
-        );
-        assert_eq!(
             model_selector.selected_models.borrow().as_slice(),
-            &[acp::ModelId::new("manual")]
+            &[AgentModelId::new("manual")]
         );
-    }
-
-    #[derive(Default)]
-    struct TestAgentServer {
-        saved_defaults: Arc<Mutex<Vec<Option<acp::ModelId>>>>,
-    }
-
-    impl AgentServer for TestAgentServer {
-        fn logo(&self) -> IconName {
-            IconName::ZedAssistant
-        }
-
-        fn agent_id(&self) -> AgentId {
-            AgentId::new("test-agent")
-        }
-
-        fn connect(
-            &self,
-            _delegate: agent_servers::AgentServerDelegate,
-            _project: Entity<Project>,
-            _cx: &mut App,
-        ) -> Task<anyhow::Result<Rc<dyn AgentConnection>>> {
-            Task::ready(Err(anyhow::anyhow!("test agent server cannot connect")))
-        }
-
-        fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
-            self
-        }
-
-        fn set_default_model(
-            &self,
-            model_id: Option<acp::ModelId>,
-            _fs: Arc<dyn Fs>,
-            _cx: &mut App,
-        ) {
-            self.saved_defaults.lock().push(model_id);
-        }
     }
 
     struct TestModelSelector {
         models: Vec<AgentModelInfo>,
         selected_model: RefCell<AgentModelInfo>,
-        selected_models: RefCell<Vec<acp::ModelId>>,
+        selected_models: RefCell<Vec<AgentModelId>>,
     }
 
     impl TestModelSelector {
         fn new() -> Self {
             let models = vec![
                 AgentModelInfo {
-                    id: acp::ModelId::new("auto"),
+                    id: AgentModelId::new("auto"),
                     name: "Auto".into(),
                     description: None,
                     icon: None,
@@ -689,7 +616,7 @@ mod tests {
                     cost: None,
                 },
                 AgentModelInfo {
-                    id: acp::ModelId::new("manual"),
+                    id: AgentModelId::new("manual"),
                     name: "Manual".into(),
                     description: None,
                     icon: None,
@@ -711,7 +638,7 @@ mod tests {
             Task::ready(Ok(AgentModelList::Flat(self.models.clone())))
         }
 
-        fn select_model(&self, model_id: acp::ModelId, _cx: &mut App) -> Task<Result<()>> {
+        fn select_model(&self, model_id: AgentModelId, _cx: &mut App) -> Task<Result<()>> {
             self.selected_models.borrow_mut().push(model_id.clone());
             if let Some(model) = self.models.iter().find(|model| model.id == model_id) {
                 *self.selected_model.borrow_mut() = model.clone();
@@ -728,7 +655,7 @@ mod tests {
         entries
             .iter()
             .map(|entry| match entry {
-                ModelPickerEntry::Model(info, _) => info.id.0.as_ref(),
+                ModelPickerEntry::Model(info, _) => info.id.as_ref(),
                 ModelPickerEntry::Separator(s) => &s,
             })
             .collect()
@@ -809,10 +736,10 @@ mod tests {
 
         for entry in &entries {
             if let ModelPickerEntry::Model(info, is_favorite) = entry {
-                if info.id.0.as_ref() == "zed/claude" {
+                if info.id.as_ref() == "zed/claude" {
                     assert!(is_favorite, "zed/claude should be a favorite");
                 } else {
-                    assert!(!is_favorite, "{} should not be a favorite", info.id.0);
+                    assert!(!is_favorite, "{} should not be a favorite", info.id);
                 }
             }
         }
@@ -873,7 +800,7 @@ mod tests {
     fn test_flat_model_list_with_favorites(_cx: &mut TestAppContext) {
         let models = AgentModelList::Flat(vec![
             acp_thread::AgentModelInfo {
-                id: acp::ModelId::new("zed/claude".to_string()),
+                id: AgentModelId::new("zed/claude"),
                 name: "Claude".into(),
                 description: None,
                 icon: None,
@@ -881,7 +808,7 @@ mod tests {
                 cost: None,
             },
             acp_thread::AgentModelInfo {
-                id: acp::ModelId::new("zed/gemini".to_string()),
+                id: AgentModelId::new("zed/gemini"),
                 name: "Gemini".into(),
                 description: None,
                 icon: None,
@@ -906,7 +833,7 @@ mod tests {
 
     #[gpui::test]
     fn test_favorites_count_returns_correct_count(_cx: &mut TestAppContext) {
-        let empty_favorites: HashSet<acp::ModelId> = HashSet::default();
+        let empty_favorites: HashSet<AgentModelId> = HashSet::default();
         assert_eq!(empty_favorites.len(), 0);
 
         let one_favorite = create_favorites(vec!["model-a"]);
@@ -923,7 +850,7 @@ mod tests {
     fn test_is_favorite_flag_set_correctly_in_entries(_cx: &mut TestAppContext) {
         let models = AgentModelList::Flat(vec![
             acp_thread::AgentModelInfo {
-                id: acp::ModelId::new("favorite-model".to_string()),
+                id: AgentModelId::new("favorite-model"),
                 name: "Favorite".into(),
                 description: None,
                 icon: None,
@@ -931,7 +858,7 @@ mod tests {
                 cost: None,
             },
             acp_thread::AgentModelInfo {
-                id: acp::ModelId::new("regular-model".to_string()),
+                id: AgentModelId::new("regular-model"),
                 name: "Regular".into(),
                 description: None,
                 icon: None,
@@ -945,9 +872,9 @@ mod tests {
 
         for entry in &entries {
             if let ModelPickerEntry::Model(info, is_favorite) = entry {
-                if info.id.0.as_ref() == "favorite-model" {
+                if info.id.as_ref() == "favorite-model" {
                     assert!(*is_favorite, "favorite-model should have is_favorite=true");
-                } else if info.id.0.as_ref() == "regular-model" {
+                } else if info.id.as_ref() == "regular-model" {
                     assert!(!*is_favorite, "regular-model should have is_favorite=false");
                 }
             }

--- a/crates/agent_ui/src/model_selector_popover.rs
+++ b/crates/agent_ui/src/model_selector_popover.rs
@@ -1,8 +1,6 @@
 use std::rc::Rc;
-use std::sync::Arc;
 
 use acp_thread::{AgentModelIcon, AgentModelInfo, AgentModelSelector};
-use fs::Fs;
 use gpui::{Entity, FocusHandle};
 use picker::popover_menu::PickerPopoverMenu;
 use ui::{PopoverMenuHandle, Tooltip, prelude::*};
@@ -18,17 +16,14 @@ pub struct ModelSelectorPopover {
 impl ModelSelectorPopover {
     pub(crate) fn new(
         selector: Rc<dyn AgentModelSelector>,
-        agent_server: Rc<dyn agent_servers::AgentServer>,
-        fs: Arc<dyn Fs>,
         menu_handle: PopoverMenuHandle<ModelSelector>,
         focus_handle: FocusHandle,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
         Self {
-            selector: cx.new(move |cx| {
-                acp_model_selector(selector, agent_server, fs, focus_handle.clone(), window, cx)
-            }),
+            selector: cx
+                .new(move |cx| acp_model_selector(selector, focus_handle.clone(), window, cx)),
             menu_handle,
         }
     }

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -574,8 +574,6 @@ fn render_registry_agent_button(
                     CustomAgentServerSettings::Registry {
                         env: Default::default(),
                         default_mode: None,
-                        default_model: None,
-                        favorite_models: Vec::new(),
                         default_config_options: HashMap::default(),
                         favorite_config_option_values: HashMap::default(),
                     }

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -226,9 +226,7 @@ impl AgentServerStore {
                 registry_id.to_string(),
                 settings.unwrap_or_else(|| settings::CustomAgentServerSettings::Registry {
                     default_mode: None,
-                    default_model: None,
                     env: Default::default(),
-                    favorite_models: Vec::new(),
                     default_config_options: HashMap::default(),
                     favorite_config_option_values: HashMap::default(),
                 }),
@@ -1357,16 +1355,6 @@ pub enum CustomAgentServerSettings {
         ///
         /// Default: None
         default_mode: Option<String>,
-        /// The default model to use for this agent.
-        ///
-        /// This should be the model ID as reported by the agent.
-        ///
-        /// Default: None
-        default_model: Option<String>,
-        /// The favorite models for this agent.
-        ///
-        /// Default: []
-        favorite_models: Vec<String>,
         /// Default values for session config options.
         ///
         /// This is a map from config option ID to value ID.
@@ -1391,16 +1379,6 @@ pub enum CustomAgentServerSettings {
         ///
         /// Default: None
         default_mode: Option<String>,
-        /// The default model to use for this agent.
-        ///
-        /// This should be the model ID as reported by the agent.
-        ///
-        /// Default: None
-        default_model: Option<String>,
-        /// The favorite models for this agent.
-        ///
-        /// Default: []
-        favorite_models: Vec<String>,
         /// Default values for session config options.
         ///
         /// This is a map from config option ID to value ID.
@@ -1428,24 +1406,6 @@ impl CustomAgentServerSettings {
         match self {
             CustomAgentServerSettings::Custom { default_mode, .. }
             | CustomAgentServerSettings::Registry { default_mode, .. } => default_mode.as_deref(),
-        }
-    }
-
-    pub fn default_model(&self) -> Option<&str> {
-        match self {
-            CustomAgentServerSettings::Custom { default_model, .. }
-            | CustomAgentServerSettings::Registry { default_model, .. } => default_model.as_deref(),
-        }
-    }
-
-    pub fn favorite_models(&self) -> &[String] {
-        match self {
-            CustomAgentServerSettings::Custom {
-                favorite_models, ..
-            }
-            | CustomAgentServerSettings::Registry {
-                favorite_models, ..
-            } => favorite_models,
         }
     }
 
@@ -1486,8 +1446,6 @@ impl From<settings::CustomAgentServerSettings> for CustomAgentServerSettings {
                 args,
                 env,
                 default_mode,
-                default_model,
-                favorite_models,
                 default_config_options,
                 favorite_config_option_values,
             } => CustomAgentServerSettings::Custom {
@@ -1497,24 +1455,18 @@ impl From<settings::CustomAgentServerSettings> for CustomAgentServerSettings {
                     env: Some(env),
                 },
                 default_mode,
-                default_model,
-                favorite_models,
                 default_config_options,
                 favorite_config_option_values,
             },
             settings::CustomAgentServerSettings::Registry {
                 env,
                 default_mode,
-                default_model,
                 default_config_options,
-                favorite_models,
                 favorite_config_option_values,
             } => CustomAgentServerSettings::Registry {
                 env,
                 default_mode,
-                default_model,
                 default_config_options,
-                favorite_models,
                 favorite_config_option_values,
             },
         }
@@ -1597,8 +1549,6 @@ mod tests {
                                 settings::CustomAgentServerSettings::Registry {
                                     env: HashMap::default(),
                                     default_mode: None,
-                                    default_model: None,
-                                    favorite_models: Vec::new(),
                                     default_config_options: HashMap::default(),
                                     favorite_config_option_values: HashMap::default(),
                                 }

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -498,19 +498,6 @@ pub enum CustomAgentServerSettings {
         ///
         /// Default: None
         default_mode: Option<String>,
-        /// The default model to use for this agent.
-        ///
-        /// This should be the model ID as reported by the agent.
-        ///
-        /// Default: None
-        default_model: Option<String>,
-        /// The favorite models for this agent.
-        ///
-        /// These are the model IDs as reported by the agent.
-        ///
-        /// Default: []
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        favorite_models: Vec<String>,
         /// Default values for session config options.
         ///
         /// This is a map from config option ID to value ID.
@@ -540,19 +527,6 @@ pub enum CustomAgentServerSettings {
         ///
         /// Default: None
         default_mode: Option<String>,
-        /// The default model to use for this agent.
-        ///
-        /// This should be the model ID as reported by the agent.
-        ///
-        /// Default: None
-        default_model: Option<String>,
-        /// The favorite models for this agent.
-        ///
-        /// These are the model IDs as reported by the agent.
-        ///
-        /// Default: []
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        favorite_models: Vec<String>,
         /// Default values for session config options.
         ///
         /// This is a map from config option ID to value ID.


### PR DESCRIPTION
Brings stable logout and additional directories support as well as
removing dep on rmcp + tokio

This also removed the unstable model selector (replaced awhile ago by
session config options) so it removes all of that code.

Native agent still uses it because we have a special model selector that
would need more work to rip out

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
