### PR TITLE
terminal_view: Forward ctrl-q to PTY when terminal is focused on Linux

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1240,6 +1240,7 @@
       "ctrl-c": ["terminal::SendKeystroke", "ctrl-c"],
       "ctrl-e": ["terminal::SendKeystroke", "ctrl-e"],
       "ctrl-o": ["terminal::SendKeystroke", "ctrl-o"],
+      "ctrl-q": ["terminal::SendKeystroke", "ctrl-q"],
       "ctrl-w": ["terminal::SendKeystroke", "ctrl-w"],
       "ctrl-r": ["terminal::SendKeystroke", "ctrl-r"],
       "ctrl-backspace": ["terminal::SendKeystroke", "ctrl-w"],

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -2316,6 +2316,28 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
+    #[gpui::test]
+    async fn ctrl_q_is_forwarded_to_terminal_not_quit(cx: &mut TestAppContext) {
+        let (project, _workspace, window_handle) = init_test_with_window(cx).await;
+        cx.update(load_default_keymap);
+        let (_pane, terminal, _terminal_view) =
+            add_display_only_terminal(&project, window_handle, true, cx);
+
+        let mut cx = VisualTestContext::from_window(window_handle.into(), cx);
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("ctrl-q");
+        assert_eq!(
+            terminal.update(&mut cx, |terminal, _| terminal.take_input_log()),
+            vec![vec![0x11]],
+            "ctrl-q in a focused terminal should send 0x11 to the PTY, not trigger zed::Quit",
+        );
+    }
+
     // Working directory calculation tests
 
     // No Worktrees in project -> home_dir()


### PR DESCRIPTION
## Context

On Linux, `ctrl-q` is globally bound to `zed::Quit`. When a `TerminalView` is focused, pressing `ctrl-q` quit the application instead of forwarding the keycode to the shell, breaking programs like `ftp`, `tig`, and any app that uses XON/XOFF flow control.

Windows already had the fix: its `Terminal` keymap context overrides `ctrl-q` with `["terminal::SendKeystroke", "ctrl-q"]`. The Linux keymap was simply missing that override.

Closes #58809

Manual test after fix below :

[Screencast from 2026-06-09 00-46-37.webm](https://github.com/user-attachments/assets/3d103b2a-bff1-4559-af1d-2a52d57a6b18)


## How to Review

- **`assets/keymaps/default-linux.json`** : One-line addition in the `Terminal` context under the "Overrides for conflicting keybindings" comment, mirroring the existing Windows entry.
- **`crates/terminal_view/src/terminal_view.rs`** : Regression test `ctrl_q_is_forwarded_to_terminal_not_quit` (Linux-only, `#[cfg(target_os = "linux")]`): loads the default keymap, focuses a display-only terminal, simulates `ctrl-q`, and asserts the PTY receives byte `0x11` instead of the quit action firing.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed `ctrl-q` quitting Zed instead of being forwarded to the shell when a terminal is focused on Linux

