### PR TITLE
Fix Devcontainer bugs/spec mismatches

### DIFF
--- a/crates/dev_container/src/devcontainer_api.rs
+++ b/crates/dev_container/src/devcontainer_api.rs
@@ -58,6 +58,8 @@ pub(crate) struct DevContainerUp {
     pub(crate) extension_ids: Vec<String>,
     #[serde(default)]
     pub(crate) remote_env: HashMap<String, String>,
+    #[serde(default)]
+    pub(crate) started_at: Option<String>,
 }
 
 #[derive(Debug)]

--- a/crates/dev_container/src/devcontainer_json.rs
+++ b/crates/dev_container/src/devcontainer_json.rs
@@ -213,7 +213,7 @@ pub(crate) struct DevContainer {
     user_env_probe: Option<UserEnvProbe>,
     pub(crate) override_command: Option<bool>,
     shutdown_action: Option<ShutdownAction>,
-    init: Option<bool>,
+    pub(crate) init: Option<bool>,
     pub(crate) privileged: Option<bool>,
     pub(crate) cap_add: Option<Vec<String>>,
     pub(crate) security_opt: Option<Vec<String>>,

--- a/crates/dev_container/src/devcontainer_json.rs
+++ b/crates/dev_container/src/devcontainer_json.rs
@@ -215,8 +215,8 @@ pub(crate) struct DevContainer {
     shutdown_action: Option<ShutdownAction>,
     init: Option<bool>,
     pub(crate) privileged: Option<bool>,
-    cap_add: Option<Vec<String>>,
-    security_opt: Option<Vec<String>>,
+    pub(crate) cap_add: Option<Vec<String>>,
+    pub(crate) security_opt: Option<Vec<String>>,
     #[serde(default, deserialize_with = "deserialize_mount_definitions")]
     pub(crate) mounts: Option<Vec<MountDefinition>>,
     pub(crate) features: Option<HashMap<String, FeatureOptions>>,

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -780,6 +780,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
     fn build_merged_resources(
         &self,
         base_image: DockerInspect,
+        image_tag: &str,
     ) -> Result<DockerBuildResources, DevContainerError> {
         let dev_container = match &self.config {
             ConfigStatus::Deserialized(_) => {
@@ -798,6 +799,32 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
 
         let privileged = dev_container.privileged.unwrap_or(false)
             || self.features.iter().any(|f| f.privileged());
+
+        let mut cap_add: Vec<String> = dev_container.cap_add.clone().unwrap_or_default();
+        let mut security_opt: Vec<String> = dev_container.security_opt.clone().unwrap_or_default();
+
+        if let Some(metadata_entries) = &base_image.config.labels.metadata {
+            for entry in metadata_entries {
+                if let Some(serde_json_lenient::Value::Array(caps)) = entry.get("capAdd") {
+                    for cap in caps {
+                        if let Some(s) = cap.as_str() {
+                            if !cap_add.contains(&s.to_string()) {
+                                cap_add.push(s.to_string());
+                            }
+                        }
+                    }
+                }
+                if let Some(serde_json_lenient::Value::Array(opts)) = entry.get("securityOpt") {
+                    for opt in opts {
+                        if let Some(s) = opt.as_str() {
+                            if !security_opt.contains(&s.to_string()) {
+                                security_opt.push(s.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         let entrypoint_script = if dev_container.override_command == Some(false) {
             None
@@ -818,10 +845,16 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             Some(entrypoint_script_lines.join("\n").trim().to_string())
         };
 
+        let container_env = dev_container.container_env.clone().unwrap_or_default();
+
         Ok(DockerBuildResources {
             image: base_image,
+            image_tag: image_tag.to_string(),
             additional_mounts: mounts,
+            container_env,
             privileged,
+            cap_add,
+            security_opt,
             entrypoint_script,
         })
     }
@@ -842,7 +875,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
                     .update_remote_user_uid(built_docker_image, &base_image)
                     .await?;
 
-                let resources = self.build_merged_resources(built_docker_image)?;
+                let resources = self.build_merged_resources(built_docker_image, &base_image)?;
                 Ok(DevContainerBuildResources::Docker(resources))
             }
             DevContainerBuildType::Dockerfile(_) => {
@@ -857,7 +890,8 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
                     .update_remote_user_uid(built_docker_image, &features_build_info.image_tag)
                     .await?;
 
-                let resources = self.build_merged_resources(built_docker_image)?;
+                let resources =
+                    self.build_merged_resources(built_docker_image, &features_build_info.image_tag)?;
                 Ok(DevContainerBuildResources::Docker(resources))
             }
             DevContainerBuildType::DockerCompose => {
@@ -1183,7 +1217,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             .update_remote_user_uid(built_service_image, built_service_image_tag)
             .await?;
 
-        let resources = self.build_merged_resources(built_service_image)?;
+        let resources = self.build_merged_resources(built_service_image, built_service_image_tag)?;
 
         let network_mode = main_service.network_mode.as_ref();
         let network_mode_service = network_mode.and_then(|mode| mode.strip_prefix("service:"));
@@ -1283,10 +1317,21 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             ]
         });
 
+        let cap_add = if resources.cap_add.is_empty() {
+            None
+        } else {
+            Some(resources.cap_add)
+        };
+        let security_opt = if resources.security_opt.is_empty() {
+            None
+        } else {
+            Some(resources.security_opt)
+        };
+
         let mut main_service = DockerComposeService {
             entrypoint,
-            cap_add: Some(vec!["SYS_PTRACE".to_string()]),
-            security_opt: Some(vec!["seccomp=unconfined".to_string()]),
+            cap_add,
+            security_opt,
             labels: Some(runtime_labels),
             volumes,
             privileged: Some(resources.privileged),
@@ -2006,16 +2051,43 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
             command.arg(format!("{}={}", key, val));
         }
 
-        if let Some(metadata) = &build_resources.image.config.labels.metadata {
-            let serialized_metadata = serde_json_lenient::to_string(metadata).map_err(|e| {
-                log::error!("Problem serializing image metadata: {e}");
-                DevContainerError::ContainerNotValid(build_resources.image.id.clone())
-            })?;
-            command.arg("-l");
-            command.arg(format!(
-                "{}={}",
-                "devcontainer.metadata", serialized_metadata
-            ));
+        {
+            let mut metadata_entries: Vec<serde_json_lenient::Value> = Vec::new();
+
+            if let Some(image_metadata) = &build_resources.image.config.labels.metadata {
+                for entry in image_metadata {
+                    if let Ok(val) = serde_json_lenient::to_value(entry) {
+                        metadata_entries.push(val);
+                    }
+                }
+            }
+
+            if let Ok(substituted_json) = self.parse_nonremote_vars_for_content(&self.raw_config)
+            {
+                let config_entry = build_devcontainer_metadata_entry(&substituted_json);
+                if !config_entry.is_empty() {
+                    metadata_entries.push(serde_json_lenient::Value::Object(config_entry));
+                }
+            }
+
+            if !metadata_entries.is_empty() {
+                let serialized =
+                    serde_json_lenient::to_string(&metadata_entries).map_err(|e| {
+                        log::error!("Problem serializing metadata: {e}");
+                        DevContainerError::ContainerNotValid(build_resources.image.id.clone())
+                    })?;
+                command.arg("-l");
+                command.arg(format!("devcontainer.metadata={serialized}"));
+            }
+        }
+
+        for cap in &build_resources.cap_add {
+            command.arg("--cap-add");
+            command.arg(cap);
+        }
+        for opt in &build_resources.security_opt {
+            command.arg("--security-opt");
+            command.arg(opt);
         }
 
         if let Some(forward_ports) = &self.dev_container().forward_ports {
@@ -2031,15 +2103,20 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
             command.arg(app_port);
         }
 
+        for (key, value) in &build_resources.container_env {
+            command.arg("-e");
+            command.arg(format!("{key}={value}"));
+        }
+
         if let Some(entrypoint_script) = build_resources.entrypoint_script {
             command.arg("--entrypoint");
             command.arg("/bin/sh");
-            command.arg(&build_resources.image.id);
+            command.arg(&build_resources.image_tag);
             command.arg("-c");
             command.arg(entrypoint_script);
             command.arg("-");
         } else {
-            command.arg(&build_resources.image.id);
+            command.arg(&build_resources.image_tag);
         }
 
         Ok(command)
@@ -2124,19 +2201,19 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
                         .await?;
                 }
             }
-            if let Some(post_start_command) = &config.post_start_command {
-                for (command_name, command) in post_start_command.script_commands() {
-                    log::debug!("Running post start command {command_name}");
-                    self.docker_client
-                        .run_docker_exec(
-                            &devcontainer_up.container_id,
-                            &remote_folder,
-                            &devcontainer_up.remote_user,
-                            &devcontainer_up.remote_env,
-                            command,
-                        )
-                        .await?;
-                }
+        }
+        if let Some(post_start_command) = &config.post_start_command {
+            for (command_name, command) in post_start_command.script_commands() {
+                log::debug!("Running post start command {command_name}");
+                self.docker_client
+                    .run_docker_exec(
+                        &devcontainer_up.container_id,
+                        &remote_folder,
+                        &devcontainer_up.remote_user,
+                        &devcontainer_up.remote_env,
+                        command,
+                    )
+                    .await?;
             }
         }
         if let Some(post_attach_command) = &config.post_attach_command {
@@ -2472,8 +2549,12 @@ pub(crate) async fn spawn_dev_container(
 #[derive(Debug)]
 struct DockerBuildResources {
     image: DockerInspect,
+    image_tag: String,
     additional_mounts: Vec<MountDefinition>,
+    container_env: HashMap<String, String>,
     privileged: bool,
+    cap_add: Vec<String>,
+    security_opt: Vec<String>,
     entrypoint_script: Option<String>,
 }
 
@@ -2988,6 +3069,47 @@ fn get_container_user_from_config(
     Ok("root".to_string())
 }
 
+fn build_devcontainer_metadata_entry(
+    raw_json: &serde_json_lenient::Value,
+) -> serde_json_lenient::Map<String, serde_json_lenient::Value> {
+    use serde_json_lenient::Value;
+    static METADATA_PROPERTIES: &[&str] = &[
+        "onCreateCommand",
+        "updateContentCommand",
+        "postCreateCommand",
+        "postStartCommand",
+        "postAttachCommand",
+        "waitFor",
+        "customizations",
+        "mounts",
+        "containerEnv",
+        "containerUser",
+        "init",
+        "privileged",
+        "capAdd",
+        "securityOpt",
+        "remoteUser",
+        "userEnvProbe",
+        "remoteEnv",
+        "overrideCommand",
+        "portsAttributes",
+        "otherPortsAttributes",
+        "forwardPorts",
+        "shutdownAction",
+        "updateRemoteUserUID",
+        "hostRequirements",
+    ];
+
+    let Value::Object(full) = raw_json else {
+        return serde_json_lenient::Map::new();
+    };
+
+    full.iter()
+        .filter(|(key, value)| METADATA_PROPERTIES.contains(&key.as_str()) && !value.is_null())
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
 fn normalize_label_path(path: &str) -> String {
     #[cfg(not(target_os = "windows"))]
     {
@@ -3304,8 +3426,12 @@ mod test {
                 mounts: None,
                 state: None,
             },
+            image_tag: "mcr.microsoft.com/devcontainers/base:ubuntu".to_string(),
             additional_mounts: vec![],
+            container_env: HashMap::new(),
             privileged: false,
+            cap_add: vec!["SYS_PTRACE".to_string()],
+            security_opt: vec!["seccomp=unconfined".to_string()],
             entrypoint_script: Some("echo Container started\n    trap \"exit 0\" 15\n    exec \"$@\"\n    while sleep 1 & wait $!; do :; done".to_string()),
         };
         let docker_run_command = devcontainer_manifest.create_docker_run_command(build_resources);
@@ -3334,6 +3460,10 @@ mod test {
                 OsStr::new(&format!(
                     "devcontainer.config_file={expected_config_file_label}"
                 )),
+                OsStr::new("--cap-add"),
+                OsStr::new("SYS_PTRACE"),
+                OsStr::new("--security-opt"),
+                OsStr::new("seccomp=unconfined"),
                 OsStr::new("--entrypoint"),
                 OsStr::new("/bin/sh"),
                 OsStr::new("mcr.microsoft.com/devcontainers/base:ubuntu"),
@@ -3381,7 +3511,7 @@ mod test {
         };
 
         let resources = devcontainer_manifest
-            .build_merged_resources(base_image)
+            .build_merged_resources(base_image, "mcr.microsoft.com/devcontainers/base:ubuntu")
             .unwrap();
         assert!(
             resources.entrypoint_script.is_none(),
@@ -6447,10 +6577,26 @@ RUN echo $RUBY_VERSION2
                         .to_string(),
                     config: DockerInspectConfig {
                         labels: DockerConfigLabels {
-                            metadata: Some(vec![HashMap::from([(
-                                "remoteUser".to_string(),
-                                Value::String("vscode".to_string()),
-                            )])]),
+                            metadata: Some(vec![
+                                HashMap::from([(
+                                    "remoteUser".to_string(),
+                                    Value::String("vscode".to_string()),
+                                )]),
+                                HashMap::from([
+                                    (
+                                        "capAdd".to_string(),
+                                        Value::Array(vec![Value::String(
+                                            "SYS_PTRACE".to_string(),
+                                        )]),
+                                    ),
+                                    (
+                                        "securityOpt".to_string(),
+                                        Value::Array(vec![Value::String(
+                                            "seccomp=unconfined".to_string(),
+                                        )]),
+                                    ),
+                                ]),
+                            ]),
                         },
                         image_user: Some("root".to_string()),
                         env: Vec::new(),
@@ -6504,10 +6650,26 @@ RUN echo $RUBY_VERSION2
                         .to_string(),
                     config: DockerInspectConfig {
                         labels: DockerConfigLabels {
-                            metadata: Some(vec![HashMap::from([(
-                                "remoteUser".to_string(),
-                                Value::String("vscode".to_string()),
-                            )])]),
+                            metadata: Some(vec![
+                                HashMap::from([(
+                                    "remoteUser".to_string(),
+                                    Value::String("vscode".to_string()),
+                                )]),
+                                HashMap::from([
+                                    (
+                                        "capAdd".to_string(),
+                                        Value::Array(vec![Value::String(
+                                            "SYS_PTRACE".to_string(),
+                                        )]),
+                                    ),
+                                    (
+                                        "securityOpt".to_string(),
+                                        Value::Array(vec![Value::String(
+                                            "seccomp=unconfined".to_string(),
+                                        )]),
+                                    ),
+                                ]),
+                            ]),
                         },
                         image_user: Some("root".to_string()),
                         env: Vec::new(),

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -600,7 +600,12 @@ impl DevContainerManifest {
                     DevContainerError::ResourceFetchFailed
                 })?;
 
-            let feature_manifest = FeatureManifest::new(consecutive_id, feature_ref.to_string(), feature_dir, feature_json);
+            let feature_manifest = FeatureManifest::new(
+                consecutive_id,
+                feature_ref.to_string(),
+                feature_dir,
+                feature_json,
+            );
 
             log::debug!("Prepared feature content for '{}'", feature_ref);
 
@@ -791,52 +796,69 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             }
             ConfigStatus::VariableParsed(dev_container) => dev_container,
         };
-        let mut mounts = dev_container.mounts.clone().unwrap_or(Vec::new());
-
-        let mut feature_mounts = self.features.iter().flat_map(|f| f.mounts()).collect();
-
-        mounts.append(&mut feature_mounts);
-
-        let privileged = dev_container.privileged.unwrap_or(false)
-            || self.features.iter().any(|f| f.privileged());
-
-        let mut cap_add: Vec<String> = dev_container.cap_add.clone().unwrap_or_default();
-        let mut security_opt: Vec<String> = dev_container.security_opt.clone().unwrap_or_default();
+        let mut mounts = Vec::new();
+        let mut cap_add = Vec::new();
+        let mut security_opt = Vec::new();
+        let mut privileged = false;
+        let mut init = false;
 
         if let Some(metadata_entries) = &base_image.config.labels.metadata {
             for entry in metadata_entries {
-                if let Some(serde_json_lenient::Value::Array(caps)) = entry.get("capAdd") {
-                    for cap in caps {
-                        if let Some(s) = cap.as_str() {
-                            if !cap_add.contains(&s.to_string()) {
-                                cap_add.push(s.to_string());
-                            }
+                if let Some(serde_json_lenient::Value::Array(metadata_mounts)) = entry.get("mounts")
+                {
+                    for mount in metadata_mounts {
+                        if let Some(mount) = mount_definition_from_metadata(mount) {
+                            append_mount_with_target_override(&mut mounts, mount);
                         }
                     }
                 }
+                if entry.get("privileged").and_then(|value| value.as_bool()) == Some(true) {
+                    privileged = true;
+                }
+                if entry.get("init").and_then(|value| value.as_bool()) == Some(true) {
+                    init = true;
+                }
+                if let Some(serde_json_lenient::Value::Array(caps)) = entry.get("capAdd") {
+                    for cap in caps.iter().filter_map(|cap| cap.as_str()) {
+                        push_unique_string(&mut cap_add, cap);
+                    }
+                }
                 if let Some(serde_json_lenient::Value::Array(opts)) = entry.get("securityOpt") {
-                    for opt in opts {
-                        if let Some(s) = opt.as_str() {
-                            if !security_opt.contains(&s.to_string()) {
-                                security_opt.push(s.to_string());
-                            }
-                        }
+                    for opt in opts.iter().filter_map(|opt| opt.as_str()) {
+                        push_unique_string(&mut security_opt, opt);
                     }
                 }
             }
         }
 
         for feature in &self.features {
+            for mount in feature.mounts() {
+                append_mount_with_target_override(&mut mounts, mount);
+            }
+            if feature.privileged() {
+                privileged = true;
+            }
+            if feature.init() {
+                init = true;
+            }
             for cap in feature.cap_add() {
-                if !cap_add.contains(&cap) {
-                    cap_add.push(cap);
-                }
+                push_unique_string(&mut cap_add, &cap);
             }
             for opt in feature.security_opt() {
-                if !security_opt.contains(&opt) {
-                    security_opt.push(opt);
-                }
+                push_unique_string(&mut security_opt, &opt);
             }
+        }
+
+        for mount in dev_container.mounts.clone().unwrap_or_default() {
+            append_mount_with_target_override(&mut mounts, mount);
+        }
+        privileged |= dev_container.privileged.unwrap_or(false);
+        init |= dev_container.init.unwrap_or(false);
+        for cap in dev_container.cap_add.clone().unwrap_or_default() {
+            push_unique_string(&mut cap_add, &cap);
+        }
+        for opt in dev_container.security_opt.clone().unwrap_or_default() {
+            push_unique_string(&mut security_opt, &opt);
         }
 
         let entrypoint_script = if dev_container.override_command == Some(false) {
@@ -871,11 +893,6 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
                 }
             }
         }
-        for feature in &self.features {
-            for (k, v) in feature.container_env() {
-                container_env.insert(k, v);
-            }
-        }
         if let Some(config_env) = &dev_container.container_env {
             for (k, v) in config_env {
                 container_env.insert(k.clone(), v.clone());
@@ -888,6 +905,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             additional_mounts: mounts,
             container_env,
             privileged,
+            init,
             cap_add,
             security_opt,
             entrypoint_script,
@@ -905,17 +923,31 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
         match dev_container.build_type() {
             DevContainerBuildType::Image(base_image) => {
                 let built_docker_image = self.build_docker_image().await?;
-
-                let image_tag = self
+                let has_features = dev_container
+                    .features
+                    .as_ref()
+                    .is_some_and(|features| !features.is_empty());
+                let features_image_tag = self
                     .features_build_info
                     .as_ref()
-                    .map(|info| info.image_tag.as_str())
-                    .unwrap_or(&base_image);
+                    .map(|info| info.image_tag.as_str());
+                let uid_base_image = if has_features {
+                    features_image_tag.unwrap_or(&base_image)
+                } else {
+                    &base_image
+                };
+                let will_update_remote_user_uid =
+                    self.should_update_remote_user_uid(&built_docker_image)?;
 
                 let built_docker_image = self
-                    .update_remote_user_uid(built_docker_image, image_tag)
+                    .update_remote_user_uid(built_docker_image, uid_base_image)
                     .await?;
 
+                let image_tag = if has_features || will_update_remote_user_uid {
+                    features_image_tag.unwrap_or(&base_image)
+                } else {
+                    &base_image
+                };
                 let resources = self.build_merged_resources(built_docker_image, image_tag)?;
                 Ok(DevContainerBuildResources::Docker(resources))
             }
@@ -931,8 +963,8 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
                     .update_remote_user_uid(built_docker_image, &features_build_info.image_tag)
                     .await?;
 
-                let resources =
-                    self.build_merged_resources(built_docker_image, &features_build_info.image_tag)?;
+                let resources = self
+                    .build_merged_resources(built_docker_image, &features_build_info.image_tag)?;
                 Ok(DevContainerBuildResources::Docker(resources))
             }
             DevContainerBuildType::DockerCompose => {
@@ -974,6 +1006,10 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
         let remote_env = self.runtime_remote_env(&running_container.config.env_as_map()?)?;
 
         Ok(DevContainerUp {
+            started_at: running_container
+                .state
+                .as_ref()
+                .and_then(|state| state.started_at.clone()),
             container_id: running_container.id,
             remote_user,
             remote_workspace_folder: remote_workspace_folder.display().to_string(),
@@ -1258,7 +1294,8 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             .update_remote_user_uid(built_service_image, built_service_image_tag)
             .await?;
 
-        let resources = self.build_merged_resources(built_service_image, built_service_image_tag)?;
+        let resources =
+            self.build_merged_resources(built_service_image, built_service_image_tag)?;
 
         let network_mode = main_service.network_mode.as_ref();
         let network_mode_service = network_mode.and_then(|mode| mode.strip_prefix("service:"));
@@ -1324,8 +1361,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
                 }
             }
 
-            if let Ok(substituted_json) = self.parse_nonremote_vars_for_content(&self.raw_config)
-            {
+            if let Ok(substituted_json) = self.parse_nonremote_vars_for_content(&self.raw_config) {
                 let config_entry = build_devcontainer_metadata_entry(&substituted_json);
                 if !config_entry.is_empty() {
                     metadata_entries.push(serde_json_lenient::Value::Object(config_entry));
@@ -1333,17 +1369,19 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             }
 
             if !metadata_entries.is_empty() {
-                let serialized =
-                    serde_json_lenient::to_string(&metadata_entries).map_err(|e| {
-                        log::error!("Error serializing docker image metadata: {e}");
-                        DevContainerError::ContainerNotValid(resources.image.id.clone())
-                    })?;
-                runtime_labels.insert("devcontainer.metadata".to_string(), serialized);
+                let serialized = serde_json_lenient::to_string(&metadata_entries).map_err(|e| {
+                    log::error!("Error serializing docker image metadata: {e}");
+                    DevContainerError::ContainerNotValid(resources.image.id.clone())
+                })?;
+                runtime_labels.insert(
+                    "devcontainer.metadata".to_string(),
+                    escape_compose_interpolation(&serialized),
+                );
             }
         }
 
         for (k, v) in self.identifying_labels() {
-            runtime_labels.insert(k.to_string(), v.to_string());
+            runtime_labels.insert(k.to_string(), escape_compose_interpolation(&v));
         }
 
         let config_volumes: HashMap<String, DockerComposeVolume> = resources
@@ -1399,8 +1437,16 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
         let environment = if resources.container_env.is_empty() {
             None
         } else {
-            Some(resources.container_env)
+            Some(
+                resources
+                    .container_env
+                    .into_iter()
+                    .map(|(key, value)| (key, escape_compose_interpolation(&value)))
+                    .collect(),
+            )
         };
+        let privileged = resources.privileged.then_some(true);
+        let init = resources.init.then_some(true);
 
         let mut main_service = DockerComposeService {
             entrypoint,
@@ -1408,7 +1454,8 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             security_opt,
             labels: Some(runtime_labels),
             volumes,
-            privileged: Some(resources.privileged),
+            privileged,
+            init,
             environment,
             ..Default::default()
         };
@@ -1578,6 +1625,14 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
     }
 
     #[cfg(target_os = "windows")]
+    fn should_update_remote_user_uid(
+        &self,
+        _image: &DockerInspect,
+    ) -> Result<bool, DevContainerError> {
+        Ok(false)
+    }
+
+    #[cfg(target_os = "windows")]
     async fn update_remote_user_uid(
         &self,
         image: DockerInspect,
@@ -1585,27 +1640,37 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
     ) -> Result<DockerInspect, DevContainerError> {
         Ok(image)
     }
+
+    #[cfg(not(target_os = "windows"))]
+    fn should_update_remote_user_uid(
+        &self,
+        image: &DockerInspect,
+    ) -> Result<bool, DevContainerError> {
+        if self.features_build_info.is_none() {
+            return Ok(false);
+        }
+        if self.dev_container().update_remote_user_uid == Some(false) {
+            return Ok(false);
+        }
+        let remote_user = get_remote_user_from_config(image, self)?;
+        Ok(remote_user != "root" && !remote_user.chars().all(|c| c.is_ascii_digit()))
+    }
+
     #[cfg(not(target_os = "windows"))]
     async fn update_remote_user_uid(
         &self,
         image: DockerInspect,
         base_image: &str,
     ) -> Result<DockerInspect, DevContainerError> {
-        let dev_container = self.dev_container();
-
         let Some(features_build_info) = &self.features_build_info else {
             return Ok(image);
         };
 
-        // updateRemoteUserUID defaults to true per the devcontainers spec
-        if dev_container.update_remote_user_uid == Some(false) {
+        if !self.should_update_remote_user_uid(&image)? {
             return Ok(image);
         }
 
         let remote_user = get_remote_user_from_config(&image, self)?;
-        if remote_user == "root" || remote_user.chars().all(|c| c.is_ascii_digit()) {
-            return Ok(image);
-        }
 
         let image_user = image
             .config
@@ -2081,6 +2146,9 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
         if build_resources.privileged {
             command.arg("--privileged");
         }
+        if build_resources.init {
+            command.arg("--init");
+        }
 
         let run_args = match &self.dev_container().run_args {
             Some(run_args) => run_args,
@@ -2144,8 +2212,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
                 }
             }
 
-            if let Ok(substituted_json) = self.parse_nonremote_vars_for_content(&self.raw_config)
-            {
+            if let Ok(substituted_json) = self.parse_nonremote_vars_for_content(&self.raw_config) {
                 let config_entry = build_devcontainer_metadata_entry(&substituted_json);
                 if !config_entry.is_empty() {
                     metadata_entries.push(serde_json_lenient::Value::Object(config_entry));
@@ -2153,11 +2220,10 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
             }
 
             if !metadata_entries.is_empty() {
-                let serialized =
-                    serde_json_lenient::to_string(&metadata_entries).map_err(|e| {
-                        log::error!("Problem serializing metadata: {e}");
-                        DevContainerError::ContainerNotValid(build_resources.image.id.clone())
-                    })?;
+                let serialized = serde_json_lenient::to_string(&metadata_entries).map_err(|e| {
+                    log::error!("Problem serializing metadata: {e}");
+                    DevContainerError::ContainerNotValid(build_resources.image.id.clone())
+                })?;
                 command.arg("-l");
                 command.arg(format!("devcontainer.metadata={serialized}"));
             }
@@ -2223,7 +2289,8 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
 
         let devcontainer_up = self.run_dev_container(build_resources).await?;
 
-        self.run_remote_scripts(&devcontainer_up, true, true).await?;
+        self.run_remote_scripts(&devcontainer_up, true, true)
+            .await?;
 
         Ok(devcontainer_up)
     }
@@ -2285,9 +2352,26 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
                 }
             }
         }
-        if container_started {
-            if let Some(post_start_command) = &config.post_start_command {
-                for (command_name, command) in post_start_command.script_commands() {
+        if let Some(post_start_command) = &config.post_start_command {
+            let script_commands = post_start_command.script_commands();
+            if let Some(started_at) = &devcontainer_up.started_at {
+                if !script_commands.is_empty() {
+                    for command_name in script_commands.keys() {
+                        log::debug!("Running post start command {command_name}");
+                    }
+                    let script = post_start_marker_script(started_at, script_commands);
+                    self.docker_client
+                        .run_docker_exec(
+                            &devcontainer_up.container_id,
+                            &remote_folder,
+                            &devcontainer_up.remote_user,
+                            &devcontainer_up.remote_env,
+                            Command::new(script),
+                        )
+                        .await?;
+                }
+            } else if container_started {
+                for (command_name, command) in script_commands {
                     log::debug!("Running post start command {command_name}");
                     self.docker_client
                         .run_docker_exec(
@@ -2342,12 +2426,11 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
         if let Some(docker_ps) = self.check_for_existing_container().await? {
             log::debug!("Dev container already found. Proceeding with it");
 
-            let docker_inspect = self.docker_client.inspect(&docker_ps.id).await?;
+            let mut docker_inspect = self.docker_client.inspect(&docker_ps.id).await?;
 
             let container_started = !docker_inspect.is_running();
             if container_started {
                 log::debug!("Container not running. Will attempt to start, and then proceed");
-
                 match self.dev_container().build_type() {
                     DevContainerBuildType::DockerCompose => {
                         let resources = self.docker_compose_manifest().await?;
@@ -2356,6 +2439,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
                     }
                     _ => self.docker_client.start_container(&docker_ps.id).await?,
                 }
+                docker_inspect = self.docker_client.inspect(&docker_ps.id).await?;
             }
 
             let remote_user = get_remote_user_from_config(&docker_inspect, self)?;
@@ -2365,6 +2449,10 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
             let remote_env = self.runtime_remote_env(&docker_inspect.config.env_as_map()?)?;
 
             let dev_container_up = DevContainerUp {
+                started_at: docker_inspect
+                    .state
+                    .as_ref()
+                    .and_then(|state| state.started_at.clone()),
                 container_id: docker_ps.id,
                 remote_user: remote_user,
                 remote_workspace_folder: remote_folder.display().to_string(),
@@ -2372,7 +2460,8 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
                 remote_env,
             };
 
-            self.run_remote_scripts(&dev_container_up, false, container_started).await?;
+            self.run_remote_scripts(&dev_container_up, false, container_started)
+                .await?;
 
             Ok(Some(dev_container_up))
         } else {
@@ -2639,6 +2728,7 @@ struct DockerBuildResources {
     additional_mounts: Vec<MountDefinition>,
     container_env: HashMap<String, String>,
     privileged: bool,
+    init: bool,
     cap_add: Vec<String>,
     security_opt: Vec<String>,
     entrypoint_script: Option<String>,
@@ -3155,6 +3245,120 @@ fn get_container_user_from_config(
     Ok("root".to_string())
 }
 
+fn push_unique_string(values: &mut Vec<String>, value: &str) {
+    if !values.iter().any(|existing| existing == value) {
+        values.push(value.to_string());
+    }
+}
+
+fn append_mount_with_target_override(mounts: &mut Vec<MountDefinition>, mount: MountDefinition) {
+    mounts.retain(|existing| existing.target != mount.target);
+    mounts.push(mount);
+}
+
+fn mount_definition_from_metadata(value: &serde_json_lenient::Value) -> Option<MountDefinition> {
+    match value {
+        serde_json_lenient::Value::String(value) => parse_mount_definition_string(value),
+        serde_json_lenient::Value::Object(object) => {
+            let source = object
+                .get("source")
+                .or_else(|| object.get("src"))
+                .and_then(|value| value.as_str())
+                .map(str::to_string);
+            let target = object
+                .get("target")
+                .or_else(|| object.get("dst"))
+                .or_else(|| object.get("destination"))
+                .and_then(|value| value.as_str())?
+                .to_string();
+            let mount_type = object
+                .get("type")
+                .and_then(|value| value.as_str())
+                .map(str::to_string);
+            Some(MountDefinition {
+                source,
+                target,
+                mount_type,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn parse_mount_definition_string(value: &str) -> Option<MountDefinition> {
+    let mut source = None;
+    let mut target = None;
+    let mut mount_type = None;
+
+    for part in value.split(',') {
+        let Some((key, value)) = part.trim().split_once('=') else {
+            continue;
+        };
+        match key.trim() {
+            "source" | "src" => source = Some(value.trim().to_string()),
+            "target" | "dst" | "destination" => target = Some(value.trim().to_string()),
+            "type" => mount_type = Some(value.trim().to_string()),
+            _ => {}
+        }
+    }
+
+    target.map(|target| MountDefinition {
+        source,
+        target,
+        mount_type,
+    })
+}
+
+fn escape_compose_interpolation(value: &str) -> String {
+    value.replace('$', "$$")
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn command_to_shell_string(command: &Command) -> String {
+    let mut command_parts = vec![command.get_program().display().to_string()];
+    command_parts.extend(command.get_args().map(|arg| arg.display().to_string()));
+    command_parts.join(" ")
+}
+
+fn post_start_marker_script(started_at: &str, script_commands: HashMap<String, Command>) -> String {
+    let started_at = shell_single_quote(started_at);
+    let mut script = format!(
+        r#"user_id="$(id -u)"
+home_directory="${{HOME:-}}"
+if [ -z "$home_directory" ]; then
+  home_directory="$( (command -v getent >/dev/null 2>&1 && getent passwd "$user_id" || grep -E "^[^:]*:[^:]*:${{user_id}}:" /etc/passwd || true) | head -n 1 | cut -d: -f6)"
+fi
+if [ -z "$home_directory" ]; then
+  home_directory=/root
+fi
+marker_directory="$home_directory/.devcontainer"
+marker="$marker_directory/.postStartCommandMarker"
+started_at={started_at}
+marker_available=false
+if mkdir -p "$marker_directory"; then
+  previous_started_at="$(cat "$marker" 2>/dev/null || true)"
+  if [ "$previous_started_at" = "$started_at" ]; then
+    exit 0
+  fi
+  marker_available=true
+fi
+"#,
+    );
+    for command in script_commands.into_values() {
+        script.push_str(&command_to_shell_string(&command));
+        script.push_str(" || exit $?\n");
+    }
+    script.push_str(
+        r#"if [ "$marker_available" = "true" ]; then
+  printf '%s' "$started_at" > "$marker" || exit $?
+fi"#,
+    );
+    script
+}
+
 fn build_devcontainer_metadata_entry(
     raw_json: &serde_json_lenient::Value,
 ) -> serde_json_lenient::Map<String, serde_json_lenient::Value> {
@@ -3224,6 +3428,13 @@ mod test {
         sync::{Arc, Mutex},
     };
 
+    #[cfg(not(target_os = "windows"))]
+    use std::{
+        fs as std_fs,
+        process::Command as StdCommand,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
     use async_trait::async_trait;
     use fs::{FakeFs, Fs};
     use gpui::{AppContext, TestAppContext};
@@ -3239,13 +3450,13 @@ mod test {
     use crate::{
         DevContainerConfig, DevContainerContext,
         command_json::CommandRunner,
-        devcontainer_api::DevContainerError,
+        devcontainer_api::{DevContainerError, DevContainerUp},
         devcontainer_json::MountDefinition,
         devcontainer_manifest::{
             ConfigStatus, DevContainerManifest, DockerBuildResources, DockerComposeResources,
-            DockerInspect, dockerfile_inject_alias, extract_feature_id, find_primary_service,
-            get_remote_user_from_config, image_from_dockerfile, is_local_feature_ref,
-            resolve_compose_dockerfile,
+            DockerInspect, dockerfile_inject_alias, escape_compose_interpolation,
+            extract_feature_id, find_primary_service, get_remote_user_from_config,
+            image_from_dockerfile, is_local_feature_ref, resolve_compose_dockerfile,
         },
         docker::{
             DockerClient, DockerComposeConfig, DockerComposeService, DockerComposeServiceBuild,
@@ -3514,6 +3725,7 @@ mod test {
             additional_mounts: vec![],
             container_env: HashMap::new(),
             privileged: false,
+            init: false,
             cap_add: vec!["SYS_PTRACE".to_string()],
             security_opt: vec!["seccomp=unconfined".to_string()],
             entrypoint_script: Some("echo Container started\n    trap \"exit 0\" 15\n    exec \"$@\"\n    while sleep 1 & wait $!; do :; done".to_string()),
@@ -3614,6 +3826,206 @@ mod test {
             args.contains(&OsStr::new("mcr.microsoft.com/devcontainers/base:ubuntu")),
             "image id must still be present in docker run command"
         );
+    }
+
+    #[gpui::test]
+    async fn should_use_devcontainer_cli_post_start_marker_for_started_container(
+        cx: &mut TestAppContext,
+    ) {
+        let (test_dependencies, mut devcontainer_manifest) = init_default_devcontainer_manifest(
+            cx,
+            r#"{
+                "image": "test_image:latest",
+                "postStartCommand": "echo post-start",
+                "postAttachCommand": "echo post-attach"
+            }"#,
+        )
+        .await
+        .unwrap();
+        devcontainer_manifest.parse_nonremote_vars().unwrap();
+
+        let devcontainer_up = DevContainerUp {
+            started_at: Some("2026-06-23T10:00:00Z".to_string()),
+            container_id: "container".to_string(),
+            remote_user: "root".to_string(),
+            remote_workspace_folder: "/workspaces/project".to_string(),
+            extension_ids: Vec::new(),
+            remote_env: HashMap::new(),
+        };
+
+        devcontainer_manifest
+            .run_remote_scripts(&devcontainer_up, false, false)
+            .await
+            .unwrap();
+
+        let docker_exec_commands = test_dependencies
+            .docker
+            .exec_commands_recorded
+            .lock()
+            .unwrap();
+        assert_eq!(docker_exec_commands.len(), 2);
+        let post_start_script = docker_exec_commands[0]
+            ._inner_command
+            .get_program()
+            .to_string_lossy();
+        assert!(post_start_script.contains("marker_directory=\"$home_directory/.devcontainer\""));
+        assert!(post_start_script.contains("marker=\"$marker_directory/.postStartCommandMarker\""));
+        assert!(!post_start_script.contains("/tmp/zed-devcontainer"));
+        assert!(post_start_script.contains("echo post-start || exit $?"));
+        assert!(
+            post_start_script.find("echo post-start").unwrap()
+                < post_start_script.find("printf '%s'").unwrap(),
+            "postStartCommand marker must be written only after the command succeeds"
+        );
+        assert_eq!(docker_exec_commands[1]._inner_command.get_program(), "echo");
+        assert_eq!(
+            docker_exec_commands[1]
+                ._inner_command
+                .get_args()
+                .collect::<Vec<_>>(),
+            vec![OsStr::new("post-attach")]
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn post_start_marker_script_runs_command_when_marker_directory_cannot_be_created() {
+        let mut command = Command::new("echo");
+        command.arg("post-start");
+        let script = super::post_start_marker_script(
+            "2026-06-23T10:00:00Z",
+            HashMap::from([("default".to_string(), command)]),
+        );
+
+        let output = StdCommand::new("sh")
+            .arg("-c")
+            .arg(script)
+            .env("HOME", "/dev/null")
+            .output()
+            .expect("shell should run postStartCommand marker script");
+
+        assert!(
+            output.status.success(),
+            "script should not fail when marker directory cannot be created: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "post-start\n");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn post_start_marker_script_marks_only_after_success() {
+        let home_directory = temporary_home_directory("post-start-success");
+        let started_at = "2026-06-23T10:00:00Z";
+        let marker = home_directory
+            .join(".devcontainer")
+            .join(".postStartCommandMarker");
+        let mut command = Command::new("echo");
+        command.arg("post-start");
+        let script = super::post_start_marker_script(
+            started_at,
+            HashMap::from([("default".to_string(), command)]),
+        );
+
+        let output = StdCommand::new("sh")
+            .arg("-c")
+            .arg(&script)
+            .env("HOME", &home_directory)
+            .output()
+            .expect("shell should run postStartCommand marker script");
+        assert!(
+            output.status.success(),
+            "script should run successfully: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "post-start\n");
+        assert_eq!(
+            std_fs::read_to_string(&marker).expect("marker should be written"),
+            started_at
+        );
+
+        let output = StdCommand::new("sh")
+            .arg("-c")
+            .arg(&script)
+            .env("HOME", &home_directory)
+            .output()
+            .expect("shell should run postStartCommand marker script");
+        assert!(
+            output.status.success(),
+            "script should skip successfully: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "");
+
+        std_fs::remove_dir_all(home_directory).expect("temporary home should be removed");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn post_start_marker_script_surfaces_marker_write_failure() {
+        let home_directory = temporary_home_directory("post-start-marker-write-failure");
+        let marker = home_directory
+            .join(".devcontainer")
+            .join(".postStartCommandMarker");
+        std_fs::create_dir_all(&marker).expect("marker path should be a directory");
+        let mut command = Command::new("echo");
+        command.arg("post-start");
+        let script = super::post_start_marker_script(
+            "2026-06-23T10:00:00Z",
+            HashMap::from([("default".to_string(), command)]),
+        );
+
+        let output = StdCommand::new("sh")
+            .arg("-c")
+            .arg(script)
+            .env("HOME", &home_directory)
+            .output()
+            .expect("shell should run postStartCommand marker script");
+
+        assert!(!output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "post-start\n");
+        assert!(marker.is_dir());
+
+        std_fs::remove_dir_all(home_directory).expect("temporary home should be removed");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn post_start_marker_script_does_not_mark_after_failure() {
+        let home_directory = temporary_home_directory("post-start-failure");
+        let marker = home_directory
+            .join(".devcontainer")
+            .join(".postStartCommandMarker");
+        let script = super::post_start_marker_script(
+            "2026-06-23T10:00:00Z",
+            HashMap::from([("default".to_string(), Command::new("false"))]),
+        );
+
+        let output = StdCommand::new("sh")
+            .arg("-c")
+            .arg(script)
+            .env("HOME", &home_directory)
+            .output()
+            .expect("shell should run postStartCommand marker script");
+
+        assert!(!output.status.success());
+        assert!(!marker.exists());
+
+        std_fs::remove_dir_all(home_directory).expect("temporary home should be removed");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn temporary_home_directory(prefix: &str) -> PathBuf {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "zed-devcontainer-{prefix}-{}-{now}",
+            std::process::id()
+        ));
+        std_fs::create_dir_all(&path).expect("temporary home should be created");
+        path
     }
 
     #[gpui::test]
@@ -3803,6 +4215,15 @@ mod test {
                 .as_ref()
                 .and_then(|env| env.get("LOCAL_ENV_VAR_4")),
             Some(&"default".to_string())
+        );
+    }
+
+    #[test]
+    fn escape_compose_interpolation_uses_compose_dollar_escape() {
+        assert_eq!(escape_compose_interpolation("pa$word"), "pa$$word");
+        assert_eq!(
+            escape_compose_interpolation("${containerEnv:PATH}"),
+            "$${containerEnv:PATH}"
         );
     }
 
@@ -4243,27 +4664,40 @@ chmod +x ./install.sh
         assert!(args.contains(&"--security-opt".to_string()));
         assert!(args.contains(&"seccomp=unconfined".to_string()));
 
-        let metadata_arg = args.iter().find(|a| a.starts_with("devcontainer.metadata=")).unwrap();
+        let metadata_arg = args
+            .iter()
+            .find(|a| a.starts_with("devcontainer.metadata="))
+            .unwrap();
         let metadata_json = &metadata_arg["devcontainer.metadata=".len()..];
-        let metadata: Vec<serde_json_lenient::Value> = serde_json_lenient::from_str(metadata_json).unwrap();
+        let metadata: Vec<serde_json_lenient::Value> =
+            serde_json_lenient::from_str(metadata_json).unwrap();
         assert_eq!(metadata.len(), 4);
         assert_eq!(metadata[0]["remoteUser"], "node");
-        assert_eq!(metadata[1]["id"], "ghcr.io/devcontainers/features/docker-in-docker:2");
+        assert_eq!(
+            metadata[1]["id"],
+            "ghcr.io/devcontainers/features/docker-in-docker:2"
+        );
         assert_eq!(metadata[1]["privileged"], true);
         assert_eq!(metadata[2]["id"], "ghcr.io/devcontainers/features/go:1");
-        assert!(metadata[2]["capAdd"].as_array().unwrap().contains(&serde_json_lenient::Value::String("SYS_PTRACE".to_string())));
+        assert!(
+            metadata[2]["capAdd"]
+                .as_array()
+                .unwrap()
+                .contains(&serde_json_lenient::Value::String("SYS_PTRACE".to_string()))
+        );
         assert_eq!(metadata[3]["remoteUser"], "node");
         assert!(metadata[3].get("onCreateCommand").is_some());
 
-        let env_args: Vec<&String> = args.iter()
+        let env_args: Vec<&String> = args
+            .iter()
             .enumerate()
             .filter(|(_, a)| *a == "-e")
             .filter_map(|(i, _)| args.get(i + 1))
             .collect();
         assert!(env_args.contains(&&"VARIABLE_VALUE=value".to_string()));
-        assert!(env_args.contains(&&"DOCKER_BUILDKIT=1".to_string()));
-        assert!(env_args.contains(&&"GOPATH=/go".to_string()));
-        assert!(env_args.contains(&&"GOROOT=/usr/local/go".to_string()));
+        assert!(!env_args.contains(&&"DOCKER_BUILDKIT=1".to_string()));
+        assert!(!env_args.contains(&&"GOPATH=/go".to_string()));
+        assert!(!env_args.contains(&&"GOROOT=/usr/local/go".to_string()));
 
         let image_arg = args.iter().find(|a| a.contains("-features")).unwrap();
         assert!(image_arg.ends_with("-features"));
@@ -4566,22 +5000,41 @@ ENV DOCKER_BUILDKIT=1
 
         let app_service = runtime_config.services.get("app").expect("app service");
         assert_eq!(app_service.cap_add, Some(vec!["SYS_PTRACE".to_string()]));
-        assert_eq!(app_service.security_opt, Some(vec!["seccomp=unconfined".to_string()]));
+        assert_eq!(
+            app_service.security_opt,
+            Some(vec!["seccomp=unconfined".to_string()])
+        );
         assert_eq!(app_service.privileged, Some(true));
         assert!(app_service.entrypoint.is_some());
 
         let labels = app_service.labels.as_ref().unwrap();
-        assert_eq!(labels.get("devcontainer.local_folder").unwrap(), "/path/to/local/project");
-        assert_eq!(labels.get("devcontainer.config_file").unwrap(), "/path/to/local/project/.devcontainer/devcontainer.json");
+        assert_eq!(
+            labels.get("devcontainer.local_folder").unwrap(),
+            "/path/to/local/project"
+        );
+        assert_eq!(
+            labels.get("devcontainer.config_file").unwrap(),
+            "/path/to/local/project/.devcontainer/devcontainer.json"
+        );
 
         let metadata_json = labels.get("devcontainer.metadata").unwrap();
-        let metadata: Vec<serde_json_lenient::Value> = serde_json_lenient::from_str(metadata_json).unwrap();
+        let metadata: Vec<serde_json_lenient::Value> =
+            serde_json_lenient::from_str(metadata_json).unwrap();
         assert!(metadata.len() >= 2);
         assert_eq!(metadata[0]["remoteUser"], "vscode");
-        let has_dind_feature = metadata.iter().any(|e| e.get("id").and_then(|v| v.as_str()) == Some("ghcr.io/devcontainers/features/docker-in-docker:2"));
-        assert!(has_dind_feature, "metadata should include docker-in-docker feature entry");
+        let has_dind_feature = metadata.iter().any(|e| {
+            e.get("id").and_then(|v| v.as_str())
+                == Some("ghcr.io/devcontainers/features/docker-in-docker:2")
+        });
+        assert!(
+            has_dind_feature,
+            "metadata should include docker-in-docker feature entry"
+        );
         let has_forward_ports = metadata.iter().any(|e| e.get("forwardPorts").is_some());
-        assert!(has_forward_ports, "metadata should include devcontainer.json config entry with forwardPorts");
+        assert!(
+            has_forward_ports,
+            "metadata should include devcontainer.json config entry with forwardPorts"
+        );
 
         assert_eq!(app_service.volumes.len(), 1);
         assert_eq!(app_service.volumes[0].target, "/var/lib/docker");
@@ -4589,7 +5042,11 @@ ENV DOCKER_BUILDKIT=1
         let db_service = runtime_config.services.get("db").expect("db service");
         assert_eq!(db_service.ports.len(), 3);
 
-        assert!(runtime_config.volumes.contains_key("dind-var-lib-docker-42dad4b4ca7b8ced"))
+        assert!(
+            runtime_config
+                .volumes
+                .contains_key("dind-var-lib-docker-42dad4b4ca7b8ced")
+        )
     }
 
     #[test]
@@ -6627,9 +7084,7 @@ RUN echo $RUBY_VERSION2
                                 HashMap::from([
                                     (
                                         "capAdd".to_string(),
-                                        Value::Array(vec![Value::String(
-                                            "SYS_PTRACE".to_string(),
-                                        )]),
+                                        Value::Array(vec![Value::String("SYS_PTRACE".to_string())]),
                                     ),
                                     (
                                         "securityOpt".to_string(),
@@ -6700,9 +7155,7 @@ RUN echo $RUBY_VERSION2
                                 HashMap::from([
                                     (
                                         "capAdd".to_string(),
-                                        Value::Array(vec![Value::String(
-                                            "SYS_PTRACE".to_string(),
-                                        )]),
+                                        Value::Array(vec![Value::String("SYS_PTRACE".to_string())]),
                                     ),
                                     (
                                         "securityOpt".to_string(),

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -127,11 +127,11 @@ impl DevContainerManifest {
         let labels = vec![
             (
                 "devcontainer.local_folder",
-                (self.local_project_directory.display()).to_string(),
+                normalize_label_path(&self.local_project_directory.display().to_string()),
             ),
             (
                 "devcontainer.config_file",
-                (self.config_file().display()).to_string(),
+                normalize_label_path(&self.config_file().display().to_string()),
             ),
         ];
         labels
@@ -2986,6 +2986,24 @@ fn get_container_user_from_config(
     }
 
     Ok("root".to_string())
+}
+
+fn normalize_label_path(path: &str) -> String {
+    #[cfg(not(target_os = "windows"))]
+    {
+        path.to_string()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let normalized = path.replace('/', "\\");
+        if normalized.len() >= 2 && normalized.as_bytes()[1] == b':' {
+            let mut result = normalized[..1].to_lowercase();
+            result.push_str(&normalized[1..]);
+            result
+        } else {
+            normalized
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -3431,7 +3431,6 @@ mod test {
     #[cfg(not(target_os = "windows"))]
     use std::{
         fs as std_fs,
-        process::Command as StdCommand,
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -3897,12 +3896,7 @@ mod test {
             HashMap::from([("default".to_string(), command)]),
         );
 
-        let output = StdCommand::new("sh")
-            .arg("-c")
-            .arg(script)
-            .env("HOME", "/dev/null")
-            .output()
-            .expect("shell should run postStartCommand marker script");
+        let output = run_shell_script(&script, Path::new("/dev/null"));
 
         assert!(
             output.status.success(),
@@ -3927,12 +3921,7 @@ mod test {
             HashMap::from([("default".to_string(), command)]),
         );
 
-        let output = StdCommand::new("sh")
-            .arg("-c")
-            .arg(&script)
-            .env("HOME", &home_directory)
-            .output()
-            .expect("shell should run postStartCommand marker script");
+        let output = run_shell_script(&script, &home_directory);
         assert!(
             output.status.success(),
             "script should run successfully: {}",
@@ -3944,12 +3933,7 @@ mod test {
             started_at
         );
 
-        let output = StdCommand::new("sh")
-            .arg("-c")
-            .arg(&script)
-            .env("HOME", &home_directory)
-            .output()
-            .expect("shell should run postStartCommand marker script");
+        let output = run_shell_script(&script, &home_directory);
         assert!(
             output.status.success(),
             "script should skip successfully: {}",
@@ -3975,12 +3959,7 @@ mod test {
             HashMap::from([("default".to_string(), command)]),
         );
 
-        let output = StdCommand::new("sh")
-            .arg("-c")
-            .arg(script)
-            .env("HOME", &home_directory)
-            .output()
-            .expect("shell should run postStartCommand marker script");
+        let output = run_shell_script(&script, &home_directory);
 
         assert!(!output.status.success());
         assert_eq!(String::from_utf8_lossy(&output.stdout), "post-start\n");
@@ -4001,17 +3980,19 @@ mod test {
             HashMap::from([("default".to_string(), Command::new("false"))]),
         );
 
-        let output = StdCommand::new("sh")
-            .arg("-c")
-            .arg(script)
-            .env("HOME", &home_directory)
-            .output()
-            .expect("shell should run postStartCommand marker script");
+        let output = run_shell_script(&script, &home_directory);
 
         assert!(!output.status.success());
         assert!(!marker.exists());
 
         std_fs::remove_dir_all(home_directory).expect("temporary home should be removed");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn run_shell_script(script: &str, home_directory: &Path) -> Output {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg(script).env("HOME", home_directory);
+        gpui::block_on(command.output()).expect("shell should run postStartCommand marker script")
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -3362,7 +3362,8 @@ fi
     );
     for command in script_commands.into_values() {
         script.push_str(&command_to_shell_string(&command));
-        script.push_str(" || exit $?\n");
+        script.push_str("\ncommand_status=$?\n");
+        script.push_str("[ \"$command_status\" -eq 0 ] || exit \"$command_status\"\n");
     }
     script.push_str(
         r#"if [ "$marker_available" = "true" ]; then
@@ -3970,7 +3971,9 @@ mod test {
         assert!(post_start_script.contains("marker_directory=\"$home_directory/.devcontainer\""));
         assert!(post_start_script.contains("marker=\"$marker_directory/.postStartCommandMarker\""));
         assert!(!post_start_script.contains("/tmp/zed-devcontainer"));
-        assert!(post_start_script.contains("echo post-start || exit $?"));
+        assert!(post_start_script.contains(
+            "echo post-start\ncommand_status=$?\n[ \"$command_status\" -eq 0 ] || exit \"$command_status\""
+        ));
         assert!(
             post_start_script.find("echo post-start").unwrap()
                 < post_start_script.find("printf '%s'").unwrap(),
@@ -4004,6 +4007,36 @@ mod test {
             String::from_utf8_lossy(&output.stderr)
         );
         assert_eq!(String::from_utf8_lossy(&output.stdout), "post-start\n");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn post_start_marker_script_accepts_background_command() {
+        let home_directory = temporary_home_directory("post-start-background");
+        let started_at = "2026-06-23T10:00:00Z";
+        let marker = home_directory
+            .join(".devcontainer")
+            .join(".postStartCommandMarker");
+        let mut command = Command::new("true");
+        command.arg("&");
+        let script = super::post_start_marker_script(
+            started_at,
+            HashMap::from([("default".to_string(), command)]),
+        );
+
+        let output = run_shell_script(&script, &home_directory);
+
+        assert!(
+            output.status.success(),
+            "background command should be accepted: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(
+            std_fs::read_to_string(&marker).expect("marker should be written"),
+            started_at
+        );
+
+        std_fs::remove_dir_all(home_directory).expect("temporary home should be removed");
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -142,7 +142,15 @@ impl DevContainerManifest {
         content: &str,
     ) -> Result<serde_json_lenient::Value, DevContainerError> {
         let mut value = deserialize_devcontainer_json_to_value(content)?;
-        let mut to_visit = vec![&mut value];
+        self.substitute_nonremote_vars_in_value(&mut value)?;
+        Ok(value)
+    }
+
+    fn substitute_nonremote_vars_in_value(
+        &self,
+        value: &mut serde_json_lenient::Value,
+    ) -> Result<(), DevContainerError> {
+        let mut to_visit = vec![value];
 
         while let Some(value) = to_visit.pop() {
             use serde_json_lenient::Value;
@@ -185,7 +193,7 @@ impl DevContainerManifest {
             }
         }
 
-        Ok(value)
+        Ok(())
     }
 
     fn parse_nonremote_vars(&mut self) -> Result<(), DevContainerError> {
@@ -801,32 +809,40 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
         let mut security_opt = Vec::new();
         let mut privileged = false;
         let mut init = false;
+        let mut metadata_entries = base_image
+            .config
+            .labels
+            .metadata
+            .clone()
+            .unwrap_or_default();
+        for entry in &mut metadata_entries {
+            for value in entry.values_mut() {
+                self.substitute_nonremote_vars_in_value(value)?;
+            }
+        }
 
-        if let Some(metadata_entries) = &base_image.config.labels.metadata {
-            for entry in metadata_entries {
-                if let Some(serde_json_lenient::Value::Array(metadata_mounts)) = entry.get("mounts")
-                {
-                    for mount in metadata_mounts {
-                        if let Some(mount) = mount_definition_from_metadata(mount) {
-                            append_mount_with_target_override(&mut mounts, mount);
-                        }
+        for entry in &metadata_entries {
+            if let Some(serde_json_lenient::Value::Array(metadata_mounts)) = entry.get("mounts") {
+                for mount in metadata_mounts {
+                    if let Some(mount) = mount_definition_from_metadata(mount) {
+                        append_mount_with_target_override(&mut mounts, mount);
                     }
                 }
-                if entry.get("privileged").and_then(|value| value.as_bool()) == Some(true) {
-                    privileged = true;
+            }
+            if entry.get("privileged").and_then(|value| value.as_bool()) == Some(true) {
+                privileged = true;
+            }
+            if entry.get("init").and_then(|value| value.as_bool()) == Some(true) {
+                init = true;
+            }
+            if let Some(serde_json_lenient::Value::Array(caps)) = entry.get("capAdd") {
+                for cap in caps.iter().filter_map(|cap| cap.as_str()) {
+                    push_unique_string(&mut cap_add, cap);
                 }
-                if entry.get("init").and_then(|value| value.as_bool()) == Some(true) {
-                    init = true;
-                }
-                if let Some(serde_json_lenient::Value::Array(caps)) = entry.get("capAdd") {
-                    for cap in caps.iter().filter_map(|cap| cap.as_str()) {
-                        push_unique_string(&mut cap_add, cap);
-                    }
-                }
-                if let Some(serde_json_lenient::Value::Array(opts)) = entry.get("securityOpt") {
-                    for opt in opts.iter().filter_map(|opt| opt.as_str()) {
-                        push_unique_string(&mut security_opt, opt);
-                    }
+            }
+            if let Some(serde_json_lenient::Value::Array(opts)) = entry.get("securityOpt") {
+                for opt in opts.iter().filter_map(|opt| opt.as_str()) {
+                    push_unique_string(&mut security_opt, opt);
                 }
             }
         }
@@ -881,14 +897,11 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
         };
 
         let mut container_env = HashMap::new();
-        if let Some(metadata_entries) = &base_image.config.labels.metadata {
-            for entry in metadata_entries {
-                if let Some(serde_json_lenient::Value::Object(env_map)) = entry.get("containerEnv")
-                {
-                    for (k, v) in env_map {
-                        if let Some(s) = v.as_str() {
-                            container_env.insert(k.clone(), s.to_string());
-                        }
+        for entry in &metadata_entries {
+            if let Some(serde_json_lenient::Value::Object(env_map)) = entry.get("containerEnv") {
+                for (k, v) in env_map {
+                    if let Some(s) = v.as_str() {
+                        container_env.insert(k.clone(), s.to_string());
                     }
                 }
             }
@@ -3828,6 +3841,88 @@ mod test {
     }
 
     #[gpui::test]
+    async fn should_substitute_nonremote_variables_in_image_metadata(cx: &mut TestAppContext) {
+        let (_, mut devcontainer_manifest) = init_default_devcontainer_manifest(
+            cx,
+            r#"{
+                "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+            }"#,
+        )
+        .await
+        .unwrap();
+        devcontainer_manifest.parse_nonremote_vars().unwrap();
+
+        let metadata = serde_json_lenient::from_str(
+            r#"[
+                {
+                    "id": "ghcr.io/devcontainers/features/docker-in-docker:2",
+                    "mounts": [
+                        {
+                            "source": "dind-var-lib-docker-${devcontainerId}",
+                            "target": "/var/lib/docker",
+                            "type": "volume"
+                        }
+                    ]
+                },
+                {
+                    "containerEnv": {
+                        "PATH": "/custom/bin:${PATH}"
+                    }
+                }
+            ]"#,
+        )
+        .unwrap();
+        let base_image = DockerInspect {
+            id: "base-image-id".to_string(),
+            config: DockerInspectConfig {
+                labels: DockerConfigLabels {
+                    metadata: Some(metadata),
+                },
+                image_user: None,
+                env: vec!["PATH=/usr/local/bin:/usr/bin".to_string()],
+            },
+            mounts: None,
+            state: None,
+        };
+
+        let resources = devcontainer_manifest
+            .build_merged_resources(base_image, "mcr.microsoft.com/devcontainers/base:ubuntu")
+            .unwrap();
+
+        assert_eq!(
+            resources.additional_mounts,
+            vec![MountDefinition {
+                source: Some(format!(
+                    "dind-var-lib-docker-{}",
+                    devcontainer_manifest.devcontainer_id()
+                )),
+                target: "/var/lib/docker".to_string(),
+                mount_type: Some("volume".to_string()),
+            }]
+        );
+        assert_eq!(
+            resources.container_env.get("PATH").map(String::as_str),
+            Some("/custom/bin:${PATH}")
+        );
+        let persisted_mount_source = resources
+            .image
+            .config
+            .labels
+            .metadata
+            .as_ref()
+            .and_then(|entries| entries.first())
+            .and_then(|entry| entry.get("mounts"))
+            .and_then(|mounts| mounts.as_array())
+            .and_then(|mounts| mounts.first())
+            .and_then(|mount| mount.get("source"))
+            .and_then(|source| source.as_str());
+        assert_eq!(
+            persisted_mount_source,
+            Some("dind-var-lib-docker-${devcontainerId}")
+        );
+    }
+
+    #[gpui::test]
     async fn should_use_devcontainer_cli_post_start_marker_for_started_container(
         cx: &mut TestAppContext,
     ) {
@@ -4659,7 +4754,9 @@ chmod +x ./install.sh
             "ghcr.io/devcontainers/features/docker-in-docker:2"
         );
         assert_eq!(metadata[1]["privileged"], true);
+        assert!(metadata[1].get("containerEnv").is_none());
         assert_eq!(metadata[2]["id"], "ghcr.io/devcontainers/features/go:1");
+        assert!(metadata[2].get("containerEnv").is_none());
         assert!(
             metadata[2]["capAdd"]
                 .as_array()

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -600,7 +600,7 @@ impl DevContainerManifest {
                     DevContainerError::ResourceFetchFailed
                 })?;
 
-            let feature_manifest = FeatureManifest::new(consecutive_id, feature_dir, feature_json);
+            let feature_manifest = FeatureManifest::new(consecutive_id, feature_ref.to_string(), feature_dir, feature_json);
 
             log::debug!("Prepared feature content for '{}'", feature_ref);
 
@@ -826,6 +826,19 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             }
         }
 
+        for feature in &self.features {
+            for cap in feature.cap_add() {
+                if !cap_add.contains(&cap) {
+                    cap_add.push(cap);
+                }
+            }
+            for opt in feature.security_opt() {
+                if !security_opt.contains(&opt) {
+                    security_opt.push(opt);
+                }
+            }
+        }
+
         let entrypoint_script = if dev_container.override_command == Some(false) {
             None
         } else {
@@ -845,7 +858,29 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             Some(entrypoint_script_lines.join("\n").trim().to_string())
         };
 
-        let container_env = dev_container.container_env.clone().unwrap_or_default();
+        let mut container_env = HashMap::new();
+        if let Some(metadata_entries) = &base_image.config.labels.metadata {
+            for entry in metadata_entries {
+                if let Some(serde_json_lenient::Value::Object(env_map)) = entry.get("containerEnv")
+                {
+                    for (k, v) in env_map {
+                        if let Some(s) = v.as_str() {
+                            container_env.insert(k.clone(), s.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        for feature in &self.features {
+            for (k, v) in feature.container_env() {
+                container_env.insert(k, v);
+            }
+        }
+        if let Some(config_env) = &dev_container.container_env {
+            for (k, v) in config_env {
+                container_env.insert(k.clone(), v.clone());
+            }
+        }
 
         Ok(DockerBuildResources {
             image: base_image,
@@ -871,11 +906,17 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             DevContainerBuildType::Image(base_image) => {
                 let built_docker_image = self.build_docker_image().await?;
 
+                let image_tag = self
+                    .features_build_info
+                    .as_ref()
+                    .map(|info| info.image_tag.as_str())
+                    .unwrap_or(&base_image);
+
                 let built_docker_image = self
-                    .update_remote_user_uid(built_docker_image, &base_image)
+                    .update_remote_user_uid(built_docker_image, image_tag)
                     .await?;
 
-                let resources = self.build_merged_resources(built_docker_image, &base_image)?;
+                let resources = self.build_merged_resources(built_docker_image, image_tag)?;
                 Ok(DevContainerBuildResources::Docker(resources))
             }
             DevContainerBuildType::Dockerfile(_) => {
@@ -1265,13 +1306,40 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
     ) -> Result<DockerComposeConfig, DevContainerError> {
         let mut runtime_labels = HashMap::new();
 
-        if let Some(metadata) = &resources.image.config.labels.metadata {
-            let serialized_metadata = serde_json_lenient::to_string(metadata).map_err(|e| {
-                log::error!("Error serializing docker image metadata: {e}");
-                DevContainerError::ContainerNotValid(resources.image.id.clone())
-            })?;
+        {
+            let mut metadata_entries: Vec<serde_json_lenient::Value> = Vec::new();
 
-            runtime_labels.insert("devcontainer.metadata".to_string(), serialized_metadata);
+            if let Some(image_metadata) = &resources.image.config.labels.metadata {
+                for entry in image_metadata {
+                    if let Ok(val) = serde_json_lenient::to_value(entry) {
+                        metadata_entries.push(val);
+                    }
+                }
+            }
+
+            for feature in &self.features {
+                let entry = feature.build_metadata_entry();
+                if !entry.is_empty() {
+                    metadata_entries.push(serde_json_lenient::Value::Object(entry));
+                }
+            }
+
+            if let Ok(substituted_json) = self.parse_nonremote_vars_for_content(&self.raw_config)
+            {
+                let config_entry = build_devcontainer_metadata_entry(&substituted_json);
+                if !config_entry.is_empty() {
+                    metadata_entries.push(serde_json_lenient::Value::Object(config_entry));
+                }
+            }
+
+            if !metadata_entries.is_empty() {
+                let serialized =
+                    serde_json_lenient::to_string(&metadata_entries).map_err(|e| {
+                        log::error!("Error serializing docker image metadata: {e}");
+                        DevContainerError::ContainerNotValid(resources.image.id.clone())
+                    })?;
+                runtime_labels.insert("devcontainer.metadata".to_string(), serialized);
+            }
         }
 
         for (k, v) in self.identifying_labels() {
@@ -1328,6 +1396,12 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             Some(resources.security_opt)
         };
 
+        let environment = if resources.container_env.is_empty() {
+            None
+        } else {
+            Some(resources.container_env)
+        };
+
         let mut main_service = DockerComposeService {
             entrypoint,
             cap_add,
@@ -1335,6 +1409,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             labels: Some(runtime_labels),
             volumes,
             privileged: Some(resources.privileged),
+            environment,
             ..Default::default()
         };
         // let mut extra_service_port_declarations: Vec<(String, DockerComposeService)> = Vec::new();
@@ -2059,6 +2134,13 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
                     if let Ok(val) = serde_json_lenient::to_value(entry) {
                         metadata_entries.push(val);
                     }
+                }
+            }
+
+            for feature in &self.features {
+                let entry = feature.build_metadata_entry();
+                if !entry.is_empty() {
+                    metadata_entries.push(serde_json_lenient::Value::Object(entry));
                 }
             }
 
@@ -3154,8 +3236,6 @@ mod test {
     use serde_json_lenient::Value;
     use util::{command::Command, paths::SanitizedPath};
 
-    #[cfg(not(target_os = "windows"))]
-    use crate::docker::DockerComposeServicePort;
     use crate::{
         DevContainerConfig, DevContainerContext,
         command_json::CommandRunner,
@@ -4156,42 +4236,37 @@ chmod +x ./install.sh
             .find(|c| c.args.get(0).is_some_and(|a| a == "run"))
             .expect("found");
 
-        assert_eq!(
-            docker_run_command.args,
-            vec![
-                "run".to_string(),
-                "--privileged".to_string(),
-                "--cap-add=SYS_PTRACE".to_string(),
-                "--sig-proxy=true".to_string(),
-                "-d".to_string(),
-                "--mount".to_string(),
-                "type=bind,source=/path/to/local/project,target=/workspace2,consistency=cached".to_string(),
-                "--mount".to_string(),
-                "type=volume,source=dev-containers-cli-bashhistory,target=/home/node/commandhistory,consistency=cached".to_string(),
-                "--mount".to_string(),
-                "type=volume,source=dind-var-lib-docker-42dad4b4ca7b8ced,target=/var/lib/docker,consistency=cached".to_string(),
-                "-l".to_string(),
-                "devcontainer.local_folder=/path/to/local/project".to_string(),
-                "-l".to_string(),
-                "devcontainer.config_file=/path/to/local/project/.devcontainer/devcontainer.json".to_string(),
-                "-l".to_string(),
-                "devcontainer.metadata=[{\"remoteUser\":\"node\"}]".to_string(),
-                "-p".to_string(),
-                "8082:8082".to_string(),
-                "-p".to_string(),
-                "8083:8083".to_string(),
-                "-p".to_string(),
-                "8084:8084".to_string(),
-                "-p".to_string(),
-                "8085:8086".to_string(),
-                "--entrypoint".to_string(),
-                "/bin/sh".to_string(),
-                "sha256:610e6cfca95280188b021774f8cf69dd6f49bdb6eebc34c5ee2010f4d51cc105".to_string(),
-                "-c".to_string(),
-                "echo Container started\ntrap \"exit 0\" 15\n/usr/local/share/docker-init.sh\nexec \"$@\"\nwhile sleep 1 & wait $!; do :; done".to_string(),
-                "-".to_string()
-            ]
-        );
+        let args = &docker_run_command.args;
+
+        assert!(args.contains(&"--cap-add".to_string()));
+        assert!(args.contains(&"SYS_PTRACE".to_string()));
+        assert!(args.contains(&"--security-opt".to_string()));
+        assert!(args.contains(&"seccomp=unconfined".to_string()));
+
+        let metadata_arg = args.iter().find(|a| a.starts_with("devcontainer.metadata=")).unwrap();
+        let metadata_json = &metadata_arg["devcontainer.metadata=".len()..];
+        let metadata: Vec<serde_json_lenient::Value> = serde_json_lenient::from_str(metadata_json).unwrap();
+        assert_eq!(metadata.len(), 4);
+        assert_eq!(metadata[0]["remoteUser"], "node");
+        assert_eq!(metadata[1]["id"], "ghcr.io/devcontainers/features/docker-in-docker:2");
+        assert_eq!(metadata[1]["privileged"], true);
+        assert_eq!(metadata[2]["id"], "ghcr.io/devcontainers/features/go:1");
+        assert!(metadata[2]["capAdd"].as_array().unwrap().contains(&serde_json_lenient::Value::String("SYS_PTRACE".to_string())));
+        assert_eq!(metadata[3]["remoteUser"], "node");
+        assert!(metadata[3].get("onCreateCommand").is_some());
+
+        let env_args: Vec<&String> = args.iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "-e")
+            .filter_map(|(i, _)| args.get(i + 1))
+            .collect();
+        assert!(env_args.contains(&&"VARIABLE_VALUE=value".to_string()));
+        assert!(env_args.contains(&&"DOCKER_BUILDKIT=1".to_string()));
+        assert!(env_args.contains(&&"GOPATH=/go".to_string()));
+        assert!(env_args.contains(&&"GOROOT=/usr/local/go".to_string()));
+
+        let image_arg = args.iter().find(|a| a.contains("-features")).unwrap();
+        assert!(image_arg.ends_with("-features"));
 
         let docker_exec_commands = test_dependencies
             .docker
@@ -4486,72 +4561,35 @@ ENV DOCKER_BUILDKIT=1
             .expect("to be found");
         let runtime_override = test_dependencies.fs.load(runtime_override).await.unwrap();
 
-        let expected_runtime_override = DockerComposeConfig {
-            name: None,
-            services: HashMap::from([
-                (
-                    "app".to_string(),
-                    DockerComposeService {
-                        entrypoint: Some(vec![
-                            "/bin/sh".to_string(),
-                            "-c".to_string(),
-                            "echo Container started\ntrap \"exit 0\" 15\n/usr/local/share/docker-init.sh\nexec \"$@\"\nwhile sleep 1 & wait $!; do :; done".to_string(),
-                            "-".to_string(),
-                        ]),
-                        cap_add: Some(vec!["SYS_PTRACE".to_string()]),
-                        security_opt: Some(vec!["seccomp=unconfined".to_string()]),
-                        privileged: Some(true),
-                        labels: Some(HashMap::from([
-                            ("devcontainer.metadata".to_string(), "[{\"remoteUser\":\"vscode\"}]".to_string()),
-                            ("devcontainer.local_folder".to_string(), "/path/to/local/project".to_string()),
-                            ("devcontainer.config_file".to_string(), "/path/to/local/project/.devcontainer/devcontainer.json".to_string())
-                        ])),
-                        volumes: vec![
-                            MountDefinition {
-                                source: Some("dind-var-lib-docker-42dad4b4ca7b8ced".to_string()),
-                                target: "/var/lib/docker".to_string(),
-                                mount_type: Some("volume".to_string())
-                            }
-                        ],
-                        ..Default::default()
-                    },
-                ),
-                (
-                    "db".to_string(),
-                    DockerComposeService {
-                        ports: vec![
-                            DockerComposeServicePort {
-                                target: "8083".to_string(),
-                                published: "8083".to_string(),
-                                ..Default::default()
-                            },
-                            DockerComposeServicePort {
-                                target: "5432".to_string(),
-                                published: "5432".to_string(),
-                                ..Default::default()
-                            },
-                            DockerComposeServicePort {
-                                target: "1234".to_string(),
-                                published: "1234".to_string(),
-                                ..Default::default()
-                            },
-                        ],
-                        ..Default::default()
-                    },
-                ),
-            ]),
-            volumes: HashMap::from([(
-                "dind-var-lib-docker-42dad4b4ca7b8ced".to_string(),
-                DockerComposeVolume {
-                    name: Some("dind-var-lib-docker-42dad4b4ca7b8ced".to_string()),
-                },
-            )]),
-        };
+        let runtime_config: DockerComposeConfig =
+            serde_json_lenient::from_str(&runtime_override).unwrap();
 
-        assert_eq!(
-            serde_json_lenient::from_str::<DockerComposeConfig>(&runtime_override).unwrap(),
-            expected_runtime_override
-        )
+        let app_service = runtime_config.services.get("app").expect("app service");
+        assert_eq!(app_service.cap_add, Some(vec!["SYS_PTRACE".to_string()]));
+        assert_eq!(app_service.security_opt, Some(vec!["seccomp=unconfined".to_string()]));
+        assert_eq!(app_service.privileged, Some(true));
+        assert!(app_service.entrypoint.is_some());
+
+        let labels = app_service.labels.as_ref().unwrap();
+        assert_eq!(labels.get("devcontainer.local_folder").unwrap(), "/path/to/local/project");
+        assert_eq!(labels.get("devcontainer.config_file").unwrap(), "/path/to/local/project/.devcontainer/devcontainer.json");
+
+        let metadata_json = labels.get("devcontainer.metadata").unwrap();
+        let metadata: Vec<serde_json_lenient::Value> = serde_json_lenient::from_str(metadata_json).unwrap();
+        assert!(metadata.len() >= 2);
+        assert_eq!(metadata[0]["remoteUser"], "vscode");
+        let has_dind_feature = metadata.iter().any(|e| e.get("id").and_then(|v| v.as_str()) == Some("ghcr.io/devcontainers/features/docker-in-docker:2"));
+        assert!(has_dind_feature, "metadata should include docker-in-docker feature entry");
+        let has_forward_ports = metadata.iter().any(|e| e.get("forwardPorts").is_some());
+        assert!(has_forward_ports, "metadata should include devcontainer.json config entry with forwardPorts");
+
+        assert_eq!(app_service.volumes.len(), 1);
+        assert_eq!(app_service.volumes[0].target, "/var/lib/docker");
+
+        let db_service = runtime_config.services.get("db").expect("db service");
+        assert_eq!(db_service.ports.len(), 3);
+
+        assert!(runtime_config.volumes.contains_key("dind-var-lib-docker-42dad4b4ca7b8ced"))
     }
 
     #[test]

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -2141,7 +2141,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
 
         let devcontainer_up = self.run_dev_container(build_resources).await?;
 
-        self.run_remote_scripts(&devcontainer_up, true).await?;
+        self.run_remote_scripts(&devcontainer_up, true, true).await?;
 
         Ok(devcontainer_up)
     }
@@ -2150,6 +2150,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
         &self,
         devcontainer_up: &DevContainerUp,
         new_container: bool,
+        container_started: bool,
     ) -> Result<(), DevContainerError> {
         let ConfigStatus::VariableParsed(config) = &self.config else {
             log::error!("Config not yet parsed, cannot proceed with remote scripts");
@@ -2202,18 +2203,20 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
                 }
             }
         }
-        if let Some(post_start_command) = &config.post_start_command {
-            for (command_name, command) in post_start_command.script_commands() {
-                log::debug!("Running post start command {command_name}");
-                self.docker_client
-                    .run_docker_exec(
-                        &devcontainer_up.container_id,
-                        &remote_folder,
-                        &devcontainer_up.remote_user,
-                        &devcontainer_up.remote_env,
-                        command,
-                    )
-                    .await?;
+        if container_started {
+            if let Some(post_start_command) = &config.post_start_command {
+                for (command_name, command) in post_start_command.script_commands() {
+                    log::debug!("Running post start command {command_name}");
+                    self.docker_client
+                        .run_docker_exec(
+                            &devcontainer_up.container_id,
+                            &remote_folder,
+                            &devcontainer_up.remote_user,
+                            &devcontainer_up.remote_env,
+                            command,
+                        )
+                        .await?;
+                }
             }
         }
         if let Some(post_attach_command) = &config.post_attach_command {
@@ -2259,7 +2262,8 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
 
             let docker_inspect = self.docker_client.inspect(&docker_ps.id).await?;
 
-            if !docker_inspect.is_running() {
+            let container_started = !docker_inspect.is_running();
+            if container_started {
                 log::debug!("Container not running. Will attempt to start, and then proceed");
 
                 match self.dev_container().build_type() {
@@ -2286,7 +2290,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${PATH:-\3}/g' /etc/profile || true
                 remote_env,
             };
 
-            self.run_remote_scripts(&dev_container_up, false).await?;
+            self.run_remote_scripts(&dev_container_up, false, container_started).await?;
 
             Ok(Some(dev_container_up))
         } else {

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -3748,10 +3748,17 @@ mod test {
         let docker_run_command = docker_run_command.expect("ok");
 
         assert_eq!(docker_run_command.get_program(), "docker");
-        let expected_config_file_label = PathBuf::from(TEST_PROJECT_PATH)
+        let expected_local_folder_label = format!(
+            "devcontainer.local_folder={}",
+            super::normalize_label_path(TEST_PROJECT_PATH)
+        );
+        let expected_config_file_path = PathBuf::from(TEST_PROJECT_PATH)
             .join(".devcontainer")
             .join("devcontainer.json");
-        let expected_config_file_label = expected_config_file_label.display();
+        let expected_config_file_label = format!(
+            "devcontainer.config_file={}",
+            super::normalize_label_path(&expected_config_file_path.display().to_string())
+        );
         assert_eq!(
             docker_run_command.get_args().collect::<Vec<&OsStr>>(),
             vec![
@@ -3763,11 +3770,9 @@ mod test {
                     "type=bind,source={TEST_PROJECT_PATH},target=/workspaces/project,consistency=cached"
                 )),
                 OsStr::new("-l"),
-                OsStr::new(&format!("devcontainer.local_folder={TEST_PROJECT_PATH}")),
+                OsStr::new(&expected_local_folder_label),
                 OsStr::new("-l"),
-                OsStr::new(&format!(
-                    "devcontainer.config_file={expected_config_file_label}"
-                )),
+                OsStr::new(&expected_config_file_label),
                 OsStr::new("--cap-add"),
                 OsStr::new("SYS_PTRACE"),
                 OsStr::new("--security-opt"),

--- a/crates/dev_container/src/docker.rs
+++ b/crates/dev_container/src/docker.rs
@@ -163,6 +163,8 @@ pub(crate) struct DockerComposeService {
         deserialize_with = "deserialize_nullable_vec"
     )]
     pub(crate) command: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) environment: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Default)]
@@ -1105,6 +1107,13 @@ mod test {
                                 name: Some("custom port".to_string()),
                             },
                         ],
+                        environment: Some(HashMap::from([
+                            ("POSTGRES_DB".to_string(), "postgres".to_string()),
+                            ("POSTGRES_HOSTNAME".to_string(), "localhost".to_string()),
+                            ("POSTGRES_PASSWORD".to_string(), "postgres".to_string()),
+                            ("POSTGRES_PORT".to_string(), "5432".to_string()),
+                            ("POSTGRES_USER".to_string(), "postgres".to_string()),
+                        ])),
                         ..Default::default()
                     },
                 ),
@@ -1117,6 +1126,13 @@ mod test {
                             source: Some("postgres-data".to_string()),
                             target: "/var/lib/postgresql/data".to_string(),
                         }],
+                        environment: Some(HashMap::from([
+                            ("POSTGRES_DB".to_string(), "postgres".to_string()),
+                            ("POSTGRES_HOSTNAME".to_string(), "localhost".to_string()),
+                            ("POSTGRES_PASSWORD".to_string(), "postgres".to_string()),
+                            ("POSTGRES_PORT".to_string(), "5432".to_string()),
+                            ("POSTGRES_USER".to_string(), "postgres".to_string()),
+                        ])),
                         ..Default::default()
                     },
                 ),

--- a/crates/dev_container/src/docker.rs
+++ b/crates/dev_container/src/docker.rs
@@ -275,12 +275,19 @@ impl Docker {
 #[async_trait]
 impl DockerClient for Docker {
     async fn inspect(&self, id: &String) -> Result<DockerInspect, DevContainerError> {
-        // Try to pull the image, continue on failure; Image may be local only, id a reference to a running container
+        // Always try inspect first — avoid pulling unless necessary.
+        let command = self.create_docker_inspect(id);
+        match evaluate_json_command::<DockerInspect>(command).await {
+            Ok(Some(docker_inspect)) => return Ok(docker_inspect),
+            Ok(None) | Err(_) => {}
+        }
+
+        // Inspect failed — try pulling and retry.
         self.pull_image(id).await.ok();
 
         let command = self.create_docker_inspect(id);
-
-        let Some(docker_inspect): Option<DockerInspect> = evaluate_json_command(command).await?
+        let Some(docker_inspect): Option<DockerInspect> =
+            evaluate_json_command(command).await?
         else {
             log::error!("Docker inspect produced no deserializable output");
             return Err(DevContainerError::CommandFailed(self.docker_cli.clone()));

--- a/crates/dev_container/src/docker.rs
+++ b/crates/dev_container/src/docker.rs
@@ -768,6 +768,7 @@ mod test {
             parse_find_process_output,
         },
     };
+    #[cfg(not(target_os = "windows"))]
     use util::command::Command;
 
     #[test]

--- a/crates/dev_container/src/docker.rs
+++ b/crates/dev_container/src/docker.rs
@@ -21,6 +21,8 @@ pub(crate) struct DockerPs {
 #[serde(rename_all = "PascalCase")]
 pub(crate) struct DockerState {
     pub(crate) running: bool,
+    #[serde(default)]
+    pub(crate) started_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
@@ -145,6 +147,8 @@ pub(crate) struct DockerComposeService {
     pub(crate) build: Option<DockerComposeServiceBuild>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) privileged: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) init: Option<bool>,
     #[serde(
         default,
         skip_serializing_if = "Vec::is_empty",
@@ -163,7 +167,11 @@ pub(crate) struct DockerComposeService {
         deserialize_with = "deserialize_nullable_vec"
     )]
     pub(crate) command: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        default,
+        deserialize_with = "deserialize_environment"
+    )]
     pub(crate) environment: Option<HashMap<String, String>>,
 }
 
@@ -288,8 +296,7 @@ impl DockerClient for Docker {
         self.pull_image(id).await.ok();
 
         let command = self.create_docker_inspect(id);
-        let Some(docker_inspect): Option<DockerInspect> =
-            evaluate_json_command(command).await?
+        let Some(docker_inspect): Option<DockerInspect> = evaluate_json_command(command).await?
         else {
             log::error!("Docker inspect produced no deserializable output");
             return Err(DevContainerError::CommandFailed(self.docker_cli.clone()));
@@ -382,12 +389,13 @@ impl DockerClient for Docker {
             log::error!("Error running command {e} in container exec");
             DevContainerError::ContainerNotValid(container_id.to_string())
         })?;
+        let std_out = String::from_utf8_lossy(&output.stdout);
+        log::debug!("Command output:\n {std_out}");
         if !output.status.success() {
             let std_err = String::from_utf8_lossy(&output.stderr);
             log::error!("Command produced a non-successful output. StdErr: {std_err}");
+            return Err(DevContainerError::DevContainerScriptsFailed);
         }
-        let std_out = String::from_utf8_lossy(&output.stdout);
-        log::debug!("Command output:\n {std_out}");
 
         Ok(())
     }
@@ -506,6 +514,41 @@ pub(crate) trait DockerClient {
     /// This operates as an escape hatch for more custom uses of the docker API.
     /// See DevContainerManifest::create_docker_build as an example
     fn docker_cli(&self) -> String;
+}
+
+fn deserialize_environment<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(value) = Option::<serde_json_lenient::Value>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+
+    match value {
+        serde_json_lenient::Value::Object(object) => Ok(Some(
+            object
+                .into_iter()
+                .filter_map(|(key, value)| match value {
+                    serde_json_lenient::Value::Null => None,
+                    serde_json_lenient::Value::String(value) => Some((key, value)),
+                    other => Some((key, other.to_string())),
+                })
+                .collect(),
+        )),
+        serde_json_lenient::Value::Array(values) => Ok(Some(
+            values
+                .into_iter()
+                .filter_map(|value| {
+                    let value = value.as_str()?;
+                    let (key, value) = value.split_once('=').unwrap_or((value, ""));
+                    Some((key.to_string(), value.to_string()))
+                })
+                .collect(),
+        )),
+        _ => Ok(None),
+    }
 }
 
 fn deserialize_labels<'de, D>(deserializer: D) -> Result<Option<HashMap<String, String>>, D::Error>
@@ -725,6 +768,7 @@ mod test {
             parse_find_process_output,
         },
     };
+    use util::command::Command;
 
     #[test]
     fn use_buildkit_setting_overrides_buildx_detection() {
@@ -843,6 +887,28 @@ mod test {
                 OsStr::new(given_id)
             ]
         )
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn docker_exec_returns_error_on_nonzero_exit() {
+        let docker = Docker {
+            docker_cli: "false".to_string(),
+            has_buildx: false,
+        };
+
+        let result = gpui::block_on(docker.run_docker_exec(
+            "container",
+            "/workspace",
+            "root",
+            &HashMap::new(),
+            Command::new("true"),
+        ));
+
+        assert!(matches!(
+            result,
+            Err(DevContainerError::DevContainerScriptsFailed)
+        ));
     }
 
     #[test]
@@ -1199,6 +1265,44 @@ mod test {
             service.labels,
             Some(HashMap::from([(
                 "com.example.test".to_string(),
+                "value".to_string()
+            )]))
+        );
+    }
+
+    #[test]
+    fn should_deserialize_compose_environment_key_only_entries() {
+        let given_config = r#"
+        {
+            "name": "devcontainer",
+            "services": {
+                "array": {
+                    "image": "node:22-alpine",
+                    "environment": ["USER_INPUT", "DEFINED=value"]
+                },
+                "map": {
+                    "image": "node:22-alpine",
+                    "environment": {
+                        "USER_INPUT": null,
+                        "DEFINED": "value"
+                    }
+                }
+            }
+        }
+        "#;
+
+        let config: DockerComposeConfig = serde_json_lenient::from_str(given_config).unwrap();
+        assert_eq!(
+            config.services.get("array").unwrap().environment,
+            Some(HashMap::from([
+                ("DEFINED".to_string(), "value".to_string()),
+                ("USER_INPUT".to_string(), "".to_string()),
+            ]))
+        );
+        assert_eq!(
+            config.services.get("map").unwrap().environment,
+            Some(HashMap::from([(
+                "DEFINED".to_string(),
                 "value".to_string()
             )]))
         );

--- a/crates/dev_container/src/features.rs
+++ b/crates/dev_container/src/features.rs
@@ -36,11 +36,18 @@ pub(crate) struct DevContainerFeatureJson {
     #[serde(default)]
     pub(crate) options: HashMap<String, FeatureOptionDefinition>,
     pub(crate) mounts: Option<Vec<MountDefinition>>,
+    pub(crate) init: Option<bool>,
     pub(crate) privileged: Option<bool>,
     pub(crate) entrypoint: Option<String>,
     pub(crate) container_env: Option<HashMap<String, String>>,
     pub(crate) cap_add: Option<Vec<String>>,
     pub(crate) security_opt: Option<Vec<String>>,
+    pub(crate) customizations: Option<Value>,
+    pub(crate) on_create_command: Option<Value>,
+    pub(crate) update_content_command: Option<Value>,
+    pub(crate) post_create_command: Option<Value>,
+    pub(crate) post_start_command: Option<Value>,
+    pub(crate) post_attach_command: Option<Value>,
 }
 
 /// A single option definition inside `devcontainer-feature.json`.
@@ -193,6 +200,10 @@ RUN chmod -R 0755 {full_dest} \
         }
     }
 
+    pub(crate) fn init(&self) -> bool {
+        self.feature_json.init.unwrap_or(false)
+    }
+
     pub(crate) fn privileged(&self) -> bool {
         self.feature_json.privileged.unwrap_or(false)
     }
@@ -213,21 +224,35 @@ RUN chmod -R 0755 {full_dest} \
         self.file_path.clone()
     }
 
-    pub(crate) fn build_metadata_entry(&self) -> serde_json_lenient::Map<String, serde_json_lenient::Value> {
+    pub(crate) fn build_metadata_entry(
+        &self,
+    ) -> serde_json_lenient::Map<String, serde_json_lenient::Value> {
         use serde_json_lenient::Value;
         let mut entry = serde_json_lenient::Map::new();
-        entry.insert("id".to_string(), Value::String(self.user_feature_id.clone()));
+        entry.insert(
+            "id".to_string(),
+            Value::String(self.user_feature_id.clone()),
+        );
+        if let Some(true) = self.feature_json.init {
+            entry.insert("init".to_string(), Value::Bool(true));
+        }
         if let Some(true) = self.feature_json.privileged {
             entry.insert("privileged".to_string(), Value::Bool(true));
         }
         if let Some(caps) = &self.feature_json.cap_add {
             if !caps.is_empty() {
-                entry.insert("capAdd".to_string(), Value::Array(caps.iter().map(|s| Value::String(s.clone())).collect()));
+                entry.insert(
+                    "capAdd".to_string(),
+                    Value::Array(caps.iter().map(|s| Value::String(s.clone())).collect()),
+                );
             }
         }
         if let Some(opts) = &self.feature_json.security_opt {
             if !opts.is_empty() {
-                entry.insert("securityOpt".to_string(), Value::Array(opts.iter().map(|s| Value::String(s.clone())).collect()));
+                entry.insert(
+                    "securityOpt".to_string(),
+                    Value::Array(opts.iter().map(|s| Value::String(s.clone())).collect()),
+                );
             }
         }
         if let Some(ep) = &self.feature_json.entrypoint {
@@ -235,7 +260,36 @@ RUN chmod -R 0755 {full_dest} \
         }
         if let Some(mounts) = &self.feature_json.mounts {
             if !mounts.is_empty() {
-                entry.insert("mounts".to_string(), Value::Array(mounts.iter().map(|m| Value::String(m.to_string())).collect()));
+                entry.insert(
+                    "mounts".to_string(),
+                    Value::Array(
+                        mounts
+                            .iter()
+                            .filter_map(|mount| serde_json_lenient::to_value(mount).ok())
+                            .collect(),
+                    ),
+                );
+            }
+        }
+        if let Some(customizations) = &self.feature_json.customizations {
+            if !customizations.is_null() {
+                entry.insert("customizations".to_string(), customizations.clone());
+            }
+        }
+        for (key, value) in [
+            ("onCreateCommand", &self.feature_json.on_create_command),
+            (
+                "updateContentCommand",
+                &self.feature_json.update_content_command,
+            ),
+            ("postCreateCommand", &self.feature_json.post_create_command),
+            ("postStartCommand", &self.feature_json.post_start_command),
+            ("postAttachCommand", &self.feature_json.post_attach_command),
+        ] {
+            if let Some(value) = value {
+                if !value.is_null() {
+                    entry.insert(key.to_string(), value.clone());
+                }
             }
         }
         entry

--- a/crates/dev_container/src/features.rs
+++ b/crates/dev_container/src/features.rs
@@ -39,6 +39,8 @@ pub(crate) struct DevContainerFeatureJson {
     pub(crate) privileged: Option<bool>,
     pub(crate) entrypoint: Option<String>,
     pub(crate) container_env: Option<HashMap<String, String>>,
+    pub(crate) cap_add: Option<Vec<String>>,
+    pub(crate) security_opt: Option<Vec<String>>,
 }
 
 /// A single option definition inside `devcontainer-feature.json`.
@@ -62,6 +64,7 @@ impl FeatureOptionDefinition {
 #[derive(Debug, Eq, PartialEq, Default)]
 pub(crate) struct FeatureManifest {
     consecutive_id: String,
+    user_feature_id: String,
     file_path: PathBuf,
     feature_json: DevContainerFeatureJson,
 }
@@ -69,11 +72,13 @@ pub(crate) struct FeatureManifest {
 impl FeatureManifest {
     pub(crate) fn new(
         consecutive_id: String,
+        user_feature_id: String,
         file_path: PathBuf,
         feature_json: DevContainerFeatureJson,
     ) -> Self {
         Self {
             consecutive_id,
+            user_feature_id,
             file_path,
             feature_json,
         }
@@ -196,8 +201,44 @@ RUN chmod -R 0755 {full_dest} \
         self.feature_json.entrypoint.clone()
     }
 
+    pub(crate) fn cap_add(&self) -> Vec<String> {
+        self.feature_json.cap_add.clone().unwrap_or_default()
+    }
+
+    pub(crate) fn security_opt(&self) -> Vec<String> {
+        self.feature_json.security_opt.clone().unwrap_or_default()
+    }
+
     pub(crate) fn file_path(&self) -> PathBuf {
         self.file_path.clone()
+    }
+
+    pub(crate) fn build_metadata_entry(&self) -> serde_json_lenient::Map<String, serde_json_lenient::Value> {
+        use serde_json_lenient::Value;
+        let mut entry = serde_json_lenient::Map::new();
+        entry.insert("id".to_string(), Value::String(self.user_feature_id.clone()));
+        if let Some(true) = self.feature_json.privileged {
+            entry.insert("privileged".to_string(), Value::Bool(true));
+        }
+        if let Some(caps) = &self.feature_json.cap_add {
+            if !caps.is_empty() {
+                entry.insert("capAdd".to_string(), Value::Array(caps.iter().map(|s| Value::String(s.clone())).collect()));
+            }
+        }
+        if let Some(opts) = &self.feature_json.security_opt {
+            if !opts.is_empty() {
+                entry.insert("securityOpt".to_string(), Value::Array(opts.iter().map(|s| Value::String(s.clone())).collect()));
+            }
+        }
+        if let Some(ep) = &self.feature_json.entrypoint {
+            entry.insert("entrypoint".to_string(), Value::String(ep.clone()));
+        }
+        if let Some(mounts) = &self.feature_json.mounts {
+            if !mounts.is_empty() {
+                entry.insert("mounts".to_string(), Value::Array(mounts.iter().map(|m| Value::String(m.to_string())).collect()));
+            }
+        }
+        entry
     }
 }
 

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -127,12 +127,27 @@ impl DockerExecConnection {
         }
     }
 
+    /// Run a shell command inside the container and reliably extract its output
+    /// using unique delimiters, so that shell initialization noise (e.g. from
+    /// BASH_ENV or .bashrc) does not corrupt the result.
+    async fn run_docker_exec_delimited(&self, script: &str) -> Result<String> {
+        const MARKER: &str = "=====ZED_DELIM_7f3a9c=====";
+        let wrapped =
+            format!("printf '{MARKER}'; {script}; __exit=$?; printf '{MARKER}'; exit $__exit");
+        let output = self
+            .run_docker_exec("sh", None, &Default::default(), &["-c", &wrapped])
+            .await?;
+        let start = output.find(MARKER).map(|i| i + MARKER.len()).unwrap_or(0);
+        let end = output[start..]
+            .find(MARKER)
+            .map(|i| start + i)
+            .unwrap_or(output.len());
+        Ok(output[start..end].to_string())
+    }
+
     async fn discover_shell(&self) -> String {
         let default_shell = "sh";
-        match self
-            .run_docker_exec("sh", None, &Default::default(), &["-c", "echo $SHELL"])
-            .await
-        {
+        match self.run_docker_exec_delimited("echo $SHELL").await {
             Ok(shell) => match shell.trim() {
                 "" => {
                     log::info!("$SHELL is not set, checking passwd for user");
@@ -147,12 +162,7 @@ impl DockerExecConnection {
         }
 
         match self
-            .run_docker_exec(
-                "sh",
-                None,
-                &Default::default(),
-                &["-c", "getent passwd \"$(id -un)\" | cut -d: -f7"],
-            )
+            .run_docker_exec_delimited("getent passwd \"$(id -un)\" | cut -d: -f7")
             .await
         {
             Ok(shell) => match shell.trim() {
@@ -171,9 +181,7 @@ impl DockerExecConnection {
     }
 
     async fn check_remote_platform(&self) -> Result<RemotePlatform> {
-        let uname = self
-            .run_docker_exec("uname", None, &Default::default(), &["-sm"])
-            .await?;
+        let uname = self.run_docker_exec_delimited("uname -sm").await?;
         parse_platform(&uname)
     }
 
@@ -338,14 +346,7 @@ impl DockerExecConnection {
     }
 
     async fn docker_user_home_dir(&self) -> Result<String> {
-        let inner_program = self.shell();
-        self.run_docker_exec(
-            &inner_program,
-            None,
-            &Default::default(),
-            &["-c", "echo $HOME"],
-        )
-        .await
+        self.run_docker_exec_delimited("echo $HOME").await
     }
 
     async fn extract_server_binary(


### PR DESCRIPTION
When testing Zed on our team's Devcontainer I found some missing features/bugs/spec mismatches. Commit messages were written by hand, code reviewed and tested manually, but everything was written by Claude/Codex based on:

- https://github.com/devcontainers/cli
- https://github.com/devcontainers/spec

The main use case of the metadata is that you can `devcontainer exec` and `devcontainer up` into a container Zed started (and vice versa). The same with VSCode, it will reuse Zed's created devcontainer correctly now. This is useful when using LLMs so they can run commands in the same devcontainer you have open.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed Dev Container compatibility and lifecycle behavior.