### PR TITLE
editor: Only compute word-diff highlights for visible rows

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4516,6 +4516,11 @@ impl EditorElement {
     ) {
         let colors = cx.theme().colors();
 
+        let visible_start =
+            DisplayPoint::new(start_row, 0).to_offset(&snapshot.display_snapshot, Bias::Left);
+        let visible_end = DisplayPoint::new(DisplayRow(start_row.0 + row_infos.len() as u32), 0)
+            .to_offset(&snapshot.display_snapshot, Bias::Right);
+
         let word_highlights = display_hunks
             .into_iter()
             .filter_map(|(hunk, _)| match hunk {
@@ -4526,6 +4531,7 @@ impl EditorElement {
             })
             .filter(|(_, status)| status.is_modified())
             .flat_map(|(word_diffs, _)| word_diffs)
+            .filter(|word_diff| word_diff.start < visible_end && word_diff.end > visible_start)
             .flat_map(|word_diff| {
                 let display_ranges = snapshot
                     .display_snapshot


### PR DESCRIPTION
Word diffs are stored per-hunk for the entire hunk range, but layout_word_diff_highlights converted every word diff of every hunk touching the viewport to display points each frame, even for the off-screen portion of a large, partially-visible hunk. Each conversion walks the inlay/fold/tab/wrap/block trees, so scrolling through a large modified hunk (especially in split diff mode, where both editors lay out every frame) caused frame drops proportional to the hunk's total size rather than its visible portion.

Filter word diffs by the visible buffer-offset window before converting. Buffer offset to display point is order-preserving, so this is equivalent to the existing per-row filtering applied to the converted ranges.

Release Notes:

- Improved scrolling performance in diff views containing large hunks with many computed word diffs