### PR TITLE
markdown: Render YAML frontmatter as a table in preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10812,6 +10812,7 @@ dependencies = [
  "mermaid_render",
  "node_runtime",
  "pulldown-cmark 0.13.0",
+ "serde_yaml_ng",
  "settings",
  "smallvec",
  "stacksafe",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -125,6 +125,9 @@
     // The maximum width, in pixels, of the rendered markdown content when
     // limit_content_width is enabled.
     "max_width": 800,
+    // Whether to render YAML frontmatter as a table in Markdown previews.
+    // When disabled, frontmatter is hidden from the preview.
+    "render_frontmatter": true,
   },
   // Determines the modifier to be used to add multiple cursors with the mouse. The open hover link mouse gestures will adapt such that it do not conflict with the multicursor modifier.
   //

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -31,6 +31,7 @@ log.workspace = true
 markup5ever_rcdom.workspace = true
 mermaid_render = { path = "../mermaid_render" }
 pulldown-cmark.workspace = true
+serde_yaml_ng.workspace = true
 settings.workspace = true
 smallvec.workspace = true
 stacksafe.workspace = true

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1722,8 +1722,10 @@ impl MarkdownElement {
 
         // Recover precise source ranges for rendered text by scanning forward
         // through the block, so selection and search highlights land on the
-        // right source offsets. Values without a verbatim source span (e.g.
-        // block scalars) fall back to the whole block range.
+        // right source offsets. Values the YAML parser normalizes away from
+        // their source text (block scalars, and numbers or quoted strings
+        // re-serialized to a different spelling) have no verbatim span and fall
+        // back to the whole block range.
         let mut cursor = content_range.start;
         for (row_index, row) in rows.iter().enumerate() {
             let key_range = locate_metadata_span(source, content_range, &mut cursor, &row.key);
@@ -4586,6 +4588,38 @@ mod tests {
         );
         // Recognized but not rendered: the frontmatter is stripped from the body.
         assert_eq!(rendered.text_for_range(0..24), "Body");
+    }
+
+    #[gpui::test]
+    fn test_frontmatter_falls_back_to_code_block_for_invalid_yaml(cx: &mut TestAppContext) {
+        let rendered = render_markdown_with_options(
+            "---\nkey: [unterminated\n---\nBody",
+            None,
+            MarkdownOptions {
+                render_metadata_blocks: true,
+                ..Default::default()
+            },
+            cx,
+        );
+        // Frontmatter that isn't a valid YAML mapping renders verbatim as a code
+        // block rather than a table, with the body still following it.
+        assert_eq!(rendered.text_for_range(0..31), "key: [unterminated\nBody");
+    }
+
+    #[gpui::test]
+    fn test_frontmatter_renders_nested_mapping_value(cx: &mut TestAppContext) {
+        let rendered = render_markdown_with_options(
+            "---\nmeta:\n  nested: true\n---\nBody",
+            None,
+            MarkdownOptions {
+                render_metadata_blocks: true,
+                ..Default::default()
+            },
+            cx,
+        );
+        // A nested mapping keeps its YAML text in the value cell so the structure
+        // stays readable instead of collapsing to one line.
+        assert_eq!(rendered.text_for_range(0..33), "meta\nnested: true\nBody");
     }
 
     fn render_markdown_with_code_span_link(

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1746,9 +1746,15 @@ impl MarkdownElement {
             };
             self.push_metadata_cell(builder, content_range, markdown_end, row_index, false, cx, {
                 let value = &row.value;
+                let raw_text_style = self.style.code_block.text.to_owned();
                 move |builder| match value {
-                    MetadataValue::Scalar(text) | MetadataValue::Raw(text) => {
+                    MetadataValue::Scalar(text) => {
                         builder.push_text(text, value_range);
+                    }
+                    MetadataValue::Raw(text) => {
+                        builder.push_text_style(raw_text_style);
+                        builder.push_text(text, value_range);
+                        builder.pop_text_style();
                     }
                     MetadataValue::List(items) => {
                         builder.push_image_child(

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -43,13 +43,13 @@ use gpui::{
 use language::{CharClassifier, Language, LanguageRegistry, Rope};
 use parser::CodeBlockMetadata;
 use parser::{
-    MarkdownEvent, MarkdownTag, MarkdownTagEnd, ParsedMetadataBlock, parse_links_only,
-    parse_markdown_with_options,
+    MarkdownEvent, MarkdownTag, MarkdownTagEnd, MetadataValue, ParsedMetadataBlock,
+    parse_links_only, parse_markdown_with_options,
 };
 use pulldown_cmark::{Alignment, BlockQuoteKind};
 use sum_tree::TreeMap;
 use theme::SyntaxTheme;
-use ui::{Checkbox, CopyButton, ScrollAxes, Scrollbars, Tooltip, WithScrollbar, prelude::*};
+use ui::{Checkbox, Chip, CopyButton, ScrollAxes, Scrollbars, Tooltip, WithScrollbar, prelude::*};
 use util::ResultExt;
 
 use crate::parser::CodeBlockKind;
@@ -419,13 +419,33 @@ pub struct Markdown {
     active_search_highlight: Option<usize>,
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub struct MarkdownOptions {
     pub parse_links_only: bool,
     pub parse_html: bool,
     pub render_mermaid_diagrams: bool,
     pub parse_heading_slugs: bool,
+    /// Recognize frontmatter so it is stripped from the document body even when
+    /// it isn't rendered. Whether it's drawn is controlled by
+    /// `render_metadata_blocks`.
+    pub parse_metadata_blocks: bool,
     pub render_metadata_blocks: bool,
+}
+
+fn locate_metadata_span(
+    source: &str,
+    content_range: &Range<usize>,
+    cursor: &mut usize,
+    needle: &str,
+) -> Range<usize> {
+    if !needle.is_empty()
+        && let Some(offset) = source[*cursor..content_range.end].find(needle)
+    {
+        let start = *cursor + offset;
+        *cursor = start + needle.len();
+        return start..start + needle.len();
+    }
+    content_range.clone()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -763,6 +783,14 @@ impl Markdown {
         self.parse(cx);
     }
 
+    pub fn set_options(&mut self, options: MarkdownOptions, cx: &mut Context<Self>) {
+        if self.options == options {
+            return;
+        }
+        self.options = options;
+        self.parse(cx);
+    }
+
     pub fn request_autoscroll_to_source_index(
         &mut self,
         source_index: usize,
@@ -997,7 +1025,8 @@ impl Markdown {
         let should_parse_html = self.options.parse_html;
         let should_render_mermaid_diagrams = self.options.render_mermaid_diagrams;
         let should_parse_heading_slugs = self.options.parse_heading_slugs;
-        let should_parse_metadata_blocks = self.options.render_metadata_blocks;
+        let should_parse_metadata_blocks =
+            self.options.parse_metadata_blocks || self.options.render_metadata_blocks;
         let language_registry = self.language_registry.clone();
         let fallback = self.fallback_code_block_language.clone();
 
@@ -1661,50 +1690,8 @@ impl MarkdownElement {
         cx: &App,
     ) {
         let content_range = &metadata_block.content_range;
-        if let Some(rows) = metadata_block.rows.as_deref() {
-            builder.push_div(
-                div()
-                    .grid()
-                    .grid_cols(2)
-                    .w_full()
-                    .mb_2()
-                    .border_1()
-                    .border_color(cx.theme().colors().border)
-                    .rounded_sm()
-                    .overflow_hidden(),
-                content_range,
-                markdown_end,
-            );
-
-            for (row_index, row) in rows.iter().enumerate() {
-                self.push_metadata_cell(
-                    builder,
-                    source,
-                    row.key.clone(),
-                    content_range,
-                    markdown_end,
-                    MetadataCellStyle {
-                        row_index,
-                        is_key: true,
-                    },
-                    cx,
-                );
-                self.push_metadata_cell(
-                    builder,
-                    source,
-                    row.value.clone(),
-                    content_range,
-                    markdown_end,
-                    MetadataCellStyle {
-                        row_index,
-                        is_key: false,
-                    },
-                    cx,
-                );
-            }
-
-            builder.pop_div();
-        } else {
+        let Some(rows) = metadata_block.rows.as_deref() else {
+            // Not a valid YAML mapping: render the raw content as a code block.
             let mut metadata_block = div().w_full().rounded_md();
             metadata_block.style().refine(&self.style.code_block);
             builder.push_text_style(self.style.code_block.text.to_owned());
@@ -1715,18 +1702,79 @@ impl MarkdownElement {
             builder.pop_div();
             builder.pop_code_block();
             builder.pop_text_style();
+            return;
+        };
+
+        builder.push_div(
+            div()
+                .grid()
+                .grid_cols(2)
+                .w_full()
+                .mb_2()
+                .border_1()
+                .border_color(cx.theme().colors().border)
+                .rounded_sm()
+                .overflow_hidden(),
+            content_range,
+            markdown_end,
+        );
+
+        // Recover precise source ranges for rendered text by scanning forward
+        // through the block, so selection and search highlights land on the
+        // right source offsets. Values without a verbatim source span (e.g.
+        // block scalars) fall back to the whole block range.
+        let mut cursor = content_range.start;
+        for (row_index, row) in rows.iter().enumerate() {
+            let key_range = locate_metadata_span(source, content_range, &mut cursor, &row.key);
+            self.push_metadata_cell(builder, content_range, markdown_end, row_index, true, cx, {
+                let key = row.key.clone();
+                move |builder| {
+                    builder.push_text_style(TextStyleRefinement {
+                        color: Some(cx.theme().colors().text_muted),
+                        font_weight: Some(FontWeight::SEMIBOLD),
+                        ..Default::default()
+                    });
+                    builder.push_text(&key, key_range);
+                    builder.pop_text_style();
+                }
+            });
+            let value_range = match &row.value {
+                MetadataValue::Scalar(text) | MetadataValue::Raw(text) => {
+                    locate_metadata_span(source, content_range, &mut cursor, text)
+                }
+                MetadataValue::List(_) => content_range.clone(),
+            };
+            self.push_metadata_cell(builder, content_range, markdown_end, row_index, false, cx, {
+                let value = &row.value;
+                move |builder| match value {
+                    MetadataValue::Scalar(text) | MetadataValue::Raw(text) => {
+                        builder.push_text(text, value_range);
+                    }
+                    MetadataValue::List(items) => {
+                        builder.push_image_child(
+                            h_flex()
+                                .flex_wrap()
+                                .gap_1()
+                                .children(items.iter().map(|item| Chip::new(item.clone()))),
+                        );
+                    }
+                }
+            });
         }
+
+        builder.pop_div();
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn push_metadata_cell(
         &self,
         builder: &mut MarkdownElementBuilder,
-        source: &str,
-        text_range: Range<usize>,
         block_range: &Range<usize>,
         markdown_end: usize,
-        cell_style: MetadataCellStyle,
+        row_index: usize,
+        is_key: bool,
         cx: &App,
+        push_content: impl FnOnce(&mut MarkdownElementBuilder),
     ) {
         builder.push_div(
             div()
@@ -1736,27 +1784,15 @@ impl MarkdownElement {
                 .px_2()
                 .py_1()
                 .border_color(cx.theme().colors().border)
-                .when(cell_style.row_index > 0, |this| this.border_t_1())
-                .when(!cell_style.is_key, |this| this.border_l_1())
-                .when(cell_style.is_key, |this| {
+                .when(row_index > 0, |this| this.border_t_1())
+                .when(!is_key, |this| this.border_l_1())
+                .when(is_key, |this| {
                     this.bg(cx.theme().colors().panel_background)
                 }),
             block_range,
             markdown_end,
         );
-
-        let text_style = if cell_style.is_key {
-            TextStyleRefinement {
-                color: Some(cx.theme().colors().text_muted),
-                font_weight: Some(FontWeight::SEMIBOLD),
-                ..Default::default()
-            }
-        } else {
-            TextStyleRefinement::default()
-        };
-        builder.push_text_style(text_style);
-        builder.push_text(&source[text_range.clone()], text_range);
-        builder.pop_text_style();
+        push_content(builder);
         builder.pop_div();
     }
 
@@ -2177,13 +2213,21 @@ impl Element for MarkdownElement {
             self.style.base_text_style.clone(),
             self.style.syntax.clone(),
         );
-        let (parsed_markdown, images, active_root_block, render_mermaid_diagrams, mermaid_state) = {
+        let (
+            parsed_markdown,
+            images,
+            active_root_block,
+            render_mermaid_diagrams,
+            render_metadata_blocks,
+            mermaid_state,
+        ) = {
             let markdown = self.markdown.read(cx);
             (
                 markdown.parsed_markdown.clone(),
                 markdown.images_by_source_offset.clone(),
                 markdown.active_root_block,
                 markdown.options.render_mermaid_diagrams,
+                markdown.options.render_metadata_blocks,
                 markdown.mermaid_state.clone(),
             )
         };
@@ -2542,13 +2586,17 @@ impl Element for MarkdownElement {
                             if let Some(metadata_block) =
                                 parsed_markdown.metadata_blocks.get(&range.start)
                             {
-                                self.push_metadata_block(
-                                    &mut builder,
-                                    &parsed_markdown.source,
-                                    metadata_block,
-                                    markdown_end,
-                                    cx,
-                                );
+                                if render_metadata_blocks {
+                                    self.push_metadata_block(
+                                        &mut builder,
+                                        &parsed_markdown.source,
+                                        metadata_block,
+                                        markdown_end,
+                                        cx,
+                                    );
+                                }
+                                // Consume the block's inner events regardless, so the
+                                // raw frontmatter never leaks into the document body.
                                 rendered_metadata_block = true;
                             }
                         }
@@ -3202,11 +3250,6 @@ fn alignment_to_text_align(alignment: Alignment) -> Option<TextAlign> {
         Alignment::Right => Some(TextAlign::Right),
         Alignment::None => None,
     }
-}
-
-struct MetadataCellStyle {
-    row_index: usize,
-    is_key: bool,
 }
 
 struct MarkdownElementBuilder {
@@ -4499,7 +4542,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_frontmatter_falls_back_to_code_block_for_nested_yaml(cx: &mut TestAppContext) {
+    fn test_frontmatter_renders_list_values_as_chips(cx: &mut TestAppContext) {
         let rendered = render_markdown_with_options(
             "---\ntags:\n  - zed\n---\nBody",
             None,
@@ -4509,7 +4552,24 @@ mod tests {
             },
             cx,
         );
-        assert_eq!(rendered.text_for_range(0..26), "tags:\n  - zed\nBody");
+        // The key and body render as text; list items become chips (which are
+        // not part of the selectable text), and the raw YAML never leaks.
+        assert_eq!(rendered.text_for_range(0..26), "tags\nBody");
+    }
+
+    #[gpui::test]
+    fn test_frontmatter_hidden_when_not_rendered(cx: &mut TestAppContext) {
+        let rendered = render_markdown_with_options(
+            "---\ntitle: Post\n---\nBody",
+            None,
+            MarkdownOptions {
+                parse_metadata_blocks: true,
+                ..Default::default()
+            },
+            cx,
+        );
+        // Recognized but not rendered: the frontmatter is stripped from the body.
+        assert_eq!(rendered.text_for_range(0..24), "Body");
     }
 
     fn render_markdown_with_code_span_link(

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1743,6 +1743,9 @@ impl MarkdownElement {
                 MetadataValue::Scalar(text) | MetadataValue::Raw(text) => {
                     locate_metadata_span(source, content_range, &mut cursor, text)
                 }
+                // Unused: list items render as chips, not text. The cursor isn't
+                // advanced past them because scanning for a normalized item
+                // (`TRUE` stored as `true`) can overshoot into a later key.
                 MetadataValue::List(_) => content_range.clone(),
             };
             self.push_metadata_cell(

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1691,7 +1691,8 @@ impl MarkdownElement {
     ) {
         let content_range = &metadata_block.content_range;
         let Some(rows) = metadata_block.rows.as_deref() else {
-            // Not a valid YAML mapping: render the raw content as a code block.
+            // No table rows (invalid or unsupported frontmatter): render the
+            // raw content as a code block.
             let mut metadata_block = div().w_full().rounded_md();
             metadata_block.style().refine(&self.style.code_block);
             builder.push_text_style(self.style.code_block.text.to_owned());

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1745,28 +1745,36 @@ impl MarkdownElement {
                 }
                 MetadataValue::List(_) => content_range.clone(),
             };
-            self.push_metadata_cell(builder, content_range, markdown_end, row_index, false, cx, {
-                let value = &row.value;
-                let raw_text_style = self.style.code_block.text.to_owned();
-                move |builder| match value {
-                    MetadataValue::Scalar(text) => {
-                        builder.push_text(text, value_range);
+            self.push_metadata_cell(
+                builder,
+                content_range,
+                markdown_end,
+                row_index,
+                false,
+                cx,
+                {
+                    let value = &row.value;
+                    let raw_text_style = self.style.code_block.text.to_owned();
+                    move |builder| match value {
+                        MetadataValue::Scalar(text) => {
+                            builder.push_text(text, value_range);
+                        }
+                        MetadataValue::Raw(text) => {
+                            builder.push_text_style(raw_text_style);
+                            builder.push_text(text, value_range);
+                            builder.pop_text_style();
+                        }
+                        MetadataValue::List(items) => {
+                            builder.push_image_child(
+                                h_flex()
+                                    .flex_wrap()
+                                    .gap_1()
+                                    .children(items.iter().map(|item| Chip::new(item.clone()))),
+                            );
+                        }
                     }
-                    MetadataValue::Raw(text) => {
-                        builder.push_text_style(raw_text_style);
-                        builder.push_text(text, value_range);
-                        builder.pop_text_style();
-                    }
-                    MetadataValue::List(items) => {
-                        builder.push_image_child(
-                            h_flex()
-                                .flex_wrap()
-                                .gap_1()
-                                .children(items.iter().map(|item| Chip::new(item.clone()))),
-                        );
-                    }
-                }
-            });
+                },
+            );
         }
 
         builder.pop_div();
@@ -1793,9 +1801,7 @@ impl MarkdownElement {
                 .border_color(cx.theme().colors().border)
                 .when(row_index > 0, |this| this.border_t_1())
                 .when(!is_key, |this| this.border_l_1())
-                .when(is_key, |this| {
-                    this.bg(cx.theme().colors().panel_background)
-                }),
+                .when(is_key, |this| this.bg(cx.theme().colors().panel_background)),
             block_range,
             markdown_end,
         );

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -425,27 +425,10 @@ pub struct MarkdownOptions {
     pub parse_html: bool,
     pub render_mermaid_diagrams: bool,
     pub parse_heading_slugs: bool,
-    /// Recognize frontmatter so it is stripped from the document body even when
-    /// it isn't rendered. Whether it's drawn is controlled by
-    /// `render_metadata_blocks`.
+    /// Recognizes frontmatter so it is stripped from the body even when
+    /// `render_metadata_blocks` is off.
     pub parse_metadata_blocks: bool,
     pub render_metadata_blocks: bool,
-}
-
-fn locate_metadata_span(
-    source: &str,
-    content_range: &Range<usize>,
-    cursor: &mut usize,
-    needle: &str,
-) -> Range<usize> {
-    if !needle.is_empty()
-        && let Some(offset) = source[*cursor..content_range.end].find(needle)
-    {
-        let start = *cursor + offset;
-        *cursor = start + needle.len();
-        return start..start + needle.len();
-    }
-    content_range.clone()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -1691,8 +1674,6 @@ impl MarkdownElement {
     ) {
         let content_range = &metadata_block.content_range;
         let Some(rows) = metadata_block.rows.as_deref() else {
-            // No table rows (invalid or unsupported frontmatter): render the
-            // raw content as a code block.
             let mut metadata_block = div().w_full().rounded_md();
             metadata_block.style().refine(&self.style.code_block);
             builder.push_text_style(self.style.code_block.text.to_owned());
@@ -1720,42 +1701,52 @@ impl MarkdownElement {
             markdown_end,
         );
 
-        // Recover precise source ranges for rendered text by scanning forward
-        // through the block, so selection and search highlights land on the
-        // right source offsets. Values the YAML parser normalizes away from
-        // their source text (block scalars, and numbers or quoted strings
-        // re-serialized to a different spelling) have no verbatim span and fall
-        // back to the whole block range.
+        // Scan forward for each rendered string so selection and search land on
+        // the right source offsets. Values the YAML parser normalizes (block
+        // scalars, re-spelled numbers and quoted strings) have no verbatim span
+        // and fall back to the whole block range.
         let mut cursor = content_range.start;
         for (row_index, row) in rows.iter().enumerate() {
             let key_range = locate_metadata_span(source, content_range, &mut cursor, &row.key);
-            self.push_metadata_cell(builder, content_range, markdown_end, row_index, true, cx, {
-                let key = row.key.clone();
-                move |builder| {
-                    builder.push_text_style(TextStyleRefinement {
-                        color: Some(cx.theme().colors().text_muted),
-                        font_weight: Some(FontWeight::SEMIBOLD),
-                        ..Default::default()
-                    });
-                    builder.push_text(&key, key_range);
-                    builder.pop_text_style();
-                }
-            });
+            self.push_metadata_cell(
+                builder,
+                content_range,
+                markdown_end,
+                MetadataCellStyle {
+                    row_index,
+                    is_key: true,
+                },
+                cx,
+                {
+                    let key = row.key.clone();
+                    move |builder| {
+                        builder.push_text_style(TextStyleRefinement {
+                            color: Some(cx.theme().colors().text_muted),
+                            font_weight: Some(FontWeight::SEMIBOLD),
+                            ..Default::default()
+                        });
+                        builder.push_text(&key, key_range);
+                        builder.pop_text_style();
+                    }
+                },
+            );
             let value_range = match &row.value {
                 MetadataValue::Scalar(text) | MetadataValue::Raw(text) => {
                     locate_metadata_span(source, content_range, &mut cursor, text)
                 }
-                // Unused: list items render as chips, not text. The cursor isn't
-                // advanced past them because scanning for a normalized item
-                // (`TRUE` stored as `true`) can overshoot into a later key.
+                // Unused: chips aren't text. The cursor stays put because a
+                // normalized item (`TRUE` stored as `true`) can't be located and
+                // scanning for it would overshoot into a later key.
                 MetadataValue::List(_) => content_range.clone(),
             };
             self.push_metadata_cell(
                 builder,
                 content_range,
                 markdown_end,
-                row_index,
-                false,
+                MetadataCellStyle {
+                    row_index,
+                    is_key: false,
+                },
                 cx,
                 {
                     let value = &row.value;
@@ -1785,14 +1776,12 @@ impl MarkdownElement {
         builder.pop_div();
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn push_metadata_cell(
         &self,
         builder: &mut MarkdownElementBuilder,
         block_range: &Range<usize>,
         markdown_end: usize,
-        row_index: usize,
-        is_key: bool,
+        cell_style: MetadataCellStyle,
         cx: &App,
         push_content: impl FnOnce(&mut MarkdownElementBuilder),
     ) {
@@ -1804,9 +1793,11 @@ impl MarkdownElement {
                 .px_2()
                 .py_1()
                 .border_color(cx.theme().colors().border)
-                .when(row_index > 0, |this| this.border_t_1())
-                .when(!is_key, |this| this.border_l_1())
-                .when(is_key, |this| this.bg(cx.theme().colors().panel_background)),
+                .when(cell_style.row_index > 0, |this| this.border_t_1())
+                .when(!cell_style.is_key, |this| this.border_l_1())
+                .when(cell_style.is_key, |this| {
+                    this.bg(cx.theme().colors().panel_background)
+                }),
             block_range,
             markdown_end,
         );
@@ -2613,8 +2604,8 @@ impl Element for MarkdownElement {
                                         cx,
                                     );
                                 }
-                                // Consume the block's inner events regardless, so the
-                                // raw frontmatter never leaks into the document body.
+                                // Set even when not rendering, so the block's inner
+                                // events are consumed rather than leaking into the body.
                                 rendered_metadata_block = true;
                             }
                         }
@@ -3268,6 +3259,27 @@ fn alignment_to_text_align(alignment: Alignment) -> Option<TextAlign> {
         Alignment::Right => Some(TextAlign::Right),
         Alignment::None => None,
     }
+}
+
+fn locate_metadata_span(
+    source: &str,
+    content_range: &Range<usize>,
+    cursor: &mut usize,
+    needle: &str,
+) -> Range<usize> {
+    if !needle.is_empty()
+        && let Some(offset) = source[*cursor..content_range.end].find(needle)
+    {
+        let start = *cursor + offset;
+        *cursor = start + needle.len();
+        return start..start + needle.len();
+    }
+    content_range.clone()
+}
+
+struct MetadataCellStyle {
+    row_index: usize,
+    is_key: bool,
 }
 
 struct MarkdownElementBuilder {
@@ -4570,8 +4582,7 @@ mod tests {
             },
             cx,
         );
-        // The key and body render as text; list items become chips (which are
-        // not part of the selectable text), and the raw YAML never leaks.
+        // List items become chips, which aren't part of the selectable text.
         assert_eq!(rendered.text_for_range(0..26), "tags\nBody");
     }
 
@@ -4601,8 +4612,7 @@ mod tests {
             },
             cx,
         );
-        // Frontmatter that isn't a valid YAML mapping renders verbatim as a code
-        // block rather than a table, with the body still following it.
+        // Invalid YAML renders verbatim as a code block instead of a table.
         assert_eq!(rendered.text_for_range(0..31), "key: [unterminated\nBody");
     }
 
@@ -4617,8 +4627,7 @@ mod tests {
             },
             cx,
         );
-        // A nested mapping keeps its YAML text in the value cell so the structure
-        // stays readable instead of collapsing to one line.
+        // A nested mapping keeps its YAML text instead of collapsing to one line.
         assert_eq!(rendered.text_for_range(0..33), "meta\nnested: true\nBody");
     }
 

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -45,9 +45,8 @@ pub(crate) struct ParsedMarkdownData {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ParsedMetadataBlock {
     pub content_range: Range<usize>,
-    /// Parsed key/value rows, or `None` when the block can't be rendered as a
-    /// table (invalid or unsupported frontmatter), in which case the raw
-    /// content is rendered as a code block.
+    /// `None` when the frontmatter is invalid or in an unsupported format, in
+    /// which case the raw content is rendered as a code block.
     pub rows: Option<Vec<MetadataRow>>,
 }
 
@@ -61,8 +60,7 @@ pub(crate) struct MetadataRow {
 pub(crate) enum MetadataValue {
     Scalar(String),
     List(Vec<String>),
-    /// Nested mappings and other structures we don't render specially, kept as
-    /// their re-serialized YAML text.
+    /// Structures with no special rendering, kept as re-serialized YAML text.
     Raw(String),
 }
 
@@ -180,8 +178,6 @@ fn build_heading_slugs(
     slugs
 }
 
-/// Dispatches on the block's delimiter format. `None` means the caller renders
-/// the raw content as a code block instead of a table.
 fn parse_metadata_rows(
     kind: MetadataBlockKind,
     source: &str,
@@ -194,9 +190,8 @@ fn parse_metadata_rows(
     }
 }
 
-/// `None` signals the block isn't a non-empty YAML mapping. Entries with a
-/// non-scalar or empty key are skipped, so one such entry doesn't discard the
-/// whole table.
+/// Entries with a non-scalar or empty key are skipped rather than discarding
+/// the whole table.
 fn parse_yaml_metadata_rows(source: &str, source_range: Range<usize>) -> Option<Vec<MetadataRow>> {
     let content = source.get(source_range)?;
     let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(content).ok()?;
@@ -1172,10 +1167,8 @@ mod tests {
 
     #[test]
     fn test_metadata_rows_pluses_format_unsupported() {
-        // A block is dispatched by its delimiter format, not its content: TOML
-        // (`+++`) frontmatter isn't parsed yet, so it yields no rows and falls
-        // back to a raw code block even when the content happens to be valid
-        // YAML that the YAML path would otherwise render as a table.
+        // Dispatch is on the delimiter, not the content: valid YAML inside a
+        // `+++` block still yields no rows.
         let source = "title: Post\n";
         assert!(
             parse_metadata_rows(MetadataBlockKind::YamlStyle, source, 0..source.len()).is_some()

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -45,8 +45,9 @@ pub(crate) struct ParsedMarkdownData {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ParsedMetadataBlock {
     pub content_range: Range<usize>,
-    /// Parsed key/value rows, or `None` when the block isn't a valid YAML
-    /// mapping (in which case the raw content is rendered as a code block).
+    /// Parsed key/value rows, or `None` when the block can't be rendered as a
+    /// table (invalid or unsupported frontmatter), in which case the raw
+    /// content is rendered as a code block.
     pub rows: Option<Vec<MetadataRow>>,
 }
 
@@ -179,9 +180,22 @@ fn build_heading_slugs(
     slugs
 }
 
-/// `None` signals the block isn't a valid, non-empty YAML mapping, so the
-/// caller renders the raw content as a code block instead.
-fn parse_metadata_rows(source: &str, source_range: Range<usize>) -> Option<Vec<MetadataRow>> {
+/// Dispatches on the block's delimiter format. `None` means the caller renders
+/// the raw content as a code block instead of a table.
+fn parse_metadata_rows(
+    kind: MetadataBlockKind,
+    source: &str,
+    source_range: Range<usize>,
+) -> Option<Vec<MetadataRow>> {
+    match kind {
+        MetadataBlockKind::YamlStyle => parse_yaml_metadata_rows(source, source_range),
+        // TOML (`+++`) frontmatter is recognized as a block but not parsed yet.
+        MetadataBlockKind::PlusesStyle => None,
+    }
+}
+
+/// `None` signals the block isn't a valid, non-empty YAML mapping.
+fn parse_yaml_metadata_rows(source: &str, source_range: Range<usize>) -> Option<Vec<MetadataRow>> {
     let content = source.get(source_range)?;
     let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(content).ok()?;
     let serde_yaml_ng::Value::Mapping(mapping) = value else {
@@ -203,15 +217,15 @@ fn parse_metadata_rows(source: &str, source_range: Range<usize>) -> Option<Vec<M
 }
 
 fn metadata_value(value: &serde_yaml_ng::Value) -> MetadataValue {
+    let raw = || MetadataValue::Raw(metadata_raw(value));
     match value {
         serde_yaml_ng::Value::Sequence(items) => items
             .iter()
             .map(metadata_scalar)
             .collect::<Option<Vec<_>>>()
-            .map_or_else(|| MetadataValue::Raw(metadata_raw(value)), MetadataValue::List),
-        serde_yaml_ng::Value::Mapping(_) => MetadataValue::Raw(metadata_raw(value)),
-        scalar => metadata_scalar(scalar)
-            .map_or_else(|| MetadataValue::Raw(metadata_raw(value)), MetadataValue::Scalar),
+            .map_or_else(raw, MetadataValue::List),
+        serde_yaml_ng::Value::Mapping(_) => raw(),
+        scalar => metadata_scalar(scalar).map_or_else(raw, MetadataValue::Scalar),
     }
 }
 
@@ -466,7 +480,7 @@ pub(crate) fn parse_markdown_with_options(
                     within_link = false;
                 } else if let pulldown_cmark::TagEnd::CodeBlock = tag {
                     within_code_block = false;
-                } else if let pulldown_cmark::TagEnd::MetadataBlock(_) = tag {
+                } else if let pulldown_cmark::TagEnd::MetadataBlock(kind) = tag {
                     within_metadata = false;
                     let block_start = current_metadata_block_start.take();
                     let content_range = metadata_block_content_range.take();
@@ -477,7 +491,7 @@ pub(crate) fn parse_markdown_with_options(
                         metadata_blocks.insert(
                             block_start,
                             ParsedMetadataBlock {
-                                rows: parse_metadata_rows(text, content_range.clone()),
+                                rows: parse_metadata_rows(kind, text, content_range.clone()),
                                 content_range,
                             },
                         );
@@ -1079,7 +1093,8 @@ mod tests {
     #[test]
     fn test_metadata_rows_parse_value_kinds() {
         let source = "title: Post\ntags:\n  - a\n  - b\nmeta:\n  nested: true\n";
-        let rows = parse_metadata_rows(source, 0..source.len()).expect("expected metadata rows");
+        let rows = parse_metadata_rows(MetadataBlockKind::YamlStyle, source, 0..source.len())
+            .expect("expected metadata rows");
 
         assert_eq!(
             rows,
@@ -1103,7 +1118,8 @@ mod tests {
     #[test]
     fn test_metadata_rows_preserve_block_scalars() {
         let source = "scope: |\n  line one\n  line two\n";
-        let rows = parse_metadata_rows(source, 0..source.len()).expect("expected metadata rows");
+        let rows = parse_metadata_rows(MetadataBlockKind::YamlStyle, source, 0..source.len())
+            .expect("expected metadata rows");
 
         assert_eq!(
             rows,
@@ -1123,8 +1139,26 @@ mod tests {
             "\n",
             "key: [unterminated\n",
         ] {
-            assert!(parse_metadata_rows(source, 0..source.len()).is_none());
+            assert!(
+                parse_metadata_rows(MetadataBlockKind::YamlStyle, source, 0..source.len())
+                    .is_none()
+            );
         }
+    }
+
+    #[test]
+    fn test_metadata_rows_pluses_format_unsupported() {
+        // A block is dispatched by its delimiter format, not its content: TOML
+        // (`+++`) frontmatter isn't parsed yet, so it yields no rows and falls
+        // back to a raw code block even when the content happens to be valid
+        // YAML that the YAML path would otherwise render as a table.
+        let source = "title: Post\n";
+        assert!(
+            parse_metadata_rows(MetadataBlockKind::YamlStyle, source, 0..source.len()).is_some()
+        );
+        assert!(
+            parse_metadata_rows(MetadataBlockKind::PlusesStyle, source, 0..source.len()).is_none()
+        );
     }
 
     #[test]

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -45,13 +45,24 @@ pub(crate) struct ParsedMarkdownData {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ParsedMetadataBlock {
     pub content_range: Range<usize>,
+    /// Parsed key/value rows, or `None` when the block isn't a valid YAML
+    /// mapping (in which case the raw content is rendered as a code block).
     pub rows: Option<Vec<MetadataRow>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct MetadataRow {
-    pub key: Range<usize>,
-    pub value: Range<usize>,
+    pub key: String,
+    pub value: MetadataValue,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum MetadataValue {
+    Scalar(String),
+    List(Vec<String>),
+    /// Nested mappings and other structures we don't render specially, kept as
+    /// their re-serialized YAML text.
+    Raw(String),
 }
 
 impl ParseState {
@@ -168,49 +179,58 @@ fn build_heading_slugs(
     slugs
 }
 
-fn parse_metadata_table_rows(source: &str, source_range: Range<usize>) -> Option<Vec<MetadataRow>> {
-    let mut rows = Vec::new();
-    let mut line_start = source_range.start;
+/// `None` signals the block isn't a valid, non-empty YAML mapping, so the
+/// caller renders the raw content as a code block instead.
+fn parse_metadata_rows(source: &str, source_range: Range<usize>) -> Option<Vec<MetadataRow>> {
+    let content = source.get(source_range)?;
+    let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(content).ok()?;
+    let serde_yaml_ng::Value::Mapping(mapping) = value else {
+        return None;
+    };
 
-    for line in source[source_range].split_inclusive('\n') {
-        let line_end = line_start + line.len();
-        let content_end = line_start + line.trim_end_matches(['\r', '\n']).len();
-        let content_range = line_start..content_end;
-        let line_text = &source[content_range.clone()];
+    let rows = mapping
+        .iter()
+        .map(|(key, value)| {
+            let key = metadata_scalar(key).filter(|key| !key.is_empty())?;
+            Some(MetadataRow {
+                key,
+                value: metadata_value(value),
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
 
-        if line_text.is_empty()
-            || line_text
-                .chars()
-                .next()
-                .is_some_and(|character| character.is_whitespace())
-        {
-            return None;
-        }
-
-        let delimiter = line_text.find(':')?;
-        let key = trim_metadata_range(source, content_range.start..content_range.start + delimiter);
-        let value = trim_metadata_range(
-            source,
-            content_range.start + delimiter + 1..content_range.end,
-        );
-        if key.is_empty() || value.is_empty() {
-            return None;
-        }
-
-        rows.push(MetadataRow { key, value });
-        line_start = line_end;
-    }
-
-    if rows.is_empty() { None } else { Some(rows) }
+    (!rows.is_empty()).then_some(rows)
 }
 
-fn trim_metadata_range(source: &str, range: Range<usize>) -> Range<usize> {
-    let text = &source[range.clone()];
-    let start_offset = text.len() - text.trim_start().len();
-    let end_offset = text.trim_end().len();
-    let start = range.start + start_offset;
-    let end = (range.start + end_offset).max(start);
-    start..end
+fn metadata_value(value: &serde_yaml_ng::Value) -> MetadataValue {
+    match value {
+        serde_yaml_ng::Value::Sequence(items) => items
+            .iter()
+            .map(metadata_scalar)
+            .collect::<Option<Vec<_>>>()
+            .map_or_else(|| MetadataValue::Raw(metadata_raw(value)), MetadataValue::List),
+        serde_yaml_ng::Value::Mapping(_) => MetadataValue::Raw(metadata_raw(value)),
+        scalar => metadata_scalar(scalar)
+            .map_or_else(|| MetadataValue::Raw(metadata_raw(value)), MetadataValue::Scalar),
+    }
+}
+
+fn metadata_scalar(value: &serde_yaml_ng::Value) -> Option<String> {
+    match value {
+        serde_yaml_ng::Value::Null => Some(String::new()),
+        serde_yaml_ng::Value::Bool(value) => Some(value.to_string()),
+        serde_yaml_ng::Value::Number(value) => Some(value.to_string()),
+        serde_yaml_ng::Value::String(value) => Some(value.clone()),
+        serde_yaml_ng::Value::Sequence(_)
+        | serde_yaml_ng::Value::Mapping(_)
+        | serde_yaml_ng::Value::Tagged(_) => None,
+    }
+}
+
+fn metadata_raw(value: &serde_yaml_ng::Value) -> String {
+    serde_yaml_ng::to_string(value)
+        .map(|raw| raw.trim_end().to_owned())
+        .unwrap_or_default()
 }
 
 fn is_br_tag(html: &str) -> bool {
@@ -457,7 +477,7 @@ pub(crate) fn parse_markdown_with_options(
                         metadata_blocks.insert(
                             block_start,
                             ParsedMetadataBlock {
-                                rows: parse_metadata_table_rows(text, content_range.clone()),
+                                rows: parse_metadata_rows(text, content_range.clone()),
                                 content_range,
                             },
                         );
@@ -1004,8 +1024,8 @@ mod tests {
                     ParsedMetadataBlock {
                         content_range: 4..16,
                         rows: Some(vec![MetadataRow {
-                            key: 4..9,
-                            value: 11..15,
+                            key: "title".into(),
+                            value: MetadataValue::Scalar("Post".into()),
                         }]),
                     },
                 )]),
@@ -1043,12 +1063,12 @@ mod tests {
                     content_range: 4..28,
                     rows: Some(vec![
                         MetadataRow {
-                            key: 4..9,
-                            value: 11..15,
+                            key: "title".into(),
+                            value: MetadataValue::Scalar("Post".into()),
                         },
                         MetadataRow {
-                            key: 16..22,
-                            value: 24..27,
+                            key: "author".into(),
+                            value: MetadataValue::Scalar("Zed".into()),
                         },
                     ]),
                 },
@@ -1057,58 +1077,54 @@ mod tests {
     }
 
     #[test]
-    fn test_metadata_blocks_store_fallback_for_nested_yaml() {
-        let parsed =
-            parse_markdown_with_options("---\ntags:\n  - zed\n---\nBody", false, false, true);
+    fn test_metadata_rows_parse_value_kinds() {
+        let source = "title: Post\ntags:\n  - a\n  - b\nmeta:\n  nested: true\n";
+        let rows = parse_metadata_rows(source, 0..source.len()).expect("expected metadata rows");
 
         assert_eq!(
-            parsed.metadata_blocks,
-            BTreeMap::from_iter([(
-                0,
-                ParsedMetadataBlock {
-                    content_range: 4..18,
-                    rows: None,
+            rows,
+            vec![
+                MetadataRow {
+                    key: "title".into(),
+                    value: MetadataValue::Scalar("Post".into()),
                 },
-            )])
+                MetadataRow {
+                    key: "tags".into(),
+                    value: MetadataValue::List(vec!["a".into(), "b".into()]),
+                },
+                MetadataRow {
+                    key: "meta".into(),
+                    value: MetadataValue::Raw("nested: true".into()),
+                },
+            ]
         );
     }
 
     #[test]
-    fn test_metadata_table_rows_parse_simple_colon_pairs() {
-        let source = "title: Post\nauthor: Zed\n";
-        let Some(rows) = parse_metadata_table_rows(source, 0..source.len()) else {
-            panic!("expected metadata rows");
-        };
-        let pairs = rows
-            .into_iter()
-            .map(|row| (&source[row.key], &source[row.value]))
-            .collect::<Vec<_>>();
+    fn test_metadata_rows_preserve_block_scalars() {
+        let source = "scope: |\n  line one\n  line two\n";
+        let rows = parse_metadata_rows(source, 0..source.len()).expect("expected metadata rows");
 
-        assert_eq!(pairs, vec![("title", "Post"), ("author", "Zed")]);
+        assert_eq!(
+            rows,
+            vec![MetadataRow {
+                key: "scope".into(),
+                value: MetadataValue::Scalar("line one\nline two\n".into()),
+            }]
+        );
     }
 
     #[test]
-    fn test_metadata_table_rows_reject_non_simple_colon_pairs() {
+    fn test_metadata_rows_reject_non_mapping() {
         for source in [
-            "tags:\n  - zed\n",
-            "title = Post\n",
-            "title:\n",
-            "title:   \n",
-            ": Post\n",
-            " title: Post\n",
+            "just a string\n",
+            "- a\n- b\n",
+            "",
             "\n",
+            "key: [unterminated\n",
         ] {
-            assert!(parse_metadata_table_rows(source, 0..source.len()).is_none());
+            assert!(parse_metadata_rows(source, 0..source.len()).is_none());
         }
-    }
-
-    #[test]
-    fn test_trim_metadata_range_returns_valid_empty_range() {
-        let source = "key:   \n";
-        let trimmed = trim_metadata_range(source, 4..7);
-
-        assert_eq!(trimmed, 7..7);
-        assert!(source[trimmed].is_empty());
     }
 
     #[test]

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -194,7 +194,9 @@ fn parse_metadata_rows(
     }
 }
 
-/// `None` signals the block isn't a valid, non-empty YAML mapping.
+/// `None` signals the block isn't a non-empty YAML mapping. Entries with a
+/// non-scalar or empty key are skipped, so one such entry doesn't discard the
+/// whole table.
 fn parse_yaml_metadata_rows(source: &str, source_range: Range<usize>) -> Option<Vec<MetadataRow>> {
     let content = source.get(source_range)?;
     let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(content).ok()?;
@@ -204,14 +206,14 @@ fn parse_yaml_metadata_rows(source: &str, source_range: Range<usize>) -> Option<
 
     let rows = mapping
         .iter()
-        .map(|(key, value)| {
+        .filter_map(|(key, value)| {
             let key = metadata_scalar(key).filter(|key| !key.is_empty())?;
             Some(MetadataRow {
                 key,
                 value: metadata_value(value),
             })
         })
-        .collect::<Option<Vec<_>>>()?;
+        .collect::<Vec<_>>();
 
     (!rows.is_empty()).then_some(rows)
 }
@@ -1144,6 +1146,28 @@ mod tests {
                     .is_none()
             );
         }
+    }
+
+    #[test]
+    fn test_metadata_rows_skip_entries_with_unrenderable_keys() {
+        // A bare `null` key is the null scalar, i.e. an empty key, so it's skipped.
+        let source = "title: Post\nnull: ignored\nauthor: Zed\n";
+        let rows = parse_metadata_rows(MetadataBlockKind::YamlStyle, source, 0..source.len())
+            .expect("expected metadata rows");
+
+        assert_eq!(
+            rows,
+            vec![
+                MetadataRow {
+                    key: "title".into(),
+                    value: MetadataValue::Scalar("Post".into()),
+                },
+                MetadataRow {
+                    key: "author".into(),
+                    value: MetadataValue::Scalar("Zed".into()),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/markdown_preview/src/markdown_preview_settings.rs
+++ b/crates/markdown_preview/src/markdown_preview_settings.rs
@@ -7,6 +7,8 @@ pub struct MarkdownPreviewSettings {
     /// The maximum width of the rendered markdown content, or `None` to render
     /// content edge to edge.
     pub max_width: Option<Pixels>,
+    /// Whether to render YAML frontmatter as a table.
+    pub render_frontmatter: bool,
 }
 
 impl Settings for MarkdownPreviewSettings {
@@ -17,6 +19,9 @@ impl Settings for MarkdownPreviewSettings {
         } else {
             None
         };
-        Self { max_width }
+        Self {
+            max_width,
+            render_frontmatter: content.render_frontmatter.unwrap_or(true),
+        }
     }
 }

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -22,7 +22,7 @@ use markdown::{
 };
 use project::search::SearchQuery;
 use project::{Project, ProjectPath};
-use settings::{SeedQuerySetting, Settings, update_settings_file};
+use settings::{SeedQuerySetting, Settings, SettingsStore, update_settings_file};
 use theme::{SystemAppearance, Theme, ThemeRegistry};
 use theme_settings::ThemeSettings;
 use ui::utils::WithRemSize;
@@ -50,12 +50,26 @@ use crate::{ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop, ScrollUp,
 
 const REPARSE_DEBOUNCE: Duration = Duration::from_millis(200);
 
+fn markdown_preview_options(cx: &App) -> MarkdownOptions {
+    MarkdownOptions {
+        parse_html: true,
+        render_mermaid_diagrams: true,
+        parse_heading_slugs: true,
+        // Always recognize frontmatter so it's stripped from the body; whether
+        // it's drawn is controlled by the `render_frontmatter` setting.
+        parse_metadata_blocks: true,
+        render_metadata_blocks: MarkdownPreviewSettings::get_global(cx).render_frontmatter,
+        ..Default::default()
+    }
+}
+
 pub struct MarkdownPreviewView {
     workspace: WeakEntity<Workspace>,
     active_editor: Option<EditorState>,
     focus_handle: FocusHandle,
     markdown: Entity<Markdown>,
     _markdown_subscription: Subscription,
+    _settings_subscription: Subscription,
     active_source_index: Option<usize>,
     scroll_handle: ScrollHandle,
     image_cache: Entity<RetainAllImageCache>,
@@ -288,13 +302,7 @@ impl MarkdownPreviewView {
                     SharedString::default(),
                     Some(language_registry),
                     None,
-                    MarkdownOptions {
-                        parse_html: true,
-                        render_mermaid_diagrams: true,
-                        parse_heading_slugs: true,
-                        render_metadata_blocks: true,
-                        ..Default::default()
-                    },
+                    markdown_preview_options(cx),
                     cx,
                 )
             });
@@ -308,6 +316,11 @@ impl MarkdownPreviewView {
                         this.sync_active_root_block(cx);
                     },
                 ),
+                _settings_subscription: cx.observe_global::<SettingsStore>(|this, cx| {
+                    let options = markdown_preview_options(cx);
+                    this.markdown
+                        .update(cx, |markdown, cx| markdown.set_options(options, cx));
+                }),
                 markdown,
                 active_source_index: None,
                 scroll_handle: ScrollHandle::new(),

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -55,8 +55,6 @@ fn markdown_preview_options(cx: &App) -> MarkdownOptions {
         parse_html: true,
         render_mermaid_diagrams: true,
         parse_heading_slugs: true,
-        // Always recognize frontmatter so it's stripped from the body; whether
-        // it's drawn is controlled by the `render_frontmatter` setting.
         parse_metadata_blocks: true,
         render_metadata_blocks: MarkdownPreviewSettings::get_global(cx).render_frontmatter,
         ..Default::default()

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -1211,6 +1211,11 @@ pub struct MarkdownPreviewSettingsContent {
     ///
     /// Default: 800
     pub max_width: Option<f32>,
+    /// Whether to render YAML frontmatter as a table in Markdown previews.
+    /// When disabled, frontmatter is hidden from the preview.
+    ///
+    /// Default: true
+    pub render_frontmatter: Option<bool>,
 }
 
 /// The settings for the image viewer.


### PR DESCRIPTION
Zed's Markdown preview has rendered YAML frontmatter as metadata since #57845, but the parser only handled trivial flat `key: value` lines. Quoted strings, values containing `:` or `/`, block scalars (`|`), and lists all fell through to a fallback that renders the entire block as one run-on paragraph — so most real-world frontmatter (spec files, `CLAUDE.md`, Hugo/Astro/Obsidian notes) renders unreadably.

This parses the frontmatter with a YAML parser (`serde_yaml_ng`, already in the dependency tree) and renders it as a table:

- Scalars render as text, with multi-line block scalars preserved.
- List values render as chips, matching how Obsidian and GitHub display frontmatter properties.
- Nested mappings render as their YAML text in a monospace style within the value cell, so the structure stays aligned and readable.
- A whole block that isn't a valid YAML mapping falls back to a code block; a leading `---` is never rendered as a thematic break.

Parsing dispatches on the block's delimiter, so a TOML parser can be added for `+++` blocks later without changing the row/value model or the renderer. For now `+++` blocks fall back to a code block rather than being parsed as YAML.

It also adds a `markdown.preview.render_frontmatter` setting (default `true`). When disabled, the block is recognized and hidden rather than leaking into the document body. The setting applies to open previews live.

### Context

- Requested in discussion https://github.com/zed-industries/zed/discussions/55557 (parity with VSCode / Neovim / Obsidian).
- Builds on and fixes the initial rendering from #57845.
- Related: #43444, #7938.

### Screenshots

<img width="1200" height="796" alt="frontmatter-before-after" src="https://github.com/user-attachments/assets/73f1cee0-4c7b-47dd-91a8-2b4c3fd2f1d7" />

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Improved Markdown preview to render YAML frontmatter as a table with list values shown as chips, configurable via the `markdown.preview.render_frontmatter` setting
