### PR TITLE
ui: Fix stale tracked scrollbar handles

### DIFF
--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -82,6 +82,7 @@ where
     let element_id = config.id.take().unwrap_or_else(|| caller_location.into());
     let track_color = config.track_color;
     let has_border = config.border;
+    let scrollable_handle = config.scrollable_handle.clone();
 
     let state = window.use_keyed_state(element_id, cx, |_, cx| {
         let parent_id = cx.entity_id();
@@ -90,6 +91,7 @@ where
 
     state.update(cx, |state, cx| {
         state.0.update(cx, |state, _cx| {
+            state.update_scroll_handle(scrollable_handle);
             state.update_colors(track_color, has_border)
         })
     });
@@ -658,6 +660,13 @@ impl<T: ScrollableHandle> ScrollbarState<T> {
             mouse_in_parent: true,
             last_prepaint_state: None,
             _auto_hide_task: None,
+        }
+    }
+
+    fn update_scroll_handle(&mut self, scrollable_handle: Handle<T>) {
+        if let Handle::Tracked(scroll_handle) = scrollable_handle {
+            self.manually_added = true;
+            self.scroll_handle = scroll_handle;
         }
     }
 


### PR DESCRIPTION
Update persisted scrollbar state with the latest explicitly tracked scroll handle on each render. This keeps custom scrollbars connected when their scrollable content rebuilds with a new ScrollHandle, such as after deleting an item from the Remote Projects list.

Untracked scrollbars keep their existing behavior so their scroll state is not reset across renders.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes https://github.com/zed-industries/zed/issues/58816

Release Notes:

- N/A or Added/Fixed/Improved ...
