### PR TITLE
Remove double-click handling from git panel filenames

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6242,7 +6242,7 @@ impl GitPanel {
                 cx.listener(move |this, event: &ClickEvent, window, cx| {
                     this.selected_entry = Some(ix);
                     cx.notify();
-                    if event.click_count() > 1 || event.modifiers().secondary() {
+                    if event.modifiers().secondary() {
                         this.open_solo_diff(&Default::default(), window, cx)
                     } else {
                         this.open_diff(&Default::default(), window, cx);


### PR DESCRIPTION
Previously in the git panel, double clicking a filename would trigger both the first-click action *and* the second-click action.

This PR removes the second click handling since we don't have a good pattern for single-and-double-click handling.

### Before


https://github.com/user-attachments/assets/f03e53ae-a330-4f60-812d-a45a2d3f5f30

### After


https://github.com/user-attachments/assets/e09493a1-6477-4d43-80ea-26322dd1f083




Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A