### PR TITLE
Moves 'Go to Symbol' modal layer to right, away from editor.

### DIFF
--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -6,9 +6,9 @@ use editor::{Anchor, AnchorRangeExt, Editor, scroll::Autoscroll};
 use editor::{MultiBufferOffset, RowHighlightOptions, SelectionEffects};
 use fuzzy::StringMatch;
 use gpui::{
-    App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, HighlightStyle,
-    ParentElement, Point, Render, Styled, StyledText, Task, TextStyle, WeakEntity, Window, div,
-    rems,
+    AlignItems, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
+    HighlightStyle, ParentElement, Point, Render, Styled, StyledText, Task, TextStyle, WeakEntity,
+    Window, div, rems,
 };
 use language::{Outline, OutlineItem};
 use ordered_float::OrderedFloat;
@@ -136,6 +136,10 @@ impl ModalView for OutlineView {
             picker.delegate.restore_active_editor(window, cx)
         });
         DismissDecision::Dismiss(true)
+    }
+
+    fn align_items(&self) -> AlignItems {
+        AlignItems::FlexEnd
     }
 }
 

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    AnyView, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable as _, ManagedView,
-    MouseButton, Subscription,
+    AlignItems, AnyView, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable as _,
+    ManagedView, MouseButton, Subscription,
 };
 use ui::prelude::*;
 
@@ -26,6 +26,10 @@ pub trait ModalView: ManagedView {
     fn render_bare(&self) -> bool {
         false
     }
+
+    fn align_items(&self) -> AlignItems {
+        AlignItems::Center
+    }
 }
 
 trait ModalViewHandle {
@@ -33,6 +37,7 @@ trait ModalViewHandle {
     fn view(&self) -> AnyView;
     fn fade_out_background(&self, cx: &mut App) -> bool;
     fn render_bare(&self, cx: &mut App) -> bool;
+    fn align_items(&self, cx: &mut App) -> AlignItems;
 }
 
 impl<V: ModalView> ModalViewHandle for Entity<V> {
@@ -50,6 +55,10 @@ impl<V: ModalView> ModalViewHandle for Entity<V> {
 
     fn render_bare(&self, cx: &mut App) -> bool {
         self.read(cx).render_bare()
+    }
+
+    fn align_items(&self, cx: &mut App) -> AlignItems {
+        self.read(cx).align_items()
     }
 }
 
@@ -221,8 +230,11 @@ impl Render for ModalLayer {
                 v_flex()
                     .h(px(0.0))
                     .top_20()
-                    .items_center()
                     .track_focus(&active_modal.focus_handle)
+                    .map(|mut this| {
+                        this.style().align_items = Some(active_modal.modal.align_items(cx));
+                        this
+                    })
                     .child(
                         h_flex()
                             .occlude()


### PR DESCRIPTION
Fixes #58812.

The PR moves 'Go to Symbol' modal layer to right, away from editor, to avoid covering code.

NB: Other modal layers, e.g. Command palette, stay in center position.

New position:
<img width="1920" height="1077" alt="image" src="https://github.com/user-attachments/assets/e3c1aa9a-b9d9-4f2c-9b2c-74c7d5ef5697" />

Current position:
<img width="1920" height="1080" alt="Image" src="https://github.com/user-attachments/assets/2186fc9f-ab7c-4159-b003-0facab027392" />

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #58812

Release Notes:

- outline: Moves 'Go to Symbol' modal layer to right, away from editor, to avoid covering code
