### PR TITLE
Reset threads to main when their git worktree is deleted

### DIFF
--- a/crates/agent_ui/src/terminal_thread_metadata_store.rs
+++ b/crates/agent_ui/src/terminal_thread_metadata_store.rs
@@ -301,6 +301,68 @@ impl TerminalThreadMetadataStore {
         cx.notify();
     }
 
+    /// For every terminal thread that has a `(main, folder)` worktree pair
+    /// where `main` equals `main_worktree_path`, `folder` differs from `main`
+    /// (i.e. it was a linked worktree), and `folder` is not in
+    /// `live_folder_paths`, rewrite each such pair to `(main, main)`, dedupe
+    /// pairs, re-index, and persist. Only terminals matching
+    /// `remote_connection` identity are affected. The terminal's
+    /// `working_directory` is intentionally left untouched; terminal restore
+    /// already tolerates missing directories.
+    ///
+    /// Used to repoint terminal threads at the main repo checkout when their
+    /// linked git worktree has been deleted. Returns the affected terminal ids.
+    pub fn reset_deleted_worktree_folder_paths<S: std::hash::BuildHasher>(
+        &mut self,
+        main_worktree_path: &Path,
+        live_folder_paths: &std::collections::HashSet<PathBuf, S>,
+        remote_connection: Option<&RemoteConnectionOptions>,
+        cx: &mut Context<Self>,
+    ) -> Vec<TerminalId> {
+        let mut deleted_folder_paths: HashSet<PathBuf> = HashSet::default();
+        let mut terminal_ids = Vec::new();
+        for terminal in self.terminals.values() {
+            if !same_remote_connection_identity(
+                terminal.remote_connection.as_ref(),
+                remote_connection,
+            ) {
+                continue;
+            }
+            let dead_folder_paths = terminal
+                .worktree_paths
+                .ordered_pairs()
+                .filter(|(main, folder)| {
+                    main.as_path() == main_worktree_path
+                        && folder != main
+                        && !live_folder_paths.contains(folder.as_path())
+                })
+                .map(|(_, folder)| folder.clone())
+                .collect::<Vec<_>>();
+            if !dead_folder_paths.is_empty() {
+                terminal_ids.push(terminal.terminal_id);
+                deleted_folder_paths.extend(dead_folder_paths);
+            }
+        }
+
+        if terminal_ids.is_empty() {
+            return terminal_ids;
+        }
+
+        for terminal_id in &terminal_ids {
+            if let Some(mut terminal) = self.terminals.get(terminal_id).cloned() {
+                for folder_path in &deleted_folder_paths {
+                    terminal
+                        .worktree_paths
+                        .reset_folder_path_to_main(folder_path);
+                }
+                self.save_internal(terminal);
+            }
+        }
+
+        cx.notify();
+        terminal_ids
+    }
+
     fn save_internal(&mut self, metadata: TerminalThreadMetadata) {
         if let Some(existing) = self.terminals.get(&metadata.terminal_id) {
             if existing.folder_paths() != metadata.folder_paths()
@@ -718,6 +780,93 @@ mod tests {
                     .main_worktree_paths()
                     .paths(),
                 old_main_paths.paths()
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_reset_deleted_worktree_folder_paths(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let main_path = Path::new("/repo");
+        let main_paths = PathList::new(&[main_path]);
+        let dead_paths = PathList::new(&[Path::new("/wt-dead")]);
+        let live_paths = PathList::new(&[Path::new("/wt-live")]);
+
+        // Terminal on the deleted worktree; its working directory must be
+        // preserved even though the worktree paths are rewritten.
+        let mut dead_terminal = metadata(
+            "Dev Server",
+            WorktreePaths::from_path_lists(main_paths.clone(), dead_paths.clone()).unwrap(),
+        );
+        dead_terminal.working_directory = Some(PathBuf::from("/wt-dead/src"));
+        let dead_terminal_id = dead_terminal.terminal_id;
+
+        // Terminal on a worktree that still exists.
+        let live_terminal = metadata(
+            "Logs",
+            WorktreePaths::from_path_lists(main_paths.clone(), live_paths.clone()).unwrap(),
+        );
+        let live_terminal_id = live_terminal.terminal_id;
+
+        // Remote terminal on the deleted worktree must be left alone when
+        // resetting for the local connection.
+        let mut remote_terminal = metadata(
+            "Remote",
+            WorktreePaths::from_path_lists(main_paths.clone(), dead_paths.clone()).unwrap(),
+        );
+        remote_terminal.remote_connection = Some(RemoteConnectionOptions::Mock(
+            remote::MockConnectionOptions { id: 1 },
+        ));
+        let remote_terminal_id = remote_terminal.terminal_id;
+
+        cx.update(|cx| {
+            TerminalThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.save(dead_terminal, cx);
+                store.save(live_terminal, cx);
+                store.save(remote_terminal, cx);
+            });
+        });
+
+        let live_folder_paths = HashSet::from_iter([PathBuf::from("/wt-live")]);
+        let affected = cx.update(|cx| {
+            TerminalThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.reset_deleted_worktree_folder_paths(main_path, &live_folder_paths, None, cx)
+            })
+        });
+        cx.run_until_parked();
+
+        assert_eq!(affected, vec![dead_terminal_id]);
+
+        cx.update(|cx| {
+            let store = TerminalThreadMetadataStore::global(cx);
+            let store = store.read(cx);
+
+            let dead_entry = store.entry(dead_terminal_id).unwrap();
+            assert_eq!(dead_entry.folder_paths(), &main_paths);
+            assert_eq!(dead_entry.main_worktree_paths(), &main_paths);
+            assert_eq!(
+                dead_entry.working_directory,
+                Some(PathBuf::from("/wt-dead/src"))
+            );
+
+            assert_eq!(
+                store.entry(live_terminal_id).unwrap().folder_paths(),
+                &live_paths
+            );
+            assert_eq!(
+                store.entry(remote_terminal_id).unwrap().folder_paths(),
+                &dead_paths
+            );
+
+            // The path index reflects the rewrite.
+            assert!(store.entries_for_path(&dead_paths, None).next().is_none());
+            assert_eq!(
+                store
+                    .entries_for_path(&main_paths, None)
+                    .map(|entry| entry.terminal_id)
+                    .collect::<Vec<_>>(),
+                vec![dead_terminal_id]
             );
         });
     }

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -1002,6 +1002,61 @@ impl ThreadMetadataStore {
         self.mutate_thread_paths(&thread_ids, mutate, cx);
     }
 
+    /// For every non-archived thread that has a `(main, folder)` worktree
+    /// pair where `main` equals `main_worktree_path`, `folder` differs from
+    /// `main` (i.e. it was a linked worktree), and `folder` is not in
+    /// `live_folder_paths`, rewrite each such pair to `(main, main)`, dedupe
+    /// pairs, re-index, and persist. Only threads matching
+    /// `remote_connection` identity are affected.
+    ///
+    /// Used to repoint threads at the main repo checkout when their linked
+    /// git worktree has been deleted. Returns the affected thread ids.
+    pub fn reset_deleted_worktree_folder_paths<S: std::hash::BuildHasher>(
+        &mut self,
+        main_worktree_path: &Path,
+        live_folder_paths: &std::collections::HashSet<PathBuf, S>,
+        remote_connection: Option<&RemoteConnectionOptions>,
+        cx: &mut Context<Self>,
+    ) -> Vec<ThreadId> {
+        let mut deleted_folder_paths: HashSet<PathBuf> = HashSet::default();
+        let mut thread_ids = Vec::new();
+        for thread in self.threads.values() {
+            if thread.archived
+                || !same_remote_connection_identity(
+                    thread.remote_connection.as_ref(),
+                    remote_connection,
+                )
+            {
+                continue;
+            }
+            let dead_folder_paths = thread
+                .worktree_paths
+                .ordered_pairs()
+                .filter(|(main, folder)| {
+                    main.as_path() == main_worktree_path
+                        && folder != main
+                        && !live_folder_paths.contains(folder.as_path())
+                })
+                .map(|(_, folder)| folder.clone())
+                .collect::<Vec<_>>();
+            if !dead_folder_paths.is_empty() {
+                thread_ids.push(thread.thread_id);
+                deleted_folder_paths.extend(dead_folder_paths);
+            }
+        }
+
+        self.mutate_thread_paths(
+            &thread_ids,
+            |paths| {
+                for folder_path in &deleted_folder_paths {
+                    paths.reset_folder_path_to_main(folder_path);
+                }
+            },
+            cx,
+        );
+        thread_ids
+    }
+
     fn mutate_thread_paths(
         &mut self,
         thread_ids: &[ThreadId],
@@ -3192,6 +3247,159 @@ mod tests {
                 remote_main_entries,
                 vec!["remote-a-session", "remote-linked"]
             );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_reset_deleted_worktree_folder_paths(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let now = Utc::now();
+        let main_path = Path::new("/project");
+        let main_paths = PathList::new(&[main_path]);
+        let dead_paths = PathList::new(&[Path::new("/wt-dead")]);
+        let live_paths = PathList::new(&[Path::new("/wt-live")]);
+        let remote = RemoteConnectionOptions::Mock(remote::MockConnectionOptions { id: 1 });
+
+        // Thread whose only folder is the deleted worktree.
+        let mut dead_thread = make_metadata("dead-session", "Dead", now, PathList::default());
+        dead_thread.worktree_paths =
+            WorktreePaths::from_path_lists(main_paths.clone(), dead_paths.clone()).unwrap();
+        let dead_thread_id = dead_thread.thread_id;
+
+        // Thread that references both the main checkout and the deleted
+        // worktree (built via the production `add_path` route).
+        let mut dual_thread = make_metadata("dual-session", "Dual", now, main_paths.clone());
+        dual_thread
+            .worktree_paths
+            .add_path(main_path, Path::new("/wt-dead"));
+        let dual_thread_id = dual_thread.thread_id;
+
+        // Thread on a worktree that still exists.
+        let mut live_thread = make_metadata("live-session", "Live", now, PathList::default());
+        live_thread.worktree_paths =
+            WorktreePaths::from_path_lists(main_paths.clone(), live_paths.clone()).unwrap();
+
+        // Archived thread on the deleted worktree must be left alone.
+        let mut archived_thread =
+            make_metadata("archived-session", "Archived", now, PathList::default());
+        archived_thread.worktree_paths =
+            WorktreePaths::from_path_lists(main_paths.clone(), dead_paths.clone()).unwrap();
+        archived_thread.archived = true;
+
+        // Remote thread on the same paths must be left alone when resetting
+        // for the local connection.
+        let mut remote_thread = make_metadata("remote-session", "Remote", now, PathList::default());
+        remote_thread.worktree_paths =
+            WorktreePaths::from_path_lists(main_paths.clone(), dead_paths.clone()).unwrap();
+        remote_thread.remote_connection = Some(remote.clone());
+        let remote_thread_id = remote_thread.thread_id;
+
+        // Thread in a different repo whose folder also doesn't exist in the
+        // live set; untouched because its main path doesn't match.
+        let mut other_repo_thread =
+            make_metadata("other-session", "Other", now, PathList::default());
+        other_repo_thread.worktree_paths = WorktreePaths::from_path_lists(
+            PathList::new(&[Path::new("/other")]),
+            PathList::new(&[Path::new("/other-wt")]),
+        )
+        .unwrap();
+
+        cx.update(|cx| {
+            let store = ThreadMetadataStore::global(cx);
+            store.update(cx, |store, cx| {
+                store.save(dead_thread, cx);
+                store.save(dual_thread, cx);
+                store.save(live_thread, cx);
+                store.save(archived_thread, cx);
+                store.save(remote_thread, cx);
+                store.save(other_repo_thread, cx);
+            });
+        });
+        cx.run_until_parked();
+
+        let live_folder_paths = HashSet::from_iter([PathBuf::from("/wt-live")]);
+        let affected = cx.update(|cx| {
+            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.reset_deleted_worktree_folder_paths(main_path, &live_folder_paths, None, cx)
+            })
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            HashSet::from_iter(affected),
+            HashSet::from_iter([dead_thread_id, dual_thread_id])
+        );
+
+        cx.update(|cx| {
+            let store = ThreadMetadataStore::global(cx);
+            let store = store.read(cx);
+
+            let entry_by_session = |session: &str| {
+                let session = acp::SessionId::new(session);
+                store
+                    .entries()
+                    .find(|e| e.session_id.as_ref() == Some(&session))
+                    .unwrap()
+            };
+
+            let dead = entry_by_session("dead-session");
+            assert_eq!(dead.folder_paths(), &main_paths);
+            assert_eq!(dead.main_worktree_paths(), &main_paths);
+
+            let dual = entry_by_session("dual-session");
+            assert_eq!(dual.worktree_paths.ordered_pairs().count(), 1);
+            assert_eq!(dual.folder_paths(), &main_paths);
+            assert_eq!(dual.main_worktree_paths(), &main_paths);
+
+            assert_eq!(entry_by_session("live-session").folder_paths(), &live_paths);
+            assert_eq!(
+                entry_by_session("archived-session").folder_paths(),
+                &dead_paths
+            );
+            assert_eq!(
+                entry_by_session("remote-session").folder_paths(),
+                &dead_paths
+            );
+            assert_eq!(
+                entry_by_session("other-session").folder_paths(),
+                &PathList::new(&[Path::new("/other-wt")])
+            );
+
+            // The path index reflects the rewrite.
+            assert!(store.entries_for_path(&dead_paths, None).next().is_none());
+            let mut main_path_sessions: Vec<_> = store
+                .entries_for_path(&main_paths, None)
+                .filter_map(|e| e.session_id.as_ref().map(|s| s.0.to_string()))
+                .collect();
+            main_path_sessions.sort();
+            assert_eq!(main_path_sessions, vec!["dead-session", "dual-session"]);
+        });
+
+        // Resetting with the matching remote identity affects the remote
+        // thread that was previously skipped.
+        let affected = cx.update(|cx| {
+            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.reset_deleted_worktree_folder_paths(
+                    main_path,
+                    &live_folder_paths,
+                    Some(&remote),
+                    cx,
+                )
+            })
+        });
+        cx.run_until_parked();
+
+        assert_eq!(affected, vec![remote_thread_id]);
+        cx.update(|cx| {
+            let store = ThreadMetadataStore::global(cx);
+            let store = store.read(cx);
+            let session = acp::SessionId::new("remote-session");
+            let remote_entry = store
+                .entries()
+                .find(|e| e.session_id.as_ref() == Some(&session))
+                .unwrap();
+            assert_eq!(remote_entry.folder_paths(), &main_paths);
         });
     }
 

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -495,7 +495,19 @@ impl FileHandle for std::fs::File {
 
         let os_str: OsString = OsString::from_wide(&buf[..written as usize]);
         anyhow::ensure!(!os_str.is_empty(), "Could find a path for the file handle");
-        Ok(PathBuf::from(os_str))
+        let path = PathBuf::from(os_str);
+
+        // When a file or directory is deleted on NTFS while a handle remains open,
+        // the entry is moved to a special `\$Extend\$Deleted\` location until the
+        // last handle is closed. `GetFinalPathNameByHandleW` happily returns that
+        // path, which would otherwise be mistaken for an external rename. Treat it
+        // as deletion instead.
+        let normalized = path.to_string_lossy().replace('/', "\\").to_lowercase();
+        anyhow::ensure!(
+            !normalized.contains("\\$extend\\$deleted\\"),
+            "file handle points to NTFS pending-deletion area: {path:?}"
+        );
+        Ok(path)
     }
 }
 

--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -167,7 +167,7 @@ impl WorktreePicker {
                     picker.delegate.all_worktrees = all_worktrees;
                     picker.delegate.default_branch =
                         default_branch.and_then(|branch| RemoteBranchName::parse(&branch));
-                    picker.delegate.refresh_project_worktree_paths(window, cx);
+                    picker.delegate.refresh_project_worktree_paths(cx);
                     picker.refresh(window, cx);
                 })?;
 
@@ -468,26 +468,21 @@ impl WorktreePickerDelegate {
         !worktree.is_main && !self.project_worktree_paths.contains(&worktree.path)
     }
 
-    fn refresh_project_worktree_paths(&mut self, window: &mut Window, cx: &mut App) {
+    fn refresh_project_worktree_paths(&mut self, cx: &mut App) {
         let mut paths = self.active_worktree_paths.clone();
 
-        if let Some(multi_workspace) = window.root::<MultiWorkspace>().flatten()
-            && let Some(workspace) = self.workspace.upgrade()
-        {
-            let group_key = workspace.read(cx).project_group_key(cx);
-            if let Some(group_workspaces) = multi_workspace
-                .read(cx)
-                .workspaces_for_project_group(&group_key, cx)
-            {
-                for group_workspace in group_workspaces {
-                    for worktree in group_workspace
-                        .read(cx)
-                        .project()
-                        .read(cx)
-                        .visible_worktrees(cx)
-                    {
-                        paths.insert(worktree.read(cx).abs_path().to_path_buf());
-                    }
+        // Consider every workspace in every open window so a worktree with a
+        // live workspace anywhere can't be deleted out from under it.
+        for window in cx.windows() {
+            let Some(multi_workspace) = window.downcast::<MultiWorkspace>() else {
+                continue;
+            };
+            let Ok(multi_workspace) = multi_workspace.read(cx) else {
+                continue;
+            };
+            for workspace in multi_workspace.workspaces() {
+                for worktree in workspace.read(cx).project().read(cx).visible_worktrees(cx) {
+                    paths.insert(worktree.read(cx).abs_path().to_path_buf());
                 }
             }
         }
@@ -1736,6 +1731,59 @@ mod tests {
         assert!(
             !repo_contains_worktree(&repository, &worktree_path, &mut cx).await,
             "worktree should be removed after successful delete"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_worktree_with_workspace_in_another_window_cannot_be_deleted(
+        cx: &mut TestAppContext,
+    ) {
+        let (fs, worktree_picker, repository, worktree_path, mut cx) =
+            init_worktree_picker_test(cx).await;
+
+        let can_delete_worktree = |worktree_picker: &Entity<WorktreePicker>,
+                                   cx: &mut VisualTestContext| {
+            worktree_picker.update(cx, |worktree_picker, cx| {
+                worktree_picker.picker.update(cx, |picker, cx| {
+                    picker.delegate.refresh_project_worktree_paths(cx);
+                    let worktree = picker
+                        .delegate
+                        .all_worktrees
+                        .iter()
+                        .find(|worktree| worktree.path == worktree_path)
+                        .expect("worktree should be listed")
+                        .clone();
+                    picker.delegate.can_delete_worktree(&worktree)
+                })
+            })
+        };
+
+        // With no workspace open at the worktree, it is deletable.
+        assert!(can_delete_worktree(&worktree_picker, &mut cx));
+
+        // Open a workspace at the worktree in a second window.
+        let worktree_project = Project::test(fs.clone(), [worktree_path.as_path()], &mut cx).await;
+        let _second_window =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(worktree_project, window, cx));
+        cx.run_until_parked();
+
+        // The worktree now has a live workspace in another window, so the
+        // picker must refuse to delete it.
+        assert!(!can_delete_worktree(&worktree_picker, &mut cx));
+
+        // Attempting the delete action is a no-op.
+        let index = worktree_index(&worktree_picker, &worktree_path, &mut cx);
+        worktree_picker.update_in(&mut cx, |worktree_picker, window, cx| {
+            worktree_picker.picker.update(cx, |picker, cx| {
+                picker.delegate.delete_worktree(index, true, window, cx);
+            })
+        });
+        cx.run_until_parked();
+
+        assert!(deleting_worktree_paths(&worktree_picker, &mut cx).is_empty());
+        assert!(
+            repo_contains_worktree(&repository, &worktree_path, &mut cx).await,
+            "worktree with a live workspace in another window must not be deleted"
         );
     }
 

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -9571,7 +9571,7 @@ async fn compute_snapshot(
     };
     let worktrees_future = {
         let backend = backend.clone();
-        async move { backend.worktrees().await.log_err().unwrap_or_default() }
+        async move { backend.worktrees().await.log_err() }
     };
     let (branches, head_commit, all_worktrees) =
         futures::future::join3(branches_future, head_commit_future, worktrees_future).await;
@@ -9584,10 +9584,16 @@ async fn compute_snapshot(
     let branch = branches.iter().find(|branch| branch.is_head).cloned();
     let branch_list: Arc<[Branch]> = branches.into();
 
-    let linked_worktrees: Arc<[GitWorktree]> = all_worktrees
-        .into_iter()
-        .filter(|wt| wt.path != *work_directory_abs_path)
-        .collect();
+    let linked_worktrees: Arc<[GitWorktree]> = match all_worktrees {
+        Some(all_worktrees) => all_worktrees
+            .into_iter()
+            .filter(|wt| wt.path != *work_directory_abs_path)
+            .collect(),
+        // Keep the previous list when listing fails: a transient git error
+        // must not make the linked worktrees appear deleted to observers of
+        // `GitWorktreeListChanged`.
+        None => prev_snapshot.linked_worktrees.clone(),
+    };
 
     let remote_origin_url = backend.remote_url("origin").await;
     let remote_upstream_url = backend.remote_url("upstream").await;

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -137,6 +137,34 @@ impl WorktreePaths {
         self.paths = PathList::new(&folders);
     }
 
+    /// Rewrite every pair whose folder path matches the given path to
+    /// `(main, main)`, then drop duplicate pairs that can result from the
+    /// rewrite (e.g. when the pair `(main, main)` was already present).
+    pub fn reset_folder_path_to_main(&mut self, folder_path: &Path) {
+        let mut mains: Vec<PathBuf> = Vec::new();
+        let mut folders: Vec<PathBuf> = Vec::new();
+        for (main, folder) in self.ordered_pairs() {
+            let new_folder = if folder.as_path() == folder_path {
+                main.clone()
+            } else {
+                folder.clone()
+            };
+            let is_duplicate =
+                mains
+                    .iter()
+                    .zip(&folders)
+                    .any(|(existing_main, existing_folder)| {
+                        existing_main == main && *existing_folder == new_folder
+                    });
+            if !is_duplicate {
+                mains.push(main.clone());
+                folders.push(new_folder);
+            }
+        }
+        self.main_paths = PathList::new(&mains);
+        self.paths = PathList::new(&folders);
+    }
+
     /// Remove all pairs whose folder path matches the given path.
     /// This removes the corresponding entries from both lists.
     pub fn remove_folder_path(&mut self, folder_path: &Path) {
@@ -1394,5 +1422,91 @@ impl WorktreeHandle {
             WorktreeHandle::Strong(handle) => Some(handle.clone()),
             WorktreeHandle::Weak(handle) => handle.upgrade(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use util::path;
+
+    fn pairs(worktree_paths: &WorktreePaths) -> Vec<(PathBuf, PathBuf)> {
+        worktree_paths
+            .ordered_pairs()
+            .map(|(main, folder)| (main.clone(), folder.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn test_reset_folder_path_to_main_rewrites_matching_pair() {
+        let mut worktree_paths = WorktreePaths::from_path_lists(
+            PathList::new(&[path!("/main")]),
+            PathList::new(&[path!("/worktrees/feature")]),
+        )
+        .unwrap();
+
+        worktree_paths.reset_folder_path_to_main(Path::new(path!("/worktrees/feature")));
+
+        assert_eq!(
+            pairs(&worktree_paths),
+            vec![(PathBuf::from(path!("/main")), PathBuf::from(path!("/main")))]
+        );
+    }
+
+    #[test]
+    fn test_reset_folder_path_to_main_leaves_other_pairs_untouched() {
+        let mut worktree_paths = WorktreePaths::from_path_lists(
+            PathList::new(&[path!("/main"), path!("/other")]),
+            PathList::new(&[path!("/worktrees/feature"), path!("/other")]),
+        )
+        .unwrap();
+
+        worktree_paths.reset_folder_path_to_main(Path::new(path!("/worktrees/feature")));
+
+        assert_eq!(
+            pairs(&worktree_paths),
+            vec![
+                (PathBuf::from(path!("/main")), PathBuf::from(path!("/main"))),
+                (
+                    PathBuf::from(path!("/other")),
+                    PathBuf::from(path!("/other"))
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_reset_folder_path_to_main_dedupes_resulting_pairs() {
+        // A thread that references both the main checkout and a linked
+        // worktree of the same repo must end up with a single (main, main)
+        // pair after the worktree is reset.
+        let mut worktree_paths =
+            WorktreePaths::from_folder_paths(&PathList::new(&[path!("/main")]));
+        worktree_paths.add_path(
+            Path::new(path!("/main")),
+            Path::new(path!("/worktrees/feature")),
+        );
+        assert_eq!(pairs(&worktree_paths).len(), 2);
+
+        worktree_paths.reset_folder_path_to_main(Path::new(path!("/worktrees/feature")));
+
+        assert_eq!(
+            pairs(&worktree_paths),
+            vec![(PathBuf::from(path!("/main")), PathBuf::from(path!("/main")))]
+        );
+    }
+
+    #[test]
+    fn test_reset_folder_path_to_main_is_noop_for_unknown_path() {
+        let mut worktree_paths = WorktreePaths::from_path_lists(
+            PathList::new(&[path!("/main")]),
+            PathList::new(&[path!("/worktrees/feature")]),
+        )
+        .unwrap();
+        let before = pairs(&worktree_paths);
+
+        worktree_paths.reset_folder_path_to_main(Path::new(path!("/worktrees/unrelated")));
+
+        assert_eq!(pairs(&worktree_paths), before);
     }
 }

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -922,7 +922,7 @@ impl WorktreeStore {
         self.send_project_updates(cx);
 
         let handle_id = worktree.entity_id();
-        cx.subscribe(worktree, |_, worktree, event, cx| {
+        cx.subscribe(worktree, |this, worktree, event, cx| {
             let worktree_id = worktree.read(cx).id();
             match event {
                 worktree::Event::UpdatedEntries(changes) => {
@@ -941,8 +941,7 @@ impl WorktreeStore {
                     cx.emit(WorktreeStoreEvent::WorktreeDeletedEntry(worktree_id, *id))
                 }
                 worktree::Event::Deleted => {
-                    // The worktree root itself has been deleted (for single-file worktrees)
-                    // The worktree will be removed via the observe_release callback
+                    this.remove_worktree(worktree_id, cx);
                 }
                 worktree::Event::UpdatedRootRepoCommonDir { .. } => {
                     cx.emit(WorktreeStoreEvent::WorktreeUpdatedRootRepoCommonDir(

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -27,7 +27,7 @@ use buffer_diff::{
 use collections::{BTreeSet, HashMap, HashSet};
 use encoding_rs;
 use fs::{FakeFs, PathEventKind};
-use futures::{StreamExt, future};
+use futures::{FutureExt as _, StreamExt, future};
 use git::{
     GitHostingProviderRegistry,
     repository::{RepoPath, repo_path},
@@ -5955,6 +5955,42 @@ async fn test_rescan_and_remote_updates(cx: &mut gpui::TestAppContext) {
                 rel_path("d/file4"),
             ]
         );
+    });
+}
+
+#[gpui::test]
+async fn test_removed_worktree_root_is_removed_from_project(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    cx.executor().allow_parking();
+
+    let dir = TempTree::new(json!({
+        "file.txt": "contents"
+    }));
+    let project = Project::test(Arc::new(RealFs::new(None, cx.executor())), [dir.path()], cx).await;
+    let worktree_id = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).id()
+    });
+    let mut project_events = cx.events(&project);
+
+    std::fs::remove_dir_all(dir.path()).unwrap();
+
+    let removed = async {
+        while let Some(event) = project_events.next().await {
+            if matches!(event, Event::WorktreeRemoved(id) if id == worktree_id) {
+                break;
+            }
+        }
+    };
+    let timeout = cx
+        .background_executor
+        .timer(std::time::Duration::from_secs(5));
+    futures::select_biased! {
+        _ = removed.fuse() => {}
+        _ = timeout.fuse() => panic!("timed out waiting for removed worktree root to be removed from project"),
+    }
+
+    project.read_with(cx, |project, cx| {
+        assert!(project.worktrees(cx).next().is_none());
     });
 }
 

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -28,9 +28,10 @@ use feature_flags::{
     AgentThreadWorktreeLabel, AgentThreadWorktreeLabelFlag, FeatureFlag, FeatureFlagAppExt as _,
 };
 use gpui::{
-    Action as _, AnyElement, App, ClickEvent, Context, DismissEvent, Entity, EntityId, FocusHandle,
-    Focusable, KeyContext, ListState, Modifiers, Pixels, Render, SharedString, Task, TaskExt,
-    WeakEntity, Window, WindowHandle, linear_color_stop, linear_gradient, list, prelude::*, px,
+    Action as _, AnyElement, App, AsyncWindowContext, ClickEvent, Context, DismissEvent, Entity,
+    EntityId, FocusHandle, Focusable, KeyContext, ListState, Modifiers, Pixels, Render,
+    SharedString, Task, TaskExt, WeakEntity, Window, WindowHandle, linear_color_stop,
+    linear_gradient, list, prelude::*, px,
 };
 use itertools::Itertools;
 use language_model::LanguageModelRegistry;
@@ -3876,22 +3877,26 @@ impl Sidebar {
         let provisional_key = Some(project_group_key.clone());
         let active_workspace = multi_workspace.read(cx).workspace().clone();
         let modal_workspace = active_workspace.clone();
-
-        let open_task = multi_workspace.update(cx, |this, cx| {
-            this.find_or_create_workspace(
-                folder_paths,
-                host,
-                provisional_key,
-                |options, window, cx| connect_remote(active_workspace, options, window, cx),
-                &[],
-                None,
-                OpenMode::Activate,
-                window,
-                cx,
-            )
-        });
+        let fs = active_workspace.read(cx).app_state().fs.clone();
 
         cx.spawn_in(window, async move |this, cx| {
+            let (metadata, folder_paths) =
+                Self::resolve_deleted_worktree_paths(metadata, folder_paths, fs, cx).await;
+
+            let open_task = multi_workspace.update_in(cx, |this, window, cx| {
+                this.find_or_create_workspace(
+                    folder_paths,
+                    host,
+                    provisional_key,
+                    |options, window, cx| connect_remote(active_workspace, options, window, cx),
+                    &[],
+                    None,
+                    OpenMode::Activate,
+                    window,
+                    cx,
+                )
+            })?;
+
             let result = open_task.await;
             // Dismiss the modal as soon as the open attempt completes so
             // failures or cancellations do not leave a stale connection modal behind.
@@ -3913,6 +3918,84 @@ impl Sidebar {
             anyhow::Ok(())
         })
         .detach_and_log_err(cx);
+    }
+
+    /// Lazy fallback for worktrees deleted while Zed was closed (so no
+    /// `GitWorktreeListChanged` event could fire): if the thread's worktree
+    /// pairs reference linked-worktree folders that no longer exist on disk,
+    /// repoint those pairs at their main worktree paths and persist before
+    /// opening. Threads with archived-worktree records keep their recorded
+    /// paths — restoring those is the archive flow's job.
+    async fn resolve_deleted_worktree_paths(
+        metadata: ThreadMetadata,
+        folder_paths: PathList,
+        fs: Arc<dyn fs::Fs>,
+        cx: &mut AsyncWindowContext,
+    ) -> (ThreadMetadata, PathList) {
+        // Remote project directories can't be inspected from here.
+        if metadata.remote_connection.is_some() {
+            return (metadata, folder_paths);
+        }
+
+        let linked_folder_paths: Vec<PathBuf> = metadata
+            .worktree_paths
+            .ordered_pairs()
+            .filter(|(main, folder)| main != folder)
+            .map(|(_, folder)| folder.clone())
+            .collect();
+        if linked_folder_paths.is_empty() {
+            return (metadata, folder_paths);
+        }
+
+        let mut deleted_folder_paths = Vec::new();
+        for folder_path in linked_folder_paths {
+            // Treat fs errors as "still exists": only a confirmed missing
+            // directory may rewrite the thread's paths.
+            if matches!(fs.metadata(&folder_path).await, Ok(None)) {
+                deleted_folder_paths.push(folder_path);
+            }
+        }
+        if deleted_folder_paths.is_empty() {
+            return (metadata, folder_paths);
+        }
+
+        let archived_worktrees = match cx.update(|_window, cx| {
+            ThreadMetadataStore::global(cx)
+                .read(cx)
+                .get_archived_worktrees_for_thread(metadata.thread_id, cx)
+        }) {
+            Ok(task) => task.await.log_err(),
+            Err(_) => None,
+        };
+        // On a lookup failure, conservatively assume records exist and leave
+        // the paths alone.
+        let Some(archived_worktrees) = archived_worktrees else {
+            return (metadata, folder_paths);
+        };
+        if !archived_worktrees.is_empty() {
+            return (metadata, folder_paths);
+        }
+
+        let mut worktree_paths = metadata.worktree_paths.clone();
+        for folder_path in &deleted_folder_paths {
+            worktree_paths.reset_folder_path_to_main(folder_path);
+        }
+
+        let updated = cx.update(|_window, cx| {
+            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.update_worktree_paths(&[metadata.thread_id], worktree_paths.clone(), cx);
+            });
+        });
+        if updated.log_err().is_none() {
+            return (metadata, folder_paths);
+        }
+
+        let folder_paths = worktree_paths.folder_path_list().clone();
+        let metadata = ThreadMetadata {
+            worktree_paths,
+            ..metadata
+        };
+        (metadata, folder_paths)
     }
 
     fn find_current_workspace_for_path_list(

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -986,23 +986,36 @@ impl Sidebar {
         .detach();
 
         let git_store = workspace.read(cx).project().read(cx).git_store().clone();
-        cx.subscribe_in(
-            &git_store,
-            window,
-            |this, _, event: &project::git_store::GitStoreEvent, _window, cx| {
-                if matches!(
-                    event,
+        cx.subscribe_in(&git_store, window, {
+            let workspace = workspace.downgrade();
+            move |this, git_store, event: &project::git_store::GitStoreEvent, _window, cx| {
+                match event {
+                    project::git_store::GitStoreEvent::RepositoryUpdated(
+                        repository_id,
+                        project::git_store::RepositoryEvent::GitWorktreeListChanged,
+                        _,
+                    ) => {
+                        if let Some(workspace) = workspace.upgrade() {
+                            this.reset_threads_for_deleted_git_worktrees(
+                                &workspace,
+                                git_store,
+                                *repository_id,
+                                cx,
+                            );
+                        }
+                        this.schedule_update_entries(false, cx);
+                    }
                     project::git_store::GitStoreEvent::RepositoryUpdated(
                         _,
-                        project::git_store::RepositoryEvent::GitWorktreeListChanged
-                            | project::git_store::RepositoryEvent::HeadChanged,
+                        project::git_store::RepositoryEvent::HeadChanged,
                         _,
-                    )
-                ) {
-                    this.schedule_update_entries(false, cx);
+                    ) => {
+                        this.schedule_update_entries(false, cx);
+                    }
+                    _ => {}
                 }
-            },
-        )
+            }
+        })
         .detach();
 
         cx.subscribe_in(
@@ -1083,6 +1096,62 @@ impl Sidebar {
                 &old_folder_paths,
                 remote_connection.as_ref(),
                 &apply_path_changes,
+                store_cx,
+            );
+        });
+    }
+
+    /// When a repository's linked-worktree list changes, repoint any
+    /// non-archived threads whose folder path was a now-deleted linked
+    /// worktree of this repository back at the main repo checkout. This
+    /// covers worktrees deleted via Zed's worktree picker as well as ones
+    /// removed externally (e.g. `git worktree remove` in a terminal).
+    fn reset_threads_for_deleted_git_worktrees(
+        &self,
+        workspace: &Entity<Workspace>,
+        git_store: &Entity<project::git_store::GitStore>,
+        repository_id: project::git_store::RepositoryId,
+        cx: &mut Context<Self>,
+    ) {
+        let project = workspace.read(cx).project().clone();
+        let Some(repository) = git_store
+            .read(cx)
+            .repositories()
+            .get(&repository_id)
+            .cloned()
+        else {
+            return;
+        };
+        let snapshot = repository.read(cx).snapshot();
+        let Some(main_worktree_path) = snapshot.main_worktree_abs_path().map(Path::to_path_buf)
+        else {
+            return;
+        };
+        let mut live_folder_paths: HashSet<PathBuf> = snapshot
+            .linked_worktrees()
+            .iter()
+            .map(|worktree| worktree.path.clone())
+            .collect();
+        // The snapshot's linked-worktree list excludes the repo's own working
+        // directory, so when this project is itself opened at a linked
+        // worktree, that worktree must be counted as live or its threads
+        // would be wrongly reset to main.
+        live_folder_paths.insert(snapshot.work_directory_abs_path.to_path_buf());
+        let remote_connection = project.read(cx).remote_connection_options(cx);
+
+        ThreadMetadataStore::global(cx).update(cx, |store, store_cx| {
+            store.reset_deleted_worktree_folder_paths(
+                &main_worktree_path,
+                &live_folder_paths,
+                remote_connection.as_ref(),
+                store_cx,
+            );
+        });
+        TerminalThreadMetadataStore::global(cx).update(cx, |store, store_cx| {
+            store.reset_deleted_worktree_folder_paths(
+                &main_worktree_path,
+                &live_folder_paths,
+                remote_connection.as_ref(),
                 store_cx,
             );
         });

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -6347,6 +6347,182 @@ async fn test_git_worktree_added_live_updates_sidebar(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_thread_on_live_worktree_is_not_reset_when_workspace_opens_at_worktree(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project",
+        serde_json::json!({
+            ".git": {},
+            "src": {},
+        }),
+    )
+    .await;
+    cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+
+    fs.add_linked_worktree_for_repo(
+        Path::new("/project/.git"),
+        false,
+        git::repository::Worktree {
+            path: PathBuf::from("/wt/rosewood"),
+            ref_name: Some("refs/heads/rosewood".into()),
+            sha: "abc".into(),
+            is_main: false,
+            is_bare: false,
+        },
+    )
+    .await;
+
+    // Simulate a restart with a workspace restored at the linked worktree
+    // itself. The repository snapshot of this project excludes the repo's
+    // own working directory from its linked-worktree list, which must not
+    // make the worktree look deleted.
+    let project = project::Project::test(fs.clone(), ["/wt/rosewood".as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    save_thread_metadata_with_main_paths(
+        "wt-thread",
+        "Worktree Thread",
+        PathList::new(&[PathBuf::from("/wt/rosewood")]),
+        PathList::new(&[PathBuf::from("/project")]),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+        cx,
+    );
+
+    multi_workspace.update_in(cx, |_, _window, cx| cx.notify());
+    cx.run_until_parked();
+
+    // Change the repo's worktree list (an unrelated worktree appears) so
+    // GitWorktreeListChanged fires with the thread metadata already loaded.
+    // The open worktree is absent from this repo's linked-worktree list, so
+    // a naive reset would wrongly treat it as deleted.
+    fs.add_linked_worktree_for_repo(
+        Path::new("/project/.git"),
+        true,
+        git::repository::Worktree {
+            path: PathBuf::from("/wt/other"),
+            ref_name: Some("refs/heads/other".into()),
+            sha: "def".into(),
+            is_main: false,
+            is_bare: false,
+        },
+    )
+    .await;
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec!["v [project]", "  Worktree Thread {rosewood}"]
+    );
+
+    cx.update(|_, cx| {
+        let store = ThreadMetadataStore::global(cx);
+        let store = store.read(cx);
+        let session = acp::SessionId::new("wt-thread");
+        let entry = store
+            .entries()
+            .find(|e| e.session_id.as_ref() == Some(&session))
+            .unwrap();
+        assert_eq!(
+            entry.folder_paths().paths(),
+            &[PathBuf::from("/wt/rosewood")],
+            "thread attached to a still-valid worktree must not be reset to main"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_thread_resets_to_main_when_git_worktree_deleted(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project",
+        serde_json::json!({
+            ".git": {},
+            "src": {},
+        }),
+    )
+    .await;
+    cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+
+    // Register the linked worktree in the repo's git state before the
+    // project scans, so the initial repository snapshot includes it.
+    fs.add_linked_worktree_for_repo(
+        Path::new("/project/.git"),
+        false,
+        git::repository::Worktree {
+            path: PathBuf::from("/wt/rosewood"),
+            ref_name: Some("refs/heads/rosewood".into()),
+            sha: "abc".into(),
+            is_main: false,
+            is_bare: false,
+        },
+    )
+    .await;
+
+    let project = project::Project::test(fs.clone(), ["/project".as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    save_thread_metadata_with_main_paths(
+        "wt-thread",
+        "Worktree Thread",
+        PathList::new(&[PathBuf::from("/wt/rosewood")]),
+        PathList::new(&[PathBuf::from("/project")]),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+        cx,
+    );
+
+    multi_workspace.update_in(cx, |_, _window, cx| cx.notify());
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec!["v [project]", "  Worktree Thread {rosewood}"]
+    );
+
+    // Delete the linked worktree, as `git worktree remove` would (whether
+    // through Zed's worktree picker or externally in a terminal).
+    fs.remove_worktree_for_repo(Path::new("/project/.git"), true, "refs/heads/rosewood")
+        .await;
+    cx.run_until_parked();
+
+    // The thread was repointed at the main checkout; the chip is gone.
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec!["v [project]", "  Worktree Thread"]
+    );
+
+    cx.update(|_, cx| {
+        let store = ThreadMetadataStore::global(cx);
+        let store = store.read(cx);
+        let session = acp::SessionId::new("wt-thread");
+        let entry = store
+            .entries()
+            .find(|e| e.session_id.as_ref() == Some(&session))
+            .unwrap();
+        assert_eq!(entry.folder_paths().paths(), &[PathBuf::from("/project")]);
+        assert_eq!(
+            entry.main_worktree_paths().paths(),
+            &[PathBuf::from("/project")]
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_two_worktree_workspaces_absorbed_when_main_added(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.executor());

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -6523,6 +6523,200 @@ async fn test_thread_resets_to_main_when_git_worktree_deleted(cx: &mut TestAppCo
 }
 
 #[gpui::test]
+async fn test_opening_thread_with_worktree_deleted_while_zed_was_closed_falls_back_to_main(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project",
+        serde_json::json!({
+            ".git": {},
+            "src": {},
+        }),
+    )
+    .await;
+    cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+
+    // The thread metadata references a linked worktree that is neither on
+    // disk nor in the repo's git state: it was deleted while Zed was closed,
+    // so no GitWorktreeListChanged event could ever fire for it.
+    let project = project::Project::test(fs.clone(), ["/project".as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    save_thread_metadata_with_main_paths(
+        "wt-thread",
+        "Worktree Thread",
+        PathList::new(&[PathBuf::from("/wt/rosewood")]),
+        PathList::new(&[PathBuf::from("/project")]),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+        cx,
+    );
+
+    multi_workspace.update_in(cx, |_, _window, cx| cx.notify());
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec!["v [project]", "  Worktree Thread {rosewood}"]
+    );
+
+    // Activate the thread the way a sidebar click on a closed-workspace row
+    // does.
+    let session = acp::SessionId::new("wt-thread");
+    let metadata = cx.update(|_, cx| {
+        ThreadMetadataStore::global(cx)
+            .read(cx)
+            .entries()
+            .find(|e| e.session_id.as_ref() == Some(&session))
+            .cloned()
+            .unwrap()
+    });
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        let key = workspace::ProjectGroupKey::from_worktree_paths(&metadata.worktree_paths, None);
+        sidebar.open_workspace_and_activate_thread(
+            metadata.clone(),
+            metadata.folder_paths().clone(),
+            &key,
+            window,
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    // The metadata was repointed at the main checkout before opening…
+    cx.update(|_, cx| {
+        let store = ThreadMetadataStore::global(cx);
+        let store = store.read(cx);
+        let entry = store
+            .entries()
+            .find(|e| e.session_id.as_ref() == Some(&session))
+            .unwrap();
+        assert_eq!(entry.folder_paths().paths(), &[PathBuf::from("/project")]);
+        assert_eq!(
+            entry.main_worktree_paths().paths(),
+            &[PathBuf::from("/project")]
+        );
+    });
+
+    // …so no workspace was opened at the dead path; the existing main
+    // workspace was reused.
+    multi_workspace.read_with(cx, |multi_workspace, cx| {
+        let workspace_paths: Vec<_> = multi_workspace
+            .workspaces()
+            .map(|workspace| workspace_path_list(workspace, cx).paths().to_vec())
+            .collect();
+        assert_eq!(workspace_paths, vec![vec![PathBuf::from("/project")]]);
+    });
+
+    // The chip is gone in the sidebar.
+    assert_eq!(
+        visible_entries_as_strings(&sidebar, cx),
+        vec!["v [project]", "  Worktree Thread"]
+    );
+}
+
+#[gpui::test]
+async fn test_opening_thread_with_live_worktree_keeps_worktree_paths(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project",
+        serde_json::json!({
+            ".git": {},
+            "src": {},
+        }),
+    )
+    .await;
+    cx.update(|cx| <dyn fs::Fs>::set_global(fs.clone(), cx));
+
+    // The linked worktree exists on disk.
+    fs.add_linked_worktree_for_repo(
+        Path::new("/project/.git"),
+        false,
+        git::repository::Worktree {
+            path: PathBuf::from("/wt/rosewood"),
+            ref_name: Some("refs/heads/rosewood".into()),
+            sha: "abc".into(),
+            is_main: false,
+            is_bare: false,
+        },
+    )
+    .await;
+
+    let project = project::Project::test(fs.clone(), ["/project".as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let sidebar = setup_sidebar(&multi_workspace, cx);
+
+    save_thread_metadata_with_main_paths(
+        "wt-thread",
+        "Worktree Thread",
+        PathList::new(&[PathBuf::from("/wt/rosewood")]),
+        PathList::new(&[PathBuf::from("/project")]),
+        chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+        cx,
+    );
+
+    multi_workspace.update_in(cx, |_, _window, cx| cx.notify());
+    cx.run_until_parked();
+
+    let session = acp::SessionId::new("wt-thread");
+    let metadata = cx.update(|_, cx| {
+        ThreadMetadataStore::global(cx)
+            .read(cx)
+            .entries()
+            .find(|e| e.session_id.as_ref() == Some(&session))
+            .cloned()
+            .unwrap()
+    });
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        let key = workspace::ProjectGroupKey::from_worktree_paths(&metadata.worktree_paths, None);
+        sidebar.open_workspace_and_activate_thread(
+            metadata.clone(),
+            metadata.folder_paths().clone(),
+            &key,
+            window,
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    // The metadata is untouched and a workspace was opened at the worktree.
+    cx.update(|_, cx| {
+        let store = ThreadMetadataStore::global(cx);
+        let store = store.read(cx);
+        let entry = store
+            .entries()
+            .find(|e| e.session_id.as_ref() == Some(&session))
+            .unwrap();
+        assert_eq!(
+            entry.folder_paths().paths(),
+            &[PathBuf::from("/wt/rosewood")]
+        );
+    });
+    multi_workspace.read_with(cx, |multi_workspace, cx| {
+        assert!(
+            multi_workspace
+                .workspaces()
+                .any(|workspace| workspace_path_list(workspace, cx).paths()
+                    == [PathBuf::from("/wt/rosewood")]),
+            "a workspace should have been opened at the live worktree path"
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_two_worktree_workspaces_absorbed_when_main_added(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.executor());

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1177,7 +1177,6 @@ impl LocalWorktree {
                 };
                 let fs_case_sensitive = fs.is_case_sensitive().await;
 
-                let is_single_file = snapshot.snapshot.root_dir().is_none();
                 let mut scanner = BackgroundScanner {
                     fs,
                     fs_case_sensitive,
@@ -1203,7 +1202,6 @@ impl LocalWorktree {
                     settings,
                     watcher,
                     track_git_repositories,
-                    is_single_file,
                     defer_watch,
                 };
 
@@ -3983,9 +3981,6 @@ struct BackgroundScanner {
     settings: WorktreeSettings,
     share_private_files: bool,
     track_git_repositories: bool,
-    /// Whether this is a single-file worktree (root is a file, not a directory).
-    /// Used to determine if we should give up after repeated canonicalization failures.
-    is_single_file: bool,
     defer_watch: bool,
 }
 
@@ -4167,20 +4162,28 @@ impl BackgroundScanner {
             while let Poll::Ready(Some(more_paths)) = futures::poll!(fs_events_rx.next()) {
                 paths.extend(more_paths);
             }
-            self.process_events(
-                paths
-                    .into_iter()
-                    .filter(|event| event.kind.is_some())
-                    .collect(),
-            )
-            .await;
+            if !self
+                .process_events(
+                    paths
+                        .into_iter()
+                        .filter(|event| event.kind.is_some())
+                        .collect(),
+                )
+                .await
+            {
+                return;
+            }
         }
         if let Some(abs_path) = containing_git_repository {
-            self.process_events(vec![PathEvent {
-                path: abs_path,
-                kind: Some(fs::PathEventKind::Changed),
-            }])
-            .await;
+            if !self
+                .process_events(vec![PathEvent {
+                    path: abs_path,
+                    kind: Some(fs::PathEventKind::Changed),
+                }])
+                .await
+            {
+                return;
+            }
         }
 
         // Continue processing events until the worktree is dropped.
@@ -4210,12 +4213,15 @@ impl BackgroundScanner {
                             state.snapshot.absolutize(&request.path)
                         };
 
-                        if let Some(abs_path) = self.fs.canonicalize(&abs_path).await.log_err() {
-                            self.process_events(vec![PathEvent {
-                                path: abs_path,
-                                kind: Some(fs::PathEventKind::Changed),
-                            }])
-                            .await;
+                        if let Some(abs_path) = self.fs.canonicalize(&abs_path).await.log_err()
+                            && !self
+                                .process_events(vec![PathEvent {
+                                    path: abs_path,
+                                    kind: Some(fs::PathEventKind::Changed),
+                                }])
+                                .await
+                        {
+                            return;
                         }
                     }
                     self.send_status_update(false, request.done, &[]).await;
@@ -4226,7 +4232,9 @@ impl BackgroundScanner {
                     while let Poll::Ready(Some(more_paths)) = futures::poll!(fs_events_rx.next()) {
                         paths.extend(more_paths);
                     }
-                    self.process_events(paths.into_iter().filter(|event| event.kind.is_some()).collect()).await;
+                    if !self.process_events(paths.into_iter().filter(|event| event.kind.is_some()).collect()).await {
+                        return;
+                    }
                 }
 
                 _ = global_gitignore_events.next().fuse() => {
@@ -4347,7 +4355,7 @@ impl BackgroundScanner {
         events
     }
 
-    async fn process_events(&self, mut events: Vec<PathEvent>) {
+    async fn process_events(&self, mut events: Vec<PathEvent>) -> bool {
         let root_path = self.state.lock().await.snapshot.abs_path.clone();
         let root_canonical_path = self.fs.canonicalize(root_path.as_path()).await;
         let root_canonical_path = match &root_canonical_path {
@@ -4380,21 +4388,15 @@ impl BackgroundScanner {
                         .unbounded_send(ScanState::RootUpdated { new_path })
                         .ok();
                 } else {
-                    log::error!("root path could not be canonicalized: {err:#}");
-
-                    // For single-file worktrees, if we can't canonicalize and the file handle
-                    // fallback also failed, the file is gone - close the worktree
-                    if self.is_single_file {
-                        log::info!(
-                            "single-file worktree root {:?} no longer exists, marking as deleted",
-                            root_path.as_path()
-                        );
-                        self.status_updates_tx
-                            .unbounded_send(ScanState::RootDeleted)
-                            .ok();
-                    }
+                    log::info!(
+                        "worktree root {:?} no longer exists, marking as deleted: {err:#}",
+                        root_path.as_path()
+                    );
+                    self.status_updates_tx
+                        .unbounded_send(ScanState::RootDeleted)
+                        .ok();
                 }
-                return;
+                return false;
             }
         };
 
@@ -4603,7 +4605,7 @@ impl BackgroundScanner {
         }
 
         if relative_paths.is_empty() && dot_git_abs_paths.is_empty() {
-            return;
+            return true;
         }
 
         if !work_dirs_needing_exclude_update.is_empty() {
@@ -4671,6 +4673,7 @@ impl BackgroundScanner {
         }
         self.send_status_update(false, SmallVec::new(), &relative_paths)
             .await;
+        true
     }
 
     async fn update_global_gitignore(&self, abs_path: &Path) {


### PR DESCRIPTION
When a linked git worktree is deleted — via Zed's worktree picker or externally with `git worktree remove` — agent threads attached to it were left dangling: their sidebar rows pointed at a nonexistent directory and opening them tried to open a workspace there.

This PR:

- Reacts to `RepositoryEvent::GitWorktreeListChanged` in the sidebar: non-archived threads (and terminal threads) whose folder path was the deleted worktree are repointed at the main repo checkout, persisted, re-indexed, and regrouped under the main project. This covers deletions from Zed's worktree picker as well as external `git worktree remove`.
- Adds a lazy fallback at thread-open time for worktrees deleted while Zed was closed (when no event can fire): folder paths confirmed missing on disk are reset to main before the workspace opens. Threads with archived-worktree records are left to the archive restore flow.
- Extends the worktree picker's delete guard to consider every workspace in every open window, so a worktree with a live workspace anywhere can no longer be deleted out from under it.
- Hardens `compute_snapshot` so a transient `git worktree list` failure keeps the previous worktree list instead of making every linked worktree appear deleted, and counts a repo's own working directory as live so workspaces opened at a linked worktree don't have their threads wrongly reset on restart.

Archived threads intentionally keep their recorded paths — those serve as restoration keys for the worktree archive flow.

Closes AI-345

Release Notes:

- Fixed agent threads being left pointing at deleted git worktrees; they are now redirected to the main repository checkout. Git worktrees with open workspaces in other windows can no longer be deleted from the worktree picker.
