### PR TITLE
helix: Fix paste crash

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3081,6 +3081,8 @@ impl Editor {
         self.use_modal_editing
     }
 
+    /// Inserted text is normalized to LF line endings before being applied.
+    /// Normalize before measuring inserted text for post-edit offsets.
     pub fn edit<I, S, T>(&mut self, edits: I, cx: &mut Context<Self>)
     where
         I: IntoIterator<Item = (Range<S>, T)>,

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2660,6 +2660,7 @@ impl Buffer {
 
     /// Applies the given edits to the buffer. Each edit is specified as a range of text to
     /// delete, and a string of text to insert at that location. Adjacent edits are coalesced.
+    /// Inserted text is normalized to LF line endings before being applied.
     ///
     /// If an [`AutoindentMode`] is provided, then the buffer will enqueue an auto-indent
     /// request for the edited ranges, which will be processed when the buffer finishes

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -16,7 +16,7 @@ use language::{CharClassifier, CharKind, Point, Selection};
 use multi_buffer::MultiBufferSnapshot;
 use search::{BufferSearchBar, SearchOptions};
 use settings::Settings;
-use text::{Bias, SelectionGoal};
+use text::{Bias, LineEnding, SelectionGoal};
 use theme::ActiveTheme as _;
 use ui::px;
 use workspace::searchable::{self, Direction, FilteredSearchRange};
@@ -750,13 +750,16 @@ impl Vim {
                     let snapshot = display_map.buffer_snapshot();
                     let grapheme_count = snapshot.grapheme_count_for_range(&byte_range);
                     let anchor = snapshot.anchor_before(byte_range.start);
-
-                    selection_info.push((anchor, grapheme_count, was_empty, was_reversed));
+                    let mut replacement_len = 0;
 
                     if !byte_range.is_empty() {
-                        let replacement_text = text.repeat(grapheme_count);
+                        let mut replacement_text = text.repeat(grapheme_count);
+                        LineEnding::normalize(&mut replacement_text);
+                        replacement_len = replacement_text.len();
                         edits.push((byte_range, replacement_text));
                     }
+
+                    selection_info.push((anchor, replacement_len, was_empty, was_reversed));
                 }
 
                 editor.edit(edits, cx);
@@ -765,12 +768,11 @@ impl Vim {
                 let snapshot = editor.buffer().read(cx).snapshot(cx);
                 let ranges: Vec<_> = selection_info
                     .into_iter()
-                    .map(|(start_anchor, grapheme_count, was_empty, was_reversed)| {
+                    .map(|(start_anchor, replacement_len, was_empty, was_reversed)| {
                         let start_point = start_anchor.to_point(&snapshot);
                         if was_empty {
                             start_point..start_point
                         } else {
-                            let replacement_len = text.len() * grapheme_count;
                             let end_offset = start_anchor.to_offset(&snapshot) + replacement_len;
                             let end_point = snapshot.offset_to_point(end_offset);
                             if was_reversed {
@@ -2488,6 +2490,23 @@ mod test {
         cx.simulate_keystrokes("r x");
 
         cx.assert_state("«xxˇ»", Mode::HelixNormal);
+    }
+
+    #[gpui::test]
+    async fn test_replace_with_crlf(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.set_state("«xˇ»z", Mode::HelixNormal);
+
+        let vim =
+            cx.update_editor(|editor, _window, _cx| editor.addon::<VimAddon>().cloned().unwrap());
+        cx.update(|window, cx| {
+            vim.entity.update(cx, |vim, cx| {
+                vim.helix_replace("a\r\nb", window, cx);
+            });
+        });
+
+        cx.assert_state("«a\nbˇ»z", Mode::HelixNormal);
     }
 
     #[gpui::test]

--- a/crates/vim/src/helix/paste.rs
+++ b/crates/vim/src/helix/paste.rs
@@ -2,6 +2,7 @@ use editor::{ToOffset, movement};
 use gpui::{Action, Context, Window};
 use schemars::JsonSchema;
 use serde::Deserialize;
+use text::LineEnding;
 
 use crate::{Vim, state::Mode};
 
@@ -125,8 +126,14 @@ impl Vim {
                     } else {
                         display_map.buffer_snapshot().anchor_before(point)
                     };
-                    edits.push((point..point, to_insert.repeat(count)));
-                    new_selections.push((anchor, to_insert.len() * count));
+                    let mut to_insert = to_insert.repeat(count);
+                    // Buffer edits normalize line endings, so measure the normalized text.
+                    // Otherwise CRLF paste text can produce a selection range past the inserted text.
+                    // which can cause panics (selection offset greater than snapshot len) or invalid
+                    // selections
+                    LineEnding::normalize(&mut to_insert);
+                    new_selections.push((anchor, to_insert.len()));
+                    edits.push((point..point, to_insert));
                 }
 
                 editor.edit(edits, cx);
@@ -203,6 +210,18 @@ mod test {
         cx.write_to_clipboard(ClipboardItem::new_string("X".to_string()));
         cx.simulate_keystrokes("p");
         cx.assert_state("«Xˇ»\n«Xˇ»\n«Xˇ»\nend", Mode::HelixNormal);
+    }
+
+    #[gpui::test]
+    async fn test_system_clipboard_crlf_paste_at_end_of_buffer(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+        cx.set_state("ˇ", Mode::HelixNormal);
+
+        cx.write_to_clipboard(ClipboardItem::new_string("a\r\nb".to_string()));
+        cx.simulate_keystrokes("p");
+
+        cx.assert_state("«a\nbˇ»", Mode::HelixNormal);
     }
 
     #[gpui::test]


### PR DESCRIPTION
Closes [#58343](<https://github.com/zed-industries/zed/issues/58343>)

This crash happened because Helix paste restored  selection using the raw clipboard text length, but buffer edits normalize CRLF line endings to LF before inserting. When pasting CRLF text at or near EOF, the restored selection could extend past the normalized snapshot length and panic in `MutableSelectionsCollection::select_ranges`. The fix normalizes the text before measuring it for selection restoration and adds regression coverage for CRLF paste in Helix mode.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](<https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist>)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Fixed a crash that could occur when pasting at the end of a file in Helix mode
