### PR TITLE
editor: Show diagnostic severity in filename color and minimap overlays

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6226,6 +6226,62 @@ impl EditorElement {
     }
 
     fn paint_minimap(&self, layout: &mut EditorLayout, window: &mut Window, cx: &mut App) {
+        let scrollbar_settings = EditorSettings::get_global(cx).scrollbar;
+        let diagnostic_overlays: Vec<(u32, Hsla)> =
+            if scrollbar_settings.diagnostics != ScrollbarDiagnostics::None {
+                let snapshot = &layout.position_map.snapshot;
+                let max_point = snapshot.display_snapshot.buffer_snapshot().max_point();
+                let error_color = cx.theme().status().error.opacity(0.35);
+                let warning_color = cx.theme().status().warning.opacity(0.35);
+                let info_color = cx.theme().status().info.opacity(0.35);
+                let hint_color = cx.theme().status().hint.opacity(0.35);
+                snapshot
+                    .display_snapshot
+                    .buffer_snapshot()
+                    .diagnostics_in_range::<Point>(Point::zero()..max_point)
+                    .filter(|diagnostic| {
+                        match (
+                            scrollbar_settings.diagnostics,
+                            diagnostic.diagnostic.severity,
+                        ) {
+                            (ScrollbarDiagnostics::All, _) => true,
+                            (ScrollbarDiagnostics::Error, lsp::DiagnosticSeverity::ERROR) => true,
+                            (
+                                ScrollbarDiagnostics::Warning,
+                                lsp::DiagnosticSeverity::ERROR | lsp::DiagnosticSeverity::WARNING,
+                            ) => true,
+                            (
+                                ScrollbarDiagnostics::Information,
+                                lsp::DiagnosticSeverity::ERROR
+                                | lsp::DiagnosticSeverity::WARNING
+                                | lsp::DiagnosticSeverity::INFORMATION,
+                            ) => true,
+                            _ => false,
+                        }
+                    })
+                    .sorted_by_key(|diagnostic| {
+                        std::cmp::Reverse(diagnostic.diagnostic.severity)
+                    })
+                    .map(|diagnostic| {
+                        let row = diagnostic
+                            .range
+                            .start
+                            .to_display_point(&snapshot.display_snapshot)
+                            .row()
+                            .0;
+                        let color = match diagnostic.diagnostic.severity {
+                            lsp::DiagnosticSeverity::ERROR => error_color,
+                            lsp::DiagnosticSeverity::WARNING => warning_color,
+                            lsp::DiagnosticSeverity::INFORMATION => info_color,
+                            _ => hint_color,
+                        };
+                        (row, color)
+                    })
+                    .collect()
+            } else {
+                vec![]
+            };
+
         if let Some(mut layout) = layout.minimap.take() {
             let minimap_hitbox = layout.thumb_layout.hitbox.clone();
             let dragging_minimap = self.editor.read(cx).scroll_manager.is_dragging_minimap();
@@ -6233,6 +6289,25 @@ impl EditorElement {
             window.paint_layer(layout.thumb_layout.hitbox.bounds, |window| {
                 window.with_element_namespace("minimap", |window| {
                     layout.minimap.paint(window, cx);
+                    for &(row, color) in &diagnostic_overlays {
+                        let y_offset = layout.minimap_line_height
+                            * (row as f32 - layout.minimap_scroll_top as f32);
+                        if y_offset >= px(0.) && y_offset < minimap_hitbox.bounds.size.height {
+                            window.paint_quad(fill(
+                                Bounds {
+                                    origin: point(
+                                        minimap_hitbox.bounds.origin.x,
+                                        minimap_hitbox.bounds.origin.y + y_offset,
+                                    ),
+                                    size: size(
+                                        minimap_hitbox.bounds.size.width,
+                                        layout.minimap_line_height,
+                                    ),
+                                },
+                                color,
+                            ));
+                        }
+                    }
                     if let Some(thumb_bounds) = layout.thumb_layout.thumb_bounds {
                         let minimap_thumb_color = match layout.thumb_layout.thumb_state {
                             ScrollbarThumbState::Idle => {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -6269,8 +6269,11 @@ impl ProjectPanel {
             .get(&(worktree_id, entry.path.clone()))
             .copied();
 
-        let filename_text_color =
-            entry_git_aware_label_color(git_status, entry.is_ignored, is_marked);
+        let filename_text_color = match diagnostic_severity {
+            Some(DiagnosticSeverity::ERROR) => Color::Error,
+            Some(DiagnosticSeverity::WARNING) => Color::Warning,
+            _ => entry_git_aware_label_color(git_status, entry.is_ignored, is_marked),
+        };
 
         let is_cut = self
             .clipboard


### PR DESCRIPTION
## Summary

Two related improvements to make file diagnostics more visible at a glance:

**Project panel — filename color**
- File names now turn red (error) or yellow (warning) when they have active diagnostics
- The `diagnostic_severity` field was already being computed in `EntryDetails` but only used for the icon badge; now also applied to the label color via `filename_text_color`

**Minimap — diagnostic line overlays**
- Lines with diagnostics are now highlighted with a semi-transparent color overlay in the minimap (red for errors, yellow for warnings, matching VS Code behavior)
- Reuses the existing `scrollbar.diagnostics` setting — the same filter applied to the scrollbar also controls minimap overlay visibility
- Overlays are painted after the minimap content and sorted by severity so more severe diagnostics render on top when multiple severities share a line

## Files changed

- `crates/project_panel/src/project_panel.rs` — override `filename_text_color` based on `diagnostic_severity`
- `crates/editor/src/element.rs` — add diagnostic overlay loop in `paint_minimap`

Release Notes:

- Improved: file names in the project panel now turn red/yellow when they have active errors/warnings
- Improved: the minimap now highlights lines with diagnostics using a colored overlay, matching VS Code behavior