### PR TITLE
Add no_proxy setting to bypass proxy for specific hosts

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2614,13 +2614,21 @@
   // `socks5h`. `http` will be used when no scheme is specified.
   //
   // By default no proxy will be used, or Zed will try get proxy settings from
-  // environment variables. If certain hosts should not be proxied,
-  // set the `no_proxy` environment variable and provide a comma-separated list.
+  // environment variables.
   //
   // Examples:
   //   - "proxy": "socks5h://localhost:10808"
   //   - "proxy": "http://127.0.0.1:10809"
   "proxy": "",
+  // A comma-separated list of hosts that should bypass the configured proxy.
+  //
+  // Supports hosts, domain suffixes, host:port entries, and IPv4/IPv6 CIDR
+  // ranges for literal IP hosts.
+  //
+  // Examples:
+  //   - "no_proxy": "localhost,127.0.0.1,::1"
+  //   - "no_proxy": "192.168.0.0/16,.internal.company"
+  "no_proxy": "",
   // Set to configure aliases for the command palette.
   // When typing a query which is a key of this object, the value will be used instead.
   //

--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -8,7 +8,6 @@ use client::ProxySettings;
 use collections::{HashMap, HashSet};
 pub use custom::*;
 use fs::Fs;
-use http_client::read_no_proxy_from_env;
 use project::{AgentId, Project, agent_server_store::AgentServerStore};
 
 use acp_thread::AgentConnection;
@@ -113,6 +112,8 @@ impl dyn AgentServer {
 pub fn load_proxy_env(cx: &mut App) -> HashMap<String, String> {
     let proxy_url = cx
         .read_global(|settings: &SettingsStore, _| settings.get::<ProxySettings>(None).proxy_url());
+    let no_proxy = cx
+        .read_global(|settings: &SettingsStore, _| settings.get::<ProxySettings>(None).no_proxy());
     let mut env = HashMap::default();
 
     if let Some(proxy_url) = &proxy_url {
@@ -124,7 +125,7 @@ pub fn load_proxy_env(cx: &mut App) -> HashMap<String, String> {
         env.insert(env_var.to_owned(), proxy_url.to_string());
     }
 
-    if let Some(no_proxy) = read_no_proxy_from_env() {
+    if let Some(no_proxy) = no_proxy {
         env.insert("NO_PROXY".to_owned(), no_proxy);
     } else if proxy_url.is_some() {
         // We sometimes need local MCP servers that we don't want to proxy

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -27,7 +27,9 @@ use futures::{
     stream::BoxStream,
 };
 use gpui::{App, AsyncApp, Entity, Global, Task, TaskExt, WeakEntity, actions};
-use http_client::{HttpClient, HttpClientWithUrl, http, read_proxy_from_env};
+use http_client::{
+    HttpClient, HttpClientWithUrl, http, read_no_proxy_from_env, read_proxy_from_env,
+};
 use parking_lot::{Mutex, RwLock};
 use postage::watch;
 use proxy::connect_proxy_stream;
@@ -132,6 +134,7 @@ impl Settings for ClientSettings {
 #[derive(Deserialize, Default, RegisterSetting)]
 pub struct ProxySettings {
     pub proxy: Option<String>,
+    pub no_proxy: Option<String>,
 }
 
 impl ProxySettings {
@@ -148,6 +151,15 @@ impl ProxySettings {
             })
             .or_else(read_proxy_from_env)
     }
+
+    pub fn no_proxy(&self) -> Option<String> {
+        self.no_proxy
+            .as_deref()
+            .map(str::trim)
+            .filter(|input| !input.is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(read_no_proxy_from_env)
+    }
 }
 
 impl Settings for ProxySettings {
@@ -158,6 +170,12 @@ impl Settings for ProxySettings {
                 .as_deref()
                 .map(str::trim)
                 .filter(|proxy| !proxy.is_empty())
+                .map(ToOwned::to_owned),
+            no_proxy: content
+                .no_proxy
+                .as_deref()
+                .map(str::trim)
+                .filter(|no_proxy| !no_proxy.is_empty())
                 .map(ToOwned::to_owned),
         }
     }
@@ -2014,9 +2032,14 @@ mod tests {
         assert_eq!(ProxySettings::from_settings(&content).proxy, None);
 
         content.proxy = Some("http://127.0.0.1:10809".to_owned());
+        content.no_proxy = Some(" localhost,127.0.0.1 ".to_owned());
         assert_eq!(
             ProxySettings::from_settings(&content).proxy.as_deref(),
             Some("http://127.0.0.1:10809")
+        );
+        assert_eq!(
+            ProxySettings::from_settings(&content).no_proxy.as_deref(),
+            Some("localhost,127.0.0.1")
         );
     }
 

--- a/crates/edit_prediction_cli/src/headless.rs
+++ b/crates/edit_prediction_cli/src/headless.rs
@@ -2,7 +2,6 @@ use client::{Client, ProxySettings, RefreshLlmTokenListener, UserStore};
 use db::AppDatabase;
 use extension::ExtensionHostProxy;
 use fs::RealFs;
-use gpui::http_client::read_proxy_from_env;
 use gpui::{App, AppContext, Entity};
 use gpui_tokio::Tokio;
 use language::LanguageRegistry;
@@ -46,15 +45,13 @@ pub fn init(cx: &mut App) -> EpAppState {
         std::env::consts::OS,
         std::env::consts::ARCH
     );
-    let proxy_str = ProxySettings::get_global(cx).proxy.to_owned();
-    let proxy_url = proxy_str
-        .as_ref()
-        .and_then(|input| input.parse().ok())
-        .or_else(read_proxy_from_env);
+    let proxy_settings = ProxySettings::get_global(cx);
+    let proxy_url = proxy_settings.proxy_url();
+    let no_proxy = proxy_settings.no_proxy();
     let http = {
         let _guard = Tokio::handle(cx).enter();
 
-        ReqwestClient::proxy_and_user_agent(proxy_url, &user_agent)
+        ReqwestClient::proxy_and_user_agent(proxy_url, no_proxy, &user_agent)
             .expect("could not start HTTP client")
     };
     cx.set_http_client(Arc::new(http));

--- a/crates/eval_cli/src/headless.rs
+++ b/crates/eval_cli/src/headless.rs
@@ -5,7 +5,6 @@ use client::{Client, ProxySettings, RefreshLlmTokenListener, UserStore};
 use db::AppDatabase;
 use extension::ExtensionHostProxy;
 use fs::RealFs;
-use gpui::http_client::read_proxy_from_env;
 use gpui::{App, AppContext as _, Entity};
 use gpui_tokio::Tokio;
 use language::LanguageRegistry;
@@ -48,14 +47,12 @@ pub fn init(cx: &mut App) -> Arc<AgentCliAppState> {
         std::env::consts::OS,
         std::env::consts::ARCH
     );
-    let proxy_str = ProxySettings::get_global(cx).proxy.to_owned();
-    let proxy_url = proxy_str
-        .as_ref()
-        .and_then(|input| input.parse().ok())
-        .or_else(read_proxy_from_env);
+    let proxy_settings = ProxySettings::get_global(cx);
+    let proxy_url = proxy_settings.proxy_url();
+    let no_proxy = proxy_settings.no_proxy();
     let http = {
         let _guard = Tokio::handle(cx).enter();
-        ReqwestClient::proxy_and_user_agent(proxy_url, &user_agent)
+        ReqwestClient::proxy_and_user_agent(proxy_url, no_proxy, &user_agent)
             .expect("could not start HTTP client")
     };
     cx.set_http_client(Arc::new(http));

--- a/crates/remote_server/src/server.rs
+++ b/crates/remote_server/src/server.rs
@@ -20,9 +20,8 @@ use futures::{
     select, select_biased,
 };
 use git::GitHostingProviderRegistry;
-use gpui::{App, AppContext as _, Context, Entity, UpdateGlobal as _};
+use gpui::{App, AppContext as _, Entity, UpdateGlobal as _};
 use gpui_tokio::Tokio;
-use http_client::{Url, read_proxy_from_env};
 use language::LanguageRegistry;
 use net::async_net::{UnixListener, UnixStream};
 use node_runtime::{NodeBinaryOptions, NodeRuntime};
@@ -654,13 +653,16 @@ pub fn execute_run(
             let fs = Arc::new(RealFs::new(None, cx.background_executor().clone()));
             let node_settings_rx = initialize_settings(session.clone(), fs.clone(), cx);
 
-            let proxy_url = read_proxy_settings(cx);
+            let proxy_settings = ProxySettings::get_global(cx);
+            let proxy_url = proxy_settings.proxy_url();
+            let no_proxy = proxy_settings.no_proxy();
 
             let http_client = {
                 let _guard = Tokio::handle(cx).enter();
                 Arc::new(
                     ReqwestClient::proxy_and_user_agent(
                         proxy_url,
+                        no_proxy,
                         &format!(
                             "Zed-Server/{} ({}; {})",
                             env!("CARGO_PKG_VERSION"),
@@ -1274,22 +1276,6 @@ pub fn handle_settings_file_changes(
         }
     })
     .detach();
-}
-
-fn read_proxy_settings(cx: &mut Context<HeadlessProject>) -> Option<Url> {
-    let proxy_str = ProxySettings::get_global(cx).proxy.to_owned();
-
-    proxy_str
-        .as_deref()
-        .map(str::trim)
-        .filter(|input| !input.is_empty())
-        .and_then(|input| {
-            input
-                .parse::<Url>()
-                .inspect_err(|e| log::error!("Error parsing proxy settings: {}", e))
-                .ok()
-        })
-        .or_else(read_proxy_from_env)
 }
 
 fn cleanup_old_binaries() -> Result<()> {

--- a/crates/reqwest_client/src/reqwest_client.rs
+++ b/crates/reqwest_client/src/reqwest_client.rs
@@ -21,6 +21,7 @@ static REDACT_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"key=[^&]+")
 pub struct ReqwestClient {
     client: reqwest::Client,
     proxy: Option<Url>,
+    no_proxy: Option<String>,
     user_agent: Option<HeaderValue>,
     handle: tokio::runtime::Handle,
 }
@@ -46,7 +47,11 @@ impl ReqwestClient {
         Ok(client.into())
     }
 
-    pub fn proxy_and_user_agent(proxy: Option<Url>, user_agent: &str) -> anyhow::Result<Self> {
+    pub fn proxy_and_user_agent(
+        proxy: Option<Url>,
+        no_proxy: Option<String>,
+        user_agent: &str,
+    ) -> anyhow::Result<Self> {
         let user_agent = HeaderValue::from_str(user_agent)?;
 
         let mut map = HeaderMap::new();
@@ -65,8 +70,11 @@ impl ReqwestClient {
                 })
                 .ok()
         }) {
-            // Respect NO_PROXY env var
-            client = client.proxy(proxy.no_proxy(reqwest::NoProxy::from_env()));
+            let no_proxy_rules = no_proxy
+                .as_deref()
+                .and_then(reqwest::NoProxy::from_string)
+                .or_else(reqwest::NoProxy::from_env);
+            client = client.proxy(proxy.no_proxy(no_proxy_rules));
             client_has_proxy = true;
         } else {
             client_has_proxy = false;
@@ -77,6 +85,7 @@ impl ReqwestClient {
             .build()?;
         let mut client: ReqwestClient = client.into();
         client.proxy = client_has_proxy.then_some(proxy).flatten();
+        client.no_proxy = no_proxy;
         client.user_agent = Some(user_agent);
         Ok(client)
     }
@@ -103,6 +112,7 @@ impl From<reqwest::Client> for ReqwestClient {
             client,
             handle,
             proxy: None,
+            no_proxy: None,
             user_agent: None,
         }
     }
@@ -287,37 +297,55 @@ mod tests {
         assert_eq!(client.proxy(), None);
 
         let proxy = Url::parse("http://localhost:10809").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
 
         let proxy = Url::parse("https://localhost:10809").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
 
         let proxy = Url::parse("socks4://localhost:10808").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
 
         let proxy = Url::parse("socks4a://localhost:10808").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
 
         let proxy = Url::parse("socks5://localhost:10808").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
 
         let proxy = Url::parse("socks5h://localhost:10808").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
     }
 
     #[test]
     fn test_invalid_proxy_uri() {
         let proxy = Url::parse("socks://127.0.0.1:20170").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy), "test").unwrap();
+        let client = ReqwestClient::proxy_and_user_agent(Some(proxy), None, "test").unwrap();
         assert!(
             client.proxy.is_none(),
             "An invalid proxy URL should add no proxy to the client!"
         )
+    }
+
+    #[test]
+    fn test_no_proxy_setting_is_stored() {
+        let proxy = Url::parse("http://localhost:10809").unwrap();
+        let client = ReqwestClient::proxy_and_user_agent(
+            Some(proxy),
+            Some("localhost,127.0.0.1".to_owned()),
+            "test",
+        )
+        .unwrap();
+        assert_eq!(client.no_proxy.as_deref(), Some("localhost,127.0.0.1"));
     }
 }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -206,6 +206,7 @@ impl VsCodeSettings {
             project: self.project_settings_content(),
             project_panel: self.project_panel_settings_content(),
             proxy: self.read_string("http.proxy"),
+            no_proxy: None,
             remote: RemoteSettingsContent::default(),
             repl: None,
             server_url: None,

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -215,6 +215,7 @@ pub struct SettingsContent {
     pub node: Option<NodeBinarySettings>,
 
     pub proxy: Option<String>,
+    pub no_proxy: Option<String>,
 
     /// The URL of the Zed server to connect to.
     pub server_url: Option<String>,

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7834,7 +7834,7 @@ fn ai_page(cx: &App) -> SettingsPage {
 }
 
 fn network_page() -> SettingsPage {
-    fn network_section() -> [SettingsPageItem; 3] {
+    fn network_section() -> [SettingsPageItem; 4] {
         [
             SettingsPageItem::SectionHeader("Network"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -7849,6 +7849,22 @@ fn network_page() -> SettingsPage {
                 }),
                 metadata: Some(Box::new(SettingsFieldMetadata {
                     placeholder: Some("socks5h://localhost:10808"),
+                    ..Default::default()
+                })),
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Proxy Bypass",
+                description: "Comma-separated hosts and IP ranges to connect to directly.",
+                field: Box::new(SettingField {
+                    json_path: Some("no_proxy"),
+                    pick: |settings_content| settings_content.no_proxy.as_ref(),
+                    write: |settings_content, value| {
+                        settings_content.no_proxy = value;
+                    },
+                }),
+                metadata: Some(Box::new(SettingsFieldMetadata {
+                    placeholder: Some("localhost,127.0.0.1,::1,.internal.company"),
                     ..Default::default()
                 })),
                 files: USER,

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -503,11 +503,13 @@ fn main() {
             std::env::consts::OS,
             std::env::consts::ARCH
         );
-        let proxy_url = ProxySettings::get_global(cx).proxy_url();
+        let proxy_settings = ProxySettings::get_global(cx);
+        let proxy_url = proxy_settings.proxy_url();
+        let no_proxy = proxy_settings.no_proxy();
         let http = {
             let _guard = Tokio::handle(cx).enter();
 
-            ReqwestClient::proxy_and_user_agent(proxy_url, &user_agent)
+            ReqwestClient::proxy_and_user_agent(proxy_url, no_proxy, &user_agent)
                 .expect("could not start HTTP client")
         };
         cx.set_http_client(Arc::new(http));


### PR DESCRIPTION
I use Zed at work and connect to a local OpenAI-compatible LLM, but I also need to use a proxy for updates and to access the Internet. This feature allows you to add exceptions for local networks, thereby avoiding the need to regularly enable or disable the proxy.

This pull request adds a `no_proxy` parameter that accepts a comma-separated list of hosts, thereby bypassing the configured proxy.

**Supported formats:**
- Simple hostnames: `localhost`, `myhost`
- Domain suffixes: `.internal.company` (matches any subdomain)
- Host + port: `example.com:8443`
- IPv4/IPv6 CIDR ranges: `192.168.0.0/16`, `fd00::/8`
- Wildcard: `*` (bypass the proxy for everything)

If the setting is empty, it falls back to the `NO_PROXY`/`no_proxy` environment variable (same fallback behavior as the existing `proxy` setting).

**Release Notes:**

- Added a `no_proxy` setting to bypass the configured proxy for specific hosts, domain suffixes, IP ranges, and ports. Falls back to the `NO_PROXY` environment variable if unset.

**Self-Review Checklist:**

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable