### PR TITLE
collab: Add a warning about modifying database schema files

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -1,3 +1,6 @@
+-- WARNING: If you are modifying this file you MUST open a PR to the Cloud repository prior to merging any changes.
+-- If you are not Zed staff you MUST coordinate with a staff member to apply the schema migrations before this PR is merged.
+
 CREATE TABLE "users" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "github_login" VARCHAR,

--- a/crates/collab/migrations/20251208000000_test_schema.sql
+++ b/crates/collab/migrations/20251208000000_test_schema.sql
@@ -1,5 +1,8 @@
 -- This file is auto-generated. Do not modify it by hand.
 -- To regenerate, run `cargo xtask db dump-schema app --collab` from the Cloud repository.
+--
+-- WARNING: If you are modifying this file you MUST open a PR to the Cloud repository prior to merging any changes.
+-- If you are not Zed staff you MUST coordinate with a staff member to apply the schema migrations before this PR is merged.
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 
@@ -224,7 +227,8 @@ CREATE TABLE public.language_servers (
     id bigint NOT NULL,
     name character varying NOT NULL,
     capabilities text NOT NULL,
-    worktree_id bigint
+    worktree_id bigint,
+    language_name character varying
 );
 
 CREATE TABLE public.notification_kinds (


### PR DESCRIPTION
This PR updates the test database schema files in Collab with a warning about adding the corresponding database migration in Cloud before merging any changes.

This should pair with the Danger warning to provide additional signposting (and also for agents who may be modifying the files).

Includes the re-dumped schema for the addition of the `language_name` column on the `language_servers` table.

Release Notes:

- N/A
