### PR TITLE
Fix indentations for expressions in C/C++

### DIFF
--- a/crates/grammars/src/c/indents.scm
+++ b/crates/grammars/src/c/indents.scm
@@ -9,6 +9,10 @@
   (else_clause)
 ] @indent
 
+(expression_statement
+  (_) @indent
+  ";" @end)
+
 (_
   "{"
   "}" @end) @indent

--- a/crates/grammars/src/cpp/indents.scm
+++ b/crates/grammars/src/cpp/indents.scm
@@ -9,7 +9,6 @@
   (else_clause)
 ] @indent
 
-
 (expression_statement
   (_) @indent
   ";" @end)

--- a/crates/grammars/src/cpp/indents.scm
+++ b/crates/grammars/src/cpp/indents.scm
@@ -9,6 +9,11 @@
   (else_clause)
 ] @indent
 
+
+(expression_statement
+  (_) @indent
+  ";" @end)
+
 (_
   "{"
   "}" @end) @indent


### PR DESCRIPTION
Indentations are not correctly handled for expressions in C/C++. To fix this i have updated indents.scm for both C/C++, there could be more languages which have this problem but i have only noticed it in these languages. 

Current indentation behaviour:

https://github.com/user-attachments/assets/2804d3a6-2dde-484b-b1f4-0a867801bc0c

Expected indentation behaviour:

https://github.com/user-attachments/assets/b1ebe840-7391-4f5d-bfe0-87d413f5dfe2

Release Notes:

- Improved indentation for C/C++ to be more consistent.
