### PR TITLE
Deadlock detect profiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4073,7 +4073,7 @@ dependencies = [
  "alsa",
  "coreaudio-rs 0.13.0",
  "dasp_sample",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "libc",
  "mach2 0.5.0",
@@ -4996,6 +4996,28 @@ name = "deflate64"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+
+[[package]]
+name = "deloxide"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3911e98c3d9d7c9b36c3f4104f9fbc721011d9f8e6596556e30ad3cd7f03b550"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "chrono",
+ "clap",
+ "flate2",
+ "fxhash",
+ "lazy_static",
+ "parking_lot",
+ "rand 0.9.4",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "webbrowser",
+]
 
 [[package]]
 name = "der"
@@ -7068,6 +7090,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "gaoya"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7706,6 +7737,7 @@ dependencies = [
  "core-text",
  "core-video",
  "ctor",
+ "deloxide",
  "derive_more",
  "embed-resource",
  "env_logger 0.11.8",
@@ -9248,7 +9280,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -9256,10 +9288,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -10064,7 +10145,7 @@ source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=c3a55bbc20
 dependencies = [
  "cxx",
  "glib",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "lazy_static",
  "livekit-protocol",
@@ -11296,7 +11377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.10.0",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "ndk-sys",
  "num_enum",
@@ -11315,7 +11396,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.0",
 ]
 
 [[package]]
@@ -15321,6 +15402,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rmpv"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15696,7 +15787,7 @@ checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
  "core-foundation 0.10.0",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls 0.23.40",
@@ -16781,6 +16872,16 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simd_helpers"
@@ -20822,6 +20923,22 @@ dependencies = [
  "serde",
  "serde_json",
  "web_search",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.0",
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -28,6 +28,10 @@ test-support = [
 ]
 inspector = ["gpui_macros/inspector"]
 leak-detection = ["backtrace"]
+# Replaces the profiler's internal spinlocks with deadlock-detecting mutexes
+# from the `deloxide` crate. Not enabled by default because of its runtime
+# overhead; intended for debugging lock-ordering issues in the profiler.
+deadlock-detection = ["dep:deloxide"]
 wayland = [
     "bitflags",
 ]
@@ -103,6 +107,7 @@ waker-fn = "1.2.0"
 lyon = "1.0"
 pin-project = "1.1.10"
 spin = "0.10.0"
+deloxide = { version = "1.0", optional = true }
 pollster.workspace = true
 url.workspace = true
 uuid.workspace = true

--- a/crates/gpui/src/profiler.rs
+++ b/crates/gpui/src/profiler.rs
@@ -22,17 +22,20 @@ use serde::{Deserialize, Serialize};
 use crate::{SharedString, TasksIncluded};
 
 #[doc(hidden)]
+#[must_use]
 pub fn get_all_timings(included: gpui::TasksIncluded) -> Vec<gpui::ThreadTaskTimings> {
     let global_thread_timings = GLOBAL_THREAD_TIMINGS.lock();
     ThreadTaskTimings::collect(&global_thread_timings, included)
 }
 
 #[doc(hidden)]
+#[must_use]
 pub fn get_current_thread_timings(included: TasksIncluded) -> gpui::ThreadTaskTimings {
-    gpui::profiler::get_current_thread_task_timings(included)
+    THREAD_TIMINGS.with(|timings| timings.lock().get_thread_task_timings(included))
 }
 
 #[doc(hidden)]
+#[must_use]
 pub fn take_all_stats(included: TasksIncluded) -> Vec<gpui::ThreadTaskStatistics> {
     let global_timings = GLOBAL_THREAD_TIMINGS.lock();
     ThreadTaskStatistics::collect_and_reset(&global_timings, included)
@@ -629,11 +632,6 @@ pub fn save_task_timing() {
     });
 }
 
-#[doc(hidden)]
-pub fn get_current_thread_task_timings(include_running: TasksIncluded) -> ThreadTaskTimings {
-    THREAD_TIMINGS.with(|timings| timings.lock().get_thread_task_timings(include_running))
-}
-
 static PROFILER_ENABLED: AtomicBool = AtomicBool::new(false);
 
 /// Enables or disables task timing trace collection at runtime.
@@ -663,4 +661,72 @@ pub fn set_trace_enabled(enabled: bool) -> bool {
 /// Returns whether task timing tracing is enabled.
 pub fn trace_enabled() -> bool {
     PROFILER_ENABLED.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        sync::atomic::{AtomicBool, Ordering},
+        thread,
+    };
+
+    /// This test interacts with globals in GPUI. Only one instance of it can run and not while
+    /// anything else interacts with the GPUI.
+    #[test]
+    #[ignore]
+    fn profiler_does_not_deadlock() {
+        static RUNNING: AtomicBool = AtomicBool::new(true);
+
+        let threads: Vec<_> = (0..4)
+            .into_iter()
+            .flat_map(|_| {
+                [
+                    loop_get_timings,
+                    loop_take_all_stats,
+                    loop_get_current_thread_timings,
+                ]
+            })
+            .chain([rapidly_toggle_tracing_enabled as fn()])
+            .map(thread::spawn)
+            .collect();
+
+        // give some time to deadlock
+        thread::sleep(Duration::from_millis(200));
+
+        // stop the test
+        RUNNING.store(false, Ordering::Relaxed);
+        thread::sleep(Duration::from_millis(1));
+
+        let hanging = threads.iter().all(thread::JoinHandle::is_finished);
+        assert!(!hanging);
+
+        //////////////////////////////////// 
+
+        fn rapidly_toggle_tracing_enabled() {
+            let mut on = false;
+            while RUNNING.load(Ordering::Relaxed) {
+                on = !on;
+                set_trace_enabled(on);
+            }
+        }
+
+        fn loop_get_timings() {
+            while RUNNING.load(Ordering::Relaxed) {
+                let _ = get_all_timings(TasksIncluded::CompletedAndRunning);
+            }
+        }
+
+        fn loop_take_all_stats() {
+            while RUNNING.load(Ordering::Relaxed) {
+                let _ = take_all_stats(TasksIncluded::CompletedAndRunning);
+            }
+        }
+
+        fn loop_get_current_thread_timings() {
+            while RUNNING.load(Ordering::Relaxed) {
+                let _ = get_current_thread_timings(TasksIncluded::CompletedAndRunning);
+            }
+        }
+    }
 }

--- a/crates/gpui/src/profiler.rs
+++ b/crates/gpui/src/profiler.rs
@@ -6,7 +6,7 @@ use std::{
     hash::{DefaultHasher, Hash, Hasher},
     hint::cold_path,
     sync::{
-        Arc,
+        Arc, LazyLock,
         atomic::{AtomicBool, Ordering},
     },
     thread::ThreadId,
@@ -20,6 +20,20 @@ pub(crate) use actions::{save_action_timing, update_running_action};
 use serde::{Deserialize, Serialize};
 
 use crate::{SharedString, TasksIncluded};
+
+/// The mutex used by the profiler internals.
+///
+/// By default this is a [`spin::Mutex`], which is optimal here because the
+/// profiler is careful to never block while a lock is held. When the
+/// `deadlock-detection` feature is enabled it instead becomes a deadlock
+/// detecting mutex from the `deloxide` crate. Both share the same
+/// guard-returning `lock()` API, so this is a drop-in replacement.
+#[cfg(not(feature = "deadlock-detection"))]
+pub(crate) type ProfilerMutex<T> = spin::Mutex<T>;
+
+/// See [`ProfilerMutex`].
+#[cfg(feature = "deadlock-detection")]
+pub(crate) type ProfilerMutex<T> = deloxide::Mutex<T>;
 
 #[doc(hidden)]
 #[must_use]
@@ -387,7 +401,7 @@ const MAX_TASK_TIMINGS: usize = (16 * 1024 * 1024) / core::mem::size_of::<TaskTi
 pub(crate) type TaskTimings = VecDeque<TaskTiming>;
 
 #[doc(hidden)]
-pub type GuardedTaskTimings = spin::Mutex<ThreadTimings>;
+pub type GuardedTaskTimings = ProfilerMutex<ThreadTimings>;
 
 #[doc(hidden)]
 pub struct GlobalThreadTimings {
@@ -486,8 +500,8 @@ impl TaskStatistics {
 }
 
 #[doc(hidden)]
-pub static GLOBAL_THREAD_TIMINGS: spin::Mutex<Vec<GlobalThreadTimings>> =
-    spin::Mutex::new(Vec::new());
+pub static GLOBAL_THREAD_TIMINGS: LazyLock<ProfilerMutex<Vec<GlobalThreadTimings>>> =
+    LazyLock::new(|| ProfilerMutex::new(Vec::new()));
 
 thread_local! {
     #[doc(hidden)]
@@ -496,7 +510,7 @@ thread_local! {
         let thread_name = current_thread.name();
         let thread_id = current_thread.id();
         let timings = ThreadTimings::new(thread_name.map(|e| e.to_string()), thread_id);
-        let timings = Arc::new(spin::Mutex::new(timings));
+        let timings = Arc::new(ProfilerMutex::new(timings));
 
         {
             let timings = Arc::downgrade(&timings);
@@ -676,9 +690,17 @@ mod tests {
     #[test]
     #[ignore]
     fn profiler_does_not_deadlock() {
+        // When deadlock detection is enabled, start the detector so that
+        // `deloxide::Mutex` reports any lock-ordering cycles encountered below.
+        #[cfg(feature = "deadlock-detection")]
+        deloxide::Deloxide::new()
+            .callback(|info| panic!("profiler deadlock detected: {:?}", info.thread_cycle))
+            .start()
+            .expect("failed to start deadlock detector");
+
         static RUNNING: AtomicBool = AtomicBool::new(true);
 
-        let threads: Vec<_> = (0..4)
+        let threads: Vec<_> = (0..80)
             .into_iter()
             .flat_map(|_| {
                 [
@@ -692,16 +714,21 @@ mod tests {
             .collect();
 
         // give some time to deadlock
-        thread::sleep(Duration::from_millis(200));
+        thread::sleep(Duration::from_secs(30));
 
         // stop the test
         RUNNING.store(false, Ordering::Relaxed);
-        thread::sleep(Duration::from_millis(1));
+        // deadlock detection mutexes are slow on debug builds to break down
+        thread::sleep(Duration::from_secs(10));
 
-        let hanging = threads.iter().all(thread::JoinHandle::is_finished);
-        assert!(!hanging);
+        let not_deadlocked = threads.iter().all(thread::JoinHandle::is_finished);
+        assert!(not_deadlocked);
 
-        //////////////////////////////////// 
+        for t in threads {
+            t.join().expect("should not panic");
+        }
+
+        ////////////////////////////////////
 
         fn rapidly_toggle_tracing_enabled() {
             let mut on = false;

--- a/crates/gpui/src/profiler/actions.rs
+++ b/crates/gpui/src/profiler/actions.rs
@@ -5,7 +5,10 @@ use std::{
 
 use itertools::Itertools;
 
+use std::sync::LazyLock;
+
 use crate::action::Action;
+use crate::profiler::ProfilerMutex;
 
 #[doc(hidden)]
 #[derive(Clone)]
@@ -165,10 +168,8 @@ impl ActionTiming {
     }
 }
 
-// The profiler is careful to never block when the lock is held, therefore a
-// spinlock is optimal.
-static ACTION_STATISTICS: spin::Mutex<ActionStatistics> =
-    const { spin::Mutex::new(ActionStatistics::new()) };
+static ACTION_STATISTICS: LazyLock<ProfilerMutex<ActionStatistics>> =
+    LazyLock::new(|| ProfilerMutex::new(ActionStatistics::new()));
 
 #[doc(hidden)]
 pub(crate) fn update_running_action(action: &(dyn Action + 'static), cx: &mut crate::App) {


### PR DESCRIPTION
This supersedes #58455 adding a hang test inspired by @RemcoSmitsDev and @Anthony-Eid work there. That test was hard to reason about for me so I wrote a new one that should hit all access patterns. It also fails. This includes deadlock detecting mutexes (at huge performance cost therefore gated behind a feature) so we can be sure there can be no hangs.

You can compile zed to run with deadlock detecting mutexes in the profiler with: 
`cargo b --release --feature gpui/deadlock-detection`

The test is also ignored by default due to its high runtime, run it with:
`cargo test --release --features deadlock-detection -- profiler_does_not --ignored`

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A
