### PR TITLE
Call `watcher.add()` on the background

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1081,7 +1081,14 @@ impl Fs for RealFs {
             pending_paths.clone(),
         ));
 
-        if let Err(e) = watcher.add(path) {
+        if let Err(e) = executor
+            .spawn({
+                let path = path.to_owned();
+                let watcher = watcher.clone();
+                async move { watcher.add(&path) }
+            })
+            .await
+        {
             log::warn!("Failed to watch {}:\n{e}", path.display());
         }
 
@@ -1097,10 +1104,17 @@ impl Fs for RealFs {
                     target = SanitizedPath::new(&canonical).as_path().to_path_buf();
                 }
             }
-            watcher.add(&target).ok();
-            if let Some(parent) = target.parent() {
-                watcher.add(parent).log_err();
-            }
+            executor
+                .spawn({
+                    let watcher = watcher.clone();
+                    async move {
+                        watcher.add(&target).ok();
+                        if let Some(parent) = target.parent() {
+                            watcher.add(parent).log_err();
+                        }
+                    }
+                })
+                .await;
         }
 
         (


### PR DESCRIPTION
Calling into `notify` for `FsWatcher::add` can be slow, because it recreates the watcher from scratch with a potentially large set of paths each time, leading to main thread profiles like this:

<details>

```
    381 Thread_32754797   DispatchQueue_1: com.apple.main-thread  (serial)
    + 381 start  (in dyld) + 6992  [0x1892f3e00]
    +   381 main  (in zed) + 36  [0x100125abc]
    +     381 _RINvNtCsg55jX0GwzBC_3std2rt10lang_startuECsf3XzjJJqRAP_3zed  (in zed) + 60  [0x10012aa2c]  rt.rs:205
    +       381 _RNvNtCsg55jX0GwzBC_3std2rt19lang_start_internal  (in zed) + 952  [0x1110b1d70]
    +         381 _RNCINvNtCsg55jX0GwzBC_3std2rt10lang_startuE0Csf3XzjJJqRAP_3zed  (in zed) + 16  [0x10012d870]  rt.rs:206
    +           381 _RINvNtNtCsg55jX0GwzBC_3std3sys9backtrace28___rust_begin_short_backtraceFEuuECsf3XzjJJqRAP_3zed  (in zed) + 12  [0x10012add0]  backtrace.rs:166
    +             381 _RNvYFEuINtNtNtCsl8K0bEFm1U0_4core3ops8function6FnOnceuE9call_onceCsf3XzjJJqRAP_3zed  (in zed) + 16  [0x1003dee50]  function.rs:250
    +               381 _RNvCsf3XzjJJqRAP_3zed4main  (in zed) + 6400  [0x10011dcec]  main.rs:477
    +                 381 _RINvMs1_NtCsgjP5pDkznW1_4gpui3appNtB6_11Application3runNCNvCsf3XzjJJqRAP_3zed4mainsa_0EBV_  (in zed) + 560  [0x10013ec10]  app.rs:206
    +                   381 _RNvXs_NtCs81yL5M70g3J_10gpui_macos8platformNtB4_11MacPlatformNtNtCsgjP5pDkznW1_4gpui8platform8Platform3run  (in zed) + 1588  [0x1024cbb80]
    +                     381 _RNvXs_NtCshCxYTO3sBFQ_5cocoa6appkitONtNtCs9AHijhoLXFI_4objc7runtime6ObjectNtB4_13NSApplication3run  (in zed) + 280  [0x108e3ef30]
    +                       381 _RINvNtNtCs9AHijhoLXFI_4objc7message8platform15send_unverifiedNtNtB6_7runtime6ObjectuuECs959CsFWdQ3N_16cocoa_foundation  (in zed) + 120  [0x108e4992c]
    +                         381 _RINvXs2_NtCs9AHijhoLXFI_4objc7messageuNtB6_16MessageArguments6invokeuECs959CsFWdQ3N_16cocoa_foundation  (in zed) + 56  [0x108e49e50]
    +                           381 -[NSApplication run]  (in AppKit) + 368  [0x18db8f13c]
    +                             381 -[NSApplication(NSEventRouting) nextEventMatchingMask:untilDate:inMode:dequeue:]  (in AppKit) + 72  [0x18e7315bc]
    +                               381 -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]  (in AppKit) + 688  [0x18e7318b0]
    +                                 381 _DPSNextEvent  (in AppKit) + 576  [0x18db9c084]
    +                                   381 _DPSBlockUntilNextEventMatchingListInMode  (in AppKit) + 228  [0x18e24835c]
    +                                     381 _BlockUntilNextEventMatchingListInMode  (in HIToolbox) + 48  [0x1966e014c]
    +                                       381 ReceiveNextEventCommon  (in HIToolbox) + 488  [0x1965568bc]
    +                                         381 RunCurrentEventLoopInMode  (in HIToolbox) + 320  [0x196553560]
    +                                           381 _CFRunLoopRunSpecificWithOptions  (in CoreFoundation) + 532  [0x1898401c4]
    +                                             381 __CFRunLoopRun  (in CoreFoundation) + 1944  [0x18976dcb8]
    +                                               381 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__  (in CoreFoundation) + 16  [0x1897ab724]
    +                                                 381 _dispatch_main_queue_callback_4CF  (in libdispatch.dylib) + 44  [0x189505924]
    +                                                   381 _dispatch_main_queue_drain  (in libdispatch.dylib) + 176  [0x1895059e4]
    +                                                     381 _dispatch_main_queue_drain.cold.6  (in libdispatch.dylib) + 832  [0x18952e3f0]
    +                                                       381 _dispatch_client_callout  (in libdispatch.dylib) + 16  [0x1895104b0]
    +                                                         381 _RNvNtCs81yL5M70g3J_10gpui_macos10dispatcher10trampoline  (in zed) + 180  [0x1024b4dfc]
    +                                                           381 _RNvMs9_NtCsjlwukVg2ydK_10async_task8runnableINtB5_8RunnableNtCsbEblUdxr2jC_9scheduler12RunnableMetaE3runBX_  (in zed) + 164  [0x110ed2db0]
    +                                                             381 _RNvMs2_NtCsjlwukVg2ydK_10async_task3rawINtB5_7RawTaskINtNvNtCsbEblUdxr2jC_9scheduler8executor32spawn_local_with_source_location7CheckedINtNtCsl8K0bEFm1U0_4core3pin3PinINtNtCs1OjIl8oxbrv_5alloc5boxed3BoxDNtNtNtB2e_6future6future6Futurep6OutputuEL_EEEuNCINvMBU_NtBU_13LocalExecutor5spawnB29_E0NtBW_12RunnableMetaE3runCsgjP5pDkznW1_4gpui  (in zed) + 684  [0x10ff2a560]
    +                                                               381 _RNvXs_NvNtCsbEblUdxr2jC_9scheduler8executor32spawn_local_with_source_locationINtB4_7CheckedINtNtCsl8K0bEFm1U0_4core3pin3PinINtNtCs1OjIl8oxbrv_5alloc5boxed3BoxDNtNtNtB1w_6future6future6Futurep6OutputuEL_EEEB2x_4pollCsgjP5pDkznW1_4gpui  (in zed) + 120  [0x110129bcc]
    +                                                                 381 _RNvXs_NtNtCsl8K0bEFm1U0_4core6future6futureINtNtB8_3pin3PinINtNtCs1OjIl8oxbrv_5alloc5boxed3BoxDNtB4_6Futurep6OutputuEL_EEB1v_4pollCsgjP5pDkznW1_4gpui  (in zed) + 36  [0x1101ba000]
    +                                                                   381 _RNvXs_NtNtCsl8K0bEFm1U0_4core6future6futureINtNtB8_3pin3PinINtNtCs1OjIl8oxbrv_5alloc5boxed3BoxDNtB4_6Futurep6OutputuEL_EEB1v_4pollCsgjP5pDkznW1_4gpui  (in zed) + 36  [0x1101ba000]
    +                                                                     381 _RNCINvMs6_NtCsgjP5pDkznW1_4gpui3appNtB8_3App5spawnNCINvMs0_NtB8_7contextINtBV_7ContextNtNtCskrUQfyMZHci_7project9lsp_store8LspStoreE5spawnNCNCNvMsa_B1o_NtB1o_33LanguageServerWatchedPathsBuilder5build00uE0uE0B1q_  (in zed) + 324  [0x10ab77ef0]
    +                                                                       381 _RINCNCINvMs0_NtNtCsgjP5pDkznW1_4gpui3app7contextINtBb_7ContextNtNtCskrUQfyMZHci_7project9lsp_store8LspStoreE5spawnNCNCNvMsa_B10_NtB10_33LanguageServerWatchedPathsBuilder5build00uE00lEB12_  (in zed) + 392  [0x10b329924]
    +                                                                         381 _RINCNCNCNvMsa_NtCskrUQfyMZHci_7project9lsp_storeNtBc_33LanguageServerWatchedPathsBuilder5build000lEBe_  (in zed) + 372  [0x10a30f064]
    +                                                                           381 _RINCNCNCNCNCNvMsa_NtCskrUQfyMZHci_7project9lsp_storeNtBg_33LanguageServerWatchedPathsBuilder5build00000sEBi_  (in zed) + 408  [0x10a30d6dc]
    +                                                                             381 _RNvXs_NtNtCsl8K0bEFm1U0_4core6future6futureINtNtB8_3pin3PinINtNtCs1OjIl8oxbrv_5alloc5boxed3BoxDNtB4_6Futurep6OutputTIBG_IBW_DNtNtCsFYnhxM3PYB_12futures_core6stream6Streamp4ItemINtNtB10_3vec3VecNtCs7edSlm1TnjK_2fs9PathEventENtNtB8_6marker4SendEL_EEINtNtB10_4sync3ArcDNtB37_7WatcherEL_EEB3z_EL_EEB1v_4pollCskyZGcZ2zQ8A_8settings  (in zed) + 44  [0x10dd1b210]
    +                                                                               381 _RNCNvXs15_Cs7edSlm1TnjK_2fsNtB8_6RealFsNtB8_2Fs5watch0B8_  (in zed) + 908  [0x10f58f688]
    +                                                                                 381 _RNvXs0_NtCs7edSlm1TnjK_2fs10fs_watcherNtB5_9FsWatcherNtB7_7Watcher3add  (in zed) + 960  [0x10f585fd0]
    +                                                                                   381 _RNvMNtCs7edSlm1TnjK_2fs10fs_watcherNtB2_9FsWatcher17add_existing_path  (in zed) + 288  [0x10f581fcc]
    +                                                                                     381 _RNvNtCs7edSlm1TnjK_2fs10fs_watcher22register_existing_path  (in zed) + 1484  [0x10f5851d8]
    +                                                                                       381 _RINvMs3_NtCs7edSlm1TnjK_2fs10fs_watcherNtB6_13GlobalWatcher3addNCNvB6_22register_existing_path0EB8_  (in zed) + 480  [0x10f57d294]
    +                                                                                         381 _RNvMs3_NtCs7edSlm1TnjK_2fs10fs_watcherNtB5_13GlobalWatcher5watch  (in zed) + 300  [0x10f5830a8]
    +                                                                                           381 _RNvXs2_NtCs7edSlm1TnjK_2fs10fs_watcherNtNtCscPkd0REG2xI_6notify7fsevent14FsEventWatcherNtB5_12WatchBackend5watchB7_  (in zed) + 12  [0x10f5946e8]
    +                                                                                             381 _RNvXs2_NtCscPkd0REG2xI_6notify7fseventNtB5_14FsEventWatcherNtB7_7Watcher5watch  (in zed) + 12  [0x10fa0a1e4]
    +                                                                                               352 _RNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB5_14FsEventWatcher11watch_inner  (in zed) + 76  [0x10fa05bfc]
    +                                                                                               ! 343 _RNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB5_14FsEventWatcher3run  (in zed) + 452  [0x10fa064d4]
    +                                                                                               ! : 343 FSEventStreamCreate  (in FSEvents) + 76  [0x193f02d4c]
    +                                                                                               ! :   186 _FSEventStreamCreate  (in FSEvents) + 1296  [0x193f07be0]
    +                                                                                               ! :   | 128 watch_all_parents  (in FSEvents) + 412  [0x193f06064]
    +                                                                                               ! :   | + 128 open  (in libsystem_kernel.dylib) + 64  [0x1896798f0]
    +                                                                                               ! :   | +   128 __open  (in libsystem_kernel.dylib) + 8  [0x18966e694]
    +                                                                                               ! :   | 40 watch_all_parents  (in FSEvents) + 252  [0x193f05fc4]
    +                                                                                               ! :   | + 38 realpath$DARWIN_EXTSN  (in libsystem_c.dylib) + 1128  [0x189552d08]
    +                                                                                               ! :   | + ! 38 __getattrlist  (in libsystem_kernel.dylib) + 8  [0x18966e63c]
    +                                                                                               ! :   | + 1 realpath$DARWIN_EXTSN  (in libsystem_c.dylib) + 836  [0x189552be4]
    +                                                                                               ! :   | + ! 1 _platform_strchr  (in libsystem_platform.dylib) + 60  [0x1896bb69c]
    +                                                                                               ! :   | + 1 realpath$DARWIN_EXTSN  (in libsystem_c.dylib) + 1728  [0x189552f60]
    +                                                                                               ! :   | +   1 _platform_strlcat  (in libsystem_platform.dylib) + 104  [0x1896b98f4]
    +                                                                                               ! :   | +     1 _platform_memmove  (in libsystem_platform.dylib) + 436  [0x1896bb514]
    +                                                                                               ! :   | 12 watch_all_parents  (in FSEvents) + 480  [0x193f060a8]
    +                                                                                               ! :   | + 12 kevent  (in libsystem_kernel.dylib) + 8  [0x189673fc4]
    +                                                                                               ! :   | 5 watch_all_parents  (in FSEvents) + 436  [0x193f0607c]
    +                                                                                               ! :   | + 5 fcntl  (in libsystem_kernel.dylib) + 88  [0x18966e76c]
    +                                                                                               ! :   | +   5 __fcntl  (in libsystem_kernel.dylib) + 8  [0x18966e8c4]
    +                                                                                               ! :   | 1 watch_all_parents  (in FSEvents) + 520  [0x193f060d0]
    +                                                                                               ! :   |   1 stpcpy  (in libsystem_c.dylib) + 72  [0x18954de68]
    +                                                                                               ! :   144 _FSEventStreamCreate  (in FSEvents) + 1228  [0x193f07b9c]
    +                                                                                               ! :   | 54 watch_path  (in FSEvents) + 624  [0x193f05b5c]
    +                                                                                               ! :   | + 54 open  (in libsystem_kernel.dylib) + 64  [0x1896798f0]
    +                                                                                               ! :   | +   54 __open  (in libsystem_kernel.dylib) + 8  [0x18966e694]
    +                                                                                               ! :   | 45 watch_path  (in FSEvents) + 188  [0x193f059a8]
    +                                                                                               ! :   | + 41 realpath$DARWIN_EXTSN  (in libsystem_c.dylib) + 1128  [0x189552d08]
    +                                                                                               ! :   | + ! 41 __getattrlist  (in libsystem_kernel.dylib) + 8  [0x18966e63c]
    +                                                                                               ! :   | + 1 _platform_strlcpy  (in libsystem_platform.dylib) + 116  [0x1896b90d8]
    +                                                                                               ! :   | + 1 realpath$DARWIN_EXTSN  (in libsystem_c.dylib) + 836  [0x189552be4]
    +                                                                                               ! :   | + ! 1 _platform_strchr  (in libsystem_platform.dylib) + 12  [0x1896bb66c]
    +                                                                                               ! :   | + 1 realpath$DARWIN_EXTSN  (in libsystem_c.dylib) + 884  [0x189552c14]
    +                                                                                               ! :   | + ! 1 _platform_memmove  (in libsystem_platform.dylib) + 444  [0x1896bb51c]
    +                                                                                               ! :   | + 1 realpath$DARWIN_EXTSN  (in libsystem_c.dylib) + 328  [0x1895529e8]
    +                                                                                               ! :   | 35 watch_path  (in FSEvents) + 212  [0x193f059c0]
    +                                                                                               ! :   | + 35 open  (in libsystem_kernel.dylib) + 64  [0x1896798f0]
    +                                                                                               ! :   | +   35 __open  (in libsystem_kernel.dylib) + 8  [0x18966e694]
    +                                                                                               ! :   | 4 watch_path  (in FSEvents) + 644  [0x193f05b70]
    +                                                                                               ! :   | + 4 fstat  (in libsystem_kernel.dylib) + 8  [0x18967c288]
    +                                                                                               ! :   | 2 watch_path  (in FSEvents) + 656  [0x193f05b7c]
    +                                                                                               ! :   | + 2 fstat  (in libsystem_kernel.dylib) + 8  [0x18967c288]
    +                                                                                               ! :   | 2 watch_path  (in FSEvents) + 664  [0x193f05b84]
    +                                                                                               ! :   | + 2 close  (in libsystem_kernel.dylib) + 8  [0x18966e8f0]
    +                                                                                               ! :   | 1 watch_path  (in FSEvents) + 320  [0x193f05a2c]
    +                                                                                               ! :   | + 1 fcntl  (in libsystem_kernel.dylib) + 88  [0x18966e76c]
    +                                                                                               ! :   | +   1 __fcntl  (in libsystem_kernel.dylib) + 8  [0x18966e8c4]
    +                                                                                               ! :   | 1 watch_path  (in FSEvents) + 468  [0x193f05ac0]
    +                                                                                               ! :   |   1 kevent  (in libsystem_kernel.dylib) + 8  [0x189673fc4]
    +                                                                                               ! :   11 _FSEventStreamCreate  (in FSEvents) + 696  [0x193f07988]
    +                                                                                               ! :   | 11 fsevent_realpath  (in FSEvents) + 168  [0x193f08d6c]
    +                                                                                               ! :   |   11 __getattrlist  (in libsystem_kernel.dylib) + 8,4  [0x18966e63c,0x18966e638]
    +                                                                                               ! :   2 _FSEventStreamCreate  (in FSEvents) + 568  [0x193f07908]
    +                                                                                               ! :     2 CFStringGetFileSystemRepresentation  (in CoreFoundation) + 56  [0x1896ff2e4]
    +                                                                                               ! :       1 @objc NSString.__swiftFillFileSystemRepresentation(pointer:maxLength:)  (in Foundation) + 52  [0x18b76d45c]
    +                                                                                               ! :       + 1 NSString.__swiftFillFileSystemRepresentation(pointer:maxLength:)  (in Foundation) + 188  [0x18b76cfd8]
    +                                                                                               ! :       +   1 _objc_rootAutorelease  (in libobjc.A.dylib) + 108  [0x18925b080]
    +                                                                                               ! :       +     1 <deduplicated_symbol>  (in libobjc.A.dylib) + 116  [0x18928aa8c]
    +                                                                                               ! :       +       1 AutoreleasePoolPage::add(objc_object*)  (in libobjc.A.dylib) + 188  [0x18928ab78]
    +                                                                                               ! :       1 @objc NSString.__swiftFillFileSystemRepresentation(pointer:maxLength:)  (in Foundation) + 64  [0x18b76d468]
    +                                                                                               ! :         1 objc_msgSend  (in libobjc.A.dylib) + 56  [0x189255838]
    +                                                                                               ! 9 _RNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB5_14FsEventWatcher3run  (in zed) + 996  [0x10fa066f4]
    +                                                                                               !   9 _RNvMs9_NtNtCsg55jX0GwzBC_3std4sync4mpscINtB5_8ReceiverINtNtCsl8K0bEFm1U0_4core6result6ResultNtNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB1A_14FsEventWatcher3run20CFRunLoopSendWrapperNtNtB1C_5error5ErrorEE4recvB1C_  (in zed) + 12  [0x10f9ee51c]
    +                                                                                               !     9 _RNvMsg_NtNtCsg55jX0GwzBC_3std4sync4mpmcINtB5_8ReceiverINtNtCsl8K0bEFm1U0_4core6result6ResultNtNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB1A_14FsEventWatcher3run20CFRunLoopSendWrapperNtNtB1C_5error5ErrorEE4recvB1C_  (in zed) + 132  [0x10f9f89b4]
    +                                                                                               !       9 _RNvMs1_NtNtNtCsg55jX0GwzBC_3std4sync4mpmc4listINtB5_7ChannelINtNtCsl8K0bEFm1U0_4core6result6ResultNtNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB1G_14FsEventWatcher3run20CFRunLoopSendWrapperNtNtB1I_5error5ErrorEE4recvB1I_  (in zed) + 240  [0x10f9db974]
    +                                                                                               !         9 _RINvMNtNtNtCsg55jX0GwzBC_3std4sync4mpmc7contextNtB3_7Context4withNCNvMs1_NtB5_4listINtB19_7ChannelINtNtCsl8K0bEFm1U0_4core6result6ResultNtNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB2i_14FsEventWatcher3run20CFRunLoopSendWrapperNtNtB2k_5error5ErrorEE4recvs_0uEB2k_  (in zed) + 52  [0x10f9e32cc]
    +                                                                                               !           9 _RINvMs2_NtNtCsg55jX0GwzBC_3std6thread5localINtB6_8LocalKeyINtNtCsl8K0bEFm1U0_4core4cell4CellINtNtBZ_6option6OptionNtNtNtNtBa_4sync4mpmc7context7ContextEEE8try_withNCINvMB1Q_B1O_4withNCNvMs1_NtB1S_4listINtB32_7ChannelINtNtBZ_6result6ResultNtNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB3W_14FsEventWatcher3run20CFRunLoopSendWrapperNtNtB3Y_5error5ErrorEE4recvs_0uEs_0uEB3Y_  (in zed) + 144  [0x10f9f5808]
    +                                                                                               !             9 _RNCINvMNtNtNtCsg55jX0GwzBC_3std4sync4mpmc7contextNtB5_7Context4withNCNvMs1_NtB7_4listINtB1b_7ChannelINtNtCsl8K0bEFm1U0_4core6result6ResultNtNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB2k_14FsEventWatcher3run20CFRunLoopSendWrapperNtNtB2m_5error5ErrorEE4recvs_0uEs_0B2m_  (in zed) + 436  [0x10f9e3b60]
    +                                                                                               !               9 _RNCNvMs1_NtNtNtCsg55jX0GwzBC_3std4sync4mpmc4listINtB7_7ChannelINtNtCsl8K0bEFm1U0_4core6result6ResultNtNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB1I_14FsEventWatcher3run20CFRunLoopSendWrapperNtNtB1K_5error5ErrorEE4recvs_0B1K_  (in zed) + 204  [0x10f9daa9c]
    +                                                                                               !                 9 _RNvMNtNtNtCsg55jX0GwzBC_3std4sync4mpmc7contextNtB2_7Context10wait_untilCscPkd0REG2xI_6notify  (in zed) + 332  [0x10f9e5ac4]
    +                                                                                               !                   9 _RNvMs_NtNtCsg55jX0GwzBC_3std6thread6threadNtB4_6Thread4park  (in zed) + 48  [0x1110a7ebc]
    +                                                                                               !                     9 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x1894f8b20]
    +                                                                                               !                       9 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x1894f8490]
    +                                                                                               !                         9 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x18966dbb0]
    +                                                                                               29 _RNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB5_14FsEventWatcher11watch_inner  (in zed) + 40  [0x10fa05bd8]
    +                                                                                                 28 _RNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB5_14FsEventWatcher4stop  (in zed) + 288  [0x10fa06b9c]
    +                                                                                                 : 28 _RNvMs0_NtNtCsg55jX0GwzBC_3std6thread11join_handleINtB5_10JoinHandleuE4joinCscPkd0REG2xI_6notify  (in zed) + 40  [0x10f9f48d8]
    +                                                                                                 :   28 _RNvMs1_NtNtCsg55jX0GwzBC_3std6thread9lifecycleINtB5_9JoinInneruE4joinCscPkd0REG2xI_6notify  (in zed) + 24  [0x10f9f22ac]
    +                                                                                                 :     28 _RNvMs0_NtNtNtCsg55jX0GwzBC_3std3sys6thread4unixNtB5_6Thread4join  (in zed) + 24  [0x11109fb60]
    +                                                                                                 :       28 _pthread_join  (in libsystem_pthread.dylib) + 616  [0x1896b4114]
    +                                                                                                 :         28 __ulock_wait  (in libsystem_kernel.dylib) + 8  [0x18966faf8]
    +                                                                                                 1 _RNvMs1_NtCscPkd0REG2xI_6notify7fseventNtB5_14FsEventWatcher4stop  (in zed) + 392  [0x10fa06c04]
    +                                                                                                   1 _RINvNtCsl8K0bEFm1U0_4core3ptr13drop_in_placeINtNtCscrO8BByWRtk_21objc2_core_foundation8retained10CFRetainedNtNtNtBL_9generated11___CFRunLoop9CFRunLoopEECscPkd0REG2xI_6notify  (in zed) + 12  [0x10f9ea548]
    +                                                                                                     1 _RNvXs1_NtCscrO8BByWRtk_21objc2_core_foundation8retainedINtB5_10CFRetainedNtNtNtB7_9generated11___CFRunLoop9CFRunLoopENtNtNtCsl8K0bEFm1U0_4core3ops4drop4Drop4dropCscPkd0REG2xI_6notify  (in zed) + 16  [0x10f9ecbc0]
    +                                                                                                       1 _CFRelease  (in CoreFoundation) + 308  [0x189841ed8]
    +                                                                                                         1 __CFRunLoopDeallocate  (in CoreFoundation) + 336  [0x18979adcc]
    +                                                                                                           1 _CFRelease  (in CoreFoundation) + 308  [0x189841ed8]
    +                                                                                                             1 __CFBasicHashDrain  (in CoreFoundation) + 336  [0x18970cf68]
    +                                                                                                               1 _CFRelease  (in CoreFoundation) + 308  [0x189841ed8]
    +                                                                                                                 1 __CFRunLoopModeDeallocate  (in CoreFoundation) + 196  [0x18979b524]
    +                                                                                                                   1 dispatch_release  (in libdispatch.dylib) + 152  [0x1894f71b4]
    +                                                                                                                     1 _dispatch_xref_dispose  (in libdispatch.dylib) + 148  [0x1894f7254]
    +                                                                                                                       1 _dispatch_runloop_queue_xref_dispose  (in libdispatch.dylib) + 88  [0x1895051fc]
    +                                                                                                                         1 _dispatch_root_queue_push  (in libdispatch.dylib) + 128  [0x189504894]
```

</details>

This can get especially bad if a language server asks us to watch a bunch of paths.

This PR makes `Fs::watch` call `FSWatcher::add` on the background instead, so the main thread doesn't hang in this situation. 

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed a hang when using language servers that requested to watch many paths outside the project.