### PR TITLE
git: Do not run `git stash list` on every file save

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -8574,7 +8574,6 @@ impl Repository {
 
                 let has_head = prev_snapshot.head_commit.is_some();
 
-                let stash_entries = backend.stash_entries().await?;
                 let changed_path_statuses = cx
                     .background_spawn(async move {
                         let mut changed_paths =
@@ -8631,11 +8630,6 @@ impl Repository {
                     .await?;
 
                 this.update(&mut cx, |this, cx| {
-                    if this.snapshot.stash_entries != stash_entries {
-                        cx.emit(RepositoryEvent::StashEntriesChanged);
-                        this.snapshot.stash_entries = stash_entries;
-                    }
-
                     if !changed_path_statuses.is_empty() {
                         cx.emit(RepositoryEvent::StatusesChanged);
                         this.snapshot


### PR DESCRIPTION
Currently `git stash list` will run on every `paths_changed` event e.g. every time files are modified or saved.
This is unnecessary since the git stashes will only change when a `git stash` command is run. Which can either happen from within Zed or from a terminal. Changes there are already tracked by monitoring `.git/logs/refs/stash`.
I verified that Zed's git stash view still works as expected.

I'm noticing that Zed performs very badly when working with a large git repo via SSH remote development. In particular I've noticed bad performance when working with https://github.com/pytorch/pytorch which includes lots of submodules.
I'm hoping that this PR will reduce the amount of git processes and hopefully make it more responsive without having to manually add folders to `file_scan_exclusions`.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


Release Notes:

- Reduce git processes run on every file change