### PR TITLE
gpui: Fix title bar clicks being delayed on macOS 27

### DIFF
--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -289,15 +289,9 @@ unsafe fn build_classes() {
                 character_index_for_point as extern "C" fn(&Object, Sel, NSPoint) -> u64,
             );
 
-            // Undocumented SPI, also implemented by Chromium's content view: tells
-            // AppKit/the window server which parts of the view should be treated as
-            // opaque app content rather than title bar, scoping the system's
-            // title-bar machinery (window-move, and on macOS 27 the title bar
-            // gesture recognizers whose multi-click disambiguation delays single
-            // clicks by the double-click interval) away from our custom-drawn
-            // title bar. Our layer-backed Metal view is "locally transparent" from
-            // AppKit's perspective, so without this AppKit assumes the title-bar
-            // region under `NSFullSizeContentViewWindowMask` is its own.
+            // Undocumented SPI, also implemented by Chromium's content view. This
+            // lets full size content windows mark our Metal view as app owned title
+            // bar content, avoiding AppKit's title bar click-delay behavior.
             decl.add_method(
                 sel!(_opaqueRectForWindowMoveWhenInTitlebar),
                 opaque_rect_for_window_move_when_in_titlebar
@@ -2769,10 +2763,22 @@ extern "C" fn accepts_first_mouse(this: &Object, _: Sel, _: id) -> BOOL {
 }
 
 extern "C" fn opaque_rect_for_window_move_when_in_titlebar(this: &Object, _: Sel) -> NSRect {
-    // Declare the entire view as opaque content for window-move purposes; window
-    // dragging from the custom title bar is initiated by the app itself via
-    // `performWindowDragWithEvent:`.
-    unsafe { msg_send![this, bounds] }
+    unsafe {
+        let window: id = msg_send![this, window];
+        if window == nil {
+            return NSRect::new(NSPoint::new(0., 0.), NSSize::new(0., 0.));
+        }
+
+        let style_mask: NSWindowStyleMask = msg_send![window, styleMask];
+        if style_mask.contains(NSWindowStyleMask::NSFullSizeContentViewWindowMask) {
+            // Declare the entire view as opaque content for window move purposes
+            // when using a custom titlebar, so AppKit doesn't wait for double click
+            // disambiguation before delivering clicks to titlebar controls.
+            msg_send![this, bounds]
+        } else {
+            NSRect::new(NSPoint::new(0., 0.), NSSize::new(0., 0.))
+        }
+    }
 }
 
 extern "C" fn character_index_for_point(this: &Object, _: Sel, position: NSPoint) -> u64 {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -288,6 +288,21 @@ unsafe fn build_classes() {
                 sel!(characterIndexForPoint:),
                 character_index_for_point as extern "C" fn(&Object, Sel, NSPoint) -> u64,
             );
+
+            // Undocumented SPI, also implemented by Chromium's content view: tells
+            // AppKit/the window server which parts of the view should be treated as
+            // opaque app content rather than title bar, scoping the system's
+            // title-bar machinery (window-move, and on macOS 27 the title bar
+            // gesture recognizers whose multi-click disambiguation delays single
+            // clicks by the double-click interval) away from our custom-drawn
+            // title bar. Our layer-backed Metal view is "locally transparent" from
+            // AppKit's perspective, so without this AppKit assumes the title-bar
+            // region under `NSFullSizeContentViewWindowMask` is its own.
+            decl.add_method(
+                sel!(_opaqueRectForWindowMoveWhenInTitlebar),
+                opaque_rect_for_window_move_when_in_titlebar
+                    as extern "C" fn(&Object, Sel) -> NSRect,
+            );
             decl.register()
         };
         BLURRED_VIEW_CLASS = {
@@ -2751,6 +2766,13 @@ extern "C" fn accepts_first_mouse(this: &Object, _: Sel, _: id) -> BOOL {
     let mut lock = window_state.as_ref().lock();
     lock.first_mouse = true;
     YES
+}
+
+extern "C" fn opaque_rect_for_window_move_when_in_titlebar(this: &Object, _: Sel) -> NSRect {
+    // Declare the entire view as opaque content for window-move purposes; window
+    // dragging from the custom title bar is initiated by the app itself via
+    // `performWindowDragWithEvent:`.
+    unsafe { msg_send![this, bounds] }
 }
 
 extern "C" fn character_index_for_point(this: &Object, _: Sel, position: NSPoint) -> u64 {


### PR DESCRIPTION
Fixes a macOS 27 beta regression where clicks on custom titlebar controls were delayed by the system double-click interval.

After updating to macOS 27 dev beta, I noticed that our titlebar buttons had a delay before click events took effect. After some digging, I discovered that AppKit can treat that titlebar region as system-owned and delay click delivery while waiting to disambiguate double-clicks. I noticed that Slack had titlebar buttons that weren't affected by the double-click disambiguation delay, so I had Claude dig through the Chromium/Electron codebase to discover what they did differently.

Chromium uses a private AppKit SPI, `_opaqueRectForWindowMoveWhenInTitlebar`, that allows them to set what regions should be treated as owned by a view vs. owned by AppKit. My fix uses the same API and returns the view bounds when `NSWindowStyleMask::NSFullSizeContentViewWindowMask` is set, which happens when a GPUI app uses a full-size content view for a custom titlebar. Otherwise, we return bounds of `NSRect::new(NSPoint::new(0., 0.), NSSize::new(0., 0.))` so apps using macOS's native titlebar still work as expected.

### Before

https://github.com/user-attachments/assets/ba9e0d2d-b85c-4d98-bc7d-bea00368d9cf

### After 

https://github.com/user-attachments/assets/b78bd7d4-6b43-48d3-a615-2c7a29e32e71


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

-  Fixed clicks on titlebar controls being delayed on the macOS 27 beta.
