### PR TITLE
text: Preserve structural sharing when rebuilding the fragment tree

### DIFF
--- a/crates/editor_benchmarks/src/main.rs
+++ b/crates/editor_benchmarks/src/main.rs
@@ -15,6 +15,7 @@ struct Args {
     regex: bool,
     whole_word: bool,
     case_sensitive: bool,
+    single: bool,
 }
 
 fn parse_args() -> Args {
@@ -26,6 +27,7 @@ fn parse_args() -> Args {
         regex: false,
         whole_word: false,
         case_sensitive: false,
+        single: false,
     };
 
     let mut positional = Vec::new();
@@ -34,6 +36,7 @@ fn parse_args() -> Args {
             "--regex" => parsed.regex = true,
             "--whole-word" => parsed.whole_word = true,
             "--case-sensitive" => parsed.case_sensitive = true,
+            "--single" => parsed.single = true,
             "-r" | "--replace" => {
                 parsed.replace = args_iter.next();
             }
@@ -105,6 +108,7 @@ fn main() {
 
     let query = Arc::new(query);
     let has_replacement = args.replace.is_some();
+    let single = args.single;
 
     gpui_platform::headless().run(move |cx| {
         release_channel::init_test(
@@ -152,8 +156,9 @@ fn main() {
 
                         if has_replacement && !matches.is_empty() {
                             window_handle.update(cx, |editor: &mut Editor, window, cx| {
-                                let mut match_iter = matches.iter();
-                                println!("Replacing all matches...");
+                                let to_replace = if single { 1 } else { matches.len() };
+                                let mut match_iter = matches.iter().take(to_replace);
+                                println!("Replacing {to_replace} matches...");
                                 let timer = std::time::Instant::now();
                                 editor.replace_all(
                                     &mut match_iter,
@@ -163,10 +168,7 @@ fn main() {
                                     cx,
                                 );
                                 let replace_elapsed = timer.elapsed();
-                                println!(
-                                    "Replaced {} matches in {replace_elapsed:?}",
-                                    matches.len()
-                                );
+                                println!("Replaced {to_replace} matches in {replace_elapsed:?}");
                             })?;
                         }
 

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -2838,33 +2838,62 @@ impl BufferSnapshot {
     }
 }
 
+/// A chunk of fragments accumulated by [`FragmentBuilder`]. `Tree` chunks are
+/// subtrees sliced off the previous fragment tree and are kept intact so they
+/// continue to share nodes with it; `Loose` chunks batch individually pushed
+/// fragments so they can be turned into a subtree in one shot.
+enum FragmentChunk {
+    Tree(SumTree<Fragment>),
+    Loose(Vec<Fragment>),
+}
+
 struct FragmentBuilder {
-    fragments: Vec<Fragment>,
+    chunks: Vec<FragmentChunk>,
     summary: FragmentSummary,
 }
 
 impl FragmentBuilder {
     fn new(init: SumTree<Fragment>) -> Self {
-        Self {
-            summary: init.summary().clone(),
-            fragments: init.iter().cloned().collect(),
+        let summary = init.summary().clone();
+        let mut chunks = Vec::new();
+        if !init.is_empty() {
+            chunks.push(FragmentChunk::Tree(init));
         }
+        Self { chunks, summary }
     }
     fn append(&mut self, items: SumTree<Fragment>, cx: &Option<clock::Global>) {
         if !items.is_empty() {
             self.summary.add_summary(items.summary(), cx);
-            self.fragments.extend(items.iter().cloned());
+            self.chunks.push(FragmentChunk::Tree(items));
         }
     }
     fn push(&mut self, fragment: Fragment, cx: &Option<clock::Global>) {
-        self.append(SumTree::from_item(fragment, cx), cx);
+        self.summary
+            .add_summary(&sum_tree::Item::summary(&fragment, cx), cx);
+        match self.chunks.last_mut() {
+            Some(FragmentChunk::Loose(fragments)) => fragments.push(fragment),
+            _ => self.chunks.push(FragmentChunk::Loose(vec![fragment])),
+        }
     }
     fn to_sum_tree(self, cx: &Option<clock::Global>) -> SumTree<Fragment> {
-        if self.fragments.len() > 1024 {
-            SumTree::from_par_iter(self.fragments, cx)
-        } else {
-            SumTree::from_iter(self.fragments, cx)
+        // Appending a `Tree` chunk only touches the right spine and grafts the
+        // subtree by cloning `Arc`s, so the untouched regions stay shared with
+        // the previous fragment tree. `Loose` runs (newly inserted or rewritten
+        // fragments) are built in one pass, parallelizing the large ones.
+        let mut tree = SumTree::new(cx);
+        for chunk in self.chunks {
+            match chunk {
+                FragmentChunk::Tree(subtree) => tree.append(subtree, cx),
+                FragmentChunk::Loose(fragments) => {
+                    if fragments.len() > 1024 {
+                        tree.append(SumTree::from_par_iter(fragments, cx), cx);
+                    } else {
+                        tree.append(SumTree::from_iter(fragments, cx), cx);
+                    }
+                }
+            }
         }
+        tree
     }
     fn summary(&self) -> &FragmentSummary {
         &self.summary


### PR DESCRIPTION
## Context

`apply_remote_edit` and `apply_local_edit` rebuild the fragment `SumTree` through `FragmentBuilder`. Since #51941, the builder collapsed the entire tree into a flat `Vec<Fragment>` (cloning every fragment) and rebuilt a fresh tree from scratch on every call. The new tree shared no nodes with the previous one, so each edit cost O(N) in the *total* number of fragments: clone all fragments, allocate an entirely new tree, and then free the whole previous tree on assignment — the last part showing up as a large amount of time spent dropping `SumTree`s.

That batching was a deliberate win for the bulk `replace_all` path (#51941, one `edit()` carrying millions of ranges), but it penalizes every other caller — most notably `apply_remote_edit`, which runs once per op in a loop in `apply_ops` and so rebuilt the whole tree per remote operation.

## This change

Make `FragmentBuilder` chunk-based. Appended slices are kept as intact `SumTree` subtrees, so they keep sharing nodes with the previous tree; only individually pushed fragments are batched into `Vec`s. `to_sum_tree` appends the shared subtrees (touching just the right spine) and builds the loose runs in one pass, parallelizing the large ones.

Net effect:
- Small edits on large/heavily-fragmented buffers (the `apply_remote_edit` collaborative path) go back to O(edited + log N) with a cheap drop, instead of O(total fragments).
- The bulk `replace_all` path keeps its batched build and is not regressed.

## Benchmarks

Using the file from #38927 (619 MB CSV, 10,325,246 matches of `"` → `""`), `release-fast`:

| Case | flatten (#51941) | this PR |
|---|---|---|
| `replace_all` (all matches) | 50.70 s | 45.16 s |
| replace 1 match (`--single`) | 16.0 ms | 16.0 ms |

`replace_all` is ~11% faster and not regressed. The single-match-on-a-freshly-loaded-file case is unchanged, because a fresh `Buffer::local` is barely fragmented, so even the from-scratch rebuild is cheap there; the structural-sharing win is on heavily-fragmented buffers receiving small edits.

The `--single` flag added to `editor_benchmarks` makes the latter case measurable.

Release Notes:

- Improved the performance of applying edits to large buffers