### PR TITLE
Change OpenAI compatible URL placeholder in edit prediction settings

### DIFF
--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -3,8 +3,9 @@ use crate::commit::get_messages;
 use crate::repository::{GitBinary, RepoPath};
 use anyhow::{Context as _, Result};
 use collections::{HashMap, HashSet};
-use futures::AsyncWriteExt;
+use futures::{AsyncWriteExt, try_join};
 use serde::{Deserialize, Serialize};
+use smol::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
 use std::ops::Range;
 use text::{LineEnding, Rope};
 use time::OffsetDateTime;
@@ -25,9 +26,7 @@ impl Blame {
         content: &Rope,
         line_ending: LineEnding,
     ) -> Result<Self> {
-        let output = run_git_blame(git, path, content, line_ending).await?;
-        let mut entries = parse_git_blame(&output)?;
-        entries.sort_unstable_by_key(|entry| entry.range.start);
+        let mut entries = run_git_blame(git, path, content, line_ending).await?;
 
         let mut unique_shas = HashSet::default();
 
@@ -40,19 +39,21 @@ impl Blame {
             .await
             .context("failed to get commit messages")?;
 
+        entries.sort_unstable_by_key(|entry| entry.range.start);
         Ok(Self { entries, messages })
     }
 }
 
 const GIT_BLAME_NO_COMMIT_ERROR: &str = "fatal: no such ref: HEAD";
 const GIT_BLAME_NO_PATH: &str = "fatal: no such path";
+const BLAME_PARSE_YIELD_INTERVAL: usize = 512;
 
 async fn run_git_blame(
     git: &GitBinary,
     path: &RepoPath,
     contents: &Rope,
     line_ending: LineEnding,
-) -> Result<String> {
+) -> Result<Vec<BlameEntry>> {
     let mut child = {
         let span = ztracing::debug_span!("spawning git-blame command", path = path.as_unix_str());
         let _enter = span.enter();
@@ -66,28 +67,82 @@ async fn run_git_blame(
             .context("starting git blame process")?
     };
 
-    let stdin = child
+    let mut stdin = child
         .stdin
-        .as_mut()
+        .take()
         .context("failed to get pipe to stdin of git blame command")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("failed to get stdout from git blame command")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("failed to get stderr from git blame command")?;
 
-    for chunk in text::chunks_with_line_ending(contents, line_ending) {
-        stdin.write_all(chunk.as_bytes()).await?;
-    }
-    stdin.flush().await?;
+    let write_stdin = async move {
+        for chunk in text::chunks_with_line_ending(contents, line_ending) {
+            stdin.write_all(chunk.as_bytes()).await?;
+        }
+        stdin.flush().await.map_err(Into::into)
+    };
 
-    let output = child.output().await.context("reading git blame output")?;
+    let read_stdout = async move {
+        let mut parser = GitBlameParser::new();
+        let mut reader = BufReader::new(stdout);
+        let mut line_buffer = String::new();
+        let mut lines_read = 0;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        loop {
+            line_buffer.clear();
+            let bytes_read = reader
+                .read_line(&mut line_buffer)
+                .await
+                .context("reading git blame stdout")?;
+            if bytes_read == 0 {
+                break;
+            }
+
+            let line = line_buffer.trim_end_matches(&['\r', '\n'][..]);
+            parser.push_line(line)?;
+            lines_read += 1;
+
+            if lines_read % BLAME_PARSE_YIELD_INTERVAL == 0 {
+                smol::future::yield_now().await;
+            }
+        }
+
+        Ok(parser.entries)
+    };
+
+    let read_stderr = async move {
+        let mut stderr_output = String::new();
+        BufReader::new(stderr)
+            .read_to_string(&mut stderr_output)
+            .await
+            .context("reading git blame stderr")?;
+        Result::<String>::Ok(stderr_output)
+    };
+
+    let wait_for_status = async {
+        child
+            .status()
+            .await
+            .context("waiting for git blame process")
+    };
+
+    let ((), entries, stderr, status) =
+        try_join!(write_stdin, read_stdout, read_stderr, wait_for_status)?;
+
+    if !status.success() {
         let trimmed = stderr.trim();
         if trimmed == GIT_BLAME_NO_COMMIT_ERROR || trimmed.contains(GIT_BLAME_NO_PATH) {
-            return Ok(String::new());
+            return Ok(Vec::new());
         }
         anyhow::bail!("git blame process failed: {stderr}");
     }
 
-    Ok(String::from_utf8(output.stdout)?)
+    Ok(entries)
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -177,7 +232,7 @@ impl BlameEntry {
     }
 }
 
-// parse_git_blame parses the output of `git blame --incremental`, which returns
+// GitBlameParser parses the output of `git blame --incremental`, which returns
 // all the blame-entries for a given path incrementally, as it finds them.
 //
 // Each entry *always* starts with:
@@ -213,22 +268,32 @@ impl BlameEntry {
 //    filename index.js
 //
 // More about `--incremental` output: https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-blame.html
-fn parse_git_blame(output: &str) -> Result<Vec<BlameEntry>> {
-    let mut entries: Vec<BlameEntry> = Vec::new();
-    let mut index: HashMap<Oid, usize> = HashMap::default();
+struct GitBlameParser {
+    entries: Vec<BlameEntry>,
+    index: HashMap<Oid, usize>,
+    current_entry: Option<BlameEntry>,
+}
 
-    let mut current_entry: Option<BlameEntry> = None;
+impl GitBlameParser {
+    fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            index: HashMap::default(),
+            current_entry: None,
+        }
+    }
 
-    for line in output.lines() {
+    fn push_line(&mut self, line: &str) -> Result<()> {
         let mut done = false;
 
-        match &mut current_entry {
+        match &mut self.current_entry {
             None => {
                 let mut new_entry = BlameEntry::new_from_blame_line(line)?;
 
-                if let Some(existing_entry) = index
+                if let Some(existing_entry) = self
+                    .index
                     .get(&new_entry.sha)
-                    .and_then(|slot| entries.get(*slot))
+                    .and_then(|slot| self.entries.get(*slot))
                 {
                     new_entry.author.clone_from(&existing_entry.author);
                     new_entry
@@ -249,11 +314,11 @@ fn parse_git_blame(output: &str) -> Result<Vec<BlameEntry>> {
                     new_entry.summary.clone_from(&existing_entry.summary);
                 }
 
-                current_entry.replace(new_entry);
+                self.current_entry.replace(new_entry);
             }
             Some(entry) => {
                 let Some((key, value)) = line.split_once(' ') else {
-                    continue;
+                    return Ok(());
                 };
                 let is_committed = !entry.sha.is_zero();
                 match key {
@@ -282,25 +347,44 @@ fn parse_git_blame(output: &str) -> Result<Vec<BlameEntry>> {
             }
         };
 
-        if done && let Some(entry) = current_entry.take() {
-            index.insert(entry.sha, entries.len());
-
-            // We only want annotations that have a commit.
-            if !entry.sha.is_zero() {
-                entries.push(entry);
-            }
+        if done {
+            self.push_current_entry();
         }
+
+        Ok(())
     }
 
-    Ok(entries)
+    fn push_current_entry(&mut self) {
+        let Some(entry) = self.current_entry.take() else {
+            return;
+        };
+
+        self.index.insert(entry.sha, self.entries.len());
+
+        // We only want annotations that have a commit.
+        if !entry.sha.is_zero() {
+            self.entries.push(entry);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
+    use crate::blame::GitBlameParser;
+
     use super::BlameEntry;
-    use super::parse_git_blame;
+
+    fn parse_git_blame(output: &str) -> anyhow::Result<Vec<BlameEntry>> {
+        let mut parser = GitBlameParser::new();
+
+        for line in output.lines() {
+            parser.push_line(line)?;
+        }
+
+        Ok(parser.entries)
+    }
 
     fn read_test_data(filename: &str) -> String {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/crates/opencode/src/opencode.rs
+++ b/crates/opencode/src/opencode.rs
@@ -141,18 +141,24 @@ pub enum Model {
     KimiK2_6,
     #[serde(rename = "minimax-m2.7")]
     MiniMaxM2_7,
+    #[serde(rename = "minimax-m3")]
+    MiniMaxM3,
+    #[serde(rename = "minimax-m3-free")]
+    MiniMaxM3Free,
     #[serde(rename = "mimo-v2.5-pro")]
     MimoV2_5Pro,
     #[serde(rename = "mimo-v2.5")]
     MimoV2_5,
     #[serde(rename = "big-pickle")]
     BigPickle,
-    #[serde(rename = "nemotron-3-super-free")]
-    Nemotron3SuperFree,
+    #[serde(rename = "nemotron-3-ultra-free")]
+    Nemotron3UltraFree,
     #[serde(rename = "qwen3.5-plus")]
     Qwen3_5Plus,
     #[serde(rename = "qwen3.6-plus")]
     Qwen3_6Plus,
+    #[serde(rename = "qwen3.7-plus")]
+    Qwen3_7Plus,
     #[serde(rename = "qwen3.7-max")]
     Qwen3_7Max,
 
@@ -188,7 +194,7 @@ impl Model {
     }
 
     pub fn default_free_fast() -> Self {
-        Self::Nemotron3SuperFree
+        Self::Nemotron3UltraFree
     }
 
     pub fn available_subscriptions(&self) -> &'static [OpenCodeSubscription] {
@@ -199,19 +205,22 @@ impl Model {
             | Self::KimiK2_6
             | Self::KimiK2_5
             | Self::MiniMaxM2_5
-            | Self::Qwen3_5Plus
+            | Self::MiniMaxM2_7
+            | Self::DeepSeekV4Flash
             | Self::Qwen3_6Plus => &[OpenCodeSubscription::Zen, OpenCodeSubscription::Go],
 
             // Go-only models
-            Self::MiniMaxM2_7
-            | Self::MimoV2_5Pro
+            Self::MimoV2_5Pro
             | Self::MimoV2_5
             | Self::DeepSeekV4Pro
-            | Self::DeepSeekV4Flash
-            | Self::Qwen3_7Max => &[OpenCodeSubscription::Go],
+            | Self::Qwen3_7Plus
+            | Self::Qwen3_7Max
+            | Self::MiniMaxM3 => &[OpenCodeSubscription::Go],
 
             // Free models
-            Self::Nemotron3SuperFree | Self::BigPickle => &[OpenCodeSubscription::Free],
+            Self::Nemotron3UltraFree | Self::BigPickle | Self::MiniMaxM3Free => {
+                &[OpenCodeSubscription::Free]
+            }
 
             // Custom models get their subscription from settings, not from here
             Self::Custom { .. } => &[],
@@ -264,13 +273,16 @@ impl Model {
             Self::KimiK2_5 => "kimi-k2.5",
             Self::KimiK2_6 => "kimi-k2.6",
             Self::MiniMaxM2_7 => "minimax-m2.7",
+            Self::MiniMaxM3 => "minimax-m3",
             Self::MimoV2_5Pro => "mimo-v2.5-pro",
             Self::MimoV2_5 => "mimo-v2.5",
             Self::Qwen3_5Plus => "qwen3.5-plus",
             Self::Qwen3_6Plus => "qwen3.6-plus",
+            Self::Qwen3_7Plus => "qwen3.7-plus",
             Self::Qwen3_7Max => "qwen3.7-max",
             Self::BigPickle => "big-pickle",
-            Self::Nemotron3SuperFree => "nemotron-3-super-free",
+            Self::Nemotron3UltraFree => "nemotron-3-ultra-free",
+            Self::MiniMaxM3Free => "minimax-m3-free",
 
             Self::Custom { name, .. } => name,
         }
@@ -319,13 +331,16 @@ impl Model {
             Self::KimiK2_5 => "Kimi K2.5",
             Self::KimiK2_6 => "Kimi K2.6",
             Self::MiniMaxM2_7 => "MiniMax M2.7",
+            Self::MiniMaxM3 => "MiniMax M3",
             Self::MimoV2_5Pro => "MiMo V2.5 Pro",
             Self::MimoV2_5 => "MiMo V2.5",
             Self::Qwen3_5Plus => "Qwen3.5 Plus",
             Self::Qwen3_6Plus => "Qwen3.6 Plus",
+            Self::Qwen3_7Plus => "Qwen3.7 Plus",
             Self::Qwen3_7Max => "Qwen3.7 Max",
             Self::BigPickle => "Big Pickle",
-            Self::Nemotron3SuperFree => "Nemotron 3 Super Free",
+            Self::Nemotron3UltraFree => "Nemotron 3 Ultra Free",
+            Self::MiniMaxM3Free => "MiniMax M3 Free",
 
             Self::Custom {
                 name, display_name, ..
@@ -375,7 +390,9 @@ impl Model {
 
             Self::Gemini3_1Pro | Self::Gemini3Flash | Self::Gemini3_5Flash => ApiProtocol::Google,
 
-            Self::Qwen3_7Max => ApiProtocol::Anthropic,
+            Self::Qwen3_7Max | Self::Qwen3_7Plus => ApiProtocol::Anthropic,
+
+            Self::MiniMaxM3 | Self::MiniMaxM3Free => ApiProtocol::Anthropic,
 
             Self::Glm5
             | Self::Glm5_1
@@ -389,7 +406,7 @@ impl Model {
             | Self::DeepSeekV4Pro
             | Self::DeepSeekV4Flash
             | Self::BigPickle
-            | Self::Nemotron3SuperFree => ApiProtocol::OpenAiChat,
+            | Self::Nemotron3UltraFree => ApiProtocol::OpenAiChat,
 
             Self::Custom { protocol, .. } => *protocol,
         }
@@ -405,7 +422,9 @@ impl Model {
             | Self::MimoV2_5Pro
             | Self::Glm5
             | Self::Glm5_1
-            | Self::Nemotron3SuperFree
+            | Self::MiniMaxM2_5
+            | Self::MiniMaxM2_7
+            | Self::Nemotron3UltraFree
             | Self::BigPickle => true,
 
             Self::Custom {
@@ -446,6 +465,8 @@ impl Model {
 
             // OpenAI-compatible models
             Self::MiniMaxM2_7 => 204_800,
+            Self::MiniMaxM3 => 512_000,
+            Self::MiniMaxM3Free => 200_000,
             Self::MiniMaxM2_5 => 204_800,
             Self::Glm5 | Self::Glm5_1 => {
                 if subscription == OpenCodeSubscription::Go {
@@ -458,10 +479,17 @@ impl Model {
             Self::GrokBuild0_1 => 256_000,
             Self::MimoV2_5Pro => 1_048_576,
             Self::MimoV2_5 => 1_000_000,
-            Self::Qwen3_5Plus | Self::Qwen3_6Plus => 262_144,
-            Self::Qwen3_7Max => 1_000_000,
+            Self::Qwen3_5Plus => 262_144,
+            Self::Qwen3_6Plus => {
+                if subscription == OpenCodeSubscription::Go {
+                    1_000_000
+                } else {
+                    262_144
+                }
+            }
+            Self::Qwen3_7Max | Self::Qwen3_7Plus => 1_000_000,
             Self::BigPickle => 200_000,
-            Self::Nemotron3SuperFree => 204_800,
+            Self::Nemotron3UltraFree => 1_000_000,
             Self::DeepSeekV4Pro | Self::DeepSeekV4Flash => 1_000_000,
 
             Self::Custom { max_tokens, .. } => *max_tokens,
@@ -503,6 +531,8 @@ impl Model {
 
             // OpenAI-compatible models
             Self::MiniMaxM2_7 => Some(131_072),
+            Self::MiniMaxM3 => Some(131_072),
+            Self::MiniMaxM3Free => Some(32_000),
             Self::MiniMaxM2_5 => {
                 if subscription == OpenCodeSubscription::Go {
                     Some(65_536)
@@ -520,9 +550,11 @@ impl Model {
             Self::BigPickle => Some(32_000),
             Self::KimiK2_6 | Self::KimiK2_5 => Some(65_536),
             Self::GrokBuild0_1 => Some(256_000),
-            Self::Qwen3_7Max | Self::Qwen3_6Plus | Self::Qwen3_5Plus => Some(65_536),
+            Self::Qwen3_7Max | Self::Qwen3_7Plus | Self::Qwen3_6Plus | Self::Qwen3_5Plus => {
+                Some(65_536)
+            }
             Self::DeepSeekV4Pro | Self::DeepSeekV4Flash => Some(384_000),
-            Self::Nemotron3SuperFree => Some(128_000),
+            Self::Nemotron3UltraFree => Some(128_000),
             Self::MimoV2_5Pro | Self::MimoV2_5 => Some(128_000),
 
             Self::Custom {
@@ -578,7 +610,10 @@ impl Model {
             | Self::GrokBuild0_1
             | Self::MimoV2_5
             | Self::Qwen3_5Plus
-            | Self::Qwen3_6Plus => true,
+            | Self::Qwen3_6Plus
+            | Self::Qwen3_7Plus
+            | Self::MiniMaxM3
+            | Self::MiniMaxM3Free => true,
 
             // OpenAI-compatible models without image support
             Self::MiniMaxM2_5
@@ -590,7 +625,7 @@ impl Model {
             | Self::DeepSeekV4Flash
             | Self::Qwen3_7Max
             | Self::BigPickle
-            | Self::Nemotron3SuperFree => false,
+            | Self::Nemotron3UltraFree => false,
 
             Self::Custom { protocol, .. } => matches!(
                 protocol,
@@ -611,7 +646,7 @@ impl Model {
                 ReasoningEffort::XHigh,
             ]),
 
-            Self::MimoV2_5Pro | Self::MimoV2_5 => Some(vec![
+            Self::Nemotron3UltraFree | Self::MimoV2_5Pro | Self::MimoV2_5 => Some(vec![
                 ReasoningEffort::Low,
                 ReasoningEffort::Medium,
                 ReasoningEffort::High,

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -15,6 +15,9 @@ use workspace::AppState;
 const OLLAMA_API_URL_PLACEHOLDER: &str = "http://localhost:11434";
 const OLLAMA_MODEL_PLACEHOLDER: &str = "qwen2.5-coder:3b-base";
 
+const OPENAI_COMPATIBLE_API_URL_PLACEHOLDER: &str = "http://localhost:11434/v1/completions";
+const OPENAI_COMPATIBLE_MODEL_PLACEHOLDER: &str = "qwen2.5-coder:3b-base";
+
 use crate::{
     SettingField, SettingItem, SettingsFieldMetadata, SettingsPageItem, SettingsWindow, USER,
     components::{SettingsInputField, SettingsSectionHeader},
@@ -522,7 +525,7 @@ fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
                 json_path: Some("edit_predictions.open_ai_compatible_api.api_url"),
             }),
             metadata: Some(Box::new(SettingsFieldMetadata {
-                placeholder: Some(OLLAMA_API_URL_PLACEHOLDER),
+                placeholder: Some(OPENAI_COMPATIBLE_API_URL_PLACEHOLDER),
                 ..Default::default()
             })),
             files: USER,
@@ -556,7 +559,7 @@ fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
                 json_path: Some("edit_predictions.open_ai_compatible_api.model"),
             }),
             metadata: Some(Box::new(SettingsFieldMetadata {
-                placeholder: Some(OLLAMA_MODEL_PLACEHOLDER),
+                placeholder: Some(OPENAI_COMPATIBLE_MODEL_PLACEHOLDER),
                 ..Default::default()
             })),
             files: USER,

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -15,7 +15,7 @@ use workspace::AppState;
 const OLLAMA_API_URL_PLACEHOLDER: &str = "http://localhost:11434";
 const OLLAMA_MODEL_PLACEHOLDER: &str = "qwen2.5-coder:3b-base";
 
-const OPENAI_COMPATIBLE_API_URL_PLACEHOLDER: &str = "http://localhost:11434/v1/completions";
+const OPENAI_COMPATIBLE_API_URL_PLACEHOLDER: &str = "http://localhost:8080/v1/completions";
 const OPENAI_COMPATIBLE_MODEL_PLACEHOLDER: &str = "qwen2.5-coder:3b-base";
 
 use crate::{


### PR DESCRIPTION
Change the url placeholder from http://localhost:11434 to http://localhost:8080/v1/completions to match the URL endpoint in the [docs](https://zed.dev/docs/ai/edit-prediction)
```json
{
  "edit_predictions": {
    "provider": "open_ai_compatible_api",
    "open_ai_compatible_api": {
      "api_url": "http://localhost:8080/v1/completions",
      "model": "deepseek-coder-6.7b-base",
      "prompt_format": "deepseek_coder",
      "max_output_tokens": 512
    }
  }
}
```
Note: http://localhost:8080/v1/completions/ with an extra / does not work.


Added the constants OPENAI_COMPATIBLE_API_URL_PLACEHOLDER and OPENAI_COMPATIBLE_MODEL_PLACEHOLDER.
I am not so sure about the standard prefixes for these variable names. The function name is open_ai_compatible_settings() but I used OPENAI_COMPATIBLE.

### Initial Issue
I noticed that using http://localhost:8080 doesn't work with llama.cpp. Giving errors like this from (zed: open log):
```
2026-06-06T17:55:39+01:00 ERROR [crates/edit_prediction/src/edit_prediction.rs:2464] custom server error: 404 Not Found - {"error":{"message":"File Not Found","type":"not_found_error","code":404}}
```
After reading the docs above, I found out that I had to add /v1/completions to the end. 

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [  ] Unsafe blocks (if any) have justifying comments
- [  ] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [  ] Tests cover the new/changed behavior
- [  ] Performance impact has been considered and is acceptable

Release Notes:
- N/A
