### PR TITLE
Link data retention consent callout to Anthropic's policy article

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -36,8 +36,7 @@ use workspace::{OpenOptions, SERIALIZATION_THROTTLE_TIME};
 
 use super::*;
 
-// TODO: Replace with the final link explaining Anthropic's data retention policy.
-const DATA_RETENTION_LEARN_MORE_URL: &str = "#link-tbd";
+const DATA_RETENTION_LEARN_MORE_URL: &str = "https://support.claude.com/en/articles/15425996-data-retention-practices-for-mythos-class-models";
 
 #[derive(Default)]
 struct ThreadFeedbackState {


### PR DESCRIPTION
Resolves a leftover TODO from the Claude Fable 5 data-retention work: the "Learn More" button in the data-retention consent callout pointed at a `#link-tbd` placeholder, so it did nothing. It now opens Anthropic's data retention practices support article.

Release Notes:

- N/A
