### PR TITLE
language_models: Remove retired GPT-5.2 and GPT-5.3-Codex from ChatGPT Subscription

### DIFF
--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -276,9 +276,9 @@ impl LanguageModelProvider for OpenAiSubscribedProvider {
 // `GET <codex_base_url>/models?client_version=...` (see
 // codex-rs/codex-api/src/endpoint/models.rs in openai/codex) and falls back to
 // a bundled models.json. Beyond going stale, the static approach also can't
-// model per-account access (e.g. free accounts cannot use gpt-5.4 or
-// gpt-5.3-codex even though paid accounts can), so the backend still rejects
-// some requests. The bundled list at
+// model per-account access (e.g. free accounts cannot use gpt-5.4 even though
+// paid accounts can), so the backend still rejects some requests. The bundled
+// list at
 // codex-rs/models-manager/models.json (openai/codex) is the closest
 // approximation; the entries below mirror that file's picker-visible models.
 #[derive(Clone, Debug, PartialEq)]
@@ -286,19 +286,11 @@ enum ChatGptModel {
     Gpt55,
     Gpt54,
     Gpt54Mini,
-    Gpt53Codex,
-    Gpt52,
 }
 
 impl ChatGptModel {
     fn all() -> Vec<Self> {
-        vec![
-            Self::Gpt55,
-            Self::Gpt54,
-            Self::Gpt54Mini,
-            Self::Gpt53Codex,
-            Self::Gpt52,
-        ]
+        vec![Self::Gpt55, Self::Gpt54, Self::Gpt54Mini]
     }
 
     fn id(&self) -> &str {
@@ -306,8 +298,6 @@ impl ChatGptModel {
             Self::Gpt55 => "gpt-5.5",
             Self::Gpt54 => "gpt-5.4",
             Self::Gpt54Mini => "gpt-5.4-mini",
-            Self::Gpt53Codex => "gpt-5.3-codex",
-            Self::Gpt52 => "gpt-5.2",
         }
     }
 
@@ -316,8 +306,6 @@ impl ChatGptModel {
             Self::Gpt55 => "GPT-5.5",
             Self::Gpt54 => "GPT-5.4",
             Self::Gpt54Mini => "GPT-5.4 Mini",
-            Self::Gpt53Codex => "GPT-5.3 Codex",
-            Self::Gpt52 => "GPT-5.2",
         }
     }
 
@@ -363,7 +351,7 @@ impl ChatGptModel {
     fn supports_priority(&self) -> bool {
         match self {
             Self::Gpt55 | Self::Gpt54 => true,
-            Self::Gpt54Mini | Self::Gpt53Codex | Self::Gpt52 => false,
+            Self::Gpt54Mini => false,
         }
     }
 }


### PR DESCRIPTION
Closes #58305

OpenAI sunset GPT-5.2 and GPT-5.3-Codex in Codex for ChatGPT account logins on June 2nd, so sending to them via the ChatGPT Subscription provider now fails with error. This PR removes those models from ChatGPT Subscription model list.

Release Notes:

- Removed the retired GPT-5.2 and GPT-5.3 Codex models from the ChatGPT Subscription provider.