### PR TITLE
Add no_proxy setting to bypass proxy for specific hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,6 @@ dependencies = [
  "google_ai",
  "gpui",
  "gpui_tokio",
- "http_client",
  "indoc",
  "language_model",
  "libc",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2728,13 +2728,21 @@
   // `socks5h`. `http` will be used when no scheme is specified.
   //
   // By default no proxy will be used, or Zed will try get proxy settings from
-  // environment variables. If certain hosts should not be proxied,
-  // set the `no_proxy` environment variable and provide a comma-separated list.
+  // environment variables.
   //
   // Examples:
   //   - "proxy": "socks5h://localhost:10808"
   //   - "proxy": "http://127.0.0.1:10809"
   "proxy": "",
+  // A comma-separated list of hosts that should bypass the configured proxy.
+  //
+  // Supports hosts, domain suffixes, host:port entries, and IPv4/IPv6 CIDR
+  // ranges for literal IP hosts.
+  //
+  // Examples:
+  //   - "no_proxy": "localhost,127.0.0.1,::1"
+  //   - "no_proxy": "192.168.0.0/16,.internal.company"
+  "no_proxy": "",
   // Set to configure aliases for the command palette.
   // When typing a query which is a key of this object, the value will be used instead.
   //

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2735,9 +2735,10 @@
   //   - "proxy": "http://127.0.0.1:10809"
   "proxy": "",
   // A comma-separated list of hosts that should bypass the configured proxy.
-  // Defaults to localhost addresses to avoid accidentally routing local
-  // connections through the proxy. This overrides the NO_PROXY environment
-  // variable entirely when set.
+  // When left empty, Zed falls back to the NO_PROXY environment variable, and
+  // then to "localhost,127.0.0.1,::1" so local connections are not proxied.
+  // Setting this replaces both, so include the localhost addresses yourself if
+  // you still need them.
   //
   // Supports hosts, domain suffixes, host:port entries, and IPv4/IPv6 CIDR
   // ranges for literal IP hosts.
@@ -2745,7 +2746,7 @@
   // Examples:
   //   - "no_proxy": "localhost,127.0.0.1,::1"
   //   - "no_proxy": "192.168.0.0/16,.internal.company"
-  "no_proxy": "localhost,127.0.0.1,::1",
+  "no_proxy": "",
   // Set to configure aliases for the command palette.
   // When typing a query which is a key of this object, the value will be used instead.
   //

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2735,6 +2735,9 @@
   //   - "proxy": "http://127.0.0.1:10809"
   "proxy": "",
   // A comma-separated list of hosts that should bypass the configured proxy.
+  // Defaults to localhost addresses to avoid accidentally routing local
+  // connections through the proxy. This overrides the NO_PROXY environment
+  // variable entirely when set.
   //
   // Supports hosts, domain suffixes, host:port entries, and IPv4/IPv6 CIDR
   // ranges for literal IP hosts.
@@ -2742,7 +2745,7 @@
   // Examples:
   //   - "no_proxy": "localhost,127.0.0.1,::1"
   //   - "no_proxy": "192.168.0.0/16,.internal.company"
-  "no_proxy": "",
+  "no_proxy": "localhost,127.0.0.1,::1",
   // Set to configure aliases for the command palette.
   // When typing a query which is a key of this object, the value will be used instead.
   //

--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -40,7 +40,6 @@ gpui.workspace = true
 feature_flags.workspace = true
 gpui_tokio = { workspace = true, optional = true }
 google_ai.workspace = true
-http_client.workspace = true
 indoc.workspace = true
 language_model.workspace = true
 log.workspace = true

--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -8,7 +8,6 @@ use client::ProxySettings;
 use collections::{HashMap, HashSet};
 pub use custom::*;
 use fs::Fs;
-use http_client::read_no_proxy_from_env;
 use project::{AgentId, Project, agent_server_store::AgentServerStore};
 
 use acp_thread::AgentConnection;
@@ -113,6 +112,8 @@ impl dyn AgentServer {
 pub fn load_proxy_env(cx: &mut App) -> HashMap<String, String> {
     let proxy_url = cx
         .read_global(|settings: &SettingsStore, _| settings.get::<ProxySettings>(None).proxy_url());
+    let no_proxy = cx
+        .read_global(|settings: &SettingsStore, _| settings.get::<ProxySettings>(None).no_proxy());
     let mut env = HashMap::default();
 
     if let Some(proxy_url) = &proxy_url {
@@ -124,7 +125,7 @@ pub fn load_proxy_env(cx: &mut App) -> HashMap<String, String> {
         env.insert(env_var.to_owned(), proxy_url.to_string());
     }
 
-    if let Some(no_proxy) = read_no_proxy_from_env() {
+    if let Some(no_proxy) = no_proxy {
         env.insert("NO_PROXY".to_owned(), no_proxy);
     } else if proxy_url.is_some() {
         // We sometimes need local MCP servers that we don't want to proxy

--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -110,10 +110,10 @@ impl dyn AgentServer {
 
 /// Load the default proxy environment variables to pass through to the agent
 pub fn load_proxy_env(cx: &mut App) -> HashMap<String, String> {
-    let proxy_url = cx
-        .read_global(|settings: &SettingsStore, _| settings.get::<ProxySettings>(None).proxy_url());
-    let no_proxy = cx
-        .read_global(|settings: &SettingsStore, _| settings.get::<ProxySettings>(None).no_proxy());
+    let (proxy_url, no_proxy) = cx.read_global(|settings: &SettingsStore, _| {
+        let proxy_settings = settings.get::<ProxySettings>(None);
+        (proxy_settings.proxy_url(), proxy_settings.no_proxy())
+    });
     let mut env = HashMap::default();
 
     if let Some(proxy_url) = &proxy_url {
@@ -127,9 +127,6 @@ pub fn load_proxy_env(cx: &mut App) -> HashMap<String, String> {
 
     if let Some(no_proxy) = no_proxy {
         env.insert("NO_PROXY".to_owned(), no_proxy);
-    } else if proxy_url.is_some() {
-        // We sometimes need local MCP servers that we don't want to proxy
-        env.insert("NO_PROXY".to_owned(), "localhost,127.0.0.1".to_owned());
     }
 
     env

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -131,6 +131,8 @@ impl Settings for ClientSettings {
     }
 }
 
+const DEFAULT_NO_PROXY: &str = "localhost,127.0.0.1,::1";
+
 #[derive(Deserialize, Default, RegisterSetting)]
 pub struct ProxySettings {
     pub proxy: Option<String>,
@@ -154,11 +156,9 @@ impl ProxySettings {
 
     pub fn no_proxy(&self) -> Option<String> {
         self.no_proxy
-            .as_deref()
-            .map(str::trim)
-            .filter(|input| !input.is_empty())
-            .map(ToOwned::to_owned)
+            .clone()
             .or_else(read_no_proxy_from_env)
+            .or_else(|| Some(DEFAULT_NO_PROXY.to_owned()))
     }
 }
 
@@ -1351,6 +1351,7 @@ impl Client {
 
         let http = self.http.clone();
         let proxy = http.proxy().cloned();
+        let no_proxy = http.no_proxy().map(str::to_owned);
         let user_agent = http.user_agent().cloned();
         let credentials = credentials.clone();
         let rpc_url = self.rpc_url(http, release_channel);
@@ -1380,7 +1381,7 @@ impl Client {
                         .zip(rpc_url.port_or_known_default())
                         .context("missing host in rpc url")?;
                     Ok(match proxy {
-                        Some(proxy) if !excluded_from_proxy(rpc_host.0) => {
+                        Some(proxy) if !excluded_from_proxy(no_proxy.as_deref(), rpc_host.0) => {
                             connect_proxy_stream(&proxy, rpc_host).await?
                         }
                         _ => Box::new(TcpStream::connect(rpc_host).await?),

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -27,7 +27,9 @@ use futures::{
     stream::BoxStream,
 };
 use gpui::{App, AsyncApp, Entity, Global, Task, TaskExt, WeakEntity, actions};
-use http_client::{HttpClient, HttpClientWithUrl, http, read_proxy_from_env};
+use http_client::{
+    HttpClient, HttpClientWithUrl, http, read_no_proxy_from_env, read_proxy_from_env,
+};
 use parking_lot::{Mutex, RwLock};
 use postage::watch;
 use proxy::{connect_proxy_stream, excluded_from_proxy};
@@ -132,6 +134,7 @@ impl Settings for ClientSettings {
 #[derive(Deserialize, Default, RegisterSetting)]
 pub struct ProxySettings {
     pub proxy: Option<String>,
+    pub no_proxy: Option<String>,
 }
 
 impl ProxySettings {
@@ -148,6 +151,15 @@ impl ProxySettings {
             })
             .or_else(read_proxy_from_env)
     }
+
+    pub fn no_proxy(&self) -> Option<String> {
+        self.no_proxy
+            .as_deref()
+            .map(str::trim)
+            .filter(|input| !input.is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(read_no_proxy_from_env)
+    }
 }
 
 impl Settings for ProxySettings {
@@ -158,6 +170,12 @@ impl Settings for ProxySettings {
                 .as_deref()
                 .map(str::trim)
                 .filter(|proxy| !proxy.is_empty())
+                .map(ToOwned::to_owned),
+            no_proxy: content
+                .no_proxy
+                .as_deref()
+                .map(str::trim)
+                .filter(|no_proxy| !no_proxy.is_empty())
                 .map(ToOwned::to_owned),
         }
     }
@@ -2019,9 +2037,14 @@ mod tests {
         assert_eq!(ProxySettings::from_settings(&content).proxy, None);
 
         content.proxy = Some("http://127.0.0.1:10809".to_owned());
+        content.no_proxy = Some(" localhost,127.0.0.1 ".to_owned());
         assert_eq!(
             ProxySettings::from_settings(&content).proxy.as_deref(),
             Some("http://127.0.0.1:10809")
+        );
+        assert_eq!(
+            ProxySettings::from_settings(&content).no_proxy.as_deref(),
+            Some("localhost,127.0.0.1")
         );
     }
 

--- a/crates/client/src/proxy.rs
+++ b/crates/client/src/proxy.rs
@@ -19,12 +19,11 @@ impl<T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static> A
 {
 }
 
-/// Whether `NO_PROXY` in the environment excludes `host` from proxying,
+/// Whether the HTTP client's proxy bypass list excludes `host` from proxying,
 /// matching the exclusions the HTTP client already applies to its own
 /// requests.
-pub(crate) fn excluded_from_proxy(host: &str) -> bool {
-    http_client::read_no_proxy_from_env()
-        .is_some_and(|no_proxy| proxy_handshake::no_proxy_matches(&no_proxy, host))
+pub(crate) fn excluded_from_proxy(no_proxy: Option<&str>, host: &str) -> bool {
+    no_proxy.is_some_and(|no_proxy| proxy_handshake::no_proxy_matches(no_proxy, host))
 }
 
 pub(crate) async fn connect_proxy_stream(

--- a/crates/edit_prediction_cli/src/headless.rs
+++ b/crates/edit_prediction_cli/src/headless.rs
@@ -2,7 +2,6 @@ use client::{Client, ProxySettings, RefreshLlmTokenListener, UserStore};
 use db::AppDatabase;
 use extension::ExtensionHostProxy;
 use fs::RealFs;
-use gpui::http_client::read_proxy_from_env;
 use gpui::{App, AppContext, Entity};
 use gpui_tokio::Tokio;
 use language::LanguageRegistry;
@@ -46,15 +45,13 @@ pub fn init(cx: &mut App) -> EpAppState {
         std::env::consts::OS,
         std::env::consts::ARCH
     );
-    let proxy_str = ProxySettings::get_global(cx).proxy.to_owned();
-    let proxy_url = proxy_str
-        .as_ref()
-        .and_then(|input| input.parse().ok())
-        .or_else(read_proxy_from_env);
+    let proxy_settings = ProxySettings::get_global(cx);
+    let proxy_url = proxy_settings.proxy_url();
+    let no_proxy = proxy_settings.no_proxy();
     let http = {
         let _guard = Tokio::handle(cx).enter();
 
-        ReqwestClient::proxy_and_user_agent(proxy_url, &user_agent)
+        ReqwestClient::proxy_and_user_agent(proxy_url, no_proxy, &user_agent)
             .expect("could not start HTTP client")
     };
     cx.set_http_client(Arc::new(http));

--- a/crates/eval_cli/src/headless.rs
+++ b/crates/eval_cli/src/headless.rs
@@ -5,7 +5,6 @@ use client::{Client, ProxySettings, RefreshLlmTokenListener, UserStore};
 use db::AppDatabase;
 use extension::ExtensionHostProxy;
 use fs::RealFs;
-use gpui::http_client::read_proxy_from_env;
 use gpui::{App, AppContext as _, Entity};
 use gpui_tokio::Tokio;
 use language::LanguageRegistry;
@@ -48,14 +47,12 @@ pub fn init(cx: &mut App) -> Arc<AgentCliAppState> {
         std::env::consts::OS,
         std::env::consts::ARCH
     );
-    let proxy_str = ProxySettings::get_global(cx).proxy.to_owned();
-    let proxy_url = proxy_str
-        .as_ref()
-        .and_then(|input| input.parse().ok())
-        .or_else(read_proxy_from_env);
+    let proxy_settings = ProxySettings::get_global(cx);
+    let proxy_url = proxy_settings.proxy_url();
+    let no_proxy = proxy_settings.no_proxy();
     let http = {
         let _guard = Tokio::handle(cx).enter();
-        ReqwestClient::proxy_and_user_agent(proxy_url, &user_agent)
+        ReqwestClient::proxy_and_user_agent(proxy_url, no_proxy, &user_agent)
             .expect("could not start HTTP client")
     };
     cx.set_http_client(Arc::new(http));

--- a/crates/http_client/src/http_client.rs
+++ b/crates/http_client/src/http_client.rs
@@ -114,6 +114,10 @@ pub trait HttpClient: 'static + Send + Sync {
 
     fn proxy(&self) -> Option<&Url>;
 
+    fn no_proxy(&self) -> Option<&str> {
+        None
+    }
+
     fn send(
         &self,
         req: http::Request<AsyncBody>,
@@ -202,6 +206,10 @@ impl HttpClient for HttpClientWithProxy {
 
     fn proxy(&self) -> Option<&Url> {
         self.proxy.as_ref()
+    }
+
+    fn no_proxy(&self) -> Option<&str> {
+        self.client.no_proxy()
     }
 
     #[cfg(feature = "test-support")]
@@ -335,6 +343,10 @@ impl HttpClient for HttpClientWithUrl {
 
     fn proxy(&self) -> Option<&Url> {
         self.client.proxy.as_ref()
+    }
+
+    fn no_proxy(&self) -> Option<&str> {
+        self.client.no_proxy()
     }
 
     #[cfg(feature = "test-support")]

--- a/crates/remote_server/src/server.rs
+++ b/crates/remote_server/src/server.rs
@@ -20,9 +20,8 @@ use futures::{
     select, select_biased,
 };
 use git::GitHostingProviderRegistry;
-use gpui::{App, AppContext as _, Context, Entity, UpdateGlobal as _};
+use gpui::{App, AppContext as _, Entity, UpdateGlobal as _};
 use gpui_tokio::Tokio;
-use http_client::{Url, read_proxy_from_env};
 use language::LanguageRegistry;
 use net::async_net::{UnixListener, UnixStream};
 use node_runtime::{NodeBinaryOptions, NodeRuntime};
@@ -680,13 +679,16 @@ pub fn execute_run(
             let fs = Arc::new(RealFs::new(None, cx.background_executor().clone()));
             let node_settings_rx = initialize_settings(session.clone(), fs.clone(), cx);
 
-            let proxy_url = read_proxy_settings(cx);
+            let proxy_settings = ProxySettings::get_global(cx);
+            let proxy_url = proxy_settings.proxy_url();
+            let no_proxy = proxy_settings.no_proxy();
 
             let http_client = {
                 let _guard = Tokio::handle(cx).enter();
                 Arc::new(
                     ReqwestClient::proxy_and_user_agent(
                         proxy_url,
+                        no_proxy,
                         &format!(
                             "Zed-Server/{} ({}; {})",
                             env!("CARGO_PKG_VERSION"),
@@ -1298,22 +1300,6 @@ pub fn handle_settings_file_changes(
         }
     })
     .detach();
-}
-
-fn read_proxy_settings(cx: &mut Context<HeadlessProject>) -> Option<Url> {
-    let proxy_str = ProxySettings::get_global(cx).proxy.to_owned();
-
-    proxy_str
-        .as_deref()
-        .map(str::trim)
-        .filter(|input| !input.is_empty())
-        .and_then(|input| {
-            input
-                .parse::<Url>()
-                .inspect_err(|e| log::error!("Error parsing proxy settings: {}", e))
-                .ok()
-        })
-        .or_else(read_proxy_from_env)
 }
 
 fn cleanup_old_binaries() -> Result<()> {

--- a/crates/reqwest_client/src/reqwest_client.rs
+++ b/crates/reqwest_client/src/reqwest_client.rs
@@ -272,6 +272,10 @@ impl http_client::HttpClient for ReqwestClient {
         self.proxy.as_ref()
     }
 
+    fn no_proxy(&self) -> Option<&str> {
+        self.no_proxy.as_deref()
+    }
+
     fn user_agent(&self) -> Option<&HeaderValue> {
         self.user_agent.as_ref()
     }
@@ -469,6 +473,6 @@ mod tests {
             "test",
         )
         .unwrap();
-        assert_eq!(client.no_proxy.as_deref(), Some("localhost,127.0.0.1"));
+        assert_eq!(client.no_proxy(), Some("localhost,127.0.0.1"));
     }
 }

--- a/crates/reqwest_client/src/reqwest_client.rs
+++ b/crates/reqwest_client/src/reqwest_client.rs
@@ -21,6 +21,7 @@ static REDACT_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"key=[^&]+")
 pub struct ReqwestClient {
     client: reqwest::Client,
     proxy: Option<Url>,
+    no_proxy: Option<String>,
     user_agent: Option<HeaderValue>,
     handle: tokio::runtime::Handle,
 }
@@ -63,8 +64,12 @@ impl ReqwestClient {
         Ok(client.into())
     }
 
-    pub fn proxy_and_user_agent(proxy: Option<Url>, user_agent: &str) -> anyhow::Result<Self> {
-        Self::proxy_user_agent_and_read_timeout(proxy, user_agent, None)
+    pub fn proxy_and_user_agent(
+        proxy: Option<Url>,
+        no_proxy: Option<String>,
+        user_agent: &str,
+    ) -> anyhow::Result<Self> {
+        Self::proxy_user_agent_and_read_timeout(proxy, no_proxy, user_agent, None)
     }
 
     /// Like [`ReqwestClient::proxy_and_user_agent`], but also applies a
@@ -82,6 +87,7 @@ impl ReqwestClient {
     /// suspended must re-validate the stream on wake themselves.
     pub fn proxy_user_agent_and_read_timeout(
         proxy: Option<Url>,
+        no_proxy: Option<String>,
         user_agent: &str,
         read_timeout: Option<Duration>,
     ) -> anyhow::Result<Self> {
@@ -103,8 +109,11 @@ impl ReqwestClient {
                 })
                 .ok()
         }) {
-            // Respect NO_PROXY env var
-            client = client.proxy(proxy.no_proxy(reqwest::NoProxy::from_env()));
+            let no_proxy_rules = no_proxy
+                .as_deref()
+                .and_then(reqwest::NoProxy::from_string)
+                .or_else(reqwest::NoProxy::from_env);
+            client = client.proxy(proxy.no_proxy(no_proxy_rules));
             client_has_proxy = true;
         } else {
             client_has_proxy = false;
@@ -115,6 +124,7 @@ impl ReqwestClient {
             .build()?;
         let mut client: ReqwestClient = client.into();
         client.proxy = client_has_proxy.then_some(proxy).flatten();
+        client.no_proxy = no_proxy;
         client.user_agent = Some(user_agent);
         Ok(client)
     }
@@ -141,6 +151,7 @@ impl From<reqwest::Client> for ReqwestClient {
             client,
             handle,
             proxy: None,
+            no_proxy: None,
             user_agent: None,
         }
     }
@@ -409,37 +420,55 @@ mod tests {
         assert_eq!(client.proxy(), None);
 
         let proxy = Url::parse("http://localhost:10809").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
 
         let proxy = Url::parse("https://localhost:10809").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
 
         let proxy = Url::parse("socks4://localhost:10808").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
 
         let proxy = Url::parse("socks4a://localhost:10808").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
 
         let proxy = Url::parse("socks5://localhost:10808").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
 
         let proxy = Url::parse("socks5h://localhost:10808").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), "test").unwrap();
+        let client =
+            ReqwestClient::proxy_and_user_agent(Some(proxy.clone()), None, "test").unwrap();
         assert_eq!(client.proxy(), Some(&proxy));
     }
 
     #[test]
     fn test_invalid_proxy_uri() {
         let proxy = Url::parse("socks://127.0.0.1:20170").unwrap();
-        let client = ReqwestClient::proxy_and_user_agent(Some(proxy), "test").unwrap();
+        let client = ReqwestClient::proxy_and_user_agent(Some(proxy), None, "test").unwrap();
         assert!(
             client.proxy.is_none(),
             "An invalid proxy URL should add no proxy to the client!"
         )
+    }
+
+    #[test]
+    fn test_no_proxy_setting_is_stored() {
+        let proxy = Url::parse("http://localhost:10809").unwrap();
+        let client = ReqwestClient::proxy_and_user_agent(
+            Some(proxy),
+            Some("localhost,127.0.0.1".to_owned()),
+            "test",
+        )
+        .unwrap();
+        assert_eq!(client.no_proxy.as_deref(), Some("localhost,127.0.0.1"));
     }
 }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -206,6 +206,7 @@ impl VsCodeSettings {
             project: self.project_settings_content(),
             project_panel: self.project_panel_settings_content(),
             proxy: self.read_string("http.proxy"),
+            no_proxy: None,
             reduce_motion: self.read_enum("workbench.reduceMotion", |s| match s {
                 "on" => Some(ReduceMotionMode::On),
                 "off" => Some(ReduceMotionMode::Off),

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -242,6 +242,7 @@ pub struct SettingsContent {
     pub node: Option<NodeBinarySettings>,
 
     pub proxy: Option<String>,
+    pub no_proxy: Option<String>,
 
     /// Whether to reduce non-essential motion in the UI, such as loading
     /// spinners and pulsating labels, by rendering them in a static state.

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8709,6 +8709,7 @@ fn network_page() -> SettingsPage {
                 title: "Proxy Bypass",
                 description: "Comma-separated hosts and IP ranges to connect to directly.",
                 field: Box::new(SettingField {
+                    organization_override: None,
                     json_path: Some("no_proxy"),
                     pick: |settings_content| settings_content.no_proxy.as_ref(),
                     write: |settings_content, value, _| {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8711,7 +8711,7 @@ fn network_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("no_proxy"),
                     pick: |settings_content| settings_content.no_proxy.as_ref(),
-                    write: |settings_content, value| {
+                    write: |settings_content, value, _| {
                         settings_content.no_proxy = value;
                     },
                 }),

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8685,7 +8685,7 @@ fn ai_page(cx: &App) -> SettingsPage {
 }
 
 fn network_page() -> SettingsPage {
-    fn network_section() -> [SettingsPageItem; 3] {
+    fn network_section() -> [SettingsPageItem; 4] {
         [
             SettingsPageItem::SectionHeader("Network"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -8701,6 +8701,22 @@ fn network_page() -> SettingsPage {
                 }),
                 metadata: Some(Box::new(SettingsFieldMetadata {
                     placeholder: Some("socks5h://localhost:10808"),
+                    ..Default::default()
+                })),
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Proxy Bypass",
+                description: "Comma-separated hosts and IP ranges to connect to directly.",
+                field: Box::new(SettingField {
+                    json_path: Some("no_proxy"),
+                    pick: |settings_content| settings_content.no_proxy.as_ref(),
+                    write: |settings_content, value| {
+                        settings_content.no_proxy = value;
+                    },
+                }),
+                metadata: Some(Box::new(SettingsFieldMetadata {
+                    placeholder: Some("localhost,127.0.0.1,::1,.internal.company"),
                     ..Default::default()
                 })),
                 files: USER,

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -504,11 +504,13 @@ fn main() {
             std::env::consts::OS,
             std::env::consts::ARCH
         );
-        let proxy_url = ProxySettings::get_global(cx).proxy_url();
+        let proxy_settings = ProxySettings::get_global(cx);
+        let proxy_url = proxy_settings.proxy_url();
+        let no_proxy = proxy_settings.no_proxy();
         let http = {
             let _guard = Tokio::handle(cx).enter();
 
-            ReqwestClient::proxy_and_user_agent(proxy_url, &user_agent)
+            ReqwestClient::proxy_and_user_agent(proxy_url, no_proxy, &user_agent)
                 .expect("could not start HTTP client")
         };
         cx.set_http_client(Arc::new(http));

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3296,7 +3296,27 @@ Or to set a `socks5` proxy:
 }
 ```
 
-If you wish to exclude certain hosts from using the proxy, set the `NO_PROXY` environment variable. This accepts a comma-separated list of hostnames, host suffixes, IPv4/IPv6 addresses or blocks that should not use the proxy. For example if your environment included `NO_PROXY="google.com, 192.168.1.0/24"` all hosts in `192.168.1.*`, `google.com` and `*.google.com` would bypass the proxy. See [reqwest NoProxy docs](https://docs.rs/reqwest/latest/reqwest/struct.NoProxy.html#method.from_string) for more.
+To exclude certain hosts from the proxy, use the [`no_proxy`](#no-proxy) setting.
+
+## No Proxy
+
+- Description: A comma-separated list of hosts that bypass the configured proxy
+- Setting: `no_proxy`
+- Default: `""`
+
+**Options**
+
+Accepts a comma-separated list of hostnames, host suffixes, `host:port` entries, IPv4/IPv6 addresses or CIDR blocks that should not use the proxy. For example, with `"no_proxy": "google.com,192.168.1.0/24"` all hosts in `192.168.1.*`, `google.com` and `*.google.com` bypass the proxy. See the [reqwest NoProxy docs](https://docs.rs/reqwest/latest/reqwest/struct.NoProxy.html#method.from_string) for the full syntax.
+
+```json [settings]
+{
+  "no_proxy": "localhost,127.0.0.1,::1,.internal.company"
+}
+```
+
+When this setting is empty, Zed falls back to the `NO_PROXY` environment variable, and then to `localhost,127.0.0.1,::1` so that local services such as MCP servers and locally hosted LLMs are never routed through the proxy. Setting `no_proxy` replaces both, so include the localhost addresses yourself if you still need them.
+
+The bypass list applies to Zed's HTTP requests as well as to the collaboration WebSocket connection.
 
 ## On Last Window Closed
 

--- a/docs/src/remote-development.md
+++ b/docs/src/remote-development.md
@@ -208,7 +208,8 @@ Alternatively, you can configure the proxy in the remote machine's `~/.config/ze
 
 ```json
 {
-  "proxy": "http://proxy.example.com:8080"
+  "proxy": "http://proxy.example.com:8080",
+  "no_proxy": "localhost,127.0.0.1"
 }
 ```
 


### PR DESCRIPTION
I use Zed at work and connect to a local OpenAI-compatible LLM, but I also need to use a proxy for updates and to access the Internet. This feature allows you to add exceptions for local networks, thereby avoiding the need to regularly enable or disable the proxy.

This pull request adds a `no_proxy` parameter that accepts a comma-separated list of hosts, thereby bypassing the configured proxy.

**Supported formats:**
- Simple hostnames: `localhost`, `myhost`
- Domain suffixes: `.internal.company` (matches any subdomain)
- Host + port: `example.com:8443`
- IPv4/IPv6 CIDR ranges: `192.168.0.0/16`, `fd00::/8`
- Wildcard: `*` (bypass the proxy for everything)

If the setting is empty, it falls back to the `NO_PROXY`/`no_proxy` environment variable (same fallback behavior as the existing `proxy` setting).

Release Notes:

- Added a `no_proxy` setting to bypass the configured proxy for specific hosts, domain suffixes, IP ranges, and ports. Falls back to the `NO_PROXY` environment variable if unset.

**Self-Review Checklist:**

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable