### PR TITLE
lsp: Bound the incoming language server message queue

### DIFF
--- a/crates/lsp/src/input_handler.rs
+++ b/crates/lsp/src/input_handler.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use anyhow::{Context as _, Result};
 use collections::HashMap;
 use futures::{
-    AsyncBufReadExt, AsyncRead, AsyncReadExt as _,
-    channel::mpsc::{UnboundedReceiver, UnboundedSender, unbounded},
+    AsyncBufReadExt, AsyncRead, AsyncReadExt as _, SinkExt as _,
+    channel::mpsc::{Receiver, Sender, channel},
 };
 use gpui::{BackgroundExecutor, Task};
 use log::warn;
@@ -18,10 +18,18 @@ use crate::{
 };
 
 const HEADER_DELIMITER: &[u8; 4] = b"\r\n\r\n";
+
+/// Bounds the number of incoming LSP messages buffered between the background
+/// reader and the foreground dispatcher. When the queue is full, the reader
+/// stops reading the server's stdout, letting the OS pipe apply backpressure
+/// to the server instead of buffering messages in memory without limit while
+/// the foreground thread is unresponsive.
+pub(crate) const INCOMING_MESSAGE_QUEUE_CAPACITY: usize = 128;
+
 /// Handler for stdout of language server.
 pub struct LspStdoutHandler {
     pub(super) loop_handle: Task<Result<()>>,
-    pub(super) incoming_messages: UnboundedReceiver<NotificationOrRequest>,
+    pub(super) incoming_messages: Receiver<NotificationOrRequest>,
 }
 
 async fn read_headers<Stdout>(reader: &mut BufReader<Stdout>, buffer: &mut Vec<u8>) -> Result<()>
@@ -51,7 +59,7 @@ impl LspStdoutHandler {
     where
         Input: AsyncRead + Unpin + Send + 'static,
     {
-        let (tx, notifications_channel) = unbounded();
+        let (tx, notifications_channel) = channel(INCOMING_MESSAGE_QUEUE_CAPACITY);
         let loop_handle = cx.spawn(Self::handler(stdout, tx, response_handlers, io_handlers));
         Self {
             loop_handle,
@@ -61,7 +69,7 @@ impl LspStdoutHandler {
 
     async fn handler<Input>(
         stdout: Input,
-        notifications_sender: UnboundedSender<NotificationOrRequest>,
+        mut notifications_sender: Sender<NotificationOrRequest>,
         response_handlers: Arc<Mutex<Option<HashMap<RequestId, ResponseHandler>>>>,
         io_handlers: Arc<Mutex<HashMap<i32, IoHandler>>>,
     ) -> anyhow::Result<()>
@@ -98,7 +106,7 @@ impl LspStdoutHandler {
             }
 
             if let Ok(msg) = serde_json::from_slice::<NotificationOrRequest>(&buffer) {
-                notifications_sender.unbounded_send(msg)?;
+                notifications_sender.send(msg).await?;
             } else if let Ok(AnyResponse {
                 id, error, result, ..
             }) = serde_json::from_slice(&buffer)
@@ -131,6 +139,53 @@ impl LspStdoutHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::{AsyncWriteExt as _, StreamExt as _};
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    async fn test_backpressure_when_messages_are_not_consumed(cx: &mut TestAppContext) {
+        let total_messages = INCOMING_MESSAGE_QUEUE_CAPACITY * 4;
+        let (mut writer, reader) = async_pipe::pipe();
+        let mut handler = LspStdoutHandler::new(
+            reader,
+            Arc::new(Mutex::new(Some(HashMap::default()))),
+            Arc::new(Mutex::new(HashMap::default())),
+            cx.background_executor.clone(),
+        );
+
+        cx.background_executor
+            .spawn(async move {
+                let payload = r#"{"jsonrpc":"2.0","method":"test/notification","params":{}}"#;
+                let message = format!("Content-Length: {}\r\n\r\n{}", payload.len(), payload);
+                for _ in 0..total_messages {
+                    writer.write_all(message.as_bytes()).await.unwrap();
+                }
+            })
+            .detach();
+
+        cx.run_until_parked();
+        let mut received = 0;
+        while handler.incoming_messages.try_recv().is_ok() {
+            received += 1;
+        }
+        assert!(
+            received < total_messages,
+            "the reader buffered all {total_messages} messages while the consumer was wedged"
+        );
+        assert!(
+            received <= INCOMING_MESSAGE_QUEUE_CAPACITY + 2,
+            "expected at most {} buffered messages, got {received}",
+            INCOMING_MESSAGE_QUEUE_CAPACITY + 2
+        );
+
+        while received < total_messages {
+            assert!(
+                handler.incoming_messages.next().await.is_some(),
+                "the message stream ended after {received} of {total_messages} messages"
+            );
+            received += 1;
+        }
+    }
 
     #[gpui::test]
     async fn test_read_headers() {


### PR DESCRIPTION
The background task reading a language server's stdout pushed every parsed message into an unbounded channel consumed on the foreground thread. If the main thread stalled while a server kept emitting notifications, messages accumulated at wire speed with no limit — matching the report in #58190 of 391 GB of memory growth during a multi-hour hang with a chatty server.

This bounds the queue at 128 messages. When full, the reader stops reading the server's stdout, so the OS pipe applies back pressure to the server instead of Zed buffering its output in memory. No messages are dropped, and healthy operation is unaffected. In flight client requests behind a full queue fail via their existing background executor timeouts.

Adds a regression test that wedges the consumer, asserts the queue stays bounded, then drains it and asserts no messages were lost.

Helps with #58190 and may also help with #31461.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- lsp: Improve Zed's memory usage when LSP's emitted messages faster than the foreground thread can handle them
