### PR TITLE
Run Windows shell COM work on OLE thread

### DIFF
--- a/crates/gpui_windows/src/destination_list.rs
+++ b/crates/gpui_windows/src/destination_list.rs
@@ -1,5 +1,6 @@
 use std::{path::PathBuf, sync::Arc};
 
+use anyhow::Context;
 use itertools::Itertools;
 use smallvec::SmallVec;
 use windows::{
@@ -65,10 +66,11 @@ pub(crate) fn update_jump_list(
     recent_workspaces: &[SmallVec<[PathBuf; 2]>],
     dock_menus: &[(SharedString, SharedString)],
 ) -> anyhow::Result<Vec<SmallVec<[PathBuf; 2]>>> {
-    let (list, removed) = create_destination_list()?;
-    add_recent_folders(&list, recent_workspaces, removed.as_ref())?;
-    add_dock_menu(&list, dock_menus)?;
-    unsafe { list.CommitList() }?;
+    let (list, removed) = create_destination_list().context("unable to create destination list")?;
+    add_recent_folders(&list, recent_workspaces, removed.as_ref())
+        .context("unable to add recent folders")?;
+    add_dock_menu(&list, dock_menus).context("unable to add dock menu")?;
+    unsafe { list.CommitList() }.context("unable to commit list")?;
     Ok(removed)
 }
 

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -144,12 +144,12 @@ impl WindowsShellExecutor {
     }
 }
 
-struct OleInitializer {
+pub(crate) struct OleInitializer {
     not_send: std::marker::PhantomData<*const ()>,
 }
 
 impl OleInitializer {
-    fn new(context: &'static str) -> Result<Self> {
+    pub(crate) fn new(context: &'static str) -> Result<Self> {
         // SAFETY: OLE initialization is thread-local. Constructing this guard records
         // a successful initialization on the current thread, and its `Drop` implementation
         // balances it with `OleUninitialize` on the same thread.

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -6,6 +6,7 @@ use std::{
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
+        mpsc,
     },
 };
 
@@ -41,6 +42,7 @@ pub struct WindowsPlatform {
     text_system: Arc<dyn PlatformTextSystem>,
     direct_write_text_system: Option<Arc<DirectWriteTextSystem>>,
     drop_target_helper: Option<IDropTargetHelper>,
+    shell_executor: WindowsShellExecutor,
     /// Flag to instruct the `VSyncProvider` thread to invalidate the directx devices
     /// as resizing them has failed, causing us to have lost at least the render target.
     invalidate_devices: Arc<AtomicBool>,
@@ -77,6 +79,93 @@ struct PlatformCallbacks {
     will_open_app_menu: Cell<Option<Box<dyn FnMut()>>>,
     validate_app_menu_command: Cell<Option<Box<dyn FnMut(&dyn Action) -> bool>>>,
     keyboard_layout_change: Cell<Option<Box<dyn FnMut()>>>,
+}
+
+type WindowsShellJob = Box<dyn FnOnce() + Send + 'static>;
+
+/// Runs short Windows shell COM jobs on a dedicated OLE-initialized thread.
+///
+/// Windows shell APIs such as jump lists and shell namespace operations require COM/OLE
+/// initialization, but GPUI's generic background executor uses Windows thread-pool threads
+/// that do not guarantee any particular COM apartment.
+#[derive(Clone)]
+struct WindowsShellExecutor {
+    sender: mpsc::Sender<WindowsShellJob>,
+}
+
+impl WindowsShellExecutor {
+    fn new() -> Self {
+        let (sender, receiver) = mpsc::channel::<WindowsShellJob>();
+        std::thread::spawn(move || {
+            let _ole_initializer =
+                OleInitializer::new("unable to initialize Windows OLE for shell executor")
+                    .log_err();
+            for job in receiver {
+                job();
+            }
+        });
+        Self { sender }
+    }
+
+    /// Queues a shell job and returns a task that resolves with its result.
+    fn spawn<T>(
+        &self,
+        background_executor: &BackgroundExecutor,
+        job: impl FnOnce() -> Result<T> + Send + 'static,
+    ) -> Task<Result<T>>
+    where
+        T: Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(Box::new(move || {
+                _ = tx.send(job());
+            }))
+            .log_err();
+
+        background_executor.spawn(async move {
+            rx.await
+                .context("Windows shell executor stopped before completing job")?
+        })
+    }
+
+    /// Queues a shell job and logs any error without waiting for completion.
+    fn detach(
+        &self,
+        background_executor: &BackgroundExecutor,
+        job: impl FnOnce() -> Result<()> + Send + 'static,
+    ) {
+        let task = self.spawn(background_executor, job);
+        background_executor
+            .spawn(async move {
+                task.await.log_err();
+            })
+            .detach();
+    }
+}
+
+struct OleInitializer {
+    not_send: std::marker::PhantomData<*const ()>,
+}
+
+impl OleInitializer {
+    fn new(context: &'static str) -> Result<Self> {
+        // SAFETY: OLE initialization is thread-local. Constructing this guard records
+        // a successful initialization on the current thread, and its `Drop` implementation
+        // balances it with `OleUninitialize` on the same thread.
+        unsafe { OleInitialize(None) }.context(context)?;
+        Ok(Self {
+            not_send: std::marker::PhantomData,
+        })
+    }
+}
+
+impl Drop for OleInitializer {
+    fn drop(&mut self) {
+        // SAFETY: `OleInitializer` is only constructed after `OleInitialize` succeeds, and
+        // the guard is not sent to another thread, so this balances that call on the same thread.
+        unsafe { OleUninitialize() };
+    }
 }
 
 impl WindowsPlatformState {
@@ -195,6 +284,7 @@ impl WindowsPlatform {
             direct_write_text_system,
             disable_direct_composition,
             drop_target_helper,
+            shell_executor: WindowsShellExecutor::new(),
             invalidate_devices: Arc::new(AtomicBool::new(false)),
         })
     }
@@ -248,11 +338,10 @@ impl WindowsPlatform {
             .map(|menu| (menu.name.clone(), menu.description.clone()))
             .collect::<Vec<_>>();
         let recent_workspaces = borrow.recent_workspaces.clone();
-        self.background_executor
-            .spawn(async move {
-                update_jump_list(&recent_workspaces, &dock_menus).log_err();
-            })
-            .detach();
+        self.shell_executor
+            .detach(&self.background_executor, move || {
+                update_jump_list(&recent_workspaces, &dock_menus).map(|_| ())
+            });
     }
 
     fn update_jump_list(
@@ -275,11 +364,13 @@ impl WindowsPlatform {
             .map(|menu| (menu.name.clone(), menu.description.clone()))
             .collect::<Vec<_>>();
         let recent_workspaces = jump_list.recent_workspaces.clone();
-        self.background_executor.spawn(async move {
-            update_jump_list(&recent_workspaces, &dock_menus)
-                .log_err()
-                .unwrap_or_default()
-        })
+        let task = self
+            .shell_executor
+            .spawn(&self.background_executor, move || {
+                update_jump_list(&recent_workspaces, &dock_menus)
+            });
+        self.background_executor
+            .spawn(async move { task.await.log_err().unwrap_or_default() })
     }
 
     fn find_current_active_window(&self) -> Option<HWND> {
@@ -560,12 +651,11 @@ impl Platform for WindowsPlatform {
         options: PathPromptOptions,
     ) -> Receiver<Result<Option<Vec<PathBuf>>>> {
         let (tx, rx) = oneshot::channel();
-        let window = self.find_current_active_window();
-        self.foreground_executor()
-            .spawn(async move {
-                let _ = tx.send(file_open_dialog(options, window));
-            })
-            .detach();
+        let window = self.find_current_active_window().map(SafeHwnd::from);
+        spawn_file_dialog(
+            move || file_open_dialog(options, window.map(|window| window.as_raw())),
+            tx,
+        );
 
         rx
     }
@@ -578,12 +668,17 @@ impl Platform for WindowsPlatform {
         let directory = directory.to_owned();
         let suggested_name = suggested_name.map(|s| s.to_owned());
         let (tx, rx) = oneshot::channel();
-        let window = self.find_current_active_window();
-        self.foreground_executor()
-            .spawn(async move {
-                let _ = tx.send(file_save_dialog(directory, suggested_name, window));
-            })
-            .detach();
+        let window = self.find_current_active_window().map(SafeHwnd::from);
+        spawn_file_dialog(
+            move || {
+                file_save_dialog(
+                    directory,
+                    suggested_name,
+                    window.map(|window| window.as_raw()),
+                )
+            },
+            tx,
+        );
 
         rx
     }
@@ -598,13 +693,11 @@ impl Platform for WindowsPlatform {
             return;
         }
         let path = path.to_path_buf();
-        self.background_executor()
-            .spawn(async move {
+        self.shell_executor
+            .detach(&self.background_executor, move || {
                 open_target_in_explorer(&path)
                     .with_context(|| format!("Revealing path {} in explorer", path.display()))
-                    .log_err();
-            })
-            .detach();
+            });
     }
 
     fn open_with_system(&self, path: &Path) {
@@ -1127,6 +1220,22 @@ fn open_target_in_explorer(target: &Path) -> Result<()> {
             Err(anyhow::anyhow!("Can not open target path: {}", err))
         }
     })
+}
+
+fn spawn_file_dialog<T>(
+    dialog: impl FnOnce() -> Result<Option<T>> + Send + 'static,
+    tx: oneshot::Sender<Result<Option<T>>>,
+) where
+    T: Send + 'static,
+{
+    // we spawn a separate thread here to not block the main thread, but we do
+    // not want to use the background executor either as those threads might not
+    // have OLE initialized
+    std::thread::spawn(move || {
+        let result = OleInitializer::new("unable to initialize Windows OLE for file dialog")
+            .and_then(|_ole_initializer| dialog());
+        drop(tx.send(result));
+    });
 }
 
 fn file_open_dialog(

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -677,77 +677,33 @@ impl PlatformWindow for WindowsWindow {
     ) -> Option<Receiver<usize>> {
         let (done_tx, done_rx) = oneshot::channel();
         let msg = msg.to_string();
-        let detail_string = detail.map(|detail| detail.to_string());
-        let handle = self.0.hwnd;
-        let answers = answers.to_vec();
-        self.0
-            .executor
-            .spawn(async move {
-                unsafe {
-                    let mut config = TASKDIALOGCONFIG::default();
-                    config.cbSize = std::mem::size_of::<TASKDIALOGCONFIG>() as _;
-                    config.hwndParent = handle;
-                    let title;
-                    let main_icon;
-                    match level {
-                        PromptLevel::Info => {
-                            title = windows::core::w!("Info");
-                            main_icon = TD_INFORMATION_ICON;
-                        }
-                        PromptLevel::Warning => {
-                            title = windows::core::w!("Warning");
-                            main_icon = TD_WARNING_ICON;
-                        }
-                        PromptLevel::Critical => {
-                            title = windows::core::w!("Critical");
-                            main_icon = TD_ERROR_ICON;
-                        }
-                    };
-                    config.pszWindowTitle = title;
-                    config.Anonymous1.pszMainIcon = main_icon;
-                    let instruction = HSTRING::from(msg);
-                    config.pszMainInstruction = PCWSTR::from_raw(instruction.as_ptr());
-                    let hints_encoded;
-                    if let Some(ref hints) = detail_string {
-                        hints_encoded = HSTRING::from(hints);
-                        config.pszContent = PCWSTR::from_raw(hints_encoded.as_ptr());
-                    };
-                    let mut button_id_map = Vec::with_capacity(answers.len());
-                    let mut buttons = Vec::new();
-                    let mut btn_encoded = Vec::new();
-                    for (index, btn) in answers.iter().enumerate() {
-                        let encoded = HSTRING::from(btn.label().as_ref());
-                        let button_id = match btn {
-                            PromptButton::Ok(_) => IDOK.0,
-                            PromptButton::Cancel(_) => IDCANCEL.0,
-                            // the first few low integer values are reserved for known buttons
-                            // so for simplicity we just go backwards from -1
-                            PromptButton::Other(_) => -(index as i32) - 1,
-                        };
-                        button_id_map.push(button_id);
-                        buttons.push(TASKDIALOG_BUTTON {
-                            nButtonID: button_id,
-                            pszButtonText: PCWSTR::from_raw(encoded.as_ptr()),
-                        });
-                        btn_encoded.push(encoded);
-                    }
-                    config.cButtons = buttons.len() as _;
-                    config.pButtons = buttons.as_ptr();
-
-                    config.pfCallback = None;
-                    let mut res = std::mem::zeroed();
-                    let _ = TaskDialogIndirect(&config, Some(&mut res), None, None)
-                        .context("unable to create task dialog")
-                        .log_err();
-
-                    if let Some(clicked) =
-                        button_id_map.iter().position(|&button_id| button_id == res)
-                    {
-                        let _ = done_tx.send(clicked);
-                    }
-                }
+        let detail = detail.map(|detail| detail.to_string());
+        let handle = SafeHwnd::from(self.0.hwnd);
+        let buttons = answers
+            .iter()
+            .enumerate()
+            .map(|(index, button)| {
+                let button_id = match button {
+                    PromptButton::Ok(_) => IDOK.0,
+                    PromptButton::Cancel(_) => IDCANCEL.0,
+                    // The first few low integer values are reserved for known buttons, so use
+                    // negative IDs for custom buttons.
+                    PromptButton::Other(_) => -(index as i32) - 1,
+                };
+                (button.label().as_ref().to_string(), button_id)
             })
-            .detach();
+            .collect::<Vec<_>>();
+        std::thread::spawn(move || {
+            let result = OleInitializer::new("unable to initialize Windows OLE for task dialog")
+                .and_then(|_ole_initializer| task_dialog(level, msg, detail, buttons, handle));
+            match result {
+                Ok(Some(clicked)) => drop(done_tx.send(clicked)),
+                Ok(None) => {}
+                Err(error) => {
+                    Err::<(), _>(error).log_err();
+                }
+            }
+        });
 
         Some(done_rx)
     }
@@ -1182,6 +1138,60 @@ impl IDropTarget_Impl for WindowsDragDropHandler_Impl {
 
         Ok(())
     }
+}
+
+fn task_dialog(
+    level: PromptLevel,
+    msg: String,
+    detail: Option<String>,
+    buttons: Vec<(String, i32)>,
+    handle: SafeHwnd,
+) -> Result<Option<usize>> {
+    let mut config = TASKDIALOGCONFIG {
+        cbSize: std::mem::size_of::<TASKDIALOGCONFIG>() as _,
+        hwndParent: handle.as_raw(),
+        ..TASKDIALOGCONFIG::default()
+    };
+    let (title, main_icon) = match level {
+        PromptLevel::Info => (windows::core::w!("Info"), TD_INFORMATION_ICON),
+        PromptLevel::Warning => (windows::core::w!("Warning"), TD_WARNING_ICON),
+        PromptLevel::Critical => (windows::core::w!("Critical"), TD_ERROR_ICON),
+    };
+    config.pszWindowTitle = title;
+    config.Anonymous1.pszMainIcon = main_icon;
+
+    let instruction = HSTRING::from(msg);
+    config.pszMainInstruction = PCWSTR::from_raw(instruction.as_ptr());
+
+    let detail = detail.map(HSTRING::from);
+    if let Some(detail) = detail.as_ref() {
+        config.pszContent = PCWSTR::from_raw(detail.as_ptr());
+    }
+
+    let mut labels = Vec::with_capacity(buttons.len());
+    let mut task_dialog_buttons = Vec::with_capacity(buttons.len());
+    for (label, button_id) in &buttons {
+        let label = HSTRING::from(label);
+        task_dialog_buttons.push(TASKDIALOG_BUTTON {
+            nButtonID: *button_id,
+            pszButtonText: PCWSTR::from_raw(label.as_ptr()),
+        });
+        labels.push(label);
+    }
+    config.cButtons = task_dialog_buttons.len() as _;
+    config.pButtons = task_dialog_buttons.as_ptr();
+    config.pfCallback = None;
+
+    let mut response = 0;
+    // SAFETY: All `PCWSTR` fields in `config` point into `HSTRING`s and button storage
+    // that are kept alive until `TaskDialogIndirect` returns. The dialog runs on a
+    // dedicated thread after `OleInitialize` has succeeded for that thread.
+    unsafe { TaskDialogIndirect(&config, Some(&mut response), None, None) }
+        .context("unable to create task dialog")?;
+
+    Ok(buttons
+        .iter()
+        .position(|(_, button_id)| *button_id == response))
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
File dialogs and shell APIs can block or require COM/OLE initialization. Notably the file dialog change fixes us blocking the main thread while having the dialog open which caused us to record hangs.

Release Notes:

- Fixed zed's windows becoming unresponsive on windows when having a file dialog open
