### PR TITLE
auto_update: Offload update installation to background thread

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -720,8 +720,10 @@ impl AutoUpdater {
         });
 
         let install_result = if cfg!(test) {
-            match cx.try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone())
-            .map(|test_install| test_install(target_path, cx)) {
+            match cx
+                .try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone())
+                .map(|test_install| test_install(target_path, cx))
+            {
                 Some(result) => result,
                 None => return Ok(()),
             }
@@ -836,7 +838,6 @@ impl AutoUpdater {
 
         Ok(installer_dir.path().join(filename))
     }
-
 
     async fn install_release(
         installer_dir: InstallerDir,

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -719,15 +719,17 @@ impl AutoUpdater {
             cx.notify();
         });
 
-        let install_result = if cfg!(test) {
-            match cx
-                .try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone())
-                .map(|test_install| test_install(target_path, cx))
-            {
-                Some(result) => result,
-                None => return Ok(()),
-            }
-        } else {
+        #[cfg(test)]
+        let install_result = match cx
+            .try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone())
+            .map(|test_install| test_install(&target_path, cx))
+        {
+            Some(result) => result,
+            None => return Ok(()),
+        };
+
+        #[cfg(not(test))]
+        let install_result = {
             let running_app_path = cx.update(|cx| cx.app_path())?;
             let background_executor = cx.background_executor().clone();
             let channel = cx.update(|cx| ReleaseChannel::global(cx).dev_name());
@@ -839,6 +841,7 @@ impl AutoUpdater {
         Ok(installer_dir.path().join(filename))
     }
 
+    #[cfg_attr(test, allow(dead_code))]
     async fn install_release(
         installer_dir: InstallerDir,
         target_path: PathBuf,

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -719,8 +719,12 @@ impl AutoUpdater {
             cx.notify();
         });
 
-        let install_result = if let Some(result) = Self::test_install(&target_path, cx) {
-            result
+        let install_result = if cfg!(test) {
+            match cx.try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone())
+            .map(|test_install| test_install(target_path, cx)) {
+                Some(result) => result,
+                None => return Ok(()),
+            }
         } else {
             let running_app_path = cx.update(|cx| cx.app_path())?;
             let background_executor = cx.background_executor().clone();

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -719,8 +719,20 @@ impl AutoUpdater {
             cx.notify();
         });
 
-        let new_binary_path = Self::install_release(installer_dir, &target_path, cx)
-            .await
+        let running_app_path = cx.update(|cx| cx.app_path())?;
+        let background_executor = cx.background_executor();
+        let channel = cx.update(|cx| ReleaseChannel::global(cx).dev_name());
+        let install_result = {
+            #[cfg(test)]
+            if let Some(test_install) = cx.try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone()) {
+                test_install(&target_path, cx)
+            } else {
+                Self::install_release(installer_dir, &target_path, running_app_path, channel, background_executor).await
+            }
+            #[cfg(not(test))]
+            Self::install_release(installer_dir, &target_path, running_app_path, channel, background_executor).await
+        };
+        let new_binary_path = install_result
             .with_context(|| format!("Failed to install update at: {}", target_path.display()))?;
         if let Some(new_binary_path) = new_binary_path {
             cx.update(|cx| cx.set_restart_path(new_binary_path));
@@ -822,25 +834,13 @@ impl AutoUpdater {
     async fn install_release(
         installer_dir: InstallerDir,
         target_path: &Path,
-        cx: &AsyncApp,
+        running_app_path: PathBuf,
+        channel: &str,
+        background_executor: &BackgroundExecutor,
     ) -> Result<Option<PathBuf>> {
-        #[cfg(test)]
-        if let Some(test_install) =
-            cx.try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone())
-        {
-            return test_install(target_path, cx);
-        }
         match OS {
-            "macos" => {
-                let running_app_path = cx.update(|cx| cx.app_path())?;
-                let background_executor = cx.background_executor();
-                install_release_macos(&installer_dir, target_path, running_app_path, background_executor).await
-            },
-            "linux" => {
-                let channel = cx.update(|cx| ReleaseChannel::global(cx).dev_name());
-                let running_app_path = cx.update(|cx| cx.app_path())?;
-                install_release_linux(&installer_dir, target_path, channel, running_app_path).await
-            },
+            "macos" => install_release_macos(&installer_dir, target_path, running_app_path, background_executor).await,
+            "linux" => install_release_linux(&installer_dir, target_path, channel, running_app_path).await,
             "windows" => install_release_windows(target_path).await,
             unsupported_os => anyhow::bail!("not supported: {unsupported_os}"),
         }

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -837,16 +837,6 @@ impl AutoUpdater {
         Ok(installer_dir.path().join(filename))
     }
 
-    #[cfg(test)]
-    fn test_install(target_path: &Path, cx: &AsyncApp) -> Option<Result<Option<PathBuf>>> {
-        cx.try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone())
-            .map(|test_install| test_install(target_path, cx))
-    }
-
-    #[cfg(not(test))]
-    fn test_install(_target_path: &Path, _cx: &AsyncApp) -> Option<Result<Option<PathBuf>>> {
-        None
-    }
 
     async fn install_release(
         installer_dir: InstallerDir,

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -831,8 +831,16 @@ impl AutoUpdater {
             return test_install(target_path, cx);
         }
         match OS {
-            "macos" => install_release_macos(&installer_dir, target_path, cx).await,
-            "linux" => install_release_linux(&installer_dir, target_path, cx).await,
+            "macos" => {
+                let running_app_path = cx.update(|cx| cx.app_path())?;
+                let background_executor = cx.background_executor();
+                install_release_macos(&installer_dir, target_path, running_app_path, background_executor).await
+            },
+            "linux" => {
+                let channel = cx.update(|cx| ReleaseChannel::global(cx).dev_name());
+                let running_app_path = cx.update(|cx| cx.app_path())?;
+                install_release_linux(&installer_dir, target_path, channel, running_app_path).await
+            },
             "windows" => install_release_windows(target_path).await,
             unsupported_os => anyhow::bail!("not supported: {unsupported_os}"),
         }
@@ -978,11 +986,10 @@ async fn download_release(
 async fn install_release_linux(
     temp_dir: &InstallerDir,
     downloaded_tar_gz: &Path,
-    cx: &AsyncApp,
+    channel: &str,
+    running_app_path: PathBuf,
 ) -> Result<Option<PathBuf>> {
-    let channel = cx.update(|cx| ReleaseChannel::global(cx).dev_name());
     let home_dir = PathBuf::from(env::var("HOME").context("no HOME env var set")?);
-    let running_app_path = cx.update(|cx| cx.app_path())?;
 
     let extracted = temp_dir.path().join("zed");
     fs::create_dir_all(&extracted)
@@ -1047,9 +1054,9 @@ async fn install_release_linux(
 async fn install_release_macos(
     temp_dir: &InstallerDir,
     downloaded_dmg: &Path,
-    cx: &AsyncApp,
+    running_app_path: PathBuf,
+    background_executor: &BackgroundExecutor
 ) -> Result<Option<PathBuf>> {
-    let running_app_path = cx.update(|cx| cx.app_path())?;
     let running_app_filename = running_app_path
         .file_name()
         .with_context(|| format!("invalid running app path {running_app_path:?}"))?;
@@ -1077,7 +1084,7 @@ async fn install_release_macos(
     // Create an MacOsUnmounter that will be dropped (and thus unmount the disk) when this function exits
     let _unmounter = MacOsUnmounter {
         mount_path: mount_path.clone(),
-        background_executor: cx.background_executor(),
+        background_executor
     };
 
     let mut cmd = new_command("rsync");

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -720,17 +720,33 @@ impl AutoUpdater {
         });
 
         let running_app_path = cx.update(|cx| cx.app_path())?;
-        let background_executor = cx.background_executor();
+        let background_executor = cx.background_executor().clone();
         let channel = cx.update(|cx| ReleaseChannel::global(cx).dev_name());
         let install_result = {
             #[cfg(test)]
-            if let Some(test_install) = cx.try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone()) {
+            if let Some(test_install) =
+                cx.try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone())
+            {
                 test_install(&target_path, cx)
             } else {
-                Self::install_release(installer_dir, &target_path, running_app_path, channel, background_executor).await
+                cx.background_spawn(Self::install_release(
+                    installer_dir,
+                    target_path.clone(),
+                    running_app_path,
+                    channel,
+                    background_executor,
+                ))
+                .await
             }
             #[cfg(not(test))]
-            Self::install_release(installer_dir, &target_path, running_app_path, channel, background_executor).await
+            cx.background_spawn(Self::install_release(
+                installer_dir,
+                target_path.clone(),
+                running_app_path,
+                channel,
+                background_executor,
+            ))
+            .await
         };
         let new_binary_path = install_result
             .with_context(|| format!("Failed to install update at: {}", target_path.display()))?;
@@ -833,15 +849,25 @@ impl AutoUpdater {
 
     async fn install_release(
         installer_dir: InstallerDir,
-        target_path: &Path,
+        target_path: PathBuf,
         running_app_path: PathBuf,
         channel: &str,
-        background_executor: &BackgroundExecutor,
+        background_executor: BackgroundExecutor,
     ) -> Result<Option<PathBuf>> {
         match OS {
-            "macos" => install_release_macos(&installer_dir, target_path, running_app_path, background_executor).await,
-            "linux" => install_release_linux(&installer_dir, target_path, channel, running_app_path).await,
-            "windows" => install_release_windows(target_path).await,
+            "macos" => {
+                install_release_macos(
+                    &installer_dir,
+                    &target_path,
+                    running_app_path,
+                    &background_executor,
+                )
+                .await
+            }
+            "linux" => {
+                install_release_linux(&installer_dir, &target_path, channel, running_app_path).await
+            }
+            "windows" => install_release_windows(&target_path).await,
             unsupported_os => anyhow::bail!("not supported: {unsupported_os}"),
         }
     }
@@ -1055,7 +1081,7 @@ async fn install_release_macos(
     temp_dir: &InstallerDir,
     downloaded_dmg: &Path,
     running_app_path: PathBuf,
-    background_executor: &BackgroundExecutor
+    background_executor: &BackgroundExecutor,
 ) -> Result<Option<PathBuf>> {
     let running_app_filename = running_app_path
         .file_name()
@@ -1084,7 +1110,7 @@ async fn install_release_macos(
     // Create an MacOsUnmounter that will be dropped (and thus unmount the disk) when this function exits
     let _unmounter = MacOsUnmounter {
         mount_path: mount_path.clone(),
-        background_executor
+        background_executor,
     };
 
     let mut cmd = new_command("rsync");

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -719,26 +719,12 @@ impl AutoUpdater {
             cx.notify();
         });
 
-        let running_app_path = cx.update(|cx| cx.app_path())?;
-        let background_executor = cx.background_executor().clone();
-        let channel = cx.update(|cx| ReleaseChannel::global(cx).dev_name());
-        let install_result = {
-            #[cfg(test)]
-            if let Some(test_install) =
-                cx.try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone())
-            {
-                test_install(&target_path, cx)
-            } else {
-                cx.background_spawn(Self::install_release(
-                    installer_dir,
-                    target_path.clone(),
-                    running_app_path,
-                    channel,
-                    background_executor,
-                ))
-                .await
-            }
-            #[cfg(not(test))]
+        let install_result = if let Some(result) = Self::test_install(&target_path, cx) {
+            result
+        } else {
+            let running_app_path = cx.update(|cx| cx.app_path())?;
+            let background_executor = cx.background_executor().clone();
+            let channel = cx.update(|cx| ReleaseChannel::global(cx).dev_name());
             cx.background_spawn(Self::install_release(
                 installer_dir,
                 target_path.clone(),
@@ -845,6 +831,17 @@ impl AutoUpdater {
         }?;
 
         Ok(installer_dir.path().join(filename))
+    }
+
+    #[cfg(test)]
+    fn test_install(target_path: &Path, cx: &AsyncApp) -> Option<Result<Option<PathBuf>>> {
+        cx.try_read_global::<tests::InstallOverride, _>(|g, _| g.0.clone())
+            .map(|test_install| test_install(target_path, cx))
+    }
+
+    #[cfg(not(test))]
+    fn test_install(_target_path: &Path, _cx: &AsyncApp) -> Option<Result<Option<PathBuf>>> {
+        None
     }
 
     async fn install_release(


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #55279

When auto-updating, Zed first downloads the update and then performs the installation. On each platform, this installation phase runs external commands that spawn new processes. These operations can block the thread they run on—especially under heavy system load or when security/antivirus software is active. (An analysis of the blockages on Windows is documented in https://github.com/zed-industries/zed/issues/55279#issuecomment-4638072228). 

This PR moves the installation process to a background thread. This ensures that even if process spawning block, the main UI thread remains responsive.

Release Notes:

- Fixed a UI freeze that could occur when installing auto-updates.
