### PR TITLE
Use typed errors when listing OpenRouter models

### DIFF
--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -103,12 +103,7 @@ impl State {
         cx.spawn(async move |this, cx| {
             let models = list_models(http_client.as_ref(), &api_url, &api_key, &extra_headers)
                 .await
-                .map_err(|e| {
-                    LanguageModelCompletionError::Other(anyhow::anyhow!(
-                        "OpenRouter error: {:?}",
-                        e
-                    ))
-                })?;
+                .map_err(LanguageModelCompletionError::from)?;
 
             this.update(cx, |this, cx| {
                 this.available_models = models;


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Fixes OpenRouter model listing to use the existing typed error conversion instead of wrapping all failures as a generic `Other` error.

This preserves specific error handling for cases like authentication failures, rate limits, server overloads, response parsing errors, and HTTP send/read failures when fetching OpenRouter models.

Release Notes:

- Improved OpenRouter model-list error handling
