### PR TITLE
Add supports_disabling_thinking to Cloud model listings

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -482,6 +482,32 @@ async fn test_thinking(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_thinking_allowed_when_model_cannot_disable_thinking(cx: &mut TestAppContext) {
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+    fake_model.set_supports_thinking(true);
+
+    // With thinking toggled off, a model that can disable thinking honors
+    // the toggle...
+    thread.update(cx, |thread, cx| {
+        thread.set_thinking_enabled(false, cx);
+        let request = thread
+            .build_completion_request(CompletionIntent::UserPrompt, cx)
+            .unwrap();
+        assert!(!request.thinking_allowed);
+    });
+
+    // ...but a model that always thinks ignores the stale toggle state.
+    fake_model.set_supports_disabling_thinking(false);
+    thread.update(cx, |thread, cx| {
+        let request = thread
+            .build_completion_request(CompletionIntent::UserPrompt, cx)
+            .unwrap();
+        assert!(request.thinking_allowed);
+    });
+}
+
+#[gpui::test]
 async fn test_system_prompt(cx: &mut TestAppContext) {
     let ThreadTest {
         model,

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -3607,7 +3607,10 @@ impl Thread {
             tool_choice: None,
             stop: Vec::new(),
             temperature: AgentSettings::temperature_for_model(model, cx),
-            thinking_allowed: self.thinking_enabled,
+            // Models that can't run with thinking disabled ignore the
+            // toggle state, which may be stale from a previously selected
+            // model that could.
+            thinking_allowed: self.thinking_enabled || !model.supports_disabling_thinking(),
             thinking_effort: self.thinking_effort.clone(),
             speed: self.speed(),
         };

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4629,6 +4629,24 @@ impl ThreadView {
             return None;
         }
 
+        // A toggle would be dishonest for models that always think: only
+        // offer the effort selector.
+        if !model.supports_disabling_thinking() {
+            let effort_levels = model.supported_effort_levels();
+            if effort_levels.is_empty() {
+                return None;
+            }
+            return Some(
+                self.render_effort_selector(
+                    effort_levels,
+                    thread.thinking_effort().cloned(),
+                    true,
+                    cx,
+                )
+                .into_any_element(),
+            );
+        }
+
         let thinking = thread.thinking_enabled();
 
         let (tooltip_label, icon, color) = if thinking {
@@ -4693,6 +4711,7 @@ impl ThreadView {
         let right_btn = self.render_effort_selector(
             model.supported_effort_levels(),
             thread.thinking_effort().cloned(),
+            false,
             cx,
         );
 
@@ -4707,6 +4726,7 @@ impl ThreadView {
         &self,
         supported_effort_levels: Vec<LanguageModelEffortLevel>,
         selected_effort: Option<String>,
+        standalone: bool,
         cx: &Context<Self>,
     ) -> impl IntoElement {
         let weak_self = cx.weak_entity();
@@ -4772,9 +4792,17 @@ impl ThreadView {
             }
         });
 
+        // When rendered as the right half of the split button next to the
+        // thinking toggle, only the right corners are rounded.
+        let trigger = if standalone {
+            ButtonLike::new("effort-selector-trigger")
+        } else {
+            ButtonLike::new_rounded_right("effort-selector-trigger")
+        };
+
         PopoverMenu::new("effort-selector")
             .trigger_with_tooltip(
-                ButtonLike::new_rounded_right("effort-selector-trigger")
+                trigger
                     .selected_style(ButtonStyle::Tinted(TintColor::Accent))
                     .child(Label::new(label).size(LabelSize::Small).color(label_color))
                     .child(Icon::new(icon).size(IconSize::XSmall).color(Color::Muted)),
@@ -10512,7 +10540,12 @@ impl Render for ThreadView {
                 }
                 if let Some(thread) = this.as_native_thread(cx) {
                     thread.update(cx, |thread, cx| {
-                        thread.set_thinking_enabled(!thread.thinking_enabled(), cx);
+                        let model_allows_disabling = thread
+                            .model()
+                            .is_none_or(|model| model.supports_disabling_thinking());
+                        if model_allows_disabling {
+                            thread.set_thinking_enabled(!thread.thinking_enabled(), cx);
+                        }
                     });
                 }
             }))

--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -298,6 +298,12 @@ pub struct LanguageModel {
     pub supports_tools: bool,
     pub supports_images: bool,
     pub supports_thinking: bool,
+    /// Whether thinking can be turned off entirely for this model, allowing
+    /// clients to offer an "off" choice alongside `supported_effort_levels`.
+    /// Some models (e.g. Claude Fable 5) always think and cannot honor an
+    /// "off" request. Only meaningful when `supports_thinking` is `true`.
+    #[serde(default)]
+    pub supports_disabling_thinking: bool,
     #[serde(default)]
     pub supports_fast_mode: bool,
     pub supported_effort_levels: Vec<SupportedEffortLevel>,

--- a/crates/language_model/src/fake_provider.rs
+++ b/crates/language_model/src/fake_provider.rs
@@ -124,6 +124,7 @@ pub struct FakeLanguageModel {
     >,
     forbid_requests: AtomicBool,
     supports_thinking: AtomicBool,
+    supports_disabling_thinking: AtomicBool,
     supports_streaming_tools: AtomicBool,
     supports_images: AtomicBool,
     max_token_count: AtomicU64,
@@ -140,6 +141,7 @@ impl Default for FakeLanguageModel {
             current_completion_txs: Mutex::new(Vec::new()),
             forbid_requests: AtomicBool::new(false),
             supports_thinking: AtomicBool::new(false),
+            supports_disabling_thinking: AtomicBool::new(true),
             supports_streaming_tools: AtomicBool::new(false),
             supports_images: AtomicBool::new(false),
             max_token_count: AtomicU64::new(1_000_000),
@@ -174,6 +176,10 @@ impl FakeLanguageModel {
 
     pub fn set_supports_thinking(&self, supports: bool) {
         self.supports_thinking.store(supports, SeqCst);
+    }
+
+    pub fn set_supports_disabling_thinking(&self, supports: bool) {
+        self.supports_disabling_thinking.store(supports, SeqCst);
     }
 
     pub fn set_supports_streaming_tools(&self, supports: bool) {
@@ -304,6 +310,10 @@ impl LanguageModel for FakeLanguageModel {
 
     fn supports_thinking(&self) -> bool {
         self.supports_thinking.load(SeqCst)
+    }
+
+    fn supports_disabling_thinking(&self) -> bool {
+        self.supports_disabling_thinking.load(SeqCst)
     }
 
     fn supports_streaming_tools(&self) -> bool {

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -88,6 +88,13 @@ pub trait LanguageModel: Send + Sync {
         false
     }
 
+    /// Whether thinking can be turned off entirely for this model. Some
+    /// models (e.g. Claude Fable 5) always think and cannot honor an "off"
+    /// request. Only meaningful when `supports_thinking` returns `true`.
+    fn supports_disabling_thinking(&self) -> bool {
+        true
+    }
+
     fn supports_fast_mode(&self) -> bool {
         false
     }

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -764,6 +764,7 @@ mod tests {
                         supports_tools: true,
                         supports_images: false,
                         supports_thinking: false,
+                        supports_disabling_thinking: false,
                         supports_fast_mode: false,
                         supported_effort_levels: Vec::new(),
                         supports_streaming_tools: false,

--- a/crates/language_models_cloud/src/language_models_cloud.rs
+++ b/crates/language_models_cloud/src/language_models_cloud.rs
@@ -336,6 +336,10 @@ impl<TP: CloudLlmTokenProvider + 'static> LanguageModel for CloudLanguageModel<T
         self.model.supports_thinking
     }
 
+    fn supports_disabling_thinking(&self) -> bool {
+        self.model.supports_disabling_thinking
+    }
+
     fn supports_fast_mode(&self) -> bool {
         self.model.supports_fast_mode
     }


### PR DESCRIPTION
Claude Fable 5 always thinks and cannot honor a request with thinking disabled, but the cloud models listing gives clients no way to tell it apart from models where thinking is optional (e.g. Claude Opus 4.6): both report `supports_thinking: true` plus the same adaptive effort levels. As a result, the agent panel shows a thinking toggle for Fable even though turning it off isn't actually supported.

zed-industries/cloud#2789 adds a `supports_disabling_thinking` field to the models listing. This PR mirrors it through `cloud_llm_client::LanguageModel` (serde-defaulted to `false`, so a server without the field is treated as "don't claim thinking can be turned off") and exposes it as `LanguageModel::supports_disabling_thinking()`, forwarded from the listing by `CloudLanguageModel`. The agent panel now hides the thinking toggle for models that report `false`, showing only the effort selector.

The trait default is `true`: every non-cloud provider in the tree treats thinking as toggleable today, and only the cloud listing knows about always-thinking models.

Draft until zed-industries/cloud#2789 lands and deploys.

Release Notes:

- Fixed the agent panel offering a thinking toggle for models that cannot run with thinking disabled.
