### PR TITLE
helix: Add `z c` keymap to `ScrollCursorCenter`

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -550,6 +550,9 @@
       "space y": "editor::Copy",
       "space /": "pane::DeploySearch",
 
+      // View mode
+      "z c": "editor::ScrollCursorCenter",
+
       // Debug mode (Helix space G)
       "space shift-g l": "debugger::Start",
       "space shift-g r": "debugger::Restart",
@@ -1007,6 +1010,7 @@
       "ctrl-d": "project_panel::ScrollDown",
       "z t": "project_panel::ScrollCursorTop",
       "z z": "project_panel::ScrollCursorCenter",
+      "z c": "project_panel::ScrollCursorCenter",
       "z b": "project_panel::ScrollCursorBottom",
       "0": ["vim::Number", 0],
       "1": ["vim::Number", 1],
@@ -1038,6 +1042,7 @@
       "ctrl-d": "outline_panel::ScrollDown",
       "z t": "outline_panel::ScrollCursorTop",
       "z z": "outline_panel::ScrollCursorCenter",
+      "z c": "outline_panel::ScrollCursorCenter",
       "z b": "outline_panel::ScrollCursorBottom",
       "0": ["vim::Number", 0],
       "1": ["vim::Number", 1],


### PR DESCRIPTION
Helix's keymap to `Vertically center the line` (`align_view_center` command) is `zc` ([documentation](https://docs.helix-editor.com/keymap.html#view-mode)). 

Release Notes:

- Added Helix's `z c` keymap to editor, project panel and outline panel to scroll cursor to center
