### PR TITLE
Fix update version button stuck on "Downloading" step

### DIFF
--- a/crates/title_bar/src/update_version.rs
+++ b/crates/title_bar/src/update_version.rs
@@ -21,6 +21,7 @@ impl UpdateVersion {
                 if this.status.is_updated() {
                     this.dismissed = false;
                 }
+                cx.notify();
             })
             .detach();
             Self {


### PR DESCRIPTION
Very often, I'd wake up, to which point there's a new Nightly release out, and the update button would be stuck in the "Downloading..." step. It'd only immediately change its state to "Restart" once I quit the app and re-open it again. Turns out we were just missing a cx.notify in the callback to trigger a re-render.

Release Notes:

- Fixed a bug where the update version button would be stuck in the "Downloading..." step.