### PR TITLE
Escape control characters in syntax tree view node labels

### DIFF
--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -377,7 +377,7 @@ impl SyntaxTreeView {
         row.child(if node.is_named() {
             Label::new(node.kind()).color(Color::Default)
         } else {
-            Label::new(format!("\"{}\"", node.kind())).color(Color::Created)
+            Label::new(format!("\"{}\"", node.kind().escape_debug())).color(Color::Created)
         })
         .child(
             div()


### PR DESCRIPTION
When a Tree-sitter grammar uses a literal control-character token (for example a `"\n"` newline), the syntax tree view (`dev: open syntax tree view`) embedded the raw character into the node label, which broke the row height and layout.

This escapes the anonymous node's kind with `str::escape_debug()`, so control characters are shown as `\n`, `\t`, etc. on a single line.

Closes #54725
