### PR TITLE
recent_projects: Close remote projects window on button press

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -1622,6 +1622,7 @@ impl RemoteServerProjects {
                                         .on_click(cx.listener({
                                             let connection = connection.clone();
                                             move |this, _, window, cx| {
+                                                cx.emit(DismissEvent);
                                                 this.create_remote_project(
                                                     index,
                                                     connection.clone().into(),


### PR DESCRIPTION
When clicking the "Open Folder" button in a remote project window, the "Remote Projects" window was not being dismissed. Now we're emitting a DismissEvent so we can close it.

Release Notes:

- Fixed the Remote Projects modal not being dismissed on "Open Folder" click. 
