### PR TITLE
Make `zed://` links clickable in terminal

### DIFF
--- a/crates/terminal/src/alacritty/hyperlinks.rs
+++ b/crates/terminal/src/alacritty/hyperlinks.rs
@@ -19,7 +19,7 @@ use util::paths::{PathStyle, UrlExt};
 
 use crate::Range;
 
-const URL_REGEX: &str = r#"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file://|git://|ssh:|ftp://)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩`']+"#;
+const URL_REGEX: &str = r#"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file://|git://|ssh:|ftp://|zed://)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩`']+"#;
 const WIDE_CHAR_SPACERS: Flags =
     Flags::from_bits(Flags::LEADING_WIDE_CHAR_SPACER.bits() | Flags::WIDE_CHAR_SPACER.bits())
         .unwrap();

--- a/crates/terminal/src/alacritty/hyperlinks.rs
+++ b/crates/terminal/src/alacritty/hyperlinks.rs
@@ -518,6 +518,11 @@ mod tests {
                 "mailto:bob@example.com",
             ],
         );
+        re_test(
+            URL_REGEX,
+            "open zed://channel/the-channel and zed://settings/theme now",
+            vec!["zed://channel/the-channel", "zed://settings/theme"],
+        );
     }
 
     #[test]


### PR DESCRIPTION
The PR makes Zed'd own `zed://` links clickable in the Zed's integrated terminal. Previously, you had to copy and paste such links. Now you can hover and follow the link on cmd+click:

<img width="794" height="354" alt="Screenshot 2026-06-09 at 15 25 18" src="https://github.com/user-attachments/assets/0c9be498-ba63-4a10-8852-cf2e23fa9597" />

</br></br>

**Use case**

A CLI tool can output a `zed://` link, e.g. to open a remote dev environment. If Zed's terminal makes them clickable, users can open the remote simply by clicking on the link. 

More specifically, [we're adding Zed support to dstack](https://github.com/dstackai/dstack/pull/3947). The `dstack` CLI allows users to launch a remote dev environment with GPU. So this PR is needed to make the UX smooth: Users run the `dstack` CLI in the local terminal, the CLI prints the the `zed://` link, and the users can click the link and open a new remote Zed window.

**Implementation details**

`zed://` links are routed through the OS as other links and not internally. One downside is that dev builds may open an installed Zed version. Made this tradeoff to keep the diff simple.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Made `zed://` links clickable in the terminal
