### PR TITLE
Restore access to old threads that mention rules

### DIFF
--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -40,7 +40,7 @@ pub enum MentionUri {
     /// deserialize. `id` (an opaque `prompt_store::PromptId`) is preserved
     /// verbatim so re-saved threads stay loadable by older Zed versions.
     Rule {
-        #[serde(default = "default_rule_id")]
+        #[serde(default = "default_deprecated_rule_id")]
         id: serde_json::Value,
         name: String,
     },
@@ -212,7 +212,7 @@ impl MentionUri {
                     // Deprecated: parses legacy rule mentions.
                     let name = single_query_param(&url, "name")?.context("Missing rule name")?;
                     let id = if rule_id.is_empty() {
-                        default_rule_id()
+                        default_deprecated_rule_id()
                     } else {
                         serde_json::json!({ "User": { "uuid": rule_id } })
                     };
@@ -604,8 +604,9 @@ fn default_include_errors() -> bool {
 }
 
 /// Placeholder rule `id` for legacy mentions missing one, shaped so older Zed
-/// versions can still deserialize it as a `prompt_store::PromptId`.
-fn default_rule_id() -> serde_json::Value {
+/// versions can still deserialize it as a `prompt_store::PromptId`. The `id` is
+/// never used as a key, so the shared value is fine even for multiple mentions.
+fn default_deprecated_rule_id() -> serde_json::Value {
     serde_json::json!({ "User": { "uuid": "00000000-0000-0000-0000-000000000000" } })
 }
 

--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -36,6 +36,13 @@ pub enum MentionUri {
         id: acp::SessionId,
         name: String,
     },
+    /// Deprecated: rules were removed in favor of skills, but this variant is
+    /// retained so that threads saved before the removal can still be
+    /// deserialized. Older payloads also contain an `id` field, which serde
+    /// ignores when deserializing into this variant.
+    Rule {
+        name: String,
+    },
     Diagnostics {
         #[serde(default = "default_include_errors")]
         include_errors: bool,
@@ -200,6 +207,10 @@ impl MentionUri {
                         id: acp::SessionId::new(thread_id),
                         name,
                     })
+                } else if path.starts_with("/agent/rule/") {
+                    // Deprecated: retained so legacy rule mentions still parse.
+                    let name = single_query_param(&url, "name")?.context("Missing rule name")?;
+                    Ok(Self::Rule { name })
                 } else if path == "/agent/diagnostics" {
                     let mut include_errors = default_include_errors();
                     let mut include_warnings = false;
@@ -330,6 +341,7 @@ impl MentionUri {
             MentionUri::PastedImage { name } => name.clone(),
             MentionUri::Symbol { name, .. } => name.clone(),
             MentionUri::Thread { name, .. } => name.clone(),
+            MentionUri::Rule { name, .. } => name.clone(),
             MentionUri::Diagnostics { .. } => "Diagnostics".to_string(),
             MentionUri::TerminalSelection { line_count } => {
                 if *line_count == 1 {
@@ -430,6 +442,7 @@ impl MentionUri {
                 .unwrap_or_else(|| IconName::Folder.path().into()),
             MentionUri::Symbol { .. } => IconName::Code.path().into(),
             MentionUri::Thread { .. } => IconName::Thread.path().into(),
+            MentionUri::Rule { .. } => IconName::Reader.path().into(),
             MentionUri::Diagnostics { .. } => IconName::Warning.path().into(),
             MentionUri::TerminalSelection { .. } => IconName::Terminal.path().into(),
             MentionUri::Selection { .. } => IconName::Reader.path().into(),
@@ -509,6 +522,14 @@ impl MentionUri {
             MentionUri::Thread { name, id } => {
                 let mut url = Url::parse("zed:///").unwrap();
                 url.set_path(&format!("/agent/thread/{id}"));
+                url.query_pairs_mut().append_pair("name", name);
+                url
+            }
+            MentionUri::Rule { name } => {
+                // Deprecated: the original `id` is no longer retained, so the
+                // legacy URI is reconstructed without it.
+                let mut url = Url::parse("zed:///").unwrap();
+                url.set_path("/agent/rule/");
                 url.query_pairs_mut().append_pair("name", name);
                 url
             }
@@ -801,6 +822,31 @@ mod tests {
             _ => panic!("Expected Thread variant"),
         }
         assert_eq!(parsed.to_uri().to_string(), thread_uri);
+    }
+
+    #[test]
+    fn test_parse_legacy_rule_uri() {
+        // Rules were removed, but legacy threads still reference them by URI.
+        let rule_uri = "zed:///agent/rule/d8694ff2-90d5-4b6f-be33-33c1763acd52?name=Some+rule";
+        let parsed = MentionUri::parse(rule_uri, PathStyle::local()).unwrap();
+        match &parsed {
+            MentionUri::Rule { name } => assert_eq!(name, "Some rule"),
+            _ => panic!("Expected Rule variant"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_legacy_rule_mention() {
+        // Threads saved before rules were removed serialized the now-deleted
+        // `id` field; it must be ignored rather than causing a hard failure.
+        let json = r#"{"Rule":{"id":{"User":{"uuid":"d8694ff2-90d5-4b6f-be33-33c1763acd52"}},"name":"Some rule"}}"#;
+        let parsed: MentionUri = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            parsed,
+            MentionUri::Rule {
+                name: "Some rule".to_string()
+            }
+        );
     }
 
     #[test]

--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -604,8 +604,7 @@ fn default_include_errors() -> bool {
 }
 
 /// Placeholder rule `id` for legacy mentions missing one, shaped so older Zed
-/// versions can still deserialize it as a `prompt_store::PromptId`. The `id` is
-/// never used as a key, so the shared value is fine even for multiple mentions.
+/// versions can still deserialize it as a `prompt_store::PromptId`.
 fn default_deprecated_rule_id() -> serde_json::Value {
     serde_json::json!({ "User": { "uuid": "00000000-0000-0000-0000-000000000000" } })
 }

--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -38,9 +38,12 @@ pub enum MentionUri {
     },
     /// Deprecated: rules were removed in favor of skills, but this variant is
     /// retained so that threads saved before the removal can still be
-    /// deserialized. Older payloads also contain an `id` field, which serde
-    /// ignores when deserializing into this variant.
+    /// deserialized. The `id` field (matching the old `prompt_store::PromptId`
+    /// serialization) is preserved verbatim so that re-saved threads stay
+    /// loadable by older Zed versions that still require it.
     Rule {
+        #[serde(default = "default_rule_id")]
+        id: serde_json::Value,
         name: String,
     },
     Diagnostics {
@@ -207,10 +210,15 @@ impl MentionUri {
                         id: acp::SessionId::new(thread_id),
                         name,
                     })
-                } else if path.starts_with("/agent/rule/") {
+                } else if let Some(rule_id) = path.strip_prefix("/agent/rule/") {
                     // Deprecated: retained so legacy rule mentions still parse.
                     let name = single_query_param(&url, "name")?.context("Missing rule name")?;
-                    Ok(Self::Rule { name })
+                    let id = if rule_id.is_empty() {
+                        default_rule_id()
+                    } else {
+                        serde_json::json!({ "User": { "uuid": rule_id } })
+                    };
+                    Ok(Self::Rule { id, name })
                 } else if path == "/agent/diagnostics" {
                     let mut include_errors = default_include_errors();
                     let mut include_warnings = false;
@@ -525,11 +533,14 @@ impl MentionUri {
                 url.query_pairs_mut().append_pair("name", name);
                 url
             }
-            MentionUri::Rule { name } => {
-                // Deprecated: the original `id` is no longer retained, so the
-                // legacy URI is reconstructed without it.
+            MentionUri::Rule { id, name } => {
                 let mut url = Url::parse("zed:///").unwrap();
-                url.set_path("/agent/rule/");
+                let rule_id = id
+                    .get("User")
+                    .and_then(|user| user.get("uuid"))
+                    .and_then(|uuid| uuid.as_str())
+                    .unwrap_or_default();
+                url.set_path(&format!("/agent/rule/{rule_id}"));
                 url.query_pairs_mut().append_pair("name", name);
                 url
             }
@@ -592,6 +603,13 @@ impl fmt::Display for MentionLink<'_> {
 
 fn default_include_errors() -> bool {
     true
+}
+
+/// Placeholder for the deprecated rule `id` field. Used when a legacy rule
+/// mention is missing its id so the value still serializes into a shape older
+/// Zed versions can deserialize as a `prompt_store::PromptId`.
+fn default_rule_id() -> serde_json::Value {
+    serde_json::json!({ "User": { "uuid": "00000000-0000-0000-0000-000000000000" } })
 }
 
 fn query_param(url: &Url, name: &'static str) -> Option<String> {
@@ -830,23 +848,39 @@ mod tests {
         let rule_uri = "zed:///agent/rule/d8694ff2-90d5-4b6f-be33-33c1763acd52?name=Some+rule";
         let parsed = MentionUri::parse(rule_uri, PathStyle::local()).unwrap();
         match &parsed {
-            MentionUri::Rule { name } => assert_eq!(name, "Some rule"),
+            MentionUri::Rule { name, .. } => assert_eq!(name, "Some rule"),
             _ => panic!("Expected Rule variant"),
         }
+        // The legacy id is encoded back into the URI so older versions round-trip.
+        assert_eq!(parsed.to_uri().to_string(), rule_uri);
     }
 
     #[test]
-    fn test_deserialize_legacy_rule_mention() {
-        // Threads saved before rules were removed serialized the now-deleted
-        // `id` field; it must be ignored rather than causing a hard failure.
+    fn test_legacy_rule_mention_preserves_id() {
+        // Threads saved before rules were removed include an `id` field that
+        // older Zed versions still require; it must survive a load + save
+        // round-trip rather than being dropped.
         let json = r#"{"Rule":{"id":{"User":{"uuid":"d8694ff2-90d5-4b6f-be33-33c1763acd52"}},"name":"Some rule"}}"#;
         let parsed: MentionUri = serde_json::from_str(json).unwrap();
+        match &parsed {
+            MentionUri::Rule { name, .. } => assert_eq!(name, "Some rule"),
+            _ => panic!("Expected Rule variant"),
+        }
+        let reserialized = serde_json::to_value(&parsed).unwrap();
         assert_eq!(
-            parsed,
-            MentionUri::Rule {
-                name: "Some rule".to_string()
-            }
+            reserialized["Rule"]["id"]["User"]["uuid"],
+            "d8694ff2-90d5-4b6f-be33-33c1763acd52"
         );
+    }
+
+    #[test]
+    fn test_legacy_rule_mention_without_id_gets_placeholder() {
+        // A rule mention missing its id (e.g. saved by an intermediate version)
+        // must still serialize with a valid id so older versions can load it.
+        let json = r#"{"Rule":{"name":"Some rule"}}"#;
+        let parsed: MentionUri = serde_json::from_str(json).unwrap();
+        let reserialized = serde_json::to_value(&parsed).unwrap();
+        assert!(reserialized["Rule"]["id"]["User"]["uuid"].is_string());
     }
 
     #[test]

--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -36,11 +36,9 @@ pub enum MentionUri {
         id: acp::SessionId,
         name: String,
     },
-    /// Deprecated: rules were removed in favor of skills, but this variant is
-    /// retained so that threads saved before the removal can still be
-    /// deserialized. The `id` field (matching the old `prompt_store::PromptId`
-    /// serialization) is preserved verbatim so that re-saved threads stay
-    /// loadable by older Zed versions that still require it.
+    /// Deprecated: kept so threads from before rules became skills still
+    /// deserialize. `id` (an opaque `prompt_store::PromptId`) is preserved
+    /// verbatim so re-saved threads stay loadable by older Zed versions.
     Rule {
         #[serde(default = "default_rule_id")]
         id: serde_json::Value,
@@ -211,7 +209,7 @@ impl MentionUri {
                         name,
                     })
                 } else if let Some(rule_id) = path.strip_prefix("/agent/rule/") {
-                    // Deprecated: retained so legacy rule mentions still parse.
+                    // Deprecated: parses legacy rule mentions.
                     let name = single_query_param(&url, "name")?.context("Missing rule name")?;
                     let id = if rule_id.is_empty() {
                         default_rule_id()
@@ -605,9 +603,8 @@ fn default_include_errors() -> bool {
     true
 }
 
-/// Placeholder for the deprecated rule `id` field. Used when a legacy rule
-/// mention is missing its id so the value still serializes into a shape older
-/// Zed versions can deserialize as a `prompt_store::PromptId`.
+/// Placeholder rule `id` for legacy mentions missing one, shaped so older Zed
+/// versions can still deserialize it as a `prompt_store::PromptId`.
 fn default_rule_id() -> serde_json::Value {
     serde_json::json!({ "User": { "uuid": "00000000-0000-0000-0000-000000000000" } })
 }
@@ -844,22 +841,19 @@ mod tests {
 
     #[test]
     fn test_parse_legacy_rule_uri() {
-        // Rules were removed, but legacy threads still reference them by URI.
         let rule_uri = "zed:///agent/rule/d8694ff2-90d5-4b6f-be33-33c1763acd52?name=Some+rule";
         let parsed = MentionUri::parse(rule_uri, PathStyle::local()).unwrap();
         match &parsed {
             MentionUri::Rule { name, .. } => assert_eq!(name, "Some rule"),
             _ => panic!("Expected Rule variant"),
         }
-        // The legacy id is encoded back into the URI so older versions round-trip.
+        // The id round-trips through the URI.
         assert_eq!(parsed.to_uri().to_string(), rule_uri);
     }
 
     #[test]
     fn test_legacy_rule_mention_preserves_id() {
-        // Threads saved before rules were removed include an `id` field that
-        // older Zed versions still require; it must survive a load + save
-        // round-trip rather than being dropped.
+        // The `id` older Zed versions require must survive a load + save.
         let json = r#"{"Rule":{"id":{"User":{"uuid":"d8694ff2-90d5-4b6f-be33-33c1763acd52"}},"name":"Some rule"}}"#;
         let parsed: MentionUri = serde_json::from_str(json).unwrap();
         match &parsed {
@@ -875,8 +869,7 @@ mod tests {
 
     #[test]
     fn test_legacy_rule_mention_without_id_gets_placeholder() {
-        // A rule mention missing its id (e.g. saved by an intermediate version)
-        // must still serialize with a valid id so older versions can load it.
+        // A mention missing its id still serializes a valid id for older versions.
         let json = r#"{"Rule":{"name":"Some rule"}}"#;
         let parsed: MentionUri = serde_json::from_str(json).unwrap();
         let reserialized = serde_json::to_value(&parsed).unwrap();

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -365,6 +365,19 @@ impl UserMessage {
                         MentionUri::Thread { .. } => {
                             write!(&mut thread_context, "\n{}\n", content).ok();
                         }
+                        MentionUri::Rule { .. } => {
+                            // Deprecated: retained so legacy rule mentions in
+                            // older threads are still included as context.
+                            write!(
+                                &mut rules_context,
+                                "\n{}",
+                                MarkdownCodeBlock {
+                                    tag: "",
+                                    text: content
+                                }
+                            )
+                            .ok();
+                        }
                         MentionUri::Fetch { url } => {
                             write!(&mut fetch_context, "\nFetch: {}\n\n{}", url, content).ok();
                         }

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -366,8 +366,7 @@ impl UserMessage {
                             write!(&mut thread_context, "\n{}\n", content).ok();
                         }
                         MentionUri::Rule { .. } => {
-                            // Deprecated: retained so legacy rule mentions in
-                            // older threads are still included as context.
+                            // Deprecated: keeps legacy rule mentions as context.
                             write!(
                                 &mut rules_context,
                                 "\n{}",

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -10353,7 +10353,9 @@ pub(crate) fn open_link(
             MentionUri::TerminalSelection { .. } => {}
             MentionUri::GitDiff { .. } => {}
             MentionUri::MergeConflict { .. } => {}
-            MentionUri::Rule { .. } => {}
+            MentionUri::Rule { name, .. } => {
+                crate::ui::open_migrated_rule(workspace, &name, window, cx);
+            }
             MentionUri::Skill {
                 skill_file_path, ..
             } => {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -10353,6 +10353,7 @@ pub(crate) fn open_link(
             MentionUri::TerminalSelection { .. } => {}
             MentionUri::GitDiff { .. } => {}
             MentionUri::MergeConflict { .. } => {}
+            MentionUri::Rule { .. } => {}
             MentionUri::Skill {
                 skill_file_path, ..
             } => {

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -166,7 +166,8 @@ impl MentionSet {
             ))),
             MentionUri::PastedImage { .. }
             | MentionUri::TerminalSelection { .. }
-            | MentionUri::MergeConflict { .. } => {
+            | MentionUri::MergeConflict { .. }
+            | MentionUri::Rule { .. } => {
                 Task::ready(Err(anyhow!("Unsupported mention URI type for paste")))
             }
         }
@@ -346,6 +347,10 @@ impl MentionSet {
             MentionUri::MergeConflict { .. } => {
                 debug_panic!("unexpected merge conflict URI");
                 Task::ready(Err(anyhow!("unexpected merge conflict URI")))
+            }
+            MentionUri::Rule { .. } => {
+                debug_panic!("unexpected rule URI");
+                Task::ready(Err(anyhow!("unexpected rule URI")))
             }
         };
         let task = cx

--- a/crates/agent_ui/src/ui/mention_crease.rs
+++ b/crates/agent_ui/src/ui/mention_crease.rs
@@ -232,6 +232,9 @@ pub(crate) fn open_migrated_rule(
             workspace::notifications::NotificationId::unique::<RulesMigratedToSkillsToast>(),
             "Rules have been migrated to Skills.",
         )
+        .on_click("View docs", |_, cx| {
+            cx.open_url("https://zed.dev/docs/ai/skills");
+        })
         .autohide(),
         cx,
     );

--- a/crates/agent_ui/src/ui/mention_crease.rs
+++ b/crates/agent_ui/src/ui/mention_crease.rs
@@ -215,8 +215,11 @@ fn open_mention_uri(
 }
 
 /// Rules were migrated to Skills. Notify the user that the feature moved and,
-/// best-effort, open the skill file the rule was migrated into. Does nothing
-/// (besides showing the notification) when no matching skill file exists.
+/// best-effort, open the skill file the rule was migrated into. Migrated skills
+/// always live in the local global skills dir, so the file is resolved against
+/// the local filesystem regardless of whether the active project is local,
+/// remote (SSH), or collab. Does nothing (besides the notification) when no
+/// matching skill file exists.
 pub(crate) fn open_migrated_rule(
     workspace: &mut Workspace,
     name: &str,
@@ -239,9 +242,30 @@ pub(crate) fn open_migrated_rule(
     let skill_file_path = agent_skills::global_skills_dir()
         .join(slug)
         .join(agent_skills::SKILL_FILE_NAME);
-    if skill_file_path.exists() {
-        open_skill_file(workspace, skill_file_path, window, cx);
+
+    if workspace.project().read(cx).is_local() {
+        // Local project: open the editable on-disk file if it exists.
+        if skill_file_path.exists() {
+            open_skill_file(workspace, skill_file_path, window, cx);
+        }
+        return;
     }
+
+    // Remote/collab project: `open_abs_path` resolves the path against the
+    // remote project, where this local file does not exist. Read it from the
+    // local filesystem and show it as a read-only buffer instead.
+    let fs = workspace.app_state().fs.clone();
+    cx.spawn_in(window, async move |workspace, cx| {
+        let Ok(content) = fs.load(&skill_file_path).await else {
+            // No migrated skill file (or it couldn't be read): do nothing.
+            return Ok(());
+        };
+        let title = skill_content_buffer_title(&skill_file_path);
+        workspace.update_in(cx, |workspace, window, cx| {
+            open_skill_content_buffer(workspace, title, content, window, cx);
+        })
+    })
+    .detach_and_log_err(cx);
 }
 
 fn open_skill_file(
@@ -259,34 +283,8 @@ fn open_skill_file(
     // would crash Zed if a user clicked a built-in skill mention while
     // connected to a remote project.
     if let Some(content) = agent_skills::builtin_skill_content(&skill_file_path) {
-        let languages = workspace.project().read(cx).languages().clone();
-        let buffer = cx.new(|cx| Buffer::local(content, cx));
-        // Set markdown highlighting asynchronously — the buffer
-        // opens instantly and the highlighting appears once loaded.
-        cx.spawn({
-            let buffer = buffer.clone();
-            async move |_, cx| {
-                if let Ok(markdown) = languages.language_for_name("Markdown").await {
-                    buffer.update(cx, |buffer, cx| buffer.set_language(Some(markdown), cx));
-                }
-            }
-        })
-        .detach();
-        let editor = cx.new(|cx| {
-            let mut editor = Editor::for_buffer(buffer, None, window, cx);
-            editor.set_read_only(true);
-            let title = skill_file_path
-                .parent()
-                .and_then(|p| p.file_name())
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or_else(|| "built-in skill".into());
-            editor
-                .buffer()
-                .update(cx, |buffer, cx| buffer.set_title(title, cx));
-            editor
-        });
-        let pane = workspace.active_pane().clone();
-        workspace.add_item(pane, Box::new(editor), None, true, true, window, cx);
+        let title = skill_content_buffer_title(&skill_file_path);
+        open_skill_content_buffer(workspace, title, content, window, cx);
         return;
     }
 
@@ -301,6 +299,53 @@ fn open_skill_file(
             cx,
         )
         .detach_and_log_err(cx);
+}
+
+fn skill_content_buffer_title(skill_file_path: &std::path::Path) -> String {
+    skill_file_path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "skill".into())
+}
+
+/// Open `content` as a local, read-only Markdown buffer. Used for skills that
+/// have no openable on-disk file in the active project: built-in skills (whose
+/// paths are synthetic) and migrated rules viewed from a remote/collab project
+/// (whose files live in the local global skills dir). The buffer is
+/// deliberately not registered with the project's buffer store, which keeps it
+/// out of search and avoids `Project::create_local_buffer` panicking on remote
+/// projects.
+fn open_skill_content_buffer(
+    workspace: &mut Workspace,
+    title: String,
+    content: impl Into<String>,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let languages = workspace.project().read(cx).languages().clone();
+    let buffer = cx.new(|cx| Buffer::local(content, cx));
+    // Set markdown highlighting asynchronously — the buffer
+    // opens instantly and the highlighting appears once loaded.
+    cx.spawn({
+        let buffer = buffer.clone();
+        async move |_, cx| {
+            if let Ok(markdown) = languages.language_for_name("Markdown").await {
+                buffer.update(cx, |buffer, cx| buffer.set_language(Some(markdown), cx));
+            }
+        }
+    })
+    .detach();
+    let editor = cx.new(|cx| {
+        let mut editor = Editor::for_buffer(buffer, None, window, cx);
+        editor.set_read_only(true);
+        editor
+            .buffer()
+            .update(cx, |buffer, cx| buffer.set_title(title, cx));
+        editor
+    });
+    let pane = workspace.active_pane().clone();
+    workspace.add_item(pane, Box::new(editor), None, true, true, window, cx);
 }
 
 fn open_file(

--- a/crates/agent_ui/src/ui/mention_crease.rs
+++ b/crates/agent_ui/src/ui/mention_crease.rs
@@ -214,12 +214,10 @@ fn open_mention_uri(
     });
 }
 
-/// Rules were migrated to Skills. Notify the user that the feature moved and,
-/// best-effort, open the skill file the rule was migrated into. Migrated skills
-/// always live in the local global skills dir, so the file is resolved against
-/// the local filesystem regardless of whether the active project is local,
-/// remote (SSH), or collab. Does nothing (besides the notification) when no
-/// matching skill file exists.
+/// Notify the user that rules became skills and open the skill the rule was
+/// migrated into. Migrated skills live in the local global skills dir, so the
+/// file is always resolved against the local filesystem (local, SSH, or
+/// collab). Does nothing else when no matching skill exists.
 pub(crate) fn open_migrated_rule(
     workspace: &mut Workspace,
     name: &str,
@@ -254,14 +252,12 @@ pub(crate) fn open_migrated_rule(
         return;
     }
 
-    // Remote/collab project: `open_abs_path` resolves the path against the
-    // remote project, where this local file does not exist. Read it from the
-    // local filesystem and show it as a read-only buffer instead.
+    // Remote/collab: `open_abs_path` targets the remote project, where this
+    // local file doesn't exist, so read it locally and show it read-only.
     let fs = workspace.app_state().fs.clone();
     cx.spawn_in(window, async move |workspace, cx| {
         let Ok(content) = fs.load(&skill_file_path).await else {
-            // No migrated skill file (or it couldn't be read): do nothing.
-            return Ok(());
+            return Ok(()); // No readable migrated skill: do nothing.
         };
         let title = skill_content_buffer_title(&skill_file_path);
         workspace.update_in(cx, |workspace, window, cx| {
@@ -277,14 +273,8 @@ fn open_skill_file(
     window: &mut Window,
     cx: &mut Context<Workspace>,
 ) {
-    // Built-in skills have synthetic paths that don't exist on disk.
-    // Open a read-only buffer with the embedded content instead.
-    //
-    // The buffer is intentionally not registered with the project's buffer
-    // store: it has no on-disk backing, isn't searchable, and `Project::
-    // create_local_buffer` panics for remote projects (SSH/collab), which
-    // would crash Zed if a user clicked a built-in skill mention while
-    // connected to a remote project.
+    // Built-in skills have synthetic paths with no on-disk file, so show their
+    // embedded content in a local buffer instead.
     if let Some(content) = agent_skills::builtin_skill_content(&skill_file_path) {
         let title = skill_content_buffer_title(&skill_file_path);
         open_skill_content_buffer(workspace, title, content, window, cx);
@@ -312,13 +302,11 @@ fn skill_content_buffer_title(skill_file_path: &std::path::Path) -> String {
         .unwrap_or_else(|| "skill".into())
 }
 
-/// Open `content` as a local, read-only Markdown buffer. Used for skills that
-/// have no openable on-disk file in the active project: built-in skills (whose
-/// paths are synthetic) and migrated rules viewed from a remote/collab project
-/// (whose files live in the local global skills dir). The buffer is
-/// deliberately not registered with the project's buffer store, which keeps it
-/// out of search and avoids `Project::create_local_buffer` panicking on remote
-/// projects.
+/// Open `content` as a local, read-only Markdown buffer, for skills with no
+/// openable file in the active project (built-in skills, and migrated rules on
+/// remote/collab projects). It's deliberately not registered with the project's
+/// buffer store: that keeps it out of search and avoids
+/// `Project::create_local_buffer` panicking on remote projects.
 fn open_skill_content_buffer(
     workspace: &mut Workspace,
     title: String,

--- a/crates/agent_ui/src/ui/mention_crease.rs
+++ b/crates/agent_ui/src/ui/mention_crease.rs
@@ -199,6 +199,9 @@ fn open_mention_uri(
         } => {
             open_skill_file(workspace, skill_file_path, window, cx);
         }
+        MentionUri::Rule { name, .. } => {
+            open_migrated_rule(workspace, &name, window, cx);
+        }
         MentionUri::Fetch { url } => {
             cx.open_url(url.as_str());
         }
@@ -207,9 +210,38 @@ fn open_mention_uri(
         | MentionUri::Diagnostics { .. }
         | MentionUri::TerminalSelection { .. }
         | MentionUri::GitDiff { .. }
-        | MentionUri::MergeConflict { .. }
-        | MentionUri::Rule { .. } => {}
+        | MentionUri::MergeConflict { .. } => {}
     });
+}
+
+/// Rules were migrated to Skills. Notify the user that the feature moved and,
+/// best-effort, open the skill file the rule was migrated into. Does nothing
+/// (besides showing the notification) when no matching skill file exists.
+pub(crate) fn open_migrated_rule(
+    workspace: &mut Workspace,
+    name: &str,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    struct RulesMigratedToSkillsToast;
+    workspace.show_toast(
+        workspace::Toast::new(
+            workspace::notifications::NotificationId::unique::<RulesMigratedToSkillsToast>(),
+            "Rules have been migrated to Skills.",
+        )
+        .autohide(),
+        cx,
+    );
+
+    let Some(slug) = agent_skills::slugify_skill_name(name) else {
+        return;
+    };
+    let skill_file_path = agent_skills::global_skills_dir()
+        .join(slug)
+        .join(agent_skills::SKILL_FILE_NAME);
+    if skill_file_path.exists() {
+        open_skill_file(workspace, skill_file_path, window, cx);
+    }
 }
 
 fn open_skill_file(

--- a/crates/agent_ui/src/ui/mention_crease.rs
+++ b/crates/agent_ui/src/ui/mention_crease.rs
@@ -207,7 +207,8 @@ fn open_mention_uri(
         | MentionUri::Diagnostics { .. }
         | MentionUri::TerminalSelection { .. }
         | MentionUri::GitDiff { .. }
-        | MentionUri::MergeConflict { .. } => {}
+        | MentionUri::MergeConflict { .. }
+        | MentionUri::Rule { .. } => {}
     });
 }
 


### PR DESCRIPTION
Removing the `Rule` variant from `MentionUri` in #58080 broke deserialization of any thread saved before the rules-to-skills migration. Loading one failed with `unknown variant `Rule``, making those threads inaccessible.

This restores access without bringing back the rules feature:

- Reintroduce a backward-compatible `Rule` mention variant so legacy threads deserialize again.
- Preserve the original rule `id` through save/load so a thread re-saved by a newer build still loads on older Zed versions (and synthesize a valid placeholder when the id is missing).
- Clicking a legacy rule mention now opens the skill the rule was migrated into, and shows a notification linking the Skills docs. On remote/collab projects the migrated file lives on the local machine, so it opens as a read-only buffer. If no matching skill exists, it does nothing.

Closes https://github.com/zed-industries/zed/issues/58498
Closes AI-371

Release Notes:

- Fixed old threads that mention Rules being inaccessible after Rules were migrated to Skills
