### PR TITLE
workspace: Add VS Code-style activity bar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1732,6 +1732,12 @@
     "hour_format": "hour12",
   },
   // Status bar-related settings.
+  "activity_bar": {
+    // Whether to show a VS Code-style vertical activity bar on the left for panel buttons.
+    "enabled": false,
+    // Size of icons in the activity bar: "small" or "medium".
+    "icon_size": "medium",
+  },
   "status_bar": {
     // Whether to show the status bar.
     "experimental.show": true,

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1735,8 +1735,13 @@
   "activity_bar": {
     // Whether to show a VS Code-style vertical activity bar on the left for panel buttons.
     "enabled": false,
-    // Size of icons in the activity bar: "small" or "medium".
+    // Size of icons in the activity bar: "small", "medium", or "large".
     "icon_size": "medium",
+    // Panel buttons to show in the status bar instead of the activity bar.
+    // "status_bar_buttons": ["TerminalPanel", "search"],
+    // Order of buttons in the activity bar. Use panel keys (e.g. "ProjectPanel", "GitPanel")
+    // and "search" for the project search button. Omit to use the default order.
+    // "button_order": ["ProjectPanel", "search", "GitPanel", "agent_panel", "TerminalPanel"],
   },
   "status_bar": {
     // Whether to show the status bar.
@@ -1751,6 +1756,8 @@
     "line_endings_button": false,
     // Control when to show the active encoding in the status bar.
     "active_encoding_button": "non_utf8",
+    // Size of panel button icons in the status bar: "small", "medium", or "large".
+    "panel_button_icon_size": "small",
   },
   // Settings specific to the terminal
   "terminal": {

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -10,7 +10,10 @@ use project::project_settings::{GoToDiagnosticSeverityFilter, ProjectSettings};
 use settings::Settings;
 use ui::{Button, ButtonLike, Color, Icon, IconName, Label, Tooltip, h_flex, prelude::*};
 use util::ResultExt;
-use workspace::{HideStatusItem, StatusItemView, ToolbarItemEvent, Workspace, item::ItemHandle};
+use workspace::{
+    HideStatusItem, StatusItemView, ToolbarItemEvent, Workspace, item::ItemHandle,
+    status_bar::status_bar_icon_size,
+};
 
 use crate::{Deploy, IncludeWarnings, ProjectDiagnosticsEditor};
 
@@ -33,10 +36,11 @@ impl Render for DiagnosticIndicator {
             return indicator.hidden();
         }
 
+        let icon_size = status_bar_icon_size(cx);
         let diagnostic_indicator = match (self.summary.error_count, self.summary.warning_count) {
             (0, 0) => h_flex().child(
                 Icon::new(IconName::Check)
-                    .size(IconSize::Small)
+                    .size(icon_size)
                     .color(Color::Default),
             ),
             (error_count, warning_count) => h_flex()
@@ -44,7 +48,7 @@ impl Render for DiagnosticIndicator {
                 .when(error_count > 0, |this| {
                     this.child(
                         Icon::new(IconName::XCircle)
-                            .size(IconSize::Small)
+                            .size(icon_size)
                             .color(Color::Error),
                     )
                     .child(Label::new(error_count.to_string()).size(LabelSize::Small))
@@ -52,7 +56,7 @@ impl Render for DiagnosticIndicator {
                 .when(warning_count > 0, |this| {
                     this.child(
                         Icon::new(IconName::Warning)
-                            .size(IconSize::Small)
+                            .size(icon_size)
                             .color(Color::Warning),
                     )
                     .child(Label::new(warning_count.to_string()).size(LabelSize::Small))

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -38,7 +38,7 @@ use util::ResultExt as _;
 
 use workspace::{
     HideStatusItem, StatusItemView, Toast, Workspace, create_and_open_local_file, item::ItemHandle,
-    notifications::NotificationId,
+    notifications::NotificationId, status_bar::status_bar_icon_size,
 };
 use zed_actions::{OpenBrowser, OpenSettingsAt};
 
@@ -80,6 +80,7 @@ impl Render for EditPredictionButton {
         }
 
         let language_settings = all_language_settings(None, cx);
+        let status_icon_size = status_bar_icon_size(cx);
 
         match language_settings.edit_predictions.provider {
             EditPredictionProvider::Copilot => {
@@ -107,7 +108,7 @@ impl Render for EditPredictionButton {
                 if let Status::Error(e) = status {
                     return div().child(
                         IconButton::new("copilot-error", icon)
-                            .icon_size(IconSize::Small)
+                            .icon_size(status_icon_size)
                             .on_click(cx.listener(move |_, _, window, cx| {
                                 if let Some(workspace) = Workspace::for_window(window, cx) {
                                     workspace.update(cx, |workspace, cx| {
@@ -172,7 +173,7 @@ impl Render for EditPredictionButton {
                         })
                         .anchor(Anchor::BottomRight)
                         .trigger_with_tooltip(
-                            IconButton::new("copilot-icon", icon),
+                            IconButton::new("copilot-icon", icon).icon_size(status_icon_size),
                             |_window, cx| Tooltip::for_action("GitHub Copilot", &ToggleMenu, cx),
                         )
                         .with_handle(self.popover_menu_handle.clone()),
@@ -218,6 +219,7 @@ impl Render for EditPredictionButton {
                         .trigger_with_tooltip(
                             IconButton::new("codestral-icon", IconName::AiMistral)
                                 .shape(IconButtonShape::Square)
+                                .icon_size(status_icon_size)
                                 .when(!has_api_key, |this| {
                                     this.indicator(Indicator::dot().color(Color::Error))
                                         .indicator_border_color(Some(
@@ -262,6 +264,7 @@ impl Render for EditPredictionButton {
                         .trigger(
                             IconButton::new("openai-compatible-api-icon", IconName::AiOpenAiCompat)
                                 .shape(IconButtonShape::Square)
+                                .icon_size(status_icon_size)
                                 .when(!enabled, |this| {
                                     this.indicator(Indicator::dot().color(Color::Ignored))
                                         .indicator_border_color(Some(
@@ -292,6 +295,7 @@ impl Render for EditPredictionButton {
                         .trigger_with_tooltip(
                             IconButton::new("ollama-icon", IconName::AiOllama)
                                 .shape(IconButtonShape::Square)
+                                .icon_size(status_icon_size)
                                 .when(!enabled, |this| {
                                     this.indicator(Indicator::dot().color(Color::Ignored))
                                         .indicator_border_color(Some(
@@ -375,6 +379,7 @@ impl Render for EditPredictionButton {
                     return div().child(
                         IconButton::new("zed-predict-pending-button", ep_icon)
                             .shape(IconButtonShape::Square)
+                            .icon_size(status_icon_size)
                             .indicator(Indicator::dot().color(Color::Muted))
                             .indicator_border_color(Some(cx.theme().colors().status_bar_background))
                             .tooltip(move |_window, cx| {
@@ -430,6 +435,7 @@ impl Render for EditPredictionButton {
 
                 let icon_button = IconButton::new("zed-predict-pending-button", ep_icon)
                     .shape(IconButtonShape::Square)
+                    .icon_size(status_icon_size)
                     .when_some(indicator_color, |this, color| {
                         this.indicator(Indicator::dot().color(color))
                             .indicator_border_color(Some(cx.theme().colors().status_bar_background))

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -1396,7 +1396,7 @@ impl Render for LspButton {
                 .trigger_with_tooltip(
                     IconButton::new("zed-lsp-tool-button", IconName::BoltOutlined)
                         .when_some(indicator, IconButton::indicator)
-                        .icon_size(IconSize::Small)
+                        .icon_size(workspace::status_bar::status_bar_icon_size(cx))
                         .when(is_restricted, |s| s.icon_color(Color::Warning))
                         .indicator_border_color(Some(cx.theme().colors().status_bar_background)),
                     move |_window, cx| {

--- a/crates/search/src/search_status_button.rs
+++ b/crates/search/src/search_status_button.rs
@@ -4,7 +4,7 @@ use settings::Settings as _;
 use ui::{ButtonCommon, Clickable, Context, Render, Tooltip, Window, prelude::*};
 use workspace::{
     HideStatusItem, ItemHandle, StatusItemView, activity_bar::activity_bar_hides_search_button,
-    status_bar::status_bar_icon_size,
+    status_bar::{configure_status_bar_icon_button, status_bar_icon_size},
 };
 
 pub const SEARCH_ICON: IconName = IconName::MagnifyingGlass;
@@ -31,8 +31,10 @@ impl Render for SearchButton {
 
         let focus_handle = self.pane_item_focus_handle.clone();
         button.child(
-            IconButton::new("project-search-indicator", SEARCH_ICON)
-                .icon_size(status_bar_icon_size(cx))
+            configure_status_bar_icon_button(
+                IconButton::new("project-search-indicator", SEARCH_ICON),
+                status_bar_icon_size(cx),
+            )
                 .tooltip(move |_window, cx| {
                     if let Some(focus_handle) = &focus_handle {
                         Tooltip::for_action_in(

--- a/crates/search/src/search_status_button.rs
+++ b/crates/search/src/search_status_button.rs
@@ -2,7 +2,7 @@ use editor::EditorSettings;
 use gpui::{App, FocusHandle};
 use settings::Settings as _;
 use ui::{ButtonCommon, Clickable, Context, Render, Tooltip, Window, prelude::*};
-use workspace::{ActivityBarSettings, HideStatusItem, ItemHandle, StatusItemView};
+use workspace::{HideStatusItem, ItemHandle, StatusItemView, activity_bar::activity_bar_hides_search_button};
 
 pub const SEARCH_ICON: IconName = IconName::MagnifyingGlass;
 
@@ -22,8 +22,7 @@ impl Render for SearchButton {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl ui::IntoElement {
         let button = div();
 
-        if !EditorSettings::get_global(cx).search.button || ActivityBarSettings::get_global(cx).enabled
-        {
+        if !EditorSettings::get_global(cx).search.button || activity_bar_hides_search_button(cx) {
             return button.hidden();
         }
 

--- a/crates/search/src/search_status_button.rs
+++ b/crates/search/src/search_status_button.rs
@@ -2,7 +2,10 @@ use editor::EditorSettings;
 use gpui::{App, FocusHandle};
 use settings::Settings as _;
 use ui::{ButtonCommon, Clickable, Context, Render, Tooltip, Window, prelude::*};
-use workspace::{HideStatusItem, ItemHandle, StatusItemView, activity_bar::activity_bar_hides_search_button};
+use workspace::{
+    HideStatusItem, ItemHandle, StatusItemView, activity_bar::activity_bar_hides_search_button,
+    status_bar::status_bar_icon_size,
+};
 
 pub const SEARCH_ICON: IconName = IconName::MagnifyingGlass;
 
@@ -29,7 +32,7 @@ impl Render for SearchButton {
         let focus_handle = self.pane_item_focus_handle.clone();
         button.child(
             IconButton::new("project-search-indicator", SEARCH_ICON)
-                .icon_size(IconSize::Small)
+                .icon_size(status_bar_icon_size(cx))
                 .tooltip(move |_window, cx| {
                     if let Some(focus_handle) = &focus_handle {
                         Tooltip::for_action_in(

--- a/crates/search/src/search_status_button.rs
+++ b/crates/search/src/search_status_button.rs
@@ -2,7 +2,7 @@ use editor::EditorSettings;
 use gpui::{App, FocusHandle};
 use settings::Settings as _;
 use ui::{ButtonCommon, Clickable, Context, Render, Tooltip, Window, prelude::*};
-use workspace::{HideStatusItem, ItemHandle, StatusItemView};
+use workspace::{ActivityBarSettings, HideStatusItem, ItemHandle, StatusItemView};
 
 pub const SEARCH_ICON: IconName = IconName::MagnifyingGlass;
 
@@ -22,7 +22,8 @@ impl Render for SearchButton {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl ui::IntoElement {
         let button = div();
 
-        if !EditorSettings::get_global(cx).search.button {
+        if !EditorSettings::get_global(cx).search.button || ActivityBarSettings::get_global(cx).enabled
+        {
             return button.hidden();
         }
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -211,6 +211,7 @@ impl VsCodeSettings {
             server_url: None,
             session: None,
             status_bar: self.status_bar_settings_content(),
+            activity_bar: None,
             tab_bar: self.tab_bar_settings_content(),
             tabs: self.item_settings_content(),
             telemetry: self.telemetry_settings_content(),

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -791,6 +791,7 @@ impl VsCodeSettings {
             cursor_position_button: None,
             line_endings_button: None,
             active_encoding_button: None,
+            panel_button_icon_size: None,
         })
     }
 

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -140,6 +140,7 @@ pub struct SettingsContent {
     pub tabs: Option<ItemSettingsContent>,
     pub tab_bar: Option<TabBarSettingsContent>,
     pub status_bar: Option<StatusBarSettingsContent>,
+    pub activity_bar: Option<ActivityBarSettingsContent>,
 
     pub preview_tabs: Option<PreviewTabsSettingsContent>,
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -471,6 +471,18 @@ pub struct ActivityBarSettingsContent {
     ///
     /// Default: medium
     pub icon_size: Option<ActivityBarIconSize>,
+    /// Panel buttons to show in the status bar instead of the activity bar. Use panel keys
+    /// (e.g. "ProjectPanel", "GitPanel") and "search" for the project search button. Buttons
+    /// appear at their dock position in the status bar (left or right).
+    ///
+    /// Default: null (all buttons in the activity bar)
+    pub status_bar_buttons: Option<Vec<String>>,
+    /// Order of buttons in the activity bar. Use panel keys (e.g. "ProjectPanel", "GitPanel")
+    /// and "search" for the project search button. Buttons not listed appear after these, sorted
+    /// by their default priority.
+    ///
+    /// Default: null (uses a VS Code-inspired default order)
+    pub button_order: Option<Vec<String>>,
 }
 
 #[derive(
@@ -492,6 +504,7 @@ pub enum ActivityBarIconSize {
     Small,
     #[default]
     Medium,
+    Large,
 }
 
 #[with_fallible_options]
@@ -522,6 +535,10 @@ pub struct StatusBarSettingsContent {
     ///
     /// Default: non_utf8
     pub active_encoding_button: Option<EncodingDisplayOptions>,
+    /// Size of panel button icons in the status bar.
+    ///
+    /// Default: small
+    pub panel_button_icon_size: Option<ActivityBarIconSize>,
 }
 
 #[derive(

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -462,6 +462,40 @@ pub struct TabBarSettingsContent {
 
 #[with_fallible_options]
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, PartialEq, Eq)]
+pub struct ActivityBarSettingsContent {
+    /// Whether to show a VS Code-style vertical activity bar on the left for panel buttons.
+    ///
+    /// Default: false
+    pub enabled: Option<bool>,
+    /// Size of icons in the activity bar.
+    ///
+    /// Default: medium
+    pub icon_size: Option<ActivityBarIconSize>,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantNames,
+    strum::VariantArray,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityBarIconSize {
+    Small,
+    #[default]
+    Medium,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, PartialEq, Eq)]
 pub struct StatusBarSettingsContent {
     /// Whether to show the status bar.
     ///

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3676,6 +3676,50 @@ fn search_and_files_page() -> SettingsPage {
 }
 
 fn window_and_layout_page() -> SettingsPage {
+    fn activity_bar_section() -> [SettingsPageItem; 3] {
+        [
+            SettingsPageItem::SectionHeader("Activity Bar"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Activity Bar",
+                description: "Show a VS Code-style vertical activity bar on the left for panel buttons.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("activity_bar.enabled"),
+                    pick: |settings_content| {
+                        settings_content.activity_bar.as_ref()?.enabled.as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .activity_bar
+                            .get_or_insert_default()
+                            .enabled = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Activity Bar Icon Size",
+                description: "Size of icons in the activity bar.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("activity_bar.icon_size"),
+                    pick: |settings_content| {
+                        settings_content.activity_bar.as_ref()?.icon_size.as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .activity_bar
+                            .get_or_insert_default()
+                            .icon_size = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+        ]
+    }
+
     fn status_bar_section() -> [SettingsPageItem; 11] {
         [
             SettingsPageItem::SectionHeader("Status Bar"),
@@ -4824,6 +4868,7 @@ fn window_and_layout_page() -> SettingsPage {
     SettingsPage {
         title: "Window & Layout",
         items: concat_sections![
+            activity_bar_section(),
             status_bar_section(),
             title_bar_section(),
             tab_bar_section(),

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3724,8 +3724,8 @@ fn window_and_layout_page() -> SettingsPage {
         [
             SettingsPageItem::SectionHeader("Status Bar"),
             SettingsPageItem::SettingItem(SettingItem {
-                title: "Panel Button Icon Size",
-                description: "Size of panel button icons in the status bar.",
+                title: "Status Bar Icon Size",
+                description: "Size of icons in the status bar, including panel buttons, search, diagnostics, and language servers.",
                 field: Box::new(SettingField {
                     organization_override: None,
                     json_path: Some("status_bar.panel_button_icon_size"),

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3676,48 +3676,149 @@ fn search_and_files_page() -> SettingsPage {
 }
 
 fn window_and_layout_page() -> SettingsPage {
-    fn activity_bar_section() -> [SettingsPageItem; 3] {
-        [
-            SettingsPageItem::SectionHeader("Activity Bar"),
-            SettingsPageItem::SettingItem(SettingItem {
-                title: "Activity Bar",
-                description: "Show a VS Code-style vertical activity bar on the left for panel buttons. Use activity_bar.status_bar_buttons in settings.json to move specific buttons back to the status bar.",
-                field: Box::new(SettingField {
-                    organization_override: None,
-                    json_path: Some("activity_bar.enabled"),
-                    pick: |settings_content| {
-                        settings_content.activity_bar.as_ref()?.enabled.as_ref()
-                    },
-                    write: |settings_content, value, _| {
-                        settings_content
-                            .activity_bar
-                            .get_or_insert_default()
-                            .enabled = value;
-                    },
+    fn activity_bar_section() -> Box<[SettingsPageItem]> {
+        concat_sections!(
+            @vec,
+            [
+                SettingsPageItem::SectionHeader("Activity Bar"),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Activity Bar",
+                    description: "Show a VS Code-style vertical activity bar on the left for panel buttons.",
+                    field: Box::new(SettingField {
+                        organization_override: None,
+                        json_path: Some("activity_bar.enabled"),
+                        pick: |settings_content| {
+                            settings_content.activity_bar.as_ref()?.enabled.as_ref()
+                        },
+                        write: |settings_content, value, _| {
+                            settings_content
+                                .activity_bar
+                                .get_or_insert_default()
+                                .enabled = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
                 }),
-                metadata: None,
-                files: USER,
-            }),
-            SettingsPageItem::SettingItem(SettingItem {
-                title: "Activity Bar Icon Size",
-                description: "Size of icons in the activity bar.",
-                field: Box::new(SettingField {
-                    organization_override: None,
-                    json_path: Some("activity_bar.icon_size"),
-                    pick: |settings_content| {
-                        settings_content.activity_bar.as_ref()?.icon_size.as_ref()
-                    },
-                    write: |settings_content, value, _| {
-                        settings_content
-                            .activity_bar
-                            .get_or_insert_default()
-                            .icon_size = value;
-                    },
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Activity Bar Icon Size",
+                    description: "Size of icons in the activity bar.",
+                    field: Box::new(SettingField {
+                        organization_override: None,
+                        json_path: Some("activity_bar.icon_size"),
+                        pick: |settings_content| {
+                            settings_content.activity_bar.as_ref()?.icon_size.as_ref()
+                        },
+                        write: |settings_content, value, _| {
+                            settings_content
+                                .activity_bar
+                                .get_or_insert_default()
+                                .icon_size = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
                 }),
-                metadata: None,
-                files: USER,
-            }),
-        ]
+                SettingsPageItem::SectionHeader("Activity Bar Button Placement"),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Project Panel in Status Bar",
+                    description: "Show the project panel button in the status bar instead of the activity bar.",
+                    field: Box::new(SettingField {
+                        organization_override: None,
+                        json_path: Some("activity_bar.status_bar_buttons.ProjectPanel"),
+                        pick: crate::pick_activity_bar_status_bar_button_project_panel,
+                        write: crate::write_activity_bar_status_bar_button_project_panel,
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Project Search in Status Bar",
+                    description: "Show the project search button in the status bar instead of the activity bar.",
+                    field: Box::new(SettingField {
+                        organization_override: None,
+                        json_path: Some("activity_bar.status_bar_buttons.search"),
+                        pick: crate::pick_activity_bar_status_bar_button_search,
+                        write: crate::write_activity_bar_status_bar_button_search,
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Source Control in Status Bar",
+                    description: "Show the source control button in the status bar instead of the activity bar.",
+                    field: Box::new(SettingField {
+                        organization_override: None,
+                        json_path: Some("activity_bar.status_bar_buttons.GitPanel"),
+                        pick: crate::pick_activity_bar_status_bar_button_git_panel,
+                        write: crate::write_activity_bar_status_bar_button_git_panel,
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Agent Panel in Status Bar",
+                    description: "Show the agent panel button in the status bar instead of the activity bar.",
+                    field: Box::new(SettingField {
+                        organization_override: None,
+                        json_path: Some("activity_bar.status_bar_buttons.agent_panel"),
+                        pick: crate::pick_activity_bar_status_bar_button_agent_panel,
+                        write: crate::write_activity_bar_status_bar_button_agent_panel,
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Terminal in Status Bar",
+                    description: "Show the terminal button in the status bar instead of the activity bar.",
+                    field: Box::new(SettingField {
+                        organization_override: None,
+                        json_path: Some("activity_bar.status_bar_buttons.TerminalPanel"),
+                        pick: crate::pick_activity_bar_status_bar_button_terminal_panel,
+                        write: crate::write_activity_bar_status_bar_button_terminal_panel,
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Outline in Status Bar",
+                    description: "Show the outline panel button in the status bar instead of the activity bar.",
+                    field: Box::new(SettingField {
+                        organization_override: None,
+                        json_path: Some("activity_bar.status_bar_buttons.OutlinePanel"),
+                        pick: crate::pick_activity_bar_status_bar_button_outline_panel,
+                        write: crate::write_activity_bar_status_bar_button_outline_panel,
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Collaboration in Status Bar",
+                    description: "Show the collaboration panel button in the status bar instead of the activity bar.",
+                    field: Box::new(SettingField {
+                        organization_override: None,
+                        json_path: Some("activity_bar.status_bar_buttons.CollaborationPanel"),
+                        pick: crate::pick_activity_bar_status_bar_button_collaboration_panel,
+                        write: crate::write_activity_bar_status_bar_button_collaboration_panel,
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Debugger in Status Bar",
+                    description: "Show the debugger button in the status bar instead of the activity bar.",
+                    field: Box::new(SettingField {
+                        organization_override: None,
+                        json_path: Some("activity_bar.status_bar_buttons.DebugPanel"),
+                        pick: crate::pick_activity_bar_status_bar_button_debug_panel,
+                        write: crate::write_activity_bar_status_bar_button_debug_panel,
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+            ]
+        )
+        .into()
     }
 
     fn status_bar_section() -> [SettingsPageItem; 12] {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3681,7 +3681,7 @@ fn window_and_layout_page() -> SettingsPage {
             SettingsPageItem::SectionHeader("Activity Bar"),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Activity Bar",
-                description: "Show a VS Code-style vertical activity bar on the left for panel buttons.",
+                description: "Show a VS Code-style vertical activity bar on the left for panel buttons. Use activity_bar.status_bar_buttons in settings.json to move specific buttons back to the status bar.",
                 field: Box::new(SettingField {
                     organization_override: None,
                     json_path: Some("activity_bar.enabled"),
@@ -3720,9 +3720,32 @@ fn window_and_layout_page() -> SettingsPage {
         ]
     }
 
-    fn status_bar_section() -> [SettingsPageItem; 11] {
+    fn status_bar_section() -> [SettingsPageItem; 12] {
         [
             SettingsPageItem::SectionHeader("Status Bar"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Panel Button Icon Size",
+                description: "Size of panel button icons in the status bar.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("status_bar.panel_button_icon_size"),
+                    pick: |settings_content| {
+                        settings_content
+                            .status_bar
+                            .as_ref()?
+                            .panel_button_icon_size
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .status_bar
+                            .get_or_insert_default()
+                            .panel_button_icon_size = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Project Panel Button",
                 description: "Show the project panel button in the status bar.",

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -454,8 +454,237 @@ pub fn init(cx: &mut App) {
     .detach();
 }
 
+macro_rules! activity_bar_status_bar_button {
+    ($type_name:ident, $panel_key:literal, $pick_fn:ident, $write_fn:ident) => {
+        #[derive(Clone, Copy)]
+        pub(crate) struct $type_name;
+
+        impl PartialEq for $type_name {
+            fn eq(&self, _: &Self) -> bool {
+                true
+            }
+        }
+
+        pub(crate) fn $pick_fn(_: &SettingsContent) -> Option<&$type_name> {
+            Some(&$type_name)
+        }
+
+        pub(crate) fn $write_fn(
+            _: &mut SettingsContent,
+            _: Option<$type_name>,
+            _: &App,
+        ) {
+        }
+    };
+}
+
+activity_bar_status_bar_button!(
+    ActivityBarStatusBarButtonProjectPanel,
+    "ProjectPanel",
+    pick_activity_bar_status_bar_button_project_panel,
+    write_activity_bar_status_bar_button_project_panel
+);
+activity_bar_status_bar_button!(
+    ActivityBarStatusBarButtonSearch,
+    "search",
+    pick_activity_bar_status_bar_button_search,
+    write_activity_bar_status_bar_button_search
+);
+activity_bar_status_bar_button!(
+    ActivityBarStatusBarButtonGitPanel,
+    "GitPanel",
+    pick_activity_bar_status_bar_button_git_panel,
+    write_activity_bar_status_bar_button_git_panel
+);
+activity_bar_status_bar_button!(
+    ActivityBarStatusBarButtonAgentPanel,
+    "agent_panel",
+    pick_activity_bar_status_bar_button_agent_panel,
+    write_activity_bar_status_bar_button_agent_panel
+);
+activity_bar_status_bar_button!(
+    ActivityBarStatusBarButtonTerminalPanel,
+    "TerminalPanel",
+    pick_activity_bar_status_bar_button_terminal_panel,
+    write_activity_bar_status_bar_button_terminal_panel
+);
+activity_bar_status_bar_button!(
+    ActivityBarStatusBarButtonOutlinePanel,
+    "OutlinePanel",
+    pick_activity_bar_status_bar_button_outline_panel,
+    write_activity_bar_status_bar_button_outline_panel
+);
+activity_bar_status_bar_button!(
+    ActivityBarStatusBarButtonCollaborationPanel,
+    "CollaborationPanel",
+    pick_activity_bar_status_bar_button_collaboration_panel,
+    write_activity_bar_status_bar_button_collaboration_panel
+);
+activity_bar_status_bar_button!(
+    ActivityBarStatusBarButtonDebugPanel,
+    "DebugPanel",
+    pick_activity_bar_status_bar_button_debug_panel,
+    write_activity_bar_status_bar_button_debug_panel
+);
+
+fn activity_bar_status_bar_buttons_contains(settings: &SettingsContent, panel_key: &str) -> bool {
+    settings
+        .activity_bar
+        .as_ref()
+        .and_then(|activity_bar| activity_bar.status_bar_buttons.as_ref())
+        .is_some_and(|buttons| buttons.iter().any(|button| button == panel_key))
+}
+
+fn set_activity_bar_status_bar_button(
+    settings: &mut SettingsContent,
+    panel_key: &str,
+    show_in_status_bar: bool,
+) {
+    let activity_bar = settings.activity_bar.get_or_insert_default();
+    let buttons = activity_bar
+        .status_bar_buttons
+        .get_or_insert_with(Vec::new);
+
+    if show_in_status_bar {
+        if !buttons.iter().any(|button| button == panel_key) {
+            buttons.push(panel_key.to_string());
+        }
+    } else {
+        buttons.retain(|button| button != panel_key);
+        if buttons.is_empty() {
+            activity_bar.status_bar_buttons = None;
+        }
+    }
+}
+
+fn render_activity_bar_status_bar_button(
+    panel_key: &'static str,
+) -> impl Fn(
+    &SettingsWindow,
+    &SettingItem,
+    SettingsUiFile,
+    Option<&SettingsFieldMetadata>,
+    bool,
+    &mut Window,
+    &mut Context<SettingsWindow>,
+) -> Stateful<Div> {
+    move |settings_window, item, settings_file, _, sub_field, _window, cx| {
+        let settings_content = SettingsStore::global(cx).merged_settings();
+        let activity_bar_enabled = settings_content
+            .activity_bar
+            .as_ref()
+            .and_then(|activity_bar| activity_bar.enabled)
+            .unwrap_or(false);
+        let in_status_bar = activity_bar_status_bar_buttons_contains(settings_content, panel_key);
+        let toggle_state = if in_status_bar {
+            ToggleState::Selected
+        } else {
+            ToggleState::Unselected
+        };
+
+        render_settings_item(
+            settings_window,
+            item,
+            settings_file.clone(),
+            Switch::new(
+                ElementId::Name(format!("activity-bar-status-bar-{panel_key}").into()),
+                toggle_state,
+            )
+            .tab_index(0_isize)
+            .disabled(!activity_bar_enabled)
+            .on_click({
+                let panel_key = panel_key;
+                move |state, window, cx| {
+                    let show_in_status_bar = *state == ToggleState::Selected;
+                    update_settings_file(
+                        settings_file.clone(),
+                        Some("activity_bar.status_bar_buttons"),
+                        window,
+                        cx,
+                        move |settings, _| {
+                            set_activity_bar_status_bar_button(
+                                settings,
+                                panel_key,
+                                show_in_status_bar,
+                            );
+                        },
+                    )
+                    .log_err();
+                }
+            })
+            .into_any_element(),
+            sub_field,
+            cx,
+        )
+    }
+}
+
+macro_rules! register_activity_bar_status_bar_button_renderer {
+    ($renderer:expr, $type_name:ident, $panel_key:literal) => {
+        $renderer.add_renderer::<$type_name>({
+            let render = render_activity_bar_status_bar_button($panel_key);
+            move |settings_window, item, _field, settings_file, metadata, sub_field, window, cx| {
+                render(
+                    settings_window,
+                    item,
+                    settings_file,
+                    metadata,
+                    sub_field,
+                    window,
+                    cx,
+                )
+            }
+        })
+    };
+}
+
+fn init_activity_bar_renderers(renderer: &mut SettingFieldRenderer) {
+    register_activity_bar_status_bar_button_renderer!(
+        renderer,
+        ActivityBarStatusBarButtonProjectPanel,
+        "ProjectPanel"
+    );
+    register_activity_bar_status_bar_button_renderer!(
+        renderer,
+        ActivityBarStatusBarButtonSearch,
+        "search"
+    );
+    register_activity_bar_status_bar_button_renderer!(
+        renderer,
+        ActivityBarStatusBarButtonGitPanel,
+        "GitPanel"
+    );
+    register_activity_bar_status_bar_button_renderer!(
+        renderer,
+        ActivityBarStatusBarButtonAgentPanel,
+        "agent_panel"
+    );
+    register_activity_bar_status_bar_button_renderer!(
+        renderer,
+        ActivityBarStatusBarButtonTerminalPanel,
+        "TerminalPanel"
+    );
+    register_activity_bar_status_bar_button_renderer!(
+        renderer,
+        ActivityBarStatusBarButtonOutlinePanel,
+        "OutlinePanel"
+    );
+    register_activity_bar_status_bar_button_renderer!(
+        renderer,
+        ActivityBarStatusBarButtonCollaborationPanel,
+        "CollaborationPanel"
+    );
+    register_activity_bar_status_bar_button_renderer!(
+        renderer,
+        ActivityBarStatusBarButtonDebugPanel,
+        "DebugPanel"
+    );
+}
+
 fn init_renderers(cx: &mut App) {
-    cx.default_global::<SettingFieldRenderer>()
+    let renderer = cx.default_global::<SettingFieldRenderer>();
+    init_activity_bar_renderers(renderer);
+    renderer
         .add_renderer::<UnimplementedSettingField>(
             |settings_window, item, _, settings_file, _, sub_field, _, cx| {
                 render_settings_item(
@@ -565,6 +794,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::ImageFileSizeUnit>(render_dropdown)
         .add_basic_renderer::<settings::StatusStyle>(render_dropdown)
         .add_basic_renderer::<settings::EncodingDisplayOptions>(render_dropdown)
+        .add_basic_renderer::<settings::ActivityBarIconSize>(render_dropdown)
         .add_basic_renderer::<settings::PaneSplitDirectionHorizontal>(render_dropdown)
         .add_basic_renderer::<settings::PaneSplitDirectionVertical>(render_dropdown)
         .add_basic_renderer::<settings::PaneSplitDirectionVertical>(render_dropdown)

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -66,6 +66,9 @@ use workspace::{
     NextThread, Open, OpenMode, PreviousProject, PreviousThread, ProjectGroupKey, SaveIntent,
     Sidebar as WorkspaceSidebar, SidebarSide, Toast, ToggleWorkspaceSidebar, Workspace,
     notifications::NotificationId, sidebar_side_context_menu,
+    status_bar::{
+        apply_status_bar_chrome_styles, configure_status_bar_icon_button, status_bar_icon_size,
+    },
 };
 
 use zed_actions::OpenRecent;
@@ -6534,6 +6537,7 @@ impl Sidebar {
     }
 
     fn render_recent_projects_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let icon_size = status_bar_icon_size(cx);
         let multi_workspace = self.multi_workspace.upgrade();
 
         let workspace = multi_workspace
@@ -6567,9 +6571,11 @@ impl Sidebar {
                 })
             })
             .trigger_with_tooltip(
-                IconButton::new("open-project", IconName::OpenFolder)
-                    .icon_size(IconSize::Small)
-                    .selected_style(ButtonStyle::Tinted(TintColor::Accent)),
+                configure_status_bar_icon_button(
+                    IconButton::new("open-project", IconName::OpenFolder),
+                    icon_size,
+                )
+                .selected_style(ButtonStyle::Tinted(TintColor::Accent)),
                 |_window, cx| {
                     Tooltip::for_action(
                         "Add Project",
@@ -7375,10 +7381,11 @@ impl Sidebar {
         )
     }
 
-    fn render_sidebar_toggle_button(&self, _cx: &mut Context<Self>) -> impl IntoElement {
-        let on_right = AgentSettings::get_global(_cx).sidebar_side() == SidebarSide::Right;
+    fn render_sidebar_toggle_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let icon_size = status_bar_icon_size(cx);
+        let on_right = AgentSettings::get_global(cx).sidebar_side() == SidebarSide::Right;
 
-        sidebar_side_context_menu("sidebar-toggle-menu", _cx)
+        sidebar_side_context_menu("sidebar-toggle-menu", cx)
             .anchor(if on_right {
                 gpui::Anchor::BottomRight
             } else {
@@ -7395,8 +7402,10 @@ impl Sidebar {
                 } else {
                     IconName::ThreadsSidebarLeftOpen
                 };
-                IconButton::new("sidebar-close-toggle", icon)
-                    .icon_size(IconSize::Small)
+                configure_status_bar_icon_button(
+                    IconButton::new("sidebar-close-toggle", icon),
+                    icon_size,
+                )
                     .tooltip(Tooltip::element(move |_window, cx| {
                         v_flex()
                             .gap_1()
@@ -7430,19 +7439,17 @@ impl Sidebar {
     }
 
     fn render_sidebar_bottom_bar(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+        let icon_size = status_bar_icon_size(cx);
         let is_archive = matches!(self.view, SidebarView::Archive(..));
         let on_right = self.side(cx) == SidebarSide::Right;
 
-        h_flex()
-            .p_1()
-            .gap_1()
+        apply_status_bar_chrome_styles(h_flex().gap_1(), cx)
             .when(on_right, |this| this.flex_row_reverse())
             .border_t_1()
             .border_color(cx.theme().colors().border)
             .child(self.render_sidebar_toggle_button(cx))
             .child(
-                IconButton::new("history", IconName::Clock)
-                    .icon_size(IconSize::Small)
+                configure_status_bar_icon_button(IconButton::new("history", IconName::Clock), icon_size)
                     .toggle_state(is_archive)
                     .tooltip(move |_, cx| {
                         let label = if is_archive {

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -91,8 +91,7 @@ impl IconSize {
             IconSize::Small => DynamicSpacing::Base02.px(cx),
             IconSize::Medium => DynamicSpacing::Base02.px(cx),
             IconSize::XLarge => DynamicSpacing::Base02.px(cx),
-            // TODO: Wire into dynamic spacing
-            IconSize::Custom(size) => size.to_pixels(window.rem_size()),
+            IconSize::Custom(_) => DynamicSpacing::Base02.px(cx),
         };
 
         (icon_size, padding)

--- a/crates/workspace/src/activity_bar.rs
+++ b/crates/workspace/src/activity_bar.rs
@@ -1,0 +1,146 @@
+use crate::{
+    DeploySearch, PanelHandle,
+    dock::{Dock, PanelButtonLayout, render_panel_button},
+    status_bar::{HideStatusItem, add_hide_button_entry},
+    workspace_settings::ActivityBarSettings,
+};
+use gpui::{
+    Anchor, App, Context, Decorations, Entity, IntoElement, ParentElement, Render, Styled,
+    Subscription, Window, px,
+};
+use settings::{ActivityBarIconSize, Settings, SettingsStore};
+use theme::CLIENT_SIDE_DECORATION_ROUNDING;
+use ui::{ContextMenu, IconButton, IconName, IconSize, Tooltip, prelude::*, right_click_menu};
+
+const ACTIVITY_BAR_WIDTH: Pixels = px(48.);
+
+pub struct ActivityBar {
+    left_dock: Entity<Dock>,
+    right_dock: Entity<Dock>,
+    bottom_dock: Entity<Dock>,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl ActivityBar {
+    pub fn new(
+        left_dock: Entity<Dock>,
+        right_dock: Entity<Dock>,
+        bottom_dock: Entity<Dock>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        for dock in [&left_dock, &right_dock, &bottom_dock] {
+            cx.observe(dock, |_, _, cx| cx.notify()).detach();
+        }
+
+        Self {
+            left_dock,
+            right_dock,
+            bottom_dock,
+            _subscriptions: vec![cx.observe_global::<SettingsStore>(|_, cx| cx.notify())],
+        }
+    }
+}
+
+impl Render for ActivityBar {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let settings = ActivityBarSettings::get_global(cx);
+        let icon_size = match settings.icon_size {
+            ActivityBarIconSize::Small => IconSize::Small,
+            ActivityBarIconSize::Medium => IconSize::Medium,
+        };
+
+        let mut panel_targets: Vec<(u32, Entity<Dock>, usize, std::sync::Arc<dyn PanelHandle>)> =
+            Vec::new();
+        for dock in [&self.left_dock, &self.right_dock, &self.bottom_dock] {
+            let dock_entity = dock.clone();
+            for entry in dock.read(cx).panel_button_entries() {
+                let priority = entry.panel.activation_priority(cx);
+                panel_targets.push((
+                    priority,
+                    dock_entity.clone(),
+                    entry.panel_index,
+                    entry.panel,
+                ));
+            }
+        }
+        panel_targets.sort_by_key(|(priority, _, _, _)| *priority);
+
+        let mut buttons: Vec<AnyElement> = panel_targets
+            .into_iter()
+            .filter_map(|(_, dock, panel_index, panel)| {
+                render_panel_button(
+                    dock,
+                    panel_index,
+                    panel,
+                    PanelButtonLayout::Vertical,
+                    icon_size,
+                    window,
+                    cx,
+                )
+                .map(|element| element.into_any_element())
+            })
+            .collect();
+
+        if project_search_button_visible(cx) {
+            buttons.push(render_project_search_button(icon_size).into_any_element());
+        }
+
+        let colors = cx.theme().colors();
+
+        v_flex()
+            .id("activity-bar")
+            .when(!settings.enabled, |this| this.hidden())
+            .flex_none()
+            .w(ACTIVITY_BAR_WIDTH)
+            .h_full()
+            .py_1()
+            .gap_0p5()
+            .bg(colors.status_bar_background)
+            .border_r_1()
+            .border_color(colors.border)
+            .map(|el| match window.window_decorations() {
+                Decorations::Server => el,
+                Decorations::Client { tiling, .. } => el.when(!tiling.left, |el| {
+                    el.rounded_tl(CLIENT_SIDE_DECORATION_ROUNDING)
+                        .rounded_bl(CLIENT_SIDE_DECORATION_ROUNDING)
+                }),
+            })
+            .children(buttons)
+    }
+}
+
+fn project_search_button_visible(cx: &App) -> bool {
+    cx.global::<SettingsStore>()
+        .merged_settings()
+        .editor
+        .search
+        .as_ref()
+        .and_then(|search| search.button)
+        .unwrap_or(true)
+}
+
+fn render_project_search_button(icon_size: IconSize) -> impl IntoElement {
+    let hide = HideStatusItem::new(|settings| {
+        settings.editor.search.get_or_insert_default().button = Some(false);
+    });
+
+    right_click_menu("activity-bar-search-menu")
+        .menu(move |window, cx| {
+            let hide = hide.clone();
+            ContextMenu::build(window, cx, move |menu, _, _| {
+                add_hide_button_entry(menu, hide)
+            })
+        })
+        .anchor(Anchor::RightCenter)
+        .attach(Anchor::LeftCenter)
+        .trigger(move |_active, _window, _cx| {
+            IconButton::new("activity-bar-project-search", IconName::MagnifyingGlass)
+                .icon_size(icon_size)
+                .tooltip(|_, cx| {
+                    Tooltip::for_action("Project Search", &DeploySearch::default(), cx)
+                })
+                .on_click(|_, window, cx| {
+                    window.dispatch_action(Box::new(DeploySearch::default()), cx);
+                })
+        })
+}

--- a/crates/workspace/src/activity_bar.rs
+++ b/crates/workspace/src/activity_bar.rs
@@ -1,18 +1,23 @@
 use crate::{
-    DeploySearch, PanelHandle,
-    dock::{Dock, PanelButtonLayout, render_panel_button},
+    DeploySearch,
+    dock::{
+        Dock, PanelButtonLayout, panel_button_icon_size, render_panel_button,
+        vertical_panel_button_container,
+    },
     status_bar::{HideStatusItem, add_hide_button_entry},
     workspace_settings::ActivityBarSettings,
 };
 use gpui::{
-    Anchor, App, Context, Decorations, Entity, IntoElement, ParentElement, Render, Styled,
-    Subscription, Window, px,
+    Anchor, AnyElement, App, Context, Decorations, Entity, Hsla, IntoElement, ParentElement,
+    Pixels, Render, Styled, Subscription, Window, px,
 };
-use settings::{ActivityBarIconSize, Settings, SettingsStore};
+use settings::{Settings, SettingsStore};
 use theme::CLIENT_SIDE_DECORATION_ROUNDING;
 use ui::{ContextMenu, IconButton, IconName, IconSize, Tooltip, prelude::*, right_click_menu};
 
 const ACTIVITY_BAR_WIDTH: Pixels = px(48.);
+
+pub const SEARCH_BUTTON_KEY: &str = "search";
 
 pub struct ActivityBar {
     left_dock: Entity<Dock>,
@@ -44,46 +49,43 @@ impl ActivityBar {
 impl Render for ActivityBar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let settings = ActivityBarSettings::get_global(cx);
-        let icon_size = match settings.icon_size {
-            ActivityBarIconSize::Small => IconSize::Small,
-            ActivityBarIconSize::Medium => IconSize::Medium,
-        };
+        let icon_size = panel_button_icon_size(settings.icon_size);
 
-        let mut panel_targets: Vec<(u32, Entity<Dock>, usize, std::sync::Arc<dyn PanelHandle>)> =
-            Vec::new();
+        let mut items: Vec<(String, u32, AnyElement)> = Vec::new();
         for dock in [&self.left_dock, &self.right_dock, &self.bottom_dock] {
             let dock_entity = dock.clone();
             for entry in dock.read(cx).panel_button_entries() {
                 let priority = entry.panel.activation_priority(cx);
-                panel_targets.push((
-                    priority,
+                let key = entry.panel.panel_key().to_string();
+                if !panel_button_shown_in_activity_bar(&key, &settings) {
+                    continue;
+                }
+                if let Some(element) = render_panel_button(
                     dock_entity.clone(),
                     entry.panel_index,
                     entry.panel,
-                ));
-            }
-        }
-        panel_targets.sort_by_key(|(priority, _, _, _)| *priority);
-
-        let mut buttons: Vec<AnyElement> = panel_targets
-            .into_iter()
-            .filter_map(|(_, dock, panel_index, panel)| {
-                render_panel_button(
-                    dock,
-                    panel_index,
-                    panel,
                     PanelButtonLayout::Vertical,
                     icon_size,
                     window,
                     cx,
-                )
-                .map(|element| element.into_any_element())
-            })
-            .collect();
-
-        if project_search_button_visible(cx) {
-            buttons.push(render_project_search_button(icon_size).into_any_element());
+                ) {
+                    items.push((key, priority, element.into_any_element()));
+                }
+            }
         }
+
+        if project_search_button_visible(cx)
+            && panel_button_shown_in_activity_bar(SEARCH_BUTTON_KEY, &settings)
+        {
+            let active_border_color = cx.theme().colors().element_selected;
+            items.push((
+                SEARCH_BUTTON_KEY.to_string(),
+                2,
+                render_project_search_button(icon_size, active_border_color).into_any_element(),
+            ));
+        }
+
+        sort_activity_bar_items(&mut items, &settings);
 
         let colors = cx.theme().colors();
 
@@ -105,11 +107,43 @@ impl Render for ActivityBar {
                         .rounded_bl(CLIENT_SIDE_DECORATION_ROUNDING)
                 }),
             })
-            .children(buttons)
+            .children(items.into_iter().map(|(_, _, element)| element))
     }
 }
 
-fn project_search_button_visible(cx: &App) -> bool {
+fn default_button_order() -> Vec<&'static str> {
+    vec![
+        "ProjectPanel",
+        SEARCH_BUTTON_KEY,
+        "GitPanel",
+        "agent_panel",
+        "TerminalPanel",
+        "OutlinePanel",
+        "CollaborationPanel",
+        "DebugPanel",
+    ]
+}
+
+fn sort_activity_bar_items(items: &mut [(String, u32, AnyElement)], settings: &ActivityBarSettings) {
+    let order: Vec<String> = settings
+        .button_order
+        .clone()
+        .unwrap_or_else(|| default_button_order().into_iter().map(str::to_string).collect());
+
+    items.sort_by(|(left_key, left_priority, _), (right_key, right_priority, _)| {
+        let left_index = order.iter().position(|key| key == left_key);
+        let right_index = order.iter().position(|key| key == right_key);
+
+        match (left_index, right_index) {
+            (Some(left), Some(right)) => left.cmp(&right),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => left_priority.cmp(right_priority),
+        }
+    });
+}
+
+pub(crate) fn project_search_button_visible(cx: &App) -> bool {
     cx.global::<SettingsStore>()
         .merged_settings()
         .editor
@@ -119,7 +153,25 @@ fn project_search_button_visible(cx: &App) -> bool {
         .unwrap_or(true)
 }
 
-fn render_project_search_button(icon_size: IconSize) -> impl IntoElement {
+pub fn activity_bar_hides_search_button(cx: &App) -> bool {
+    let settings = ActivityBarSettings::get_global(cx);
+    settings.enabled
+        && project_search_button_visible(cx)
+        && panel_button_shown_in_activity_bar(SEARCH_BUTTON_KEY, &settings)
+}
+
+pub(crate) fn status_bar_buttons_contains(settings: &ActivityBarSettings, key: &str) -> bool {
+    settings
+        .status_bar_buttons
+        .as_ref()
+        .is_some_and(|buttons| buttons.iter().any(|button| button == key))
+}
+
+pub(crate) fn panel_button_shown_in_activity_bar(panel_key: &str, settings: &ActivityBarSettings) -> bool {
+    settings.enabled && !status_bar_buttons_contains(settings, panel_key)
+}
+
+fn render_project_search_button(icon_size: IconSize, active_border_color: Hsla) -> impl IntoElement {
     let hide = HideStatusItem::new(|settings| {
         settings.editor.search.get_or_insert_default().button = Some(false);
     });
@@ -134,13 +186,15 @@ fn render_project_search_button(icon_size: IconSize) -> impl IntoElement {
         .anchor(Anchor::RightCenter)
         .attach(Anchor::LeftCenter)
         .trigger(move |_active, _window, _cx| {
-            IconButton::new("activity-bar-project-search", IconName::MagnifyingGlass)
+            let button = IconButton::new("activity-bar-project-search", IconName::MagnifyingGlass)
                 .icon_size(icon_size)
                 .tooltip(|_, cx| {
                     Tooltip::for_action("Project Search", &DeploySearch::default(), cx)
                 })
                 .on_click(|_, window, cx| {
                     window.dispatch_action(Box::new(DeploySearch::default()), cx);
-                })
+                });
+
+            vertical_panel_button_container(false, active_border_color, button)
         })
 }

--- a/crates/workspace/src/activity_bar.rs
+++ b/crates/workspace/src/activity_bar.rs
@@ -11,11 +11,9 @@ use gpui::{
     Anchor, AnyElement, App, Context, Decorations, Entity, Hsla, IntoElement, ParentElement,
     Pixels, Render, Styled, Subscription, Window, px,
 };
-use settings::{Settings, SettingsStore};
+use settings::{ActivityBarIconSize, Settings, SettingsStore};
 use theme::CLIENT_SIDE_DECORATION_ROUNDING;
 use ui::{ContextMenu, IconButton, IconName, IconSize, Tooltip, prelude::*, right_click_menu};
-
-const ACTIVITY_BAR_WIDTH: Pixels = px(48.);
 
 pub const SEARCH_BUTTON_KEY: &str = "search";
 
@@ -50,6 +48,7 @@ impl Render for ActivityBar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let settings = ActivityBarSettings::get_global(cx);
         let icon_size = panel_button_icon_size(settings.icon_size);
+        let button_padding = activity_bar_button_padding(settings.icon_size);
 
         let mut items: Vec<(String, u32, AnyElement)> = Vec::new();
         for dock in [&self.left_dock, &self.right_dock, &self.bottom_dock] {
@@ -66,6 +65,7 @@ impl Render for ActivityBar {
                     entry.panel,
                     PanelButtonLayout::Vertical,
                     icon_size,
+                    button_padding,
                     window,
                     cx,
                 ) {
@@ -81,7 +81,8 @@ impl Render for ActivityBar {
             items.push((
                 SEARCH_BUTTON_KEY.to_string(),
                 2,
-                render_project_search_button(icon_size, active_border_color).into_any_element(),
+                render_project_search_button(icon_size, active_border_color, button_padding)
+                    .into_any_element(),
             ));
         }
 
@@ -89,15 +90,21 @@ impl Render for ActivityBar {
 
         let colors = cx.theme().colors();
 
-        v_flex()
+        let mut bar = v_flex()
             .id("activity-bar")
             .when(!settings.enabled, |this| this.hidden())
             .flex_none()
-            .w(ACTIVITY_BAR_WIDTH)
+            .w(activity_bar_width(settings.icon_size))
             .h_full()
-            .py_1()
-            .gap_0p5()
-            .bg(colors.status_bar_background)
+            .bg(colors.status_bar_background);
+
+        bar = match settings.icon_size {
+            ActivityBarIconSize::Small => bar.py_0p5().gap(px(0.)),
+            ActivityBarIconSize::Medium => bar.py_1().gap_0p5(),
+            ActivityBarIconSize::Large => bar.py_1().gap_0p5(),
+        };
+
+        bar
             .border_r_1()
             .border_color(colors.border)
             .map(|el| match window.window_decorations() {
@@ -108,6 +115,22 @@ impl Render for ActivityBar {
                 }),
             })
             .children(items.into_iter().map(|(_, _, element)| element))
+    }
+}
+
+fn activity_bar_width(icon_size: ActivityBarIconSize) -> Pixels {
+    match icon_size {
+        ActivityBarIconSize::Small => px(40.),
+        ActivityBarIconSize::Medium => px(44.),
+        ActivityBarIconSize::Large => px(48.),
+    }
+}
+
+fn activity_bar_button_padding(icon_size: ActivityBarIconSize) -> Pixels {
+    match icon_size {
+        ActivityBarIconSize::Small => px(1.),
+        ActivityBarIconSize::Medium => px(2.),
+        ActivityBarIconSize::Large => px(2.),
     }
 }
 
@@ -171,7 +194,11 @@ pub(crate) fn panel_button_shown_in_activity_bar(panel_key: &str, settings: &Act
     settings.enabled && !status_bar_buttons_contains(settings, panel_key)
 }
 
-fn render_project_search_button(icon_size: IconSize, active_border_color: Hsla) -> impl IntoElement {
+fn render_project_search_button(
+    icon_size: IconSize,
+    active_border_color: Hsla,
+    vertical_padding: Pixels,
+) -> impl IntoElement {
     let hide = HideStatusItem::new(|settings| {
         settings.editor.search.get_or_insert_default().button = Some(false);
     });
@@ -195,6 +222,6 @@ fn render_project_search_button(icon_size: IconSize, active_border_color: Hsla) 
                     window.dispatch_action(Box::new(DeploySearch::default()), cx);
                 });
 
-            vertical_panel_button_container(false, active_border_color, button)
+            vertical_panel_button_container(false, active_border_color, button, vertical_padding)
         })
 }

--- a/crates/workspace/src/activity_bar.rs
+++ b/crates/workspace/src/activity_bar.rs
@@ -4,7 +4,7 @@ use crate::{
         Dock, PanelButtonLayout, panel_button_icon_size, render_panel_button,
         vertical_panel_button_container,
     },
-    status_bar::{HideStatusItem, add_hide_button_entry},
+    status_bar::{HideStatusItem, add_hide_button_entry, configure_status_bar_icon_button},
     workspace_settings::ActivityBarSettings,
 };
 use gpui::{
@@ -194,6 +194,14 @@ pub(crate) fn panel_button_shown_in_activity_bar(panel_key: &str, settings: &Act
     settings.enabled && !status_bar_buttons_contains(settings, panel_key)
 }
 
+pub(crate) fn status_bar_only_panel_keys(settings: &ActivityBarSettings) -> Option<&[String]> {
+    if settings.enabled {
+        Some(settings.status_bar_buttons.as_deref().unwrap_or(&[]))
+    } else {
+        None
+    }
+}
+
 fn render_project_search_button(
     icon_size: IconSize,
     active_border_color: Hsla,
@@ -213,8 +221,10 @@ fn render_project_search_button(
         .anchor(Anchor::RightCenter)
         .attach(Anchor::LeftCenter)
         .trigger(move |_active, _window, _cx| {
-            let button = IconButton::new("activity-bar-project-search", IconName::MagnifyingGlass)
-                .icon_size(icon_size)
+            let button = configure_status_bar_icon_button(
+                IconButton::new("activity-bar-project-search", IconName::MagnifyingGlass),
+                icon_size,
+            )
                 .tooltip(|_, cx| {
                     Tooltip::for_action("Project Search", &DeploySearch::default(), cx)
                 })
@@ -224,4 +234,42 @@ fn render_project_search_button(
 
             vertical_panel_button_container(false, active_border_color, button, vertical_padding)
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use settings::ActivityBarIconSize;
+
+    fn activity_bar_settings(
+        enabled: bool,
+        status_bar_buttons: Option<Vec<String>>,
+    ) -> ActivityBarSettings {
+        ActivityBarSettings {
+            enabled,
+            icon_size: ActivityBarIconSize::Medium,
+            status_bar_buttons,
+            button_order: None,
+        }
+    }
+
+    #[test]
+    fn status_bar_only_panel_keys_none_when_activity_bar_disabled() {
+        let settings = activity_bar_settings(false, None);
+        assert!(status_bar_only_panel_keys(&settings).is_none());
+    }
+
+    #[test]
+    fn status_bar_only_panel_keys_empty_when_no_buttons_selected() {
+        let settings = activity_bar_settings(true, None);
+        let keys = status_bar_only_panel_keys(&settings).expect("should filter status bar buttons");
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn status_bar_only_panel_keys_lists_explicit_buttons() {
+        let settings = activity_bar_settings(true, Some(vec!["TerminalPanel".into()]));
+        let keys = status_bar_only_panel_keys(&settings).expect("should filter status bar buttons");
+        assert_eq!(keys, &["TerminalPanel"]);
+    }
 }

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -3,7 +3,7 @@ use crate::persistence::model::DockData;
 use crate::status_bar::HideStatusItem;
 use crate::{
     DraggedDock, Event, FocusFollowsMouse, ModalLayer, Pane, WorkspaceSettings,
-    workspace_settings::ActivityBarSettings,
+    workspace_settings::{ActivityBarSettings, StatusBarSettings},
 };
 use crate::{Workspace, status_bar::StatusItemView};
 use anyhow::Context as _;
@@ -11,10 +11,10 @@ use client::proto;
 use db::kvp::KeyValueStore;
 
 use gpui::{
-    Action, Anchor, AnyView, App, Axis, Context, Entity, EntityId, EventEmitter, FocusHandle,
-    Focusable, IntoElement, KeyContext, MouseButton, MouseDownEvent, MouseUpEvent, ParentElement,
-    Render, SharedString, StyleRefinement, Styled, Subscription, WeakEntity, Window, deferred, div,
-    px,
+    Action, Anchor, AnyView, App, Axis, Context, Div, Entity, EntityId, EventEmitter, FocusHandle,
+    Focusable, Hsla, IntoElement, KeyContext, MouseButton, MouseDownEvent, MouseUpEvent,
+    ParentElement, Render, SharedString, StyleRefinement, Styled, Subscription, WeakEntity, Window,
+    deferred, div, px,
 };
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore, TerminalDockPosition};
@@ -367,6 +367,31 @@ pub(crate) enum PanelButtonLayout {
     Vertical,
 }
 
+pub(crate) fn panel_button_icon_size(
+    icon_size: settings::ActivityBarIconSize,
+) -> IconSize {
+    match icon_size {
+        settings::ActivityBarIconSize::Small => IconSize::Small,
+        settings::ActivityBarIconSize::Medium => IconSize::Custom(rems_from_px(18.)),
+        settings::ActivityBarIconSize::Large => IconSize::Custom(rems_from_px(22.)),
+    }
+}
+
+pub(crate) fn vertical_panel_button_container(
+    is_active: bool,
+    active_border_color: Hsla,
+    button: impl IntoElement,
+) -> Div {
+    div()
+        .relative()
+        .w_full()
+        .flex()
+        .justify_center()
+        .py_0p5()
+        .when(is_active, |this| this.border_l_2().border_color(active_border_color))
+        .child(button)
+}
+
 pub(crate) struct PanelButtonEntry {
     pub panel_index: usize,
     pub panel: Arc<dyn PanelHandle>,
@@ -543,16 +568,9 @@ pub(crate) fn render_panel_button(
 
                 let button_container = match layout {
                     PanelButtonLayout::Horizontal => div().relative().child(button),
-                    PanelButtonLayout::Vertical => div()
-                        .relative()
-                        .w_full()
-                        .flex()
-                        .justify_center()
-                        .py_0p5()
-                        .when(is_active_button, |this| {
-                            this.border_l_2().border_color(active_border_color)
-                        })
-                        .child(button),
+                    PanelButtonLayout::Vertical => {
+                        vertical_panel_button_container(is_active_button, active_border_color, button)
+                    }
                 };
 
                 button_container.when_some(
@@ -572,6 +590,7 @@ pub(crate) fn render_panel_buttons(
     icon_size: IconSize,
     window: &mut Window,
     cx: &App,
+    only_panel_keys: Option<&[String]>,
 ) -> Vec<AnyElement> {
     let dock_position = dock.read(cx).position;
     let mut buttons: Vec<AnyElement> = dock
@@ -579,6 +598,12 @@ pub(crate) fn render_panel_buttons(
         .panel_button_entries()
         .into_iter()
         .filter_map(|entry| {
+            let panel_key = entry.panel.panel_key();
+            if let Some(keys) = only_panel_keys {
+                if !keys.iter().any(|key| key == panel_key) {
+                    return None;
+                }
+            }
             render_panel_button(
                 dock.clone(),
                 entry.panel_index,
@@ -1451,17 +1476,22 @@ impl PanelButtons {
 
 impl Render for PanelButtons {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        if ActivityBarSettings::get_global(cx).enabled {
-            return h_flex();
-        }
+        let activity_bar_settings = ActivityBarSettings::get_global(cx);
+        let only_panel_keys = if activity_bar_settings.enabled {
+            activity_bar_settings.status_bar_buttons.as_deref()
+        } else {
+            None
+        };
 
         let dock_position = self.dock.read(cx).position;
+        let icon_size = panel_button_icon_size(StatusBarSettings::get_global(cx).panel_button_icon_size);
         let buttons = render_panel_buttons(
             self.dock.clone(),
             PanelButtonLayout::Horizontal,
-            IconSize::Small,
+            icon_size,
             window,
             cx,
+            only_panel_keys,
         );
         let has_buttons = !buttons.is_empty();
 

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -3,6 +3,7 @@ use crate::persistence::model::DockData;
 use crate::status_bar::HideStatusItem;
 use crate::{
     DraggedDock, Event, FocusFollowsMouse, ModalLayer, Pane, WorkspaceSettings,
+    activity_bar::status_bar_only_panel_keys, status_bar::configure_status_bar_icon_button,
     workspace_settings::ActivityBarSettings,
 };
 use crate::{Workspace, status_bar::StatusItemView};
@@ -548,8 +549,10 @@ pub(crate) fn render_panel_button(
             .anchor(menu_anchor)
             .attach(menu_attach)
             .trigger(move |is_active, _window, _cx| {
-                let button = IconButton::new((name, is_active_button as u64), icon)
-                    .icon_size(icon_size)
+                let button = configure_status_bar_icon_button(
+                    IconButton::new((name, is_active_button as u64), icon),
+                    icon_size,
+                )
                     .toggle_state(is_active_button)
                     .on_click({
                         let action = action.boxed_clone();
@@ -1478,12 +1481,7 @@ impl PanelButtons {
 
 impl Render for PanelButtons {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let activity_bar_settings = ActivityBarSettings::get_global(cx);
-        let only_panel_keys = if activity_bar_settings.enabled {
-            activity_bar_settings.status_bar_buttons.as_deref()
-        } else {
-            None
-        };
+        let only_panel_keys = status_bar_only_panel_keys(&ActivityBarSettings::get_global(cx));
 
         let dock_position = self.dock.read(cx).position;
         let icon_size = crate::status_bar::status_bar_icon_size(cx);

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -3,7 +3,7 @@ use crate::persistence::model::DockData;
 use crate::status_bar::HideStatusItem;
 use crate::{
     DraggedDock, Event, FocusFollowsMouse, ModalLayer, Pane, WorkspaceSettings,
-    workspace_settings::{ActivityBarSettings, StatusBarSettings},
+    workspace_settings::ActivityBarSettings,
 };
 use crate::{Workspace, status_bar::StatusItemView};
 use anyhow::Context as _;
@@ -370,24 +370,21 @@ pub(crate) enum PanelButtonLayout {
 pub(crate) fn panel_button_icon_size(
     icon_size: settings::ActivityBarIconSize,
 ) -> IconSize {
-    match icon_size {
-        settings::ActivityBarIconSize::Small => IconSize::Small,
-        settings::ActivityBarIconSize::Medium => IconSize::Custom(rems_from_px(18.)),
-        settings::ActivityBarIconSize::Large => IconSize::Custom(rems_from_px(22.)),
-    }
+    crate::status_bar::icon_size_from_setting(icon_size)
 }
 
 pub(crate) fn vertical_panel_button_container(
     is_active: bool,
     active_border_color: Hsla,
     button: impl IntoElement,
+    vertical_padding: Pixels,
 ) -> Div {
     div()
         .relative()
         .w_full()
         .flex()
         .justify_center()
-        .py_0p5()
+        .py(vertical_padding)
         .when(is_active, |this| this.border_l_2().border_color(active_border_color))
         .child(button)
 }
@@ -416,6 +413,7 @@ pub(crate) fn render_panel_button(
     panel: Arc<dyn PanelHandle>,
     layout: PanelButtonLayout,
     icon_size: IconSize,
+    vertical_button_padding: Pixels,
     window: &mut Window,
     cx: &App,
 ) -> Option<impl IntoElement> {
@@ -568,9 +566,12 @@ pub(crate) fn render_panel_button(
 
                 let button_container = match layout {
                     PanelButtonLayout::Horizontal => div().relative().child(button),
-                    PanelButtonLayout::Vertical => {
-                        vertical_panel_button_container(is_active_button, active_border_color, button)
-                    }
+                    PanelButtonLayout::Vertical => vertical_panel_button_container(
+                        is_active_button,
+                        active_border_color,
+                        button,
+                        vertical_button_padding,
+                    ),
                 };
 
                 button_container.when_some(
@@ -610,6 +611,7 @@ pub(crate) fn render_panel_buttons(
                 entry.panel,
                 layout,
                 icon_size,
+                px(0.),
                 window,
                 cx,
             )
@@ -1484,7 +1486,7 @@ impl Render for PanelButtons {
         };
 
         let dock_position = self.dock.read(cx).position;
-        let icon_size = panel_button_icon_size(StatusBarSettings::get_global(cx).panel_button_icon_size);
+        let icon_size = crate::status_bar::status_bar_icon_size(cx);
         let buttons = render_panel_buttons(
             self.dock.clone(),
             PanelButtonLayout::Horizontal,

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1,7 +1,10 @@
 use crate::focus_follows_mouse::FocusFollowsMouse as _;
 use crate::persistence::model::DockData;
 use crate::status_bar::HideStatusItem;
-use crate::{DraggedDock, Event, FocusFollowsMouse, ModalLayer, Pane, WorkspaceSettings};
+use crate::{
+    DraggedDock, Event, FocusFollowsMouse, ModalLayer, Pane, WorkspaceSettings,
+    workspace_settings::ActivityBarSettings,
+};
 use crate::{Workspace, status_bar::StatusItemView};
 use anyhow::Context as _;
 use client::proto;
@@ -356,6 +359,244 @@ struct PanelEntry {
 pub struct PanelButtons {
     dock: Entity<Dock>,
     _settings_subscription: Subscription,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PanelButtonLayout {
+    Horizontal,
+    Vertical,
+}
+
+pub(crate) struct PanelButtonEntry {
+    pub panel_index: usize,
+    pub panel: Arc<dyn PanelHandle>,
+}
+
+impl Dock {
+    pub(crate) fn panel_button_entries(&self) -> Vec<PanelButtonEntry> {
+        self.panel_entries
+            .iter()
+            .enumerate()
+            .map(|(panel_index, entry)| PanelButtonEntry {
+                panel_index,
+                panel: entry.panel.clone(),
+            })
+            .collect()
+    }
+}
+
+pub(crate) fn render_panel_button(
+    dock: Entity<Dock>,
+    panel_index: usize,
+    panel: Arc<dyn PanelHandle>,
+    layout: PanelButtonLayout,
+    icon_size: IconSize,
+    window: &mut Window,
+    cx: &App,
+) -> Option<impl IntoElement> {
+    let dock_state = dock.read(cx);
+    let active_index = dock_state.active_panel_index;
+    let is_open = dock_state.is_open;
+    let dock_position = dock_state.position;
+
+    let (menu_anchor, menu_attach) = match layout {
+        PanelButtonLayout::Horizontal => match dock_position {
+            DockPosition::Left => (Anchor::BottomLeft, Anchor::TopLeft),
+            DockPosition::Bottom | DockPosition::Right => (Anchor::BottomRight, Anchor::TopRight),
+        },
+        PanelButtonLayout::Vertical => (Anchor::RightCenter, Anchor::LeftCenter),
+    };
+
+    let icon = panel.icon(window, cx)?;
+    let icon_tooltip = panel
+        .icon_tooltip(window, cx)
+        .ok_or_else(|| anyhow::anyhow!("can't render a panel button without an icon tooltip"))
+        .log_err()?;
+    let name = panel.persistent_name();
+    let supports_flexible = panel.supports_flexible_size(cx);
+    let currently_flexible = panel.has_flexible_size(window, cx);
+    let dock_for_menu = dock.clone();
+    let workspace = dock_state.workspace.clone();
+
+    let is_active_button = Some(panel_index) == active_index && is_open;
+    let (action, tooltip) = if is_active_button {
+        let action = dock_state.toggle_action();
+        let tooltip: SharedString = format!("Close {} Dock", dock_position.label()).into();
+        (action, tooltip)
+    } else {
+        let action = panel.toggle_action(window, cx);
+        (action, icon_tooltip.into())
+    };
+
+    let focus_handle = dock_state.focus_handle(cx);
+    let icon_label = panel.icon_label(window, cx);
+    let active_border_color = cx.theme().colors().element_selected;
+
+    Some(
+        right_click_menu(name)
+            .menu({
+                let panel = panel.clone();
+                move |window, cx| {
+                    const POSITIONS: [DockPosition; 3] = [
+                        DockPosition::Left,
+                        DockPosition::Right,
+                        DockPosition::Bottom,
+                    ];
+
+                    let panel_hide = panel.hide_button_setting(cx);
+                    ContextMenu::build(window, cx, |mut menu, _, cx| {
+                        let mut has_position_entries = false;
+                        for position in POSITIONS {
+                            if panel.position_is_valid(position, cx) {
+                                let is_current = position == dock_position;
+                                let panel = panel.clone();
+                                menu = menu.toggleable_entry(
+                                    format!("Dock {}", position.label()),
+                                    is_current,
+                                    IconPosition::Start,
+                                    None,
+                                    move |window, cx| {
+                                        if !is_current {
+                                            panel.set_position(position, window, cx);
+                                        }
+                                    },
+                                );
+                                has_position_entries = true;
+                            }
+                        }
+                        if supports_flexible {
+                            if has_position_entries {
+                                menu = menu.separator();
+                            }
+                            let panel_for_flex = panel.clone();
+                            let dock_for_flex = dock_for_menu.clone();
+                            let workspace_for_flex = workspace.clone();
+                            menu = menu.toggleable_entry(
+                                "Flex Width",
+                                currently_flexible,
+                                IconPosition::Start,
+                                None,
+                                move |window, cx| {
+                                    if !currently_flexible {
+                                        if let Some(ws) = workspace_for_flex.upgrade() {
+                                            ws.update(cx, |workspace, cx| {
+                                                workspace.toggle_dock_panel_flexible_size(
+                                                    &dock_for_flex,
+                                                    panel_for_flex.as_ref(),
+                                                    window,
+                                                    cx,
+                                                );
+                                            });
+                                        }
+                                    }
+                                },
+                            );
+                            let panel_for_fixed = panel.clone();
+                            let dock_for_fixed = dock_for_menu.clone();
+                            let workspace_for_fixed = workspace.clone();
+                            menu = menu.toggleable_entry(
+                                "Fixed Width",
+                                !currently_flexible,
+                                IconPosition::Start,
+                                None,
+                                move |window, cx| {
+                                    if currently_flexible {
+                                        if let Some(ws) = workspace_for_fixed.upgrade() {
+                                            ws.update(cx, |workspace, cx| {
+                                                workspace.toggle_dock_panel_flexible_size(
+                                                    &dock_for_fixed,
+                                                    panel_for_fixed.as_ref(),
+                                                    window,
+                                                    cx,
+                                                );
+                                            });
+                                        }
+                                    }
+                                },
+                            );
+                        }
+                        if let Some(hide) = panel_hide {
+                            menu = crate::status_bar::add_hide_button_entry(menu.separator(), hide);
+                        }
+                        menu
+                    })
+                }
+            })
+            .anchor(menu_anchor)
+            .attach(menu_attach)
+            .trigger(move |is_active, _window, _cx| {
+                let button = IconButton::new((name, is_active_button as u64), icon)
+                    .icon_size(icon_size)
+                    .toggle_state(is_active_button)
+                    .on_click({
+                        let action = action.boxed_clone();
+                        move |_, window, cx| {
+                            window.focus(&focus_handle, cx);
+                            window.dispatch_action(action.boxed_clone(), cx)
+                        }
+                    })
+                    .when(!is_active, |this| {
+                        this.tooltip(move |_window, cx| {
+                            Tooltip::for_action(tooltip.clone(), &*action, cx)
+                        })
+                    });
+
+                let button_container = match layout {
+                    PanelButtonLayout::Horizontal => div().relative().child(button),
+                    PanelButtonLayout::Vertical => div()
+                        .relative()
+                        .w_full()
+                        .flex()
+                        .justify_center()
+                        .py_0p5()
+                        .when(is_active_button, |this| {
+                            this.border_l_2().border_color(active_border_color)
+                        })
+                        .child(button),
+                };
+
+                button_container.when_some(
+                    icon_label
+                        .clone()
+                        .filter(|_| !is_active_button)
+                        .and_then(|label| label.parse::<usize>().ok()),
+                    |this, count| this.child(CountBadge::new(count)),
+                )
+            }),
+    )
+}
+
+pub(crate) fn render_panel_buttons(
+    dock: Entity<Dock>,
+    layout: PanelButtonLayout,
+    icon_size: IconSize,
+    window: &mut Window,
+    cx: &App,
+) -> Vec<AnyElement> {
+    let dock_position = dock.read(cx).position;
+    let mut buttons: Vec<AnyElement> = dock
+        .read(cx)
+        .panel_button_entries()
+        .into_iter()
+        .filter_map(|entry| {
+            render_panel_button(
+                dock.clone(),
+                entry.panel_index,
+                entry.panel,
+                layout,
+                icon_size,
+                window,
+                cx,
+            )
+            .map(|element| element.into_any_element())
+        })
+        .collect();
+
+    if layout == PanelButtonLayout::Horizontal && dock_position == DockPosition::Right {
+        buttons.reverse();
+    }
+
+    buttons
 }
 
 pub(crate) const PANEL_SIZE_STATE_KEY: &str = "dock_panel_size";
@@ -1210,194 +1451,30 @@ impl PanelButtons {
 
 impl Render for PanelButtons {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let dock = self.dock.read(cx);
-        let active_index = dock.active_panel_index;
-        let is_open = dock.is_open;
-        let dock_position = dock.position;
-
-        let (menu_anchor, menu_attach) = match dock.position {
-            DockPosition::Left => (Anchor::BottomLeft, Anchor::TopLeft),
-            DockPosition::Bottom | DockPosition::Right => (Anchor::BottomRight, Anchor::TopRight),
-        };
-
-        let dock_entity = self.dock.clone();
-        let workspace = dock.workspace.clone();
-        let mut buttons: Vec<_> = dock
-            .panel_entries
-            .iter()
-            .enumerate()
-            .filter_map(|(i, entry)| {
-                let icon = entry.panel.icon(window, cx)?;
-                let icon_tooltip = entry
-                    .panel
-                    .icon_tooltip(window, cx)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("can't render a panel button without an icon tooltip")
-                    })
-                    .log_err()?;
-                let name = entry.panel.persistent_name();
-                let panel = entry.panel.clone();
-                let supports_flexible = panel.supports_flexible_size(cx);
-                let currently_flexible = panel.has_flexible_size(window, cx);
-                let dock_for_menu = dock_entity.clone();
-                let workspace_for_menu = workspace.clone();
-
-                let is_active_button = Some(i) == active_index && is_open;
-                let (action, tooltip) = if is_active_button {
-                    let action = dock.toggle_action();
-
-                    let tooltip: SharedString =
-                        format!("Close {} Dock", dock.position.label()).into();
-
-                    (action, tooltip)
-                } else {
-                    let action = entry.panel.toggle_action(window, cx);
-
-                    (action, icon_tooltip.into())
-                };
-
-                let focus_handle = dock.focus_handle(cx);
-                let icon_label = entry.panel.icon_label(window, cx);
-
-                Some(
-                    right_click_menu(name)
-                        .menu(move |window, cx| {
-                            const POSITIONS: [DockPosition; 3] = [
-                                DockPosition::Left,
-                                DockPosition::Right,
-                                DockPosition::Bottom,
-                            ];
-
-                            let panel_hide = panel.hide_button_setting(cx);
-                            ContextMenu::build(window, cx, |mut menu, _, cx| {
-                                let mut has_position_entries = false;
-                                for position in POSITIONS {
-                                    if panel.position_is_valid(position, cx) {
-                                        let is_current = position == dock_position;
-                                        let panel = panel.clone();
-                                        menu = menu.toggleable_entry(
-                                            format!("Dock {}", position.label()),
-                                            is_current,
-                                            IconPosition::Start,
-                                            None,
-                                            move |window, cx| {
-                                                if !is_current {
-                                                    panel.set_position(position, window, cx);
-                                                }
-                                            },
-                                        );
-                                        has_position_entries = true;
-                                    }
-                                }
-                                if supports_flexible {
-                                    if has_position_entries {
-                                        menu = menu.separator();
-                                    }
-                                    let panel_for_flex = panel.clone();
-                                    let dock_for_flex = dock_for_menu.clone();
-                                    let workspace_for_flex = workspace_for_menu.clone();
-                                    menu = menu.toggleable_entry(
-                                        "Flex Width",
-                                        currently_flexible,
-                                        IconPosition::Start,
-                                        None,
-                                        move |window, cx| {
-                                            if !currently_flexible {
-                                                if let Some(ws) = workspace_for_flex.upgrade() {
-                                                    ws.update(cx, |workspace, cx| {
-                                                        workspace.toggle_dock_panel_flexible_size(
-                                                            &dock_for_flex,
-                                                            panel_for_flex.as_ref(),
-                                                            window,
-                                                            cx,
-                                                        );
-                                                    });
-                                                }
-                                            }
-                                        },
-                                    );
-                                    let panel_for_fixed = panel.clone();
-                                    let dock_for_fixed = dock_for_menu.clone();
-                                    let workspace_for_fixed = workspace_for_menu.clone();
-                                    menu = menu.toggleable_entry(
-                                        "Fixed Width",
-                                        !currently_flexible,
-                                        IconPosition::Start,
-                                        None,
-                                        move |window, cx| {
-                                            if currently_flexible {
-                                                if let Some(ws) = workspace_for_fixed.upgrade() {
-                                                    ws.update(cx, |workspace, cx| {
-                                                        workspace.toggle_dock_panel_flexible_size(
-                                                            &dock_for_fixed,
-                                                            panel_for_fixed.as_ref(),
-                                                            window,
-                                                            cx,
-                                                        );
-                                                    });
-                                                }
-                                            }
-                                        },
-                                    );
-                                }
-                                if let Some(hide) = panel_hide {
-                                    menu = crate::status_bar::add_hide_button_entry(
-                                        menu.separator(),
-                                        hide,
-                                    );
-                                }
-                                menu
-                            })
-                        })
-                        .anchor(menu_anchor)
-                        .attach(menu_attach)
-                        .trigger(move |is_active, _window, _cx| {
-                            // Include active state in element ID to invalidate the cached
-                            // tooltip when panel state changes (e.g., via keyboard shortcut)
-                            let button = IconButton::new((name, is_active_button as u64), icon)
-                                .icon_size(IconSize::Small)
-                                .toggle_state(is_active_button)
-                                .on_click({
-                                    let action = action.boxed_clone();
-                                    move |_, window, cx| {
-                                        window.focus(&focus_handle, cx);
-                                        window.dispatch_action(action.boxed_clone(), cx)
-                                    }
-                                })
-                                .when(!is_active, |this| {
-                                    this.tooltip(move |_window, cx| {
-                                        Tooltip::for_action(tooltip.clone(), &*action, cx)
-                                    })
-                                });
-
-                            div().relative().child(button).when_some(
-                                icon_label
-                                    .clone()
-                                    .filter(|_| !is_active_button)
-                                    .and_then(|label| label.parse::<usize>().ok()),
-                                |this, count| this.child(CountBadge::new(count)),
-                            )
-                        }),
-                )
-            })
-            .collect();
-
-        if dock_position == DockPosition::Right {
-            buttons.reverse();
+        if ActivityBarSettings::get_global(cx).enabled {
+            return h_flex();
         }
 
+        let dock_position = self.dock.read(cx).position;
+        let buttons = render_panel_buttons(
+            self.dock.clone(),
+            PanelButtonLayout::Horizontal,
+            IconSize::Small,
+            window,
+            cx,
+        );
         let has_buttons = !buttons.is_empty();
 
         h_flex()
             .gap_1()
             .when(
                 has_buttons
-                    && (dock.position == DockPosition::Bottom
-                        || dock.position == DockPosition::Right),
+                    && (dock_position == DockPosition::Bottom
+                        || dock_position == DockPosition::Right),
                 |this| this.child(Divider::vertical().color(DividerColor::Border)),
             )
             .children(buttons)
-            .when(has_buttons && dock.position == DockPosition::Left, |this| {
+            .when(has_buttons && dock_position == DockPosition::Left, |this| {
                 this.child(Divider::vertical().color(DividerColor::Border))
             })
     }

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -1,12 +1,12 @@
 use crate::{
     ItemHandle, MultiWorkspace, Pane, SidebarSide, ToggleWorkspaceSidebar,
-    sidebar_side_context_menu,
+    sidebar_side_context_menu, workspace_settings::StatusBarSettings,
 };
 use gpui::{
     Anchor, AnyView, App, Context, Decorations, Entity, IntoElement, ParentElement, Render,
-    SharedString, Styled, Subscription, WeakEntity, Window,
+    SharedString, Styled, Subscription, WeakEntity, Window, px,
 };
-use settings::{SettingsContent, update_settings_file};
+use settings::{ActivityBarIconSize, Settings, SettingsContent, SettingsStore, update_settings_file};
 use std::{any::TypeId, sync::Arc};
 use theme::CLIENT_SIDE_DECORATION_ROUNDING;
 use ui::{ContextMenu, Divider, IconPosition, Indicator, Tooltip, prelude::*, right_click_menu};
@@ -97,12 +97,25 @@ impl SidebarStatus {
     }
 }
 
+pub fn icon_size_from_setting(icon_size: ActivityBarIconSize) -> IconSize {
+    match icon_size {
+        ActivityBarIconSize::Small => IconSize::Small,
+        ActivityBarIconSize::Medium => IconSize::Medium,
+        ActivityBarIconSize::Large => IconSize::Custom(rems_from_px(20.)),
+    }
+}
+
+pub fn status_bar_icon_size(cx: &App) -> IconSize {
+    icon_size_from_setting(StatusBarSettings::get_global(cx).panel_button_icon_size)
+}
+
 pub struct StatusBar {
     left_items: Vec<Box<dyn StatusItemViewHandle>>,
     right_items: Vec<Box<dyn StatusItemViewHandle>>,
     active_pane: Entity<Pane>,
     multi_workspace: Option<WeakEntity<MultiWorkspace>>,
     _observe_active_pane: Subscription,
+    _settings_subscription: Subscription,
 }
 
 impl Render for StatusBar {
@@ -112,8 +125,10 @@ impl Render for StatusBar {
         h_flex()
             .w_full()
             .justify_between()
+            .items_center()
             .gap(DynamicSpacing::Base08.rems(cx))
-            .p(DynamicSpacing::Base04.rems(cx))
+            .px(DynamicSpacing::Base04.rems(cx))
+            .py(DynamicSpacing::Base02.rems(cx))
             .bg(cx.theme().colors().status_bar_background)
             .map(|el| match window.window_decorations() {
                 Decorations::Server => el,
@@ -200,6 +215,7 @@ impl StatusBar {
         let on_right = sidebar.side == SidebarSide::Right;
         let has_notifications = sidebar.has_notifications;
         let indicator_border = cx.theme().colors().status_bar_background;
+        let icon_size = status_bar_icon_size(cx);
 
         let toggle = sidebar_side_context_menu("sidebar-status-toggle-menu", cx)
             .anchor(if on_right {
@@ -221,7 +237,7 @@ impl StatusBar {
                         IconName::ThreadsSidebarLeftClosed
                     },
                 )
-                .icon_size(IconSize::Small)
+                .icon_size(icon_size)
                 .when(has_notifications, |this| {
                     this.indicator(Indicator::dot().color(Color::Accent))
                         .indicator_border_color(Some(indicator_border))
@@ -299,6 +315,7 @@ impl StatusBar {
             _observe_active_pane: cx.observe_in(active_pane, window, |this, _, window, cx| {
                 this.update_active_pane_item(window, cx)
             }),
+            _settings_subscription: cx.observe_global::<SettingsStore>(|_, cx| cx.notify()),
         };
         this.update_active_pane_item(window, cx);
         this

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -9,7 +9,10 @@ use gpui::{
 use settings::{ActivityBarIconSize, Settings, SettingsContent, SettingsStore, update_settings_file};
 use std::{any::TypeId, sync::Arc};
 use theme::CLIENT_SIDE_DECORATION_ROUNDING;
-use ui::{ContextMenu, Divider, IconPosition, Indicator, Tooltip, prelude::*, right_click_menu};
+use ui::{
+    ContextMenu, Divider, IconButton, IconButtonShape, IconPosition, Indicator, Tooltip, prelude::*,
+    right_click_menu,
+};
 
 /// Describes how a status-bar item can be hidden by the user.
 ///
@@ -109,6 +112,22 @@ pub fn status_bar_icon_size(cx: &App) -> IconSize {
     icon_size_from_setting(StatusBarSettings::get_global(cx).panel_button_icon_size)
 }
 
+pub fn configure_status_bar_icon_button(button: IconButton, icon_size: IconSize) -> IconButton {
+    let button = button.icon_size(icon_size);
+    if matches!(icon_size, IconSize::Custom(_)) {
+        button.shape(IconButtonShape::Square)
+    } else {
+        button
+    }
+}
+
+pub fn apply_status_bar_chrome_styles<S: Styled>(this: S, cx: &App) -> S {
+    this.items_center()
+        .px(DynamicSpacing::Base04.rems(cx))
+        .py(DynamicSpacing::Base02.rems(cx))
+        .bg(cx.theme().colors().status_bar_background)
+}
+
 pub struct StatusBar {
     left_items: Vec<Box<dyn StatusItemViewHandle>>,
     right_items: Vec<Box<dyn StatusItemViewHandle>>,
@@ -122,14 +141,13 @@ impl Render for StatusBar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let sidebar = SidebarStatus::query(&self.multi_workspace, cx);
 
-        h_flex()
-            .w_full()
-            .justify_between()
-            .items_center()
-            .gap(DynamicSpacing::Base08.rems(cx))
-            .px(DynamicSpacing::Base04.rems(cx))
-            .py(DynamicSpacing::Base02.rems(cx))
-            .bg(cx.theme().colors().status_bar_background)
+        apply_status_bar_chrome_styles(
+            h_flex()
+                .w_full()
+                .justify_between()
+                .gap(DynamicSpacing::Base08.rems(cx)),
+            cx,
+        )
             .map(|el| match window.window_decorations() {
                 Decorations::Server => el,
                 Decorations::Client { tiling, .. } => el
@@ -229,15 +247,17 @@ impl StatusBar {
                 Anchor::TopLeft
             })
             .trigger(move |_is_active, _window, _cx| {
-                IconButton::new(
-                    "toggle-workspace-sidebar",
-                    if on_right {
-                        IconName::ThreadsSidebarRightClosed
-                    } else {
-                        IconName::ThreadsSidebarLeftClosed
-                    },
+                configure_status_bar_icon_button(
+                    IconButton::new(
+                        "toggle-workspace-sidebar",
+                        if on_right {
+                            IconName::ThreadsSidebarRightClosed
+                        } else {
+                            IconName::ThreadsSidebarLeftClosed
+                        },
+                    ),
+                    icon_size,
                 )
-                .icon_size(icon_size)
                 .when(has_notifications, |this| {
                     this.indicator(Indicator::dot().color(Color::Accent))
                         .indicator_border_color(Some(indicator_border))

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -20,6 +20,7 @@ pub mod security_modal;
 pub mod shared_screen;
 pub use shared_screen::SharedScreen;
 pub mod focus_follows_mouse;
+mod activity_bar;
 mod status_bar;
 pub mod tasks;
 mod theme_preview;
@@ -154,8 +155,9 @@ use util::{
 };
 use uuid::Uuid;
 pub use workspace_settings::{
-    AutosaveSetting, BottomDockLayout, EncodingDisplayOptions, FocusFollowsMouse,
-    RestoreOnStartupBehavior, StatusBarSettings, TabBarSettings, WorkspaceSettings,
+    ActivityBarSettings, AutosaveSetting, BottomDockLayout, EncodingDisplayOptions,
+    FocusFollowsMouse, RestoreOnStartupBehavior, StatusBarSettings, TabBarSettings,
+    WorkspaceSettings,
 };
 use zed_actions::{Spawn, feedback::FileBugReport, theme::ToggleMode};
 
@@ -1367,6 +1369,7 @@ pub struct Workspace {
     last_active_center_pane: Option<WeakEntity<Pane>>,
     last_active_view_id: Option<proto::ViewId>,
     status_bar: Entity<StatusBar>,
+    activity_bar: Entity<activity_bar::ActivityBar>,
     pub(crate) modal_layer: Entity<ModalLayer>,
     toast_layer: Entity<ToastLayer>,
     titlebar_item: Option<AnyView>,
@@ -1726,6 +1729,14 @@ impl Workspace {
         let left_dock_buttons = cx.new(|cx| PanelButtons::new(left_dock.clone(), cx));
         let bottom_dock_buttons = cx.new(|cx| PanelButtons::new(bottom_dock.clone(), cx));
         let right_dock_buttons = cx.new(|cx| PanelButtons::new(right_dock.clone(), cx));
+        let activity_bar = cx.new(|cx| {
+            activity_bar::ActivityBar::new(
+                left_dock.clone(),
+                right_dock.clone(),
+                bottom_dock.clone(),
+                cx,
+            )
+        });
         let multi_workspace = window
             .root::<MultiWorkspace>()
             .flatten()
@@ -1814,6 +1825,7 @@ impl Workspace {
             last_active_center_pane: Some(center_pane.downgrade()),
             last_active_view_id: None,
             status_bar,
+            activity_bar,
             modal_layer,
             toast_layer,
             titlebar_item: None,
@@ -2582,6 +2594,14 @@ impl Workspace {
 
     pub fn status_bar_visible(&self, cx: &App) -> bool {
         StatusBarSettings::get_global(cx).show
+    }
+
+    pub fn activity_bar_visible(&self, cx: &App) -> bool {
+        ActivityBarSettings::get_global(cx).enabled
+    }
+
+    pub fn activity_bar(&self) -> &Entity<activity_bar::ActivityBar> {
+        &self.activity_bar
     }
 
     pub fn multi_workspace(&self) -> Option<&WeakEntity<MultiWorkspace>> {
@@ -8668,19 +8688,27 @@ impl Render for Workspace {
                     .flex()
                     .flex_col()
                     .child(
-                        div()
-                            .id("workspace")
-                            .bg(colors.background)
-                            .relative()
+                        h_flex()
                             .flex_1()
                             .w_full()
-                            .flex()
-                            .flex_col()
                             .overflow_hidden()
-                            .border_t_1()
-                            .border_b_1()
-                            .border_color(colors.border)
-                            .child({
+                            .when(self.activity_bar_visible(cx), |row| {
+                                row.child(self.activity_bar.clone())
+                            })
+                            .child(
+                                div()
+                                    .id("workspace")
+                                    .bg(colors.background)
+                                    .relative()
+                                    .flex_1()
+                                    .h_full()
+                                    .flex()
+                                    .flex_col()
+                                    .overflow_hidden()
+                                    .border_t_1()
+                                    .border_b_1()
+                                    .border_color(colors.border)
+                                    .child({
                                 let this = cx.entity();
                                 canvas(
                                     move |bounds, window, cx| {
@@ -9025,6 +9053,7 @@ impl Render for Workspace {
                                 })
                             }))
                             .children(self.render_notifications(window, cx)),
+                            ),
                     )
                     .when(self.status_bar_visible(cx), |parent| {
                         parent.child(self.status_bar.clone())
@@ -15666,6 +15695,39 @@ mod tests {
                 .await;
             assert!(handle.is_err());
         }
+    }
+
+    #[gpui::test]
+    async fn test_activity_bar_visibility(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, _cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        workspace.read_with(cx, |workspace, cx| {
+            assert!(
+                !workspace.activity_bar_visible(cx),
+                "Activity bar should be disabled by default"
+            );
+        });
+
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .activity_bar
+                    .get_or_insert_default()
+                    .enabled = Some(true);
+            });
+        });
+
+        workspace.read_with(cx, |workspace, cx| {
+            assert!(
+                workspace.activity_bar_visible(cx),
+                "Activity bar should be visible when enabled is true"
+            );
+        });
     }
 
     #[gpui::test]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -21,7 +21,7 @@ pub mod shared_screen;
 pub use shared_screen::SharedScreen;
 pub mod focus_follows_mouse;
 pub mod activity_bar;
-mod status_bar;
+pub mod status_bar;
 pub mod tasks;
 mod theme_preview;
 mod toast_layer;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -20,7 +20,7 @@ pub mod security_modal;
 pub mod shared_screen;
 pub use shared_screen::SharedScreen;
 pub mod focus_follows_mouse;
-mod activity_bar;
+pub mod activity_bar;
 mod status_bar;
 pub mod tasks;
 mod theme_preview;

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -167,7 +167,7 @@ impl Settings for ActivityBarSettings {
             enabled: activity_bar.enabled.unwrap(),
             icon_size: activity_bar.icon_size.unwrap(),
             status_bar_buttons: activity_bar.status_bar_buttons.clone(),
-            button_order: activity_bar.button_order.clone(),
+            button_order: activity_bar.button_order,
         }
     }
 }

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -153,6 +153,22 @@ impl Settings for TabBarSettings {
 }
 
 #[derive(Deserialize, RegisterSetting)]
+pub struct ActivityBarSettings {
+    pub enabled: bool,
+    pub icon_size: settings::ActivityBarIconSize,
+}
+
+impl Settings for ActivityBarSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        let activity_bar = content.activity_bar.clone().unwrap();
+        ActivityBarSettings {
+            enabled: activity_bar.enabled.unwrap(),
+            icon_size: activity_bar.icon_size.unwrap(),
+        }
+    }
+}
+
+#[derive(Deserialize, RegisterSetting)]
 pub struct StatusBarSettings {
     pub show: bool,
     pub show_active_file: bool,

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -156,6 +156,8 @@ impl Settings for TabBarSettings {
 pub struct ActivityBarSettings {
     pub enabled: bool,
     pub icon_size: settings::ActivityBarIconSize,
+    pub status_bar_buttons: Option<Vec<String>>,
+    pub button_order: Option<Vec<String>>,
 }
 
 impl Settings for ActivityBarSettings {
@@ -164,6 +166,8 @@ impl Settings for ActivityBarSettings {
         ActivityBarSettings {
             enabled: activity_bar.enabled.unwrap(),
             icon_size: activity_bar.icon_size.unwrap(),
+            status_bar_buttons: activity_bar.status_bar_buttons.clone(),
+            button_order: activity_bar.button_order.clone(),
         }
     }
 }
@@ -176,6 +180,7 @@ pub struct StatusBarSettings {
     pub cursor_position_button: bool,
     pub line_endings_button: bool,
     pub active_encoding_button: EncodingDisplayOptions,
+    pub panel_button_icon_size: settings::ActivityBarIconSize,
 }
 
 impl Settings for StatusBarSettings {
@@ -188,6 +193,7 @@ impl Settings for StatusBarSettings {
             cursor_position_button: status_bar.cursor_position_button.unwrap(),
             line_endings_button: status_bar.line_endings_button.unwrap(),
             active_encoding_button: status_bar.active_encoding_button.unwrap(),
+            panel_button_icon_size: status_bar.panel_button_icon_size.unwrap(),
         }
     }
 }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1754,6 +1754,23 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
   - Default: VS Code-inspired default order
   - Values: array of strings
 
+**Panel keys**
+
+Use these strings in `status_bar_buttons` and `button_order`. Placement can also be changed in **Settings → Window & Layout → Activity Bar Button Placement** without JSON.
+
+| Key | Button |
+| --- | --- |
+| `ProjectPanel` | Project panel (file explorer) |
+| `search` | Project search |
+| `GitPanel` | Source control |
+| `agent_panel` | Agent panel |
+| `TerminalPanel` | Terminal |
+| `OutlinePanel` | Outline |
+| `CollaborationPanel` | Collaboration |
+| `DebugPanel` | Debugger |
+
+Keys not listed in `button_order` appear after the listed buttons, sorted by default priority.
+
 ## Status Bar
 
 - Description: Control various elements in the status bar. Note that some items in the status bar have their own settings set elsewhere.

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1772,7 +1772,7 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
 ```
 
 - `panel_button_icon_size`:
-  - Description: Size of panel button icons in the status bar.
+  - Description: Size of icons in the status bar, including panel buttons, search, diagnostics, and language servers.
   - Default: `small`
   - Values: `small`, `medium`, `large`
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1731,7 +1731,7 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
 {
   "activity_bar": {
     "enabled": false,
-    "icon_size": "medium"
+    "icon_size": "medium",
   }
 }
 ```
@@ -1744,7 +1744,15 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
 - `icon_size`:
   - Description: Size of icons in the activity bar.
   - Default: `medium`
-  - Values: `small`, `medium`
+  - Values: `small`, `medium`, `large`
+- `status_bar_buttons`:
+  - Description: Panel buttons to show in the status bar instead of the activity bar. Use panel keys (e.g. `ProjectPanel`, `GitPanel`) and `search` for the project search button. Buttons appear at their dock position in the status bar.
+  - Default: `null` (all buttons in the activity bar)
+  - Values: array of strings
+- `button_order`:
+  - Description: Order of buttons in the activity bar. Use panel keys (e.g. `ProjectPanel`, `GitPanel`) and `search` for the project search button.
+  - Default: VS Code-inspired default order
+  - Values: array of strings
 
 ## Status Bar
 
@@ -1757,10 +1765,16 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
   "status_bar": {
     "active_language_button": true,
     "cursor_position_button": true,
-    "line_endings_button": false
+    "line_endings_button": false,
+    "panel_button_icon_size": "small"
   }
 }
 ```
+
+- `panel_button_icon_size`:
+  - Description: Size of panel button icons in the status bar.
+  - Default: `small`
+  - Values: `small`, `medium`, `large`
 
 There is an experimental setting that completely hides the status bar. This causes major usability problems (you will be unable to use many of Zed's features), but is provided for those who value screen real-estate above all else.
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1721,6 +1721,31 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
 
 `boolean` values
 
+## Activity Bar
+
+- Description: Show a VS Code-style vertical activity bar on the left for panel buttons.
+- Setting: `activity_bar`
+- Default:
+
+```json [settings]
+{
+  "activity_bar": {
+    "enabled": false,
+    "icon_size": "medium"
+  }
+}
+```
+
+**Options**
+
+- `enabled`:
+  - Description: Whether to show the activity bar.
+  - Default: `false`
+- `icon_size`:
+  - Description: Size of icons in the activity bar.
+  - Default: `medium`
+  - Values: `small`, `medium`
+
 ## Status Bar
 
 - Description: Control various elements in the status bar. Note that some items in the status bar have their own settings set elsewhere.
@@ -3245,7 +3270,6 @@ Examples:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
-
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -98,8 +98,12 @@ To disable this behavior use:
   // Show a VS Code-style vertical activity bar on the left for panel buttons.
   "activity_bar": {
     "enabled": false,
-    // Icon size in the activity bar: "small" or "medium"
-    "icon_size": "medium"
+    // Icon size in the activity bar: "small", "medium", or "large"
+    "icon_size": "medium",
+    // Move specific buttons back to the status bar (left/right by dock position)
+    // "status_bar_buttons": ["TerminalPanel", "search"],
+    // Optional button order using panel keys and "search"
+    // "button_order": ["ProjectPanel", "search", "GitPanel", "agent_panel", "TerminalPanel"]
   }
 }
 ```

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -108,6 +108,21 @@ To disable this behavior use:
 }
 ```
 
+Use these panel keys in `status_bar_buttons` and `button_order`. You can also configure placement in **Settings → Window & Layout → Activity Bar Button Placement** without editing JSON.
+
+| Key | Button |
+| --- | --- |
+| `ProjectPanel` | Project panel (file explorer) |
+| `search` | Project search |
+| `GitPanel` | Source control |
+| `agent_panel` | Agent panel |
+| `TerminalPanel` | Terminal |
+| `OutlinePanel` | Outline |
+| `CollaborationPanel` | Collaboration |
+| `DebugPanel` | Debugger |
+
+Keys not listed in `button_order` appear after the listed buttons, sorted by default priority.
+
 ### Status Bar
 
 ```json [settings]

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -91,6 +91,19 @@ To disable this behavior use:
 }
 ```
 
+### Activity Bar
+
+```json [settings]
+{
+  // Show a VS Code-style vertical activity bar on the left for panel buttons.
+  "activity_bar": {
+    "enabled": false,
+    // Icon size in the activity bar: "small" or "medium"
+    "icon_size": "medium"
+  }
+}
+```
+
 ### Status Bar
 
 ```json [settings]


### PR DESCRIPTION
Adds an optional vertical activity bar on the left for panel buttons (VS Code-style). Off by default (`activity_bar.enabled: false`).

When enabled, panel toggle buttons move from the status bar into the activity bar. Individual buttons can stay in the status bar via `status_bar_buttons`. Icon sizes are configurable separately for the activity bar and status bar. Button order can be customized in JSON via `button_order`.

Related discussions:
- https://github.com/zed-industries/zed/discussions/47593
- https://github.com/zed-industries/zed/discussions/53720
- https://github.com/zed-industries/zed/discussions/50404

### Settings

```json
{
  "activity_bar": {
    "enabled": false,
    "icon_size": "medium",
    "status_bar_buttons": ["TerminalPanel", "search"],
    "button_order": ["ProjectPanel", "search", "GitPanel", "agent_panel"]
  },
  "status_bar": {
    "panel_button_icon_size": "small"
  }
}
```

Icon sizes use two separate settings:
- `activity_bar.icon_size` — icons in the activity bar
- `status_bar.panel_button_icon_size` — icons in the status bar, threads sidebar bottom bar, search, diagnostics, and LSP

Panel keys: `ProjectPanel`, `search`, `GitPanel`, `agent_panel`, `TerminalPanel`, `OutlinePanel`, `CollaborationPanel`, `DebugPanel`.

Placement toggles are available in **Settings → Window & Layout → Activity Bar Button Placement**. `button_order` is currently JSON-only.

Documentation updated in `visual-customization.md` and `all-settings.md`, including a panel keys reference table.

### Bug fixes included

- Prevent duplicate panel buttons in activity bar and status bar when `status_bar_buttons` is unset
- Align threads sidebar bottom bar height and icon sizing with the status bar
- Scale large status bar icons correctly using square icon buttons

### Screenshots

- Activity bar disabled (default)

<img width="1896" height="1150" alt="image" src="https://github.com/user-attachments/assets/a878b219-6e3b-432d-9758-ee4973d0549a" />

- Activity bar enabled

<img width="1896" height="1150" alt="image" src="https://github.com/user-attachments/assets/df5e556c-1891-4738-bfd3-039cdf2d9bb4" />

- Hybrid layout (some buttons in status bar)

<img width="1896" height="1150" alt="image" src="https://github.com/user-attachments/assets/124466c8-55b7-433c-80a1-64491d337e88" />

- Small / medium / large icon sizes

medium:
<img width="1896" height="1150" alt="image" src="https://github.com/user-attachments/assets/f72a909c-b7e2-4395-aa25-2d5ee205df92" />

large:
<img width="1896" height="1150" alt="image" src="https://github.com/user-attachments/assets/fb959a7b-5251-4acf-8bb2-429a94d3e11f" />

### Test plan

- [x] `cargo test -p workspace activity_bar`
- [x] `./script/clippy -p workspace -p settings_ui -p search -p sidebar`
- [x] Enable activity bar and toggle all panel buttons
- [x] Move buttons between activity bar and status bar via Settings UI
- [x] Verify default layout unchanged when `activity_bar.enabled` is `false`
- [x] Verify no duplicate buttons when `status_bar_buttons` is unset
- [x] Verify threads sidebar bottom bar matches status bar height and icon sizing at small/medium/large
- [x] Check light and dark theme

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added optional VS Code-style activity bar for panel buttons, with per-button status bar placement, configurable icon sizes, and button ordering