### PR TITLE
zed_cli: Add a run database migrations arg to zed's cli for CI use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,6 +270,65 @@ jobs:
           exit 1
         fi
     timeout-minutes: 60
+  check_database_migrations:
+    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
+    runs-on: namespace-profile-16x32-ubuntu-2204
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+    - name: steps::checkout_repo
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      with:
+        clean: false
+    - name: steps::setup_cargo_config
+      run: |
+        mkdir -p ./../.cargo
+        cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+    - name: steps::cache_rust_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
+      with:
+        cache: rust
+        path: ~/.rustup
+    - name: steps::setup_linux
+      run: ./script/linux
+    - name: steps::download_wasi_sdk
+      run: ./script/download-wasi-sdk
+    - name: steps::setup_sccache
+      run: ./script/setup-sccache
+      env:
+        R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+        R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        SCCACHE_BUCKET: sccache-zed
+    - name: release::check_database_migrations::download_previous_database
+      run: |
+        mkdir -p "$RUNNER_TEMP/zed-migration/db"
+        mapfile -t run_ids < <(gh run list --repo "$GITHUB_REPOSITORY" --workflow "$GITHUB_WORKFLOW" --limit 25 --json databaseId --jq '.[].databaseId')
+        for run_id in "${run_ids[@]}"; do
+            if gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name migration-database --dir "$RUNNER_TEMP/zed-migration/db"; then
+                echo "Migrating database produced by workflow run $run_id"
+                exit 0
+            fi
+        done
+        echo "No previous database artifact found; starting from an empty database"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: release::check_database_migrations::run_database_migrations
+      run: cargo run --package zed -- --run-database-migrations --user-data-dir "$RUNNER_TEMP/zed-migration"
+    - name: release::check_database_migrations::upload_migrated_database
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+      with:
+        name: migration-database
+        path: ${{ runner.temp }}/zed-migration/db
+        if-no-files-found: error
+    - name: steps::show_sccache_stats
+      run: sccache --show-stats || true
+    - name: steps::cleanup_cargo_config
+      if: always()
+      run: |
+        rm -rf ./../.cargo
+    timeout-minutes: 60
   create_draft_release:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
     runs-on: namespace-profile-2x4-ubuntu-2404
@@ -348,6 +407,7 @@ jobs:
     - run_tests_linux
     - clippy_linux
     - check_scripts
+    - check_database_migrations
     runs-on: namespace-profile-8x32-ubuntu-2004-arm-m4
     env:
       CARGO_INCREMENTAL: 0
@@ -388,6 +448,7 @@ jobs:
     - run_tests_linux
     - clippy_linux
     - check_scripts
+    - check_database_migrations
     runs-on: namespace-profile-32x64-ubuntu-2004
     env:
       CARGO_INCREMENTAL: 0
@@ -428,6 +489,7 @@ jobs:
     - run_tests_mac
     - clippy_mac
     - check_scripts
+    - check_database_migrations
     runs-on: namespace-profile-mac-large
     env:
       CARGO_INCREMENTAL: 0
@@ -473,6 +535,7 @@ jobs:
     - run_tests_mac
     - clippy_mac
     - check_scripts
+    - check_database_migrations
     runs-on: namespace-profile-mac-large
     env:
       CARGO_INCREMENTAL: 0
@@ -518,6 +581,7 @@ jobs:
     - run_tests_windows
     - clippy_windows
     - check_scripts
+    - check_database_migrations
     runs-on: self-32vcpu-windows-2022
     env:
       CARGO_INCREMENTAL: 0
@@ -563,6 +627,7 @@ jobs:
     - run_tests_windows
     - clippy_windows
     - check_scripts
+    - check_database_migrations
     runs-on: self-32vcpu-windows-2022
     env:
       CARGO_INCREMENTAL: 0
@@ -745,6 +810,7 @@ jobs:
     - clippy_linux
     - clippy_windows
     - check_scripts
+    - check_database_migrations
     - bundle_linux_aarch64
     - bundle_linux_x86_64
     - bundle_mac_aarch64
@@ -772,6 +838,7 @@ jobs:
                 if [ "$RESULT_CLIPPY_LINUX" == "failure" ];then FAILED_JOBS="$FAILED_JOBS clippy_linux"; fi
                 if [ "$RESULT_CLIPPY_WINDOWS" == "failure" ];then FAILED_JOBS="$FAILED_JOBS clippy_windows"; fi
                 if [ "$RESULT_CHECK_SCRIPTS" == "failure" ];then FAILED_JOBS="$FAILED_JOBS check_scripts"; fi
+                if [ "$RESULT_CHECK_DATABASE_MIGRATIONS" == "failure" ];then FAILED_JOBS="$FAILED_JOBS check_database_migrations"; fi
                 if [ "$RESULT_BUNDLE_LINUX_AARCH64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_linux_aarch64"; fi
                 if [ "$RESULT_BUNDLE_LINUX_X86_64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_linux_x86_64"; fi
                 if [ "$RESULT_BUNDLE_MAC_AARCH64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_mac_aarch64"; fi
@@ -823,6 +890,7 @@ jobs:
         RESULT_CLIPPY_LINUX: ${{ needs.clippy_linux.result }}
         RESULT_CLIPPY_WINDOWS: ${{ needs.clippy_windows.result }}
         RESULT_CHECK_SCRIPTS: ${{ needs.check_scripts.result }}
+        RESULT_CHECK_DATABASE_MIGRATIONS: ${{ needs.check_database_migrations.result }}
         RESULT_BUNDLE_LINUX_AARCH64: ${{ needs.bundle_linux_aarch64.result }}
         RESULT_BUNDLE_LINUX_X86_64: ${{ needs.bundle_linux_x86_64.result }}
         RESULT_BUNDLE_MAC_AARCH64: ${{ needs.bundle_mac_aarch64.result }}

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -93,11 +93,71 @@ jobs:
       run: if ($env:RUSTC_WRAPPER) { & $env:RUSTC_WRAPPER --show-stats }; exit 0
       shell: pwsh
     timeout-minutes: 60
+  check_database_migrations:
+    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
+    runs-on: namespace-profile-16x32-ubuntu-2204
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+    - name: steps::checkout_repo
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      with:
+        clean: false
+    - name: steps::setup_cargo_config
+      run: |
+        mkdir -p ./../.cargo
+        cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+    - name: steps::cache_rust_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
+      with:
+        cache: rust
+        path: ~/.rustup
+    - name: steps::setup_linux
+      run: ./script/linux
+    - name: steps::download_wasi_sdk
+      run: ./script/download-wasi-sdk
+    - name: steps::setup_sccache
+      run: ./script/setup-sccache
+      env:
+        R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+        R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        SCCACHE_BUCKET: sccache-zed
+    - name: release::check_database_migrations::download_previous_database
+      run: |
+        mkdir -p "$RUNNER_TEMP/zed-migration/db"
+        mapfile -t run_ids < <(gh run list --repo "$GITHUB_REPOSITORY" --workflow "$GITHUB_WORKFLOW" --limit 25 --json databaseId --jq '.[].databaseId')
+        for run_id in "${run_ids[@]}"; do
+            if gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name migration-database --dir "$RUNNER_TEMP/zed-migration/db"; then
+                echo "Migrating database produced by workflow run $run_id"
+                exit 0
+            fi
+        done
+        echo "No previous database artifact found; starting from an empty database"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: release::check_database_migrations::run_database_migrations
+      run: cargo run --package zed -- --run-database-migrations --user-data-dir "$RUNNER_TEMP/zed-migration"
+    - name: release::check_database_migrations::upload_migrated_database
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+      with:
+        name: migration-database
+        path: ${{ runner.temp }}/zed-migration/db
+        if-no-files-found: error
+    - name: steps::show_sccache_stats
+      run: sccache --show-stats || true
+    - name: steps::cleanup_cargo_config
+      if: always()
+      run: |
+        rm -rf ./../.cargo
+    timeout-minutes: 60
   bundle_linux_aarch64:
     needs:
     - check_style
     - run_tests_windows
     - clippy_windows
+    - check_database_migrations
     runs-on: namespace-profile-8x32-ubuntu-2004-arm-m4
     env:
       CARGO_INCREMENTAL: 0
@@ -144,6 +204,7 @@ jobs:
     - check_style
     - run_tests_windows
     - clippy_windows
+    - check_database_migrations
     runs-on: namespace-profile-32x64-ubuntu-2004
     env:
       CARGO_INCREMENTAL: 0
@@ -190,6 +251,7 @@ jobs:
     - check_style
     - run_tests_windows
     - clippy_windows
+    - check_database_migrations
     runs-on: namespace-profile-mac-large
     env:
       CARGO_INCREMENTAL: 0
@@ -241,6 +303,7 @@ jobs:
     - check_style
     - run_tests_windows
     - clippy_windows
+    - check_database_migrations
     runs-on: namespace-profile-mac-large
     env:
       CARGO_INCREMENTAL: 0
@@ -292,6 +355,7 @@ jobs:
     - check_style
     - run_tests_windows
     - clippy_windows
+    - check_database_migrations
     runs-on: self-32vcpu-windows-2022
     env:
       CARGO_INCREMENTAL: 0
@@ -345,6 +409,7 @@ jobs:
     - check_style
     - run_tests_windows
     - clippy_windows
+    - check_database_migrations
     runs-on: self-32vcpu-windows-2022
     env:
       CARGO_INCREMENTAL: 0

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -123,6 +123,9 @@ struct Args {
     /// Will attempt to give the correct command to run
     #[arg(long)]
     system_specs: bool,
+    /// Run database migrations and exit.
+    #[arg(long)]
+    run_database_migrations: bool,
     /// Open the project in a dev container.
     ///
     /// Automatically triggers "Reopen in Dev Container" if a `.devcontainer/`
@@ -512,6 +515,18 @@ fn main() -> Result<()> {
             &format!("{} --system-specs", path.display()),
         ];
         anyhow::bail!(msg.join("\n"));
+    }
+
+    if args.run_database_migrations {
+        let mut command = std::process::Command::new(app.path());
+        command.arg("--run-database-migrations");
+        if let Some(dir) = user_data_dir.as_deref() {
+            command.arg("--user-data-dir").arg(dir);
+        }
+        let status = command
+            .status()
+            .context("failed to run database migrations")?;
+        std::process::exit(status.code().unwrap_or(1));
     }
 
     #[cfg(all(

--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -354,7 +354,7 @@ mod tests {
     use sqlez::domain::Domain;
     use sqlez_macros::sql;
 
-    use crate::{open_db, run_database_migrations};
+    use crate::{db_path, open_db, run_database_migrations};
 
     // Test bad migration panics
     #[gpui::test]
@@ -432,6 +432,27 @@ mod tests {
         };
 
         assert!(format!("{error:#}").contains("strict_failure_test"));
+
+        // Step 1 of the migration succeeded before step 2 failed, so verify that
+        // the whole migration was rolled back and the database is untouched.
+        let db_path = db_path(tempdir.path(), release_channel::ReleaseChannel::Dev);
+        let connection =
+            sqlez::connection::Connection::open_file(db_path.to_string_lossy().as_ref());
+        anyhow::ensure!(
+            connection.persistent(),
+            "could not open database {}",
+            db_path.display()
+        );
+        // The migration created `strict_failure_test`, and the migration runner
+        // created the `migrations` bookkeeping table; both must be gone.
+        let tables = connection.select::<String>(
+            "SELECT name FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+        )?()?;
+        assert_eq!(
+            tables,
+            Vec::<String>::new(),
+            "failed migration should have been rolled back"
+        );
 
         Ok(())
     }

--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -57,6 +57,61 @@ impl Migrator for AppMigrator {
     }
 }
 
+pub fn run_app_database_migrations(db_dir: &Path, scope: impl DbScope) -> anyhow::Result<PathBuf> {
+    run_database_migrations::<AppMigrator>(db_dir, scope)
+}
+
+pub fn run_database_migrations<M: Migrator>(
+    db_dir: &Path,
+    scope: impl DbScope,
+) -> anyhow::Result<PathBuf> {
+    let db_path = db_path(db_dir, scope);
+    if let Some(parent) = db_path.parent() {
+        create_dir_all(parent).context("Could not create db directory")?;
+    }
+
+    let connection = sqlez::connection::Connection::open_file(db_path.to_string_lossy().as_ref());
+    anyhow::ensure!(
+        connection.persistent(),
+        "could not open database {}",
+        db_path.display()
+    );
+
+    connection
+        .exec(CONNECTION_INITIALIZE_QUERY)
+        .with_context(|| {
+            format!(
+                "Db connection initialize query failed to prepare: {CONNECTION_INITIALIZE_QUERY}"
+            )
+        })?()
+    .with_context(|| {
+        format!("Db connection initialize query failed to execute: {CONNECTION_INITIALIZE_QUERY}")
+    })?;
+    connection
+        .exec(DB_INITIALIZE_QUERY)
+        .with_context(|| format!("Db initialize query failed to prepare: {DB_INITIALIZE_QUERY}"))?(
+    )
+    .with_context(|| format!("Db initialize query failed to execute: {DB_INITIALIZE_QUERY}"))?;
+
+    let foreign_keys_enabled = connection.select_row::<i32>("PRAGMA foreign_keys")?()?
+        .map(|enabled| enabled != 0)
+        .unwrap_or(false);
+
+    connection.exec("PRAGMA foreign_keys = OFF;")?()?;
+    let migration_result =
+        connection.with_savepoint("strict_database_migration", || M::migrate(&connection));
+    let restore_foreign_keys_result = if foreign_keys_enabled {
+        connection.exec("PRAGMA foreign_keys = ON;")?()
+    } else {
+        Ok(())
+    };
+
+    migration_result?;
+    restore_foreign_keys_result?;
+
+    Ok(db_path)
+}
+
 impl AppDatabase {
     /// Opens the production database and runs all inventory-registered
     /// migrations in dependency order.
@@ -299,7 +354,7 @@ mod tests {
     use sqlez::domain::Domain;
     use sqlez_macros::sql;
 
-    use crate::open_db;
+    use crate::{open_db, run_database_migrations};
 
     // Test bad migration panics
     #[gpui::test]
@@ -321,6 +376,64 @@ mod tests {
             .tempdir()
             .unwrap();
         let _bad_db = open_db::<BadDB>(tempdir.path(), release_channel::ReleaseChannel::Dev).await;
+    }
+
+    #[test]
+    fn test_run_database_migrations_succeeds() -> anyhow::Result<()> {
+        enum GoodDB {}
+
+        impl Domain for GoodDB {
+            const NAME: &str = "strict_db_success_test";
+            const MIGRATIONS: &[&str] = &[sql!(CREATE TABLE strict_success_test(value TEXT);)];
+        }
+
+        let tempdir = tempfile::Builder::new()
+            .prefix("DbMigrationTests")
+            .tempdir()?;
+        let db_path = run_database_migrations::<GoodDB>(
+            tempdir.path(),
+            release_channel::ReleaseChannel::Dev,
+        )?;
+        let connection =
+            sqlez::connection::Connection::open_file(db_path.to_string_lossy().as_ref());
+        anyhow::ensure!(
+            connection.persistent(),
+            "could not open database {}",
+            db_path.display()
+        );
+        let table_name = connection.select_row::<String>(
+            "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'strict_success_test'",
+        )?()?;
+
+        assert_eq!(table_name.as_deref(), Some("strict_success_test"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_run_database_migrations_returns_errors() -> anyhow::Result<()> {
+        enum BadDB {}
+
+        impl Domain for BadDB {
+            const NAME: &str = "strict_db_failure_test";
+            const MIGRATIONS: &[&str] = &[
+                sql!(CREATE TABLE strict_failure_test(value TEXT);),
+                sql!(CREATE TABLE strict_failure_test(value TEXT);),
+            ];
+        }
+
+        let tempdir = tempfile::Builder::new()
+            .prefix("DbMigrationTests")
+            .tempdir()?;
+        let Err(error) =
+            run_database_migrations::<BadDB>(tempdir.path(), release_channel::ReleaseChannel::Dev)
+        else {
+            anyhow::bail!("strict migration runner unexpectedly succeeded");
+        };
+
+        assert!(format!("{error:#}").contains("strict_failure_test"));
+
+        Ok(())
     }
 
     /// Test that DB exists but corrupted (causing recreate)

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -304,6 +304,23 @@ fn main() {
         return;
     }
 
+    if args.run_database_migrations {
+        match db::run_app_database_migrations(db::database_dir(), *release_channel::RELEASE_CHANNEL)
+        {
+            Ok(db_path) => {
+                println!(
+                    "Database migrations completed successfully for {}",
+                    db_path.display()
+                );
+            }
+            Err(error) => {
+                eprintln!("Database migrations failed: {error:#}");
+                process::exit(1);
+            }
+        }
+        return;
+    }
+
     rayon::ThreadPoolBuilder::new()
         .num_threads(std::thread::available_parallelism().map_or(1, |n| n.get().div_ceil(2)))
         .stack_size(10 * 1024 * 1024)
@@ -1684,6 +1701,10 @@ struct Args {
     /// clipboard`
     #[arg(long)]
     system_specs: bool,
+
+    /// Run database migrations and exit.
+    #[arg(long, hide = true)]
+    run_database_migrations: bool,
 
     /// Used for the MCP Server, to remove the need for netcat as a dependency,
     /// by having Zed act like netcat communicating over a Unix socket.

--- a/tooling/xtask/src/tasks/workflows/release.rs
+++ b/tooling/xtask/src/tasks/workflows/release.rs
@@ -20,6 +20,7 @@ pub(crate) fn release() -> Workflow {
     let linux_clippy = run_tests::clippy(Platform::Linux, None);
     let windows_clippy = run_tests::clippy(Platform::Windows, None);
     let check_scripts = run_tests::check_scripts();
+    let check_database_migrations = check_database_migrations();
 
     let create_draft_release = create_draft_release();
     let (non_blocking_compliance_run, job_output) = compliance_check();
@@ -28,32 +29,62 @@ pub(crate) fn release() -> Workflow {
         linux_aarch64: bundle_linux(
             Arch::AARCH64,
             None,
-            &[&linux_tests, &linux_clippy, &check_scripts],
+            &[
+                &linux_tests,
+                &linux_clippy,
+                &check_scripts,
+                &check_database_migrations,
+            ],
         ),
         linux_x86_64: bundle_linux(
             Arch::X86_64,
             None,
-            &[&linux_tests, &linux_clippy, &check_scripts],
+            &[
+                &linux_tests,
+                &linux_clippy,
+                &check_scripts,
+                &check_database_migrations,
+            ],
         ),
         mac_aarch64: bundle_mac(
             Arch::AARCH64,
             None,
-            &[&macos_tests, &macos_clippy, &check_scripts],
+            &[
+                &macos_tests,
+                &macos_clippy,
+                &check_scripts,
+                &check_database_migrations,
+            ],
         ),
         mac_x86_64: bundle_mac(
             Arch::X86_64,
             None,
-            &[&macos_tests, &macos_clippy, &check_scripts],
+            &[
+                &macos_tests,
+                &macos_clippy,
+                &check_scripts,
+                &check_database_migrations,
+            ],
         ),
         windows_aarch64: bundle_windows(
             Arch::AARCH64,
             None,
-            &[&windows_tests, &windows_clippy, &check_scripts],
+            &[
+                &windows_tests,
+                &windows_clippy,
+                &check_scripts,
+                &check_database_migrations,
+            ],
         ),
         windows_x86_64: bundle_windows(
             Arch::X86_64,
             None,
-            &[&windows_tests, &windows_clippy, &check_scripts],
+            &[
+                &windows_tests,
+                &windows_clippy,
+                &check_scripts,
+                &check_database_migrations,
+            ],
         ),
     };
 
@@ -75,6 +106,7 @@ pub(crate) fn release() -> Workflow {
         &linux_clippy,
         &windows_clippy,
         &check_scripts,
+        &check_database_migrations,
     ];
     let push_slack_notification = push_release_update_notification(
         &create_draft_release,
@@ -98,6 +130,10 @@ pub(crate) fn release() -> Workflow {
         .add_job(linux_clippy.name, linux_clippy.job)
         .add_job(windows_clippy.name, windows_clippy.job)
         .add_job(check_scripts.name, check_scripts.job)
+        .add_job(
+            check_database_migrations.name,
+            check_database_migrations.job,
+        )
         .add_job(create_draft_release.name, create_draft_release.job)
         .add_job(
             non_blocking_compliance_run.name,
@@ -147,6 +183,67 @@ impl ReleaseBundleJobs {
             self.windows_x86_64,
         ]
     }
+}
+
+/// Verifies that the database migrations in this commit apply cleanly to the
+/// database produced by previous Zed versions.
+///
+/// The database is persisted as a workflow artifact and carried forward from
+/// run to run, so the check does not depend on which CI machine runs it: each
+/// run downloads the database produced by the most recent run that uploaded
+/// one, migrates it forward, and uploads the result as the new canonical
+/// database. If no previous database exists (first run, or artifacts expired)
+/// the chain restarts from an empty database.
+pub(crate) fn check_database_migrations() -> NamedJob {
+    const MIGRATION_DATABASE_ARTIFACT: &str = "migration-database";
+    const MIGRATION_DATA_DIR: &str = "$RUNNER_TEMP/zed-migration";
+
+    fn download_previous_database() -> Step<Run> {
+        named::bash(formatdoc! {r#"
+            mkdir -p "{MIGRATION_DATA_DIR}/db"
+            mapfile -t run_ids < <(gh run list --repo "$GITHUB_REPOSITORY" --workflow "$GITHUB_WORKFLOW" --limit 25 --json databaseId --jq '.[].databaseId')
+            for run_id in "${{run_ids[@]}}"; do
+                if gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name {MIGRATION_DATABASE_ARTIFACT} --dir "{MIGRATION_DATA_DIR}/db"; then
+                    echo "Migrating database produced by workflow run $run_id"
+                    exit 0
+                fi
+            done
+            echo "No previous database artifact found; starting from an empty database"
+        "#})
+        .add_env(("GH_TOKEN", vars::GITHUB_TOKEN))
+    }
+
+    fn run_database_migrations() -> Step<Run> {
+        named::bash(format!(
+            "cargo run --package zed -- --run-database-migrations --user-data-dir \"{MIGRATION_DATA_DIR}\""
+        ))
+    }
+
+    fn upload_migrated_database() -> Step<Use> {
+        named::uses(
+            "actions",
+            "upload-artifact",
+            "330a01c490aca151604b8cf639adc76d48f6c5d4", // v5
+        )
+        .add_with(("name", MIGRATION_DATABASE_ARTIFACT))
+        .add_with(("path", "${{ runner.temp }}/zed-migration/db"))
+        .add_with(("if-no-files-found", "error"))
+    }
+
+    let platform = Platform::Linux;
+    named::job(
+        steps::use_clang(steps::release_job(&[]).runs_on(runners::LINUX_DEFAULT))
+            .add_step(steps::checkout_repo())
+            .add_step(steps::setup_cargo_config(platform))
+            .add_step(steps::cache_rust_dependencies_namespace())
+            .map(steps::install_linux_dependencies)
+            .add_step(steps::setup_sccache(platform))
+            .add_step(download_previous_database())
+            .add_step(run_database_migrations())
+            .add_step(upload_migrated_database())
+            .add_step(steps::show_sccache_stats(platform))
+            .add_step(steps::cleanup_cargo_config(platform)),
+    )
 }
 
 pub(crate) fn create_sentry_release() -> Step<Use> {

--- a/tooling/xtask/src/tasks/workflows/release_nightly.rs
+++ b/tooling/xtask/src/tasks/workflows/release_nightly.rs
@@ -1,8 +1,8 @@
 use crate::tasks::workflows::{
     nix_build::build_nix,
     release::{
-        ReleaseBundleJobs, create_sentry_release, download_workflow_artifacts, notify_on_failure,
-        prep_release_artifacts,
+        ReleaseBundleJobs, check_database_migrations, create_sentry_release,
+        download_workflow_artifacts, notify_on_failure, prep_release_artifacts,
     },
     run_bundling::{bundle_linux, bundle_mac, bundle_windows},
     run_tests::{clippy, run_platform_tests_no_filter},
@@ -19,15 +19,17 @@ pub fn release_nightly() -> Workflow {
     // run only on windows as that's our fastest platform right now.
     let tests = run_platform_tests_no_filter(Platform::Windows);
     let clippy_job = clippy(Platform::Windows, None);
+    let check_migrations = check_database_migrations();
     let nightly = Some(ReleaseChannel::Nightly);
 
+    let bundle_deps: &[&NamedJob] = &[&style, &tests, &clippy_job, &check_migrations];
     let bundle = ReleaseBundleJobs {
-        linux_aarch64: bundle_linux(Arch::AARCH64, nightly, &[&style, &tests, &clippy_job]),
-        linux_x86_64: bundle_linux(Arch::X86_64, nightly, &[&style, &tests, &clippy_job]),
-        mac_aarch64: bundle_mac(Arch::AARCH64, nightly, &[&style, &tests, &clippy_job]),
-        mac_x86_64: bundle_mac(Arch::X86_64, nightly, &[&style, &tests, &clippy_job]),
-        windows_aarch64: bundle_windows(Arch::AARCH64, nightly, &[&style, &tests, &clippy_job]),
-        windows_x86_64: bundle_windows(Arch::X86_64, nightly, &[&style, &tests, &clippy_job]),
+        linux_aarch64: bundle_linux(Arch::AARCH64, nightly, bundle_deps),
+        linux_x86_64: bundle_linux(Arch::X86_64, nightly, bundle_deps),
+        mac_aarch64: bundle_mac(Arch::AARCH64, nightly, bundle_deps),
+        mac_x86_64: bundle_mac(Arch::X86_64, nightly, bundle_deps),
+        windows_aarch64: bundle_windows(Arch::AARCH64, nightly, bundle_deps),
+        windows_x86_64: bundle_windows(Arch::X86_64, nightly, bundle_deps),
     };
 
     let nix_linux_x86 = build_nix(
@@ -57,6 +59,7 @@ pub fn release_nightly() -> Workflow {
         .add_job(style.name, style.job)
         .add_job(tests.name, tests.job)
         .add_job(clippy_job.name, clippy_job.job)
+        .add_job(check_migrations.name, check_migrations.job)
         .map(|mut workflow| {
             for job in bundle.into_jobs() {
                 workflow = workflow.add_job(job.name, job.job);


### PR DESCRIPTION
This arg will be used so we could have a CI test to make sure database migrations don't cause issues between nightly/preview/stable updates

Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- N/A
