### PR TITLE
gpui: Add support for system notifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -830,11 +830,15 @@ zstd = "0.11"
 [workspace.dependencies.windows]
 version = "0.61"
 features = [
+    "Data_Xml_Dom",
+    "Foundation",
+    "Foundation_Collections",
     "Foundation_Numerics",
     "Globalization_DateTimeFormatting",
     "Storage_Search",
     "Storage_Streams",
     "System_Threading",
+    "UI_Notifications",
     "UI_ViewManagement",
     "Wdk_System_SystemServices",
     "Win32_Foundation",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -167,6 +167,15 @@ reqwest_client = { workspace = true, features = ["test-support"] }
 wasm-bindgen = { workspace = true }
 gpui_web.workspace = true
 
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_UI_Shell",
+    "Win32_UI_Shell_PropertiesSystem",
+] }
+
 [build-dependencies]
 embed-resource = { version = "3.0", optional = true }
 

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -212,6 +212,10 @@ name = "set_menus"
 path = "examples/set_menus.rs"
 
 [[example]]
+name = "system_notifications"
+path = "examples/system_notifications.rs"
+
+[[example]]
 name = "shadow"
 path = "examples/shadow.rs"
 

--- a/crates/gpui/examples/system_notifications.rs
+++ b/crates/gpui/examples/system_notifications.rs
@@ -1,0 +1,199 @@
+#![cfg_attr(target_family = "wasm", no_main)]
+
+use gpui::{
+    App, Bounds, Context, SharedString, SystemNotification, SystemNotificationId,
+    SystemNotificationPermission, SystemNotificationPriority, Task, Window, WindowBounds,
+    WindowOptions, div, prelude::*, px, rgb, size,
+};
+use gpui_platform::application;
+
+struct SystemNotificationsExample {
+    status: SharedString,
+    counter: usize,
+}
+
+impl SystemNotificationsExample {
+    fn new() -> Self {
+        Self {
+            status: "Ready".into(),
+            counter: 0,
+        }
+    }
+
+    fn notification_id() -> SystemNotificationId {
+        SystemNotificationId("gpui.example.system-notification".into())
+    }
+
+    fn check_permission(&mut self, cx: &mut Context<Self>) {
+        let task = cx.system_notification_permission();
+        self.await_permission("permission", task, cx);
+    }
+
+    fn request_permission(&mut self, cx: &mut Context<Self>) {
+        let task = cx.request_system_notification_permission();
+        self.await_permission("request", task, cx);
+    }
+
+    fn show_notification(&mut self, cx: &mut Context<Self>) {
+        self.counter += 1;
+        let notification = SystemNotification {
+            id: Self::notification_id(),
+            title: "GPUI system notification".into(),
+            body: Some(format!("Shown from the GPUI example {} time(s).", self.counter).into()),
+            priority: SystemNotificationPriority::Normal,
+        };
+
+        let task = cx.show_system_notification(notification);
+        self.await_result("show/update", task, cx);
+    }
+
+    fn remove_notification(&mut self, cx: &mut Context<Self>) {
+        let task = cx.remove_system_notification(Self::notification_id());
+        self.await_result("remove", task, cx);
+    }
+
+    fn await_permission(
+        &mut self,
+        label: &'static str,
+        task: Task<anyhow::Result<SystemNotificationPermission>>,
+        cx: &mut Context<Self>,
+    ) {
+        self.status = format!("{label}: waiting").into();
+        cx.notify();
+        cx.spawn(async move |this, cx| {
+            let status = match task.await {
+                Ok(permission) => format!("{label}: {permission:?}"),
+                Err(error) => format!("{label} failed: {error:#}"),
+            };
+            this.update(cx, |this, cx| {
+                this.status = status.into();
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn await_result(
+        &mut self,
+        label: &'static str,
+        task: Task<anyhow::Result<()>>,
+        cx: &mut Context<Self>,
+    ) {
+        self.status = format!("{label}: waiting").into();
+        cx.notify();
+        cx.spawn(async move |this, cx| {
+            let status = match task.await {
+                Ok(()) => format!("{label}: ok"),
+                Err(error) => format!("{label} failed: {error:#}"),
+            };
+            this.update(cx, |this, cx| {
+                this.status = status.into();
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+}
+
+impl Render for SystemNotificationsExample {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_col()
+            .gap_4()
+            .size_full()
+            .p_6()
+            .bg(rgb(0xf7f8f3))
+            .text_color(rgb(0x1f2933))
+            .child(div().text_2xl().child("System notifications"))
+            .child(
+                div()
+                    .flex()
+                    .flex_wrap()
+                    .gap_2()
+                    .child(
+                        div()
+                            .id("check-permission")
+                            .px_3()
+                            .py_2()
+                            .rounded_sm()
+                            .bg(rgb(0xe1e7dd))
+                            .hover(|style| style.bg(rgb(0xd5dfcf)))
+                            .child("Check permission")
+                            .on_click(cx.listener(|this, _, _, cx| this.check_permission(cx))),
+                    )
+                    .child(
+                        div()
+                            .id("request-permission")
+                            .px_3()
+                            .py_2()
+                            .rounded_sm()
+                            .bg(rgb(0xf0dfb8))
+                            .hover(|style| style.bg(rgb(0xe8d39f)))
+                            .child("Request permission")
+                            .on_click(cx.listener(|this, _, _, cx| this.request_permission(cx))),
+                    )
+                    .child(
+                        div()
+                            .id("show-notification")
+                            .px_3()
+                            .py_2()
+                            .rounded_sm()
+                            .bg(rgb(0x1d6f9f))
+                            .text_color(rgb(0xffffff))
+                            .hover(|style| style.bg(rgb(0x155c86)))
+                            .child("Show/update")
+                            .on_click(cx.listener(|this, _, _, cx| this.show_notification(cx))),
+                    )
+                    .child(
+                        div()
+                            .id("remove-notification")
+                            .px_3()
+                            .py_2()
+                            .rounded_sm()
+                            .bg(rgb(0xf2c8bd))
+                            .hover(|style| style.bg(rgb(0xeeb7aa)))
+                            .child("Remove")
+                            .on_click(cx.listener(|this, _, _, cx| this.remove_notification(cx))),
+                    ),
+            )
+            .child(
+                div()
+                    .id("status")
+                    .p_3()
+                    .rounded_sm()
+                    .bg(rgb(0xffffff))
+                    .text_color(rgb(0x314154))
+                    .child(self.status.clone()),
+            )
+    }
+}
+
+fn run_example() {
+    application().run(|cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(520.), px(240.0)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |_, cx| cx.new(|_| SystemNotificationsExample::new()),
+        )
+        .unwrap();
+        cx.activate(true);
+    });
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn main() {
+    run_example();
+}
+
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn start() {
+    gpui_platform::web_init();
+    run_example();
+}

--- a/crates/gpui/examples/system_notifications.rs
+++ b/crates/gpui/examples/system_notifications.rs
@@ -13,11 +13,8 @@ struct SystemNotificationsExample {
 }
 
 impl SystemNotificationsExample {
-    fn new() -> Self {
-        Self {
-            status: "Ready".into(),
-            counter: 0,
-        }
+    fn new(status: SharedString) -> Self {
+        Self { status, counter: 0 }
     }
 
     fn notification_id() -> SystemNotificationId {
@@ -173,17 +170,113 @@ impl Render for SystemNotificationsExample {
 
 fn run_example() {
     application().run(|cx: &mut App| {
+        let status = initial_status();
         let bounds = Bounds::centered(None, size(px(520.), px(240.0)), cx);
         cx.open_window(
             WindowOptions {
                 window_bounds: Some(WindowBounds::Windowed(bounds)),
                 ..Default::default()
             },
-            |_, cx| cx.new(|_| SystemNotificationsExample::new()),
+            |_, cx| cx.new(|_| SystemNotificationsExample::new(status)),
         )
         .unwrap();
         cx.activate(true);
     });
+}
+
+#[cfg(target_os = "windows")]
+fn initial_status() -> SharedString {
+    match windows_notification_example::setup() {
+        Ok(shortcut_path) => format!(
+            "Ready (registered Windows toast shortcut at {})",
+            shortcut_path.display()
+        )
+        .into(),
+        Err(error) => format!("Windows toast setup failed: {error:#}").into(),
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn initial_status() -> SharedString {
+    "Ready".into()
+}
+
+#[cfg(target_os = "windows")]
+mod windows_notification_example {
+    use std::path::PathBuf;
+
+    use anyhow::{Context as _, Result};
+    use windows::{
+        Win32::{
+            Foundation::PROPERTYKEY,
+            System::Com::{
+                CLSCTX_INPROC_SERVER, CoCreateInstance, CoTaskMemFree, IPersistFile,
+                StructuredStorage::PROPVARIANT,
+            },
+            UI::Shell::{
+                FOLDERID_Programs, IShellLinkW, KNOWN_FOLDER_FLAG,
+                PropertiesSystem::IPropertyStore, SHGetKnownFolderPath,
+                SetCurrentProcessExplicitAppUserModelID, ShellLink,
+            },
+        },
+        core::{GUID, HSTRING, Interface},
+    };
+
+    const APP_USER_MODEL_ID: &str = "dev.gpui.SystemNotificationsExample";
+    const SHORTCUT_NAME: &str = "GPUI System Notifications Example.lnk";
+    const PKEY_APP_USER_MODEL_ID: PROPERTYKEY = PROPERTYKEY {
+        fmtid: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3),
+        pid: 5,
+    };
+
+    pub(super) fn setup() -> Result<PathBuf> {
+        let app_user_model_id = HSTRING::from(APP_USER_MODEL_ID);
+        unsafe {
+            SetCurrentProcessExplicitAppUserModelID(&app_user_model_id)
+                .context("setting process AppUserModelID")?;
+        }
+
+        let shortcut_path = shortcut_path().context("resolving Start Menu shortcut path")?;
+        create_shortcut(&shortcut_path).context("creating Start Menu shortcut")?;
+        Ok(shortcut_path)
+    }
+
+    fn shortcut_path() -> Result<PathBuf> {
+        let programs_path =
+            unsafe { SHGetKnownFolderPath(&FOLDERID_Programs, KNOWN_FOLDER_FLAG(0), None)? };
+        let programs_path_string = unsafe { programs_path.to_string() };
+        unsafe {
+            CoTaskMemFree(Some(programs_path.0 as _));
+        }
+
+        let mut path = PathBuf::from(programs_path_string?);
+        path.push(SHORTCUT_NAME);
+        Ok(path)
+    }
+
+    fn create_shortcut(shortcut_path: &PathBuf) -> Result<()> {
+        if let Some(parent) = shortcut_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating shortcut directory {}", parent.display()))?;
+        }
+
+        unsafe {
+            let link: IShellLinkW = CoCreateInstance(&ShellLink, None, CLSCTX_INPROC_SERVER)?;
+            let exe_path = HSTRING::from(std::env::current_exe()?.as_os_str());
+            link.SetPath(&exe_path)?;
+            link.SetDescription(&HSTRING::from("GPUI system notifications example"))?;
+
+            let store: IPropertyStore = link.cast()?;
+            let app_user_model_id = PROPVARIANT::from(APP_USER_MODEL_ID);
+            store.SetValue(&PKEY_APP_USER_MODEL_ID, &app_user_model_id)?;
+            store.Commit()?;
+
+            let persist_file: IPersistFile = link.cast()?;
+            persist_file.Save(&HSTRING::from(shortcut_path.as_os_str()), true)?;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/crates/gpui/examples/system_notifications.rs
+++ b/crates/gpui/examples/system_notifications.rs
@@ -1,5 +1,26 @@
 #![cfg_attr(target_family = "wasm", no_main)]
 
+// Requirements:
+//
+// - Windows:
+//   The application must register a Start Menu shortcut with an AppUserModelID
+//   so that it can send toast notifications.
+//   See https://learn.microsoft.com/en-us/windows/win32/shell/enable-desktop-toast-with-appusermodelid
+//
+// - macOS:
+//   The application must be a valid macOS app bundle with a stable bundle
+//   identifier, an Info.plist file with a valid CFBundleIdentifier entry, and
+//   it must request the user's permission to send notifications.
+//   See https://developer.apple.com/documentation/usernotifications/unerror/notificationsnotallowed
+//
+// - Linux (GNOME):
+//   The application must have a valid desktop application ID and a matching
+//   installed .desktop file named <app-id>.desktop with
+//   X-GNOME-UsesNotifications=true. When launched from the terminal, the
+//   application should explicitly register with the portal using the desktop
+//   application ID.
+//   Related: https://blogs.gnome.org/shell-dev/2024/04/23/notifications-46-and-beyond/
+
 use gpui::{
     App, Bounds, Context, SharedString, SystemNotification, SystemNotificationId,
     SystemNotificationPermission, SystemNotificationPriority, Task, Window, WindowBounds,
@@ -201,6 +222,11 @@ fn initial_status() -> SharedString {
     "Ready".into()
 }
 
+// This code is required to set up Windows toast notifications. The application
+// must register a shortcut with an AppUserModelID in the Start Menu so that
+// it can send toast notifications.
+//
+// See https://learn.microsoft.com/en-us/windows/win32/shell/enable-desktop-toast-with-appusermodelid
 #[cfg(target_os = "windows")]
 mod windows_notification_example {
     use std::path::PathBuf;

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -50,7 +50,8 @@ use crate::{
     PathPromptOptions, Pixels, Platform, PlatformDisplay, PlatformKeyboardLayout,
     PlatformKeyboardMapper, Point, Priority, PromptBuilder, PromptButton, PromptHandle,
     PromptLevel, Render, RenderImage, RenderablePromptHandle, Reservation, ScreenCaptureSource,
-    SharedString, SubscriberSet, Subscription, SvgRenderer, Task, TextRenderingMode, TextSystem,
+    SharedString, SubscriberSet, Subscription, SvgRenderer, SystemNotification,
+    SystemNotificationId, SystemNotificationPermission, Task, TextRenderingMode, TextSystem,
     ThermalState, Window, WindowAppearance, WindowButtonLayout, WindowHandle, WindowId,
     WindowInvalidator,
     colors::{Colors, GlobalColors},
@@ -1336,6 +1337,28 @@ impl App {
     /// schemes at runtime.
     pub fn register_url_scheme(&self, scheme: &str) -> Task<Result<()>> {
         self.platform.register_url_scheme(scheme)
+    }
+
+    /// Returns the current platform system notification permission state.
+    pub fn system_notification_permission(&self) -> Task<Result<SystemNotificationPermission>> {
+        self.platform.system_notification_permission()
+    }
+
+    /// Requests permission to show system notifications, when the platform supports it.
+    pub fn request_system_notification_permission(
+        &self,
+    ) -> Task<Result<SystemNotificationPermission>> {
+        self.platform.request_system_notification_permission()
+    }
+
+    /// Shows or updates a platform system notification.
+    pub fn show_system_notification(&self, notification: SystemNotification) -> Task<Result<()>> {
+        self.platform.show_system_notification(notification)
+    }
+
+    /// Removes a platform system notification by ID.
+    pub fn remove_system_notification(&self, id: SystemNotificationId) -> Task<Result<()>> {
+        self.platform.remove_system_notification(id)
     }
 
     /// Returns the full pathname of the current app bundle.

--- a/crates/gpui/src/app/test_app.rs
+++ b/crates/gpui/src/app/test_app.rs
@@ -28,8 +28,9 @@ use crate::{
     AnyWindowHandle, App, AppCell, AppContext, AsyncApp, BackgroundExecutor, BorrowAppContext,
     Bounds, ClipboardItem, Context, Entity, ForegroundExecutor, Global, InputEvent, Keystroke,
     MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Platform,
-    PlatformTextSystem, Point, Render, Size, Task, TestDispatcher, TestPlatform, TextSystem,
-    Window, WindowBounds, WindowHandle, WindowOptions, app::GpuiMode,
+    PlatformTextSystem, Point, Render, Size, SystemNotification, SystemNotificationId,
+    SystemNotificationPermission, Task, TestDispatcher, TestPlatform, TextSystem, Window,
+    WindowBounds, WindowHandle, WindowOptions, app::GpuiMode,
 };
 use std::{future::Future, rc::Rc, sync::Arc, time::Duration};
 
@@ -279,6 +280,21 @@ impl TestApp {
     /// Get URLs that have been opened via `cx.open_url()`.
     pub fn opened_url(&self) -> Option<String> {
         self.platform.opened_url.borrow().clone()
+    }
+
+    /// Sets the notification permission state reported by the test platform.
+    pub fn set_system_notification_permission(&self, permission: SystemNotificationPermission) {
+        self.platform.set_system_notification_permission(permission);
+    }
+
+    /// Returns the notifications shown through the test platform.
+    pub fn shown_system_notifications(&self) -> Vec<SystemNotification> {
+        self.platform.shown_system_notifications()
+    }
+
+    /// Returns the notification IDs removed through the test platform.
+    pub fn removed_system_notifications(&self) -> Vec<SystemNotificationId> {
+        self.platform.removed_system_notifications()
     }
 
     /// Check if a file path prompt is pending.

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -3,9 +3,10 @@ use crate::{
     BackgroundExecutor, BorrowAppContext, Bounds, Capslock, ClipboardItem, DrawPhase, Drawable,
     Element, Empty, EntityId, EventEmitter, ForegroundExecutor, Global, InputEvent, Keystroke,
     Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
-    Pixels, Platform, Point, Render, Result, Size, Task, TestDispatcher, TestPlatform,
-    TestScreenCaptureSource, TestWindow, TextSystem, VisualContext, Window, WindowBounds,
-    WindowHandle, WindowOptions, app::GpuiMode, window::ElementArenaScope,
+    Pixels, Platform, Point, Render, Result, Size, SystemNotification, SystemNotificationId,
+    SystemNotificationPermission, Task, TestDispatcher, TestPlatform, TestScreenCaptureSource,
+    TestWindow, TextSystem, VisualContext, Window, WindowBounds, WindowHandle, WindowOptions,
+    app::GpuiMode, window::ElementArenaScope,
 };
 use anyhow::{anyhow, bail};
 use futures::{Stream, StreamExt, channel::oneshot};
@@ -369,6 +370,22 @@ impl TestAppContext {
     /// All the urls that have been opened with cx.open_url() during this test.
     pub fn opened_url(&self) -> Option<String> {
         self.test_platform.opened_url.borrow().clone()
+    }
+
+    /// Sets the notification permission state reported by the test platform.
+    pub fn set_system_notification_permission(&self, permission: SystemNotificationPermission) {
+        self.test_platform
+            .set_system_notification_permission(permission);
+    }
+
+    /// Returns the notifications shown through the test platform.
+    pub fn shown_system_notifications(&self) -> Vec<SystemNotification> {
+        self.test_platform.shown_system_notifications()
+    }
+
+    /// Returns the notification IDs removed through the test platform.
+    pub fn removed_system_notifications(&self) -> Vec<SystemNotificationId> {
+        self.test_platform.removed_system_notifications()
     }
 
     /// Simulates the user resizing the window to the new size.
@@ -1115,7 +1132,10 @@ impl AnyWindowHandle {
 
 #[cfg(test)]
 mod tests {
-    use crate::{PathPromptOptions, TestAppContext};
+    use crate::{
+        PathPromptOptions, SystemNotification, SystemNotificationId, SystemNotificationPermission,
+        SystemNotificationPriority, TestAppContext,
+    };
     use std::path::PathBuf;
 
     #[gpui::test]
@@ -1161,5 +1181,42 @@ mod tests {
 
         let response = receiver.await.unwrap().unwrap();
         assert_eq!(response, None);
+    }
+
+    #[gpui::test]
+    async fn test_system_notification_permission(cx: &mut TestAppContext) {
+        cx.set_system_notification_permission(SystemNotificationPermission::Denied);
+
+        let permission = cx
+            .update(|cx| cx.system_notification_permission())
+            .await
+            .unwrap();
+        assert_eq!(permission, SystemNotificationPermission::Denied);
+
+        let permission = cx
+            .update(|cx| cx.request_system_notification_permission())
+            .await
+            .unwrap();
+        assert_eq!(permission, SystemNotificationPermission::Denied);
+    }
+
+    #[gpui::test]
+    async fn test_system_notification_recording(cx: &mut TestAppContext) {
+        let notification = SystemNotification {
+            id: SystemNotificationId("test-notification".into()),
+            title: "Test notification".into(),
+            body: Some("Notification body".into()),
+            priority: SystemNotificationPriority::High,
+        };
+
+        cx.update(|cx| cx.show_system_notification(notification.clone()))
+            .await
+            .unwrap();
+        cx.update(|cx| cx.remove_system_notification(notification.id.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(cx.shown_system_notifications(), vec![notification.clone()]);
+        assert_eq!(cx.removed_system_notifications(), vec![notification.id]);
     }
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -112,6 +112,53 @@ pub fn guess_compositor() -> &'static str {
     }
 }
 
+/// A stable identifier for an OS-level notification.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct SystemNotificationId(
+    /// The platform-specific notification identifier.
+    pub SharedString,
+);
+
+/// An OS-level notification to show through the active platform.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SystemNotification {
+    /// The stable identifier used to update or remove this notification.
+    pub id: SystemNotificationId,
+    /// The notification title.
+    pub title: SharedString,
+    /// Optional detail text for the notification.
+    pub body: Option<SharedString>,
+    /// The priority requested from the platform notification system.
+    pub priority: SystemNotificationPriority,
+}
+
+/// The requested priority for an OS-level notification.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SystemNotificationPriority {
+    /// Low-priority notification.
+    Low,
+    /// Normal-priority notification.
+    #[default]
+    Normal,
+    /// High-priority notification.
+    High,
+    /// Urgent notification.
+    Urgent,
+}
+
+/// The current platform notification permission state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SystemNotificationPermission {
+    /// The platform permits system notifications.
+    Granted,
+    /// The user or platform denied system notifications.
+    Denied,
+    /// The platform can request permission but no decision has been made.
+    NotDetermined,
+    /// The platform does not support system notifications in this context.
+    Unsupported,
+}
+
 #[expect(missing_docs)]
 pub trait Platform: 'static {
     fn background_executor(&self) -> BackgroundExecutor;
@@ -166,6 +213,20 @@ pub trait Platform: 'static {
     fn open_url(&self, url: &str);
     fn on_open_urls(&self, callback: Box<dyn FnMut(Vec<String>)>);
     fn register_url_scheme(&self, url: &str) -> Task<Result<()>>;
+    fn system_notification_permission(&self) -> Task<Result<SystemNotificationPermission>> {
+        Task::ready(Ok(SystemNotificationPermission::Unsupported))
+    }
+    fn request_system_notification_permission(&self) -> Task<Result<SystemNotificationPermission>> {
+        Task::ready(Ok(SystemNotificationPermission::Unsupported))
+    }
+    fn show_system_notification(&self, _notification: SystemNotification) -> Task<Result<()>> {
+        Task::ready(Err(anyhow::anyhow!(
+            "system notifications are not supported"
+        )))
+    }
+    fn remove_system_notification(&self, _id: SystemNotificationId) -> Task<Result<()>> {
+        Task::ready(Ok(()))
+    }
 
     fn prompt_for_paths(
         &self,

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -3,8 +3,8 @@ use crate::{
     DummyKeyboardMapper, ForegroundExecutor, Keymap, NoopTextSystem, PathPromptOptions, Platform,
     PlatformDisplay, PlatformHeadlessRenderer, PlatformKeyboardLayout, PlatformKeyboardMapper,
     PlatformTextSystem, PromptButton, ScreenCaptureFrame, ScreenCaptureSource, ScreenCaptureStream,
-    SourceMetadata, Task, TestDisplay, TestWindow, ThermalState, WindowAppearance, WindowParams,
-    size,
+    SourceMetadata, SystemNotification, SystemNotificationId, SystemNotificationPermission, Task,
+    TestDisplay, TestWindow, ThermalState, WindowAppearance, WindowParams, size,
 };
 use anyhow::Result;
 use collections::VecDeque;
@@ -33,6 +33,9 @@ pub(crate) struct TestPlatform {
     pub(crate) prompts: RefCell<TestPrompts>,
     screen_capture_sources: RefCell<Vec<TestScreenCaptureSource>>,
     pub opened_url: RefCell<Option<String>>,
+    pub(crate) system_notification_permission: RefCell<SystemNotificationPermission>,
+    pub(crate) shown_system_notifications: RefCell<Vec<SystemNotification>>,
+    pub(crate) removed_system_notifications: RefCell<Vec<SystemNotificationId>>,
     pub text_system: Arc<dyn PlatformTextSystem>,
     pub expect_restart: RefCell<Option<oneshot::Sender<Option<PathBuf>>>>,
     headless_renderer_factory: Option<Box<dyn Fn() -> Option<Box<dyn PlatformHeadlessRenderer>>>>,
@@ -132,6 +135,9 @@ impl TestPlatform {
             current_primary_item: Mutex::new(None),
             #[cfg(target_os = "macos")]
             current_find_pasteboard_item: Mutex::new(None),
+            system_notification_permission: RefCell::new(SystemNotificationPermission::Granted),
+            shown_system_notifications: Default::default(),
+            removed_system_notifications: Default::default(),
             weak: weak.clone(),
             opened_url: Default::default(),
             text_system,
@@ -211,6 +217,21 @@ impl TestPlatform {
 
     pub(crate) fn set_screen_capture_sources(&self, sources: Vec<TestScreenCaptureSource>) {
         *self.screen_capture_sources.borrow_mut() = sources;
+    }
+
+    pub(crate) fn set_system_notification_permission(
+        &self,
+        permission: SystemNotificationPermission,
+    ) {
+        *self.system_notification_permission.borrow_mut() = permission;
+    }
+
+    pub(crate) fn shown_system_notifications(&self) -> Vec<SystemNotification> {
+        self.shown_system_notifications.borrow().clone()
+    }
+
+    pub(crate) fn removed_system_notifications(&self) -> Vec<SystemNotificationId> {
+        self.removed_system_notifications.borrow().clone()
     }
 
     pub(crate) fn prompt(
@@ -489,6 +510,26 @@ impl Platform for TestPlatform {
 
     fn register_url_scheme(&self, _: &str) -> Task<anyhow::Result<()>> {
         unimplemented!()
+    }
+
+    fn system_notification_permission(&self) -> Task<Result<SystemNotificationPermission>> {
+        Task::ready(Ok(*self.system_notification_permission.borrow()))
+    }
+
+    fn request_system_notification_permission(&self) -> Task<Result<SystemNotificationPermission>> {
+        Task::ready(Ok(*self.system_notification_permission.borrow()))
+    }
+
+    fn show_system_notification(&self, notification: SystemNotification) -> Task<Result<()>> {
+        self.shown_system_notifications
+            .borrow_mut()
+            .push(notification);
+        Task::ready(Ok(()))
+    }
+
+    fn remove_system_notification(&self, id: SystemNotificationId) -> Task<Result<()>> {
+        self.removed_system_notifications.borrow_mut().push(id);
+        Task::ready(Ok(()))
     }
 
     fn open_with_system(&self, _path: &Path) {

--- a/crates/gpui_linux/src/linux.rs
+++ b/crates/gpui_linux/src/linux.rs
@@ -1,6 +1,8 @@
 mod dispatcher;
 mod headless;
 mod keyboard;
+#[cfg(any(feature = "wayland", feature = "x11"))]
+mod notifications;
 mod platform;
 #[cfg(any(feature = "wayland", feature = "x11"))]
 mod text_system;

--- a/crates/gpui_linux/src/linux/notifications.rs
+++ b/crates/gpui_linux/src/linux/notifications.rs
@@ -1,0 +1,87 @@
+use anyhow::{Result, anyhow};
+use ashpd::desktop::notification::{
+    Notification, NotificationProxy, Priority as PortalNotificationPriority,
+};
+use gpui::{
+    BackgroundExecutor, SystemNotification, SystemNotificationId, SystemNotificationPermission,
+    SystemNotificationPriority, Task,
+};
+
+pub(super) fn system_notification_permission(
+    executor: BackgroundExecutor,
+) -> Task<Result<SystemNotificationPermission>> {
+    executor.spawn(async move {
+        match NotificationProxy::new().await {
+            Ok(_) => Ok(SystemNotificationPermission::Granted),
+            Err(ashpd::Error::PortalNotFound(_)) => Ok(SystemNotificationPermission::Unsupported),
+            Err(error) => Err(error.into()),
+        }
+    })
+}
+
+pub(super) fn request_system_notification_permission(
+    executor: BackgroundExecutor,
+) -> Task<Result<SystemNotificationPermission>> {
+    system_notification_permission(executor)
+}
+
+pub(super) fn show_system_notification(
+    executor: BackgroundExecutor,
+    notification: SystemNotification,
+) -> Task<Result<()>> {
+    executor.spawn(async move {
+        let proxy = NotificationProxy::new()
+            .await
+            .map_err(map_notification_portal_error)?;
+        let id = notification.id.0.clone();
+        let portal_notification = portal_notification(notification);
+        proxy
+            .add_notification(id.as_str(), portal_notification)
+            .await
+            .map_err(map_notification_portal_error)
+    })
+}
+
+pub(super) fn remove_system_notification(
+    executor: BackgroundExecutor,
+    id: SystemNotificationId,
+) -> Task<Result<()>> {
+    executor.spawn(async move {
+        let proxy = NotificationProxy::new()
+            .await
+            .map_err(map_notification_portal_error)?;
+        proxy
+            .remove_notification(id.0.as_str())
+            .await
+            .map_err(map_notification_portal_error)
+    })
+}
+
+fn portal_notification(notification: SystemNotification) -> Notification {
+    let mut portal_notification = Notification::new(notification.title.as_str())
+        .priority(portal_priority(notification.priority));
+
+    if let Some(body) = notification.body {
+        portal_notification = portal_notification.body(body.as_str());
+    }
+
+    portal_notification
+}
+
+fn portal_priority(priority: SystemNotificationPriority) -> PortalNotificationPriority {
+    match priority {
+        SystemNotificationPriority::Low => PortalNotificationPriority::Low,
+        SystemNotificationPriority::Normal => PortalNotificationPriority::Normal,
+        SystemNotificationPriority::High => PortalNotificationPriority::High,
+        SystemNotificationPriority::Urgent => PortalNotificationPriority::Urgent,
+    }
+}
+
+fn map_notification_portal_error(error: ashpd::Error) -> anyhow::Error {
+    match error {
+        ashpd::Error::PortalNotFound(_) => {
+            anyhow!("system notifications are not supported by xdg-desktop-portal")
+        }
+        error => error.into(),
+    }
+}

--- a/crates/gpui_linux/src/linux/platform.rs
+++ b/crates/gpui_linux/src/linux/platform.rs
@@ -26,8 +26,9 @@ use gpui::{
     Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, DisplayId,
     ForegroundExecutor, Keymap, Menu, MenuItem, OwnedMenu, PathPromptOptions, Platform,
     PlatformDisplay, PlatformKeyboardLayout, PlatformKeyboardMapper, PlatformTextSystem,
-    PlatformWindow, Result, RunnableVariant, Task, ThermalState, WindowAppearance,
-    WindowButtonLayout, WindowParams,
+    PlatformWindow, Result, RunnableVariant, SystemNotification, SystemNotificationId,
+    SystemNotificationPermission, Task, ThermalState, WindowAppearance, WindowButtonLayout,
+    WindowParams,
 };
 #[cfg(any(feature = "wayland", feature = "x11"))]
 use gpui::{Pixels, Point, px};
@@ -622,6 +623,56 @@ impl<P: LinuxClient + 'static> Platform for LinuxPlatform<P> {
 
     fn register_url_scheme(&self, _: &str) -> Task<anyhow::Result<()>> {
         Task::ready(Err(anyhow!("register_url_scheme unimplemented")))
+    }
+
+    fn system_notification_permission(&self) -> Task<Result<SystemNotificationPermission>> {
+        #[cfg(any(feature = "wayland", feature = "x11"))]
+        {
+            super::notifications::system_notification_permission(self.background_executor())
+        }
+
+        #[cfg(not(any(feature = "wayland", feature = "x11")))]
+        {
+            Task::ready(Ok(SystemNotificationPermission::Unsupported))
+        }
+    }
+
+    fn request_system_notification_permission(&self) -> Task<Result<SystemNotificationPermission>> {
+        #[cfg(any(feature = "wayland", feature = "x11"))]
+        {
+            super::notifications::request_system_notification_permission(self.background_executor())
+        }
+
+        #[cfg(not(any(feature = "wayland", feature = "x11")))]
+        {
+            Task::ready(Ok(SystemNotificationPermission::Unsupported))
+        }
+    }
+
+    fn show_system_notification(&self, notification: SystemNotification) -> Task<Result<()>> {
+        #[cfg(any(feature = "wayland", feature = "x11"))]
+        {
+            super::notifications::show_system_notification(self.background_executor(), notification)
+        }
+
+        #[cfg(not(any(feature = "wayland", feature = "x11")))]
+        {
+            let _ = notification;
+            Task::ready(Err(anyhow!("system notifications are not supported")))
+        }
+    }
+
+    fn remove_system_notification(&self, id: SystemNotificationId) -> Task<Result<()>> {
+        #[cfg(any(feature = "wayland", feature = "x11"))]
+        {
+            super::notifications::remove_system_notification(self.background_executor(), id)
+        }
+
+        #[cfg(not(any(feature = "wayland", feature = "x11")))]
+        {
+            let _ = id;
+            Task::ready(Ok(()))
+        }
     }
 
     fn write_to_primary(&self, item: ClipboardItem) {

--- a/crates/gpui_macos/src/gpui_macos.rs
+++ b/crates/gpui_macos/src/gpui_macos.rs
@@ -9,6 +9,7 @@ mod display;
 mod display_link;
 mod events;
 mod keyboard;
+mod notifications;
 mod pasteboard;
 
 #[cfg(feature = "screen-capture")]

--- a/crates/gpui_macos/src/notifications.rs
+++ b/crates/gpui_macos/src/notifications.rs
@@ -1,0 +1,313 @@
+use crate::ns_string;
+use anyhow::{Result, anyhow};
+use block::{Block, ConcreteBlock};
+use cocoa::{
+    base::{BOOL, YES, id, nil},
+    foundation::{NSArray, NSBundle, NSInteger, NSUInteger},
+};
+use futures::channel::oneshot;
+use gpui::{
+    BackgroundExecutor, SystemNotification, SystemNotificationId, SystemNotificationPermission,
+    Task,
+};
+use objc::{class, msg_send, runtime::Object, sel, sel_impl};
+use std::{
+    ffi::{CStr, c_char},
+    sync::{Arc, Mutex},
+};
+
+const UN_AUTHORIZATION_STATUS_NOT_DETERMINED: NSInteger = 0;
+const UN_AUTHORIZATION_STATUS_DENIED: NSInteger = 1;
+const UN_AUTHORIZATION_STATUS_AUTHORIZED: NSInteger = 2;
+const UN_AUTHORIZATION_STATUS_PROVISIONAL: NSInteger = 3;
+const UN_AUTHORIZATION_STATUS_EPHEMERAL: NSInteger = 4;
+
+const UN_AUTHORIZATION_OPTION_ALERT: NSUInteger = 1 << 2;
+const UN_NOTIFICATION_PRESENTATION_OPTION_ALERT: NSUInteger = 1 << 2;
+
+pub(super) fn system_notification_permission(
+    executor: BackgroundExecutor,
+) -> Task<Result<SystemNotificationPermission>> {
+    if !has_bundle_identifier() {
+        return Task::ready(Ok(SystemNotificationPermission::Unsupported));
+    }
+
+    let Some(center) = notification_center() else {
+        return Task::ready(Ok(SystemNotificationPermission::Unsupported));
+    };
+
+    let (done_tx, done_rx) = oneshot::channel();
+    let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+    unsafe {
+        let done_tx = done_tx.clone();
+        let block = ConcreteBlock::new(move |settings: id| {
+            let permission = if settings == nil {
+                SystemNotificationPermission::Unsupported
+            } else {
+                let status: NSInteger = msg_send![settings, authorizationStatus];
+                permission_from_authorization_status(status)
+            };
+            send_result(&done_tx, Ok(permission));
+        });
+        let block = block.copy();
+        let _: () = msg_send![center, getNotificationSettingsWithCompletionHandler: block];
+    }
+
+    result_task(executor, done_rx)
+}
+
+pub(super) fn request_system_notification_permission(
+    executor: BackgroundExecutor,
+) -> Task<Result<SystemNotificationPermission>> {
+    if !has_bundle_identifier() {
+        return Task::ready(Ok(SystemNotificationPermission::Unsupported));
+    }
+
+    let Some(center) = notification_center() else {
+        return Task::ready(Ok(SystemNotificationPermission::Unsupported));
+    };
+
+    let (done_tx, done_rx) = oneshot::channel();
+    let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+    unsafe {
+        let done_tx = done_tx.clone();
+        let block = ConcreteBlock::new(move |granted: BOOL, error: id| {
+            let result = if error == nil {
+                if granted == YES {
+                    Ok(SystemNotificationPermission::Granted)
+                } else {
+                    Ok(SystemNotificationPermission::Denied)
+                }
+            } else {
+                Err(anyhow!(
+                    "failed to request system notification permission: {}",
+                    error_description(error)
+                ))
+            };
+            send_result(&done_tx, result);
+        });
+        let block = block.copy();
+        let _: () = msg_send![
+            center,
+            requestAuthorizationWithOptions: UN_AUTHORIZATION_OPTION_ALERT
+            completionHandler: block
+        ];
+    }
+
+    result_task(executor, done_rx)
+}
+
+pub(super) fn show_system_notification(
+    executor: BackgroundExecutor,
+    notification: SystemNotification,
+) -> Task<Result<()>> {
+    if !has_bundle_identifier() {
+        return Task::ready(Err(anyhow!(
+            "macOS system notifications require a bundled app with a bundle identifier"
+        )));
+    }
+
+    let Some(center) = notification_center() else {
+        return Task::ready(Err(anyhow!("system notifications are not supported")));
+    };
+
+    let (done_tx, done_rx) = oneshot::channel();
+    let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+    unsafe {
+        let content: id = msg_send![class!(UNMutableNotificationContent), new];
+        let title = ns_string(notification.title.as_ref());
+        let _: () = msg_send![content, setTitle: title];
+        if let Some(body) = notification.body {
+            let body = ns_string(body.as_ref());
+            let _: () = msg_send![content, setBody: body];
+        }
+
+        let identifier = ns_string(notification.id.0.as_ref());
+        let request: id = msg_send![
+            class!(UNNotificationRequest),
+            requestWithIdentifier: identifier
+            content: content
+            trigger: nil
+        ];
+        let _: () = msg_send![content, release];
+
+        let done_tx = done_tx.clone();
+        let block = ConcreteBlock::new(move |error: id| {
+            let result = if error == nil {
+                Ok(())
+            } else {
+                Err(anyhow!(
+                    "failed to show system notification: {}",
+                    error_description(error)
+                ))
+            };
+            send_result(&done_tx, result);
+        });
+        let block = block.copy();
+        let _: () = msg_send![center, addNotificationRequest: request withCompletionHandler: block];
+    }
+
+    result_task(executor, done_rx)
+}
+
+pub(super) fn remove_system_notification(
+    _executor: BackgroundExecutor,
+    id: SystemNotificationId,
+) -> Task<Result<()>> {
+    if !has_bundle_identifier() {
+        return Task::ready(Ok(()));
+    }
+
+    let Some(center) = notification_center() else {
+        return Task::ready(Ok(()));
+    };
+
+    unsafe {
+        let identifier = ns_string(id.0.as_ref());
+        let identifiers = NSArray::arrayWithObject(nil, identifier);
+        let _: () =
+            msg_send![center, removePendingNotificationRequestsWithIdentifiers: identifiers];
+        let _: () = msg_send![center, removeDeliveredNotificationsWithIdentifiers: identifiers];
+    }
+
+    Task::ready(Ok(()))
+}
+
+pub(super) unsafe fn set_delegate(delegate: id) {
+    unsafe {
+        if !has_bundle_identifier() {
+            return;
+        }
+
+        if let Some(center) = notification_center() {
+            let _: () = msg_send![center, setDelegate: delegate];
+        }
+    }
+}
+
+pub(super) extern "C" fn will_present_notification(
+    _this: &mut Object,
+    _: objc::runtime::Sel,
+    _: id,
+    _: id,
+    completion_handler: id,
+) {
+    unsafe {
+        if completion_handler == nil {
+            return;
+        }
+
+        let completion_handler = &*(completion_handler as *const Block<(NSUInteger,), ()>);
+        completion_handler.call((UN_NOTIFICATION_PRESENTATION_OPTION_ALERT,));
+    }
+}
+
+fn result_task<T: Send + 'static>(
+    executor: BackgroundExecutor,
+    done_rx: oneshot::Receiver<Result<T>>,
+) -> Task<Result<T>> {
+    executor.spawn(async move { done_rx.await.map_err(|error| anyhow!(error))? })
+}
+
+fn send_result<T>(done_tx: &Arc<Mutex<Option<oneshot::Sender<Result<T>>>>>, result: Result<T>) {
+    match done_tx.lock() {
+        Ok(mut done_tx) => {
+            if let Some(done_tx) = done_tx.take()
+                && done_tx.send(result).is_err()
+            {
+                log::debug!("system notification task was dropped before completion");
+            }
+        }
+        Err(error) => log::error!("failed to complete system notification task: {error}"),
+    }
+}
+
+fn notification_center() -> Option<id> {
+    unsafe {
+        let center: id = msg_send![class!(UNUserNotificationCenter), currentNotificationCenter];
+        (center != nil).then_some(center)
+    }
+}
+
+fn has_bundle_identifier() -> bool {
+    unsafe {
+        let bundle: id = NSBundle::mainBundle();
+        if bundle == nil {
+            return false;
+        }
+
+        let bundle_identifier: id = msg_send![bundle, bundleIdentifier];
+        bundle_identifier != nil
+    }
+}
+
+fn permission_from_authorization_status(status: NSInteger) -> SystemNotificationPermission {
+    match status {
+        UN_AUTHORIZATION_STATUS_NOT_DETERMINED => SystemNotificationPermission::NotDetermined,
+        UN_AUTHORIZATION_STATUS_DENIED => SystemNotificationPermission::Denied,
+        UN_AUTHORIZATION_STATUS_AUTHORIZED
+        | UN_AUTHORIZATION_STATUS_PROVISIONAL
+        | UN_AUTHORIZATION_STATUS_EPHEMERAL => SystemNotificationPermission::Granted,
+        _ => SystemNotificationPermission::Unsupported,
+    }
+}
+
+unsafe fn error_description(error: id) -> String {
+    unsafe {
+        let message: id = msg_send![error, localizedDescription];
+        let code: NSInteger = msg_send![error, code];
+        let domain: id = msg_send![error, domain];
+        let domain = string_from_ns_string(domain);
+        let message = string_from_ns_string(message);
+
+        match (domain, message) {
+            (Some(domain), Some(message)) => format!("{domain} error {code}: {message}"),
+            (Some(domain), None) => format!("{domain} error {code}"),
+            (None, Some(message)) => format!("error {code}: {message}"),
+            (None, None) => format!("{error:?}"),
+        }
+    }
+}
+
+unsafe fn string_from_ns_string(string: id) -> Option<String> {
+    unsafe {
+        if string == nil {
+            return None;
+        }
+
+        let bytes: *const c_char = msg_send![string, UTF8String];
+        (!bytes.is_null()).then(|| CStr::from_ptr(bytes).to_string_lossy().into_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_authorization_status() {
+        assert_eq!(
+            permission_from_authorization_status(UN_AUTHORIZATION_STATUS_NOT_DETERMINED),
+            SystemNotificationPermission::NotDetermined
+        );
+        assert_eq!(
+            permission_from_authorization_status(UN_AUTHORIZATION_STATUS_DENIED),
+            SystemNotificationPermission::Denied
+        );
+        assert_eq!(
+            permission_from_authorization_status(UN_AUTHORIZATION_STATUS_AUTHORIZED),
+            SystemNotificationPermission::Granted
+        );
+        assert_eq!(
+            permission_from_authorization_status(UN_AUTHORIZATION_STATUS_PROVISIONAL),
+            SystemNotificationPermission::Granted
+        );
+        assert_eq!(
+            permission_from_authorization_status(NSInteger::MAX),
+            SystemNotificationPermission::Unsupported
+        );
+    }
+}
+
+#[link(name = "UserNotifications", kind = "framework")]
+unsafe extern "C" {}

--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -31,7 +31,8 @@ use gpui::{
     Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, ForegroundExecutor,
     KeyContext, Keymap, Menu, MenuItem, OsMenu, OwnedMenu, PathPromptOptions, Platform,
     PlatformDisplay, PlatformKeyboardLayout, PlatformKeyboardMapper, PlatformTextSystem,
-    PlatformWindow, Result, SystemMenuType, Task, ThermalState, WindowAppearance, WindowParams,
+    PlatformWindow, Result, SystemMenuType, SystemNotification, SystemNotificationId,
+    SystemNotificationPermission, Task, ThermalState, WindowAppearance, WindowParams,
 };
 use itertools::Itertools;
 use objc::{
@@ -152,6 +153,11 @@ unsafe fn build_classes() {
             decl.add_method(
                 sel!(onThermalStateChange:),
                 on_thermal_state_change as extern "C" fn(&mut Object, Sel, id),
+            );
+            decl.add_method(
+                sel!(userNotificationCenter:willPresentNotification:withCompletionHandler:),
+                crate::notifications::will_present_notification
+                    as extern "C" fn(&mut Object, Sel, id, id, id),
             );
 
             decl.register()
@@ -717,6 +723,56 @@ impl Platform for MacPlatform {
             .spawn(async { done_rx.await.map_err(|e| anyhow!(e))? })
     }
 
+    fn system_notification_permission(&self) -> Task<Result<SystemNotificationPermission>> {
+        let (headless, executor) = {
+            let state = self.0.lock();
+            (state.headless, state.background_executor.clone())
+        };
+        if headless {
+            return Task::ready(Ok(SystemNotificationPermission::Unsupported));
+        }
+
+        crate::notifications::system_notification_permission(executor)
+    }
+
+    fn request_system_notification_permission(&self) -> Task<Result<SystemNotificationPermission>> {
+        let (headless, executor) = {
+            let state = self.0.lock();
+            (state.headless, state.background_executor.clone())
+        };
+        if headless {
+            return Task::ready(Ok(SystemNotificationPermission::Unsupported));
+        }
+
+        crate::notifications::request_system_notification_permission(executor)
+    }
+
+    fn show_system_notification(&self, notification: SystemNotification) -> Task<Result<()>> {
+        let (headless, executor) = {
+            let state = self.0.lock();
+            (state.headless, state.background_executor.clone())
+        };
+        if headless {
+            return Task::ready(Err(anyhow!(
+                "system notifications are not supported in headless apps"
+            )));
+        }
+
+        crate::notifications::show_system_notification(executor, notification)
+    }
+
+    fn remove_system_notification(&self, id: SystemNotificationId) -> Task<Result<()>> {
+        let (headless, executor) = {
+            let state = self.0.lock();
+            (state.headless, state.background_executor.clone())
+        };
+        if headless {
+            return Task::ready(Ok(()));
+        }
+
+        crate::notifications::remove_system_notification(executor, id)
+    }
+
     fn on_open_urls(&self, callback: Box<dyn FnMut(Vec<String>)>) {
         self.0.lock().open_urls = Some(callback);
     }
@@ -1188,6 +1244,7 @@ extern "C" fn did_finish_launching(this: &mut Object, _: Sel, _: id) {
     unsafe {
         let app: id = msg_send![APP_CLASS, sharedApplication];
         app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
+        crate::notifications::set_delegate(this as id);
 
         let notification_center: *mut Object =
             msg_send![class!(NSNotificationCenter), defaultCenter];

--- a/crates/gpui_windows/src/gpui_windows.rs
+++ b/crates/gpui_windows/src/gpui_windows.rs
@@ -11,6 +11,7 @@ mod dispatcher;
 mod display;
 mod events;
 mod keyboard;
+mod notifications;
 mod platform;
 mod system_settings;
 mod util;

--- a/crates/gpui_windows/src/notifications.rs
+++ b/crates/gpui_windows/src/notifications.rs
@@ -1,0 +1,282 @@
+use anyhow::{Result, anyhow};
+use gpui::{
+    BackgroundExecutor, SystemNotification, SystemNotificationId, SystemNotificationPermission,
+    SystemNotificationPriority, Task,
+};
+use uuid::Uuid;
+use windows::{
+    Data::Xml::Dom::XmlDocument,
+    UI::Notifications::{
+        NotificationSetting, ToastNotification, ToastNotificationManager, ToastNotificationPriority,
+    },
+    Win32::{
+        Foundation::{E_FAIL, ERROR_FILE_NOT_FOUND},
+        System::Com::CoTaskMemFree,
+        UI::Shell::GetCurrentProcessExplicitAppUserModelID,
+    },
+    core::HSTRING,
+};
+
+const NOTIFICATION_GROUP: &str = "gpui.system-notification";
+const NOTIFICATION_NAMESPACE: Uuid = Uuid::from_u128(0x341d32df_a3b8_48a5_93c5_d5cd6305eb75);
+const TAG_LENGTH: usize = 16;
+
+pub(crate) fn system_notification_permission(
+    executor: BackgroundExecutor,
+    headless: bool,
+) -> Task<Result<SystemNotificationPermission>> {
+    if headless {
+        return Task::ready(Ok(SystemNotificationPermission::Unsupported));
+    }
+
+    executor.spawn(async move {
+        let Some(app_user_model_id) = current_app_user_model_id()? else {
+            return Ok(SystemNotificationPermission::Unsupported);
+        };
+
+        let notifier = ToastNotificationManager::CreateToastNotifierWithId(&app_user_model_id)?;
+        Ok(permission_from_notification_setting(notifier.Setting()?))
+    })
+}
+
+pub(crate) fn request_system_notification_permission(
+    executor: BackgroundExecutor,
+    headless: bool,
+) -> Task<Result<SystemNotificationPermission>> {
+    system_notification_permission(executor, headless)
+}
+
+pub(crate) fn show_system_notification(
+    executor: BackgroundExecutor,
+    headless: bool,
+    notification: SystemNotification,
+) -> Task<Result<()>> {
+    if headless {
+        return Task::ready(Err(anyhow!(
+            "system notifications are not supported in headless mode"
+        )));
+    }
+
+    executor.spawn(async move {
+        let Some(app_user_model_id) = current_app_user_model_id()? else {
+            return Err(anyhow!(
+                "Windows system notifications require a process AppUserModelID"
+            ));
+        };
+
+        let notifier = ToastNotificationManager::CreateToastNotifierWithId(&app_user_model_id)?;
+        let toast = toast_notification(notification)?;
+        notifier.Show(&toast)?;
+        Ok(())
+    })
+}
+
+pub(crate) fn remove_system_notification(
+    executor: BackgroundExecutor,
+    headless: bool,
+    id: SystemNotificationId,
+) -> Task<Result<()>> {
+    if headless {
+        return Task::ready(Ok(()));
+    }
+
+    executor.spawn(async move {
+        let Some(app_user_model_id) = current_app_user_model_id()? else {
+            return Ok(());
+        };
+
+        let tag = HSTRING::from(notification_tag(&id));
+        let group = HSTRING::from(NOTIFICATION_GROUP);
+        ToastNotificationManager::History()?.RemoveGroupedTagWithId(
+            &tag,
+            &group,
+            &app_user_model_id,
+        )?;
+        Ok(())
+    })
+}
+
+fn current_app_user_model_id() -> Result<Option<HSTRING>> {
+    let app_user_model_id = unsafe {
+        match GetCurrentProcessExplicitAppUserModelID() {
+            Ok(app_user_model_id) => app_user_model_id,
+            Err(error) if missing_app_user_model_id(&error) => return Ok(None),
+            Err(error) => return Err(error.into()),
+        }
+    };
+
+    if app_user_model_id.is_null() {
+        return Ok(None);
+    }
+
+    let app_user_model_id_string = unsafe { app_user_model_id.to_string() };
+    unsafe {
+        CoTaskMemFree(Some(app_user_model_id.0 as _));
+    }
+
+    let app_user_model_id_string = app_user_model_id_string?;
+    if app_user_model_id_string.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(HSTRING::from(app_user_model_id_string)))
+    }
+}
+
+fn missing_app_user_model_id(error: &windows::core::Error) -> bool {
+    error.code() == ERROR_FILE_NOT_FOUND.to_hresult() || error.code() == E_FAIL
+}
+
+fn toast_notification(notification: SystemNotification) -> Result<ToastNotification> {
+    let tag = HSTRING::from(notification_tag(&notification.id));
+    let group = HSTRING::from(NOTIFICATION_GROUP);
+    let priority = toast_priority(notification.priority);
+    let content = toast_xml(notification)?;
+    let toast = ToastNotification::CreateToastNotification(&content)?;
+    toast.SetTag(&tag)?;
+    toast.SetGroup(&group)?;
+    if let Some(priority) = priority {
+        toast.SetPriority(priority)?;
+    }
+    Ok(toast)
+}
+
+fn toast_xml(notification: SystemNotification) -> Result<XmlDocument> {
+    let document = XmlDocument::new()?;
+    let toast = document.CreateElement(&HSTRING::from("toast"))?;
+    let visual = document.CreateElement(&HSTRING::from("visual"))?;
+    let binding = document.CreateElement(&HSTRING::from("binding"))?;
+    binding.SetAttribute(&HSTRING::from("template"), &HSTRING::from("ToastGeneric"))?;
+
+    append_text_node(&document, &binding, notification.title.as_ref())?;
+    if let Some(body) = notification.body {
+        append_text_node(&document, &binding, body.as_ref())?;
+    }
+
+    visual.AppendChild(&binding)?;
+    toast.AppendChild(&visual)?;
+    document.AppendChild(&toast)?;
+    Ok(document)
+}
+
+fn append_text_node(
+    document: &XmlDocument,
+    binding: &windows::Data::Xml::Dom::XmlElement,
+    value: &str,
+) -> Result<()> {
+    let text = document.CreateElement(&HSTRING::from("text"))?;
+    text.SetInnerText(&HSTRING::from(value))?;
+    binding.AppendChild(&text)?;
+    Ok(())
+}
+
+fn notification_tag(id: &SystemNotificationId) -> String {
+    Uuid::new_v5(&NOTIFICATION_NAMESPACE, id.0.as_bytes())
+        .simple()
+        .to_string()
+        .chars()
+        .take(TAG_LENGTH)
+        .collect()
+}
+
+fn toast_priority(priority: SystemNotificationPriority) -> Option<ToastNotificationPriority> {
+    match priority {
+        SystemNotificationPriority::Low | SystemNotificationPriority::Normal => None,
+        SystemNotificationPriority::High | SystemNotificationPriority::Urgent => {
+            Some(ToastNotificationPriority::High)
+        }
+    }
+}
+
+fn permission_from_notification_setting(
+    setting: NotificationSetting,
+) -> SystemNotificationPermission {
+    if setting == NotificationSetting::Enabled {
+        SystemNotificationPermission::Granted
+    } else if setting == NotificationSetting::DisabledForApplication
+        || setting == NotificationSetting::DisabledForUser
+        || setting == NotificationSetting::DisabledByGroupPolicy
+        || setting == NotificationSetting::DisabledByManifest
+    {
+        SystemNotificationPermission::Denied
+    } else {
+        SystemNotificationPermission::Unsupported
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::SharedString;
+
+    #[test]
+    fn notification_tag_is_deterministic_and_length_limited() {
+        let id = SystemNotificationId(SharedString::from(
+            "a-very-long-notification-id-that-exceeds-windows-tag-limits",
+        ));
+        let tag = notification_tag(&id);
+
+        assert_eq!(tag, notification_tag(&id));
+        assert_eq!(tag.len(), TAG_LENGTH);
+        assert!(tag.chars().all(|character| character.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn notification_tag_distinguishes_ids() {
+        let first = SystemNotificationId(SharedString::from("first"));
+        let second = SystemNotificationId(SharedString::from("second"));
+
+        assert_ne!(notification_tag(&first), notification_tag(&second));
+    }
+
+    #[test]
+    fn maps_notification_priority() {
+        assert_eq!(toast_priority(SystemNotificationPriority::Low), None);
+        assert_eq!(toast_priority(SystemNotificationPriority::Normal), None);
+        assert_eq!(
+            toast_priority(SystemNotificationPriority::High),
+            Some(ToastNotificationPriority::High)
+        );
+        assert_eq!(
+            toast_priority(SystemNotificationPriority::Urgent),
+            Some(ToastNotificationPriority::High)
+        );
+    }
+
+    #[test]
+    fn maps_notification_setting() {
+        assert_eq!(
+            permission_from_notification_setting(NotificationSetting::Enabled),
+            SystemNotificationPermission::Granted
+        );
+        assert_eq!(
+            permission_from_notification_setting(NotificationSetting::DisabledForApplication),
+            SystemNotificationPermission::Denied
+        );
+        assert_eq!(
+            permission_from_notification_setting(NotificationSetting::DisabledForUser),
+            SystemNotificationPermission::Denied
+        );
+        assert_eq!(
+            permission_from_notification_setting(NotificationSetting::DisabledByGroupPolicy),
+            SystemNotificationPermission::Denied
+        );
+        assert_eq!(
+            permission_from_notification_setting(NotificationSetting::DisabledByManifest),
+            SystemNotificationPermission::Denied
+        );
+        assert_eq!(
+            permission_from_notification_setting(NotificationSetting(i32::MAX)),
+            SystemNotificationPermission::Unsupported
+        );
+    }
+
+    #[test]
+    fn maps_missing_app_user_model_id_errors() {
+        assert!(missing_app_user_model_id(&windows::core::Error::from(
+            ERROR_FILE_NOT_FOUND.to_hresult()
+        )));
+        assert!(missing_app_user_model_id(&windows::core::Error::from(
+            E_FAIL
+        )));
+    }
+}

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -817,6 +817,36 @@ impl Platform for WindowsPlatform {
         Task::ready(Err(anyhow!("register_url_scheme unimplemented")))
     }
 
+    fn system_notification_permission(&self) -> Task<Result<SystemNotificationPermission>> {
+        crate::notifications::system_notification_permission(
+            self.background_executor(),
+            self.headless,
+        )
+    }
+
+    fn request_system_notification_permission(&self) -> Task<Result<SystemNotificationPermission>> {
+        crate::notifications::request_system_notification_permission(
+            self.background_executor(),
+            self.headless,
+        )
+    }
+
+    fn show_system_notification(&self, notification: SystemNotification) -> Task<Result<()>> {
+        crate::notifications::show_system_notification(
+            self.background_executor(),
+            self.headless,
+            notification,
+        )
+    }
+
+    fn remove_system_notification(&self, id: SystemNotificationId) -> Task<Result<()>> {
+        crate::notifications::remove_system_notification(
+            self.background_executor(),
+            self.headless,
+            id,
+        )
+    }
+
     fn perform_dock_menu_action(&self, action: usize) {
         unsafe {
             PostMessageW(


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #40922

This is a very, very early look at a system notification implementation in GPUI. The main reason I'm opening this now is to see whether the team has bandwidth to review it, and whether the proposed API feels right.

<details><summary>API proposal tldr if you don't want to see the diff :)</summary>

I'm proposing the following addition to the `gpui` crate: 

```rs
trait Platform {
    fn system_notification_permission(
        &self,
    ) -> Task<Result<SystemNotificationPermission>>;

    fn request_system_notification_permission(
        &self,
    ) -> Task<Result<SystemNotificationPermission>>;

    fn show_system_notification(
        &self,
        notification: SystemNotification,
    ) -> Task<Result<()>>;

    fn remove_system_notification(
        &self,
        id: SystemNotificationId,
    ) -> Task<Result<()>>;
}
```

And to the `App` :

```rs
impl App {
    pub fn system_notification_permission(
        &self,
    ) -> Task<Result<SystemNotificationPermission>>;

    pub fn request_system_notification_permission(
        &self,
    ) -> Task<Result<SystemNotificationPermission>>;

    pub fn show_system_notification(
        &self,
        notification: SystemNotification,
    ) -> Task<Result<()>>;

    pub fn remove_system_notification(
        &self,
        id: SystemNotificationId,
    ) -> Task<Result<()>>;
}
```

</details>

**Early** preview:

| Windows | MacOS | Gnome (Wayland) | Hyprland (Wayland) | i3 (Xorg - terrible scaling) |
|-|-|-|-|-|
|<video src="https://github.com/user-attachments/assets/20c9e128-86c8-4c1e-b42e-78dccfa43851"></video>|<video src="https://github.com/user-attachments/assets/2d599a9f-bdd9-442a-bc32-13fcec9ab027"></video>|<video src="https://github.com/user-attachments/assets/604eb20d-5569-44b4-83cd-9b3d0003d356"></video>|<video src="https://github.com/user-attachments/assets/8bd32ab1-1824-4a04-b88c-a2a402a77a30"></video>|<video src="https://github.com/user-attachments/assets/3273155a-9480-49ad-afb4-2d9515e7d2f8"></video>|

This is still a work in progress. Next, I plan to add portal host registration for GNOME, replace the raw `objc`/`msg_send!` notification code with typed `objc2-user-notifications` bindings, and continue improving the implementation where possible.

Release Notes:

- Added support for system notification on `gpui`
