### PR TITLE
Document Pro threshold billing behavior

### DIFF
--- a/docs/src/ai/billing.md
+++ b/docs/src/ai/billing.md
@@ -18,19 +18,22 @@ This page embeds data from Orb, our invoicing and metering partner.
 
 ### Billing cycles {#billing-cycles}
 
-Zed is billed on a monthly basis based on the date you initially subscribe. You'll receive _at least_ one invoice from Zed each month you're subscribed to Zed Pro, and more than one if you use more than $10 in incremental token spend within the month.
+Zed is billed on a monthly basis based on the date you initially subscribe. You'll receive _at least_ one invoice from Zed each month you're subscribed to Zed Pro, and may receive more than one invoice if you use hosted models beyond your included monthly token credit.
 
-### Threshold billing {#threshold-billing}
+### Zed Pro threshold billing {#threshold-billing}
 
-Zed utilizes threshold billing to ensure timely payment collection. Every time your usage of Zed's hosted models crosses a $10 spend threshold, a new invoice is generated, and the threshold resets to $0.
+For individual Zed Pro subscriptions, Zed uses threshold billing to ensure timely payment collection for hosted model usage. Threshold billing controls when already-allowed token usage is invoiced during the month; your [monthly spend limit](./plans-and-usage.md#usage-spend-limits) still controls when hosted model usage stops.
 
-For example,
+Threshold invoices start at $10 of incremental token spend. For higher token usage, Zed may automatically raise your invoicing threshold in $10 increments, up to $100, so you receive fewer mid-cycle invoices. Once raised, the invoicing threshold is not automatically lowered during the same subscription.
+
+For Zed Business billing, see [Organization billing](#organization).
+
+For example:
 
 - You subscribe on February 1. Your first invoice is $10.
 - You use $12 of incremental tokens in the month of February, with the first $10 spent on February 15. You'll receive an invoice for $10 on February 15.
-- On March 1, you receive an invoice for $12: $10 (March Pro subscription) and $2 in leftover token spend, since your usage didn't cross the $10 threshold.
-
-For high-volume users, the threshold automatically scales up over time to keep invoicing manageable, so subsequent invoices may trigger at larger increments rather than every $10.
+- If you use substantially more hosted model tokens, Zed may raise the invoicing threshold before generating later mid-cycle invoices.
+- On March 1, you receive your next monthly subscription invoice, plus any remaining token spend that was not already invoiced during February.
 
 ### Payment failures {#payment-failures}
 

--- a/docs/src/ai/billing.md
+++ b/docs/src/ai/billing.md
@@ -24,7 +24,7 @@ Zed is billed on a monthly basis based on the date you initially subscribe. You'
 
 For individual Zed Pro subscriptions, Zed uses threshold billing to ensure timely payment collection. Threshold billing controls when already-allowed token usage is invoiced during the month; your [monthly spend limit](./plans-and-usage.md#usage-spend-limits) still controls when hosted model usage stops.
 
-Threshold invoices start at $10 of incremental token spend. For higher token usage, Zed may automatically raise your invoicing threshold in $10 increments, up to $100, so you receive fewer mid-cycle invoices. Once raised, the invoicing threshold is not automatically lowered during the same subscription.
+Threshold invoices start at $10 of pre-tax incremental token spend. For higher token usage, Zed may automatically raise your pre-tax invoicing threshold in $10 increments, up to $100, so you receive fewer mid-cycle invoices. Once raised, the invoicing threshold is not automatically lowered during the same subscription.
 
 For Zed Business billing, see [Organization billing](#organization).
 
@@ -32,7 +32,6 @@ For example:
 
 - You subscribe on February 1. Your first invoice is $10.
 - You use $12 of incremental tokens in the month of February, with the first $10 spent on February 15. You'll receive an invoice for $10 on February 15.
-- If you use substantially more hosted model tokens, Zed may raise the invoicing threshold before generating later mid-cycle invoices.
 - On March 1, you receive your next monthly subscription invoice, plus any remaining token spend that was not already invoiced during February.
 
 ### Payment failures {#payment-failures}

--- a/docs/src/ai/billing.md
+++ b/docs/src/ai/billing.md
@@ -22,7 +22,7 @@ Zed is billed on a monthly basis based on the date you initially subscribe. You'
 
 ### Zed Pro threshold billing {#threshold-billing}
 
-For individual Zed Pro subscriptions, Zed uses threshold billing to ensure timely payment collection for hosted model usage. Threshold billing controls when already-allowed token usage is invoiced during the month; your [monthly spend limit](./plans-and-usage.md#usage-spend-limits) still controls when hosted model usage stops.
+For individual Zed Pro subscriptions, Zed uses threshold billing to ensure timely payment collection. Threshold billing controls when already-allowed token usage is invoiced during the month; your [monthly spend limit](./plans-and-usage.md#usage-spend-limits) still controls when hosted model usage stops.
 
 Threshold invoices start at $10 of incremental token spend. For higher token usage, Zed may automatically raise your invoicing threshold in $10 increments, up to $100, so you receive fewer mid-cycle invoices. Once raised, the invoicing threshold is not automatically lowered during the same subscription.
 

--- a/docs/src/ai/plans-and-usage.md
+++ b/docs/src/ai/plans-and-usage.md
@@ -51,7 +51,7 @@ Monthly included credit resets on your monthly billing date. To view your curren
 
 ### Zed Pro {#pro-spend-limits}
 
-On your Billing page you'll find an input for `Monthly Spend Limit`. For Zed Pro, the dollar amount here specifies your _monthly_ limit for spend on tokens, _not counting_ the $5/month included with your Pro subscription.
+On your Billing page you'll find an input for `Monthly Spend Limit`. For Zed Pro, the dollar amount here specifies your pre-tax _monthly_ limit for spend on tokens, _not counting_ the $5/month included with your Pro subscription.
 
 The default value for Pro users is $10, for a total monthly spend with Zed of $20 ($10 for your Pro subscription, $10 in incremental token spend). This can be set to $0 to limit your spend with Zed to exactly $10/month. If you adjust this limit _higher_ than $10 and consume more than $10 of incremental token spend, that usage may be billed during the month via [Zed Pro threshold billing](./billing.md#threshold-billing).
 
@@ -59,7 +59,7 @@ Once the spend limit is hit, we'll stop any further usage until your token spend
 
 ### Zed Business {#business-spend-limits}
 
-On Zed Business, administrators set an org-wide spend limit from the Data & Privacy page in the organization dashboard. Seats and AI usage are consolidated into [Organization billing](./billing.md#organization). Once the org-wide spend limit is reached, we'll stop hosted model usage for members until the limit resets or an administrator raises it.
+On Zed Business, administrators set a pre-tax org-wide spend limit from the Data & Privacy page in the organization dashboard. Seats and AI usage are consolidated into [Organization billing](./billing.md#organization). Once the org-wide spend limit is reached, we'll stop hosted model usage for members until the limit resets or an administrator raises it.
 
 > **Note:** Spend limits are a Zed Pro and Business feature. Student plan users cannot configure spend limits; usage is capped at the $10/month included credit.
 

--- a/docs/src/ai/plans-and-usage.md
+++ b/docs/src/ai/plans-and-usage.md
@@ -49,13 +49,17 @@ Monthly included credit resets on your monthly billing date. To view your curren
 
 ## Spend Limits {#usage-spend-limits}
 
-On your Billing page you'll find an input for `Monthly Spend Limit`. The dollar amount here specifies your _monthly_ limit for spend on tokens, _not counting_ the $5/month included with your Pro subscription.
+### Zed Pro {#pro-spend-limits}
 
-The default value for all Pro users is $10, for a total monthly spend with Zed of $20 ($10 for your Pro subscription, $10 in incremental token spend). This can be set to $0 to limit your spend with Zed to exactly $10/month. If you adjust this limit _higher_ than $10 and consume more than $10 of incremental token spend, you'll be billed via [threshold billing](./billing.md#threshold-billing).
+On your Billing page you'll find an input for `Monthly Spend Limit`. For Zed Pro, the dollar amount here specifies your _monthly_ limit for spend on tokens, _not counting_ the $5/month included with your Pro subscription.
+
+The default value for Pro users is $10, for a total monthly spend with Zed of $20 ($10 for your Pro subscription, $10 in incremental token spend). This can be set to $0 to limit your spend with Zed to exactly $10/month. If you adjust this limit _higher_ than $10 and consume more than $10 of incremental token spend, that usage may be billed during the month via [Zed Pro threshold billing](./billing.md#threshold-billing).
 
 Once the spend limit is hit, we'll stop any further usage until your token spend limit resets.
 
-On Zed Business, administrators set an org-wide spend limit from the Data & Privacy page in the organization dashboard. See [Organization Billing](./billing.md#ai-usage) for details.
+### Zed Business {#business-spend-limits}
+
+On Zed Business, administrators set an org-wide spend limit from the Data & Privacy page in the organization dashboard. Seats and AI usage are consolidated into [Organization billing](./billing.md#organization). Once the org-wide spend limit is reached, we'll stop hosted model usage for members until the limit resets or an administrator raises it.
 
 > **Note:** Spend limits are a Zed Pro and Business feature. Student plan users cannot configure spend limits; usage is capped at the $10/month included credit.
 


### PR DESCRIPTION
This updates docs to reflect changes threshold billing behavior for individual Zed Pro subscriptions.

- Scope threshold billing language explicitly to individual Zed Pro subscriptions.
- Remove stale language saying each $10 threshold crossing resets the threshold to $0.
- Document that threshold invoices start at $10, may rise in $10 increments up to $100, and are not automatically lowered during the same subscription.
- Split spend-limit docs between Zed Pro and Zed Business, with Business readers linked to organization billing.

Release Notes:

- N/A
