### PR TITLE
Use more .array_windows::<N>()

### DIFF
--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -1647,10 +1647,8 @@ impl Editor {
             this.change_selections(Default::default(), window, cx, |s| s.select(selections));
 
             let selections = this.selections.all::<Point>(&this.display_snapshot(cx));
-            let selections_on_single_row = selections.windows(2).all(|selections| {
-                selections[0].start.row == selections[1].start.row
-                    && selections[0].end.row == selections[1].end.row
-                    && selections[0].start.row == selections[0].end.row
+            let selections_on_single_row = selections.array_windows::<2>().all(|[a, b]| {
+                a.start.row == b.start.row && a.end.row == b.end.row && a.start.row == a.end.row
             });
             let selections_selecting = selections
                 .iter()

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -2104,7 +2104,7 @@ impl<'a> PathComponentSlice<'a> {
 
     fn elision_range(&self, budget: usize, matches: &[usize]) -> Option<Range<usize>> {
         let eligible_range = {
-            assert!(matches.windows(2).all(|w| w[0] <= w[1]));
+            assert!(matches.is_sorted());
             let mut matches = matches.iter().copied().peekable();
             let mut longest: Option<Range<usize>> = None;
             let mut cur = 0..0;

--- a/crates/markdown/src/html/html_rendering.rs
+++ b/crates/markdown/src/html/html_rendering.rs
@@ -391,9 +391,7 @@ impl MarkdownElement {
         boundaries.sort_unstable();
         boundaries.dedup();
 
-        for segment in boundaries.windows(2) {
-            let start = segment[0];
-            let end = segment[1];
+        for &[start, end] in boundaries.array_windows::<2>() {
             if start >= end {
                 continue;
             }

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -3446,10 +3446,8 @@ impl OutlinePanel {
                     };
                     let fetched_outlines = outline_task.await;
                     let outlines_with_children = fetched_outlines
-                        .windows(2)
-                        .filter_map(|window| {
-                            let current = &window[0];
-                            let next = &window[1];
+                        .array_windows::<2>()
+                        .filter_map(|[current, next]| {
                             if next.depth > current.depth {
                                 Some((current.range.clone(), current.depth))
                             } else {

--- a/crates/zeta_prompt/src/multi_region.rs
+++ b/crates/zeta_prompt/src/multi_region.rs
@@ -569,8 +569,8 @@ pub fn nearest_marker_number(cursor_offset: Option<usize>, marker_offsets: &[usi
 fn cursor_block_index(cursor_offset: Option<usize>, marker_offsets: &[usize]) -> usize {
     let cursor = cursor_offset.unwrap_or(0);
     marker_offsets
-        .windows(2)
-        .position(|window| cursor >= window[0] && cursor < window[1])
+        .array_windows::<2>()
+        .position(|&[a, b]| cursor >= a && cursor < b)
         .unwrap_or_else(|| marker_offsets.len().saturating_sub(2))
 }
 
@@ -1207,10 +1207,7 @@ hhhhhhhhhh = 8;
             Some(text.len()),
             "offsets: {offsets:?}"
         );
-        assert!(
-            offsets.windows(2).all(|window| window[0] <= window[1]),
-            "offsets must be sorted: {offsets:?}"
-        );
+        assert!(offsets.is_sorted(), "offsets must be sorted: {offsets:?}");
     }
 
     #[test]


### PR DESCRIPTION
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

The fight against entropy continues...

Release Notes:

- N/A or Added/Fixed/Improved ...
