### PR TITLE
Fix Deno test task example quoting

### DIFF
--- a/docs/src/languages/deno.md
+++ b/docs/src/languages/deno.md
@@ -122,7 +122,7 @@ To run deno tasks like tests from the ui, add this to `.zed/tasks.json`
 [
   {
     "label": "deno test",
-    "command": "deno test -A '$ZED_FILE'",
+    "command": "deno test -A $ZED_FILE",
     "tags": ["js-test"]
   }
 ]


### PR DESCRIPTION
Updates the Deno runnable support docs so the copied test task uses `$ZED_FILE` without nested single quotes. With the old example, Zed's task shell wrapper could produce a command with conflicting quotes and fail when running `deno test`.

Testing:

- `pnpm dlx prettier@3.5.0 docs/src/languages/deno.md --check`
- `git diff --check`

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #58072

Release Notes:

- N/A
