### PR TITLE
Remove experimental microphone gain normalization option

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -521,14 +521,6 @@
     "button_layout": "platform_default",
   },
   "audio": {
-    // Automatically increase or decrease you microphone's volume. This affects how
-    // loud you sound to others.
-    //
-    // Recommended: off (default)
-    // Microphones are too quite in zed, until everyone is on experimental
-    // audio and has auto speaker volume on this will make you very loud
-    // compared to other speakers.
-    "experimental.auto_microphone_volume": false,
     // Select specific output audio device.
     // `null` means use system default.
     // Any unrecognized output device will fall back to system default.

--- a/crates/audio/src/audio.rs
+++ b/crates/audio/src/audio.rs
@@ -8,7 +8,6 @@ pub const CHANNEL_COUNT: ChannelCount = nz!(2);
 
 mod audio_settings;
 pub use audio_settings::AudioSettings;
-pub use audio_settings::LIVE_SETTINGS;
 
 mod audio_pipeline;
 pub use audio_pipeline::Audio;

--- a/crates/audio/src/audio_pipeline.rs
+++ b/crates/audio/src/audio_pipeline.rs
@@ -19,17 +19,13 @@ mod rodio_ext;
 pub use crate::audio_settings::AudioSettings;
 pub use rodio_ext::RodioExt;
 
-use crate::audio_settings::LIVE_SETTINGS;
-
 use crate::Sound;
 
 use super::{CHANNEL_COUNT, SAMPLE_RATE};
 pub const BUFFER_SIZE: usize = // echo canceller and livekit want 10ms of audio
     (SAMPLE_RATE.get() as usize / 100) * CHANNEL_COUNT.get() as usize;
 
-pub fn init(cx: &mut App) {
-    LIVE_SETTINGS.initialize(cx);
-}
+pub fn init(_cx: &mut App) {}
 
 // TODO(jk): this is currently cached only once - we should observe and react instead
 pub fn ensure_devices_initialized(cx: &mut App) {

--- a/crates/audio/src/audio_settings.rs
+++ b/crates/audio/src/audio_settings.rs
@@ -1,22 +1,10 @@
-use std::{
-    str::FromStr,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use std::str::FromStr;
 
 use cpal::DeviceId;
-use gpui::App;
-use settings::{RegisterSetting, Settings, SettingsStore};
+use settings::{RegisterSetting, Settings};
 
 #[derive(Clone, Debug, RegisterSetting)]
 pub struct AudioSettings {
-    /// Automatically increase or decrease you microphone's volume. This affects how
-    /// loud you sound to others.
-    ///
-    /// Recommended: off (default)
-    /// Microphones are too quite in zed, until everyone is on experimental
-    /// audio and has auto speaker volume on this will make you very loud
-    /// compared to other speakers.
-    pub auto_microphone_volume: bool,
     /// Select specific output audio device.
     pub output_audio_device: Option<DeviceId>,
     /// Select specific input audio device.
@@ -28,7 +16,6 @@ impl Settings for AudioSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let audio = &content.audio.as_ref().unwrap();
         AudioSettings {
-            auto_microphone_volume: audio.auto_microphone_volume.unwrap(),
             output_audio_device: audio
                 .output_audio_device
                 .as_ref()
@@ -40,33 +27,3 @@ impl Settings for AudioSettings {
         }
     }
 }
-
-/// See docs on [LIVE_SETTINGS]
-pub struct LiveSettings {
-    pub auto_microphone_volume: AtomicBool,
-}
-
-impl LiveSettings {
-    pub(crate) fn initialize(&self, cx: &mut App) {
-        cx.observe_global::<SettingsStore>(move |cx| {
-            LIVE_SETTINGS.auto_microphone_volume.store(
-                AudioSettings::get_global(cx).auto_microphone_volume,
-                Ordering::Relaxed,
-            );
-        })
-        .detach();
-
-        let init_settings = AudioSettings::get_global(cx);
-        LIVE_SETTINGS
-            .auto_microphone_volume
-            .store(init_settings.auto_microphone_volume, Ordering::Relaxed);
-    }
-}
-
-/// Allows access to settings from the audio thread. Updated by
-/// observer of SettingsStore. Needed because audio playback and recording are
-/// real time and must each run in a dedicated OS thread, therefore we can not
-/// use the background executor.
-pub static LIVE_SETTINGS: LiveSettings = LiveSettings {
-    auto_microphone_volume: AtomicBool::new(true),
-};

--- a/crates/livekit_client/src/livekit_client/playback.rs
+++ b/crates/livekit_client/src/livekit_client/playback.rs
@@ -22,9 +22,6 @@ use livekit::webrtc::{
 };
 use log::info;
 use parking_lot::Mutex;
-use rodio::Source;
-use rodio::conversions::SampleTypeConverter;
-use rodio::source::{AutomaticGainControlSettings, LimitSettings};
 use serde::{Deserialize, Serialize};
 use settings::Settings;
 use std::cell::RefCell;
@@ -337,14 +334,6 @@ impl AudioStack {
                         let ten_ms_buffer_size =
                             (config.channels() as u32 * config.sample_rate() / 100) as usize;
                         let mut buf: Vec<i16> = Vec::with_capacity(ten_ms_buffer_size);
-                        let mut rodio_effects = RodioEffectsAdaptor::new(buf.len())
-                            .automatic_gain_control(AutomaticGainControlSettings {
-                                target_level: 0.50,
-                                attack_time: Duration::from_secs(1),
-                                release_time: Duration::from_secs(0),
-                                absolute_max_gain: 5.0,
-                            })
-                            .limit(LimitSettings::live_performance());
 
                         let stream = device
                             .build_input_stream_raw(
@@ -376,20 +365,6 @@ impl AudioStack {
                                                     sample_rate,
                                                 )
                                                 .to_owned();
-
-                                            if audio::LIVE_SETTINGS
-                                                .auto_microphone_volume
-                                                .load(Ordering::Relaxed)
-                                            {
-                                                rodio_effects
-                                                    .inner_mut()
-                                                    .inner_mut()
-                                                    .fill_buffer_with(&sampled);
-                                                sampled.clear();
-                                                sampled.extend(SampleTypeConverter::<_, i16>::new(
-                                                    rodio_effects.by_ref(),
-                                                ));
-                                            }
 
                                             apm.lock()
                                                 .process_stream(
@@ -431,69 +406,6 @@ impl AudioStack {
             device_change_listener.next().await;
             drop(end_on_drop_tx)
         }
-    }
-}
-
-/// This allows using of Rodio's effects library within our home brewn audio
-/// pipeline. The alternative would be inlining Rodio's effects which is
-/// problematic from a legal stance. We would then have to make clear that code
-/// is not owned by zed-industries while the code would be surrounded by
-/// zed-industries owned code.
-///
-/// This adaptor does incur a slight performance penalty (copying into a
-/// pre-allocated vec and back) however the impact will be immeasurably low.
-///
-/// There is no latency impact.
-pub struct RodioEffectsAdaptor {
-    input: Vec<rodio::Sample>,
-    pos: usize,
-}
-
-impl RodioEffectsAdaptor {
-    // This implementation incorrect terminology confusing everyone. A normal
-    // audio frame consists of all samples for one moment in time (one for mono,
-    // two for stereo). Here a frame of audio refers to a 10ms buffer of samples.
-    fn new(samples_per_frame: usize) -> Self {
-        Self {
-            input: Vec::with_capacity(samples_per_frame),
-            pos: 0,
-        }
-    }
-
-    fn fill_buffer_with(&mut self, integer_samples: &[i16]) {
-        self.input.clear();
-        self.input.extend(SampleTypeConverter::<_, f32>::new(
-            integer_samples.iter().copied(),
-        ));
-        self.pos = 0;
-    }
-}
-
-impl Iterator for RodioEffectsAdaptor {
-    type Item = rodio::Sample;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let sample = self.input.get(self.pos)?;
-        self.pos += 1;
-        Some(*sample)
-    }
-}
-
-impl rodio::Source for RodioEffectsAdaptor {
-    fn current_span_len(&self) -> Option<usize> {
-        None
-    }
-
-    fn channels(&self) -> rodio::ChannelCount {
-        rodio::nz!(2)
-    }
-
-    fn sample_rate(&self) -> rodio::SampleRate {
-        rodio::nz!(48000)
-    }
-
-    fn total_duration(&self) -> Option<Duration> {
-        None
     }
 }
 

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -469,17 +469,6 @@ impl strum::VariantNames for BaseKeymapContent {
 #[with_fallible_options]
 #[derive(Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug)]
 pub struct AudioSettingsContent {
-    /// Automatically increase or decrease you microphone's volume. This affects how
-    /// loud you sound to others.
-    ///
-    /// Recommended: off (default)
-    /// Microphones are too quite in zed, until everyone is on experimental
-    /// audio and has auto speaker volume on this will make you very loud
-    /// compared to other speakers.
-    #[serde(rename = "experimental.auto_microphone_volume")]
-    pub auto_microphone_volume: Option<bool>,
-    /// Remove background noises. Works great for typing, cars, dogs, AC. Does
-    /// not work well on music.
     /// Select specific output audio device.
     #[serde(rename = "experimental.output_audio_device")]
     pub output_audio_device: Option<AudioOutputDeviceName>,


### PR DESCRIPTION
Release Notes:

- Removed the `experimental.auto_microphone_volume` setting (since #58036 microphone volumes are now normalized by default)
