### PR TITLE
terminal: Add per-terminal theme overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18270,6 +18270,7 @@ dependencies = [
  "task",
  "terminal",
  "theme",
+ "theme_selector",
  "theme_settings",
  "ui",
  "util",

--- a/crates/repl/src/outputs/plain.rs
+++ b/crates/repl/src/outputs/plain.rs
@@ -362,8 +362,9 @@ impl Render for TerminalOutput {
 
         let text_style = text_style(window, cx);
         let minimum_contrast = TerminalSettings::get_global(cx).minimum_contrast;
+        let theme = cx.theme().clone();
         let (rects, batched_text_runs) = terminal.read(cx).with_renderable_cells(|cells| {
-            TerminalElement::layout_grid(cells, 0, &text_style, None, minimum_contrast, cx)
+            TerminalElement::layout_grid(cells, 0, &text_style, None, minimum_contrast, &theme)
         });
 
         // lines are 0-indexed, so we must add 1 to get the number of lines

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -41,6 +41,7 @@ settings.workspace = true
 shellexpand.workspace = true
 terminal.workspace = true
 theme.workspace = true
+theme_selector.workspace = true
 theme_settings.workspace = true
 ui.workspace = true
 util.workspace = true

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -17,7 +17,7 @@ use terminal::{
     TerminalBounds, is_app_chosen_exact_color as terminal_is_app_chosen_exact_color,
     is_default_background_color, terminal_settings::TerminalSettings,
 };
-use theme::{ActiveTheme, Theme};
+use theme::Theme;
 use theme_settings::ThemeSettings;
 use ui::utils::ensure_minimum_contrast;
 use ui::{ParentElement, Tooltip};
@@ -375,10 +375,9 @@ impl TerminalElement {
         text_style: &TextStyle,
         hyperlink: Option<(HighlightStyle, &Range)>,
         minimum_contrast: f32,
-        cx: &App,
+        theme: &Theme,
     ) -> (Vec<LayoutRect>, Vec<BatchedTextRun>) {
         let start_time = Instant::now();
-        let theme = cx.theme();
 
         // Pre-allocate with estimated capacity to reduce reallocations
         let estimated_cells = grid.size_hint().0;
@@ -971,7 +970,7 @@ impl Element for TerminalElement {
                         }),
                 };
 
-                let theme = cx.theme().clone();
+                let theme = self.terminal_view.read(cx).effective_theme(cx);
 
                 let link_style = HighlightStyle {
                     color: Some(theme.colors().link_text_hover),
@@ -1173,7 +1172,7 @@ impl Element for TerminalElement {
                             .as_ref()
                             .map(|last_hovered_word| (link_style, &last_hovered_word.word_match)),
                         minimum_contrast,
-                        cx,
+                        &theme,
                     )
                 } else {
                     // Calculate which screen rows are visible based on pixel positions.
@@ -1204,7 +1203,7 @@ impl Element for TerminalElement {
                             .as_ref()
                             .map(|last_hovered_word| (link_style, &last_hovered_word.word_match)),
                         minimum_contrast,
-                        cx,
+                        &theme,
                     )
                 };
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -32,6 +32,7 @@ use std::{
     time::Duration,
 };
 use task::TaskId;
+use theme::{Theme, ThemeRegistry};
 use terminal::{
     Clear, Copy, Event, HoveredWord, MaybeNavigationTarget, Modes, Paste, PasteText, Point, Range,
     ScrollLineDown, ScrollLineUp, ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop,
@@ -141,6 +142,10 @@ pub struct TerminalView {
     blinking_terminal_enabled: bool,
     needs_serialize: bool,
     custom_title: Option<String>,
+    // Per-terminal theme override (name + resolved theme). Resolved once at set
+    // time and re-resolved on settings change so the render path never resolves
+    // by name per frame.
+    theme_override: Option<(SharedString, Arc<Theme>)>,
     hover: Option<HoverTarget>,
     hover_tooltip_update: Task<()>,
     workspace_id: Option<WorkspaceId>,
@@ -294,6 +299,7 @@ impl TerminalView {
             scroll_handle,
             needs_serialize: false,
             custom_title: None,
+            theme_override: None,
             ime_state: None,
             self_handle: cx.entity().downgrade(),
             rename_editor: None,
@@ -313,6 +319,68 @@ impl TerminalView {
             max_lines_when_unfocused,
         };
         cx.notify();
+    }
+
+    /// Set or clear this terminal's per-terminal theme override by name. An
+    /// unresolvable name is logged and leaves the terminal on the window theme.
+    pub fn set_theme_override(
+        &mut self,
+        theme_name: Option<SharedString>,
+        cx: &mut Context<Self>,
+    ) {
+        self.theme_override = theme_name.and_then(|name| {
+            ThemeRegistry::global(cx)
+                .get(name.as_ref())
+                .log_err()
+                .map(|theme| (name, theme))
+        });
+        cx.notify();
+    }
+
+    pub fn theme_override_name(&self) -> Option<&SharedString> {
+        self.theme_override.as_ref().map(|(name, _)| name)
+    }
+
+    /// The theme this terminal renders with: its per-terminal override when set,
+    /// otherwise the window/global active theme.
+    pub fn effective_theme(&self, cx: &App) -> Arc<Theme> {
+        self.theme_override
+            .as_ref()
+            .map(|(_, theme)| theme.clone())
+            .unwrap_or_else(|| cx.theme().clone())
+    }
+
+    fn set_terminal_theme(
+        &mut self,
+        _: &zed_actions::theme::Terminal,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let current = self.theme_override_name().cloned();
+        let view = self.self_handle.clone();
+        self.workspace
+            .update(cx, |workspace, cx| {
+                theme_selector::toggle_theme_selector_for_override(
+                    workspace,
+                    current,
+                    move |theme_name, cx| {
+                        view.update(cx, |view, cx| view.set_theme_override(theme_name, cx))
+                            .log_err();
+                    },
+                    window,
+                    cx,
+                );
+            })
+            .log_err();
+    }
+
+    fn clear_terminal_theme(
+        &mut self,
+        _: &zed_actions::theme::ClearTerminal,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.set_theme_override(None, cx);
     }
 
     const MAX_EMBEDDED_LINES: usize = 1_000;
@@ -587,6 +655,14 @@ impl TerminalView {
         if breadcrumb_visibility_changed {
             cx.emit(ItemEvent::UpdateBreadcrumbs);
         }
+
+        if let Some((name, _)) = &self.theme_override {
+            let name = name.clone();
+            if let Some(theme) = ThemeRegistry::global(cx).get(name.as_ref()).log_err() {
+                self.theme_override = Some((name, theme));
+            }
+        }
+
         cx.notify();
     }
 
@@ -1332,6 +1408,8 @@ impl Render for TerminalView {
             .on_action(cx.listener(TerminalView::select_all))
             .on_action(cx.listener(TerminalView::rerun_task))
             .on_action(cx.listener(TerminalView::rename_terminal))
+            .on_action(cx.listener(TerminalView::set_terminal_theme))
+            .on_action(cx.listener(TerminalView::clear_terminal_theme))
             .on_key_down(cx.listener(Self::key_down))
             .on_mouse_down(
                 MouseButton::Right,
@@ -2858,6 +2936,105 @@ mod tests {
 
         terminal_view.update(cx, |view, _cx| {
             assert!(view.custom_title().is_none());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_per_terminal_theme_override(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, _workspace, window) = init_test_with_window(cx).await;
+
+        // Register two themes that differ only in their terminal background, so
+        // we can prove each terminal resolves its own theme.
+        let (bg_a, bg_b) = cx.update(|cx| {
+            let registry = ThemeRegistry::global(cx);
+            let base = registry.get("One Dark").unwrap();
+
+            let mut theme_a = (*base).clone();
+            theme_a.id = "per-terminal-a".to_string();
+            theme_a.name = "Per Terminal A".into();
+            theme_a.styles.colors.terminal_background = gpui::hsla(0.1, 0.5, 0.5, 1.0);
+
+            let mut theme_b = (*base).clone();
+            theme_b.id = "per-terminal-b".to_string();
+            theme_b.name = "Per Terminal B".into();
+            theme_b.styles.colors.terminal_background = gpui::hsla(0.6, 0.5, 0.5, 1.0);
+
+            let bg_a = theme_a.colors().terminal_background;
+            let bg_b = theme_b.colors().terminal_background;
+
+            registry.register_test_themes([theme::ThemeFamily {
+                id: "per-terminal-family".to_string(),
+                name: "Per Terminal Family".into(),
+                author: "test".into(),
+                themes: vec![theme_a, theme_b],
+                scales: theme::default_color_scales(),
+            }]);
+            (bg_a, bg_b)
+        });
+
+        // Two terminals living in the same window.
+        let (_pane_a, _term_a, view_a) = add_display_only_terminal(&project, window, false, cx);
+        let (_pane_b, _term_b, view_b) = add_display_only_terminal(&project, window, false, cx);
+
+        view_a.update(cx, |view, cx| {
+            view.set_theme_override(Some("Per Terminal A".into()), cx)
+        });
+        view_b.update(cx, |view, cx| {
+            view.set_theme_override(Some("Per Terminal B".into()), cx)
+        });
+
+        // AC-1: each terminal renders with its own theme.
+        cx.update(|cx| {
+            let ta = view_a.read(cx).effective_theme(cx);
+            let tb = view_b.read(cx).effective_theme(cx);
+            assert_eq!(ta.name.as_ref(), "Per Terminal A");
+            assert_eq!(tb.name.as_ref(), "Per Terminal B");
+            assert_eq!(ta.colors().terminal_background, bg_a);
+            assert_eq!(tb.colors().terminal_background, bg_b);
+            assert_ne!(
+                ta.colors().terminal_background,
+                tb.colors().terminal_background
+            );
+        });
+
+        // AC-2: clearing one terminal falls back to the window/global theme and
+        // leaves the other terminal's override intact.
+        view_a.update(cx, |view, cx| view.set_theme_override(None, cx));
+        cx.update(|cx| {
+            let global_name = cx.theme().name.clone();
+            let ta = view_a.read(cx).effective_theme(cx);
+            assert_eq!(ta.name, global_name);
+            assert!(view_a.read(cx).theme_override_name().is_none());
+
+            let tb = view_b.read(cx).effective_theme(cx);
+            assert_eq!(tb.name.as_ref(), "Per Terminal B");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_terminal_theme_override_invalid_name_falls_back(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, _workspace, window) = init_test_with_window(cx).await;
+        let (_pane, _term, view) = add_display_only_terminal(&project, window, false, cx);
+
+        view.update(cx, |view, cx| {
+            view.set_theme_override(Some("No Such Theme 12345".into()), cx);
+            assert!(
+                view.theme_override_name().is_none(),
+                "an unresolvable theme name is not stored as an override"
+            );
+        });
+
+        cx.update(|cx| {
+            let effective = view.read(cx).effective_theme(cx);
+            assert_eq!(
+                effective.name,
+                cx.theme().name,
+                "an unresolved override falls back to the window/global theme"
+            );
         });
     }
 

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -3,8 +3,8 @@ mod icon_theme_selector;
 use fs::Fs;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{
-    App, Context, DismissEvent, Entity, EventEmitter, Focusable, Render, UpdateGlobal, WeakEntity,
-    Window, actions,
+    App, Context, DismissEvent, Entity, EventEmitter, Focusable, Render, SharedString,
+    UpdateGlobal, WeakEntity, Window, actions,
 };
 use picker::{Picker, PickerDelegate};
 use settings::{Settings, SettingsStore, update_settings_file};
@@ -55,6 +55,39 @@ fn toggle_theme_selector(
             cx.entity().downgrade(),
             fs,
             toggle.themes_filter.as_ref(),
+            None,
+            None,
+            cx,
+        );
+        ThemeSelector::new(delegate, window, cx)
+    });
+}
+
+/// Applies a previewed/selected theme override by name (`None` clears it). Used
+/// to drive a per-target override (e.g. a single terminal) instead of mutating
+/// the global theme settings.
+type ApplyThemeOverride = Box<dyn Fn(Option<SharedString>, &mut App)>;
+
+/// Open the theme selector scoped to a single override target rather than the
+/// global theme. Navigation previews live via `apply_override`, dismiss reverts
+/// to `current_override`, and confirm keeps the selection without persisting to
+/// the settings file.
+pub fn toggle_theme_selector_for_override(
+    workspace: &mut Workspace,
+    current_override: Option<SharedString>,
+    apply_override: impl Fn(Option<SharedString>, &mut App) + 'static,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let fs = workspace.app_state().fs.clone();
+    let apply_override: ApplyThemeOverride = Box::new(apply_override);
+    workspace.toggle_modal(window, cx, move |window, cx| {
+        let delegate = ThemeSelectorDelegate::new(
+            cx.entity().downgrade(),
+            fs,
+            None,
+            current_override,
+            Some(apply_override),
             cx,
         );
         ThemeSelector::new(delegate, window, cx)
@@ -148,6 +181,12 @@ struct ThemeSelectorDelegate {
     selected_theme: Option<Arc<Theme>>,
     selected_index: usize,
     selector: WeakEntity<ThemeSelector>,
+    /// The override the target carried before the selector opened; restored on
+    /// dismiss. Only meaningful in override (per-target) mode.
+    original_override: Option<SharedString>,
+    /// When set, the selector drives a per-target override via this callback
+    /// instead of mutating global theme settings.
+    apply_override: Option<ApplyThemeOverride>,
 }
 
 impl ThemeSelectorDelegate {
@@ -155,6 +194,8 @@ impl ThemeSelectorDelegate {
         selector: WeakEntity<ThemeSelector>,
         fs: Arc<dyn Fs>,
         themes_filter: Option<&Vec<String>>,
+        original_override: Option<SharedString>,
+        apply_override: Option<ApplyThemeOverride>,
         cx: &mut Context<ThemeSelector>,
     ) -> Self {
         let original_theme = cx.theme().clone();
@@ -197,10 +238,16 @@ impl ThemeSelectorDelegate {
             })
             .collect();
 
-        // The current theme is likely in this list, so default to first showing that.
+        // The current theme is likely in this list, so default to first showing
+        // that — or the target's existing override when one is set.
         let selected_index = matches
             .iter()
-            .position(|mat| mat.string == original_theme.name)
+            .position(|mat| Some(mat.string.as_str()) == original_override.as_deref())
+            .or_else(|| {
+                matches
+                    .iter()
+                    .position(|mat| mat.string == original_theme.name)
+            })
             .unwrap_or(0);
 
         Self {
@@ -215,6 +262,8 @@ impl ThemeSelectorDelegate {
             selection_completed: false,
             selected_theme: None,
             selector,
+            original_override,
+            apply_override,
         }
     }
 
@@ -248,24 +297,33 @@ impl ThemeSelectorDelegate {
     }
 
     fn revert_theme(&mut self, cx: &mut App) {
-        if !self.selection_completed {
+        if self.selection_completed {
+            return;
+        }
+        if let Some(apply) = &self.apply_override {
+            apply(self.original_override.clone(), cx);
+        } else {
             SettingsStore::update_global(cx, |store, _| {
                 store.override_global(self.original_theme_settings.clone());
             });
-            self.selection_completed = true;
         }
+        self.selection_completed = true;
     }
 
     fn set_theme(&mut self, new_theme: Arc<Theme>, cx: &mut App) {
-        // Update the global (in-memory) theme settings.
-        SettingsStore::update_global(cx, |store, _| {
-            override_global_theme(
-                store,
-                &new_theme,
-                &self.original_theme_settings.theme,
-                self.original_system_appearance,
-            )
-        });
+        if let Some(apply) = &self.apply_override {
+            apply(Some(new_theme.name.clone()), cx);
+        } else {
+            // Update the global (in-memory) theme settings.
+            SettingsStore::update_global(cx, |store, _| {
+                override_global_theme(
+                    store,
+                    &new_theme,
+                    &self.original_theme_settings.theme,
+                    self.original_system_appearance,
+                )
+            });
+        }
 
         self.new_theme = new_theme;
     }
@@ -394,15 +452,19 @@ impl PickerDelegate for ThemeSelectorDelegate {
     ) {
         self.selection_completed = true;
 
-        let theme_name: Arc<str> = self.new_theme.name.as_str().into();
-        let theme_appearance = self.new_theme.appearance;
-        let system_appearance = SystemAppearance::global(cx).0;
+        // Per-target override mode: the theme was already applied live during
+        // preview; nothing is persisted to the settings file (session-scoped).
+        if self.apply_override.is_none() {
+            let theme_name: Arc<str> = self.new_theme.name.as_str().into();
+            let theme_appearance = self.new_theme.appearance;
+            let system_appearance = SystemAppearance::global(cx).0;
 
-        telemetry::event!("Settings Changed", setting = "theme", value = theme_name);
+            telemetry::event!("Settings Changed", setting = "theme", value = theme_name);
 
-        update_settings_file(self.fs.clone(), cx, move |settings, _| {
-            theme_settings::set_theme(settings, theme_name, theme_appearance, system_appearance);
-        });
+            update_settings_file(self.fs.clone(), cx, move |settings, _| {
+                theme_settings::set_theme(settings, theme_name, theme_appearance, system_appearance);
+            });
+        }
 
         self.selector
             .update(cx, |_, cx| {
@@ -573,6 +635,8 @@ mod tests {
     use gpui::{TestAppContext, VisualTestContext};
     use project::Project;
     use serde_json::json;
+    use std::cell::RefCell;
+    use std::rc::Rc;
     use theme::{Appearance, ThemeFamily, ThemeRegistry, default_color_scales};
     use util::path;
     use workspace::MultiWorkspace;
@@ -711,6 +775,72 @@ mod tests {
             previewed_theme_name(&picker, cx),
             "Test Light",
             "previewed theme should be preserved after clearing an empty filter"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_theme_selector_override_mode_previews_and_reverts(cx: &mut TestAppContext) {
+        let app_state = setup_test(cx).await;
+        let project = Project::test(app_state.fs.clone(), [path!("/test").as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+
+        // Record every override the selector applies through the callback.
+        let applied: Rc<RefCell<Vec<Option<String>>>> = Rc::new(RefCell::new(Vec::new()));
+
+        let picker = {
+            let applied = applied.clone();
+            workspace.update_in(cx, |workspace, window, cx| {
+                super::toggle_theme_selector_for_override(
+                    workspace,
+                    None,
+                    move |name, _cx| applied.borrow_mut().push(name.map(|n| n.to_string())),
+                    window,
+                    cx,
+                );
+            });
+            cx.run_until_parked();
+            workspace.update(cx, |workspace, cx| {
+                workspace
+                    .active_modal::<ThemeSelector>(cx)
+                    .expect("theme selector should be open in override mode")
+                    .read(cx)
+                    .picker
+                    .clone()
+            })
+        };
+
+        // Previewing a theme applies it to the target via the override callback,
+        // not to global settings.
+        let target_index = picker.read_with(cx, |picker, _| {
+            picker
+                .delegate
+                .matches
+                .iter()
+                .position(|m| m.string == "Test Light")
+                .unwrap()
+        });
+        picker.update_in(cx, |picker, window, cx| {
+            picker.set_selected_index(target_index, None, true, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            applied.borrow().last().cloned().flatten().as_deref(),
+            Some("Test Light"),
+            "previewing should apply the theme to the target via the override callback"
+        );
+
+        // Dismissing without confirming reverts to the original (None) override.
+        picker.update_in(cx, |picker, window, cx| {
+            picker.delegate.dismissed(window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            applied.borrow().last().cloned().flatten(),
+            None,
+            "dismiss should revert the target to its original override"
         );
     }
 }

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -397,7 +397,16 @@ pub mod feedback {
 pub mod theme {
     use gpui::actions;
 
-    actions!(theme, [ToggleMode]);
+    actions!(
+        theme,
+        [
+            ToggleMode,
+            /// Sets a theme for the focused terminal only, without changing the global theme.
+            Terminal,
+            /// Clears the focused terminal's theme override, returning it to the window/global theme.
+            ClearTerminal
+        ]
+    );
 }
 
 pub mod theme_selector {


### PR DESCRIPTION
## Summary

Let each terminal carry its own theme, independent of the window/global theme, so multiple terminals in one window are visually distinguishable at a glance. The theme is chosen per terminal from the theme picker (`theme: terminal`) and is never written to `settings.json` — it is session-scoped and user-driven.

This addresses the recurring request for a terminal theme distinct from the editor theme — #22957 ("Separate editor and terminal themes") and discussion #38126 ("set the color theme of the terminal pane") — and generalizes it to per-pane granularity: each terminal, not just "the terminal".

It's a companion to #58755 (per-window theme overrides), applying the same "distinguish your contexts at a glance" idea one level deeper — to individual terminals within a window rather than whole windows. The two are independent and can land separately.

## Demo

Four terminals in one window, each with its own theme, set with `theme: terminal`:

![Per-terminal themes](https://raw.githubusercontent.com/42piratas/zed-an/main/assets/per-terminal-theme.png)

## How it works

A terminal resolves all of its colors from just two `cx.theme()` reads inside `TerminalElement` (`prepaint` and `layout_grid`). Rather than mutate any global, the element now reads the owning view's *effective theme*, so panes in the same window can render different themes with no global swap:

- **terminal_view**: `TerminalView` holds an optional resolved theme override. `effective_theme()` returns that override or falls back to the window/global active theme, and is re-resolved on settings change. `TerminalElement` reads `effective_theme` at its two theme-capture points; `layout_grid` now takes the theme explicitly.
- **zed_actions / terminal_view**: `theme: terminal` opens the theme picker scoped to the focused terminal; `theme: clear terminal` reverts it to the window/global theme. Palette-discoverable, no keybinding.
- **theme_selector**: the picker gained an optional apply-override callback so it can drive a single terminal's theme — live preview while navigating, revert on dismiss, no settings-file write — leaving the global theme-selection path unchanged.

## Out of scope

Persisting per-terminal themes across restart (session-scoped for now); reading a terminal theme from project settings; activity-based theme switching.

## Testing

Open two or more terminals in one window → command palette → **theme: terminal** in each → pick different themes. Confirm each terminal renders its own theme while the tab bar and other terminals stay on the window theme, that no `theme` key is written to any settings file, and that **theme: clear terminal** reverts. Unit tests cover per-view resolution + fallback (`terminal_view`) and the selector's override-mode preview/revert (`theme_selector`).

## Release Notes:

- Added per-terminal theme overrides (`theme: terminal`) so each terminal can use its own theme.
