### PR TITLE
docs: Add csharp-ls to C# docs

### DIFF
--- a/docs/src/languages/csharp.md
+++ b/docs/src/languages/csharp.md
@@ -10,15 +10,16 @@ C# support is available through the [C# extension](https://github.com/zed-extens
 - Tree-sitter: [tree-sitter/tree-sitter-c-sharp](https://github.com/tree-sitter/tree-sitter-c-sharp)
 - Language Servers:
   - [roslyn-language-server](https://www.nuget.org/packages/roslyn-language-server#readme)
+  - [csharp-ls](https://github.com/razzmatazz/csharp-language-server)
   - [OmniSharp/omnisharp-roslyn](https://github.com/OmniSharp/omnisharp-roslyn)
 
-Roslyn is enabled by default. To switch back to OmniSharp, add the following to your Zed settings file:
+Roslyn is enabled by default. To switch to csharp-ls or OmniSharp, add the following to your Zed settings file:
 
 ```json [settings]
 {
   "languages": {
     "CSharp": {
-      "language_servers": ["omnisharp", "!roslyn", "..."]
+      "language_servers": ["csharp-ls", "!roslyn", "!omnisharp", "..."]
     }
   }
 }
@@ -108,6 +109,35 @@ Roslyn can be configured with the following language server settings:
       "binary": {
         "path": "/path/to/roslyn-language-server",
         "arguments": ["--stdio", "--autoLoadProjects" /* add extra arguments */]
+      }
+    }
+  }
+}
+```
+
+csharp-ls can be configured in a Zed settings file with:
+
+```json [settings]
+{
+  "lsp": {
+    "csharp-ls": {
+      "binary": {
+        "path": "/path/to/csharp-ls",
+        "arguments": [ /* add extra arguments */ ]
+      },
+      "settings": {
+        // Default values are shown below.
+        "logLevel": "information",
+        "applyFormattingOptions": false,
+        "analyzersEnabled": false,
+        "useMetadataUris": true,
+        "razorSupport": false,
+        "solutionPathOverride": null,
+        "locale": null,
+        "debug": {
+          "debugMode": false,
+          "solutionLoadDelay": null
+        },
       }
     }
   }

--- a/docs/src/languages/csharp.md
+++ b/docs/src/languages/csharp.md
@@ -123,7 +123,9 @@ csharp-ls can be configured in a Zed settings file with:
     "csharp-ls": {
       "binary": {
         "path": "/path/to/csharp-ls",
-        "arguments": [ /* add extra arguments */ ]
+        "arguments": [
+          /* add extra arguments */
+        ]
       },
       "settings": {
         // Default values are shown below.
@@ -137,7 +139,7 @@ csharp-ls can be configured in a Zed settings file with:
         "debug": {
           "debugMode": false,
           "solutionLoadDelay": null
-        },
+        }
       }
     }
   }


### PR DESCRIPTION
I was chatting with somebody today and they told me Zed is terrible because it [only supports OmniSharp for C# as per the marketing site](https://zed.dev/languages/csharp) which I knew 100% to be false. While looking to do a quick fix for that, I realized the Zed marketing website code is not part of this repo (as [confirmed by a quick search](https://github.com/search?q=repo%3Azed-industries%2Fzed+LINQ+expressions&type=code)) but that [Zed C# docs](https://zed.dev/docs/languages/csharp) are part of the repo and they too don't include the changes from https://github.com/zed-extensions/csharp/pull/77. Here's a quick update for that!

I did test that `csharp-ls` actually receives the [extra settings](https://github.com/razzmatazz/csharp-language-server#configuration) by setting `"razorSupport": true` and confirming that with the LSP logs.

**Note**: I'd wait for https://github.com/zed-extensions/csharp/pull/89 to be merged before merging this PR.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
