### PR TITLE
git: Stop appending the project name to new worktree paths

### DIFF
--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -384,7 +384,12 @@ pub fn worktree_info_from_thread_paths<S: std::hash::BuildHasher>(
         let is_linked = main_path != folder_path;
 
         if is_linked {
-            let short_name = linked_worktree_short_name(main_path, folder_path).unwrap_or_default();
+            let short_name = linked_worktree_short_name(
+                main_path,
+                folder_path,
+                branch_names.get(folder_path).map(|name| name.as_ref()),
+            )
+            .unwrap_or_default();
             let project_name = main_path
                 .file_name()
                 .map(|n| SharedString::from(n.to_string_lossy().to_string()))

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -322,37 +322,37 @@ impl Worktree {
         })
     }
 
-    /// Returns a display name for the worktree, suitable for use in the UI.
+    /// Returns a name for the worktree based on its checked-out ref.
     ///
     /// If the worktree is attached to a branch, returns the branch name.
     /// Otherwise, returns the short SHA of the worktree's HEAD commit.
-    pub fn display_name(&self) -> &str {
+    fn branch_or_sha(&self) -> &str {
+        debug_assert!(!self.is_bare, "branch_or_sha called on a bare worktree");
         self.branch_name()
-            .unwrap_or(&self.sha[..self.sha.len().min(SHORT_SHA_LENGTH)])
+            .unwrap_or(&self.sha[..SHORT_SHA_LENGTH])
     }
 
-    pub fn directory_name(&self, main_worktree_path: Option<&Path>) -> String {
+    pub fn directory_name(&self) -> Option<&str> {
+        self.path.file_name().and_then(|name| name.to_str())
+    }
+
+    /// Returns a display name for the worktree, suitable for use in the UI.
+    ///
+    /// The main worktree is labeled "main worktree". Other worktrees use their
+    /// leaf directory name, falling back to the branch name (or commit SHA) when
+    /// it matches the main worktree's.
+    pub fn display_name(&self, main_worktree_path: Option<&Path>) -> String {
+        debug_assert!(!self.is_bare, "display_name called on a bare worktree");
         if self.is_main {
             return "main worktree".to_string();
         }
 
-        let dir_name = self
-            .path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or(self.display_name());
+        let dir_name = self.directory_name().unwrap_or_else(|| self.branch_or_sha());
 
         if let Some(main_path) = main_worktree_path {
             let main_dir = main_path.file_name().and_then(|n| n.to_str());
             if main_dir == Some(dir_name) {
-                if let Some(parent_name) = self
-                    .path
-                    .parent()
-                    .and_then(|p| p.file_name())
-                    .and_then(|n| n.to_str())
-                {
-                    return parent_name.to_string();
-                }
+                return self.branch_or_sha().to_string();
             }
         }
 
@@ -538,8 +538,8 @@ impl CommitFile {
 }
 
 impl CommitDetails {
-    pub fn short_sha(&self) -> SharedString {
-        self.sha[..SHORT_SHA_LENGTH].to_string().into()
+    pub fn short_sha(&self) -> &str {
+        &self.sha[..SHORT_SHA_LENGTH]
     }
 }
 
@@ -4477,7 +4477,7 @@ mod tests {
 
         let new_worktree = worktrees
             .iter()
-            .find(|w| w.display_name() == "test-branch")
+            .find(|w| w.branch_or_sha() == "test-branch")
             .expect("should find worktree with test-branch");
         assert_eq!(
             new_worktree.path.canonicalize().unwrap(),
@@ -4541,7 +4541,7 @@ mod tests {
         let worktrees = repo.worktrees().await.unwrap();
         assert_eq!(worktrees.len(), 1);
         assert!(
-            worktrees.iter().all(|w| w.display_name() != "to-remove"),
+            worktrees.iter().all(|w| w.branch_or_sha() != "to-remove"),
             "removed worktree should not appear in list"
         );
         assert!(!worktree_path.exists());
@@ -4647,7 +4647,7 @@ mod tests {
         assert_eq!(worktrees.len(), 2);
         let moved_worktree = worktrees
             .iter()
-            .find(|w| w.display_name() == "old-name")
+            .find(|w| w.branch_or_sha() == "old-name")
             .expect("should find worktree by branch name");
         assert_eq!(
             moved_worktree.path.canonicalize().unwrap(),

--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -317,6 +317,14 @@ struct WorktreePickerDelegate {
     deleting_worktree_paths: HashSet<PathBuf>,
 }
 
+/// Returns the path of the main worktree in `worktrees`, if one is present.
+fn main_worktree_path(worktrees: &[GitWorktree]) -> Option<&Path> {
+    worktrees
+        .iter()
+        .find(|worktree| worktree.is_main)
+        .map(|worktree| worktree.path.as_path())
+}
+
 fn remove_worktree_command(path: &Path, force: bool) -> String {
     if force {
         format!("worktree remove --force {}", path.display())
@@ -489,12 +497,7 @@ impl WorktreePickerDelegate {
             return;
         };
         let path = worktree.path.clone();
-        let display_name = worktree.directory_name(
-            self.all_worktrees
-                .iter()
-                .find(|worktree| worktree.is_main)
-                .map(|worktree| worktree.path.as_path()),
-        );
+        let display_name = worktree.display_name(main_worktree_path(&self.all_worktrees));
         let workspace = self.workspace.clone();
 
         self.deleting_worktree_paths.insert(path.clone());
@@ -701,13 +704,8 @@ impl PickerDelegate for WorktreePickerDelegate {
         let repo_worktrees = self.all_repo_worktrees().to_vec();
 
         let normalized_query = query.replace(' ', "-");
-        let main_worktree_path = self
-            .all_worktrees
-            .iter()
-            .find(|wt| wt.is_main)
-            .map(|wt| wt.path.clone());
         let has_named_worktree = self.all_worktrees.iter().any(|worktree| {
-            worktree.directory_name(main_worktree_path.as_deref()) == normalized_query
+            worktree.directory_name() == Some(normalized_query.as_str())
         });
         let create_named_disabled_reason: Option<String> = if self.has_multiple_repositories {
             Some("Cannot create a named worktree in a project with multiple repositories".into())
@@ -725,10 +723,7 @@ impl PickerDelegate for WorktreePickerDelegate {
             let mut matches = self.build_fixed_entries();
 
             if !repo_worktrees.is_empty() {
-                let main_worktree_path = repo_worktrees
-                    .iter()
-                    .find(|wt| wt.is_main)
-                    .map(|wt| wt.path.clone());
+                let main_worktree_path = main_worktree_path(&repo_worktrees).map(Path::to_path_buf);
 
                 let mut sorted = repo_worktrees;
                 let project_paths = &self.project_worktree_paths;
@@ -737,8 +732,8 @@ impl PickerDelegate for WorktreePickerDelegate {
                     let a_is_current = project_paths.contains(&a.path);
                     let b_is_current = project_paths.contains(&b.path);
                     b_is_current.cmp(&a_is_current).then_with(|| {
-                        a.directory_name(main_worktree_path.as_deref())
-                            .cmp(&b.directory_name(main_worktree_path.as_deref()))
+                        a.display_name(main_worktree_path.as_deref())
+                            .cmp(&b.display_name(main_worktree_path.as_deref()))
                     })
                 });
 
@@ -756,18 +751,12 @@ impl PickerDelegate for WorktreePickerDelegate {
             return Task::ready(());
         }
 
-        let main_worktree_path = repo_worktrees
-            .iter()
-            .find(|wt| wt.is_main)
-            .map(|wt| wt.path.clone());
+        let main_worktree_path = main_worktree_path(&repo_worktrees);
         let candidates: Vec<_> = repo_worktrees
             .iter()
             .enumerate()
             .map(|(ix, worktree)| {
-                StringMatchCandidate::new(
-                    ix,
-                    &worktree.directory_name(main_worktree_path.as_deref()),
-                )
+                StringMatchCandidate::new(ix, &worktree.display_name(main_worktree_path))
             })
             .collect();
 
@@ -893,18 +882,14 @@ impl PickerDelegate for WorktreePickerDelegate {
                             cx,
                         );
                     } else {
-                        let main_worktree_path = self
-                            .all_worktrees
-                            .iter()
-                            .find(|wt| wt.is_main)
-                            .map(|wt| wt.path.as_path());
+                        let main_worktree_path = main_worktree_path(&self.all_worktrees);
                         if let Some(workspace) = self.workspace.upgrade() {
                             workspace.update(cx, |workspace, cx| {
                                 crate::worktree_service::handle_switch_worktree(
                                     workspace,
                                     &SwitchWorktree {
                                         path: worktree.path.clone(),
-                                        display_name: worktree.directory_name(main_worktree_path),
+                                        display_name: worktree.display_name(main_worktree_path),
                                     },
                                     window,
                                     self.focused_dock,
@@ -1008,12 +993,8 @@ impl PickerDelegate for WorktreePickerDelegate {
                 worktree,
                 positions,
             } => {
-                let main_worktree_path = self
-                    .all_worktrees
-                    .iter()
-                    .find(|wt| wt.is_main)
-                    .map(|wt| wt.path.as_path());
-                let display_name = worktree.directory_name(main_worktree_path);
+                let display_name =
+                    worktree.display_name(main_worktree_path(&self.all_worktrees));
                 let first_line = display_name.lines().next().unwrap_or(&display_name);
                 let positions: Vec<_> = positions
                     .iter()

--- a/crates/git_ui/src/worktree_service.rs
+++ b/crates/git_ui/src/worktree_service.rs
@@ -813,12 +813,7 @@ async fn do_create_worktree(
         match result {
             Ok(Ok(worktrees)) => {
                 for worktree in worktrees {
-                    if let Some(name) = worktree
-                        .path
-                        .parent()
-                        .and_then(|p| p.file_name())
-                        .and_then(|n| n.to_str())
-                    {
+                    if let Some(name) = worktree.directory_name() {
                         existing_worktree_names.push(name.to_string());
                     }
                     existing_worktree_paths.insert(worktree.path.clone());

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4377,6 +4377,32 @@ impl RepositorySnapshot {
         }
     }
 
+    /// Returns the current branch name, or the short HEAD SHA when detached.
+    pub fn branch_or_sha(&self) -> Option<&str> {
+        self.branch
+            .as_ref()
+            .map(|branch| branch.name())
+            .or_else(|| {
+                self.head_commit.as_ref().map(|commit| commit.short_sha())
+            })
+    }
+
+    pub fn path_for_new_linked_worktree(
+        &self,
+        worktree_name: &str,
+        worktree_directory_setting: &str,
+    ) -> Result<PathBuf> {
+        let repository_anchor = self
+            .main_worktree_abs_path()
+            .unwrap_or(self.common_dir_abs_path.as_ref());
+        let directory = worktrees_directory_for_repo(
+            repository_anchor,
+            worktree_directory_setting,
+            self.path_style,
+        )?;
+        self.path_style.join_path(&directory, worktree_name)
+    }
+
     /// The main worktree is the original checkout that other worktrees were
     /// created from.
     ///
@@ -6997,28 +7023,6 @@ impl Repository {
             .then_some(&self.work_directory_abs_path)
     }
 
-    pub fn path_for_new_linked_worktree(
-        &self,
-        branch_name: &str,
-        worktree_directory_setting: &str,
-    ) -> Result<PathBuf> {
-        let repository_anchor = self
-            .snapshot
-            .main_worktree_abs_path()
-            .unwrap_or(self.common_dir_abs_path.as_ref());
-        let project_name = repository_anchor
-            .file_name()
-            .and_then(|name| name.to_str())
-            .ok_or_else(|| anyhow!("git repo must have a directory name"))?;
-        let directory = worktrees_directory_for_repo(
-            repository_anchor,
-            worktree_directory_setting,
-            self.path_style,
-        )?;
-        let directory = self.path_style.join_path(&directory, branch_name)?;
-        self.path_style.join_path(&directory, project_name)
-    }
-
     pub fn worktrees(&mut self) -> oneshot::Receiver<Result<Vec<GitWorktree>>> {
         let id = self.id;
         self.send_job("worktrees", None, move |repo, _| async move {
@@ -8546,6 +8550,7 @@ pub fn repo_identity_path(common_dir: &Path) -> &Path {
 pub fn linked_worktree_short_name(
     main_worktree_path: &Path,
     linked_worktree_path: &Path,
+    fallback: Option<&str>,
 ) -> Option<SharedString> {
     if main_worktree_path == linked_worktree_path {
         return None;
@@ -8553,16 +8558,12 @@ pub fn linked_worktree_short_name(
 
     let project_name = main_worktree_path.file_name()?.to_str()?;
     let directory_name = linked_worktree_path.file_name()?.to_str()?;
-    let name = if directory_name != project_name {
-        directory_name.to_string()
+    let name = if directory_name == project_name {
+        fallback.unwrap_or(directory_name)
     } else {
-        linked_worktree_path
-            .parent()?
-            .file_name()?
-            .to_str()?
-            .to_string()
+        directory_name
     };
-    Some(name.into())
+    Some(name.to_string().into())
 }
 
 fn get_permalink_in_rust_registry_src(
@@ -8956,14 +8957,37 @@ mod tests {
         let work_dir = Path::new("/home/user/dev/lsp-tests");
         let directory =
             worktrees_directory_for_repo(work_dir, "../worktrees", PathStyle::Posix).unwrap();
-        let directory = PathStyle::Posix
-            .join_path(&directory, "nimble-sky")
-            .unwrap();
-        let path = PathStyle::Posix.join_path(&directory, "lsp-tests").unwrap();
+        let path = PathStyle::Posix.join_path(&directory, "nimble-sky").unwrap();
 
         assert_eq!(
             path,
-            PathBuf::from("/home/user/dev/worktrees/lsp-tests/nimble-sky/lsp-tests")
+            PathBuf::from("/home/user/dev/worktrees/lsp-tests/nimble-sky")
+        );
+    }
+
+    #[test]
+    fn test_path_for_new_linked_worktree() {
+        let snapshot = RepositorySnapshot::empty(
+            RepositoryId(0),
+            Arc::from(Path::new("/home/user/dev/lsp-tests")),
+            None,
+            None,
+            None,
+            PathStyle::Posix,
+        );
+
+        assert_eq!(
+            snapshot
+                .path_for_new_linked_worktree("nimble-sky", "../worktrees")
+                .unwrap(),
+            PathBuf::from("/home/user/dev/worktrees/lsp-tests/nimble-sky")
+        );
+
+        assert_eq!(
+            snapshot
+                .path_for_new_linked_worktree("nimble-sky", ".worktrees")
+                .unwrap(),
+            PathBuf::from("/home/user/dev/lsp-tests/.worktrees/nimble-sky")
         );
     }
 

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -1764,20 +1764,29 @@ mod resolve_worktree_tests {
             (
                 "/home/bob/zed",
                 "/home/bob/worktrees/olivetti/zed",
+                None,
+                Some("zed".into()),
+            ),
+            (
+                "/home/bob/zed",
+                "/home/bob/worktrees/olivetti/zed",
+                Some("olivetti"),
                 Some("olivetti".into()),
             ),
-            ("/home/bob/zed", "/home/bob/zed2", Some("zed2".into())),
+            ("/home/bob/zed", "/home/bob/zed2", None, Some("zed2".into())),
             (
                 "/home/bob/zed",
                 "/home/bob/worktrees/zed/selectric",
+                None,
                 Some("selectric".into()),
             ),
-            ("/home/bob/zed", "/home/bob/zed", None),
+            ("/home/bob/zed", "/home/bob/zed", None, None),
         ];
-        for (main_worktree_path, linked_worktree_path, expected) in examples {
+        for (main_worktree_path, linked_worktree_path, fallback, expected) in examples {
             let short_name = linked_worktree_short_name(
                 Path::new(main_worktree_path),
                 Path::new(linked_worktree_path),
+                fallback,
             );
             assert_eq!(
                 short_name, expected,

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -622,7 +622,11 @@ fn workspace_menu_worktree_labels(
                     snapshot
                         .main_worktree_abs_path()
                         .and_then(|main_worktree_path| {
-                            project::linked_worktree_short_name(main_worktree_path, root_path)
+                            project::linked_worktree_short_name(
+                                main_worktree_path,
+                                root_path,
+                                snapshot.branch_or_sha(),
+                            )
                         })
                         .unwrap_or_else(|| folder_name.clone())
                 } else {

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -205,6 +205,7 @@ impl Render for TitleBar {
                         linked_worktree_short_name(
                             main_worktree_path,
                             repo.work_directory_abs_path.as_ref(),
+                            repo.branch_or_sha(),
                         )
                     })
                     .or_else(|| {


### PR DESCRIPTION
New linked worktrees are now created at `<worktree>/<project>/<name>`,
removing the redundant `<project>` segment that was originally appended
last.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes https://github.com/zed-industries/zed/issues/58055
Closes https://github.com/zed-industries/zed/issues/57703 

Release Notes:

- Fixed the project name being redundantly appended to the path of newly
  created worktrees