### PR TITLE
Support explicit oauth endpoints 

### DIFF
--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -307,17 +307,46 @@ fn context_server_http_input(
         |oauth| {
             let mut lines = vec![
                 String::from("\n    \"oauth\": {"),
-
                 format!("      \"client_id\": {},", serde_json::to_string(&oauth.client_id).unwrap()),
             ];
-            if let Some(client_secret) = oauth.client_secret {
+            if let Some(client_secret) = &oauth.client_secret {
                 lines.push(format!(
-                    "      \"client_secret\": {}",
-                    serde_json::to_string(&client_secret).unwrap()
+                    "      \"client_secret\": {},",
+                    serde_json::to_string(client_secret).unwrap()
                 ));
             } else {
                 lines.push(String::from(
-                    "      /// Optional client secret for confidential clients\n      // \"client_secret\": \"your-client-secret\"",
+                    "      /// Optional client secret for confidential clients\n      // \"client_secret\": \"your-client-secret\",",
+                ));
+            }
+            if let Some(authorize_url) = &oauth.authorize_url {
+                lines.push(format!(
+                    "      \"authorize_url\": {},",
+                    serde_json::to_string(authorize_url).unwrap()
+                ));
+            } else {
+                lines.push(String::from(
+                    "      /// Explicit OAuth authorization endpoint (skips .well-known discovery)\n      // \"authorize_url\": \"https://accounts.google.com/o/oauth2/v2/auth\",",
+                ));
+            }
+            if let Some(token_url) = &oauth.token_url {
+                lines.push(format!(
+                    "      \"token_url\": {},",
+                    serde_json::to_string(token_url).unwrap()
+                ));
+            } else {
+                lines.push(String::from(
+                    "      /// Explicit OAuth token endpoint\n      // \"token_url\": \"https://oauth2.googleapis.com/token\",",
+                ));
+            }
+            if let Some(scope) = &oauth.scope {
+                lines.push(format!(
+                    "      \"scope\": {}",
+                    serde_json::to_string(scope).unwrap()
+                ));
+            } else {
+                lines.push(String::from(
+                    "      /// OAuth scope(s) to request (space-separated)\n      // \"scope\": \"https://www.googleapis.com/auth/cloud-platform\"",
                 ));
             }
             lines.push(String::from("    },"));
@@ -1405,6 +1434,9 @@ mod tests {
             Some(OAuthClientSettings {
                 client_id: String::from("client-id"),
                 client_secret: Some(String::from("client-secret")),
+                authorize_url: None,
+                token_url: None,
+                scope: None,
             }),
         )));
 
@@ -1412,5 +1444,42 @@ mod tests {
         let oauth = oauth.expect("oauth should be present");
         assert_eq!(oauth.client_id, "client-id");
         assert_eq!(oauth.client_secret.as_deref(), Some("client-secret"));
+    }
+
+    #[test]
+    fn context_server_http_input_preserves_explicit_oauth_urls() {
+        let text = context_server_http_input(Some((
+            ContextServerId("gke-mcp".into()),
+            String::from("https://container.googleapis.com/mcp"),
+            HashMap::default(),
+            Some(OAuthClientSettings {
+                client_id: String::from("my-client-id.apps.googleusercontent.com"),
+                client_secret: None,
+                authorize_url: Some(String::from("https://accounts.google.com/o/oauth2/v2/auth")),
+                token_url: Some(String::from("https://oauth2.googleapis.com/token")),
+                scope: Some(String::from(
+                    "https://www.googleapis.com/auth/cloud-platform",
+                )),
+            }),
+        )));
+
+        let (id, url, _, oauth) = parse_http_input(&text).unwrap();
+        assert_eq!(id, ContextServerId("gke-mcp".into()));
+        assert_eq!(url, "https://container.googleapis.com/mcp");
+        let oauth = oauth.expect("oauth should be present");
+        assert_eq!(oauth.client_id, "my-client-id.apps.googleusercontent.com");
+        assert_eq!(oauth.client_secret, None);
+        assert_eq!(
+            oauth.authorize_url.as_deref(),
+            Some("https://accounts.google.com/o/oauth2/v2/auth")
+        );
+        assert_eq!(
+            oauth.token_url.as_deref(),
+            Some("https://oauth2.googleapis.com/token")
+        );
+        assert_eq!(
+            oauth.scope.as_deref(),
+            Some("https://www.googleapis.com/auth/cloud-platform")
+        );
     }
 }

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -662,6 +662,12 @@ impl ContextServerStore {
         cx: &mut Context<Self>,
     ) {
         let id = server.id();
+
+        let was_authenticating = matches!(
+            self.servers.get(&id),
+            Some(ContextServerState::Authenticating { .. })
+        );
+
         if matches!(
             self.servers.get(&id),
             Some(
@@ -672,21 +678,85 @@ impl ContextServerStore {
         ) {
             self.stop_server(&id, cx).log_err();
         }
+
         let task = cx.spawn({
             let id = server.id();
             let server = server.clone();
             let configuration = configuration.clone();
 
             async move |this, cx| {
-                let new_state = match server.clone().start(cx).await {
-                    Ok(_) => {
-                        debug_assert!(server.client().is_some());
-                        ContextServerState::Running {
-                            server,
-                            configuration,
+                // For servers with explicit OAuth endpoints (e.g. Google Cloud MCP)
+                // that accept `initialize` unauthenticated but reject tool calls,
+                // go directly to AuthRequired if no cached session exists.
+                let preemptive_discovery = if !was_authenticating {
+                    if let ContextServerConfiguration::Http {
+                        url,
+                        oauth: Some(oauth_settings),
+                        ..
+                    } = configuration.as_ref()
+                    {
+                        if oauth_settings.authorize_url.is_some()
+                            && oauth_settings.token_url.is_some()
+                            && !configuration.has_static_auth_header()
+                        {
+                            let credentials_provider =
+                                cx.update(|cx| zed_credentials_provider::global(cx));
+                            let has_cached_session =
+                                ContextServerStore::load_session(&credentials_provider, url, cx)
+                                    .await
+                                    .ok()
+                                    .flatten()
+                                    .is_some();
+                            if !has_cached_session {
+                                Some(build_explicit_discovery(oauth_settings, url))
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                let new_state = if let Some(discovery_result) = preemptive_discovery {
+                    match discovery_result {
+                        Ok(discovery) => {
+                            log::info!(
+                                "{id} requires OAuth authorization (auth server: {})",
+                                discovery.auth_server_metadata.issuer,
+                            );
+                            ContextServerState::AuthRequired {
+                                server,
+                                configuration,
+                                discovery: Arc::new(discovery),
+                            }
+                        }
+                        Err(error) => {
+                            log::error!("{id} {error}");
+                            ContextServerState::Error {
+                                configuration,
+                                server,
+                                error: error.into(),
+                            }
                         }
                     }
-                    Err(err) => resolve_start_failure(&id, err, server, configuration, cx).await,
+                } else {
+                    match server.clone().start(cx).await {
+                        Ok(_) => {
+                            debug_assert!(server.client().is_some());
+                            ContextServerState::Running {
+                                server,
+                                configuration,
+                            }
+                        }
+                        Err(err) => {
+                            resolve_start_failure(&id, err, server, configuration, cx).await
+                        }
+                    }
                 };
                 this.update(cx, |this, cx| {
                     this.update_server_state(id.clone(), new_state, cx)
@@ -1648,6 +1718,64 @@ impl ContextServerStore {
     }
 }
 
+/// Constructs an `OAuthDiscovery` from explicitly-configured OAuth endpoints,
+/// for servers that don't support `.well-known` metadata discovery.
+fn build_explicit_discovery(
+    oauth_settings: &OAuthClientSettings,
+    server_url: &url::Url,
+) -> Result<OAuthDiscovery, String> {
+    let authorize_url_str = oauth_settings
+        .authorize_url
+        .as_deref()
+        .ok_or("authorize_url is required for explicit OAuth discovery")?;
+    let token_url_str = oauth_settings
+        .token_url
+        .as_deref()
+        .ok_or("token_url is required for explicit OAuth discovery")?;
+
+    let authorize_url =
+        url::Url::parse(authorize_url_str).map_err(|e| format!("Invalid authorize_url: {e}"))?;
+    let token_url =
+        url::Url::parse(token_url_str).map_err(|e| format!("Invalid token_url: {e}"))?;
+
+    let scopes = oauth_settings
+        .scope
+        .as_deref()
+        .map(|s| s.split_whitespace().map(String::from).collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    // Derive the issuer from the authorization endpoint's origin.
+    let issuer_str = authorize_url.origin().ascii_serialization();
+    let issuer =
+        url::Url::parse(&issuer_str).map_err(|e| format!("Failed to derive issuer URL: {e}"))?;
+
+    Ok(OAuthDiscovery {
+        resource_metadata: oauth::ProtectedResourceMetadata {
+            resource: server_url.clone(),
+            authorization_servers: vec![server_url.clone()],
+            scopes_supported: if scopes.is_empty() {
+                None
+            } else {
+                Some(scopes.clone())
+            },
+        },
+        auth_server_metadata: oauth::AuthServerMetadata {
+            issuer,
+            authorization_endpoint: authorize_url,
+            token_endpoint: token_url,
+            registration_endpoint: None,
+            scopes_supported: None,
+            grant_types_supported: Some(vec![
+                "authorization_code".to_string(),
+                "refresh_token".to_string(),
+            ]),
+            code_challenge_methods_supported: Some(vec!["S256".to_string()]),
+            client_id_metadata_document_supported: false,
+        },
+        scopes,
+    })
+}
+
 /// Determines the appropriate server state after a start attempt fails.
 ///
 /// When the error is an HTTP 401 with no static auth header configured,
@@ -1726,7 +1854,39 @@ async fn resolve_start_failure(
         .unwrap_or(&default_www_authenticate);
     let http_client = cx.update(|cx| cx.http_client());
 
-    match context_server::oauth::discover(&http_client, &server_url, www_authenticate).await {
+    // Check if explicit OAuth endpoints are configured (for servers that don't
+    // support .well-known discovery, e.g. Google Cloud).
+    let explicit_discovery = if let ContextServerConfiguration::Http {
+        oauth: Some(oauth_settings),
+        ..
+    } = configuration.as_ref()
+    {
+        if oauth_settings.authorize_url.is_some() && oauth_settings.token_url.is_some() {
+            match build_explicit_discovery(oauth_settings, &server_url) {
+                Ok(discovery) => Some(discovery),
+                Err(error) => {
+                    log::error!("{id} {error}");
+                    return ContextServerState::Error {
+                        configuration,
+                        server,
+                        error: error.into(),
+                    };
+                }
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let discovery_result = if let Some(discovery) = explicit_discovery {
+        Ok(discovery)
+    } else {
+        context_server::oauth::discover(&http_client, &server_url, www_authenticate).await
+    };
+
+    match discovery_result {
         Ok(discovery) => {
             use context_server::oauth::{
                 ClientRegistrationStrategy, determine_registration_strategy,
@@ -1774,5 +1934,211 @@ async fn resolve_start_failure(
                 error: format!("OAuth discovery failed: {discovery_err}").into(),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project_settings::OAuthClientSettings;
+
+    #[test]
+    fn test_build_explicit_discovery_success() {
+        let oauth_settings = OAuthClientSettings {
+            client_id: "my-client-id".to_string(),
+            client_secret: None,
+            authorize_url: Some("https://accounts.google.com/o/oauth2/v2/auth".to_string()),
+            token_url: Some("https://oauth2.googleapis.com/token".to_string()),
+            scope: Some("https://www.googleapis.com/auth/cloud-platform".to_string()),
+        };
+        let server_url = url::Url::parse("https://container.googleapis.com/mcp").unwrap();
+
+        let discovery = build_explicit_discovery(&oauth_settings, &server_url).unwrap();
+
+        assert_eq!(
+            discovery.auth_server_metadata.issuer.as_str(),
+            "https://accounts.google.com/"
+        );
+        assert_eq!(
+            discovery
+                .auth_server_metadata
+                .authorization_endpoint
+                .as_str(),
+            "https://accounts.google.com/o/oauth2/v2/auth"
+        );
+        assert_eq!(
+            discovery.auth_server_metadata.token_endpoint.as_str(),
+            "https://oauth2.googleapis.com/token"
+        );
+        assert_eq!(
+            discovery.resource_metadata.resource.as_str(),
+            "https://container.googleapis.com/mcp"
+        );
+        assert_eq!(
+            discovery.scopes,
+            vec!["https://www.googleapis.com/auth/cloud-platform"]
+        );
+    }
+
+    #[test]
+    fn test_build_explicit_discovery_multiple_scopes() {
+        let oauth_settings = OAuthClientSettings {
+            client_id: "id".to_string(),
+            client_secret: None,
+            authorize_url: Some("https://auth.example.com/authorize".to_string()),
+            token_url: Some("https://auth.example.com/token".to_string()),
+            scope: Some("read write admin".to_string()),
+        };
+        let server_url = url::Url::parse("https://mcp.example.com").unwrap();
+
+        let discovery = build_explicit_discovery(&oauth_settings, &server_url).unwrap();
+
+        assert_eq!(discovery.scopes, vec!["read", "write", "admin"]);
+        assert_eq!(
+            discovery.resource_metadata.scopes_supported,
+            Some(vec![
+                "read".to_string(),
+                "write".to_string(),
+                "admin".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn test_build_explicit_discovery_no_scope() {
+        let oauth_settings = OAuthClientSettings {
+            client_id: "id".to_string(),
+            client_secret: None,
+            authorize_url: Some("https://auth.example.com/authorize".to_string()),
+            token_url: Some("https://auth.example.com/token".to_string()),
+            scope: None,
+        };
+        let server_url = url::Url::parse("https://mcp.example.com").unwrap();
+
+        let discovery = build_explicit_discovery(&oauth_settings, &server_url).unwrap();
+
+        assert!(discovery.scopes.is_empty());
+        assert_eq!(discovery.resource_metadata.scopes_supported, None);
+    }
+
+    #[test]
+    fn test_build_explicit_discovery_invalid_authorize_url() {
+        let oauth_settings = OAuthClientSettings {
+            client_id: "id".to_string(),
+            client_secret: None,
+            authorize_url: Some("not a url".to_string()),
+            token_url: Some("https://auth.example.com/token".to_string()),
+            scope: None,
+        };
+        let server_url = url::Url::parse("https://mcp.example.com").unwrap();
+
+        let result = build_explicit_discovery(&oauth_settings, &server_url);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid authorize_url"));
+    }
+
+    #[test]
+    fn test_build_explicit_discovery_invalid_token_url() {
+        let oauth_settings = OAuthClientSettings {
+            client_id: "id".to_string(),
+            client_secret: None,
+            authorize_url: Some("https://auth.example.com/authorize".to_string()),
+            token_url: Some("not a url".to_string()),
+            scope: None,
+        };
+        let server_url = url::Url::parse("https://mcp.example.com").unwrap();
+
+        let result = build_explicit_discovery(&oauth_settings, &server_url);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid token_url"));
+    }
+
+    #[test]
+    fn test_build_explicit_discovery_missing_authorize_url() {
+        let oauth_settings = OAuthClientSettings {
+            client_id: "id".to_string(),
+            client_secret: None,
+            authorize_url: None,
+            token_url: Some("https://auth.example.com/token".to_string()),
+            scope: None,
+        };
+        let server_url = url::Url::parse("https://mcp.example.com").unwrap();
+
+        let result = build_explicit_discovery(&oauth_settings, &server_url);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("authorize_url is required"));
+    }
+
+    #[test]
+    fn test_build_explicit_discovery_missing_token_url() {
+        let oauth_settings = OAuthClientSettings {
+            client_id: "id".to_string(),
+            client_secret: None,
+            authorize_url: Some("https://auth.example.com/authorize".to_string()),
+            token_url: None,
+            scope: None,
+        };
+        let server_url = url::Url::parse("https://mcp.example.com").unwrap();
+
+        let result = build_explicit_discovery(&oauth_settings, &server_url);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("token_url is required"));
+    }
+
+    #[test]
+    fn test_build_explicit_discovery_issuer_derived_from_authorize_url_origin() {
+        let oauth_settings = OAuthClientSettings {
+            client_id: "id".to_string(),
+            client_secret: None,
+            authorize_url: Some(
+                "https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize".to_string(),
+            ),
+            token_url: Some(
+                "https://login.microsoftonline.com/tenant/oauth2/v2.0/token".to_string(),
+            ),
+            scope: None,
+        };
+        let server_url = url::Url::parse("https://mcp.azure.com").unwrap();
+
+        let discovery = build_explicit_discovery(&oauth_settings, &server_url).unwrap();
+
+        assert_eq!(
+            discovery.auth_server_metadata.issuer.as_str(),
+            "https://login.microsoftonline.com/"
+        );
+    }
+
+    #[test]
+    fn test_build_explicit_discovery_metadata_fields() {
+        let oauth_settings = OAuthClientSettings {
+            client_id: "id".to_string(),
+            client_secret: None,
+            authorize_url: Some("https://auth.example.com/authorize".to_string()),
+            token_url: Some("https://auth.example.com/token".to_string()),
+            scope: None,
+        };
+        let server_url = url::Url::parse("https://mcp.example.com").unwrap();
+
+        let discovery = build_explicit_discovery(&oauth_settings, &server_url).unwrap();
+
+        assert_eq!(discovery.auth_server_metadata.registration_endpoint, None);
+        assert_eq!(
+            discovery.auth_server_metadata.grant_types_supported,
+            Some(vec![
+                "authorization_code".to_string(),
+                "refresh_token".to_string()
+            ])
+        );
+        assert_eq!(
+            discovery
+                .auth_server_metadata
+                .code_challenge_methods_supported,
+            Some(vec!["S256".to_string()])
+        );
+        assert!(
+            !discovery
+                .auth_server_metadata
+                .client_id_metadata_document_supported
+        );
     }
 }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -256,6 +256,9 @@ impl From<settings::ContextServerSettingsContent> for ContextServerSettings {
                 oauth: oauth.map(|o| OAuthClientSettings {
                     client_id: o.client_id,
                     client_secret: o.client_secret,
+                    authorize_url: o.authorize_url,
+                    token_url: o.token_url,
+                    scope: o.scope,
                 }),
             },
         }
@@ -296,6 +299,9 @@ impl Into<settings::ContextServerSettingsContent> for ContextServerSettings {
                 oauth: oauth.map(|o| settings::OAuthClientSettings {
                     client_id: o.client_id,
                     client_secret: o.client_secret,
+                    authorize_url: o.authorize_url,
+                    token_url: o.token_url,
+                    scope: o.scope,
                 }),
             },
         }
@@ -314,6 +320,17 @@ pub struct OAuthClientSettings {
     /// the system keychain.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_secret: Option<String>,
+    /// Explicit OAuth authorization endpoint URL. When provided along with
+    /// `token_url`, skips `.well-known` discovery. Required for servers like
+    /// Google Cloud that don't implement MCP OAuth discovery.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorize_url: Option<String>,
+    /// Explicit OAuth token endpoint URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_url: Option<String>,
+    /// OAuth scope to request. Space-separated if multiple scopes needed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
 }
 
 impl ContextServerSettings {

--- a/crates/project/tests/integration/context_server_store.rs
+++ b/crates/project/tests/integration/context_server_store.rs
@@ -15,7 +15,7 @@ use serde_json::json;
 use settings::settings_content::SaturatingBool;
 use settings::{ContextServerCommand, Settings, SettingsStore};
 use std::sync::Arc;
-use std::{cell::RefCell, path::PathBuf, rc::Rc};
+use std::{cell::RefCell, collections::HashMap, path::PathBuf, rc::Rc};
 use util::path;
 
 #[gpui::test]
@@ -1071,6 +1071,193 @@ async fn test_context_server_stdio_timeout(cx: &mut TestAppContext) {
         result.is_ok(),
         "Stdio server should be created successfully with timeout"
     );
+}
+
+#[gpui::test]
+async fn test_explicit_oauth_triggers_auth_required_when_no_cached_session(
+    cx: &mut TestAppContext,
+) {
+    const SERVER_ID: &str = "gke-mcp";
+    let server_id = ContextServerId(SERVER_ID.into());
+
+    // The FakeHttpClient won't be hit for the preemptive auth path since
+    // explicit URLs bypass discovery. Provide a 200 response for the case
+    // where the server would actually try to start (it shouldn't).
+    let client = FakeHttpClient::create(|_| async move {
+        use http_client::AsyncBody;
+        Ok(Response::builder()
+            .status(200)
+            .body(AsyncBody::from("{}"))
+            .unwrap())
+    });
+    cx.update(|cx| cx.set_http_client(client));
+
+    let (_fs, project) = setup_context_server_test(cx, json!({"code.rs": ""}), vec![]).await;
+    let store = project.read_with(cx, |project, _| project.context_server_store());
+
+    set_context_server_configuration(
+        vec![(
+            server_id.0.clone(),
+            settings::ContextServerSettingsContent::Http {
+                enabled: true,
+                url: "https://container.googleapis.com/mcp".to_string(),
+                headers: Default::default(),
+                timeout: None,
+                oauth: Some(settings::OAuthClientSettings {
+                    client_id: "test-client-id.apps.googleusercontent.com".to_string(),
+                    client_secret: None,
+                    authorize_url: Some("https://accounts.google.com/o/oauth2/v2/auth".to_string()),
+                    token_url: Some("https://oauth2.googleapis.com/token".to_string()),
+                    scope: Some("https://www.googleapis.com/auth/cloud-platform".to_string()),
+                }),
+            },
+        )],
+        cx,
+    );
+
+    let _server_events = assert_server_events(
+        &store,
+        vec![
+            (server_id.clone(), ContextServerStatus::Starting),
+            (server_id.clone(), ContextServerStatus::AuthRequired),
+        ],
+        cx,
+    );
+    cx.run_until_parked();
+}
+
+#[gpui::test]
+async fn test_http_server_without_explicit_oauth_starts_normally(cx: &mut TestAppContext) {
+    const SERVER_ID: &str = "normal-http";
+    let server_id = ContextServerId(SERVER_ID.into());
+
+    let client = FakeHttpClient::create(|_| async move {
+        use http_client::AsyncBody;
+        Ok(Response::builder()
+            .status(200)
+            .header("Content-Type", "application/json")
+            .body(AsyncBody::from(
+                serde_json::to_string(&json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "serverInfo": {
+                            "name": "test-server",
+                            "version": "1.0.0"
+                        }
+                    }
+                }))
+                .unwrap(),
+            ))
+            .unwrap())
+    });
+    cx.update(|cx| cx.set_http_client(client));
+
+    let (_fs, project) = setup_context_server_test(cx, json!({"code.rs": ""}), vec![]).await;
+    let store = project.read_with(cx, |project, _| project.context_server_store());
+
+    set_context_server_configuration(
+        vec![(
+            server_id.0.clone(),
+            settings::ContextServerSettingsContent::Http {
+                enabled: true,
+                url: "https://mcp.example.com/api".to_string(),
+                headers: Default::default(),
+                timeout: None,
+                oauth: Some(settings::OAuthClientSettings {
+                    client_id: "test-client-id".to_string(),
+                    client_secret: None,
+                    authorize_url: None,
+                    token_url: None,
+                    scope: None,
+                }),
+            },
+        )],
+        cx,
+    );
+
+    let _server_events = assert_server_events(
+        &store,
+        vec![
+            (server_id.clone(), ContextServerStatus::Starting),
+            (server_id.clone(), ContextServerStatus::Running),
+        ],
+        cx,
+    );
+    cx.run_until_parked();
+}
+
+#[gpui::test]
+async fn test_explicit_oauth_with_static_auth_header_starts_normally(cx: &mut TestAppContext) {
+    const SERVER_ID: &str = "static-auth-http";
+    let server_id = ContextServerId(SERVER_ID.into());
+
+    let client = FakeHttpClient::create(|_| async move {
+        use http_client::AsyncBody;
+        Ok(Response::builder()
+            .status(200)
+            .header("Content-Type", "application/json")
+            .body(AsyncBody::from(
+                serde_json::to_string(&json!({
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "serverInfo": {
+                            "name": "test-server",
+                            "version": "1.0.0"
+                        }
+                    }
+                }))
+                .unwrap(),
+            ))
+            .unwrap())
+    });
+    cx.update(|cx| cx.set_http_client(client));
+
+    let (_fs, project) = setup_context_server_test(cx, json!({"code.rs": ""}), vec![]).await;
+    let store = project.read_with(cx, |project, _| project.context_server_store());
+
+    // Even with explicit OAuth URLs, if a static Authorization header is
+    // present, the preemptive auth should be skipped.
+    let mut headers = HashMap::default();
+    headers.insert(
+        "Authorization".to_string(),
+        "Bearer static-token".to_string(),
+    );
+
+    set_context_server_configuration(
+        vec![(
+            server_id.0.clone(),
+            settings::ContextServerSettingsContent::Http {
+                enabled: true,
+                url: "https://mcp.example.com/api".to_string(),
+                headers,
+                timeout: None,
+                oauth: Some(settings::OAuthClientSettings {
+                    client_id: "test-client-id".to_string(),
+                    client_secret: None,
+                    authorize_url: Some("https://auth.example.com/authorize".to_string()),
+                    token_url: Some("https://auth.example.com/token".to_string()),
+                    scope: None,
+                }),
+            },
+        )],
+        cx,
+    );
+
+    let _server_events = assert_server_events(
+        &store,
+        vec![
+            (server_id.clone(), ContextServerStatus::Starting),
+            (server_id.clone(), ContextServerStatus::Running),
+        ],
+        cx,
+    );
+    cx.run_until_parked();
 }
 
 fn assert_server_events(

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -474,6 +474,17 @@ pub struct OAuthClientSettings {
     /// the system keychain.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_secret: Option<String>,
+    /// Explicit OAuth authorization endpoint URL. When provided along with
+    /// `token_url`, skips `.well-known` discovery. Required for servers like
+    /// Google Cloud that don't implement MCP OAuth discovery.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorize_url: Option<String>,
+    /// Explicit OAuth token endpoint URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_url: Option<String>,
+    /// OAuth scope to request. Space-separated if multiple scopes needed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes:

I think there are a few related discussions, although it's not immediately clear. Eg:

- https://github.com/zed-industries/zed/discussions/53245
- https://github.com/zed-industries/zed/discussions/33837
- https://github.com/zed-industries/zed/discussions/34719
- https://github.com/zed-industries/zed/discussions/53780


Release Notes:

- Added support for explicit `authorize_url`, `token_url`, and `scope` in MCP context server OAuth configuration, enabling authentication with servers that don't implement `.well-known` OAuth discovery (e.g. Google Cloud MCP endpoints).



Detail:

Support explicit OAuth endpoints for MCP context servers

Some MCP servers (e.g. Google Cloud's GKE MCP at `https://container.googleapis.com/mcp`) require OAuth authentication but don't implement the `.well-known/oauth-authorization-server` metadata discovery that Zed's MCP OAuth flow relies on. These servers accept `initialize` without authentication but reject all tool calls with 401, leaving users stuck with no way to authenticate outside of manually supplying a bearer token header in the MCP config json.

Solution

Add optional `authorize_url`, `token_url`, and `scope` fields to the existing `oauth` configuration block for HTTP context servers. When these are provided, Zed constructs the OAuth discovery metadata directly instead of fetching `.well-known` endpoints.

Example configuration:

```json
{
  "context_servers": {
    "gke-mcp": {
      "type": "http",
      "url": "https://container.googleapis.com/mcp",
      "oauth": {
        "client_id": "YOUR_CLIENT_ID",
        "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
        "token_url": "https://oauth2.googleapis.com/token",
        "scope": "https://www.googleapis.com/auth/cloud-platform"
      }
    }
  }
}
```

Behavior

- When explicit OAuth URLs are configured and no cached keychain session exists, Zed immediately presents the "Authenticate" button instead of silently starting a server that will fail on every tool call.
- When a cached session exists in the keychain (from a previous successful auth), the server starts normally without re-prompting.
- After OAuth completes, the token is persisted in the keychain and the server restarts with the token provider.
- Existing servers without explicit endpoints continue to use `.well-known` discovery unchanged.

Implementation notes

- Extracted `build_explicit_discovery()` as a pure function for constructing `OAuthDiscovery` from explicit settings. Used by both the preemptive-auth path in `run_server` and the fallback path in `resolve_start_failure`.
- The issuer is derived from the authorization endpoint's origin (e.g. `https://accounts.google.com/o/oauth2/v2/auth` → `https://accounts.google.com/`).
- The preemptive auth check runs inside the async task and queries the keychain first, avoiding unnecessary re-authentication on Zed restart.

