### PR TITLE
git_ui: Fix Enter key selecting branch in commit modal branch picker

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1011,7 +1011,7 @@
     },
   },
   {
-    "context": "GitCommit > Editor",
+    "context": "GitCommit > Editor && mode == auto_height",
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "editor::Newline",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1117,7 +1117,7 @@
     },
   },
   {
-    "context": "GitCommit > Editor",
+    "context": "GitCommit > Editor && mode == auto_height",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "editor::Newline",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1003,7 +1003,7 @@
     },
   },
   {
-    "context": "GitCommit > Editor",
+    "context": "GitCommit > Editor && mode == auto_height",
     "use_key_equivalents": true,
     "bindings": {
       "escape": "menu::Cancel",


### PR DESCRIPTION
## Context

When the "Switch branch" picker is opened from the git commit modal and the user presses Enter, a `\n` character was inserted into the input instead of confirming the branch selection.

The `"GitCommit > Editor"` keymap context bound `enter` to `editor::Newline`. This context matches *any* `Editor` descended from `GitCommit` in the element tree, including the single-line search editor inside the branch picker popover. Because a context-path binding is more specific than the global `enter: menu::Confirm` binding, it took precedence and the picker never received the confirm action.

The commit message editor uses `EditorMode::AutoHeight` (reported in key context as `mode == auto_height`); the picker's search editor uses `EditorMode::SingleLine`. Narrowing the context to `"GitCommit > Editor && mode == auto_height"` restricts the `editor::Newline` binding to the commit message editor only. Single-line editors inside the same modal now fall through to the global `enter: menu::Confirm`, which correctly confirms the selection.

Closes #58022

## How to Review

Three identical one-line changes, one per platform keymap (`default-linux.json`, `default-macos.json`, `default-windows.json`):

- `"GitCommit > Editor"` → `"GitCommit > Editor && mode == auto_height"`

Video of manual test after fix :

[Screencast from 2026-06-02 23-16-32.webm](https://github.com/user-attachments/assets/67652cc5-4f8d-42f4-a5a9-ade3499ee880)

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed Enter key inserting a newline instead of selecting a branch in the commit modal branch picker

