### PR TITLE
Add MCP step-up authorization flow part 2/2

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1126,6 +1126,7 @@ pub struct AcpThread {
     terminals: HashMap<acp::TerminalId, Entity<Terminal>>,
     pending_terminal_output: HashMap<acp::TerminalId, Vec<Vec<u8>>>,
     pending_terminal_exit: HashMap<acp::TerminalId, acp::TerminalExitStatus>,
+    pending_oauth_upgrades: HashMap<String, futures::channel::oneshot::Sender<()>>,
     had_error: bool,
     /// The user's unsent prompt text, persisted so it can be restored when reloading the thread.
     draft_prompt: Option<Vec<acp::ContentBlock>>,
@@ -1176,6 +1177,11 @@ pub enum AcpThreadEvent {
     EntriesRemoved(Range<usize>),
     ToolAuthorizationRequested(acp::ToolCallId),
     ToolAuthorizationReceived(acp::ToolCallId),
+    OAuthUpgradeRequested {
+        server_id: String,
+        existing_scopes: Vec<String>,
+        required_scopes: Vec<String>,
+    },
     Retry(RetryStatus),
     SubagentSpawned(acp::SessionId),
     Stopped(acp::StopReason),
@@ -1335,6 +1341,7 @@ impl AcpThread {
             terminals: HashMap::default(),
             pending_terminal_output: HashMap::default(),
             pending_terminal_exit: HashMap::default(),
+            pending_oauth_upgrades: HashMap::default(),
             had_error: false,
             draft_prompt: None,
             ui_scroll_position: None,
@@ -1733,6 +1740,34 @@ impl AcpThread {
                 }),
                 cx,
             );
+        }
+    }
+
+    pub fn request_oauth_upgrade(
+        &mut self,
+        server_id: String,
+        existing_scopes: Vec<String>,
+        required_scopes: Vec<String>,
+        cx: &mut Context<Self>,
+    ) -> Result<Task<Result<(), anyhow::Error>>> {
+        let (tx, rx) = futures::channel::oneshot::channel();
+
+        self.pending_oauth_upgrades.insert(server_id.clone(), tx);
+
+        cx.emit(AcpThreadEvent::OAuthUpgradeRequested {
+            server_id,
+            existing_scopes,
+            required_scopes,
+        });
+
+        Ok(cx.spawn(async move |_this, _cx| {
+            rx.await
+                .map_err(|_| anyhow::anyhow!("OAuth upgrade cancelled by UI"))
+        }))
+    }
+    pub fn resolve_oauth_upgrade(&mut self, server_id: &String) {
+        if let Some(channel) = self.pending_oauth_upgrades.remove(server_id) {
+            let _ = channel.send(());
         }
     }
 
@@ -5876,6 +5911,112 @@ mod tests {
             thread.read_with(cx, |t, _| t.status()),
             ThreadStatus::Idle,
             "running_turn must be cleared even when tx was dropped without send"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_oauth_upgrade_request_and_resolve(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(project, PathList::new(&[Path::new(path!("/test"))]), cx)
+            })
+            .await
+            .unwrap();
+
+        let server_id = "test_server".to_string();
+        let existing_scopes = vec!["scope1".to_string()];
+        let required_scopes = vec!["scope1".to_string(), "scope2".to_string()];
+
+        let (event_tx, mut event_rx) = mpsc::unbounded();
+
+        let thread_clone = thread.clone();
+        cx.update(|cx| {
+            cx.subscribe(
+                &thread_clone,
+                move |_thread, event: &AcpThreadEvent, _cx| {
+                    if let AcpThreadEvent::OAuthUpgradeRequested {
+                        server_id,
+                        existing_scopes,
+                        required_scopes,
+                    } = event
+                    {
+                        event_tx
+                            .unbounded_send((
+                                server_id.clone(),
+                                existing_scopes.clone(),
+                                required_scopes.clone(),
+                            ))
+                            .unwrap();
+                    }
+                },
+            )
+            .detach();
+        });
+
+        let upgrade_task = thread
+            .update(cx, |thread, cx| {
+                thread.request_oauth_upgrade(
+                    server_id.clone(),
+                    existing_scopes.clone(),
+                    required_scopes.clone(),
+                    cx,
+                )
+            })
+            .unwrap();
+
+        let (emitted_server_id, emitted_existing_scopes, emitted_required_scopes) =
+            event_rx.next().await.unwrap();
+        assert_eq!(emitted_server_id, server_id);
+        assert_eq!(emitted_existing_scopes, existing_scopes);
+        assert_eq!(emitted_required_scopes, required_scopes);
+
+        cx.executor().run_until_parked();
+
+        thread.update(cx, |thread, _cx| {
+            thread.resolve_oauth_upgrade(&server_id);
+        });
+
+        let result = upgrade_task.await;
+        assert!(result.is_ok());
+
+        thread.read_with(cx, |thread, _| {
+            assert!(thread.pending_oauth_upgrades.is_empty());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_oauth_upgrade_cancellation(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(project, PathList::new(&[Path::new(path!("/test"))]), cx)
+            })
+            .await
+            .unwrap();
+
+        let server_id = "cancel_server".to_string();
+        let upgrade_task = thread
+            .update(cx, |thread, cx| {
+                thread.request_oauth_upgrade(server_id, vec![], vec![], cx)
+            })
+            .unwrap();
+
+        drop(thread);
+
+        let result = upgrade_task.await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "OAuth upgrade cancelled by UI"
         );
     }
 }

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1856,6 +1856,32 @@ impl NativeAgentConnection {
                                 log::debug!("Assistant message complete: {:?}", stop_reason);
                                 return Ok(acp::PromptResponse::new(stop_reason));
                             }
+                            ThreadEvent::OAuthUpgradeRequested {
+                                server_id,
+                                existing_scopes,
+                                required_scopes,
+                                response,
+                            } => {
+                                let outcome_task = acp_thread.update(cx, |thread, cx| {
+                                    thread.request_oauth_upgrade(
+                                        server_id.to_string(),
+                                        existing_scopes,
+                                        required_scopes,
+                                        cx,
+                                    )
+                                })??;
+                                cx.background_spawn(async move {
+                                    if let Ok(_) = outcome_task.await {
+                                        response
+                                            .send(())
+                                            .map_err(|_| {
+                                                anyhow!("oauth upgrade receiver was dropped")
+                                            })
+                                            .log_err();
+                                    }
+                                })
+                                .detach();
+                            }
                         }
                     }
                     Err(e) => {
@@ -4813,6 +4839,43 @@ mod internal_tests {
             assert_eq!(scroll.item_ix, 5);
             assert_eq!(scroll.offset_in_item, gpui::px(12.5));
         });
+    }
+
+    #[gpui::test]
+    async fn test_handle_oauth_upgrade_requested_event(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs.clone(), [], cx).await;
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        let agent =
+            cx.update(|cx| NativeAgent::new(thread_store, Templates::new(), fs.clone(), cx));
+
+        let acp_thread =
+            cx.update(|cx| agent.update(cx, |agent, cx| agent.new_session(project, cx)));
+
+        let (event_tx, event_rx) = mpsc::unbounded::<Result<ThreadEvent>>();
+
+        let _handler_task = cx.update(|cx| {
+            NativeAgentConnection::handle_thread_events(event_rx, acp_thread.downgrade(), cx)
+        });
+
+        let (response_tx, mut response_rx) = oneshot::channel::<()>();
+
+        event_tx
+            .unbounded_send(Ok(ThreadEvent::OAuthUpgradeRequested {
+                server_id: ContextServerId("test-server".into()),
+                existing_scopes: vec!["read:repo".into()],
+                required_scopes: vec!["read:repo".into(), "write:repo".into()],
+                response: response_tx,
+            }))
+            .unwrap();
+
+        cx.run_until_parked();
+
+        assert!(
+            response_rx.try_recv().is_ok(),
+            "The channel should not be resolved before the upgrade task completes"
+        );
     }
 
     #[gpui::test]

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -698,6 +698,12 @@ pub enum ThreadEvent {
     SubagentSpawned(acp::SessionId),
     Retry(acp_thread::RetryStatus),
     Stop(acp::StopReason),
+    OAuthUpgradeRequested {
+        server_id: context_server::ContextServerId,
+        existing_scopes: Vec<String>,
+        required_scopes: Vec<String>,
+        response: futures::channel::oneshot::Sender<()>,
+    },
 }
 
 #[derive(Debug)]
@@ -3916,6 +3922,41 @@ impl ToolCallEventStream {
         self.stream.send_plan(plan);
     }
 
+    /// Prompts the display of the OAuth scope upgrade modal and waits
+    /// for the user to complete the authentication flow.
+    pub fn prompt_oauth_upgrade(
+        &self,
+        server_id: context_server::ContextServerId,
+        existing_scopes: Vec<String>,
+        required_scopes: Vec<String>,
+        cx: &mut App,
+    ) -> Task<Result<()>> {
+        let stream = self.stream.clone();
+
+        cx.spawn(async move |_cx| {
+            let (response_tx, response_rx) = oneshot::channel();
+
+            if let Err(error) = stream
+                .0
+                .unbounded_send(Ok(ThreadEvent::OAuthUpgradeRequested {
+                    server_id,
+                    existing_scopes,
+                    required_scopes,
+                    response: response_tx,
+                }))
+            {
+                log::error!("Failed to send OAuth upgrade prompt: {error}");
+                return Err(anyhow!("Failed to send OAuth upgrade prompt: {error}"));
+            }
+
+            response_rx
+                .await
+                .map_err(|_| anyhow!("OAuth upgrade cancelled or channel closed"))?;
+
+            Ok(())
+        })
+    }
+
     /// Authorize a third-party tool (e.g., MCP tool from a context server).
     ///
     /// Unlike built-in tools, third-party tools don't support pattern-based permissions.
@@ -4820,6 +4861,57 @@ mod tests {
                 );
             }
         });
+    }
+
+    #[gpui::test]
+    async fn test_prompt_oauth_upgrade_success(cx: &mut TestAppContext) {
+        let (stream, mut receiver, _) = ToolCallEventStream::test_with_cancellation();
+        let server_id = context_server::ContextServerId("test-server".into());
+        let existing = vec!["read".to_string()];
+        let required = vec!["read".to_string(), "write".to_string()];
+
+        let task = cx.update(|cx| {
+            stream.prompt_oauth_upgrade(server_id.clone(), existing.clone(), required.clone(), cx)
+        });
+
+        let event = receiver.next().await.unwrap().unwrap();
+        if let ThreadEvent::OAuthUpgradeRequested {
+            server_id: id,
+            existing_scopes,
+            required_scopes,
+            response,
+        } = event
+        {
+            assert_eq!(id, server_id);
+            assert_eq!(existing_scopes, existing);
+            assert_eq!(required_scopes, required);
+            response.send(()).unwrap();
+        } else {
+            panic!("unexpected event");
+        }
+
+        task.await.unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_prompt_oauth_upgrade_cancelled(cx: &mut TestAppContext) {
+        let (stream, mut receiver, _) = ToolCallEventStream::test_with_cancellation();
+
+        let task = cx.update(|cx| {
+            stream.prompt_oauth_upgrade(
+                context_server::ContextServerId("test".into()),
+                vec![],
+                vec![],
+                cx,
+            )
+        });
+
+        let event = receiver.next().await.unwrap().unwrap();
+        if let ThreadEvent::OAuthUpgradeRequested { response, .. } = event {
+            drop(response);
+        }
+
+        assert!(task.await.is_err());
     }
 
     #[gpui::test]

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -2,6 +2,7 @@ use crate::{AgentToolOutput, AnyAgentTool, ToolCallEventStream, ToolInput};
 use agent_client_protocol::schema as acp;
 use anyhow::Result;
 use collections::{BTreeMap, HashMap};
+use context_server::transport::TransportError;
 use context_server::{ContextServerId, client::NotificationSubscription};
 use futures::FutureExt as _;
 use gpui::{App, AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Task};
@@ -263,7 +264,10 @@ impl ContextServerRegistry {
             | ContextServerStatus::Error(_)
             | ContextServerStatus::AuthRequired
             | ContextServerStatus::ClientSecretRequired { .. }
-            | ContextServerStatus::InsufficientScope => {
+            | ContextServerStatus::InsufficientScope {
+                existing_scopes: _,
+                required_scopes: _,
+            } => {
                 if let Some(registered_server) = self.registered_servers.remove(server_id) {
                     if !registered_server.tools.is_empty() {
                         cx.emit(ContextServerRegistryEvent::ToolsChanged);
@@ -348,7 +352,7 @@ impl AnyAgentTool for ContextServerTool {
         let authorize =
             event_stream.authorize_third_party_tool(initial_title, tool_id, display_name, cx);
 
-        cx.spawn(async move |cx| {
+        cx.spawn(async move |mut async_cx| {
             let input = input
                 .recv()
                 .await
@@ -358,9 +362,9 @@ impl AnyAgentTool for ContextServerTool {
                 .await
                 .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
-            let Some(protocol) = server.client() else {
-                return Err(anyhow::anyhow!("Context server not initialized").into());
-            };
+            let mut protocol = server.client().ok_or_else(|| {
+                anyhow::anyhow!("Context server not initialized")
+            })?;
 
             let arguments = if let serde_json::Value::Object(map) = input {
                 Some(map.into_iter().collect())
@@ -374,18 +378,141 @@ impl AnyAgentTool for ContextServerTool {
                 arguments
             );
 
-            let request = protocol.request::<context_server::types::requests::CallTool>(
-                context_server::types::CallToolParams {
-                    name: tool_name,
-                    arguments,
-                    meta: None,
-                },
-            );
+            let mut retry = true;
 
-            let response = futures::select! {
-                response = request.fuse() => response?,
-                _ = event_stream.cancelled_by_user().fuse() => {
-                    return Err(anyhow::anyhow!("MCP tool cancelled by user").into());
+            let response = loop {
+                let request = protocol.request::<context_server::types::requests::CallTool>(
+                    context_server::types::CallToolParams {
+                        name: tool_name.clone(),
+                        arguments: arguments.clone(),
+                        meta: None,
+                    },
+                );
+
+                let result = futures::select! {
+                    res = request.fuse() => res,
+                    _ = event_stream.cancelled_by_user().fuse() => {
+                        return Err(anyhow::anyhow!("MCP tool cancelled by user").into());
+                    }
+                };
+
+                match result {
+                    Ok(res) => break res,
+                    Err(err) => {
+                        if retry {
+                            if let Some(TransportError::InsufficientScope { www_authenticate }) = err.downcast_ref::<TransportError>() {
+                                log::info!("Tool execution blocked by 403 Insufficient Scope.");
+                                retry = false;
+
+                                let server_id = self.server_id.clone();
+                                let configuration = async_cx.update(|cx| {
+                                    self.store.read(cx).configuration_for_server(&server_id)
+                                }).ok_or_else(|| anyhow::anyhow!("Failed to read context server config"))?;
+
+                                let http_client = async_cx.update(|cx| cx.http_client());
+
+                                let required_scopes = www_authenticate.scope.clone().unwrap_or_default();
+
+                                let server_url = match configuration.as_ref() {
+                                    project::context_server_store::ContextServerConfiguration::Http { url, .. } => Some(url.clone()),
+                                    _ => None,
+                                };
+
+                                if let Some(server_url) = server_url {
+                                    if let Ok(discovery) = context_server::oauth::discover(&http_client, &server_url, &www_authenticate).await {
+                                        let existing_scopes = ContextServerStore::get_active_scopes(&server_url, &mut async_cx).await;
+
+                                        let state_updated = async_cx.update(|cx| {
+                                            self.store.update(cx, |store, cx| {
+                                                    store.set_server_insufficient_scope(
+                                                    &server_id,
+                                                    discovery.clone(),
+                                                    existing_scopes.clone(),
+                                                    required_scopes.clone(),
+                                                    cx,
+                                                ).is_ok()
+                                            })
+                                        });
+
+                                        if !state_updated {
+                                            log::warn!("Could not transition server state to InsufficientScope");
+                                        }
+
+                                        let prompt_task = async_cx.update(|cx| {
+                                            event_stream.prompt_oauth_upgrade(
+                                                server_id.clone(),
+                                                existing_scopes.clone(),
+                                                required_scopes.clone(),
+                                                cx
+                                            )
+                                        }).fuse();
+
+                                        let cancel_signal = event_stream.cancelled_by_user().fuse();
+
+                                        futures::pin_mut!(prompt_task, cancel_signal);
+
+                                        let prompt_result = futures::select! {
+                                            res = prompt_task => res,
+                                            _ = cancel_signal => {
+                                                log::info!("User cancelled tool execution during OAuth prompt.");
+                                                let _ = async_cx.update(|cx| {
+                                                    let _ = self.store.update(cx, |store, cx| {
+                                                        store.set_server_running(&server_id, cx)
+                                                    });
+                                                });
+                                                return Err(anyhow::anyhow!("MCP tool cancelled by user").into());
+                                            }
+                                        };
+
+                                        if prompt_result.is_err() {
+                                            log::info!("OAuth upgrade cancelled by user.");
+                                            let _ = async_cx.update(|cx| {
+                                                let _ = self.store.update(cx, |store, cx| {
+                                                    store.set_server_running(&server_id, cx)
+                                                });
+                                            });
+                                            return Err(anyhow::anyhow!("Tool execution blocked: User cancelled OAuth upgrade.").into());
+                                        }
+
+                                        log::info!("OAuth upgrade accepted. Waiting for server to restart...");
+
+                                        let mut new_protocol = None;
+                                        for _ in 0..50 {
+                                            new_protocol = async_cx.update(|cx| {
+                                                self.store.read(cx)
+                                                    .get_running_server(&server_id)
+                                                    .and_then(|s| s.client())
+                                            });
+
+                                            if new_protocol.is_some() {
+                                                break;
+                                            }
+                                            let timer = async_cx.background_executor().timer(std::time::Duration::from_millis(100)).fuse();
+                                            let cancel_signal = event_stream.cancelled_by_user().fuse();
+
+                                            futures::pin_mut!(timer, cancel_signal);
+
+                                            futures::select! {
+                                                _ = timer => {},
+                                                _ = cancel_signal => {
+                                                    log::info!("User cancelled tool execution while waiting for server restart.");
+                                                    return Err(anyhow::anyhow!("MCP tool cancelled by user").into());
+                                                }
+                                            }
+                                        }
+
+                                        if let Some(new_p) = new_protocol {
+                                            protocol = new_p;
+                                            continue;
+                                        } else {
+                                            return Err(anyhow::anyhow!("Server failed to restart in time after OAuth upgrade").into());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        return Err(anyhow::anyhow!(err.to_string()).into());
+                    }
                 }
             };
 
@@ -414,14 +541,15 @@ impl AnyAgentTool for ContextServerTool {
                                 mime_type.clone(),
                             )),
                         )));
-                        let language_model_image = cx
-                            .background_spawn({
-                                let mime_type = mime_type.clone();
-                                async move {
-                                    LanguageModelImage::from_base64_image(&data, &mime_type)
-                                }
-                            })
-                            .await;
+                        let language_model_image = async_cx
+                        .background_executor()
+                        .spawn({
+                            let mime_type = mime_type.clone();
+                            async move {
+                                LanguageModelImage::from_base64_image(&data, &mime_type)
+                            }
+                        })
+                        .await;
                         match language_model_image {
                             Ok(Some(image)) => {
                                 llm_output.push(LanguageModelToolResultContent::Image(image));

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -262,7 +262,8 @@ impl ContextServerRegistry {
             ContextServerStatus::Stopped
             | ContextServerStatus::Error(_)
             | ContextServerStatus::AuthRequired
-            | ContextServerStatus::ClientSecretRequired { .. } => {
+            | ContextServerStatus::ClientSecretRequired { .. }
+            | ContextServerStatus::InsufficientScope => {
                 if let Some(registered_server) = self.registered_servers.remove(server_id) {
                     if !registered_server.tools.is_empty() {
                         cx.emit(ContextServerRegistryEvent::ToolsChanged);

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -695,6 +695,7 @@ impl AgentConfiguration {
                 AiSettingItemStatus::ClientSecretRequired
             }
             ContextServerStatus::Authenticating => AiSettingItemStatus::Authenticating,
+            ContextServerStatus::InsufficientScope => AiSettingItemStatus::InsufficientScope,
         };
 
         let is_remote = server_configuration

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -2,6 +2,7 @@ mod add_llm_provider_modal;
 pub mod configure_context_server_modal;
 mod configure_context_server_tools_modal;
 mod manage_profiles_modal;
+pub mod scope_upgrade_modal;
 mod tool_picker;
 
 use std::{ops::Range, rc::Rc, sync::Arc};
@@ -29,7 +30,10 @@ use language_models::AllLanguageModelSettings;
 use notifications::status_toast::StatusToast;
 use project::{
     agent_server_store::{AgentId, AgentServerStore, ExternalAgentSource},
-    context_server_store::{ContextServerConfiguration, ContextServerStatus, ContextServerStore},
+    context_server_store::{
+        ContextServerConfiguration, ContextServerStatus, ContextServerStore,
+        ServerStatusChangedEvent,
+    },
 };
 use settings::{Settings, SettingsStore, update_settings_file};
 use ui::{
@@ -100,6 +104,15 @@ impl AgentConfiguration {
             cx.subscribe(&agent_server_store, |_, _, _, cx| cx.notify()),
             cx.observe(&agent_connection_store, |_, _, cx| cx.notify()),
             cx.subscribe(&context_server_store, |_, _, _, cx| cx.notify()),
+            cx.subscribe_in(&context_server_store, window, {
+                let _workspace = workspace.clone();
+
+                move |_this, _, event: &ServerStatusChangedEvent, _window, cx| {
+                    if let ContextServerStatus::InsufficientScope { .. } = &event.status {
+                        cx.notify();
+                    }
+                }
+            }),
         ];
 
         let mut this = Self {
@@ -668,7 +681,22 @@ impl AgentConfiguration {
             server_status,
             ContextServerStatus::ClientSecretRequired { .. }
         );
+        let insufficient_scope = matches!(
+            server_status,
+            ContextServerStatus::InsufficientScope {
+                existing_scopes: _,
+                required_scopes: _
+            }
+        );
         let authenticating = matches!(server_status, ContextServerStatus::Authenticating);
+        let (existing_scopes, required_scopes) = if insufficient_scope {
+            self.context_server_store
+                .read(cx)
+                .insufficient_scope_details(&context_server_id)
+                .unwrap_or_default()
+        } else {
+            (vec![], vec![])
+        };
         let context_server_store = self.context_server_store.clone();
         let workspace = self.workspace.clone();
         let language_registry = self.language_registry.clone();
@@ -695,7 +723,10 @@ impl AgentConfiguration {
                 AiSettingItemStatus::ClientSecretRequired
             }
             ContextServerStatus::Authenticating => AiSettingItemStatus::Authenticating,
-            ContextServerStatus::InsufficientScope => AiSettingItemStatus::InsufficientScope,
+            ContextServerStatus::InsufficientScope {
+                existing_scopes: _,
+                required_scopes: _,
+            } => AiSettingItemStatus::InsufficientScope,
         };
 
         let is_remote = server_configuration
@@ -905,6 +936,52 @@ impl AgentConfiguration {
                                     context_server_store.update(cx, |store, cx| {
                                         store.authenticate_server(&context_server_id, cx).log_err();
                                     });
+                                }
+                            }),
+                    )
+                    .into_any_element(),
+            )
+        } else if insufficient_scope {
+            Some(
+                feedback_base_container()
+                    .child(
+                        h_flex()
+                            .pr_4()
+                            .min_w_0()
+                            .w_full()
+                            .gap_2()
+                            .child(
+                                Icon::new(IconName::Info)
+                                    .size(IconSize::XSmall)
+                                    .color(Color::Muted),
+                            )
+                            .child(
+                                Label::new("Server requires additional permissions")
+                                    .color(Color::Muted)
+                                    .size(LabelSize::Small),
+                            ),
+                    )
+                    .child(
+                        Button::new("upgrade-permissions    -server", "Upgrade Permissions")
+                            .style(ButtonStyle::Outlined)
+                            .label_size(LabelSize::Small)
+                            .on_click({
+                                let context_server_id = context_server_id.clone();
+                                let context_server_store = self.context_server_store.clone();
+                                let existing_scopes = existing_scopes.clone();
+                                let required_scopes = required_scopes.clone();
+                                let workspace = self.workspace.clone();
+                                move |_event, window, cx| {
+                                    crate::agent_configuration::scope_upgrade_modal::ScopeUpgradeModal::show_modal(
+                                        context_server_id.clone(),
+                                        context_server_store.clone(),
+                                        existing_scopes.clone(),
+                                        required_scopes.clone(),
+                                        workspace.clone(),
+                                        window,
+                                        cx,
+                                    )
+                                    .detach();
                                 }
                             }),
                     )

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -463,6 +463,7 @@ impl ConfigureContextServerModal {
             Some(ContextServerStatus::Starting)
             | Some(ContextServerStatus::Running)
             | Some(ContextServerStatus::Stopped)
+            | Some(ContextServerStatus::InsufficientScope)
             | None => State::Idle,
         }
     }
@@ -765,7 +766,8 @@ impl ConfigureContextServerModal {
                     }
                     ContextServerStatus::Authenticating
                     | ContextServerStatus::Starting
-                    | ContextServerStatus::Stopped => {}
+                    | ContextServerStatus::Stopped
+                    | ContextServerStatus::InsufficientScope => {}
                 }
             },
         ));
@@ -1316,7 +1318,9 @@ fn wait_for_context_server(
                     let _ = tx.send(Err(error.clone()));
                 }
             }
-            ContextServerStatus::Starting | ContextServerStatus::Authenticating => {}
+            ContextServerStatus::Starting
+            | ContextServerStatus::Authenticating
+            | ContextServerStatus::InsufficientScope => {}
         }
     });
 

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -463,7 +463,10 @@ impl ConfigureContextServerModal {
             Some(ContextServerStatus::Starting)
             | Some(ContextServerStatus::Running)
             | Some(ContextServerStatus::Stopped)
-            | Some(ContextServerStatus::InsufficientScope)
+            | Some(ContextServerStatus::InsufficientScope {
+                existing_scopes: _,
+                required_scopes: _,
+            })
             | None => State::Idle,
         }
     }
@@ -767,7 +770,10 @@ impl ConfigureContextServerModal {
                     ContextServerStatus::Authenticating
                     | ContextServerStatus::Starting
                     | ContextServerStatus::Stopped
-                    | ContextServerStatus::InsufficientScope => {}
+                    | ContextServerStatus::InsufficientScope {
+                        existing_scopes: _,
+                        required_scopes: _,
+                    } => {}
                 }
             },
         ));
@@ -1320,7 +1326,10 @@ fn wait_for_context_server(
             }
             ContextServerStatus::Starting
             | ContextServerStatus::Authenticating
-            | ContextServerStatus::InsufficientScope => {}
+            | ContextServerStatus::InsufficientScope {
+                existing_scopes: _,
+                required_scopes: _,
+            } => {}
         }
     });
 

--- a/crates/agent_ui/src/agent_configuration/scope_upgrade_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/scope_upgrade_modal.rs
@@ -1,0 +1,348 @@
+use context_server::ContextServerId;
+use gpui::{
+    DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, ScrollHandle, Window, prelude::*,
+};
+use project::context_server_store::ContextServerStore;
+use ui::{
+    CommonAnimationExt, Divider, DividerColor, KeyBinding, Modal, ModalFooter, ModalHeader,
+    Section, WithScrollbar, prelude::*,
+};
+use workspace::ModalView;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum State {
+    Idle,
+    Waiting,
+    Error(SharedString),
+}
+
+pub struct ScopeUpgradeModal {
+    server_id: ContextServerId,
+    context_server_store: Entity<ContextServerStore>,
+    existing_scopes: Vec<String>,
+    required_scopes: Vec<String>,
+    state: State,
+    focus_handle: FocusHandle,
+    scroll_handle: ScrollHandle,
+}
+
+impl ScopeUpgradeModal {
+    pub fn new(
+        server_id: ContextServerId,
+        context_server_store: Entity<ContextServerStore>,
+        existing_scopes: Vec<String>,
+        required_scopes: Vec<String>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self {
+            server_id,
+            context_server_store,
+            existing_scopes,
+            required_scopes,
+            state: State::Idle,
+            focus_handle: cx.focus_handle(),
+            scroll_handle: ScrollHandle::new(),
+        }
+    }
+
+    fn cancel(&mut self, _: &menu::Cancel, _: &mut Window, cx: &mut Context<Self>) {
+        cx.emit(DismissEvent)
+    }
+
+    fn render_modal_header(&self) -> ModalHeader {
+        ModalHeader::new()
+            .headline(format!("Upgrade Permissions: {}", self.server_id.0))
+            .show_dismiss_button(true)
+    }
+
+    fn render_modal_description(
+        &self,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> AnyElement {
+        Label::new("This MCP Server requires new scopes to complete the action.")
+            .color(Color::Muted)
+            .into_any_element()
+    }
+
+    fn render_modal_content(&self, _cx: &App) -> AnyElement {
+        v_flex()
+            .gap_4()
+            .py_2()
+            .child(
+                v_flex()
+                    .gap_1p5()
+                    .child(
+                        Label::new("Previously granted:")
+                            .color(Color::Muted)
+                            .size(LabelSize::Small),
+                    )
+                    .children(if self.existing_scopes.is_empty() {
+                        vec![
+                            Label::new("None")
+                                .color(Color::Muted)
+                                .size(LabelSize::Small)
+                                .into_any_element(),
+                        ]
+                    } else {
+                        self.existing_scopes
+                            .iter()
+                            .map(|scope| {
+                                h_flex()
+                                    .gap_2()
+                                    .child(Icon::new(IconName::Check).size(IconSize::XSmall))
+                                    .child(Label::new(scope.clone()).size(LabelSize::Small))
+                                    .into_any_element()
+                            })
+                            .collect::<Vec<_>>()
+                    }),
+            )
+            .child(Divider::horizontal().color(DividerColor::BorderVariant))
+            .child(
+                v_flex()
+                    .gap_1p5()
+                    .child(Label::new("Newly requested:").size(LabelSize::Small))
+                    .children(self.required_scopes.iter().map(|scope| {
+                        h_flex()
+                            .gap_2()
+                            .child(Icon::new(IconName::Plus).size(IconSize::XSmall))
+                            .child(Label::new(scope.clone()).size(LabelSize::Small))
+                            .into_any_element()
+                    })),
+            )
+            .children(match &self.state {
+                State::Waiting => Some(
+                    h_flex()
+                        .w_full()
+                        .justify_center()
+                        .gap_2()
+                        .py_2()
+                        .child(
+                            Icon::new(IconName::LoadCircle)
+                                .size(IconSize::Small)
+                                .color(Color::Muted)
+                                .with_rotate_animation(3),
+                        )
+                        .child(
+                            Label::new("Please complete authentication in your browser...")
+                                .color(Color::Muted)
+                                .size(LabelSize::Small),
+                        ),
+                ),
+                State::Error(err) => Some(
+                    h_flex()
+                        .w_full()
+                        .gap_2()
+                        .py_2()
+                        .child(
+                            Icon::new(IconName::Warning)
+                                .size(IconSize::Small)
+                                .color(Color::Error),
+                        )
+                        .child(
+                            Label::new(err.clone())
+                                .color(Color::Error)
+                                .size(LabelSize::Small),
+                        ),
+                ),
+                State::Idle => None,
+            })
+            .into_any_element()
+    }
+
+    fn render_modal_footer(&self, cx: &mut Context<Self>) -> ModalFooter {
+        let focus_handle = self.focus_handle(cx);
+        let is_busy = matches!(self.state, State::Waiting);
+
+        ModalFooter::new().end_slot(
+            h_flex()
+                .gap_2()
+                .child(
+                    Button::new("cancel", "Cancel")
+                        .key_binding(
+                            KeyBinding::for_action_in(&menu::Cancel, &focus_handle, cx)
+                                .map(|kb| kb.size(rems_from_px(12.))),
+                        )
+                        .on_click(cx.listener(|this, _event, window, cx| {
+                            this.cancel(&menu::Cancel, window, cx);
+                        })),
+                )
+                .child(
+                    Button::new("accept-scopes", "Accept New Scopes")
+                        .style(ButtonStyle::Filled)
+                        .disabled(is_busy)
+                        .key_binding(
+                            KeyBinding::for_action_in(&menu::Confirm, &focus_handle, cx)
+                                .map(|kb| kb.size(rems_from_px(12.))),
+                        )
+                        .on_click(cx.listener(|this, _event, _window, cx| {
+                            this.state = State::Waiting;
+                            cx.notify();
+
+                            let store = this.context_server_store.clone();
+                            let server_id = this.server_id.clone();
+                            let result = store
+                                .update(cx, |store, cx| store.authenticate_server(&server_id, cx));
+                            if let Err(err) = result {
+                                this.state = State::Error(
+                                    format!("Failed to start authentication: {err}").into(),
+                                );
+                                cx.notify();
+                            }
+                            let wait_for_context_server_task =
+                                wait_for_context_server(&store, server_id.clone(), cx);
+
+                            cx.spawn({
+                                async move |this, cx| {
+                                    let result = wait_for_context_server_task.await;
+
+                                    this.update(cx, |this, cx| match result {
+                                        Ok(project::context_server_store::ContextServerStatus::Running) => {
+                                            cx.emit(DismissEvent);
+                                        }
+                                        Err(err) => {
+                                            this.state = State::Error(err.into());
+                                            cx.notify();
+                                        }
+                                        _ => {}
+                                    }).ok();
+                                }
+                            })
+                            .detach();
+                        })),
+                ),
+        )
+    }
+
+    pub fn show_modal(
+        server_id: context_server::ContextServerId,
+        context_server_store: gpui::Entity<project::context_server_store::ContextServerStore>,
+        existing_scopes: Vec<String>,
+        required_scopes: Vec<String>,
+        workspace: gpui::WeakEntity<workspace::Workspace>,
+        window: &mut gpui::Window,
+        cx: &mut gpui::App,
+    ) -> gpui::Task<anyhow::Result<()>> {
+        window.spawn(cx, async move |cx| {
+            workspace.update_in(cx, |workspace, window, cx| {
+                workspace.toggle_modal(window, cx, |window, cx| {
+                    Self::new(
+                        server_id,
+                        context_server_store,
+                        existing_scopes,
+                        required_scopes,
+                        window,
+                        cx,
+                    )
+                })
+            })
+        })
+    }
+}
+
+impl ModalView for ScopeUpgradeModal {}
+
+impl Focusable for ScopeUpgradeModal {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl EventEmitter<DismissEvent> for ScopeUpgradeModal {}
+
+impl Render for ScopeUpgradeModal {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .elevation_3(cx)
+            .w(rems(36.))
+            .key_context("ScopeUpgradeModal")
+            .on_action(cx.listener(|this, action: &menu::Cancel, window, cx| {
+                this.cancel(action, window, cx)
+            }))
+            .capture_any_mouse_down(cx.listener(|this, _, window, cx| {
+                this.focus_handle(cx).focus(window, cx);
+            }))
+            .child(
+                Modal::new("upgrade-context-server-scopes", None)
+                    .header(self.render_modal_header())
+                    .section(
+                        Section::new().child(
+                            div()
+                                .id("modal-content")
+                                .max_h(vh(0.6, window))
+                                .overflow_y_scroll()
+                                .track_scroll(&self.scroll_handle)
+                                .child(self.render_modal_description(window, cx))
+                                .child(self.render_modal_content(cx))
+                                .vertical_scrollbar_for(&self.scroll_handle, window, cx),
+                        ),
+                    )
+                    .footer(self.render_modal_footer(cx)),
+            )
+    }
+}
+
+fn wait_for_context_server(
+    context_server_store: &gpui::Entity<ContextServerStore>,
+    context_server_id: ContextServerId,
+    cx: &mut gpui::App,
+) -> gpui::Task<Result<project::context_server_store::ContextServerStatus, std::sync::Arc<str>>> {
+    use parking_lot::Mutex;
+    use project::context_server_store::{ContextServerStatus, ServerStatusChangedEvent};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    const WAIT_TIMEOUT: Duration = Duration::from_secs(120);
+
+    let (tx, rx) = futures::channel::oneshot::channel();
+    let tx = Arc::new(Mutex::new(Some(tx)));
+
+    let context_server_id_for_timeout = context_server_id.clone();
+    let subscription = cx.subscribe(context_server_store, move |_, event, _cx| {
+        let ServerStatusChangedEvent { server_id, status } = event;
+
+        if server_id != &context_server_id {
+            return;
+        }
+
+        match status {
+            ContextServerStatus::Running | ContextServerStatus::AuthRequired => {
+                if let Some(tx) = tx.lock().take() {
+                    let _ = tx.send(Ok(status.clone()));
+                }
+            }
+            ContextServerStatus::Stopped => {
+                log::debug!("Context server is restarting.");
+            }
+            ContextServerStatus::Error(error) => {
+                if let Some(tx) = tx.lock().take() {
+                    let _ = tx.send(Err(error.clone()));
+                }
+            }
+            ContextServerStatus::Starting
+            | ContextServerStatus::Authenticating
+            | ContextServerStatus::InsufficientScope {
+                existing_scopes: _,
+                required_scopes: _,
+            }
+            | ContextServerStatus::ClientSecretRequired { .. } => {}
+        }
+    });
+
+    cx.spawn(async move |cx| {
+        let timeout = cx.background_executor().timer(WAIT_TIMEOUT);
+        let result = futures::future::select(rx, timeout).await;
+        drop(subscription);
+        match result {
+            futures::future::Either::Left((Ok(inner), _)) => inner,
+            futures::future::Either::Left((Err(_), _)) => {
+                Err(Arc::from("Context server store was dropped"))
+            }
+            futures::future::Either::Right(_) => Err(Arc::from(format!(
+                "Timed out waiting for context server `{}` to start. Check the Zed log for details.",
+                context_server_id_for_timeout
+            ))),
+        }
+    })
+}

--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -1435,7 +1435,8 @@ impl AgentDiff {
             | AcpThreadEvent::ModeUpdated(_)
             | AcpThreadEvent::ConfigOptionsUpdated(_)
             | AcpThreadEvent::WorkingDirectoriesUpdated
-            | AcpThreadEvent::PromptUpdated => {}
+            | AcpThreadEvent::PromptUpdated
+            | AcpThreadEvent::OAuthUpgradeRequested { .. } => {}
         }
     }
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -296,6 +296,11 @@ impl Conversation {
                     | AcpThreadEvent::ModeUpdated(_)
                     | AcpThreadEvent::ConfigOptionsUpdated(_)
                     | AcpThreadEvent::WorkingDirectoriesUpdated
+                    | AcpThreadEvent::OAuthUpgradeRequested {
+                        server_id: _,
+                        existing_scopes: _,
+                        required_scopes: _,
+                    }
                     | AcpThreadEvent::PromptUpdated => {}
                 }
             }
@@ -498,6 +503,11 @@ fn affects_thread_metadata(event: &AcpThreadEvent) -> bool {
         | AcpThreadEvent::TitleUpdated
         | AcpThreadEvent::ToolAuthorizationRequested(_)
         | AcpThreadEvent::ToolAuthorizationReceived(_)
+        | AcpThreadEvent::OAuthUpgradeRequested {
+            server_id: _,
+            existing_scopes: _,
+            required_scopes: _,
+        }
         | AcpThreadEvent::Stopped(_)
         | AcpThreadEvent::Error
         | AcpThreadEvent::LoadError(_)
@@ -1558,6 +1568,59 @@ impl ConversationView {
                         active.thread_retry_status = Some(retry.clone());
                     });
                 }
+            }
+            AcpThreadEvent::OAuthUpgradeRequested {
+                server_id,
+                existing_scopes,
+                required_scopes,
+            } => {
+                self.notify_with_sound("New scopes required", IconName::Warning, window, cx);
+
+                let Some(workspace) = self.workspace.upgrade() else {
+                    return;
+                };
+                let context_server_store = workspace
+                    .read(cx)
+                    .project()
+                    .read(cx)
+                    .context_server_store()
+                    .clone();
+
+                let context_server_id =
+                    context_server::ContextServerId(std::sync::Arc::from(server_id.clone()));
+
+                crate::agent_configuration::scope_upgrade_modal::ScopeUpgradeModal::show_modal(
+                    context_server_id.clone(),
+                    context_server_store.clone(),
+                    existing_scopes.clone(),
+                    required_scopes.clone(),
+                    self.workspace.clone(),
+                    window,
+                    cx,
+                )
+                .detach();
+                let target_server_id = server_id.clone();
+                let thread_handle = thread.clone();
+
+                let subscription = cx.subscribe(
+                    &context_server_store,
+                    move |_this,
+                          _store,
+                          event: &project::context_server_store::ServerStatusChangedEvent,
+                          _cx| {
+                        if event.server_id == context_server_id {
+                            if let project::context_server_store::ContextServerStatus::Running =
+                                event.status
+                            {
+                                thread_handle.update(_cx, |thread, _cx| {
+                                    thread.resolve_oauth_upgrade(&target_server_id.to_string());
+                                });
+                            }
+                        }
+                    },
+                );
+
+                self._subscriptions.push(subscription);
             }
             AcpThreadEvent::Stopped(stop_reason) => {
                 if let Some(active) = self.thread_view(&session_id) {
@@ -7147,6 +7210,57 @@ pub(crate) mod tests {
                 "Tool call should no longer be waiting for confirmation after AuthorizeToolCall action"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_oauth_upgrade_requested_flow(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (conversation_view, cx) =
+            setup_conversation_view(StubAgentServer::default_response(), cx).await;
+        add_to_workspace(conversation_view.clone(), cx);
+
+        let thread = conversation_view.read_with(cx, |view, cx| {
+            view.active_thread().unwrap().read(cx).thread.clone()
+        });
+
+        let server_id = "test-server";
+        let existing_scopes = vec!["read".to_string()];
+        let required_scopes = vec!["read".to_string(), "write".to_string()];
+
+        cx.update_entity(&thread, |_, cx| {
+            cx.emit(AcpThreadEvent::OAuthUpgradeRequested {
+                server_id: server_id.to_string(),
+                existing_scopes,
+                required_scopes,
+            });
+        });
+
+        cx.run_until_parked();
+
+        let workspace = conversation_view
+            .read_with(cx, |view, _cx| view.workspace.clone())
+            .upgrade()
+            .unwrap();
+        workspace.read_with(cx, |workspace, cx| {
+            let modal = workspace
+                .active_modal::<crate::agent_configuration::scope_upgrade_modal::ScopeUpgradeModal>(
+                    cx,
+                );
+            assert!(modal.is_some());
+        });
+
+        let context_server_store = workspace.read_with(cx, |workspace, cx| {
+            workspace.project().read(cx).context_server_store().clone()
+        });
+
+        cx.update_entity(&context_server_store, |_, cx| {
+            cx.emit(project::context_server_store::ServerStatusChangedEvent {
+                server_id: context_server::ContextServerId(server_id.into()),
+                status: project::context_server_store::ContextServerStatus::Running,
+            });
+        });
+        cx.run_until_parked();
     }
 
     #[gpui::test]

--- a/crates/context_server/src/oauth.rs
+++ b/crates/context_server/src/oauth.rs
@@ -212,6 +212,7 @@ pub struct OAuthSession {
     pub resource: Url,
     pub client_registration: OAuthClientRegistration,
     pub tokens: OAuthTokens,
+    pub granted_scopes: Vec<String>,
 }
 
 impl std::fmt::Debug for OAuthSession {
@@ -2718,6 +2719,7 @@ mod tests {
                 refresh_token: refresh_token.map(String::from),
                 expires_at,
             },
+            granted_scopes: Vec::new(),
         }
     }
 

--- a/crates/context_server/src/transport/http.rs
+++ b/crates/context_server/src/transport/http.rs
@@ -18,6 +18,8 @@ pub enum TransportError {
     /// The server returned 401 and token refresh either wasn't possible or
     /// failed. The caller should initiate the OAuth authorization flow.
     AuthRequired { www_authenticate: WwwAuthenticate },
+    /// The server returned 403 and there are insufficient scopes for this request.
+    InsufficientScope { www_authenticate: WwwAuthenticate },
 }
 
 impl std::fmt::Display for TransportError {
@@ -25,6 +27,9 @@ impl std::fmt::Display for TransportError {
         match self {
             TransportError::AuthRequired { .. } => {
                 write!(f, "OAuth authorization required")
+            }
+            TransportError::InsufficientScope { .. } => {
+                write!(f, "Scope Permission Required")
             }
         }
     }
@@ -149,9 +154,10 @@ impl HttpTransport {
 
         let request = self.build_request(message.as_bytes())?;
         let mut response = self.http_client.send(request).await?;
+        let status = response.status().as_u16();
 
         // On 401, try refreshing the token and retry once.
-        if response.status().as_u16() == 401 {
+        if status == 401 || status == 403 {
             let www_auth_header = response
                 .headers()
                 .get("www-authenticate")
@@ -165,6 +171,15 @@ impl HttpTransport {
                     error: None,
                     error_description: None,
                 });
+
+            if status == 403 {
+                let required_scopes = www_authenticate.scope.clone().unwrap_or_default();
+                log::warn!(
+                    "Server returned 403 Forbidden. Authorization header lacks the required scopes for this server. Required Scopes {:?}",
+                    required_scopes
+                );
+                return Err(TransportError::InsufficientScope { www_authenticate }.into());
+            }
 
             if let Some(ref provider) = self.token_provider {
                 if provider.try_refresh().await.unwrap_or(false) {
@@ -709,6 +724,11 @@ mod tests {
                     Some(vec!["read".to_string(), "write".to_string()]),
                 );
             }
+            TransportError::InsufficientScope { .. } => {
+                panic!(
+                    "Expected TransportError::AuthRequired, got TransportError::InsufficientScope"
+                );
+            }
         }
         assert_eq!(provider.refresh_count(), 1);
     }
@@ -746,6 +766,11 @@ mod tests {
                 assert!(www_authenticate.resource_metadata.is_none());
                 assert!(www_authenticate.scope.is_none());
             }
+            TransportError::InsufficientScope { .. } => {
+                panic!(
+                    "Expected TransportError::AuthRequired, got TransportError::InsufficientScope"
+                );
+            }
         }
     }
 
@@ -782,5 +807,68 @@ mod tests {
             .expect("error should be TransportError");
         // Refresh was attempted exactly once.
         assert_eq!(provider.refresh_count(), 1);
+    }
+
+    #[gpui::test]
+    async fn test_403_returns_insufficient_scope_successfully(cx: &mut TestAppContext) {
+        let client = make_fake_http_client(|_req| {
+            Box::pin(async {
+                Ok(Response::builder()
+                    .status(403)
+                    .header(
+                        "WWW-Authenticate",
+                        r#"Bearer error="insufficient_scope", scope="files:read files:write user:profile", resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource", error_description="Additional file write permission required""#,
+                    )
+                    .body(AsyncBody::from(b"Forbidden".to_vec()))
+                    .unwrap())
+            })
+        });
+
+        let provider = FakeTokenProvider::new(Some("token"), true);
+        let transport = HttpTransport::new_with_token_provider(
+            client,
+            "http://mcp.example.com/mcp".to_string(),
+            HashMap::default(),
+            cx.background_executor.clone(),
+            Some(provider.clone()),
+        );
+
+        let err = transport
+            .send(r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#.to_string())
+            .await
+            .unwrap_err();
+
+        let transport_err = err
+            .downcast_ref::<TransportError>()
+            .expect("error should be TransportError");
+
+        match transport_err {
+            TransportError::InsufficientScope { www_authenticate } => {
+                assert_eq!(
+                    www_authenticate.error,
+                    Some(oauth::BearerError::InsufficientScope)
+                );
+                assert_eq!(
+                    www_authenticate.scope,
+                    Some(vec![
+                        "files:read".to_string(),
+                        "files:write".to_string(),
+                        "user:profile".to_string()
+                    ])
+                );
+                assert_eq!(
+                    www_authenticate
+                        .resource_metadata
+                        .as_ref()
+                        .map(|u| u.as_str()),
+                    Some("https://mcp.example.com/.well-known/oauth-protected-resource"),
+                );
+                assert_eq!(
+                    www_authenticate.error_description.as_deref(),
+                    Some("Additional file write permission required")
+                );
+            }
+            _ => panic!("Expected TransportError::InsufficientScope"),
+        }
     }
 }

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -64,6 +64,8 @@ pub enum ContextServerStatus {
     /// The OAuth browser flow is in progress — the user has been redirected
     /// to the authorization server and we're waiting for the callback.
     Authenticating,
+    /// The server returned 403 and new scope permissions are needed.
+    InsufficientScope,
 }
 
 impl ContextServerStatus {
@@ -80,6 +82,7 @@ impl ContextServerStatus {
                 }
             }
             ContextServerState::Authenticating { .. } => ContextServerStatus::Authenticating,
+            ContextServerState::InsufficientScope { .. } => ContextServerStatus::InsufficientScope,
         }
     }
 }
@@ -125,6 +128,13 @@ enum ContextServerState {
         configuration: Arc<ContextServerConfiguration>,
         _task: Task<()>,
     },
+    /// The server requires new scopes to accomplish a given task.
+    InsufficientScope {
+        server: Arc<ContextServer>,
+        configuration: Arc<ContextServerConfiguration>,
+        _discovery: Arc<OAuthDiscovery>,
+        _required_scopes: Vec<String>,
+    },
 }
 
 impl ContextServerState {
@@ -136,7 +146,8 @@ impl ContextServerState {
             | ContextServerState::Error { server, .. }
             | ContextServerState::AuthRequired { server, .. }
             | ContextServerState::ClientSecretRequired { server, .. }
-            | ContextServerState::Authenticating { server, .. } => server.clone(),
+            | ContextServerState::Authenticating { server, .. }
+            | ContextServerState::InsufficientScope { server, .. } => server.clone(),
         }
     }
 
@@ -148,7 +159,8 @@ impl ContextServerState {
             | ContextServerState::Error { configuration, .. }
             | ContextServerState::AuthRequired { configuration, .. }
             | ContextServerState::ClientSecretRequired { configuration, .. }
-            | ContextServerState::Authenticating { configuration, .. } => configuration.clone(),
+            | ContextServerState::Authenticating { configuration, .. }
+            | ContextServerState::InsufficientScope { configuration, .. } => configuration.clone(),
         }
     }
 }
@@ -1660,16 +1672,31 @@ async fn resolve_start_failure(
 ) -> ContextServerState {
     let www_authenticate = err.downcast_ref::<TransportError>().map(|e| match e {
         TransportError::AuthRequired { www_authenticate } => www_authenticate.clone(),
+        TransportError::InsufficientScope { www_authenticate } => www_authenticate.clone(),
+    });
+
+    let is_insufficient_scope = err.downcast_ref::<TransportError>().map_or(false, |e| {
+        matches!(e, TransportError::InsufficientScope { .. })
     });
 
     if www_authenticate.is_some() && configuration.has_static_auth_header() {
-        log::warn!("{id} received 401 with a static Authorization header configured");
-        return ContextServerState::Error {
-            configuration,
-            server,
-            error: "Server returned 401 Unauthorized. Check your configured Authorization header."
-                .into(),
-        };
+        if is_insufficient_scope {
+            log::warn!("{id} received 403 Forbidden with a static Authorization header configured");
+            return ContextServerState::Error {
+                configuration,
+                server,
+                error: "Server returned 403 Forbidden. Your configured static Authorization header lacks the required scopes for this server.".into(),
+            };
+        } else {
+            log::warn!("{id} received 401 with a static Authorization header configured");
+            return ContextServerState::Error {
+                configuration,
+                server,
+                error:
+                    "Server returned 401 Unauthorized. Check your configured Authorization header."
+                        .into(),
+            };
+        }
     }
 
     let server_url = match configuration.as_ref() {
@@ -1677,7 +1704,9 @@ async fn resolve_start_failure(
             url.clone()
         }
         _ => {
-            if www_authenticate.is_some() {
+            if is_insufficient_scope {
+                log::error!("{id} got OAuth 403 on a non-HTTP transport or with static auth");
+            } else if www_authenticate.is_some() {
                 log::error!("{id} got OAuth 401 on a non-HTTP transport or with static auth");
             } else {
                 log::error!("{id} context server failed to start: {err}");
@@ -1755,14 +1784,28 @@ async fn resolve_start_failure(
                 };
             }
 
-            log::info!(
-                "{id} requires OAuth authorization (auth server: {})",
-                discovery.auth_server_metadata.issuer,
-            );
-            ContextServerState::AuthRequired {
-                server,
-                configuration,
-                discovery: Arc::new(discovery),
+            if is_insufficient_scope {
+                let required_scopes = www_authenticate.scope.clone().unwrap_or_default();
+                log::info!(
+                    "{id} requires token scope upgrade. Missing permissions: {:?}",
+                    required_scopes
+                );
+                ContextServerState::InsufficientScope {
+                    server,
+                    configuration,
+                    _discovery: Arc::new(discovery),
+                    _required_scopes: required_scopes,
+                }
+            } else {
+                log::info!(
+                    "{id} requires OAuth authorization (auth server: {})",
+                    discovery.auth_server_metadata.issuer,
+                );
+                ContextServerState::AuthRequired {
+                    server,
+                    configuration,
+                    discovery: Arc::new(discovery),
+                }
             }
         }
         Err(discovery_err) => {
@@ -1771,6 +1814,198 @@ async fn resolve_start_failure(
                 configuration,
                 server,
                 error: format!("OAuth discovery failed: {discovery_err}").into(),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::context_server_store::{
+        ContextServerConfiguration, ContextServerId, ContextServerState, resolve_start_failure,
+    };
+    use context_server::ContextServer;
+    use context_server::oauth;
+    use context_server::transport::TransportError;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    #[gpui::test]
+    async fn test_resolve_start_failure_insufficient_scope_with_static_auth(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let id = ContextServerId("mcp-test".into());
+
+        let server = Arc::new(ContextServer::new(
+            id.clone(),
+            Arc::new(context_server::test::create_fake_transport(
+                id.0.to_string(),
+                cx.executor(),
+            )),
+        ));
+
+        let mut headers = HashMap::default();
+        headers.insert(
+            "Authorization".to_string(),
+            "Bearer static-token".to_string(),
+        );
+
+        let configuration = Arc::new(ContextServerConfiguration::Http {
+            url: url::Url::parse("http://localhost/").unwrap(),
+            headers,
+            timeout: None,
+            oauth: None,
+        });
+
+        let www_authenticate = oauth::WwwAuthenticate {
+            resource_metadata: Some(
+                url::Url::parse("https://mcp.example.com/.well-known/oauth-protected-resource")
+                    .unwrap(),
+            ),
+            scope: Some(vec!["files:read".to_string(), "files:write".to_string()]),
+            error: Some(oauth::BearerError::InsufficientScope),
+            error_description: Some("Additional file write permission required".to_string()),
+        };
+
+        let err = TransportError::InsufficientScope {
+            www_authenticate: www_authenticate.clone(),
+        };
+
+        let state = resolve_start_failure(
+            &id,
+            anyhow::Error::from(err),
+            server.clone(),
+            configuration.clone(),
+            &cx.to_async(),
+        )
+        .await;
+
+        match state {
+            ContextServerState::Error { error, .. } => {
+                assert!(
+                    error.to_string().contains("403 Forbidden")
+                        || error.to_string().contains("lacks the required scopes")
+                );
+            }
+            _ => panic!("expected Error state for static auth + insufficient scope"),
+        }
+    }
+
+    #[gpui::test]
+    async fn test_resolve_start_failure_discover_with_insufficient_scope(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let id = ContextServerId("mcp-test".into());
+
+        let server = Arc::new(ContextServer::new(
+            id.clone(),
+            Arc::new(context_server::test::create_fake_transport(
+                id.0.to_string(),
+                cx.executor(),
+            )),
+        ));
+
+        let headers = HashMap::default();
+
+        let configuration = Arc::new(ContextServerConfiguration::Http {
+            url: url::Url::parse("http://localhost/").unwrap(),
+            headers,
+            timeout: None,
+            oauth: None,
+        });
+
+        let www_authenticate = oauth::WwwAuthenticate {
+            resource_metadata: None,
+            scope: Some(vec![
+                "files:read".to_string(),
+                "files:write".to_string(),
+                "user:profile".to_string(),
+            ]),
+            error: Some(oauth::BearerError::InsufficientScope),
+            error_description: Some("Additional file write permission required".to_string()),
+        };
+
+        let client = http_client::FakeHttpClient::create(move |req| {
+            let uri = req.uri().to_string();
+            Box::pin(async move {
+                use http_client::AsyncBody;
+                if uri.contains(".well-known/oauth-protected-resource") {
+                    let body = serde_json::to_string(&serde_json::json!({
+                        "resource": "http://localhost/",
+                        "authorization_servers": ["http://localhost"],
+                        "scopes_supported": ["files:read", "files:write", "user:profile"]
+                    }))
+                    .unwrap();
+
+                    Ok(http_client::Response::builder()
+                        .status(200)
+                        .header("Content-Type", "application/json")
+                        .body(AsyncBody::from(body.into_bytes()))
+                        .unwrap())
+                } else if uri.contains(".well-known/oauth-authorization-server")
+                    || uri.contains(".well-known/openid-configuration")
+                {
+                    let body = serde_json::to_string(&serde_json::json!({
+                        "issuer": "http://localhost",
+                        "authorization_endpoint": "http://localhost/authorize",
+                        "token_endpoint": "http://localhost/token",
+                        "code_challenge_methods_supported": ["S256"],
+                        "client_id_metadata_document_supported": true
+                    }))
+                    .unwrap();
+
+                    Ok(http_client::Response::builder()
+                        .status(200)
+                        .header("Content-Type", "application/json")
+                        .body(AsyncBody::from(body.into_bytes()))
+                        .unwrap())
+                } else {
+                    Ok(http_client::Response::builder()
+                        .status(404)
+                        .body(AsyncBody::default())
+                        .unwrap())
+                }
+            })
+        });
+
+        cx.update(|cx| cx.set_http_client(client));
+
+        let err = TransportError::InsufficientScope {
+            www_authenticate: www_authenticate.clone(),
+        };
+
+        let state = resolve_start_failure(
+            &id,
+            anyhow::Error::from(err),
+            server.clone(),
+            configuration.clone(),
+            &cx.to_async(),
+        )
+        .await;
+
+        match &state {
+            ContextServerState::InsufficientScope {
+                _required_scopes, ..
+            } => {
+                assert_eq!(
+                    _required_scopes,
+                    &vec![
+                        "files:read".to_string(),
+                        "files:write".to_string(),
+                        "user:profile".to_string()
+                    ]
+                );
+            }
+            ContextServerState::Error { error, .. } => {
+                panic!(
+                    "expected InsufficientScope state from discovery path, got Error: {}",
+                    error
+                )
+            }
+            ContextServerState::AuthRequired { .. } => {
+                panic!("expected InsufficientScope state from discovery path, got AuthRequired")
+            }
+            _ => {
+                panic!("expected InsufficientScope state from discovery path, got different state")
             }
         }
     }

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -65,7 +65,10 @@ pub enum ContextServerStatus {
     /// to the authorization server and we're waiting for the callback.
     Authenticating,
     /// The server returned 403 and new scope permissions are needed.
-    InsufficientScope,
+    InsufficientScope {
+        existing_scopes: Vec<String>,
+        required_scopes: Vec<String>,
+    },
 }
 
 impl ContextServerStatus {
@@ -82,7 +85,14 @@ impl ContextServerStatus {
                 }
             }
             ContextServerState::Authenticating { .. } => ContextServerStatus::Authenticating,
-            ContextServerState::InsufficientScope { .. } => ContextServerStatus::InsufficientScope,
+            ContextServerState::InsufficientScope {
+                _existing_scopes,
+                _required_scopes,
+                ..
+            } => ContextServerStatus::InsufficientScope {
+                existing_scopes: _existing_scopes.clone(),
+                required_scopes: _required_scopes.clone(),
+            },
         }
     }
 }
@@ -133,6 +143,7 @@ enum ContextServerState {
         server: Arc<ContextServer>,
         configuration: Arc<ContextServerConfiguration>,
         _discovery: Arc<OAuthDiscovery>,
+        _existing_scopes: Vec<String>,
         _required_scopes: Vec<String>,
     },
 }
@@ -370,6 +381,15 @@ impl ContextServerStore {
         matches!(self.state, ContextServerStoreState::Remote { .. })
     }
 
+    /// Loads the currently granted scopes for a given server URL
+    pub async fn get_active_scopes(server_url: &url::Url, cx: &AsyncApp) -> Vec<String> {
+        let credentials_provider = cx.update(|cx| zed_credentials_provider::global(cx));
+        match Self::load_session(&credentials_provider, server_url, cx).await {
+            Ok(Some(session)) => session.granted_scopes.clone(),
+            _ => vec![],
+        }
+    }
+
     /// Returns all configured context server ids, excluding the ones that are disabled
     pub fn configured_server_ids(&self) -> Vec<ContextServerId> {
         self.context_server_settings
@@ -538,6 +558,20 @@ impl ContextServerStore {
 
     pub fn status_for_server(&self, id: &ContextServerId) -> Option<ContextServerStatus> {
         self.servers.get(id).map(ContextServerStatus::from_state)
+    }
+
+    pub fn insufficient_scope_details(
+        &self,
+        id: &ContextServerId,
+    ) -> Option<(Vec<String>, Vec<String>)> {
+        match self.servers.get(id) {
+            Some(ContextServerState::InsufficientScope {
+                _existing_scopes,
+                _required_scopes,
+                ..
+            }) => Some((_existing_scopes.clone(), _required_scopes.clone())),
+            _ => None,
+        }
     }
 
     pub fn configuration_for_server(
@@ -742,6 +776,54 @@ impl ContextServerStore {
             server_id: id.clone(),
             status: ContextServerStatus::Stopped,
         });
+        Ok(())
+    }
+
+    pub fn set_server_insufficient_scope(
+        &mut self,
+        id: &ContextServerId,
+        discovery: OAuthDiscovery,
+        existing_scopes: Vec<String>,
+        required_scopes: Vec<String>,
+        cx: &mut Context<Self>,
+    ) -> Result<()> {
+        let state = self.servers.get(id).context("Context server not found")?;
+
+        let server = state.server();
+        let configuration = state.configuration();
+
+        self.update_server_state(
+            id.clone(),
+            ContextServerState::InsufficientScope {
+                server,
+                configuration,
+                _discovery: Arc::new(discovery),
+                _existing_scopes: existing_scopes,
+                _required_scopes: required_scopes,
+            },
+            cx,
+        );
+
+        Ok(())
+    }
+
+    pub fn set_server_running(
+        &mut self,
+        id: &ContextServerId,
+        cx: &mut Context<Self>,
+    ) -> Result<()> {
+        let state = self.servers.get(id).context("Context server not found")?;
+        let server = state.server();
+        let configuration = state.configuration();
+
+        self.update_server_state(
+            id.clone(),
+            ContextServerState::Running {
+                server,
+                configuration,
+            },
+            cx,
+        );
         Ok(())
     }
 
@@ -1034,14 +1116,37 @@ impl ContextServerStore {
     ) -> Result<()> {
         let state = self.servers.get(id).context("Context server not found")?;
 
-        let (discovery, server, configuration) = match state {
-            ContextServerState::AuthRequired {
-                discovery,
-                server,
-                configuration,
-            } => (discovery.clone(), server.clone(), configuration.clone()),
-            _ => anyhow::bail!("Server is not in AuthRequired state"),
-        };
+        let (discovery, server, configuration, is_insufficient_scope, existing_scopes, new_scopes) =
+            match state {
+                ContextServerState::AuthRequired {
+                    discovery,
+                    server,
+                    configuration,
+                } => (
+                    discovery.clone(),
+                    server.clone(),
+                    configuration.clone(),
+                    false,
+                    None,
+                    None,
+                ),
+                ContextServerState::InsufficientScope {
+                    server,
+                    configuration,
+                    _discovery,
+                    _existing_scopes,
+                    _required_scopes,
+                    ..
+                } => (
+                    _discovery.clone(),
+                    server.clone(),
+                    configuration.clone(),
+                    true,
+                    Some(_existing_scopes.clone()),
+                    Some(_required_scopes.clone()),
+                ),
+                _ => anyhow::bail!("Server is not in AuthRequired state"),
+            };
 
         let needs_keychain_check = match configuration.as_ref() {
             ContextServerConfiguration::Http {
@@ -1058,6 +1163,10 @@ impl ContextServerStore {
             let id = id.clone();
             let server = server.clone();
             let configuration = configuration.clone();
+            let is_insufficient_scope = is_insufficient_scope;
+            let fallback_existing = existing_scopes.unwrap_or_default();
+            let required_scopes = new_scopes.unwrap_or_default();
+
             async move |this, cx| {
                 if let Some(server_url) = needs_keychain_check {
                     let credentials_provider = cx.update(|cx| zed_credentials_provider::global(cx));
@@ -1091,22 +1200,38 @@ impl ContextServerStore {
                     id.clone(),
                     discovery.clone(),
                     configuration.clone(),
+                    required_scopes,
                     cx,
                 )
                 .await;
 
                 if let Err(err) = &result {
                     log::error!("{} OAuth authentication failed: {:?}", id, err);
+
                     this.update(cx, |this, cx| {
-                        this.update_server_state(
-                            id.clone(),
+                        let reverted_state = if is_insufficient_scope {
+                            let required_scopes = discovery
+                                .auth_server_metadata
+                                .scopes_supported
+                                .clone()
+                                .unwrap_or_default();
+
+                            ContextServerState::InsufficientScope {
+                                server,
+                                configuration,
+                                _discovery: discovery,
+                                _existing_scopes: fallback_existing,
+                                _required_scopes: required_scopes,
+                            }
+                        } else {
                             ContextServerState::Error {
                                 server,
                                 configuration,
                                 error: format!("{err:#}").into(),
-                            },
-                            cx,
-                        )
+                            }
+                        };
+
+                        this.update_server_state(id.clone(), reverted_state, cx)
                     })
                     .log_err();
                 }
@@ -1177,6 +1302,7 @@ impl ContextServerStore {
                     id.clone(),
                     discovery.clone(),
                     configuration.clone(),
+                    Vec::new(),
                     cx,
                 )
                 .await;
@@ -1241,11 +1367,46 @@ impl ContextServerStore {
         Ok(())
     }
 
+    /// Executes the OAuth loopback flow using pre-discovered parameters,
+    /// updating tokens and restarting the target transport seamlessly.
+    pub fn authenticate_server_inline(
+        &mut self,
+        id: ContextServerId,
+        discovery: context_server::oauth::OAuthDiscovery,
+        required_scopes: Vec<String>,
+        cx: &mut Context<Self>,
+    ) -> gpui::Task<Result<()>> {
+        let configuration = match self.servers.get(&id) {
+            Some(state) => state.configuration(),
+            None => {
+                return cx.spawn(async move |_, _| anyhow::bail!("Server not found"));
+            }
+        };
+
+        cx.spawn({
+            let discovery: std::sync::Arc<_> = discovery.into();
+
+            // Fix the lifetime error here by using the nightly async closure syntax
+            async move |this, cx| {
+                Self::run_oauth_flow(
+                    this.clone(), // Cloning `this` to perfectly match your original authenticate_server logic
+                    id,
+                    discovery,
+                    configuration,
+                    required_scopes,
+                    cx,
+                )
+                .await
+            }
+        })
+    }
+
     async fn run_oauth_flow(
         this: WeakEntity<Self>,
         id: ContextServerId,
         discovery: Arc<OAuthDiscovery>,
         configuration: Arc<ContextServerConfiguration>,
+        required_scopes: Vec<String>,
         cx: &mut AsyncApp,
     ) -> Result<()> {
         let resource = oauth::canonical_server_uri(&discovery.resource_metadata.resource);
@@ -1293,11 +1454,18 @@ impl ContextServerStore {
                 .context("Failed to resolve OAuth client registration")?,
         };
 
+        let mut merged_scopes = discovery.scopes.clone();
+        for scope in &required_scopes {
+            if !merged_scopes.contains(scope) {
+                merged_scopes.push(scope.clone());
+            }
+        }
+
         let auth_url = oauth::build_authorization_url(
             &discovery.auth_server_metadata,
             &client_registration.client_id,
             &redirect_uri,
-            &discovery.scopes,
+            &merged_scopes,
             &resource,
             &pkce,
             &state_param,
@@ -1331,6 +1499,7 @@ impl ContextServerStore {
             resource: discovery.resource_metadata.resource.clone(),
             client_registration,
             tokens,
+            granted_scopes: merged_scopes,
         };
 
         Self::store_session(&credentials_provider, &server_url, &session, cx)
@@ -1719,12 +1888,13 @@ async fn resolve_start_failure(
         }
     };
 
+    let credentials_provider = cx.update(|cx| zed_credentials_provider::global(cx));
+
     // When the error is NOT a 401 but there is a cached OAuth session in the
     // keychain, the session is likely stale/expired and caused the failure
     // (e.g. timeout because the server rejected the token silently). Clear it
     // so the next start attempt can get a clean 401 and trigger the auth flow.
     if www_authenticate.is_none() {
-        let credentials_provider = cx.update(|cx| zed_credentials_provider::global(cx));
         match ContextServerStore::load_session(&credentials_provider, &server_url, cx).await {
             Ok(Some(_)) => {
                 log::info!("{id} start failed with a cached OAuth session present; clearing it");
@@ -1785,15 +1955,24 @@ async fn resolve_start_failure(
             }
 
             if is_insufficient_scope {
+                let existing_scopes =
+                    match ContextServerStore::load_session(&credentials_provider, &server_url, &cx)
+                        .await
+                    {
+                        Ok(Some(session)) => session.granted_scopes.clone(),
+                        _ => vec![],
+                    };
                 let required_scopes = www_authenticate.scope.clone().unwrap_or_default();
                 log::info!(
-                    "{id} requires token scope upgrade. Missing permissions: {:?}",
-                    required_scopes
+                    "{id} requires token scope upgrade. Missing permissions: {:?}. Existing permissions: {:?}",
+                    required_scopes,
+                    existing_scopes
                 );
                 ContextServerState::InsufficientScope {
                     server,
                     configuration,
                     _discovery: Arc::new(discovery),
+                    _existing_scopes: existing_scopes,
                     _required_scopes: required_scopes,
                 }
             } else {

--- a/crates/ui/src/components/ai/ai_setting_item.rs
+++ b/crates/ui/src/components/ai/ai_setting_item.rs
@@ -12,6 +12,7 @@ pub enum AiSettingItemStatus {
     AuthRequired,
     ClientSecretRequired,
     Authenticating,
+    InsufficientScope,
 }
 
 impl AiSettingItemStatus {
@@ -23,6 +24,7 @@ impl AiSettingItemStatus {
             Self::Error => "Server has an error.",
             Self::AuthRequired => "Authentication required.",
             Self::ClientSecretRequired => "Client secret required.",
+            Self::InsufficientScope => "Scopes required.",
             Self::Authenticating => "Waiting for authorization…",
         }
     }
@@ -33,7 +35,9 @@ impl AiSettingItemStatus {
             Self::Starting | Self::Authenticating => Some(Color::Muted),
             Self::Running => Some(Color::Success),
             Self::Error => Some(Color::Error),
-            Self::AuthRequired | Self::ClientSecretRequired => Some(Color::Warning),
+            Self::AuthRequired | Self::ClientSecretRequired | Self::InsufficientScope => {
+                Some(Color::Warning)
+            }
         }
     }
 


### PR DESCRIPTION
### Summary

Support for MCP OAuth authorization was developed in https://github.com/zed-industries/zed/pull/51768.

During initial authorization or at runtime, the MCP Client may receive scope-related errors, specifically insufficient scope. This happens when an MCP server requires higher privileges for a specific tool or resource action prompted by the user. The protocol MCP Step-Up Authorization Flow is a security mechanism which allows the MCP Server to request a higher level of authentication, which would allow AI agents to start with minimal, read-only access and dynamically request elevated privileges only when a high-stakes action is required.

This PR contains the last two steps required to complete the protocol's flow:
- Initiate re-authorization with the determined scope set, prompting the user to authorize the newly required scopes. This step required new UI/UX elements to allow the user to verify the required permissions and the already granted permissions before choosing to accept the new scope set or cancel the request.
- Retry the original request with the new authorization transparently.

The first two steps, which consist of detecting the HTTP 403 Forbidden error in the MCP server's response and the extracting the required scopes from the received WWW-Authenticate Header, were implemented in the following PR: #58787.

**This PR depends on #58787. Please review the first patch before reviewing this PR.**

### Feature Video

https://github.com/user-attachments/assets/7000f482-3877-4a6a-9497-990c106bdc0d

### Tests

New tests were added in the following files:
- `acp_thread.rs`: verifies that the OAuth upgrade process successfully broadcasts request events to the UI, resolves positively upon user approval, and throws an error if aborted or dropped;
- `agent.rs`: verifies that the connection handler correctly intercepts OAuthUpgradeRequested thread events and keeps the response channel open until the upgrade operation completes;
- `thread.rs`: validates that an OAuth upgrade prompt dispatches a ThreadEvent, resolving successfully when the response channel is triggered and returning an error if the channel is dropped;
- `conversation_view.rs`: confirms that an OAuthUpgradeRequested event triggers and presents the ScopeUpgradeModal in the workspace UI, and that the workspace properly responds to subsequent server status change events


Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Closes #52195 

Release Notes:

- Implemented the final two steps of MCP Step-Up Authorization Flow, which include the re-authorization of the required scopes and the new attempt at the original request with the new scope set
