### PR TITLE
editor: Expand the gutter width to contain new timestamp format

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11372,7 +11372,7 @@ impl EditorSnapshot {
                 self.git_blame_gutter_max_author_length
                     .map(|max_author_length| {
                         let renderer = cx.global::<GlobalBlameRenderer>().0.clone();
-                        const MAX_RELATIVE_TIMESTAMP: &str = "60 minutes ago";
+                        const MAX_RELATIVE_TIMESTAMP: &str = "2 years, 11 months ago";
 
                         /// The number of characters to dedicate to gaps and margins.
                         const SPACING_WIDTH: usize = 4;


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #58922

In #57973, a new timestamp format was introduced. For example, for a commit from 13 months ago, the old formatter would output `"1 year ago"`, whereas the new format outputs `"1 year, 1 month ago"`.

This new compound format is significantly longer than `"60 minutes ago"`, which is currently used to calculate the maximum width of the blame column here:
https://github.com/zed-industries/zed/blob/d989c7c5cdd057de2375a55bdc109ff61409801c/crates/editor/src/editor.rs#L11376-L11391

As a result, when a blame entry uses the `"{M} years, {N} months ago"` format, its width exceeds the pre-calculated maximum, causing the text to overlap with the line numbers.

This PR updates the placeholder string used for the maximum width calculation to `"2 years, 11 months ago"`, ensuring the column is wide enough to accommodate the longest possible compound timestamp. 

Before:
<img width="1407" height="598" alt="before" src="https://github.com/user-attachments/assets/f025f423-9ccc-432d-813c-4b861227a7a1" /> 

After:
<img width="1481" height="594" alt="after" src="https://github.com/user-attachments/assets/c60cbd17-fdd4-471c-a4fc-3c2e7a3ccd5d" />

Release Notes:

- Fixed an issue where Git blame text would overlap with line numbers in the gutter.
