### PR TITLE
sidebar: Hide collapse affordances in project header upon searching

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -2272,6 +2272,8 @@ impl Sidebar {
     ) -> AnyElement {
         let host = key.host();
 
+        let has_filter = self.has_filter_query(cx);
+
         let id_prefix = if is_sticky { "sticky-" } else { "" };
         let id = SharedString::from(format!("{id_prefix}project-header-{ix}"));
         let group_name = SharedString::from(format!("{id_prefix}header-group-{ix}"));
@@ -2311,16 +2313,18 @@ impl Sidebar {
         let group_name_for_gradient = group_name.clone();
         let gradient_overlay = move || {
             GradientFade::new(base_bg, hover_solid, hover_solid)
-                .width(px(64.0))
+                .width(px(92.0))
                 .right(px(-2.0))
-                .gradient_stop(0.75)
-                .group_name(group_name_for_gradient.clone())
+                .gradient_stop(0.85)
+                .when(!has_filter, |this| {
+                    this.group_name(group_name_for_gradient.clone())
+                })
         };
 
         let header = h_flex()
             .id(id)
             .group(&group_name)
-            .cursor_pointer()
+            .when(!has_filter, |this| this.cursor_pointer())
             .relative()
             .h(Tab::content_height(cx))
             .w_full()
@@ -2335,7 +2339,7 @@ impl Sidebar {
                     this.border_color(gpui::transparent_black())
                 }
             })
-            .hover(|s| s.bg(hover_solid))
+            .when(!has_filter, |this| this.hover(|s| s.bg(hover_solid)))
             .child(
                 h_flex()
                     .relative()
@@ -2386,15 +2390,17 @@ impl Sidebar {
                             },
                         )
                     })
-                    .child(
-                        div()
-                            .when(!is_focused, |this| this.visible_on_hover(&group_name))
-                            .child(
-                                Icon::new(disclosure_icon)
-                                    .size(IconSize::Small)
-                                    .color(Color::Muted),
-                            ),
-                    ),
+                    .when(!has_filter, |this| {
+                        this.child(
+                            div()
+                                .when(!is_focused, |this| this.visible_on_hover(&group_name))
+                                .child(
+                                    Icon::new(disclosure_icon)
+                                        .size(IconSize::Small)
+                                        .color(Color::Muted),
+                                ),
+                        )
+                    }),
             )
             .child(gradient_overlay())
             .child(
@@ -2431,7 +2437,7 @@ impl Sidebar {
                 cx.listener(move |this, event: &gpui::ClickEvent, window, cx| {
                     if event.modifiers().secondary() {
                         this.activate_or_open_workspace_for_group(&key_for_focus, window, cx);
-                    } else {
+                    } else if !this.has_filter_query(cx) {
                         this.toggle_collapse(&key_for_toggle, window, cx);
                     }
                 }),

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -2315,7 +2315,7 @@ impl Sidebar {
             GradientFade::new(base_bg, hover_solid, hover_solid)
                 .width(px(92.0))
                 .right(px(-2.0))
-                .gradient_stop(0.85)
+                .gradient_stop(0.7)
                 .when(!has_filter, |this| {
                     this.group_name(group_name_for_gradient.clone())
                 })

--- a/crates/ui/src/components/ai/thread_item.rs
+++ b/crates/ui/src/components/ai/thread_item.rs
@@ -271,7 +271,7 @@ impl RenderOnce for ThreadItem {
         let gradient_overlay = GradientFade::new(base_bg, hover_bg, hover_bg)
             .width(px(64.0))
             .right(px(-10.0))
-            .gradient_stop(0.75)
+            .gradient_stop(0.7)
             .group_name("thread-item");
 
         let separator_color = Color::Custom(color.text_muted.opacity(0.4));


### PR DESCRIPTION
Closes AI-358

This PR hides the chevron and removes hover styles from the project header when there is an active search, given groups can't be collapsed while that's happening. We could allow it, but I think it's not super worth it; this feels like like a pragmatic move.

Release Notes:

- Sidebar: Fixed a bug where affordances to collapse the project header would appear when searching.
