### PR TITLE
Fix stale Git UI on reftable repositories on Linux

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3313,6 +3313,15 @@ impl BackgroundScannerState {
             .add(&repository_dir_abs_path)
             .context("failed to add repository directory to watcher")
             .log_err();
+        // On Linux, the native watcher is non-recursive, so subdirectories inside `.git` need explicit watching.
+        // For repos using the reftable backend, watch the `.git/reftable` directory so that ref changes are detected.
+        let reftable_path = common_dir_abs_path.join("reftable");
+        if fs.is_dir(&reftable_path).await {
+            watcher
+                .add(&reftable_path)
+                .context("failed to add reftable directory to watcher")
+                .log_err();
+        }
 
         let work_directory_id = work_dir_entry.id;
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3314,7 +3314,7 @@ impl BackgroundScannerState {
             .context("failed to add repository directory to watcher")
             .log_err();
 
-        // On Linux, the native watcher is non-recursive, so subdirectories inside `.git` need explicit watching.
+        // On Linux and FreeBSD, the native watcher is non-recursive, so subdirectories inside `.git` need explicit watching.
         // For repos using the reftable backend, watch the `.git/reftable` directory so that ref changes are detected.
         #[cfg(not(any(target_os = "windows", target_os = "macos")))]
         {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3316,15 +3316,12 @@ impl BackgroundScannerState {
 
         // On Linux and FreeBSD, the native watcher is non-recursive, so subdirectories inside `.git` need explicit watching.
         // For repos using the reftable backend, watch the `.git/reftable` directory so that ref changes are detected.
-        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
-        {
-            let reftable_path = common_dir_abs_path.join("reftable");
-            if fs.is_dir(&reftable_path).await {
-                watcher
-                    .add(&reftable_path)
-                    .context("failed to add reftable directory to watcher")
-                    .log_err();
-            }
+        let reftable_path = common_dir_abs_path.join("reftable");
+        if fs.is_dir(&reftable_path).await {
+            watcher
+                .add(&reftable_path)
+                .context("failed to add reftable directory to watcher")
+                .log_err();
         }
 
         let work_directory_id = work_dir_entry.id;

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3313,14 +3313,18 @@ impl BackgroundScannerState {
             .add(&repository_dir_abs_path)
             .context("failed to add repository directory to watcher")
             .log_err();
+
         // On Linux, the native watcher is non-recursive, so subdirectories inside `.git` need explicit watching.
         // For repos using the reftable backend, watch the `.git/reftable` directory so that ref changes are detected.
-        let reftable_path = common_dir_abs_path.join("reftable");
-        if fs.is_dir(&reftable_path).await {
-            watcher
-                .add(&reftable_path)
-                .context("failed to add reftable directory to watcher")
-                .log_err();
+        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+        {
+            let reftable_path = common_dir_abs_path.join("reftable");
+            if fs.is_dir(&reftable_path).await {
+                watcher
+                    .add(&reftable_path)
+                    .context("failed to add reftable directory to watcher")
+                    .log_err();
+            }
         }
 
         let work_directory_id = work_dir_entry.id;


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

The non-recursive Linux watcher causes subdirectories inside `.git/` to need explicit watching. For repos using the reftable backend, all ref data lives in `.git/reftable/`. Operations in the UI like uncommitting and creating new branches only modify refs inside `.git/reftable` without changing `.git/HEAD`'s contents, so no inotify event fires on `.git/` itself and the git UI never refreshes.

Essentially all this change does is check if `.git/reftable/` exists and if it does, add it to the watcher. On the recursive macOS/Windows watchers, `FsWatcher::add` returns early safely so this *should* not be a performance loss apart from the brief lookup.

Release Notes:

- Fixed Git UI not refreshing on Linux for repositories using the reftable backend.