### PR TITLE
themes: Add `tag.component.jsx` token to differentiate React components from HTML tags

### DIFF
--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -367,6 +367,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "tag.component.jsx": {
+            "color": "#59c2ffff",
+            "font_style": null,
+            "font_weight": null
+          },
           "text.literal": {
             "color": "#fe8f40ff",
             "font_style": null,
@@ -769,6 +774,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "tag.component.jsx": {
+            "color": "#389ee6ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "text.literal": {
             "color": "#f98d3fff",
             "font_style": null,
@@ -1168,6 +1178,11 @@
           },
           "tag": {
             "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.component.jsx": {
+            "color": "#73cfffff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -377,6 +377,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "tag.component.jsx": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
           "text.literal": {
             "color": "#83a598ff",
             "font_style": null,
@@ -791,6 +796,11 @@
           },
           "tag": {
             "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.component.jsx": {
+            "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
           },
@@ -1211,6 +1221,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "tag.component.jsx": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
           "text.literal": {
             "color": "#83a598ff",
             "font_style": null,
@@ -1625,6 +1640,11 @@
           },
           "tag": {
             "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.component.jsx": {
+            "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2045,6 +2065,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "tag.component.jsx": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "text.literal": {
             "color": "#066578ff",
             "font_style": null,
@@ -2459,6 +2484,11 @@
           },
           "tag": {
             "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.component.jsx": {
+            "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -374,6 +374,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "tag.component.jsx": {
+            "color": "#6eb4bfff",
+            "font_style": null,
+            "font_weight": null
+          },
           "text.literal": {
             "color": "#a1c181ff",
             "font_style": null,
@@ -783,6 +788,11 @@
           },
           "tag": {
             "color": "#5c78e2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "tag.component.jsx": {
+            "color": "#3882b7ff",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
## Summary

- JSX/TSX grammars already capture `@tag.jsx` (native HTML elements like `<div>`) and `@tag.component.jsx` (React components like `<MyComponent>`) as separate tree-sitter tokens
- No built-in theme defined different colors for these two tokens — both fell back to the generic `tag` color, making all JSX tags look identical
- This adds `tag.component.jsx` entries to all built-in themes using each theme's existing `type` color, which is semantically correct: a React component is a type/class

## Before / After

Before: `<div>` and `<MyComponent>` share the same highlight color
After: `<div>` uses `tag` color, `<MyComponent>` uses `type` color (e.g. teal in One Dark)

## Themes updated

- `assets/themes/one/one.json` — One Dark, One Light
- `assets/themes/gruvbox/gruvbox.json` — all 6 Gruvbox variants
- `assets/themes/ayu/ayu.json` — Ayu Dark, Light, Mirage

No grammar or language changes needed — the tree-sitter captures were already correct.

Release Notes:

- Improved: JSX/TSX component tags (e.g. `<MyComponent>`) are now highlighted with a distinct color from native HTML tags (e.g. `<div>`) in all built-in themes (One, Gruvbox, Ayu)