### PR TITLE
Preserve remote project groups during restore

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -862,6 +862,8 @@ impl RecentProjectsDelegate {
         style: ProjectPickerStyle,
     ) -> Self {
         let render_paths = style == ProjectPickerStyle::Modal;
+        let has_any_non_local_projects = project_connection_options.is_some()
+            || window_project_groups.iter().any(|k| k.host().is_some());
         Self {
             workspace,
             open_folders,
@@ -872,7 +874,7 @@ impl RecentProjectsDelegate {
             create_new_window,
             render_paths,
             snap_selection_to_first_non_header_match: true,
-            has_any_non_local_projects: project_connection_options.is_some(),
+            has_any_non_local_projects,
             project_connection_options,
             focus_handle,
             style,
@@ -1325,7 +1327,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                     .map(|p| p.compact().to_string_lossy().to_string())
                     .collect();
                 let tooltip_path: SharedString = ordered_paths.join("\n").into();
-                let icon = icon_for_remote_connection(self.project_connection_options.as_ref());
+                let icon = icon_for_remote_connection(key.host().as_ref());
 
                 let mut path_start_offset = 0;
                 let (match_labels, path_highlights): (Vec<_>, Vec<_>) = paths

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -1156,22 +1156,43 @@ impl PickerDelegate for RecentProjectsDelegate {
                                 .log_err();
                         } else {
                             let path_list = key.path_list().clone();
-                            if let Some(task) = handle
+                            let host = key.host();
+                            let provisional_key = Some(key.clone());
+                            handle
                                 .update(cx, |multi_workspace, window, cx| {
-                                    multi_workspace.find_or_create_local_workspace(
+                                    let active_workspace = multi_workspace.workspace().clone();
+                                    let modal_workspace = active_workspace.clone();
+                                    let task = multi_workspace.find_or_create_workspace(
                                         path_list,
-                                        Some(key.clone()),
+                                        host,
+                                        provisional_key,
+                                        move |options, window, cx| {
+                                            remote_connection::connect_with_modal(
+                                                &active_workspace,
+                                                options,
+                                                window,
+                                                cx,
+                                            )
+                                        },
                                         &[],
                                         None,
                                         OpenMode::Activate,
                                         window,
                                         cx,
-                                    )
+                                    );
+                                    window
+                                        .spawn(cx, async move |cx| {
+                                            let result = task.await;
+                                            remote_connection::dismiss_connection_modal(
+                                                &modal_workspace,
+                                                cx,
+                                            );
+                                            result?;
+                                            anyhow::Ok(())
+                                        })
+                                        .detach_and_log_err(cx);
                                 })
-                                .log_err()
-                            {
-                                task.detach_and_log_err(cx);
-                            }
+                                .log_err();
                         }
                     });
                 }
@@ -2345,12 +2366,17 @@ impl RecentProjectsDelegate {
 
 #[cfg(test)]
 mod tests {
+    use extension::ExtensionHostProxy;
+    use fs::FakeFs;
     use gpui::{TestAppContext, UpdateGlobal, VisualTestContext};
-
+    use http_client::BlockedHttpClient;
+    use node_runtime::NodeRuntime;
+    use remote::RemoteClient;
+    use remote_server::{HeadlessAppState, HeadlessProject};
     use serde_json::json;
     use settings::SettingsStore;
     use util::path;
-    use workspace::{AppState, open_paths};
+    use workspace::{AppState, ProjectGroup, open_paths};
 
     use super::*;
 
@@ -2566,6 +2592,153 @@ mod tests {
 
         draw(cx);
         assert_pinned_to_bottom(&picker, cx, "after redraw");
+    }
+
+    #[gpui::test]
+    async fn test_project_picker_reopens_remote_project_group_as_remote(
+        cx: &mut TestAppContext,
+        server_cx: &mut TestAppContext,
+    ) {
+        let app_state = init_test(cx);
+        let executor = cx.executor();
+
+        cx.update(|cx| {
+            release_channel::init(semver::Version::new(0, 0, 0), cx);
+        });
+        server_cx.update(|cx| {
+            release_channel::init(semver::Version::new(0, 0, 0), cx);
+        });
+
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(path!("/local-project"), json!({ "src": { "main.rs": "" } }))
+            .await;
+
+        cx.update(|cx| {
+            open_paths(
+                &[PathBuf::from(path!("/local-project"))],
+                app_state.clone(),
+                workspace::OpenOptions::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+        executor.run_until_parked();
+
+        let (opts, server_session, connect_guard) = RemoteClient::fake_server(cx, server_cx);
+
+        let remote_fs = FakeFs::new(server_cx.executor());
+        remote_fs
+            .insert_tree(
+                path!("/remote-project"),
+                json!({
+                    "src": {
+                        "lib.rs": "pub fn hello() {}",
+                    }
+                }),
+            )
+            .await;
+
+        server_cx.update(HeadlessProject::init);
+        let http_client = Arc::new(BlockedHttpClient);
+        let node_runtime = NodeRuntime::unavailable();
+        let languages = Arc::new(language::LanguageRegistry::new(server_cx.executor()));
+        let proxy = Arc::new(ExtensionHostProxy::new());
+
+        let _headless = server_cx.new(|cx| {
+            HeadlessProject::new(
+                HeadlessAppState {
+                    session: server_session,
+                    fs: remote_fs.clone(),
+                    http_client,
+                    node_runtime,
+                    languages,
+                    extension_host_proxy: proxy,
+                    startup_time: std::time::Instant::now(),
+                },
+                false,
+                cx,
+            )
+        });
+
+        drop(connect_guard);
+
+        let remote_key = ProjectGroupKey::new(
+            Some(opts.clone()),
+            PathList::new(&[PathBuf::from(path!("/remote-project"))]),
+        );
+
+        let multi_workspace = cx.update(|cx| cx.windows()[0].downcast::<MultiWorkspace>().unwrap());
+
+        let recent_projects = multi_workspace
+            .update(cx, {
+                let remote_key = remote_key.clone();
+                move |multi_workspace, window, cx| {
+                    multi_workspace.test_add_project_group(ProjectGroup {
+                        key: remote_key.clone(),
+                        workspaces: Vec::new(),
+                        expanded: true,
+                    });
+
+                    let workspace = multi_workspace.workspace().clone();
+                    let focus_handle = workspace.read(cx).focus_handle(cx);
+                    workspace.update(cx, |workspace, cx| {
+                        RecentProjects::open(
+                            workspace,
+                            false,
+                            vec![remote_key.clone()],
+                            window,
+                            focus_handle,
+                            cx,
+                        );
+                    });
+
+                    workspace
+                        .read(cx)
+                        .active_modal::<RecentProjects>(cx)
+                        .expect("recent projects modal should be open")
+                }
+            })
+            .unwrap();
+
+        multi_workspace
+            .update(cx, |_, window, cx| {
+                recent_projects.update(cx, |recent_projects, cx| {
+                    recent_projects.picker.update(cx, |picker, cx| {
+                        picker.update_matches(String::new(), window, cx);
+                        let project_group_index = picker
+                            .delegate
+                            .filtered_entries
+                            .iter()
+                            .position(|entry| matches!(entry, ProjectPickerEntry::ProjectGroup(_)))
+                            .expect("picker should include the remote project group");
+                        picker.delegate.selected_index = project_group_index;
+                        picker.delegate.confirm(false, window, cx);
+                    });
+                });
+            })
+            .unwrap();
+
+        executor.run_until_parked();
+
+        multi_workspace
+            .update(cx, |multi_workspace, _, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    assert!(
+                        workspace.project().read(cx).is_remote(),
+                        "picker should reopen the project group as a remote workspace"
+                    );
+                    assert_eq!(
+                        workspace.project_group_key(cx).host(),
+                        Some(opts.clone()),
+                        "reopened workspace should keep the saved remote connection options"
+                    );
+                });
+            })
+            .unwrap();
     }
 
     #[gpui::test]

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -2674,7 +2674,6 @@ mod tests {
 
         let recent_projects = multi_workspace
             .update(cx, {
-                let remote_key = remote_key.clone();
                 move |multi_workspace, window, cx| {
                     multi_workspace.test_add_project_group(ProjectGroup {
                         key: remote_key.clone(),

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -2750,6 +2750,7 @@ mod tests {
     use crate::PathList;
     use crate::ProjectGroupKey;
     use crate::{
+        AppState,
         multi_workspace::MultiWorkspace,
         persistence::{
             model::{
@@ -2764,7 +2765,7 @@ mod tests {
     use gpui::AppContext as _;
     use pretty_assertions::assert_eq;
     use project::Project;
-    use remote::SshConnectionOptions;
+    use remote::{RemoteConnectionOptions, SshConnectionOptions};
     use serde_json::json;
     use std::{thread, time::Duration};
 
@@ -4638,6 +4639,83 @@ mod tests {
         assert_eq!(group_none.active_workspace.workspace_id, WorkspaceId(4));
         assert_eq!(group_none.state.active_workspace_id, None);
         assert_eq!(group_none.state.sidebar_open, false);
+    }
+
+    #[gpui::test]
+    async fn test_restore_multiworkspace_preserves_remote_project_group_keys(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        use crate::persistence::model::{MultiWorkspaceState, SerializedProjectGroup};
+
+        crate::tests::init_test(cx);
+
+        let fs = fs::FakeFs::new(cx.executor());
+        fs.insert_tree("/local-project", json!({ "src": {} })).await;
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+
+        let local_key = ProjectGroupKey::new(None, PathList::new(&["/local-project"]));
+        let remote_key = ProjectGroupKey::new(
+            Some(RemoteConnectionOptions::Ssh(SshConnectionOptions {
+                host: "remote-host".into(),
+                ..Default::default()
+            })),
+            PathList::new(&["/remote-project"]),
+        );
+
+        let window_id = WindowId::from(10_u64);
+        let kvp = cx.update(|cx| KeyValueStore::global(cx));
+        write_multi_workspace_state(
+            &kvp,
+            window_id,
+            MultiWorkspaceState {
+                active_workspace_id: Some(WorkspaceId(1)),
+                project_groups: vec![
+                    SerializedProjectGroup::from_group(&local_key, true),
+                    SerializedProjectGroup::from_group(&remote_key, true),
+                ],
+                sidebar_open: true,
+                sidebar_state: None,
+            },
+        )
+        .await;
+
+        let serialized = cx.update(|cx| {
+            read_serialized_multi_workspaces(
+                vec![SessionWorkspace {
+                    workspace_id: WorkspaceId(1),
+                    location: SerializedWorkspaceLocation::Local,
+                    paths: PathList::new(&["/local-project"]),
+                    window_id: Some(window_id),
+                }],
+                cx,
+            )
+        });
+
+        assert_eq!(serialized.len(), 1, "should restore one multi-workspace");
+
+        let app_state = cx.update(AppState::test);
+        let restored_handle: gpui::WindowHandle<MultiWorkspace> = cx
+            .update({
+                let serialized = serialized.into_iter().next().unwrap();
+                move |cx| {
+                    cx.spawn(async move |mut cx| {
+                        crate::restore_multiworkspace(serialized, app_state, &mut cx).await
+                    })
+                }
+            })
+            .await
+            .expect("restore_multiworkspace should succeed");
+
+        cx.run_until_parked();
+
+        let restored_keys = restored_handle
+            .read_with(cx, |mw, _| mw.project_group_keys())
+            .unwrap();
+        assert_eq!(
+            restored_keys,
+            vec![local_key, remote_key],
+            "restored multi-workspace should preserve remote project group hosts"
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
## Context

Remote project groups could be restored or reopened as local projects when a previous window was restored with a local project active. This keeps each project group's saved remote connection metadata in use when reopening dormant project groups from the project picker, so remote groups reconnect remotely instead of opening matching local paths.

This also includes an earlier icon fix on this branch: project groups in the recent projects picker now derive their remote/local icon from each group key's host instead of the currently active project's connection.

Closes #58569
Closes https://github.com/zed-industries/zed/issues/58566

Video of manual test after fix below :

[Screencast from 2026-06-05 01-12-24.webm](https://github.com/user-attachments/assets/75f6949f-f441-4bde-905f-4c38ae60b375)

## How to Review

`crates/recent_projects/src/recent_projects.rs` : Updates project-group activation in the recent projects picker to use the remote-aware `find_or_create_workspace` path, preserving `ProjectGroupKey::host()` and using the existing remote connection modal flow. Also fixes project group icon selection so remote groups display the proper remote icon, and adds a regression test that reopens a dormant remote project group through the picker.

`crates/workspace/src/persistence.rs` : Adds coverage proving restored multi-workspace state preserves remote project group keys when the active workspace is local.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed remote projects being restored or reopened as local projects from restored project groups.