### PR TITLE
Add MCP step-up authorization flow part 1/2

### DIFF
--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -262,7 +262,8 @@ impl ContextServerRegistry {
             ContextServerStatus::Stopped
             | ContextServerStatus::Error(_)
             | ContextServerStatus::AuthRequired
-            | ContextServerStatus::ClientSecretRequired { .. } => {
+            | ContextServerStatus::ClientSecretRequired { .. }
+            | ContextServerStatus::InsufficientScope => {
                 if let Some(registered_server) = self.registered_servers.remove(server_id) {
                     if !registered_server.tools.is_empty() {
                         cx.emit(ContextServerRegistryEvent::ToolsChanged);

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -695,6 +695,7 @@ impl AgentConfiguration {
                 AiSettingItemStatus::ClientSecretRequired
             }
             ContextServerStatus::Authenticating => AiSettingItemStatus::Authenticating,
+            ContextServerStatus::InsufficientScope => AiSettingItemStatus::InsufficientScope,
         };
 
         let is_remote = server_configuration

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -463,6 +463,7 @@ impl ConfigureContextServerModal {
             Some(ContextServerStatus::Starting)
             | Some(ContextServerStatus::Running)
             | Some(ContextServerStatus::Stopped)
+            | Some(ContextServerStatus::InsufficientScope)
             | None => State::Idle,
         }
     }
@@ -765,7 +766,8 @@ impl ConfigureContextServerModal {
                     }
                     ContextServerStatus::Authenticating
                     | ContextServerStatus::Starting
-                    | ContextServerStatus::Stopped => {}
+                    | ContextServerStatus::Stopped
+                    | ContextServerStatus::InsufficientScope => {}
                 }
             },
         ));
@@ -1316,7 +1318,9 @@ fn wait_for_context_server(
                     let _ = tx.send(Err(error.clone()));
                 }
             }
-            ContextServerStatus::Starting | ContextServerStatus::Authenticating => {}
+            ContextServerStatus::Starting
+            | ContextServerStatus::Authenticating
+            | ContextServerStatus::InsufficientScope => {}
         }
     });
 

--- a/crates/context_server/src/transport/http.rs
+++ b/crates/context_server/src/transport/http.rs
@@ -18,6 +18,8 @@ pub enum TransportError {
     /// The server returned 401 and token refresh either wasn't possible or
     /// failed. The caller should initiate the OAuth authorization flow.
     AuthRequired { www_authenticate: WwwAuthenticate },
+    /// The server returned 403 and there are insufficient scopes for this request.
+    InsufficientScope { www_authenticate: WwwAuthenticate },
 }
 
 impl std::fmt::Display for TransportError {
@@ -25,6 +27,9 @@ impl std::fmt::Display for TransportError {
         match self {
             TransportError::AuthRequired { .. } => {
                 write!(f, "OAuth authorization required")
+            }
+            TransportError::InsufficientScope { .. } => {
+                write!(f, "Scope Permission Required")
             }
         }
     }
@@ -149,9 +154,10 @@ impl HttpTransport {
 
         let request = self.build_request(message.as_bytes())?;
         let mut response = self.http_client.send(request).await?;
+        let status = response.status().as_u16();
 
         // On 401, try refreshing the token and retry once.
-        if response.status().as_u16() == 401 {
+        if status == 401 || status == 403 {
             let www_auth_header = response
                 .headers()
                 .get("www-authenticate")
@@ -165,6 +171,15 @@ impl HttpTransport {
                     error: None,
                     error_description: None,
                 });
+
+            if status == 403 {
+                let required_scopes = www_authenticate.scope.clone().unwrap_or_default();
+                log::warn!(
+                    "Server returned 403 Forbidden. Authorization header lacks the required scopes for this server. Required Scopes {:?}",
+                    required_scopes
+                );
+                return Err(TransportError::InsufficientScope { www_authenticate }.into());
+            }
 
             if let Some(ref provider) = self.token_provider {
                 if provider.try_refresh().await.unwrap_or(false) {
@@ -709,6 +724,11 @@ mod tests {
                     Some(vec!["read".to_string(), "write".to_string()]),
                 );
             }
+            TransportError::InsufficientScope { .. } => {
+                panic!(
+                    "Expected TransportError::AuthRequired, got TransportError::InsufficientScope"
+                );
+            }
         }
         assert_eq!(provider.refresh_count(), 1);
     }
@@ -746,6 +766,11 @@ mod tests {
                 assert!(www_authenticate.resource_metadata.is_none());
                 assert!(www_authenticate.scope.is_none());
             }
+            TransportError::InsufficientScope { .. } => {
+                panic!(
+                    "Expected TransportError::AuthRequired, got TransportError::InsufficientScope"
+                );
+            }
         }
     }
 
@@ -782,5 +807,68 @@ mod tests {
             .expect("error should be TransportError");
         // Refresh was attempted exactly once.
         assert_eq!(provider.refresh_count(), 1);
+    }
+
+    #[gpui::test]
+    async fn test_403_returns_insufficient_scope_successfully(cx: &mut TestAppContext) {
+        let client = make_fake_http_client(|_req| {
+            Box::pin(async {
+                Ok(Response::builder()
+                    .status(403)
+                    .header(
+                        "WWW-Authenticate",
+                        r#"Bearer error="insufficient_scope", scope="files:read files:write user:profile", resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource", error_description="Additional file write permission required""#,
+                    )
+                    .body(AsyncBody::from(b"Forbidden".to_vec()))
+                    .unwrap())
+            })
+        });
+
+        let provider = FakeTokenProvider::new(Some("token"), true);
+        let transport = HttpTransport::new_with_token_provider(
+            client,
+            "http://mcp.example.com/mcp".to_string(),
+            HashMap::default(),
+            cx.background_executor.clone(),
+            Some(provider.clone()),
+        );
+
+        let err = transport
+            .send(r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#.to_string())
+            .await
+            .unwrap_err();
+
+        let transport_err = err
+            .downcast_ref::<TransportError>()
+            .expect("error should be TransportError");
+
+        match transport_err {
+            TransportError::InsufficientScope { www_authenticate } => {
+                assert_eq!(
+                    www_authenticate.error,
+                    Some(oauth::BearerError::InsufficientScope)
+                );
+                assert_eq!(
+                    www_authenticate.scope,
+                    Some(vec![
+                        "files:read".to_string(),
+                        "files:write".to_string(),
+                        "user:profile".to_string()
+                    ])
+                );
+                assert_eq!(
+                    www_authenticate
+                        .resource_metadata
+                        .as_ref()
+                        .map(|u| u.as_str()),
+                    Some("https://mcp.example.com/.well-known/oauth-protected-resource"),
+                );
+                assert_eq!(
+                    www_authenticate.error_description.as_deref(),
+                    Some("Additional file write permission required")
+                );
+            }
+            _ => panic!("Expected TransportError::InsufficientScope"),
+        }
     }
 }

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -64,6 +64,8 @@ pub enum ContextServerStatus {
     /// The OAuth browser flow is in progress — the user has been redirected
     /// to the authorization server and we're waiting for the callback.
     Authenticating,
+    /// The server returned 403 and new scope permissions are needed.
+    InsufficientScope,
 }
 
 impl ContextServerStatus {
@@ -80,6 +82,7 @@ impl ContextServerStatus {
                 }
             }
             ContextServerState::Authenticating { .. } => ContextServerStatus::Authenticating,
+            ContextServerState::InsufficientScope { .. } => ContextServerStatus::InsufficientScope,
         }
     }
 }
@@ -125,6 +128,13 @@ enum ContextServerState {
         configuration: Arc<ContextServerConfiguration>,
         _task: Task<()>,
     },
+    /// The server requires new scopes to accomplish a given task.
+    InsufficientScope {
+        server: Arc<ContextServer>,
+        configuration: Arc<ContextServerConfiguration>,
+        _discovery: Arc<OAuthDiscovery>,
+        _required_scopes: Vec<String>,
+    },
 }
 
 impl ContextServerState {
@@ -136,7 +146,8 @@ impl ContextServerState {
             | ContextServerState::Error { server, .. }
             | ContextServerState::AuthRequired { server, .. }
             | ContextServerState::ClientSecretRequired { server, .. }
-            | ContextServerState::Authenticating { server, .. } => server.clone(),
+            | ContextServerState::Authenticating { server, .. }
+            | ContextServerState::InsufficientScope { server, .. } => server.clone(),
         }
     }
 
@@ -148,7 +159,8 @@ impl ContextServerState {
             | ContextServerState::Error { configuration, .. }
             | ContextServerState::AuthRequired { configuration, .. }
             | ContextServerState::ClientSecretRequired { configuration, .. }
-            | ContextServerState::Authenticating { configuration, .. } => configuration.clone(),
+            | ContextServerState::Authenticating { configuration, .. }
+            | ContextServerState::InsufficientScope { configuration, .. } => configuration.clone(),
         }
     }
 }
@@ -1660,16 +1672,31 @@ async fn resolve_start_failure(
 ) -> ContextServerState {
     let www_authenticate = err.downcast_ref::<TransportError>().map(|e| match e {
         TransportError::AuthRequired { www_authenticate } => www_authenticate.clone(),
+        TransportError::InsufficientScope { www_authenticate } => www_authenticate.clone(),
+    });
+
+    let is_insufficient_scope = err.downcast_ref::<TransportError>().map_or(false, |e| {
+        matches!(e, TransportError::InsufficientScope { .. })
     });
 
     if www_authenticate.is_some() && configuration.has_static_auth_header() {
-        log::warn!("{id} received 401 with a static Authorization header configured");
-        return ContextServerState::Error {
-            configuration,
-            server,
-            error: "Server returned 401 Unauthorized. Check your configured Authorization header."
-                .into(),
-        };
+        if is_insufficient_scope {
+            log::warn!("{id} received 403 Forbidden with a static Authorization header configured");
+            return ContextServerState::Error {
+                configuration,
+                server,
+                error: "Server returned 403 Forbidden. Your configured static Authorization header lacks the required scopes for this server.".into(),
+            };
+        } else {
+            log::warn!("{id} received 401 with a static Authorization header configured");
+            return ContextServerState::Error {
+                configuration,
+                server,
+                error:
+                    "Server returned 401 Unauthorized. Check your configured Authorization header."
+                        .into(),
+            };
+        }
     }
 
     let server_url = match configuration.as_ref() {
@@ -1677,7 +1704,9 @@ async fn resolve_start_failure(
             url.clone()
         }
         _ => {
-            if www_authenticate.is_some() {
+            if is_insufficient_scope {
+                log::error!("{id} got OAuth 403 on a non-HTTP transport or with static auth");
+            } else if www_authenticate.is_some() {
                 log::error!("{id} got OAuth 401 on a non-HTTP transport or with static auth");
             } else {
                 log::error!("{id} context server failed to start: {err}");
@@ -1755,14 +1784,28 @@ async fn resolve_start_failure(
                 };
             }
 
-            log::info!(
-                "{id} requires OAuth authorization (auth server: {})",
-                discovery.auth_server_metadata.issuer,
-            );
-            ContextServerState::AuthRequired {
-                server,
-                configuration,
-                discovery: Arc::new(discovery),
+            if is_insufficient_scope {
+                let required_scopes = www_authenticate.scope.clone().unwrap_or_default();
+                log::info!(
+                    "{id} requires token scope upgrade. Missing permissions: {:?}",
+                    required_scopes
+                );
+                ContextServerState::InsufficientScope {
+                    server,
+                    configuration,
+                    _discovery: Arc::new(discovery),
+                    _required_scopes: required_scopes,
+                }
+            } else {
+                log::info!(
+                    "{id} requires OAuth authorization (auth server: {})",
+                    discovery.auth_server_metadata.issuer,
+                );
+                ContextServerState::AuthRequired {
+                    server,
+                    configuration,
+                    discovery: Arc::new(discovery),
+                }
             }
         }
         Err(discovery_err) => {
@@ -1771,6 +1814,198 @@ async fn resolve_start_failure(
                 configuration,
                 server,
                 error: format!("OAuth discovery failed: {discovery_err}").into(),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::context_server_store::{
+        ContextServerConfiguration, ContextServerId, ContextServerState, resolve_start_failure,
+    };
+    use context_server::ContextServer;
+    use context_server::oauth;
+    use context_server::transport::TransportError;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    #[gpui::test]
+    async fn test_resolve_start_failure_insufficient_scope_with_static_auth(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let id = ContextServerId("mcp-test".into());
+
+        let server = Arc::new(ContextServer::new(
+            id.clone(),
+            Arc::new(context_server::test::create_fake_transport(
+                id.0.to_string(),
+                cx.executor(),
+            )),
+        ));
+
+        let mut headers = HashMap::default();
+        headers.insert(
+            "Authorization".to_string(),
+            "Bearer static-token".to_string(),
+        );
+
+        let configuration = Arc::new(ContextServerConfiguration::Http {
+            url: url::Url::parse("http://localhost/").unwrap(),
+            headers,
+            timeout: None,
+            oauth: None,
+        });
+
+        let www_authenticate = oauth::WwwAuthenticate {
+            resource_metadata: Some(
+                url::Url::parse("https://mcp.example.com/.well-known/oauth-protected-resource")
+                    .unwrap(),
+            ),
+            scope: Some(vec!["files:read".to_string(), "files:write".to_string()]),
+            error: Some(oauth::BearerError::InsufficientScope),
+            error_description: Some("Additional file write permission required".to_string()),
+        };
+
+        let err = TransportError::InsufficientScope {
+            www_authenticate: www_authenticate.clone(),
+        };
+
+        let state = resolve_start_failure(
+            &id,
+            anyhow::Error::from(err),
+            server.clone(),
+            configuration.clone(),
+            &cx.to_async(),
+        )
+        .await;
+
+        match state {
+            ContextServerState::Error { error, .. } => {
+                assert!(
+                    error.to_string().contains("403 Forbidden")
+                        || error.to_string().contains("lacks the required scopes")
+                );
+            }
+            _ => panic!("expected Error state for static auth + insufficient scope"),
+        }
+    }
+
+    #[gpui::test]
+    async fn test_resolve_start_failure_discover_with_insufficient_scope(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let id = ContextServerId("mcp-test".into());
+
+        let server = Arc::new(ContextServer::new(
+            id.clone(),
+            Arc::new(context_server::test::create_fake_transport(
+                id.0.to_string(),
+                cx.executor(),
+            )),
+        ));
+
+        let headers = HashMap::default();
+
+        let configuration = Arc::new(ContextServerConfiguration::Http {
+            url: url::Url::parse("http://localhost/").unwrap(),
+            headers,
+            timeout: None,
+            oauth: None,
+        });
+
+        let www_authenticate = oauth::WwwAuthenticate {
+            resource_metadata: None,
+            scope: Some(vec![
+                "files:read".to_string(),
+                "files:write".to_string(),
+                "user:profile".to_string(),
+            ]),
+            error: Some(oauth::BearerError::InsufficientScope),
+            error_description: Some("Additional file write permission required".to_string()),
+        };
+
+        let client = http_client::FakeHttpClient::create(move |req| {
+            let uri = req.uri().to_string();
+            Box::pin(async move {
+                use http_client::AsyncBody;
+                if uri.contains(".well-known/oauth-protected-resource") {
+                    let body = serde_json::to_string(&serde_json::json!({
+                        "resource": "http://localhost/",
+                        "authorization_servers": ["http://localhost"],
+                        "scopes_supported": ["files:read", "files:write", "user:profile"]
+                    }))
+                    .unwrap();
+
+                    Ok(http_client::Response::builder()
+                        .status(200)
+                        .header("Content-Type", "application/json")
+                        .body(AsyncBody::from(body.into_bytes()))
+                        .unwrap())
+                } else if uri.contains(".well-known/oauth-authorization-server")
+                    || uri.contains(".well-known/openid-configuration")
+                {
+                    let body = serde_json::to_string(&serde_json::json!({
+                        "issuer": "http://localhost",
+                        "authorization_endpoint": "http://localhost/authorize",
+                        "token_endpoint": "http://localhost/token",
+                        "code_challenge_methods_supported": ["S256"],
+                        "client_id_metadata_document_supported": true
+                    }))
+                    .unwrap();
+
+                    Ok(http_client::Response::builder()
+                        .status(200)
+                        .header("Content-Type", "application/json")
+                        .body(AsyncBody::from(body.into_bytes()))
+                        .unwrap())
+                } else {
+                    Ok(http_client::Response::builder()
+                        .status(404)
+                        .body(AsyncBody::default())
+                        .unwrap())
+                }
+            })
+        });
+
+        cx.update(|cx| cx.set_http_client(client));
+
+        let err = TransportError::InsufficientScope {
+            www_authenticate: www_authenticate.clone(),
+        };
+
+        let state = resolve_start_failure(
+            &id,
+            anyhow::Error::from(err),
+            server.clone(),
+            configuration.clone(),
+            &cx.to_async(),
+        )
+        .await;
+
+        match &state {
+            ContextServerState::InsufficientScope {
+                _required_scopes, ..
+            } => {
+                assert_eq!(
+                    _required_scopes,
+                    &vec![
+                        "files:read".to_string(),
+                        "files:write".to_string(),
+                        "user:profile".to_string()
+                    ]
+                );
+            }
+            ContextServerState::Error { error, .. } => {
+                panic!(
+                    "expected InsufficientScope state from discovery path, got Error: {}",
+                    error
+                )
+            }
+            ContextServerState::AuthRequired { .. } => {
+                panic!("expected InsufficientScope state from discovery path, got AuthRequired")
+            }
+            _ => {
+                panic!("expected InsufficientScope state from discovery path, got different state")
             }
         }
     }

--- a/crates/ui/src/components/ai/ai_setting_item.rs
+++ b/crates/ui/src/components/ai/ai_setting_item.rs
@@ -12,6 +12,7 @@ pub enum AiSettingItemStatus {
     AuthRequired,
     ClientSecretRequired,
     Authenticating,
+    InsufficientScope,
 }
 
 impl AiSettingItemStatus {
@@ -23,6 +24,7 @@ impl AiSettingItemStatus {
             Self::Error => "Server has an error.",
             Self::AuthRequired => "Authentication required.",
             Self::ClientSecretRequired => "Client secret required.",
+            Self::InsufficientScope => "Scopes required.",
             Self::Authenticating => "Waiting for authorization…",
         }
     }
@@ -33,7 +35,9 @@ impl AiSettingItemStatus {
             Self::Starting | Self::Authenticating => Some(Color::Muted),
             Self::Running => Some(Color::Success),
             Self::Error => Some(Color::Error),
-            Self::AuthRequired | Self::ClientSecretRequired => Some(Color::Warning),
+            Self::AuthRequired | Self::ClientSecretRequired | Self::InsufficientScope => {
+                Some(Color::Warning)
+            }
         }
     }
 


### PR DESCRIPTION
### Summary:

Recently, support for MCP OAuth authorization was implemented in #43162. Currently, when a user prompts an AI agent to complete a task with certain tools or resources, and the MCP Server requires higher privileges to access said tools, there is no way of handling this permission escalation.

To achieve this, we need to implement the MCP Step-Up Authorization flow, which is a security mechanism within the OAuth protocol that allows a server to request a higher level of authentication. During initial authorization or at runtime, the MCP Client may receive scope-related errors, specifically insufficient scope. The Client addresses these errors by initiating this mechanism to acquire a new access token with an increased set of scopes.

This PR implements the first two steps of MCP Step-Up Authorization Flow:
- Intercept the MCP Server response and detect a HTTP 403 Forbidden Error and WWW-Authenticate Header.
- Extract the newly required scopes from the received WWW-Authenticate Header

The last two steps, which consist of prompting the user to accept the required scopes and retrying the originally failed request, will be developed in a future PR.

### Feature Video:

https://github.com/user-attachments/assets/4199cc81-74bf-4496-b158-13a01ebe8eb8

### Tests:
New tests were added to ensure that a server response containing a HTTP 403 Forbidden is detected and extracted sucessfully.


### Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Closes #52195

Release Notes:

- Implemented initial steps of MCP Step-Up Authorization Flow, where a HTTP 403 Forbidden error is detected and the new requested scopes are parsed from the received WWW-Authenticate Header
