### PR TITLE
worktree: Fix event storm causing worktree entries disapearing

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1336,6 +1336,11 @@ struct FakeFsState {
     job_event_subscribers: Arc<Mutex<Vec<JobEventSender>>>,
     trash: Vec<(TrashedEntry, FakeFsEntry)>,
     file_to_create_before_watch_add: Option<(PathBuf, PathBuf)>,
+    read_dir_block: Option<(
+        PathBuf,
+        async_channel::Sender<()>,
+        async_channel::Receiver<()>,
+    )>,
 }
 
 #[cfg(feature = "test-support")]
@@ -1655,6 +1660,7 @@ impl FakeFs {
                 job_event_subscribers: Arc::new(Mutex::new(Vec::new())),
                 trash: Vec::new(),
                 file_to_create_before_watch_add: None,
+                read_dir_block: None,
             })),
         });
 
@@ -1839,6 +1845,20 @@ impl FakeFs {
             normalize_path(watch_path.as_ref()),
             normalize_path(path.as_ref()),
         ));
+    }
+
+    pub fn block_next_read_dir(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> (async_channel::Receiver<()>, async_channel::Sender<()>) {
+        let (read_started_tx, read_started_rx) = async_channel::bounded(1);
+        let (resume_read_tx, resume_read_rx) = async_channel::bounded(1);
+        self.state.lock().read_dir_block = Some((
+            normalize_path(path.as_ref()),
+            read_started_tx,
+            resume_read_rx,
+        ));
+        (read_started_rx, resume_read_tx)
     }
 
     pub fn flush_events(&self, count: usize) {
@@ -3098,6 +3118,20 @@ impl Fs for FakeFs {
     ) -> Result<Pin<Box<dyn Send + Stream<Item = Result<PathBuf>>>>> {
         self.simulate_random_delay().await;
         let path = normalize_path(path);
+        let read_dir_block = {
+            let mut state = self.state.lock();
+            match &state.read_dir_block {
+                Some((blocked_path, _, _)) if blocked_path == &path => state.read_dir_block.take(),
+                _ => None,
+            }
+        };
+        if let Some((_, read_started_tx, resume_read_rx)) = read_dir_block
+            && read_started_tx.send(()).await.is_ok()
+            && resume_read_rx.recv().await.is_err()
+        {
+            log::debug!("blocked FakeFs::read_dir resumed by dropping the release sender");
+        }
+
         let mut state = self.state.lock();
         state.read_dir_call_count += 1;
         let entry = state.entry(&path)?;

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -1360,6 +1360,100 @@ async fn test_root_rescan_does_not_miss_event_before_readding_root_watcher(
 }
 
 #[gpui::test]
+async fn test_subtree_rescan_can_publish_removed_descendants_before_readding_them(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    cx.background_executor.set_num_cpus(2);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            "dir": {
+                "child.txt": "",
+                "nested": {
+                    "grandchild.txt": "",
+                },
+            },
+            "other.txt": "",
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    let (read_dir_started, resume_read_dir) = fs.block_next_read_dir("/root/dir");
+    fs.emit_fs_event("/root/dir", Some(fs::PathEventKind::Rescan));
+    read_dir_started.recv().await.unwrap();
+
+    tree.read_with(cx, |tree, _| {
+        tree.as_local()
+            .unwrap()
+            .manually_refresh_entries_for_paths(vec![rel_path("other.txt").into()])
+    })
+    .recv()
+    .await;
+    tree.read_with(cx, |tree, _| {
+        tree.as_local()
+            .unwrap()
+            .manually_refresh_entries_for_paths(vec![rel_path("dir/nested/grandchild.txt").into()])
+    })
+    .recv()
+    .await;
+
+    tree.update(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("dir")).is_some());
+        assert!(tree.entry_for_path(rel_path("other.txt")).is_some());
+    });
+    tree.update(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("dir/child.txt")).is_none());
+        assert!(tree.entry_for_path(rel_path("dir/nested")).is_none());
+        assert!(
+            tree.entry_for_path(rel_path("dir/nested/grandchild.txt"))
+                .is_some()
+        );
+    });
+
+    assert!(
+        fs.metadata(Path::new("/root/dir/child.txt"))
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        fs.metadata(Path::new("/root/dir/nested/grandchild.txt"))
+            .await
+            .unwrap()
+            .is_some()
+    );
+
+    resume_read_dir.send(()).await.unwrap();
+    wait_for_condition(cx, |cx| {
+        tree.read_with(cx, |tree, _| {
+            tree.entry_for_path(rel_path("dir/child.txt")).is_some()
+                && tree.entry_for_path(rel_path("dir/nested")).is_some()
+                && tree
+                    .entry_for_path(rel_path("dir/nested/grandchild.txt"))
+                    .is_some()
+        })
+    })
+    .await;
+}
+
+#[gpui::test]
 async fn test_subtree_rescan_reports_unchanged_descendants_as_updated(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.background_executor.clone());


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Release Notes:

- N/A or Added/Fixed/Improved ...
