### PR TITLE
git_ui: Fix panic when splitting a pane containing a commit view

### DIFF
--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -82,6 +82,7 @@ pub struct CommitView {
     stash: Option<usize>,
     multibuffer: Entity<MultiBuffer>,
     repository: Entity<Repository>,
+    project: Entity<Project>,
     workspace: WeakEntity<Workspace>,
     remote: Option<GitRemote>,
 }
@@ -471,6 +472,7 @@ impl CommitView {
             multibuffer,
             stash,
             repository,
+            project,
             workspace,
             remote,
         }
@@ -1173,7 +1175,7 @@ impl Item for CommitView {
         let Some(workspace_entity) = self.workspace.upgrade() else {
             return Task::ready(None);
         };
-        let project = workspace_entity.read(cx).project().clone();
+        let project = self.project.clone();
         let diff_view_style = self.editor.read(cx).diff_view_style();
         let multibuffer = self.multibuffer.clone();
         Task::ready(Some(cx.new(|cx| {
@@ -1223,6 +1225,7 @@ impl Item for CommitView {
                 commit: self.commit.clone(),
                 stash: self.stash,
                 repository: self.repository.clone(),
+                project: self.project.clone(),
                 workspace: self.workspace.clone(),
                 remote: self.remote.clone(),
             }


### PR DESCRIPTION
Closes FR-65

Release Notes:

- Fixed a crash when splitting a pane containing a commit view.