### PR TITLE
markdown: Fix example crash on Linux

### DIFF
--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -45,7 +45,7 @@ assets.workspace = true
 env_logger.workspace = true
 fs = {workspace = true, features = ["test-support"]}
 gpui = { workspace = true, features = ["test-support"] }
-gpui_platform.workspace = true
+gpui_platform = { workspace = true, features = ["wayland", "x11"] }
 language = { workspace = true, features = ["test-support"] }
 languages = { workspace = true, features = ["load-grammars"] }
 node_runtime.workspace = true


### PR DESCRIPTION
  markdown: Fix example crash on Linux by enabling wayland/x11 features

   The markdown example panics with `unreachable!()` on Linux because
   `gpui_platform`'s default features are empty, and the example doesn't
   explicitly enable `wayland` or `x11`.

Release Notes:

- N/A
