### PR TITLE
python: Add multi-venv LSP support

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -88,7 +88,8 @@ pub use text_diff::{
 use theme::SyntaxTheme;
 pub use toolchain::{
     LanguageToolchainStore, LocalLanguageToolchainStore, Toolchain, ToolchainList, ToolchainLister,
-    ToolchainMetadata, ToolchainScope,
+    ToolchainMetadata, ToolchainRootIndicator, ToolchainRootMarker, ToolchainRootMarkerKind,
+    ToolchainScope,
 };
 use tree_sitter::{self, QueryCursor, WasmStore, wasmtime};
 use util::rel_path::RelPath;

--- a/crates/language/src/toolchain.rs
+++ b/crates/language/src/toolchain.rs
@@ -18,7 +18,10 @@ use util::rel_path::RelPath;
 use crate::LanguageName;
 
 // Re-export core data types from language_core.
-pub use language_core::{Toolchain, ToolchainList, ToolchainMetadata, ToolchainScope};
+pub use language_core::{
+    Toolchain, ToolchainList, ToolchainMetadata, ToolchainRootIndicator, ToolchainRootMarker,
+    ToolchainRootMarkerKind, ToolchainScope,
+};
 
 #[async_trait]
 pub trait ToolchainLister: Send + Sync + 'static {

--- a/crates/language_core/src/language_core.rs
+++ b/crates/language_core/src/language_core.rs
@@ -36,4 +36,7 @@ pub use lsp_adapter::{
 };
 pub use manifest::ManifestName;
 pub use queries::{LanguageQueries, QUERY_FILENAME_PREFIXES};
-pub use toolchain::{Toolchain, ToolchainList, ToolchainMetadata, ToolchainScope};
+pub use toolchain::{
+    Toolchain, ToolchainList, ToolchainMetadata, ToolchainRootIndicator, ToolchainRootMarker,
+    ToolchainRootMarkerKind, ToolchainScope,
+};

--- a/crates/language_core/src/toolchain.rs
+++ b/crates/language_core/src/toolchain.rs
@@ -86,13 +86,58 @@ impl ToolchainScope {
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
+pub enum ToolchainRootMarkerKind {
+    File,
+    Directory,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct ToolchainRootMarker {
+    pub name: SharedString,
+    pub kind: ToolchainRootMarkerKind,
+    pub required_child: Option<SharedString>,
+}
+
+impl ToolchainRootMarker {
+    pub fn file(name: SharedString) -> Self {
+        Self {
+            name,
+            kind: ToolchainRootMarkerKind::File,
+            required_child: None,
+        }
+    }
+
+    pub fn directory(name: SharedString) -> Self {
+        Self {
+            name,
+            kind: ToolchainRootMarkerKind::Directory,
+            required_child: None,
+        }
+    }
+
+    pub fn directory_with_required_child(name: SharedString, required_child: SharedString) -> Self {
+        Self {
+            name,
+            kind: ToolchainRootMarkerKind::Directory,
+            required_child: Some(required_child),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum ToolchainRootIndicator {
+    Manifest(ManifestName),
+    Marker(ToolchainRootMarker),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ToolchainMetadata {
     /// Returns a term which we should use in UI to refer to toolchains produced by a given `ToolchainLister`.
     pub term: SharedString,
     /// A user-facing placeholder describing the semantic meaning of a path to a new toolchain.
     pub new_toolchain_placeholder: SharedString,
-    /// The name of the manifest file for this toolchain.
-    pub manifest_name: ManifestName,
+    /// Ordered project root indicators for this toolchain.
+    pub root_indicators: Vec<ToolchainRootIndicator>,
 }
 
 type DefaultIndex = usize;

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -1,9 +1,11 @@
 use gpui::{App, SharedString, UpdateGlobal};
+use language::language_settings::AllLanguageSettings;
 use node_runtime::NodeRuntime;
+use pet_core::python_environment::PythonEnvironmentKind;
 use project::Fs;
 use python::PyprojectTomlManifestProvider;
 use rust::CargoManifestProvider;
-use settings::{SemanticTokenRules, SettingsStore};
+use settings::{SemanticTokenRules, Settings, SettingsStore};
 use smol::stream::StreamExt;
 use std::sync::Arc;
 use util::ResultExt;
@@ -73,6 +75,29 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
     let basedpyright_lsp_adapter = Arc::new(BasedPyrightLspAdapter::new(node.clone()));
     let ruff_lsp_adapter = Arc::new(RuffLspAdapter::new(fs.clone()));
     let python_toolchain_provider = Arc::new(python::PythonToolchainProvider::new(fs.clone()));
+
+    {
+        let python_name = LanguageName::new_static("Python");
+        let python_toolchain_provider = python_toolchain_provider.clone();
+        let update_preferred = move |cx: &mut App| {
+            let settings = AllLanguageSettings::get(None, cx);
+            let preferred = settings
+                .language(None, Some(&python_name), cx)
+                .tasks
+                .variables
+                .get(python::PREFERRED_ENVIRONMENT_VARIABLE)
+                .and_then(|s| {
+                    serde_json::from_value::<PythonEnvironmentKind>(serde_json::Value::String(
+                        s.clone(),
+                    ))
+                    .ok()
+                });
+            python_toolchain_provider.update_preferred_environment(preferred);
+        };
+        update_preferred(cx);
+        cx.observe_global::<SettingsStore>(update_preferred).detach();
+    }
+
     let rust_context_provider = Arc::new(rust::RustContextProvider);
     let rust_lsp_adapter = Arc::new(rust::RustLspAdapter);
     let tailwind_adapter = Arc::new(tailwind::TailwindLspAdapter::new(node.clone()));

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -13,7 +13,10 @@ use language::{
 };
 use language::{ContextProvider, LspAdapter, LspAdapterDelegate};
 use language::{LanguageName, ManifestName, ManifestProvider, ManifestQuery};
-use language::{Toolchain, ToolchainList, ToolchainLister, ToolchainMetadata};
+use language::{
+    Toolchain, ToolchainList, ToolchainLister, ToolchainMetadata, ToolchainRootIndicator,
+    ToolchainRootMarker,
+};
 use lsp::{CompletionItemKind, LanguageServerBinary, Uri};
 use lsp::{LanguageServerBinaryOptions, LanguageServerName};
 use node_runtime::{NodeRuntime, VersionStrategy};
@@ -1165,11 +1168,21 @@ fn python_env_kind_display(k: &PythonEnvironmentKind) -> &'static str {
 
 pub(crate) struct PythonToolchainProvider {
     fs: Arc<dyn Fs>,
+    preferred_environment: Arc<Mutex<Option<PythonEnvironmentKind>>>,
 }
+
+pub(crate) const PREFERRED_ENVIRONMENT_VARIABLE: &str = "PYTHON_PREFERRED_ENVIRONMENT";
 
 impl PythonToolchainProvider {
     pub fn new(fs: Arc<dyn Fs>) -> Self {
-        Self { fs }
+        Self {
+            fs,
+            preferred_environment: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn update_preferred_environment(&self, kind: Option<PythonEnvironmentKind>) {
+        *self.preferred_environment.lock() = kind;
     }
 }
 
@@ -1190,15 +1203,22 @@ static ENV_PRIORITY_LIST: &[PythonEnvironmentKind] = &[
     PythonEnvironmentKind::Homebrew,
 ];
 
-fn env_priority(kind: Option<PythonEnvironmentKind>) -> usize {
+fn env_priority(kind: Option<PythonEnvironmentKind>, preferred: Option<PythonEnvironmentKind>) -> usize {
+    if let Some(preferred) = preferred
+        && kind == Some(preferred)
+    {
+        return 0;
+    }
+    let shift = if preferred.is_some() { 1 } else { 0 };
     if let Some(kind) = kind {
         ENV_PRIORITY_LIST
             .iter()
             .position(|blessed_env| blessed_env == &kind)
-            .unwrap_or(ENV_PRIORITY_LIST.len())
+            .map(|pos| pos + shift)
+            .unwrap_or(ENV_PRIORITY_LIST.len() + shift)
     } else {
         // Unknown toolchains are less useful than non-blessed ones.
-        ENV_PRIORITY_LIST.len() + 1
+        ENV_PRIORITY_LIST.len() + shift + 1
     }
 }
 
@@ -1328,7 +1348,9 @@ impl ToolchainLister for PythonToolchainProvider {
 
         let wr = worktree_root;
         let wr_venv = get_worktree_venv_declaration(&wr).await;
+        let preferred_environment = *self.preferred_environment.lock();
         // Sort detected environments by:
+        //     user-preferred environment kind
         //     environment name matching activation file (<workdir>/.venv)
         //     environment project dir matching worktree_root
         //     general env priority
@@ -1356,8 +1378,11 @@ impl ToolchainLister for PythonToolchainProvider {
                     )
                 };
 
-            // Compare environment priorities
-            let priority_ordering = || env_priority(lhs.kind).cmp(&env_priority(rhs.kind));
+            // Compare environment priorities, applying user preference as a boost
+            let priority_ordering = || {
+                env_priority(lhs.kind, preferred_environment)
+                    .cmp(&env_priority(rhs.kind, preferred_environment))
+            };
 
             // Compare conda prefixes
             let conda_ordering = || {
@@ -1410,7 +1435,15 @@ impl ToolchainLister for PythonToolchainProvider {
             new_toolchain_placeholder: SharedString::new_static(
                 "A path to the python3 executable within a virtual environment, or path to virtual environment itself",
             ),
-            manifest_name: ManifestName::from(SharedString::new_static("pyproject.toml")),
+            root_indicators: vec![
+                ToolchainRootIndicator::Manifest(ManifestName::from(SharedString::new_static(
+                    "pyproject.toml",
+                ))),
+                ToolchainRootIndicator::Marker(ToolchainRootMarker::directory_with_required_child(
+                    SharedString::new_static(".venv"),
+                    SharedString::new_static("pyvenv.cfg"),
+                )),
+            ],
         }
     }
 
@@ -3365,6 +3398,106 @@ mod tests {
                 delegate,
             });
             assert_eq!(result.as_deref(), RelPath::unix("deep/nested").ok());
+        }
+    }
+
+    mod env_priority_tests {
+        use pet_core::python_environment::PythonEnvironmentKind;
+
+        use crate::python::env_priority;
+
+        #[test]
+        fn preferred_environment_has_priority_zero() {
+            // Conda is normally very low priority (index 9 in ENV_PRIORITY_LIST),
+            // but when set as preferred it should get priority 0.
+            assert_eq!(
+                env_priority(Some(PythonEnvironmentKind::Conda), Some(PythonEnvironmentKind::Conda)),
+                0
+            );
+            // Uv is normally index 1, but with Conda as preferred it shifts to 2.
+            assert_eq!(
+                env_priority(Some(PythonEnvironmentKind::Uv), Some(PythonEnvironmentKind::Conda)),
+                2
+            );
+            // UvWorkspace is index 0 normally, shifts to 1 when something else is preferred.
+            assert_eq!(
+                env_priority(
+                    Some(PythonEnvironmentKind::UvWorkspace),
+                    Some(PythonEnvironmentKind::Conda)
+                ),
+                1
+            );
+        }
+
+        #[test]
+        fn default_order_when_no_preference() {
+            // Without a preference, UvWorkspace (index 0) beats Conda (index 9).
+            assert!(
+                env_priority(Some(PythonEnvironmentKind::UvWorkspace), None)
+                    < env_priority(Some(PythonEnvironmentKind::Conda), None)
+            );
+            // Unknown kind falls after all known kinds.
+            assert!(
+                env_priority(Some(PythonEnvironmentKind::Homebrew), None)
+                    < env_priority(None, None)
+            );
+        }
+
+        #[test]
+        fn non_preferred_kind_keeps_relative_order() {
+            // When Venv is preferred, UvWorkspace and Uv keep their relative order
+            // (UvWorkspace before Uv), just shifted by 1.
+            assert!(
+                env_priority(
+                    Some(PythonEnvironmentKind::UvWorkspace),
+                    Some(PythonEnvironmentKind::Venv)
+                ) < env_priority(
+                    Some(PythonEnvironmentKind::Uv),
+                    Some(PythonEnvironmentKind::Venv)
+                )
+            );
+        }
+    }
+
+    mod preferred_environment_provider_tests {
+        use gpui::TestAppContext;
+        use pet_core::python_environment::PythonEnvironmentKind;
+
+        use crate::python::{PREFERRED_ENVIRONMENT_VARIABLE, PythonToolchainProvider};
+
+        #[gpui::test]
+        fn update_preferred_environment_stored_and_cleared(cx: &mut TestAppContext) {
+            let fs = project::FakeFs::new(cx.executor());
+            let provider = PythonToolchainProvider::new(fs);
+
+            assert_eq!(*provider.preferred_environment.lock(), None);
+
+            provider.update_preferred_environment(Some(PythonEnvironmentKind::Conda));
+            assert_eq!(
+                *provider.preferred_environment.lock(),
+                Some(PythonEnvironmentKind::Conda)
+            );
+
+            provider.update_preferred_environment(None);
+            assert_eq!(*provider.preferred_environment.lock(), None);
+        }
+
+        #[test]
+        fn preferred_environment_variable_name_is_parseable_to_kind() {
+            // Verify that the variable name constant is correct and that the
+            // recognized kind strings (as serialized by serde) round-trip correctly.
+            assert_eq!(
+                PREFERRED_ENVIRONMENT_VARIABLE,
+                "PYTHON_PREFERRED_ENVIRONMENT"
+            );
+
+            let parsed: Option<PythonEnvironmentKind> =
+                serde_json::from_value(serde_json::Value::String("Venv".to_string())).ok();
+            assert_eq!(parsed, Some(PythonEnvironmentKind::Venv));
+
+            let parsed: Option<PythonEnvironmentKind> =
+                serde_json::from_value(serde_json::Value::String("unknown_kind".to_string())).ok();
+            assert_eq!(parsed, None);
         }
     }
 }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1425,12 +1425,16 @@ impl LocalLspStore {
         };
         let delegate: Arc<dyn ManifestDelegate> =
             Arc::new(ManifestQueryDelegate::new(worktree.read(cx).snapshot()));
+        let root_indicators = language
+            .toolchain_lister()
+            .map(|lister| lister.meta().root_indicators);
 
         self.lsp_tree
             .get(
                 project_path,
                 language.name(),
                 language.manifest(),
+                root_indicators.as_deref(),
                 &delegate,
                 cx,
             )
@@ -2649,11 +2653,18 @@ impl LocalLspStore {
             return;
         };
         let delegate: Arc<dyn ManifestDelegate> = Arc::new(ManifestQueryDelegate::new(snapshot));
+        let root_indicators = language
+            .toolchain_lister()
+            .map(|lister| lister.meta().root_indicators);
 
-        for server_id in
-            self.lsp_tree
-                .get(path, language.name(), language.manifest(), &delegate, cx)
-        {
+        for server_id in self.lsp_tree.get(
+            path,
+            language.name(),
+            language.manifest(),
+            root_indicators.as_deref(),
+            &delegate,
+            cx,
+        ) {
             let server = self
                 .language_servers
                 .get(&server_id)
@@ -2867,6 +2878,9 @@ impl LocalLspStore {
             return;
         };
         let language_name = language.name();
+        let root_indicators = language
+            .toolchain_lister()
+            .map(|lister| lister.meta().root_indicators);
         let (reused, delegate, servers) = self
             .reuse_existing_language_server(&self.lsp_tree, &worktree, &language_name, cx)
             .map(|(delegate, apply)| (true, delegate, apply(&mut self.lsp_tree)))
@@ -2881,6 +2895,7 @@ impl LocalLspStore {
                         ProjectPath { worktree_id, path },
                         language.name(),
                         language.manifest(),
+                        root_indicators.as_deref(),
                         &delegate,
                         cx,
                     )
@@ -4573,10 +4588,19 @@ impl LspStore {
         &mut self,
         _: Entity<LocalToolchainStore>,
         event: &ToolchainStoreEvent,
-        _: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
-        if let ToolchainStoreEvent::ToolchainActivated = event {
-            self.request_workspace_config_refresh()
+        match event {
+            ToolchainStoreEvent::ToolchainActivated => {
+                self.request_workspace_config_refresh()
+            }
+            ToolchainStoreEvent::CustomToolchainsModified | ToolchainStoreEvent::ToolchainsValidated => {
+                // Recalculate language servers for changed toolchains
+                if let LspStoreMode::Local(local) = &mut self.mode {
+                    local.lsp_tree.invalidate_toolchains();
+                }
+                self.refresh_server_tree(cx);
+            }
         }
     }
 
@@ -5541,11 +5565,15 @@ impl LspStore {
                         .unwrap_or_else(|| file.path().clone());
                     let worktree_path = ProjectPath { worktree_id, path };
                     let abs_path = file.abs_path(cx);
+                    let root_indicators = language
+                        .toolchain_lister()
+                        .map(|lister| lister.meta().root_indicators);
                     let nodes = rebase
                         .walk(
                             worktree_path,
                             language.name(),
                             language.manifest(),
+                            root_indicators.as_deref(),
                             delegate.clone(),
                             cx,
                         )

--- a/crates/project/src/manifest_tree.rs
+++ b/crates/project/src/manifest_tree.rs
@@ -11,7 +11,10 @@ use std::{borrow::Borrow, collections::hash_map::Entry, ops::ControlFlow, sync::
 
 use collections::HashMap;
 use gpui::{App, AppContext as _, Context, Entity, Subscription};
-use language::{ManifestDelegate, ManifestName, ManifestQuery};
+use language::{
+    ManifestDelegate, ManifestName, ManifestQuery, ToolchainRootIndicator, ToolchainRootMarker,
+    ToolchainRootMarkerKind,
+};
 pub use manifest_store::ManifestProvidersStore;
 use path_trie::{LabelPresence, RootPathTrie, TriePath};
 use settings::{SettingsStore, WorktreeId};
@@ -190,6 +193,57 @@ impl ManifestTree {
             })
     }
 
+    pub(crate) fn root_for_path_with_indicators(
+        &mut self,
+        project_path: &ProjectPath,
+        root_indicators: &[ToolchainRootIndicator],
+        delegate: &Arc<dyn ManifestDelegate>,
+        cx: &mut App,
+    ) -> Option<ProjectPath> {
+        debug_assert_eq!(delegate.worktree_id(), project_path.worktree_id);
+        for candidate_root in project_path.path.ancestors() {
+            for root_indicator in root_indicators {
+                let is_root = match root_indicator {
+                    ToolchainRootIndicator::Manifest(manifest_name) => {
+                        self.manifest_matches_root(candidate_root, manifest_name, delegate, cx)
+                    }
+                    ToolchainRootIndicator::Marker(root_marker) => {
+                        marker_matches_root(candidate_root, root_marker, delegate)
+                    }
+                };
+
+                if is_root {
+                    return Some(ProjectPath {
+                        worktree_id: project_path.worktree_id,
+                        path: candidate_root.into(),
+                    });
+                }
+            }
+        }
+
+        None
+    }
+
+    fn manifest_matches_root(
+        &mut self,
+        candidate_root: &RelPath,
+        manifest_name: &ManifestName,
+        delegate: &Arc<dyn ManifestDelegate>,
+        cx: &mut App,
+    ) -> bool {
+        ManifestProvidersStore::global(cx)
+            .get(manifest_name.borrow())
+            .and_then(|provider| {
+                provider.search(ManifestQuery {
+                    path: Arc::from(candidate_root),
+                    depth: 1,
+                    delegate: delegate.clone(),
+                })
+            })
+            .as_deref()
+            .is_some_and(|root| root == candidate_root)
+    }
+
     fn on_worktree_store_event(
         &mut self,
         _: Entity<WorktreeStore>,
@@ -222,4 +276,35 @@ impl ManifestDelegate for ManifestQueryDelegate {
     fn worktree_id(&self) -> WorktreeId {
         self.worktree.id()
     }
+}
+
+fn marker_matches_root(
+    candidate_root: &RelPath,
+    root_marker: &ToolchainRootMarker,
+    delegate: &Arc<dyn ManifestDelegate>,
+) -> bool {
+    let Ok(marker_name) = RelPath::unix(root_marker.name.as_ref()) else {
+        return false;
+    };
+    let marker_path = candidate_root.join(marker_name);
+    let marker_is_dir = match root_marker.kind {
+        ToolchainRootMarkerKind::File => false,
+        ToolchainRootMarkerKind::Directory => true,
+    };
+
+    if !delegate.exists(&marker_path, Some(marker_is_dir)) {
+        return false;
+    }
+
+    if let Some(required_child) = root_marker.required_child.as_ref() {
+        let Ok(required_child) = RelPath::unix(required_child.as_ref()) else {
+            return false;
+        };
+        let required_child_path = marker_path.join(required_child);
+        if !delegate.exists(&required_child_path, Some(false)) {
+            return false;
+        }
+    }
+
+    true
 }

--- a/crates/project/src/manifest_tree/server_tree.rs
+++ b/crates/project/src/manifest_tree/server_tree.rs
@@ -15,7 +15,7 @@ use collections::IndexMap;
 use gpui::{App, Entity};
 use language::{
     CachedLspAdapter, LanguageName, LanguageRegistry, ManifestDelegate, ManifestName, Toolchain,
-    language_settings::AllLanguageSettings,
+    ToolchainRootIndicator, language_settings::AllLanguageSettings,
 };
 use lsp::LanguageServerName;
 use settings::{Settings, SettingsLocation, WorktreeId};
@@ -140,10 +140,18 @@ impl LanguageServerTree {
         path: ProjectPath,
         language_name: LanguageName,
         manifest_name: Option<&ManifestName>,
+        root_indicators: Option<&[ToolchainRootIndicator]>,
         delegate: &Arc<dyn ManifestDelegate>,
         cx: &mut App,
     ) -> impl Iterator<Item = LanguageServerId> + 'a {
-        let manifest_location = self.manifest_location_for_path(&path, manifest_name, delegate, cx);
+        let manifest_location = self.manifest_location_for_path(
+            &path,
+            &language_name,
+            manifest_name,
+            root_indicators,
+            delegate,
+            cx,
+        );
         let adapters = self.adapters_for_language(&manifest_location, &language_name, cx);
         self.get_with_adapters(manifest_location, adapters)
     }
@@ -154,10 +162,18 @@ impl LanguageServerTree {
         path: ProjectPath,
         language_name: LanguageName,
         manifest_name: Option<&ManifestName>,
+        root_indicators: Option<&[ToolchainRootIndicator]>,
         delegate: &Arc<dyn ManifestDelegate>,
         cx: &'a mut App,
     ) -> impl Iterator<Item = LanguageServerTreeNode> + 'a {
-        let manifest_location = self.manifest_location_for_path(&path, manifest_name, delegate, cx);
+        let manifest_location = self.manifest_location_for_path(
+            &path,
+            &language_name,
+            manifest_name,
+            root_indicators,
+            delegate,
+            cx,
+        );
         let adapters = self.adapters_for_language(&manifest_location, &language_name, cx);
         self.init_with_adapters(manifest_location, language_name, adapters, cx)
     }
@@ -221,12 +237,35 @@ impl LanguageServerTree {
     fn manifest_location_for_path(
         &self,
         path: &ProjectPath,
+        language_name: &LanguageName,
         manifest_name: Option<&ManifestName>,
+        root_indicators: Option<&[ToolchainRootIndicator]>,
         delegate: &Arc<dyn ManifestDelegate>,
         cx: &mut App,
     ) -> ProjectPath {
         // Find out what the root location of our subproject is.
         // That's where we'll look for language settings (that include a set of language servers).
+        if let Some(root_indicators) = root_indicators {
+            return self
+                .manifest_tree
+                .update(cx, |this, cx| {
+                    this.root_for_path_with_indicators(path, root_indicators, delegate, cx)
+                })
+                .or_else(|| {
+                    self.toolchains
+                        .read(cx)
+                        .active_toolchain_for_path(path.worktree_id, &path.path, language_name)
+                        .map(|(active_path, _)| ProjectPath {
+                            worktree_id: path.worktree_id,
+                            path: active_path,
+                        })
+                })
+                .unwrap_or_else(|| ProjectPath {
+                    worktree_id: path.worktree_id,
+                    path: RelPath::empty().into(),
+                });
+        }
+
         self.manifest_tree.update(cx, |this, cx| {
             this.root_for_path_or_worktree_root(path, manifest_name, delegate, cx)
         })
@@ -324,6 +363,11 @@ impl LanguageServerTree {
         }
     }
 
+    /// Invalidate all cached toolchain nodes so they get recalculated on next query.
+    pub(crate) fn invalidate_toolchains(&mut self) {
+        self.instances.clear();
+    }
+
     pub(crate) fn register_reused(
         &mut self,
         worktree_id: WorktreeId,
@@ -393,12 +437,18 @@ impl ServerTreeRebase {
         path: ProjectPath,
         language_name: LanguageName,
         manifest_name: Option<&ManifestName>,
+        root_indicators: Option<&[ToolchainRootIndicator]>,
         delegate: Arc<dyn ManifestDelegate>,
         cx: &'a mut App,
     ) -> impl Iterator<Item = LanguageServerTreeNode> + 'a {
-        let manifest =
-            self.new_tree
-                .manifest_location_for_path(&path, manifest_name, &delegate, cx);
+        let manifest = self.new_tree.manifest_location_for_path(
+            &path,
+            &language_name,
+            manifest_name,
+            root_indicators,
+            &delegate,
+            cx,
+        );
         let adapters = self
             .new_tree
             .adapters_for_language(&manifest, &language_name, cx);

--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, str::FromStr, sync::Arc};
+use std::{path::{Path, PathBuf}, str::FromStr, sync::Arc};
 
 use anyhow::{Context as _, Result, bail};
 
@@ -24,9 +24,7 @@ use task::Shell;
 use util::{ResultExt as _, rel_path::RelPath};
 
 use crate::{
-    ProjectEnvironment, ProjectPath,
-    manifest_tree::{ManifestQueryDelegate, ManifestTree},
-    worktree_store::WorktreeStore,
+    ProjectEnvironment, ProjectEntryId, ProjectPath, WorktreeStoreEvent, manifest_tree::{ManifestQueryDelegate, ManifestTree}, worktree_store::{WorktreeStore}
 };
 
 pub struct ToolchainStore {
@@ -34,6 +32,7 @@ pub struct ToolchainStore {
     user_toolchains: BTreeMap<ToolchainScope, IndexSet<Toolchain>>,
     worktree_store: Entity<WorktreeStore>,
     _sub: Subscription,
+    _worktree_sub : Option<Subscription>,
 }
 
 enum ToolchainStoreInner {
@@ -74,11 +73,18 @@ impl ToolchainStore {
         let _sub = cx.subscribe(&entity, |_, _, e: &ToolchainStoreEvent, cx| {
             cx.emit(e.clone())
         });
+
+        let _worktree_sub = cx.subscribe(&worktree_store, |this, _, event: &WorktreeStoreEvent, cx| {
+            if let WorktreeStoreEvent::WorktreeDeletedEntry(worktree_id, entry_id) = event {
+                let _ = this.on_worktree_deleted_entry(*worktree_id, *entry_id, cx);
+            }
+        });
         Self {
             mode: ToolchainStoreInner::Local(entity),
             worktree_store,
             user_toolchains: Default::default(),
             _sub,
+            _worktree_sub: Some(_worktree_sub),
         }
     }
 
@@ -97,6 +103,7 @@ impl ToolchainStore {
             user_toolchains: Default::default(),
             worktree_store,
             _sub,
+            _worktree_sub: None,
         }
     }
     pub(crate) fn activate_toolchain(
@@ -186,7 +193,7 @@ impl ToolchainStore {
             .filter(|(scope, _)| {
                 if let ToolchainScope::Subproject(subproject_root_path, relative_path) = scope {
                     target_root_path == *subproject_root_path
-                        && relative_path.starts_with(&path.path)
+                        && path.path.starts_with(relative_path)
                 } else {
                     true
                 }
@@ -243,6 +250,39 @@ impl ToolchainStore {
             }
         }
     }
+
+    pub(crate) fn on_worktree_deleted_entry(
+        &mut self,
+        worktree_id: WorktreeId,
+        entry_id: ProjectEntryId,
+        cx: &mut Context<Self>,
+    ) -> Task<()> {
+        let Some(worktree) = self.worktree_store.read(cx).worktree_for_id(worktree_id, cx) else {
+            return Task::ready(());
+        };
+
+        let Some(entry) = worktree.read(cx).entry_for_id(entry_id) else {
+            return Task::ready(());
+        };
+
+        if !entry.is_dir() {
+            return Task::ready(());
+        }
+
+        let deleted_rel_path = entry.path.clone();
+        let deleted_abs = worktree.read(cx).absolutize(&deleted_rel_path);
+
+        self.validate_and_cleanup_toolchains(&deleted_abs, cx);
+
+        if let ToolchainStoreInner::Local(local) = &self.mode {
+            local.update(cx, |local, cx| {
+                local.on_worktree_deleted_entry(worktree_id, &deleted_abs, cx);
+            });
+        }
+
+        Task::ready(())
+    }
+
     async fn handle_activate_toolchain(
         this: Entity<Self>,
         envelope: TypedEnvelope<proto::ActivateToolchain>,
@@ -408,6 +448,33 @@ impl ToolchainStore {
             ToolchainStoreInner::Remote(_) => None,
         }
     }
+
+    pub(crate) fn validate_and_cleanup_toolchains(
+        &mut self,
+        deleted_abs: &Path,
+        cx: &mut Context<Self>,
+    ) {
+        let toolchains_to_remove: Vec<(ToolchainScope, Toolchain)> = self
+            .user_toolchains
+            .iter()
+            .flat_map(|(scope, toolchains)| {
+                toolchains
+                    .iter()
+                    .filter_map(|toolchain| {
+                        if Path::new(toolchain.path.as_str()).starts_with(deleted_abs) {
+                            Some((scope.clone(), toolchain.clone()))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        for (scope, toolchain) in toolchains_to_remove {
+            self.remove_toolchain(toolchain, scope, cx);
+        }
+    }
 }
 
 pub struct LocalToolchainStore {
@@ -472,6 +539,7 @@ struct RemoteStore(WeakEntity<RemoteToolchainStore>);
 pub enum ToolchainStoreEvent {
     ToolchainActivated,
     CustomToolchainsModified,
+    ToolchainsValidated,
 }
 
 impl EventEmitter<ToolchainStoreEvent> for LocalToolchainStore {}
@@ -512,7 +580,7 @@ impl LocalToolchainStore {
                 .await
                 .ok()?;
             let toolchains = language.toolchain_lister()?;
-            let manifest_name = toolchains.meta().manifest_name;
+            let metadata = toolchains.meta();
             let (snapshot, worktree) = this
                 .update(cx, |this, cx| {
                     this.worktree_store
@@ -528,13 +596,18 @@ impl LocalToolchainStore {
                 Arc::from(ManifestQueryDelegate::new(snapshot)) as Arc<dyn ManifestDelegate>;
             let relative_path = manifest_tree
                 .update(cx, |this, cx| {
-                    this.root_for_path(&path, &manifest_name, &delegate, cx)
+                    this.root_for_path_with_indicators(
+                        &path,
+                        &metadata.root_indicators,
+                        &delegate,
+                        cx,
+                    )
                 })
-                .ok()?
-                .unwrap_or_else(|| ProjectPath {
-                    path: Arc::from(RelPath::empty()),
-                    worktree_id,
-                });
+                .ok()?;
+            let relative_path = relative_path.unwrap_or_else(|| ProjectPath {
+                path: Arc::from(RelPath::empty()),
+                worktree_id,
+            });
             let abs_path = worktree.update(cx, |this, _| this.absolutize(&relative_path.path));
 
             let project_env = environment
@@ -564,16 +637,27 @@ impl LocalToolchainStore {
         relative_path: &Arc<RelPath>,
         language_name: LanguageName,
     ) -> Option<Toolchain> {
+        self.active_toolchain_for_path(worktree_id, relative_path, &language_name)
+            .map(|(_, toolchain)| toolchain)
+    }
+
+    pub(crate) fn active_toolchain_for_path(
+        &self,
+        worktree_id: WorktreeId,
+        relative_path: &Arc<RelPath>,
+        language_name: &LanguageName,
+    ) -> Option<(Arc<RelPath>, Toolchain)> {
         let ancestors = relative_path.ancestors();
 
         self.active_toolchains
-            .get(&(worktree_id, language_name))
+            .get(&(worktree_id, language_name.clone()))
             .and_then(|paths| {
-                ancestors
-                    .into_iter()
-                    .find_map(|root_path| paths.get(root_path))
+                ancestors.into_iter().find_map(|root_path| {
+                    paths
+                        .get(root_path)
+                        .map(|toolchain| (root_path.into(), toolchain.clone()))
+                })
             })
-            .cloned()
     }
 
     fn resolve_toolchain(
@@ -605,6 +689,30 @@ impl LocalToolchainStore {
             cx.background_spawn(async move { toolchain_lister.resolve(path, project_env).await })
                 .await
         })
+    }
+
+    pub(crate) fn on_worktree_deleted_entry(
+        &mut self,
+        worktree_id: WorktreeId,
+        deleted_abs: &Path,
+        cx: &mut Context<Self>,
+    ) {
+        let mut did_remove = false;
+        for ((w_id, _), paths) in self.active_toolchains.iter_mut() {
+            if *w_id != worktree_id {
+                continue;
+            }
+            let before = paths.len();
+            paths.retain(|_, toolchain| {
+                !Path::new(toolchain.path.as_str()).starts_with(deleted_abs)
+            });
+            if paths.len() != before {
+                did_remove = true;
+            }
+        }
+        if did_remove {
+            cx.emit(ToolchainStoreEvent::CustomToolchainsModified);
+        }
     }
 }
 

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -15,6 +15,7 @@ mod search;
 mod search_history;
 mod signature_help;
 mod task_inventory;
+mod toolchain_store;
 mod trusted_worktrees;
 mod yarn;
 
@@ -13465,7 +13466,9 @@ fn python_lang(fs: Arc<FakeFs>) -> Arc<Language> {
                 new_toolchain_placeholder: SharedString::new_static(
                     "A path to the python3 executable within a virtual environment, or path to virtual environment itself",
                 ),
-                manifest_name: ManifestName::from(SharedString::new_static("pyproject.toml")),
+                root_indicators: vec![language::ToolchainRootIndicator::Manifest(
+                    ManifestName::from(SharedString::new_static("pyproject.toml")),
+                )],
             }
         }
         fn activation_script(

--- a/crates/project/tests/integration/toolchain_store.rs
+++ b/crates/project/tests/integration/toolchain_store.rs
@@ -1,0 +1,891 @@
+use std::{path::PathBuf, sync::Arc};
+
+use async_trait::async_trait;
+use collections::HashMap;
+use fs::FakeFs;
+use gpui::{SharedString, TestAppContext};
+use language::{
+    FakeLspAdapter, Language, LanguageConfig, LanguageMatcher, LanguageName, ManifestName,
+    Toolchain, ToolchainList, ToolchainLister, ToolchainMetadata, ToolchainRootIndicator,
+    ToolchainRootMarker, ToolchainScope,
+};
+use fs::Fs as _;
+use lsp::Uri;
+use project::{ManifestProvidersStore, Project, ProjectPath, Toolchains};
+use serde_json::json;
+use task::ShellKind;
+use util::{path, rel_path::rel_path};
+
+use super::init_test;
+
+// ---------------------------------------------------------------------------
+// Feature 1 – Root indicators
+// ---------------------------------------------------------------------------
+
+/// A toolchain lister that returns `.venv/` directories found in ancestors,
+/// and declares `.venv/pyvenv.cfg` (directory + required child) as root indicator.
+struct VenvMarkerLister(Arc<FakeFs>);
+
+#[async_trait]
+impl ToolchainLister for VenvMarkerLister {
+    async fn list(
+        &self,
+        worktree_root: PathBuf,
+        subroot_relative_path: Arc<util::rel_path::RelPath>,
+        _: Option<HashMap<String, String>>,
+    ) -> ToolchainList {
+        let mut toolchains = vec![];
+        for ancestor in subroot_relative_path.ancestors() {
+            let venv_path = worktree_root.join(ancestor.as_std_path()).join(".venv");
+            if self.0.is_dir(&venv_path).await {
+                toolchains.push(Toolchain {
+                    name: SharedString::from(format!("{}/venv", ancestor.as_unix_str())),
+                    path: venv_path
+                        .join("bin/python3")
+                        .to_string_lossy()
+                        .into_owned()
+                        .into(),
+                    language_name: LanguageName(SharedString::new_static("Python")),
+                    as_json: serde_json::Value::Null,
+                });
+            }
+        }
+        ToolchainList {
+            toolchains,
+            ..Default::default()
+        }
+    }
+
+    async fn resolve(
+        &self,
+        _: PathBuf,
+        _: Option<HashMap<String, String>>,
+    ) -> anyhow::Result<Toolchain> {
+        Err(anyhow::anyhow!("not implemented"))
+    }
+
+    fn meta(&self) -> ToolchainMetadata {
+        ToolchainMetadata {
+            term: SharedString::new_static("Virtual Environment"),
+            new_toolchain_placeholder: SharedString::new_static("path to python3"),
+            root_indicators: vec![ToolchainRootIndicator::Marker(
+                ToolchainRootMarker::directory_with_required_child(
+                    SharedString::new_static(".venv"),
+                    SharedString::new_static("pyvenv.cfg"),
+                ),
+            )],
+        }
+    }
+
+    fn activation_script(
+        &self,
+        _: &Toolchain,
+        _: ShellKind,
+        _: &gpui::App,
+    ) -> futures::future::BoxFuture<'static, Vec<String>> {
+        Box::pin(async { vec![] })
+    }
+}
+
+fn python_lang_with_venv_marker(fs: Arc<FakeFs>) -> Arc<Language> {
+    Arc::new(
+        Language::new(
+            LanguageConfig {
+                name: "Python".into(),
+                matcher: LanguageMatcher {
+                    path_suffixes: vec!["py".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            None,
+        )
+        .with_toolchain_lister(Some(Arc::new(VenvMarkerLister(fs)))),
+    )
+}
+
+/// A lister that uses BOTH the manifest indicator (pyproject.toml) AND the
+/// marker indicator (.venv/pyvenv.cfg), in that order.
+struct ManifestAndVenvMarkerLister(Arc<FakeFs>);
+
+#[async_trait]
+impl ToolchainLister for ManifestAndVenvMarkerLister {
+    async fn list(
+        &self,
+        worktree_root: PathBuf,
+        subroot_relative_path: Arc<util::rel_path::RelPath>,
+        _: Option<HashMap<String, String>>,
+    ) -> ToolchainList {
+        let mut toolchains = vec![];
+        for ancestor in subroot_relative_path.ancestors() {
+            let venv_path = worktree_root.join(ancestor.as_std_path()).join(".venv");
+            if self.0.is_dir(&venv_path).await {
+                toolchains.push(Toolchain {
+                    name: SharedString::from(format!("{}/venv", ancestor.as_unix_str())),
+                    path: venv_path
+                        .join("bin/python3")
+                        .to_string_lossy()
+                        .into_owned()
+                        .into(),
+                    language_name: LanguageName(SharedString::new_static("Python")),
+                    as_json: serde_json::Value::Null,
+                });
+            }
+        }
+        ToolchainList {
+            toolchains,
+            ..Default::default()
+        }
+    }
+
+    async fn resolve(
+        &self,
+        _: PathBuf,
+        _: Option<HashMap<String, String>>,
+    ) -> anyhow::Result<Toolchain> {
+        Err(anyhow::anyhow!("not implemented"))
+    }
+
+    fn meta(&self) -> ToolchainMetadata {
+        ToolchainMetadata {
+            term: SharedString::new_static("Virtual Environment"),
+            new_toolchain_placeholder: SharedString::new_static("path to python3"),
+            root_indicators: vec![
+                ToolchainRootIndicator::Manifest(ManifestName::from(
+                    SharedString::new_static("pyproject.toml"),
+                )),
+                ToolchainRootIndicator::Marker(ToolchainRootMarker::directory_with_required_child(
+                    SharedString::new_static(".venv"),
+                    SharedString::new_static("pyvenv.cfg"),
+                )),
+            ],
+        }
+    }
+
+    fn activation_script(
+        &self,
+        _: &Toolchain,
+        _: ShellKind,
+        _: &gpui::App,
+    ) -> futures::future::BoxFuture<'static, Vec<String>> {
+        Box::pin(async { vec![] })
+    }
+}
+
+fn python_lang_with_manifest_and_venv_marker(fs: Arc<FakeFs>) -> Arc<Language> {
+    Arc::new(
+        Language::new(
+            LanguageConfig {
+                name: "Python".into(),
+                matcher: LanguageMatcher {
+                    path_suffixes: vec!["py".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            None,
+        )
+        .with_manifest(Some(ManifestName::from(SharedString::new_static(
+            "pyproject.toml",
+        ))))
+        .with_toolchain_lister(Some(Arc::new(ManifestAndVenvMarkerLister(fs)))),
+    )
+}
+
+#[gpui::test]
+async fn test_venv_marker_used_as_root_indicator(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".zed": {
+                "settings.json": r#"{"languages": {"Python": {"language_servers": ["ty"]}}}"#
+            },
+            "service": {
+                ".venv": {
+                    "pyvenv.cfg": "home = /usr/bin",
+                    "bin": {}
+                },
+                "main.py": ""
+            },
+            "other.py": ""
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    let _fake_server = language_registry.register_fake_lsp(
+        "Python",
+        FakeLspAdapter {
+            name: "ty",
+            ..Default::default()
+        },
+    );
+    language_registry.add(python_lang_with_venv_marker(fs.clone()));
+
+    let (service_buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/root/service/main.py"), cx)
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    let servers = project.update(cx, |project, cx| {
+        project.lsp_store().update(cx, |this, cx| {
+            service_buffer.update(cx, |buffer, cx| {
+                this.running_language_servers_for_local_buffer(buffer, cx)
+                    .map(|(adapter, server)| (adapter.clone(), server.clone()))
+                    .collect::<Vec<_>>()
+            })
+        })
+    });
+    assert_eq!(servers.len(), 1);
+    let (_, server) = servers.into_iter().next().unwrap();
+    // The LSP root must be `service/`, not the worktree root, because `.venv/pyvenv.cfg`
+    // signals that `service/` is the subproject boundary.
+    assert_eq!(
+        server.workspace_folders(),
+        std::collections::BTreeSet::from_iter(
+            [Uri::from_file_path(path!("/root/service")).unwrap()].into_iter()
+        )
+    );
+}
+
+#[gpui::test]
+async fn test_venv_marker_without_required_child_not_recognized(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    // `.venv/` exists but `pyvenv.cfg` is absent – not a valid root indicator.
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".zed": {
+                "settings.json": r#"{"languages": {"Python": {"language_servers": ["ty"]}}}"#
+            },
+            "service": {
+                ".venv": {
+                    "bin": {}
+                },
+                "main.py": ""
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    let _fake_server = language_registry.register_fake_lsp(
+        "Python",
+        FakeLspAdapter {
+            name: "ty",
+            ..Default::default()
+        },
+    );
+    language_registry.add(python_lang_with_venv_marker(fs.clone()));
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/root/service/main.py"), cx)
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    let servers = project.update(cx, |project, cx| {
+        project.lsp_store().update(cx, |this, cx| {
+            buffer.update(cx, |buffer, cx| {
+                this.running_language_servers_for_local_buffer(buffer, cx)
+                    .map(|(_, server)| server.clone())
+                    .collect::<Vec<_>>()
+            })
+        })
+    });
+    assert_eq!(servers.len(), 1);
+    // No valid root indicator → falls back to worktree root.
+    assert_eq!(
+        servers[0].workspace_folders(),
+        std::collections::BTreeSet::from_iter(
+            [Uri::from_file_path(path!("/root")).unwrap()].into_iter()
+        )
+    );
+}
+
+#[gpui::test]
+async fn test_inner_venv_marker_overrides_outer_manifest(cx: &mut TestAppContext) {
+    use language::{ManifestProvider, ManifestQuery};
+    init_test(cx);
+
+    // Register a minimal pyproject.toml provider so the manifest indicator is functional.
+    struct PyprojectProvider;
+    impl ManifestProvider for PyprojectProvider {
+        fn name(&self) -> ManifestName {
+            SharedString::new_static("pyproject.toml").into()
+        }
+        fn search(
+            &self,
+            ManifestQuery {
+                path,
+                depth,
+                delegate,
+            }: ManifestQuery,
+        ) -> Option<Arc<util::rel_path::RelPath>> {
+            for ancestor in path.ancestors().take(depth) {
+                let pyproject = ancestor.join(rel_path("pyproject.toml"));
+                if delegate.exists(&pyproject, Some(false)) {
+                    return Some(Arc::from(ancestor));
+                }
+            }
+            None
+        }
+    }
+    cx.update(|cx| {
+        ManifestProvidersStore::global(cx).register(Arc::new(PyprojectProvider))
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".zed": {
+                "settings.json": r#"{"languages": {"Python": {"language_servers": ["ty"]}}}"#
+            },
+            "pyproject.toml": "",
+            "service": {
+                ".venv": {
+                    "pyvenv.cfg": "home = /usr/bin",
+                    "bin": {}
+                },
+                "main.py": ""
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    let _fake_server = language_registry.register_fake_lsp(
+        "Python",
+        FakeLspAdapter {
+            name: "ty",
+            ..Default::default()
+        },
+    );
+    // This language checks manifest first, then .venv marker.
+    language_registry.add(python_lang_with_manifest_and_venv_marker(fs.clone()));
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/root/service/main.py"), cx)
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    let servers = project.update(cx, |project, cx| {
+        project.lsp_store().update(cx, |this, cx| {
+            buffer.update(cx, |buffer, cx| {
+                this.running_language_servers_for_local_buffer(buffer, cx)
+                    .map(|(_, server)| server.clone())
+                    .collect::<Vec<_>>()
+            })
+        })
+    });
+    assert_eq!(servers.len(), 1);
+    // `root_for_path_with_indicators` walks from the file outward; it finds `service/`
+    // via the manifest indicator first (pyproject.toml is checked at `service/` which
+    // doesn't exist, then the marker at `service/.venv/pyvenv.cfg` matches).
+    // The outer `pyproject.toml` at root must not win over the inner `.venv/pyvenv.cfg`.
+    assert_eq!(
+        servers[0].workspace_folders(),
+        std::collections::BTreeSet::from_iter(
+            [Uri::from_file_path(path!("/root/service")).unwrap()].into_iter()
+        )
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Feature 2 – Subproject toolchain scope isolation
+// ---------------------------------------------------------------------------
+
+#[gpui::test]
+async fn test_user_toolchain_scoped_to_subproject_not_visible_in_other_subproject(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "project-a": { ".venv": { "pyvenv.cfg": "", "bin": {} }, "main.py": "" },
+            "project-b": { ".venv": { "pyvenv.cfg": "", "bin": {} }, "main.py": "" }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    // A toolchain lister is required for `available_toolchains` to resolve the language.
+    project.read_with(cx, |project, _| project.languages().clone()).add(
+        python_lang_with_venv_marker(fs.clone()),
+    );
+    let worktree_id = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).id()
+    });
+    let worktree_abs = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).abs_path()
+    });
+
+    let toolchain_a = Toolchain {
+        name: "project-a venv".into(),
+        path: format!("{}/project-a/.venv/bin/python3", worktree_abs.display()).into(),
+        language_name: LanguageName::new_static("Python"),
+        as_json: serde_json::Value::Null,
+    };
+
+    project.update(cx, |project, cx| {
+        project.add_toolchain(
+            toolchain_a.clone(),
+            ToolchainScope::Subproject(worktree_abs.clone(), rel_path("project-a").into()),
+            cx,
+        )
+    });
+
+    // Listing toolchains for a file in project-b must not surface project-a's toolchain.
+    let toolchains_for_b = project
+        .update(cx, |project, cx| {
+            project.available_toolchains(
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path("project-b/main.py").into(),
+                },
+                LanguageName::new_static("Python"),
+                cx,
+            )
+        })
+        .await;
+
+    let Toolchains { user_toolchains, .. } = toolchains_for_b.expect("toolchains available");
+    let subproject_toolchains: Vec<_> = user_toolchains
+        .into_values()
+        .flat_map(|set| set.into_iter())
+        .collect();
+    assert!(
+        !subproject_toolchains.contains(&toolchain_a),
+        "project-a toolchain must not appear when listing toolchains for project-b"
+    );
+
+    // Conversely, listing for project-a must include the toolchain.
+    let toolchains_for_a = project
+        .update(cx, |project, cx| {
+            project.available_toolchains(
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path("project-a/main.py").into(),
+                },
+                LanguageName::new_static("Python"),
+                cx,
+            )
+        })
+        .await;
+
+    let Toolchains {
+        user_toolchains: user_toolchains_a,
+        ..
+    } = toolchains_for_a.expect("toolchains available");
+    let subproject_toolchains_a: Vec<_> = user_toolchains_a
+        .into_values()
+        .flat_map(|set| set.into_iter())
+        .collect();
+    assert!(
+        subproject_toolchains_a.contains(&toolchain_a),
+        "project-a toolchain must appear when listing toolchains for project-a"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Feature 3 – Toolchain cleanup on directory deletion
+// ---------------------------------------------------------------------------
+
+#[gpui::test]
+async fn test_active_toolchain_cleared_when_containing_dir_deleted(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "service": {
+                ".venv": {
+                    "pyvenv.cfg": "",
+                    "bin": { "python3": "" }
+                },
+                "main.py": ""
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    cx.run_until_parked();
+
+    let worktree_id = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).id()
+    });
+    let worktree_abs = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).abs_path()
+    });
+
+    let toolchain = Toolchain {
+        name: "service venv".into(),
+        path: format!("{}/service/.venv/bin/python3", worktree_abs.display()).into(),
+        language_name: LanguageName::new_static("Python"),
+        as_json: serde_json::Value::Null,
+    };
+
+    project
+        .update(cx, |project, cx| {
+            project.activate_toolchain(
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path("service").into(),
+                },
+                toolchain.clone(),
+                cx,
+            )
+        })
+        .await
+        .expect("toolchain activated");
+
+    // Verify the toolchain is active for a file inside the service subproject.
+    let active_before = project
+        .update(cx, |project, cx| {
+            project.active_toolchain(
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path("service/main.py").into(),
+                },
+                LanguageName::new_static("Python"),
+                cx,
+            )
+        })
+        .await;
+    assert_eq!(
+        active_before.as_ref().map(|t| t.path.as_ref()),
+        Some(toolchain.path.as_ref()),
+        "toolchain must be active before directory deletion"
+    );
+
+    // Delete the directory that contains the toolchain executable.
+    let venv_entry_id = project.read_with(cx, |project, cx| {
+        project
+            .entry_for_path(
+                &ProjectPath {
+                    worktree_id,
+                    path: rel_path("service/.venv").into(),
+                },
+                cx,
+            )
+            .map(|e| e.id)
+    });
+    let venv_entry_id = venv_entry_id.expect(".venv entry must exist in worktree snapshot");
+
+    project
+        .update(cx, |project, cx| {
+            project.delete_entry(venv_entry_id, false, cx)
+        })
+        .expect("delete_entry returned a task")
+        .await
+        .expect("delete_entry succeeded");
+    cx.run_until_parked();
+
+    let active_after = project
+        .update(cx, |project, cx| {
+            project.active_toolchain(
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path("service/main.py").into(),
+                },
+                LanguageName::new_static("Python"),
+                cx,
+            )
+        })
+        .await;
+    assert!(
+        active_after.is_none(),
+        "toolchain must be cleared after its containing directory is deleted"
+    );
+}
+
+#[gpui::test]
+async fn test_user_toolchain_cleared_when_containing_dir_deleted(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "service": {
+                ".venv": {
+                    "pyvenv.cfg": "",
+                    "bin": { "python3": "" }
+                },
+                "main.py": ""
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    cx.run_until_parked();
+
+    let worktree_id = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).id()
+    });
+    let worktree_abs = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).abs_path()
+    });
+
+    let toolchain = Toolchain {
+        name: "service venv".into(),
+        path: format!("{}/service/.venv/bin/python3", worktree_abs.display()).into(),
+        language_name: LanguageName::new_static("Python"),
+        as_json: serde_json::Value::Null,
+    };
+
+    project.update(cx, |project, cx| {
+        project.add_toolchain(
+            toolchain.clone(),
+            ToolchainScope::Subproject(worktree_abs.clone(), rel_path("service").into()),
+            cx,
+        )
+    });
+
+    let user_toolchains_before = project.read_with(cx, |project, cx| {
+        project.user_toolchains(cx).unwrap_or_default()
+    });
+    let all_before: Vec<_> = user_toolchains_before
+        .into_values()
+        .flat_map(|s| s.into_iter())
+        .collect();
+    assert!(
+        all_before.contains(&toolchain),
+        "toolchain must be present in user_toolchains before deletion"
+    );
+
+    let venv_entry_id = project.read_with(cx, |project, cx| {
+        project
+            .entry_for_path(
+                &ProjectPath {
+                    worktree_id,
+                    path: rel_path("service/.venv").into(),
+                },
+                cx,
+            )
+            .map(|e| e.id)
+    });
+    let venv_entry_id = venv_entry_id.expect(".venv entry must exist in worktree snapshot");
+
+    project
+        .update(cx, |project, cx| {
+            project.delete_entry(venv_entry_id, false, cx)
+        })
+        .expect("delete_entry returned a task")
+        .await
+        .expect("delete_entry succeeded");
+    cx.run_until_parked();
+
+    let user_toolchains_after = project.read_with(cx, |project, cx| {
+        project.user_toolchains(cx).unwrap_or_default()
+    });
+    let all_after: Vec<_> = user_toolchains_after
+        .into_values()
+        .flat_map(|s| s.into_iter())
+        .collect();
+    assert!(
+        !all_after.contains(&toolchain),
+        "toolchain must be removed from user_toolchains after its directory is deleted"
+    );
+}
+
+#[gpui::test]
+async fn test_parent_directory_deletion_clears_nested_toolchain(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    // Toolchain is two levels deep; deleting a grandparent should still clean it up.
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "service": {
+                ".venv": {
+                    "pyvenv.cfg": "",
+                    "bin": { "python3": "" }
+                },
+                "main.py": ""
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    cx.run_until_parked();
+
+    let worktree_id = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).id()
+    });
+    let worktree_abs = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).abs_path()
+    });
+
+    let toolchain = Toolchain {
+        name: "service venv".into(),
+        path: format!("{}/service/.venv/bin/python3", worktree_abs.display()).into(),
+        language_name: LanguageName::new_static("Python"),
+        as_json: serde_json::Value::Null,
+    };
+
+    project
+        .update(cx, |project, cx| {
+            project.activate_toolchain(
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path("service").into(),
+                },
+                toolchain.clone(),
+                cx,
+            )
+        })
+        .await
+        .expect("toolchain activated");
+
+    // Delete the `service/` directory – the toolchain is two levels inside it.
+    let service_entry_id = project.read_with(cx, |project, cx| {
+        project
+            .entry_for_path(
+                &ProjectPath {
+                    worktree_id,
+                    path: rel_path("service").into(),
+                },
+                cx,
+            )
+            .map(|e| e.id)
+    });
+    let service_entry_id = service_entry_id.expect("service entry must exist");
+
+    project
+        .update(cx, |project, cx| {
+            project.delete_entry(service_entry_id, false, cx)
+        })
+        .expect("delete_entry returned a task")
+        .await
+        .expect("delete_entry succeeded");
+    cx.run_until_parked();
+
+    let active_after = project
+        .update(cx, |project, cx| {
+            project.active_toolchain(
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path("service/main.py").into(),
+                },
+                LanguageName::new_static("Python"),
+                cx,
+            )
+        })
+        .await;
+    assert!(
+        active_after.is_none(),
+        "toolchain must be cleared when the grandparent directory containing it is deleted"
+    );
+}
+
+#[gpui::test]
+async fn test_file_deletion_does_not_clear_toolchain(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "service": {
+                ".venv": {
+                    "pyvenv.cfg": "",
+                    "bin": { "python3": "" }
+                },
+                "main.py": "",
+                "util.py": ""
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    cx.run_until_parked();
+
+    let worktree_id = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).id()
+    });
+    let worktree_abs = project.read_with(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).abs_path()
+    });
+
+    let toolchain = Toolchain {
+        name: "service venv".into(),
+        path: format!("{}/service/.venv/bin/python3", worktree_abs.display()).into(),
+        language_name: LanguageName::new_static("Python"),
+        as_json: serde_json::Value::Null,
+    };
+
+    project
+        .update(cx, |project, cx| {
+            project.activate_toolchain(
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path("service").into(),
+                },
+                toolchain.clone(),
+                cx,
+            )
+        })
+        .await
+        .expect("toolchain activated");
+
+    // Delete a regular Python file – the toolchain must NOT be cleared.
+    let util_entry_id = project.read_with(cx, |project, cx| {
+        project
+            .entry_for_path(
+                &ProjectPath {
+                    worktree_id,
+                    path: rel_path("service/util.py").into(),
+                },
+                cx,
+            )
+            .map(|e| e.id)
+    });
+    let util_entry_id = util_entry_id.expect("util.py entry must exist");
+
+    project
+        .update(cx, |project, cx| {
+            project.delete_entry(util_entry_id, false, cx)
+        })
+        .expect("delete_entry returned a task")
+        .await
+        .expect("delete_entry succeeded");
+    cx.run_until_parked();
+
+    let active_after = project
+        .update(cx, |project, cx| {
+            project.active_toolchain(
+                ProjectPath {
+                    worktree_id,
+                    path: rel_path("service/main.py").into(),
+                },
+                LanguageName::new_static("Python"),
+                cx,
+            )
+        })
+        .await;
+    assert_eq!(
+        active_after.as_ref().map(|t| t.path.as_ref()),
+        Some(toolchain.path.as_ref()),
+        "toolchain must survive file deletion (only directory deletion triggers cleanup)"
+    );
+}

--- a/crates/toolchain_selector/src/active_toolchain.rs
+++ b/crates/toolchain_selector/src/active_toolchain.rs
@@ -169,7 +169,7 @@ impl ActiveToolchain {
                     .ok()?;
                 let Toolchains {
                     toolchains,
-                    root_path: relative_path,
+                    root_path,
                     user_toolchains,
                 } = cx
                     .update(|_, cx| {
@@ -192,12 +192,23 @@ impl ActiveToolchain {
                             // Ignore global toolchains when making a default choice. They're unlikely to be the right choice.
                             None
                         } else {
-                            toolchains.first()
+                            toolchains
+                                .first()
+                                .map(|toolchain| (toolchain.clone(), Some(scope.clone())))
                         }
                     })
-                    .or_else(|| toolchains.toolchains.first())
-                    .cloned();
-                if let Some(toolchain) = &default_choice {
+                    .or_else(|| {
+                        toolchains
+                            .toolchains
+                            .first()
+                            .cloned()
+                            .map(|toolchain| (toolchain, None))
+                    });
+                if let Some((toolchain, scope)) = &default_choice {
+                    let active_path = match scope {
+                        Some(ToolchainScope::Subproject(_, relative_path)) => relative_path.clone(),
+                        _ => root_path.clone(),
+                    };
                     let worktree_root_path = project.read_with(cx, |this, cx| {
                         this.worktree_for_id(worktree_id, cx)
                             .map(|worktree| worktree.read(cx).abs_path())
@@ -206,7 +217,7 @@ impl ActiveToolchain {
                     db.set_toolchain(
                         workspace_id,
                         worktree_root_path,
-                        relative_path.clone(),
+                        active_path.clone(),
                         toolchain.clone(),
                     )
                     .await
@@ -216,7 +227,7 @@ impl ActiveToolchain {
                             this.activate_toolchain(
                                 ProjectPath {
                                     worktree_id,
-                                    path: relative_path,
+                                    path: active_path,
                                 },
                                 toolchain.clone(),
                                 cx,
@@ -225,7 +236,7 @@ impl ActiveToolchain {
                         .await;
                 }
 
-                default_choice
+                default_choice.map(|(toolchain, _)| toolchain)
             }
         })
     }

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -912,7 +912,7 @@ impl PickerDelegate for ToolchainSelectorDelegate {
 
     fn confirm(&mut self, _: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
         if let Some(string_match) = self.matches.get(self.selected_index) {
-            let (toolchain, _) = self.candidates[string_match.candidate_id].clone();
+            let (toolchain, scope) = self.candidates[string_match.candidate_id].clone();
             if let Some(workspace_id) = self
                 .workspace
                 .read_with(cx, |this, _| this.database_id())
@@ -922,8 +922,11 @@ impl PickerDelegate for ToolchainSelectorDelegate {
                 let workspace = self.workspace.clone();
                 let worktree_id = self.worktree_id;
                 let worktree_abs_path_root = self.worktree_abs_path_root.clone();
-                let path = self.relative_path.clone();
-                let relative_path = self.relative_path.clone();
+                let active_path = match scope {
+                    Some(ToolchainScope::Subproject(_, relative_path)) => relative_path,
+                    _ => self.relative_path.clone(),
+                };
+                let relative_path = active_path.clone();
                 let db = workspace::WorkspaceDb::global(cx);
                 cx.spawn_in(window, async move |_, cx| {
                     db.set_toolchain(
@@ -938,7 +941,10 @@ impl PickerDelegate for ToolchainSelectorDelegate {
                         .update(cx, |this, cx| {
                             this.project().update(cx, |this, cx| {
                                 this.activate_toolchain(
-                                    ProjectPath { worktree_id, path },
+                                    ProjectPath {
+                                        worktree_id,
+                                        path: active_path,
+                                    },
                                     toolchain,
                                     cx,
                                 )


### PR DESCRIPTION
## What

In a monorepo or workspace with multiple Python subprojects, each subproject may have its own `.venv` virtual environment but no `pyproject.toml`. Previously, the only way Zed could identify a subproject root was through a manifest file (e.g. `pyproject.toml`), so `.venv`-only subprojects were invisible as boundaries.

## Why

`ToolchainMetadata` only allowed a single `manifest_name` to declare a subproject root. There was no way to express "a `.venv` directory containing `pyvenv.cfg` is also a valid root indicator," and no mechanism to walk ancestor directories checking multiple indicator types in priority order.

Additionally, a `starts_with` comparison in `toolchain_store.rs` was reversed, causing user-scoped toolchains to silently match the wrong subproject, and stale toolchains were never removed when a `.venv` directory was deleted.

## Fix

- `crates/language_core/src/toolchain.rs`: Replace `manifest_name: ManifestName` in `ToolchainMetadata` with `root_indicators: Vec<ToolchainRootIndicator>`, a unified enum that accepts either a `Manifest(ManifestName)` or a `Marker(ToolchainRootMarker)`. A `ToolchainRootMarker` can match a file, a directory, or a directory that must also contain a required child entry.

- `crates/languages/src/python.rs`: Add `.venv/pyvenv.cfg` (directory + required child) as a second root indicator alongside `pyproject.toml`. Add a `PYTHON_PREFERRED_ENVIRONMENT` task variable that boosts the matching environment kind to priority 0 in toolchain sorting. Update `env_priority` to shift all other priorities when a preference is active so relative ordering is preserved.

- `crates/project/src/manifest_tree.rs`: Add `root_for_path_with_indicators` which walks from a file outward, checking each ancestor against the ordered indicator list, and stops at the first match.

- `crates/project/src/manifest_tree/server_tree.rs`: Thread `root_indicators` through `get`, `walk`, `manifest_location_for_path`, and `ServerTreeRebase::walk`. When indicators are present, the indicator-based root is used; otherwise the existing manifest-based path is unchanged.

- `crates/project/src/lsp_store.rs`: Propagate `root_indicators` at every call-site that queries the LSP tree. Handle the new `CustomToolchainsModified` and `ToolchainsValidated` events by invalidating and rebuilding the server tree so language servers are re-bound when a venv changes.

- `crates/project/src/toolchain_store.rs`: Fix reversed `starts_with` that caused user-scoped toolchains to match the wrong subproject path. Subscribe to `WorktreeStoreEvent::WorktreeDeletedEntry` and clean up both active and user toolchains whose executable paths lie inside the deleted directory. Add `ToolchainStoreEvent::ToolchainsValidated`.

- `crates/toolchain_selector/src/active_toolchain.rs` and `toolchain_selector.rs`: Use the subproject's own root path (not the worktree root) when persisting and activating a toolchain that belongs to a `Subproject` scope.

- `crates/project/tests/integration/toolchain_store.rs`: Integration tests covering marker-based root detection, required-child validation, inner-marker overrides outer-manifest, subproject scope isolation, stale cleanup on directory deletion, and negative cases (file deletion must not trigger cleanup).

Closes #41923

Co-authored-by: Guilherme José <guilherme.a.jose@tecnico.ulisboa.pt>

## Self-Review Checklist

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content is consistent with the [UI/UX checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Added support for multi-venv Python monorepos: Zed now recognises a `.venv/pyvenv.cfg` directory as a subproject boundary, so each subproject gets its own language server and interpreter. A `PYTHON_PREFERRED_ENVIRONMENT` task variable can pin a specific environment kind (e.g. `Conda`) to the top of the toolchain list.
