### PR TITLE
git: Keep agent checkpoint scratch index out of the watched .git directory

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -3487,16 +3487,11 @@ impl GitBinary {
     }
 
     fn path_for_index_id(&self, id: Uuid) -> PathBuf {
-        // Keep the scratch index OUT of the watched `.git` directory. The agent
-        // checkpoint feature creates one of these per repo per turn, and Zed
-        // watches every repo's `.git` dir for git state — so writing them here
-        // generates a burst of fs events per checkpoint, which in a large
-        // multi-repo workspace floods the file watcher (zed-industries/zed#58444;
-        // amplified on Linux by the per-event watch broadcast in #25843).
-        //
-        // The temp index is transient scratch: `with_temp_index` copies the real
-        // index *from* `self.git_directory` and never renames this file back into
-        // place, so it can live anywhere writable.
+        // Keep the scratch index OUT of the watched `.git` directory. prevents backpressure fanout
+        // on linux, see #58444.
+        // The temp index is transient scratch: `with_temp_index` copies the
+        // real index *from* `self.git_directory` and never renames this file back into place, so it
+        // can live anywhere writable.
         std::env::temp_dir().join(format!("zed-git-index-{id}.tmp"))
     }
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -3487,7 +3487,17 @@ impl GitBinary {
     }
 
     fn path_for_index_id(&self, id: Uuid) -> PathBuf {
-        self.git_directory.join(format!("index-{}.tmp", id))
+        // Keep the scratch index OUT of the watched `.git` directory. The agent
+        // checkpoint feature creates one of these per repo per turn, and Zed
+        // watches every repo's `.git` dir for git state — so writing them here
+        // generates a burst of fs events per checkpoint, which in a large
+        // multi-repo workspace floods the file watcher (zed-industries/zed#58444;
+        // amplified on Linux by the per-event watch broadcast in #25843).
+        //
+        // The temp index is transient scratch: `with_temp_index` copies the real
+        // index *from* `self.git_directory` and never renames this file back into
+        // place, so it can live anywhere writable.
+        std::env::temp_dir().join(format!("zed-git-index-{id}.tmp"))
     }
 
     pub async fn run<S>(&self, args: &[S]) -> Result<String>
@@ -4322,13 +4332,13 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_path_for_index_id_uses_real_git_directory(cx: &mut TestAppContext) {
+    async fn test_path_for_index_id_is_outside_git_directory(cx: &mut TestAppContext) {
         cx.executor().allow_parking();
         let working_directory = PathBuf::from("/code/worktree");
         let git_directory = PathBuf::from("/code/repo/.git/modules/worktree");
         let git = GitBinary::new(
             PathBuf::from("git"),
-            working_directory,
+            working_directory.clone(),
             git_directory.clone(),
             cx.executor(),
             false,
@@ -4336,9 +4346,17 @@ mod tests {
 
         let path = git.path_for_index_id(Uuid::nil());
 
+        // The scratch index must not live inside the watched `.git` directory (or
+        // anywhere in the worktree), so checkpoint churn doesn't flood the file
+        // watcher (#58444).
+        assert!(
+            !path.starts_with(&git_directory),
+            "scratch index leaked into .git: {path:?}"
+        );
+        assert!(!path.starts_with(&working_directory));
         assert_eq!(
             path,
-            git_directory.join(format!("index-{}.tmp", Uuid::nil()))
+            std::env::temp_dir().join(format!("zed-git-index-{}.tmp", Uuid::nil()))
         );
     }
 


### PR DESCRIPTION
## What

`GitBinary::with_temp_index` (used by the agent checkpoint feature) writes a temporary scratch index — `index-<uuid>.tmp` — into the repository's `.git` directory. This moves that scratch file to a temp directory outside the worktree.

## Why

Zed watches every repository's `.git` directory for git-state changes. The checkpoint runs on every agent turn and snapshots every repo, so each turn writes a temp index into every repo's `.git` — a burst of filesystem events per checkpoint, across all repos.

On Linux those events are then broadcast to every watch registration and filtered per-registration, which pegs the file-watcher thread. Profiling a 258-repo workspace during an agent turn:

- the `notify` event-loop thread sat at 100%, ~57% self-time in `Path::starts_with`;
- a watcher probe showed a single `.git/index-<uuid>.tmp` event delivered to *every* watched directory — ~100M callback invocations ≈ ~14k real events × ~7,000 watch registrations.

`with_temp_index` already copies the real index *from* the repo's git directory and never renames the scratch file back into place — it's pure throwaway scratch, so there's no reason for it to live inside the watched `.git`. Moving it out removes the event source.

## Verification

Built locally with a temporary watcher probe: after the change, the `.git/index-*.tmp` event flood disappears during agent turns, and checkpoint/restore continue to work.

## Scope / notes

- Verified on Linux. The broadcast amplification is Linux-specific (per-directory `NonRecursive` watches); on macOS the recursive watch would instead feed these events into per-repo git-state recomputation, so this should help there too, though I haven't profiled macOS.
- This removes one event *source*. The general amplifier — every fs event being broadcast to all watch registrations on Linux — is separate (#25843).
- Related: #58444.
- Minor: `std::env::temp_dir()` may be on a different filesystem than the repo (a cross-fs copy of the index); happy to use a same-filesystem scratch location if preferred.

Release Notes:

- Fixed a burst of file-watcher activity (high CPU on Linux) when sending agent messages in workspaces with many git repositories