### PR TITLE
Pin workflow actions and service images to immutable SHAs

### DIFF
--- a/.github/workflows/after_release.yml
+++ b/.github/workflows/after_release.yml
@@ -41,7 +41,7 @@ jobs:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
     permissions:
       contents: read
-    uses: zed-industries/zed/.github/workflows/deploy_docs.yml@main
+    uses: zed-industries/zed/.github/workflows/deploy_docs.yml@3f16f7b9082f8828e4d6ae207d2349b1ef932517
     secrets:
       DOCS_AMPLITUDE_API_KEY: ${{ secrets.DOCS_AMPLITUDE_API_KEY }}
       DOCS_CONSENT_IO_INSTANCE: ${{ secrets.DOCS_CONSENT_IO_INSTANCE }}

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -73,7 +73,7 @@ jobs:
       run: cargo nextest run --package collab --no-fail-fast
     services:
       postgres:
-        image: postgres:15
+        image: postgres:15@sha256:1b92e7a80c021647bf70f5d3eb66066a998e4f5cf43c07bb9dc9f729782cf88e
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:
@@ -87,7 +87,7 @@ jobs:
     runs-on: namespace-profile-16x32-ubuntu-2204
     steps:
     - name: deploy_collab::publish::install_doctl
-      uses: digitalocean/action-doctl@v2
+      uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f
       with:
         token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
     - name: deploy_collab::publish::sign_into_registry
@@ -117,7 +117,7 @@ jobs:
       with:
         clean: false
     - name: deploy_collab::deploy::install_doctl
-      uses: digitalocean/action-doctl@v2
+      uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f
       with:
         token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
     - name: deploy_collab::deploy::sign_into_kubernetes

--- a/.github/workflows/deploy_nightly_docs.yml
+++ b/.github/workflows/deploy_nightly_docs.yml
@@ -10,7 +10,7 @@ jobs:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
     permissions:
       contents: read
-    uses: zed-industries/zed/.github/workflows/deploy_docs.yml@main
+    uses: zed-industries/zed/.github/workflows/deploy_docs.yml@3f16f7b9082f8828e4d6ae207d2349b1ef932517
     secrets:
       DOCS_AMPLITUDE_API_KEY: ${{ secrets.DOCS_AMPLITUDE_API_KEY }}
       DOCS_CONSENT_IO_INSTANCE: ${{ secrets.DOCS_CONSENT_IO_INSTANCE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
     timeout-minutes: 60
     services:
       postgres:
-        image: postgres:15
+        image: postgres:15@sha256:1b92e7a80c021647bf70f5d3eb66066a998e4f5cf43c07bb9dc9f729782cf88e
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 60
     services:
       postgres:
-        image: postgres:15
+        image: postgres:15@sha256:1b92e7a80c021647bf70f5d3eb66066a998e4f5cf43c07bb9dc9f729782cf88e
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -399,7 +399,7 @@ jobs:
     timeout-minutes: 60
     services:
       postgres:
-        image: postgres:15
+        image: postgres:15@sha256:1b92e7a80c021647bf70f5d3eb66066a998e4f5cf43c07bb9dc9f729782cf88e
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:
@@ -794,12 +794,12 @@ jobs:
           echo "BUF_BASE_BRANCH=$GITHUB_BASE_REF" >> "$GITHUB_ENV"
         fi
     - name: run_tests::check_postgres_and_protobuf_migrations::bufbuild_setup_action
-      uses: bufbuild/buf-setup-action@v1
+      uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99
       with:
         version: v1.29.0
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: run_tests::check_postgres_and_protobuf_migrations::bufbuild_breaking_action
-      uses: bufbuild/buf-breaking-action@v1
+      uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba
       with:
         input: crates/proto/proto/
         against: https://github.com/${GITHUB_REPOSITORY}.git#branch=${BUF_BASE_BRANCH},subdir=crates/proto/proto/

--- a/tooling/xtask/src/tasks/workflows/deploy_collab.rs
+++ b/tooling/xtask/src/tasks/workflows/deploy_collab.rs
@@ -48,7 +48,7 @@ fn tests(deps: &[&NamedJob]) -> NamedJob {
             .runs_on(runners::LINUX_XL)
             .add_service(
                 "postgres",
-                Container::new("postgres:15")
+                Container::new("postgres:15@sha256:1b92e7a80c021647bf70f5d3eb66066a998e4f5cf43c07bb9dc9f729782cf88e")
                     .add_env(("POSTGRES_HOST_AUTH_METHOD", "trust"))
                     .ports(vec![Port::Name("5432:5432".into())])
                     .options(
@@ -70,8 +70,12 @@ fn tests(deps: &[&NamedJob]) -> NamedJob {
 
 fn publish(deps: &[&NamedJob]) -> NamedJob {
     fn install_doctl() -> Step<Use> {
-        named::uses("digitalocean", "action-doctl", "v2")
-            .add_with(("token", vars::DIGITALOCEAN_ACCESS_TOKEN))
+        named::uses(
+            "digitalocean",
+            "action-doctl",
+            "3cb3953159719656269e044e0e24ca16dd2a690f", // v2.5.2
+        )
+        .add_with(("token", vars::DIGITALOCEAN_ACCESS_TOKEN))
     }
 
     fn sign_into_registry() -> Step<Run> {
@@ -110,8 +114,12 @@ fn publish(deps: &[&NamedJob]) -> NamedJob {
 
 fn deploy(deps: &[&NamedJob]) -> NamedJob {
     fn install_doctl() -> Step<Use> {
-        named::uses("digitalocean", "action-doctl", "v2")
-            .add_with(("token", vars::DIGITALOCEAN_ACCESS_TOKEN))
+        named::uses(
+            "digitalocean",
+            "action-doctl",
+            "3cb3953159719656269e044e0e24ca16dd2a690f", // v2.5.2
+        )
+        .add_with(("token", vars::DIGITALOCEAN_ACCESS_TOKEN))
     }
 
     fn sign_into_kubernetes() -> Step<Run> {

--- a/tooling/xtask/src/tasks/workflows/deploy_docs.rs
+++ b/tooling/xtask/src/tasks/workflows/deploy_docs.rs
@@ -258,7 +258,9 @@ pub(crate) fn deploy_docs_workflow_call(
             "zed-industries",
             "zed",
             ".github/workflows/deploy_docs.yml",
-            "main",
+            // Pinned to a commit rather than the mutable `main` ref (supply-chain hardening).
+            // Same-repo reusable workflow; bump via Dependabot or alongside deploy_docs.yml changes.
+            "3f16f7b9082f8828e4d6ae207d2349b1ef932517",
         )
         .with(
             Input::default()

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -585,7 +585,7 @@ fn run_platform_tests_impl(platform: Platform, filter_packages: bool) -> NamedJo
             .when(platform == Platform::Linux, |job| {
                 job.add_service(
                     "postgres",
-                    Container::new("postgres:15")
+                    Container::new("postgres:15@sha256:1b92e7a80c021647bf70f5d3eb66066a998e4f5cf43c07bb9dc9f729782cf88e")
                         .add_env(("POSTGRES_HOST_AUTH_METHOD", "trust"))
                         .ports(vec![Port::Name("5432:5432".into())])
                         .options(
@@ -659,13 +659,22 @@ pub(crate) fn check_postgres_and_protobuf_migrations() -> NamedJob {
     }
 
     fn bufbuild_setup_action() -> Step<Use> {
-        named::uses("bufbuild", "buf-setup-action", "v1")
-            .add_with(("version", "v1.29.0"))
-            .add_with(("github_token", vars::GITHUB_TOKEN))
+        named::uses(
+            "bufbuild",
+            "buf-setup-action",
+            "a47c93e0b1648d5651a065437926377d060baa99", // v1.50.0
+        )
+        .add_with(("version", "v1.29.0"))
+        .add_with(("github_token", vars::GITHUB_TOKEN))
     }
 
     fn bufbuild_breaking_action() -> Step<Use> {
-        named::uses("bufbuild", "buf-breaking-action", "v1").add_with(("input", "crates/proto/proto/"))
+        named::uses(
+            "bufbuild",
+            "buf-breaking-action",
+            "c57b3d842a5c3f3b454756ef65305a50a587c5ba", // v1.1.4
+        )
+        .add_with(("input", "crates/proto/proto/"))
             .add_with(("against", "https://github.com/${GITHUB_REPOSITORY}.git#branch=${BUF_BASE_BRANCH},subdir=crates/proto/proto/"))
     }
 


### PR DESCRIPTION
Pins the remaining tag- and branch-referenced GitHub Actions and the `postgres` service image to specific commit SHAs / digests, so workflow runs resolve to fixed versions. Edited in the xtask workflow DSL and regenerated with `cargo xtask workflows`.

- `bufbuild/buf-setup-action` → `a47c93e0` (v1.50.0)
- `bufbuild/buf-breaking-action` → `c57b3d84` (v1.1.4)
- `digitalocean/action-doctl` → `3cb39531` (v2.5.2)
- `postgres:15` → `@sha256:1b92e7a8…`
- `deploy_docs.yml` reusable workflow → pinned to a commit

Release Notes:

- N/A
