### PR TITLE
agent_ui: Open pasted images in editor on click

### DIFF
--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -19,6 +19,7 @@ mod inline_assistant;
 mod inline_prompt_editor;
 mod language_model_selector;
 mod mention_set;
+pub use mention_set::set_app_quitting;
 mod message_editor;
 mod mode_selector;
 mod model_selector;

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -35,7 +35,7 @@ use std::{
 use text::OffsetRangeExt;
 use ui::{Disclosure, Toggleable, prelude::*};
 use util::{ResultExt, debug_panic, rel_path::RelPath};
-use workspace::{Workspace, notifications::NotifyResultExt as _};
+use workspace::{ItemHandle, OpenOptions, Workspace, notifications::NotifyResultExt as _};
 
 use crate::ui::MentionCrease;
 
@@ -928,8 +928,8 @@ pub(crate) async fn insert_images_as_context(
                 name.clone(),
                 IconName::Image.path().into(),
                 None,
-                None,
-                None,
+                Some(mention_uri.clone()),
+                Some(workspace.clone()),
                 Some(Task::ready(Ok(image.clone())).shared()),
                 editor.clone(),
                 window,
@@ -1391,7 +1391,9 @@ impl Render for LoadingContext {
 
         let id = ElementId::from(("loading_context", self.id));
 
-        MentionCrease::new(id, self.icon.clone(), self.label.clone())
+        let is_pasted_image = matches!(&self.mention_uri, Some(MentionUri::PastedImage { .. }));
+
+        let mut crease = MentionCrease::new(id, self.icon.clone(), self.label.clone())
             .mention_uri(self.mention_uri.clone())
             .workspace(self.workspace.clone())
             .is_toggled(is_in_text_selection)
@@ -1418,8 +1420,153 @@ impl Render for LoadingContext {
                     })
                     .into()
                 })
-            })
+            });
+
+        // Pasted images only exist as in-memory data, so clicking the crease
+        // materializes the image and opens it full-size in an editor tab.
+        if is_pasted_image {
+            if let Some(image_task) = self.image.clone() {
+                let workspace = self.workspace.clone();
+                crease = crease.on_click_image(move |window, cx| {
+                    if let Err(err) = open_pasted_image(&image_task, &workspace, window, cx) {
+                        log::error!("Failed to open pasted image: {err}");
+                        if let Some(workspace) = workspace.as_ref().and_then(|w| w.upgrade()) {
+                            workspace.update(cx, |workspace, cx| {
+                                workspace.show_error(err, cx);
+                            });
+                        }
+                    }
+                });
+            }
+        }
+
+        crease
     }
+}
+
+/// Set to `true` when the application is quitting so that temp files for
+/// opened pasted images are not deleted on shutdown.
+///
+/// We deliberately keep these files around across Zed restarts (and OS
+/// reboots) so that a pasted-image tab the user left open is restored
+/// faithfully, showing the same image, until the user explicitly closes it.
+static APP_QUIT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Signals that the application is quitting, so that temp files backing open
+/// pasted-image tabs are preserved rather than deleted as their editors are
+/// released during shutdown.
+pub fn set_app_quitting() {
+    APP_QUIT.store(true, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Writes a pasted image to a persistent file and opens it in an editor tab.
+///
+/// Pasted images only exist as in-memory data, so to show them at full size we
+/// materialize them on disk. The file is written under the Zed data directory
+/// (not the OS temp dir) so it survives Zed restarts and OS reboots, letting an
+/// open pasted-image tab be restored faithfully. When the tab is closed, the
+/// editor entity is released and we delete the file - unless the app is
+/// quitting, in which case we keep it so the tab can be restored next launch.
+fn open_pasted_image(
+    image_task: &Shared<Task<Result<Arc<Image>, String>>>,
+    workspace: &Option<WeakEntity<Workspace>>,
+    window: &mut Window,
+    cx: &mut App,
+) -> anyhow::Result<()> {
+    let workspace = workspace
+        .as_ref()
+        .and_then(|w| w.upgrade())
+        .ok_or_else(|| anyhow!("Failed to upgrade workspace"))?;
+
+    let image = image_task
+        .peek()
+        .cloned()
+        .transpose()
+        .map_err(|e| anyhow!("Failed to load pasted image: {e}"))?
+        .ok_or_else(|| anyhow!("Image data not available yet"))?;
+
+    let extension = match image.format {
+        ImageFormat::Png => "png",
+        ImageFormat::Jpeg => "jpeg",
+        ImageFormat::Webp => "webp",
+        ImageFormat::Gif => "gif",
+        ImageFormat::Svg => "svg",
+        ImageFormat::Bmp => "bmp",
+        ImageFormat::Tiff => "tiff",
+        ImageFormat::Ico => "ico",
+        ImageFormat::Pnm => "pnm",
+    };
+    let directory = paths::data_dir().join("pasted_images");
+    std::fs::create_dir_all(&directory).map_err(|e| {
+        anyhow!(
+            "Failed to create pasted image directory {}: {e}",
+            directory.display()
+        )
+    })?;
+    let file_name = format!("zed-pasted-image-{}.{}", uuid::Uuid::new_v4(), extension);
+    let image_location = directory.join(&file_name);
+
+    std::fs::write(&image_location, image.bytes()).map_err(|e| {
+        anyhow!(
+            "Failed to write pasted image file {}: {e}",
+            image_location.display()
+        )
+    })?;
+
+    let open_task = workspace.update(cx, |workspace, cx| {
+        workspace.open_abs_path(
+            image_location.clone(),
+            OpenOptions {
+                focus: Some(true),
+                ..Default::default()
+            },
+            window,
+            cx,
+        )
+    });
+
+    register_pasted_image_cleanup(open_task, image_location, cx);
+
+    Ok(())
+}
+
+/// After a pasted image opens in an editor, arranges to delete its backing
+/// file once the editor's tab is closed (the editor entity is released).
+/// Cleanup is skipped while the app is quitting so the file survives to back
+/// the restored tab on the next launch.
+fn register_pasted_image_cleanup(
+    open_task: Task<anyhow::Result<Box<dyn ItemHandle>>>,
+    image_location: PathBuf,
+    cx: &mut App,
+) {
+    cx.spawn(async move |cx| {
+        let item_handle = match open_task.await {
+            Ok(item_handle) => item_handle,
+            Err(e) => {
+                log::error!("Failed to open pasted image in editor: {e}");
+                return;
+            }
+        };
+        let Some(editor) = item_handle.downcast::<Editor>() else {
+            log::error!("Opened pasted image item was not an editor");
+            return;
+        };
+        cx.update(|cx| {
+            cx.observe_release(&editor, move |_editor, _cx| {
+                if APP_QUIT.load(std::sync::atomic::Ordering::Relaxed) {
+                    return;
+                }
+                if let Err(e) = std::fs::remove_file(&image_location) {
+                    log::error!(
+                        "Failed to delete pasted image file {}: {e}",
+                        image_location.display()
+                    );
+                }
+            })
+            .detach();
+        });
+    })
+    .detach();
 }
 
 struct ImageHover {

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -13,7 +13,6 @@ use acp_thread::MentionUri;
 use agent::ThreadStore;
 use agent_client_protocol::schema::v1 as acp;
 use anyhow::{Result, anyhow};
-use base64::Engine as _;
 use editor::{
     Addon, AnchorRangeExt, ContextMenuOptions, Editor, EditorElement, EditorEvent, EditorMode,
     EditorStyle, Inlay, MultiBuffer, MultiBufferOffset, MultiBufferSnapshot, ToOffset,
@@ -1830,7 +1829,10 @@ impl MessageEditor {
         for (range, mention_uri, mention) in mentions {
             let adjusted_start = insertion_start + range.start;
             let anchor = snapshot.anchor_before(MultiBufferOffset(adjusted_start));
-            let image_preview = image_preview_task_for_mention(&mention);
+            // For image mentions, hand the decoded image to the crease so it
+            // shows a hover preview - matching freshly pasted images.
+            let image_preview =
+                decode_mention_image(&mention).map(|image| Task::ready(Ok(image)).shared());
             let Some((crease_id, tx, crease_entity)) = insert_crease_for_mention(
                 snapshot.anchor_to_buffer_anchor(anchor).unwrap().0,
                 range.end - range.start,
@@ -2110,29 +2112,18 @@ fn build_chunks_from_creases(
     (chunks, tracked_buffers)
 }
 
-fn image_preview_task_for_mention(
-    mention: &Mention,
-) -> Option<futures::future::Shared<Task<Result<Arc<Image>, String>>>> {
+/// Decode a `Mention::Image`'s base64-encoded data into an `Arc<Image>`,
+/// suitable for handing to a crease as its hover-preview source.
+/// Returns `None` for non-image mentions or when decoding fails.
+fn decode_mention_image(mention: &Mention) -> Option<Arc<Image>> {
     let Mention::Image(mention_image) = mention else {
         return None;
     };
-
-    let bytes =
-        match base64::engine::general_purpose::STANDARD.decode(mention_image.data.as_bytes()) {
-            Ok(bytes) => bytes,
-            Err(error) => {
-                log::error!("failed to decode image mention: {error}");
-                return None;
-            }
-        };
-
-    Some(
-        Task::ready(Ok::<Arc<Image>, String>(Arc::new(Image::from_bytes(
-            mention_image.format,
-            bytes,
-        ))))
-        .shared(),
-    )
+    use base64::Engine as _;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(mention_image.data.as_bytes())
+        .log_err()?;
+    Some(Arc::new(Image::from_bytes(mention_image.format, bytes)))
 }
 
 fn mention_to_content_block(

--- a/crates/agent_ui/src/ui/mention_crease.rs
+++ b/crates/agent_ui/src/ui/mention_crease.rs
@@ -14,6 +14,8 @@ use theme_settings::ThemeSettings;
 use ui::{ButtonLike, TintColor, Tooltip, prelude::*};
 use workspace::{OpenOptions, Workspace};
 
+type OnClickImage = Box<dyn Fn(&mut Window, &mut App) + 'static>;
+
 use crate::open_abs_path_at_point;
 
 #[derive(IntoElement)]
@@ -27,6 +29,7 @@ pub struct MentionCrease {
     is_loading: bool,
     tooltip: Option<SharedString>,
     image_preview: Option<Box<dyn Fn(&mut Window, &mut App) -> AnyView + 'static>>,
+    on_click_image: Option<OnClickImage>,
 }
 
 impl MentionCrease {
@@ -45,6 +48,7 @@ impl MentionCrease {
             is_loading: false,
             tooltip: None,
             image_preview: None,
+            on_click_image: None,
         }
     }
 
@@ -80,10 +84,17 @@ impl MentionCrease {
         self.image_preview = Some(Box::new(builder));
         self
     }
+
+    /// Overrides the default click behavior (opening the mention URI) with a
+    /// custom handler. Used by pasted-image creases to open the image itself.
+    pub fn on_click_image(mut self, handler: impl Fn(&mut Window, &mut App) + 'static) -> Self {
+        self.on_click_image = Some(Box::new(handler));
+        self
+    }
 }
 
 impl RenderOnce for MentionCrease {
-    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+    fn render(mut self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let settings = ThemeSettings::get_global(cx);
         let font_size = settings.agent_buffer_font_size(cx);
         let buffer_font = settings.buffer_font.clone();
@@ -95,20 +106,33 @@ impl RenderOnce for MentionCrease {
             px(window.line_height().into()) - px(1.),
         ));
 
+        // Image creases provide a custom click handler (`on_click_image`);
+        // everything else opens its mention URI in the workspace. Either way we
+        // end up with at most one click handler.
+        let click_handler: Option<OnClickImage> = if let Some(handler) = self.on_click_image.take()
+        {
+            Some(handler)
+        } else if let Some((mention_uri, workspace)) =
+            self.mention_uri.clone().zip(self.workspace.clone())
+        {
+            Some(Box::new(move |window: &mut Window, cx: &mut App| {
+                open_mention_uri(mention_uri.clone(), &workspace, window, cx);
+            }))
+        } else {
+            None
+        };
+
         ButtonLike::new(self.id)
             .style(ButtonStyle::Outlined)
             .size(ButtonSize::Compact)
             .height(button_height)
             .selected_style(ButtonStyle::Tinted(TintColor::Accent))
             .toggle_state(self.is_toggled)
-            .when_some(
-                self.mention_uri.clone().zip(self.workspace.clone()),
-                |this, (mention_uri, workspace)| {
-                    this.on_click(move |_event, window, cx| {
-                        open_mention_uri(mention_uri.clone(), &workspace, window, cx);
-                    })
-                },
-            )
+            .when_some(click_handler, |this, handler| {
+                this.on_click(move |_event, window, cx| {
+                    handler(window, cx);
+                })
+            })
             .child(
                 h_flex()
                     .pb_px()

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -16,7 +16,7 @@ pub mod visual_tests;
 pub(crate) mod windows_only_instance;
 
 use agent_settings::{UserAgentsMdState, init_user_agents_md};
-use agent_ui::AgentDiffToolbar;
+use agent_ui::{AgentDiffToolbar, set_app_quitting};
 use anyhow::Context as _;
 pub use app_menus::*;
 use assets::Assets;
@@ -1843,6 +1843,10 @@ fn quit(_: &Quit, cx: &mut App) {
                 .log_err();
         }
         futures::future::join_all(flush_tasks).await;
+
+        // Signal that the app is quitting so pasted-image temp files are kept
+        // (they back open tabs that should be restored on the next launch).
+        set_app_quitting();
 
         cx.update(|cx| cx.quit());
         anyhow::Ok(())


### PR DESCRIPTION
Builds on the merged hover-preview work (#58165). That change shows a small thumbnail on hover, but large screenshots are unreadable at that size. Clicking a pasted-image chip now materializes the image to a file and opens it full-size in an editor tab.

Pasted images only exist as in-memory data, so the file is written under the Zed data directory (not the OS temp dir) so it survives Zed restarts and OS reboots, letting an open pasted-image tab be restored faithfully. When the tab is closed, the editor entity is released and the file is deleted - unless the app is quitting, in which case it is kept so the tab can be restored on the next launch.

Click handling dispatches on the mention URI variant: only PastedImage mentions use this new handler. File-attached images (File mentions) continue to open at their original on-disk path via the existing open_mention_uri path, unchanged.

Also tidies the hover-preview decode helper from #58165 to use the codebase-standard `.log_err()` and return `Option<Arc<Image>>` instead of a nested `Shared<Task<...>>`.

**[Known limitation (pre-existing)](https://github.com/zed-industries/zed/issues/58491)**: when a thread is restored from disk, image mentions lose their originating URI during persistence (`UserMessageContent::Image` stores only bytes), so a restored file-attached image is currently indistinguishable from a pasted one and opens via a temp file. Fixing that requires preserving the URI in the agent persistence layer and is out of scope for this PR; because click handling here dispatches on the URI variant, that future fix needs no changes to this code (the PR is forward-compatibl).

Release Notes:

- Improved pasted images in the agent panel: clicking a pasted-image chip now opens the image full-size in an editor tab.

Self-Review Checklist:

- [x] I've had my own diff reviewed for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Performance impact has been considered and is acceptable
- [x] Manual tests cover the new/changed behavior

[Zed click image to open.webm](https://github.com/user-attachments/assets/e5ff5d22-f6ff-4525-a3fe-509e7ef35210)

Closes #58153

Release Notes:

- Improved pasted images in the agent panel: clicking a pasted-image chip now opens the image full-size in an editor tab.
