### PR TITLE
gpui: Put profiler behind feature and disable it

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -39,6 +39,7 @@ screen-capture = [
 ]
 windows-manifest = ["dep:embed-resource"]
 input-latency-histogram = ["dep:hdrhistogram"]
+profiler = []
 
 [lib]
 path = "src/gpui.rs"

--- a/crates/gpui/src/action.rs
+++ b/crates/gpui/src/action.rs
@@ -342,6 +342,7 @@ impl ActionRegistry {
         Ok(self.build_action(name, None)?)
     }
 
+    #[cfg(feature = "profiler")]
     pub(crate) fn try_resolve_action(&self, type_id: &TypeId) -> Option<&'static str> {
         self.names_by_type_id.get(type_id).copied()
     }

--- a/crates/gpui/src/profiler.rs
+++ b/crates/gpui/src/profiler.rs
@@ -21,21 +21,46 @@ use serde::{Deserialize, Serialize};
 
 use crate::{SharedString, TasksIncluded};
 
+#[cfg(feature = "profiler")]
 #[doc(hidden)]
 pub fn get_all_timings(included: gpui::TasksIncluded) -> Vec<gpui::ThreadTaskTimings> {
     let global_thread_timings = GLOBAL_THREAD_TIMINGS.lock();
     ThreadTaskTimings::collect(&global_thread_timings, included)
 }
 
+#[cfg(feature = "profiler")]
 #[doc(hidden)]
 pub fn get_current_thread_timings(included: TasksIncluded) -> gpui::ThreadTaskTimings {
     gpui::profiler::get_current_thread_task_timings(included)
 }
 
+#[cfg(feature = "profiler")]
 #[doc(hidden)]
 pub fn take_all_stats(included: TasksIncluded) -> Vec<gpui::ThreadTaskStatistics> {
     let global_timings = GLOBAL_THREAD_TIMINGS.lock();
     ThreadTaskStatistics::collect_and_reset(&global_timings, included)
+}
+
+#[cfg(not(feature = "profiler"))]
+#[doc(hidden)]
+pub fn get_all_timings(_included: gpui::TasksIncluded) -> Vec<gpui::ThreadTaskTimings> {
+    Vec::new()
+}
+#[cfg(not(feature = "profiler"))]
+#[doc(hidden)]
+pub fn get_current_thread_timings(_included: TasksIncluded) -> gpui::ThreadTaskTimings {
+    gpui::ThreadTaskTimings {
+        thread_name: None,
+        thread_id: std::thread::current().id(),
+        timings: Vec::new(),
+        stats: TaskStatistics::default(),
+        total_pushed: 0,
+    }
+}
+#[cfg(not(feature = "profiler"))]
+#[doc(hidden)]
+pub fn take_all_stats(_included: TasksIncluded) -> Vec<gpui::ThreadTaskStatistics> {
+    Vec::new()
 }
 
 #[doc(hidden)]
@@ -378,6 +403,7 @@ impl ProfilingCollector {
 // Allow 16MiB of task timing entries.
 // VecDeque grows by doubling its capacity when full, so keep this a power of 2 to avoid wasting
 // memory.
+#[cfg(feature = "profiler")]
 const MAX_TASK_TIMINGS: usize = (16 * 1024 * 1024) / core::mem::size_of::<TaskTiming>();
 
 #[doc(hidden)]
@@ -530,6 +556,7 @@ impl ThreadTimings {
         }
     }
 
+    #[cfg(feature = "profiler")]
     pub fn update_running_task(
         &mut self,
         spawned: SpawnTime,
@@ -542,7 +569,10 @@ impl ThreadTimings {
             start,
         });
     }
+    #[cfg(not(feature = "profiler"))]
+    pub fn update_running_task(&mut self, _: SpawnTime, _: &'static std::panic::Location<'_>) {}
 
+    #[cfg(feature = "profiler")]
     pub fn save_task_timing(&mut self, ended: YieldTime) {
         let ActiveTiming {
             location,
@@ -571,6 +601,8 @@ impl ThreadTimings {
             self.total_pushed += 1;
         }
     }
+    #[cfg(not(feature = "profiler"))]
+    pub fn save_task_timing(&mut self, _: YieldTime) {}
 
     // Running tasks are included in the reliability trace, which is written
     // whenever the foreground executor makes no progress for > n seconds

--- a/crates/gpui/src/profiler/actions.rs
+++ b/crates/gpui/src/profiler/actions.rs
@@ -1,7 +1,4 @@
-use std::{
-    hint::cold_path,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use itertools::Itertools;
 
@@ -75,10 +72,14 @@ impl ActionStatistics {
         self.longest_runtimes.is_empty()
     }
 
+    #[cfg(feature = "profiler")]
     pub fn update_running_action(&mut self, action: &'static str, started: Instant) {
         self.running = Some((action, started));
     }
+    #[cfg(not(feature = "profiler"))]
+    pub fn update_running_action(&mut self, _action: &'static str, _started: Instant) {}
 
+    #[cfg(feature = "profiler")]
     pub fn save_action_timing(&mut self) {
         let now = Instant::now();
         let (action, started) = self
@@ -88,7 +89,7 @@ impl ActionStatistics {
 
         let runtime = now.duration_since(started);
         if runtime >= self.runtime_to_beat {
-            cold_path(); // most actions are not the worst, optimize for that
+            std::hint::cold_path(); // most actions are not the worst, optimize for that
 
             if self.longest_runtimes.is_full()
                 && let Some(to_replace) = self
@@ -119,6 +120,8 @@ impl ActionStatistics {
                 .expect("never empty");
         }
     }
+    #[cfg(not(feature = "profiler"))]
+    pub fn save_action_timing(&mut self) {}
 
     pub fn longest_runtimes(&self, include_running: bool) -> impl Iterator<Item = ActionTiming> {
         self.longest_runtimes.iter().copied().chain(
@@ -167,10 +170,12 @@ impl ActionTiming {
 
 // The profiler is careful to never block when the lock is held, therefore a
 // spinlock is optimal.
+#[cfg(feature = "profiler")]
 static ACTION_STATISTICS: spin::Mutex<ActionStatistics> =
     const { spin::Mutex::new(ActionStatistics::new()) };
 
 #[doc(hidden)]
+#[cfg(feature = "profiler")]
 pub(crate) fn update_running_action(action: &(dyn Action + 'static), cx: &mut crate::App) {
     let now = Instant::now();
     let action = action.type_id();
@@ -179,11 +184,27 @@ pub(crate) fn update_running_action(action: &(dyn Action + 'static), cx: &mut cr
 }
 
 #[doc(hidden)]
+#[cfg(not(feature = "profiler"))]
+pub(crate) fn update_running_action(_: &(dyn Action + 'static), _: &mut crate::App) {}
+
+#[doc(hidden)]
+#[cfg(feature = "profiler")]
 pub(crate) fn save_action_timing() {
     ACTION_STATISTICS.lock().save_action_timing();
 }
 
 #[doc(hidden)]
+#[cfg(not(feature = "profiler"))]
+pub(crate) fn save_action_timing() {}
+
+#[doc(hidden)]
+#[cfg(feature = "profiler")]
 pub fn take_action_stats() -> ActionStatistics {
     ACTION_STATISTICS.lock().take()
+}
+
+#[doc(hidden)]
+#[cfg(not(feature = "profiler"))]
+pub fn take_action_stats() -> ActionStatistics {
+    ActionStatistics::default()
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -20,6 +20,7 @@ use crate::{
     WindowOptions, WindowParams, WindowTextSystem, point, prelude::*, profiler, px, rems, size,
     transparent_black,
 };
+
 use anyhow::{Context as _, Result, anyhow};
 use collections::{FxHashMap, FxHashSet};
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
This disables the GPUI profiler by default, it is opt in using the feature gpui/profiler. We had one report of a possible deadlock, until that is resolved the profiler will be disabled. By doing this with a feature we can keep the code and fix forward on nightly post release. It will also be useful to other GPUI users who are not using the profiler infrastructure and now no longer need to pay the overhead (0.1%).

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A