### PR TITLE
Fix Wayland IME handling with multiple windows

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -604,6 +604,9 @@ impl WaylandWindowStatePtr {
 
     fn update_ime_enabled(&self) {
         let mut state = self.state.borrow_mut();
+        if !state.active {
+            return;
+        }
         let client = state.client.clone();
         let ime_enabled = state
             .input_handler


### PR DESCRIPTION
Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Fix an issue introduced by PR #58237 where IME could not be enabled when multiple windows were open.
The fix ensures that `update_ime_enabled` only updates IME state for the active window.

Release Notes:

- N/A
