### PR TITLE
Update to theme schema v0.2.1

### DIFF
--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "$schema": "https://zed.dev/schema/themes/v0.2.1.json",
   "name": "Ayu",
   "author": "Zed Industries",
   "themes": [

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "$schema": "https://zed.dev/schema/themes/v0.2.1.json",
   "name": "Gruvbox",
   "author": "Zed Industries",
   "themes": [

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://zed.dev/schema/themes/v0.2.0.json",
+  "$schema": "https://zed.dev/schema/themes/v0.2.1.json",
   "name": "One",
   "author": "Zed Industries",
   "themes": [

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -17,7 +17,7 @@ use theme::{Appearance, AppearanceContent};
 use crate::vscode::VsCodeTheme;
 use crate::vscode::VsCodeThemeConverter;
 
-const ZED_THEME_SCHEMA_URL: &str = "https://zed.dev/schema/themes/v0.2.0.json";
+const ZED_THEME_SCHEMA_URL: &str = "https://zed.dev/schema/themes/v0.2.1.json";
 
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/docs/src/extensions/themes.md
+++ b/docs/src/extensions/themes.md
@@ -7,13 +7,13 @@ description: "Themes for Zed extensions."
 
 The `themes` directory in an extension should contain one or more theme files.
 
-Each theme file should adhere to the JSON schema specified at [`https://zed.dev/schema/themes/v0.2.0.json`](https://zed.dev/schema/themes/v0.2.0.json).
+Each theme file should adhere to the JSON schema specified at [`https://zed.dev/schema/themes/v0.2.1.json`](https://zed.dev/schema/themes/v0.2.1.json).
 
 See [this blog post](https://zed.dev/blog/user-themes-now-in-preview) for additional background on creating themes.
 
 ## Theme JSON Structure
 
-The structure of a Zed theme is defined in the [Zed Theme JSON Schema](https://zed.dev/schema/themes/v0.2.0.json).
+The structure of a Zed theme is defined in the [Zed Theme JSON Schema](https://zed.dev/schema/themes/v0.2.1.json).
 
 A Zed theme consists of a Theme Family object including:
 


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #58837

Release Notes:

- Adds the following theme properties that are missing in the current schema:

```
editor.hover_line_number
scrollbar.thumb.active_background
search.active_match_background
version_control.added
version_control.conflict_marker.ours
version_control.conflict_marker.theirs
version_control.deleted
version_control.modified
version_control.word_added
version_control.word_deleted
```

## Important note

This is **not** the actual schema change, just updated references. The schema itself needs to be updated, but it does not live in this repository. The docs are hosted on Cloudflare, but the current schema (https://zed.dev/schema/themes/v0.2.0.json) is hosted with Vercel. 

Before this PR can land, a new version of the schema needs to be added and hosted by Zed. I've uploaded an updated schema here: https://gist.githubusercontent.com/valtism/e5e885a62e1e3783add456c1dfec1fe9/raw/07dc652c2d869433ef416d59141af9c4145623dc/v0.2.1.json