### PR TITLE
project_panel: Do not ignore first focus clicks on items

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5679,7 +5679,7 @@ impl ProjectPanel {
             )
             .on_click(
                 cx.listener(move |project_panel, event: &gpui::ClickEvent, window, cx| {
-                    if event.is_right_click() || event.first_focus() || show_editor {
+                    if event.is_right_click() || show_editor {
                         return;
                     }
                     if event.standard_click() {


### PR DESCRIPTION
When handling click events on entries in project panel, we were returning early if the click was the one that brought the Zed window into focus. This effectively ignored the click action on the item. This leads to two clicks being required to act on an item in the project panel if the Zed window is out of focus. The existing behaviour is also inconsistent with other UI controls, where clicking on them when the window is out of focus actually acts upon them.

This behaviour was introduced in https://github.com/zed-industries/zed/pull/9553.

This PR fixes the click handler on the entries so that events with `first_focus() == true` are no longer ignored.

Before:

https://github.com/user-attachments/assets/d51ec11d-c47a-4ea3-af6d-63bf6daf3c44

After:

https://github.com/user-attachments/assets/87b9e6a8-9ef0-463f-8557-e15d25b519ca

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #58261 

Release Notes:

- Fixed project panel needing a second click to change the file if the window is not in focus
