### PR TITLE
Add folder_disclosure setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -774,6 +774,9 @@
     "file_icons": true,
     // Whether to show folder icons or chevrons for directories in the project panel.
     "folder_icons": true,
+    // Disclosure chevron next to the folder icon for directories (JetBrains-style).
+    // "off", "compact", or "comfortable". No effect when "folder_icons" is false.
+    "folder_disclosure": "off",
     // Whether to show the git status in the project panel.
     "git_status": true,
     // Amount of indentation for nested items.

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -43,8 +43,8 @@ use rayon::slice::ParallelSliceMut;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use settings::{
-    DockSide, ProjectPanelEntrySpacing, Settings, SettingsStore, ShowDiagnostics, ShowIndentGuides,
-    update_settings_file,
+    DockSide, FolderDisclosure, ProjectPanelEntrySpacing, Settings, SettingsStore, ShowDiagnostics,
+    ShowIndentGuides, update_settings_file,
 };
 use smallvec::SmallVec;
 use std::{
@@ -5853,6 +5853,29 @@ impl ProjectPanel {
                                     .when_some(symlink_element, |this, el| this.child(el))
                                     .into_any_element(),
                             )
+                        },
+                    )
+                    .when_some(
+                        match settings.folder_disclosure {
+                            FolderDisclosure::Off => None,
+                            FolderDisclosure::Compact => Some((px(12.), IconSize::XSmall)),
+                            FolderDisclosure::Comfortable => Some((px(18.), IconSize::Small)),
+                        }
+                        .filter(|_| settings.folder_icons),
+                        |this, (width, chevron_size)| {
+                            // Reserve a fixed disclosure column so folder and file icons stay
+                            // aligned, showing the chevron only for directories (JetBrains-style).
+                            this.child(h_flex().flex_none().w(width).justify_center().children(
+                                kind.is_dir().then(|| {
+                                    Icon::new(if details.is_expanded {
+                                        IconName::ChevronDown
+                                    } else {
+                                        IconName::ChevronRight
+                                    })
+                                    .size(chevron_size)
+                                    .color(Color::Muted)
+                                }),
+                            ))
                         },
                     )
                     .child(if let Some(icon) = &icon {

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -3,8 +3,8 @@ use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockSide, ProjectPanelEntrySpacing, ProjectPanelSortMode, ProjectPanelSortOrder,
-    RegisterSetting, Settings, ShowDiagnostics, ShowIndentGuides,
+    DockSide, FolderDisclosure, ProjectPanelEntrySpacing, ProjectPanelSortMode,
+    ProjectPanelSortOrder, RegisterSetting, Settings, ShowDiagnostics, ShowIndentGuides,
 };
 use ui::{
     px,
@@ -20,6 +20,7 @@ pub struct ProjectPanelSettings {
     pub entry_spacing: ProjectPanelEntrySpacing,
     pub file_icons: bool,
     pub folder_icons: bool,
+    pub folder_disclosure: FolderDisclosure,
     pub git_status: bool,
     pub indent_size: f32,
     pub indent_guides: IndentGuidesSettings,
@@ -105,6 +106,7 @@ impl Settings for ProjectPanelSettings {
             entry_spacing: project_panel.entry_spacing.unwrap(),
             file_icons: project_panel.file_icons.unwrap(),
             folder_icons: project_panel.folder_icons.unwrap(),
+            folder_disclosure: project_panel.folder_disclosure.unwrap_or_default(),
             git_status: project_panel.git_status.unwrap()
                 && content
                     .git

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -805,6 +805,7 @@ impl VsCodeSettings {
             entry_spacing: None,
             file_icons: None,
             folder_icons: None,
+            folder_disclosure: None,
             git_status: self.read_bool("git.decorations.enabled"),
             hide_gitignore: self.read_bool("explorer.excludeGitIgnore"),
             hide_hidden: None,

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -719,6 +719,13 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: true
     pub folder_icons: Option<bool>,
+    /// Disclosure chevron shown alongside the folder icon for directories
+    /// (JetBrains-style), so their expanded/collapsed state is visible at a glance.
+    /// `compact` and `comfortable` control how much room the chevron takes.
+    /// Has no effect when `folder_icons` is false (chevrons are already shown).
+    ///
+    /// Default: off
+    pub folder_disclosure: Option<FolderDisclosure>,
     /// Whether to show the git status in the project panel.
     ///
     /// Default: true
@@ -814,6 +821,31 @@ pub enum ProjectPanelEntrySpacing {
     Comfortable,
     /// The standard spacing of entries.
     Standard,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum FolderDisclosure {
+    /// No disclosure chevron.
+    #[default]
+    Off,
+    /// A compact disclosure chevron.
+    Compact,
+    /// A roomier disclosure chevron.
+    Comfortable,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4638,7 +4638,7 @@ fn window_and_layout_page() -> SettingsPage {
 }
 
 fn panels_page() -> SettingsPage {
-    fn project_panel_section() -> [SettingsPageItem; 29] {
+    fn project_panel_section() -> [SettingsPageItem; 30] {
         [
             SettingsPageItem::SectionHeader("Project Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -4755,6 +4755,28 @@ fn panels_page() -> SettingsPage {
                             .project_panel
                             .get_or_insert_default()
                             .folder_icons = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Folder Disclosure",
+                description: "Disclosure chevron next to the folder icon for directories (JetBrains-style). No effect when folder icons are off.",
+                field: Box::new(SettingField {
+                    json_path: Some("project_panel.folder_disclosure"),
+                    pick: |settings_content| {
+                        settings_content
+                            .project_panel
+                            .as_ref()?
+                            .folder_disclosure
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .project_panel
+                            .get_or_insert_default()
+                            .folder_disclosure = value;
                     },
                 }),
                 metadata: None,

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4919,6 +4919,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
     "entry_spacing": "comfortable",
     "file_icons": true,
     "folder_icons": true,
+    "folder_disclosure": "off",
     "git_status": true,
     "indent_size": 20,
     "auto_reveal_entries": true,

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -459,6 +459,7 @@ Project panel can be shown/hidden with {#action project_panel::ToggleFocus} ({#k
     "entry_spacing": "comfortable", // Vertical spacing (comfortable, standard)
     "file_icons": true,             // Show/hide file icons
     "folder_icons": true,           // Show/hide folder icons
+    "folder_disclosure": "off",     // Folder chevron: "off", "compact", "comfortable"
     "git_status": true,             // Indicate new/updated files
     "indent_size": 20,              // Pixels for each successive indent
     "auto_reveal_entries": true,    // Show file in panel when activating its buffer


### PR DESCRIPTION
Adds `project_panel.folder_disclosure` — directories show a disclosure chevron **next to** the folder icon, so you can see expanded/collapsed state at a glance (like JetBrains / VS Code).

`"off"` (default) · `"compact"` · `"comfortable"` — the presets control how much room the chevron takes. Nothing changes unless you opt in.

Today the panel is either/or: `folder_icons: true` (icon only) or `false` (chevron only). This lets you have both, with file and folder icons staying aligned. No effect when `folder_icons` is off, since chevrons already show then. In the settings editor + docs.

<img width="235" height="560" alt="fd_states" src="https://github.com/user-attachments/assets/e296275d-28c9-4fb5-a72e-10b6cbab4a2d" />
<img width="235" height="560" alt="fd_light" src="https://github.com/user-attachments/assets/68a9a1b3-ab56-4ba0-8660-0bc7aeb5a160" />

Different states:

<img width="1470" height="1172" alt="fd_presets_dark" src="https://github.com/user-attachments/assets/171fdb0e-f195-41f8-b1b7-7d90d37fd0c2" />

Release Notes:

- Added `project_panel.folder_disclosure` to show a disclosure chevron alongside folder icons
