### PR TITLE
cloud_api_client: Always pass up an organization ID when creating an LLM token

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1603,7 +1603,7 @@ impl Client {
     pub async fn cached_llm_token(
         &self,
         llm_token: &LlmApiToken,
-        organization_id: Option<OrganizationId>,
+        organization_id: OrganizationId,
     ) -> Result<String> {
         let system_id = self.telemetry().system_id().map(|x| x.to_string());
         let cloud_client = self.cloud_client();
@@ -1627,7 +1627,7 @@ impl Client {
     pub async fn authenticated_llm_request(
         &self,
         llm_token: &LlmApiToken,
-        organization_id: Option<OrganizationId>,
+        organization_id: OrganizationId,
         build_request: impl Fn(&str) -> Result<http_client::Request<http_client::AsyncBody>>,
     ) -> Result<http_client::Response<http_client::AsyncBody>> {
         let http_client = self.http_client();
@@ -1648,7 +1648,7 @@ impl Client {
     pub async fn refresh_llm_token(
         &self,
         llm_token: &LlmApiToken,
-        organization_id: Option<OrganizationId>,
+        organization_id: OrganizationId,
     ) -> Result<String> {
         let system_id = self.telemetry().system_id().map(|x| x.to_string());
         let cloud_client = self.cloud_client();
@@ -1668,7 +1668,7 @@ impl Client {
     pub async fn clear_and_refresh_llm_token(
         &self,
         llm_token: &LlmApiToken,
-        organization_id: Option<OrganizationId>,
+        organization_id: OrganizationId,
     ) -> Result<String> {
         let system_id = self.telemetry().system_id().map(|x| x.to_string());
         let cloud_client = self.cloud_client();

--- a/crates/client/src/llm_token.rs
+++ b/crates/client/src/llm_token.rs
@@ -1,4 +1,5 @@
 use super::{Client, UserStore};
+use anyhow::anyhow;
 use cloud_api_client::LlmApiToken;
 use cloud_api_types::websocket_protocol::MessageToClient;
 use cloud_llm_client::{EXPIRED_LLM_TOKEN_HEADER_NAME, OUTDATED_LLM_TOKEN_HEADER_NAME};
@@ -106,6 +107,9 @@ impl RefreshLlmTokenListener {
             .current_organization()
             .map(|organization| organization.id.clone());
         cx.spawn(async move |this, cx| {
+            let organization_id =
+                organization_id.ok_or_else(|| anyhow!("No organization selected."))?;
+
             match mode {
                 TokenRefreshMode::Refresh => {
                     client

--- a/crates/cloud_api_client/src/cloud_api_client.rs
+++ b/crates/cloud_api_client/src/cloud_api_client.rs
@@ -157,7 +157,7 @@ impl CloudApiClient {
     async fn create_llm_token(
         &self,
         system_id: Option<String>,
-        organization_id: Option<OrganizationId>,
+        organization_id: OrganizationId,
     ) -> Result<CreateLlmTokenResponse, ClientApiError> {
         let request_builder = Request::builder()
             .method(Method::POST)

--- a/crates/cloud_api_client/src/llm_token.rs
+++ b/crates/cloud_api_client/src/llm_token.rs
@@ -17,7 +17,7 @@ impl LlmApiToken {
         &self,
         client: &CloudApiClient,
         system_id: Option<String>,
-        organization_id: Option<OrganizationId>,
+        organization_id: OrganizationId,
     ) -> Result<String, ClientApiError> {
         let lock = self.0.upgradable_read().await;
         if let Some(token) = lock.as_ref() {
@@ -37,7 +37,7 @@ impl LlmApiToken {
         &self,
         client: &CloudApiClient,
         system_id: Option<String>,
-        organization_id: Option<OrganizationId>,
+        organization_id: OrganizationId,
     ) -> Result<String, ClientApiError> {
         Self::fetch(self.0.write().await, client, system_id, organization_id).await
     }
@@ -54,7 +54,7 @@ impl LlmApiToken {
         &self,
         client: &CloudApiClient,
         system_id: Option<String>,
-        organization_id: Option<OrganizationId>,
+        organization_id: OrganizationId,
     ) -> Result<String, ClientApiError> {
         let mut lock = self.0.write().await;
         *lock = None;
@@ -65,7 +65,7 @@ impl LlmApiToken {
         mut lock: RwLockWriteGuard<'_, Option<String>>,
         client: &CloudApiClient,
         system_id: Option<String>,
-        organization_id: Option<OrganizationId>,
+        organization_id: OrganizationId,
     ) -> Result<String, ClientApiError> {
         let result = client.create_llm_token(system_id, organization_id).await;
         match result {

--- a/crates/cloud_api_types/src/cloud_api_types.rs
+++ b/crates/cloud_api_types/src/cloud_api_types.rs
@@ -77,10 +77,9 @@ pub struct AcceptTermsOfServiceResponse {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct LlmToken(pub String);
 
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct CreateLlmTokenBody {
-    #[serde(default)]
-    pub organization_id: Option<OrganizationId>,
+    pub organization_id: OrganizationId,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, anyhow};
 use buffer_diff::BufferDiff;
 use client::{Client, EditPredictionUsage, UserStore, global_llm_token};
 use cloud_api_client::LlmApiToken;
@@ -1054,6 +1054,8 @@ impl EditPredictionStore {
         cx.spawn(async move |this, cx| {
             let experiments = cx
                 .background_spawn(async move {
+                    let organization_id =
+                        organization_id.ok_or_else(|| anyhow!("No organization selected."))?;
                     let url = client
                         .http_client()
                         .build_zed_llm_url("/edit_prediction_experiments", &[])?;
@@ -3086,6 +3088,9 @@ impl EditPredictionStore {
     where
         Res: DeserializeOwned,
     {
+        let organization_id =
+            organization_id.ok_or_else(|| anyhow!("No organization selected."))?;
+
         let response = client
             .authenticated_llm_request(&llm_token, organization_id, |token| {
                 build(

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -1,5 +1,3 @@
-use super::*;
-use crate::udiff::apply_diff_to_string;
 use client::{RefreshLlmTokenListener, UserStore, test::FakeServer};
 use clock::FakeSystemClock;
 use clock::ReplicaId;
@@ -15,8 +13,6 @@ use cloud_llm_client::{
 };
 use db::AppDatabase;
 use edit_prediction_types::EditPredictionRequestTrigger;
-use settings::EditPredictionDataCollectionChoice;
-
 use futures::{
     AsyncReadExt, FutureExt, StreamExt,
     channel::{mpsc, oneshot},
@@ -31,12 +27,12 @@ use language::{
     Anchor, Buffer, BufferEditSource, Capability, CursorShape, Diagnostic, DiagnosticEntry,
     DiagnosticSet, DiagnosticSeverity, Operation, Point, Selection, SelectionGoal,
 };
-
 use lsp::LanguageServerId;
 use parking_lot::Mutex;
 use pretty_assertions::{assert_eq, assert_matches};
 use project::{FakeFs, Project};
 use serde_json::json;
+use settings::EditPredictionDataCollectionChoice;
 use settings::SettingsStore;
 use std::{ops::Range, path::Path, sync::Arc, time::Duration};
 use util::{
@@ -47,11 +43,14 @@ use uuid::Uuid;
 use workspace::{AppState, CollaboratorId, MultiWorkspace};
 use zeta_prompt::ZetaPromptInput;
 
+use crate::udiff::apply_diff_to_string;
 use crate::{
     BufferEditPrediction, EDIT_PREDICTION_SETTLED_QUIESCENCE, EditPredictionId,
     EditPredictionJumpsFeatureFlag, EditPredictionStore, REJECT_REQUEST_DEBOUNCE,
     REQUEST_TIMEOUT_BACKOFF,
 };
+
+use super::*;
 
 #[gpui::test]
 async fn test_current_state(cx: &mut TestAppContext) {
@@ -2833,7 +2832,7 @@ fn init_test_with_fake_client_and_legacy_data_collection(
     cx: &mut TestAppContext,
     legacy_data_collection_choice: Option<&str>,
 ) -> (Entity<EditPredictionStore>, RequestChannels) {
-    cx.update(move |cx| {
+    let result = cx.update(move |cx| {
         cx.set_global(AppDatabase::test_new());
         let settings_store = SettingsStore::test(cx);
         cx.set_global(settings_store);
@@ -2934,13 +2933,49 @@ fn init_test_with_fake_client_and_legacy_data_collection(
 
         (
             ep_store,
+            user_store,
             RequestChannels {
                 predict: predict_req_rx,
                 reject: reject_req_rx,
                 settled: settled_req_rx,
             },
         )
-    })
+    });
+
+    let (ep_store, user_store, channels) = result;
+    set_test_organization(&user_store, cx);
+    (ep_store, channels)
+}
+
+/// Configures a current organization on the given `UserStore` for tests.
+///
+/// The test client starts out signed out, which causes `UserStore` to clear the
+/// current organization once that initial status is processed. This waits for
+/// that to happen before configuring the organization, so it isn't subsequently
+/// wiped out.
+fn set_test_organization(user_store: &Entity<UserStore>, cx: &mut TestAppContext) {
+    cx.run_until_parked();
+    cx.update(|cx| {
+        user_store.update(cx, |store, cx| {
+            store.set_current_organization_configuration_for_test(
+                Arc::new(Organization {
+                    id: OrganizationId("org_1".into()),
+                    name: "Organization 1".into(),
+                    is_personal: false,
+                }),
+                OrganizationConfiguration {
+                    is_zed_model_provider_enabled: true,
+                    is_agent_thread_feedback_enabled: true,
+                    is_collaboration_enabled: true,
+                    edit_prediction: OrganizationEditPredictionConfiguration {
+                        is_enabled: true,
+                        is_feedback_enabled: true,
+                    },
+                },
+                cx,
+            )
+        });
+    });
 }
 
 #[gpui::test]
@@ -3383,6 +3418,9 @@ async fn make_test_ep_store(
         RefreshLlmTokenListener::register(client.clone(), user_store.clone(), cx);
     });
     let _server = FakeServer::for_client(42, &client, cx).await;
+
+    let project_user_store = cx.update(|cx| project.read(cx).user_store());
+    set_test_organization(&project_user_store, cx);
 
     let ep_store = cx.new(|cx| {
         let mut ep_store = EditPredictionStore::new(client, project.read(cx).user_store(), cx);

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -1,5 +1,5 @@
 use ai_onboarding::YoungAccountBanner;
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use client::{Client, RefreshLlmTokenListener, UserStore, global_llm_token, zed_urls};
 use cloud_api_client::LlmApiToken;
 use cloud_api_types::OrganizationId;
@@ -52,6 +52,8 @@ impl CloudLlmTokenProvider for ClientTokenProvider {
         let client = self.client.clone();
         let llm_api_token = self.llm_api_token.clone();
         Box::pin(async move {
+            let organization_id =
+                organization_id.ok_or_else(|| anyhow!("No organization selected."))?;
             client
                 .cached_llm_token(&llm_api_token, organization_id)
                 .await
@@ -65,6 +67,8 @@ impl CloudLlmTokenProvider for ClientTokenProvider {
         let client = self.client.clone();
         let llm_api_token = self.llm_api_token.clone();
         Box::pin(async move {
+            let organization_id =
+                organization_id.ok_or_else(|| anyhow!("No organization selected."))?;
             client
                 .refresh_llm_token(&llm_api_token, organization_id)
                 .await
@@ -332,7 +336,7 @@ impl LanguageModelProvider for CloudLanguageModelProvider {
                         | client::Status::Reauthenticated
                         | client::Status::Connected { .. }
                 ) {
-                    return Err(AuthenticateError::Other(anyhow::anyhow!(
+                    return Err(AuthenticateError::Other(anyhow!(
                         "sign-in did not complete: {current_status:?}"
                     )));
                 }

--- a/crates/web_search_providers/src/cloud.rs
+++ b/crates/web_search_providers/src/cloud.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use client::{Client, UserStore, global_llm_token};
 use cloud_api_client::LlmApiToken;
 use cloud_api_types::OrganizationId;
@@ -69,6 +69,8 @@ async fn perform_web_search(
     organization_id: Option<OrganizationId>,
     body: WebSearchBody,
 ) -> Result<WebSearchResponse> {
+    let organization_id = organization_id.ok_or_else(|| anyhow!("No organization selected."))?;
+
     let url = client.http_client().build_zed_llm_url("/web_search", &[])?;
     let body = serde_json::to_string(&body)?;
     let mut response = client


### PR DESCRIPTION
This PR makes it so we always pass up an organization ID when creating an LLM token.

We should have an organization ID in all cases.

Release Notes:

- N/A
