### PR TITLE
markdown: Rasterize Mermaid diagrams at display DPI for crisp output

### DIFF
--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -170,28 +170,56 @@ impl SvgRenderer {
     }
 
     /// Renders the given bytes into an image buffer.
+    ///
+    /// The SVG is rasterized at a fixed [`SMOOTH_SVG_SCALE_FACTOR`] density. For
+    /// content that may be shown on high-DPI or fractional-DPI displays, prefer
+    /// [`Self::render_single_frame_at_density`], which rasterizes at the display's
+    /// actual device pixel ratio so the result stays crisp instead of being
+    /// upscaled from a fixed 2x bitmap.
     pub fn render_single_frame(
         &self,
         bytes: &[u8],
         scale_factor: f32,
     ) -> Result<Arc<RenderImage>, usvg::Error> {
-        self.render_pixmap(
-            bytes,
-            SvgSize::ScaleFactor(scale_factor * SMOOTH_SVG_SCALE_FACTOR),
-        )
-        .map(|pixmap| {
-            let mut buffer =
-                image::ImageBuffer::from_raw(pixmap.width(), pixmap.height(), pixmap.take())
-                    .unwrap();
+        self.render_single_frame_at_density(bytes, scale_factor, SMOOTH_SVG_SCALE_FACTOR)
+    }
 
-            for pixel in buffer.chunks_exact_mut(4) {
-                swap_rgba_pa_to_bgra(pixel);
-            }
+    /// Renders the given SVG bytes into a raster image, rasterizing at the
+    /// display's device pixel density so the result is crisp on any DPI
+    /// (including fractional and >2x displays) rather than at a fixed 2x.
+    ///
+    /// `content_scale` is the logical scaling applied to the SVG's intrinsic
+    /// size (e.g. `1.0` for natural size). `device_scale_factor` is the
+    /// display's pixel density, i.e. `Window::scale_factor()`.
+    ///
+    /// The returned image's `scale_factor` is set so its logical (layout) size
+    /// is `intrinsic_size * content_scale`, independent of the rasterization
+    /// density — only the pixel resolution changes with the display DPI.
+    pub fn render_single_frame_at_density(
+        &self,
+        bytes: &[u8],
+        content_scale: f32,
+        device_scale_factor: f32,
+    ) -> Result<Arc<RenderImage>, usvg::Error> {
+        // Never rasterize below the historical 2x supersample floor, so standard
+        // and low-DPI displays keep their existing anti-aliasing quality; raise
+        // it to the real device density so high-DPI/fractional displays are
+        // sampled 1:1 and crisp instead of being upscaled from a 2x bitmap.
+        let raster_density = device_scale_factor.max(SMOOTH_SVG_SCALE_FACTOR);
+        self.render_pixmap(bytes, SvgSize::ScaleFactor(content_scale * raster_density))
+            .map(|pixmap| {
+                let mut buffer =
+                    image::ImageBuffer::from_raw(pixmap.width(), pixmap.height(), pixmap.take())
+                        .unwrap();
 
-            let mut image = RenderImage::new(SmallVec::from_const([Frame::new(buffer)]));
-            image.scale_factor = SMOOTH_SVG_SCALE_FACTOR;
-            Arc::new(image)
-        })
+                for pixel in buffer.chunks_exact_mut(4) {
+                    swap_rgba_pa_to_bgra(pixel);
+                }
+
+                let mut image = RenderImage::new(SmallVec::from_const([Frame::new(buffer)]));
+                image.scale_factor = raster_density;
+                Arc::new(image)
+            })
     }
 
     pub(crate) fn render_alpha_mask(
@@ -301,6 +329,41 @@ fn fix_generic_font_families(db: &mut usvg::fontdb::Database) {
 mod tests {
     use super::*;
     use usvg::fontdb::{Database, Family, Query};
+
+    const TEST_SVG: &[u8] =
+        br#"<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50"></svg>"#;
+
+    #[test]
+    fn render_density_controls_resolution_not_logical_size() {
+        let renderer = SvgRenderer::new(Arc::new(()));
+
+        // At a low/standard DPI we never go below the 2x supersample floor, so
+        // the pixel buffer is 2x the intrinsic size and the logical size is 1:1.
+        let standard = renderer
+            .render_single_frame_at_density(TEST_SVG, 1.0, 1.0)
+            .expect("standard render");
+        assert_eq!(standard.size(0).width.0, 200);
+        assert_eq!(standard.size(0).height.0, 100);
+        assert_eq!(standard.scale_factor, SMOOTH_SVG_SCALE_FACTOR);
+        assert_eq!(standard.render_size(0).width.0 as i32, 100);
+
+        // On a 3x display we rasterize at 3x for crisp pixels, but the logical
+        // (layout) size is unchanged because scale_factor tracks the density.
+        let high_dpi = renderer
+            .render_single_frame_at_density(TEST_SVG, 1.0, 3.0)
+            .expect("high-dpi render");
+        assert_eq!(high_dpi.size(0).width.0, 300);
+        assert_eq!(high_dpi.size(0).height.0, 150);
+        assert_eq!(high_dpi.scale_factor, 3.0);
+        assert_eq!(high_dpi.render_size(0).width.0 as i32, 100);
+
+        // The legacy entry point is unchanged: still a fixed 2x rasterization.
+        let legacy = renderer
+            .render_single_frame(TEST_SVG, 1.0)
+            .expect("legacy render");
+        assert_eq!(legacy.size(0).width.0, 200);
+        assert_eq!(legacy.scale_factor, SMOOTH_SVG_SCALE_FACTOR);
+    }
 
     const IBM_PLEX_REGULAR: &[u8] =
         include_bytes!("../../../assets/fonts/ibm-plex-sans/IBMPlexSans-Regular.ttf");

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -587,6 +587,27 @@ impl Markdown {
         cx.notify();
     }
 
+    /// Updates the display density used to rasterize Mermaid diagrams. When the
+    /// preview is shown on (or moved to) a display with a different DPI, the
+    /// cached bitmaps are re-rasterized at the new density so they stay crisp
+    /// rather than being upscaled from a stale, lower-resolution bitmap.
+    pub(crate) fn set_mermaid_device_scale_factor(
+        &mut self,
+        device_scale_factor: f32,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.options.render_mermaid_diagrams {
+            return;
+        }
+        if self
+            .mermaid_state
+            .set_device_scale_factor(device_scale_factor)
+        {
+            self.mermaid_state.update(&self.parsed_markdown, cx);
+            cx.notify();
+        }
+    }
+
     pub(crate) fn is_mermaid_showing_code(&self, source_offset: usize) -> bool {
         self.mermaid_showing_code.contains(&source_offset)
     }
@@ -1909,6 +1930,13 @@ impl Element for MarkdownElement {
             self.style.base_text_style.clone(),
             self.style.syntax.clone(),
         );
+        // Ensure Mermaid diagrams are rasterized at the current display's device
+        // pixel ratio so they stay crisp on high-DPI / fractional-DPI displays
+        // and re-render when the window moves to a different-DPI monitor.
+        let device_scale_factor = window.scale_factor();
+        self.markdown.update(cx, |markdown, cx| {
+            markdown.set_mermaid_device_scale_factor(device_scale_factor, cx);
+        });
         let (parsed_markdown, images, active_root_block, render_mermaid_diagrams, mermaid_state) = {
             let markdown = self.markdown.read(cx);
             (

--- a/crates/markdown/src/mermaid.rs
+++ b/crates/markdown/src/mermaid.rs
@@ -31,10 +31,26 @@ pub(crate) struct ParsedMarkdownMermaidDiagramContents {
     pub(crate) scale: u32,
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub(crate) struct MermaidState {
     cache: MermaidDiagramCache,
     order: Vec<ParsedMarkdownMermaidDiagramContents>,
+    /// The display device pixel ratio the cached diagrams were rasterized at.
+    /// When the preview moves to a display with a different DPI, the cache is
+    /// invalidated so diagrams are re-rasterized crisply at the new density.
+    device_scale_factor: f32,
+}
+
+impl Default for MermaidState {
+    fn default() -> Self {
+        Self {
+            cache: MermaidDiagramCache::default(),
+            order: Vec::new(),
+            // 2.0 matches gpui's historical fixed supersample, so the first
+            // render before a real scale factor is known matches prior behavior.
+            device_scale_factor: 2.0,
+        }
+    }
 }
 
 struct CachedMermaidDiagram {
@@ -47,6 +63,20 @@ impl MermaidState {
     pub(crate) fn clear(&mut self) {
         self.cache.clear();
         self.order.clear();
+    }
+
+    /// Updates the display density used for rasterization. If it changed
+    /// (e.g. the window moved to a different-DPI monitor), the cached bitmaps
+    /// are dropped so the next `update` re-rasterizes them at the new density.
+    /// Returns `true` if the cache was invalidated.
+    pub(crate) fn set_device_scale_factor(&mut self, device_scale_factor: f32) -> bool {
+        if (self.device_scale_factor - device_scale_factor).abs() < f32::EPSILON {
+            return false;
+        }
+        self.device_scale_factor = device_scale_factor;
+        self.cache.clear();
+        self.order.clear();
+        true
     }
 
     fn get_fallback_image(
@@ -82,7 +112,12 @@ impl MermaidState {
                     Self::get_fallback_image(idx, &self.order, new_order.len(), &self.cache);
                 self.cache.insert(
                     new_content.clone(),
-                    Arc::new(CachedMermaidDiagram::new(new_content.clone(), fallback, cx)),
+                    Arc::new(CachedMermaidDiagram::new(
+                        new_content.clone(),
+                        fallback,
+                        self.device_scale_factor,
+                        cx,
+                    )),
                 );
             }
         }
@@ -98,6 +133,7 @@ impl CachedMermaidDiagram {
     fn new(
         contents: ParsedMarkdownMermaidDiagramContents,
         fallback_image: Option<Arc<RenderImage>>,
+        device_scale_factor: f32,
         cx: &mut Context<Markdown>,
     ) -> Self {
         let render_image = Arc::new(OnceLock::<anyhow::Result<Arc<RenderImage>>>::new());
@@ -111,8 +147,15 @@ impl CachedMermaidDiagram {
                     let svg_string =
                         mermaid_render::render_to_svg(&contents.contents, &mermaid_theme)?;
                     let scale = contents.scale as f32 / 100.0;
+                    // Rasterize at the display's actual device pixel ratio so the
+                    // diagram is crisp on high-DPI and fractional-DPI displays,
+                    // rather than being upscaled from a fixed 2x bitmap.
                     svg_renderer
-                        .render_single_frame(svg_string.as_bytes(), scale)
+                        .render_single_frame_at_density(
+                            svg_string.as_bytes(),
+                            scale,
+                            device_scale_factor,
+                        )
                         .map_err(|error| anyhow::anyhow!("{error}"))
                 })
                 .await;


### PR DESCRIPTION
Closes #58438

### Problem

Mermaid diagrams in the Markdown preview look soft/blurry compared to the same diagram rendered in a browser. The SVG generation (`merman`) is fine — the issue is the **rasterization step**.

In `crates/markdown/src/mermaid.rs`, each diagram's SVG is rasterized **once** at a fixed 2× supersample (`SMOOTH_SVG_SCALE_FACTOR` in `crates/gpui/src/svg_renderer.rs`), regardless of the display's device pixel ratio, then shown as a static bitmap constrained by `max_w_full()`. The window's actual `scale_factor()` is never plumbed in. So:

- **2× Retina at natural size** → ~1:1, crisp (the case the constant was tuned for).
- **Fractional DPI (1.5×, common on Windows/Linux & scaled external monitors)** → the 2× bitmap is resampled to a non-integer target → **blur**.
- **3× displays** → the 2× bitmap is *below* native resolution → soft.

There's also an existing in-tree TODO acknowledging the limitation in `crates/gpui/src/elements/img.rs`:

```rust
// TODO: Can we make SVGs always rescale?
// let scale_factor = cx.scale_factor();
```

### Change

Rasterize Mermaid SVGs at the window's actual `scale_factor()` instead of a fixed 2×:

- **`SvgRenderer::render_single_frame_at_density`** (new): rasterizes at `max(device_scale_factor, SMOOTH_SVG_SCALE_FACTOR)` and tags the resulting `RenderImage` with that density, so the **logical layout size is unchanged** — only the pixel resolution scales with DPI. The `.max(2.0)` floor keeps standard/low-DPI displays at their existing anti-aliasing quality. `render_single_frame` now delegates to it with the fixed 2× factor, so **all other callers (icons, SVG preview, image loader) are unaffected**.
- **`MermaidState`** gains a `device_scale_factor`. When the preview moves to a different-DPI monitor, `set_device_scale_factor` invalidates the cached bitmaps so they re-rasterize crisply at the new density. (The default is `2.0` to match prior behavior before a real scale factor is known; `clear()` preserves the density so theme-driven re-renders stay correct.)
- **`MarkdownElement::request_layout`** plumbs `window.scale_factor()` into the markdown entity before rendering.

### Testing

- `cargo check -p gpui` and `cargo check -p markdown` pass locally.
- Added a `gpui` unit test (`render_density_controls_resolution_not_logical_size`) verifying that density controls pixel resolution while logical size stays constant, and that the legacy `render_single_frame` entry point is unchanged.
- ⚠️ I was unable to run the test suites locally — `cargo test` needs the Metal shader compiler (`xcrun metal`, full Xcode), and this machine only has Command Line Tools. The new test is small and self-contained; please confirm it passes in CI.

### Notes / follow-ups

This is a first step toward the `img.rs` TODO. It makes diagrams crisp at any **display DPI** and re-renders on DPI change, but the bitmap is still a fixed-size raster scaled to fit the pane via `max_w_full()` — so extreme down/up-scaling within a pane can still soften slightly. Fully matching the browser would require re-rasterizing on pane resize (keying the cache on rendered pixel size), which is a larger change I'm happy to follow up on if maintainers prefer that direction.

Marked as draft pending CI confirmation of the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)