### PR TITLE
gpui_linux: Improve error message when X11 and Wayland feature flags are missing

### DIFF
--- a/crates/gpui_linux/src/linux.rs
+++ b/crates/gpui_linux/src/linux.rs
@@ -52,6 +52,8 @@ pub fn current_platform(headless: bool) -> Rc<dyn gpui::Platform> {
         "Headless" => Rc::new(LinuxPlatform {
             inner: HeadlessClient::new(),
         }),
-        _ => unreachable!("Maybe you forgot to add \"features = [\"x11\", \"wayland\"]\" to gpui_platform?"),
+        _ => unreachable!(
+            r#"At least one of the "wayland" or "x11" features must be enabled on gpui_linux or gpui_platform."#
+        ),
     }
 }

--- a/crates/gpui_linux/src/linux.rs
+++ b/crates/gpui_linux/src/linux.rs
@@ -52,6 +52,6 @@ pub fn current_platform(headless: bool) -> Rc<dyn gpui::Platform> {
         "Headless" => Rc::new(LinuxPlatform {
             inner: HeadlessClient::new(),
         }),
-        _ => unreachable!(),
+        _ => unreachable!("Maybe you forgot to add \"features = [\"x11\", \"wayland\"]\" to gpui_platform?"),
     }
 }


### PR DESCRIPTION
Improves `gpui_linux` error messages for missing feature flags. Currently, you'd need to look at the source & Rust backtrace to diagnose the error shown when the feature flags are missing.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


Release Notes:

- Improve `gpui_linux` error messages for missing feature flags
