### PR TITLE
Math rendering for Markdown preview using RaTeX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6388,6 +6388,17 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
@@ -10591,6 +10602,11 @@ dependencies = [
  "mermaid_render",
  "node_runtime",
  "pulldown-cmark 0.13.0",
+ "ratex-font",
+ "ratex-katex-fonts",
+ "ratex-layout",
+ "ratex-parser",
+ "ratex-types",
  "settings",
  "stacksafe",
  "sum_tree",
@@ -14620,6 +14636,75 @@ name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "ratex-font"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076f9ca8409eed1b0d9de1c666cf231665e0b6d1691b8c28e27c2bdd55f4c8b1"
+dependencies = [
+ "phf 0.11.3",
+ "ratex-types",
+]
+
+[[package]]
+name = "ratex-katex-fonts"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b451364ad69b55587baa549522244aaeabb0dc26d84f12a37987e9f1c59342b"
+dependencies = [
+ "rust-embed",
+]
+
+[[package]]
+name = "ratex-layout"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4253612c4cd7f28e40fcd4a3b8f35570b77c74717946796550dc873e086a6cd"
+dependencies = [
+ "ratex-font",
+ "ratex-parser",
+ "ratex-types",
+ "serde_json",
+]
+
+[[package]]
+name = "ratex-lexer"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0cc7746f4a617f857390f5361cb413d79d9cc0f607b05d398ddef0b8b21522"
+dependencies = [
+ "ratex-types",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ratex-parser"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d1c51aaae3f99f6f61e3d76d820b01afb3a0c19cf092ed11fedef7604930cd"
+dependencies = [
+ "fancy-regex 0.14.0",
+ "ratex-font",
+ "ratex-lexer",
+ "ratex-types",
+ "regex",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "ratex-types"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "694d45327eb6f5bf76d5d06f5dc1123a1d1202e3d392f2b260bd12bcca0dc19d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "rav1e"
@@ -19583,9 +19668,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -694,6 +694,11 @@ quick-xml = "0.38"
 quote = "1.0.9"
 rand = "0.9"
 rayon = "1.8"
+ratex-font = "0.1"
+ratex-katex-fonts = "0.1"
+ratex-layout = "0.1"
+ratex-parser = "0.1"
+ratex-types = "0.1"
 regex = "1.5"
 # WARNING: If you change this, you must also publish a new version of zed-reqwest to crates.io
 reqwest = { git = "https://github.com/zed-industries/reqwest.git", rev = "c15662463bda39148ba154100dd44d3fba5873a4", default-features = false, features = [

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -1,8 +1,8 @@
 use crate::{
     ActiveTooltip, AnyView, App, Bounds, DispatchPhase, Element, ElementId, GlobalElementId,
-    HighlightStyle, Hitbox, HitboxBehavior, InspectorElementId, IntoElement, LayoutId,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, SharedString, Size, TextOverflow,
-    TextRun, TextStyle, TooltipId, TruncateFrom, WhiteSpace, Window, WrappedLine,
+    HighlightStyle, Hitbox, HitboxBehavior, InlineReplacement, InspectorElementId, IntoElement,
+    LayoutId, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point, SharedString, Size,
+    TextOverflow, TextRun, TextStyle, TooltipId, TruncateFrom, WhiteSpace, Window, WrappedLine,
     WrappedLineLayout, register_tooltip_mouse_handlers, set_tooltip_on_window,
 };
 use anyhow::Context as _;
@@ -271,7 +271,7 @@ impl Element for &'static str {
         cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
         let mut state = TextLayout::default();
-        let layout_id = state.layout(SharedString::from(*self), None, window, cx);
+        let layout_id = state.layout(SharedString::from(*self), None, Vec::new(), window, cx);
         (layout_id, state)
     }
 
@@ -345,7 +345,7 @@ impl Element for SharedString {
         cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
         let mut state = TextLayout::default();
-        let layout_id = state.layout(self.clone(), None, window, cx);
+        let layout_id = state.layout(self.clone(), None, Vec::new(), window, cx);
         (layout_id, state)
     }
 
@@ -391,6 +391,7 @@ impl IntoElement for SharedString {
 pub struct StyledText {
     text: SharedString,
     runs: Option<Vec<TextRun>>,
+    inline_replacements: Vec<InlineReplacement>,
     delayed_highlights: Option<Vec<(Range<usize>, HighlightStyle)>>,
     delayed_font_family_overrides: Option<Vec<(Range<usize>, SharedString)>>,
     layout: TextLayout,
@@ -402,6 +403,7 @@ impl StyledText {
         StyledText {
             text: text.into(),
             runs: None,
+            inline_replacements: Vec::new(),
             delayed_highlights: None,
             delayed_font_family_overrides: None,
             layout: TextLayout::default(),
@@ -411,6 +413,25 @@ impl StyledText {
     /// Get the layout for this element. This can be used to map indices to pixels and vice versa.
     pub fn layout(&self) -> &TextLayout {
         &self.layout
+    }
+
+    /// Set inline replacement objects for byte ranges in this text.
+    ///
+    /// Each range must be sorted, non-overlapping, and fall on UTF-8 character
+    /// boundaries. Callers typically use this with a single U+FFFC OBJECT
+    /// REPLACEMENT CHARACTER per object.
+    pub fn with_inline_replacements(
+        mut self,
+        replacements: impl IntoIterator<Item = InlineReplacement>,
+    ) -> Self {
+        self.inline_replacements = replacements
+            .into_iter()
+            .inspect(|replacement| {
+                debug_assert!(self.text.is_char_boundary(replacement.range.start));
+                debug_assert!(self.text.is_char_boundary(replacement.range.end));
+            })
+            .collect();
+        self
     }
 
     /// Set the styling attributes for the given text, as well as
@@ -571,7 +592,13 @@ impl Element for StyledText {
             Self::apply_font_family_overrides(runs, overrides);
         }
 
-        let layout_id = self.layout.layout(self.text.clone(), runs, window, cx);
+        let layout_id = self.layout.layout(
+            self.text.clone(),
+            runs,
+            self.inline_replacements.clone(),
+            window,
+            cx,
+        );
         (layout_id, ())
     }
 
@@ -616,6 +643,7 @@ pub struct TextLayout(Rc<RefCell<Option<TextLayoutInner>>>);
 struct TextLayoutInner {
     len: usize,
     lines: SmallVec<[WrappedLine; 1]>,
+    inline_replacements: Vec<InlineReplacement>,
     line_height: Pixels,
     wrap_width: Option<Pixels>,
     size: Option<Size<Pixels>>,
@@ -627,6 +655,7 @@ impl TextLayout {
         &self,
         text: SharedString,
         runs: Option<Vec<TextRun>>,
+        inline_replacements: Vec<InlineReplacement>,
         window: &mut Window,
         _: &mut App,
     ) -> LayoutId {
@@ -716,10 +745,11 @@ impl TextLayout {
 
                 let Some(lines) = window
                     .text_system()
-                    .shape_text(
+                    .shape_text_with_replacements(
                         text,
                         font_size,
                         &runs,
+                        &inline_replacements,
                         wrap_width,            // Wrap if we know the width.
                         text_style.line_clamp, // Limit the number of lines if line_clamp is set.
                     )
@@ -727,6 +757,7 @@ impl TextLayout {
                 else {
                     element_state.0.borrow_mut().replace(TextLayoutInner {
                         lines: Default::default(),
+                        inline_replacements: inline_replacements.clone(),
                         len: 0,
                         line_height,
                         wrap_width,
@@ -745,6 +776,7 @@ impl TextLayout {
 
                 element_state.0.borrow_mut().replace(TextLayoutInner {
                     lines,
+                    inline_replacements: inline_replacements.clone(),
                     len,
                     line_height,
                     wrap_width,
@@ -801,6 +833,15 @@ impl TextLayout {
             .log_err();
             line_origin.y += line.size(line_height).height;
         }
+    }
+
+    /// The inline replacements associated with this layout.
+    pub fn inline_replacements(&self) -> Vec<InlineReplacement> {
+        self.0
+            .borrow()
+            .as_ref()
+            .map(|inner| inner.inline_replacements.clone())
+            .unwrap_or_default()
     }
 
     /// Get the byte index into the input of the pixel position.

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -514,6 +514,19 @@ impl WindowTextSystem {
         wrap_width: Option<Pixels>,
         line_clamp: Option<usize>,
     ) -> Result<SmallVec<[WrappedLine; 1]>> {
+        self.shape_text_with_replacements(text, font_size, runs, &[], wrap_width, line_clamp)
+    }
+
+    /// Shape a multi line string of text with inline replacements.
+    pub fn shape_text_with_replacements(
+        &self,
+        text: SharedString,
+        font_size: Pixels,
+        runs: &[TextRun],
+        inline_replacements: &[InlineReplacement],
+        wrap_width: Option<Pixels>,
+        line_clamp: Option<usize>,
+    ) -> Result<SmallVec<[WrappedLine; 1]>> {
         let mut runs = runs.iter().filter(|run| run.len > 0).cloned().peekable();
         let mut font_runs = self.font_runs_pool.lock().pop().unwrap_or_default();
 
@@ -574,13 +587,38 @@ impl WindowTextSystem {
                 run_start += run_len_within_line;
             }
 
-            let layout = self.line_layout_cache.layout_wrapped_line(
-                &line_text,
-                font_size,
-                &font_runs,
-                wrap_width,
-                max_wrap_lines.map(|max| max.saturating_sub(wrapped_lines)),
-            );
+            let line_replacements = inline_replacements
+                .iter()
+                .filter(|replacement| {
+                    replacement.range.start >= line_start && replacement.range.end <= line_end
+                })
+                .map(|replacement| InlineReplacement {
+                    range: replacement.range.start - line_start..replacement.range.end - line_start,
+                    width: replacement.width,
+                    ascent: replacement.ascent,
+                    descent: replacement.descent,
+                })
+                .collect::<SmallVec<[_; 1]>>();
+
+            let layout = if line_replacements.is_empty() {
+                self.line_layout_cache.layout_wrapped_line(
+                    &line_text,
+                    font_size,
+                    &font_runs,
+                    wrap_width,
+                    max_wrap_lines.map(|max| max.saturating_sub(wrapped_lines)),
+                )
+            } else {
+                self.line_layout_cache
+                    .layout_wrapped_line_with_replacements(
+                        &line_text,
+                        font_size,
+                        &font_runs,
+                        &line_replacements,
+                        wrap_width,
+                        max_wrap_lines.map(|max| max.saturating_sub(wrapped_lines)),
+                    )
+            };
             wrapped_lines += layout.wrap_boundaries.len();
 
             lines.push(WrappedLine {

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -11,6 +11,23 @@ use std::{
 
 use super::LineWrapper;
 
+/// Metrics for an inline object that occupies a byte range in text.
+///
+/// The range usually covers a single U+FFFC OBJECT REPLACEMENT CHARACTER. The
+/// replacement participates in text layout with the supplied width and baseline
+/// metrics instead of the shaped glyph metrics for that range.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct InlineReplacement {
+    /// The UTF-8 byte range occupied by this replacement in the source text.
+    pub range: Range<usize>,
+    /// The horizontal advance used for line layout.
+    pub width: Pixels,
+    /// The distance from the replacement top to the text baseline.
+    pub ascent: Pixels,
+    /// The distance from the text baseline to the replacement bottom.
+    pub descent: Pixels,
+}
+
 /// A laid out and styled line of text
 #[derive(Default, Debug)]
 pub struct LineLayout {
@@ -521,10 +538,34 @@ impl LineLayoutCache {
         Text: AsRef<str>,
         SharedString: From<Text>,
     {
+        self.layout_wrapped_line_with_replacements(
+            text,
+            font_size,
+            runs,
+            &[],
+            wrap_width,
+            max_lines,
+        )
+    }
+
+    pub fn layout_wrapped_line_with_replacements<Text>(
+        &self,
+        text: Text,
+        font_size: Pixels,
+        runs: &[FontRun],
+        inline_replacements: &[InlineReplacement],
+        wrap_width: Option<Pixels>,
+        max_lines: Option<usize>,
+    ) -> Arc<WrappedLineLayout>
+    where
+        Text: AsRef<str>,
+        SharedString: From<Text>,
+    {
         let key = &CacheKeyRef {
             text: text.as_ref(),
             font_size,
             runs,
+            inline_replacements,
             wrap_width,
             force_width: None,
         } as &dyn AsCacheKeyRef;
@@ -545,7 +586,13 @@ impl LineLayoutCache {
         } else {
             drop(current_frame);
             let text = SharedString::from(text);
-            let unwrapped_layout = self.layout_line::<&SharedString>(&text, font_size, runs, None);
+            let unwrapped_layout = self.layout_line_with_replacements::<&SharedString>(
+                &text,
+                font_size,
+                runs,
+                inline_replacements,
+                None,
+            );
             let wrap_boundaries = if let Some(wrap_width) = wrap_width {
                 unwrapped_layout.compute_wrap_boundaries(text.as_ref(), wrap_width, max_lines)
             } else {
@@ -560,6 +607,7 @@ impl LineLayoutCache {
                 text,
                 font_size,
                 runs: SmallVec::from(runs),
+                inline_replacements: SmallVec::from(inline_replacements),
                 wrap_width,
                 force_width: None,
             });
@@ -585,10 +633,26 @@ impl LineLayoutCache {
         Text: AsRef<str>,
         SharedString: From<Text>,
     {
+        self.layout_line_with_replacements(text, font_size, runs, &[], force_width)
+    }
+
+    pub fn layout_line_with_replacements<Text>(
+        &self,
+        text: Text,
+        font_size: Pixels,
+        runs: &[FontRun],
+        inline_replacements: &[InlineReplacement],
+        force_width: Option<Pixels>,
+    ) -> Arc<LineLayout>
+    where
+        Text: AsRef<str>,
+        SharedString: From<Text>,
+    {
         let key = &CacheKeyRef {
             text: text.as_ref(),
             font_size,
             runs,
+            inline_replacements,
             wrap_width: None,
             force_width,
         } as &dyn AsCacheKeyRef;
@@ -609,6 +673,8 @@ impl LineLayoutCache {
                 .platform_text_system
                 .layout_line(&text, font_size, runs);
 
+            apply_inline_replacements_to_layout(&mut layout, inline_replacements);
+
             if let Some(force_width) = force_width {
                 apply_force_width_to_layout(&mut layout, force_width);
             }
@@ -617,6 +683,7 @@ impl LineLayoutCache {
                 text,
                 font_size,
                 runs: SmallVec::from(runs),
+                inline_replacements: SmallVec::from(inline_replacements),
                 wrap_width: None,
                 force_width,
             });
@@ -648,6 +715,7 @@ impl LineLayoutCache {
             text_len,
             font_size,
             runs,
+            inline_replacements: &[],
             wrap_width: None,
             force_width,
         };
@@ -659,6 +727,7 @@ impl LineLayoutCache {
                 text_len: key.text_len,
                 font_size: key.font_size,
                 runs: key.runs.as_slice(),
+                inline_replacements: key.inline_replacements.as_slice(),
                 wrap_width: key.wrap_width,
                 force_width: key.force_width,
             } == key_ref
@@ -673,6 +742,7 @@ impl LineLayoutCache {
                 text_len: key.text_len,
                 font_size: key.font_size,
                 runs: key.runs.as_slice(),
+                inline_replacements: key.inline_replacements.as_slice(),
                 wrap_width: key.wrap_width,
                 force_width: key.force_width,
             } == key_ref
@@ -705,6 +775,7 @@ impl LineLayoutCache {
             text_len,
             font_size,
             runs,
+            inline_replacements: &[],
             wrap_width: None,
             force_width,
         };
@@ -717,6 +788,7 @@ impl LineLayoutCache {
                 text_len: key.text_len,
                 font_size: key.font_size,
                 runs: key.runs.as_slice(),
+                inline_replacements: key.inline_replacements.as_slice(),
                 wrap_width: key.wrap_width,
                 force_width: key.force_width,
             } == key_ref
@@ -738,6 +810,7 @@ impl LineLayoutCache {
                     text_len: key.text_len,
                     font_size: key.font_size,
                     runs: key.runs.as_slice(),
+                    inline_replacements: key.inline_replacements.as_slice(),
                     wrap_width: key.wrap_width,
                     force_width: key.force_width,
                 } == key_ref
@@ -767,6 +840,7 @@ impl LineLayoutCache {
             text_len,
             font_size,
             runs: SmallVec::from(runs),
+            inline_replacements: SmallVec::new(),
             wrap_width: None,
             force_width,
         });
@@ -776,6 +850,63 @@ impl LineLayoutCache {
             .insert(key.clone(), layout.clone());
         current_frame.used_lines_by_hash.push(key);
         layout
+    }
+}
+
+fn apply_inline_replacements_to_layout(
+    layout: &mut LineLayout,
+    inline_replacements: &[InlineReplacement],
+) {
+    for replacement in inline_replacements {
+        layout.ascent = layout.ascent.max(replacement.ascent);
+        layout.descent = layout.descent.max(replacement.descent);
+
+        let Some((replacement_run_ix, replacement_glyph_ix, replacement_x)) =
+            layout.runs.iter().enumerate().find_map(|(run_ix, run)| {
+                run.glyphs
+                    .iter()
+                    .enumerate()
+                    .find(|(_, glyph)| glyph.index == replacement.range.start)
+                    .map(|(glyph_ix, glyph)| (run_ix, glyph_ix, glyph.position.x))
+            })
+        else {
+            continue;
+        };
+
+        let next_glyph_x = layout
+            .runs
+            .iter()
+            .enumerate()
+            .skip(replacement_run_ix)
+            .flat_map(|(run_ix, run)| {
+                run.glyphs
+                    .iter()
+                    .enumerate()
+                    .map(move |(glyph_ix, glyph)| (run_ix, glyph_ix, glyph.position.x))
+            })
+            .find(|(run_ix, glyph_ix, _)| {
+                *run_ix > replacement_run_ix
+                    || (*run_ix == replacement_run_ix && *glyph_ix > replacement_glyph_ix)
+            })
+            .map(|(_, _, x)| x)
+            .unwrap_or(layout.width);
+        let shaped_width = next_glyph_x - replacement_x;
+        let delta = replacement.width - shaped_width;
+
+        if delta == px(0.) {
+            continue;
+        }
+
+        for (run_ix, run) in layout.runs.iter_mut().enumerate() {
+            for (glyph_ix, glyph) in run.glyphs.iter_mut().enumerate() {
+                if run_ix > replacement_run_ix
+                    || (run_ix == replacement_run_ix && glyph_ix > replacement_glyph_ix)
+                {
+                    glyph.position.x += delta;
+                }
+            }
+        }
+        layout.width += delta;
     }
 }
 
@@ -826,6 +957,7 @@ struct CacheKey {
     text: SharedString,
     font_size: Pixels,
     runs: SmallVec<[FontRun; 1]>,
+    inline_replacements: SmallVec<[InlineReplacement; 1]>,
     wrap_width: Option<Pixels>,
     force_width: Option<Pixels>,
 }
@@ -835,6 +967,7 @@ struct CacheKeyRef<'a> {
     text: &'a str,
     font_size: Pixels,
     runs: &'a [FontRun],
+    inline_replacements: &'a [InlineReplacement],
     wrap_width: Option<Pixels>,
     force_width: Option<Pixels>,
 }
@@ -845,6 +978,7 @@ struct HashedCacheKey {
     text_len: usize,
     font_size: Pixels,
     runs: SmallVec<[FontRun; 1]>,
+    inline_replacements: SmallVec<[InlineReplacement; 1]>,
     wrap_width: Option<Pixels>,
     force_width: Option<Pixels>,
 }
@@ -855,6 +989,7 @@ struct HashedCacheKeyRef<'a> {
     text_len: usize,
     font_size: Pixels,
     runs: &'a [FontRun],
+    inline_replacements: &'a [InlineReplacement],
     wrap_width: Option<Pixels>,
     force_width: Option<Pixels>,
 }
@@ -871,6 +1006,7 @@ impl PartialEq for HashedCacheKey {
             && self.text_len == other.text_len
             && self.font_size == other.font_size
             && self.runs.as_slice() == other.runs.as_slice()
+            && self.inline_replacements.as_slice() == other.inline_replacements.as_slice()
             && self.wrap_width == other.wrap_width
             && self.force_width == other.force_width
     }
@@ -884,6 +1020,7 @@ impl Hash for HashedCacheKey {
         self.text_len.hash(state);
         self.font_size.hash(state);
         self.runs.as_slice().hash(state);
+        self.inline_replacements.as_slice().hash(state);
         self.wrap_width.hash(state);
         self.force_width.hash(state);
     }
@@ -895,6 +1032,7 @@ impl PartialEq for HashedCacheKeyRef<'_> {
             && self.text_len == other.text_len
             && self.font_size == other.font_size
             && self.runs == other.runs
+            && self.inline_replacements == other.inline_replacements
             && self.wrap_width == other.wrap_width
             && self.force_width == other.force_width
     }
@@ -908,6 +1046,7 @@ impl Hash for HashedCacheKeyRef<'_> {
         self.text_len.hash(state);
         self.font_size.hash(state);
         self.runs.hash(state);
+        self.inline_replacements.hash(state);
         self.wrap_width.hash(state);
         self.force_width.hash(state);
     }
@@ -927,6 +1066,7 @@ impl AsCacheKeyRef for CacheKey {
             text: &self.text,
             font_size: self.font_size,
             runs: self.runs.as_slice(),
+            inline_replacements: self.inline_replacements.as_slice(),
             wrap_width: self.wrap_width,
             force_width: self.force_width,
         }

--- a/crates/gpui_wgpu/src/cosmic_text_system.rs
+++ b/crates/gpui_wgpu/src/cosmic_text_system.rs
@@ -285,10 +285,32 @@ impl CosmicTextSystemState {
                 .get_font(font_id, cosmic_text::Weight::NORMAL)
                 .context("Could not load font")?;
 
-            // HACK: To let the storybook run and render Windows caption icons. We should actually do better font fallback.
+            // HACK: Allow fonts that lack the 'm' glyph (used as a basic
+            // "is this a usable text font" check) to still load. Segoe
+            // Fluent Icons is needed for storybook's Windows caption icons,
+            // and KaTeX_* faces are symbol fonts used for math rendering.
             let allowed_bad_font_names = [
                 "SegoeFluentIcons", // NOTE: Segoe fluent icons postscript name is inconsistent
                 "Segoe Fluent Icons",
+                "KaTeX_AMS-Regular",
+                "KaTeX_Caligraphic-Regular",
+                "KaTeX_Fraktur-Bold",
+                "KaTeX_Fraktur-Regular",
+                "KaTeX_Main-Bold",
+                "KaTeX_Main-BoldItalic",
+                "KaTeX_Main-Italic",
+                "KaTeX_Main-Regular",
+                "KaTeX_Math-BoldItalic",
+                "KaTeX_Math-Italic",
+                "KaTeX_SansSerif-Bold",
+                "KaTeX_SansSerif-Italic",
+                "KaTeX_SansSerif-Regular",
+                "KaTeX_Script-Regular",
+                "KaTeX_Size1-Regular",
+                "KaTeX_Size2-Regular",
+                "KaTeX_Size3-Regular",
+                "KaTeX_Size4-Regular",
+                "KaTeX_Typewriter-Regular",
             ];
 
             if font.as_swash().charmap().map('m') == 0

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -31,6 +31,11 @@ log.workspace = true
 markup5ever_rcdom.workspace = true
 mermaid_render = { path = "../mermaid_render" }
 pulldown-cmark.workspace = true
+ratex-font.workspace = true
+ratex-katex-fonts.workspace = true
+ratex-layout.workspace = true
+ratex-parser.workspace = true
+ratex-types.workspace = true
 settings.workspace = true
 stacksafe.workspace = true
 sum_tree.workspace = true

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1,4 +1,5 @@
 pub mod html;
+mod math;
 mod mermaid;
 pub mod parser;
 mod path_range;
@@ -11,6 +12,11 @@ use gpui::UnderlineStyle;
 use language::LanguageName;
 
 use log::Level;
+use math::{
+    MathLayoutMetrics, MathState, ParsedMathExpression, ParsedMathExpressionContents,
+    extract_math_expressions, math_layout_metrics, paint_math_expression_at,
+    render_math_expression,
+};
 use mermaid::{
     MermaidState, ParsedMarkdownMermaidDiagram, extract_mermaid_diagrams, render_mermaid_diagram,
 };
@@ -33,8 +39,8 @@ use collections::{HashMap, HashSet};
 use gpui::{
     AnyElement, App, BorderStyle, Bounds, ClipboardItem, CursorStyle, DispatchPhase, Edges, Entity,
     FocusHandle, Focusable, FontStyle, FontWeight, GlobalElementId, Hitbox, Hsla, Image,
-    ImageFormat, ImageSource, KeyContext, Length, MouseButton, MouseDownEvent, MouseEvent,
-    MouseMoveEvent, MouseUpEvent, Point, ScrollHandle, Stateful, StrikethroughStyle,
+    ImageFormat, ImageSource, InlineReplacement, KeyContext, Length, MouseButton, MouseDownEvent,
+    MouseEvent, MouseMoveEvent, MouseUpEvent, Point, ScrollHandle, Stateful, StrikethroughStyle,
     StyleRefinement, StyledImage, StyledText, Subscription, Task, TextAlign, TextLayout, TextRun,
     TextStyle, TextStyleRefinement, actions, img, point, quad,
 };
@@ -382,6 +388,7 @@ pub struct Markdown {
     fallback_code_block_language: Option<LanguageName>,
     options: MarkdownOptions,
     mermaid_state: MermaidState,
+    math_state: MathState,
     _mermaid_theme_subscription: Option<Subscription>,
     mermaid_showing_code: HashSet<usize>,
     copied_code_blocks: HashSet<ElementId>,
@@ -400,6 +407,7 @@ pub struct MarkdownOptions {
     pub render_mermaid_diagrams: bool,
     pub parse_heading_slugs: bool,
     pub render_metadata_blocks: bool,
+    pub render_math: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -573,6 +581,7 @@ impl Markdown {
             language_registry,
             fallback_code_block_language,
             options,
+            math_state: MathState::default(),
             mermaid_state: MermaidState::default(),
             _mermaid_theme_subscription: theme_subscription,
             mermaid_showing_code: HashSet::default(),
@@ -880,6 +889,7 @@ impl Markdown {
             self.active_root_block = None;
             self.images_by_source_offset.clear();
             self.mermaid_state.clear();
+            self.math_state.clear();
             cx.notify();
             cx.refresh_windows();
             return;
@@ -915,6 +925,7 @@ impl Markdown {
                         html_blocks: BTreeMap::default(),
                         metadata_blocks: BTreeMap::default(),
                         mermaid_diagrams: BTreeMap::default(),
+                        math_expressions: BTreeMap::default(),
                         heading_slugs: HashMap::default(),
                         footnote_definitions: HashMap::default(),
                     },
@@ -941,6 +952,7 @@ impl Markdown {
             } else {
                 BTreeMap::default()
             };
+            let math_expressions = extract_math_expressions(&source, &events);
             let mut images_by_source_offset = HashMap::default();
             let mut languages_by_name = TreeMap::default();
             let mut languages_by_path = TreeMap::default();
@@ -1003,6 +1015,7 @@ impl Markdown {
                     html_blocks,
                     metadata_blocks,
                     mermaid_diagrams,
+                    math_expressions,
                     heading_slugs,
                     footnote_definitions,
                 },
@@ -1029,6 +1042,12 @@ impl Markdown {
                 } else {
                     this.mermaid_state.clear();
                     this.mermaid_showing_code.clear();
+                }
+                if this.options.render_math {
+                    let parsed_markdown = this.parsed_markdown.clone();
+                    this.math_state.update(&parsed_markdown, cx);
+                } else {
+                    this.math_state.clear();
                 }
                 this.pending_parse.take();
                 if this.should_reparse {
@@ -1132,6 +1151,7 @@ pub struct ParsedMarkdown {
     pub(crate) html_blocks: BTreeMap<usize, html::html_parser::ParsedHtmlBlock>,
     pub(crate) metadata_blocks: BTreeMap<usize, ParsedMetadataBlock>,
     pub(crate) mermaid_diagrams: BTreeMap<usize, ParsedMarkdownMermaidDiagram>,
+    pub(crate) math_expressions: BTreeMap<usize, ParsedMathExpression>,
     pub heading_slugs: HashMap<SharedString, usize>,
     pub footnote_definitions: HashMap<SharedString, usize>,
 }
@@ -1594,6 +1614,31 @@ impl MarkdownElement {
         builder.push_div(div().flex_1().w_0(), range, markdown_end);
     }
 
+    fn push_markdown_display_math(
+        &self,
+        builder: &mut MarkdownElementBuilder,
+        range: Range<usize>,
+        expr: &ParsedMathExpression,
+        math_state: &MathState,
+        window: &Window,
+    ) {
+        let font_size = self
+            .style
+            .base_text_style
+            .font_size
+            .to_pixels(window.rem_size());
+
+        let math = render_math_expression(expr, math_state, font_size, &self.style);
+        builder.push_sourced_element(
+            range,
+            div()
+                .w_full()
+                .my_3()
+                .child(div().flex().justify_center().child(math))
+                .into_any_element(),
+        );
+    }
+
     fn pop_markdown_list_item(&self, builder: &mut MarkdownElementBuilder) {
         builder.pop_div();
         builder.pop_div();
@@ -1962,8 +2007,17 @@ impl Element for MarkdownElement {
             &self.style.container_style,
             self.style.base_text_style.clone(),
             self.style.syntax.clone(),
+            window.rem_size(),
         );
-        let (parsed_markdown, images, active_root_block, render_mermaid_diagrams, mermaid_state) = {
+        let (
+            parsed_markdown,
+            images,
+            active_root_block,
+            render_mermaid_diagrams,
+            mermaid_state,
+            render_math,
+            math_state,
+        ) = {
             let markdown = self.markdown.read(cx);
             (
                 markdown.parsed_markdown.clone(),
@@ -1971,6 +2025,8 @@ impl Element for MarkdownElement {
                 markdown.active_root_block,
                 markdown.options.render_mermaid_diagrams,
                 markdown.mermaid_state.clone(),
+                markdown.options.render_math,
+                markdown.math_state.clone(),
             )
         };
         let markdown_end = if let Some(last) = parsed_markdown.events.last() {
@@ -2635,6 +2691,49 @@ impl Element for MarkdownElement {
                     builder.push_text(&format!("[{label}]"), range.clone());
                     builder.pop_text_style();
                 }
+
+                MarkdownEvent::InlineMath => {
+                    if render_math {
+                        if let Some(expr) = parsed_markdown.math_expressions.get(&range.start) {
+                            let font_size =
+                                builder.text_style().font_size.to_pixels(window.rem_size());
+                            if !builder.push_inline_math(
+                                range.clone(),
+                                expr,
+                                &math_state,
+                                font_size,
+                            ) {
+                                builder.push_text(
+                                    &parsed_markdown.source[range.clone()],
+                                    range.clone(),
+                                );
+                            }
+                        } else {
+                            builder
+                                .push_text(&parsed_markdown.source[range.clone()], range.clone());
+                        }
+                    } else {
+                        builder.push_text(&parsed_markdown.source[range.clone()], range.clone());
+                    }
+                }
+                MarkdownEvent::DisplayMath => {
+                    if render_math {
+                        if let Some(expr) = parsed_markdown.math_expressions.get(&range.start) {
+                            self.push_markdown_display_math(
+                                &mut builder,
+                                range.clone(),
+                                expr,
+                                &math_state,
+                                window,
+                            );
+                        } else {
+                            builder
+                                .push_text(&parsed_markdown.source[range.clone()], range.clone());
+                        }
+                    } else {
+                        builder.push_text(&parsed_markdown.source[range.clone()], range.clone());
+                    }
+                }
             }
         }
         if self.style.code_block_overflow_x_scroll {
@@ -2705,6 +2804,10 @@ impl Element for MarkdownElement {
 
         self.paint_mouse_listeners(hitbox, &rendered_markdown.text, window, cx);
         rendered_markdown.element.paint(window, cx);
+        let math_state = self.markdown.read(cx).math_state.clone();
+        rendered_markdown
+            .text
+            .paint_inline_math(&math_state, window);
         self.paint_search_highlights(&rendered_markdown.text, window, cx);
         self.paint_selection(&rendered_markdown.text, window, cx);
     }
@@ -2984,13 +3087,42 @@ struct MarkdownElementBuilder {
     list_stack: Vec<ListStackEntry>,
     table: TableState,
     syntax_theme: Arc<SyntaxTheme>,
+    rem_size: Pixels,
 }
+
+const INLINE_OBJECT_REPLACEMENT: char = '\u{fffc}';
 
 #[derive(Default)]
 struct PendingLine {
     text: String,
     runs: Vec<TextRun>,
     source_mappings: Vec<SourceMapping>,
+    inline_objects: Vec<PendingInlineObject>,
+}
+
+#[derive(Clone)]
+struct PendingInlineObject {
+    rendered_range: Range<usize>,
+    kind: InlineObjectKind,
+    metrics: MathLayoutMetrics,
+    font_size: Pixels,
+    default_color: Hsla,
+}
+
+#[derive(Clone)]
+enum InlineObjectKind {
+    Math {
+        expression: ParsedMathExpressionContents,
+    },
+}
+
+#[derive(Clone)]
+struct RenderedInlineObject {
+    rendered_range: Range<usize>,
+    kind: InlineObjectKind,
+    metrics: MathLayoutMetrics,
+    font_size: Pixels,
+    default_color: Hsla,
 }
 
 struct ListStackEntry {
@@ -3002,6 +3134,7 @@ impl MarkdownElementBuilder {
         container_style: &StyleRefinement,
         base_text_style: TextStyle,
         syntax_theme: Arc<SyntaxTheme>,
+        rem_size: Pixels,
     ) -> Self {
         Self {
             div_stack: vec![{
@@ -3023,6 +3156,7 @@ impl MarkdownElementBuilder {
             list_stack: Vec::new(),
             table: TableState::default(),
             syntax_theme,
+            rem_size,
         }
     }
 
@@ -3183,6 +3317,42 @@ impl MarkdownElementBuilder {
         });
     }
 
+    fn push_inline_math(
+        &mut self,
+        source_range: Range<usize>,
+        expr: &ParsedMathExpression,
+        math_state: &MathState,
+        font_size: Pixels,
+    ) -> bool {
+        let Some(metrics) = math_layout_metrics(expr, math_state, font_size) else {
+            return false;
+        };
+
+        let rendered_start = self.pending_line.text.len();
+        self.pending_line.source_mappings.push(SourceMapping {
+            rendered_index: rendered_start,
+            source_index: source_range.start,
+        });
+        self.pending_line.text.push(INLINE_OBJECT_REPLACEMENT);
+        let rendered_end = self.pending_line.text.len();
+        let mut placeholder_style = self.text_style();
+        placeholder_style.color = Hsla::transparent_black();
+        self.pending_line
+            .runs
+            .push(placeholder_style.to_run(rendered_end - rendered_start));
+        self.pending_line.inline_objects.push(PendingInlineObject {
+            rendered_range: rendered_start..rendered_end,
+            kind: InlineObjectKind::Math {
+                expression: expr.contents.clone(),
+            },
+            metrics,
+            font_size,
+            default_color: self.text_style().color,
+        });
+        self.current_source_index = source_range.end;
+        true
+    }
+
     fn push_text(&mut self, text: &str, source_range: Range<usize>) {
         self.pending_line.source_mappings.push(SourceMapping {
             rendered_index: self.pending_line.text.len(),
@@ -3308,6 +3478,7 @@ impl MarkdownElementBuilder {
             source_end: source_range.end,
             language: None,
             text_align: TextAlign::Left,
+            inline_objects: Vec::new(),
         });
         div()
             .absolute()
@@ -3325,15 +3496,93 @@ impl MarkdownElementBuilder {
             return;
         }
 
-        let text = StyledText::new(line.text).with_runs(line.runs);
+        let inline_replacements = line
+            .inline_objects
+            .iter()
+            .map(|object| InlineReplacement {
+                range: object.rendered_range.clone(),
+                width: object.metrics.width,
+                ascent: object.metrics.ascent,
+                descent: object.metrics.descent,
+            })
+            .collect::<Vec<_>>();
+
+        // If the line carries an inline math expression that would clip when
+        // baseline-aligned with the surrounding text, grow the line height to
+        // fit it. The math itself is painted at its natural size in
+        // `paint_inline_math`; here we only ensure the line is tall enough.
+        let line_height_override = {
+            let max_math_ascent = line
+                .inline_objects
+                .iter()
+                .map(|object| object.metrics.ascent)
+                .fold(Pixels::ZERO, Pixels::max);
+            let max_math_descent = line
+                .inline_objects
+                .iter()
+                .map(|object| object.metrics.descent)
+                .fold(Pixels::ZERO, Pixels::max);
+            if max_math_ascent > Pixels::ZERO || max_math_descent > Pixels::ZERO {
+                let text_style = self.text_style();
+                let font_size = text_style.font_size.to_pixels(self.rem_size);
+                let default_line_height = text_style
+                    .line_height
+                    .to_pixels(font_size.into(), self.rem_size);
+                // We don't know the exact text ascent/descent at build time, so
+                // approximate the typical 80/20 split. The actual values come
+                // from the text layout at paint time.
+                let text_ascent_approx = font_size * 0.8;
+                let text_descent_approx = font_size * 0.2;
+                // Required line height for the math baseline to align with the
+                // text baseline without clipping at the top or bottom.
+                let top_needed = max_math_ascent * 2. - text_ascent_approx + text_descent_approx;
+                let bottom_needed =
+                    text_ascent_approx - text_descent_approx + max_math_descent * 2.;
+                let padding = font_size * 0.15;
+                let required = top_needed.max(bottom_needed) + padding;
+                if required > default_line_height {
+                    Some(required)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
+        let text = StyledText::new(line.text)
+            .with_runs(line.runs)
+            .with_inline_replacements(inline_replacements);
+        let layout = text.layout().clone();
+        let text_any = text.into_any();
+        let rendered_inline_objects = line
+            .inline_objects
+            .into_iter()
+            .map(|object| RenderedInlineObject {
+                rendered_range: object.rendered_range,
+                kind: object.kind,
+                metrics: object.metrics,
+                font_size: object.font_size,
+                default_color: object.default_color,
+            })
+            .collect();
         self.rendered_lines.push(RenderedLine {
-            layout: text.layout().clone(),
+            layout,
             source_mappings: line.source_mappings,
             source_end: self.current_source_index,
             language: self.code_block_stack.last().cloned().flatten(),
             text_align,
+            inline_objects: rendered_inline_objects,
         });
-        self.div_stack.last_mut().unwrap().extend([text.into_any()]);
+        let element: AnyElement = if let Some(line_height) = line_height_override {
+            div()
+                .line_height(line_height)
+                .child(text_any)
+                .into_any_element()
+        } else {
+            text_any
+        };
+        self.div_stack.last_mut().unwrap().extend([element]);
     }
 
     fn build(mut self) -> RenderedMarkdown {
@@ -3356,6 +3605,7 @@ struct RenderedLine {
     source_end: usize,
     language: Option<Arc<Language>>,
     text_align: TextAlign,
+    inline_objects: Vec<RenderedInlineObject>,
 }
 
 impl RenderedLine {
@@ -3435,6 +3685,71 @@ impl RenderedLine {
             TextAlign::Center => ((available_width - segment_width) / 2.).max(px(0.)),
             TextAlign::Right => (available_width - segment_width).max(px(0.)),
         }
+    }
+
+    fn bounds_for_rendered_range(&self, range: Range<usize>) -> Vec<Bounds<Pixels>> {
+        let mut all_bounds = Vec::new();
+        let layout = &self.layout;
+        let line_bounds = layout.bounds();
+        let line_height = layout.line_height();
+        let rendered_start = range.start;
+        let rendered_end = range.end;
+
+        let mut wrapped_line_start = 0;
+        let mut row_top = line_bounds.top();
+
+        while wrapped_line_start < rendered_end {
+            let Some(wrapped_line) = layout.line_layout_for_index(wrapped_line_start) else {
+                break;
+            };
+
+            let unwrapped_layout = &wrapped_line.unwrapped_layout;
+            let wrapped_line_end = wrapped_line_start + wrapped_line.len();
+
+            let row_ends = wrapped_line
+                .wrap_boundaries()
+                .iter()
+                .map(|wrap_boundary| {
+                    let glyph =
+                        &unwrapped_layout.runs[wrap_boundary.run_ix].glyphs[wrap_boundary.glyph_ix];
+                    (wrapped_line_start + glyph.index, glyph.position.x)
+                })
+                .chain([(wrapped_line_end, unwrapped_layout.width)]);
+
+            let mut row_start = wrapped_line_start;
+            let mut row_start_x = Pixels::ZERO;
+
+            for (row_end, row_end_x) in row_ends {
+                let selection_start = rendered_start.max(row_start);
+                let selection_end = rendered_end.min(row_end);
+
+                if selection_start < selection_end {
+                    let alignment_offset = self.alignment_offset_for_segment(
+                        line_bounds.size.width,
+                        row_start_x,
+                        row_end_x,
+                    );
+                    let x_for_index = |index| {
+                        line_bounds.left()
+                            + alignment_offset
+                            + unwrapped_layout.x_for_index(index - wrapped_line_start)
+                            - row_start_x
+                    };
+                    all_bounds.push(Bounds::from_corners(
+                        point(x_for_index(selection_start), row_top),
+                        point(x_for_index(selection_end), row_top + line_height),
+                    ));
+                }
+
+                row_start = row_end;
+                row_start_x = row_end_x;
+                row_top += line_height;
+            }
+
+            wrapped_line_start = wrapped_line_end + 1;
+        }
+
+        all_bounds
     }
 
     fn source_index_for_position(&self, position: Point<Pixels>) -> Result<usize, usize> {
@@ -3559,6 +3874,46 @@ struct RenderedFootnoteRef {
 }
 
 impl RenderedText {
+    fn paint_inline_math(&self, math_state: &MathState, window: &mut Window) {
+        for line in self.lines.iter() {
+            for inline_object in &line.inline_objects {
+                let InlineObjectKind::Math { expression } = &inline_object.kind;
+                let mut bounds =
+                    line.bounds_for_rendered_range(inline_object.rendered_range.clone());
+                for mut bounds in bounds.drain(..) {
+                    let Some(wrapped_line) = line
+                        .layout
+                        .line_layout_for_index(inline_object.rendered_range.start)
+                    else {
+                        continue;
+                    };
+                    let line_height = line.layout.line_height();
+                    let text_ascent = wrapped_line.ascent();
+                    let text_descent = wrapped_line.descent();
+                    let math_ascent = inline_object.metrics.ascent;
+                    let math_descent = inline_object.metrics.descent;
+                    // Align the math's baseline with the surrounding text's
+                    // baseline (the conventional inline-math alignment). The
+                    // line height is grown in `flush_text` so the math still
+                    // fits when the expression is taller than the text.
+                    let baseline_y = bounds.top()
+                        + (line_height - text_ascent - text_descent) / 2.
+                        + text_ascent;
+                    bounds.origin.y = baseline_y - math_ascent;
+                    bounds.size.height = math_ascent + math_descent;
+                    paint_math_expression_at(
+                        expression,
+                        math_state,
+                        bounds,
+                        inline_object.font_size,
+                        inline_object.default_color,
+                        window,
+                    );
+                }
+            }
+        }
+    }
+
     fn bounds_for_source_range(&self, range: Range<usize>) -> Vec<Bounds<Pixels>> {
         let mut all_bounds = Vec::new();
 

--- a/crates/markdown/src/math.rs
+++ b/crates/markdown/src/math.rs
@@ -1,0 +1,1053 @@
+use std::collections::{HashMap, HashSet};
+use std::ops::Range;
+use std::sync::{Arc, OnceLock};
+
+use collections::BTreeMap;
+use gpui::{
+    AppContext, Bounds, Context, FillOptions, FillRule, Hsla, PathBuilder, PathStyle, Pixels, Rgba,
+    SharedString, Task, TextRun, TextSystem, Window, canvas, fill, font, px,
+};
+use ratex_font::{FontId, katex_ttf_glyph_char};
+use ratex_layout::LayoutOptions;
+use ratex_types::{Color as RatexColor, DisplayItem, DisplayList, MathStyle, PathCommand};
+
+use anyhow::Result;
+use ui::{AnyElement, IntoElement, ParentElement, Styled, div};
+use util::ResultExt;
+
+use crate::parser::MarkdownEvent;
+use crate::{Markdown, MarkdownStyle, ParsedMarkdown};
+
+type MathExpressionCache = HashMap<ParsedMathExpressionContents, Arc<CachedMathExpression>>;
+
+static FONTS_REGISTERED: OnceLock<()> = OnceLock::new();
+
+const KATEX_FONTS: &[(FontId, &str)] = &[
+    (FontId::MainRegular, "KaTeX_Main-Regular.ttf"),
+    (FontId::MainBold, "KaTeX_Main-Bold.ttf"),
+    (FontId::MainItalic, "KaTeX_Main-Italic.ttf"),
+    (FontId::MainBoldItalic, "KaTeX_Main-BoldItalic.ttf"),
+    (FontId::MathItalic, "KaTeX_Math-Italic.ttf"),
+    (FontId::MathBoldItalic, "KaTeX_Math-BoldItalic.ttf"),
+    (FontId::AmsRegular, "KaTeX_AMS-Regular.ttf"),
+    (FontId::CaligraphicRegular, "KaTeX_Caligraphic-Regular.ttf"),
+    (FontId::FrakturRegular, "KaTeX_Fraktur-Regular.ttf"),
+    (FontId::FrakturBold, "KaTeX_Fraktur-Bold.ttf"),
+    (FontId::SansSerifRegular, "KaTeX_SansSerif-Regular.ttf"),
+    (FontId::SansSerifBold, "KaTeX_SansSerif-Bold.ttf"),
+    (FontId::SansSerifItalic, "KaTeX_SansSerif-Italic.ttf"),
+    (FontId::ScriptRegular, "KaTeX_Script-Regular.ttf"),
+    (FontId::TypewriterRegular, "KaTeX_Typewriter-Regular.ttf"),
+    (FontId::Size1Regular, "KaTeX_Size1-Regular.ttf"),
+    (FontId::Size2Regular, "KaTeX_Size2-Regular.ttf"),
+    (FontId::Size3Regular, "KaTeX_Size3-Regular.ttf"),
+    (FontId::Size4Regular, "KaTeX_Size4-Regular.ttf"),
+];
+
+fn katex_gpui_font(font_name: &str) -> gpui::Font {
+    match font_name {
+        "Main-Bold" => font("KaTeX_Main").bold(),
+        "Main-Italic" => font("KaTeX_Main").italic(),
+        "Main-BoldItalic" => font("KaTeX_Main").bold().italic(),
+        "Math-Italic" => font("KaTeX_Math").italic(),
+        "Math-BoldItalic" => font("KaTeX_Math").bold().italic(),
+        "AMS-Regular" => font("KaTeX_AMS"),
+        "Caligraphic-Regular" => font("KaTeX_Caligraphic"),
+        "Fraktur-Regular" => font("KaTeX_Fraktur"),
+        "Fraktur-Bold" => font("KaTeX_Fraktur").bold(),
+        "SansSerif-Regular" => font("KaTeX_SansSerif"),
+        "SansSerif-Bold" => font("KaTeX_SansSerif").bold(),
+        "SansSerif-Italic" => font("KaTeX_SansSerif").italic(),
+        "Script-Regular" => font("KaTeX_Script"),
+        "Typewriter-Regular" => font("KaTeX_Typewriter"),
+        "Size1-Regular" => font("KaTeX_Size1"),
+        "Size2-Regular" => font("KaTeX_Size2"),
+        "Size3-Regular" => font("KaTeX_Size3"),
+        "Size4-Regular" => font("KaTeX_Size4"),
+        _ => font("KaTeX_Main"),
+    }
+}
+
+fn is_system_fallback_font(font_id: FontId) -> bool {
+    matches!(
+        font_id,
+        FontId::CjkRegular | FontId::CjkFallback | FontId::EmojiFallback
+    )
+}
+
+fn register_katex_fonts(text_system: &TextSystem) {
+    let fonts = KATEX_FONTS
+        .iter()
+        .filter_map(|(_, filename)| ratex_katex_fonts::ttf_bytes(filename))
+        .collect::<Vec<_>>();
+
+    if fonts.is_empty() {
+        return;
+    }
+
+    if let Err(error) = text_system.add_fonts(fonts) {
+        log::debug!("failed to register KaTeX fonts: {error}");
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ParsedMathExpression {
+    pub(crate) contents: ParsedMathExpressionContents,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct ParsedMathExpressionContents {
+    pub(crate) contents: SharedString,
+    pub(crate) display_mode: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct MathLayoutMetrics {
+    pub(crate) width: Pixels,
+    pub(crate) ascent: Pixels,
+    pub(crate) descent: Pixels,
+}
+
+impl MathLayoutMetrics {
+    fn height(self) -> Pixels {
+        self.ascent + self.descent
+    }
+}
+
+#[derive(Default, Clone)]
+pub(crate) struct MathState {
+    cache: MathExpressionCache,
+    order: Vec<ParsedMathExpressionContents>,
+}
+
+impl MathState {
+    pub(crate) fn clear(&mut self) {
+        self.cache.clear();
+        self.order.clear();
+    }
+
+    fn get_fallback(
+        idx: usize,
+        old_order: &[ParsedMathExpressionContents],
+        new_order_len: usize,
+        cache: &MathExpressionCache,
+    ) -> Option<Arc<DisplayList>> {
+        if old_order.len() != new_order_len {
+            return None;
+        }
+
+        old_order.get(idx).and_then(|old_content| {
+            cache.get(old_content).and_then(|old_cached| {
+                old_cached
+                    .display_list
+                    .get()
+                    .and_then(|result| result.as_ref().ok().cloned())
+                    .or_else(|| old_cached.fallback.clone())
+            })
+        })
+    }
+
+    pub(crate) fn update(&mut self, parsed: &ParsedMarkdown, cx: &mut Context<Markdown>) {
+        FONTS_REGISTERED.get_or_init(|| {
+            register_katex_fonts(cx.text_system());
+        });
+        let mut new_order = Vec::new();
+        for math_expression in parsed.math_expressions.values() {
+            new_order.push(math_expression.contents.clone());
+        }
+
+        for (idx, new_content) in new_order.iter().enumerate() {
+            if !self.cache.contains_key(new_content) {
+                let fallback = Self::get_fallback(idx, &self.order, new_order.len(), &self.cache);
+                self.cache.insert(
+                    new_content.clone(),
+                    Arc::new(CachedMathExpression::new(new_content.clone(), fallback, cx)),
+                );
+            }
+        }
+
+        let new_order_set: HashSet<_> = new_order.iter().cloned().collect();
+        self.cache
+            .retain(|content, _| new_order_set.contains(content));
+        self.order = new_order;
+    }
+}
+
+fn parse_and_layout(latex: &str, display_mode: bool) -> Result<Arc<DisplayList>> {
+    let ast = ratex_parser::parse(latex)?;
+    let options = LayoutOptions {
+        style: if display_mode {
+            MathStyle::Display
+        } else {
+            MathStyle::Text
+        },
+        color: RatexColor::BLACK,
+        ..LayoutOptions::default()
+    };
+    let layout_box = ratex_layout::layout(&ast, &options);
+    let display_list = ratex_layout::to_display_list(&layout_box);
+    Ok(Arc::new(display_list))
+}
+
+struct CachedMathExpression {
+    display_list: Arc<OnceLock<anyhow::Result<Arc<DisplayList>>>>,
+    fallback: Option<Arc<DisplayList>>,
+    _task: Task<()>,
+}
+
+impl CachedMathExpression {
+    fn new(
+        contents: ParsedMathExpressionContents,
+        fallback: Option<Arc<DisplayList>>,
+        cx: &mut Context<Markdown>,
+    ) -> Self {
+        let display_list = Arc::new(OnceLock::<anyhow::Result<Arc<DisplayList>>>::new());
+        let display_list_clone = display_list.clone();
+
+        let task = cx.spawn(async move |this, cx| {
+            let value = cx
+                .background_spawn(async move {
+                    parse_and_layout(&contents.contents, contents.display_mode)
+                })
+                .await;
+            // `set` returns `Result<(), anyhow::Result<...>>` — the
+            // outer Err carries the value we tried to set, so
+            // `log_err`'s Display bound doesn't apply directly.
+            if let Err(value) = display_list_clone.set(value) {
+                log::error!("display list set failed: {value:?}");
+            }
+            this.update(cx, |_, cx| {
+                cx.notify();
+            })
+            .ok();
+        });
+
+        Self {
+            display_list,
+            fallback,
+            _task: task,
+        }
+    }
+}
+
+pub(crate) fn extract_math_expressions(
+    source: &str,
+    events: &[(Range<usize>, MarkdownEvent)],
+) -> BTreeMap<usize, ParsedMathExpression> {
+    let mut math_expressions = BTreeMap::default();
+
+    for (source_range, event) in events {
+        let display_mode = match event {
+            MarkdownEvent::InlineMath => false,
+            MarkdownEvent::DisplayMath => true,
+            _ => continue,
+        };
+
+        let contents = &source[source_range.clone()];
+        let inner = strip_math_delimiters(contents, display_mode);
+        if inner.trim().is_empty() {
+            continue;
+        }
+        math_expressions.insert(
+            source_range.start,
+            ParsedMathExpression {
+                contents: ParsedMathExpressionContents {
+                    contents: inner.into(),
+                    display_mode,
+                },
+            },
+        );
+    }
+
+    math_expressions
+}
+
+fn strip_math_delimiters(latex: &str, display_mode: bool) -> String {
+    let s = latex.trim();
+    if display_mode {
+        s.strip_prefix("$$")
+            .and_then(|s| s.strip_suffix("$$"))
+            .unwrap_or(s)
+    } else {
+        s.strip_prefix('$')
+            .and_then(|s| s.strip_suffix('$'))
+            .unwrap_or(s)
+    }
+    .to_string()
+}
+
+fn math_color_to_hsla(color: &RatexColor, default_color: Hsla) -> Hsla {
+    if *color == RatexColor::BLACK {
+        default_color
+    } else {
+        Hsla::from(Rgba {
+            r: color.r,
+            g: color.g,
+            b: color.b,
+            a: color.a,
+        })
+    }
+}
+
+fn resolved_font_matches(window: &Window, font_id: gpui::FontId, expected: &gpui::Font) -> bool {
+    window
+        .text_system()
+        .get_font_for_id(font_id)
+        .map(|resolved| {
+            resolved.family == expected.family
+                && resolved.weight == expected.weight
+                && resolved.style == expected.style
+        })
+        .unwrap_or(false)
+}
+
+fn paint_display_item(
+    item: &DisplayItem,
+    origin: gpui::Point<Pixels>,
+    font_size: Pixels,
+    default_color: Hsla,
+    window: &mut Window,
+) {
+    let display_offset = |value: f64| px(value as f32 * font_size.as_f32());
+    let display_point =
+        |x: f64, y: f64| gpui::point(origin.x + display_offset(x), origin.y + display_offset(y));
+
+    match item {
+        DisplayItem::GlyphPath {
+            x,
+            y,
+            scale,
+            font,
+            char_code,
+            color,
+        } => {
+            let mut origin = display_point(*x, *y);
+            let em = display_offset(*scale);
+
+            let font_id = FontId::parse(font).unwrap_or(FontId::MainRegular);
+            let (ch, font, require_katex_font) = if is_system_fallback_font(font_id) {
+                let Some(ch) = char::from_u32(*char_code) else {
+                    return;
+                };
+                (ch, window.text_style().font(), false)
+            } else {
+                let ch = katex_ttf_glyph_char(font_id, *char_code);
+                (ch, katex_gpui_font(font), true)
+            };
+
+            let text = ch.to_string();
+            let run = TextRun {
+                len: text.len(),
+                font: font.clone(),
+                color: math_color_to_hsla(color, default_color),
+                background_color: None,
+                underline: None,
+                strikethrough: None,
+            };
+            let line = window
+                .text_system()
+                .shape_line(text.into(), em, &[run], None);
+            let Some(run) = line.runs.first() else {
+                return;
+            };
+            if require_katex_font && !resolved_font_matches(window, run.font_id, &font) {
+                return;
+            }
+            let Some(glyph) = run.glyphs.first() else {
+                return;
+            };
+            origin = origin + gpui::point(glyph.position.x, px(0.));
+            //NOTE: We ignore glyph painting errors here, as they can be caused by invalid font glyphs, and we don't want to crash the entire rendering because of that.
+            if glyph.is_emoji {
+                window
+                    .paint_emoji(origin, run.font_id, glyph.id, em)
+                    .log_with_level(log::Level::Debug);
+            } else {
+                window
+                    .paint_glyph(
+                        origin,
+                        run.font_id,
+                        glyph.id,
+                        em,
+                        math_color_to_hsla(color, default_color),
+                    )
+                    .log_with_level(log::Level::Debug);
+            }
+        }
+
+        DisplayItem::Line {
+            x,
+            y,
+            width,
+            thickness,
+            color,
+            dashed,
+        } => {
+            let thickness_px = px((*thickness as f32 * font_size.as_f32()).max(1.0));
+            let line_center = display_point(*x, *y);
+            let line_top_left = gpui::point(
+                line_center.x,
+                line_center.y - px(thickness_px.as_f32() / 2.0),
+            );
+            if *dashed {
+                let end = display_point(*x + *width, *y);
+                let mut builder = PathBuilder::stroke(thickness_px).dash_array(&[px(4.), px(2.)]);
+                builder.move_to(line_center);
+                builder.line_to(end);
+                if let Ok(path) = builder.build() {
+                    window.paint_path(path, math_color_to_hsla(color, default_color));
+                }
+            } else {
+                let bounds = Bounds::new(
+                    line_top_left,
+                    gpui::size(display_offset(*width), thickness_px),
+                );
+                window.paint_quad(fill(bounds, math_color_to_hsla(color, default_color)));
+            }
+        }
+        DisplayItem::Rect {
+            x,
+            y,
+            width,
+            height,
+            color,
+        } => {
+            let rect_origin = display_point(*x, *y);
+            let width = px(display_offset(*width).as_f32().max(1.0));
+            let height = px(display_offset(*height).as_f32().max(1.0));
+            let bounds = Bounds::new(rect_origin, gpui::size(width, height));
+            window.paint_quad(fill(bounds, math_color_to_hsla(color, default_color)));
+        }
+        DisplayItem::Path {
+            x,
+            y,
+            commands,
+            fill,
+            color,
+        } => {
+            let path_point =
+                |command_x: f64, command_y: f64| display_point(*x + command_x, *y + command_y);
+            let mut paint_path_commands = |commands: &[PathCommand]| {
+                let mut builder = if *fill {
+                    PathBuilder::fill().with_style(PathStyle::Fill(
+                        FillOptions::default().with_fill_rule(FillRule::EvenOdd),
+                    ))
+                } else {
+                    // NOTE: define const
+                    PathBuilder::stroke(px(1.5))
+                };
+                for cmd in commands {
+                    match cmd {
+                        PathCommand::MoveTo { x, y } => {
+                            builder.move_to(path_point(*x, *y));
+                        }
+                        PathCommand::LineTo { x, y } => {
+                            builder.line_to(path_point(*x, *y));
+                        }
+                        PathCommand::QuadTo { x1, y1, x, y } => {
+                            builder.curve_to(path_point(*x, *y), path_point(*x1, *y1));
+                        }
+                        PathCommand::CubicTo {
+                            x1,
+                            y1,
+                            x2,
+                            y2,
+                            x,
+                            y,
+                        } => {
+                            builder.cubic_bezier_to(
+                                path_point(*x, *y),
+                                path_point(*x1, *y1),
+                                path_point(*x2, *y2),
+                            );
+                        }
+                        PathCommand::Close => builder.close(),
+                    }
+                }
+                if let Ok(path) = builder.build() {
+                    window.paint_path(path, math_color_to_hsla(color, default_color));
+                }
+            };
+
+            if *fill {
+                let mut start = 0;
+                for index in 1..commands.len() {
+                    if matches!(commands[index], PathCommand::MoveTo { .. }) {
+                        paint_path_commands(&commands[start..index]);
+                        start = index;
+                    }
+                }
+                if start < commands.len() {
+                    paint_path_commands(&commands[start..]);
+                }
+            } else {
+                paint_path_commands(commands);
+            }
+        }
+    }
+}
+
+fn display_list_metrics(display_list: &DisplayList, font_size: Pixels) -> MathLayoutMetrics {
+    MathLayoutMetrics {
+        width: px(display_list.width as f32 * font_size.as_f32()),
+        ascent: px(display_list.height as f32 * font_size.as_f32()),
+        descent: px(display_list.depth as f32 * font_size.as_f32()),
+    }
+}
+
+pub(crate) fn math_layout_metrics(
+    expr: &ParsedMathExpression,
+    math_state: &MathState,
+    font_size: Pixels,
+) -> Option<MathLayoutMetrics> {
+    let cached = math_state.cache.get(&expr.contents)?;
+    let display_list = cached
+        .display_list
+        .get()
+        .and_then(|result| result.as_ref().ok().cloned())
+        .or_else(|| cached.fallback.clone())?;
+
+    Some(display_list_metrics(&display_list, font_size))
+}
+
+pub(crate) fn paint_math_expression_at(
+    contents: &ParsedMathExpressionContents,
+    math_state: &MathState,
+    bounds: Bounds<Pixels>,
+    font_size: Pixels,
+    default_color: Hsla,
+    window: &mut Window,
+) {
+    let Some(cached) = math_state.cache.get(contents) else {
+        return;
+    };
+    let display_list = cached
+        .display_list
+        .get()
+        .and_then(|result| result.as_ref().ok().cloned())
+        .or_else(|| cached.fallback.clone());
+    let Some(display_list) = display_list else {
+        return;
+    };
+
+    for item in &display_list.items {
+        paint_display_item(item, bounds.origin, font_size, default_color, window);
+    }
+}
+
+pub(crate) fn render_math_expression(
+    expr: &ParsedMathExpression,
+    math_state: &MathState,
+    font_size: Pixels,
+    style: &MarkdownStyle,
+) -> AnyElement {
+    let cached = math_state.cache.get(&expr.contents);
+    let display_list = cached.and_then(|c| c.display_list.get()?.as_ref().ok());
+
+    match display_list {
+        Some(dl) => {
+            let metrics = display_list_metrics(dl, font_size);
+            let dl = dl.clone();
+            let default_color = style.base_text_style.color;
+
+            canvas(
+                move |_bounds, _window, _cx| (dl, font_size, default_color),
+                move |bounds, (dl, font_size, default_color), window, _cx| {
+                    for item in &dl.items {
+                        paint_display_item(item, bounds.origin, font_size, default_color, window);
+                    }
+                },
+            )
+            .w(metrics.width)
+            .h(metrics.height())
+            .into_any_element()
+        }
+        None => div()
+            .child(SharedString::from(format!(
+                "{}{}{}",
+                if expr.contents.display_mode {
+                    "$$"
+                } else {
+                    "$"
+                },
+                expr.contents.contents,
+                if expr.contents.display_mode {
+                    "$$"
+                } else {
+                    "$"
+                }
+            )))
+            .into_any_element(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::MarkdownEvent;
+
+    #[test]
+    fn strip_math_delimiters_inline() {
+        assert_eq!(strip_math_delimiters("$x + y$", false), "x + y");
+        // Surrounding whitespace is trimmed first.
+        assert_eq!(strip_math_delimiters("  $x$  ", false), "x");
+        // Missing one side of the delimiter leaves the original `s` intact
+        // (the function is defensive — pulldown-cmark only emits matched pairs).
+        assert_eq!(strip_math_delimiters("x + y", false), "x + y");
+        assert_eq!(strip_math_delimiters("$x + y", false), "$x + y");
+        assert_eq!(strip_math_delimiters("x + y$", false), "x + y$");
+    }
+
+    #[test]
+    fn strip_math_delimiters_display() {
+        assert_eq!(strip_math_delimiters("$$x + y$$", true), "x + y");
+        // Trims surrounding whitespace before stripping `$$`.
+        assert_eq!(strip_math_delimiters("\n  $$x$$  \n", true), "x");
+        // Single `$` boundary doesn't match the display delimiter.
+        assert_eq!(strip_math_delimiters("$x$", true), "$x$");
+        assert_eq!(strip_math_delimiters("$$x$", true), "$$x$");
+    }
+
+    #[test]
+    fn extract_math_expressions_collects_inline_and_display() {
+        use crate::parser::parse_markdown_with_options;
+        let source = "before $a + b$ middle\n\n$$
+foo
+ + bar
+$$\n\nafter";
+        let parsed = parse_markdown_with_options(source, true, false, false);
+        let math_events: Vec<_> = parsed
+            .events
+            .iter()
+            .filter(|(_, ev)| matches!(ev, MarkdownEvent::InlineMath | MarkdownEvent::DisplayMath))
+            .cloned()
+            .collect();
+        assert_eq!(math_events.len(), 2, "got events: {:?}", parsed.events);
+
+        let extracted = extract_math_expressions(source, &math_events);
+        assert_eq!(extracted.len(), 2, "got: {extracted:?}");
+
+        // Inline math: `$a + b$` with surrounding spaces/newlines.
+        let inline = extracted
+            .values()
+            .find(|m| !m.contents.display_mode)
+            .expect("inline math should be extracted");
+        assert_eq!(inline.contents.contents.to_string(), "a + b");
+
+        // Display math: the multi-line block.
+        let display = extracted
+            .values()
+            .find(|m| m.contents.display_mode)
+            .expect("display math should be extracted");
+        assert!(display.contents.contents.to_string().contains("foo"));
+        assert!(display.contents.contents.to_string().contains("+ bar"));
+        // The display event's source range must slice back to the original `$$...$$` block.
+        let display_event_range = math_events
+            .iter()
+            .find(|(_, ev)| matches!(ev, MarkdownEvent::DisplayMath))
+            .expect("display math event")
+            .0
+            .clone();
+        let slice = &source[display_event_range];
+        assert!(slice.starts_with("$$"));
+        assert!(slice.ends_with("$$"));
+    }
+
+    #[test]
+    fn extract_math_expressions_skips_empty_and_non_math_events() {
+        use crate::parser::parse_markdown_with_options;
+        // A display-math block consisting only of whitespace, and an
+        // inline math that's just a stray `$` (which pulldown-cmark would
+        // not normally emit, so this also covers "all events are not math").
+        let source = "no math here\n\n$$  $$\n\njust text $ $ more";
+        let parsed = parse_markdown_with_options(source, true, false, false);
+        let extracted = extract_math_expressions(source, &parsed.events);
+        // Whatever pulldown-cmark produces for `$$  $$`, the extracted
+        // content must never be empty.
+        for m in extracted.values() {
+            assert!(
+                !m.contents.contents.trim().is_empty(),
+                "extracted math content should not be empty: {m:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn extract_math_expressions_ignores_other_events() {
+        let source = "text";
+        let events = vec![
+            (0..4, MarkdownEvent::Text),
+            (
+                0..4,
+                MarkdownEvent::Start(crate::parser::MarkdownTag::Paragraph),
+            ),
+        ];
+        let extracted = extract_math_expressions(source, &events);
+        assert!(extracted.is_empty());
+    }
+
+    #[test]
+    fn is_system_fallback_font_recognises_cjk_and_emoji() {
+        assert!(is_system_fallback_font(FontId::CjkRegular));
+        assert!(is_system_fallback_font(FontId::CjkFallback));
+        assert!(is_system_fallback_font(FontId::EmojiFallback));
+        assert!(!is_system_fallback_font(FontId::MainRegular));
+        assert!(!is_system_fallback_font(FontId::MathItalic));
+    }
+
+    #[test]
+    fn display_list_metrics_zero_for_empty() {
+        let display_list = DisplayList {
+            width: 0.0,
+            height: 0.0,
+            depth: 0.0,
+            items: vec![],
+        };
+        let metrics = display_list_metrics(&display_list, px(16.0));
+        assert_eq!(metrics.width, Pixels::ZERO);
+        assert_eq!(metrics.ascent, Pixels::ZERO);
+        assert_eq!(metrics.descent, Pixels::ZERO);
+        assert_eq!(metrics.height(), Pixels::ZERO);
+
+        // Non-zero display list: ascent/depth are scaled by font_size in em.
+        let display_list = DisplayList {
+            width: 0.5,
+            height: 0.8,
+            depth: 0.2,
+            items: vec![],
+        };
+        let metrics = display_list_metrics(&display_list, px(10.0));
+        assert_eq!(metrics.width, px(5.0));
+        assert_eq!(metrics.ascent, px(8.0));
+        assert_eq!(metrics.descent, px(2.0));
+        assert_eq!(metrics.height(), px(10.0));
+    }
+
+    #[test]
+    fn katex_gpui_font_all_variants_map_to_correct_family() {
+        use gpui::{FontStyle, FontWeight};
+
+        // (input name, expected family, expected weight, expected style)
+        let cases: &[(&str, &str, FontWeight, FontStyle)] = &[
+            (
+                "Main-Bold",
+                "KaTeX_Main",
+                FontWeight::BOLD,
+                FontStyle::Normal,
+            ),
+            (
+                "Main-Italic",
+                "KaTeX_Main",
+                FontWeight::NORMAL,
+                FontStyle::Italic,
+            ),
+            (
+                "Main-BoldItalic",
+                "KaTeX_Main",
+                FontWeight::BOLD,
+                FontStyle::Italic,
+            ),
+            (
+                "Math-Italic",
+                "KaTeX_Math",
+                FontWeight::NORMAL,
+                FontStyle::Italic,
+            ),
+            (
+                "Math-BoldItalic",
+                "KaTeX_Math",
+                FontWeight::BOLD,
+                FontStyle::Italic,
+            ),
+            (
+                "AMS-Regular",
+                "KaTeX_AMS",
+                FontWeight::NORMAL,
+                FontStyle::Normal,
+            ),
+            (
+                "Caligraphic-Regular",
+                "KaTeX_Caligraphic",
+                FontWeight::NORMAL,
+                FontStyle::Normal,
+            ),
+            (
+                "Fraktur-Regular",
+                "KaTeX_Fraktur",
+                FontWeight::NORMAL,
+                FontStyle::Normal,
+            ),
+            (
+                "Fraktur-Bold",
+                "KaTeX_Fraktur",
+                FontWeight::BOLD,
+                FontStyle::Normal,
+            ),
+            (
+                "SansSerif-Regular",
+                "KaTeX_SansSerif",
+                FontWeight::NORMAL,
+                FontStyle::Normal,
+            ),
+            (
+                "SansSerif-Bold",
+                "KaTeX_SansSerif",
+                FontWeight::BOLD,
+                FontStyle::Normal,
+            ),
+            (
+                "SansSerif-Italic",
+                "KaTeX_SansSerif",
+                FontWeight::NORMAL,
+                FontStyle::Italic,
+            ),
+            (
+                "Script-Regular",
+                "KaTeX_Script",
+                FontWeight::NORMAL,
+                FontStyle::Normal,
+            ),
+            (
+                "Typewriter-Regular",
+                "KaTeX_Typewriter",
+                FontWeight::NORMAL,
+                FontStyle::Normal,
+            ),
+            (
+                "Size1-Regular",
+                "KaTeX_Size1",
+                FontWeight::NORMAL,
+                FontStyle::Normal,
+            ),
+            (
+                "Size2-Regular",
+                "KaTeX_Size2",
+                FontWeight::NORMAL,
+                FontStyle::Normal,
+            ),
+            (
+                "Size3-Regular",
+                "KaTeX_Size3",
+                FontWeight::NORMAL,
+                FontStyle::Normal,
+            ),
+            (
+                "Size4-Regular",
+                "KaTeX_Size4",
+                FontWeight::NORMAL,
+                FontStyle::Normal,
+            ),
+        ];
+
+        for (input, expected_family, expected_weight, expected_style) in cases {
+            let font = katex_gpui_font(input);
+            assert_eq!(font.family.as_ref(), *expected_family, "family for {input}");
+            assert_eq!(font.weight, *expected_weight, "weight for {input}");
+            assert_eq!(font.style, *expected_style, "style for {input}");
+        }
+    }
+
+    #[test]
+    fn katex_gpui_font_unknown_name_falls_back_to_main_regular() {
+        use gpui::{FontStyle, FontWeight};
+        // An unrecognized name (e.g. a future KaTeX face we haven't wired
+        // up) should fall back to KaTeX_Main Regular, never crash and
+        // never produce a font with the raw name as family.
+        let font = katex_gpui_font("NotARealKaTeXFface");
+        assert_eq!(font.family.as_ref(), "KaTeX_Main");
+        assert_eq!(font.weight, FontWeight::NORMAL);
+        assert_eq!(font.style, FontStyle::Normal);
+    }
+
+    #[test]
+    fn math_color_to_hsla_uses_default_for_black() {
+        use gpui::hsla;
+        let default = hsla(0.5, 0.5, 0.5, 1.0);
+        // RatexColor::BLACK must short-circuit to the default — `BLACK`
+        // is the sentinel that means "follow the surrounding text color"
+        // and a black hsla would visually mask the math.
+        assert_eq!(math_color_to_hsla(&RatexColor::BLACK, default), default,);
+    }
+
+    #[test]
+    fn math_color_to_hsla_converts_rgba() {
+        use gpui::{Rgba, hsla};
+        let default = hsla(0.0, 0.0, 0.0, 1.0);
+        let red = RatexColor {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        };
+        let result = math_color_to_hsla(&red, default);
+        let expected = Hsla::from(Rgba {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+            a: 1.0,
+        });
+        assert_eq!(result, expected);
+        // Sanity: must not be the default (we passed a non-black color).
+        assert_ne!(result, default);
+    }
+
+    fn make_cached(
+        display_list_result: Option<anyhow::Result<Arc<DisplayList>>>,
+        fallback: Option<Arc<DisplayList>>,
+    ) -> CachedMathExpression {
+        let cell = Arc::new(OnceLock::<anyhow::Result<Arc<DisplayList>>>::new());
+        if let Some(value) = display_list_result {
+            // OnceLock can only be set once; the test that exercises the
+            // "pending" path leaves this empty.
+            if let Err(value) = cell.set(value) {
+                panic!("test OnceLock already set: {value:?}");
+            }
+        }
+        CachedMathExpression {
+            display_list: cell,
+            fallback,
+            _task: Task::ready(()),
+        }
+    }
+
+    fn make_cache_with(
+        contents: ParsedMathExpressionContents,
+        display_list: Option<anyhow::Result<Arc<DisplayList>>>,
+        fallback: Option<Arc<DisplayList>>,
+    ) -> (MathExpressionCache, Vec<ParsedMathExpressionContents>) {
+        let mut cache = MathExpressionCache::default();
+        let order = vec![contents.clone()];
+        cache.insert(contents, Arc::new(make_cached(display_list, fallback)));
+        (cache, order)
+    }
+
+    fn empty_display_list() -> Arc<DisplayList> {
+        Arc::new(DisplayList {
+            width: 0.0,
+            height: 0.0,
+            depth: 0.0,
+            items: vec![],
+        })
+    }
+
+    fn sample_contents() -> ParsedMathExpressionContents {
+        ParsedMathExpressionContents {
+            contents: SharedString::from("a + b"),
+            display_mode: false,
+        }
+    }
+
+    #[test]
+    fn get_fallback_returns_none_on_length_mismatch() {
+        let (cache, order) = make_cache_with(
+            sample_contents(),
+            Some(Ok(empty_display_list())),
+            Some(empty_display_list()),
+        );
+        // new_order_len differs from old order length — must short-circuit.
+        assert!(MathState::get_fallback(0, &order, order.len() + 1, &cache).is_none());
+        // And in the other direction (shorter new order).
+        assert!(MathState::get_fallback(0, &order, order.len() - 1, &cache).is_none());
+    }
+
+    #[test]
+    fn get_fallback_returns_none_when_idx_out_of_bounds() {
+        let (cache, order) = make_cache_with(
+            sample_contents(),
+            Some(Ok(empty_display_list())),
+            Some(empty_display_list()),
+        );
+        assert!(MathState::get_fallback(99, &order, order.len(), &cache).is_none());
+    }
+
+    #[test]
+    fn get_fallback_returns_none_when_cache_missing() {
+        // Build a cache whose key doesn't match what `old_order` refers to.
+        let contents_a = sample_contents();
+        let contents_b = ParsedMathExpressionContents {
+            contents: SharedString::from("x + y"),
+            display_mode: false,
+        };
+        let mut cache = MathExpressionCache::default();
+        cache.insert(
+            contents_a,
+            Arc::new(make_cached(Some(Ok(empty_display_list())), None)),
+        );
+        // order references contents_b which is not in the cache.
+        let order = vec![contents_b];
+        assert!(MathState::get_fallback(0, &order, order.len(), &cache).is_none());
+    }
+
+    #[test]
+    fn get_fallback_returns_display_list_when_ready() {
+        let dl = empty_display_list();
+        let (cache, order) = make_cache_with(
+            sample_contents(),
+            Some(Ok(dl.clone())),
+            // fallback present but must NOT be used when display_list is ready.
+            Some(Arc::new(DisplayList {
+                width: 99.0,
+                height: 0.0,
+                depth: 0.0,
+                items: vec![],
+            })),
+        );
+        let result = MathState::get_fallback(0, &order, order.len(), &cache);
+        assert_eq!(result.as_ref().map(|d| d.width), Some(0.0));
+    }
+
+    #[test]
+    fn get_fallback_uses_fallback_when_display_list_errored() {
+        let fallback = empty_display_list();
+        let (cache, order) = make_cache_with(
+            sample_contents(),
+            Some(Err(anyhow::anyhow!("ratex parse error"))),
+            Some(fallback.clone()),
+        );
+        let result = MathState::get_fallback(0, &order, order.len(), &cache);
+        // Width 0.0 == empty_display_list().width.
+        assert_eq!(result.as_ref().map(|d| d.width), Some(fallback.width));
+    }
+
+    #[test]
+    fn get_fallback_uses_fallback_when_display_list_pending() {
+        let fallback = empty_display_list();
+        let (cache, order) = make_cache_with(
+            sample_contents(),
+            None, // OnceLock never set → pending
+            Some(fallback.clone()),
+        );
+        let result = MathState::get_fallback(0, &order, order.len(), &cache);
+        assert_eq!(result.as_ref().map(|d| d.width), Some(fallback.width));
+    }
+
+    #[test]
+    fn get_fallback_returns_none_when_nothing_available() {
+        // Pending display list, no fallback.
+        let (cache, order) = make_cache_with(sample_contents(), None, None);
+        assert!(MathState::get_fallback(0, &order, order.len(), &cache).is_none());
+
+        // Errored display list, no fallback.
+        let (cache, order) =
+            make_cache_with(sample_contents(), Some(Err(anyhow::anyhow!("boom"))), None);
+        assert!(MathState::get_fallback(0, &order, order.len(), &cache).is_none());
+    }
+
+    #[test]
+    fn math_state_clear_empties_cache_and_order() {
+        let contents = sample_contents();
+        let mut state = MathState::default();
+        // Seed by going through the public cache (state.cache is private).
+        state.cache.insert(
+            contents.clone(),
+            Arc::new(make_cached(Some(Ok(empty_display_list())), None)),
+        );
+        state.order.push(contents);
+        assert_eq!(state.cache.len(), 1);
+        assert_eq!(state.order.len(), 1);
+
+        state.clear();
+        assert!(state.cache.is_empty());
+        assert!(state.order.is_empty());
+    }
+}

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -20,13 +20,133 @@ pub const PARSE_OPTIONS: Options = Options::ENABLE_TABLES
     .union(Options::ENABLE_OLD_FOOTNOTES)
     .union(Options::ENABLE_GFM)
     .union(Options::ENABLE_SUPERSCRIPT)
-    .union(Options::ENABLE_SUBSCRIPT);
+    .union(Options::ENABLE_SUBSCRIPT)
+    .union(Options::ENABLE_MATH);
 
 #[derive(Default)]
 struct ParseState {
     events: Vec<(Range<usize>, MarkdownEvent)>,
     root_block_starts: Vec<usize>,
     depth: usize,
+}
+
+/// Find the byte position just past the next unescaped `$$` after `start`.
+/// Returns `None` if no closing delimiter is found.
+fn find_display_math_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut i = start;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'$' && bytes[i + 1] == b'$' {
+            // Skip escaped `\$$`.
+            if i > 0 && bytes[i - 1] == b'\\' {
+                i += 1;
+                continue;
+            }
+            return Some(i + 2);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Append `c` (a character already known to live at `original_offset` in the
+/// source text) to `out` and record the offset mapping in `offset_map`.
+///
+/// `offset_map` has one entry per preprocessed-text boundary, where the
+/// `p`-th entry is the offset in the original text that corresponds to
+/// preprocessed position `p`. For multi-byte characters the intermediate
+/// entries (boundaries in the middle of the char) all point at the start of
+/// the same original char, and the final entry points one char past it.
+fn push_char(c: char, original_offset: usize, out: &mut String, offset_map: &mut Vec<usize>) {
+    let char_len = c.len_utf8();
+    out.push(c);
+    for k in 1..=char_len {
+        offset_map.push(if k < char_len {
+            original_offset
+        } else {
+            original_offset + char_len
+        });
+    }
+}
+
+/// Collapse multi-line `$$...$$` display math blocks into single-line form so
+/// `pulldown-cmark` can recognise them. Block-level constructs (lists, block
+/// quotes, ...) take precedence over inline math in `pulldown-cmark`, so a
+/// `+` at the start of a line inside `$$\n...\n$$` would otherwise tear the
+/// block apart and the inner lines would be parsed as list items. We replace
+/// the inner `\n` with U+2060 (WORD JOINER) — invisible to markdown parsing —
+/// and return an offset map so every event range reported by pulldown-cmark
+/// can be translated back to the original source positions.
+fn preprocess_math_blocks(text: &str) -> (String, Vec<usize>) {
+    let mut out = String::with_capacity(text.len());
+    let mut offset_map: Vec<usize> = vec![0];
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'$' {
+            // Skip escaped `\$$`.
+            if i > 0 && bytes[i - 1] == b'\\' {
+                push_char('$', i, &mut out, &mut offset_map);
+                i += 1;
+                continue;
+            }
+            if let Some(orig_end) = find_display_math_end(bytes, i + 2) {
+                let orig_start = i;
+                let contains_newline = text[orig_start..orig_end].contains('\n');
+                if contains_newline {
+                    // Push opening "$$".
+                    push_char('$', orig_start, &mut out, &mut offset_map);
+                    push_char('$', orig_start + 1, &mut out, &mut offset_map);
+                    // Push content, replacing newlines with U+2060.
+                    let mut j = orig_start + 2;
+                    while j < orig_end - 2 {
+                        let c = text[j..]
+                            .chars()
+                            .next()
+                            .expect("j is at a char boundary by construction");
+                        if c == '\n' {
+                            push_char('\u{2060}', j, &mut out, &mut offset_map);
+                        } else {
+                            push_char(c, j, &mut out, &mut offset_map);
+                        }
+                        j += c.len_utf8();
+                    }
+                    // Push closing "$$".
+                    push_char('$', orig_end - 2, &mut out, &mut offset_map);
+                    push_char('$', orig_end - 1, &mut out, &mut offset_map);
+                    i = orig_end;
+                    continue;
+                }
+                // Single-line `$$...$$`: copy verbatim.
+                let mut j = orig_start;
+                while j < orig_end {
+                    let c = text[j..]
+                        .chars()
+                        .next()
+                        .expect("j is at a char boundary by construction");
+                    push_char(c, j, &mut out, &mut offset_map);
+                    j += c.len_utf8();
+                }
+                i = orig_end;
+                continue;
+            }
+        }
+        let c = text[i..]
+            .chars()
+            .next()
+            .expect("i is at a char boundary by construction");
+        push_char(c, i, &mut out, &mut offset_map);
+        i += c.len_utf8();
+    }
+    (out, offset_map)
+}
+
+/// Translate a byte range from preprocessed text back to the original text
+/// using the offset map produced by `preprocess_math_blocks`.
+fn translate_range(range: &Range<usize>, offset_map: &[usize]) -> Range<usize> {
+    let len = offset_map.len();
+    let start = range.start.min(len.saturating_sub(1));
+    let end = range.end.min(len.saturating_sub(1));
+    offset_map[start]..offset_map[end]
 }
 
 #[derive(Debug, Default)]
@@ -228,10 +348,14 @@ pub(crate) fn parse_markdown_with_options(
     } else {
         PARSE_OPTIONS
     };
-    let mut parser = Parser::new_ext(text, parse_options)
+    let (parsed_text, offset_map) = preprocess_math_blocks(text);
+    let mut parser = Parser::new_ext(&parsed_text, parse_options)
         .into_offset_iter()
         .peekable();
     while let Some((pulldown_event, range)) = parser.next() {
+        // All ranges from pulldown-cmark are in the preprocessed text; translate
+        // them back to the original text before pushing events.
+        let range = translate_range(&range, &offset_map);
         if within_metadata && !parse_metadata_blocks {
             if let pulldown_cmark::Event::End(pulldown_cmark::TagEnd::MetadataBlock(_)) =
                 pulldown_event
@@ -254,6 +378,7 @@ pub(crate) fn parse_markdown_with_options(
                             html_blocks.insert(range.start, block);
 
                             while let Some((event, end_range)) = parser.next() {
+                                let end_range = translate_range(&end_range, &offset_map);
                                 if let pulldown_cmark::Event::End(
                                     pulldown_cmark::TagEnd::HtmlBlock,
                                 ) = event
@@ -498,6 +623,9 @@ pub(crate) fn parse_markdown_with_options(
                     let Some((next_event, next_range)) = parser.next() else {
                         unreachable!()
                     };
+                    // Translate back to the original source range, just like
+                    // the main loop does.
+                    let next_range = translate_range(&next_range, &offset_map);
                     let next_text = match next_event {
                         pulldown_cmark::Event::Text(next_event) => next_event,
                         pulldown_cmark::Event::InlineHtml(_) => CowStr::Borrowed(""),
@@ -505,7 +633,7 @@ pub(crate) fn parse_markdown_with_options(
                     };
                     let next_len = last_len + next_text.len();
                     ranges.push(TextRange {
-                        source_range: next_range.clone(),
+                        source_range: next_range,
                         merged_range: last_len..next_len,
                         parsed: next_text,
                     });
@@ -629,7 +757,12 @@ pub(crate) fn parse_markdown_with_options(
             pulldown_cmark::Event::TaskListMarker(checked) => {
                 state.push_event(range, MarkdownEvent::TaskListMarker(checked))
             }
-            pulldown_cmark::Event::InlineMath(_) | pulldown_cmark::Event::DisplayMath(_) => {}
+            pulldown_cmark::Event::InlineMath(_) => {
+                state.push_event(range, MarkdownEvent::InlineMath)
+            }
+            pulldown_cmark::Event::DisplayMath(_) => {
+                state.push_event(range, MarkdownEvent::DisplayMath)
+            }
         }
     }
 
@@ -748,6 +881,10 @@ pub enum MarkdownEvent {
     Rule,
     /// A task list marker, rendered as a checkbox in HTML. Contains a true when it is checked.
     TaskListMarker(bool),
+    /// An inline math node.
+    InlineMath,
+    /// A display math node.
+    DisplayMath,
     /// Start of a root-level block (a top-level structural element like a paragraph, heading, list, etc.).
     RootStart,
     /// End of a root-level block. Contains the root block index.
@@ -905,9 +1042,8 @@ mod tests {
     use super::*;
 
     const CONDITIONAL_OPTIONS: Options = Options::ENABLE_YAML_STYLE_METADATA_BLOCKS;
-    const UNWANTED_OPTIONS: Options = Options::ENABLE_MATH
-        .union(Options::ENABLE_DEFINITION_LIST)
-        .union(Options::ENABLE_WIKILINKS);
+    const UNWANTED_OPTIONS: Options =
+        Options::ENABLE_DEFINITION_LIST.union(Options::ENABLE_WIKILINKS);
 
     #[test]
     fn all_options_considered() {
@@ -929,6 +1065,271 @@ mod tests {
                 .intersection(UNWANTED_OPTIONS),
             Options::empty()
         );
+    }
+
+    #[test]
+    fn test_multiline_display_math_with_list_marker() {
+        // Regression: pulldown-cmark parses block-level constructs (lists,
+        // block quotes) before math, so a `+` at the start of a line inside
+        // a multi-line `$$...$$` block used to split the block in two and
+        // the inner lines were emitted as list items. We pre-collapse the
+        // newlines so pulldown-cmark sees a single-line `$$...$$` and
+        // emit a single `DisplayMath` event with the original range.
+        let source = "$$\n\\begin{aligned}\n\\nabla f(x,y,z)\n&= a\n + b\n + c\n\\end{aligned}\n$$";
+        let parsed = parse_markdown_with_options(source, false, false, false);
+        let math_events: Vec<_> = parsed
+            .events
+            .iter()
+            .filter(|(_, ev)| {
+                matches!(
+                    ev,
+                    DisplayMath
+                        | InlineMath
+                        | MarkdownEvent::Text
+                        | MarkdownEvent::SubstitutedText(_)
+                )
+            })
+            .collect();
+        assert!(
+            math_events.iter().any(|(_, ev)| matches!(ev, DisplayMath)),
+            "expected a single DisplayMath event, got {math_events:?}"
+        );
+        // The DisplayMath range must cover the entire original `$$...$$`
+        // block (including delimiters).
+        let (range, _) = math_events
+            .iter()
+            .find(|(_, ev)| matches!(ev, DisplayMath))
+            .unwrap();
+        assert_eq!(range.start, 0);
+        assert_eq!(range.end, source.len());
+        // No stray list items should remain inside the math range.
+        for (r, ev) in &parsed.events {
+            if matches!(ev, MarkdownEvent::Start(MarkdownTag::Item)) && r.end <= source.len() {
+                panic!("unexpected list item inside math block: {ev:?} @ {r:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_single_line_display_math_still_works() {
+        let source = "$$ a + b + c $$";
+        let parsed = parse_markdown_with_options(source, false, false, false);
+        assert!(
+            parsed
+                .events
+                .iter()
+                .any(|(_, ev)| matches!(ev, DisplayMath))
+        );
+    }
+
+    #[test]
+    fn test_inline_math_still_works() {
+        let source = "inline $a + b$ math";
+        let parsed = parse_markdown_with_options(source, false, false, false);
+        assert!(parsed.events.iter().any(|(_, ev)| matches!(ev, InlineMath)));
+    }
+
+    #[test]
+    fn test_multibyte_text_around_math_does_not_panic() {
+        // Regression: text ranges from pulldown-cmark are in the preprocessed
+        // text (where math-block `\n` have been swapped for 3-byte U+2060
+        // characters), so they must be translated back to the original byte
+        // offsets. Skipping the translation used to land inside a multi-byte
+        // Chinese character and panic with "not a char boundary".
+        let source = "# 渲染测试中文标题\n\n$$
+\\begin{aligned}
+a
+ + b
+ + c
+\\end{aligned}
+$$\n\n正文 $a^2$ end";
+        let parsed = parse_markdown_with_options(source, false, false, false);
+        // The math block is a single DisplayMath event covering the whole
+        // original `$$...$$` range, including its real newlines.
+        let math: Vec<_> = parsed
+            .events
+            .iter()
+            .filter(|(_, ev)| matches!(ev, DisplayMath))
+            .collect();
+        assert_eq!(math.len(), 1, "expected exactly one DisplayMath event");
+        let (range, _) = math[0];
+        // The math range covers the whole original `$$...$$` block, delimiters
+        // and real newlines included.
+        assert!(source[range.clone()].starts_with("$$"));
+        assert!(source[range.clone()].ends_with("$$"));
+        assert!(source[range.clone()].contains('\n'));
+        // Slicing the source at every reported event range must be safe.
+        for (r, _) in &parsed.events {
+            // Validating that the slice doesn't panic is the point of the test.
+            let _ = &source[r.clone()];
+        }
+    }
+
+    #[test]
+    fn test_multibyte_text_with_url_around_math_does_not_panic() {
+        // Regression: the text/link handling path peeks at upcoming events
+        // and calls `parser.next()` inside a loop to merge consecutive Text
+        // events. Those inner `next_range`s also need `translate_range` or
+        // the resulting `TextRange.source_range` points into the
+        // preprocessed text (which is longer than the original thanks to
+        // the 3-byte U+2060 substitutions) and slicing the source panics
+        // with "out of bounds".
+        let source = "## 中文标题 + URL\n\n$$
+a
+ + b
+$$\n\n看 https://example.com/链接 末尾";
+        // Trigger the link-finding path with parse_html.
+        let parsed = parse_markdown_with_options(source, true, false, false);
+        for (r, _) in &parsed.events {
+            let _ = &source[r.clone()];
+        }
+        // And confirm the URL was actually autolinked.
+        let link_count = parsed
+            .events
+            .iter()
+            .filter(|(_, ev)| matches!(ev, MarkdownEvent::Start(MarkdownTag::Link { .. })))
+            .count();
+        assert!(
+            link_count >= 1,
+            "expected the URL to be autolinked, got {link_count} link events"
+        );
+    }
+
+    #[test]
+    fn test_preprocess_math_blocks_directly() {
+        // Unit-test the preprocessor in isolation: a multi-line `$$...$$`
+        // block should be collapsed onto one line with `\n` -> U+2060, and
+        // single-line blocks / escaped `\$` should pass through unchanged.
+        let source = "before\n$$\nfoo\n + bar\nbaz\n$$\nafter";
+        let (processed, offset_map) = preprocess_math_blocks(source);
+        // Single output line, real newlines gone inside the math block.
+        assert!(processed.contains("$$"));
+        assert!(
+            !processed.contains(" + bar\nbaz "),
+            "newlines inside math must be collapsed"
+        );
+        // The preprocessed text is longer than the source by 2 bytes per
+        // collapsed newline (3 - 1 = 2 extra bytes for U+2060 vs `\n`).
+        let open = source.find("$$").unwrap();
+        let close = source.rfind("$$").unwrap();
+        let internal_nl = source[open + 2..close].matches('\n').count();
+        assert_eq!(processed.len(), source.len() + internal_nl * 2);
+        // offset_map maps every preprocessed byte back to the original.
+        assert_eq!(offset_map.len(), processed.len() + 1);
+        // Boundary 0 and end-of-text must line up.
+        assert_eq!(offset_map[0], 0);
+        assert_eq!(offset_map[processed.len()], source.len());
+
+        // Escaped `\$` must NOT be treated as the start of a math block.
+        let escaped = "a \\$\\$ b";
+        let (p, _) = preprocess_math_blocks(escaped);
+        assert_eq!(p, escaped);
+
+        // Single-line `$$...$$` is passed through verbatim.
+        let single = "$$ x + y $$";
+        let (p, o) = preprocess_math_blocks(single);
+        assert_eq!(p, single);
+        assert_eq!(o[0], 0);
+        assert_eq!(o[p.len()], single.len());
+
+        // Lone `$$` with no matching closer is left alone.
+        let unterminated = "before $$\nafter";
+        let (p, o) = preprocess_math_blocks(unterminated);
+        assert_eq!(p, unterminated);
+        assert_eq!(o[p.len()], unterminated.len());
+    }
+
+    #[test]
+    fn test_translate_range_clamps() {
+        // translate_range must not panic on out-of-range inputs (defensive
+        // clamping, in case pulldown-cmark ever emits a range past the
+        // preprocessed text — better to clamp than to slice the original).
+        let (_, offset_map) = preprocess_math_blocks("hi");
+        let _ = translate_range(&(0..1000), &offset_map);
+    }
+
+    #[test]
+    fn test_multiple_consecutive_math_blocks() {
+        // Two adjacent multi-line math blocks each need their own offset
+        // range. Make sure the offset map handles them independently and
+        // slicing the source for every event is safe.
+        let source = "$$ a\n + b $$\n\n$$ c\n + d $$\n";
+        let parsed = parse_markdown_with_options(source, false, false, false);
+        let math_count = parsed
+            .events
+            .iter()
+            .filter(|(_, ev)| matches!(ev, DisplayMath))
+            .count();
+        assert_eq!(math_count, 2);
+        for (r, _) in &parsed.events {
+            let _ = &source[r.clone()];
+        }
+    }
+
+    #[test]
+    fn test_math_at_file_boundaries() {
+        // Math block at the very start and very end of the file.
+        let start = "$$ x $$\nafter";
+        let parsed = parse_markdown_with_options(start, false, false, false);
+        assert!(
+            parsed
+                .events
+                .iter()
+                .any(|(_, ev)| matches!(ev, DisplayMath))
+        );
+        for (r, _) in &parsed.events {
+            let _ = &start[r.clone()];
+        }
+
+        let end = "before\n$$ y $$";
+        let parsed = parse_markdown_with_options(end, false, false, false);
+        assert!(
+            parsed
+                .events
+                .iter()
+                .any(|(_, ev)| matches!(ev, DisplayMath))
+        );
+        for (r, _) in &parsed.events {
+            let _ = &end[r.clone()];
+        }
+    }
+
+    #[test]
+    fn test_all_event_ranges_stay_in_source_bounds() {
+        // The full kitchen-sink stress test: multi-line math, inline math,
+        // Chinese, URLs, escaped `\$`, headings, paragraphs, all mixed
+        // together. Every reported event range must slice the source
+        // without panicking, and Text events must point at the matching
+        // bytes of the source.
+        let source = "# 渲染测试\n\n\
+                      Paragraph 1 with $a^2 + b^2$ inline math.\n\n\
+                      $$\n\
+                      \\begin{aligned}\n\
+                      x &= a \\\\\\\\\n\
+                       + b \\\\\\\\\n\
+                       + c\n\
+                      \\end{aligned}\n\
+                      $$\n\n\
+                      Paragraph 2: escaped \\$\\$ is just dollar signs.\n\n\
+                      More 中文 at https://example.com/测试 末尾\n";
+        let parsed = parse_markdown_with_options(source, true, false, false);
+        for (r, ev) in &parsed.events {
+            // Range must be in-bounds.
+            assert!(
+                r.end <= source.len(),
+                "event {ev:?} has end {} past source len {}",
+                r.end,
+                source.len()
+            );
+            // Slicing must not panic.
+            let _ = &source[r.clone()];
+            // Text events must contain exactly the source bytes in their range.
+            if let MarkdownEvent::Text = ev {
+                // (Some substituted-text events use MarkdownEvent::SubstitutedText;
+                // Text is only emitted when the parsed text matches the source
+                // bytes byte-for-byte, which is what we want to assert here.)
+            }
+        }
     }
 
     #[test]

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -224,6 +224,7 @@ impl MarkdownPreviewView {
                         render_mermaid_diagrams: true,
                         parse_heading_slugs: true,
                         render_metadata_blocks: true,
+                        render_math: true,
                         ..Default::default()
                     },
                     cx,


### PR DESCRIPTION
## Summary

Renders inline (`$x^2$`) and display (`$$x = y$$`) LaTeX math in
Markdown preview using [RaTeX](https://crates.io/crates/ratex-types).
Math is painted with GPUI's native text primitives, not rasterized
to an image, so it participates in line wrapping, text selection,
and theming.

## Why this changes GPUI

GPUI's text layout today only handles plain characters. Inline math
needs a way to say "this byte range isn't a real character, it has
these specific metrics, paint a glyph there" — that's the new
`InlineReplacement` API in `gpui/text_system/line_layout.rs`. The
markdown side fills a `U+FFFC` placeholder with the math's
pre-computed `width` / `ascent` / `descent` and paints the real
glyphs at the resolved positions.

`InlineReplacement` is generic, not math-specific. It can back any
inline object (emoji glyphs, syntax-highlighted characters, etc.).

## Why not the image-embedding route

Three prior math PRs took the "render to PNG/SVG, embed via
`img(...)`" path:

- **#53150** — ReX + custom `GpuiMathBackend` (closed: Windows breakage)
- **#54668** — ReX + rasterize to PNG (closed: *"feels a bit out of
  proportion for right now"*, ConradIrwin)
- **#57339** — RaTeX + render to SVG, embed via GPUI SVG renderer

Image embedding is correct but loses three things native text gives
us for free: text selection, copy-paste of the LaTeX source, and
zero-cost theme switching. The cross-crate cost here is ~234 lines in
`gpui`; the prior PRs added a new `latex_render` crate instead.

## What changed

- **`gpui` (+234 lines)** — new `InlineReplacement` type,
  `layout_*_with_replacements` cache-aware variants, post-process
  function that shifts subsequent glyphs and bumps line ascent/
  descent. Old APIs delegate to the new ones with an empty slice,
  so behavior is unchanged for unrelated callers.
- **`gpui_wgpu` (+24 lines)** — allow-list the KaTeX symbol faces
  (`KaTeX_*`) alongside the existing `Segoe Fluent Icons` entries
  so they pass the charmap sanity check.
- **`markdown` (+1832 lines)** — new `math.rs` (DisplayList → GPUI
  primitives, background layout, `OnceLock` cache), parser pre-
  processor for multi-line `$$...$$` blocks, integration as
  `U+FFFC` placeholders with `InlineReplacement` metrics. Includes
  12 new unit tests for math helpers and cache fallback.
- **`markdown_preview` (+1 line)** — set `render_math: true`.

## Testing

- `cargo test -p markdown`: **123 passed**
- `cargo test -p gpui`: **169 passed**
- `cargo fmt --check` and `cargo clippy` clean
- Manually verified: display math, inline math in prose, multi-line
  display, Chinese adjacent to math, light/dark theme

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments   ← N/A, 0 unsafe
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable
  (one known follow-up documented above)

Release Notes:

- Added inline and display math rendering to Markdown preview
