### PR TITLE
Bump notify for v1.6.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11469,7 +11469,7 @@ dependencies = [
 [[package]]
 name = "notify"
 version = "8.2.0"
-source = "git+https://github.com/zed-industries/notify.git?rev=ce58c24cad542c28e04ced02e20325a4ec28a31d#ce58c24cad542c28e04ced02e20325a4ec28a31d"
+source = "git+https://github.com/zed-industries/notify.git?rev=964aa676489c599105d97b9e6a00d15d372b9605#964aa676489c599105d97b9e6a00d15d372b9605"
 dependencies = [
  "bitflags 2.10.0",
  "fsevent-sys",
@@ -11497,7 +11497,7 @@ dependencies = [
 [[package]]
 name = "notify-types"
 version = "2.0.0"
-source = "git+https://github.com/zed-industries/notify.git?rev=ce58c24cad542c28e04ced02e20325a4ec28a31d#ce58c24cad542c28e04ced02e20325a4ec28a31d"
+source = "git+https://github.com/zed-industries/notify.git?rev=964aa676489c599105d97b9e6a00d15d372b9605#964aa676489c599105d97b9e6a00d15d372b9605"
 
 [[package]]
 name = "ntapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -885,8 +885,8 @@ features = [
 
 [patch.crates-io]
 async-task = { git = "https://github.com/smol-rs/async-task.git", rev = "b4486cd71e4e94fbda54ce6302444de14f4d190e" }
-notify = { git = "https://github.com/zed-industries/notify.git", rev = "ce58c24cad542c28e04ced02e20325a4ec28a31d" }
-notify-types = { git = "https://github.com/zed-industries/notify.git", rev = "ce58c24cad542c28e04ced02e20325a4ec28a31d" }
+notify = { git = "https://github.com/zed-industries/notify.git", rev = "964aa676489c599105d97b9e6a00d15d372b9605" }
+notify-types = { git = "https://github.com/zed-industries/notify.git", rev = "964aa676489c599105d97b9e6a00d15d372b9605" }
 windows-capture = { git = "https://github.com/zed-industries/windows-capture.git", rev = "f0d6c1b6691db75461b732f6d5ff56eed002eeb9" }
 calloop = { git = "https://github.com/zed-industries/calloop" }
 livekit = { git = "https://github.com/zed-industries/livekit-rust-sdks", rev = "c3a55bbc207008f1ca3474b6037fdd3c443cad0f" }


### PR DESCRIPTION
For https://github.com/zed-industries/notify/pull/3, which fixes a hang that we saw on v1.5.x and v1.6.x.

Note that on main we've bumped notify to v9.0.0-rc4 upstream, which contains this hang fix and also a number of other changes. I opted to cherry-pick just this fix to v1.6.x so that the larger bump has a full week on preview before going to stable.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed a hang that could occur when opening a new workspace.