### PR TITLE
git_ui: Allow opening new worktree in separate window as secondary action

### DIFF
--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -902,16 +902,29 @@ impl PickerDelegate for WorktreePickerDelegate {
                 }
                 if let Some(workspace) = self.workspace.upgrade() {
                     workspace.update(cx, |workspace, cx| {
-                        crate::worktree_service::handle_create_worktree(
-                            workspace,
-                            &CreateWorktree {
-                                worktree_name: None,
-                                branch_target: NewWorktreeBranchTarget::CurrentBranch,
-                            },
-                            window,
-                            self.focused_dock,
-                            cx,
-                        );
+                        if secondary {
+                            crate::worktree_service::handle_create_worktree_in_new_window(
+                                workspace,
+                                &CreateWorktree {
+                                    worktree_name: None,
+                                    branch_target: NewWorktreeBranchTarget::CurrentBranch,
+                                },
+                                window,
+                                self.focused_dock,
+                                cx,
+                            );
+                        } else {
+                            crate::worktree_service::handle_create_worktree(
+                                workspace,
+                                &CreateWorktree {
+                                    worktree_name: None,
+                                    branch_target: NewWorktreeBranchTarget::CurrentBranch,
+                                },
+                                window,
+                                self.focused_dock,
+                                cx,
+                            );
+                        }
                     });
                 }
             }
@@ -921,19 +934,35 @@ impl PickerDelegate for WorktreePickerDelegate {
                 }
                 if let Some(workspace) = self.workspace.upgrade() {
                     workspace.update(cx, |workspace, cx| {
-                        crate::worktree_service::handle_create_worktree(
-                            workspace,
-                            &CreateWorktree {
-                                worktree_name: None,
-                                branch_target: NewWorktreeBranchTarget::RemoteBranch {
-                                    remote_name: default_branch.remote_name.clone(),
-                                    branch_name: default_branch.branch_name.clone(),
+                        if secondary {
+                            crate::worktree_service::handle_create_worktree_in_new_window(
+                                workspace,
+                                &CreateWorktree {
+                                    worktree_name: None,
+                                    branch_target: NewWorktreeBranchTarget::RemoteBranch {
+                                        remote_name: default_branch.remote_name.clone(),
+                                        branch_name: default_branch.branch_name.clone(),
+                                    },
                                 },
-                            },
-                            window,
-                            self.focused_dock,
-                            cx,
-                        );
+                                window,
+                                self.focused_dock,
+                                cx,
+                            );
+                        } else {
+                            crate::worktree_service::handle_create_worktree(
+                                workspace,
+                                &CreateWorktree {
+                                    worktree_name: None,
+                                    branch_target: NewWorktreeBranchTarget::RemoteBranch {
+                                        remote_name: default_branch.remote_name.clone(),
+                                        branch_name: default_branch.branch_name.clone(),
+                                    },
+                                },
+                                window,
+                                self.focused_dock,
+                                cx,
+                            );
+                        }
                     });
                 }
             }
@@ -989,16 +1018,29 @@ impl PickerDelegate for WorktreePickerDelegate {
                 };
                 if let Some(workspace) = self.workspace.upgrade() {
                     workspace.update(cx, |workspace, cx| {
-                        crate::worktree_service::handle_create_worktree(
-                            workspace,
-                            &CreateWorktree {
-                                worktree_name: Some(name.clone()),
-                                branch_target,
-                            },
-                            window,
-                            self.focused_dock,
-                            cx,
-                        );
+                        if secondary {
+                            crate::worktree_service::handle_create_worktree_in_new_window(
+                                workspace,
+                                &CreateWorktree {
+                                    worktree_name: Some(name.clone()),
+                                    branch_target,
+                                },
+                                window,
+                                self.focused_dock,
+                                cx,
+                            );
+                        } else {
+                            crate::worktree_service::handle_create_worktree(
+                                workspace,
+                                &CreateWorktree {
+                                    worktree_name: Some(name.clone()),
+                                    branch_target,
+                                },
+                                window,
+                                self.focused_dock,
+                                cx,
+                            );
+                        }
                     });
                 }
             }
@@ -1540,7 +1582,7 @@ pub async fn open_remote_worktree(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fs::FakeFs;
+    use fs::{FakeFs, Fs};
     use gpui::{AppContext, TestAppContext, VisualTestContext};
     use project::project_settings::ProjectSettings;
     use project::{Project, WorktreeSettings};
@@ -1573,6 +1615,7 @@ mod tests {
         init_test(cx);
 
         let fs = FakeFs::new(cx.executor());
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
         fs.insert_tree(
             path!("/root"),
             json!({
@@ -1810,6 +1853,44 @@ mod tests {
                 );
             });
         });
+    }
+
+    #[gpui::test]
+    async fn test_secondary_create_opens_in_new_window(cx: &mut TestAppContext) {
+        let (_fs, worktree_picker, _repository, _worktree_path, mut cx) =
+            init_worktree_picker_test(cx).await;
+
+        let source_workspace = worktree_picker.update(&mut cx, |worktree_picker, cx| {
+            worktree_picker.picker.update(cx, |picker, _| {
+                picker
+                    .delegate
+                    .workspace
+                    .upgrade()
+                    .expect("workspace should exist")
+            })
+        });
+
+        worktree_picker.update_in(&mut cx, |worktree_picker, window, cx| {
+            worktree_picker.picker.update(cx, |picker, cx| {
+                picker.delegate.default_branch = None;
+                picker.refresh(window, cx);
+                picker.delegate.selected_index = 0;
+                picker.delegate.confirm(true, window, cx);
+            })
+        });
+        cx.run_until_parked();
+
+        let active_workspace = cx.update(|window, cx| {
+            window
+                .root::<MultiWorkspace>()
+                .expect("window should have a multi workspace root")
+                .expect("window root should be set")
+                .read(cx)
+                .workspace()
+                .clone()
+        });
+
+        assert_eq!(active_workspace, source_workspace);
     }
 
     #[gpui::test]

--- a/crates/git_ui/src/worktree_service.rs
+++ b/crates/git_ui/src/worktree_service.rs
@@ -188,6 +188,7 @@ impl Render for WorktreeFetchFailedToast {
                                 RemoteBranchFetchMode::UseLocal,
                                 // User-initiated retry of a foreground create.
                                 true,
+                                false,
                                 cx,
                             );
                             task.detach_and_log_err(cx);
@@ -593,6 +594,29 @@ pub fn handle_create_worktree(
     fallback_focused_dock: Option<DockPosition>,
     cx: &mut gpui::Context<Workspace>,
 ) {
+    handle_create_worktree_internal(workspace, action, window, fallback_focused_dock, false, cx)
+}
+
+/// Like [`handle_create_worktree`], but opens the new worktree in its own
+/// window instead of adding it to the current window.
+pub fn handle_create_worktree_in_new_window(
+    workspace: &mut Workspace,
+    action: &zed_actions::CreateWorktree,
+    window: &mut gpui::Window,
+    fallback_focused_dock: Option<DockPosition>,
+    cx: &mut gpui::Context<Workspace>,
+) {
+    handle_create_worktree_internal(workspace, action, window, fallback_focused_dock, true, cx)
+}
+
+fn handle_create_worktree_internal(
+    workspace: &mut Workspace,
+    action: &zed_actions::CreateWorktree,
+    window: &mut gpui::Window,
+    fallback_focused_dock: Option<DockPosition>,
+    open_in_new_window: bool,
+    cx: &mut gpui::Context<Workspace>,
+) {
     let task = create_worktree_workspace_inner(
         workspace,
         action,
@@ -601,6 +625,7 @@ pub fn handle_create_worktree(
         RemoteBranchFetchMode::Fetch,
         // The user explicitly asked to create a worktree, so foreground it.
         true,
+        open_in_new_window,
         cx,
     );
     task.detach_and_log_err(cx);
@@ -649,6 +674,7 @@ pub fn create_worktree_workspace(
         RemoteBranchFetchMode::Fetch,
         // Agent-created worktree workspaces open in the background.
         false,
+        false,
         cx,
     )
 }
@@ -660,6 +686,7 @@ fn create_worktree_workspace_inner(
     fallback_focused_dock: Option<DockPosition>,
     remote_branch_fetch_mode: RemoteBranchFetchMode,
     activate: bool,
+    open_in_new_window: bool,
     cx: &mut gpui::Context<Workspace>,
 ) -> Task<anyhow::Result<CreatedWorktreeWorkspace>> {
     let project = workspace.project().clone();
@@ -763,6 +790,7 @@ fn create_worktree_workspace_inner(
             window_handle,
             remote_connection_options,
             activate,
+            open_in_new_window,
             &mut cx,
         )
         .await;
@@ -877,6 +905,7 @@ async fn do_create_worktree(
     window_handle: Option<gpui::WindowHandle<MultiWorkspace>>,
     remote_connection_options: Option<RemoteConnectionOptions>,
     activate: bool,
+    open_in_new_window: bool,
     cx: &mut AsyncWindowContext,
 ) -> anyhow::Result<CreatedWorktreeWorkspace> {
     // List existing worktrees from all repos to detect name collisions
@@ -981,6 +1010,7 @@ async fn do_create_worktree(
         remote_connection_options,
         WorktreeOperation::Create,
         activate,
+        open_in_new_window,
         cx,
     )
     .await?;
@@ -1022,6 +1052,7 @@ async fn do_switch_worktree(
         WorktreeOperation::Switch,
         // Switching is always an explicit, foreground user action.
         true,
+        false,
         cx,
     )
     .await
@@ -1041,6 +1072,7 @@ async fn open_worktree_workspace(
     remote_connection_options: Option<RemoteConnectionOptions>,
     operation: WorktreeOperation,
     activate: bool,
+    open_in_new_window: bool,
     cx: &mut AsyncWindowContext,
 ) -> anyhow::Result<Entity<Workspace>> {
     let window_handle = window_handle
@@ -1055,7 +1087,9 @@ async fn open_worktree_workspace(
     // checkout rather than inheriting the source workspace's open files and
     // dock layout. The state transfer only applies when we're foregrounding
     // a freshly-created worktree for the user.
-    let transfer_state = is_creating_new_worktree && activate;
+    // When `open_in_new_window` is true, the new workspace goes into its own
+    // window so there's no source workspace state to transfer.
+    let transfer_state = is_creating_new_worktree && activate && !open_in_new_window;
 
     let source_for_transfer = if transfer_state {
         Some(workspace.clone())
@@ -1101,7 +1135,11 @@ async fn open_worktree_workspace(
                 },
                 &[],
                 init,
-                OpenMode::Add,
+                if open_in_new_window {
+                    OpenMode::NewWindow
+                } else {
+                    OpenMode::Add
+                },
                 source_for_transfer.clone(),
                 window,
                 cx,
@@ -1243,9 +1281,9 @@ async fn open_worktree_workspace(
         .ok();
 
     window_handle.update(cx, |multi_workspace, window, cx| {
-        if activate {
+        if activate && !open_in_new_window {
             multi_workspace.activate(new_workspace.clone(), source_for_transfer, window, cx);
-        } else {
+        } else if !open_in_new_window {
             // Background open: register the new workspace as a retained tab
             // but leave the user where they are.
             multi_workspace.add_background_workspace(new_workspace.clone(), window, cx);
@@ -1257,7 +1295,10 @@ async fn open_worktree_workspace(
                 // background — the worktree was created either way.
                 workspace.run_create_worktree_tasks(window, cx);
 
-                if activate && let Some(dock_position) = focused_dock {
+                if activate
+                    && !open_in_new_window
+                    && let Some(dock_position) = focused_dock
+                {
                     let dock = workspace.dock_at_position(dock_position);
                     if let Some(panel) = dock.read(cx).active_panel() {
                         panel.panel_focus_handle(cx).focus(window, cx);
@@ -1479,6 +1520,64 @@ mod tests {
                 .as_slice(),
             ["setup worktree"],
             "switching back to the main worktree should not rerun create_worktree hooks"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_create_worktree_in_new_window_does_not_switch_source_window(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "src": {
+                        "main.rs": "fn main() {}",
+                    },
+                },
+            }),
+        )
+        .await;
+
+        let main_project_root = PathBuf::from(path!("/root/project"));
+        let project = Project::test(fs.clone(), [main_project_root.as_path()], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        multi_workspace.update(cx, |multi_workspace, cx| {
+            multi_workspace.retain_active_workspace(cx);
+        });
+
+        let source_workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+        source_workspace.update_in(cx, |workspace, window, cx| {
+            handle_create_worktree_in_new_window(
+                workspace,
+                &zed_actions::CreateWorktree {
+                    worktree_name: Some("feature".to_string()),
+                    branch_target: NewWorktreeBranchTarget::CurrentBranch,
+                },
+                window,
+                None,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        let active_workspace =
+            multi_workspace.read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone());
+
+        assert_eq!(
+            active_workspace, source_workspace,
+            "creating a worktree in a new window should leave the source window active workspace unchanged"
         );
     }
 


### PR DESCRIPTION
Close #58918

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #58918

Release Notes:

- Added ability to open new worktree in separate window as secondary action
