### PR TITLE
terminal: Add activity-driven terminal theme switching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18270,6 +18270,7 @@ dependencies = [
  "task",
  "terminal",
  "theme",
+ "theme_selector",
  "theme_settings",
  "ui",
  "util",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1911,9 +1911,17 @@
     // shell builtins and very short commands may not register. A theme chosen
     // manually with the `theme: terminal` action takes precedence over activity
     // switching for that terminal.
+    //
+    // The `terminal: toggle activity theme` action turns switching on and off
+    // without discarding the theme names. Interactive programs (editors,
+    // pagers, REPLs, `claude`, …) hold the foreground while waiting for input,
+    // so they count as busy only while producing output and idle once it stops;
+    // `interactive_programs` adds more program names to that built-in set.
     // "activity_theme": {
     //   "busy": "Ayu Dark",
-    //   "idle": "Ayu Light"
+    //   "idle": "Ayu Light",
+    //   "enabled": true,
+    //   "interactive_programs": []
     // },
     // Set the terminal's font size. If this option is not included,
     // the terminal will default to matching the buffer's font size.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1904,6 +1904,17 @@
       //    "never"
       "show": null,
     },
+    // Automatically switch each terminal's theme based on its activity: one
+    // theme while a command is running, another while idle at the shell prompt.
+    // Both theme names are required. Omitting this setting (the default) keeps
+    // terminals on the window theme. Activity is detected heuristically, so
+    // shell builtins and very short commands may not register. A theme chosen
+    // manually with the `theme: terminal` action takes precedence over activity
+    // switching for that terminal.
+    // "activity_theme": {
+    //   "busy": "Ayu Dark",
+    //   "idle": "Ayu Light"
+    // },
     // Set the terminal's font size. If this option is not included,
     // the terminal will default to matching the buffer's font size.
     // "font_size": 15,

--- a/crates/repl/src/outputs/plain.rs
+++ b/crates/repl/src/outputs/plain.rs
@@ -362,8 +362,9 @@ impl Render for TerminalOutput {
 
         let text_style = text_style(window, cx);
         let minimum_contrast = TerminalSettings::get_global(cx).minimum_contrast;
+        let theme = cx.theme().clone();
         let (rects, batched_text_runs) = terminal.read(cx).with_renderable_cells(|cells| {
-            TerminalElement::layout_grid(cells, 0, &text_style, None, minimum_contrast, cx)
+            TerminalElement::layout_grid(cells, 0, &text_style, None, minimum_contrast, &theme)
         });
 
         // lines are 0-indexed, so we must add 1 to get the number of lines

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -869,6 +869,7 @@ impl VsCodeSettings {
     fn terminal_settings_content(&self) -> Option<TerminalSettingsContent> {
         let (font_family, font_fallbacks) = self.read_fonts("terminal.integrated.fontFamily");
         skip_default(TerminalSettingsContent {
+            activity_theme: None,
             alternate_scroll: None,
             blinking: self
                 .read_bool("terminal.integrated.cursorBlinking")

--- a/crates/settings_content/src/terminal.rs
+++ b/crates/settings_content/src/terminal.rs
@@ -192,6 +192,9 @@ pub struct TerminalSettingsContent {
     /// A theme chosen manually with the `theme: terminal` action takes
     /// precedence over activity switching for that terminal.
     ///
+    /// Use the `terminal: toggle activity theme` action to turn switching on
+    /// and off without losing the configured theme names.
+    ///
     /// Example: `{ "busy": "Ayu Dark", "idle": "Ayu Light" }`
     ///
     /// Default: null
@@ -205,6 +208,20 @@ pub struct ActivityThemeContent {
     pub busy: String,
     /// Theme applied while the terminal is idle at the shell prompt.
     pub idle: String,
+    /// Whether activity switching is currently on. Lets the
+    /// `terminal: toggle activity theme` action flip the feature without
+    /// discarding the `busy`/`idle` theme names. When omitted, switching is on.
+    ///
+    /// Default: true
+    pub enabled: Option<bool>,
+    /// Extra foreground programs to treat as interactive, in addition to the
+    /// built-in set (editors, pagers, REPLs, `claude`, …). An interactive
+    /// program holds the terminal foreground while waiting for input, so it is
+    /// considered busy only while it is actively producing output and idle once
+    /// that output stops. Matched case-insensitively against the program name.
+    ///
+    /// Default: []
+    pub interactive_programs: Option<Vec<String>>,
 }
 
 /// Shell configuration to open the terminal with.

--- a/crates/settings_content/src/terminal.rs
+++ b/crates/settings_content/src/terminal.rs
@@ -183,6 +183,28 @@ pub struct TerminalSettingsContent {
     ///
     /// Default: "system"
     pub bell: Option<TerminalBell>,
+    /// Automatically switch each terminal's theme based on its activity: one
+    /// theme while a command is running, another while idle at the shell
+    /// prompt. Both theme names are required when this is set.
+    ///
+    /// Activity is detected heuristically (Zed does not parse OSC 133 prompt
+    /// markers), so shell builtins and very short commands may not register.
+    /// A theme chosen manually with the `theme: terminal` action takes
+    /// precedence over activity switching for that terminal.
+    ///
+    /// Example: `{ "busy": "Ayu Dark", "idle": "Ayu Light" }`
+    ///
+    /// Default: null
+    pub activity_theme: Option<ActivityThemeContent>,
+}
+
+/// A pair of theme names selected by terminal activity state.
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct ActivityThemeContent {
+    /// Theme applied while the terminal is running a command.
+    pub busy: String,
+    /// Theme applied while the terminal is idle at the shell prompt.
+    pub idle: String,
 }
 
 /// Shell configuration to open the terminal with.

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -52,7 +52,8 @@ pub use vte::ansi::{Color, NamedColor, Rgb};
 use gpui::{
     App, AppContext as _, BackgroundExecutor, Bounds, ClipboardItem, Context, EventEmitter, Hsla,
     Keystroke, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels,
-    Point as GpuiPoint, Rgba, ScrollWheelEvent, Size, Task, TouchPhase, Window, actions, black, px,
+    Point as GpuiPoint, Rgba, ScrollWheelEvent, SharedString, Size, Task, TouchPhase, Window,
+    actions, black, px,
 };
 
 #[cfg(not(windows))]
@@ -602,6 +603,9 @@ actions!(
         ToggleViMode,
         /// Selects all text in the terminal.
         SelectAll,
+        /// Turns activity-driven terminal theme switching on or off, keeping the
+        /// configured busy/idle theme names.
+        ToggleActivityTheme,
     ]
 );
 
@@ -938,6 +942,7 @@ impl TerminalBuilder {
             event_loop_task: Task::ready(Ok(())),
             background_executor: background_executor.clone(),
             path_style,
+            last_output_at: None,
             #[cfg(any(test, feature = "test-support"))]
             input_log: Vec::new(),
             #[cfg(any(test, feature = "test-support"))]
@@ -1163,6 +1168,7 @@ impl TerminalBuilder {
                 event_loop_task: Task::ready(Ok(())),
                 background_executor,
                 path_style,
+                last_output_at: None,
                 #[cfg(any(test, feature = "test-support"))]
                 input_log: Vec::new(),
                 #[cfg(any(test, feature = "test-support"))]
@@ -1324,6 +1330,9 @@ pub struct Terminal {
     event_loop_task: Task<Result<(), anyhow::Error>>,
     background_executor: BackgroundExecutor,
     path_style: PathStyle,
+    /// When the terminal last received PTY output. Drives the busy/idle state of
+    /// interactive foreground programs (see [`OUTPUT_FLOW_WINDOW`]).
+    last_output_at: Option<Instant>,
     #[cfg(any(test, feature = "test-support"))]
     input_log: Vec<Vec<u8>>,
     #[cfg(any(test, feature = "test-support"))]
@@ -1386,11 +1395,54 @@ pub enum TerminalActivity {
     Busy,
 }
 
-fn derive_activity(task_running: bool, has_foreground_process: bool) -> TerminalActivity {
-    if task_running || has_foreground_process {
-        TerminalActivity::Busy
-    } else {
-        TerminalActivity::Idle
+/// How the terminal's foreground program maps onto activity. The foreground
+/// process is the shell at the prompt and the running command otherwise; an
+/// "interactive" program (an editor, pager, REPL, `claude`, …) is special in
+/// that it holds the foreground the whole time it is open, even while waiting
+/// for input, so its presence alone does not mean the terminal is busy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ForegroundClass {
+    /// The shell prompt, or no foreground info: idle.
+    Prompt,
+    /// A one-shot command (e.g. `sleep`, `npm`, `cargo`): busy while it runs.
+    Command,
+    /// An interactive program: busy only while it is producing output.
+    Interactive,
+}
+
+fn derive_activity(
+    task_running: bool,
+    foreground: ForegroundClass,
+    output_recent: bool,
+) -> TerminalActivity {
+    if task_running {
+        return TerminalActivity::Busy;
+    }
+    match foreground {
+        ForegroundClass::Prompt => TerminalActivity::Idle,
+        ForegroundClass::Command => TerminalActivity::Busy,
+        // An interactive program (`claude`, an editor, a REPL) sits in the
+        // foreground while waiting for input, so presence alone is not busy:
+        // it is busy only while output is actively flowing and idle once it
+        // stops (e.g. Claude streaming a reply vs. waiting at its prompt).
+        ForegroundClass::Interactive => {
+            if output_recent {
+                TerminalActivity::Busy
+            } else {
+                TerminalActivity::Idle
+            }
+        }
+    }
+}
+
+/// Classify the foreground program name into how it maps onto activity. `extra`
+/// is the user's `interactive_programs` setting, added to the built-in set.
+fn classify_foreground(name: Option<&str>, extra: &[SharedString]) -> ForegroundClass {
+    match name {
+        None => ForegroundClass::Prompt,
+        Some(name) if is_shell_program(name) => ForegroundClass::Prompt,
+        Some(name) if is_interactive_program(name, extra) => ForegroundClass::Interactive,
+        Some(_) => ForegroundClass::Command,
     }
 }
 
@@ -1404,6 +1456,31 @@ fn is_shell_program(name: &str) -> bool {
     ];
     SHELLS.iter().any(|shell| name.eq_ignore_ascii_case(shell))
 }
+
+/// Programs that hold the terminal foreground while waiting for input, so their
+/// busy/idle state is driven by whether they are producing output rather than
+/// by their mere presence. Compared case-insensitively; `extra` extends this
+/// built-in set from the `interactive_programs` setting.
+fn is_interactive_program(name: &str, extra: &[SharedString]) -> bool {
+    const INTERACTIVE: &[&str] = &[
+        // Agentic / conversational CLIs.
+        "claude",
+        // Editors.
+        "vim", "nvim", "vi", "emacs", "nano", "helix", "hx",
+        // Pagers.
+        "less", "more", "man",
+        // REPLs.
+        "python", "python3", "node", "irb", "ipython", "bpython", "ghci", "iex",
+    ];
+    INTERACTIVE.iter().any(|p| name.eq_ignore_ascii_case(p))
+        || extra.iter().any(|p| name.eq_ignore_ascii_case(p))
+}
+
+/// How long after the last byte of PTY output an interactive program is still
+/// considered busy. Comfortably longer than a typical animated-spinner frame
+/// (Claude, progress bars) so a working program reads steadily busy, but short
+/// enough that going quiet flips it to idle within about a second.
+const OUTPUT_FLOW_WINDOW: Duration = Duration::from_millis(1000);
 
 const FIND_HYPERLINK_THROTTLE_PX: Pixels = px(5.0);
 
@@ -1466,6 +1543,10 @@ impl Terminal {
                 //NOOP, Handled in render
             }
             TerminalBackendEvent::Wakeup => {
+                // PTY output arrived; remember when, so an interactive foreground
+                // program counts as busy while it streams and idle once it goes
+                // quiet (see `activity_state`).
+                self.last_output_at = Some(Instant::now());
                 cx.emit(Event::Wakeup);
 
                 if let TerminalType::Pty { info, .. } = &self.terminal_type {
@@ -2576,8 +2657,10 @@ impl Terminal {
     }
 
     /// Whether this terminal is busy running a command or idle at the prompt.
-    /// See [`TerminalActivity`] for the heuristic's limitations.
-    pub fn activity_state(&self) -> TerminalActivity {
+    /// `interactive_programs` is the user's `interactive_programs` setting,
+    /// extending the built-in interactive set. See [`TerminalActivity`] for the
+    /// heuristic's limitations.
+    pub fn activity_state(&self, interactive_programs: &[SharedString]) -> TerminalActivity {
         #[cfg(any(test, feature = "test-support"))]
         if let Some(activity_override) = self.activity_override {
             return activity_override;
@@ -2587,19 +2670,14 @@ impl Terminal {
             self.task().map(|task| task.status),
             Some(TaskStatus::Running)
         );
-        derive_activity(task_running, self.has_foreground_process())
-    }
-
-    /// Whether a command other than the shell currently occupies the terminal
-    /// foreground. At the prompt the foreground process is the shell; while a
-    /// command runs it is that command. This is the heuristic's core (Zed does
-    /// not parse OSC 133), so an unrecognized shell or a shell builtin can
-    /// misread.
-    pub fn has_foreground_process(&self) -> bool {
-        match self.foreground_process_command_name() {
-            Some(ref name) => !is_shell_program(name),
-            None => false,
-        }
+        let foreground = classify_foreground(
+            self.foreground_process_command_name().as_deref(),
+            interactive_programs,
+        );
+        let output_recent = self
+            .last_output_at
+            .is_some_and(|at| at.elapsed() < OUTPUT_FLOW_WINDOW);
+        derive_activity(task_running, foreground, output_recent)
     }
 
     /// Refresh the cached foreground process info from the live PTY foreground
@@ -2979,15 +3057,36 @@ mod tests {
     use task::{Shell, ShellBuilder};
 
     #[test]
-    fn test_activity_state() {
+    fn test_derive_activity() {
+        use ForegroundClass::*;
         use TerminalActivity::*;
-        // A running task marks the terminal busy.
-        assert_eq!(derive_activity(true, false), Busy);
-        // A non-shell foreground process marks the terminal busy.
-        assert_eq!(derive_activity(false, true), Busy);
-        // Neither signal: the terminal is idle at the prompt.
-        assert_eq!(derive_activity(false, false), Idle);
-        assert_eq!(derive_activity(true, true), Busy);
+        // A running task marks the terminal busy regardless of the foreground.
+        assert_eq!(derive_activity(true, Prompt, false), Busy);
+        // A one-shot command marks the terminal busy while it runs.
+        assert_eq!(derive_activity(false, Command, false), Busy);
+        // At the prompt (or no foreground info) the terminal is idle.
+        assert_eq!(derive_activity(false, Prompt, false), Idle);
+        // An interactive program is busy only while output is flowing.
+        assert_eq!(derive_activity(false, Interactive, true), Busy);
+        assert_eq!(derive_activity(false, Interactive, false), Idle);
+    }
+
+    #[test]
+    fn test_classify_foreground() {
+        use ForegroundClass::*;
+        let extra = [SharedString::from("lazygit")];
+        // Shells (and missing info) are the prompt.
+        assert_eq!(classify_foreground(Some("zsh"), &extra), Prompt);
+        assert_eq!(classify_foreground(Some("PowerShell"), &extra), Prompt);
+        assert_eq!(classify_foreground(None, &extra), Prompt);
+        // One-shot commands are busy by presence.
+        assert_eq!(classify_foreground(Some("npm"), &extra), Command);
+        assert_eq!(classify_foreground(Some("cargo"), &extra), Command);
+        // Built-in and user-configured interactive programs.
+        assert_eq!(classify_foreground(Some("claude"), &extra), Interactive);
+        assert_eq!(classify_foreground(Some("Vim"), &extra), Interactive);
+        assert_eq!(classify_foreground(Some("python3"), &extra), Interactive);
+        assert_eq!(classify_foreground(Some("lazygit"), &extra), Interactive);
     }
 
     #[test]
@@ -3000,6 +3099,21 @@ mod tests {
         assert!(!is_shell_program("sleep"));
         assert!(!is_shell_program("npm"));
         assert!(!is_shell_program("cargo"));
+    }
+
+    #[test]
+    fn test_is_interactive_program() {
+        let extra = [SharedString::from("lazygit")];
+        // Built-in interactive set, matched case-insensitively.
+        assert!(is_interactive_program("claude", &[]));
+        assert!(is_interactive_program("NVIM", &[]));
+        assert!(is_interactive_program("less", &[]));
+        assert!(is_interactive_program("node", &[]));
+        // Extended via settings.
+        assert!(is_interactive_program("lazygit", &extra));
+        // One-shot commands and shells are not interactive.
+        assert!(!is_interactive_program("npm", &extra));
+        assert!(!is_interactive_program("zsh", &extra));
     }
 
     #[test]

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -940,6 +940,8 @@ impl TerminalBuilder {
             path_style,
             #[cfg(any(test, feature = "test-support"))]
             input_log: Vec::new(),
+            #[cfg(any(test, feature = "test-support"))]
+            activity_override: None,
         };
 
         TerminalBuilder {
@@ -1163,6 +1165,8 @@ impl TerminalBuilder {
                 path_style,
                 #[cfg(any(test, feature = "test-support"))]
                 input_log: Vec::new(),
+                #[cfg(any(test, feature = "test-support"))]
+                activity_override: None,
             };
 
             if !activation_script.is_empty() && no_task {
@@ -1322,6 +1326,8 @@ pub struct Terminal {
     path_style: PathStyle,
     #[cfg(any(test, feature = "test-support"))]
     input_log: Vec<Vec<u8>>,
+    #[cfg(any(test, feature = "test-support"))]
+    activity_override: Option<TerminalActivity>,
 }
 
 struct CopyTemplate {
@@ -1366,6 +1372,37 @@ impl TaskStatus {
             success: error_code == 0,
         };
     }
+}
+
+/// Whether a terminal is actively running a command (`Busy`) or sitting at the
+/// shell prompt (`Idle`).
+///
+/// This is a heuristic: Zed does not parse OSC 133 shell-integration prompt
+/// markers, so the state is derived from task status and the PTY foreground
+/// process group. Shell builtins and sub-second commands can misread.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalActivity {
+    Idle,
+    Busy,
+}
+
+fn derive_activity(task_running: bool, has_foreground_process: bool) -> TerminalActivity {
+    if task_running || has_foreground_process {
+        TerminalActivity::Busy
+    } else {
+        TerminalActivity::Idle
+    }
+}
+
+/// Known interactive shell program names, compared case-insensitively against
+/// the terminal's foreground process to decide whether it is sitting at the
+/// prompt (a shell) or running a command (anything else).
+fn is_shell_program(name: &str) -> bool {
+    const SHELLS: &[&str] = &[
+        "bash", "sh", "zsh", "fish", "dash", "ksh", "tcsh", "csh", "nu", "nushell", "pwsh",
+        "powershell", "cmd", "xonsh", "elvish",
+    ];
+    SHELLS.iter().any(|shell| name.eq_ignore_ascii_case(shell))
 }
 
 const FIND_HYPERLINK_THROTTLE_PX: Pixels = px(5.0);
@@ -2538,6 +2575,48 @@ impl Terminal {
         self.task.as_ref()
     }
 
+    /// Whether this terminal is busy running a command or idle at the prompt.
+    /// See [`TerminalActivity`] for the heuristic's limitations.
+    pub fn activity_state(&self) -> TerminalActivity {
+        #[cfg(any(test, feature = "test-support"))]
+        if let Some(activity_override) = self.activity_override {
+            return activity_override;
+        }
+
+        let task_running = matches!(
+            self.task().map(|task| task.status),
+            Some(TaskStatus::Running)
+        );
+        derive_activity(task_running, self.has_foreground_process())
+    }
+
+    /// Whether a command other than the shell currently occupies the terminal
+    /// foreground. At the prompt the foreground process is the shell; while a
+    /// command runs it is that command. This is the heuristic's core (Zed does
+    /// not parse OSC 133), so an unrecognized shell or a shell builtin can
+    /// misread.
+    pub fn has_foreground_process(&self) -> bool {
+        match self.foreground_process_command_name() {
+            Some(ref name) => !is_shell_program(name),
+            None => false,
+        }
+    }
+
+    /// Refresh the cached foreground process info from the live PTY foreground
+    /// process group, emitting [`Event::TitleChanged`] if it changed. The info
+    /// is otherwise only refreshed on terminal output, so a silent command
+    /// (e.g. `sleep`) would not register; activity-driven theming polls this.
+    pub fn poll_foreground_process_info(&self, cx: &mut Context<Self>) {
+        if let TerminalType::Pty { info, .. } = &self.terminal_type {
+            info.emit_title_changed_if_changed(cx);
+        }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn set_activity_for_test(&mut self, activity: Option<TerminalActivity>) {
+        self.activity_override = activity;
+    }
+
     pub fn wait_for_completed_task(&self, cx: &App) -> Task<Option<ExitStatus>> {
         if let Some(task) = self.task() {
             if task.status == TaskStatus::Running {
@@ -2898,6 +2977,30 @@ mod tests {
     use parking_lot::Mutex;
     use rand::{Rng, distr, rngs::StdRng};
     use task::{Shell, ShellBuilder};
+
+    #[test]
+    fn test_activity_state() {
+        use TerminalActivity::*;
+        // A running task marks the terminal busy.
+        assert_eq!(derive_activity(true, false), Busy);
+        // A non-shell foreground process marks the terminal busy.
+        assert_eq!(derive_activity(false, true), Busy);
+        // Neither signal: the terminal is idle at the prompt.
+        assert_eq!(derive_activity(false, false), Idle);
+        assert_eq!(derive_activity(true, true), Busy);
+    }
+
+    #[test]
+    fn test_is_shell_program() {
+        // The foreground being a shell means the terminal is at the prompt.
+        assert!(is_shell_program("zsh"));
+        assert!(is_shell_program("Bash"));
+        assert!(is_shell_program("PowerShell"));
+        // A real command means the terminal is busy.
+        assert!(!is_shell_program("sleep"));
+        assert!(!is_shell_program("npm"));
+        assert!(!is_shell_program("cargo"));
+    }
 
     #[test]
     fn test_normalize_path_command_name() {

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -1,5 +1,5 @@
 use collections::HashMap;
-use gpui::{FontFallbacks, FontFeatures, FontWeight, Pixels, px};
+use gpui::{FontFallbacks, FontFeatures, FontWeight, Pixels, SharedString, px};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -50,6 +50,14 @@ pub struct TerminalSettings {
     pub path_hyperlink_timeout_ms: u64,
     pub show_count_badge: bool,
     pub bell: TerminalBell,
+    pub activity_theme: Option<ActivityTheme>,
+}
+
+/// Themes to apply to a terminal depending on whether it is busy or idle.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivityTheme {
+    pub busy: SharedString,
+    pub idle: SharedString,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -132,6 +140,10 @@ impl settings::Settings for TerminalSettings {
             path_hyperlink_timeout_ms: project_content.path_hyperlink_timeout_ms.unwrap(),
             show_count_badge: user_content.show_count_badge.unwrap(),
             bell: user_content.bell.unwrap(),
+            activity_theme: user_content.activity_theme.map(|activity_theme| ActivityTheme {
+                busy: activity_theme.busy.into(),
+                idle: activity_theme.idle.into(),
+            }),
         }
     }
 }

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -58,6 +58,14 @@ pub struct TerminalSettings {
 pub struct ActivityTheme {
     pub busy: SharedString,
     pub idle: SharedString,
+    /// Whether activity switching is currently on. The theme names are kept
+    /// even when this is false so the `terminal: toggle activity theme` action
+    /// can flip the feature without discarding them.
+    pub enabled: bool,
+    /// Foreground programs to treat as interactive in addition to the built-in
+    /// set (editors, pagers, REPLs, `claude`, …). An interactive program is
+    /// busy only while it is producing output and idle once that output stops.
+    pub interactive_programs: Vec<SharedString>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -143,8 +151,26 @@ impl settings::Settings for TerminalSettings {
             activity_theme: user_content.activity_theme.map(|activity_theme| ActivityTheme {
                 busy: activity_theme.busy.into(),
                 idle: activity_theme.idle.into(),
+                enabled: activity_theme.enabled.unwrap_or(true),
+                interactive_programs: activity_theme
+                    .interactive_programs
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
             }),
         }
+    }
+}
+
+impl TerminalSettings {
+    /// The configured activity theme, but only when activity switching is
+    /// currently enabled. Returns `None` when unconfigured or toggled off, so
+    /// callers can gate the whole feature on a single check.
+    pub fn active_activity_theme(&self) -> Option<&ActivityTheme> {
+        self.activity_theme
+            .as_ref()
+            .filter(|activity_theme| activity_theme.enabled)
     }
 }
 

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -41,6 +41,7 @@ settings.workspace = true
 shellexpand.workspace = true
 terminal.workspace = true
 theme.workspace = true
+theme_selector.workspace = true
 theme_settings.workspace = true
 ui.workspace = true
 util.workspace = true

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -17,7 +17,7 @@ use terminal::{
     TerminalBounds, is_app_chosen_exact_color as terminal_is_app_chosen_exact_color,
     is_default_background_color, terminal_settings::TerminalSettings,
 };
-use theme::{ActiveTheme, Theme};
+use theme::Theme;
 use theme_settings::ThemeSettings;
 use ui::utils::ensure_minimum_contrast;
 use ui::{ParentElement, Tooltip};
@@ -375,10 +375,9 @@ impl TerminalElement {
         text_style: &TextStyle,
         hyperlink: Option<(HighlightStyle, &Range)>,
         minimum_contrast: f32,
-        cx: &App,
+        theme: &Theme,
     ) -> (Vec<LayoutRect>, Vec<BatchedTextRun>) {
         let start_time = Instant::now();
-        let theme = cx.theme();
 
         // Pre-allocate with estimated capacity to reduce reallocations
         let estimated_cells = grid.size_hint().0;
@@ -971,7 +970,7 @@ impl Element for TerminalElement {
                         }),
                 };
 
-                let theme = cx.theme().clone();
+                let theme = self.terminal_view.read(cx).effective_theme(cx);
 
                 let link_style = HighlightStyle {
                     color: Some(theme.colors().link_text_hover),
@@ -1173,7 +1172,7 @@ impl Element for TerminalElement {
                             .as_ref()
                             .map(|last_hovered_word| (link_style, &last_hovered_word.word_match)),
                         minimum_contrast,
-                        cx,
+                        &theme,
                     )
                 } else {
                     // Calculate which screen rows are visible based on pixel positions.
@@ -1204,7 +1203,7 @@ impl Element for TerminalElement {
                             .as_ref()
                             .map(|last_hovered_word| (link_style, &last_hovered_word.word_match)),
                         minimum_contrast,
-                        cx,
+                        &theme,
                     )
                 };
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -32,6 +32,7 @@ use std::{
     time::Duration,
 };
 use task::TaskId;
+use theme::{Theme, ThemeRegistry};
 use terminal::{
     Clear, Copy, Event, HoveredWord, MaybeNavigationTarget, Modes, Paste, PasteText, Point, Range,
     ScrollLineDown, ScrollLineUp, ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop,
@@ -141,6 +142,10 @@ pub struct TerminalView {
     blinking_terminal_enabled: bool,
     needs_serialize: bool,
     custom_title: Option<String>,
+    // Per-terminal theme override (name + resolved theme). Resolved once at set
+    // time and re-resolved on settings change so the render path never resolves
+    // by name per frame.
+    theme_override: Option<(SharedString, Arc<Theme>)>,
     hover: Option<HoverTarget>,
     hover_tooltip_update: Task<()>,
     workspace_id: Option<WorkspaceId>,
@@ -294,6 +299,7 @@ impl TerminalView {
             scroll_handle,
             needs_serialize: false,
             custom_title: None,
+            theme_override: None,
             ime_state: None,
             self_handle: cx.entity().downgrade(),
             rename_editor: None,
@@ -313,6 +319,68 @@ impl TerminalView {
             max_lines_when_unfocused,
         };
         cx.notify();
+    }
+
+    /// Set or clear this terminal's per-terminal theme override by name. An
+    /// unresolvable name is logged and leaves the terminal on the window theme.
+    pub fn set_theme_override(
+        &mut self,
+        theme_name: Option<SharedString>,
+        cx: &mut Context<Self>,
+    ) {
+        self.theme_override = theme_name.and_then(|name| {
+            ThemeRegistry::global(cx)
+                .get(name.as_ref())
+                .log_err()
+                .map(|theme| (name, theme))
+        });
+        cx.notify();
+    }
+
+    pub fn theme_override_name(&self) -> Option<&SharedString> {
+        self.theme_override.as_ref().map(|(name, _)| name)
+    }
+
+    /// The theme this terminal renders with: its per-terminal override when set,
+    /// otherwise the window/global active theme.
+    pub fn effective_theme(&self, cx: &App) -> Arc<Theme> {
+        self.theme_override
+            .as_ref()
+            .map(|(_, theme)| theme.clone())
+            .unwrap_or_else(|| cx.theme().clone())
+    }
+
+    fn set_terminal_theme(
+        &mut self,
+        _: &zed_actions::theme::Terminal,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let current = self.theme_override_name().cloned();
+        let view = self.self_handle.clone();
+        self.workspace
+            .update(cx, |workspace, cx| {
+                theme_selector::toggle_theme_selector_for_override(
+                    workspace,
+                    current,
+                    move |theme_name, cx| {
+                        view.update(cx, |view, cx| view.set_theme_override(theme_name, cx))
+                            .log_err();
+                    },
+                    window,
+                    cx,
+                );
+            })
+            .log_err();
+    }
+
+    fn clear_terminal_theme(
+        &mut self,
+        _: &zed_actions::theme::ClearTerminal,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.set_theme_override(None, cx);
     }
 
     const MAX_EMBEDDED_LINES: usize = 1_000;
@@ -587,6 +655,14 @@ impl TerminalView {
         if breadcrumb_visibility_changed {
             cx.emit(ItemEvent::UpdateBreadcrumbs);
         }
+
+        if let Some((name, _)) = &self.theme_override {
+            let name = name.clone();
+            if let Some(theme) = ThemeRegistry::global(cx).get(name.as_ref()).log_err() {
+                self.theme_override = Some((name, theme));
+            }
+        }
+
         cx.notify();
     }
 
@@ -1332,6 +1408,8 @@ impl Render for TerminalView {
             .on_action(cx.listener(TerminalView::select_all))
             .on_action(cx.listener(TerminalView::rerun_task))
             .on_action(cx.listener(TerminalView::rename_terminal))
+            .on_action(cx.listener(TerminalView::set_terminal_theme))
+            .on_action(cx.listener(TerminalView::clear_terminal_theme))
             .on_key_down(cx.listener(Self::key_down))
             .on_mouse_down(
                 MouseButton::Right,
@@ -2858,6 +2936,105 @@ mod tests {
 
         terminal_view.update(cx, |view, _cx| {
             assert!(view.custom_title().is_none());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_per_terminal_theme_override(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, _workspace, window) = init_test_with_window(cx).await;
+
+        // Register two themes that differ only in their terminal background, so
+        // we can prove each terminal resolves its own theme.
+        let (bg_a, bg_b) = cx.update(|cx| {
+            let registry = ThemeRegistry::global(cx);
+            let base = registry.get("One Dark").unwrap();
+
+            let mut theme_a = (*base).clone();
+            theme_a.id = "per-terminal-a".to_string();
+            theme_a.name = "Per Terminal A".into();
+            theme_a.styles.colors.terminal_background = gpui::hsla(0.1, 0.5, 0.5, 1.0);
+
+            let mut theme_b = (*base).clone();
+            theme_b.id = "per-terminal-b".to_string();
+            theme_b.name = "Per Terminal B".into();
+            theme_b.styles.colors.terminal_background = gpui::hsla(0.6, 0.5, 0.5, 1.0);
+
+            let bg_a = theme_a.colors().terminal_background;
+            let bg_b = theme_b.colors().terminal_background;
+
+            registry.register_test_themes([theme::ThemeFamily {
+                id: "per-terminal-family".to_string(),
+                name: "Per Terminal Family".into(),
+                author: "test".into(),
+                themes: vec![theme_a, theme_b],
+                scales: theme::default_color_scales(),
+            }]);
+            (bg_a, bg_b)
+        });
+
+        // Two terminals living in the same window.
+        let (_pane_a, _term_a, view_a) = add_display_only_terminal(&project, window, false, cx);
+        let (_pane_b, _term_b, view_b) = add_display_only_terminal(&project, window, false, cx);
+
+        view_a.update(cx, |view, cx| {
+            view.set_theme_override(Some("Per Terminal A".into()), cx)
+        });
+        view_b.update(cx, |view, cx| {
+            view.set_theme_override(Some("Per Terminal B".into()), cx)
+        });
+
+        // AC-1: each terminal renders with its own theme.
+        cx.update(|cx| {
+            let ta = view_a.read(cx).effective_theme(cx);
+            let tb = view_b.read(cx).effective_theme(cx);
+            assert_eq!(ta.name.as_ref(), "Per Terminal A");
+            assert_eq!(tb.name.as_ref(), "Per Terminal B");
+            assert_eq!(ta.colors().terminal_background, bg_a);
+            assert_eq!(tb.colors().terminal_background, bg_b);
+            assert_ne!(
+                ta.colors().terminal_background,
+                tb.colors().terminal_background
+            );
+        });
+
+        // AC-2: clearing one terminal falls back to the window/global theme and
+        // leaves the other terminal's override intact.
+        view_a.update(cx, |view, cx| view.set_theme_override(None, cx));
+        cx.update(|cx| {
+            let global_name = cx.theme().name.clone();
+            let ta = view_a.read(cx).effective_theme(cx);
+            assert_eq!(ta.name, global_name);
+            assert!(view_a.read(cx).theme_override_name().is_none());
+
+            let tb = view_b.read(cx).effective_theme(cx);
+            assert_eq!(tb.name.as_ref(), "Per Terminal B");
+        });
+    }
+
+    #[gpui::test]
+    async fn test_terminal_theme_override_invalid_name_falls_back(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, _workspace, window) = init_test_with_window(cx).await;
+        let (_pane, _term, view) = add_display_only_terminal(&project, window, false, cx);
+
+        view.update(cx, |view, cx| {
+            view.set_theme_override(Some("No Such Theme 12345".into()), cx);
+            assert!(
+                view.theme_override_name().is_none(),
+                "an unresolvable theme name is not stored as an override"
+            );
+        });
+
+        cx.update(|cx| {
+            let effective = view.read(cx).effective_theme(cx);
+            assert_eq!(
+                effective.name,
+                cx.theme().name,
+                "an unresolved override falls back to the window/global theme"
+            );
         });
     }
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -21,6 +21,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use settings::{
     SeedQuerySetting, Settings, SettingsStore, TerminalBell, TerminalBlink, WorkingDirectory,
+    update_settings_file,
 };
 use std::{
     any::Any,
@@ -37,7 +38,7 @@ use terminal::{
     Clear, Copy, Event, HoveredWord, MaybeNavigationTarget, Modes, Paste, PasteText, Point, Range,
     ScrollLineDown, ScrollLineUp, ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop,
     Search, ShowCharacterPalette, TaskState, TaskStatus, Terminal, TerminalActivity, TerminalBounds,
-    ToggleViMode,
+    ToggleActivityTheme, ToggleViMode,
     terminal_settings::{CursorShape, TerminalSettings},
 };
 use terminal_element::TerminalElement;
@@ -51,11 +52,12 @@ use ui::{
 };
 use util::ResultExt;
 use workspace::{
-    CloseActiveItem, DraggedSelection, DraggedTab, NewCenterTerminal, NewTerminal, Pane,
+    CloseActiveItem, DraggedSelection, DraggedTab, NewCenterTerminal, NewTerminal, Pane, Toast,
     ToolbarItemLocation, Workspace, WorkspaceId, delete_unloaded_items,
     item::{
         HighlightedText, Item, ItemEvent, SerializableItem, TabContentParams, TabTooltipContent,
     },
+    notifications::NotificationId,
     register_serializable_item,
     searchable::{
         Direction, SearchEvent, SearchOptions, SearchToken, SearchableItem, SearchableItemHandle,
@@ -124,8 +126,45 @@ pub fn init(cx: &mut App) {
 
     cx.observe_new(|workspace: &mut Workspace, _window, _cx| {
         workspace.register_action(TerminalView::deploy);
+        workspace.register_action(toggle_activity_theme);
     })
     .detach();
+}
+
+/// Flip activity-driven theme switching on or off, persisting the change to the
+/// user settings file. The configured busy/idle theme names are preserved, so
+/// the feature can be turned back on without re-entering them. Does nothing
+/// (beyond a hint) when `terminal.activity_theme` has not been configured.
+fn toggle_activity_theme(
+    workspace: &mut Workspace,
+    _: &ToggleActivityTheme,
+    _window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let Some(activity_theme) = TerminalSettings::get_global(cx).activity_theme.as_ref() else {
+        struct ActivityThemeUnconfigured;
+        workspace.show_toast(
+            Toast::new(
+                NotificationId::unique::<ActivityThemeUnconfigured>(),
+                "Set \"terminal.activity_theme\" with \"busy\" and \"idle\" themes to use this.",
+            )
+            .autohide(),
+            cx,
+        );
+        return;
+    };
+
+    let now_enabled = !activity_theme.enabled;
+    let fs = workspace.app_state().fs.clone();
+    update_settings_file(fs, cx, move |settings, _| {
+        if let Some(activity_theme) = settings
+            .terminal
+            .as_mut()
+            .and_then(|terminal| terminal.activity_theme.as_mut())
+        {
+            activity_theme.enabled = Some(now_enabled);
+        }
+    });
 }
 
 pub struct BlockProperties {
@@ -313,7 +352,7 @@ impl TerminalView {
             cx.observe_global::<SettingsStore>(Self::settings_changed),
         ];
 
-        let activity_poll = if TerminalSettings::get_global(cx).activity_theme.is_some() {
+        let activity_poll = if TerminalSettings::get_global(cx).active_activity_theme().is_some() {
             Self::spawn_activity_poll(cx)
         } else {
             Task::ready(())
@@ -458,11 +497,15 @@ impl TerminalView {
         }
 
         let settings = TerminalSettings::get_global(cx);
-        let Some(activity_theme) = settings.activity_theme.as_ref() else {
+        let Some(activity_theme) = settings.active_activity_theme() else {
             return;
         };
+        let interactive_programs = activity_theme.interactive_programs.clone();
 
-        let desired = self.terminal.read(cx).activity_state();
+        let desired = self
+            .terminal
+            .read(cx)
+            .activity_state(&interactive_programs);
         if self.applied_activity == Some(desired) {
             // Already showing the right theme; drop any pending opposite flip.
             // This is the common case on each poll/`Wakeup`, so it stays
@@ -492,7 +535,7 @@ impl TerminalView {
                 if this.theme_override_source == Some(ThemeOverrideSource::User) {
                     return;
                 }
-                if this.terminal.read(cx).activity_state() != desired {
+                if this.terminal.read(cx).activity_state(&interactive_programs) != desired {
                     return;
                 }
                 this.applied_activity = Some(desired);
@@ -777,7 +820,7 @@ impl TerminalView {
             TerminalBlink::On => true,
             TerminalBlink::TerminalControlled => self.blinking_terminal_enabled,
         };
-        let activity_theme_enabled = settings.activity_theme.is_some();
+        let activity_theme_enabled = settings.active_activity_theme().is_some();
         let new_cursor_shape = settings.cursor_shape;
         let old_cursor_shape = self.cursor_shape;
         if old_cursor_shape != new_cursor_shape {
@@ -3236,6 +3279,8 @@ mod tests {
                     Some(settings::ActivityThemeContent {
                         busy: "Activity Busy".to_owned(),
                         idle: "Activity Idle".to_owned(),
+                        enabled: None,
+                        interactive_programs: None,
                     });
             });
         });
@@ -3327,6 +3372,8 @@ mod tests {
                     Some(settings::ActivityThemeContent {
                         busy: "Poll Busy".to_owned(),
                         idle: "Poll Idle".to_owned(),
+                        enabled: None,
+                        interactive_programs: None,
                     });
             });
         });
@@ -3370,6 +3417,88 @@ mod tests {
             override_name(&view, cx),
             Some("Poll Idle".to_string()),
             "reverts to idle once the (un-reset) debounce elapses"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_activity_theme_toggle_off(cx: &mut TestAppContext) {
+        // Toggling the feature off (via the `enabled` flag) drops the
+        // activity-driven theme without discarding the configured names, and
+        // toggling it back on resumes switching.
+        cx.executor().allow_parking();
+
+        let (project, _workspace, window) = init_test_with_window(cx).await;
+
+        cx.update(|cx| {
+            let registry = ThemeRegistry::global(cx);
+            let base = registry.get("One Dark").unwrap();
+            let mut busy = (*base).clone();
+            busy.id = "toggle-busy".to_string();
+            busy.name = "Toggle Busy".into();
+            let mut idle = (*base).clone();
+            idle.id = "toggle-idle".to_string();
+            idle.name = "Toggle Idle".into();
+            registry.register_test_themes([theme::ThemeFamily {
+                id: "toggle-family".to_string(),
+                name: "Toggle Family".into(),
+                author: "test".into(),
+                themes: vec![busy, idle],
+                scales: theme::default_color_scales(),
+            }]);
+        });
+
+        let set_enabled = |enabled: Option<bool>, cx: &mut TestAppContext| {
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.terminal.get_or_insert_default().activity_theme =
+                        Some(settings::ActivityThemeContent {
+                            busy: "Toggle Busy".to_owned(),
+                            idle: "Toggle Idle".to_owned(),
+                            enabled,
+                            interactive_programs: None,
+                        });
+                });
+            });
+        };
+
+        set_enabled(Some(true), cx);
+
+        let (_pane, terminal, view) = add_display_only_terminal(&project, window, false, cx);
+        let override_name = |view: &Entity<TerminalView>, cx: &mut TestAppContext| {
+            view.read_with(cx, |view, _| {
+                view.theme_override_name().map(|name| name.to_string())
+            })
+        };
+
+        // Busy → busy theme applies while enabled.
+        terminal.update(cx, |terminal, _| {
+            terminal.set_activity_for_test(Some(TerminalActivity::Busy))
+        });
+        view.update(cx, |view, cx| view.schedule_activity_theme_update(cx));
+        cx.executor()
+            .advance_clock(ACTIVITY_BUSY_DEBOUNCE + Duration::from_millis(10));
+        cx.run_until_parked();
+        assert_eq!(override_name(&view, cx), Some("Toggle Busy".to_string()));
+
+        // Toggle off: the activity-driven override is dropped (back to the
+        // window theme), even though the terminal is still "busy".
+        set_enabled(Some(false), cx);
+        cx.run_until_parked();
+        assert_eq!(
+            override_name(&view, cx),
+            None,
+            "toggling activity theme off clears the activity-driven override"
+        );
+
+        // Toggle back on: switching resumes and re-applies the busy theme.
+        set_enabled(Some(true), cx);
+        cx.executor()
+            .advance_clock(ACTIVITY_BUSY_DEBOUNCE + Duration::from_millis(10));
+        cx.run_until_parked();
+        assert_eq!(
+            override_name(&view, cx),
+            Some("Toggle Busy".to_string()),
+            "toggling activity theme back on resumes switching"
         );
     }
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -36,7 +36,8 @@ use theme::{Theme, ThemeRegistry};
 use terminal::{
     Clear, Copy, Event, HoveredWord, MaybeNavigationTarget, Modes, Paste, PasteText, Point, Range,
     ScrollLineDown, ScrollLineUp, ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop,
-    Search, ShowCharacterPalette, TaskState, TaskStatus, Terminal, TerminalBounds, ToggleViMode,
+    Search, ShowCharacterPalette, TaskState, TaskStatus, Terminal, TerminalActivity, TerminalBounds,
+    ToggleViMode,
     terminal_settings::{CursorShape, TerminalSettings},
 };
 use terminal_element::TerminalElement;
@@ -77,6 +78,17 @@ fn viewport_line_for_point(point: Point, display_offset: usize) -> Option<usize>
 }
 
 const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
+
+// Activity-driven theme switching debounces both edges: a state change is only
+// committed if it still holds after the delay. Busy is held off briefly so
+// sub-second commands never flash; idle settles a bit longer to coalesce
+// back-to-back commands.
+const ACTIVITY_BUSY_DEBOUNCE: Duration = Duration::from_millis(250);
+const ACTIVITY_IDLE_DEBOUNCE: Duration = Duration::from_millis(400);
+// Foreground-process info only refreshes on terminal output, so silent commands
+// (e.g. `sleep`) emit no event. When activity theming is on, poll at this
+// cadence so busy/idle transitions are caught regardless of output.
+const ACTIVITY_POLL_INTERVAL: Duration = Duration::from_millis(300);
 
 /// Event to transmit the scroll from the element to the view
 #[derive(Clone, Debug, PartialEq)]
@@ -146,6 +158,20 @@ pub struct TerminalView {
     // time and re-resolved on settings change so the render path never resolves
     // by name per frame.
     theme_override: Option<(SharedString, Arc<Theme>)>,
+    // Who set `theme_override`: an explicit user pick wins over activity-driven
+    // switching until cleared.
+    theme_override_source: Option<ThemeOverrideSource>,
+    // The activity state currently reflected by the theme, so redundant flips
+    // are skipped and the debounce can confirm the state still holds.
+    applied_activity: Option<TerminalActivity>,
+    // The state the in-flight debounce is waiting to apply, so a repeated poll
+    // does not keep resetting the debounce timer before it can elapse.
+    pending_activity: Option<TerminalActivity>,
+    // Pending debounced activity-driven theme switch; dropping it cancels.
+    activity_debounce: Task<()>,
+    // Repeating poll that refreshes foreground-process info while activity
+    // theming is enabled; empty (no-op) task when disabled.
+    activity_poll: Task<()>,
     hover: Option<HoverTarget>,
     hover_tooltip_update: Task<()>,
     workspace_id: Option<WorkspaceId>,
@@ -159,6 +185,14 @@ pub struct TerminalView {
     rename_editor_subscription: Option<Subscription>,
     _subscriptions: Vec<Subscription>,
     _terminal_subscriptions: Vec<Subscription>,
+}
+
+/// Distinguishes a theme the user picked explicitly from one set automatically
+/// by activity state, so the explicit choice is never clobbered.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ThemeOverrideSource {
+    User,
+    Activity,
 }
 
 #[derive(Default, Clone)]
@@ -279,6 +313,12 @@ impl TerminalView {
             cx.observe_global::<SettingsStore>(Self::settings_changed),
         ];
 
+        let activity_poll = if TerminalSettings::get_global(cx).activity_theme.is_some() {
+            Self::spawn_activity_poll(cx)
+        } else {
+            Task::ready(())
+        };
+
         Self {
             terminal,
             workspace: workspace_handle,
@@ -300,6 +340,11 @@ impl TerminalView {
             needs_serialize: false,
             custom_title: None,
             theme_override: None,
+            theme_override_source: None,
+            applied_activity: None,
+            pending_activity: None,
+            activity_debounce: Task::ready(()),
+            activity_poll,
             ime_state: None,
             self_handle: cx.entity().downgrade(),
             rename_editor: None,
@@ -321,11 +366,25 @@ impl TerminalView {
         cx.notify();
     }
 
-    /// Set or clear this terminal's per-terminal theme override by name. An
-    /// unresolvable name is logged and leaves the terminal on the window theme.
+    /// Set or clear this terminal's per-terminal theme override by name, as an
+    /// explicit user choice. An explicit choice suppresses activity-driven
+    /// switching for this terminal until it is cleared. An unresolvable name is
+    /// logged and leaves the terminal on the window theme.
     pub fn set_theme_override(
         &mut self,
         theme_name: Option<SharedString>,
+        cx: &mut Context<Self>,
+    ) {
+        self.apply_theme_override(theme_name, ThemeOverrideSource::User, cx);
+    }
+
+    /// Resolves and applies (or clears) the theme override, recording who set
+    /// it. The render path only ever reads the resolved theme, so resolution
+    /// happens here rather than per frame.
+    fn apply_theme_override(
+        &mut self,
+        theme_name: Option<SharedString>,
+        source: ThemeOverrideSource,
         cx: &mut Context<Self>,
     ) {
         self.theme_override = theme_name.and_then(|name| {
@@ -334,6 +393,7 @@ impl TerminalView {
                 .log_err()
                 .map(|theme| (name, theme))
         });
+        self.theme_override_source = self.theme_override.as_ref().map(|_| source);
         cx.notify();
     }
 
@@ -381,6 +441,89 @@ impl TerminalView {
         cx: &mut Context<Self>,
     ) {
         self.set_theme_override(None, cx);
+        // Hand control back to activity-driven switching, if it is configured.
+        self.applied_activity = None;
+        self.pending_activity = None;
+        self.schedule_activity_theme_update(cx);
+    }
+
+    /// Recompute the terminal's activity state and, when `activity_theme` is
+    /// configured and the user has not pinned an explicit theme, debounce-apply
+    /// the busy or idle theme. Both edges are debounced so fast or back-to-back
+    /// commands do not strobe the theme.
+    fn schedule_activity_theme_update(&mut self, cx: &mut Context<Self>) {
+        // An explicit user choice always wins over activity switching.
+        if self.theme_override_source == Some(ThemeOverrideSource::User) {
+            return;
+        }
+
+        let settings = TerminalSettings::get_global(cx);
+        let Some(activity_theme) = settings.activity_theme.as_ref() else {
+            return;
+        };
+
+        let desired = self.terminal.read(cx).activity_state();
+        if self.applied_activity == Some(desired) {
+            // Already showing the right theme; drop any pending opposite flip.
+            // This is the common case on each poll/`Wakeup`, so it stays
+            // allocation-free.
+            self.activity_debounce = Task::ready(());
+            self.pending_activity = None;
+            return;
+        }
+        if self.pending_activity == Some(desired) {
+            // A transition to this state is already being debounced; leave its
+            // timer running rather than restarting it every poll.
+            return;
+        }
+
+        let (delay, theme_name) = match desired {
+            TerminalActivity::Busy => (ACTIVITY_BUSY_DEBOUNCE, activity_theme.busy.clone()),
+            TerminalActivity::Idle => (ACTIVITY_IDLE_DEBOUNCE, activity_theme.idle.clone()),
+        };
+
+        self.pending_activity = Some(desired);
+        self.activity_debounce = cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(delay).await;
+            this.update(cx, |this, cx| {
+                this.pending_activity = None;
+                // The user may have pinned a theme, or the activity state may
+                // have flipped back, while we were waiting out the debounce.
+                if this.theme_override_source == Some(ThemeOverrideSource::User) {
+                    return;
+                }
+                if this.terminal.read(cx).activity_state() != desired {
+                    return;
+                }
+                this.applied_activity = Some(desired);
+                this.apply_theme_override(Some(theme_name), ThemeOverrideSource::Activity, cx);
+            })
+            .log_err();
+        });
+    }
+
+    /// A repeating task that refreshes the terminal's foreground-process info
+    /// and re-evaluates activity. Needed because that info is otherwise only
+    /// refreshed on terminal output, so a silent command emits no event.
+    fn spawn_activity_poll(cx: &mut Context<Self>) -> Task<()> {
+        cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(ACTIVITY_POLL_INTERVAL)
+                    .await;
+                let alive = this
+                    .update(cx, |this, cx| {
+                        this.terminal.update(cx, |terminal, cx| {
+                            terminal.poll_foreground_process_info(cx);
+                        });
+                        this.schedule_activity_theme_update(cx);
+                    })
+                    .is_ok();
+                if !alive {
+                    break;
+                }
+            }
+        })
     }
 
     const MAX_EMBEDDED_LINES: usize = 1_000;
@@ -634,6 +777,7 @@ impl TerminalView {
             TerminalBlink::On => true,
             TerminalBlink::TerminalControlled => self.blinking_terminal_enabled,
         };
+        let activity_theme_enabled = settings.activity_theme.is_some();
         let new_cursor_shape = settings.cursor_shape;
         let old_cursor_shape = self.cursor_shape;
         if old_cursor_shape != new_cursor_shape {
@@ -660,6 +804,23 @@ impl TerminalView {
             let name = name.clone();
             if let Some(theme) = ThemeRegistry::global(cx).get(name.as_ref()).log_err() {
                 self.theme_override = Some((name, theme));
+            }
+        }
+
+        if activity_theme_enabled {
+            // Re-evaluate so a renamed busy/idle theme is picked up. Clearing the
+            // applied state forces a re-resolve on the next debounce tick.
+            self.applied_activity = None;
+            self.pending_activity = None;
+            self.activity_poll = Self::spawn_activity_poll(cx);
+            self.schedule_activity_theme_update(cx);
+        } else {
+            self.activity_poll = Task::ready(());
+            if self.theme_override_source == Some(ThemeOverrideSource::Activity) {
+                // The feature was turned off: drop the activity-driven override.
+                self.applied_activity = None;
+                self.pending_activity = None;
+                self.apply_theme_override(None, ThemeOverrideSource::Activity, cx);
             }
         }
 
@@ -1177,6 +1338,7 @@ fn subscribe_for_terminal_events(
                     cx.emit(Event::Wakeup);
                     cx.emit(ItemEvent::UpdateTab);
                     cx.emit(SearchEvent::MatchesInvalidated);
+                    terminal_view.schedule_activity_theme_update(cx);
                 }
 
                 Event::Bell => {
@@ -1208,6 +1370,7 @@ fn subscribe_for_terminal_events(
 
                 Event::TitleChanged => {
                     cx.emit(ItemEvent::UpdateTab);
+                    terminal_view.schedule_activity_theme_update(cx);
                 }
 
                 Event::NewNavigationTarget(maybe_navigation_target) => {
@@ -3036,6 +3199,178 @@ mod tests {
                 "an unresolved override falls back to the window/global theme"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_activity_theme_switch(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, _workspace, window) = init_test_with_window(cx).await;
+
+        // Register distinct busy/idle themes so we can prove which one is active.
+        cx.update(|cx| {
+            let registry = ThemeRegistry::global(cx);
+            let base = registry.get("One Dark").unwrap();
+
+            let mut busy = (*base).clone();
+            busy.id = "activity-busy".to_string();
+            busy.name = "Activity Busy".into();
+
+            let mut idle = (*base).clone();
+            idle.id = "activity-idle".to_string();
+            idle.name = "Activity Idle".into();
+
+            registry.register_test_themes([theme::ThemeFamily {
+                id: "activity-family".to_string(),
+                name: "Activity Family".into(),
+                author: "test".into(),
+                themes: vec![busy, idle],
+                scales: theme::default_color_scales(),
+            }]);
+        });
+
+        // Turn on activity-driven theming.
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.terminal.get_or_insert_default().activity_theme =
+                    Some(settings::ActivityThemeContent {
+                        busy: "Activity Busy".to_owned(),
+                        idle: "Activity Idle".to_owned(),
+                    });
+            });
+        });
+
+        let (_pane, terminal, view) = add_display_only_terminal(&project, window, false, cx);
+
+        let override_name = |view: &Entity<TerminalView>, cx: &mut TestAppContext| {
+            view.read_with(cx, |view, _| {
+                view.theme_override_name().map(|name| name.to_string())
+            })
+        };
+
+        // Busy → after the busy debounce, the terminal adopts the busy theme.
+        terminal.update(cx, |terminal, _| {
+            terminal.set_activity_for_test(Some(TerminalActivity::Busy))
+        });
+        view.update(cx, |view, cx| view.schedule_activity_theme_update(cx));
+        cx.executor()
+            .advance_clock(ACTIVITY_BUSY_DEBOUNCE + Duration::from_millis(10));
+        cx.run_until_parked();
+        assert_eq!(
+            override_name(&view, cx),
+            Some("Activity Busy".to_string()),
+            "a running terminal switches to the busy theme after the debounce"
+        );
+
+        // Idle → after the (longer) idle debounce, it reverts to the idle theme.
+        terminal.update(cx, |terminal, _| {
+            terminal.set_activity_for_test(Some(TerminalActivity::Idle))
+        });
+        view.update(cx, |view, cx| view.schedule_activity_theme_update(cx));
+        cx.executor()
+            .advance_clock(ACTIVITY_IDLE_DEBOUNCE + Duration::from_millis(10));
+        cx.run_until_parked();
+        assert_eq!(
+            override_name(&view, cx),
+            Some("Activity Idle".to_string()),
+            "an idle terminal reverts to the idle theme after the settle delay"
+        );
+
+        // A theme picked explicitly by the user suppresses activity switching.
+        view.update(cx, |view, cx| {
+            view.set_theme_override(Some("Activity Idle".into()), cx)
+        });
+        terminal.update(cx, |terminal, _| {
+            terminal.set_activity_for_test(Some(TerminalActivity::Busy))
+        });
+        view.update(cx, |view, cx| view.schedule_activity_theme_update(cx));
+        cx.executor()
+            .advance_clock(ACTIVITY_BUSY_DEBOUNCE + Duration::from_millis(10));
+        cx.run_until_parked();
+        assert_eq!(
+            override_name(&view, cx),
+            Some("Activity Idle".to_string()),
+            "an explicit user theme is not overridden by activity switching"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_activity_theme_poll_does_not_reset_debounce(cx: &mut TestAppContext) {
+        // Regression: the foreground-info poll re-evaluates activity faster than
+        // the idle debounce, so a naive implementation kept restarting the idle
+        // timer and never reverted. A pending transition must keep its timer.
+        cx.executor().allow_parking();
+
+        let (project, _workspace, window) = init_test_with_window(cx).await;
+
+        cx.update(|cx| {
+            let registry = ThemeRegistry::global(cx);
+            let base = registry.get("One Dark").unwrap();
+            let mut busy = (*base).clone();
+            busy.id = "poll-busy".to_string();
+            busy.name = "Poll Busy".into();
+            let mut idle = (*base).clone();
+            idle.id = "poll-idle".to_string();
+            idle.name = "Poll Idle".into();
+            registry.register_test_themes([theme::ThemeFamily {
+                id: "poll-family".to_string(),
+                name: "Poll Family".into(),
+                author: "test".into(),
+                themes: vec![busy, idle],
+                scales: theme::default_color_scales(),
+            }]);
+        });
+
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.terminal.get_or_insert_default().activity_theme =
+                    Some(settings::ActivityThemeContent {
+                        busy: "Poll Busy".to_owned(),
+                        idle: "Poll Idle".to_owned(),
+                    });
+            });
+        });
+
+        let (_pane, terminal, view) = add_display_only_terminal(&project, window, false, cx);
+        let override_name = |view: &Entity<TerminalView>, cx: &mut TestAppContext| {
+            view.read_with(cx, |view, _| {
+                view.theme_override_name().map(|name| name.to_string())
+            })
+        };
+
+        // Settle into busy.
+        terminal.update(cx, |terminal, _| {
+            terminal.set_activity_for_test(Some(TerminalActivity::Busy))
+        });
+        view.update(cx, |view, cx| view.schedule_activity_theme_update(cx));
+        cx.executor()
+            .advance_clock(ACTIVITY_BUSY_DEBOUNCE + Duration::from_millis(10));
+        cx.run_until_parked();
+        assert_eq!(override_name(&view, cx), Some("Poll Busy".to_string()));
+
+        // Now go idle and simulate polls firing inside the idle debounce window.
+        terminal.update(cx, |terminal, _| {
+            terminal.set_activity_for_test(Some(TerminalActivity::Idle))
+        });
+        view.update(cx, |view, cx| view.schedule_activity_theme_update(cx)); // schedules idle
+        cx.executor().advance_clock(ACTIVITY_POLL_INTERVAL); // a poll tick, < idle debounce
+        cx.run_until_parked();
+        view.update(cx, |view, cx| view.schedule_activity_theme_update(cx)); // must NOT reset the timer
+        assert_eq!(
+            override_name(&view, cx),
+            Some("Poll Busy".to_string()),
+            "still busy: the idle debounce has not elapsed yet"
+        );
+
+        // Cross the original idle deadline; the un-reset timer fires.
+        cx.executor()
+            .advance_clock(ACTIVITY_IDLE_DEBOUNCE - ACTIVITY_POLL_INTERVAL + Duration::from_millis(10));
+        cx.run_until_parked();
+        assert_eq!(
+            override_name(&view, cx),
+            Some("Poll Idle".to_string()),
+            "reverts to idle once the (un-reset) debounce elapses"
+        );
     }
 
     #[gpui::test]

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -3,8 +3,8 @@ mod icon_theme_selector;
 use fs::Fs;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{
-    App, Context, DismissEvent, Entity, EventEmitter, Focusable, Render, UpdateGlobal, WeakEntity,
-    Window, actions,
+    App, Context, DismissEvent, Entity, EventEmitter, Focusable, Render, SharedString,
+    UpdateGlobal, WeakEntity, Window, actions,
 };
 use picker::{Picker, PickerDelegate};
 use settings::{Settings, SettingsStore, update_settings_file};
@@ -55,6 +55,39 @@ fn toggle_theme_selector(
             cx.entity().downgrade(),
             fs,
             toggle.themes_filter.as_ref(),
+            None,
+            None,
+            cx,
+        );
+        ThemeSelector::new(delegate, window, cx)
+    });
+}
+
+/// Applies a previewed/selected theme override by name (`None` clears it). Used
+/// to drive a per-target override (e.g. a single terminal) instead of mutating
+/// the global theme settings.
+type ApplyThemeOverride = Box<dyn Fn(Option<SharedString>, &mut App)>;
+
+/// Open the theme selector scoped to a single override target rather than the
+/// global theme. Navigation previews live via `apply_override`, dismiss reverts
+/// to `current_override`, and confirm keeps the selection without persisting to
+/// the settings file.
+pub fn toggle_theme_selector_for_override(
+    workspace: &mut Workspace,
+    current_override: Option<SharedString>,
+    apply_override: impl Fn(Option<SharedString>, &mut App) + 'static,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let fs = workspace.app_state().fs.clone();
+    let apply_override: ApplyThemeOverride = Box::new(apply_override);
+    workspace.toggle_modal(window, cx, move |window, cx| {
+        let delegate = ThemeSelectorDelegate::new(
+            cx.entity().downgrade(),
+            fs,
+            None,
+            current_override,
+            Some(apply_override),
             cx,
         );
         ThemeSelector::new(delegate, window, cx)
@@ -148,6 +181,12 @@ struct ThemeSelectorDelegate {
     selected_theme: Option<Arc<Theme>>,
     selected_index: usize,
     selector: WeakEntity<ThemeSelector>,
+    /// The override the target carried before the selector opened; restored on
+    /// dismiss. Only meaningful in override (per-target) mode.
+    original_override: Option<SharedString>,
+    /// When set, the selector drives a per-target override via this callback
+    /// instead of mutating global theme settings.
+    apply_override: Option<ApplyThemeOverride>,
 }
 
 impl ThemeSelectorDelegate {
@@ -155,6 +194,8 @@ impl ThemeSelectorDelegate {
         selector: WeakEntity<ThemeSelector>,
         fs: Arc<dyn Fs>,
         themes_filter: Option<&Vec<String>>,
+        original_override: Option<SharedString>,
+        apply_override: Option<ApplyThemeOverride>,
         cx: &mut Context<ThemeSelector>,
     ) -> Self {
         let original_theme = cx.theme().clone();
@@ -197,10 +238,16 @@ impl ThemeSelectorDelegate {
             })
             .collect();
 
-        // The current theme is likely in this list, so default to first showing that.
+        // The current theme is likely in this list, so default to first showing
+        // that — or the target's existing override when one is set.
         let selected_index = matches
             .iter()
-            .position(|mat| mat.string == original_theme.name)
+            .position(|mat| Some(mat.string.as_str()) == original_override.as_deref())
+            .or_else(|| {
+                matches
+                    .iter()
+                    .position(|mat| mat.string == original_theme.name)
+            })
             .unwrap_or(0);
 
         Self {
@@ -215,6 +262,8 @@ impl ThemeSelectorDelegate {
             selection_completed: false,
             selected_theme: None,
             selector,
+            original_override,
+            apply_override,
         }
     }
 
@@ -248,24 +297,33 @@ impl ThemeSelectorDelegate {
     }
 
     fn revert_theme(&mut self, cx: &mut App) {
-        if !self.selection_completed {
+        if self.selection_completed {
+            return;
+        }
+        if let Some(apply) = &self.apply_override {
+            apply(self.original_override.clone(), cx);
+        } else {
             SettingsStore::update_global(cx, |store, _| {
                 store.override_global(self.original_theme_settings.clone());
             });
-            self.selection_completed = true;
         }
+        self.selection_completed = true;
     }
 
     fn set_theme(&mut self, new_theme: Arc<Theme>, cx: &mut App) {
-        // Update the global (in-memory) theme settings.
-        SettingsStore::update_global(cx, |store, _| {
-            override_global_theme(
-                store,
-                &new_theme,
-                &self.original_theme_settings.theme,
-                self.original_system_appearance,
-            )
-        });
+        if let Some(apply) = &self.apply_override {
+            apply(Some(new_theme.name.clone()), cx);
+        } else {
+            // Update the global (in-memory) theme settings.
+            SettingsStore::update_global(cx, |store, _| {
+                override_global_theme(
+                    store,
+                    &new_theme,
+                    &self.original_theme_settings.theme,
+                    self.original_system_appearance,
+                )
+            });
+        }
 
         self.new_theme = new_theme;
     }
@@ -394,15 +452,19 @@ impl PickerDelegate for ThemeSelectorDelegate {
     ) {
         self.selection_completed = true;
 
-        let theme_name: Arc<str> = self.new_theme.name.as_str().into();
-        let theme_appearance = self.new_theme.appearance;
-        let system_appearance = SystemAppearance::global(cx).0;
+        // Per-target override mode: the theme was already applied live during
+        // preview; nothing is persisted to the settings file (session-scoped).
+        if self.apply_override.is_none() {
+            let theme_name: Arc<str> = self.new_theme.name.as_str().into();
+            let theme_appearance = self.new_theme.appearance;
+            let system_appearance = SystemAppearance::global(cx).0;
 
-        telemetry::event!("Settings Changed", setting = "theme", value = theme_name);
+            telemetry::event!("Settings Changed", setting = "theme", value = theme_name);
 
-        update_settings_file(self.fs.clone(), cx, move |settings, _| {
-            theme_settings::set_theme(settings, theme_name, theme_appearance, system_appearance);
-        });
+            update_settings_file(self.fs.clone(), cx, move |settings, _| {
+                theme_settings::set_theme(settings, theme_name, theme_appearance, system_appearance);
+            });
+        }
 
         self.selector
             .update(cx, |_, cx| {
@@ -573,6 +635,8 @@ mod tests {
     use gpui::{TestAppContext, VisualTestContext};
     use project::Project;
     use serde_json::json;
+    use std::cell::RefCell;
+    use std::rc::Rc;
     use theme::{Appearance, ThemeFamily, ThemeRegistry, default_color_scales};
     use util::path;
     use workspace::MultiWorkspace;
@@ -711,6 +775,72 @@ mod tests {
             previewed_theme_name(&picker, cx),
             "Test Light",
             "previewed theme should be preserved after clearing an empty filter"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_theme_selector_override_mode_previews_and_reverts(cx: &mut TestAppContext) {
+        let app_state = setup_test(cx).await;
+        let project = Project::test(app_state.fs.clone(), [path!("/test").as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+
+        // Record every override the selector applies through the callback.
+        let applied: Rc<RefCell<Vec<Option<String>>>> = Rc::new(RefCell::new(Vec::new()));
+
+        let picker = {
+            let applied = applied.clone();
+            workspace.update_in(cx, |workspace, window, cx| {
+                super::toggle_theme_selector_for_override(
+                    workspace,
+                    None,
+                    move |name, _cx| applied.borrow_mut().push(name.map(|n| n.to_string())),
+                    window,
+                    cx,
+                );
+            });
+            cx.run_until_parked();
+            workspace.update(cx, |workspace, cx| {
+                workspace
+                    .active_modal::<ThemeSelector>(cx)
+                    .expect("theme selector should be open in override mode")
+                    .read(cx)
+                    .picker
+                    .clone()
+            })
+        };
+
+        // Previewing a theme applies it to the target via the override callback,
+        // not to global settings.
+        let target_index = picker.read_with(cx, |picker, _| {
+            picker
+                .delegate
+                .matches
+                .iter()
+                .position(|m| m.string == "Test Light")
+                .unwrap()
+        });
+        picker.update_in(cx, |picker, window, cx| {
+            picker.set_selected_index(target_index, None, true, window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            applied.borrow().last().cloned().flatten().as_deref(),
+            Some("Test Light"),
+            "previewing should apply the theme to the target via the override callback"
+        );
+
+        // Dismissing without confirming reverts to the original (None) override.
+        picker.update_in(cx, |picker, window, cx| {
+            picker.delegate.dismissed(window, cx);
+        });
+        cx.run_until_parked();
+        assert_eq!(
+            applied.borrow().last().cloned().flatten(),
+            None,
+            "dismiss should revert the target to its original override"
         );
     }
 }

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -397,7 +397,16 @@ pub mod feedback {
 pub mod theme {
     use gpui::actions;
 
-    actions!(theme, [ToggleMode]);
+    actions!(
+        theme,
+        [
+            ToggleMode,
+            /// Sets a theme for the focused terminal only, without changing the global theme.
+            Terminal,
+            /// Clears the focused terminal's theme override, returning it to the window/global theme.
+            ClearTerminal
+        ]
+    );
 }
 
 pub mod theme_selector {


### PR DESCRIPTION
> **Stacked on #58861.** This builds on per-terminal theme overrides (#58861), which is not yet merged. Until it lands, this branch includes that commit, so the diff below also shows the per-terminal-theme change; the activity-theme work is the second commit. I'll rebase onto `main` once #58861 merges. Opening as a draft for early feedback.

## Summary

Let a terminal change its theme automatically based on what it's doing: one theme while it's **running a command**, another while it's **idle at the prompt**. For example, a dark theme while a build runs and a light one the moment it finishes — so you can tell at a glance, across a wall of terminals, which ones are still working.

It's opt-in and off by default. You set two theme names under `terminal.activity_theme`; with the key absent there is zero behavior change.

This builds directly on per-terminal theme overrides (#58861): activity simply drives the *same* per-terminal override a user can set by hand, rather than introducing a second theming mechanism. The two compose — an explicit per-terminal theme wins over activity switching for that terminal.

## Demo

Four terminals in one window with `activity_theme` set, each switching to the busy theme while a command runs and back to the idle theme when it returns to the prompt:

![Activity-driven terminal themes](https://raw.githubusercontent.com/42piratas/zed-an/main/assets/terminal-activity-theme.gif)

```jsonc
// settings.json
"terminal": {
  "activity_theme": { "busy": "Ayu Dark", "idle": "Ayu Light" }
}
```

## How it works

- **terminal**: `Terminal::activity_state()` returns `Busy`/`Idle`. A terminal is busy when a spawned task is `Running`, or when its foreground process is something other than a known shell (`zsh`, `bash`, `fish`, `pwsh`, …); at the prompt the foreground process *is* the shell. This is a heuristic — Zed does not parse OSC 133 shell-integration prompt markers — so shell builtins and very short commands can misread.
- **terminal_view**: when `activity_theme` is set, a terminal resolves the busy/idle theme name and applies it through the per-terminal override path. Foreground-process info is otherwise only refreshed on terminal output, so a lightweight poll (active only while the feature is on) keeps silent commands such as `sleep` registering. Both transitions are debounced — and only committed if the state still holds — so fast or back-to-back commands don't strobe the theme.
- An explicit `theme: terminal` choice suppresses activity switching for that terminal; `theme: clear terminal` hands control back to activity (or to the window theme when `activity_theme` is unset).

## Out of scope

- **OSC 133 prompt markers** — the precise command-start/end signal; a much larger, separate effort. This ships the foreground-process/task heuristic plus debounce; its absence is the known reliability ceiling.
- **Per-state config beyond two themes** (per-exit-code, per-command) — busy/idle only.
- **Persistence of runtime state** — `activity_theme` itself is a normal setting; no per-terminal runtime state is serialized.

## Testing

Set `terminal.activity_theme` to two installed themes, then in a terminal: sit at the prompt (idle theme), run a long command such as `sleep 5` (switches to the busy theme, then back to idle when it exits), and run `ls` repeatedly to confirm fast commands don't strobe. Confirm that removing the setting restores current behavior, and that a manual `theme: terminal` override suppresses switching until cleared. Unit tests cover the busy/idle derivation and shell detection (`terminal`) and the busy↔idle switch, user-override suppression, and the poll-vs-debounce timing (`terminal_view`).

## Release Notes:

- Added activity-driven terminal themes (`terminal.activity_theme`) so a terminal can use one theme while running a command and another while idle.
