### PR TITLE
Enable handoff feature flag by default for staff

### DIFF
--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -40,10 +40,6 @@ pub struct HandoffFeatureFlag;
 impl FeatureFlag for HandoffFeatureFlag {
     const NAME: &'static str = "handoff";
     type Value = PresenceFlag;
-
-    fn enabled_for_staff() -> bool {
-        false
-    }
 }
 register_feature_flag!(HandoffFeatureFlag);
 


### PR DESCRIPTION
Enables the "handoff" feature flag by default for Zed staff by removing the `enabled_for_staff()` override on `HandoffFeatureFlag`, which falls back to the trait default of `true`.

Closes AI-381

Release Notes:

- N/A