### PR TITLE
agent: Add debugger tool for AI agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "collections",
  "context_server",
  "ctor",
+ "dap",
  "db",
  "editor",
  "env_logger 0.11.8",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1159,6 +1159,7 @@
           "create_directory": true,
           "create_thread": true,
           "delete_path": true,
+          "debugger": true,
           "diagnostics": true,
           "apply_code_action": true,
           "edit_file": true,
@@ -1186,6 +1187,7 @@
         // "enable_all_context_servers": true,
         "tools": {
           "create_thread": true,
+          "debugger": true,
           "diagnostics": true,
           "fetch": true,
           "list_agents_and_models": true,

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -31,6 +31,7 @@ cloud_api_types.workspace = true
 cloud_llm_client.workspace = true
 collections.workspace = true
 context_server.workspace = true
+dap.workspace = true
 db.workspace = true
 feature_flags.workspace = true
 fs.workspace = true

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -398,6 +398,16 @@ pub trait SiblingThreadHost {
     fn list_available_agents(&self, cx: &mut App) -> Result<AvailableAgents>;
 }
 
+/// Implemented by the UI layer to let native-agent tools start debug sessions
+/// through the workspace debugger UI, without depending on `debugger_ui`.
+pub trait DebuggerHost {
+    fn start_debug_session(
+        &self,
+        request: DebugSessionRequest,
+        cx: &mut AsyncApp,
+    ) -> Task<Result<DebugSessionInfo>>;
+}
+
 pub struct NativeAgent {
     /// Session ID -> Session mapping
     sessions: HashMap<acp::SessionId, Session>,
@@ -411,6 +421,8 @@ pub struct NativeAgent {
     models: LanguageModels,
     /// Handler installed by the UI for `create_thread` / `list_agents_and_models` tools.
     sibling_thread_host: Option<Rc<dyn SiblingThreadHost>>,
+    /// Handler installed by the UI for native-agent debugger tools.
+    debugger_host: Option<Rc<dyn DebuggerHost>>,
     fs: Arc<dyn Fs>,
     _subscriptions: Vec<Subscription>,
     /// Tracks the lifecycle of global skills directory observation. We
@@ -580,6 +592,7 @@ impl NativeAgent {
                 templates,
                 models: LanguageModels::new(cx),
                 sibling_thread_host: None,
+                debugger_host: None,
                 fs,
                 _subscriptions: subscriptions,
                 skills_state: SkillsState::default(),
@@ -712,6 +725,14 @@ impl NativeAgent {
 
     pub fn sibling_thread_host(&self) -> Option<Rc<dyn SiblingThreadHost>> {
         self.sibling_thread_host.clone()
+    }
+
+    pub fn set_debugger_host(&mut self, host: Rc<dyn DebuggerHost>) {
+        self.debugger_host = Some(host);
+    }
+
+    pub fn debugger_host(&self) -> Option<Rc<dyn DebuggerHost>> {
+        self.debugger_host.clone()
     }
 
     fn new_session(
@@ -3235,6 +3256,24 @@ impl ThreadEnvironment for NativeThreadEnvironment {
                 )
             })?;
         host.list_available_agents(cx)
+    }
+
+    fn start_debug_session(
+        &self,
+        request: DebugSessionRequest,
+        cx: &mut AsyncApp,
+    ) -> Task<Result<DebugSessionInfo>> {
+        let host = match self.agent.read_with(cx, |agent, _| agent.debugger_host()) {
+            Ok(Some(host)) => host,
+            Ok(None) => {
+                return Task::ready(Err(anyhow!(
+                    "No debugger host is registered. This usually means the \
+                     agent panel hasn't been initialized in this workspace."
+                )));
+            }
+            Err(err) => return Task::ready(Err(err)),
+        };
+        host.start_debug_session(request, cx)
     }
 }
 

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -1015,6 +1015,7 @@ async fn test_debugger_tool_ask_mode_gating(cx: &mut TestAppContext) {
         model, thread, fs, ..
     } = setup(cx, TestModel::Fake).await;
     let fake_model = model.as_fake();
+    cx.update(|cx| cx.update_flags(false, vec!["debugger-tool".to_string()]));
 
     // Enable the debugger tool in an "ask" profile and a write-capable profile.
     fs.insert_file(
@@ -1154,6 +1155,461 @@ async fn test_debugger_tool_ask_mode_gating(cx: &mut TestAppContext) {
         text.contains("\"changed\": true"),
         "expected the breakpoint to be added, got: {text}"
     );
+}
+
+#[gpui::test]
+async fn test_debugger_tool_permission_rules_match_start_session_details(cx: &mut TestAppContext) {
+    let ThreadTest { thread, .. } = setup(cx, TestModel::Fake).await;
+    let tool = debugger_tool_for_thread(&thread, cx);
+
+    set_debugger_permission_rules(
+        cx,
+        settings::ToolPermissionMode::Allow,
+        &[r#""secret_token":"nested-match""#],
+        &[],
+    );
+    let (event_stream, _receiver) = ToolCallEventStream::test();
+    let result = cx
+        .update(|cx| {
+            tool.clone().run(
+                ToolInput::resolved(debugger_start_session_input()),
+                event_stream,
+                cx,
+            )
+        })
+        .await;
+    assert!(
+        result.is_err(),
+        "expected start_session to be denied by a config path rule"
+    );
+
+    set_debugger_permission_rules(
+        cx,
+        settings::ToolPermissionMode::Allow,
+        &[],
+        &[r#"build_task:"build-secret".*tcp_connection:.*9229"#],
+    );
+    let (event_stream, mut receiver) = ToolCallEventStream::test();
+    let task = cx.update(|cx| {
+        tool.run(
+            ToolInput::resolved(debugger_start_session_input()),
+            event_stream,
+            cx,
+        )
+    });
+    let authorization = receiver.expect_authorization().await;
+    let title = authorization
+        .tool_call
+        .fields
+        .title
+        .as_deref()
+        .unwrap_or("");
+    assert!(
+        title.contains("Debug secret"),
+        "expected start_session authorization, got title: {title}"
+    );
+    drop(task);
+}
+
+#[gpui::test]
+async fn test_debugger_tool_permission_rules_match_breakpoint_expressions(cx: &mut TestAppContext) {
+    let ThreadTest { thread, .. } = setup(cx, TestModel::Fake).await;
+    let tool = debugger_tool_for_thread(&thread, cx);
+
+    set_debugger_permission_rules(
+        cx,
+        settings::ToolPermissionMode::Allow,
+        &[r#"condition:"secret == true".*hit_condition:">= 10""#],
+        &[],
+    );
+    let (event_stream, _receiver) = ToolCallEventStream::test();
+    let result = cx
+        .update(|cx| {
+            tool.clone().run(
+                ToolInput::resolved(DebuggerToolInput::SetBreakpoints {
+                    breakpoints: vec![BreakpointInput {
+                        path: path!("/test/main.js").into(),
+                        line: 3,
+                        enabled: true,
+                        condition: Some("secret == true".into()),
+                        hit_condition: Some(">= 10".into()),
+                        log_message: Some("secret {value}".into()),
+                    }],
+                }),
+                event_stream,
+                cx,
+            )
+        })
+        .await;
+    assert_debugger_error_contains(result, "Command blocked by security rule for debugger tool");
+
+    set_debugger_permission_rules(
+        cx,
+        settings::ToolPermissionMode::Allow,
+        &[],
+        &[r#"log_message:"secret \{value\}""#],
+    );
+    let (event_stream, mut receiver) = ToolCallEventStream::test();
+    let task = cx.update(|cx| {
+        tool.run(
+            ToolInput::resolved(DebuggerToolInput::SetBreakpoints {
+                breakpoints: vec![BreakpointInput {
+                    path: path!("/test/main.js").into(),
+                    line: 3,
+                    enabled: true,
+                    condition: Some("secret == true".into()),
+                    hit_condition: Some(">= 10".into()),
+                    log_message: Some("secret {value}".into()),
+                }],
+            }),
+            event_stream,
+            cx,
+        )
+    });
+    let authorization = receiver.expect_authorization().await;
+    let title = authorization
+        .tool_call
+        .fields
+        .title
+        .as_deref()
+        .unwrap_or("");
+    assert!(
+        title.contains("breakpoint"),
+        "expected breakpoint authorization, got title: {title}"
+    );
+    drop(task);
+}
+
+#[gpui::test]
+async fn test_debugger_tool_rejects_excessive_snapshot_and_control_limits(cx: &mut TestAppContext) {
+    let ThreadTest { thread, .. } = setup(cx, TestModel::Fake).await;
+    let tool = debugger_tool_for_thread(&thread, cx);
+
+    let (event_stream, _receiver) = ToolCallEventStream::test();
+    let result = cx
+        .update(|cx| {
+            tool.clone().run(
+                ToolInput::resolved(DebuggerToolInput::Snapshot(SnapshotInput {
+                    session_id: Some(1),
+                    limits: Some(snapshot_limits_with_max_frames(201)),
+                })),
+                event_stream,
+                cx,
+            )
+        })
+        .await;
+    assert_debugger_error_contains(result, "max_frames");
+
+    let (event_stream, _receiver) = ToolCallEventStream::test();
+    let result = cx
+        .update(|cx| {
+            tool.clone().run(
+                ToolInput::resolved(DebuggerToolInput::Control(ControlInput {
+                    session_id: Some(1),
+                    thread_id: Some(2),
+                    action: ControlAction::Continue,
+                    path: None,
+                    line: None,
+                    timeout_ms: Some(300_001),
+                    snapshot_limits: None,
+                })),
+                event_stream,
+                cx,
+            )
+        })
+        .await;
+    assert_debugger_error_contains(result, "timeout_ms");
+
+    let (event_stream, _receiver) = ToolCallEventStream::test();
+    let result = cx
+        .update(|cx| {
+            tool.run(
+                ToolInput::resolved(DebuggerToolInput::Control(ControlInput {
+                    session_id: Some(1),
+                    thread_id: Some(2),
+                    action: ControlAction::Continue,
+                    path: None,
+                    line: None,
+                    timeout_ms: Some(30_000),
+                    snapshot_limits: Some(snapshot_limits_with_max_output_bytes(1_048_577)),
+                })),
+                event_stream,
+                cx,
+            )
+        })
+        .await;
+    assert_debugger_error_contains(result, "max_output_bytes");
+}
+
+#[test]
+fn test_debugger_tool_permission_rules_match_resolved_control_ids() {
+    let inputs = control_permission_inputs_for_test(
+        "control",
+        ControlInput {
+            session_id: None,
+            thread_id: None,
+            action: ControlAction::Continue,
+            path: None,
+            line: None,
+            timeout_ms: None,
+            snapshot_limits: None,
+        },
+        12,
+        34,
+    );
+    assert_eq!(
+        inputs,
+        vec!["control action:continue session_id:12 thread_id:34"]
+    );
+    assert!(
+        !inputs[0].contains("auto"),
+        "resolved control permission input must not contain auto: {}",
+        inputs[0]
+    );
+
+    let mut permissions = agent_settings::ToolPermissions::default();
+    permissions.default = settings::ToolPermissionMode::Allow;
+    permissions.tools.insert(
+        DebuggerTool::NAME.into(),
+        agent_settings::ToolRules {
+            default: Some(settings::ToolPermissionMode::Allow),
+            always_allow: vec![],
+            always_deny: vec![
+                agent_settings::CompiledRegex::new(
+                    r"action:continue session_id:12 thread_id:34",
+                    false,
+                )
+                .expect("debugger deny regex should compile"),
+            ],
+            always_confirm: vec![],
+            invalid_patterns: vec![],
+        },
+    );
+
+    assert!(matches!(
+        ToolPermissionDecision::from_input(
+            DebuggerTool::NAME,
+            &inputs,
+            &permissions,
+            util::shell::ShellKind::system(),
+        ),
+        ToolPermissionDecision::Deny(_)
+    ));
+}
+
+#[gpui::test]
+async fn test_debugger_tool_permission_rules_match_resolved_paths(cx: &mut TestAppContext) {
+    let ThreadTest { thread, fs, .. } = setup(cx, TestModel::Fake).await;
+    fs.insert_tree(
+        path!("/test"),
+        json!({ "src": { "main.js": "let a = 1;\nlet b = 2;\n" } }),
+    )
+    .await;
+    cx.run_until_parked();
+
+    let tool = debugger_tool_for_thread(&thread, cx);
+
+    set_debugger_permission_rules(
+        cx,
+        settings::ToolPermissionMode::Allow,
+        &[],
+        &[r"path:/test/src/main\.js line:3"],
+    );
+    let (event_stream, mut receiver) = ToolCallEventStream::test();
+    let task = cx.update(|cx| {
+        tool.clone().run(
+            ToolInput::resolved(DebuggerToolInput::SetBreakpoints {
+                breakpoints: vec![BreakpointInput {
+                    path: "src/main.js".into(),
+                    line: 3,
+                    enabled: true,
+                    condition: None,
+                    hit_condition: None,
+                    log_message: None,
+                }],
+            }),
+            event_stream,
+            cx,
+        )
+    });
+    let authorization = receiver.expect_authorization().await;
+    let title = authorization
+        .tool_call
+        .fields
+        .title
+        .as_deref()
+        .unwrap_or("");
+    assert!(
+        title.contains("breakpoint"),
+        "expected breakpoint authorization, got title: {title}"
+    );
+    drop(task);
+
+    set_debugger_permission_rules(
+        cx,
+        settings::ToolPermissionMode::Allow,
+        &[r"path:/test/src/main\.js line:1"],
+        &[],
+    );
+    let (event_stream, _receiver) = ToolCallEventStream::test();
+    let result = cx
+        .update(|cx| {
+            tool.clone().run(
+                ToolInput::resolved(DebuggerToolInput::SetBreakpoints {
+                    breakpoints: vec![BreakpointInput {
+                        path: path!("/test/src/./main.js").into(),
+                        line: 1,
+                        enabled: true,
+                        condition: None,
+                        hit_condition: None,
+                        log_message: None,
+                    }],
+                }),
+                event_stream,
+                cx,
+            )
+        })
+        .await;
+    assert_debugger_error_contains(result, "Command blocked by security rule for debugger tool");
+
+    set_debugger_permission_rules(
+        cx,
+        settings::ToolPermissionMode::Allow,
+        &[r"action:run_to_line session_id:12 thread_id:34 path:/test/src/main\.js line:5"],
+        &[],
+    );
+    let (event_stream, _receiver) = ToolCallEventStream::test();
+    let result = cx
+        .update(|cx| {
+            tool.run(
+                ToolInput::resolved(DebuggerToolInput::Control(ControlInput {
+                    session_id: Some(12),
+                    thread_id: Some(34),
+                    action: ControlAction::RunToLine,
+                    path: Some(path!("/test/src/./main.js").into()),
+                    line: Some(5),
+                    timeout_ms: None,
+                    snapshot_limits: None,
+                })),
+                event_stream,
+                cx,
+            )
+        })
+        .await;
+    assert_debugger_error_contains(result, "Command blocked by security rule for debugger tool");
+}
+
+#[allow(clippy::arc_with_non_send_sync)]
+fn debugger_tool_for_thread(thread: &Entity<Thread>, cx: &mut TestAppContext) -> Arc<DebuggerTool> {
+    thread.update(cx, |thread, cx| {
+        Arc::new(DebuggerTool::new(
+            thread.project().clone(),
+            Rc::new(FakeThreadEnvironment::default()),
+            cx.weak_entity(),
+        ))
+    })
+}
+
+fn snapshot_limits_with_max_frames(max_frames: usize) -> SnapshotLimitsInput {
+    SnapshotLimitsInput {
+        max_frames: Some(max_frames),
+        max_variables_per_scope: None,
+        max_variable_value_length: None,
+        max_output_events: None,
+        max_output_bytes: None,
+        max_source_context_lines: None,
+    }
+}
+
+fn snapshot_limits_with_max_output_bytes(max_output_bytes: usize) -> SnapshotLimitsInput {
+    SnapshotLimitsInput {
+        max_frames: None,
+        max_variables_per_scope: None,
+        max_variable_value_length: None,
+        max_output_events: None,
+        max_output_bytes: Some(max_output_bytes),
+        max_source_context_lines: None,
+    }
+}
+
+fn assert_debugger_error_contains(
+    result: std::result::Result<DebuggerToolOutput, DebuggerToolOutput>,
+    expected: &str,
+) {
+    let error = match result {
+        Err(DebuggerToolOutput::Error { error, .. }) => error,
+        Ok(DebuggerToolOutput::Error { error, .. }) => error,
+        other => panic!("expected debugger error containing `{expected}`, got {other:?}"),
+    };
+    assert!(
+        error.contains(expected),
+        "expected debugger error to contain `{expected}`, got: {error}"
+    );
+}
+
+fn debugger_start_session_input() -> DebuggerToolInput {
+    DebuggerToolInput::StartSession(StartSessionInput {
+        scenario: task::DebugScenario {
+            adapter: "node".into(),
+            label: "Debug secret".into(),
+            build: Some(task::BuildTaskDefinition::ByName("build-secret".into())),
+            config: json!({
+                "request": "launch",
+                "program": "src/secret.js",
+                "cwd": "/test",
+                "args": ["--smoke"],
+                "nested": {
+                    "level1": {
+                        "level2": {
+                            "level3": {
+                                "secret_token": "nested-match"
+                            }
+                        }
+                    }
+                },
+            }),
+            tcp_connection: Some(task::TcpArgumentsTemplate {
+                port: Some(9229),
+                host: Some("127.0.0.1".parse().expect("test host should parse")),
+                timeout: Some(1000),
+            }),
+        },
+        worktree_id: Some(7),
+    })
+}
+
+fn set_debugger_permission_rules(
+    cx: &mut TestAppContext,
+    default: settings::ToolPermissionMode,
+    always_deny: &[&str],
+    always_confirm: &[&str],
+) {
+    cx.update(|cx| {
+        let mut settings = agent_settings::AgentSettings::get_global(cx).clone();
+        settings.tool_permissions.tools.insert(
+            DebuggerTool::NAME.into(),
+            agent_settings::ToolRules {
+                default: Some(default),
+                always_allow: vec![],
+                always_deny: always_deny
+                    .iter()
+                    .map(|pattern| {
+                        agent_settings::CompiledRegex::new(pattern, false)
+                            .expect("debugger deny regex should compile")
+                    })
+                    .collect(),
+                always_confirm: always_confirm
+                    .iter()
+                    .map(|pattern| {
+                        agent_settings::CompiledRegex::new(pattern, false)
+                            .expect("debugger confirm regex should compile")
+                    })
+                    .collect(),
+                invalid_patterns: vec![],
+            },
+        );
+        agent_settings::AgentSettings::override_global(settings, cx);
+    });
 }
 
 fn debugger_tool_result<'a>(
@@ -5999,6 +6455,95 @@ async fn test_max_subagent_depth_prevents_tool_registration(cx: &mut TestAppCont
             "subagent tool should not be present at max depth"
         );
     });
+}
+
+#[gpui::test]
+async fn test_debugger_tool_gated_by_feature_flag(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    cx.update(|cx| {
+        cx.update_flags(false, vec![]);
+        assert!(
+            !tool_feature_flag_enabled(DebuggerTool::NAME, cx),
+            "expected debugger tool feature flag to be off"
+        );
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/test"), json!({})).await;
+    let project = Project::test(fs, [path!("/test").as_ref()], cx).await;
+    let project_context = cx.new(|_cx| ProjectContext::default());
+    let context_server_store = project.read_with(cx, |project, _| project.context_server_store());
+    let context_server_registry =
+        cx.new(|cx| ContextServerRegistry::new(context_server_store.clone(), cx));
+    let model = Arc::new(FakeLanguageModel::default());
+    let environment = Rc::new(cx.update(|cx| {
+        FakeThreadEnvironment::default().with_terminal(FakeTerminalHandle::new_never_exits(cx))
+    }));
+
+    let thread = cx.new(|cx| {
+        let mut thread = Thread::new(
+            project,
+            project_context,
+            context_server_registry,
+            Templates::new(),
+            Some(model.clone() as Arc<dyn LanguageModel>),
+            cx,
+        );
+        thread.add_default_tools(environment, cx);
+        thread
+    });
+
+    thread.read_with(cx, |thread, _| {
+        assert!(
+            thread.has_registered_tool(DebuggerTool::NAME),
+            "expected debugger tool to be registered regardless of feature flag"
+        );
+    });
+
+    thread
+        .update(cx, |thread, cx| {
+            thread.send(UserMessageId::new(), ["hello"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    let completion = model.pending_completions().pop().unwrap();
+    let tool_names = tool_names_for_completion(&completion);
+    assert!(
+        !tool_names
+            .iter()
+            .any(|tool_name| tool_name == DebuggerTool::NAME),
+        "expected debugger tool to be hidden without debugger-tool flag, \
+         but completion tools were: {tool_names:?}"
+    );
+    model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    cx.update(|cx| {
+        cx.update_flags(false, vec!["debugger-tool".to_string()]);
+        assert!(
+            tool_feature_flag_enabled(DebuggerTool::NAME, cx),
+            "expected debugger tool feature flag to be on"
+        );
+    });
+
+    thread
+        .update(cx, |thread, cx| {
+            thread.send(UserMessageId::new(), ["hello again"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    let completion = model.pending_completions().pop().unwrap();
+    let tool_names = tool_names_for_completion(&completion);
+    assert!(
+        tool_names
+            .iter()
+            .any(|tool_name| tool_name == DebuggerTool::NAME),
+        "expected debugger tool to be exposed when debugger-tool flag is on, \
+         but completion tools were: {tool_names:?}"
+    );
 }
 
 #[gpui::test]

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -1010,6 +1010,172 @@ async fn test_tool_authorization(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_debugger_tool_ask_mode_gating(cx: &mut TestAppContext) {
+    let ThreadTest {
+        model, thread, fs, ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    // Enable the debugger tool in an "ask" profile and a write-capable profile.
+    fs.insert_file(
+        paths::settings_file(),
+        json!({
+            "agent": {
+                "profiles": {
+                    "ask": {
+                        "name": "Ask",
+                        "tools": { DebuggerTool::NAME: true }
+                    },
+                    "test-write": {
+                        "name": "Test Write",
+                        "tools": { DebuggerTool::NAME: true }
+                    }
+                }
+            }
+        })
+        .to_string()
+        .into_bytes(),
+    )
+    .await;
+    fs.insert_tree(
+        path!("/test"),
+        json!({ "main.js": "let a = 1;\nlet b = 2;\n" }),
+    )
+    .await;
+    cx.run_until_parked();
+
+    thread.update(cx, |thread, cx| {
+        let project = thread.project().clone();
+        let environment = Rc::new(FakeThreadEnvironment::default());
+        thread.add_tool(DebuggerTool::new(project, environment, cx.weak_entity()));
+        thread.set_profile(AgentProfileId("ask".into()), cx);
+    });
+
+    let mut events = thread
+        .update(cx, |thread, cx| {
+            thread.send(UserMessageId::new(), ["debug"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    // Read-only operations are available in Ask mode without a permission prompt.
+    let list_breakpoints_input = json!({ "operation": "list_breakpoints" });
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "debugger_1".into(),
+            name: DebuggerTool::NAME.into(),
+            raw_input: list_breakpoints_input.to_string(),
+            input: list_breakpoints_input,
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let result = debugger_tool_result(&completion, "debugger_1");
+    assert!(
+        !result.is_error,
+        "read-only debugger operation should succeed in ask mode: {:?}",
+        result.content
+    );
+
+    // Mutating operations are rejected in Ask mode before requesting permission.
+    let set_breakpoints_input = json!({
+        "operation": "set_breakpoints",
+        "breakpoints": [{ "path": path!("/test/main.js"), "line": 1 }]
+    });
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "debugger_2".into(),
+            name: DebuggerTool::NAME.into(),
+            raw_input: set_breakpoints_input.to_string(),
+            input: set_breakpoints_input.clone(),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let result = debugger_tool_result(&completion, "debugger_2");
+    assert!(result.is_error, "write operation should fail in ask mode");
+    let text = result
+        .content
+        .first()
+        .and_then(|content| content.to_str())
+        .unwrap_or_default();
+    assert!(
+        text.contains("Ask mode"),
+        "expected ask-mode rejection, got: {text}"
+    );
+
+    // In a write-capable profile the same operation runs once the user grants
+    // permission.
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test-write".into()), cx);
+    });
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "debugger_3".into(),
+            name: DebuggerTool::NAME.into(),
+            raw_input: set_breakpoints_input.to_string(),
+            input: set_breakpoints_input,
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+
+    let auth = next_tool_call_authorization(&mut events).await;
+    auth.response
+        .send(acp_thread::SelectedPermissionOutcome::new(
+            acp::PermissionOptionId::new("allow"),
+            acp::PermissionOptionKind::AllowOnce,
+        ))
+        .unwrap();
+    cx.run_until_parked();
+
+    let completion = fake_model.pending_completions().pop().unwrap();
+    let result = debugger_tool_result(&completion, "debugger_3");
+    assert!(
+        !result.is_error,
+        "write operation should succeed in write mode after permission: {:?}",
+        result.content
+    );
+    let text = result
+        .content
+        .first()
+        .and_then(|content| content.to_str())
+        .unwrap_or_default();
+    assert!(
+        text.contains("\"changed\": true"),
+        "expected the breakpoint to be added, got: {text}"
+    );
+}
+
+fn debugger_tool_result<'a>(
+    completion: &'a LanguageModelRequest,
+    tool_use_id: &str,
+) -> &'a LanguageModelToolResult {
+    completion
+        .messages
+        .last()
+        .unwrap()
+        .content
+        .iter()
+        .find_map(|content| match content {
+            MessageContent::ToolResult(result) if result.tool_use_id.to_string() == tool_use_id => {
+                Some(result)
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("no tool result for {tool_use_id}"))
+}
+
+#[gpui::test]
 async fn test_tool_hallucination(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
     let fake_model = model.as_fake();

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1,11 +1,11 @@
 use crate::{
     ApplyCodeActionTool, CodeActionStore, ContextServerRegistry, CopyPathTool, CreateDirectoryTool,
-    CreateThreadTool, DbLanguageModel, DbThread, DeletePathTool, DiagnosticsTool, EditFileTool,
-    FetchTool, FindPathTool, FindReferencesTool, GetCodeActionsTool, GoToDefinitionTool, GrepTool,
-    ListAgentsAndModelsTool, ListDirectoryTool, MovePathTool, ProjectSnapshot, ReadFileTool,
-    RenameTool, SandboxedTerminalTool, SpawnAgentTool, SystemPromptTemplate, Template, Templates,
-    TerminalTool, ToolPermissionDecision, WebSearchTool, WriteFileTool,
-    decide_permission_from_settings,
+    CreateThreadTool, DbLanguageModel, DbThread, DebuggerTool, DeletePathTool, DiagnosticsTool,
+    EditFileTool, FetchTool, FindPathTool, FindReferencesTool, GetCodeActionsTool,
+    GoToDefinitionTool, GrepTool, ListAgentsAndModelsTool, ListDirectoryTool, MovePathTool,
+    ProjectSnapshot, ReadFileTool, RenameTool, SandboxedTerminalTool, SpawnAgentTool,
+    SystemPromptTemplate, Template, Templates, TerminalTool, ToolPermissionDecision, WebSearchTool,
+    WriteFileTool, decide_permission_from_settings,
 };
 use acp_thread::{MentionUri, UserMessageId};
 use action_log::ActionLog;
@@ -38,6 +38,7 @@ use gpui::{
     App, AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Task, WeakEntity,
 };
 use heck::ToSnakeCase as _;
+use language::Buffer;
 use language_model::{
     CompletionIntent, LanguageModel, LanguageModelCompletionError, LanguageModelCompletionEvent,
     LanguageModelId, LanguageModelImage, LanguageModelProviderId, LanguageModelRegistry,
@@ -46,7 +47,7 @@ use language_model::{
     LanguageModelToolUse, LanguageModelToolUseId, MessageContent, Role, SelectedModel, Speed,
     StopReason, TokenUsage, ZED_CLOUD_PROVIDER_ID,
 };
-use project::Project;
+use project::{Project, WorktreeId};
 use prompt_store::ProjectContext;
 use schemars::{JsonSchema, Schema};
 use serde::de::DeserializeOwned;
@@ -65,6 +66,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
+use task::{DebugScenario, SharedTaskContext};
 use util::{ResultExt, debug_panic, markdown::MarkdownCodeBlock, paths::PathStyle};
 use uuid::Uuid;
 
@@ -776,6 +778,19 @@ pub trait ThreadEnvironment {
             "Listing available agents is not supported in this environment"
         ))
     }
+
+    /// Starts a debug session through the host UI, if the environment provides one.
+    fn start_debug_session(
+        &self,
+        request: DebugSessionRequest,
+        cx: &mut AsyncApp,
+    ) -> Task<Result<DebugSessionInfo>> {
+        let _ = request;
+        let _ = cx;
+        Task::ready(Err(anyhow::anyhow!(
+            "Starting debug sessions is not supported in this environment"
+        )))
+    }
 }
 
 /// A request to create a new sibling thread.
@@ -815,6 +830,31 @@ pub struct SiblingThreadInfo {
     /// unusual worktree layout that affected how the new worktree was set
     /// up). Empty when nothing noteworthy happened.
     pub warning: Option<String>,
+}
+
+/// A request to start a debug session through the workspace debugger UI.
+#[derive(Clone)]
+pub struct DebugSessionRequest {
+    /// Debug scenario to start.
+    pub scenario: DebugScenario,
+    /// Task context used for variable substitution and build-task resolution.
+    pub task_context: SharedTaskContext,
+    /// Buffer used to resolve build-task variables, when available.
+    pub active_buffer: Option<Entity<Buffer>>,
+    /// Worktree to start the debug session in. When absent, the debugger UI
+    /// falls back to the active buffer's worktree or the first visible worktree.
+    pub worktree_id: Option<WorktreeId>,
+}
+
+/// Information returned when a debug session is accepted by the debugger UI.
+#[derive(Debug, Clone)]
+pub struct DebugSessionInfo {
+    /// The DAP session id allocated for the created session.
+    pub session_id: u64,
+    /// The label assigned to the session.
+    pub label: String,
+    /// The debug adapter used to start the session.
+    pub adapter: String,
 }
 
 /// A list of agents and, for each, the models available for use.
@@ -2127,6 +2167,11 @@ impl Thread {
         self.add_tool(DeletePathTool::new(
             self.project.clone(),
             self.action_log.clone(),
+        ));
+        self.add_tool(DebuggerTool::new(
+            self.project.clone(),
+            environment.clone(),
+            cx.weak_entity(),
         ));
         self.add_tool(EditFileTool::new(
             self.project.clone(),

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -10,6 +10,7 @@ use crate::{
 use acp_thread::{MentionUri, UserMessageId};
 use action_log::ActionLog;
 use agent_settings::UserAgentsMd;
+use feature_flags::{DebuggerToolFeatureFlag, FeatureFlagAppExt as _};
 
 use crate::sandboxing::{
     SandboxRequest, ThreadSandbox, ThreadSandboxGrants, sandboxing_available_for_project,
@@ -2168,11 +2169,13 @@ impl Thread {
             self.project.clone(),
             self.action_log.clone(),
         ));
-        self.add_tool(DebuggerTool::new(
-            self.project.clone(),
-            environment.clone(),
-            cx.weak_entity(),
-        ));
+        if cx.has_flag::<DebuggerToolFeatureFlag>() {
+            self.add_tool(DebuggerTool::new(
+                self.project.clone(),
+                environment.clone(),
+                cx.weak_entity(),
+            ));
+        }
         self.add_tool(EditFileTool::new(
             self.project.clone(),
             cx.weak_entity(),

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -10,7 +10,6 @@ use crate::{
 use acp_thread::{MentionUri, UserMessageId};
 use action_log::ActionLog;
 use agent_settings::UserAgentsMd;
-use feature_flags::{DebuggerToolFeatureFlag, FeatureFlagAppExt as _};
 
 use crate::sandboxing::{
     SandboxRequest, ThreadSandbox, ThreadSandboxGrants, sandboxing_available_for_project,
@@ -2169,13 +2168,11 @@ impl Thread {
             self.project.clone(),
             self.action_log.clone(),
         ));
-        if cx.has_flag::<DebuggerToolFeatureFlag>() {
-            self.add_tool(DebuggerTool::new(
-                self.project.clone(),
-                environment.clone(),
-                cx.weak_entity(),
-            ));
-        }
+        self.add_tool(DebuggerTool::new(
+            self.project.clone(),
+            environment.clone(),
+            cx.weak_entity(),
+        ));
         self.add_tool(EditFileTool::new(
             self.project.clone(),
             cx.weak_entity(),

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -3,6 +3,7 @@ mod context_server_registry;
 mod copy_path_tool;
 mod create_directory_tool;
 mod create_thread_tool;
+mod debugger_tool;
 mod delete_path_tool;
 mod diagnostics_tool;
 mod edit_file_tool;
@@ -67,6 +68,7 @@ pub use context_server_registry::*;
 pub use copy_path_tool::*;
 pub use create_directory_tool::*;
 pub use create_thread_tool::*;
+pub use debugger_tool::*;
 pub use delete_path_tool::*;
 pub use diagnostics_tool::*;
 pub use edit_file_tool::*;
@@ -178,6 +180,7 @@ tools! {
     CopyPathTool,
     CreateDirectoryTool,
     CreateThreadTool,
+    DebuggerTool,
     DeletePathTool,
     DiagnosticsTool,
     EditFileTool,

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -31,7 +31,8 @@ mod write_file_tool;
 
 use crate::AgentTool;
 use feature_flags::{
-    CreateThreadToolFeatureFlag, FeatureFlagAppExt as _, LspToolFeatureFlag, RenameToolFeatureFlag,
+    CreateThreadToolFeatureFlag, DebuggerToolFeatureFlag, FeatureFlagAppExt as _,
+    LspToolFeatureFlag, RenameToolFeatureFlag,
 };
 use gpui::App;
 use language_model::{LanguageModelRequestTool, LanguageModelToolSchemaFormat};
@@ -212,6 +213,7 @@ tools! {
 pub fn tool_feature_flag_enabled(tool_name: &str, cx: &App) -> bool {
     match tool_name {
         RenameTool::NAME => cx.has_flag::<RenameToolFeatureFlag>(),
+        DebuggerTool::NAME => cx.has_flag::<DebuggerToolFeatureFlag>(),
         FindReferencesTool::NAME
         | GetCodeActionsTool::NAME
         | ApplyCodeActionTool::NAME

--- a/crates/agent/src/tools/debugger_tool.rs
+++ b/crates/agent/src/tools/debugger_tool.rs
@@ -1,0 +1,973 @@
+use agent_client_protocol::schema as acp;
+use anyhow::{Context as _, Result, anyhow};
+use dap::{DapRegistry, client::SessionId};
+use gpui::{App, Entity, SharedString, Task, WeakEntity};
+use language_model::LanguageModelToolResultContent;
+use project::{Project, WorktreeId, debugger::agent_api::*};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{path::PathBuf, rc::Rc, sync::Arc, time::Duration};
+use task::{DebugScenario, SharedTaskContext};
+use util::markdown::MarkdownInlineCode;
+
+use crate::{
+    AgentTool, DebugSessionRequest, Thread, ThreadEnvironment, ToolCallEventStream, ToolInput,
+    ToolPermissionContext,
+    sandboxing::{SandboxRequest, sandboxing_enabled},
+};
+
+const DEFAULT_CONTROL_TIMEOUT_MS: u64 = 30_000;
+
+/// Interact with Zed's debugger. Read-only operations such as `snapshot`,
+/// `list_sessions`, `list_breakpoints`, and `list_adapters` are available in
+/// Ask mode. Operations that start sessions, change breakpoints, or control
+/// execution require Write mode and user permission.
+///
+/// Prefer `snapshot` when inspecting a paused debug session: it returns a
+/// bounded view of threads, stack frames, source context, variables, and recent
+/// output in one call. Use `list_sessions` first when there are multiple active
+/// sessions.
+///
+/// <guidelines>
+/// - In Ask mode, only use read-only operations.
+/// - Before controlling execution, inspect `list_sessions` or `snapshot` and use
+///   explicit `session_id` and `thread_id` when possible.
+/// - `continue`, `step`, `pause`, and `run_to_line` wait for the debugger to
+///   stop, exit, or time out, then return a fresh snapshot.
+/// - `start_session` runs code through Zed's debugger UI; use an existing debug
+///   scenario shape with adapter, label, and adapter-specific config.
+/// - Do not use this tool for expression evaluation; evaluation is intentionally
+///   not available.
+/// </guidelines>
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "operation", rename_all = "snake_case")]
+pub enum DebuggerToolInput {
+    /// List active debug sessions.
+    ListSessions,
+    /// Inspect debugger state for a session.
+    Snapshot(SnapshotInput),
+    /// List source breakpoints in the project.
+    ListBreakpoints,
+    /// Add or update source breakpoints. Requires Write mode and permission.
+    SetBreakpoints { breakpoints: Vec<BreakpointInput> },
+    /// Remove source breakpoints. Requires Write mode and permission.
+    RemoveBreakpoints {
+        breakpoints: Vec<BreakpointLocationInput>,
+    },
+    /// Continue, pause, step, or run to a line. Requires Write mode and permission.
+    Control(ControlInput),
+    /// List registered debug adapters and their configuration schemas.
+    ListAdapters,
+    /// Start a debug session through Zed's debugger UI. Requires Write mode and permission.
+    StartSession(StartSessionInput),
+    /// Stop a debug session. Requires Write mode and permission.
+    StopSession { session_id: u64 },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct SnapshotInput {
+    /// DAP session id. When omitted, uses the active debug session, otherwise the first session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<u64>,
+    /// Optional bounds for returned stack, variables, output, and source context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limits: Option<SnapshotLimitsInput>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct SnapshotLimitsInput {
+    /// Maximum total stack frames across all stopped threads. Defaults to 20.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_frames: Option<usize>,
+    /// Maximum variables per scope. Defaults to 50.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_variables_per_scope: Option<usize>,
+    /// Maximum bytes per variable value. Defaults to 1024.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_variable_value_length: Option<usize>,
+    /// Maximum recent output events. Defaults to 100.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_events: Option<usize>,
+    /// Maximum recent output bytes. Defaults to 16384.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_output_bytes: Option<usize>,
+    /// Maximum source context lines around each frame. Defaults to 5.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_source_context_lines: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct BreakpointInput {
+    /// Absolute source path as reported by the debugger, or a project-resolvable absolute path.
+    pub path: PathBuf,
+    /// 1-based line number.
+    pub line: u32,
+    /// Whether the breakpoint should be enabled. Defaults to true.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Optional condition expression that must be true for the breakpoint to stop.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
+    /// Optional hit count condition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hit_condition: Option<String>,
+    /// Optional logpoint message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct BreakpointLocationInput {
+    /// Absolute source path as reported by the debugger, or a project-resolvable absolute path.
+    pub path: PathBuf,
+    /// 1-based line number.
+    pub line: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ControlInput {
+    /// DAP session id. When omitted, uses the active debug session, otherwise the first session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<u64>,
+    /// DAP thread id. When omitted, chooses a suitable thread based on the action.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<i64>,
+    /// Execution control action.
+    pub action: ControlAction,
+    /// Source path for `run_to_line`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    /// 1-based line for `run_to_line`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    /// Maximum time to wait for the debugger to stop. Defaults to 30000ms.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+    /// Optional bounds for the snapshot returned after control completes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_limits: Option<SnapshotLimitsInput>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlAction {
+    Continue,
+    Pause,
+    StepOver,
+    StepIn,
+    StepOut,
+    RunToLine,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct StartSessionInput {
+    /// Debug scenario to start. This is the same shape as Zed debug scenarios:
+    /// include `adapter`, `label`, and adapter-specific launch/attach config.
+    pub scenario: DebugScenario,
+    /// Optional worktree id. Omit to use the active buffer's worktree or first visible worktree.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum DebuggerToolOutput {
+    Success {
+        operation: String,
+        message: String,
+        data: Value,
+    },
+    Error {
+        operation: Option<String>,
+        error: String,
+    },
+}
+
+impl From<DebuggerToolOutput> for LanguageModelToolResultContent {
+    fn from(output: DebuggerToolOutput) -> Self {
+        match &output {
+            DebuggerToolOutput::Success {
+                operation,
+                message,
+                data,
+            } => {
+                let data = serde_json::to_string_pretty(data).unwrap_or_else(|error| {
+                    format!("<failed to serialize debugger output: {error}>")
+                });
+                format!("Debugger `{operation}` succeeded: {message}\n\n```json\n{data}\n```")
+                    .into()
+            }
+            DebuggerToolOutput::Error { operation, error } => {
+                let operation = operation.as_deref().unwrap_or("unknown");
+                format!("Debugger `{operation}` failed: {error}").into()
+            }
+        }
+    }
+}
+
+pub struct DebuggerTool {
+    project: Entity<Project>,
+    environment: Rc<dyn ThreadEnvironment>,
+    thread: WeakEntity<Thread>,
+}
+
+impl DebuggerTool {
+    pub fn new(
+        project: Entity<Project>,
+        environment: Rc<dyn ThreadEnvironment>,
+        thread: WeakEntity<Thread>,
+    ) -> Self {
+        Self {
+            project,
+            environment,
+            thread,
+        }
+    }
+
+    fn api(&self, cx: &App) -> AgentDebuggerApi {
+        let project = self.project.read(cx);
+        AgentDebuggerApi::new(project.dap_store(), project.breakpoint_store())
+    }
+
+    fn is_ask_profile(&self, cx: &App) -> bool {
+        self.thread
+            .read_with(cx, |thread, _| thread.profile().as_str() == "ask")
+            .unwrap_or(false)
+    }
+}
+
+impl AgentTool for DebuggerTool {
+    type Input = DebuggerToolInput;
+    type Output = DebuggerToolOutput;
+
+    const NAME: &'static str = "debugger";
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Other
+    }
+
+    fn initial_title(
+        &self,
+        input: Result<Self::Input, serde_json::Value>,
+        _cx: &mut App,
+    ) -> SharedString {
+        match input {
+            Ok(input) => initial_title_for_input(&input),
+            Err(value) => value
+                .get("operation")
+                .and_then(|value| value.as_str())
+                .map(|operation| format!("Debugger: {operation}").into())
+                .unwrap_or_else(|| "Debugger".into()),
+        }
+    }
+
+    fn run(
+        self: Arc<Self>,
+        input: ToolInput<Self::Input>,
+        event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<Self::Output, Self::Output>> {
+        cx.spawn(async move |cx| {
+            let input = input
+                .recv()
+                .await
+                .map_err(|error| DebuggerToolOutput::Error {
+                    operation: None,
+                    error: format!("Failed to receive debugger tool input: {error}"),
+                })?;
+            let operation = operation_name(&input).to_string();
+            match self
+                .run_operation(input, operation.clone(), event_stream, cx)
+                .await
+            {
+                Ok(output) => Ok(output),
+                Err(error) => Err(DebuggerToolOutput::Error {
+                    operation: Some(operation),
+                    error: error.to_string(),
+                }),
+            }
+        })
+    }
+}
+
+impl DebuggerTool {
+    async fn run_operation(
+        self: Arc<Self>,
+        input: DebuggerToolInput,
+        operation: String,
+        event_stream: ToolCallEventStream,
+        cx: &mut gpui::AsyncApp,
+    ) -> Result<DebuggerToolOutput> {
+        match input {
+            DebuggerToolInput::ListSessions => {
+                let data = cx.update(|cx| sessions_to_json(self.api(cx).list_sessions(cx)));
+                Ok(success(operation, "listed debug sessions", data))
+            }
+            DebuggerToolInput::Snapshot(input) => {
+                let (api, session_id, limits) = cx.update(|cx| {
+                    let api = self.api(cx);
+                    let session_id = resolve_session_id(&self.project, &api, input.session_id, cx)?;
+                    anyhow::Ok((api, session_id, limits_from_input(input.limits)))
+                })?;
+                let snapshot_task = cx.update(|cx| api.snapshot(session_id, limits, cx));
+                let snapshot = snapshot_task.await?;
+                Ok(success(
+                    operation,
+                    "captured debugger snapshot",
+                    snapshot_to_json(snapshot),
+                ))
+            }
+            DebuggerToolInput::ListBreakpoints => {
+                let data = cx.update(|cx| breakpoints_to_json(self.api(cx).list_breakpoints(cx)));
+                Ok(success(operation, "listed breakpoints", data))
+            }
+            DebuggerToolInput::ListAdapters => {
+                let data = cx
+                    .update(|cx| serde_json::to_value(DapRegistry::global(cx).adapters_schema()))?;
+                Ok(success(operation, "listed debug adapters", data))
+            }
+            DebuggerToolInput::SetBreakpoints { breakpoints } => {
+                self.ensure_write_mode(&operation, cx)?;
+                authorize_debugger_operation(
+                    &event_stream,
+                    "Set debugger breakpoint(s)",
+                    permission_inputs(
+                        &operation,
+                        breakpoints.iter().map(|breakpoint| {
+                            format!("{}:{}", breakpoint.path.display(), breakpoint.line)
+                        }),
+                    ),
+                    cx,
+                )
+                .await?;
+
+                let api = cx.update(|cx| self.api(cx));
+                let mut results = Vec::new();
+                for breakpoint in breakpoints {
+                    let breakpoint = resolve_breakpoint_input(&self.project, breakpoint, cx)?;
+                    let task = cx
+                        .update(|cx| api.set_source_breakpoint(breakpoint.into_agent_input(), cx));
+                    let result = task.await?;
+                    results.push(breakpoint_edit_result_to_json(result));
+                }
+                Ok(success(
+                    operation,
+                    "set breakpoint(s)",
+                    Value::Array(results),
+                ))
+            }
+            DebuggerToolInput::RemoveBreakpoints { breakpoints } => {
+                self.ensure_write_mode(&operation, cx)?;
+                authorize_debugger_operation(
+                    &event_stream,
+                    "Remove debugger breakpoint(s)",
+                    permission_inputs(
+                        &operation,
+                        breakpoints.iter().map(|breakpoint| {
+                            format!("{}:{}", breakpoint.path.display(), breakpoint.line)
+                        }),
+                    ),
+                    cx,
+                )
+                .await?;
+
+                let api = cx.update(|cx| self.api(cx));
+                let mut results = Vec::new();
+                for breakpoint in breakpoints {
+                    let breakpoint = resolve_breakpoint_location(&self.project, breakpoint, cx)?;
+                    let task = cx.update(|cx| {
+                        api.remove_source_breakpoint(breakpoint.path, breakpoint.line, cx)
+                    });
+                    let result = task.await?;
+                    results.push(breakpoint_edit_result_to_json(result));
+                }
+                Ok(success(
+                    operation,
+                    "removed breakpoint(s)",
+                    Value::Array(results),
+                ))
+            }
+            DebuggerToolInput::Control(input) => {
+                self.ensure_write_mode(&operation, cx)?;
+                let action = input.action;
+                authorize_debugger_operation(
+                    &event_stream,
+                    format!("Debugger {}", action.label()),
+                    permission_inputs(
+                        &operation,
+                        [format!(
+                            "{} session:{:?} thread:{:?}",
+                            action.permission_name(),
+                            input.session_id,
+                            input.thread_id
+                        )],
+                    ),
+                    cx,
+                )
+                .await?;
+
+                let snapshot_limits = input.snapshot_limits.clone();
+                let (session_id, control_result) = self.run_control(input, cx).await?;
+                let api = cx.update(|cx| self.api(cx));
+                let limits = limits_from_input(snapshot_limits);
+                let snapshot_task = cx.update(|cx| api.snapshot(session_id, limits, cx));
+                let snapshot = snapshot_task.await?;
+                Ok(success(
+                    operation,
+                    "controlled debugger execution and captured snapshot",
+                    json!({
+                        "control": control_result_to_json(control_result),
+                        "snapshot": snapshot_to_json(snapshot),
+                    }),
+                ))
+            }
+            DebuggerToolInput::StartSession(input) => {
+                self.ensure_write_mode(&operation, cx)?;
+                authorize_debugger_operation(
+                    &event_stream,
+                    format!(
+                        "Start debug session {}",
+                        MarkdownInlineCode(&input.scenario.label)
+                    ),
+                    permission_inputs(
+                        &operation,
+                        [format!(
+                            "start_session adapter:{} label:{}",
+                            input.scenario.adapter, input.scenario.label
+                        )],
+                    ),
+                    cx,
+                )
+                .await?;
+
+                if cx.update(|cx| sandboxing_enabled(cx)) {
+                    let request = SandboxRequest {
+                        unsandboxed: true,
+                        ..Default::default()
+                    };
+                    let approve = cx.update(|cx| {
+                        event_stream.authorize_sandbox(
+                            "Start debug session outside the agent terminal sandbox",
+                            request,
+                            cx,
+                        )
+                    });
+                    approve.await?;
+                }
+
+                let request = DebugSessionRequest {
+                    scenario: input.scenario,
+                    task_context: SharedTaskContext::default(),
+                    active_buffer: None,
+                    worktree_id: input.worktree_id.map(WorktreeId::from_proto),
+                };
+                let info = self.environment.start_debug_session(request, cx).await?;
+                Ok(success(
+                    operation,
+                    "started debug session",
+                    json!({
+                        "session_id": info.session_id,
+                        "label": info.label,
+                        "adapter": info.adapter,
+                    }),
+                ))
+            }
+            DebuggerToolInput::StopSession { session_id } => {
+                self.ensure_write_mode(&operation, cx)?;
+                authorize_debugger_operation(
+                    &event_stream,
+                    format!("Stop debug session {session_id}"),
+                    permission_inputs(&operation, [format!("stop_session session:{session_id}")]),
+                    cx,
+                )
+                .await?;
+                let project = self.project.clone();
+                let shutdown = cx.update(|cx| {
+                    let dap_store = project.read(cx).dap_store();
+                    dap_store.update(cx, |dap_store, cx| {
+                        dap_store.shutdown_session(SessionId::from_proto(session_id), cx)
+                    })
+                });
+                shutdown.await?;
+                Ok(success(
+                    operation,
+                    "stopped debug session",
+                    json!({ "session_id": session_id }),
+                ))
+            }
+        }
+    }
+
+    fn ensure_write_mode(&self, operation: &str, cx: &gpui::AsyncApp) -> Result<()> {
+        if cx.update(|cx| self.is_ask_profile(cx)) {
+            anyhow::bail!(
+                "debugger.{operation} is not available in Ask mode. Switch to Write mode to start sessions, change breakpoints, or control execution."
+            );
+        }
+        Ok(())
+    }
+
+    async fn run_control(
+        &self,
+        input: ControlInput,
+        cx: &mut gpui::AsyncApp,
+    ) -> Result<(SessionId, AgentDebuggerControlResult)> {
+        let timeout = Duration::from_millis(input.timeout_ms.unwrap_or(DEFAULT_CONTROL_TIMEOUT_MS));
+        let (api, session_id, thread_id) = cx.update(|cx| {
+            let api = self.api(cx);
+            let session_id = resolve_session_id(&self.project, &api, input.session_id, cx)?;
+            let thread_id = input.thread_id.map(project::debugger::session::ThreadId);
+            anyhow::Ok((api, session_id, thread_id))
+        })?;
+        let thread_id = match thread_id {
+            Some(thread_id) => thread_id,
+            None => choose_thread_for_action(&api, session_id, input.action, cx).await?,
+        };
+
+        match input.action {
+            ControlAction::Continue => {
+                let task = cx.update(|cx| api.continue_thread(session_id, thread_id, timeout, cx));
+                task.await
+            }
+            ControlAction::Pause => {
+                let task = cx.update(|cx| api.pause_thread(session_id, thread_id, timeout, cx));
+                task.await
+            }
+            ControlAction::StepOver => {
+                let task = cx.update(|cx| {
+                    api.step_thread(
+                        session_id,
+                        thread_id,
+                        AgentDebuggerStepKind::Over,
+                        timeout,
+                        cx,
+                    )
+                });
+                task.await
+            }
+            ControlAction::StepIn => {
+                let task = cx.update(|cx| {
+                    api.step_thread(
+                        session_id,
+                        thread_id,
+                        AgentDebuggerStepKind::In,
+                        timeout,
+                        cx,
+                    )
+                });
+                task.await
+            }
+            ControlAction::StepOut => {
+                let task = cx.update(|cx| {
+                    api.step_thread(
+                        session_id,
+                        thread_id,
+                        AgentDebuggerStepKind::Out,
+                        timeout,
+                        cx,
+                    )
+                });
+                task.await
+            }
+            ControlAction::RunToLine => {
+                let path = input
+                    .path
+                    .context("path is required for debugger control run_to_line")?;
+                let path = resolve_debugger_path(&self.project, path, cx)?;
+                let line = input
+                    .line
+                    .context("line is required for debugger control run_to_line")?;
+                let task =
+                    cx.update(|cx| api.run_to_line(session_id, thread_id, path, line, timeout, cx));
+                task.await
+            }
+        }
+        .map(|result| (session_id, result))
+    }
+}
+
+impl BreakpointInput {
+    fn into_agent_input(self) -> AgentSourceBreakpointInput {
+        AgentSourceBreakpointInput {
+            path: self.path,
+            line: self.line,
+            enabled: self.enabled,
+            condition: self.condition,
+            hit_condition: self.hit_condition,
+            log_message: self.log_message,
+        }
+    }
+}
+
+impl ControlAction {
+    fn label(self) -> &'static str {
+        match self {
+            ControlAction::Continue => "continue",
+            ControlAction::Pause => "pause",
+            ControlAction::StepOver => "step over",
+            ControlAction::StepIn => "step in",
+            ControlAction::StepOut => "step out",
+            ControlAction::RunToLine => "run to line",
+        }
+    }
+
+    fn permission_name(self) -> &'static str {
+        match self {
+            ControlAction::Continue => "continue",
+            ControlAction::Pause => "pause",
+            ControlAction::StepOver => "step_over",
+            ControlAction::StepIn => "step_in",
+            ControlAction::StepOut => "step_out",
+            ControlAction::RunToLine => "run_to_line",
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn success(operation: String, message: impl Into<String>, data: Value) -> DebuggerToolOutput {
+    DebuggerToolOutput::Success {
+        operation,
+        message: message.into(),
+        data,
+    }
+}
+
+async fn authorize_debugger_operation(
+    event_stream: &ToolCallEventStream,
+    title: impl Into<String>,
+    input_values: Vec<String>,
+    cx: &mut gpui::AsyncApp,
+) -> Result<()> {
+    let title = title.into();
+    let task = cx.update(|cx| {
+        event_stream.authorize(
+            title,
+            ToolPermissionContext::new(DebuggerTool::NAME, input_values),
+            cx,
+        )
+    });
+    task.await
+}
+
+fn permission_inputs(operation: &str, values: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut inputs = values.into_iter().collect::<Vec<_>>();
+    if inputs.is_empty() {
+        inputs.push(operation.to_string());
+    } else {
+        for input in &mut inputs {
+            *input = format!("{operation} {input}");
+        }
+    }
+    inputs
+}
+
+fn operation_name(input: &DebuggerToolInput) -> &'static str {
+    match input {
+        DebuggerToolInput::ListSessions => "list_sessions",
+        DebuggerToolInput::Snapshot(_) => "snapshot",
+        DebuggerToolInput::ListBreakpoints => "list_breakpoints",
+        DebuggerToolInput::SetBreakpoints { .. } => "set_breakpoints",
+        DebuggerToolInput::RemoveBreakpoints { .. } => "remove_breakpoints",
+        DebuggerToolInput::Control(_) => "control",
+        DebuggerToolInput::ListAdapters => "list_adapters",
+        DebuggerToolInput::StartSession(_) => "start_session",
+        DebuggerToolInput::StopSession { .. } => "stop_session",
+    }
+}
+
+fn initial_title_for_input(input: &DebuggerToolInput) -> SharedString {
+    match input {
+        DebuggerToolInput::ListSessions => "List debug sessions".into(),
+        DebuggerToolInput::Snapshot(input) => input
+            .session_id
+            .map(|session_id| format!("Inspect debug session {session_id}").into())
+            .unwrap_or_else(|| "Inspect debugger".into()),
+        DebuggerToolInput::ListBreakpoints => "List debugger breakpoints".into(),
+        DebuggerToolInput::SetBreakpoints { breakpoints } => {
+            format!("Set {} debugger breakpoint(s)", breakpoints.len()).into()
+        }
+        DebuggerToolInput::RemoveBreakpoints { breakpoints } => {
+            format!("Remove {} debugger breakpoint(s)", breakpoints.len()).into()
+        }
+        DebuggerToolInput::Control(input) => format!("Debugger {}", input.action.label()).into(),
+        DebuggerToolInput::ListAdapters => "List debug adapters".into(),
+        DebuggerToolInput::StartSession(input) => format!(
+            "Start debug session {}",
+            MarkdownInlineCode(&input.scenario.label)
+        )
+        .into(),
+        DebuggerToolInput::StopSession { session_id } => {
+            format!("Stop debug session {session_id}").into()
+        }
+    }
+}
+
+fn limits_from_input(input: Option<SnapshotLimitsInput>) -> AgentDebuggerSnapshotLimits {
+    let mut limits = AgentDebuggerSnapshotLimits::default();
+    if let Some(input) = input {
+        if let Some(value) = input.max_frames {
+            limits.max_frames = value;
+        }
+        if let Some(value) = input.max_variables_per_scope {
+            limits.max_variables_per_scope = value;
+        }
+        if let Some(value) = input.max_variable_value_length {
+            limits.max_variable_value_length = value;
+        }
+        if let Some(value) = input.max_output_events {
+            limits.max_output_events = value;
+        }
+        if let Some(value) = input.max_output_bytes {
+            limits.max_output_bytes = value;
+        }
+        if let Some(value) = input.max_source_context_lines {
+            limits.max_source_context_lines = value;
+        }
+    }
+    limits
+}
+
+fn thread_picker_limits() -> AgentDebuggerSnapshotLimits {
+    AgentDebuggerSnapshotLimits {
+        max_frames: 0,
+        max_variables_per_scope: 0,
+        max_variable_value_length: 0,
+        max_output_events: 0,
+        max_output_bytes: 0,
+        max_source_context_lines: 0,
+    }
+}
+
+fn resolve_breakpoint_input(
+    project: &Entity<Project>,
+    mut breakpoint: BreakpointInput,
+    cx: &gpui::AsyncApp,
+) -> Result<BreakpointInput> {
+    breakpoint.path = resolve_debugger_path(project, breakpoint.path, cx)?;
+    Ok(breakpoint)
+}
+
+fn resolve_breakpoint_location(
+    project: &Entity<Project>,
+    mut breakpoint: BreakpointLocationInput,
+    cx: &gpui::AsyncApp,
+) -> Result<BreakpointLocationInput> {
+    breakpoint.path = resolve_debugger_path(project, breakpoint.path, cx)?;
+    Ok(breakpoint)
+}
+
+fn resolve_debugger_path(
+    project: &Entity<Project>,
+    path: PathBuf,
+    cx: &gpui::AsyncApp,
+) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path);
+    }
+
+    project.read_with(cx, |project, cx| {
+        let project_path = project.find_project_path(&path, cx).ok_or_else(|| {
+            anyhow!(
+                "Could not resolve debugger source path `{}` in this project",
+                path.display()
+            )
+        })?;
+        let worktree = project
+            .worktree_for_id(project_path.worktree_id, cx)
+            .with_context(|| format!("Could not find worktree for `{}`", path.display()))?;
+        Ok(worktree.read(cx).absolutize(&project_path.path))
+    })
+}
+
+fn resolve_session_id(
+    project: &Entity<Project>,
+    api: &AgentDebuggerApi,
+    session_id: Option<u64>,
+    cx: &App,
+) -> Result<SessionId> {
+    if let Some(session_id) = session_id {
+        return Ok(SessionId::from_proto(session_id));
+    }
+    if let Some((session, _)) = project.read(cx).active_debug_session(cx) {
+        return Ok(session.read(cx).session_id());
+    }
+    api.list_sessions(cx)
+        .first()
+        .map(|session| session.session_id)
+        .ok_or_else(|| anyhow!("No active debug sessions. Start a debug session first."))
+}
+
+async fn choose_thread_for_action(
+    api: &AgentDebuggerApi,
+    session_id: SessionId,
+    action: ControlAction,
+    cx: &mut gpui::AsyncApp,
+) -> Result<project::debugger::session::ThreadId> {
+    let snapshot_task = cx.update(|cx| api.snapshot(session_id, thread_picker_limits(), cx));
+    let snapshot = snapshot_task.await?;
+    let preferred_status = match action {
+        ControlAction::Pause => AgentDebuggerThreadStatus::Running,
+        ControlAction::Continue
+        | ControlAction::StepOver
+        | ControlAction::StepIn
+        | ControlAction::StepOut
+        | ControlAction::RunToLine => AgentDebuggerThreadStatus::Stopped,
+    };
+    if let Some(thread) = snapshot
+        .threads
+        .iter()
+        .find(|thread| thread.status == preferred_status)
+    {
+        return Ok(thread.thread_id);
+    }
+
+    if action == ControlAction::Pause {
+        return snapshot
+            .threads
+            .first()
+            .map(|thread| thread.thread_id)
+            .ok_or_else(|| anyhow!("No debugger threads available in session {:?}", session_id));
+    }
+
+    Err(anyhow!(
+        "No stopped debugger thread is available in session {:?}; inspect a snapshot or pause the session first",
+        session_id
+    ))
+}
+
+fn sessions_to_json(sessions: Vec<AgentDebuggerSession>) -> Value {
+    Value::Array(sessions.into_iter().map(session_to_json).collect())
+}
+
+fn session_to_json(session: AgentDebuggerSession) -> Value {
+    json!({
+        "session_id": session.session_id.0,
+        "parent_session_id": session.parent_session_id.map(|id| id.0),
+        "child_session_ids": session.child_session_ids.into_iter().map(|id| id.0).collect::<Vec<_>>(),
+        "label": session.label,
+        "adapter": session.adapter,
+        "status": format!("{:?}", session.status).to_lowercase(),
+        "is_attached": session.is_attached,
+        "has_ever_stopped": session.has_ever_stopped,
+    })
+}
+
+fn breakpoints_to_json(breakpoints: Vec<AgentSourceBreakpoint>) -> Value {
+    Value::Array(
+        breakpoints
+            .into_iter()
+            .map(|breakpoint| {
+                json!({
+                    "path": breakpoint.path,
+                    "line": breakpoint.line,
+                    "enabled": breakpoint.enabled,
+                    "condition": breakpoint.condition,
+                    "hit_condition": breakpoint.hit_condition,
+                    "log_message": breakpoint.log_message,
+                })
+            })
+            .collect(),
+    )
+}
+
+fn breakpoint_edit_result_to_json(result: AgentBreakpointEditResult) -> Value {
+    json!({
+        "path": result.path,
+        "line": result.line,
+        "changed": result.changed,
+    })
+}
+
+fn control_result_to_json(result: AgentDebuggerControlResult) -> Value {
+    json!({
+        "status": format!("{:?}", result.status).to_lowercase(),
+        "stopped_thread_id": result.stopped_thread_id.map(|thread_id| thread_id.0),
+    })
+}
+
+fn snapshot_to_json(snapshot: AgentDebuggerSnapshot) -> Value {
+    json!({
+        "session": session_to_json(snapshot.session),
+        "threads": snapshot.threads.into_iter().map(thread_to_json).collect::<Vec<_>>(),
+        "output": snapshot.output.into_iter().map(output_to_json).collect::<Vec<_>>(),
+        "notes": snapshot.notes,
+    })
+}
+
+fn thread_to_json(thread: AgentDebuggerThread) -> Value {
+    json!({
+        "thread_id": thread.thread_id.0,
+        "name": thread.name,
+        "status": format!("{:?}", thread.status).to_lowercase(),
+        "frames": thread.frames.into_iter().map(frame_to_json).collect::<Vec<_>>(),
+    })
+}
+
+fn frame_to_json(frame: AgentDebuggerStackFrame) -> Value {
+    json!({
+        "frame_id": frame.frame_id,
+        "name": frame.name,
+        "source_path": frame.source_path,
+        "line": frame.line,
+        "column": frame.column,
+        "scopes": frame.scopes.into_iter().map(scope_to_json).collect::<Vec<_>>(),
+        "source_context": frame.source_context.map(source_context_to_json),
+    })
+}
+
+fn scope_to_json(scope: AgentDebuggerScope) -> Value {
+    json!({
+        "name": scope.name,
+        "expensive": scope.expensive,
+        "variables_reference": scope.variables_reference,
+        "variables_truncated": scope.variables_truncated,
+        "variables": scope.variables.into_iter().map(variable_to_json).collect::<Vec<_>>(),
+    })
+}
+
+fn variable_to_json(variable: AgentDebuggerVariable) -> Value {
+    json!({
+        "name": variable.name,
+        "value": variable.value,
+        "type": variable.type_name,
+        "variables_reference": variable.variables_reference,
+        "named_variables": variable.named_variables,
+        "indexed_variables": variable.indexed_variables,
+        "value_truncated": variable.value_truncated,
+    })
+}
+
+fn source_context_to_json(context: AgentSourceContext) -> Value {
+    json!({
+        "start_line": context.start_line,
+        "truncated_before": context.truncated_before,
+        "truncated_after": context.truncated_after,
+        "lines": context.lines.into_iter().map(|line| {
+            json!({
+                "line": line.line,
+                "text": line.text,
+            })
+        }).collect::<Vec<_>>(),
+    })
+}
+
+fn output_to_json(output: AgentDebuggerOutputEvent) -> Value {
+    json!({
+        "category": output.category,
+        "output": output.output,
+        "output_truncated": output.output_truncated,
+        "source_path": output.source_path,
+        "line": output.line,
+        "column": output.column,
+    })
+}

--- a/crates/agent/src/tools/debugger_tool.rs
+++ b/crates/agent/src/tools/debugger_tool.rs
@@ -694,12 +694,50 @@ fn initial_title_for_input(input: &DebuggerToolInput) -> SharedString {
             .unwrap_or_else(|| "Inspect debugger".into()),
         DebuggerToolInput::ListBreakpoints => "List debugger breakpoints".into(),
         DebuggerToolInput::SetBreakpoints { breakpoints } => {
-            format!("Set {} debugger breakpoint(s)", breakpoints.len()).into()
+            if breakpoints.len() == 1 {
+                let breakpoint = &breakpoints[0];
+                format!(
+                    "Set debugger breakpoint at {}:{}",
+                    MarkdownInlineCode(&breakpoint.path.to_string_lossy()),
+                    breakpoint.line
+                )
+                .into()
+            } else {
+                format!("Set {} debugger breakpoints", breakpoints.len()).into()
+            }
         }
         DebuggerToolInput::RemoveBreakpoints { breakpoints } => {
-            format!("Remove {} debugger breakpoint(s)", breakpoints.len()).into()
+            if breakpoints.len() == 1 {
+                let breakpoint = &breakpoints[0];
+                format!(
+                    "Remove debugger breakpoint at {}:{}",
+                    MarkdownInlineCode(&breakpoint.path.to_string_lossy()),
+                    breakpoint.line
+                )
+                .into()
+            } else {
+                format!("Remove {} debugger breakpoints", breakpoints.len()).into()
+            }
         }
-        DebuggerToolInput::Control(input) => format!("Debugger {}", input.action.label()).into(),
+        DebuggerToolInput::Control(input) => match input.action {
+            ControlAction::RunToLine => format!(
+                "Debugger run to line at {}:{}",
+                MarkdownInlineCode(
+                    &input
+                        .path
+                        .as_deref()
+                        .map(std::path::Path::to_string_lossy)
+                        .unwrap_or_default()
+                ),
+                input.line.unwrap_or_default()
+            )
+            .into(),
+            ControlAction::Continue
+            | ControlAction::Pause
+            | ControlAction::StepOver
+            | ControlAction::StepIn
+            | ControlAction::StepOut => format!("Debugger {}", input.action.label()).into(),
+        },
         DebuggerToolInput::ListAdapters => "List debug adapters".into(),
         DebuggerToolInput::StartSession(input) => format!(
             "Start debug session {}",
@@ -831,18 +869,39 @@ async fn choose_thread_for_action(
         return Ok(thread.thread_id);
     }
 
-    if action == ControlAction::Pause {
-        return snapshot
-            .threads
-            .first()
-            .map(|thread| thread.thread_id)
-            .ok_or_else(|| anyhow!("No debugger threads available in session {:?}", session_id));
+    let has_threads = !snapshot.threads.is_empty();
+    match action {
+        ControlAction::Pause => {
+            if has_threads {
+                // Pause works on a running thread; if none is running, fall back
+                // to the first thread (some adapters pause by id regardless).
+                Ok(snapshot.threads[0].thread_id)
+            } else {
+                Err(anyhow!(
+                    "No debugger threads available in session {:?}. The session must be running before it can be paused.",
+                    session_id
+                ))
+            }
+        }
+        ControlAction::Continue
+        | ControlAction::StepOver
+        | ControlAction::StepIn
+        | ControlAction::StepOut
+        | ControlAction::RunToLine => {
+            if has_threads {
+                Err(anyhow!(
+                    "No stopped debugger thread is available in session {:?}. The debugger must be paused at a breakpoint before it can be {}; pause the session or wait for a breakpoint to hit.",
+                    session_id,
+                    action.label()
+                ))
+            } else {
+                Err(anyhow!(
+                    "No debugger threads available in session {:?}. Inspect a snapshot to confirm the session is still running.",
+                    session_id
+                ))
+            }
+        }
     }
-
-    Err(anyhow!(
-        "No stopped debugger thread is available in session {:?}; inspect a snapshot or pause the session first",
-        session_id
-    ))
 }
 
 fn sessions_to_json(sessions: Vec<AgentDebuggerSession>) -> Value {

--- a/crates/agent/src/tools/debugger_tool.rs
+++ b/crates/agent/src/tools/debugger_tool.rs
@@ -720,18 +720,15 @@ fn initial_title_for_input(input: &DebuggerToolInput) -> SharedString {
             }
         }
         DebuggerToolInput::Control(input) => match input.action {
-            ControlAction::RunToLine => format!(
-                "Debugger run to line at {}:{}",
-                MarkdownInlineCode(
-                    &input
-                        .path
-                        .as_deref()
-                        .map(std::path::Path::to_string_lossy)
-                        .unwrap_or_default()
-                ),
-                input.line.unwrap_or_default()
-            )
-            .into(),
+            ControlAction::RunToLine => match (input.path.as_deref(), input.line) {
+                (Some(path), Some(line)) => format!(
+                    "Debugger run to line at {}:{}",
+                    MarkdownInlineCode(&path.to_string_lossy()),
+                    line
+                )
+                .into(),
+                _ => "Debugger run to line".into(),
+            },
             ControlAction::Continue
             | ControlAction::Pause
             | ControlAction::StepOver
@@ -873,8 +870,8 @@ async fn choose_thread_for_action(
     match action {
         ControlAction::Pause => {
             if has_threads {
-                // Pause works on a running thread; if none is running, fall back
-                // to the first thread (some adapters pause by id regardless).
+                // Some adapters accept a pause-by-thread-id even when no thread
+                // is currently running, so fall back to the first thread.
                 Ok(snapshot.threads[0].thread_id)
             } else {
                 Err(anyhow!(
@@ -890,9 +887,8 @@ async fn choose_thread_for_action(
         | ControlAction::RunToLine => {
             if has_threads {
                 Err(anyhow!(
-                    "No stopped debugger thread is available in session {:?}. The debugger must be paused at a breakpoint before it can be {}; pause the session or wait for a breakpoint to hit.",
-                    session_id,
-                    action.label()
+                    "No stopped debugger thread is available in session {:?}. The debugger must be paused at a breakpoint before this action can run; pause the session or wait for a breakpoint to hit.",
+                    session_id
                 ))
             } else {
                 Err(anyhow!(

--- a/crates/agent/src/tools/debugger_tool.rs
+++ b/crates/agent/src/tools/debugger_tool.rs
@@ -1,4 +1,4 @@
-use agent_client_protocol::schema as acp;
+use agent_client_protocol::schema::v1 as acp;
 use anyhow::{Context as _, Result, anyhow};
 use dap::{DapRegistry, client::SessionId};
 use gpui::{App, Entity, SharedString, Task, WeakEntity};
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{path::PathBuf, rc::Rc, sync::Arc, time::Duration};
 use task::{DebugScenario, SharedTaskContext};
-use util::markdown::MarkdownInlineCode;
+use util::{markdown::MarkdownInlineCode, paths::normalize_lexically};
 
 use crate::{
     AgentTool, DebugSessionRequest, Thread, ThreadEnvironment, ToolCallEventStream, ToolInput,
@@ -18,6 +18,13 @@ use crate::{
 };
 
 const DEFAULT_CONTROL_TIMEOUT_MS: u64 = 30_000;
+const MAX_CONTROL_TIMEOUT_MS: u64 = 300_000;
+const MAX_SNAPSHOT_FRAMES: usize = 200;
+const MAX_SNAPSHOT_VARIABLES_PER_SCOPE: usize = 500;
+const MAX_SNAPSHOT_VARIABLE_VALUE_LENGTH: usize = 16 * 1024;
+const MAX_SNAPSHOT_OUTPUT_EVENTS: usize = 1_000;
+const MAX_SNAPSHOT_OUTPUT_BYTES: usize = 1024 * 1024;
+const MAX_SNAPSHOT_SOURCE_CONTEXT_LINES: usize = 200;
 
 /// Interact with Zed's debugger. Read-only operations such as `snapshot`,
 /// `list_sessions`, `list_breakpoints`, and `list_adapters` are available in
@@ -79,22 +86,22 @@ pub struct SnapshotInput {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct SnapshotLimitsInput {
-    /// Maximum total stack frames across all stopped threads. Defaults to 20.
+    /// Maximum total stack frames across all stopped threads. Defaults to 20; maximum 200.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_frames: Option<usize>,
-    /// Maximum variables per scope. Defaults to 50.
+    /// Maximum variables per scope. Defaults to 50; maximum 500.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_variables_per_scope: Option<usize>,
-    /// Maximum bytes per variable value. Defaults to 1024.
+    /// Maximum bytes per variable value. Defaults to 1024; maximum 16384.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_variable_value_length: Option<usize>,
-    /// Maximum recent output events. Defaults to 100.
+    /// Maximum recent output events. Defaults to 100; maximum 1000.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_output_events: Option<usize>,
-    /// Maximum recent output bytes. Defaults to 16384.
+    /// Maximum recent output bytes. Defaults to 16384; maximum 1048576.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_output_bytes: Option<usize>,
-    /// Maximum source context lines around each frame. Defaults to 5.
+    /// Maximum source context lines around each frame. Defaults to 5; maximum 200.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_source_context_lines: Option<usize>,
 }
@@ -146,7 +153,7 @@ pub struct ControlInput {
     /// 1-based line for `run_to_line`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub line: Option<u32>,
-    /// Maximum time to wait for the debugger to stop. Defaults to 30000ms.
+    /// Maximum time to wait for the debugger to stop. Defaults to 30000ms; maximum 300000ms.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
     /// Optional bounds for the snapshot returned after control completes.
@@ -311,10 +318,11 @@ impl DebuggerTool {
                 Ok(success(operation, "listed debug sessions", data))
             }
             DebuggerToolInput::Snapshot(input) => {
-                let (api, session_id, limits) = cx.update(|cx| {
+                let limits = limits_from_input(input.limits)?;
+                let (api, session_id) = cx.update(|cx| {
                     let api = self.api(cx);
                     let session_id = resolve_session_id(&self.project, &api, input.session_id, cx)?;
-                    anyhow::Ok((api, session_id, limits_from_input(input.limits)))
+                    anyhow::Ok((api, session_id))
                 })?;
                 let snapshot_task = cx.update(|cx| api.snapshot(session_id, limits, cx));
                 let snapshot = snapshot_task.await?;
@@ -335,15 +343,14 @@ impl DebuggerTool {
             }
             DebuggerToolInput::SetBreakpoints { breakpoints } => {
                 self.ensure_write_mode(&operation, cx)?;
+                let breakpoints = breakpoints
+                    .into_iter()
+                    .map(|breakpoint| resolve_breakpoint_input(&self.project, breakpoint, cx))
+                    .collect::<Result<Vec<_>>>()?;
                 authorize_debugger_operation(
                     &event_stream,
                     "Set debugger breakpoint(s)",
-                    permission_inputs(
-                        &operation,
-                        breakpoints.iter().map(|breakpoint| {
-                            format!("{}:{}", breakpoint.path.display(), breakpoint.line)
-                        }),
-                    ),
+                    breakpoint_permission_inputs(&operation, breakpoints.iter())?,
                     cx,
                 )
                 .await?;
@@ -351,7 +358,6 @@ impl DebuggerTool {
                 let api = cx.update(|cx| self.api(cx));
                 let mut results = Vec::new();
                 for breakpoint in breakpoints {
-                    let breakpoint = resolve_breakpoint_input(&self.project, breakpoint, cx)?;
                     let task = cx
                         .update(|cx| api.set_source_breakpoint(breakpoint.into_agent_input(), cx));
                     let result = task.await?;
@@ -365,15 +371,14 @@ impl DebuggerTool {
             }
             DebuggerToolInput::RemoveBreakpoints { breakpoints } => {
                 self.ensure_write_mode(&operation, cx)?;
+                let breakpoints = breakpoints
+                    .into_iter()
+                    .map(|breakpoint| resolve_breakpoint_location(&self.project, breakpoint, cx))
+                    .collect::<Result<Vec<_>>>()?;
                 authorize_debugger_operation(
                     &event_stream,
                     "Remove debugger breakpoint(s)",
-                    permission_inputs(
-                        &operation,
-                        breakpoints.iter().map(|breakpoint| {
-                            format!("{}:{}", breakpoint.path.display(), breakpoint.line)
-                        }),
-                    ),
+                    breakpoint_location_permission_inputs(&operation, breakpoints.iter()),
                     cx,
                 )
                 .await?;
@@ -381,7 +386,6 @@ impl DebuggerTool {
                 let api = cx.update(|cx| self.api(cx));
                 let mut results = Vec::new();
                 for breakpoint in breakpoints {
-                    let breakpoint = resolve_breakpoint_location(&self.project, breakpoint, cx)?;
                     let task = cx.update(|cx| {
                         api.remove_source_breakpoint(breakpoint.path, breakpoint.line, cx)
                     });
@@ -396,28 +400,21 @@ impl DebuggerTool {
             }
             DebuggerToolInput::Control(input) => {
                 self.ensure_write_mode(&operation, cx)?;
-                let action = input.action;
+                validate_control_timeout(input.timeout_ms)?;
+                let snapshot_limits = limits_from_input(input.snapshot_limits.clone())?;
+                let resolved_input = self.resolve_control_input(input, cx).await?;
+                let action = resolved_input.action;
                 authorize_debugger_operation(
                     &event_stream,
                     format!("Debugger {}", action.label()),
-                    permission_inputs(
-                        &operation,
-                        [format!(
-                            "{} session:{:?} thread:{:?}",
-                            action.permission_name(),
-                            input.session_id,
-                            input.thread_id
-                        )],
-                    ),
+                    permission_inputs(&operation, [control_permission_input(&resolved_input)]),
                     cx,
                 )
                 .await?;
 
-                let snapshot_limits = input.snapshot_limits.clone();
-                let (session_id, control_result) = self.run_control(input, cx).await?;
+                let (session_id, control_result) = self.run_control(resolved_input, cx).await?;
                 let api = cx.update(|cx| self.api(cx));
-                let limits = limits_from_input(snapshot_limits);
-                let snapshot_task = cx.update(|cx| api.snapshot(session_id, limits, cx));
+                let snapshot_task = cx.update(|cx| api.snapshot(session_id, snapshot_limits, cx));
                 let snapshot = snapshot_task.await?;
                 Ok(success(
                     operation,
@@ -436,13 +433,7 @@ impl DebuggerTool {
                         "Start debug session {}",
                         MarkdownInlineCode(&input.scenario.label)
                     ),
-                    permission_inputs(
-                        &operation,
-                        [format!(
-                            "start_session adapter:{} label:{}",
-                            input.scenario.adapter, input.scenario.label
-                        )],
-                    ),
+                    start_session_permission_inputs(&operation, &input)?,
                     cx,
                 )
                 .await?;
@@ -454,8 +445,8 @@ impl DebuggerTool {
                     };
                     let approve = cx.update(|cx| {
                         event_stream.authorize_sandbox(
-                            "Start debug session outside the agent terminal sandbox",
                             request,
+                            "Start debug session outside the agent terminal sandbox".to_string(),
                             cx,
                         )
                     });
@@ -484,7 +475,10 @@ impl DebuggerTool {
                 authorize_debugger_operation(
                     &event_stream,
                     format!("Stop debug session {session_id}"),
-                    permission_inputs(&operation, [format!("stop_session session:{session_id}")]),
+                    permission_inputs(
+                        &operation,
+                        [format!("stop_session session_id:{session_id}")],
+                    ),
                     cx,
                 )
                 .await?;
@@ -514,12 +508,22 @@ impl DebuggerTool {
         Ok(())
     }
 
-    async fn run_control(
+    async fn resolve_control_input(
         &self,
-        input: ControlInput,
+        mut input: ControlInput,
         cx: &mut gpui::AsyncApp,
-    ) -> Result<(SessionId, AgentDebuggerControlResult)> {
-        let timeout = Duration::from_millis(input.timeout_ms.unwrap_or(DEFAULT_CONTROL_TIMEOUT_MS));
+    ) -> Result<ResolvedControlInput> {
+        if input.action == ControlAction::RunToLine {
+            let path = input
+                .path
+                .take()
+                .context("path is required for debugger control run_to_line")?;
+            input.path = Some(resolve_debugger_path(&self.project, path, cx)?);
+            input
+                .line
+                .context("line is required for debugger control run_to_line")?;
+        }
+
         let (api, session_id, thread_id) = cx.update(|cx| {
             let api = self.api(cx);
             let session_id = resolve_session_id(&self.project, &api, input.session_id, cx)?;
@@ -530,6 +534,26 @@ impl DebuggerTool {
             Some(thread_id) => thread_id,
             None => choose_thread_for_action(&api, session_id, input.action, cx).await?,
         };
+
+        Ok(ResolvedControlInput {
+            session_id,
+            thread_id,
+            action: input.action,
+            path: input.path,
+            line: input.line,
+            timeout_ms: input.timeout_ms,
+        })
+    }
+
+    async fn run_control(
+        &self,
+        input: ResolvedControlInput,
+        cx: &mut gpui::AsyncApp,
+    ) -> Result<(SessionId, AgentDebuggerControlResult)> {
+        let timeout = Duration::from_millis(control_timeout_ms(input.timeout_ms)?);
+        let session_id = input.session_id;
+        let thread_id = input.thread_id;
+        let api = cx.update(|cx| self.api(cx));
 
         match input.action {
             ControlAction::Continue => {
@@ -580,7 +604,6 @@ impl DebuggerTool {
                 let path = input
                     .path
                     .context("path is required for debugger control run_to_line")?;
-                let path = resolve_debugger_path(&self.project, path, cx)?;
                 let line = input
                     .line
                     .context("line is required for debugger control run_to_line")?;
@@ -604,6 +627,15 @@ impl BreakpointInput {
             log_message: self.log_message,
         }
     }
+}
+
+struct ResolvedControlInput {
+    session_id: SessionId,
+    thread_id: project::debugger::session::ThreadId,
+    action: ControlAction,
+    path: Option<PathBuf>,
+    line: Option<u32>,
+    timeout_ms: Option<u64>,
 }
 
 impl ControlAction {
@@ -669,6 +701,153 @@ fn permission_inputs(operation: &str, values: impl IntoIterator<Item = String>) 
         }
     }
     inputs
+}
+
+fn breakpoint_permission_inputs<'a>(
+    operation: &str,
+    breakpoints: impl IntoIterator<Item = &'a BreakpointInput>,
+) -> Result<Vec<String>> {
+    let inputs = breakpoints
+        .into_iter()
+        .map(|breakpoint| {
+            let condition =
+                permission_value_to_string(&breakpoint.condition, "breakpoint condition")?;
+            let hit_condition =
+                permission_value_to_string(&breakpoint.hit_condition, "breakpoint hit condition")?;
+            let log_message =
+                permission_value_to_string(&breakpoint.log_message, "breakpoint log message")?;
+            anyhow::Ok(format!(
+                "path:{} line:{} enabled:{} condition:{} hit_condition:{} log_message:{}",
+                breakpoint.path.display(),
+                breakpoint.line,
+                breakpoint.enabled,
+                condition,
+                hit_condition,
+                log_message
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(permission_inputs(operation, inputs))
+}
+
+fn breakpoint_location_permission_inputs<'a>(
+    operation: &str,
+    breakpoints: impl IntoIterator<Item = &'a BreakpointLocationInput>,
+) -> Vec<String> {
+    permission_inputs(
+        operation,
+        breakpoints.into_iter().map(|breakpoint| {
+            format!(
+                "path:{} line:{}",
+                breakpoint.path.display(),
+                breakpoint.line
+            )
+        }),
+    )
+}
+
+fn control_permission_input(input: &ResolvedControlInput) -> String {
+    let mut value = format!(
+        "action:{} session_id:{} thread_id:{}",
+        input.action.permission_name(),
+        input.session_id.0,
+        input.thread_id.0
+    );
+
+    if input.action == ControlAction::RunToLine {
+        let path = input
+            .path
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "missing".to_string());
+        let line = input
+            .line
+            .map(|line| line.to_string())
+            .unwrap_or_else(|| "missing".to_string());
+        value.push_str(&format!(" path:{path} line:{line}"));
+    }
+
+    value
+}
+
+#[cfg(test)]
+pub fn control_permission_inputs_for_test(
+    operation: &str,
+    input: ControlInput,
+    resolved_session_id: u64,
+    resolved_thread_id: i64,
+) -> Vec<String> {
+    permission_inputs(
+        operation,
+        [control_permission_input(&ResolvedControlInput {
+            session_id: SessionId::from_proto(resolved_session_id),
+            thread_id: project::debugger::session::ThreadId(resolved_thread_id),
+            action: input.action,
+            path: input.path,
+            line: input.line,
+            timeout_ms: input.timeout_ms,
+        })],
+    )
+}
+
+fn start_session_permission_inputs(
+    operation: &str,
+    input: &StartSessionInput,
+) -> Result<Vec<String>> {
+    let scenario = &input.scenario;
+    let worktree_id = input
+        .worktree_id
+        .map(|worktree_id| worktree_id.to_string())
+        .unwrap_or_else(|| "none".to_string());
+    let build_task = scenario
+        .build
+        .as_ref()
+        .map(|build| permission_value_to_string(build, "start_session build"))
+        .transpose()?
+        .unwrap_or_else(|| "null".to_string());
+    let tcp_connection = scenario
+        .tcp_connection
+        .as_ref()
+        .map(|tcp_connection| {
+            permission_value_to_string(tcp_connection, "start_session tcp_connection")
+        })
+        .transpose()?
+        .unwrap_or_else(|| "null".to_string());
+    let config = permission_value_to_string(&scenario.config, "start_session config")?;
+
+    Ok(permission_inputs(
+        operation,
+        [format!(
+            "adapter:{} label:{} worktree_id:{} build_task:{} tcp_connection:{} config:{}",
+            scenario.adapter, scenario.label, worktree_id, build_task, tcp_connection, config
+        )],
+    ))
+}
+
+fn permission_value_to_string(value: &impl Serialize, value_name: &str) -> Result<String> {
+    let value = serde_json::to_value(value).with_context(|| {
+        format!("Failed to serialize debugger {value_name} for permission matching")
+    })?;
+    serde_json::to_string(&sort_json_value(value)).with_context(|| {
+        format!("Failed to serialize debugger {value_name} JSON for permission matching")
+    })
+}
+
+fn sort_json_value(value: Value) -> Value {
+    match value {
+        Value::Array(values) => Value::Array(values.into_iter().map(sort_json_value).collect()),
+        Value::Object(object) => {
+            let mut entries = object.into_iter().collect::<Vec<_>>();
+            entries.sort_by(|(left_key, _), (right_key, _)| left_key.cmp(right_key));
+
+            let mut sorted = serde_json::Map::new();
+            for (key, value) in entries {
+                sorted.insert(key, sort_json_value(value));
+            }
+            Value::Object(sorted)
+        }
+        value => value,
+    }
 }
 
 fn operation_name(input: &DebuggerToolInput) -> &'static str {
@@ -747,29 +926,66 @@ fn initial_title_for_input(input: &DebuggerToolInput) -> SharedString {
     }
 }
 
-fn limits_from_input(input: Option<SnapshotLimitsInput>) -> AgentDebuggerSnapshotLimits {
+fn limits_from_input(input: Option<SnapshotLimitsInput>) -> Result<AgentDebuggerSnapshotLimits> {
     let mut limits = AgentDebuggerSnapshotLimits::default();
     if let Some(input) = input {
         if let Some(value) = input.max_frames {
-            limits.max_frames = value;
+            limits.max_frames = validate_snapshot_limit("max_frames", value, MAX_SNAPSHOT_FRAMES)?;
         }
         if let Some(value) = input.max_variables_per_scope {
-            limits.max_variables_per_scope = value;
+            limits.max_variables_per_scope = validate_snapshot_limit(
+                "max_variables_per_scope",
+                value,
+                MAX_SNAPSHOT_VARIABLES_PER_SCOPE,
+            )?;
         }
         if let Some(value) = input.max_variable_value_length {
-            limits.max_variable_value_length = value;
+            limits.max_variable_value_length = validate_snapshot_limit(
+                "max_variable_value_length",
+                value,
+                MAX_SNAPSHOT_VARIABLE_VALUE_LENGTH,
+            )?;
         }
         if let Some(value) = input.max_output_events {
-            limits.max_output_events = value;
+            limits.max_output_events =
+                validate_snapshot_limit("max_output_events", value, MAX_SNAPSHOT_OUTPUT_EVENTS)?;
         }
         if let Some(value) = input.max_output_bytes {
-            limits.max_output_bytes = value;
+            limits.max_output_bytes =
+                validate_snapshot_limit("max_output_bytes", value, MAX_SNAPSHOT_OUTPUT_BYTES)?;
         }
         if let Some(value) = input.max_source_context_lines {
-            limits.max_source_context_lines = value;
+            limits.max_source_context_lines = validate_snapshot_limit(
+                "max_source_context_lines",
+                value,
+                MAX_SNAPSHOT_SOURCE_CONTEXT_LINES,
+            )?;
         }
     }
-    limits
+    Ok(limits)
+}
+
+fn validate_snapshot_limit(field_name: &str, value: usize, maximum: usize) -> Result<usize> {
+    if value > maximum {
+        anyhow::bail!(
+            "debugger snapshot limit `{field_name}` must be at most {maximum}, got {value}"
+        );
+    }
+    Ok(value)
+}
+
+fn validate_control_timeout(timeout_ms: Option<u64>) -> Result<()> {
+    control_timeout_ms(timeout_ms).map(|_| ())
+}
+
+fn control_timeout_ms(timeout_ms: Option<u64>) -> Result<u64> {
+    let timeout_ms = timeout_ms.unwrap_or(DEFAULT_CONTROL_TIMEOUT_MS);
+    if timeout_ms > MAX_CONTROL_TIMEOUT_MS {
+        anyhow::bail!(
+            "debugger control `timeout_ms` must be at most {MAX_CONTROL_TIMEOUT_MS}, got {timeout_ms}"
+        );
+    }
+    Ok(timeout_ms)
 }
 
 fn thread_picker_limits() -> AgentDebuggerSnapshotLimits {
@@ -807,7 +1023,7 @@ fn resolve_debugger_path(
     cx: &gpui::AsyncApp,
 ) -> Result<PathBuf> {
     if path.is_absolute() {
-        return Ok(path);
+        return normalize_debugger_path(path);
     }
 
     project.read_with(cx, |project, cx| {
@@ -820,7 +1036,16 @@ fn resolve_debugger_path(
         let worktree = project
             .worktree_for_id(project_path.worktree_id, cx)
             .with_context(|| format!("Could not find worktree for `{}`", path.display()))?;
-        Ok(worktree.read(cx).absolutize(&project_path.path))
+        normalize_debugger_path(worktree.read(cx).absolutize(&project_path.path))
+    })
+}
+
+fn normalize_debugger_path(path: PathBuf) -> Result<PathBuf> {
+    normalize_lexically(&path).with_context(|| {
+        format!(
+            "Could not normalize debugger source path `{}`",
+            path.display()
+        )
     })
 }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -4665,15 +4665,15 @@ impl AgentPanel {
                 } else {
                     cx.emit(AgentPanelEvent::EntryChanged);
                 }
-                this.ensure_sibling_host_installed(&server_view, window, cx);
+                this.ensure_native_agent_hosts_installed(&server_view, window, cx);
                 cx.notify();
             },
         )
         .detach();
 
-        // Try installing the host eagerly as well, in case the connection is
+        // Try installing the hosts eagerly as well, in case the connection is
         // already established by the time the observe fires.
-        self.ensure_sibling_host_installed(&conversation_view, window, cx);
+        self.ensure_native_agent_hosts_installed(&conversation_view, window, cx);
 
         if let Some(model) = model_override {
             // The native thread is constructed asynchronously after the
@@ -4699,24 +4699,30 @@ impl AgentPanel {
         AgentThread { conversation_view }
     }
 
-    fn ensure_sibling_host_installed(
+    fn ensure_native_agent_hosts_installed(
         &self,
         conversation_view: &Entity<ConversationView>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !cx.has_flag::<CreateThreadToolFeatureFlag>() {
-            return;
-        }
         let Some(native_connection) = conversation_view.read(cx).as_native_connection(cx) else {
             return;
         };
-        let host = Rc::new(AgentPanelSiblingHost::new(
+        let debugger_host = Rc::new(AgentPanelDebuggerHost::new(
             cx.weak_entity(),
             window.window_handle(),
-        )) as Rc<dyn agent::SiblingThreadHost>;
+        )) as Rc<dyn agent::DebuggerHost>;
+        let sibling_thread_host = cx.has_flag::<CreateThreadToolFeatureFlag>().then(|| {
+            Rc::new(AgentPanelSiblingHost::new(
+                cx.weak_entity(),
+                window.window_handle(),
+            )) as Rc<dyn agent::SiblingThreadHost>
+        });
         native_connection.0.update(cx, |native_agent, _cx| {
-            native_agent.set_sibling_thread_host(host);
+            native_agent.set_debugger_host(debugger_host);
+            if let Some(host) = sibling_thread_host {
+                native_agent.set_sibling_thread_host(host);
+            }
         });
     }
 
@@ -4780,6 +4786,58 @@ fn parse_provider_slash_model(input: &str) -> Option<language_model::SelectedMod
         provider: language_model::LanguageModelProviderId::from(provider.to_string()),
         model: language_model::LanguageModelId::from(model.to_string()),
     })
+}
+
+pub(crate) struct AgentPanelDebuggerHost {
+    panel: WeakEntity<AgentPanel>,
+    window: gpui::AnyWindowHandle,
+}
+
+impl AgentPanelDebuggerHost {
+    pub(crate) fn new(panel: WeakEntity<AgentPanel>, window: gpui::AnyWindowHandle) -> Self {
+        Self { panel, window }
+    }
+}
+
+impl agent::DebuggerHost for AgentPanelDebuggerHost {
+    fn start_debug_session(
+        &self,
+        request: agent::DebugSessionRequest,
+        cx: &mut gpui::AsyncApp,
+    ) -> Task<Result<agent::DebugSessionInfo>> {
+        let panel = self.panel.clone();
+        let window = self.window;
+        cx.spawn(async move |cx| {
+            let workspace = panel.read_with(cx, |panel, _cx| panel.workspace.clone())?;
+            let workspace = workspace
+                .upgrade()
+                .ok_or_else(|| anyhow!("Workspace is no longer available"))?;
+            let agent::DebugSessionRequest {
+                scenario,
+                task_context,
+                active_buffer,
+                worktree_id,
+            } = request;
+            let info = window.update(cx, |_root, window, cx| {
+                workspace.update(cx, |workspace, cx| {
+                    workspace.start_debug_session(
+                        scenario,
+                        task_context,
+                        active_buffer,
+                        worktree_id,
+                        window,
+                        cx,
+                    )
+                })
+            })??;
+
+            Ok(agent::DebugSessionInfo {
+                session_id: info.session_id,
+                label: info.label,
+                adapter: info.adapter,
+            })
+        })
+    }
 }
 
 /// Bridges agent-side `SiblingThreadHost` calls to `AgentPanel`. Constructed

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -4854,7 +4854,7 @@ impl agent::DebuggerHost for AgentPanelDebuggerHost {
 
                     let inferred_active_buffer = active_buffer
                         .is_none()
-                        .then_some(active_editor_buffer.clone())
+                        .then_some(active_editor_buffer)
                         .flatten()
                         .filter(|_| active_editor_matches_explicit_worktree);
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -85,7 +85,7 @@ use gpui::{
 use language::LanguageRegistry;
 use language_model::LanguageModelRegistry;
 use notifications::status_toast::StatusToast;
-use project::{Project, ProjectPath, Worktree};
+use project::{Project, ProjectPath, Worktree, WorktreeId};
 use settings::TerminalDockPosition;
 use settings::{NotifyWhenAgentWaiting, Settings, update_settings_file};
 
@@ -4814,10 +4814,119 @@ impl agent::DebuggerHost for AgentPanelDebuggerHost {
                 .ok_or_else(|| anyhow!("Workspace is no longer available"))?;
             let agent::DebugSessionRequest {
                 scenario,
-                task_context,
-                active_buffer,
-                worktree_id,
+                mut task_context,
+                mut active_buffer,
+                mut worktree_id,
             } = request;
+
+            let default_task_context = task::TaskContext::default();
+            let task_context_was_default = *task_context == default_task_context;
+            let explicit_worktree_id = worktree_id;
+            let (
+                active_editor_task_context,
+                inferred_active_buffer,
+                inferred_worktree_id,
+                inferred_worktree_context,
+            ) = window.update(cx, |_root, window, cx| {
+                workspace.update(cx, |workspace, cx| {
+                    let active_editor = workspace
+                        .active_item(cx)
+                        .and_then(|item| item.act_as::<Editor>(cx));
+
+                    let active_editor_buffer = active_editor.as_ref().and_then(|active_editor| {
+                        active_editor.update(cx, |editor, cx| {
+                            let selection = editor.selections.newest_anchor();
+                            let multi_buffer = editor.buffer().clone();
+                            let multi_buffer_snapshot = multi_buffer.read(cx).snapshot(cx);
+                            let (buffer_snapshot, _) =
+                                multi_buffer_snapshot.point_to_buffer_offset(selection.head())?;
+                            multi_buffer.read(cx).buffer(buffer_snapshot.remote_id())
+                        })
+                    });
+                    let active_editor_matches_explicit_worktree = explicit_worktree_id
+                        .map(|worktree_id| {
+                            active_editor_buffer
+                                .as_ref()
+                                .and_then(|buffer| buffer.read(cx).file())
+                                .is_some_and(|file| file.worktree_id(cx) == worktree_id)
+                        })
+                        .unwrap_or(true);
+
+                    let inferred_active_buffer = active_buffer
+                        .is_none()
+                        .then_some(active_editor_buffer.clone())
+                        .flatten()
+                        .filter(|_| active_editor_matches_explicit_worktree);
+
+                    let buffer_for_worktree =
+                        active_buffer.as_ref().or(inferred_active_buffer.as_ref());
+                    let inferred_worktree_id = worktree_id
+                        .is_none()
+                        .then(|| {
+                            buffer_for_worktree
+                                .and_then(|buffer| buffer.read(cx).file())
+                                .map(|file| file.worktree_id(cx))
+                                .or_else(|| {
+                                    workspace
+                                        .visible_worktrees(cx)
+                                        .next()
+                                        .map(|worktree| worktree.read(cx).id())
+                                })
+                        })
+                        .flatten();
+
+                    let context_worktree_id = worktree_id.or(inferred_worktree_id);
+                    let inferred_worktree_context = task_context_was_default
+                        .then(|| {
+                            context_worktree_id.and_then(|worktree_id| {
+                                task_context_for_worktree(workspace, worktree_id, cx)
+                            })
+                        })
+                        .flatten();
+                    let should_use_active_editor_task_context = task_context_was_default
+                        && active_editor_matches_explicit_worktree
+                        && !(explicit_worktree_id.is_some() && inferred_worktree_context.is_some());
+                    let active_editor_task_context = should_use_active_editor_task_context
+                        .then(|| {
+                            active_editor.as_ref().map(|active_editor| {
+                                active_editor
+                                    .update(cx, |editor, cx| editor.task_context(window, cx))
+                            })
+                        })
+                        .flatten();
+
+                    (
+                        active_editor_task_context,
+                        inferred_active_buffer,
+                        inferred_worktree_id,
+                        inferred_worktree_context,
+                    )
+                })
+            })?;
+
+            if active_buffer.is_none() {
+                active_buffer = inferred_active_buffer;
+            }
+            if worktree_id.is_none() {
+                worktree_id = inferred_worktree_id;
+            }
+            if task_context_was_default {
+                let inferred_active_editor_task_context =
+                    if let Some(active_editor_task_context) = active_editor_task_context {
+                        active_editor_task_context.await
+                    } else {
+                        None
+                    };
+                let inferred_task_context = if explicit_worktree_id.is_some() {
+                    inferred_worktree_context.or(inferred_active_editor_task_context)
+                } else {
+                    inferred_active_editor_task_context.or(inferred_worktree_context)
+                };
+                if let Some(inferred_task_context) = inferred_task_context {
+                    task_context = inferred_task_context.into();
+                }
+            }
+
             let info = window.update(cx, |_root, window, cx| {
                 workspace.update(cx, |workspace, cx| {
                     workspace.start_debug_session(
@@ -4838,6 +4947,33 @@ impl agent::DebuggerHost for AgentPanelDebuggerHost {
             })
         })
     }
+}
+
+fn task_context_for_worktree(
+    workspace: &Workspace,
+    worktree_id: WorktreeId,
+    cx: &App,
+) -> Option<task::TaskContext> {
+    let worktree = workspace
+        .project()
+        .read(cx)
+        .worktree_for_id(worktree_id, cx)?;
+    let worktree = worktree.read(cx);
+    if !worktree.is_visible() || !worktree.root_entry().is_some_and(|entry| entry.is_dir()) {
+        return None;
+    }
+
+    let worktree_abs_path = worktree.abs_path().to_path_buf();
+    let mut task_variables = task::TaskVariables::default();
+    task_variables.insert(
+        task::VariableName::WorktreeRoot,
+        worktree_abs_path.to_string_lossy().into_owned(),
+    );
+    Some(task::TaskContext {
+        cwd: Some(worktree_abs_path),
+        task_variables,
+        project_env: HashMap::default(),
+    })
 }
 
 /// Bridges agent-side `SiblingThreadHost` calls to `AgentPanel`. Constructed

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -41,7 +41,7 @@ use util::{ResultExt, debug_panic, maybe};
 use workspace::SplitDirection;
 use workspace::item::SaveOptions;
 use workspace::{
-    Item, Pane, Workspace,
+    DebugSessionStartInfo, Item, Pane, Workspace,
     dock::{DockPosition, Panel, PanelEvent},
 };
 use zed_actions::debug_panel::ToggleFocus;
@@ -183,37 +183,62 @@ impl DebugPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.start_session_result(
+            scenario,
+            task_context,
+            active_buffer,
+            worktree_id,
+            window,
+            cx,
+        )
+        .log_err();
+    }
+
+    pub(crate) fn start_session_result(
+        &mut self,
+        scenario: DebugScenario,
+        task_context: SharedTaskContext,
+        active_buffer: Option<Entity<Buffer>>,
+        worktree_id: Option<WorktreeId>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Result<DebugSessionStartInfo> {
         let dap_store = self.project.read(cx).dap_store();
-        let Some(adapter) = DapRegistry::global(cx).adapter(&scenario.adapter) else {
-            return;
+        let label = scenario.label.clone();
+        let adapter_name = scenario.adapter.clone();
+        let Some(adapter) = DapRegistry::global(cx).adapter(&adapter_name) else {
+            return Err(anyhow!("No debug adapter registered for {adapter_name}"));
         };
         let quirks = SessionQuirks {
             compact: adapter.compact_child_session(),
             prefer_thread_name: adapter.prefer_thread_name(),
         };
+        let worktree = worktree_id.or_else(|| {
+            active_buffer
+                .as_ref()
+                .and_then(|buffer| buffer.read(cx).file())
+                .map(|file| file.worktree_id(cx))
+        });
+
+        let worktree = worktree
+            .and_then(|id| self.project.read(cx).worktree_for_id(id, cx))
+            .or_else(|| self.project.read(cx).visible_worktrees(cx).next())
+            .ok_or_else(|| anyhow!("Could not find a worktree to spawn the debug session in"))?;
+
         let session = dap_store.update(cx, |dap_store, cx| {
             dap_store.new_session(
-                Some(scenario.label.clone()),
-                DebugAdapterName(scenario.adapter.clone()),
+                Some(label.clone()),
+                DebugAdapterName(adapter_name.clone()),
                 task_context.clone(),
                 None,
                 quirks,
                 cx,
             )
         });
-        let worktree = worktree_id.or_else(|| {
-            active_buffer
-                .as_ref()
-                .and_then(|buffer| buffer.read(cx).file())
-                .map(|f| f.worktree_id(cx))
-        });
-
-        let Some(worktree) = worktree
-            .and_then(|id| self.project.read(cx).worktree_for_id(id, cx))
-            .or_else(|| self.project.read(cx).visible_worktrees(cx).next())
-        else {
-            log::debug!("Could not find a worktree to spawn the debug session in");
-            return;
+        let info = DebugSessionStartInfo {
+            session_id: session.read(cx).session_id().to_proto(),
+            label: label.to_string(),
+            adapter: adapter_name.to_string(),
         };
 
         self.debug_scenario_scheduled_last = true;
@@ -300,6 +325,8 @@ impl DebugPanel {
                 debug_panic!("Session state should be in building because we are just starting it");
             }
         });
+
+        Ok(info)
     }
 
     pub(crate) fn rerun_last_session(
@@ -1967,11 +1994,9 @@ impl workspace::DebuggerProvider for DebuggerProvider {
         worktree_id: Option<WorktreeId>,
         window: &mut Window,
         cx: &mut App,
-    ) {
-        self.0.update(cx, |_, cx| {
-            cx.defer_in(window, move |this, window, cx| {
-                this.start_session(definition, context, buffer, worktree_id, window, cx);
-            })
+    ) -> Result<DebugSessionStartInfo> {
+        self.0.update(cx, |debug_panel, cx| {
+            debug_panel.start_session_result(definition, context, buffer, worktree_id, window, cx)
         })
     }
 

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -213,17 +213,22 @@ impl DebugPanel {
             compact: adapter.compact_child_session(),
             prefer_thread_name: adapter.prefer_thread_name(),
         };
-        let worktree = worktree_id.or_else(|| {
-            active_buffer
+        let project = self.project.read(cx);
+        let worktree = if let Some(worktree_id) = worktree_id {
+            project.worktree_for_id(worktree_id, cx).ok_or_else(|| {
+                anyhow!("Could not find worktree {worktree_id} to spawn the debug session in")
+            })?
+        } else {
+            let worktree_id = active_buffer
                 .as_ref()
                 .and_then(|buffer| buffer.read(cx).file())
-                .map(|file| file.worktree_id(cx))
-        });
+                .map(|file| file.worktree_id(cx));
 
-        let worktree = worktree
-            .and_then(|id| self.project.read(cx).worktree_for_id(id, cx))
-            .or_else(|| self.project.read(cx).visible_worktrees(cx).next())
-            .ok_or_else(|| anyhow!("Could not find a worktree to spawn the debug session in"))?;
+            worktree_id
+                .and_then(|id| project.worktree_for_id(id, cx))
+                .or_else(|| project.visible_worktrees(cx).next())
+                .ok_or_else(|| anyhow!("Could not find a worktree to spawn the debug session in"))?
+        };
 
         let session = dap_store.update(cx, |dap_store, cx| {
             dap_store.new_session(

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -1775,7 +1775,8 @@ impl RunningState {
                         cx,
                     )
                 })
-                .ok();
+                .and_then(|result| result)
+                .log_err();
         } else {
             self.restart_session(cx);
         }

--- a/crates/debugger_ui/src/tests.rs
+++ b/crates/debugger_ui/src/tests.rs
@@ -13,6 +13,8 @@ use workspace::MultiWorkspace;
 use crate::{debugger_panel::DebugPanel, session::DebugSession};
 
 #[cfg(test)]
+mod agent_api;
+#[cfg(test)]
 mod attach_modal;
 #[cfg(test)]
 mod console;
@@ -125,7 +127,7 @@ pub fn start_debug_session_with<T: Fn(&Arc<DebugAdapterClient>) + 'static>(
                 cx,
             )
         })
-    })?;
+    })??;
     cx.run_until_parked();
     let session = workspace.read_with(cx, |workspace, cx| {
         workspace

--- a/crates/debugger_ui/src/tests/agent_api.rs
+++ b/crates/debugger_ui/src/tests/agent_api.rs
@@ -1,17 +1,21 @@
 #![expect(clippy::result_large_err)]
 use crate::tests::{init_test, init_test_workspace, start_debug_session};
 use dap::{
-    Scope, StackFrame, Variable,
-    requests::{Scopes, StackTrace, Threads, Variables},
+    ErrorResponse, Message, Scope, StackFrame, Variable,
+    requests::{Continue, Scopes, SetBreakpoints, StackTrace, Threads, Variables},
 };
 use gpui::{BackgroundExecutor, TestAppContext};
 use project::debugger::agent_api::{
     AgentDebuggerApi, AgentDebuggerSessionStatus, AgentDebuggerSnapshotLimits,
     AgentDebuggerThreadStatus, AgentSourceBreakpointInput,
 };
-use project::{FakeFs, Project};
+use project::{FakeFs, Project, WorktreeId};
 use serde_json::json;
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 use task::SharedTaskContext;
 use unindent::Unindent as _;
 use util::path;
@@ -20,6 +24,20 @@ fn agent_api(project: &gpui::Entity<Project>, cx: &mut TestAppContext) -> AgentD
     project.read_with(cx, |project, _| {
         AgentDebuggerApi::new(project.dap_store(), project.breakpoint_store())
     })
+}
+
+fn error_response(message: &str) -> ErrorResponse {
+    ErrorResponse {
+        error: Some(Message {
+            id: 1,
+            format: message.into(),
+            variables: None,
+            send_telemetry: None,
+            show_user: None,
+            url: None,
+            url_label: None,
+        }),
+    }
 }
 
 #[gpui::test]
@@ -304,6 +322,367 @@ async fn test_agent_api_snapshot_is_bounded(executor: BackgroundExecutor, cx: &m
     assert_eq!(long_variable.value, "this val");
     assert!(long_variable.value_truncated);
     assert!(!scope.variables[1].value_truncated);
+}
+
+#[gpui::test]
+async fn test_agent_api_snapshot_skips_dap_requests_for_terminated_session(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+    fs.insert_tree(path!("/project"), json!({ "main.js": "" }))
+        .await;
+
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let session_id = session.read_with(cx, |session, _| session.session_id());
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+    let thread_requests = Arc::new(Mutex::new(0));
+
+    client.on_request::<Threads, _>({
+        let thread_requests = thread_requests.clone();
+        move |_, _| {
+            *thread_requests.lock().unwrap() += 1;
+            Err(error_response(
+                "threads should not be requested for terminated sessions",
+            ))
+        }
+    });
+
+    client
+        .fake_event(dap::messages::Events::Output(dap::OutputEvent {
+            category: Some(dap::OutputEventCategory::Stdout),
+            output: "session finished\n".to_string(),
+            data: None,
+            variables_reference: None,
+            source: None,
+            line: None,
+            column: None,
+            group: None,
+            location_reference: None,
+        }))
+        .await;
+    client
+        .fake_event(dap::messages::Events::Terminated(Some(
+            dap::TerminatedEvent { restart: None },
+        )))
+        .await;
+
+    for _ in 0..100 {
+        if session.read_with(cx, |session, _| session.is_terminated()) {
+            break;
+        }
+        assert!(cx.dispatcher.tick(false));
+    }
+    assert!(session.read_with(cx, |session, _| session.is_terminated()));
+
+    let api = agent_api(&project, cx);
+    let snapshot = cx
+        .update(|cx| {
+            api.snapshot_session_for_test(
+                session.clone(),
+                AgentDebuggerSnapshotLimits::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.session.session_id, session_id);
+    assert_eq!(
+        snapshot.session.status,
+        AgentDebuggerSessionStatus::Terminated
+    );
+    assert!(snapshot.threads.is_empty());
+    assert_eq!(snapshot.output.len(), 1);
+    assert!(
+        snapshot
+            .notes
+            .iter()
+            .any(|note| note == "Session has ended; threads were not requested")
+    );
+    assert_eq!(*thread_requests.lock().unwrap(), 0);
+}
+
+#[gpui::test]
+async fn test_agent_api_snapshot_returns_partial_data_when_nested_requests_fail(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+    fs.insert_tree(path!("/project"), json!({ "main.js": "debugger;\n" }))
+        .await;
+
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+
+    client.on_request::<Threads, _>(move |_, _| {
+        Ok(dap::ThreadsResponse {
+            threads: vec![
+                dap::Thread {
+                    id: 1,
+                    name: "Thread with stack error".into(),
+                },
+                dap::Thread {
+                    id: 2,
+                    name: "Thread with partial frames".into(),
+                },
+            ],
+        })
+    });
+
+    client.on_request::<StackTrace, _>(move |_, args| match args.thread_id {
+        1 => Err(error_response("stack trace failed")),
+        2 => Ok(dap::StackTraceResponse {
+            stack_frames: vec![
+                StackFrame {
+                    id: 20,
+                    name: "Frame with scopes error".into(),
+                    source: None,
+                    line: 1,
+                    column: 1,
+                    end_line: None,
+                    end_column: None,
+                    can_restart: None,
+                    instruction_pointer_reference: None,
+                    module_id: None,
+                    presentation_hint: None,
+                },
+                StackFrame {
+                    id: 21,
+                    name: "Frame with variables error".into(),
+                    source: None,
+                    line: 1,
+                    column: 1,
+                    end_line: None,
+                    end_column: None,
+                    can_restart: None,
+                    instruction_pointer_reference: None,
+                    module_id: None,
+                    presentation_hint: None,
+                },
+            ],
+            total_frames: None,
+        }),
+        thread_id => panic!("unexpected thread id {thread_id}"),
+    });
+
+    client.on_request::<Scopes, _>(move |_, args| match args.frame_id {
+        20 => Err(error_response("scopes failed")),
+        21 => Ok(dap::ScopesResponse {
+            scopes: vec![Scope {
+                name: "Locals".into(),
+                presentation_hint: None,
+                variables_reference: 200,
+                named_variables: Some(1),
+                indexed_variables: None,
+                expensive: false,
+                source: None,
+                line: None,
+                column: None,
+                end_line: None,
+                end_column: None,
+            }],
+        }),
+        frame_id => panic!("unexpected frame id {frame_id}"),
+    });
+
+    client.on_request::<Variables, _>(move |_, args| match args.variables_reference {
+        200 => Err(error_response("variables failed")),
+        variables_reference => panic!("unexpected variables reference {variables_reference}"),
+    });
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: Some(true),
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+    cx.run_until_parked();
+
+    let api = agent_api(&project, cx);
+    let session_id = session.read_with(cx, |session, _| session.session_id());
+    let snapshot = cx
+        .update(|cx| {
+            api.snapshot(
+                session_id,
+                AgentDebuggerSnapshotLimits {
+                    max_frames: 10,
+                    max_variables_per_scope: 10,
+                    max_variable_value_length: 1024,
+                    max_output_events: 10,
+                    max_output_bytes: 1024,
+                    max_source_context_lines: 0,
+                },
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.threads.len(), 2);
+    assert_eq!(snapshot.threads[0].thread_id.0, 1);
+    assert!(snapshot.threads[0].frames.is_empty());
+    assert_eq!(snapshot.threads[1].thread_id.0, 2);
+    assert_eq!(snapshot.threads[1].frames.len(), 2);
+    assert!(snapshot.threads[1].frames[0].scopes.is_empty());
+    let scope = &snapshot.threads[1].frames[1].scopes[0];
+    assert_eq!(scope.name, "Locals");
+    assert!(scope.variables.is_empty());
+    assert!(scope.variables_truncated);
+
+    assert!(
+        snapshot
+            .notes
+            .iter()
+            .any(|note| note.contains("Stack frames for thread")),
+        "expected a stack frame failure note, got {:?}",
+        snapshot.notes
+    );
+    assert!(
+        snapshot
+            .notes
+            .iter()
+            .any(|note| note.contains("Scopes for frame")),
+        "expected a scopes failure note, got {:?}",
+        snapshot.notes
+    );
+    assert!(
+        snapshot
+            .notes
+            .iter()
+            .any(|note| note.contains("Variables for scope")),
+        "expected a variables failure note, got {:?}",
+        snapshot.notes
+    );
+}
+
+#[gpui::test]
+async fn test_agent_run_to_line_removes_temporary_breakpoint_when_continue_fails(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+    fs.insert_tree(
+        path!("/project"),
+        json!({ "src": { "main.js": "let a = 1;\nlet b = 2;\n" } }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+    let breakpoint_requests = Arc::new(Mutex::new(Vec::<Vec<u64>>::new()));
+
+    client.on_request::<SetBreakpoints, _>({
+        let breakpoint_requests = breakpoint_requests.clone();
+        move |_, args| {
+            let lines = args
+                .breakpoints
+                .unwrap_or_default()
+                .into_iter()
+                .map(|breakpoint| breakpoint.line)
+                .collect::<Vec<_>>();
+            breakpoint_requests.lock().unwrap().push(lines);
+            Ok(dap::SetBreakpointsResponse {
+                breakpoints: Vec::default(),
+            })
+        }
+    });
+
+    client.on_request::<Continue, _>(move |_, _| Err(error_response("continue failed")));
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+    cx.run_until_parked();
+
+    let api = agent_api(&project, cx);
+    let session_id = session.read_with(cx, |session, _| session.session_id());
+    let result = cx
+        .update(|cx| {
+            api.run_to_line(
+                session_id,
+                project::debugger::session::ThreadId(1),
+                PathBuf::from(path!("/project/src/main.js")),
+                2,
+                Duration::from_millis(100),
+                cx,
+            )
+        })
+        .await;
+
+    assert!(result.is_err());
+    let breakpoint_requests = breakpoint_requests.lock().unwrap();
+    assert_eq!(&*breakpoint_requests, &[vec![2], Vec::<u64>::new()]);
+}
+
+#[gpui::test]
+async fn test_start_debug_session_rejects_invalid_explicit_worktree_id(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+    fs.insert_tree(path!("/project"), json!({ "main.js": "" }))
+        .await;
+
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    let invalid_worktree_id = WorktreeId::from_usize(usize::MAX);
+
+    let error = workspace
+        .update(cx, |multi, window, cx| {
+            multi.workspace().update(cx, |workspace, cx| {
+                workspace.start_debug_session(
+                    task::DebugScenario {
+                        adapter: "fake-adapter".into(),
+                        label: "agent session".into(),
+                        build: None,
+                        config: json!({ "request": "launch" }),
+                        tcp_connection: None,
+                    },
+                    SharedTaskContext::default(),
+                    None,
+                    Some(invalid_worktree_id),
+                    window,
+                    cx,
+                )
+            })
+        })
+        .unwrap()
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains(&format!("Could not find worktree {invalid_worktree_id}")),
+        "unexpected error: {error:#}"
+    );
 }
 
 #[gpui::test]

--- a/crates/debugger_ui/src/tests/agent_api.rs
+++ b/crates/debugger_ui/src/tests/agent_api.rs
@@ -1,0 +1,358 @@
+#![expect(clippy::result_large_err)]
+use crate::tests::{init_test, init_test_workspace, start_debug_session};
+use dap::{
+    Scope, StackFrame, Variable,
+    requests::{Scopes, StackTrace, Threads, Variables},
+};
+use gpui::{BackgroundExecutor, TestAppContext};
+use project::debugger::agent_api::{
+    AgentDebuggerApi, AgentDebuggerSessionStatus, AgentDebuggerSnapshotLimits,
+    AgentDebuggerThreadStatus, AgentSourceBreakpointInput,
+};
+use project::{FakeFs, Project};
+use serde_json::json;
+use std::{path::PathBuf, sync::Arc};
+use task::SharedTaskContext;
+use unindent::Unindent as _;
+use util::path;
+
+fn agent_api(project: &gpui::Entity<Project>, cx: &mut TestAppContext) -> AgentDebuggerApi {
+    project.read_with(cx, |project, _| {
+        AgentDebuggerApi::new(project.dap_store(), project.breakpoint_store())
+    })
+}
+
+#[gpui::test]
+async fn test_agent_api_breakpoint_editing(executor: BackgroundExecutor, cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+    fs.insert_tree(
+        path!("/project"),
+        json!({
+            "src": {
+                "main.js": "let a = 1;\nlet b = 2;\nlet c = 3;\n",
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let api = agent_api(&project, cx);
+    let path = PathBuf::from(path!("/project/src/main.js"));
+
+    let input = AgentSourceBreakpointInput {
+        path: path.clone(),
+        line: 2,
+        enabled: true,
+        condition: None,
+        hit_condition: None,
+        log_message: None,
+    };
+
+    // Adding a new breakpoint reports a change.
+    let result = cx
+        .update(|cx| api.set_source_breakpoint(input.clone(), cx))
+        .await
+        .unwrap();
+    assert!(result.changed);
+    assert_eq!(result.line, 2);
+
+    // Setting an identical breakpoint is idempotent.
+    let result = cx
+        .update(|cx| api.set_source_breakpoint(input.clone(), cx))
+        .await
+        .unwrap();
+    assert!(!result.changed);
+
+    let breakpoints = cx.update(|cx| api.list_breakpoints(cx));
+    assert_eq!(breakpoints.len(), 1);
+    assert_eq!(breakpoints[0].path, path);
+    assert_eq!(breakpoints[0].line, 2);
+    assert!(breakpoints[0].enabled);
+    assert_eq!(breakpoints[0].condition, None);
+
+    // Setting the same line with a condition updates the breakpoint in place
+    // rather than toggling it off.
+    let mut conditional = input.clone();
+    conditional.condition = Some("a > 0".to_string());
+    let result = cx
+        .update(|cx| api.set_source_breakpoint(conditional, cx))
+        .await
+        .unwrap();
+    assert!(result.changed);
+
+    let breakpoints = cx.update(|cx| api.list_breakpoints(cx));
+    assert_eq!(breakpoints.len(), 1);
+    assert_eq!(breakpoints[0].condition.as_deref(), Some("a > 0"));
+
+    // Lines outside the file are rejected instead of being clipped.
+    let mut out_of_range = input.clone();
+    out_of_range.line = 1000;
+    let result = cx
+        .update(|cx| api.set_source_breakpoint(out_of_range, cx))
+        .await;
+    assert!(result.is_err());
+
+    // Removing reports a change the first time and is a no-op afterwards.
+    let result = cx
+        .update(|cx| api.remove_source_breakpoint(path.clone(), 2, cx))
+        .await
+        .unwrap();
+    assert!(result.changed);
+    let result = cx
+        .update(|cx| api.remove_source_breakpoint(path.clone(), 2, cx))
+        .await
+        .unwrap();
+    assert!(!result.changed);
+    assert!(cx.update(|cx| api.list_breakpoints(cx)).is_empty());
+}
+
+#[gpui::test]
+async fn test_agent_api_snapshot_is_bounded(executor: BackgroundExecutor, cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+
+    let test_file_content = r#"
+        const variable1 = "Value 1";
+        const variable2 = "Value 2";
+        const variable3 = "Value 3";
+        console.log(variable1);
+    "#
+    .unindent();
+
+    fs.insert_tree(
+        path!("/project"),
+        json!({
+            "src": {
+                "test.js": test_file_content,
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+
+    client.on_request::<Threads, _>(move |_, _| {
+        Ok(dap::ThreadsResponse {
+            threads: vec![dap::Thread {
+                id: 1,
+                name: "Thread 1".into(),
+            }],
+        })
+    });
+
+    let stack_frames = (1..=3)
+        .map(|id| StackFrame {
+            id,
+            name: format!("Stack Frame {id}"),
+            source: Some(dap::Source {
+                name: Some("test.js".into()),
+                path: Some(path!("/project/src/test.js").into()),
+                source_reference: None,
+                presentation_hint: None,
+                origin: None,
+                sources: None,
+                adapter_data: None,
+                checksums: None,
+            }),
+            line: id,
+            column: 1,
+            end_line: None,
+            end_column: None,
+            can_restart: None,
+            instruction_pointer_reference: None,
+            module_id: None,
+            presentation_hint: None,
+        })
+        .collect::<Vec<_>>();
+
+    client.on_request::<StackTrace, _>({
+        let stack_frames = Arc::new(stack_frames);
+        move |_, args| {
+            assert_eq!(1, args.thread_id);
+            Ok(dap::StackTraceResponse {
+                stack_frames: (*stack_frames).clone(),
+                total_frames: None,
+            })
+        }
+    });
+
+    client.on_request::<Scopes, _>(move |_, _| {
+        Ok(dap::ScopesResponse {
+            scopes: vec![Scope {
+                name: "Locals".into(),
+                presentation_hint: None,
+                variables_reference: 2,
+                named_variables: None,
+                indexed_variables: None,
+                expensive: false,
+                source: None,
+                line: None,
+                column: None,
+                end_line: None,
+                end_column: None,
+            }],
+        })
+    });
+
+    client.on_request::<Variables, _>(move |_, args| {
+        assert_eq!(2, args.variables_reference);
+        let variable = |name: &str, value: &str| Variable {
+            name: name.into(),
+            value: value.into(),
+            type_: None,
+            presentation_hint: None,
+            evaluate_name: None,
+            variables_reference: 0,
+            named_variables: None,
+            indexed_variables: None,
+            memory_reference: None,
+            declaration_location_reference: None,
+            value_location_reference: None,
+        };
+        Ok(dap::VariablesResponse {
+            variables: vec![
+                variable("variable1", "this value is too long to fit"),
+                variable("variable2", "v2"),
+                variable("variable3", "v3"),
+            ],
+        })
+    });
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    cx.run_until_parked();
+
+    let api = agent_api(&project, cx);
+    let session_id = session.read_with(cx, |session, _| session.session_id());
+
+    let limits = AgentDebuggerSnapshotLimits {
+        max_frames: 2,
+        max_variables_per_scope: 2,
+        max_variable_value_length: 8,
+        max_output_events: 10,
+        max_output_bytes: 1024,
+        max_source_context_lines: 3,
+    };
+    let snapshot = cx
+        .update(|cx| api.snapshot(session_id, limits, cx))
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.session.session_id, session_id);
+    assert_eq!(snapshot.session.status, AgentDebuggerSessionStatus::Stopped);
+    assert!(snapshot.session.has_ever_stopped);
+
+    assert_eq!(snapshot.threads.len(), 1);
+    let thread = &snapshot.threads[0];
+    assert_eq!(thread.name, "Thread 1");
+    assert_eq!(thread.status, AgentDebuggerThreadStatus::Stopped);
+
+    // Stack frames are bounded by max_frames.
+    assert_eq!(thread.frames.len(), 2);
+    assert!(
+        snapshot
+            .notes
+            .iter()
+            .any(|note| note.contains("Stack frames truncated")),
+        "expected a stack frame truncation note, got {:?}",
+        snapshot.notes
+    );
+
+    let frame = &thread.frames[0];
+    assert_eq!(frame.name, "Stack Frame 1");
+    assert_eq!(
+        frame.source_path.as_deref(),
+        Some(std::path::Path::new(path!("/project/src/test.js")))
+    );
+
+    // Source context is bounded by max_source_context_lines and centered on
+    // the frame's line.
+    let source_context = frame.source_context.as_ref().unwrap();
+    assert!(source_context.lines.len() <= 3);
+    assert!(
+        source_context
+            .lines
+            .iter()
+            .any(|line| line.line == frame.line as u32)
+    );
+
+    // Variables are bounded by max_variables_per_scope and their values by
+    // max_variable_value_length.
+    assert_eq!(frame.scopes.len(), 1);
+    let scope = &frame.scopes[0];
+    assert_eq!(scope.name, "Locals");
+    assert_eq!(scope.variables.len(), 2);
+    assert!(scope.variables_truncated);
+    let long_variable = &scope.variables[0];
+    assert_eq!(long_variable.name, "variable1");
+    assert_eq!(long_variable.value, "this val");
+    assert!(long_variable.value_truncated);
+    assert!(!scope.variables[1].value_truncated);
+}
+
+#[gpui::test]
+async fn test_start_debug_session_returns_session_info(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+    fs.insert_tree(path!("/project"), json!({ "main.js": "" }))
+        .await;
+
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+
+    let _subscription = project::debugger::test::intercept_debug_sessions(cx, |_| {});
+    let info = workspace
+        .update(cx, |multi, window, cx| {
+            multi.workspace().update(cx, |workspace, cx| {
+                workspace.start_debug_session(
+                    task::DebugScenario {
+                        adapter: "fake-adapter".into(),
+                        label: "agent session".into(),
+                        build: None,
+                        config: json!({ "request": "launch" }),
+                        tcp_connection: None,
+                    },
+                    SharedTaskContext::default(),
+                    None,
+                    None,
+                    window,
+                    cx,
+                )
+            })
+        })
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(info.label, "agent session");
+    assert_eq!(info.adapter, "fake-adapter");
+
+    cx.run_until_parked();
+
+    // The reported session id refers to a real session in the DAP store.
+    let api = agent_api(&project, cx);
+    let sessions = cx.update(|cx| api.list_sessions(cx));
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].session_id.to_proto(), info.session_id);
+    assert_eq!(sessions[0].label.as_deref(), Some("agent session"));
+    assert_eq!(sessions[0].adapter, "fake-adapter");
+}

--- a/crates/debugger_ui/src/tests/attach_modal.rs
+++ b/crates/debugger_ui/src/tests/attach_modal.rs
@@ -233,9 +233,10 @@ async fn test_attach_with_pick_pid_variable(executor: BackgroundExecutor, cx: &m
                     None,
                     window,
                     cx,
-                );
+                )
             })
         })
+        .unwrap()
         .unwrap();
 
     cx.run_until_parked();

--- a/crates/debugger_ui/src/tests/new_process_modal.rs
+++ b/crates/debugger_ui/src/tests/new_process_modal.rs
@@ -155,9 +155,10 @@ async fn test_debug_session_substitutes_variables_and_relativizes_paths(
                         None,
                         window,
                         cx,
-                    );
+                    )
                 })
             })
+            .unwrap()
             .unwrap();
 
         cx.run_until_parked();

--- a/crates/editor/src/code_actions.rs
+++ b/crates/editor/src/code_actions.rs
@@ -248,14 +248,9 @@ impl Editor {
 
                 workspace.update(cx, |workspace, cx| {
                     dap::send_telemetry(&scenario, TelemetrySpawnLocation::Gutter, cx);
-                    workspace.start_debug_session(
-                        scenario,
-                        context,
-                        Some(buffer),
-                        None,
-                        window,
-                        cx,
-                    );
+                    workspace
+                        .start_debug_session(scenario, context, Some(buffer), None, window, cx)
+                        .log_err();
                 });
                 Some(Task::ready(Ok(())))
             }

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -131,6 +131,18 @@ impl FeatureFlag for AgentSettingsUiFeatureFlag {
 }
 register_feature_flag!(AgentSettingsUiFeatureFlag);
 
+pub struct DebuggerToolFeatureFlag;
+
+impl FeatureFlag for DebuggerToolFeatureFlag {
+    const NAME: &'static str = "debugger-tool";
+    type Value = PresenceFlag;
+
+    fn enabled_for_staff() -> bool {
+        false
+    }
+}
+register_feature_flag!(DebuggerToolFeatureFlag);
+
 pub struct AutoWatchFeatureFlag;
 
 impl FeatureFlag for AutoWatchFeatureFlag {

--- a/crates/project/src/debugger.rs
+++ b/crates/project/src/debugger.rs
@@ -11,6 +11,7 @@
 //!   current set of breakpoints.
 //! - Since DAP store knows about all of the available debug sessions, it is responsible for routing RPC requests to sessions. It also knows how to find adapters for particular kind of session.
 
+pub mod agent_api;
 pub mod breakpoint_store;
 pub mod dap_command;
 pub mod dap_store;

--- a/crates/project/src/debugger/agent_api.rs
+++ b/crates/project/src/debugger/agent_api.rs
@@ -1,0 +1,934 @@
+use super::{
+    breakpoint_store::{BreakpointState, BreakpointStore, SourceBreakpoint},
+    dap_store::DapStore,
+    session::{OutputToken, Session, SessionEvent, SessionStateEvent, ThreadId, ThreadStatus},
+};
+use anyhow::{Context as _, Result, anyhow};
+use dap::{
+    StackFrameId, StackFramePresentationHint, SteppingGranularity, VariableReference,
+    client::SessionId,
+};
+use futures::{FutureExt as _, select_biased};
+use gpui::{App, AsyncApp, Entity, Subscription, Task};
+use parking_lot::Mutex;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+#[derive(Clone)]
+pub struct AgentDebuggerApi {
+    dap_store: Entity<DapStore>,
+    breakpoint_store: Entity<BreakpointStore>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentDebuggerSession {
+    pub session_id: SessionId,
+    pub parent_session_id: Option<SessionId>,
+    pub child_session_ids: Vec<SessionId>,
+    pub label: Option<String>,
+    pub adapter: String,
+    pub status: AgentDebuggerSessionStatus,
+    pub is_attached: bool,
+    pub has_ever_stopped: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AgentDebuggerSessionStatus {
+    Booting,
+    Running,
+    Stopped,
+    Terminated,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentSourceBreakpoint {
+    pub path: PathBuf,
+    pub line: u32,
+    pub enabled: bool,
+    pub condition: Option<String>,
+    pub hit_condition: Option<String>,
+    pub log_message: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentSourceBreakpointInput {
+    pub path: PathBuf,
+    pub line: u32,
+    pub enabled: bool,
+    pub condition: Option<String>,
+    pub hit_condition: Option<String>,
+    pub log_message: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentBreakpointEditResult {
+    pub path: PathBuf,
+    pub line: u32,
+    pub changed: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentDebuggerSnapshotLimits {
+    pub max_frames: usize,
+    pub max_variables_per_scope: usize,
+    pub max_variable_value_length: usize,
+    pub max_output_events: usize,
+    pub max_output_bytes: usize,
+    pub max_source_context_lines: usize,
+}
+
+impl Default for AgentDebuggerSnapshotLimits {
+    fn default() -> Self {
+        Self {
+            max_frames: 20,
+            max_variables_per_scope: 50,
+            max_variable_value_length: 1024,
+            max_output_events: 100,
+            max_output_bytes: 16 * 1024,
+            max_source_context_lines: 5,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentDebuggerSnapshot {
+    pub session: AgentDebuggerSession,
+    pub threads: Vec<AgentDebuggerThread>,
+    pub output: Vec<AgentDebuggerOutputEvent>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentDebuggerThread {
+    pub thread_id: ThreadId,
+    pub name: String,
+    pub status: AgentDebuggerThreadStatus,
+    pub frames: Vec<AgentDebuggerStackFrame>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AgentDebuggerThreadStatus {
+    Running,
+    Stopped,
+    Stepping,
+    Exited,
+    Ended,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentDebuggerStackFrame {
+    pub frame_id: StackFrameId,
+    pub name: String,
+    pub source_path: Option<PathBuf>,
+    pub line: u64,
+    pub column: u64,
+    pub scopes: Vec<AgentDebuggerScope>,
+    pub source_context: Option<AgentSourceContext>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentDebuggerScope {
+    pub name: String,
+    pub expensive: bool,
+    pub variables_reference: VariableReference,
+    pub variables: Vec<AgentDebuggerVariable>,
+    pub variables_truncated: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentDebuggerVariable {
+    pub name: String,
+    pub value: String,
+    pub type_name: Option<String>,
+    pub variables_reference: VariableReference,
+    pub named_variables: Option<u64>,
+    pub indexed_variables: Option<u64>,
+    pub value_truncated: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentSourceContext {
+    pub start_line: u32,
+    pub lines: Vec<AgentSourceContextLine>,
+    pub truncated_before: bool,
+    pub truncated_after: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentSourceContextLine {
+    pub line: u32,
+    pub text: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentDebuggerOutputEvent {
+    pub category: Option<String>,
+    pub output: String,
+    pub output_truncated: bool,
+    pub source_path: Option<PathBuf>,
+    pub line: Option<u64>,
+    pub column: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AgentDebuggerStepKind {
+    In,
+    Out,
+    Over,
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentDebuggerControlResult {
+    pub status: AgentDebuggerWaitStatus,
+    pub stopped_thread_id: Option<ThreadId>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AgentDebuggerWaitStatus {
+    Stopped,
+    TimedOut,
+    SessionEnded,
+}
+
+struct AgentDebuggerStopWait {
+    receiver: futures::channel::oneshot::Receiver<AgentDebuggerWaitEvent>,
+    _stopped_subscription: Subscription,
+    _shutdown_subscription: Subscription,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum AgentDebuggerWaitEvent {
+    Stopped(Option<ThreadId>),
+    SessionEnded,
+}
+
+impl AgentDebuggerApi {
+    pub fn new(dap_store: Entity<DapStore>, breakpoint_store: Entity<BreakpointStore>) -> Self {
+        Self {
+            dap_store,
+            breakpoint_store,
+        }
+    }
+
+    pub fn list_sessions(&self, cx: &App) -> Vec<AgentDebuggerSession> {
+        self.dap_store
+            .read(cx)
+            .sessions()
+            .map(|session| Self::session_summary(session, cx))
+            .collect()
+    }
+
+    pub fn list_breakpoints(&self, cx: &App) -> Vec<AgentSourceBreakpoint> {
+        self.breakpoint_store
+            .read(cx)
+            .all_source_breakpoints(cx)
+            .into_values()
+            .flatten()
+            .map(AgentSourceBreakpoint::from_project_breakpoint)
+            .collect()
+    }
+
+    pub fn set_source_breakpoint(
+        &self,
+        breakpoint: AgentSourceBreakpointInput,
+        cx: &mut App,
+    ) -> Task<Result<AgentBreakpointEditResult>> {
+        let breakpoint_store = self.breakpoint_store.clone();
+        cx.spawn(async move |cx| {
+            let source_breakpoint = breakpoint.to_project_breakpoint()?;
+            let path = source_breakpoint.path.as_ref().to_path_buf();
+            let line = breakpoint.line;
+            let changed = breakpoint_store
+                .update(cx, |breakpoint_store, cx| {
+                    breakpoint_store.set_source_breakpoint(source_breakpoint, cx)
+                })
+                .await?;
+
+            Ok(AgentBreakpointEditResult {
+                path,
+                line,
+                changed,
+            })
+        })
+    }
+
+    pub fn remove_source_breakpoint(
+        &self,
+        path: PathBuf,
+        line: u32,
+        cx: &mut App,
+    ) -> Task<Result<AgentBreakpointEditResult>> {
+        let breakpoint_store = self.breakpoint_store.clone();
+        cx.spawn(async move |cx| {
+            let row = line_to_row(line)?;
+            let path = Arc::<Path>::from(path);
+            let changed = breakpoint_store.update(cx, |breakpoint_store, cx| {
+                breakpoint_store.remove_source_breakpoint(path.clone(), row, cx)
+            })?;
+
+            Ok(AgentBreakpointEditResult {
+                path: path.as_ref().to_path_buf(),
+                line,
+                changed,
+            })
+        })
+    }
+
+    pub fn snapshot(
+        &self,
+        session_id: SessionId,
+        limits: AgentDebuggerSnapshotLimits,
+        cx: &mut App,
+    ) -> Task<Result<AgentDebuggerSnapshot>> {
+        let dap_store = self.dap_store.clone();
+        let breakpoint_store = self.breakpoint_store.clone();
+        cx.spawn(async move |cx| {
+            let session = session_by_id(&dap_store, session_id, cx)?;
+            let mut notes = Vec::new();
+            let session_summary = session.read_with(cx, |session, cx| {
+                AgentDebuggerApi::session_summary_for_session(session, cx)
+            });
+            let output = session.read_with(cx, |session, _| {
+                bounded_output(session, &limits, &mut notes)
+            });
+            let dap_threads = session
+                .update(cx, |session, _| session.agent_fetch_threads())
+                .await?;
+            let mut remaining_frames = limits.max_frames;
+            let mut frames_truncated = false;
+            let mut threads = Vec::new();
+
+            if limits.max_frames == 0 {
+                notes.push("Stack frames omitted because max_frames is 0".to_string());
+            }
+
+            for dap_thread in dap_threads {
+                let thread_id = ThreadId(dap_thread.id);
+                let status = session.read_with(cx, |session, _| session.thread_status(thread_id));
+                let mut frames = Vec::new();
+
+                if status == ThreadStatus::Stopped && remaining_frames > 0 {
+                    let requested_frames = remaining_frames.saturating_add(1);
+                    let mut fetched_frames = session
+                        .update(cx, |session, _| {
+                            session.agent_fetch_stack_frames(thread_id, requested_frames)
+                        })
+                        .await?
+                        .into_iter()
+                        .filter(|frame| {
+                            !(frame.id == 0
+                                && frame.line == 0
+                                && frame.column == 0
+                                && frame.presentation_hint
+                                    == Some(StackFramePresentationHint::Label))
+                        })
+                        .collect::<Vec<_>>();
+
+                    if fetched_frames.len() > remaining_frames {
+                        frames_truncated = true;
+                        fetched_frames.truncate(remaining_frames);
+                    }
+
+                    remaining_frames = remaining_frames.saturating_sub(fetched_frames.len());
+
+                    for frame in fetched_frames {
+                        frames.push(
+                            stack_frame_snapshot(
+                                &session,
+                                &breakpoint_store,
+                                frame,
+                                &limits,
+                                &mut notes,
+                                cx,
+                            )
+                            .await?,
+                        );
+                    }
+                }
+
+                threads.push(AgentDebuggerThread {
+                    thread_id,
+                    name: dap_thread.name,
+                    status: AgentDebuggerThreadStatus::from_thread_status(status),
+                    frames,
+                });
+            }
+
+            if remaining_frames == limits.max_frames
+                && !threads
+                    .iter()
+                    .any(|thread| thread.status == AgentDebuggerThreadStatus::Stopped)
+            {
+                notes.push(
+                    "No stopped threads; stack frames and variables were not requested".to_string(),
+                );
+            } else if frames_truncated {
+                notes.push(format!(
+                    "Stack frames truncated to {} frame(s)",
+                    limits.max_frames
+                ));
+            }
+
+            Ok(AgentDebuggerSnapshot {
+                session: session_summary,
+                threads,
+                output,
+                notes,
+            })
+        })
+    }
+
+    pub fn continue_thread(
+        &self,
+        session_id: SessionId,
+        thread_id: ThreadId,
+        timeout: Duration,
+        cx: &mut App,
+    ) -> Task<Result<AgentDebuggerControlResult>> {
+        let dap_store = self.dap_store.clone();
+        cx.spawn(async move |cx| {
+            let session = session_by_id(&dap_store, session_id, cx)?;
+            let stop_wait = subscribe_to_stop(session.clone(), cx)?;
+            session
+                .update(cx, |session, cx| {
+                    session.agent_continue_thread(thread_id, cx)
+                })
+                .await?;
+            wait_for_stop_or_timeout(stop_wait, timeout, cx).await
+        })
+    }
+
+    pub fn pause_thread(
+        &self,
+        session_id: SessionId,
+        thread_id: ThreadId,
+        timeout: Duration,
+        cx: &mut App,
+    ) -> Task<Result<AgentDebuggerControlResult>> {
+        let dap_store = self.dap_store.clone();
+        cx.spawn(async move |cx| {
+            let session = session_by_id(&dap_store, session_id, cx)?;
+            if session.read_with(cx, |session, _| session.thread_status(thread_id))
+                == ThreadStatus::Stopped
+            {
+                return Ok(AgentDebuggerControlResult {
+                    status: AgentDebuggerWaitStatus::Stopped,
+                    stopped_thread_id: Some(thread_id),
+                });
+            }
+
+            let stop_wait = subscribe_to_stop(session.clone(), cx)?;
+            session
+                .update(cx, |session, cx| session.agent_pause_thread(thread_id, cx))
+                .await?;
+            wait_for_stop_or_timeout(stop_wait, timeout, cx).await
+        })
+    }
+
+    pub fn step_thread(
+        &self,
+        session_id: SessionId,
+        thread_id: ThreadId,
+        step_kind: AgentDebuggerStepKind,
+        timeout: Duration,
+        cx: &mut App,
+    ) -> Task<Result<AgentDebuggerControlResult>> {
+        let dap_store = self.dap_store.clone();
+        cx.spawn(async move |cx| {
+            let session = session_by_id(&dap_store, session_id, cx)?;
+            let stop_wait = subscribe_to_stop(session.clone(), cx)?;
+            session
+                .update(cx, |session, cx| match step_kind {
+                    AgentDebuggerStepKind::In => {
+                        session.agent_step_in(thread_id, SteppingGranularity::Line, cx)
+                    }
+                    AgentDebuggerStepKind::Out => {
+                        session.agent_step_out(thread_id, SteppingGranularity::Line, cx)
+                    }
+                    AgentDebuggerStepKind::Over => {
+                        session.agent_step_over(thread_id, SteppingGranularity::Line, cx)
+                    }
+                })
+                .await?;
+            wait_for_stop_or_timeout(stop_wait, timeout, cx).await
+        })
+    }
+
+    pub fn run_to_line(
+        &self,
+        session_id: SessionId,
+        thread_id: ThreadId,
+        path: PathBuf,
+        line: u32,
+        timeout: Duration,
+        cx: &mut App,
+    ) -> Task<Result<AgentDebuggerControlResult>> {
+        let dap_store = self.dap_store.clone();
+        cx.spawn(async move |cx| {
+            let row = line_to_row(line)?;
+            let session = session_by_id(&dap_store, session_id, cx)?;
+            let stop_wait = subscribe_to_stop(session.clone(), cx)?;
+            let breakpoint = SourceBreakpoint {
+                row,
+                path: Arc::<Path>::from(path),
+                message: None,
+                condition: None,
+                hit_condition: None,
+                state: BreakpointState::Enabled,
+            };
+            session
+                .update(cx, |session, cx| {
+                    session.agent_run_to_position(breakpoint, thread_id, cx)
+                })
+                .await?;
+            wait_for_stop_or_timeout(stop_wait, timeout, cx).await
+        })
+    }
+
+    fn session_summary(session: &Entity<Session>, cx: &App) -> AgentDebuggerSession {
+        session.read_with(cx, |session, cx| {
+            Self::session_summary_for_session(session, cx)
+        })
+    }
+
+    fn session_summary_for_session(session: &Session, cx: &App) -> AgentDebuggerSession {
+        let mut child_session_ids = session.child_session_ids().into_iter().collect::<Vec<_>>();
+        child_session_ids.sort();
+        let status = if session.is_terminated() {
+            AgentDebuggerSessionStatus::Terminated
+        } else if session.is_building() {
+            AgentDebuggerSessionStatus::Booting
+        } else if session.any_stopped_thread() {
+            AgentDebuggerSessionStatus::Stopped
+        } else {
+            AgentDebuggerSessionStatus::Running
+        };
+
+        AgentDebuggerSession {
+            session_id: session.session_id(),
+            parent_session_id: session.parent_id(cx),
+            child_session_ids,
+            label: session.label().map(|label| label.to_string()),
+            adapter: session.adapter().to_string(),
+            status,
+            is_attached: session.is_attached(),
+            has_ever_stopped: session.has_ever_stopped(),
+        }
+    }
+}
+
+impl AgentSourceBreakpoint {
+    fn from_project_breakpoint(breakpoint: SourceBreakpoint) -> Self {
+        Self {
+            path: breakpoint.path.as_ref().to_path_buf(),
+            line: breakpoint.row.saturating_add(1),
+            enabled: breakpoint.state.is_enabled(),
+            condition: breakpoint
+                .condition
+                .as_ref()
+                .map(|condition| condition.to_string()),
+            hit_condition: breakpoint
+                .hit_condition
+                .as_ref()
+                .map(|hit_condition| hit_condition.to_string()),
+            log_message: breakpoint
+                .message
+                .as_ref()
+                .map(|message| message.to_string()),
+        }
+    }
+}
+
+impl AgentSourceBreakpointInput {
+    fn to_project_breakpoint(&self) -> Result<SourceBreakpoint> {
+        let row = line_to_row(self.line)?;
+        Ok(SourceBreakpoint {
+            row,
+            path: Arc::<Path>::from(self.path.clone()),
+            message: self.log_message.clone().map(Arc::<str>::from),
+            condition: self.condition.clone().map(Arc::<str>::from),
+            hit_condition: self.hit_condition.clone().map(Arc::<str>::from),
+            state: if self.enabled {
+                BreakpointState::Enabled
+            } else {
+                BreakpointState::Disabled
+            },
+        })
+    }
+}
+
+impl AgentDebuggerThreadStatus {
+    fn from_thread_status(status: ThreadStatus) -> Self {
+        match status {
+            ThreadStatus::Running => Self::Running,
+            ThreadStatus::Stopped => Self::Stopped,
+            ThreadStatus::Stepping => Self::Stepping,
+            ThreadStatus::Exited => Self::Exited,
+            ThreadStatus::Ended => Self::Ended,
+        }
+    }
+}
+
+fn line_to_row(line: u32) -> Result<u32> {
+    line.checked_sub(1)
+        .with_context(|| "Debugger source breakpoint lines are 1-based")
+}
+
+fn session_by_id(
+    dap_store: &Entity<DapStore>,
+    session_id: SessionId,
+    cx: &mut AsyncApp,
+) -> Result<Entity<Session>> {
+    dap_store
+        .read_with(cx, |dap_store, _| dap_store.session_by_id(session_id))
+        .with_context(|| format!("Could not find debugger session {:?}", session_id))
+}
+
+fn subscribe_to_stop(session: Entity<Session>, cx: &mut AsyncApp) -> Result<AgentDebuggerStopWait> {
+    let (sender, receiver) = futures::channel::oneshot::channel();
+    let sender = Arc::new(Mutex::new(Some(sender)));
+    let stopped_sender = sender.clone();
+    let stopped_subscription = cx.update(|cx| {
+        cx.subscribe(&session, move |_, event: &SessionEvent, _| {
+            if let SessionEvent::Stopped(thread_id) = event
+                && let Some(sender) = stopped_sender.lock().take()
+            {
+                sender
+                    .send(AgentDebuggerWaitEvent::Stopped(*thread_id))
+                    .ok();
+            }
+        })
+    });
+    let shutdown_subscription = cx.update(|cx| {
+        cx.subscribe(&session, move |_, event: &SessionStateEvent, _| {
+            if matches!(event, SessionStateEvent::Shutdown)
+                && let Some(sender) = sender.lock().take()
+            {
+                sender.send(AgentDebuggerWaitEvent::SessionEnded).ok();
+            }
+        })
+    });
+
+    Ok(AgentDebuggerStopWait {
+        receiver,
+        _stopped_subscription: stopped_subscription,
+        _shutdown_subscription: shutdown_subscription,
+    })
+}
+
+async fn wait_for_stop_or_timeout(
+    stop_wait: AgentDebuggerStopWait,
+    timeout: Duration,
+    cx: &mut AsyncApp,
+) -> Result<AgentDebuggerControlResult> {
+    let AgentDebuggerStopWait {
+        receiver,
+        _stopped_subscription,
+        _shutdown_subscription,
+    } = stop_wait;
+    let mut receiver = receiver.fuse();
+    let mut timer = cx.background_executor().timer(timeout).fuse();
+
+    select_biased! {
+        event = receiver => {
+            match event.map_err(|_| anyhow!("Debugger stop waiter was dropped before completion"))? {
+                AgentDebuggerWaitEvent::Stopped(stopped_thread_id) => Ok(AgentDebuggerControlResult {
+                    status: AgentDebuggerWaitStatus::Stopped,
+                    stopped_thread_id,
+                }),
+                AgentDebuggerWaitEvent::SessionEnded => Ok(AgentDebuggerControlResult {
+                    status: AgentDebuggerWaitStatus::SessionEnded,
+                    stopped_thread_id: None,
+                }),
+            }
+        }
+        _ = timer => Ok(AgentDebuggerControlResult {
+            status: AgentDebuggerWaitStatus::TimedOut,
+            stopped_thread_id: None,
+        }),
+    }
+}
+
+async fn stack_frame_snapshot(
+    session: &Entity<Session>,
+    breakpoint_store: &Entity<BreakpointStore>,
+    frame: dap::StackFrame,
+    limits: &AgentDebuggerSnapshotLimits,
+    notes: &mut Vec<String>,
+    cx: &mut AsyncApp,
+) -> Result<AgentDebuggerStackFrame> {
+    let mut scopes = Vec::new();
+    let dap_scopes = session
+        .update(cx, |session, _| session.agent_fetch_scopes(frame.id))
+        .await?;
+
+    for scope in dap_scopes {
+        let variables = if scope.variables_reference == 0 || limits.max_variables_per_scope == 0 {
+            if scope.variables_reference != 0 && limits.max_variables_per_scope == 0 {
+                notes.push(format!(
+                    "Variables for scope `{}` omitted because max_variables_per_scope is 0",
+                    scope.name
+                ));
+            }
+            Vec::new()
+        } else {
+            session
+                .update(cx, |session, cx| {
+                    session.agent_fetch_variables(
+                        scope.variables_reference,
+                        limits.max_variables_per_scope,
+                        cx,
+                    )
+                })
+                .await?
+        };
+
+        let known_variable_count = scope
+            .named_variables
+            .unwrap_or(0)
+            .saturating_add(scope.indexed_variables.unwrap_or(0));
+        let variables_truncated = if limits.max_variables_per_scope == 0 {
+            scope.variables_reference != 0
+        } else {
+            known_variable_count > variables.len() as u64
+                || variables.len() >= limits.max_variables_per_scope
+        };
+        if variables_truncated && limits.max_variables_per_scope > 0 {
+            notes.push(format!(
+                "Variables for scope `{}` truncated to {} variable(s)",
+                scope.name,
+                variables.len()
+            ));
+        }
+
+        let variables = variables
+            .into_iter()
+            .map(|variable| variable_snapshot(variable, limits.max_variable_value_length))
+            .collect::<Vec<_>>();
+        if variables.iter().any(|variable| variable.value_truncated) {
+            notes.push(format!(
+                "Variable values for scope `{}` truncated to {} byte(s)",
+                scope.name, limits.max_variable_value_length
+            ));
+        }
+
+        scopes.push(AgentDebuggerScope {
+            name: scope.name,
+            expensive: scope.expensive,
+            variables_reference: scope.variables_reference,
+            variables,
+            variables_truncated,
+        });
+    }
+
+    let source_path = frame
+        .source
+        .as_ref()
+        .and_then(|source| source.path.as_ref())
+        .map(PathBuf::from);
+    let source_context = source_context_for_frame(
+        breakpoint_store,
+        frame.source.as_ref(),
+        frame.line,
+        limits.max_source_context_lines,
+        notes,
+        cx,
+    )
+    .await?;
+
+    Ok(AgentDebuggerStackFrame {
+        frame_id: frame.id,
+        name: frame.name,
+        source_path,
+        line: frame.line,
+        column: frame.column,
+        scopes,
+        source_context,
+    })
+}
+
+async fn source_context_for_frame(
+    breakpoint_store: &Entity<BreakpointStore>,
+    source: Option<&dap::Source>,
+    line: u64,
+    max_source_context_lines: usize,
+    notes: &mut Vec<String>,
+    cx: &mut AsyncApp,
+) -> Result<Option<AgentSourceContext>> {
+    if max_source_context_lines == 0 {
+        return Ok(None);
+    }
+
+    let Some(path) = source.and_then(|source| source.path.as_ref()) else {
+        return Ok(None);
+    };
+    let row = line
+        .checked_sub(1)
+        .and_then(|line| u32::try_from(line).ok());
+    let Some(row) = row else {
+        notes.push(format!(
+            "Source context for `{path}` omitted because the debugger reported invalid line {line}"
+        ));
+        return Ok(None);
+    };
+
+    let path = Arc::<Path>::from(Path::new(path));
+    match breakpoint_store
+        .update(cx, |breakpoint_store, cx| {
+            breakpoint_store.source_context_for_path(
+                path.clone(),
+                row,
+                max_source_context_lines,
+                cx,
+            )
+        })
+        .await
+    {
+        Ok(context) => {
+            if context.truncated_before || context.truncated_after {
+                notes.push(format!(
+                    "Source context for `{}` line {} truncated to {} line(s)",
+                    path.display(),
+                    line,
+                    context.lines.len()
+                ));
+            }
+
+            Ok(Some(AgentSourceContext {
+                start_line: context.start_row.saturating_add(1),
+                lines: context
+                    .lines
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, text)| AgentSourceContextLine {
+                        line: context
+                            .start_row
+                            .saturating_add(u32::try_from(index).unwrap_or(u32::MAX))
+                            .saturating_add(1),
+                        text,
+                    })
+                    .collect(),
+                truncated_before: context.truncated_before,
+                truncated_after: context.truncated_after,
+            }))
+        }
+        Err(error) => {
+            notes.push(format!(
+                "Source context for `{}` omitted: {error}",
+                path.display()
+            ));
+            Ok(None)
+        }
+    }
+}
+
+fn variable_snapshot(variable: dap::Variable, max_value_length: usize) -> AgentDebuggerVariable {
+    let (value, value_truncated) = truncate_string(variable.value, max_value_length);
+    AgentDebuggerVariable {
+        name: variable.name,
+        value,
+        type_name: variable.type_,
+        variables_reference: variable.variables_reference,
+        named_variables: variable.named_variables,
+        indexed_variables: variable.indexed_variables,
+        value_truncated,
+    }
+}
+
+fn bounded_output(
+    session: &Session,
+    limits: &AgentDebuggerSnapshotLimits,
+    notes: &mut Vec<String>,
+) -> Vec<AgentDebuggerOutputEvent> {
+    let (events, output_token) = session.output(OutputToken(0));
+    let events = events.cloned().collect::<Vec<_>>();
+    if output_token.0 > events.len() {
+        notes.push(format!(
+            "Debugger output ring retained {} of {} event(s)",
+            events.len(),
+            output_token.0
+        ));
+    }
+
+    if limits.max_output_events == 0 || limits.max_output_bytes == 0 {
+        if !events.is_empty() {
+            notes.push("Debugger output omitted by output limits".to_string());
+        }
+        return Vec::new();
+    }
+
+    let mut bytes = 0usize;
+    let mut selected_events = Vec::new();
+    let mut truncated_by_events = false;
+    let mut truncated_by_bytes = false;
+
+    for event in events.iter().rev() {
+        if selected_events.len() >= limits.max_output_events {
+            truncated_by_events = true;
+            break;
+        }
+
+        let event_bytes = event.output.len();
+        if bytes.saturating_add(event_bytes) > limits.max_output_bytes {
+            if selected_events.is_empty() {
+                let mut event = output_event_snapshot(event.clone());
+                let (output, truncated) = truncate_string(event.output, limits.max_output_bytes);
+                event.output = output;
+                event.output_truncated = truncated;
+                selected_events.push(event);
+            }
+            truncated_by_bytes = true;
+            break;
+        }
+
+        bytes += event_bytes;
+        selected_events.push(output_event_snapshot(event.clone()));
+    }
+
+    selected_events.reverse();
+
+    if truncated_by_events {
+        notes.push(format!(
+            "Debugger output truncated to the latest {} event(s)",
+            selected_events.len()
+        ));
+    }
+    if truncated_by_bytes {
+        notes.push(format!(
+            "Debugger output truncated to {} byte(s)",
+            limits.max_output_bytes
+        ));
+    }
+
+    selected_events
+}
+
+fn output_event_snapshot(event: dap::OutputEvent) -> AgentDebuggerOutputEvent {
+    AgentDebuggerOutputEvent {
+        category: event.category.map(|category| format!("{category:?}")),
+        output: event.output,
+        output_truncated: false,
+        source_path: event
+            .source
+            .and_then(|source| source.path)
+            .map(PathBuf::from),
+        line: event.line,
+        column: event.column,
+    }
+}
+
+fn truncate_string(mut value: String, max_length: usize) -> (String, bool) {
+    if value.len() <= max_length {
+        return (value, false);
+    }
+
+    let mut boundary = max_length;
+    while boundary > 0 && !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    value.truncate(boundary);
+    (value, true)
+}

--- a/crates/project/src/debugger/agent_api.rs
+++ b/crates/project/src/debugger/agent_api.rs
@@ -287,98 +287,20 @@ impl AgentDebuggerApi {
         let breakpoint_store = self.breakpoint_store.clone();
         cx.spawn(async move |cx| {
             let session = session_by_id(&dap_store, session_id, cx)?;
-            let mut notes = Vec::new();
-            let session_summary = session.read_with(cx, |session, cx| {
-                AgentDebuggerApi::session_summary_for_session(session, cx)
-            });
-            let output = session.read_with(cx, |session, _| {
-                bounded_output(session, &limits, &mut notes)
-            });
-            let dap_threads = session
-                .update(cx, |session, _| session.agent_fetch_threads())
-                .await?;
-            let mut remaining_frames = limits.max_frames;
-            let mut frames_truncated = false;
-            let mut threads = Vec::new();
-
-            if limits.max_frames == 0 {
-                notes.push("Stack frames omitted because max_frames is 0".to_string());
-            }
-
-            for dap_thread in dap_threads {
-                let thread_id = ThreadId(dap_thread.id);
-                let status = session.read_with(cx, |session, _| session.thread_status(thread_id));
-                let mut frames = Vec::new();
-
-                if status == ThreadStatus::Stopped && remaining_frames > 0 {
-                    let requested_frames = remaining_frames.saturating_add(1);
-                    let mut fetched_frames = session
-                        .update(cx, |session, _| {
-                            session.agent_fetch_stack_frames(thread_id, requested_frames)
-                        })
-                        .await?
-                        .into_iter()
-                        .filter(|frame| {
-                            !(frame.id == 0
-                                && frame.line == 0
-                                && frame.column == 0
-                                && frame.presentation_hint
-                                    == Some(StackFramePresentationHint::Label))
-                        })
-                        .collect::<Vec<_>>();
-
-                    if fetched_frames.len() > remaining_frames {
-                        frames_truncated = true;
-                        fetched_frames.truncate(remaining_frames);
-                    }
-
-                    remaining_frames = remaining_frames.saturating_sub(fetched_frames.len());
-
-                    for frame in fetched_frames {
-                        frames.push(
-                            stack_frame_snapshot(
-                                &session,
-                                &breakpoint_store,
-                                frame,
-                                &limits,
-                                &mut notes,
-                                cx,
-                            )
-                            .await?,
-                        );
-                    }
-                }
-
-                threads.push(AgentDebuggerThread {
-                    thread_id,
-                    name: dap_thread.name,
-                    status: AgentDebuggerThreadStatus::from_thread_status(status),
-                    frames,
-                });
-            }
-
-            if remaining_frames == limits.max_frames
-                && !threads
-                    .iter()
-                    .any(|thread| thread.status == AgentDebuggerThreadStatus::Stopped)
-            {
-                notes.push(
-                    "No stopped threads; stack frames and variables were not requested".to_string(),
-                );
-            } else if frames_truncated {
-                notes.push(format!(
-                    "Stack frames truncated to {} frame(s)",
-                    limits.max_frames
-                ));
-            }
-
-            Ok(AgentDebuggerSnapshot {
-                session: session_summary,
-                threads,
-                output,
-                notes,
-            })
+            snapshot_session(session, breakpoint_store, limits, cx).await
         })
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn snapshot_session_for_test(
+        &self,
+        session: Entity<Session>,
+        limits: AgentDebuggerSnapshotLimits,
+        cx: &mut App,
+    ) -> Task<Result<AgentDebuggerSnapshot>> {
+        let breakpoint_store = self.breakpoint_store.clone();
+        cx.spawn(async move |cx| snapshot_session(session, breakpoint_store, limits, cx).await)
     }
 
     pub fn continue_thread(
@@ -587,6 +509,122 @@ fn session_by_id(
         .with_context(|| format!("Could not find debugger session {:?}", session_id))
 }
 
+async fn snapshot_session(
+    session: Entity<Session>,
+    breakpoint_store: Entity<BreakpointStore>,
+    limits: AgentDebuggerSnapshotLimits,
+    cx: &mut AsyncApp,
+) -> Result<AgentDebuggerSnapshot> {
+    let mut notes = Vec::new();
+    let session_summary = session.read_with(cx, |session, cx| {
+        AgentDebuggerApi::session_summary_for_session(session, cx)
+    });
+    let output = session.read_with(cx, |session, _| {
+        bounded_output(session, &limits, &mut notes)
+    });
+    if session_summary.status == AgentDebuggerSessionStatus::Terminated {
+        notes.push("Session has ended; threads were not requested".to_string());
+        return Ok(AgentDebuggerSnapshot {
+            session: session_summary,
+            threads: Vec::new(),
+            output,
+            notes,
+        });
+    }
+
+    let dap_threads = session
+        .update(cx, |session, _| session.agent_fetch_threads())
+        .await?;
+    let mut remaining_frames = limits.max_frames;
+    let mut frames_truncated = false;
+    let mut threads = Vec::new();
+
+    if limits.max_frames == 0 {
+        notes.push("Stack frames omitted because max_frames is 0".to_string());
+    }
+
+    for dap_thread in dap_threads {
+        let thread_id = ThreadId(dap_thread.id);
+        let status = session.read_with(cx, |session, _| session.thread_status(thread_id));
+        let mut frames = Vec::new();
+
+        if status == ThreadStatus::Stopped && remaining_frames > 0 {
+            let requested_frames = remaining_frames.saturating_add(1);
+            let fetched_frames = session
+                .update(cx, |session, _| {
+                    session.agent_fetch_stack_frames(thread_id, requested_frames)
+                })
+                .await;
+            let mut fetched_frames = match fetched_frames {
+                Ok(fetched_frames) => fetched_frames
+                    .into_iter()
+                    .filter(|frame| {
+                        !(frame.id == 0
+                            && frame.line == 0
+                            && frame.column == 0
+                            && frame.presentation_hint == Some(StackFramePresentationHint::Label))
+                    })
+                    .collect::<Vec<_>>(),
+                Err(error) => {
+                    notes.push(format!(
+                        "Stack frames for thread `{}` ({:?}) omitted: {error}",
+                        dap_thread.name, thread_id
+                    ));
+                    Vec::new()
+                }
+            };
+
+            if fetched_frames.len() > remaining_frames {
+                frames_truncated = true;
+                fetched_frames.truncate(remaining_frames);
+            }
+
+            remaining_frames = remaining_frames.saturating_sub(fetched_frames.len());
+
+            for frame in fetched_frames {
+                frames.push(
+                    stack_frame_snapshot(
+                        &session,
+                        &breakpoint_store,
+                        frame,
+                        &limits,
+                        &mut notes,
+                        cx,
+                    )
+                    .await,
+                );
+            }
+        }
+
+        threads.push(AgentDebuggerThread {
+            thread_id,
+            name: dap_thread.name,
+            status: AgentDebuggerThreadStatus::from_thread_status(status),
+            frames,
+        });
+    }
+
+    if remaining_frames == limits.max_frames
+        && !threads
+            .iter()
+            .any(|thread| thread.status == AgentDebuggerThreadStatus::Stopped)
+    {
+        notes.push("No stopped threads; stack frames and variables were not requested".to_string());
+    } else if frames_truncated {
+        notes.push(format!(
+            "Stack frames truncated to {} frame(s)",
+            limits.max_frames
+        ));
+    }
+
+    Ok(AgentDebuggerSnapshot {
+        session: session_summary,
+        threads,
+        output,
+        notes,
+    })
+}
+
 fn subscribe_to_stop(session: Entity<Session>, cx: &mut AsyncApp) -> Result<AgentDebuggerStopWait> {
     let (sender, receiver) = futures::channel::oneshot::channel();
     let sender = Arc::new(Mutex::new(Some(sender)));
@@ -659,13 +697,24 @@ async fn stack_frame_snapshot(
     limits: &AgentDebuggerSnapshotLimits,
     notes: &mut Vec<String>,
     cx: &mut AsyncApp,
-) -> Result<AgentDebuggerStackFrame> {
+) -> AgentDebuggerStackFrame {
     let mut scopes = Vec::new();
-    let dap_scopes = session
+    let dap_scopes = match session
         .update(cx, |session, _| session.agent_fetch_scopes(frame.id))
-        .await?;
+        .await
+    {
+        Ok(scopes) => scopes,
+        Err(error) => {
+            notes.push(format!(
+                "Scopes for frame `{}` ({}) omitted: {error}",
+                frame.name, frame.id
+            ));
+            Vec::new()
+        }
+    };
 
     for scope in dap_scopes {
+        let mut variables_unavailable = false;
         let variables = if scope.variables_reference == 0 || limits.max_variables_per_scope == 0 {
             if scope.variables_reference != 0 && limits.max_variables_per_scope == 0 {
                 notes.push(format!(
@@ -675,7 +724,7 @@ async fn stack_frame_snapshot(
             }
             Vec::new()
         } else {
-            session
+            match session
                 .update(cx, |session, cx| {
                     session.agent_fetch_variables(
                         scope.variables_reference,
@@ -683,20 +732,33 @@ async fn stack_frame_snapshot(
                         cx,
                     )
                 })
-                .await?
+                .await
+            {
+                Ok(variables) => variables,
+                Err(error) => {
+                    notes.push(format!(
+                        "Variables for scope `{}` omitted: {error}",
+                        scope.name
+                    ));
+                    variables_unavailable = true;
+                    Vec::new()
+                }
+            }
         };
 
         let known_variable_count = scope
             .named_variables
             .unwrap_or(0)
             .saturating_add(scope.indexed_variables.unwrap_or(0));
-        let variables_truncated = if limits.max_variables_per_scope == 0 {
+        let variables_truncated = if variables_unavailable {
+            true
+        } else if limits.max_variables_per_scope == 0 {
             scope.variables_reference != 0
         } else {
             known_variable_count > variables.len() as u64
                 || variables.len() >= limits.max_variables_per_scope
         };
-        if variables_truncated && limits.max_variables_per_scope > 0 {
+        if variables_truncated && !variables_unavailable && limits.max_variables_per_scope > 0 {
             notes.push(format!(
                 "Variables for scope `{}` truncated to {} variable(s)",
                 scope.name,
@@ -729,7 +791,7 @@ async fn stack_frame_snapshot(
         .as_ref()
         .and_then(|source| source.path.as_ref())
         .map(PathBuf::from);
-    let source_context = source_context_for_frame(
+    let source_context = match source_context_for_frame(
         breakpoint_store,
         frame.source.as_ref(),
         frame.line,
@@ -737,9 +799,19 @@ async fn stack_frame_snapshot(
         notes,
         cx,
     )
-    .await?;
+    .await
+    {
+        Ok(context) => context,
+        Err(error) => {
+            notes.push(format!(
+                "Source context for frame `{}` ({}) omitted: {error}",
+                frame.name, frame.id
+            ));
+            None
+        }
+    };
 
-    Ok(AgentDebuggerStackFrame {
+    AgentDebuggerStackFrame {
         frame_id: frame.id,
         name: frame.name,
         source_path,
@@ -747,7 +819,7 @@ async fn stack_frame_snapshot(
         column: frame.column,
         scopes,
         source_context,
-    })
+    }
 }
 
 async fn source_context_for_frame(

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -1,13 +1,13 @@
 //! Module for managing breakpoints in a project.
 //!
 //! Breakpoints are separate from a session because they're not associated with any particular debug session. They can also be set up without a session running.
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, bail};
 pub use breakpoints_in_file::{BreakpointSessionState, BreakpointWithPosition};
 use breakpoints_in_file::{BreakpointsInFile, StatefulBreakpoint};
 use collections::{BTreeMap, HashMap};
 use dap::{StackFrameId, client::SessionId};
 use gpui::{
-    App, AppContext, AsyncApp, Context, Entity, EntityId, EventEmitter, Subscription, Task,
+    App, AppContext, AsyncApp, Context, Entity, EntityId, EventEmitter, Subscription, Task, TaskExt,
 };
 use itertools::Itertools;
 use language::{Buffer, BufferSnapshot, proto::serialize_anchor as serialize_text_anchor};
@@ -17,7 +17,7 @@ use rpc::{
 };
 use std::{hash::Hash, ops::Range, path::Path, sync::Arc, u32};
 use text::{Bias, Point, PointUtf16, Unclipped};
-use util::maybe;
+use util::{ResultExt as _, maybe};
 
 use crate::{ProjectPath, buffer_store::BufferStore, worktree_store::WorktreeStore};
 
@@ -148,6 +148,14 @@ pub struct ActiveStackFrame {
     pub stack_frame_id: StackFrameId,
     pub path: Arc<Path>,
     pub position: text::Anchor,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SourceContext {
+    pub start_row: u32,
+    pub lines: Vec<String>,
+    pub truncated_before: bool,
+    pub truncated_after: bool,
 }
 
 pub struct BreakpointStore {
@@ -632,6 +640,300 @@ impl BreakpointStore {
         let breakpoint_paths = self.breakpoints.keys().cloned().collect();
         self.breakpoints.clear();
         cx.emit(BreakpointStoreEvent::BreakpointsCleared(breakpoint_paths));
+    }
+
+    pub(crate) fn set_source_breakpoint(
+        &mut self,
+        breakpoint: SourceBreakpoint,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<bool>> {
+        let buffer = self.open_buffer_for_absolute_path(breakpoint.path.clone(), cx);
+        cx.spawn(async move |this, cx| {
+            let buffer = buffer.await?;
+            this.update(cx, |this, cx| {
+                this.set_source_breakpoint_in_buffer(buffer, breakpoint, cx)
+            })?
+        })
+    }
+
+    pub(crate) fn remove_source_breakpoint(
+        &mut self,
+        path: Arc<Path>,
+        row: u32,
+        cx: &mut Context<Self>,
+    ) -> Result<bool> {
+        let Some((removed_breakpoint, remove_path)) =
+            self.remove_source_breakpoint_by_row(&path, row, cx)
+        else {
+            return Ok(false);
+        };
+
+        if remove_path {
+            self.breakpoints.remove(&path);
+        }
+
+        self.send_remote_breakpoint_toggles(&path, vec![removed_breakpoint], cx);
+        self.broadcast_breakpoints_for_path(&path);
+        cx.emit(BreakpointStoreEvent::BreakpointsUpdated(
+            path,
+            BreakpointUpdatedReason::Toggled,
+        ));
+        cx.notify();
+        Ok(true)
+    }
+
+    pub(crate) fn source_context_for_path(
+        &self,
+        path: Arc<Path>,
+        row: u32,
+        max_lines: usize,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<SourceContext>> {
+        let buffer = self.open_buffer_for_absolute_path(path, cx);
+        cx.spawn(async move |_, cx| {
+            let buffer = buffer.await?;
+            let context = buffer.read_with(cx, |buffer, _| {
+                let snapshot = buffer.snapshot();
+                let max_point = snapshot.max_point();
+                if row > max_point.row {
+                    bail!(
+                        "line {} is outside the file, which ends at line {}",
+                        row.saturating_add(1),
+                        max_point.row.saturating_add(1)
+                    );
+                }
+
+                let total_rows = max_point.row.saturating_add(1);
+                let requested_rows = u32::try_from(max_lines.max(1)).unwrap_or(u32::MAX);
+                let mut start_row = row.saturating_sub(requested_rows / 2);
+                let end_row = start_row.saturating_add(requested_rows).min(total_rows);
+                if end_row.saturating_sub(start_row) < requested_rows {
+                    start_row = end_row.saturating_sub(requested_rows);
+                }
+
+                let mut lines = Vec::new();
+                for row in start_row..end_row {
+                    let start = Point::new(row, 0);
+                    let end = Point::new(row, snapshot.line_len(row));
+                    lines.push(snapshot.text_for_range(start..end).collect::<String>());
+                }
+
+                Ok(SourceContext {
+                    start_row,
+                    lines,
+                    truncated_before: start_row > 0,
+                    truncated_after: end_row < total_rows,
+                })
+            })?;
+            Ok(context)
+        })
+    }
+
+    fn open_buffer_for_absolute_path(
+        &self,
+        path: Arc<Path>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<Buffer>>> {
+        let worktree_store = self.worktree_store.clone();
+        let buffer_store = self.buffer_store.clone();
+        cx.spawn(async move |_, cx| {
+            let project_path = worktree_store
+                .read_with(cx, |worktree_store, cx| {
+                    worktree_store.project_path_for_absolute_path(path.as_ref(), cx)
+                })
+                .with_context(|| {
+                    format!(
+                        "Could not resolve debugger source path `{}` in this project",
+                        path.display()
+                    )
+                })?;
+            let buffer = buffer_store
+                .update(cx, |buffer_store, cx| {
+                    buffer_store.open_buffer(project_path, cx)
+                })
+                .await?;
+            Ok(buffer)
+        })
+    }
+
+    fn set_source_breakpoint_in_buffer(
+        &mut self,
+        buffer: Entity<Buffer>,
+        mut breakpoint: SourceBreakpoint,
+        cx: &mut Context<Self>,
+    ) -> Result<bool> {
+        let Some(abs_path) = Self::abs_path_from_buffer(&buffer, cx) else {
+            bail!("Could not resolve debugger source buffer path");
+        };
+        breakpoint.path = abs_path.clone();
+
+        let snapshot = buffer.read(cx).snapshot();
+        let max_point = snapshot.max_point_utf16();
+        if breakpoint.row > max_point.row {
+            bail!(
+                "line {} is outside the file, which ends at line {}",
+                breakpoint.row.saturating_add(1),
+                max_point.row.saturating_add(1)
+            );
+        }
+
+        let breakpoint_set = self
+            .breakpoints
+            .entry(abs_path.clone())
+            .or_insert_with(|| BreakpointsInFile::new(buffer.clone(), cx));
+
+        if breakpoint_set.buffer != buffer {
+            let old_snapshot = breakpoint_set.buffer.read(cx).snapshot();
+            let new_snapshot = buffer.read(cx).snapshot();
+            let breakpoints = breakpoint_set
+                .breakpoints
+                .drain(..)
+                .map(|mut breakpoint| {
+                    let old_position =
+                        old_snapshot.summary_for_anchor::<PointUtf16>(breakpoint.position());
+                    let new_position = PointUtf16::new(old_position.row, 0);
+                    let new_position =
+                        new_snapshot.clip_point_utf16(Unclipped(new_position), Bias::Left);
+                    breakpoint.bp.position = new_snapshot.anchor_after(new_position);
+                    breakpoint
+                })
+                .collect();
+            *breakpoint_set = BreakpointsInFile::new(buffer.clone(), cx);
+            breakpoint_set.breakpoints = breakpoints;
+        }
+
+        let row = breakpoint.row;
+        let point = PointUtf16::new(row, 0);
+        let point = snapshot.clip_point_utf16(Unclipped(point), Bias::Left);
+        let breakpoint = BreakpointWithPosition {
+            position: snapshot.anchor_after(point),
+            bp: Breakpoint {
+                message: breakpoint.message,
+                hit_condition: breakpoint.hit_condition,
+                condition: breakpoint.condition,
+                state: breakpoint.state,
+            },
+        };
+
+        let existing_index = breakpoint_set.breakpoints.iter().position(|existing| {
+            snapshot
+                .summary_for_anchor::<PointUtf16>(existing.position())
+                .row
+                == row
+        });
+
+        let mut remote_toggles = Vec::new();
+        match existing_index {
+            Some(index) if breakpoint_set.breakpoints[index].bp == breakpoint => return Ok(false),
+            Some(index) => {
+                remote_toggles.push(breakpoint_set.breakpoints[index].bp.clone());
+                breakpoint_set.breakpoints[index] = StatefulBreakpoint::new(breakpoint.clone());
+                remote_toggles.push(breakpoint);
+            }
+            None => {
+                breakpoint_set
+                    .breakpoints
+                    .push(StatefulBreakpoint::new(breakpoint.clone()));
+                remote_toggles.push(breakpoint);
+            }
+        }
+
+        self.send_remote_breakpoint_toggles(&abs_path, remote_toggles, cx);
+        self.broadcast_breakpoints_for_path(&abs_path);
+        cx.emit(BreakpointStoreEvent::BreakpointsUpdated(
+            abs_path,
+            BreakpointUpdatedReason::Toggled,
+        ));
+        cx.notify();
+        Ok(true)
+    }
+
+    fn remove_source_breakpoint_by_row(
+        &mut self,
+        path: &Arc<Path>,
+        row: u32,
+        cx: &App,
+    ) -> Option<(BreakpointWithPosition, bool)> {
+        let breakpoint_set = self.breakpoints.get_mut(path)?;
+        let snapshot = breakpoint_set.buffer.read(cx).snapshot();
+        let index = breakpoint_set.breakpoints.iter().position(|breakpoint| {
+            snapshot
+                .summary_for_anchor::<PointUtf16>(breakpoint.position())
+                .row
+                == row
+        })?;
+        let removed_breakpoint = breakpoint_set.breakpoints.remove(index).bp;
+        Some((removed_breakpoint, breakpoint_set.breakpoints.is_empty()))
+    }
+
+    fn send_remote_breakpoint_toggles(
+        &self,
+        abs_path: &Arc<Path>,
+        breakpoints: Vec<BreakpointWithPosition>,
+        cx: &mut Context<Self>,
+    ) {
+        let BreakpointStoreMode::Remote(remote) = &self.mode else {
+            return;
+        };
+
+        for breakpoint in breakpoints {
+            let Some(breakpoint) =
+                breakpoint
+                    .bp
+                    .to_proto(abs_path, &breakpoint.position, &HashMap::default())
+            else {
+                continue;
+            };
+            let upstream_client = remote.upstream_client.clone();
+            let upstream_project_id = remote.upstream_project_id;
+            let path = abs_path.to_string_lossy().into_owned();
+            cx.background_spawn(async move {
+                upstream_client
+                    .request(proto::ToggleBreakpoint {
+                        project_id: upstream_project_id,
+                        path,
+                        breakpoint: Some(breakpoint),
+                    })
+                    .await?;
+                anyhow::Ok(())
+            })
+            .detach_and_log_err(cx);
+        }
+    }
+
+    fn broadcast_breakpoints_for_path(&self, abs_path: &Arc<Path>) {
+        if matches!(self.mode, BreakpointStoreMode::Remote(_)) {
+            return;
+        }
+
+        let Some((client, project_id)) = &self.downstream_client else {
+            return;
+        };
+        let breakpoints = self
+            .breakpoints
+            .get(abs_path)
+            .map(|breakpoint_set| {
+                breakpoint_set
+                    .breakpoints
+                    .iter()
+                    .filter_map(|breakpoint| {
+                        breakpoint.bp.bp.to_proto(
+                            abs_path,
+                            breakpoint.position(),
+                            &breakpoint.session_state,
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        client
+            .send(proto::BreakpointsForFile {
+                project_id: *project_id,
+                path: abs_path.to_string_lossy().into_owned(),
+                breakpoints,
+            })
+            .log_err();
     }
 
     pub fn breakpoints<'a>(

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -876,29 +876,35 @@ impl BreakpointStore {
             return;
         };
 
-        for breakpoint in breakpoints {
-            let Some(breakpoint) =
-                breakpoint
-                    .bp
-                    .to_proto(abs_path, &breakpoint.position, &HashMap::default())
-            else {
-                continue;
-            };
-            let upstream_client = remote.upstream_client.clone();
-            let upstream_project_id = remote.upstream_project_id;
-            let path = abs_path.to_string_lossy().into_owned();
-            cx.background_spawn(async move {
-                upstream_client
-                    .request(proto::ToggleBreakpoint {
-                        project_id: upstream_project_id,
-                        path,
-                        breakpoint: Some(breakpoint),
-                    })
-                    .await?;
-                anyhow::Ok(())
-            })
-            .detach_and_log_err(cx);
+        if breakpoints.is_empty() {
+            return;
         }
+
+        let abs_path = abs_path.clone();
+        let upstream_client = remote.upstream_client.clone();
+        let upstream_project_id = remote.upstream_project_id;
+        cx.background_spawn(async move {
+            let path = abs_path.to_string_lossy().into_owned();
+            let breakpoint_toggles = breakpoints
+                .into_iter()
+                .filter_map(|breakpoint| {
+                    breakpoint
+                        .bp
+                        .to_proto(&abs_path, &breakpoint.position, &HashMap::default())
+                        .map(|breakpoint| proto::ToggleBreakpoint {
+                            project_id: upstream_project_id,
+                            path: path.clone(),
+                            breakpoint: Some(breakpoint),
+                        })
+                })
+                .collect::<Vec<_>>();
+
+            for breakpoint_toggle in breakpoint_toggles {
+                upstream_client.request(breakpoint_toggle).await?;
+            }
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
     }
 
     fn broadcast_breakpoints_for_path(&self, abs_path: &Arc<Path>) {

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -2398,7 +2398,7 @@ impl Session {
                 let path = breakpoint.path.clone();
                 local_mode.tmp_breakpoint = Some(breakpoint);
                 let task = local_mode.send_breakpoints_from_path_result(
-                    path,
+                    path.clone(),
                     BreakpointUpdatedReason::Toggled,
                     &breakpoint_store,
                     cx,
@@ -2414,10 +2414,37 @@ impl Session {
                         return Err(error);
                     }
 
-                    this.update(cx, |this, cx| {
-                        this.agent_continue_thread(active_thread_id, cx)
-                    })?
-                    .await
+                    let continue_result = this
+                        .update(cx, |this, cx| {
+                            this.agent_continue_thread(active_thread_id, cx)
+                        })?
+                        .await;
+
+                    if let Err(error) = continue_result {
+                        let cleanup = this.update(cx, |this, cx| {
+                            this.as_running_mut().map(|local_mode| {
+                                local_mode.tmp_breakpoint.take();
+                                local_mode.send_breakpoints_from_path_result(
+                                    path,
+                                    BreakpointUpdatedReason::Toggled,
+                                    &breakpoint_store,
+                                    cx,
+                                )
+                            })
+                        })?;
+
+                        if let Some(cleanup) = cleanup
+                            && let Err(cleanup_error) = cleanup.await
+                        {
+                            log::warn!(
+                                "failed to remove temporary run-to-line breakpoint after continue failed: {cleanup_error}"
+                            );
+                        }
+
+                        return Err(error);
+                    }
+
+                    Ok(())
                 })
             }
             SessionState::Booting(_) => Task::ready(Err(anyhow!(

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -267,17 +267,37 @@ impl RunningMode {
         breakpoint_store: &Entity<BreakpointStore>,
         cx: &mut App,
     ) -> Task<()> {
-        let breakpoints =
-            breakpoint_store
-                .read(cx)
-                .source_breakpoints_from_path(&abs_path, cx)
-                .into_iter()
-                .filter(|bp| bp.state.is_enabled())
-                .chain(self.tmp_breakpoint.iter().filter_map(|breakpoint| {
-                    breakpoint.path.eq(&abs_path).then(|| breakpoint.clone())
-                }))
-                .map(Into::into)
-                .collect();
+        let log_path = abs_path.clone();
+        let task = self.send_breakpoints_from_path_result(abs_path, reason, breakpoint_store, cx);
+        cx.spawn(async move |_| {
+            if let Err(error) = task.await {
+                log::warn!("Set breakpoints request failed for path {log_path:?}: {error}");
+            }
+        })
+    }
+
+    fn send_breakpoints_from_path_result(
+        &self,
+        abs_path: Arc<Path>,
+        reason: BreakpointUpdatedReason,
+        breakpoint_store: &Entity<BreakpointStore>,
+        cx: &mut App,
+    ) -> Task<Result<()>> {
+        let breakpoints = breakpoint_store
+            .read(cx)
+            .source_breakpoints_from_path(&abs_path, cx)
+            .into_iter()
+            .filter(|bp| bp.state.is_enabled())
+            .chain(
+                self.tmp_breakpoint
+                    .iter()
+                    .filter(|breakpoint| breakpoint.state.is_enabled())
+                    .filter_map(|breakpoint| {
+                        breakpoint.path.eq(&abs_path).then(|| breakpoint.clone())
+                    }),
+            )
+            .map(Into::into)
+            .collect();
 
         let raw_breakpoints = breakpoint_store
             .read(cx)
@@ -293,28 +313,25 @@ impl RunningMode {
         });
         let session_id = self.client.id();
         let breakpoint_store = breakpoint_store.downgrade();
-        cx.spawn(async move |cx| match cx.background_spawn(task).await {
-            Ok(breakpoints) => {
-                let breakpoints =
-                    breakpoints
-                        .into_iter()
-                        .zip(raw_breakpoints)
-                        .filter_map(|(dap_bp, zed_bp)| {
-                            Some((
-                                zed_bp,
-                                BreakpointSessionState {
-                                    id: dap_bp.id?,
-                                    verified: dap_bp.verified,
-                                },
-                            ))
-                        });
-                breakpoint_store
-                    .update(cx, |this, _| {
-                        this.mark_breakpoints_verified(session_id, &abs_path, breakpoints);
-                    })
-                    .ok();
-            }
-            Err(err) => log::warn!("Set breakpoints request failed for path: {}", err),
+        cx.spawn(async move |cx| {
+            let breakpoints = cx.background_spawn(task).await?;
+            let breakpoints =
+                breakpoints
+                    .into_iter()
+                    .zip(raw_breakpoints)
+                    .filter_map(|(dap_bp, zed_bp)| {
+                        Some((
+                            zed_bp,
+                            BreakpointSessionState {
+                                id: dap_bp.id?,
+                                verified: dap_bp.verified,
+                            },
+                        ))
+                    });
+            breakpoint_store.update(cx, |this, _| {
+                this.mark_breakpoints_verified(session_id, &abs_path, breakpoints);
+            })?;
+            Ok(())
         })
     }
 
@@ -2106,6 +2123,52 @@ impl Session {
         &self.session_state().loaded_sources
     }
 
+    pub(crate) fn agent_fetch_threads(&self) -> Task<Result<Vec<dap::Thread>>> {
+        self.state.request_dap(ThreadsCommand)
+    }
+
+    pub(crate) fn agent_fetch_stack_frames(
+        &self,
+        thread_id: ThreadId,
+        max_frames: usize,
+    ) -> Task<Result<Vec<dap::StackFrame>>> {
+        self.state.request_dap(StackTraceCommand {
+            thread_id: thread_id.0,
+            start_frame: None,
+            levels: Some(u64::try_from(max_frames).unwrap_or(u64::MAX)),
+        })
+    }
+
+    pub(crate) fn agent_fetch_scopes(
+        &self,
+        stack_frame_id: StackFrameId,
+    ) -> Task<Result<Vec<dap::Scope>>> {
+        self.state.request_dap(ScopesCommand { stack_frame_id })
+    }
+
+    pub(crate) fn agent_fetch_variables(
+        &self,
+        variables_reference: VariableReference,
+        max_variables: usize,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Vec<dap::Variable>>> {
+        let request = self.state.request_dap(VariablesCommand {
+            variables_reference,
+            filter: None,
+            start: None,
+            count: Some(u64::try_from(max_variables).unwrap_or(u64::MAX)),
+            format: None,
+        });
+        let adapter = self.adapter.clone();
+        cx.spawn(async move |_, _| {
+            let mut variables = request.await?;
+            Self::normalize_variables_for_adapter(&adapter, &mut variables);
+            // Adapters may ignore the `count` argument, so enforce the bound here.
+            variables.truncate(max_variables);
+            Ok(variables)
+        })
+    }
+
     fn fallback_to_manual_restart(
         &mut self,
         res: Result<()>,
@@ -2156,6 +2219,211 @@ impl Session {
         self.breakpoint_store.update(cx, |store, cx| {
             store.remove_active_position(Some(self.id), cx)
         });
+    }
+
+    fn agent_resume_request<T: LocalDapCommand + PartialEq + Eq + Hash>(
+        &self,
+        thread_id: ThreadId,
+        command: T,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        if !T::is_supported(&self.capabilities) {
+            return Task::ready(Err(anyhow!(
+                "debug adapter does not support request: {command:?}"
+            )));
+        }
+
+        let request = self.state.request_dap(command);
+        cx.spawn(async move |this, cx| match request.await {
+            Ok(_) => {
+                this.update(cx, |this, cx| {
+                    this.breakpoint_store.update(cx, |store, cx| {
+                        store.remove_active_position(Some(this.session_id()), cx)
+                    });
+                })?;
+                Ok(())
+            }
+            Err(error) => {
+                this.update(cx, |this, cx| {
+                    this.active_snapshot.thread_states.stop_thread(thread_id);
+                    cx.notify();
+                })?;
+                Err(error)
+            }
+        })
+    }
+
+    pub(crate) fn agent_pause_thread(
+        &mut self,
+        thread_id: ThreadId,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        if !PauseCommand::is_supported(&self.capabilities) {
+            return Task::ready(Err(anyhow!("debug adapter does not support pause")));
+        }
+
+        let request = self.state.request_dap(PauseCommand {
+            thread_id: thread_id.0,
+        });
+        cx.spawn(async move |_, _| {
+            request.await?;
+            Ok(())
+        })
+    }
+
+    pub(crate) fn agent_continue_thread(
+        &mut self,
+        thread_id: ThreadId,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        self.select_historic_snapshot(None, cx);
+
+        let supports_single_thread_execution_requests =
+            self.capabilities.supports_single_thread_execution_requests;
+        self.active_snapshot
+            .thread_states
+            .continue_thread(thread_id);
+        self.agent_resume_request(
+            thread_id,
+            ContinueCommand {
+                args: ContinueArguments {
+                    thread_id: thread_id.0,
+                    single_thread: supports_single_thread_execution_requests,
+                },
+            },
+            cx,
+        )
+    }
+
+    pub(crate) fn agent_step_over(
+        &mut self,
+        thread_id: ThreadId,
+        granularity: SteppingGranularity,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        self.select_historic_snapshot(None, cx);
+
+        let supports_single_thread_execution_requests =
+            self.capabilities.supports_single_thread_execution_requests;
+        let supports_stepping_granularity = self
+            .capabilities
+            .supports_stepping_granularity
+            .unwrap_or_default();
+        let command = NextCommand {
+            inner: StepCommand {
+                thread_id: thread_id.0,
+                granularity: supports_stepping_granularity.then(|| granularity),
+                single_thread: supports_single_thread_execution_requests,
+            },
+        };
+
+        self.active_snapshot.thread_states.process_step(thread_id);
+        self.agent_resume_request(thread_id, command, cx)
+    }
+
+    pub(crate) fn agent_step_in(
+        &mut self,
+        thread_id: ThreadId,
+        granularity: SteppingGranularity,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        self.select_historic_snapshot(None, cx);
+
+        let supports_single_thread_execution_requests =
+            self.capabilities.supports_single_thread_execution_requests;
+        let supports_stepping_granularity = self
+            .capabilities
+            .supports_stepping_granularity
+            .unwrap_or_default();
+        let command = StepInCommand {
+            inner: StepCommand {
+                thread_id: thread_id.0,
+                granularity: supports_stepping_granularity.then(|| granularity),
+                single_thread: supports_single_thread_execution_requests,
+            },
+        };
+
+        self.active_snapshot.thread_states.process_step(thread_id);
+        self.agent_resume_request(thread_id, command, cx)
+    }
+
+    pub(crate) fn agent_step_out(
+        &mut self,
+        thread_id: ThreadId,
+        granularity: SteppingGranularity,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        self.select_historic_snapshot(None, cx);
+
+        let supports_single_thread_execution_requests =
+            self.capabilities.supports_single_thread_execution_requests;
+        let supports_stepping_granularity = self
+            .capabilities
+            .supports_stepping_granularity
+            .unwrap_or_default();
+        let command = StepOutCommand {
+            inner: StepCommand {
+                thread_id: thread_id.0,
+                granularity: supports_stepping_granularity.then(|| granularity),
+                single_thread: supports_single_thread_execution_requests,
+            },
+        };
+
+        self.active_snapshot.thread_states.process_step(thread_id);
+        self.agent_resume_request(thread_id, command, cx)
+    }
+
+    pub(crate) fn agent_run_to_position(
+        &mut self,
+        breakpoint: SourceBreakpoint,
+        active_thread_id: ThreadId,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        self.select_historic_snapshot(None, cx);
+
+        let breakpoint_store = self.breakpoint_store.clone();
+        match &mut self.state {
+            SessionState::Running(local_mode) => {
+                if !matches!(
+                    self.active_snapshot
+                        .thread_states
+                        .thread_state(active_thread_id),
+                    Some(ThreadStatus::Stopped)
+                ) {
+                    return Task::ready(Err(anyhow!(
+                        "cannot run to line because thread {:?} is not stopped",
+                        active_thread_id
+                    )));
+                }
+                let path = breakpoint.path.clone();
+                local_mode.tmp_breakpoint = Some(breakpoint);
+                let task = local_mode.send_breakpoints_from_path_result(
+                    path,
+                    BreakpointUpdatedReason::Toggled,
+                    &breakpoint_store,
+                    cx,
+                );
+
+                cx.spawn(async move |this, cx| {
+                    if let Err(error) = task.await {
+                        this.update(cx, |this, _| {
+                            if let Some(local_mode) = this.as_running_mut() {
+                                local_mode.tmp_breakpoint.take();
+                            }
+                        })?;
+                        return Err(error);
+                    }
+
+                    this.update(cx, |this, cx| {
+                        this.agent_continue_thread(active_thread_id, cx)
+                    })?
+                    .await
+                })
+            }
+            SessionState::Booting(_) => Task::ready(Err(anyhow!(
+                "cannot run to line while the debug session is booting"
+            ))),
+        }
     }
 
     pub fn pause_thread(&mut self, thread_id: ThreadId, cx: &mut Context<Self>) {
@@ -2635,6 +2903,43 @@ impl Session {
         self.watchers.remove(&expression);
     }
 
+    fn normalize_variables_for_adapter(
+        adapter: &DebugAdapterName,
+        variables: &mut [dap::Variable],
+    ) {
+        if adapter.0.as_ref() != "Debugpy" {
+            return;
+        }
+
+        for variable in variables.iter_mut() {
+            if variable.type_ == Some("str".into()) {
+                // reverse Python repr() escaping
+                let mut unescaped = String::with_capacity(variable.value.len());
+                let mut chars = variable.value.chars();
+                while let Some(c) = chars.next() {
+                    if c != '\\' {
+                        unescaped.push(c);
+                    } else {
+                        match chars.next() {
+                            Some('\\') => unescaped.push('\\'),
+                            Some('n') => unescaped.push('\n'),
+                            Some('t') => unescaped.push('\t'),
+                            Some('r') => unescaped.push('\r'),
+                            Some('\'') => unescaped.push('\''),
+                            Some('"') => unescaped.push('"'),
+                            Some(c) => {
+                                unescaped.push('\\');
+                                unescaped.push(c);
+                            }
+                            None => {}
+                        }
+                    }
+                }
+                variable.value = unescaped;
+            }
+        }
+    }
+
     pub fn variables(
         &mut self,
         variables_reference: VariableReference,
@@ -2655,35 +2960,7 @@ impl Session {
                     return;
                 };
 
-                if this.adapter.0.as_ref() == "Debugpy" {
-                    for variable in variables.iter_mut() {
-                        if variable.type_ == Some("str".into()) {
-                            // reverse Python repr() escaping
-                            let mut unescaped = String::with_capacity(variable.value.len());
-                            let mut chars = variable.value.chars();
-                            while let Some(c) = chars.next() {
-                                if c != '\\' {
-                                    unescaped.push(c);
-                                } else {
-                                    match chars.next() {
-                                        Some('\\') => unescaped.push('\\'),
-                                        Some('n') => unescaped.push('\n'),
-                                        Some('t') => unescaped.push('\t'),
-                                        Some('r') => unescaped.push('\r'),
-                                        Some('\'') => unescaped.push('\''),
-                                        Some('"') => unescaped.push('"'),
-                                        Some(c) => {
-                                            unescaped.push('\\');
-                                            unescaped.push(c);
-                                        }
-                                        None => {}
-                                    }
-                                }
-                            }
-                            variable.value = unescaped;
-                        }
-                    }
-                }
+                Self::normalize_variables_for_adapter(&this.adapter, &mut variables);
 
                 this.active_snapshot
                     .variables

--- a/crates/settings_ui/src/pages/tool_permissions_setup.rs
+++ b/crates/settings_ui/src/pages/tool_permissions_setup.rs
@@ -69,6 +69,12 @@ const TOOLS: &[ToolInfo] = &[
         regex_explanation: "Patterns are matched against the URL being fetched.",
     },
     ToolInfo {
+        id: "debugger",
+        name: "Debugger",
+        description: "Debugger session starts, breakpoint edits, and execution controls",
+        regex_explanation: "Patterns are matched against debugger operation details such as `start_session`, `set_breakpoints`, source paths, session ids, and thread ids. Read-only debugger inspections do not request permission.",
+    },
+    ToolInfo {
         id: "search_web",
         name: "Web Search",
         description: "Web search queries",

--- a/crates/settings_ui/src/pages/tool_permissions_setup.rs
+++ b/crates/settings_ui/src/pages/tool_permissions_setup.rs
@@ -72,7 +72,7 @@ const TOOLS: &[ToolInfo] = &[
         id: "debugger",
         name: "Debugger",
         description: "Debugger session starts, breakpoint edits, and execution controls",
-        regex_explanation: "Patterns are matched against debugger operation details such as `start_session`, `set_breakpoints`, source paths, session ids, and thread ids. Read-only debugger inspections do not request permission.",
+        regex_explanation: "Patterns are matched against debugger operation details such as full `start_session` config/build/tcp_connection values, breakpoint paths/lines/conditions/log messages, `run_to_line` source paths/lines, session ids, and thread ids. Read-only debugger inspections do not request permission.",
     },
     ToolInfo {
         id: "search_web",

--- a/crates/workspace/src/tasks.rs
+++ b/crates/workspace/src/tasks.rs
@@ -1,6 +1,6 @@
 use std::process::ExitStatus;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use collections::HashSet;
 use gpui::{AppContext, AsyncWindowContext, Context, Entity, Task, TaskExt, WeakEntity};
 use language::Buffer;
@@ -13,7 +13,7 @@ use task::{
 use ui::Window;
 use util::TryFutureExt;
 
-use crate::{SaveIntent, Toast, Workspace, notifications::NotificationId};
+use crate::{DebugSessionStartInfo, SaveIntent, Toast, Workspace, notifications::NotificationId};
 
 impl Workspace {
     pub fn schedule_task(
@@ -147,17 +147,19 @@ impl Workspace {
         worktree_id: Option<WorktreeId>,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) {
-        if let Some(provider) = self.debugger_provider.as_mut() {
-            provider.start_session(
-                scenario,
-                task_context,
-                active_buffer,
-                worktree_id,
-                window,
-                cx,
-            )
-        }
+    ) -> Result<DebugSessionStartInfo> {
+        let provider = self
+            .debugger_provider
+            .as_ref()
+            .ok_or_else(|| anyhow!("No debugger provider is registered for this workspace"))?;
+        provider.start_session(
+            scenario,
+            task_context,
+            active_buffer,
+            worktree_id,
+            window,
+            cx,
+        )
     }
 
     pub fn spawn_in_terminal(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -194,6 +194,16 @@ pub trait TerminalProvider {
     ) -> Task<Option<Result<ExitStatus>>>;
 }
 
+#[derive(Debug, Clone)]
+pub struct DebugSessionStartInfo {
+    /// The DAP session id allocated for the created session.
+    pub session_id: u64,
+    /// The label assigned to the session.
+    pub label: String,
+    /// The debug adapter used to start the session.
+    pub adapter: String,
+}
+
 pub trait DebuggerProvider {
     // `active_buffer` is used to resolve build task's name against language-specific tasks.
     fn start_session(
@@ -204,7 +214,7 @@ pub trait DebuggerProvider {
         worktree_id: Option<WorktreeId>,
         window: &mut Window,
         cx: &mut App,
-    );
+    ) -> Result<DebugSessionStartInfo>;
 
     fn spawn_task_or_modal(
         &self,


### PR DESCRIPTION
This PR adds a `debugger` tool to the native Zed agent, letting AI agents inspect and interact with Zed's DAP-based debugger. The tool is gated behind a `debugger-tool` feature flag (`enabled_for_staff` off by default).

## Motivation

Agents debugging code today must infer state from static files or terminal output. With direct debugger access they can read live variable values, stack frames, and output; set breakpoints precisely; and step through execution — exactly the context a programmer would want when debugging.

## Operations

**Read-only (Ask + Write mode, no prompt):**
- `list_sessions` — enumerate active DAP sessions with status, adapter, and parent/child topology
- `snapshot` — single-call inspection of threads, stack frames, scopes, variables, source context, and recent output; bounded by hard maximums to fit in a context window and avoid excessive DAP/output work
- `list_breakpoints` — enumerate all source breakpoints in the project
- `list_adapters` — show registered debug adapters and their configuration schemas

**Mutating (Write mode + permission prompt):**
- `set_breakpoints` / `remove_breakpoints` — idempotent breakpoint management (not toggle)
- `control` — `continue`, `pause`, `step_over`, `step_in`, `step_out`, `run_to_line`; resolves session/thread ids before authorization, waits for the next stop event (or timeout/session end), and returns a fresh snapshot when possible
- `start_session` — starts a debug session through the workspace debugger UI via `DebuggerHost`, returning a `session_id`, `label`, and `adapter`; additionally requests sandbox approval when sandboxing is enabled
- `stop_session` — shuts down a DAP session by id

Read-only operations proceed in Ask mode without a prompt. Mutating operations check for Write mode first (returning a clear error if in Ask mode) and then call `event_stream.authorize` so the user can approve or deny each operation. Permission inputs include resolved paths, resolved session/thread ids, breakpoint condition/logpoint fields, and full debug-session configuration details so user regex rules can match the meaningful parts of a request.

## Architecture

| Crate | Change |
|---|---|
| `agent` | `DebuggerTool` implementation; `DebuggerHost` trait and `DebugSessionRequest` / `DebugSessionInfo` types in `thread.rs` and `agent.rs`; tool exposure gated by `DebuggerToolFeatureFlag` through the shared `tool_feature_flag_enabled` path |
| `project` | New `debugger/agent_api.rs` module — `AgentDebuggerApi` wrapping `dap_store` and `breakpoint_store`; `session.rs` and `breakpoint_store.rs` extended with agent-facing helpers |
| `agent_ui` | `AgentPanelDebuggerHost` bridges from `agent.DebuggerHost` → `workspace.start_debug_session` without pulling `debugger_ui` into `agent`; fills omitted task/worktree context from the workspace while respecting explicit worktree requests |
| `workspace` | `DebuggerProvider::start_session` now returns `DebugSessionStartInfo`; `DebugSessionStartInfo` struct added |
| `debugger_ui` | `DebuggerPanel` implements the updated `DebuggerProvider` trait signature; test helpers updated |
| `settings_ui` | Debugger tool entry added to the tool permissions setup page |
| `assets/settings` | `"debugger": true` added to `ask` and `write` tool profiles |
| `feature_flags` | New `DebuggerToolFeatureFlag` (`"debugger-tool"`, opt-in) |

The agent never imports from `debugger_ui`. The UI bridge goes through the `DebuggerHost` trait installed by `agent_ui` when the agent panel initialises — the same pattern used by `SiblingThreadHost` for `create_thread`.

## Snapshot and control design

`snapshot` fetches stack frames, then resolves scopes and variables for stopped threads. Returned data is bounded by per-call limits with hard maximums. Source context lines are loaded from disk for each frame so the agent can see the exact line it stopped at.

Snapshots are resilient to common debugger races: if one thread/frame/scope/variable request fails, the API returns partial data with explanatory notes rather than failing the entire snapshot. Terminated sessions return their session summary and output without issuing additional DAP thread/frame requests.

`control` operations resolve the selected session/thread before authorization, block until the session emits a `Stopped` event, times out, or the session ends, then return both the control result and the latest available state. Temporary run-to-line breakpoints are removed if setup or continue fails.

## Review hardening

Follow-up review fixes in this branch also tightened:

- Remote breakpoint updates: batched remote toggle RPCs are sent sequentially to preserve old-breakpoint-off / new-breakpoint-on ordering.
- Start-session worktree handling: explicit invalid `worktree_id` now errors instead of falling back to another worktree, and explicit worktree requests do not borrow active-editor task context from a different worktree.
- Path handling: debugger paths are resolved and lexically normalized before permission matching and operations.
- Permission matching: mutating operations include the values that affect execution, including full start-session config/build/TCP details and breakpoint condition/logpoint fields.

## Tests

- Ask-mode gating: read-only ops succeed without a prompt; mutating ops fail in Ask mode and prompt in Write mode.
- Feature flag gating: debugger tool exposure follows the shared feature-flag path.
- Permission rules: start-session details, resolved paths, resolved session/thread ids, and breakpoint expression/logpoint fields are matchable by tool permission regexes.
- Limit validation: excessive snapshot and control limits are rejected.
- Breakpoint editing: idempotent set/remove, in-place conditional updates, out-of-range line errors.
- Bounded and resilient snapshots: frames/variables truncated to limits with explanatory notes; nested DAP request failures return partial snapshots; terminated sessions skip further DAP requests.
- Control cleanup: run-to-line temporary breakpoints are removed when continue fails.
- Session start: `Workspace::start_debug_session` returns matching `DebugSessionStartInfo` and rejects invalid explicit worktrees.

Interactive expression evaluation via DAP `evaluate` is intentionally excluded from scope. Breakpoint conditions/logpoints remain part of permission-gated breakpoint editing.

Release Notes:

- Added a `debugger` tool that lets AI agents inspect active debug sessions, manage breakpoints, and control execution through Zed's DAP debugger
