### PR TITLE
Fix symlinked root rename event handling

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4508,6 +4508,10 @@ impl BackgroundScanner {
                     && let Ok(path) = RelPath::new(path, PathStyle::local())
                 {
                     path
+                } else if let Ok(path) = abs_path.strip_prefix(&root_path)
+                    && let Ok(path) = RelPath::new(path, PathStyle::local())
+                {
+                    path
                 } else if let Some(path) = snapshot.external_canonical_to_relative.iter().find_map(
                     |(canonical, relative)| {
                         abs_path

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -477,6 +477,82 @@ async fn test_symlinks_pointing_outside(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_renaming_subdir_under_symlinked_root_keeps_children(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/target",
+        json!({
+            "file1.txt": "",
+            "file2.log": "",
+            "subdir-a": {
+                "config.ini": "",
+            },
+            "subdir-b": {
+                "nested": {
+                    "note.md": "",
+                },
+            },
+        }),
+    )
+    .await;
+    fs.create_symlink("/link".as_ref(), "/target".into())
+        .await
+        .unwrap();
+
+    let tree = Worktree::local(
+        Path::new("/link"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    fs.rename(
+        Path::new("/link/subdir-a"),
+        Path::new("/link/subdir-aa"),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+
+    wait_for_condition(cx, |cx| {
+        tree.read_with(cx, |tree, _| {
+            tree.entry_for_path(rel_path("subdir-a")).is_none()
+                && tree
+                    .entry_for_path(rel_path("subdir-aa/config.ini"))
+                    .is_some()
+        })
+    })
+    .await;
+
+    tree.read_with(cx, |tree, _| {
+        assert_eq!(
+            tree.entries(true, 0)
+                .map(|entry| entry.path.as_ref())
+                .collect::<Vec<_>>(),
+            vec![
+                rel_path(""),
+                rel_path("file1.txt"),
+                rel_path("file2.log"),
+                rel_path("subdir-aa"),
+                rel_path("subdir-aa/config.ini"),
+                rel_path("subdir-b"),
+                rel_path("subdir-b/nested"),
+                rel_path("subdir-b/nested/note.md"),
+            ]
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_symlinked_dir_inside_project(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.background_executor.clone());


### PR DESCRIPTION
Fixes #58619.

When a worktree is opened through a symlinked root, filesystem events can arrive rooted at either the opened symlink path or the canonical target path. The worktree event processing path already handled canonical target paths, but dropped events reported under the opened symlink root because it only derived relative paths from the canonical root.

This PR adds a regression test that opens `/link -> /target`, renames `/link/subdir-a` to `/link/subdir-aa`, and verifies `subdir-aa/config.ini` remains visible in the worktree. The production fix accepts event paths under the opened worktree root as a fallback when deriving relative paths.

Testing:

- Verified the new regression test fails with only the test commit applied.
- `cargo test -p worktree --test integration test_renaming_subdir_under_symlinked_root_keeps_children`
- `cargo test -p worktree --test integration test_symlinks_pointing_outside`