### PR TITLE
danger: Require attestation that database schema migrations have been applied

### DIFF
--- a/crates/collab/migrations/20251208000000_test_schema.sql
+++ b/crates/collab/migrations/20251208000000_test_schema.sql
@@ -1,6 +1,8 @@
 -- This file is auto-generated. Do not modify it by hand.
 -- To regenerate, run `cargo xtask db dump-schema app --collab` from the Cloud repository.
 
+-- Spurious change.
+
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 
 CREATE TABLE public.breakpoints (

--- a/crates/collab/migrations/20251208000000_test_schema.sql
+++ b/crates/collab/migrations/20251208000000_test_schema.sql
@@ -1,8 +1,6 @@
 -- This file is auto-generated. Do not modify it by hand.
 -- To regenerate, run `cargo xtask db dump-schema app --collab` from the Cloud repository.
 
--- Spurious change.
-
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
 
 CREATE TABLE public.breakpoints (

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -61,6 +61,9 @@ if (includesIssueUrl) {
   );
 }
 
+const SCHEMA_CHANGE_ATTESTATION =
+  "The corresponding database schema migration has been created in the Cloud repo and applied to the production database.";
+
 const MIGRATION_SCHEMA_FILES = [
   "crates/collab/migrations/20251208000000_test_schema.sql",
   "crates/collab/migrations.sqlite/20221109000000_test_schema.sql",
@@ -71,13 +74,24 @@ const modifiedSchemaFiles = danger.git.modified_files.filter((file) =>
 );
 
 if (modifiedSchemaFiles.length > 0) {
-  warn(
-    [
-      "This PR modifies database schema files.",
-      "",
-      "If you are making database changes, a migration needs to be added in the Cloud repository.",
-    ].join("\n"),
-  );
+  if (body.includes(SCHEMA_CHANGE_ATTESTATION)) {
+    message(
+      [
+        "This PR modifies database schema files.",
+        "",
+        `The author has attested that ${SCHEMA_CHANGE_ATTESTATION.substring(0, 1).toLowerCase() + SCHEMA_CHANGE_ATTESTATION.substring(1)}`,
+      ].join("\n"),
+    );
+  } else {
+    const modifiedSchemaFilesStr = modifiedSchemaFiles.map((path) => "`" + path + "`").join(", ");
+    fail(
+      [
+        `This PR modifies database schema files (${modifiedSchemaFilesStr}), which are typically expected to remain unchanged.`,
+        "If these changes are intentional and required, please add the following attestation to your PR description: ",
+        `"${SCHEMA_CHANGE_ATTESTATION}"`,
+      ].join("\n\n"),
+    );
+  }
 }
 
 const FIXTURE_CHANGE_ATTESTATION = "Changes to test fixtures are intentional and necessary.";

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -86,8 +86,8 @@ if (modifiedSchemaFiles.length > 0) {
     const modifiedSchemaFilesStr = modifiedSchemaFiles.map((path) => "`" + path + "`").join(", ");
     fail(
       [
-        `This PR modifies database schema files (${modifiedSchemaFilesStr}), which are typically expected to remain unchanged.`,
-        "If these changes are intentional and required, please add the following attestation to your PR description: ",
+        `This PR modifies database schema files (${modifiedSchemaFilesStr}), which requires creating a schema migration in the Cloud repository.`,
+        "Once the schema migraation has been created and applied, please add the following attestation to your PR description: ",
         `"${SCHEMA_CHANGE_ATTESTATION}"`,
       ].join("\n\n"),
     );


### PR DESCRIPTION
This PR updates the Danger check for touching the Collab schema files to require attestation that the database schema migrations have been created and applied.

If there are changes to the schema files without the attestation, Danger will fail the status check with an error:

<img width="959" height="635" alt="Screenshot 2026-06-03 at 4 58 56 PM" src="https://github.com/user-attachments/assets/e0857137-b351-4212-a023-13a7d53f5934" />

When the attestation clause is present, Danger will report it as such:

<img width="901" height="333" alt="Screenshot 2026-06-03 at 4 59 45 PM" src="https://github.com/user-attachments/assets/098b0ce4-f86e-4d41-b6af-765bc015fe6e" />

Release Notes:

- N/A
