### PR TITLE
Even more .sort_unstable() + dedup_by()

### DIFF
--- a/crates/edit_prediction_context/src/edit_prediction_context.rs
+++ b/crates/edit_prediction_context/src/edit_prediction_context.rs
@@ -650,7 +650,7 @@ fn identifiers_for_position(
         }
     }
 
-    ranges.sort_by(|a, b| a.start.cmp(&b.start).then(b.end.cmp(&a.end)));
+    ranges.sort_unstable_by(|a, b| a.start.cmp(&b.start).then(b.end.cmp(&a.end)));
     ranges.dedup_by(|a, b| {
         if a.start <= b.end {
             b.start = b.start.min(a.start);

--- a/crates/editor/src/bookmarks.rs
+++ b/crates/editor/src/bookmarks.rs
@@ -38,7 +38,7 @@ impl Editor {
         let multi_buffer_snapshot = snapshot.buffer_snapshot();
 
         let mut selections = self.selections.all::<Point>(&snapshot.display_snapshot);
-        selections.sort_by_key(|s| s.head());
+        selections.sort_unstable_by_key(|s| s.head());
         selections.dedup_by_key(|s| s.head().row);
 
         for selection in &selections {

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -620,7 +620,7 @@ pub fn parse_numstat(output: &str) -> GitDiffStat {
         };
         entries.push((path, DiffStat { added, deleted }));
     }
-    entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+    entries.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
     entries.dedup_by(|(a, _), (b, _)| a == b);
 
     GitDiffStat {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -4861,7 +4861,7 @@ impl BufferSnapshot {
                 })
                 .collect::<Vec<_>>();
 
-            opens.sort_by_key(|r| (r.start, r.end));
+            opens.sort_unstable_by_key(|r| (r.start, r.end));
             opens.dedup_by(|a, b| a.start == b.start && a.end == b.end);
             color_pairs.sort_by_key(|(_, close, _)| close.end);
 

--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -439,7 +439,7 @@ impl LspLogView {
                     }),
             )
             .collect::<Vec<_>>();
-        rows.sort_by_key(|row| row.server_id);
+        rows.sort_unstable_by_key(|row| row.server_id);
         rows.dedup_by_key(|row| row.server_id);
         Some(rows)
     }

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -42,7 +42,7 @@ fn migrate(text: &str, patterns: MigrationPatterns, query: &Query) -> Result<Opt
         }
     }
 
-    edits.sort_by_key(|(range, _)| (range.start, Reverse(range.end)));
+    edits.sort_unstable_by_key(|(range, _)| (range.start, Reverse(range.end)));
     edits.dedup_by(|(range_b, _), (range_a, _)| {
         range_a.contains(&range_b.start) || range_a.contains(&range_b.end)
     });

--- a/crates/text/src/operation_queue.rs
+++ b/crates/text/src/operation_queue.rs
@@ -47,7 +47,7 @@ impl<T: Operation> OperationQueue<T> {
     }
 
     pub fn insert(&mut self, mut ops: Vec<T>) {
-        ops.sort_by_key(|op| op.lamport_timestamp());
+        ops.sort_unstable_by_key(|op| op.lamport_timestamp());
         ops.dedup_by_key(|op| op.lamport_timestamp());
         self.0.edit(
             ops.into_iter()


### PR DESCRIPTION
Momentarily turned into a draft as I examine the soundness of this transform.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Sibling PR to https://github.com/zed-industries/zed/pull/58751, since I just learned today of `.dedup_by()` and `.dedup_by_key()`.

Release Notes:

- N/A
