### PR TITLE
collab: Only access `github_user_id` and `github_login` columns in tests

### DIFF
--- a/crates/collab/src/db/queries/shared_threads.rs
+++ b/crates/collab/src/db/queries/shared_threads.rs
@@ -64,11 +64,10 @@ impl Database {
                 return Ok(None);
             };
 
-            let user = user::Entity::find_by_id(thread.user_id).one(&*tx).await?;
-
-            let username = user
-                .map(|u| u.github_login)
-                .unwrap_or_else(|| "Unknown".to_string());
+            // We can no longer read the `github_login` from Collab.
+            //
+            // Opting to just use "Unknown" here, as the feature is staff-only and infrequently used.
+            let username = "Unknown".to_string();
 
             Ok(Some((thread, username)))
         })

--- a/crates/collab/src/db/tables/user.rs
+++ b/crates/collab/src/db/tables/user.rs
@@ -8,7 +8,9 @@ use serde::Serialize;
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: UserId,
+    #[cfg(feature = "test-support")]
     pub github_login: String,
+    #[cfg(feature = "test-support")]
     pub github_user_id: i32,
     pub admin: bool,
     pub connected_once: bool,

--- a/crates/collab/tests/integration/db_tests/db_tests.rs
+++ b/crates/collab/tests/integration/db_tests/db_tests.rs
@@ -285,7 +285,7 @@ async fn test_upsert_shared_thread(db: &Arc<Database>) {
     assert_eq!(thread.title, title);
     assert_eq!(thread.data, data);
     assert_eq!(thread.user_id, user_id);
-    assert_eq!(username, "user1");
+    assert_eq!(username, "Unknown");
 }
 
 test_both_dbs!(


### PR DESCRIPTION
This PR marks the `github_user_id` and `github_login` columns on the `User` database model as only being accessible in tests.

Closes CLO-829.

Release Notes:

- N/A
