### PR TITLE
edit_prediction_cli: Use stack-based dynamic dispatch for local readers and RNG

### DIFF
--- a/crates/edit_prediction_cli/src/split_commit.rs
+++ b/crates/edit_prediction_cli/src/split_commit.rs
@@ -241,12 +241,15 @@ pub fn run_split_commit(
     let mut processed_commits = 0usize;
 
     for input_path in inputs {
-        let input: Box<dyn BufRead> = if input_path.as_os_str() == "-" {
-            Box::new(io::BufReader::new(io::stdin()))
+        let (mut stdin_reader, mut file_reader);
+        let input: &mut dyn BufRead = if input_path.as_os_str() == "-" {
+            stdin_reader = io::BufReader::new(io::stdin());
+            &mut stdin_reader
         } else {
             let file = fs::File::open(input_path)
                 .with_context(|| format!("failed to open input file {}", input_path.display()))?;
-            Box::new(io::BufReader::new(file))
+            file_reader = io::BufReader::new(file);
+            &mut file_reader
         };
 
         for (line_num, line_result) in input.lines().enumerate() {
@@ -400,9 +403,16 @@ pub fn generate_evaluation_example_from_ordered_commit(
         "commit contains submodule/gitlink hunk"
     );
 
-    let mut rng: Box<dyn rand::RngCore> = match seed {
-        Some(seed) => Box::new(rand::rngs::StdRng::seed_from_u64(seed)),
-        None => Box::new(rand::rngs::ThreadRng::default()),
+    let (mut seeded_rng, mut thread_rng);
+    let rng: &mut dyn rand::RngCore = match seed {
+        Some(seed) => {
+            seeded_rng = rand::rngs::StdRng::seed_from_u64(seed);
+            &mut seeded_rng
+        }
+        None => {
+            thread_rng = rand::rngs::ThreadRng::default();
+            &mut thread_rng
+        }
     };
 
     // Parse and normalize the commit
@@ -428,7 +438,7 @@ pub fn generate_evaluation_example_from_ordered_commit(
     anyhow::ensure!(num_edits != 0, "no edits found in commit");
 
     let split = match split_point {
-        None => sample_split_point(&patch, rng.as_mut()),
+        None => sample_split_point(&patch, rng),
         Some(SplitPoint::Fraction(f)) => {
             let v = (f * num_edits as f64).floor() as usize;
             v.min(num_edits)
@@ -457,7 +467,7 @@ pub fn generate_evaluation_example_from_ordered_commit(
     // Sample cursor position
     let cursor = match cursor_opt {
         Some(c) => c,
-        None => sample_cursor_position(&split_commit, rng.as_mut())
+        None => sample_cursor_position(&split_commit, rng)
             .context("failed to sample cursor position")?,
     };
 

--- a/crates/edit_prediction_cli/src/split_dataset.rs
+++ b/crates/edit_prediction_cli/src/split_dataset.rs
@@ -149,13 +149,18 @@ fn parse_split_spec(spec: &str) -> Result<SplitSpec> {
 }
 
 fn read_lines_from_input(input: Option<&Path>) -> Result<Vec<String>> {
-    let reader: Box<dyn BufRead> = match input {
+    let (mut stdin_reader, mut file_reader);
+    let reader: &mut dyn BufRead = match input {
         Some(path) => {
             let file =
                 File::open(path).with_context(|| format!("failed to open '{}'", path.display()))?;
-            Box::new(BufReader::new(file))
+            file_reader = BufReader::new(file);
+            &mut file_reader
         }
-        None => Box::new(BufReader::new(io::stdin())),
+        None => {
+            stdin_reader = BufReader::new(io::stdin());
+            &mut stdin_reader
+        }
     };
 
     let lines: Vec<String> = reader


### PR DESCRIPTION
# Why

This change itself is small by itself but I'm using it to build a library of dylints so we can ~~fight entropy~~ tamper allocations across the codebase more reliably.

# What 

Three trait objects in `edit_prediction_cli` were heap-allocated with `Box<dyn ...>` even though they never escape their function. This replaces them with stack-based dynamic dispatch (`&mut dyn ...`), avoiding the allocation.

Each site binds the concrete value to a local first, then borrows it as `&mut dyn`. (Temporary lifetime extension does not propagate through `if`/`match` arms, so the binding-first idiom is required.)

Changed sites:
- `run_split_commit`: `Box<dyn BufRead>` input -> `&mut dyn BufRead`
- `read_lines_from_input` (split_dataset): `Box<dyn BufRead>` reader -> `&mut dyn BufRead`
- `generate_evaluation_example_from_ordered_commit`: `Box<dyn rand::RngCore>` -> `&mut dyn rand::RngCore` (consumers already took `&mut dyn rand::RngCore`)

Sites where the trait object escapes the function (`read_lines_streaming`, `Fs::open_sync`, `SearchQuery::detect`, and the various `Action`/screen-capture/runtime boxes) were intentionally left unchanged.

Validation: `cargo test -p edit_prediction_cli` (83 passed) and `./script/clippy -p edit_prediction_cli` (clean).

Release Notes:

- N/A