### PR TITLE
agent: Persist tracked buffer state across restarts

### DIFF
--- a/crates/action_log/src/action_log.rs
+++ b/crates/action_log/src/action_log.rs
@@ -8,7 +8,7 @@ use gpui::{
     App, AppContext, AsyncApp, Context, Entity, SharedString, Subscription, Task, WeakEntity,
 };
 use language::{Anchor, Buffer, BufferEvent, Point, ToOffset, ToPoint};
-use project::{Project, ProjectItem, lsp_store::OpenLspBufferHandle};
+use project::{Project, ProjectItem, ProjectPath, lsp_store::OpenLspBufferHandle};
 use std::{
     cmp,
     ops::Range,
@@ -152,22 +152,10 @@ impl ActionLog {
             .tracked_buffers
             .entry(buffer.clone())
             .or_insert_with(|| {
-                let open_lsp_handle = self.project.update(cx, |project, cx| {
-                    project.register_buffer_with_language_servers(&buffer, cx)
-                });
-
-                let text_snapshot = buffer.read(cx).text_snapshot();
-                let language = buffer.read(cx).language().cloned();
-                let language_registry = buffer.read(cx).language_registry();
-                let diff = cx.new(|cx| {
-                    let mut diff = BufferDiff::new(&text_snapshot, cx);
-                    diff.language_changed(language, language_registry, cx);
-                    diff
-                });
-                let (diff_update_tx, diff_update_rx) = mpsc::unbounded();
                 let diff_base;
                 let unreviewed_edits;
                 if is_created {
+                    let text_snapshot = buffer.read(cx).text_snapshot();
                     diff_base = Rope::default();
                     unreviewed_edits = Patch::new(vec![Edit {
                         old: 0..1,
@@ -177,26 +165,14 @@ impl ActionLog {
                     diff_base = buffer.read(cx).as_rope().clone();
                     unreviewed_edits = Patch::default();
                 }
-                TrackedBuffer {
-                    buffer: buffer.clone(),
+                Self::make_tracked_buffer(
+                    &self.project,
+                    buffer.clone(),
                     diff_base,
                     unreviewed_edits,
-                    snapshot: text_snapshot,
                     status,
-                    version: buffer.read(cx).version(),
-                    diff,
-                    diff_update: diff_update_tx,
-                    _open_lsp_handle: open_lsp_handle,
-                    _maintain_diff: cx.spawn({
-                        let buffer = buffer.clone();
-                        async move |this, cx| {
-                            Self::maintain_diff(this, buffer, diff_update_rx, cx)
-                                .await
-                                .ok();
-                        }
-                    }),
-                    _subscription: cx.subscribe(&buffer, Self::handle_buffer_event),
-                }
+                    cx,
+                )
             });
         tracked_buffer.version = buffer.read(cx).version();
         tracked_buffer
@@ -1056,6 +1032,94 @@ impl ActionLog {
             })
             .map(|(buffer, _)| buffer)
     }
+
+    pub fn tracked_buffer_snapshots(&self, cx: &App) -> Vec<TrackedBufferSnapshot> {
+        self.tracked_buffers
+            .values()
+            .filter_map(|tracked| {
+                let buffer = tracked.buffer.read(cx);
+                let file = buffer.file()?;
+                let project_path = ProjectPath::from_file(file.as_ref(), cx);
+                Some(TrackedBufferSnapshot {
+                    project_path,
+                    diff_base: tracked.diff_base.clone(),
+                    status: tracked.status.clone(),
+                })
+            })
+            .collect()
+    }
+
+    pub fn restore_tracked_buffer(
+        &mut self,
+        buffer: Entity<Buffer>,
+        diff_base: Rope,
+        status: TrackedBufferStatus,
+        cx: &mut Context<Self>,
+    ) {
+        if self.tracked_buffers.contains_key(&buffer) {
+            return;
+        }
+
+        let unreviewed_edits = Patch::default();
+        let tracked_buffer = Self::make_tracked_buffer(
+            &self.project,
+            buffer.clone(),
+            diff_base,
+            unreviewed_edits,
+            status,
+            cx,
+        );
+
+        // Trigger diff update to compute unreviewed_edits
+        tracked_buffer.schedule_diff_update(ChangeAuthor::Agent, cx);
+
+        self.tracked_buffers.insert(buffer, tracked_buffer);
+        cx.notify();
+    }
+
+    fn make_tracked_buffer(
+        project: &Entity<Project>,
+        buffer: Entity<Buffer>,
+        diff_base: Rope,
+        unreviewed_edits: Patch<u32>,
+        status: TrackedBufferStatus,
+        cx: &mut Context<Self>,
+    ) -> TrackedBuffer {
+        let open_lsp_handle = project.update(cx, |project, cx| {
+            project.register_buffer_with_language_servers(&buffer, cx)
+        });
+
+        let text_snapshot = buffer.read(cx).text_snapshot();
+        let language = buffer.read(cx).language().cloned();
+        let language_registry = buffer.read(cx).language_registry();
+        let diff = cx.new(|cx| {
+            let mut diff = BufferDiff::new(&text_snapshot, cx);
+            diff.language_changed(language, language_registry, cx);
+            diff
+        });
+        let (diff_update_tx, diff_update_rx) = mpsc::unbounded();
+
+        TrackedBuffer {
+            buffer: buffer.clone(),
+            diff_base,
+            unreviewed_edits,
+            snapshot: text_snapshot,
+            status,
+            version: buffer.read(cx).version(),
+            diff,
+            diff_update: diff_update_tx,
+            _open_lsp_handle: open_lsp_handle,
+            _maintain_diff: cx.spawn({
+                let buffer = buffer.clone();
+                async move |this, cx| {
+                    Self::maintain_diff(this, buffer, diff_update_rx, cx)
+                        .await
+                        .ok();
+                }
+            }),
+            _subscription: cx.subscribe(&buffer, Self::handle_buffer_event),
+        }
+    }
 }
 
 #[derive(Default, Debug, Clone, Copy)]
@@ -1274,11 +1338,17 @@ enum ChangeAuthor {
     Agent,
 }
 
-#[derive(Debug)]
-enum TrackedBufferStatus {
+#[derive(Clone, Debug)]
+pub enum TrackedBufferStatus {
     Created { existing_file_content: Option<Rope> },
     Modified,
     Deleted,
+}
+
+pub struct TrackedBufferSnapshot {
+    pub project_path: ProjectPath,
+    pub diff_base: Rope,
+    pub status: TrackedBufferStatus,
 }
 
 pub struct TrackedBuffer {
@@ -3483,6 +3553,65 @@ mod tests {
             parent_log.read_with(cx, |log, _| log.file_read_time(&abs_path).is_none()),
             "parent should NOT get file_read_time from child's buffer_created"
         );
+    }
+
+    #[gpui::test]
+    async fn test_restore_tracked_buffer(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                "file.txt": "a\nb\nc",
+            }),
+        )
+        .await;
+        cx.run_until_parked();
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+
+        let file_path = project
+            .read_with(cx, |project, cx| {
+                project.find_project_path(path!("/project/file.txt"), cx)
+            })
+            .unwrap();
+        let buffer = project
+            .update(cx, |project, cx| project.open_buffer(file_path, cx))
+            .await
+            .unwrap();
+
+        let diff_base = Rope::from("a\nchanged_b\nc");
+        let status = TrackedBufferStatus::Modified;
+
+        cx.update(|cx| {
+            action_log.update(cx, |log, cx| {
+                log.restore_tracked_buffer(buffer.clone(), diff_base.clone(), status.clone(), cx);
+            });
+        });
+        cx.run_until_parked();
+
+        // 1. Verify unreviewed hunks are correctly computed from restored state
+        assert_eq!(
+            unreviewed_hunks(&action_log, cx),
+            vec![(
+                buffer,
+                vec![HunkStatus {
+                    range: Point::new(1, 0)..Point::new(2, 0),
+                    diff_status: DiffHunkStatusKind::Modified,
+                    old_text: "changed_b\n".into()
+                }]
+            )]
+        );
+
+        // 2. Verify tracked_buffer_snapshots returns correct state
+        cx.read(|cx| {
+            let snapshots = action_log.read(cx).tracked_buffer_snapshots(cx);
+            assert_eq!(snapshots.len(), 1);
+            assert_eq!(snapshots[0].diff_base.to_string(), diff_base.to_string());
+            assert!(matches!(snapshots[0].status, TrackedBufferStatus::Modified));
+        });
     }
 
     #[derive(Debug, PartialEq)]

--- a/crates/action_log/src/action_log.rs
+++ b/crates/action_log/src/action_log.rs
@@ -8,7 +8,7 @@ use gpui::{
     App, AppContext, AsyncApp, Context, Entity, SharedString, Subscription, Task, WeakEntity,
 };
 use language::{Anchor, Buffer, BufferEvent, Point, ToOffset, ToPoint};
-use project::{Project, ProjectItem, lsp_store::OpenLspBufferHandle};
+use project::{Project, ProjectItem, ProjectPath, lsp_store::OpenLspBufferHandle};
 use std::{
     cmp,
     ops::Range,
@@ -152,26 +152,10 @@ impl ActionLog {
             .tracked_buffers
             .entry(buffer.clone())
             .or_insert_with(|| {
-                let open_lsp_handle = self.project.update(cx, |project, cx| {
-                    project.register_buffer_with_language_servers(&buffer, cx)
-                });
-
-                let text_snapshot = buffer.read(cx).text_snapshot();
-                let language = buffer.read(cx).language().cloned();
-                let language_registry = buffer.read(cx).language_registry();
-                let diff = cx.new(|cx| {
-                    BufferDiff::new(
-                        &text_snapshot,
-                        language,
-                        language_registry,
-                        buffer_diff::DiffBaseKind::Custom,
-                        cx,
-                    )
-                });
-                let (diff_update_tx, diff_update_rx) = mpsc::unbounded();
                 let diff_base;
                 let unreviewed_edits;
                 if is_created {
+                    let text_snapshot = buffer.read(cx).text_snapshot();
                     diff_base = Rope::default();
                     unreviewed_edits = Patch::new(vec![Edit {
                         old: 0..1,
@@ -181,26 +165,14 @@ impl ActionLog {
                     diff_base = buffer.read(cx).as_rope().clone();
                     unreviewed_edits = Patch::default();
                 }
-                TrackedBuffer {
-                    buffer: buffer.clone(),
+                Self::make_tracked_buffer(
+                    &self.project,
+                    buffer.clone(),
                     diff_base,
                     unreviewed_edits,
-                    snapshot: text_snapshot,
                     status,
-                    version: buffer.read(cx).version(),
-                    diff,
-                    diff_update: diff_update_tx,
-                    _open_lsp_handle: open_lsp_handle,
-                    _maintain_diff: cx.spawn({
-                        let buffer = buffer.clone();
-                        async move |this, cx| {
-                            Self::maintain_diff(this, buffer, diff_update_rx, cx)
-                                .await
-                                .ok();
-                        }
-                    }),
-                    _subscription: cx.subscribe(&buffer, Self::handle_buffer_event),
-                }
+                    cx,
+                )
             });
         tracked_buffer.version = buffer.read(cx).version();
         tracked_buffer
@@ -1045,6 +1017,98 @@ impl ActionLog {
             })
             .map(|(buffer, _)| buffer)
     }
+
+    pub fn tracked_buffer_snapshots(&self, cx: &App) -> Vec<TrackedBufferSnapshot> {
+        self.tracked_buffers
+            .values()
+            .filter_map(|tracked| {
+                let buffer = tracked.buffer.read(cx);
+                let file = buffer.file()?;
+                let project_path = ProjectPath::from_file(file.as_ref(), cx);
+                Some(TrackedBufferSnapshot {
+                    project_path,
+                    diff_base: tracked.diff_base.clone(),
+                    status: tracked.status.clone(),
+                })
+            })
+            .collect()
+    }
+
+    pub fn restore_tracked_buffer(
+        &mut self,
+        buffer: Entity<Buffer>,
+        diff_base: Rope,
+        status: TrackedBufferStatus,
+        cx: &mut Context<Self>,
+    ) {
+        if self.tracked_buffers.contains_key(&buffer) {
+            return;
+        }
+
+        let unreviewed_edits = Patch::default();
+        let tracked_buffer = Self::make_tracked_buffer(
+            &self.project,
+            buffer.clone(),
+            diff_base,
+            unreviewed_edits,
+            status,
+            cx,
+        );
+
+        // Trigger diff update to compute unreviewed_edits
+        tracked_buffer.schedule_diff_update(ChangeAuthor::Agent, cx);
+
+        self.tracked_buffers.insert(buffer, tracked_buffer);
+        cx.notify();
+    }
+
+    fn make_tracked_buffer(
+        project: &Entity<Project>,
+        buffer: Entity<Buffer>,
+        diff_base: Rope,
+        unreviewed_edits: Patch<u32>,
+        status: TrackedBufferStatus,
+        cx: &mut Context<Self>,
+    ) -> TrackedBuffer {
+        let open_lsp_handle = project.update(cx, |project, cx| {
+            project.register_buffer_with_language_servers(&buffer, cx)
+        });
+
+        let text_snapshot = buffer.read(cx).text_snapshot();
+        let language = buffer.read(cx).language().cloned();
+        let language_registry = buffer.read(cx).language_registry();
+        let diff = cx.new(|cx| {
+            BufferDiff::new(
+                &text_snapshot,
+                language,
+                language_registry,
+                buffer_diff::DiffBaseKind::Custom,
+                cx,
+            )
+        });
+        let (diff_update_tx, diff_update_rx) = mpsc::unbounded();
+
+        TrackedBuffer {
+            buffer: buffer.clone(),
+            diff_base,
+            unreviewed_edits,
+            snapshot: text_snapshot,
+            status,
+            version: buffer.read(cx).version(),
+            diff,
+            diff_update: diff_update_tx,
+            _open_lsp_handle: open_lsp_handle,
+            _maintain_diff: cx.spawn({
+                let buffer = buffer.clone();
+                async move |this, cx| {
+                    Self::maintain_diff(this, buffer, diff_update_rx, cx)
+                        .await
+                        .ok();
+                }
+            }),
+            _subscription: cx.subscribe(&buffer, Self::handle_buffer_event),
+        }
+    }
 }
 
 #[derive(Default, Debug, Clone, Copy)]
@@ -1252,11 +1316,17 @@ enum ChangeAuthor {
     Agent,
 }
 
-#[derive(Debug)]
-enum TrackedBufferStatus {
+#[derive(Clone, Debug)]
+pub enum TrackedBufferStatus {
     Created { existing_file_content: Option<Rope> },
     Modified,
     Deleted,
+}
+
+pub struct TrackedBufferSnapshot {
+    pub project_path: ProjectPath,
+    pub diff_base: Rope,
+    pub status: TrackedBufferStatus,
 }
 
 pub struct TrackedBuffer {
@@ -3459,6 +3529,65 @@ mod tests {
             parent_log.read_with(cx, |log, _| log.file_read_time(&abs_path).is_none()),
             "parent should NOT get file_read_time from child's buffer_created"
         );
+    }
+
+    #[gpui::test]
+    async fn test_restore_tracked_buffer(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                "file.txt": "a\nb\nc",
+            }),
+        )
+        .await;
+        cx.run_until_parked();
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+
+        let file_path = project
+            .read_with(cx, |project, cx| {
+                project.find_project_path(path!("/project/file.txt"), cx)
+            })
+            .unwrap();
+        let buffer = project
+            .update(cx, |project, cx| project.open_buffer(file_path, cx))
+            .await
+            .unwrap();
+
+        let diff_base = Rope::from("a\nchanged_b\nc");
+        let status = TrackedBufferStatus::Modified;
+
+        cx.update(|cx| {
+            action_log.update(cx, |log, cx| {
+                log.restore_tracked_buffer(buffer.clone(), diff_base.clone(), status.clone(), cx);
+            });
+        });
+        cx.run_until_parked();
+
+        // 1. Verify unreviewed hunks are correctly computed from restored state
+        assert_eq!(
+            unreviewed_hunks(&action_log, cx),
+            vec![(
+                buffer,
+                vec![HunkStatus {
+                    range: Point::new(1, 0)..Point::new(2, 0),
+                    diff_status: DiffHunkStatusKind::Modified,
+                    old_text: "changed_b\n".into()
+                }]
+            )]
+        );
+
+        // 2. Verify tracked_buffer_snapshots returns correct state
+        cx.read(|cx| {
+            let snapshots = action_log.read(cx).tracked_buffer_snapshots(cx);
+            assert_eq!(snapshots.len(), 1);
+            assert_eq!(snapshots[0].diff_base.to_string(), diff_base.to_string());
+            assert!(matches!(snapshots[0].status, TrackedBufferStatus::Modified));
+        });
     }
 
     #[derive(Debug, PartialEq)]

--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -1,5 +1,6 @@
 use crate::{AgentMessage, AgentMessageContent, UserMessage, UserMessageContent};
 use acp_thread::UserMessageId;
+use action_log::TrackedBufferStatus;
 use agent_client_protocol::schema as acp;
 use agent_settings::AgentProfileId;
 use anyhow::{Result, anyhow};
@@ -83,12 +84,59 @@ pub struct DbThread {
     pub ui_scroll_position: Option<SerializedScrollPosition>,
     #[serde(default)]
     pub sandboxed_terminal_temp_dir: Option<PathBuf>,
+    #[serde(default)]
+    pub tracked_buffers: Vec<SerializedTrackedBuffer>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct SerializedScrollPosition {
     pub item_ix: usize,
     pub offset_in_item: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum SerializedTrackedBufferStatus {
+    Created {
+        existing_file_content: Option<String>,
+    },
+    Modified,
+    Deleted,
+}
+
+impl From<TrackedBufferStatus> for SerializedTrackedBufferStatus {
+    fn from(status: TrackedBufferStatus) -> Self {
+        match status {
+            TrackedBufferStatus::Created {
+                existing_file_content,
+            } => SerializedTrackedBufferStatus::Created {
+                existing_file_content: existing_file_content.map(|r| r.to_string()),
+            },
+            TrackedBufferStatus::Modified => SerializedTrackedBufferStatus::Modified,
+            TrackedBufferStatus::Deleted => SerializedTrackedBufferStatus::Deleted,
+        }
+    }
+}
+
+impl From<SerializedTrackedBufferStatus> for TrackedBufferStatus {
+    fn from(status: SerializedTrackedBufferStatus) -> Self {
+        match status {
+            SerializedTrackedBufferStatus::Created {
+                existing_file_content,
+            } => TrackedBufferStatus::Created {
+                existing_file_content: existing_file_content.map(text::Rope::from),
+            },
+            SerializedTrackedBufferStatus::Modified => TrackedBufferStatus::Modified,
+            SerializedTrackedBufferStatus::Deleted => TrackedBufferStatus::Deleted,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SerializedTrackedBuffer {
+    pub worktree_id: u64,
+    pub path: String,
+    pub diff_base: String,
+    pub status: SerializedTrackedBufferStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,6 +181,7 @@ impl SharedThread {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            tracked_buffers: Default::default(),
         }
     }
 
@@ -317,6 +366,7 @@ impl DbThread {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            tracked_buffers: Default::default(),
         })
     }
 }
@@ -768,6 +818,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            tracked_buffers: Default::default(),
         }
     }
 
@@ -884,6 +935,22 @@ mod tests {
         assert!(
             db_thread.sandboxed_terminal_temp_dir.is_none(),
             "Legacy threads without sandboxed_terminal_temp_dir should default to None"
+        );
+    }
+
+    #[test]
+    fn test_tracked_buffers_defaults_to_empty() {
+        let json = r#"{
+            "title": "Old Thread",
+            "messages": [],
+            "updated_at": "2024-01-01T00:00:00Z"
+        }"#;
+
+        let db_thread: DbThread = serde_json::from_str(json).expect("Failed to deserialize");
+
+        assert!(
+            db_thread.tracked_buffers.is_empty(),
+            "Legacy threads without tracked_buffers field should default to empty list"
         );
     }
 

--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -1,5 +1,6 @@
 use crate::{AgentMessage, AgentMessageContent, UserMessage, UserMessageContent};
 use acp_thread::ClientUserMessageId;
+use action_log::TrackedBufferStatus;
 use agent_client_protocol::schema::v1 as acp;
 use agent_settings::AgentProfileId;
 use anyhow::Result;
@@ -86,6 +87,8 @@ pub struct DbThread {
     /// [`crate::sandboxing::ThreadSandboxGrants`].
     #[serde(default)]
     pub sandbox_grants: DbSandboxGrants,
+    #[serde(default)]
+    pub tracked_buffers: Vec<SerializedTrackedBuffer>,
 }
 
 /// Serialized form of the sandbox permissions the user granted "for the rest of
@@ -119,6 +122,51 @@ pub struct DbSandboxGrants {
     /// could not be created (the fallback prompt's "for this thread" option).
     #[serde(default)]
     pub sandbox_fallback: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum SerializedTrackedBufferStatus {
+    Created {
+        existing_file_content: Option<String>,
+    },
+    Modified,
+    Deleted,
+}
+
+impl From<TrackedBufferStatus> for SerializedTrackedBufferStatus {
+    fn from(status: TrackedBufferStatus) -> Self {
+        match status {
+            TrackedBufferStatus::Created {
+                existing_file_content,
+            } => SerializedTrackedBufferStatus::Created {
+                existing_file_content: existing_file_content.map(|r| r.to_string()),
+            },
+            TrackedBufferStatus::Modified => SerializedTrackedBufferStatus::Modified,
+            TrackedBufferStatus::Deleted => SerializedTrackedBufferStatus::Deleted,
+        }
+    }
+}
+
+impl From<SerializedTrackedBufferStatus> for TrackedBufferStatus {
+    fn from(status: SerializedTrackedBufferStatus) -> Self {
+        match status {
+            SerializedTrackedBufferStatus::Created {
+                existing_file_content,
+            } => TrackedBufferStatus::Created {
+                existing_file_content: existing_file_content.map(text::Rope::from),
+            },
+            SerializedTrackedBufferStatus::Modified => TrackedBufferStatus::Modified,
+            SerializedTrackedBufferStatus::Deleted => TrackedBufferStatus::Deleted,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SerializedTrackedBuffer {
+    pub worktree_id: u64,
+    pub path: String,
+    pub diff_base: String,
+    pub status: SerializedTrackedBufferStatus,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -169,6 +217,7 @@ impl SharedThread {
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
             sandbox_grants: DbSandboxGrants::default(),
+            tracked_buffers: Default::default(),
         }
     }
 
@@ -355,6 +404,7 @@ impl DbThread {
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
             sandbox_grants: DbSandboxGrants::default(),
+            tracked_buffers: Default::default(),
         })
     }
 }
@@ -806,6 +856,7 @@ mod tests {
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
             sandbox_grants: DbSandboxGrants::default(),
+            tracked_buffers: Vec::new(),
         }
     }
 
@@ -939,6 +990,22 @@ mod tests {
             db_thread.sandbox_grants,
             DbSandboxGrants::default(),
             "Legacy threads without sandbox_grants should default to empty grants"
+        );
+    }
+
+    #[test]
+    fn test_tracked_buffers_defaults_to_empty() {
+        let json = r#"{
+            "title": "Old Thread",
+            "messages": [],
+            "updated_at": "2024-01-01T00:00:00Z"
+        }"#;
+
+        let db_thread: DbThread = serde_json::from_str(json).expect("Failed to deserialize");
+
+        assert!(
+            db_thread.tracked_buffers.is_empty(),
+            "Legacy threads without tracked_buffers field should default to empty list"
         );
     }
 

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -3578,6 +3578,100 @@ async fn test_db_thread_markdown_matches_live_thread(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_db_thread_restores_tracked_buffers(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        language_model::init(cx);
+        language_model::LanguageModelRegistry::test(cx);
+    });
+
+    let ThreadTest {
+        thread,
+        fs,
+        project_context,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+
+    // Create a file in the workspace
+    fs.insert_file(
+        path!("/test/file.txt"),
+        "a\nb\nc\n".to_string().into_bytes(),
+    )
+    .await;
+    cx.run_until_parked();
+
+    let project = thread.read_with(cx, |thread, _| thread.project().clone());
+    let file_path = project
+        .read_with(cx, |project, cx| {
+            project.find_project_path(path!("/test/file.txt"), cx)
+        })
+        .unwrap();
+    let buffer = project
+        .update(cx, |project, cx| project.open_buffer(file_path, cx))
+        .await
+        .unwrap();
+
+    let diff_base = text::Rope::from("a\nchanged_b\nc\n");
+    let status = action_log::TrackedBufferStatus::Modified;
+
+    // Restore the tracked buffer to action_log
+    cx.update(|cx| {
+        thread.update(cx, |thread, cx| {
+            thread.action_log.update(cx, |log, cx| {
+                log.restore_tracked_buffer(buffer.clone(), diff_base, status, cx);
+            });
+        });
+    });
+    cx.run_until_parked();
+
+    // Verify it is tracked in the live thread
+    cx.read(|cx| {
+        let snapshots = thread
+            .read(cx)
+            .action_log
+            .read(cx)
+            .tracked_buffer_snapshots(cx);
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0].diff_base.to_string(), "a\nchanged_b\nc\n");
+    });
+
+    // Save thread to DbThread
+    let db_thread = thread.update(cx, |thread, cx| thread.to_db(cx)).await;
+    assert_eq!(db_thread.tracked_buffers.len(), 1);
+    assert_eq!(db_thread.tracked_buffers[0].diff_base, "a\nchanged_b\nc\n");
+
+    // Reconstruct Thread from DbThread
+    let context_server_registry =
+        thread.read_with(cx, |thread, _| thread.context_server_registry.clone());
+    let templates = thread.read_with(cx, |thread, _| thread.templates.clone());
+    let _model = thread.read_with(cx, |thread, _| thread.model().cloned());
+    let restored_thread = cx.new(|cx| {
+        Thread::from_db(
+            thread.read(cx).id().clone(),
+            db_thread,
+            project.clone(),
+            project_context,
+            context_server_registry,
+            templates,
+            cx,
+        )
+    });
+
+    // Run background tasks (like opening buffer and restoring tracked state)
+    cx.run_until_parked();
+
+    // Verify restored thread's action_log tracks the buffer and diff_base correctly!
+    cx.read(|cx| {
+        let snapshots = restored_thread
+            .read(cx)
+            .action_log
+            .read(cx)
+            .tracked_buffer_snapshots(cx);
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0].diff_base.to_string(), "a\nchanged_b\nc\n");
+    });
+}
+
+#[gpui::test]
 async fn test_title_generation_failure_allows_retry(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
     let fake_model = model.as_fake();

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -4025,6 +4025,100 @@ async fn test_db_thread_markdown_matches_live_thread(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_db_thread_restores_tracked_buffers(cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        language_model::init(cx);
+        language_model::LanguageModelRegistry::test(cx);
+    });
+
+    let ThreadTest {
+        thread,
+        fs,
+        project_context,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+
+    // Create a file in the workspace
+    fs.insert_file(
+        path!("/test/file.txt"),
+        "a\nb\nc\n".to_string().into_bytes(),
+    )
+    .await;
+    cx.run_until_parked();
+
+    let project = thread.read_with(cx, |thread, _| thread.project().clone());
+    let file_path = project
+        .read_with(cx, |project, cx| {
+            project.find_project_path(path!("/test/file.txt"), cx)
+        })
+        .unwrap();
+    let buffer = project
+        .update(cx, |project, cx| project.open_buffer(file_path, cx))
+        .await
+        .unwrap();
+
+    let diff_base = text::Rope::from("a\nchanged_b\nc\n");
+    let status = action_log::TrackedBufferStatus::Modified;
+
+    // Restore the tracked buffer to action_log
+    cx.update(|cx| {
+        thread.update(cx, |thread, cx| {
+            thread.action_log.update(cx, |log, cx| {
+                log.restore_tracked_buffer(buffer.clone(), diff_base, status, cx);
+            });
+        });
+    });
+    cx.run_until_parked();
+
+    // Verify it is tracked in the live thread
+    cx.read(|cx| {
+        let snapshots = thread
+            .read(cx)
+            .action_log
+            .read(cx)
+            .tracked_buffer_snapshots(cx);
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0].diff_base.to_string(), "a\nchanged_b\nc\n");
+    });
+
+    // Save thread to DbThread
+    let db_thread = thread.update(cx, |thread, cx| thread.to_db(cx)).await;
+    assert_eq!(db_thread.tracked_buffers.len(), 1);
+    assert_eq!(db_thread.tracked_buffers[0].diff_base, "a\nchanged_b\nc\n");
+
+    // Reconstruct Thread from DbThread
+    let context_server_registry =
+        thread.read_with(cx, |thread, _| thread.context_server_registry.clone());
+    let templates = thread.read_with(cx, |thread, _| thread.templates.clone());
+    let _model = thread.read_with(cx, |thread, _| thread.model().cloned());
+    let restored_thread = cx.new(|cx| {
+        Thread::from_db(
+            thread.read(cx).id().clone(),
+            db_thread,
+            project.clone(),
+            project_context,
+            context_server_registry,
+            templates,
+            cx,
+        )
+    });
+
+    // Run background tasks (like opening buffer and restoring tracked state)
+    cx.run_until_parked();
+
+    // Verify restored thread's action_log tracks the buffer and diff_base correctly!
+    cx.read(|cx| {
+        let snapshots = restored_thread
+            .read(cx)
+            .action_log
+            .read(cx)
+            .tracked_buffer_snapshots(cx);
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0].diff_base.to_string(), "a\nchanged_b\nc\n");
+    });
+}
+
+#[gpui::test]
 async fn test_title_generation_failure_allows_retry(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
     let fake_model = model.as_fake();

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1181,6 +1181,9 @@ pub struct Thread {
     /// already-granted permissions skip the approval prompt.
     /// Never persisted — lives and dies with this thread.
     sandbox_grants: Rc<RefCell<ThreadSandboxGrants>>,
+    /// Background task restoring tracked buffers from a persisted thread.
+    /// Cancelled automatically if the thread is dropped before it finishes.
+    _restore_tracked_buffers: Option<Task<()>>,
 }
 
 impl Thread {
@@ -1310,6 +1313,7 @@ impl Thread {
             inherits_parent_model_settings: true,
             sandboxed_terminal_temp_dir: None,
             sandbox_grants: Rc::new(RefCell::new(ThreadSandboxGrants::default())),
+            _restore_tracked_buffers: None,
         }
     }
 
@@ -1629,6 +1633,60 @@ impl Thread {
 
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
 
+        let _restore_tracked_buffers = if db_thread.tracked_buffers.is_empty() {
+            None
+        } else {
+            let restored_buffers = db_thread.tracked_buffers.clone();
+            let project = project.clone();
+            Some(cx.spawn(|thread: WeakEntity<Thread>, cx: &mut AsyncApp| {
+                let cx = cx.clone();
+                async move {
+                    for serialized in restored_buffers {
+                        let worktree_id = settings::WorktreeId::from_proto(serialized.worktree_id);
+                        let rel_path = match util::rel_path::RelPath::from_proto(&serialized.path) {
+                            Ok(p) => p,
+                            Err(e) => {
+                                log::error!("failed to deserialize relative path: {e}");
+                                continue;
+                            }
+                        };
+                        let project_path = project::ProjectPath {
+                            worktree_id,
+                            path: rel_path,
+                        };
+
+                        let open_task = cx.update(|cx: &mut App| {
+                            project.update(cx, |project, cx| project.open_buffer(project_path, cx))
+                        });
+
+                        let buffer = match open_task.await {
+                            Ok(buffer) => buffer,
+                            Err(e) => {
+                                log::error!("failed to open buffer for restoring agent edits: {e}");
+                                continue;
+                            }
+                        };
+
+                        let diff_base = text::Rope::from(serialized.diff_base);
+                        let status = serialized.status.into();
+
+                        let result = cx.update(|cx: &mut App| {
+                            thread.update(cx, |thread, cx| {
+                                thread.action_log.update(cx, |action_log, cx| {
+                                    action_log
+                                        .restore_tracked_buffer(buffer, diff_base, status, cx);
+                                });
+                            })
+                        });
+                        if result.is_err() {
+                            log::warn!("Thread dropped during tracked buffer restoration");
+                            break;
+                        }
+                    }
+                }
+            }))
+        };
+
         Self {
             id,
             prompt_id: PromptId::new(),
@@ -1676,11 +1734,24 @@ impl Thread {
             inherits_parent_model_settings: true,
             sandboxed_terminal_temp_dir: db_thread.sandboxed_terminal_temp_dir,
             sandbox_grants: Rc::new(RefCell::new(ThreadSandboxGrants::default())),
+            _restore_tracked_buffers,
         }
     }
 
     pub fn to_db(&self, cx: &App) -> Task<DbThread> {
         let initial_project_snapshot = self.initial_project_snapshot.clone();
+        let action_log = self.action_log.read(cx);
+        let tracked_buffers = action_log
+            .tracked_buffer_snapshots(cx)
+            .into_iter()
+            .map(|snapshot| crate::db::SerializedTrackedBuffer {
+                worktree_id: snapshot.project_path.worktree_id.to_proto(),
+                path: snapshot.project_path.path.to_proto(),
+                diff_base: snapshot.diff_base.to_string(),
+                status: snapshot.status.into(),
+            })
+            .collect();
+
         let mut thread = DbThread {
             title: self.title().unwrap_or_default(),
             messages: self.messages.clone(),
@@ -1707,6 +1778,7 @@ impl Thread {
                 }
             }),
             sandboxed_terminal_temp_dir: self.sandboxed_terminal_temp_dir.clone(),
+            tracked_buffers,
         };
 
         cx.background_spawn(async move {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1300,6 +1300,9 @@ pub struct Thread {
     /// already-granted permissions skip the approval prompt.
     /// Never persisted — lives and dies with this thread.
     sandbox_grants: Rc<RefCell<ThreadSandboxGrants>>,
+    /// Background task restoring tracked buffers from a persisted thread.
+    /// Cancelled automatically if the thread is dropped before it finishes.
+    _restore_tracked_buffers: Option<Task<()>>,
 }
 
 impl Thread {
@@ -1436,6 +1439,7 @@ impl Thread {
             inherits_parent_model_settings: true,
             sandboxed_terminal_temp_dir: None,
             sandbox_grants: Rc::new(RefCell::new(ThreadSandboxGrants::default())),
+            _restore_tracked_buffers: None,
         }
     }
 
@@ -1770,6 +1774,61 @@ impl Thread {
 
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
 
+        let _restore_tracked_buffers = if db_thread.tracked_buffers.is_empty() {
+            None
+        } else {
+            let restored_buffers = db_thread.tracked_buffers.clone();
+            let project = project.clone();
+            Some(cx.spawn(|thread: WeakEntity<Thread>, cx: &mut AsyncApp| {
+                let cx = cx.clone();
+                async move {
+                    for serialized in restored_buffers {
+                        let worktree_id = settings::WorktreeId::from_proto(serialized.worktree_id);
+                        let rel_path =
+                            match util::rel_path::RelPath::from_unix_str(&serialized.path) {
+                                Ok(p) => p.into(),
+                                Err(e) => {
+                                    log::error!("failed to deserialize relative path: {e}");
+                                    continue;
+                                }
+                            };
+                        let project_path = project::ProjectPath {
+                            worktree_id,
+                            path: rel_path,
+                        };
+
+                        let open_task = cx.update(|cx: &mut App| {
+                            project.update(cx, |project, cx| project.open_buffer(project_path, cx))
+                        });
+
+                        let buffer = match open_task.await {
+                            Ok(buffer) => buffer,
+                            Err(e) => {
+                                log::error!("failed to open buffer for restoring agent edits: {e}");
+                                continue;
+                            }
+                        };
+
+                        let diff_base = text::Rope::from(serialized.diff_base);
+                        let status = serialized.status.into();
+
+                        let result = cx.update(|cx: &mut App| {
+                            thread.update(cx, |thread, cx| {
+                                thread.action_log.update(cx, |action_log, cx| {
+                                    action_log
+                                        .restore_tracked_buffer(buffer, diff_base, status, cx);
+                                });
+                            })
+                        });
+                        if result.is_err() {
+                            log::warn!("Thread dropped during tracked buffer restoration");
+                            break;
+                        }
+                    }
+                }
+            }))
+        };
+
         Self {
             id,
             prompt_id: PromptId::new(),
@@ -1820,6 +1879,7 @@ impl Thread {
             sandbox_grants: Rc::new(RefCell::new(ThreadSandboxGrants::from_db(
                 &db_thread.sandbox_grants,
             ))),
+            _restore_tracked_buffers,
         }
     }
 
@@ -1894,6 +1954,18 @@ impl Thread {
 
     pub fn to_db(&self, cx: &App) -> Task<DbThread> {
         let initial_project_snapshot = self.initial_project_snapshot.clone();
+        let action_log = self.action_log.read(cx);
+        let tracked_buffers = action_log
+            .tracked_buffer_snapshots(cx)
+            .into_iter()
+            .map(|snapshot| crate::db::SerializedTrackedBuffer {
+                worktree_id: snapshot.project_path.worktree_id.to_proto(),
+                path: snapshot.project_path.path.as_unix_str().to_string(),
+                diff_base: snapshot.diff_base.to_string(),
+                status: snapshot.status.into(),
+            })
+            .collect();
+
         let mut thread = DbThread {
             title: self.title().unwrap_or_default(),
             messages: self.messages.clone(),
@@ -1917,6 +1989,7 @@ impl Thread {
             }),
             sandboxed_terminal_temp_dir: self.sandboxed_terminal_temp_dir.clone(),
             sandbox_grants: self.sandbox_grants.borrow().to_db(),
+            tracked_buffers,
         };
 
         cx.background_spawn(async move {

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -168,6 +168,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            tracked_buffers: Default::default(),
         }
     }
 

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -168,6 +168,7 @@ mod tests {
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
             sandbox_grants: Default::default(),
+            tracked_buffers: Default::default(),
         }
     }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -10860,6 +10860,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            tracked_buffers: Vec::new(),
         };
 
         let thread_store = cx.update(|cx| ThreadStore::global(cx));

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -10984,6 +10984,7 @@ mod tests {
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
             sandbox_grants: Default::default(),
+            tracked_buffers: Vec::new(),
         };
 
         let thread_store = cx.update(|cx| ThreadStore::global(cx));

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -1852,6 +1852,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            tracked_buffers: Vec::new(),
         }
     }
 

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -1852,6 +1852,7 @@ mod tests {
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
             sandbox_grants: Default::default(),
+            tracked_buffers: Vec::new(),
         }
     }
 


### PR DESCRIPTION
When a thread with unreviewed agent edits was saved and later restored, the tracked buffer state (diff_base and status) was lost. This caused edits to appear implicitly accepted after a restart, rather than remaining in the review state.

- Adds SerializedTrackedBuffer to DbThread to persist diff_base, status, and project path for each tracked buffer
- Restores tracked buffers in Thread::from_db by opening each buffer and re-establishing ActionLog tracking
- Extracts shared TrackedBuffer construction into ActionLog::make_tracked_buffer
- Adds From/Into impls for status conversion
- Stores the restoration task handle on Thread instead of detaching it



Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #47528

Release Notes:

- Fixed agent edits being implicitly accepted after restarting Zed (#47528)