### PR TITLE
fs: Avoid resolving symlinks when trashing

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -802,10 +802,10 @@ impl Fs for RealFs {
         // We must make the path absolute or trash will make a weird abomination
         // of the zed working directory (not usually the worktree) and whatever
         // the path variable holds.
-        let path = self
-            .canonicalize(path)
-            .await
-            .context("Could not canonicalize the path of the file")?;
+        // We deliberately use `std::path::absolute` instead of `canonicalize`
+        // to avoid resolving symlinks. Otherwise trashing a symlink would trash
+        // its target and leave the link behind.
+        let path = std::path::absolute(path).context("Could not make the path absolute")?;
 
         let (tx, rx) = futures::channel::oneshot::channel();
         std::thread::Builder::new()


### PR DESCRIPTION
Use `std::path::absolute` instead of `RealFs::canonicalize` to make the path absolute in `RealFs::trash` as `canonicalize` also resolves symlinks, so trashing a symlink moved its target to the trash and left the link dangling.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
    - Not applicable as we don't have a good infrastructure for testing `RealFs` changes without hitting the machine's actual filesystem and testing this on `FakeFs` implementation wouldn't prevent a future regression, unfortunately.
- [x] Performance impact has been considered and is acceptable

Closes #54900 

Release Notes:

- Fixed trashing of symlinks in project panel to actually trash the link and not its target.
