### PR TITLE
theme_selector: Mark the active theme with a check icon

### DIFF
--- a/crates/theme_selector/src/icon_theme_selector.rs
+++ b/crates/theme_selector/src/icon_theme_selector.rs
@@ -299,6 +299,7 @@ impl PickerDelegate for IconThemeSelectorDelegate {
         _cx: &mut Context<Picker<Self>>,
     ) -> Option<Self::ListItem> {
         let theme_match = &self.matches.get(ix)?;
+        let is_original_theme = theme_match.string.as_str() == self.original_theme.0.as_ref();
 
         Some(
             ListItem::new(ix)
@@ -308,7 +309,10 @@ impl PickerDelegate for IconThemeSelectorDelegate {
                 .child(HighlightedLabel::new(
                     theme_match.string.clone(),
                     theme_match.positions.clone(),
-                )),
+                ))
+                .when(is_original_theme, |this| {
+                    this.end_slot(Icon::new(IconName::Check).color(Color::Muted))
+                }),
         )
     }
 

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -3,8 +3,8 @@ mod icon_theme_selector;
 use fs::Fs;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{
-    App, Context, DismissEvent, Entity, EventEmitter, Focusable, Render, UpdateGlobal, WeakEntity,
-    Window, actions,
+    App, Context, DismissEvent, Entity, EventEmitter, Focusable, Render, SharedString,
+    UpdateGlobal, WeakEntity, Window, actions,
 };
 use picker::{Picker, PickerDelegate};
 use settings::{Settings, SettingsStore, update_settings_file};
@@ -134,6 +134,8 @@ struct ThemeSelectorDelegate {
     original_theme_settings: ThemeSettings,
     /// The current system appearance.
     original_system_appearance: Appearance,
+    /// The name of the original theme.
+    original_theme_name: SharedString,
     /// The currently selected new theme.
     new_theme: Arc<Theme>,
     selection_completed: bool,
@@ -196,12 +198,19 @@ impl ThemeSelectorDelegate {
             matches,
             original_theme_settings,
             original_system_appearance,
+            original_theme_name: original_theme.name.clone(),
             new_theme: original_theme, // Start with the original theme.
             selected_index,
             selection_completed: false,
             selected_theme: None,
             selector,
         }
+    }
+
+    fn is_original_theme(&self, index: usize) -> bool {
+        self.matches
+            .get(index)
+            .is_some_and(|mat| mat.string == self.original_theme_name)
     }
 
     fn show_selected_theme(
@@ -487,16 +496,28 @@ impl PickerDelegate for ThemeSelectorDelegate {
         _cx: &mut Context<Picker<Self>>,
     ) -> Option<Self::ListItem> {
         let theme_match = &self.matches.get(ix)?;
+        let is_original_theme = self.is_original_theme(ix);
 
         Some(
             ListItem::new(ix)
                 .inset(true)
                 .spacing(ListItemSpacing::Sparse)
                 .toggle_state(selected)
-                .child(HighlightedLabel::new(
-                    theme_match.string.clone(),
-                    theme_match.positions.clone(),
-                )),
+                .child(
+                    div()
+                        .flex()
+                        .flex_row()
+                        .w_full()
+                        .justify_between()
+                        .items_center()
+                        .child(HighlightedLabel::new(
+                            theme_match.string.clone(),
+                            theme_match.positions.clone(),
+                        ))
+                        .when(is_original_theme, |this| {
+                            this.child(Icon::new(IconName::Check).color(Color::Selected))
+                        }),
+                ),
         )
     }
 

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -134,7 +134,7 @@ struct ThemeSelectorDelegate {
     original_theme_settings: ThemeSettings,
     /// The current system appearance.
     original_system_appearance: Appearance,
-    /// The index of the original theme in the list of themes.
+    /// The id of the original theme in the list of themes.
     /// Using `Option<usize>` instead of `usize` because it's possible that the
     /// original theme is not present in the list of themes when it is first
     /// built, depending on the provided `themes_filter`. For example, when a

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -3,8 +3,8 @@ mod icon_theme_selector;
 use fs::Fs;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{
-    App, Context, DismissEvent, Entity, EventEmitter, Focusable, Render, SharedString,
-    UpdateGlobal, WeakEntity, Window, actions,
+    App, Context, DismissEvent, Entity, EventEmitter, Focusable, Render, UpdateGlobal, WeakEntity,
+    Window, actions,
 };
 use picker::{Picker, PickerDelegate};
 use settings::{Settings, SettingsStore, update_settings_file};
@@ -134,8 +134,14 @@ struct ThemeSelectorDelegate {
     original_theme_settings: ThemeSettings,
     /// The current system appearance.
     original_system_appearance: Appearance,
-    /// The name of the original theme.
-    original_theme_name: SharedString,
+    /// The index of the original theme in the list of themes.
+    /// Using `Option<usize>` instead of `usize` because it's possible that the
+    /// original theme is not present in the list of themes when it is first
+    /// built, depending on the provided `themes_filter`. For example, when a
+    /// theme is installed, the `themes_filter` is set to the new theme names
+    /// and, if we used `unwrap_or(0)` as a fallback, the first theme in the
+    /// list would be shown as "active".
+    original_theme_id: Option<usize>,
     /// The currently selected new theme.
     new_theme: Arc<Theme>,
     selection_completed: bool,
@@ -176,10 +182,15 @@ impl ThemeSelectorDelegate {
                 .then(a.name.cmp(&b.name))
         });
 
+        let original_theme_id = themes
+            .iter()
+            .position(|meta| meta.name == original_theme.name);
+
         let matches: Vec<StringMatch> = themes
             .iter()
-            .map(|meta| StringMatch {
-                candidate_id: 0,
+            .enumerate()
+            .map(|(id, meta)| StringMatch {
+                candidate_id: id,
                 score: 0.0,
                 positions: Default::default(),
                 string: meta.name.to_string(),
@@ -198,7 +209,7 @@ impl ThemeSelectorDelegate {
             matches,
             original_theme_settings,
             original_system_appearance,
-            original_theme_name: original_theme.name.clone(),
+            original_theme_id,
             new_theme: original_theme, // Start with the original theme.
             selected_index,
             selection_completed: false,
@@ -210,7 +221,8 @@ impl ThemeSelectorDelegate {
     fn is_original_theme(&self, index: usize) -> bool {
         self.matches
             .get(index)
-            .is_some_and(|mat| mat.string == self.original_theme_name)
+            .zip(self.original_theme_id)
+            .is_some_and(|(mat, original_theme_id)| mat.candidate_id == original_theme_id)
     }
 
     fn show_selected_theme(
@@ -503,21 +515,13 @@ impl PickerDelegate for ThemeSelectorDelegate {
                 .inset(true)
                 .spacing(ListItemSpacing::Sparse)
                 .toggle_state(selected)
-                .child(
-                    div()
-                        .flex()
-                        .flex_row()
-                        .w_full()
-                        .justify_between()
-                        .items_center()
-                        .child(HighlightedLabel::new(
-                            theme_match.string.clone(),
-                            theme_match.positions.clone(),
-                        ))
-                        .when(is_original_theme, |this| {
-                            this.child(Icon::new(IconName::Check).color(Color::Selected))
-                        }),
-                ),
+                .child(HighlightedLabel::new(
+                    theme_match.string.clone(),
+                    theme_match.positions.clone(),
+                ))
+                .when(is_original_theme, |this| {
+                    this.end_slot(Icon::new(IconName::Check).color(Color::Muted))
+                }),
         )
     }
 


### PR DESCRIPTION
While browsing themes in theme selector, the currently active theme will always be marked with a check icon so you can always have a reference of where you started from.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Here's a preview: 
<img width="950" height="806" alt="Screenshot 2026-06-03 at 13 09 46" src="https://github.com/user-attachments/assets/2081d9ec-b56d-4542-be58-e59e3569bc7a" />
<img width="958" height="818" alt="Screenshot 2026-06-03 at 13 09 52" src="https://github.com/user-attachments/assets/134d933f-c9de-4b2c-80f5-ed5be4fb2844" />


Release Notes:

- Improved the theme and icon selectors to display a check next to the active theme
