### PR TITLE
mermaid_render: Remove spurious debug assert

### DIFF
--- a/crates/mermaid_render/src/postprocess/accent_colors.rs
+++ b/crates/mermaid_render/src/postprocess/accent_colors.rs
@@ -38,8 +38,6 @@ impl NodeTracker {
     }
 
     pub fn finish_node(&mut self) {
-        debug_assert!(self.building.is_some());
-
         if let Some(rect) = self.building.take() {
             self.rects.push(rect);
         }

--- a/crates/mermaid_render/src/postprocess/accent_colors.rs
+++ b/crates/mermaid_render/src/postprocess/accent_colors.rs
@@ -37,7 +37,7 @@ impl NodeTracker {
         });
     }
 
-    pub fn finish_node(&mut self) {
+    pub fn maybe_finish_node(&mut self) {
         if let Some(rect) = self.building.take() {
             self.rects.push(rect);
         }

--- a/crates/mermaid_render/src/postprocess/accent_colors/class_diagram.rs
+++ b/crates/mermaid_render/src/postprocess/accent_colors/class_diagram.rs
@@ -58,7 +58,7 @@ impl ClassDiagramAccents {
             Event::End(e) if e.name().as_ref() == b"g" => {
                 if let Some(entry) = self.accent_g_stack.pop() {
                     if entry.is_some() {
-                        self.nodes.finish_node();
+                        self.nodes.maybe_finish_node();
                     }
                 }
                 Ok(event)

--- a/crates/mermaid_render/src/postprocess/accent_colors/mindmap.rs
+++ b/crates/mermaid_render/src/postprocess/accent_colors/mindmap.rs
@@ -38,7 +38,7 @@ impl MindmapAccents {
             Event::End(e) if e.name().as_ref() == b"g" => {
                 if let Some(maybe_section) = self.section_g_stack.pop() {
                     if maybe_section.is_some() {
-                        self.nodes.finish_node();
+                        self.nodes.maybe_finish_node();
                     }
                 }
                 Ok(event)


### PR DESCRIPTION
This debug assert was actually invalid, and panicked in debug builds on valid diagrams. We start building a node only when we find a `translate()` that we need to fix up, but unconditionally call `finish_node`. But since `finish_node` does `if let Some(...) = self.building.take()`, it's a no-op if there is no node being built, so it's safe to call.

Renamed to `maybe_finish_node` to communicate this fact

Release Notes:

- N/A or Added/Fixed/Improved ...
