### PR TITLE
Bound auto-compaction retries by incrementing attempt counter

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2437,6 +2437,12 @@ impl Thread {
                         let error_message = error.to_string();
                         match error.downcast::<LanguageModelCompletionError>() {
                             Ok(error) => {
+                                // Count this attempt before retrying, mirroring
+                                // the normal completion path below. The retry
+                                // logic relies on `attempt` starting at 1 to
+                                // bound the number of retries (and to avoid
+                                // underflow when computing the backoff delay).
+                                attempt += 1;
                                 match Self::retry_completion_error(
                                     this,
                                     event_stream,


### PR DESCRIPTION
The auto-compaction retry path in `run_turn_internal` passed the turn's `attempt` counter to the retry logic but never incremented it, unlike the normal completion path. Because the counter stayed at 0, a repeatedly-failing retryable compaction could retry without bound, and any strategy using exponential backoff would underflow when computing the delay (`2u64.pow((attempt - 1)...)` with `attempt == 0`). This increments `attempt` before retrying so compaction shares the same bounded, turn-wide retry budget as everything else.

Release Notes:

- N/A
