### PR TITLE
Add auto-surround support for tilde in Markdown

### DIFF
--- a/crates/grammars/src/markdown/config.toml
+++ b/crates/grammars/src/markdown/config.toml
@@ -14,6 +14,7 @@ brackets = [
     { start = "'", end = "'", close = false, newline = false },
     { start = "`", end = "`", close = false, newline = false },
     { start = "*", end = "*", close = false, newline = false, surround = true },
+    { start = "~", end = "~", close = false, newline = false, surround = true },
 ]
 rewrap_prefixes = [
     "[-*+]\\s+",


### PR DESCRIPTION
This enables you to easily add strikethroughs to text you have selected by typing `~` twice.
This matches VS Code's behavior.

Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Added support for surrounding selected Markdown text with `~` by typing `~`
