### PR TITLE
agent: Allow user-specified custom model IDs in Claude Agent model picker (supports claude-fable-5)

### DIFF
--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -2937,6 +2937,7 @@ mod tests {
                             "manual".to_string(),
                         )]),
                         favorite_config_option_values: HashMap::default(),
+                        custom_config_option_values: HashMap::default(),
                     }
                     .into(),
                 )])),

--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -101,6 +101,32 @@ pub trait AgentServer: Send {
         _cx: &App,
     ) {
     }
+
+    fn custom_config_option_value_ids(
+        &self,
+        _config_id: &acp_schema::SessionConfigId,
+        _cx: &App,
+    ) -> Vec<acp_schema::SessionConfigValueId> {
+        Vec::new()
+    }
+
+    fn add_custom_config_option_value(
+        &self,
+        _config_id: acp_schema::SessionConfigId,
+        _value_id: acp_schema::SessionConfigValueId,
+        _fs: Arc<dyn Fs>,
+        _cx: &App,
+    ) {
+    }
+
+    fn remove_custom_config_option_value(
+        &self,
+        _config_id: acp_schema::SessionConfigId,
+        _value_id: acp_schema::SessionConfigValueId,
+        _fs: Arc<dyn Fs>,
+        _cx: &App,
+    ) {
+    }
 }
 
 impl dyn AgentServer {

--- a/crates/agent_servers/src/custom.rs
+++ b/crates/agent_servers/src/custom.rs
@@ -123,6 +123,107 @@ impl AgentServer for CustomAgentServer {
         });
     }
 
+    fn custom_config_option_value_ids(
+        &self,
+        config_id: &acp::SessionConfigId,
+        cx: &App,
+    ) -> Vec<acp::SessionConfigValueId> {
+        let settings = cx.read_global(|settings: &SettingsStore, _| {
+            settings
+                .get::<AllAgentServersSettings>(None)
+                .get(self.agent_id().0.as_ref())
+                .cloned()
+        });
+
+        settings
+            .as_ref()
+            .and_then(|s| s.custom_config_option_values(config_id.0.as_ref()))
+            .map(|values| {
+                values
+                    .iter()
+                    .cloned()
+                    .map(acp::SessionConfigValueId::new)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn add_custom_config_option_value(
+        &self,
+        config_id: acp::SessionConfigId,
+        value_id: acp::SessionConfigValueId,
+        fs: Arc<dyn Fs>,
+        cx: &App,
+    ) {
+        let agent_id = self.agent_id();
+        let config_id = config_id.to_string();
+        let value_id = value_id.to_string();
+
+        update_settings_file(fs, cx, move |settings, _cx| {
+            let settings = settings
+                .agent_servers
+                .get_or_insert_default()
+                .entry(agent_id.0.to_string())
+                .or_insert_with(default_settings_for_agent);
+
+            match settings {
+                settings::CustomAgentServerSettings::Custom {
+                    custom_config_option_values,
+                    ..
+                }
+                | settings::CustomAgentServerSettings::Registry {
+                    custom_config_option_values,
+                    ..
+                } => {
+                    let entry = custom_config_option_values
+                        .entry(config_id.clone())
+                        .or_insert_with(Vec::new);
+                    if !entry.iter().any(|v| v == &value_id) {
+                        entry.push(value_id.clone());
+                    }
+                }
+            }
+        });
+    }
+
+    fn remove_custom_config_option_value(
+        &self,
+        config_id: acp::SessionConfigId,
+        value_id: acp::SessionConfigValueId,
+        fs: Arc<dyn Fs>,
+        cx: &App,
+    ) {
+        let agent_id = self.agent_id();
+        let config_id = config_id.to_string();
+        let value_id = value_id.to_string();
+
+        update_settings_file(fs, cx, move |settings, _cx| {
+            let settings = settings
+                .agent_servers
+                .get_or_insert_default()
+                .entry(agent_id.0.to_string())
+                .or_insert_with(default_settings_for_agent);
+
+            match settings {
+                settings::CustomAgentServerSettings::Custom {
+                    custom_config_option_values,
+                    ..
+                }
+                | settings::CustomAgentServerSettings::Registry {
+                    custom_config_option_values,
+                    ..
+                } => {
+                    if let Some(entry) = custom_config_option_values.get_mut(&config_id) {
+                        entry.retain(|v| v != &value_id);
+                        if entry.is_empty() {
+                            custom_config_option_values.remove(&config_id);
+                        }
+                    }
+                }
+            }
+        });
+    }
+
     fn set_default_mode(&self, mode_id: Option<acp::SessionModeId>, fs: Arc<dyn Fs>, cx: &mut App) {
         let agent_id = self.agent_id();
         update_settings_file(fs, cx, move |settings, _cx| {
@@ -327,6 +428,7 @@ fn default_settings_for_agent() -> settings::CustomAgentServerSettings {
         env: Default::default(),
         default_config_options: Default::default(),
         favorite_config_option_values: Default::default(),
+        custom_config_option_values: Default::default(),
     }
 }
 
@@ -421,6 +523,7 @@ mod tests {
                     default_mode: None,
                     default_config_options: HashMap::default(),
                     favorite_config_option_values: HashMap::default(),
+                    custom_config_option_values: HashMap::default(),
                 },
             )],
         );

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -1457,6 +1457,7 @@ async fn open_new_agent_servers_entry_in_settings_editor(
                                 default_mode: None,
                                 default_config_options: Default::default(),
                                 favorite_config_option_values: Default::default(),
+                                custom_config_option_values: Default::default(),
                             },
                         );
                     }

--- a/crates/agent_ui/src/agent_registry_ui.rs
+++ b/crates/agent_ui/src/agent_registry_ui.rs
@@ -524,6 +524,7 @@ impl AgentRegistryPage {
                                     env: Default::default(),
                                     default_config_options: HashMap::default(),
                                     favorite_config_option_values: HashMap::default(),
+                                    custom_config_option_values: HashMap::default(),
                                 }
                             });
                         });

--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -28,6 +28,7 @@ use crate::{
 };
 
 const PICKER_THRESHOLD: usize = 5;
+const USER_SPECIFIED_MODELS_GROUP: &str = "User-Specified Models";
 
 pub struct ConfigOptionsView {
     config_options: Rc<dyn AgentSessionConfigOptions>,
@@ -269,14 +270,20 @@ impl ConfigOptionSelector {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let option_count = config_options
+        let config_opt = config_options
             .config_options()
-            .iter()
-            .find(|opt| opt.id == config_id)
-            .map(count_config_options)
-            .unwrap_or(0);
+            .into_iter()
+            .find(|opt| opt.id == config_id);
 
-        let is_searchable = option_count >= PICKER_THRESHOLD;
+        let option_count = config_opt.as_ref().map(count_config_options).unwrap_or(0);
+
+        let is_model_category = config_opt
+            .as_ref()
+            .and_then(|o| o.category.as_ref())
+            .is_some_and(|c| *c == acp::SessionConfigOptionCategory::Model);
+
+        // Model pickers are always searchable so users can type custom model IDs.
+        let is_searchable = option_count >= PICKER_THRESHOLD || is_model_category;
 
         let picker = {
             let config_options = config_options.clone();
@@ -336,7 +343,7 @@ impl ConfigOptionSelector {
         match &option.kind {
             acp::SessionConfigKind::Select(select) => {
                 find_option_name(&select.options, &select.current_value)
-                    .unwrap_or_else(|| "Unknown".to_string())
+                    .unwrap_or_else(|| select.current_value.0.to_string())
             }
             _ => "Unknown".to_string(),
         }
@@ -470,6 +477,8 @@ impl Render for ConfigOptionSelector {
 enum ConfigOptionPickerEntry {
     Separator(SharedString),
     Option(ConfigOptionValue),
+    CustomOption(String),
+    AddCustom(String),
 }
 
 #[derive(Clone)]
@@ -490,6 +499,11 @@ struct ConfigOptionPickerDelegate {
     selected_index: usize,
     selected_description: Option<(usize, SharedString)>,
     favorites: HashSet<acp::SessionConfigValueId>,
+    custom_models: Vec<acp::SessionConfigValueId>,
+    is_model_picker: bool,
+    /// Tracks the locally-selected model value. Used when the ACP hasn't yet
+    /// confirmed a new selection (e.g. a custom model the ACP previously rejected).
+    selected_model_override: Option<acp::SessionConfigValueId>,
     _settings_subscription: Subscription,
 }
 
@@ -503,15 +517,42 @@ impl ConfigOptionPickerDelegate {
         cx: &mut Context<Picker<Self>>,
     ) -> Self {
         let favorites = agent_server.favorite_config_option_value_ids(&config_id, cx);
+        let custom_models = agent_server.custom_config_option_value_ids(&config_id, cx);
+
+        let is_model_picker = config_options
+            .config_options()
+            .iter()
+            .find(|opt| opt.id == config_id)
+            .and_then(|opt| opt.category.as_ref())
+            .is_some_and(|cat| *cat == acp::SessionConfigOptionCategory::Model);
+
+        // If the stored default is a custom model, track it as the effective selection
+        // so it shows as selected even if the ACP hasn't confirmed it yet.
+        let selected_model_override = if is_model_picker {
+            agent_server
+                .default_config_option(config_id.0.as_ref(), cx)
+                .and_then(|default| {
+                    custom_models
+                        .iter()
+                        .find(|m| m.0.as_ref() == default.as_str())
+                        .cloned()
+                })
+        } else {
+            None
+        };
 
         let all_options = extract_options(&config_options, &config_id);
-        let filtered_entries = options_to_picker_entries(&all_options, &favorites);
+        let filtered_entries = build_picker_entries(&all_options, &favorites, &custom_models, is_model_picker, "");
 
         let current_value = get_current_value(&config_options, &config_id);
         let selected_index = current_value
             .and_then(|current| {
-                filtered_entries.iter().position(|entry| {
-                    matches!(entry, ConfigOptionPickerEntry::Option(opt) if opt.value == current)
+                filtered_entries.iter().position(|entry| match entry {
+                    ConfigOptionPickerEntry::Option(opt) => opt.value == current,
+                    ConfigOptionPickerEntry::CustomOption(v) => {
+                        acp::SessionConfigValueId::new(v.clone()) == current
+                    }
+                    _ => false,
                 })
             })
             .unwrap_or(0);
@@ -522,8 +563,32 @@ impl ConfigOptionPickerDelegate {
             cx.observe_global_in::<SettingsStore>(window, move |picker, window, cx| {
                 let new_favorites = agent_server_for_subscription
                     .favorite_config_option_value_ids(&config_id_for_subscription, cx);
+                let new_custom = if picker.delegate.is_model_picker {
+                    agent_server_for_subscription
+                        .custom_config_option_value_ids(&config_id_for_subscription, cx)
+                } else {
+                    Vec::new()
+                };
+                let mut changed = false;
                 if new_favorites != picker.delegate.favorites {
                     picker.delegate.favorites = new_favorites;
+                    changed = true;
+                }
+                if new_custom != picker.delegate.custom_models {
+                    // Re-compute whether the stored default is a custom model.
+                    let new_override = agent_server_for_subscription
+                        .default_config_option(config_id_for_subscription.0.as_ref(), cx)
+                        .and_then(|default| {
+                            new_custom
+                                .iter()
+                                .find(|m| m.0.as_ref() == default.as_str())
+                                .cloned()
+                        });
+                    picker.delegate.custom_models = new_custom;
+                    picker.delegate.selected_model_override = new_override;
+                    changed = true;
+                }
+                if changed {
                     picker.refresh(window, cx);
                 }
             });
@@ -540,11 +605,17 @@ impl ConfigOptionPickerDelegate {
             selected_index,
             selected_description: None,
             favorites,
+            custom_models,
+            is_model_picker,
+            selected_model_override,
             _settings_subscription: settings_subscription,
         }
     }
 
     fn current_value(&self) -> Option<acp::SessionConfigValueId> {
+        if let Some(ref override_val) = self.selected_model_override {
+            return Some(override_val.clone());
+        }
         get_current_value(&self.config_options, &self.config_id)
     }
 }
@@ -567,13 +638,19 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
 
     fn can_select(&self, ix: usize, _window: &mut Window, _cx: &mut Context<Picker<Self>>) -> bool {
         match self.filtered_entries.get(ix) {
-            Some(ConfigOptionPickerEntry::Option(_)) => true,
+            Some(ConfigOptionPickerEntry::Option(_))
+            | Some(ConfigOptionPickerEntry::CustomOption(_))
+            | Some(ConfigOptionPickerEntry::AddCustom(_)) => true,
             Some(ConfigOptionPickerEntry::Separator(_)) | None => false,
         }
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Select an option…".into()
+        if self.is_model_picker {
+            "Select or type a custom model…".into()
+        } else {
+            "Select an option…".into()
+        }
     }
 
     fn update_matches(
@@ -583,6 +660,8 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
         cx: &mut Context<Picker<Self>>,
     ) -> Task<()> {
         let all_options = self.all_options.clone();
+        let custom_models = self.custom_models.clone();
+        let is_model_picker = self.is_model_picker;
 
         cx.spawn_in(window, async move |this, cx| {
             let filtered_options = match this
@@ -601,14 +680,23 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
             };
 
             this.update_in(cx, |this, window, cx| {
-                this.delegate.filtered_entries =
-                    options_to_picker_entries(&filtered_options, &this.delegate.favorites);
+                this.delegate.filtered_entries = build_picker_entries(
+                    &filtered_options,
+                    &this.delegate.favorites,
+                    &custom_models,
+                    is_model_picker,
+                    &query,
+                );
 
                 let current_value = this.delegate.current_value();
                 let new_index = current_value
                     .and_then(|current| {
-                        this.delegate.filtered_entries.iter().position(|entry| {
-                            matches!(entry, ConfigOptionPickerEntry::Option(opt) if opt.value == current)
+                        this.delegate.filtered_entries.iter().position(|entry| match entry {
+                            ConfigOptionPickerEntry::Option(opt) => opt.value == current,
+                            ConfigOptionPickerEntry::CustomOption(v) => {
+                                acp::SessionConfigValueId::new(v.clone()) == current
+                            }
+                            _ => false,
                         })
                     })
                     .unwrap_or(0);
@@ -621,29 +709,82 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
     }
 
     fn confirm(&mut self, _secondary: bool, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
-        if let Some(ConfigOptionPickerEntry::Option(option)) =
-            self.filtered_entries.get(self.selected_index)
-        {
-            self.agent_server.set_default_config_option(
-                self.config_id.0.as_ref(),
-                Some(option.value.0.as_ref()),
-                self.fs.clone(),
-                cx,
-            );
-            let task = self.config_options.set_config_option(
-                self.config_id.clone(),
-                option.value.clone(),
-                cx,
-            );
-
-            cx.spawn(async move |_, _| {
-                if let Err(err) = task.await {
-                    log::error!("Failed to set config option: {:?}", err);
-                }
-            })
-            .detach();
-
-            cx.emit(DismissEvent);
+        match self.filtered_entries.get(self.selected_index).cloned() {
+            Some(ConfigOptionPickerEntry::Option(option)) => {
+                // Clear override when switching back to a standard ACP model.
+                self.selected_model_override = None;
+                self.agent_server.set_default_config_option(
+                    self.config_id.0.as_ref(),
+                    Some(option.value.0.as_ref()),
+                    self.fs.clone(),
+                    cx,
+                );
+                let task = self.config_options.set_config_option(
+                    self.config_id.clone(),
+                    option.value.clone(),
+                    cx,
+                );
+                cx.spawn(async move |_, _| {
+                    if let Err(err) = task.await {
+                        log::error!("Failed to set config option: {:?}", err);
+                    }
+                })
+                .detach();
+                cx.emit(DismissEvent);
+            }
+            Some(ConfigOptionPickerEntry::CustomOption(value_str)) => {
+                let value_id = acp::SessionConfigValueId::new(value_str.clone());
+                // Track selection locally so the checkmark shows immediately.
+                self.selected_model_override = Some(value_id.clone());
+                self.agent_server.set_default_config_option(
+                    self.config_id.0.as_ref(),
+                    Some(value_str.as_str()),
+                    self.fs.clone(),
+                    cx,
+                );
+                let task = self.config_options.set_config_option(
+                    self.config_id.clone(),
+                    value_id,
+                    cx,
+                );
+                cx.spawn(async move |_, _| {
+                    if let Err(err) = task.await {
+                        log::error!("Failed to set config option: {:?}", err);
+                    }
+                })
+                .detach();
+                cx.emit(DismissEvent);
+            }
+            Some(ConfigOptionPickerEntry::AddCustom(value_str)) => {
+                let value_id = acp::SessionConfigValueId::new(value_str.clone());
+                // Track selection locally so the checkmark shows immediately.
+                self.selected_model_override = Some(value_id.clone());
+                self.agent_server.add_custom_config_option_value(
+                    self.config_id.clone(),
+                    value_id.clone(),
+                    self.fs.clone(),
+                    cx,
+                );
+                self.agent_server.set_default_config_option(
+                    self.config_id.0.as_ref(),
+                    Some(value_str.as_str()),
+                    self.fs.clone(),
+                    cx,
+                );
+                let task = self.config_options.set_config_option(
+                    self.config_id.clone(),
+                    value_id,
+                    cx,
+                );
+                cx.spawn(async move |_, _| {
+                    if let Err(err) = task.await {
+                        log::error!("Failed to set config option: {:?}", err);
+                    }
+                })
+                .detach();
+                cx.emit(DismissEvent);
+            }
+            _ => {}
         }
     }
 
@@ -738,6 +879,30 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
                         .into_any_element(),
                 )
             }
+            ConfigOptionPickerEntry::CustomOption(value_str) => {
+                Some(self.render_custom_option(ix, selected, value_str, cx))
+            }
+            ConfigOptionPickerEntry::AddCustom(query) => Some(
+                ListItem::new(ix)
+                    .inset(true)
+                    .spacing(ListItemSpacing::Sparse)
+                    .toggle_state(selected)
+                    .child(
+                        h_flex()
+                            .gap_1()
+                            .child(
+                                Icon::new(IconName::Plus)
+                                    .color(Color::Muted)
+                                    .size(IconSize::Small),
+                            )
+                            .child(
+                                Label::new(format!("Use \"{}\" as custom model", query))
+                                    .color(Color::Muted)
+                                    .truncate(),
+                            ),
+                    )
+                    .into_any_element(),
+            ),
         }
     }
 
@@ -760,6 +925,56 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
 
     fn documentation_aside_index(&self) -> Option<usize> {
         self.selected_description.as_ref().map(|(ix, _)| *ix)
+    }
+}
+
+impl ConfigOptionPickerDelegate {
+    fn render_custom_option(
+        &self,
+        ix: usize,
+        selected: bool,
+        value_str: &str,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> AnyElement {
+        let current_value = self.current_value();
+        let value_id = acp::SessionConfigValueId::new(value_str.to_string());
+        let is_selected = current_value.as_ref() == Some(&value_id);
+
+        let config_id = self.config_id.clone();
+        let agent_server = self.agent_server.clone();
+        let fs = self.fs.clone();
+        let value_str_clone = value_str.to_string();
+
+        ListItem::new(ix)
+            .inset(true)
+            .spacing(ListItemSpacing::Sparse)
+            .toggle_state(selected)
+            .child(
+                h_flex()
+                    .w_full()
+                    .child(Label::new(value_str.to_string()).truncate()),
+            )
+            .end_slot(div().pr_2().when(is_selected, |this| {
+                this.child(Icon::new(IconName::Check).color(Color::Accent))
+            }))
+            .end_slot_on_hover(
+                div().pr_1p5().child(
+                    IconButton::new(("remove-custom-model", ix), IconName::Close)
+                        .layer(ElevationIndex::ElevatedSurface)
+                        .icon_color(Color::Muted)
+                        .icon_size(IconSize::Small)
+                        .tooltip(Tooltip::text("Remove custom model"))
+                        .on_click(move |_, _, cx| {
+                            agent_server.remove_custom_config_option_value(
+                                config_id.clone(),
+                                acp::SessionConfigValueId::new(value_str_clone.clone()),
+                                fs.clone(),
+                                cx,
+                            );
+                        }),
+                ),
+            )
+            .into_any_element()
     }
 }
 
@@ -857,6 +1072,50 @@ fn options_to_picker_entries(
             current_group = option.group.clone();
         }
         entries.push(ConfigOptionPickerEntry::Option(option.clone()));
+    }
+
+    entries
+}
+
+fn build_picker_entries(
+    options: &[ConfigOptionValue],
+    favorites: &HashSet<acp::SessionConfigValueId>,
+    custom_models: &[acp::SessionConfigValueId],
+    is_model_picker: bool,
+    query: &str,
+) -> Vec<ConfigOptionPickerEntry> {
+    let mut entries = options_to_picker_entries(options, favorites);
+
+    if is_model_picker {
+        let filtered_custom: Vec<_> = if query.is_empty() {
+            custom_models.to_vec()
+        } else {
+            let q = query.to_lowercase();
+            custom_models
+                .iter()
+                .filter(|m| m.0.to_lowercase().contains(&q))
+                .cloned()
+                .collect()
+        };
+
+        if !filtered_custom.is_empty() {
+            entries.push(ConfigOptionPickerEntry::Separator(
+                USER_SPECIFIED_MODELS_GROUP.into(),
+            ));
+            for model in &filtered_custom {
+                entries.push(ConfigOptionPickerEntry::CustomOption(
+                    model.0.to_string(),
+                ));
+            }
+        }
+
+        if !query.is_empty() {
+            let already_exists = options.iter().any(|o| o.value.0.as_ref() == query)
+                || custom_models.iter().any(|m| m.0.as_ref() == query);
+            if !already_exists {
+                entries.push(ConfigOptionPickerEntry::AddCustom(query.to_string()));
+            }
+        }
     }
 
     entries

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -576,6 +576,7 @@ fn render_registry_agent_button(
                         default_mode: None,
                         default_config_options: HashMap::default(),
                         favorite_config_option_values: HashMap::default(),
+                        custom_config_option_values: HashMap::default(),
                     }
                 });
             });

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -235,6 +235,7 @@ impl AgentServerStore {
                     env: Default::default(),
                     default_config_options: HashMap::default(),
                     favorite_config_option_values: HashMap::default(),
+                    custom_config_option_values: HashMap::default(),
                 }),
             );
         });
@@ -1534,6 +1535,12 @@ pub enum CustomAgentServerSettings {
         ///
         /// Default: {}
         favorite_config_option_values: HashMap<String, Vec<String>>,
+        /// User-specified values for session config options (e.g. custom model IDs).
+        ///
+        /// This is a map from config option ID to a list of user-specified value IDs.
+        ///
+        /// Default: {}
+        custom_config_option_values: HashMap<String, Vec<String>>,
     },
     Registry {
         /// Additional environment variables to pass to the agent.
@@ -1558,6 +1565,12 @@ pub enum CustomAgentServerSettings {
         ///
         /// Default: {}
         favorite_config_option_values: HashMap<String, Vec<String>>,
+        /// User-specified values for session config options (e.g. custom model IDs).
+        ///
+        /// This is a map from config option ID to a list of user-specified value IDs.
+        ///
+        /// Default: {}
+        custom_config_option_values: HashMap<String, Vec<String>>,
     },
 }
 
@@ -1603,6 +1616,21 @@ impl CustomAgentServerSettings {
                 .map(|v| v.as_slice()),
         }
     }
+
+    pub fn custom_config_option_values(&self, config_id: &str) -> Option<&[String]> {
+        match self {
+            CustomAgentServerSettings::Custom {
+                custom_config_option_values,
+                ..
+            }
+            | CustomAgentServerSettings::Registry {
+                custom_config_option_values,
+                ..
+            } => custom_config_option_values
+                .get(config_id)
+                .map(|v| v.as_slice()),
+        }
+    }
 }
 
 impl From<settings::CustomAgentServerSettings> for CustomAgentServerSettings {
@@ -1615,6 +1643,7 @@ impl From<settings::CustomAgentServerSettings> for CustomAgentServerSettings {
                 default_mode,
                 default_config_options,
                 favorite_config_option_values,
+                custom_config_option_values,
             } => CustomAgentServerSettings::Custom {
                 command: AgentServerCommand {
                     path: PathBuf::from(shellexpand::tilde(&path.to_string_lossy()).as_ref()),
@@ -1624,17 +1653,20 @@ impl From<settings::CustomAgentServerSettings> for CustomAgentServerSettings {
                 default_mode,
                 default_config_options,
                 favorite_config_option_values,
+                custom_config_option_values,
             },
             settings::CustomAgentServerSettings::Registry {
                 env,
                 default_mode,
                 default_config_options,
                 favorite_config_option_values,
+                custom_config_option_values,
             } => CustomAgentServerSettings::Registry {
                 env,
                 default_mode,
                 default_config_options,
                 favorite_config_option_values,
+                custom_config_option_values,
             },
         }
     }
@@ -1718,6 +1750,7 @@ mod tests {
                                     default_mode: None,
                                     default_config_options: HashMap::default(),
                                     favorite_config_option_values: HashMap::default(),
+                                    custom_config_option_values: HashMap::default(),
                                 }
                                 .into(),
                             )

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -667,6 +667,13 @@ pub enum CustomAgentServerSettings {
         /// Default: {}
         #[serde(default, skip_serializing_if = "HashMap::is_empty")]
         favorite_config_option_values: HashMap<String, Vec<String>>,
+        /// User-specified values for session config options (e.g. custom model IDs).
+        ///
+        /// This is a map from config option ID to a list of user-specified value IDs.
+        ///
+        /// Default: {}
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        custom_config_option_values: HashMap<String, Vec<String>>,
     },
     // Used for the ACP extension migration
     #[serde(alias = "extension")]
@@ -696,6 +703,13 @@ pub enum CustomAgentServerSettings {
         /// Default: {}
         #[serde(default, skip_serializing_if = "HashMap::is_empty")]
         favorite_config_option_values: HashMap<String, Vec<String>>,
+        /// User-specified values for session config options (e.g. custom model IDs).
+        ///
+        /// This is a map from config option ID to a list of user-specified value IDs.
+        ///
+        /// Default: {}
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        custom_config_option_values: HashMap<String, Vec<String>>,
     },
 }
 


### PR DESCRIPTION
## Summary

- Adds a **"User-Specified Models"** section to the model config option picker in the Claude Agent panel, allowing users to type arbitrary model IDs not present in the ACP-provided list
- Custom models persist in settings (`custom_config_option_values`) and can be individually removed with an × button
- Selecting a custom model passes it through to Claude Code, which is the authoritative validator — unknown or inaccessible models are rejected there with a clear `model_not_found` error

## Motivation

When a new model is released (e.g. `claude-fable-5`), there is a gap between when Claude Code accepts it at the API level and when it appears in `initializationResult.models`. During this window the ACP bridge rejects the model ID before it ever reaches `query.setModel()`, leaving Zed users with no way to use the model regardless of whether their account has access.

The model list in `initializationResult.models` and what Claude Code actually accepts are two separate views that are not always in sync. Claude Code is already the authoritative validator: passing an invalid model ID produces a clean error (`There's an issue with the selected model (...). It may not exist or you may not have access to it.` / `errorKind: model_not_found`). There is no benefit to the bridge also validating at the picker layer.

A corresponding change to the ACP bridge to pass unknown model IDs through rather than throwing is tracked in agentclientprotocol/claude-agent-acp#762.

## Test plan

- [x] Open the Claude Agent panel, open the model dropdown — "Select or type a custom model…" placeholder appears, picker is always searchable
- [x] Type a valid model ID (e.g. `claude-fable-5`), press Enter — it appears under "User-Specified Models" and is selected with a checkmark
- [x] Reload Zed — custom model persists and remains selected
- [x] Click × on a custom model — it is removed from the list and settings
- [x] Type an invalid model ID — Claude Code returns a `model_not_found` error surfaced in the panel
- [x] Standard models from the ACP list continue to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)