### PR TITLE
ep: Make retrieved context limit configurable

### DIFF
--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -275,11 +275,7 @@ impl Display for Command {
                     write!(f, " --context-only")?;
                 }
                 if args.related_context_limit != score::EVAL_RELATED_CONTEXT_TOKENS_LIMIT {
-                    write!(
-                        f,
-                        " --related-context-limit={}",
-                        args.related_context_limit
-                    )?;
+                    write!(f, " --related-context-limit={}", args.related_context_limit)?;
                 }
                 if let Some(provider) = &args.predict.provider {
                     write!(f, " --provider={}", provider)?;

--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -274,6 +274,13 @@ impl Display for Command {
                 if args.context_only {
                     write!(f, " --context-only")?;
                 }
+                if args.related_context_limit != score::EVAL_RELATED_CONTEXT_TOKENS_LIMIT {
+                    write!(
+                        f,
+                        " --related-context-limit={}",
+                        args.related_context_limit
+                    )?;
+                }
                 if let Some(provider) = &args.predict.provider {
                     write!(f, " --provider={}", provider)?;
                 }
@@ -334,6 +341,9 @@ struct EvalArgs {
     /// Only compute editable context coverage from expected patches and retrieved context.
     #[clap(long)]
     context_only: bool,
+    /// Maximum number of retrieved context tokens to include when scoring.
+    #[clap(long, default_value_t = score::EVAL_RELATED_CONTEXT_TOKENS_LIMIT)]
+    related_context_limit: usize,
     /// Path to write summary scores as JSON
     #[clap(long)]
     summary_json: Option<PathBuf>,
@@ -1303,7 +1313,7 @@ fn main() {
                                                 score::run_context_coverage_scoring(
                                                     example,
                                                     &example_progress,
-                                                    Some(score::EVAL_RETRIEVED_CONTEXT_BYTE_LIMIT),
+                                                    Some(args.related_context_limit * 3),
                                                 )?;
                                             } else {
                                                 run_scoring(
@@ -1313,7 +1323,7 @@ fn main() {
                                                     &example_progress,
                                                     cx.clone(),
                                                     true,
-                                                    Some(score::EVAL_RETRIEVED_CONTEXT_BYTE_LIMIT),
+                                                    Some(args.related_context_limit * 3),
                                                 )
                                                 .await?;
                                             }
@@ -1472,7 +1482,7 @@ fn main() {
                             &examples,
                             args.verbose,
                             args.context_only,
-                            Some(score::EVAL_RETRIEVED_CONTEXT_BYTE_LIMIT),
+                            Some(args.related_context_limit * 3),
                         );
                         if let Some(summary_path) = &args.summary_json {
                             score::write_summary_json(&examples, summary_path)?;

--- a/crates/edit_prediction_cli/src/score.rs
+++ b/crates/edit_prediction_cli/src/score.rs
@@ -18,7 +18,7 @@ use std::io::BufWriter;
 use std::path::Path;
 use std::sync::Arc;
 
-pub const EVAL_RETRIEVED_CONTEXT_BYTE_LIMIT: usize = 4000;
+pub const EVAL_RELATED_CONTEXT_TOKENS_LIMIT: usize = 4000;
 
 pub async fn run_scoring(
     example: &mut Example,


### PR DESCRIPTION
The `--related-context-limit` param controls how many tokens can we allocate for editable context. Useful for evaluation primarly.


Release Notes:

- N/A
