### PR TITLE
markdown_preview: Highlight nested injections in code blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10597,6 +10597,8 @@ dependencies = [
  "sum_tree",
  "theme",
  "theme_settings",
+ "tree-sitter-css",
+ "tree-sitter-html",
  "ui",
  "util",
 ]

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3405,6 +3405,32 @@ impl Deref for Buffer {
 }
 
 impl BufferSnapshot {
+    pub(crate) fn for_highlighting(
+        text: Rope,
+        language: Arc<Language>,
+        language_registry: Option<Arc<LanguageRegistry>>,
+    ) -> Self {
+        let buffer_id = BufferId::from(std::num::NonZeroU64::MIN);
+        let text =
+            TextBuffer::new_normalized(ReplicaId::LOCAL, buffer_id, Default::default(), text)
+                .into_snapshot();
+        let mut syntax = SyntaxMap::new(&text).snapshot();
+        syntax.reparse(&text, language_registry, language.clone());
+        let tree_sitter_data = TreeSitterData::new(&text);
+        BufferSnapshot {
+            text,
+            syntax,
+            file: None,
+            diagnostics: Default::default(),
+            remote_selections: Default::default(),
+            tree_sitter_data: Arc::new(tree_sitter_data),
+            language: Some(language),
+            non_text_state_update_count: 0,
+            capability: Capability::ReadOnly,
+            modeline: None,
+        }
+    }
+
     /// Returns [`IndentSize`] for a given line that respects user settings and
     /// language preferences.
     pub fn indent_size_for_line(&self, row: u32) -> IndentSize {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1055,6 +1055,45 @@ impl Language {
         result
     }
 
+    pub fn highlight_text_with_injections(
+        self: &Arc<Self>,
+        text: &Rope,
+        range: Range<usize>,
+        language_registry: Option<&Arc<LanguageRegistry>>,
+    ) -> Vec<(Range<usize>, HighlightId)> {
+        if language_registry.is_none()
+            || self
+                .grammar
+                .as_ref()
+                .is_none_or(|grammar| grammar.injection_config.is_none())
+        {
+            return self.highlight_text(text, range);
+        }
+
+        let snapshot = BufferSnapshot::for_highlighting(
+            text.clone(),
+            self.clone(),
+            language_registry.cloned(),
+        );
+        let mut result = Vec::new();
+        let mut offset = 0;
+        for chunk in snapshot.chunks(
+            range,
+            LanguageAwareStyling {
+                tree_sitter: true,
+                diagnostics: false,
+            },
+        ) {
+            let end_offset = offset + chunk.text.len();
+            if let Some(highlight_id) = chunk.syntax_highlight_id {
+                result.push((offset..end_offset, highlight_id));
+            }
+            offset = end_offset;
+        }
+
+        result
+    }
+
     pub fn path_suffixes(&self) -> &[String] {
         &self.config.matcher.path_suffixes
     }

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -49,4 +49,6 @@ language = { workspace = true, features = ["test-support"] }
 languages = { workspace = true, features = ["load-grammars"] }
 node_runtime.workspace = true
 settings = { workspace = true, features = ["test-support"] }
+tree-sitter-css.workspace = true
+tree-sitter-html.workspace = true
 util = { workspace = true, features = ["test-support"] }

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1958,12 +1958,14 @@ impl Element for MarkdownElement {
         window: &mut Window,
         cx: &mut App,
     ) -> (gpui::LayoutId, Self::RequestLayoutState) {
-        let mut builder = MarkdownElementBuilder::new(
-            &self.style.container_style,
-            self.style.base_text_style.clone(),
-            self.style.syntax.clone(),
-        );
-        let (parsed_markdown, images, active_root_block, render_mermaid_diagrams, mermaid_state) = {
+        let (
+            parsed_markdown,
+            images,
+            active_root_block,
+            render_mermaid_diagrams,
+            mermaid_state,
+            language_registry,
+        ) = {
             let markdown = self.markdown.read(cx);
             (
                 markdown.parsed_markdown.clone(),
@@ -1971,8 +1973,15 @@ impl Element for MarkdownElement {
                 markdown.active_root_block,
                 markdown.options.render_mermaid_diagrams,
                 markdown.mermaid_state.clone(),
+                markdown.language_registry.clone(),
             )
         };
+        let mut builder = MarkdownElementBuilder::new(
+            &self.style.container_style,
+            self.style.base_text_style.clone(),
+            self.style.syntax.clone(),
+            language_registry,
+        );
         let markdown_end = if let Some(last) = parsed_markdown.events.last() {
             last.0.end
         } else {
@@ -2984,6 +2993,7 @@ struct MarkdownElementBuilder {
     list_stack: Vec<ListStackEntry>,
     table: TableState,
     syntax_theme: Arc<SyntaxTheme>,
+    language_registry: Option<Arc<LanguageRegistry>>,
 }
 
 #[derive(Default)]
@@ -3002,6 +3012,7 @@ impl MarkdownElementBuilder {
         container_style: &StyleRefinement,
         base_text_style: TextStyle,
         syntax_theme: Arc<SyntaxTheme>,
+        language_registry: Option<Arc<LanguageRegistry>>,
     ) -> Self {
         Self {
             div_stack: vec![{
@@ -3023,6 +3034,7 @@ impl MarkdownElementBuilder {
             list_stack: Vec::new(),
             table: TableState::default(),
             syntax_theme,
+            language_registry,
         }
     }
 
@@ -3196,7 +3208,12 @@ impl MarkdownElementBuilder {
 
         if let Some(Some(language)) = self.code_block_stack.last() {
             let mut offset = 0;
-            for (range, highlight_id) in language.highlight_text(&Rope::from(text), 0..text.len()) {
+            let text = Rope::from(text);
+            for (range, highlight_id) in language.highlight_text_with_injections(
+                &text,
+                0..text.len(),
+                self.language_registry.as_ref(),
+            ) {
                 if range.start > offset {
                     self.pending_line
                         .runs
@@ -3298,9 +3315,14 @@ impl MarkdownElementBuilder {
         let mut text_style = self.base_text_style.clone();
         text_style.color = Hsla::transparent_black();
         let text = "\u{200B}";
-        let styled_text = StyledText::new(text).with_runs(vec![text_style.to_run(text.len())]);
+        let run = text_style.to_run(text.len());
+        #[cfg(test)]
+        let runs = vec![run.clone()];
+        let styled_text = StyledText::new(text).with_runs(vec![run]);
         self.rendered_lines.push(RenderedLine {
             layout: styled_text.layout().clone(),
+            #[cfg(test)]
+            runs,
             source_mappings: vec![SourceMapping {
                 rendered_index: 0,
                 source_index: source_range.start,
@@ -3325,9 +3347,13 @@ impl MarkdownElementBuilder {
             return;
         }
 
+        #[cfg(test)]
+        let runs = line.runs.clone();
         let text = StyledText::new(line.text).with_runs(line.runs);
         self.rendered_lines.push(RenderedLine {
             layout: text.layout().clone(),
+            #[cfg(test)]
+            runs,
             source_mappings: line.source_mappings,
             source_end: self.current_source_index,
             language: self.code_block_stack.last().cloned().flatten(),
@@ -3352,6 +3378,8 @@ impl MarkdownElementBuilder {
 
 struct RenderedLine {
     layout: TextLayout,
+    #[cfg(test)]
+    runs: Vec<TextRun>,
     source_mappings: Vec<SourceMapping>,
     source_end: usize,
     language: Option<Arc<Language>>,
@@ -3798,7 +3826,7 @@ impl RenderedText {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{TestAppContext, size};
+    use gpui::{TestAppContext, rgba, size};
     use language::{Language, LanguageConfig, LanguageMatcher};
     use std::sync::{
         Arc,
@@ -3966,6 +3994,49 @@ mod tests {
         render_markdown_with_options(markdown, language_registry, MarkdownOptions::default(), cx)
     }
 
+    fn render_markdown_with_language_registry_and_style(
+        markdown: &str,
+        language_registry: Option<Arc<LanguageRegistry>>,
+        style: MarkdownStyle,
+        cx: &mut TestAppContext,
+    ) -> RenderedText {
+        struct TestWindow;
+
+        impl Render for TestWindow {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                div()
+            }
+        }
+
+        ensure_theme_initialized(cx);
+
+        let (_, cx) = cx.add_window_view(|_, _| TestWindow);
+        let markdown = cx.new(|cx| {
+            Markdown::new_with_options(
+                markdown.to_string().into(),
+                language_registry,
+                None,
+                MarkdownOptions::default(),
+                cx,
+            )
+        });
+        cx.run_until_parked();
+        let (rendered, _) = cx.draw(
+            Default::default(),
+            size(px(600.0), px(600.0)),
+            |_window, _cx| {
+                MarkdownElement::new(markdown, style).code_block_renderer(
+                    CodeBlockRenderer::Default {
+                        copy_button_visibility: CopyButtonVisibility::Hidden,
+                        wrap_button_visibility: WrapButtonVisibility::Hidden,
+                        border: false,
+                    },
+                )
+            },
+        );
+        rendered.text
+    }
+
     fn render_markdown_with_options(
         markdown: &str,
         language_registry: Option<Arc<LanguageRegistry>>,
@@ -4007,6 +4078,99 @@ mod tests {
             },
         );
         rendered.text
+    }
+
+    #[gpui::test]
+    fn test_code_block_highlights_nested_injections(cx: &mut TestAppContext) {
+        let syntax_theme = Arc::new(SyntaxTheme::new([
+            ("tag".to_string(), rgba(0x3366ccff).into()),
+            ("property".to_string(), rgba(0xcc3333ff).into()),
+            ("constant.builtin".to_string(), rgba(0x33aa66ff).into()),
+            ("punctuation".to_string(), rgba(0x666666ff).into()),
+        ]));
+        let property_color: Hsla = rgba(0xcc3333ff).into();
+
+        let html_language = Arc::new(
+            Language::new(
+                LanguageConfig {
+                    name: "HTML".into(),
+                    matcher: LanguageMatcher {
+                        path_suffixes: vec!["html".into()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Some(tree_sitter_html::LANGUAGE.into()),
+            )
+            .with_highlights_query(include_str!(
+                "../../../extensions/html/languages/html/highlights.scm"
+            ))
+            .unwrap()
+            .with_injection_query(include_str!(
+                "../../../extensions/html/languages/html/injections.scm"
+            ))
+            .unwrap(),
+        );
+        let css_language = Arc::new(
+            Language::new(
+                LanguageConfig {
+                    name: "CSS".into(),
+                    matcher: LanguageMatcher {
+                        path_suffixes: vec!["css".into()],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Some(tree_sitter_css::LANGUAGE.into()),
+            )
+            .with_highlights_query(include_str!("../../grammars/src/css/highlights.scm"))
+            .unwrap(),
+        );
+        html_language.set_theme(&syntax_theme);
+        css_language.set_theme(&syntax_theme);
+
+        let language_registry = Arc::new(LanguageRegistry::test(cx.executor()));
+        language_registry.add(html_language);
+        language_registry.add(css_language);
+
+        let rendered = render_markdown_with_language_registry_and_style(
+            "```html\n<style>\n  body {\n    color: red;\n  }\n</style>\n```",
+            Some(language_registry),
+            MarkdownStyle {
+                syntax: syntax_theme,
+                ..Default::default()
+            },
+            cx,
+        );
+
+        let line = rendered
+            .lines
+            .iter()
+            .find(|line| line.layout.text().contains("color: red"))
+            .expect("expected CSS declaration line to render");
+        let declaration = line.layout.text();
+        let color_offset = declaration
+            .find("color")
+            .expect("expected CSS property in rendered line");
+
+        assert_eq!(
+            run_color_at(line, color_offset),
+            property_color,
+            "expected CSS property inside HTML style block to use CSS highlighting"
+        );
+    }
+
+    fn run_color_at(line: &RenderedLine, offset: usize) -> Hsla {
+        let mut run_start = 0;
+        for run in &line.runs {
+            let run_end = run_start + run.len;
+            if offset < run_end {
+                return run.color;
+            }
+            run_start = run_end;
+        }
+
+        panic!("no text run found at offset {offset}");
     }
 
     #[gpui::test]


### PR DESCRIPTION
Closes #47613

Markdown Preview rendered fenced code blocks with `Language::highlight_text`, which only highlighted the root tree-sitter grammar. That meant an HTML code block could highlight the HTML tags, but nested injected languages such as CSS inside `<style>` were left with the default code color.

This adds a registry-aware highlighting path for standalone snippets. When the root language has injection queries and a language registry is available, the code builds a temporary read-only syntax snapshot and collects highlight runs from all syntax layers. Languages without injections, or code rendered without a registry, continue using the previous single-tree path.

The markdown renderer now threads its existing `LanguageRegistry` into code-block rendering, and the regression test verifies that CSS properties inside an HTML fenced block receive CSS highlighting.

- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Screenshots from #50599:

| Before | After |
|--------|-------|
| <img width="735" alt="Screenshot 2026-03-03 at 6 09 27 PM" src="https://github.com/user-attachments/assets/dc7a5129-6169-4235-bd3f-8bb51c7cf218" /> | <img width="735" alt="Screenshot 2026-03-03 at 6 10 00 PM" src="https://github.com/user-attachments/assets/32409079-fb4b-4096-8caa-a54e61713ae9" /> |

Validation:

- `cargo -q test -p markdown -F gpui_platform/runtime_shaders test_code_block_highlights_nested_injections -- --nocapture`
- `cargo -q test -p markdown -F gpui_platform/runtime_shaders --lib`
- `cargo -q test -p language --lib`
- `cargo fmt --check --package language --package markdown`
- `git diff --check`

Release Notes:

- Fixed syntax highlighting in Markdown Preview not applying to nested languages, such as CSS inside HTML code blocks
