### PR TITLE
editor: Add support for pasting images in Markdown

### DIFF
--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -286,11 +286,7 @@ impl Editor {
                     let buffer = self.buffer().read(cx).as_singleton()?;
                     let file = buffer.read(cx).file()?;
                     let worktree_id = file.worktree_id(cx);
-                    let dir_rel_path = file
-                        .path()
-                        .parent()
-                        .map(|p| p.into_arc())
-                        .unwrap_or_else(RelPath::empty_arc);
+                    let dir_rel_path = file.path().parent()?.into_arc();
                     let worktree = self
                         .project
                         .as_ref()?

--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -285,7 +285,31 @@ impl Editor {
                     match save_clipboard_image(&image, &working_dir) {
                         Ok(filename) => {
                             let markdown_text = format!("![]({filename})");
-                            return self.do_paste(&markdown_text, None, false, window, cx);
+                            // "![" is 2 bytes; we want the cursor between [ and ]
+                            let move_back_by = markdown_text.len() - 2;
+                            self.do_paste(&markdown_text, None, false, window, cx);
+                            let display_map = self.display_snapshot(cx);
+                            let new_selections = self
+                                .selections
+                                .all::<MultiBufferOffset>(&display_map)
+                                .into_iter()
+                                .map(|sel| {
+                                    let pos = MultiBufferOffset(
+                                        sel.head().0.saturating_sub(move_back_by),
+                                    );
+                                    Selection {
+                                        id: sel.id,
+                                        start: pos,
+                                        end: pos,
+                                        reversed: false,
+                                        goal: SelectionGoal::None,
+                                    }
+                                })
+                                .collect::<Vec<_>>();
+                            self.change_selections(Default::default(), window, cx, |s| {
+                                s.select(new_selections);
+                            });
+                            return;
                         }
                         Err(err) => {
                             log::error!("Failed to save clipboard image: {err}");
@@ -709,17 +733,12 @@ fn save_clipboard_image(image: &gpui::Image, directory: &Path) -> anyhow::Result
         gpui::ImageFormat::Pnm => "pnm",
     };
 
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis();
-
-    let mut filename = format!("pasted_{timestamp}.{extension}");
+    let mut filename = format!("image.{extension}");
     let mut path = directory.join(&filename);
 
     let mut counter = 1u32;
     while path.exists() {
-        filename = format!("pasted_{timestamp}_{counter}.{extension}");
+        filename = format!("image_{counter}.{extension}");
         path = directory.join(&filename);
         counter += 1;
     }

--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -263,6 +263,38 @@ impl Editor {
         if self.read_only(cx) {
             return;
         }
+
+        let clipboard_image = item.entries().iter().find_map(|entry| match entry {
+            ClipboardEntry::Image(image) if !image.bytes.is_empty() => Some(image.clone()),
+            _ => None,
+        });
+
+        if let Some(image) = clipboard_image {
+            let is_markdown = {
+                let display_map = self.display_snapshot(cx);
+                let selections = self.selections.all::<MultiBufferOffset>(&display_map);
+                selections
+                    .first()
+                    .and_then(|s| display_map.buffer_snapshot().language_at(s.head()))
+                    .map(|lang| lang.name() == "Markdown")
+                    .unwrap_or(false)
+            };
+
+            if is_markdown {
+                if let Some(working_dir) = self.working_directory(cx) {
+                    match save_clipboard_image(&image, &working_dir) {
+                        Ok(filename) => {
+                            let markdown_text = format!("![]({filename})");
+                            return self.do_paste(&markdown_text, None, false, window, cx);
+                        }
+                        Err(err) => {
+                            log::error!("Failed to save clipboard image: {err}");
+                        }
+                    }
+                }
+            }
+        }
+
         let clipboard_string = item.entries().iter().find_map(|entry| match entry {
             ClipboardEntry::String(s) => Some(s),
             _ => None,
@@ -661,4 +693,37 @@ fn is_standalone_url(text: &str) -> bool {
         .links(text)
         .next()
         .is_some_and(|link| link.start() == 0 && link.end() == text.len())
+}
+
+
+fn save_clipboard_image(image: &gpui::Image, directory: &Path) -> anyhow::Result<String> {
+    let extension = match image.format {
+        gpui::ImageFormat::Png => "png",
+        gpui::ImageFormat::Jpeg => "jpg",
+        gpui::ImageFormat::Webp => "webp",
+        gpui::ImageFormat::Gif => "gif",
+        gpui::ImageFormat::Svg => "svg",
+        gpui::ImageFormat::Bmp => "bmp",
+        gpui::ImageFormat::Tiff => "tiff",
+        gpui::ImageFormat::Ico => "ico",
+        gpui::ImageFormat::Pnm => "pnm",
+    };
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+
+    let mut filename = format!("pasted_{timestamp}.{extension}");
+    let mut path = directory.join(&filename);
+
+    let mut counter = 1u32;
+    while path.exists() {
+        filename = format!("pasted_{timestamp}_{counter}.{extension}");
+        path = directory.join(&filename);
+        counter += 1;
+    }
+
+    std::fs::write(&path, &image.bytes)?;
+    Ok(filename)
 }

--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -1,4 +1,5 @@
 use super::*;
+use util::rel_path::RelPath;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ClipboardSelection {
@@ -281,40 +282,45 @@ impl Editor {
             };
 
             if is_markdown {
-                if let Some(working_dir) = self.working_directory(cx) {
-                    match save_clipboard_image(&image, &working_dir) {
-                        Ok(filename) => {
-                            let markdown_text = format!("![]({filename})");
-                            // "![" is 2 bytes; we want the cursor between [ and ]
-                            let move_back_by = markdown_text.len() - 2;
-                            self.do_paste(&markdown_text, None, false, window, cx);
-                            let display_map = self.display_snapshot(cx);
-                            let new_selections = self
-                                .selections
-                                .all::<MultiBufferOffset>(&display_map)
-                                .into_iter()
-                                .map(|sel| {
-                                    let pos = MultiBufferOffset(
-                                        sel.head().0.saturating_sub(move_back_by),
-                                    );
-                                    Selection {
-                                        id: sel.id,
-                                        start: pos,
-                                        end: pos,
-                                        reversed: false,
-                                        goal: SelectionGoal::None,
-                                    }
-                                })
-                                .collect::<Vec<_>>();
-                            self.change_selections(Default::default(), window, cx, |s| {
-                                s.select(new_selections);
-                            });
-                            return;
-                        }
-                        Err(err) => {
-                            log::error!("Failed to save clipboard image: {err}");
-                        }
-                    }
+                let handled = maybe!({
+                    let buffer = self.buffer().read(cx).as_singleton()?;
+                    let file = buffer.read(cx).file()?;
+                    let worktree_id = file.worktree_id(cx);
+                    let dir_rel_path = file
+                        .path()
+                        .parent()
+                        .map(|p| p.into_arc())
+                        .unwrap_or_else(RelPath::empty_arc);
+                    let worktree = self
+                        .project
+                        .as_ref()?
+                        .read(cx)
+                        .worktree_for_id(worktree_id, cx)?;
+
+                    let extension = image.format.extension();
+                    let snapshot = worktree.read(cx).snapshot();
+                    let (filename, file_path) =
+                        unused_image_path(&dir_rel_path, extension, |path| {
+                            snapshot.entry_for_path(path).is_some()
+                        })?;
+
+                    let create_task = worktree.update(cx, |worktree, cx| {
+                        worktree.create_entry(file_path, false, Some(image.bytes.clone()), cx)
+                    });
+
+                    cx.spawn_in(window, async move |editor, cx| {
+                        create_task.await?;
+                        editor.update_in(cx, |editor, window, cx| {
+                            editor.insert_image_snippet(&filename, window, cx)
+                        })
+                    })
+                    .detach_and_log_err(cx);
+
+                    Some(())
+                });
+                if handled.is_some() {
+                    // stop clipboard handling when the snippet is inserted
+                    return;
                 }
             }
         }
@@ -333,6 +339,26 @@ impl Editor {
             ),
             _ => self.do_paste(&item.text().unwrap_or_default(), None, true, window, cx),
         }
+    }
+
+    fn insert_image_snippet(
+        &mut self,
+        filename: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(snippet) = Snippet::parse(&format!("![$0]({filename})")).log_err() else {
+            return;
+        };
+        let display_map = self.display_snapshot(cx);
+        let insertion_ranges: Vec<Range<MultiBufferOffset>> = self
+            .selections
+            .all::<MultiBufferOffset>(&display_map)
+            .into_iter()
+            .map(|selection| selection.start..selection.end)
+            .collect();
+        self.insert_snippet(&insertion_ranges, snippet, window, cx)
+            .log_err();
     }
 
     pub(super) fn cut_common(
@@ -707,6 +733,26 @@ fn edit_for_markdown_paste<'a>(
     (range, new_text)
 }
 
+/// Returns a filename of the form `image.{extension}` (or `image_{N}.{extension}`
+/// if taken) that does not collide with an existing entry in `dir_rel_path`,
+/// along with the full path of the candidate file.
+fn unused_image_path(
+    dir_rel_path: &RelPath,
+    extension: &str,
+    exists: impl Fn(&RelPath) -> bool,
+) -> Option<(String, Arc<RelPath>)> {
+    let mut filename = format!("image.{extension}");
+    let mut counter = 1u32;
+    loop {
+        let candidate = dir_rel_path.join(RelPath::unix(&filename).ok()?);
+        if !exists(&candidate) {
+            return Some((filename, candidate));
+        }
+        filename = format!("image_{counter}.{extension}");
+        counter += 1;
+    }
+}
+
 /// Whether `text` consists solely of a single URL, as opposed to merely
 /// starting with a scheme-like prefix (e.g. a commit message like
 /// `editor: Fix ...`, which `url::Url::parse` would accept).
@@ -717,32 +763,4 @@ fn is_standalone_url(text: &str) -> bool {
         .links(text)
         .next()
         .is_some_and(|link| link.start() == 0 && link.end() == text.len())
-}
-
-
-fn save_clipboard_image(image: &gpui::Image, directory: &Path) -> anyhow::Result<String> {
-    let extension = match image.format {
-        gpui::ImageFormat::Png => "png",
-        gpui::ImageFormat::Jpeg => "jpg",
-        gpui::ImageFormat::Webp => "webp",
-        gpui::ImageFormat::Gif => "gif",
-        gpui::ImageFormat::Svg => "svg",
-        gpui::ImageFormat::Bmp => "bmp",
-        gpui::ImageFormat::Tiff => "tiff",
-        gpui::ImageFormat::Ico => "ico",
-        gpui::ImageFormat::Pnm => "pnm",
-    };
-
-    let mut filename = format!("image.{extension}");
-    let mut path = directory.join(&filename);
-
-    let mut counter = 1u32;
-    while path.exists() {
-        filename = format!("image_{counter}.{extension}");
-        path = directory.join(&filename);
-        counter += 1;
-    }
-
-    std::fs::write(&path, &image.bytes)?;
-    Ok(filename)
 }

--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -266,7 +266,7 @@ impl Editor {
         }
 
         let clipboard_image = item.entries().iter().find_map(|entry| match entry {
-            ClipboardEntry::Image(image) if !image.bytes.is_empty() => Some(image.clone()),
+            ClipboardEntry::Image(image) if !image.bytes.is_empty() => Some(image),
             _ => None,
         });
 

--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -343,7 +343,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let Some(snippet) = Snippet::parse(&format!("![$0]({filename})")).log_err() else {
+        let Some(snippet) = Snippet::parse(&format!("![$1]({filename})$0")).log_err() else {
             return;
         };
         let display_map = self.display_snapshot(cx);

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -35630,22 +35630,13 @@ async fn test_paste_image_in_markdown_saves_file_and_inserts_markdown(cx: &mut T
         None,
     ));
 
-    // Use a real temp directory so that std::fs::write in save_clipboard_image can write
-    // the image to disk. FakeFs is used for the worktree (avoiding real inotify threads)
-    // but seeded with the real temp path so that working_directory() returns a path that
-    // actually exists on the filesystem.
-    let temp_tree = util::test::TempTree::new(serde_json::json!({
-        "test.md": "",
-    }));
-    let root_path = temp_tree.path().to_path_buf();
-
     let fs = FakeFs::new(cx.executor());
-    fs.insert_tree(&root_path, serde_json::json!({"test.md": ""}))
+    fs.insert_tree("/test", serde_json::json!({"test.md": ""}))
         .await;
-    let project = Project::test(fs, [root_path.as_path()], cx).await;
+    let project = Project::test(fs.clone(), [std::path::Path::new("/test")], cx).await;
     let buffer = project
         .update(cx, |project, cx| {
-            project.open_local_buffer(root_path.join("test.md"), cx)
+            project.open_local_buffer("/test/test.md", cx)
         })
         .await
         .unwrap();
@@ -35674,6 +35665,7 @@ async fn test_paste_image_in_markdown_saves_file_and_inserts_markdown(cx: &mut T
         cx.write_to_clipboard(ClipboardItem::new_image(&image));
         editor.paste(&Paste, window, cx);
     });
+    cx.run_until_parked();
 
     let buffer_text = cx.buffer_text();
     assert!(
@@ -35687,13 +35679,8 @@ async fn test_paste_image_in_markdown_saves_file_and_inserts_markdown(cx: &mut T
     cx.assert_editor_state(&expected_state);
 
     let filename = &buffer_text["![](".len()..buffer_text.len() - 1];
-    let image_path = root_path.join(filename);
-    assert!(
-        image_path.exists(),
-        "expected image file to be saved at {image_path:?}"
-    );
     assert_eq!(
-        std::fs::read(&image_path).unwrap(),
+        fs.read_file_sync(format!("/test/{filename}")).unwrap(),
         png_bytes,
         "image file contents should match clipboard bytes"
     );
@@ -35711,18 +35698,13 @@ async fn test_paste_multiple_images_in_markdown_increments_filename(cx: &mut Tes
         None,
     ));
 
-    let temp_tree = util::test::TempTree::new(serde_json::json!({
-        "test.md": "",
-    }));
-    let root_path = temp_tree.path().to_path_buf();
-
     let fs = FakeFs::new(cx.executor());
-    fs.insert_tree(&root_path, serde_json::json!({"test.md": ""}))
+    fs.insert_tree("/test", serde_json::json!({"test.md": ""}))
         .await;
-    let project = Project::test(fs, [root_path.as_path()], cx).await;
+    let project = Project::test(fs.clone(), [std::path::Path::new("/test")], cx).await;
     let buffer = project
         .update(cx, |project, cx| {
-            project.open_local_buffer(root_path.join("test.md"), cx)
+            project.open_local_buffer("/test/test.md", cx)
         })
         .await
         .unwrap();
@@ -35756,48 +35738,39 @@ async fn test_paste_multiple_images_in_markdown_increments_filename(cx: &mut Tes
         cx.write_to_clipboard(ClipboardItem::new_image(&image_1));
         editor.paste(&Paste, window, cx);
     });
+    cx.run_until_parked();
     let text_after_first = cx.buffer_text();
     assert_eq!(
         text_after_first, "![](image.png)",
         "first paste should produce image.png"
     );
-    assert!(root_path.join("image.png").exists());
-    assert_eq!(
-        std::fs::read(root_path.join("image.png")).unwrap(),
-        png_bytes_1
-    );
+    assert_eq!(fs.read_file_sync("/test/image.png").unwrap(), png_bytes_1);
 
     // Paste second image at end — should produce image_1.png
     cx.update_editor(|editor, window, cx| {
         cx.write_to_clipboard(ClipboardItem::new_image(&image_2));
         editor.paste(&Paste, window, cx);
     });
+    cx.run_until_parked();
     let text_after_second = cx.buffer_text();
     assert!(
         text_after_second.contains("![](image_1.png)"),
         "second paste should produce image_1.png, got: {text_after_second:?}"
     );
-    assert!(root_path.join("image_1.png").exists());
-    assert_eq!(
-        std::fs::read(root_path.join("image_1.png")).unwrap(),
-        png_bytes_2
-    );
+    assert_eq!(fs.read_file_sync("/test/image_1.png").unwrap(), png_bytes_2);
 
     // Paste third image — should produce image_2.png
     cx.update_editor(|editor, window, cx| {
         cx.write_to_clipboard(ClipboardItem::new_image(&image_3));
         editor.paste(&Paste, window, cx);
     });
+    cx.run_until_parked();
     let text_after_third = cx.buffer_text();
     assert!(
         text_after_third.contains("![](image_2.png)"),
         "third paste should produce image_2.png, got: {text_after_third:?}"
     );
-    assert!(root_path.join("image_2.png").exists());
-    assert_eq!(
-        std::fs::read(root_path.join("image_2.png")).unwrap(),
-        png_bytes_3
-    );
+    assert_eq!(fs.read_file_sync("/test/image_2.png").unwrap(), png_bytes_3);
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -35832,6 +35832,60 @@ async fn test_paste_image_in_markdown_without_open_file_falls_through(cx: &mut T
 }
 
 #[gpui::test]
+async fn test_paste_image_in_markdown_single_file_worktree_falls_through(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let markdown_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "Markdown".into(),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root", serde_json::json!({"test.md": ""}))
+        .await;
+    let project = Project::test(fs.clone(), [std::path::Path::new("/root/test.md")], cx).await;
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer("/root/test.md", cx)
+        })
+        .await
+        .unwrap();
+    buffer.update(cx, |buffer, cx| {
+        buffer.set_language(Some(markdown_language), cx);
+    });
+
+    let editor_window = cx.add_window(|window, cx| {
+        let editor = build_editor_with_project(
+            project,
+            MultiBuffer::build_from_buffer(buffer, cx),
+            window,
+            cx,
+        );
+        window.focus(&editor.focus_handle(cx), cx);
+        editor
+    });
+    cx.run_until_parked();
+    let mut cx = EditorTestContext::for_editor(editor_window, cx).await;
+
+    cx.set_state("ˇ");
+    let image = gpui::Image::from_bytes(gpui::ImageFormat::Png, vec![1, 2, 3]);
+    cx.update_editor(|editor, window, cx| {
+        cx.write_to_clipboard(ClipboardItem::new_image(&image));
+        editor.paste(&Paste, window, cx);
+    });
+    cx.run_until_parked();
+
+    cx.assert_editor_state("ˇ");
+    assert!(
+        fs.read_file_sync("/root/image.png").is_err(),
+        "no image file should be created for a single-file worktree"
+    );
+}
+
+#[gpui::test]
 async fn test_race_in_multibuffer_save(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -35619,6 +35619,146 @@ async fn test_paste_url_from_other_app_creates_markdown_link_selectively_in_mult
 }
 
 #[gpui::test]
+async fn test_paste_image_in_markdown_saves_file_and_inserts_markdown(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let markdown_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "Markdown".into(),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    // Use a real temp directory so that std::fs::write in save_clipboard_image can write
+    // the image to disk. FakeFs is used for the worktree (avoiding real inotify threads)
+    // but seeded with the real temp path so that working_directory() returns a path that
+    // actually exists on the filesystem.
+    let temp_tree = util::test::TempTree::new(serde_json::json!({
+        "test.md": "",
+    }));
+    let root_path = temp_tree.path().to_path_buf();
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(&root_path, serde_json::json!({"test.md": ""}))
+        .await;
+    let project = Project::test(fs, [root_path.as_path()], cx).await;
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(root_path.join("test.md"), cx)
+        })
+        .await
+        .unwrap();
+    buffer.update(cx, |buffer, cx| {
+        buffer.set_language(Some(markdown_language), cx);
+    });
+
+    let editor_window = cx.add_window(|window, cx| {
+        let editor = build_editor_with_project(
+            project,
+            MultiBuffer::build_from_buffer(buffer, cx),
+            window,
+            cx,
+        );
+        window.focus(&editor.focus_handle(cx), cx);
+        editor
+    });
+    cx.run_until_parked();
+    let mut cx = EditorTestContext::for_editor(editor_window, cx).await;
+
+    let png_bytes: Vec<u8> = vec![1, 2, 3, 4, 5];
+    let image = gpui::Image::from_bytes(gpui::ImageFormat::Png, png_bytes.clone());
+
+    cx.set_state("ˇ");
+    cx.update_editor(|editor, window, cx| {
+        cx.write_to_clipboard(ClipboardItem::new_image(&image));
+        editor.paste(&Paste, window, cx);
+    });
+
+    let buffer_text = cx.buffer_text();
+    assert!(
+        buffer_text.starts_with("![](pasted_") && buffer_text.ends_with(".png)"),
+        "expected markdown image syntax, got: {buffer_text:?}"
+    );
+
+    let filename = &buffer_text["![](".len()..buffer_text.len() - 1];
+    let image_path = root_path.join(filename);
+    assert!(
+        image_path.exists(),
+        "expected image file to be saved at {image_path:?}"
+    );
+    assert_eq!(
+        std::fs::read(&image_path).unwrap(),
+        png_bytes,
+        "image file contents should match clipboard bytes"
+    );
+}
+
+#[gpui::test]
+async fn test_paste_image_in_non_markdown_does_not_insert_markdown(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let rust_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "Rust".into(),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(rust_language), cx));
+    cx.set_state("ˇ");
+
+    let image = gpui::Image::from_bytes(gpui::ImageFormat::Png, vec![1, 2, 3]);
+    cx.update_editor(|editor, window, cx| {
+        cx.write_to_clipboard(ClipboardItem::new_image(&image));
+        editor.paste(&Paste, window, cx);
+    });
+
+    cx.assert_editor_state("ˇ");
+}
+
+#[gpui::test]
+async fn test_paste_image_in_markdown_without_open_file_falls_through(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let markdown_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "Markdown".into(),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    // Build an editor whose buffer has no associated file path on disk.
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        let buffer = cx.new(|cx| language::Buffer::local("", cx));
+        buffer.update(cx, |buffer, cx| {
+            buffer.set_language(Some(markdown_language), cx);
+        });
+        let multibuffer = MultiBuffer::build_from_buffer(buffer, cx);
+        build_editor(multibuffer, window, cx)
+    });
+    let mut cx = EditorTestContext::for_editor_in(editor, cx).await;
+
+    cx.set_state("ˇ");
+    let image = gpui::Image::from_bytes(gpui::ImageFormat::Png, vec![1, 2, 3]);
+    cx.update_editor(|editor, window, cx| {
+        cx.write_to_clipboard(ClipboardItem::new_image(&image));
+        editor.paste(&Paste, window, cx);
+    });
+
+    cx.assert_editor_state("ˇ");
+}
+
+#[gpui::test]
 async fn test_race_in_multibuffer_save(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -35619,9 +35619,7 @@ async fn test_paste_url_from_other_app_creates_markdown_link_selectively_in_mult
 }
 
 #[gpui::test]
-async fn test_paste_image_in_markdown_saves_file_and_inserts_markdown(
-    cx: &mut TestAppContext,
-) {
+async fn test_paste_image_in_markdown_saves_file_and_inserts_markdown(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     let markdown_language = Arc::new(Language::new(
@@ -35679,9 +35677,14 @@ async fn test_paste_image_in_markdown_saves_file_and_inserts_markdown(
 
     let buffer_text = cx.buffer_text();
     assert!(
-        buffer_text.starts_with("![](pasted_") && buffer_text.ends_with(".png)"),
+        buffer_text.starts_with("![](image") && buffer_text.ends_with(".png)"),
         "expected markdown image syntax, got: {buffer_text:?}"
     );
+
+    // Cursor should land inside [] so the user can type alt text immediately.
+    let filename_in_parens = &buffer_text["![](".len()..buffer_text.len() - 1];
+    let expected_state = format!("![ˇ]({filename_in_parens})");
+    cx.assert_editor_state(&expected_state);
 
     let filename = &buffer_text["![](".len()..buffer_text.len() - 1];
     let image_path = root_path.join(filename);
@@ -35697,9 +35700,108 @@ async fn test_paste_image_in_markdown_saves_file_and_inserts_markdown(
 }
 
 #[gpui::test]
-async fn test_paste_image_in_non_markdown_does_not_insert_markdown(
-    cx: &mut TestAppContext,
-) {
+async fn test_paste_multiple_images_in_markdown_increments_filename(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let markdown_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "Markdown".into(),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    let temp_tree = util::test::TempTree::new(serde_json::json!({
+        "test.md": "",
+    }));
+    let root_path = temp_tree.path().to_path_buf();
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(&root_path, serde_json::json!({"test.md": ""}))
+        .await;
+    let project = Project::test(fs, [root_path.as_path()], cx).await;
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(root_path.join("test.md"), cx)
+        })
+        .await
+        .unwrap();
+    buffer.update(cx, |buffer, cx| {
+        buffer.set_language(Some(markdown_language), cx);
+    });
+
+    let editor_window = cx.add_window(|window, cx| {
+        let editor = build_editor_with_project(
+            project,
+            MultiBuffer::build_from_buffer(buffer, cx),
+            window,
+            cx,
+        );
+        window.focus(&editor.focus_handle(cx), cx);
+        editor
+    });
+    cx.run_until_parked();
+    let mut cx = EditorTestContext::for_editor(editor_window, cx).await;
+
+    let png_bytes_1: Vec<u8> = vec![1, 2, 3, 4, 5];
+    let png_bytes_2: Vec<u8> = vec![6, 7, 8, 9, 10];
+    let png_bytes_3: Vec<u8> = vec![11, 12, 13, 14, 15];
+    let image_1 = gpui::Image::from_bytes(gpui::ImageFormat::Png, png_bytes_1.clone());
+    let image_2 = gpui::Image::from_bytes(gpui::ImageFormat::Png, png_bytes_2.clone());
+    let image_3 = gpui::Image::from_bytes(gpui::ImageFormat::Png, png_bytes_3.clone());
+
+    // Paste first image — should produce image.png
+    cx.set_state("ˇ");
+    cx.update_editor(|editor, window, cx| {
+        cx.write_to_clipboard(ClipboardItem::new_image(&image_1));
+        editor.paste(&Paste, window, cx);
+    });
+    let text_after_first = cx.buffer_text();
+    assert_eq!(
+        text_after_first, "![](image.png)",
+        "first paste should produce image.png"
+    );
+    assert!(root_path.join("image.png").exists());
+    assert_eq!(
+        std::fs::read(root_path.join("image.png")).unwrap(),
+        png_bytes_1
+    );
+
+    // Paste second image at end — should produce image_1.png
+    cx.update_editor(|editor, window, cx| {
+        cx.write_to_clipboard(ClipboardItem::new_image(&image_2));
+        editor.paste(&Paste, window, cx);
+    });
+    let text_after_second = cx.buffer_text();
+    assert!(
+        text_after_second.contains("![](image_1.png)"),
+        "second paste should produce image_1.png, got: {text_after_second:?}"
+    );
+    assert!(root_path.join("image_1.png").exists());
+    assert_eq!(
+        std::fs::read(root_path.join("image_1.png")).unwrap(),
+        png_bytes_2
+    );
+
+    // Paste third image — should produce image_2.png
+    cx.update_editor(|editor, window, cx| {
+        cx.write_to_clipboard(ClipboardItem::new_image(&image_3));
+        editor.paste(&Paste, window, cx);
+    });
+    let text_after_third = cx.buffer_text();
+    assert!(
+        text_after_third.contains("![](image_2.png)"),
+        "third paste should produce image_2.png, got: {text_after_third:?}"
+    );
+    assert!(root_path.join("image_2.png").exists());
+    assert_eq!(
+        std::fs::read(root_path.join("image_2.png")).unwrap(),
+        png_bytes_3
+    );
+}
+
+#[gpui::test]
+async fn test_paste_image_in_non_markdown_does_not_insert_markdown(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     let rust_language = Arc::new(Language::new(
@@ -35724,9 +35826,7 @@ async fn test_paste_image_in_non_markdown_does_not_insert_markdown(
 }
 
 #[gpui::test]
-async fn test_paste_image_in_markdown_without_open_file_falls_through(
-    cx: &mut TestAppContext,
-) {
+async fn test_paste_image_in_markdown_without_open_file_falls_through(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     let markdown_language = Arc::new(Language::new(

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -2116,6 +2116,21 @@ impl ImageFormat {
         }
     }
 
+    /// Returns the file extension for this image format (without leading dot).
+    pub const fn extension(self) -> &'static str {
+        match self {
+            ImageFormat::Png => "png",
+            ImageFormat::Jpeg => "jpg",
+            ImageFormat::Webp => "webp",
+            ImageFormat::Gif => "gif",
+            ImageFormat::Svg => "svg",
+            ImageFormat::Bmp => "bmp",
+            ImageFormat::Tiff => "tiff",
+            ImageFormat::Ico => "ico",
+            ImageFormat::Pnm => "pnm",
+        }
+    }
+
     /// Returns the ImageFormat for the given mime type, including known aliases.
     pub fn from_mime_type(mime_type: &str) -> Option<Self> {
         use strum::IntoEnumIterator;


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #18112

Release Notes:

- Added support for pasting images from clipboard into Markdown files