### PR TITLE
Add breadcrumb_font_size and breadcrumb_height settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -496,6 +496,12 @@
     "agent_review": true,
     // Whether to show code action buttons in the editor toolbar.
     "code_actions": false,
+    // Font size (in pixels) for breadcrumb text. When null, the UI font size is used.
+    // Lower this to make the breadcrumb bar more compact without shrinking the rest of the UI.
+    "breadcrumb_font_size": null,
+    // Height (in pixels) of the breadcrumb toolbar row. When null, the default height is used.
+    // Lower this together with "breadcrumb_font_size" for a more compact toolbar.
+    "breadcrumb_height": null,
   },
   // Whether to allow windows to tab together based on the user’s tabbing preference (macOS only).
   "use_system_window_tabs": false,

--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -50,7 +50,8 @@ impl Render for Breadcrumbs {
         let element = h_flex()
             .id("breadcrumb-container")
             .flex_grow_1()
-            .h_8()
+            // Fill the toolbar row so a custom `breadcrumb_height` can make it compact.
+            .h_full()
             .overflow_x_scroll()
             .text_ui(cx);
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -82,13 +82,15 @@ pub struct StickyScroll {
     pub enabled: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Toolbar {
     pub breadcrumbs: bool,
     pub quick_actions: bool,
     pub selections_menu: bool,
     pub agent_review: bool,
     pub code_actions: bool,
+    /// Font size (px) for breadcrumb text. `None` uses the UI font size.
+    pub breadcrumb_font_size: Option<f32>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -220,6 +222,7 @@ impl Settings for EditorSettings {
                 selections_menu: toolbar.selections_menu.unwrap(),
                 agent_review: toolbar.agent_review.unwrap(),
                 code_actions: toolbar.code_actions.unwrap(),
+                breadcrumb_font_size: toolbar.breadcrumb_font_size,
             },
             scrollbar: Scrollbar {
                 show: scrollbar.show.map(ui_scrollbar_settings_from_raw).unwrap(),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6657,7 +6657,13 @@ pub fn render_breadcrumb_text(
 ) -> gpui::AnyElement {
     const MAX_SEGMENTS: usize = 12;
 
-    let element = h_flex().flex_grow_1().text_ui(cx);
+    // Breadcrumb text uses the UI font size by default, but can be overridden via
+    // `toolbar.breadcrumb_font_size` to make the breadcrumb bar more compact.
+    let element = h_flex().flex_grow_1();
+    let element = match EditorSettings::get_global(cx).toolbar.breadcrumb_font_size {
+        Some(font_size) => element.text_size(px(font_size)),
+        None => element.text_ui(cx),
+    };
 
     let prefix_end_ix = cmp::min(segments.len(), MAX_SEGMENTS / 2);
     let suffix_start_ix = cmp::max(

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -352,7 +352,7 @@ impl RelativeLineNumbers {
 
 // Toolbar related settings
 #[with_fallible_options]
-#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
 pub struct ToolbarContent {
     /// Whether to display breadcrumbs in the editor toolbar.
     ///
@@ -375,6 +375,16 @@ pub struct ToolbarContent {
     ///
     /// Default: false
     pub code_actions: Option<bool>,
+    /// Font size (in pixels) for breadcrumb text. When unset, the UI font size is used.
+    /// Lower this to make the breadcrumb bar more compact without shrinking the rest of the UI.
+    ///
+    /// Default: null
+    pub breadcrumb_font_size: Option<f32>,
+    /// Height (in pixels) of the breadcrumb toolbar row. When unset, the default height is used.
+    /// Lower this together with `breadcrumb_font_size` for a more compact toolbar.
+    ///
+    /// Default: null
+    pub breadcrumb_height: Option<f32>,
 }
 
 /// Scrollbar related settings

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2449,7 +2449,7 @@ fn editor_page() -> SettingsPage {
         ]
     }
 
-    fn toolbar_section() -> [SettingsPageItem; 6] {
+    fn toolbar_section() -> [SettingsPageItem; 8] {
         [
             SettingsPageItem::SectionHeader("Toolbar"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -2567,6 +2567,54 @@ fn editor_page() -> SettingsPage {
                             .toolbar
                             .get_or_insert_default()
                             .code_actions = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Breadcrumb Font Size",
+                description: "Font size (px) for breadcrumb text. When unset, the UI font size is used.",
+                field: Box::new(SettingField {
+                    json_path: Some("toolbar.breadcrumb_font_size"),
+                    pick: |settings_content| {
+                        settings_content
+                            .editor
+                            .toolbar
+                            .as_ref()?
+                            .breadcrumb_font_size
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .editor
+                            .toolbar
+                            .get_or_insert_default()
+                            .breadcrumb_font_size = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Breadcrumb Height",
+                description: "Height (px) of the breadcrumb toolbar row. When unset, the default height is used.",
+                field: Box::new(SettingField {
+                    json_path: Some("toolbar.breadcrumb_height"),
+                    pick: |settings_content| {
+                        settings_content
+                            .editor
+                            .toolbar
+                            .as_ref()?
+                            .breadcrumb_height
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .editor
+                            .toolbar
+                            .get_or_insert_default()
+                            .breadcrumb_height = value;
                     },
                 }),
                 metadata: None,

--- a/crates/workspace/src/toolbar.rs
+++ b/crates/workspace/src/toolbar.rs
@@ -1,9 +1,10 @@
-use crate::ItemHandle;
+use crate::{ItemHandle, WorkspaceSettings};
 use gpui::{
     AnyView, App, Context, Div, Entity, EntityId, EventEmitter, Global, KeyContext,
-    ParentElement as _, Render, Styled, Window,
+    ParentElement as _, Render, Styled, Window, px,
 };
 use language::LanguageRegistry;
+use settings::Settings as _;
 use std::sync::Arc;
 use ui::prelude::*;
 use ui::{h_flex, v_flex};
@@ -117,6 +118,9 @@ impl Render for Toolbar {
         let has_left_items = self.left_items().count() > 0;
         let has_right_items = self.right_items().count() > 0;
 
+        // When set, overrides the default 32px row height for a more compact toolbar.
+        let row_height = WorkspaceSettings::get_global(cx).breadcrumb_height;
+
         v_flex()
             .group("toolbar")
             .relative()
@@ -137,7 +141,10 @@ impl Render for Toolbar {
                         .when(has_left_items, |this| {
                             this.child(
                                 h_flex()
-                                    .min_h_8()
+                                    .map(|this| match row_height {
+                                        Some(height) => this.min_h(px(height)),
+                                        None => this.min_h_8(),
+                                    })
                                     .flex_auto()
                                     .justify_start()
                                     .overflow_x_hidden()
@@ -147,7 +154,10 @@ impl Render for Toolbar {
                         .when(has_right_items, |this| {
                             this.child(
                                 h_flex()
-                                    .h_8()
+                                    .map(|this| match row_height {
+                                        Some(height) => this.h(px(height)),
+                                        None => this.h_8(),
+                                    })
                                     .flex_row_reverse()
                                     .when(has_left_items, |this| this.flex_none())
                                     .justify_end()

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -37,6 +37,8 @@ pub struct WorkspaceSettings {
     pub zoomed_padding: bool,
     pub window_decorations: settings::WindowDecorations,
     pub focus_follows_mouse: FocusFollowsMouse,
+    /// Height (px) of the breadcrumb toolbar row; `None` uses the default height.
+    pub breadcrumb_height: Option<f32>,
 }
 
 #[derive(Copy, Clone, Deserialize)]
@@ -136,6 +138,11 @@ impl Settings for WorkspaceSettings {
                         .unwrap_or(250),
                 ),
             },
+            breadcrumb_height: content
+                .editor
+                .toolbar
+                .as_ref()
+                .and_then(|toolbar| toolbar.breadcrumb_height),
         }
     }
 }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1602,7 +1602,9 @@ When trusted, project settings are synchronized automatically, language and MCP 
     "quick_actions": true,
     "selections_menu": true,
     "agent_review": true,
-    "code_actions": false
+    "code_actions": false,
+    "breadcrumb_font_size": null,
+    "breadcrumb_height": null
   }
 }
 ```

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -255,7 +255,9 @@ TBD: Centered layout related settings
     "quick_actions": true, // Whether to show quick action buttons.
     "selections_menu": true, // Whether to show the Selections menu
     "agent_review": true, // Whether to show agent review buttons
-    "code_actions": false // Whether to show code action buttons
+    "code_actions": false, // Whether to show code action buttons
+    "breadcrumb_font_size": null, // Breadcrumb text size in px; null uses the UI font size
+    "breadcrumb_height": null // Breadcrumb row height in px; null uses the default
   }
 ```
 


### PR DESCRIPTION
Two opt-in settings to make the breadcrumb bar more compact:

- `toolbar.breadcrumb_font_size` — breadcrumb text size, independent of the editor/UI font
- `toolbar.breadcrumb_height` — height of the breadcrumb toolbar row

Both default to `null`, so nothing changes unless you set them. Handy when you shrink the editor font but the breadcrumb stays big and eats vertical space. Both are in the settings editor too (searchable/editable from the UI).

Note: `breadcrumb_height` sets the toolbar row height (breadcrumbs are the row's main content). Keeps main's existing `min_h`/`h` split, just makes the value configurable.

<img width="1500" height="346" alt="breadcrumb-compact" src="https://github.com/user-attachments/assets/309e4748-23f8-4a66-81f1-ba9781a90abd" />


Release Notes:

- Added `toolbar.breadcrumb_font_size` and `toolbar.breadcrumb_height` settings for a more compact breadcrumb bar
