### PR TITLE
cli: Always open new window when `cli_default_open_behavior=new_window`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -146,8 +146,7 @@
   // May take 2 values:
   //  1. Open directories as a new workspace in the current Zed window's sidebar
   //         "cli_default_open_behavior": "existing_window"
-  //  2. Open directories in a new window (reuse existing windows for files
-  //     that are already part of an open project)
+  //  2. Always open paths in a new window
   //         "cli_default_open_behavior": "new_window"
   "cli_default_open_behavior": "existing_window",
   // Whether to attempt to restore previous file's state when opening it again.

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -47,9 +47,7 @@ pub enum OpenBehavior {
 pub enum CliBehaviorSetting {
     /// Open directories as a new workspace in the current Zed window's sidebar.
     ExistingWindow,
-    /// Classic behavior: open directories in a new window, but reuse an
-    /// existing window when opening files that are already part of an open
-    /// project.
+    /// Always open paths in a new window.
     NewWindow,
 }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -404,8 +404,7 @@ pub enum CliDefaultOpenBehavior {
     #[default]
     #[strum(serialize = "Add to Existing Window")]
     ExistingWindow,
-    /// Open directories in a new window, but reuse an existing window when
-    /// opening files that are already part of an open project.
+    /// Always open paths in a new window.
     #[strum(serialize = "Open a New Window")]
     NewWindow,
 }

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -627,10 +627,14 @@ pub async fn handle_cli_connection(
                             open_behavior = cli::OpenBehavior::ExistingWindow;
                         }
                         Some(settings::CliDefaultOpenBehavior::NewWindow) => {
-                            open_behavior = cli::OpenBehavior::Classic;
+                            open_behavior = cli::OpenBehavior::AlwaysNew;
                         }
                         None => {}
                     }
+                }
+
+                if open_behavior == cli::OpenBehavior::Default {
+                    open_behavior = cx.update(|cx| open_behavior_for_default_setting(cx));
                 }
 
                 cx.update(|cx| cx.activate(true));
@@ -662,8 +666,8 @@ pub async fn handle_cli_connection(
     }
 }
 
-/// Resolves the CLI open behavior when no explicit flag (`-n`, `-e`, `--reuse`)
-/// was given. May prompt the user interactively on first run.
+/// Resolves the CLI open behavior when no explicit open behavior flag was given.
+/// May prompt the user interactively on first run.
 ///
 /// Returns `Some(behavior)` to override the default, or `None` if no override
 /// is needed (e.g. no existing windows, paths already in a workspace, or the
@@ -771,6 +775,12 @@ pub(crate) fn open_options_for_behavior(
     location: &SerializedWorkspaceLocation,
     cx: &App,
 ) -> workspace::OpenOptions {
+    let open_behavior = if open_behavior == cli::OpenBehavior::Default {
+        open_behavior_for_default_setting(cx)
+    } else {
+        open_behavior
+    };
+
     // If reuse flag is passed, open a new workspace in an existing window.
     let requesting_window = if open_behavior == cli::OpenBehavior::Reuse {
         workspace::workspace_windows_for_location(location, cx)
@@ -789,16 +799,17 @@ pub(crate) fn open_options_for_behavior(
         },
         add_dirs_to_sidebar: match open_behavior {
             cli::OpenBehavior::ExistingWindow => true,
-            // For the default value, we consult the settings to decide
-            // whether to open in a new window or existing window.
-            cli::OpenBehavior::Default => {
-                workspace::WorkspaceSettings::get_global(cx).cli_default_open_behavior
-                    == settings::CliDefaultOpenBehavior::ExistingWindow
-            }
             _ => false,
         },
         requesting_window,
         ..Default::default()
+    }
+}
+
+fn open_behavior_for_default_setting(cx: &App) -> cli::OpenBehavior {
+    match workspace::WorkspaceSettings::get_global(cx).cli_default_open_behavior {
+        settings::CliDefaultOpenBehavior::ExistingWindow => cli::OpenBehavior::ExistingWindow,
+        settings::CliDefaultOpenBehavior::NewWindow => cli::OpenBehavior::AlwaysNew,
     }
 }
 
@@ -1090,7 +1101,7 @@ mod tests {
     use cli::CliResponse;
     use editor::Editor;
     use futures::poll;
-    use gpui::{AppContext as _, TestAppContext};
+    use gpui::{AppContext as _, TestAppContext, UpdateGlobal as _};
     use language::LineEnding;
     use remote::SshConnectionOptions;
     use rope::Rope;
@@ -2545,6 +2556,57 @@ mod tests {
             !prompt_shown,
             "no prompt should be shown when setting already configured"
         );
+    }
+
+    #[gpui::test]
+    async fn test_e2e_new_window_setting_always_opens_new_window(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(path!("/project"), json!({ "file.txt": "content" }))
+            .await;
+
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                paths::config_dir(),
+                json!({
+                    "settings.json": r#"{"cli_default_open_behavior": "new_window"}"#
+                }),
+            )
+            .await;
+
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.workspace.cli_default_open_behavior =
+                        Some(settings::CliDefaultOpenBehavior::NewWindow);
+                });
+            });
+        });
+
+        open_workspace_file(path!("/project"), Default::default(), app_state.clone(), cx).await;
+        assert_eq!(cx.windows().len(), 1);
+
+        let (status, prompt_shown) = run_cli_with_zed_handler(
+            cx,
+            app_state,
+            make_cli_open_request(
+                vec![path!("/project").to_string()],
+                cli::OpenBehavior::Default,
+            ),
+            None,
+        );
+
+        assert_eq!(status, 0);
+        assert!(
+            !prompt_shown,
+            "no prompt should be shown when setting already configured"
+        );
+        assert_eq!(cx.windows().len(), 2);
     }
 
     #[gpui::test]

--- a/docs/src/windows-and-projects.md
+++ b/docs/src/windows-and-projects.md
@@ -73,7 +73,7 @@ You can change the default CLI behavior with the `cli_default_open_behavior` set
 Options:
 
 - `existing_window` (default): Open folders in the current window's threads sidebar
-- `new_window`: Open folders in a new window
+- `new_window`: Always open folders in a new window
 
 This setting affects CLI and double-click behavior, not the File > Open menu.
 

--- a/docs/src/windows-and-projects.md
+++ b/docs/src/windows-and-projects.md
@@ -73,7 +73,7 @@ You can change the default CLI behavior with the `cli_default_open_behavior` set
 Options:
 
 - `existing_window` (default): Open folders in the current window's threads sidebar
-- `new_window`: Always open folders in a new window
+- `new_window`: Open folders in a new window
 
 This setting affects CLI and double-click behavior, not the File > Open menu.
 


### PR DESCRIPTION
This makes sure that the behaviour of the CLI matches that of the UI.
In Zed itself we always open a new window (e.g. when clicking on `Open Project in new window` in the recent projects picker), but in the CLI we where re-using existing windows even when specifying `"cli_default_open_behavior": "new_window"`.
This caused confusion, so this PR ensures that this behaviour is consistent with how `zed -n foo` behaves.

Can be tested with
```
cd crates/cli
cargo run -- --zed ../../target/debug/zed somefolder
```

Release Notes:

- cli: Ensure `zed foo` behaves exactly like `zed -n foo` when `cli_default_open_behavior` is set to `new_window`. 
 
