### PR TITLE
editor: Support snippet variables like TM_SELECTED_TEXT

### DIFF
--- a/crates/editor/src/completions.rs
+++ b/crates/editor/src/completions.rs
@@ -769,6 +769,8 @@ impl Editor {
     ) -> Option<Task<Result<()>>> {
         use language::ToOffset as _;
 
+        let overtyped_selection = self.selection_overtyped.take();
+
         let CodeContextMenu::Completions(completions_menu) = self.hide_context_menu(window, cx)?
         else {
             return None;
@@ -810,6 +812,16 @@ impl Editor {
         else {
             return None;
         };
+
+        // Overtyped text is used as `TM_SELECTED_TEXT` only when it sits
+        // exactly where this completion is being inserted
+        let snippet_selected_text = overtyped_selection.and_then(|(anchor, text)| {
+            let anchor_offset = anchor.to_offset(&multibuffer_snapshot);
+            let replace_start = replace_range_multibuffer
+                .start
+                .to_offset(&multibuffer_snapshot);
+            (anchor_offset == replace_start).then_some(text)
+        });
 
         let Some((buffer_snapshot, newest_range_buffer)) =
             multibuffer_snapshot.anchor_range_to_buffer_anchor_range(newest_selection.range())
@@ -896,9 +908,21 @@ impl Editor {
                     .iter()
                     .map(|range| range.to_offset(&multibuffer_snapshot))
                     .collect::<Vec<_>>();
-                editor
-                    .insert_snippet(&offset_ranges, snippet, window, cx)
-                    .log_err();
+                if let Some(selected_text) = snippet_selected_text {
+                    editor
+                        .insert_snippet_with_selected_text(
+                            &offset_ranges,
+                            snippet,
+                            selected_text,
+                            window,
+                            cx,
+                        )
+                        .log_err();
+                } else {
+                    editor
+                        .insert_snippet(&offset_ranges, snippet, window, cx)
+                        .log_err();
+                }
             } else {
                 editor.buffer.update(cx, |multi_buffer, cx| {
                     let auto_indent = match completion.insert_text_mode {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -43,6 +43,7 @@ mod rust_analyzer_ext;
 pub mod scroll;
 mod selections_collection;
 pub mod semantic_tokens;
+mod snippet_variables;
 mod split;
 pub mod split_editor_view;
 
@@ -399,6 +400,12 @@ pub struct SearchWithinRange;
 
 trait InvalidationRegion {
     fn ranges(&self) -> &[Range<Anchor>];
+}
+
+enum SelectedTextSource {
+    None,
+    InsertionRanges,
+    Explicit(Arc<str>),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -944,6 +951,8 @@ pub struct Editor {
     deferred_selection_effects_state: Option<DeferredSelectionEffectsState>,
     autoclose_regions: Vec<AutocloseRegion>,
     snippet_stack: InvalidationStack<SnippetState>,
+    /// Text that was replaced by the user typing over a selection
+    selection_overtyped: Option<(Anchor, Arc<str>)>,
     select_syntax_node_history: SelectSyntaxNodeHistory,
     ime_transaction: Option<TransactionId>,
     pub diagnostics_max_severity: DiagnosticSeverity,
@@ -2143,6 +2152,7 @@ impl Editor {
             deferred_selection_effects_state: None,
             autoclose_regions: Vec::new(),
             snippet_stack: InvalidationStack::default(),
+            selection_overtyped: None,
             select_syntax_node_history: SelectSyntaxNodeHistory::default(),
             ime_transaction: None,
             active_diagnostics: ActiveDiagnostic::None,
@@ -4489,6 +4499,7 @@ impl Editor {
         cx.notify();
         self.completion_tasks.clear();
         let context_menu = self.context_menu.borrow_mut().take();
+        self.selection_overtyped = None;
         self.stale_edit_prediction_in_menu.take();
         self.update_visible_edit_prediction(window, cx);
         if let Some(CodeContextMenu::Completions(_)) = &context_menu
@@ -4540,55 +4551,139 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Result<()> {
+        self.insert_snippet_inner(
+            insertion_ranges,
+            snippet,
+            SelectedTextSource::None,
+            window,
+            cx,
+        )
+    }
+
+    pub fn insert_snippet_with_selected_text(
+        &mut self,
+        insertion_ranges: &[Range<MultiBufferOffset>],
+        snippet: Snippet,
+        selected_text: Arc<str>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Result<()> {
+        self.insert_snippet_inner(
+            insertion_ranges,
+            snippet,
+            SelectedTextSource::Explicit(selected_text),
+            window,
+            cx,
+        )
+    }
+
+    pub fn insert_snippet_over_selection(
+        &mut self,
+        insertion_ranges: &[Range<MultiBufferOffset>],
+        snippet: Snippet,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Result<()> {
+        self.insert_snippet_inner(
+            insertion_ranges,
+            snippet,
+            SelectedTextSource::InsertionRanges,
+            window,
+            cx,
+        )
+    }
+
+    fn insert_snippet_inner(
+        &mut self,
+        insertion_ranges: &[Range<MultiBufferOffset>],
+        snippet: Snippet,
+        selected_text: SelectedTextSource,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Result<()> {
         struct Tabstop<T> {
             is_end_tabstop: bool,
             ranges: Vec<Range<T>>,
             choices: Option<Vec<String>>,
         }
 
+        let variable_context = (!snippet.variables.is_empty())
+            .then(|| snippet_variables::SnippetVariableContext::new(self, cx));
+
         let tabstops = self.buffer.update(cx, |buffer, cx| {
-            let snippet_text: Arc<str> = snippet.text.clone().into();
+            let resolved_snippets = {
+                let snapshot = buffer.read(cx);
+                insertion_ranges
+                    .iter()
+                    .enumerate()
+                    .map(|(cursor_index, range)| {
+                        let Some(variable_context) = &variable_context else {
+                            return snippet.clone();
+                        };
+                        let selected_text: String = match &selected_text {
+                            SelectedTextSource::None => String::new(),
+                            SelectedTextSource::InsertionRanges => {
+                                snapshot.text_for_range(range.clone()).collect()
+                            }
+                            SelectedTextSource::Explicit(text) => text.to_string(),
+                        };
+                        snippet.resolve_variables(|name| {
+                            variable_context.resolve(
+                                name,
+                                &selected_text,
+                                &snapshot,
+                                range,
+                                cursor_index,
+                            )
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            };
+
             let edits = insertion_ranges
                 .iter()
                 .cloned()
-                .map(|range| (range, snippet_text.clone()));
+                .zip(&resolved_snippets)
+                .map(|(range, resolved)| (range, Arc::<str>::from(resolved.text.as_str())));
             let autoindent_mode = AutoindentMode::Block {
                 original_indent_columns: Vec::new(),
             };
             buffer.edit(edits, Some(autoindent_mode), cx);
 
             let snapshot = &*buffer.read(cx);
-            let snippet = &snippet;
-            snippet
-                .tabstops
-                .iter()
-                .map(|tabstop| {
-                    let is_end_tabstop = tabstop.ranges.first().is_some_and(|tabstop| {
-                        tabstop.is_empty() && tabstop.start == snippet.text.len() as isize
-                    });
-                    let mut tabstop_ranges = tabstop
-                        .ranges
-                        .iter()
-                        .flat_map(|tabstop_range| {
-                            let mut delta = 0_isize;
-                            insertion_ranges.iter().map(move |insertion_range| {
-                                let insertion_start = insertion_range.start + delta;
-                                delta += snippet.text.len() as isize
-                                    - (insertion_range.end - insertion_range.start) as isize;
+            let tabstop_count = resolved_snippets.first().map_or(0, |s| s.tabstops.len());
+            (0..tabstop_count)
+                .map(|tabstop_index| {
+                    let first = &resolved_snippets[0];
+                    let is_end_tabstop =
+                        first.tabstops[tabstop_index]
+                            .ranges
+                            .first()
+                            .is_some_and(|range| {
+                                range.is_empty() && range.start == first.text.len() as isize
+                            });
 
-                                let start =
-                                    (insertion_start + tabstop_range.start).min(snapshot.len());
-                                let end = (insertion_start + tabstop_range.end).min(snapshot.len());
-                                snapshot.anchor_before(start)..snapshot.anchor_after(end)
-                            })
-                        })
-                        .collect::<Vec<_>>();
+                    let mut tabstop_ranges = Vec::new();
+                    let mut delta = 0_isize;
+                    for (range_index, insertion_range) in insertion_ranges.iter().enumerate() {
+                        let resolved = &resolved_snippets[range_index];
+                        let insertion_start = insertion_range.start + delta;
+                        delta += resolved.text.len() as isize
+                            - (insertion_range.end - insertion_range.start) as isize;
+
+                        for tabstop_range in &resolved.tabstops[tabstop_index].ranges {
+                            let start = (insertion_start + tabstop_range.start).min(snapshot.len());
+                            let end = (insertion_start + tabstop_range.end).min(snapshot.len());
+                            tabstop_ranges
+                                .push(snapshot.anchor_before(start)..snapshot.anchor_after(end));
+                        }
+                    }
                     tabstop_ranges.sort_unstable_by(|a, b| a.start.cmp(&b.start, snapshot));
 
                     Tabstop {
                         is_end_tabstop,
                         ranges: tabstop_ranges,
-                        choices: tabstop.choices.clone(),
+                        choices: first.tabstops[tabstop_index].choices.clone(),
                     }
                 })
                 .collect::<Vec<_>>()

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13998,6 +13998,39 @@ async fn test_snippet_with_multi_word_prefix(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_snippet_completion_uses_overtyped_selection(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_editor(|editor, _, cx| {
+        editor.project().unwrap().update(cx, |project, cx| {
+            project.snippets().update(cx, |snippets, _cx| {
+                let snippet = project::snippet_provider::Snippet {
+                    prefix: vec!["wrap".to_string()],
+                    body: "wrap($TM_SELECTED_TEXT)$0".to_string(),
+                    description: Some("wrap selection".to_string()),
+                    name: "wrap".to_string(),
+                };
+                snippets.add_snippet_for_test(
+                    None,
+                    PathBuf::from("test_snippets.json"),
+                    vec![Arc::new(snippet)],
+                );
+            });
+        })
+    });
+
+    cx.set_state("call «fooˇ»");
+    cx.simulate_input("wrap");
+    cx.run_until_parked();
+
+    cx.update_editor(|editor, window, cx| {
+        editor.confirm_completion(&ConfirmCompletion::default(), window, cx);
+    });
+    cx.assert_editor_state("call wrap(foo)ˇ");
+}
+
+#[gpui::test]
 async fn test_document_format_during_save(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
@@ -32484,6 +32517,110 @@ async fn test_insert_snippet(cx: &mut TestAppContext) {
     cx.assert_editor_state(
         r#"First cursor at an Unspecified Locationˇ after and second cursor at an Unspecified Locationˇ after"#,
     );
+}
+
+#[gpui::test]
+async fn test_insert_snippet_with_selected_text(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state(indoc!(r#"call «fooˇ»"#));
+    cx.update_editor(|editor, window, cx| {
+        editor.insert_snippet_at_selections(
+            &InsertSnippet {
+                language: None,
+                name: None,
+                snippet: Some("wrap($TM_SELECTED_TEXT)$0".to_string()),
+            },
+            window,
+            cx,
+        );
+    });
+    cx.assert_editor_state(indoc!(r#"call wrap(foo)ˇ"#));
+
+    // Each selection contributes its own selected text.
+    cx.set_state(indoc!(r#"«oneˇ» «twoˇ»"#));
+    cx.update_editor(|editor, window, cx| {
+        editor.insert_snippet_at_selections(
+            &InsertSnippet {
+                language: None,
+                name: None,
+                snippet: Some("[${TM_SELECTED_TEXT}]$0".to_string()),
+            },
+            window,
+            cx,
+        );
+    });
+    cx.assert_editor_state(indoc!(r#"[one]ˇ [two]ˇ"#));
+
+    // Selections of differing lengths exercise the per-range tabstop offset math:
+    // the second cursor's tabstop must account for the first replacement growing
+    // the buffer by a different amount.
+    cx.set_state(indoc!(r#"«xˇ» «yyyyˇ»"#));
+    cx.update_editor(|editor, window, cx| {
+        editor.insert_snippet_at_selections(
+            &InsertSnippet {
+                language: None,
+                name: None,
+                snippet: Some("[${TM_SELECTED_TEXT}]$0".to_string()),
+            },
+            window,
+            cx,
+        );
+    });
+    cx.assert_editor_state(indoc!(r#"[x]ˇ [yyyy]ˇ"#));
+
+    // With no selection, `${TM_SELECTED_TEXT:default}` falls back to its default.
+    cx.set_state(indoc!(r#"hereˇ"#));
+    cx.update_editor(|editor, window, cx| {
+        editor.insert_snippet_at_selections(
+            &InsertSnippet {
+                language: None,
+                name: None,
+                snippet: Some("<${TM_SELECTED_TEXT:nothing}>$0".to_string()),
+            },
+            window,
+            cx,
+        );
+    });
+    cx.assert_editor_state(indoc!(r#"here<nothing>ˇ"#));
+
+    // `TM_CURRENT_WORD` and the per-cursor `CURSOR_NUMBER` resolve independently
+    // for each cursor.
+    cx.set_state(indoc!(r#"aaaˇ bbbˇ"#));
+    cx.update_editor(|editor, window, cx| {
+        editor.insert_snippet_at_selections(
+            &InsertSnippet {
+                language: None,
+                name: None,
+                snippet: Some("[$TM_CURRENT_WORD#$CURSOR_NUMBER]$0".to_string()),
+            },
+            window,
+            cx,
+        );
+    });
+    cx.assert_editor_state(indoc!(r#"aaa[aaa#1]ˇ bbb[bbb#2]ˇ"#));
+
+    // `TM_LINE_NUMBER` and `TM_CURRENT_LINE` reflect the cursor's line.
+    cx.set_state(indoc!(
+        r#"line one
+        lineˇ two"#
+    ));
+    cx.update_editor(|editor, window, cx| {
+        editor.insert_snippet_at_selections(
+            &InsertSnippet {
+                language: None,
+                name: None,
+                snippet: Some(" L$TM_LINE_NUMBER=[$TM_CURRENT_LINE]$0".to_string()),
+            },
+            window,
+            cx,
+        );
+    });
+    cx.assert_editor_state(indoc!(
+        r#"line one
+        line L2=[line two]ˇ two"#
+    ));
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -14031,6 +14031,21 @@ async fn test_snippet_completion_uses_overtyped_selection(cx: &mut TestAppContex
 }
 
 #[gpui::test]
+async fn test_overtyping_shrinking_multiple_selections(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    // Typing a single character over several selections shrinks the buffer below
+    // the newest selection's original offset. Capturing the overtyped text for
+    // `TM_SELECTED_TEXT` must use a tracking anchor rather than resolving the
+    // stale pre-edit offset against the post-edit snapshot, which used to panic.
+    cx.set_state("«aaaaaˇ» «bbbbbˇ»");
+    cx.simulate_input("x");
+    cx.assert_editor_state("xˇ xˇ");
+}
+
+#[gpui::test]
 async fn test_document_format_during_save(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -78,7 +78,9 @@ impl Editor {
 
         self.unfold_buffers_with_selections(cx);
 
-        // Capture the text the user is about to type over
+        // Capture the text the user is about to type over. The anchor is created
+        // against the pre-edit snapshot so it tracks correctly across the edit
+        // (the edited range may differ from the selection and shrink the buffer).
         let overtyped_selection = (!text.is_empty())
             .then(|| {
                 let newest = self
@@ -90,7 +92,7 @@ impl Editor {
                         .text_for_range(newest.start..newest.end)
                         .collect::<String>()
                         .into();
-                    (newest.start, overtyped_text)
+                    (snapshot.anchor_before(newest.start), overtyped_text)
                 })
             })
             .flatten();
@@ -544,8 +546,7 @@ impl Editor {
             jsx_tag_auto_close::handle_from(this, initial_buffer_versions, window, cx);
         });
 
-        if let Some((start_offset, overtyped_text)) = overtyped_selection {
-            let anchor = self.buffer.read(cx).read(cx).anchor_before(start_offset);
+        if let Some((anchor, overtyped_text)) = overtyped_selection {
             self.selection_overtyped = Some((anchor, overtyped_text));
         }
     }

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -78,6 +78,23 @@ impl Editor {
 
         self.unfold_buffers_with_selections(cx);
 
+        // Capture the text the user is about to type over
+        let overtyped_selection = (!text.is_empty())
+            .then(|| {
+                let newest = self
+                    .selections
+                    .newest::<MultiBufferOffset>(&self.display_snapshot(cx));
+                (newest.start != newest.end).then(|| {
+                    let snapshot = self.buffer.read(cx).read(cx);
+                    let overtyped_text: Arc<str> = snapshot
+                        .text_for_range(newest.start..newest.end)
+                        .collect::<String>()
+                        .into();
+                    (newest.start, overtyped_text)
+                })
+            })
+            .flatten();
+
         let selections = self.selections.all_adjusted(&self.display_snapshot(cx));
         let mut bracket_inserted = false;
         let mut edits = Vec::new();
@@ -526,6 +543,11 @@ impl Editor {
             this.refresh_edit_prediction(true, false, window, cx);
             jsx_tag_auto_close::handle_from(this, initial_buffer_versions, window, cx);
         });
+
+        if let Some((start_offset, overtyped_text)) = overtyped_selection {
+            let anchor = self.buffer.read(cx).read(cx).anchor_before(start_offset);
+            self.selection_overtyped = Some((anchor, overtyped_text));
+        }
     }
 
     pub fn newline(&mut self, _: &Newline, window: &mut Window, cx: &mut Context<Self>) {
@@ -2192,7 +2214,7 @@ impl Editor {
             bail!("`name` or `snippet` is required")
         };
 
-        self.insert_snippet(&insertion_ranges, snippet, window, cx)
+        self.insert_snippet_over_selection(&insertion_ranges, snippet, window, cx)
     }
 }
 

--- a/crates/editor/src/snippet_variables.rs
+++ b/crates/editor/src/snippet_variables.rs
@@ -1,0 +1,201 @@
+//! Resolution of LSP snippet variables as described in the LSP snippet syntax specification:
+//! <https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax>
+
+use std::ops::Range;
+
+use gpui::App;
+use multi_buffer::{
+    MultiBufferOffset, MultiBufferRow, MultiBufferSnapshot, ToOffset as _, ToPoint as _,
+};
+use text::Point;
+use time::{Month, OffsetDateTime, Weekday};
+
+use crate::Editor;
+
+pub(crate) struct SnippetVariableContext {
+    clipboard: Option<String>,
+    filename: Option<String>,
+    filename_base: Option<String>,
+    directory: Option<String>,
+    filepath: Option<String>,
+    relative_filepath: Option<String>,
+    workspace_name: Option<String>,
+    workspace_folder: Option<String>,
+    now: OffsetDateTime,
+}
+
+impl SnippetVariableContext {
+    pub(crate) fn new(editor: &Editor, cx: &App) -> Self {
+        let clipboard = cx
+            .read_from_clipboard()
+            .and_then(|item| item.text())
+            .filter(|text| !text.is_empty());
+
+        let mut context = Self {
+            clipboard,
+            filename: None,
+            filename_base: None,
+            directory: None,
+            filepath: None,
+            relative_filepath: None,
+            workspace_name: None,
+            workspace_folder: None,
+            now: OffsetDateTime::now_local().unwrap_or_else(|_| OffsetDateTime::now_utc()),
+        };
+
+        if let Some(buffer) = editor.buffer().read(cx).as_singleton() {
+            let buffer = buffer.read(cx);
+
+            if let Some(file) = buffer.file() {
+                context.filename = Some(file.file_name(cx).to_string());
+                context.filename_base = std::path::Path::new(file.file_name(cx))
+                    .file_stem()
+                    .map(|stem| stem.to_string_lossy().into_owned());
+                context.relative_filepath =
+                    Some(file.path().display(file.path_style(cx)).into_owned());
+
+                if let Some(local_file) = file.as_local() {
+                    let abs_path = local_file.abs_path(cx);
+                    context.directory = abs_path
+                        .parent()
+                        .map(|parent| parent.to_string_lossy().into_owned());
+                    context.filepath = Some(abs_path.to_string_lossy().into_owned());
+                }
+
+                if let Some(project) = editor.project.as_ref() {
+                    let worktree_id = file.worktree_id(cx);
+                    if let Some(worktree) = project.read(cx).worktree_for_id(worktree_id, cx) {
+                        let worktree = worktree.read(cx);
+                        context.workspace_folder =
+                            Some(worktree.abs_path().to_string_lossy().into_owned());
+                        context.workspace_name = Some(worktree.root_name_str().to_string());
+                    }
+                }
+            }
+        }
+
+        context
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        name: &str,
+        selected_text: &str,
+        snapshot: &MultiBufferSnapshot,
+        range: &Range<MultiBufferOffset>,
+        cursor_index: usize,
+    ) -> Option<String> {
+        match name {
+            "TM_SELECTED_TEXT" => Some(selected_text.to_string()),
+            "TM_CURRENT_LINE" => Some(self.current_line(snapshot, range)),
+            "TM_CURRENT_WORD" => Some(self.current_word(snapshot, range)),
+            "TM_LINE_INDEX" => Some(self.line_index(snapshot, range).to_string()),
+            "TM_LINE_NUMBER" => Some((self.line_index(snapshot, range) + 1).to_string()),
+            "TM_FILENAME" => self.filename.clone(),
+            "TM_FILENAME_BASE" => self.filename_base.clone(),
+            "TM_DIRECTORY" => self.directory.clone(),
+            "TM_FILEPATH" => self.filepath.clone(),
+            "RELATIVE_FILEPATH" => self.relative_filepath.clone(),
+            "CLIPBOARD" => self.clipboard.clone(),
+            "WORKSPACE_NAME" => self.workspace_name.clone(),
+            "WORKSPACE_FOLDER" => self.workspace_folder.clone(),
+            "CURSOR_INDEX" => Some(cursor_index.to_string()),
+            "CURSOR_NUMBER" => Some((cursor_index + 1).to_string()),
+            "LINE_COMMENT" => snapshot
+                .language_scope_at(range.start)
+                .and_then(|scope| scope.line_comment_prefixes().first().cloned())
+                .map(|prefix| prefix.trim_end().to_string()),
+            "BLOCK_COMMENT_START" => snapshot.language_scope_at(range.start).and_then(|scope| {
+                scope
+                    .block_comment()
+                    .map(|comment| comment.start.trim().to_string())
+            }),
+            "BLOCK_COMMENT_END" => snapshot.language_scope_at(range.start).and_then(|scope| {
+                scope
+                    .block_comment()
+                    .map(|comment| comment.end.trim().to_string())
+            }),
+            "CURRENT_YEAR" => Some(format!("{:04}", self.now.year())),
+            "CURRENT_YEAR_SHORT" => Some(format!("{:02}", self.now.year() % 100)),
+            "CURRENT_MONTH" => Some(format!("{:02}", self.now.month() as u8)),
+            "CURRENT_MONTH_NAME" => Some(month_name(self.now.month()).to_string()),
+            "CURRENT_MONTH_NAME_SHORT" => Some(month_name(self.now.month())[..3].to_string()),
+            "CURRENT_DATE" => Some(format!("{:02}", self.now.day())),
+            "CURRENT_DAY_NAME" => Some(weekday_name(self.now.weekday()).to_string()),
+            "CURRENT_DAY_NAME_SHORT" => Some(weekday_name(self.now.weekday())[..3].to_string()),
+            "CURRENT_HOUR" => Some(format!("{:02}", self.now.hour())),
+            "CURRENT_MINUTE" => Some(format!("{:02}", self.now.minute())),
+            "CURRENT_SECOND" => Some(format!("{:02}", self.now.second())),
+            "CURRENT_SECONDS_UNIX" => Some(self.now.unix_timestamp().to_string()),
+            "CURRENT_TIMEZONE_OFFSET" => Some(timezone_offset(&self.now)),
+            "RANDOM" => Some(format!("{:06}", rand::random_range(0..1_000_000u32))),
+            "RANDOM_HEX" => Some(format!("{:06x}", rand::random_range(0..0x100_0000u32))),
+            "UUID" => Some(uuid::Uuid::new_v4().to_string()),
+            _ => None,
+        }
+    }
+
+    fn line_index(&self, snapshot: &MultiBufferSnapshot, range: &Range<MultiBufferOffset>) -> u32 {
+        range.start.to_point(snapshot).row
+    }
+
+    fn current_line(
+        &self,
+        snapshot: &MultiBufferSnapshot,
+        range: &Range<MultiBufferOffset>,
+    ) -> String {
+        let row = range.start.to_point(snapshot).row;
+        let line_start = Point::new(row, 0).to_offset(snapshot);
+        let line_end = Point::new(row, snapshot.line_len(MultiBufferRow(row))).to_offset(snapshot);
+        snapshot.text_for_range(line_start..line_end).collect()
+    }
+
+    fn current_word(
+        &self,
+        snapshot: &MultiBufferSnapshot,
+        range: &Range<MultiBufferOffset>,
+    ) -> String {
+        let (word_range, _) = snapshot.surrounding_word(range.start, None);
+        snapshot.text_for_range(word_range).collect()
+    }
+}
+
+fn month_name(month: Month) -> &'static str {
+    match month {
+        Month::January => "January",
+        Month::February => "February",
+        Month::March => "March",
+        Month::April => "April",
+        Month::May => "May",
+        Month::June => "June",
+        Month::July => "July",
+        Month::August => "August",
+        Month::September => "September",
+        Month::October => "October",
+        Month::November => "November",
+        Month::December => "December",
+    }
+}
+
+fn weekday_name(weekday: Weekday) -> &'static str {
+    match weekday {
+        Weekday::Monday => "Monday",
+        Weekday::Tuesday => "Tuesday",
+        Weekday::Wednesday => "Wednesday",
+        Weekday::Thursday => "Thursday",
+        Weekday::Friday => "Friday",
+        Weekday::Saturday => "Saturday",
+        Weekday::Sunday => "Sunday",
+    }
+}
+
+fn timezone_offset(now: &OffsetDateTime) -> String {
+    let offset = now.offset();
+    let sign = if offset.whole_seconds() < 0 { '-' } else { '+' };
+    let (hours, minutes, _) = offset.as_hms();
+    format!(
+        "{sign}{:02}:{:02}",
+        hours.unsigned_abs(),
+        minutes.unsigned_abs()
+    )
+}

--- a/crates/snippet/src/snippet.rs
+++ b/crates/snippet/src/snippet.rs
@@ -6,6 +6,8 @@ use std::{collections::BTreeMap, ops::Range};
 pub struct Snippet {
     pub text: String,
     pub tabstops: Vec<TabStop>,
+    /// Occurrences of snippet variables in order of appearance.
+    pub variables: Vec<SnippetVariable>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -14,11 +16,18 @@ pub struct TabStop {
     pub choices: Option<Vec<String>>,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct SnippetVariable {
+    pub name: String,
+    pub range: Range<usize>,
+}
+
 impl Snippet {
     pub fn parse(source: &str) -> Result<Self> {
         let mut text = String::with_capacity(source.len());
         let mut tabstops = BTreeMap::new();
-        parse_snippet(source, false, &mut text, &mut tabstops)
+        let mut variables = Vec::new();
+        parse_snippet(source, false, &mut text, &mut tabstops, &mut variables)
             .context("failed to parse snippet")?;
 
         let len = text.len() as isize;
@@ -38,7 +47,68 @@ impl Snippet {
             }
         }
 
-        Ok(Snippet { text, tabstops })
+        Ok(Snippet {
+            text,
+            tabstops,
+            variables,
+        })
+    }
+
+    /// Returns a copy of this snippet with its variables replaced by the values
+    /// returned from `resolve`. Tabstop offsets and any remaining variable spans
+    /// are shifted to account for the difference in length between a variable's
+    /// default text and its resolved value. Variables for which `resolve` returns
+    /// `None` or an empty string keep their default text.
+    pub fn resolve_variables(&self, resolve: impl Fn(&str) -> Option<String>) -> Snippet {
+        if self.variables.is_empty() {
+            return self.clone();
+        }
+
+        let mut text = String::with_capacity(self.text.len());
+        let mut last = 0;
+        let mut deltas: Vec<(usize, isize)> = Vec::new();
+        for variable in &self.variables {
+            let Some(value) = resolve(&variable.name).filter(|value| !value.is_empty()) else {
+                continue;
+            };
+            text.push_str(&self.text[last..variable.range.start]);
+            text.push_str(&value);
+            last = variable.range.end;
+            let original_len = variable.range.end - variable.range.start;
+            let delta = value.len() as isize - original_len as isize;
+            if delta != 0 {
+                deltas.push((variable.range.end, delta));
+            }
+        }
+        text.push_str(&self.text[last..]);
+
+        let remap = |offset: isize| -> isize {
+            offset
+                + deltas
+                    .iter()
+                    .filter(|(boundary, _)| *boundary as isize <= offset)
+                    .map(|(_, delta)| delta)
+                    .sum::<isize>()
+        };
+
+        let tabstops = self
+            .tabstops
+            .iter()
+            .map(|tabstop| TabStop {
+                ranges: tabstop
+                    .ranges
+                    .iter()
+                    .map(|range| remap(range.start)..remap(range.end))
+                    .collect(),
+                choices: tabstop.choices.clone(),
+            })
+            .collect();
+
+        Snippet {
+            text,
+            tabstops,
+            variables: Vec::new(),
+        }
     }
 }
 
@@ -47,12 +117,13 @@ fn parse_snippet<'a>(
     nested: bool,
     text: &mut String,
     tabstops: &mut BTreeMap<usize, TabStop>,
+    variables: &mut Vec<SnippetVariable>,
 ) -> Result<&'a str> {
     loop {
         match source.chars().next() {
             None => return Ok(""),
             Some('$') => {
-                source = parse_tabstop(&source[1..], text, tabstops)?;
+                source = parse_tabstop(&source[1..], text, tabstops, variables)?;
             }
             Some('\\') => {
                 // As specified in the LSP spec (`Grammar` section),
@@ -93,13 +164,19 @@ fn parse_tabstop<'a>(
     mut source: &'a str,
     text: &mut String,
     tabstops: &mut BTreeMap<usize, TabStop>,
+    variables: &mut Vec<SnippetVariable>,
 ) -> Result<&'a str> {
     let tabstop_start = text.len();
     let tabstop_index;
     let mut choices = None;
 
     if source.starts_with('{') {
-        let (index, rest) = parse_int(&source[1..])?;
+        let inner = &source[1..];
+        if starts_with_variable_name(inner) {
+            return parse_variable(inner, true, text, variables);
+        }
+
+        let (index, rest) = parse_int(inner)?;
         tabstop_index = index;
         source = rest;
 
@@ -108,7 +185,7 @@ fn parse_tabstop<'a>(
         }
 
         if source.starts_with(':') {
-            source = parse_snippet(&source[1..], true, text, tabstops)?;
+            source = parse_snippet(&source[1..], true, text, tabstops, variables)?;
         }
 
         if source.starts_with('}') {
@@ -116,6 +193,8 @@ fn parse_tabstop<'a>(
         } else {
             anyhow::bail!("expected a closing brace");
         }
+    } else if starts_with_variable_name(source) {
+        return parse_variable(source, false, text, variables);
     } else {
         let (index, rest) = parse_int(source)?;
         tabstop_index = index;
@@ -131,6 +210,90 @@ fn parse_tabstop<'a>(
         .ranges
         .push(tabstop_start as isize..text.len() as isize);
     Ok(source)
+}
+
+fn starts_with_variable_name(source: &str) -> bool {
+    source
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+}
+
+fn parse_variable<'a>(
+    source: &'a str,
+    braced: bool,
+    text: &mut String,
+    variables: &mut Vec<SnippetVariable>,
+) -> Result<&'a str> {
+    let name_len = source
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .unwrap_or(source.len());
+    let (name, mut source) = source.split_at(name_len);
+
+    let start = text.len();
+    if braced {
+        if let Some(rest) = source.strip_prefix(':') {
+            source = parse_variable_default(rest, text)?;
+        } else if source.starts_with('/') {
+            // Variable transforms (e.g. `${TM_FILENAME/.../.../}`) are not
+            // supported; skip past the transform body without applying it.
+            source = skip_to_closing_brace(source)?;
+        }
+
+        source = source
+            .strip_prefix('}')
+            .context("expected a closing brace")?;
+    }
+
+    variables.push(SnippetVariable {
+        name: name.to_string(),
+        range: start..text.len(),
+    });
+    Ok(source)
+}
+
+fn parse_variable_default<'a>(mut source: &'a str, text: &mut String) -> Result<&'a str> {
+    loop {
+        match source.chars().next() {
+            None => anyhow::bail!("expected a closing brace"),
+            Some('}') => return Ok(source),
+            Some('\\') => {
+                source = &source[1..];
+                if let Some(c) = source.chars().next() {
+                    if c == '$' || c == '\\' || c == '}' {
+                        text.push(c);
+                        source = &source[c.len_utf8()..];
+                    } else {
+                        text.push('\\');
+                    }
+                } else {
+                    text.push('\\');
+                }
+            }
+            Some(_) => {
+                let chunk_end = source.find(['}', '\\']).unwrap_or(source.len());
+                let (chunk, rest) = source.split_at(chunk_end);
+                text.push_str(chunk);
+                source = rest;
+            }
+        }
+    }
+}
+
+fn skip_to_closing_brace(mut source: &str) -> Result<&str> {
+    loop {
+        match source.chars().next() {
+            None => anyhow::bail!("expected a closing brace"),
+            Some('}') => return Ok(source),
+            Some('\\') => {
+                source = &source[1..];
+                if let Some(c) = source.chars().next() {
+                    source = &source[c.len_utf8()..];
+                }
+            }
+            Some(c) => source = &source[c.len_utf8()..],
+        }
+    }
 }
 
 fn parse_int(source: &str) -> Result<(usize, &str)> {
@@ -322,6 +485,74 @@ mod tests {
         let snippet = Snippet::parse("one\\\\$1two").unwrap();
         assert_eq!(snippet.text, "one\\two");
         assert_eq!(tabstops(&snippet), &[vec![4..4], vec![7..7]]);
+    }
+
+    #[test]
+    fn test_snippet_with_selected_text_variable() {
+        let snippet = Snippet::parse("wrap($TM_SELECTED_TEXT)").unwrap();
+        assert_eq!(snippet.text, "wrap()");
+        assert_eq!(
+            snippet.variables,
+            &[SnippetVariable {
+                name: "TM_SELECTED_TEXT".to_string(),
+                range: 5..5,
+            }]
+        );
+
+        let resolved = snippet
+            .resolve_variables(|name| (name == "TM_SELECTED_TEXT").then(|| "hello".to_string()));
+        assert_eq!(resolved.text, "wrap(hello)");
+        assert!(resolved.variables.is_empty());
+        // The trailing end tabstop is shifted past the inserted text.
+        assert_eq!(tabstops(&resolved), &[vec![11..11]]);
+    }
+
+    #[test]
+    fn test_snippet_with_braced_variable_and_tabstops() {
+        let snippet = Snippet::parse("${TM_SELECTED_TEXT}$1 = $2").unwrap();
+        assert_eq!(snippet.text, " = ");
+        assert_eq!(tabstops(&snippet), &[vec![0..0], vec![3..3]]);
+
+        let resolved = snippet
+            .resolve_variables(|name| (name == "TM_SELECTED_TEXT").then(|| "value".to_string()));
+        assert_eq!(resolved.text, "value = ");
+        assert_eq!(tabstops(&resolved), &[vec![5..5], vec![8..8]]);
+    }
+
+    #[test]
+    fn test_snippet_variable_default() {
+        let snippet = Snippet::parse("log(${TM_SELECTED_TEXT:msg})").unwrap();
+        assert_eq!(snippet.text, "log(msg)");
+        assert_eq!(
+            snippet.variables,
+            &[SnippetVariable {
+                name: "TM_SELECTED_TEXT".to_string(),
+                range: 4..7,
+            }]
+        );
+
+        let unresolved = snippet.resolve_variables(|_| None);
+        assert_eq!(unresolved.text, "log(msg)");
+
+        let empty = snippet.resolve_variables(|_| Some(String::new()));
+        assert_eq!(empty.text, "log(msg)");
+
+        let resolved = snippet
+            .resolve_variables(|name| (name == "TM_SELECTED_TEXT").then(|| "abc".to_string()));
+        assert_eq!(resolved.text, "log(abc)");
+        assert_eq!(tabstops(&resolved), &[vec![8..8]]);
+    }
+
+    #[test]
+    fn test_snippet_with_multiple_variables() {
+        let snippet = Snippet::parse("$TM_SELECTED_TEXT-$1-$TM_SELECTED_TEXT").unwrap();
+        assert_eq!(snippet.text, "--");
+        assert_eq!(tabstops(&snippet), &[vec![1..1], vec![2..2]]);
+
+        let resolved = snippet
+            .resolve_variables(|name| (name == "TM_SELECTED_TEXT").then(|| "xy".to_string()));
+        assert_eq!(resolved.text, "xy--xy");
+        assert_eq!(tabstops(&resolved), &[vec![3..3], vec![6..6]]);
     }
 
     fn tabstops(snippet: &Snippet) -> Vec<Vec<Range<isize>>> {

--- a/docs/src/snippets.md
+++ b/docs/src/snippets.md
@@ -39,6 +39,49 @@ The scope is determined by the language name in lowercase e.g. `python.json` for
 
 To create JSX snippets you have to use `javascript.json` snippets file, instead of `jsx.json`, but this does not apply to TSX and TypeScript which follow the above rule.
 
+## Variables
+
+Snippet bodies may reference variables with `$NAME` or `${NAME:default}`. When a variable has no value, its default (or the empty string) is used. The following [LSP snippet variables](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax) are supported:
+
+| Variable                   | Description                                                       |
+| -------------------------- | ----------------------------------------------------------------- |
+| `TM_SELECTED_TEXT`         | The currently selected text, or the empty string                  |
+| `TM_CURRENT_LINE`          | The contents of the current line                                  |
+| `TM_CURRENT_WORD`          | The word under the cursor, or the empty string                    |
+| `TM_LINE_INDEX`            | The zero-based line number                                        |
+| `TM_LINE_NUMBER`           | The one-based line number                                         |
+| `TM_FILENAME`              | The filename of the current document                              |
+| `TM_FILENAME_BASE`         | The filename of the current document without its extension        |
+| `TM_DIRECTORY`             | The directory of the current document                             |
+| `TM_FILEPATH`              | The full file path of the current document                        |
+| `RELATIVE_FILEPATH`        | The file path relative to the workspace                           |
+| `CLIPBOARD`                | The contents of your clipboard                                    |
+| `WORKSPACE_NAME`           | The name of the opened workspace or folder                        |
+| `WORKSPACE_FOLDER`         | The path of the opened workspace or folder                        |
+| `CURSOR_INDEX`             | The zero-based cursor number                                      |
+| `CURSOR_NUMBER`            | The one-based cursor number                                       |
+| `CURRENT_YEAR`             | The current year                                                  |
+| `CURRENT_YEAR_SHORT`       | The current year's last two digits                                |
+| `CURRENT_MONTH`            | The month as two digits (e.g. `02`)                               |
+| `CURRENT_MONTH_NAME`       | The full name of the month (e.g. `July`)                          |
+| `CURRENT_MONTH_NAME_SHORT` | The short name of the month (e.g. `Jul`)                          |
+| `CURRENT_DATE`             | The day of the month as two digits (e.g. `08`)                    |
+| `CURRENT_DAY_NAME`         | The name of the day (e.g. `Monday`)                               |
+| `CURRENT_DAY_NAME_SHORT`   | The short name of the day (e.g. `Mon`)                            |
+| `CURRENT_HOUR`             | The current hour in 24-hour clock format                          |
+| `CURRENT_MINUTE`           | The current minute as two digits                                  |
+| `CURRENT_SECOND`           | The current second as two digits                                  |
+| `CURRENT_SECONDS_UNIX`     | The number of seconds since the Unix epoch                        |
+| `CURRENT_TIMEZONE_OFFSET`  | The current UTC timezone offset (e.g. `-07:00`)                   |
+| `RANDOM`                   | Six random base-10 digits                                         |
+| `RANDOM_HEX`               | Six random base-16 digits                                         |
+| `UUID`                     | A version 4 UUID                                                  |
+| `LINE_COMMENT`             | The line comment token for the current language (e.g. `//`)       |
+| `BLOCK_COMMENT_START`      | The block comment start token for the current language (e.g. `/*`)|
+| `BLOCK_COMMENT_END`        | The block comment end token for the current language (e.g. `*/`)  |
+
+Variables that depend on a selection or cursor (such as `TM_SELECTED_TEXT`) are resolved per cursor, so each cursor contributes its own value.
+
 ## Known Limitations
 
 - Only the first prefix is used when a list of prefixes is passed in.


### PR DESCRIPTION
Snippet variables have been requested for a while - the tracking issue (#13301) has been open since 2024.
My workflow also includes the usage of snippets that wrap around text, so it has been on my wishlist too.

Zed parses snippet tab stops and placeholders, but not variables: a body with `$TM_SELECTED_TEXT` or `$TM_FILENAME` fails to parse and silently falls back to plain text. This wires up the LSP snippet variables so they actually resolve on insertion.

Most variables resolve per cursor - current line, word and cursor index each reflect their own selection. `TM_SELECTED_TEXT` is per cursor when you run the insert-snippet action; for completion-triggered snippets every cursor shares the primary selection's text.
`${VAR:default}` falls back to the default when a variable is empty.

The fiddly part is completions: typing a snippet's trigger replaces the selection before the snippet is ever inserted, so the "selected text" is already gone. To make wrapping-via-completion work, the text you type the trigger over is remembered and used as `TM_SELECTED_TEXT`.

A few edges are still rough:

- Variable transforms (`${TM_FILENAME/.*/.../}`) are parsed but not applied; the variable resolves as if the transform weren't there.
- Month and day names are English only; they aren't localized yet.
- `TM_SELECTED_TEXT` from a completion only works when the trigger replaces the whole selection, not a partial-word selection.
- On multi-cursor completions, every cursor shares the primary cursor's selected text.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #13301

Release Notes:

- Added support for snippet variables such as `TM_SELECTED_TEXT`, `TM_FILENAME`, `CURRENT_YEAR`, `CLIPBOARD`, and the other LSP snippet variables.
