### PR TITLE
Hide markdown code block scrollbar when wrapped

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -3876,6 +3876,22 @@ mod tests {
     }
 
     #[gpui::test]
+    fn test_wrapped_code_block_has_no_scroll_handle(cx: &mut TestAppContext) {
+        let markdown =
+            cx.new(|cx| Markdown::new("```rust\nlet value = 1;\n```".into(), None, None, cx));
+
+        markdown.update(cx, |markdown, _| {
+            assert!(markdown.code_block_scroll_handle(0).is_some());
+
+            markdown.toggle_code_block_wrap(0);
+            assert!(markdown.code_block_scroll_handle(0).is_none());
+
+            markdown.toggle_code_block_wrap(0);
+            assert!(markdown.code_block_scroll_handle(0).is_some());
+        });
+    }
+
+    #[gpui::test]
     fn test_frontmatter_renders_without_delimiters(cx: &mut TestAppContext) {
         let rendered = render_markdown_with_options(
             "---\ntitle: Post\n---\nBody",

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -2138,7 +2138,9 @@ impl Element for MarkdownElement {
                             };
 
                             let is_indented = matches!(kind, CodeBlockKind::Indented);
-                            let scroll_handle = if self.style.code_block_overflow_x_scroll {
+                            let is_wrapped =
+                                self.markdown.read(cx).is_code_block_wrapped(range.start);
+                            let scroll_handle = if self.style.code_block_overflow_x_scroll && !is_wrapped {
                                 code_block_ids.insert(range.start);
                                 Some(self.markdown.update(cx, |markdown, _| {
                                     markdown.code_block_scroll_handle(range.start)
@@ -2184,9 +2186,6 @@ impl Element for MarkdownElement {
 
                                     parent_container.style().refine(&self.style.code_block);
                                     builder.push_div(parent_container, range, markdown_end);
-
-                                    let is_wrapped =
-                                        self.markdown.read(cx).is_code_block_wrapped(range.start);
 
                                     let code_block = div()
                                         .id(("code-block", range.start))

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -612,16 +612,12 @@ impl Markdown {
     }
 
     fn code_block_scroll_handle(&mut self, id: usize) -> Option<ScrollHandle> {
-        if self.is_code_block_wrapped(id) {
-            return None;
-        }
-
-        Some(
+        (!self.is_code_block_wrapped(id)).then(|| {
             self.code_block_scroll_handles
                 .entry(id)
                 .or_insert_with(ScrollHandle::new)
-                .clone(),
-        )
+                .clone()
+        })
     }
 
     fn retain_code_block_scroll_handles(&mut self, ids: &HashSet<usize>) {
@@ -2193,18 +2189,11 @@ impl Element for MarkdownElement {
                                     parent_container.style().refine(&self.style.code_block);
                                     builder.push_div(parent_container, range, markdown_end);
 
-                                    let is_wrapped =
-                                        self.markdown.read(cx).is_code_block_wrapped(range.start);
-
                                     let code_block = div()
                                         .id(("code-block", range.start))
                                         .rounded_lg()
                                         .map(|mut code_block| {
-                                            if is_wrapped {
-                                                code_block.w_full()
-                                            } else if let Some(scroll_handle) =
-                                                scroll_handle.as_ref()
-                                            {
+                                            if let Some(scroll_handle) = scroll_handle.as_ref() {
                                                 code_block.style().restrict_scroll_to_axis =
                                                     Some(true);
                                                 code_block
@@ -2485,7 +2474,7 @@ impl Element for MarkdownElement {
                                         == WrapButtonVisibility::AlwaysVisible;
                                 let use_hover = any_hover && !any_always;
 
-                                let mut button_row = h_flex()
+                                let button_row = h_flex()
                                     .gap_0p5()
                                     .absolute()
                                     .bg(cx.theme().colors().editor_background)
@@ -2495,25 +2484,32 @@ impl Element for MarkdownElement {
                                             this.top_1().right_1().visible_on_hover("code_block")
                                         },
                                         |this| this.top_1p5().right_1p5(),
+                                    )
+                                    .when(
+                                        wrap_button_visibility != WrapButtonVisibility::Hidden,
+                                        |this| {
+                                            let is_wrapped = self
+                                                .markdown
+                                                .read(cx)
+                                                .is_code_block_wrapped(range.start);
+
+                                            this.child(render_wrap_code_block_button(
+                                                range.start,
+                                                is_wrapped,
+                                                self.markdown.clone(),
+                                            ))
+                                        },
+                                    )
+                                    .when(
+                                        copy_button_visibility != CopyButtonVisibility::Hidden,
+                                        |this| {
+                                            this.child(render_copy_code_block_button(
+                                                range.end,
+                                                code,
+                                                self.markdown.clone(),
+                                            ))
+                                        },
                                     );
-
-                                if wrap_button_visibility != WrapButtonVisibility::Hidden {
-                                    let is_wrapped =
-                                        self.markdown.read(cx).is_code_block_wrapped(range.start);
-                                    button_row = button_row.child(render_wrap_code_block_button(
-                                        range.start,
-                                        is_wrapped,
-                                        self.markdown.clone(),
-                                    ));
-                                }
-
-                                if copy_button_visibility != CopyButtonVisibility::Hidden {
-                                    button_row = button_row.child(render_copy_code_block_button(
-                                        range.end,
-                                        code,
-                                        self.markdown.clone(),
-                                    ));
-                                }
 
                                 el.child(button_row)
                             });

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -611,11 +611,17 @@ impl Markdown {
         }
     }
 
-    fn code_block_scroll_handle(&mut self, id: usize) -> ScrollHandle {
-        self.code_block_scroll_handles
-            .entry(id)
-            .or_insert_with(ScrollHandle::new)
-            .clone()
+    fn code_block_scroll_handle(&mut self, id: usize) -> Option<ScrollHandle> {
+        if self.is_code_block_wrapped(id) {
+            return None;
+        }
+
+        Some(
+            self.code_block_scroll_handles
+                .entry(id)
+                .or_insert_with(ScrollHandle::new)
+                .clone(),
+        )
     }
 
     fn retain_code_block_scroll_handles(&mut self, ids: &HashSet<usize>) {
@@ -2138,16 +2144,16 @@ impl Element for MarkdownElement {
                             };
 
                             let is_indented = matches!(kind, CodeBlockKind::Indented);
-                            let is_wrapped =
-                                self.markdown.read(cx).is_code_block_wrapped(range.start);
-                            let scroll_handle = if self.style.code_block_overflow_x_scroll && !is_wrapped {
-                                code_block_ids.insert(range.start);
-                                Some(self.markdown.update(cx, |markdown, _| {
+                            let scroll_handle = if self.style.code_block_overflow_x_scroll {
+                                self.markdown.update(cx, |markdown, _| {
                                     markdown.code_block_scroll_handle(range.start)
-                                }))
+                                })
                             } else {
                                 None
                             };
+                            if scroll_handle.is_some() {
+                                code_block_ids.insert(range.start);
+                            }
 
                             match (&self.code_block_renderer, is_indented) {
                                 (CodeBlockRenderer::Default { .. }, _) | (_, true) => {
@@ -2186,6 +2192,9 @@ impl Element for MarkdownElement {
 
                                     parent_container.style().refine(&self.style.code_block);
                                     builder.push_div(parent_container, range, markdown_end);
+
+                                    let is_wrapped =
+                                        self.markdown.read(cx).is_code_block_wrapped(range.start);
 
                                     let code_block = div()
                                         .id(("code-block", range.start))


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Follow up of #57312. Hides the scrollbar (which does not do anything) when markdown code blocks are wrapped.

Release Notes:

- Fixed the scrollbar on wrapped code blocks in the agent chat.

(As far as I can see the wrap button only exists in the agent chat and not regular markdown previews.)