### PR TITLE
Escape control characters in syntax tree view

### DIFF
--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -377,7 +377,7 @@ impl SyntaxTreeView {
         row.child(if node.is_named() {
             Label::new(node.kind()).color(Color::Default)
         } else {
-            Label::new(format!("\"{}\"", node.kind())).color(Color::Created)
+            Label::new(format_anonymous_node_kind(node.kind())).color(Color::Created)
         })
         .child(
             div()
@@ -719,6 +719,10 @@ fn format_node_range(node: Node) -> String {
     )
 }
 
+fn format_anonymous_node_kind(kind: &str) -> String {
+    format!("\"{}\"", kind.escape_debug())
+}
+
 impl Render for SyntaxTreeToolbarItemView {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         h_flex()
@@ -747,5 +751,18 @@ impl ToolbarItemView for SyntaxTreeToolbarItemView {
         self.tree_view = None;
         self.subscription = None;
         ToolbarItemLocation::Hidden
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anonymous_node_kinds_escape_control_characters() {
+        assert_eq!(format_anonymous_node_kind("\n"), "\"\\n\"");
+        assert_eq!(format_anonymous_node_kind("\r\n"), "\"\\r\\n\"");
+        assert_eq!(format_anonymous_node_kind("\t"), "\"\\t\"");
+        assert_eq!(format_anonymous_node_kind(","), "\",\"");
     }
 }


### PR DESCRIPTION
Escaping control characters so they correctly render in the syntax tree.
Note: the original issue debates whether "\n" should be printed at all. It should if it's part of the grammar syntax. In the example posted below, "\n" is printed because it's part of the c-preprocessor grammar, but "\t" which is not, is not printed.
Note2: I've added an inline test since I saw that only bigger, integration tests get their own file. Feel free to give guidance on the topic.

Screenshots of before and after:
<img width="920" height="579" alt="Screenshot 2026-06-10 at 10 42 14" src="https://github.com/user-attachments/assets/697b65d2-4ca3-4d9b-9cb9-5bc05fe50bf1" />
<img width="918" height="580" alt="Screenshot 2026-06-10 at 10 46 20" src="https://github.com/user-attachments/assets/cb83a105-81a1-4090-8d35-9def2bc1b552" />


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #54725

Release Notes:

- Fixed rendering of control-characters in syntax tree view
