### PR TITLE
Relabel mounts for podman/buildkit cases, to account for SELinux

### DIFF
--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -691,12 +691,14 @@ impl DevContainerManifest {
         let update_remote_user_uid = self.dev_container().update_remote_user_uid.unwrap_or(true);
         #[cfg(target_os = "windows")]
         let update_remote_user_uid = false;
+        let use_podman = self.docker_client.docker_cli() == "podman";
         let feature_layers: String = self
             .features
             .iter()
             .map(|manifest| {
                 manifest.generate_dockerfile_feature_layer(
                     use_buildkit,
+                    use_podman,
                     FEATURES_CONTAINER_TEMP_DEST_FOLDER,
                 )
             })
@@ -3959,6 +3961,61 @@ chmod +x ./install.sh
                     ),
                 ])
         }))
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[gpui::test]
+    async fn test_spawns_devcontainer_with_dockerfile_features_and_podman(
+        cx: &mut TestAppContext,
+    ) {
+        cx.executor().allow_parking();
+        env_logger::try_init().ok();
+        let given_devcontainer_contents = r#"
+            {
+              "name": "cli-podman-selinux-test",
+              "image": "test_image:latest",
+              "features": {
+                "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+              },
+            }
+            "#;
+
+        let mut fake_docker = FakeDocker::new();
+        fake_docker.set_podman(true);
+        let (test_dependencies, mut devcontainer_manifest) = init_devcontainer_manifest(
+            cx,
+            FakeFs::new(cx.executor()),
+            fake_http_client(),
+            Arc::new(fake_docker),
+            Arc::new(TestCommandRunner::new()),
+            HashMap::new(),
+            given_devcontainer_contents,
+        )
+        .await
+        .unwrap();
+
+        devcontainer_manifest.parse_nonremote_vars().unwrap();
+        devcontainer_manifest.build_and_run().await.unwrap();
+
+        let files = test_dependencies.fs.files();
+        let feature_dockerfile = files
+            .iter()
+            .find(|f| {
+                f.file_name()
+                    .is_some_and(|s| s.display().to_string() == "Dockerfile.extended")
+            })
+            .expect("to be found");
+        let feature_dockerfile = test_dependencies.fs.load(feature_dockerfile).await.unwrap();
+
+        assert!(
+            feature_dockerfile.contains(",relabel=private"),
+            "Podman builds must include relabel=private on bind mounts to allow \
+             access under SELinux enforcement; got:\n{feature_dockerfile}"
+        );
+        assert!(
+            feature_dockerfile.contains("target=/tmp/build-features-src/"),
+            "mount target path should still be /tmp/build-features-src/"
+        );
     }
 
     // updateRemoteUserUID is treated as false in Windows, so this test will fail

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -3965,9 +3965,7 @@ chmod +x ./install.sh
 
     #[cfg(not(target_os = "windows"))]
     #[gpui::test]
-    async fn test_spawns_devcontainer_with_dockerfile_features_and_podman(
-        cx: &mut TestAppContext,
-    ) {
+    async fn test_spawns_devcontainer_with_dockerfile_features_and_podman(cx: &mut TestAppContext) {
         cx.executor().allow_parking();
         env_logger::try_init().ok();
         let given_devcontainer_contents = r#"

--- a/crates/dev_container/src/features.rs
+++ b/crates/dev_container/src/features.rs
@@ -85,13 +85,19 @@ impl FeatureManifest {
     pub(crate) fn generate_dockerfile_feature_layer(
         &self,
         use_buildkit: bool,
+        use_podman: bool,
         dest: &str,
     ) -> String {
         let id = &self.consecutive_id;
         if use_buildkit {
+            // relabel=private tells Podman/Buildah to relabel the bind-mounted content
+            // with the container's SELinux type, preventing access denials under SELinux
+            // enforcement. Docker BuildKit does not support this option and does not need
+            // it since Docker does not enforce SELinux during builds.
+            let relabel = if use_podman { ",relabel=private" } else { "" };
             format!(
                 r#"
-RUN --mount=type=bind,from=dev_containers_feature_content_source,source=./{id},target=/tmp/build-features-src/{id} \
+RUN --mount=type=bind,from=dev_containers_feature_content_source,source=./{id},target=/tmp/build-features-src/{id}{relabel} \
 cp -ar /tmp/build-features-src/{id} {dest} \
 && chmod -R 0755 {dest}/{id} \
 && cd {dest}/{id} \


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #53697

Relabel /tmp/ files mounted during build when using podman + selinux. This permits the build to read these files.

Release Notes:

- Fixed feature download bug in SELinux
