### PR TITLE
git_ui: Add git blame for the current line in the status bar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1599,6 +1599,14 @@
       // The minimum column number to show the inline blame information at
       "min_column": 0,
     },
+    // Control whether the git blame information is shown for the current
+    // line in the status bar (GitLens-style).
+    "status_bar_blame": {
+      "enabled": false,
+      // Whether or not to display the git commit summary alongside
+      // the author and relative time.
+      "show_commit_summary": true,
+    },
     "blame": {
       "show_avatar": true,
     },

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -128,6 +128,7 @@ pub use split::{SplittableEditor, ToggleSplitDiff};
 pub use split_editor_view::SplitEditorView;
 pub use text::Bias;
 
+use ::git::blame::BlameEntry;
 use ::git::status::FileStatus;
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, BuildError};
 use anyhow::{Context as _, Result, anyhow, bail};
@@ -2826,6 +2827,18 @@ impl Editor {
 
     pub fn workspace(&self) -> Option<Entity<Workspace>> {
         self.workspace.as_ref()?.0.upgrade()
+    }
+
+    /// Returns the git blame entry for the given multibuffer row if blame data is
+    /// available. Exposes the public `BlameEntry` so that outside crates (e.g. the
+    /// status bar blame indicator can query blame.
+    pub fn blame_entry_for_row(&self, row: MultiBufferRow, cx: &mut App) -> Option<BlameEntry> {
+        let blame = self.blame.as_ref()?;
+        let row_info = self.buffer.read(cx).read(cx).row_infos(row).next()?;
+        blame
+            .update(cx, |blame, cx| blame.blame_for_rows(&[row_info], cx).next())
+            .flatten()
+            .map(|(_buffer_id, entry)| entry)
     }
 
     /// Detaches a task and shows an error notification in the workspace if available,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2487,6 +2487,8 @@ impl Editor {
 
             if editor.git_blame_inline_enabled {
                 editor.start_git_blame_inline(false, window, cx);
+            } else {
+                editor.ensure_git_blame_for_status_bar(window, cx);
             }
 
             editor.go_to_active_debug_line(window, cx);
@@ -9616,6 +9618,8 @@ impl Editor {
             if self.git_blame_inline_enabled != inline_blame_enabled {
                 self.toggle_git_blame_inline_internal(false, window, cx);
             }
+
+            self.ensure_git_blame_for_status_bar(window, cx);
 
             let minimap_settings = EditorSettings::get_global(cx).minimap;
             if self.minimap_visibility != MinimapVisibility::Disabled {

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -1752,6 +1752,18 @@ impl Editor {
         })
     }
 
+    /// The status bar blame indicator reads from the same blame state as
+    /// inline blame, so blame must run even when nothing renders inline.
+    pub(super) fn ensure_git_blame_for_status_bar(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if ProjectSettings::get_global(cx).git.status_bar_blame.enabled && self.blame.is_none() {
+            self.start_git_blame(false, window, cx);
+        }
+    }
+
     fn start_git_blame(
         &mut self,
         user_triggered: bool,

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -206,7 +206,8 @@ impl Oid {
         &self.bytes[..self.format.byte_len()]
     }
 
-    pub(crate) fn is_zero(&self) -> bool {
+    /// Whether this is the all-zero id git uses for uncommitted changes.
+    pub fn is_zero(&self) -> bool {
         self.as_bytes().iter().all(|byte| *byte == 0)
     }
 

--- a/crates/git_ui/src/blame_indicator.rs
+++ b/crates/git_ui/src/blame_indicator.rs
@@ -1,10 +1,53 @@
-use gpui::{App, Context, IntoElement, ParentElement, Render, Styled, Window};
+use editor::{Editor, ToPoint as _};
+use gpui::{
+    App, Context, Entity, IntoElement, ParentElement, Render, Styled, Subscription, WeakEntity,
+    Window,
+};
 use project::project_settings::ProjectSettings;
 use settings::Settings as _;
 use ui::{Label, h_flex, prelude::*};
 use workspace::{HideStatusItem, StatusItemView, item::ItemHandle};
 
-pub struct BlameIndicator;
+pub struct BlameIndicator {
+    active_editor: Option<WeakEntity<Editor>>,
+    current_line: Option<u32>,
+    _observe_active_editor: Option<Subscription>,
+}
+
+impl BlameIndicator {
+    pub fn new(cx: &mut Context<Self>) -> Self {
+        cx.observe_global::<settings::SettingsStore>(|_, cx| cx.notify())
+            .detach();
+        Self {
+            active_editor: None,
+            current_line: None,
+            _observe_active_editor: None,
+        }
+    }
+
+    fn on_editor_event(
+        &mut self,
+        _editor: Entity<Editor>,
+        event: &editor::EditorEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if let editor::EditorEvent::SelectionsChanged { .. } = event {
+            self.update_current_line(cx);
+            cx.notify();
+        }
+    }
+
+    fn update_current_line(&mut self, cx: &mut App) {
+        let Some(editor) = self.active_editor.as_ref().and_then(|editor| editor.upgrade()) else {
+            self.current_line = None;
+            return;
+        };
+        let editor = editor.read(cx);
+        let cursor = editor.selections.newest_anchor().head();
+        let snapshot = editor.buffer().read(cx).read(cx);
+        self.current_line = Some(cursor.to_point(&snapshot).row);
+    }
+}
 
 impl Render for BlameIndicator {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
@@ -14,17 +57,31 @@ impl Render for BlameIndicator {
             return row.hidden();
         }
 
-        row.child(Label::new("blame").size(LabelSize::Small))
+        let Some(line) = self.current_line else {
+            return row.hidden();
+        };
+
+        row.child(Label::new(format!("line {}", line + 1)).size(LabelSize::Small))
     }
 }
 
 impl StatusItemView for BlameIndicator {
     fn set_active_pane_item(
         &mut self,
-        _active_pane_item: Option<&dyn ItemHandle>,
+        active_pane_item: Option<&dyn ItemHandle>,
         _window: &mut Window,
-        _cx: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
+        if let Some(editor) = active_pane_item.and_then(|item| item.act_as::<Editor>(cx)) {
+            self.active_editor = Some(editor.downgrade());
+            self._observe_active_editor = Some(cx.subscribe(&editor, Self::on_editor_event));
+            self.update_current_line(cx);
+        } else {
+            self.active_editor = None;
+            self.current_line = None;
+            self._observe_active_editor = None;
+        }
+        cx.notify();
     }
 
     fn hide_setting(&self, _: &App) -> Option<HideStatusItem> {

--- a/crates/git_ui/src/blame_indicator.rs
+++ b/crates/git_ui/src/blame_indicator.rs
@@ -1,27 +1,38 @@
+use std::time::Duration;
+
 use editor::{Editor, ToPoint as _};
+use git::blame::BlameEntry;
 use gpui::{
-    App, Context, Entity, IntoElement, ParentElement, Render, Styled, Subscription, WeakEntity,
-    Window,
+    App, Context, Empty, Entity, IntoElement, ParentElement, Render, SharedString, Styled,
+    Subscription, Task, WeakEntity, Window,
 };
+use multi_buffer::MultiBufferRow;
 use project::project_settings::ProjectSettings;
 use settings::Settings as _;
 use ui::{Label, h_flex, prelude::*};
 use workspace::{HideStatusItem, StatusItemView, item::ItemHandle};
 
+use crate::commit_tooltip::blame_entry_relative_timestamp;
+
 pub struct BlameIndicator {
     active_editor: Option<WeakEntity<Editor>>,
-    current_line: Option<u32>,
+    current_blame: Option<SharedString>,
     _observe_active_editor: Option<Subscription>,
+    blame_update: Task<()>,
 }
 
 impl BlameIndicator {
     pub fn new(cx: &mut Context<Self>) -> Self {
-        cx.observe_global::<settings::SettingsStore>(|_, cx| cx.notify())
-            .detach();
+        cx.observe_global::<settings::SettingsStore>(|this, cx| {
+            this.refresh(cx);
+            cx.notify();
+        })
+        .detach();
         Self {
             active_editor: None,
-            current_line: None,
+            current_blame: None,
             _observe_active_editor: None,
+            blame_update: Task::ready(()),
         }
     }
 
@@ -32,36 +43,92 @@ impl BlameIndicator {
         cx: &mut Context<Self>,
     ) {
         if let editor::EditorEvent::SelectionsChanged { .. } = event {
-            self.update_current_line(cx);
-            cx.notify();
+            // Debounce so rapid cursor movement doesn't run a blame lookup per
+            // keystroke; replacing the task drops the previous timer.
+            self.blame_update = cx.spawn(async move |this, cx| {
+                cx.background_executor()
+                    .timer(Duration::from_millis(50))
+                    .await;
+                this.update(cx, |this, cx| {
+                    this.update_blame(cx);
+                    cx.notify();
+                })
+                .ok();
+            });
         }
     }
 
-    fn update_current_line(&mut self, cx: &mut App) {
-        let Some(editor) = self.active_editor.as_ref().and_then(|editor| editor.upgrade()) else {
-            self.current_line = None;
+    fn refresh(&mut self, cx: &mut Context<Self>) {
+        let enabled = ProjectSettings::get_global(cx).git.status_bar_blame.enabled;
+        let editor = self
+            .active_editor
+            .as_ref()
+            .and_then(|editor| editor.upgrade());
+
+        if let Some(editor) = editor.filter(|_| enabled) {
+            self._observe_active_editor = Some(cx.subscribe(&editor, Self::on_editor_event));
+            self.update_blame(cx);
+        } else {
+            self._observe_active_editor = None;
+            self.current_blame = None;
+        }
+    }
+
+    fn update_blame(&mut self, cx: &mut App) {
+        let Some(editor) = self
+            .active_editor
+            .as_ref()
+            .and_then(|editor| editor.upgrade())
+        else {
+            self.current_blame = None;
             return;
         };
-        let editor = editor.read(cx);
-        let cursor = editor.selections.newest_anchor().head();
-        let snapshot = editor.buffer().read(cx).read(cx);
-        self.current_line = Some(cursor.to_point(&snapshot).row);
+
+        let row = {
+            let editor = editor.read(cx);
+            let cursor = editor.selections.newest_anchor().head();
+            let snapshot = editor.buffer().read(cx).read(cx);
+            cursor.to_point(&snapshot).row
+        };
+        let entry = editor.update(cx, |editor, cx| {
+            editor.blame_entry_for_row(MultiBufferRow(row), cx)
+        });
+        let show_summary = ProjectSettings::get_global(cx)
+            .git
+            .status_bar_blame
+            .show_commit_summary;
+
+        self.current_blame = entry.map(|entry| {
+            let relative = blame_entry_relative_timestamp(&entry);
+            Self::format_blame(&entry, &relative, show_summary)
+        });
+    }
+
+    fn format_blame(entry: &BlameEntry, relative: &str, show_summary: bool) -> SharedString {
+        let author = entry.author.as_deref().unwrap_or_default();
+
+        match entry.summary.as_deref() {
+            Some(summary) if show_summary => {
+                let first_line = summary.lines().next().unwrap_or(summary);
+                format!("{author}, {relative} - {first_line}")
+            }
+            _ => format!("{author}, {relative}"),
+        }
+        .into()
     }
 }
 
 impl Render for BlameIndicator {
-    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let row = h_flex().gap_2().min_w_0().overflow_x_hidden();
-
-        if !ProjectSettings::get_global(cx).git.status_bar_blame.enabled {
-            return row.hidden();
-        }
-
-        let Some(line) = self.current_line else {
-            return row.hidden();
+    fn render(&mut self, _: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(text) = self.current_blame.clone() else {
+            return Empty.into_any_element();
         };
 
-        row.child(Label::new(format!("line {}", line + 1)).size(LabelSize::Small))
+        h_flex()
+            .min_w_0()
+            .overflow_x_hidden()
+            .child(Label::new(text).size(LabelSize::Small).truncate())
+            .into_any_element()
     }
 }
 
@@ -72,15 +139,10 @@ impl StatusItemView for BlameIndicator {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(editor) = active_pane_item.and_then(|item| item.act_as::<Editor>(cx)) {
-            self.active_editor = Some(editor.downgrade());
-            self._observe_active_editor = Some(cx.subscribe(&editor, Self::on_editor_event));
-            self.update_current_line(cx);
-        } else {
-            self.active_editor = None;
-            self.current_line = None;
-            self._observe_active_editor = None;
-        }
+        self.active_editor = active_pane_item
+            .and_then(|item| item.act_as::<Editor>(cx))
+            .map(|editor| editor.downgrade());
+        self.refresh(cx);
         cx.notify();
     }
 

--- a/crates/git_ui/src/blame_indicator.rs
+++ b/crates/git_ui/src/blame_indicator.rs
@@ -157,3 +157,187 @@ impl StatusItemView for BlameIndicator {
         }))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use editor::EditorMode;
+    use git::blame::Blame;
+    use git::repository::repo_path;
+    use gpui::{Focusable as _, TestAppContext, UpdateGlobal as _};
+    use language::language_settings::AllLanguageSettings;
+    use multi_buffer::MultiBuffer;
+    use project::{FakeFs, Project, WorktreeSettings};
+    use serde_json::json;
+    use settings::SettingsStore;
+    use std::path::Path;
+    use theme::LoadThemes;
+    use util::path;
+    use workspace::WorkspaceSettings;
+
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme_settings::init(LoadThemes::JustBase, cx);
+            AllLanguageSettings::register(cx);
+            editor::init(cx);
+            ProjectSettings::register(cx);
+            WorktreeSettings::register(cx);
+            WorkspaceSettings::register(cx);
+        });
+    }
+
+    fn blame_entry(author: Option<&str>, summary: Option<&str>) -> BlameEntry {
+        BlameEntry {
+            sha: "1b1b1b".parse().unwrap(),
+            range: 0..1,
+            original_line_number: 0,
+            author: author.map(Into::into),
+            author_mail: None,
+            author_time: Some(1_000_000_000),
+            author_tz: Some("+0000".into()),
+            committer_name: None,
+            committer_email: None,
+            committer_time: None,
+            committer_tz: None,
+            summary: summary.map(Into::into),
+            previous: None,
+            filename: "file.txt".into(),
+        }
+    }
+
+    #[test]
+    fn format_blame_matches_inline_blame_format() {
+        let entry = blame_entry(Some("Alice"), Some("Fix the bug"));
+        assert_eq!(
+            BlameIndicator::format_blame(&entry, "3 minutes ago", true),
+            SharedString::from("Alice, 3 minutes ago - Fix the bug"),
+        );
+        assert_eq!(
+            BlameIndicator::format_blame(&entry, "3 minutes ago", false),
+            SharedString::from("Alice, 3 minutes ago"),
+        );
+
+        // Multi-line summaries truncate to the first line, and a missing author
+        // renders an empty name rather than panicking.
+        let entry = blame_entry(None, Some("First line\nSecond line"));
+        assert_eq!(
+            BlameIndicator::format_blame(&entry, "3 minutes ago", true),
+            SharedString::from(", 3 minutes ago - First line"),
+        );
+    }
+
+    #[gpui::test]
+    async fn test_blame_indicator_tracks_setting(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/my-repo"),
+            json!({
+                ".git": {},
+                "file.txt": "fn main() {}\n",
+            }),
+        )
+        .await;
+        fs.set_blame_for_repo(
+            Path::new(path!("/my-repo/.git")),
+            vec![(
+                repo_path("file.txt"),
+                Blame {
+                    entries: vec![blame_entry(Some("Alice"), Some("Initial commit"))],
+                    ..Default::default()
+                },
+            )],
+        );
+
+        // The feature is off by default; turn it on before opening the editor.
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    let blame = settings
+                        .git
+                        .get_or_insert_default()
+                        .status_bar_blame
+                        .get_or_insert_default();
+                    blame.enabled = Some(true);
+                    blame.show_commit_summary = Some(true);
+                });
+            });
+        });
+
+        let project = Project::test(fs, [path!("/my-repo").as_ref()], cx).await;
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/my-repo/file.txt"), cx)
+            })
+            .await
+            .unwrap();
+        let multi_buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+
+        let (editor, cx) = cx.add_window_view(|window, cx| {
+            Editor::new(
+                EditorMode::full(),
+                multi_buffer,
+                Some(project.clone()),
+                window,
+                cx,
+            )
+        });
+
+        // Populate the editor's blame through the public toggle, then let it load.
+        // The editor must be focused: `GitBlame` defers entry generation while blurred.
+        editor.update_in(cx, |editor, window, cx| {
+            window.focus(&editor.focus_handle(cx), cx);
+            editor.toggle_git_blame(&git::Blame, window, cx);
+        });
+        cx.run_until_parked();
+
+        let indicator = cx.new(|cx| BlameIndicator::new(cx));
+
+        let expected = editor
+            .update(cx, |editor, cx| {
+                editor.blame_entry_for_row(MultiBufferRow(0), cx)
+            })
+            .expect("row 0 should have a blame entry");
+
+        // Anchor to the fixture so the comparison below can't pass vacuously if
+        // the lookup returns a wrong-but-consistent entry.
+        assert_eq!(expected.author.as_deref(), Some("Alice"));
+
+        indicator.update_in(cx, |indicator, window, cx| {
+            indicator.set_active_pane_item(Some(&editor as &dyn ItemHandle), window, cx);
+        });
+
+        // The fixture commit is years old, so its relative phrasing is stable between
+        // the indicator's render and this assertion.
+        let relative = blame_entry_relative_timestamp(&expected);
+
+        indicator.read_with(cx, |indicator, _| {
+            assert_eq!(
+                indicator.current_blame,
+                Some(BlameIndicator::format_blame(&expected, &relative, true)),
+            );
+        });
+
+        // Disabling the setting clears the indicator via its settings observer.
+        cx.update(|_, cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings
+                        .git
+                        .get_or_insert_default()
+                        .status_bar_blame
+                        .get_or_insert_default()
+                        .enabled = Some(false);
+                });
+            });
+        });
+        cx.run_until_parked();
+
+        indicator.read_with(cx, |indicator, _| {
+            assert_eq!(indicator.current_blame, None);
+        });
+    }
+}

--- a/crates/git_ui/src/blame_indicator.rs
+++ b/crates/git_ui/src/blame_indicator.rs
@@ -124,6 +124,9 @@ impl Render for BlameIndicator {
 
         h_flex()
             .min_w_0()
+            // The status bar's right cluster never shrinks, so truncation
+            // only works against an explicit cap.
+            .max_w_96()
             .overflow_x_hidden()
             .child(Label::new(text).size(LabelSize::Small).truncate())
             .into_any_element()

--- a/crates/git_ui/src/blame_indicator.rs
+++ b/crates/git_ui/src/blame_indicator.rs
@@ -39,10 +39,8 @@ impl BlameIndicator {
     }
 
     fn on_editor_changed(&mut self, _editor: Entity<Editor>, cx: &mut Context<Self>) {
-        // The editor notifies on every change (cursor movement, edits, blame
-        // data arriving, even cursor blink); debounce so a burst runs one
-        // blame lookup, and only re-render when the text actually changed.
-        // Replacing the task drops the previous timer.
+        // The editor notifies frequently (on every edit, cursor movement, even
+        // cursor blink); debounce so a burst runs one blame lookup.
         self.blame_update = cx.spawn(async move |this, cx| {
             cx.background_executor().timer(UPDATE_DEBOUNCE).await;
             this.update(cx, |this, cx| {
@@ -96,10 +94,12 @@ impl BlameIndicator {
             .status_bar_blame
             .show_commit_summary;
 
-        self.current_blame = entry.map(|entry| {
-            let relative = blame_entry_relative_timestamp(&entry);
-            Self::format_blame(&entry, &relative, show_summary)
-        });
+        self.current_blame = entry
+            .filter(|entry| !entry.sha.is_zero())
+            .map(|entry| {
+                let relative = blame_entry_relative_timestamp(&entry);
+                Self::format_blame(&entry, &relative, show_summary)
+            });
     }
 
     fn format_blame(entry: &BlameEntry, relative: &str, show_summary: bool) -> SharedString {
@@ -139,6 +139,9 @@ impl StatusItemView for BlameIndicator {
     ) {
         self.active_editor = active_pane_item
             .and_then(|item| item.act_as::<Editor>(cx))
+            // Multibuffer rows (project search, diffs) don't map directly to
+            // file rows; hide there rather than blaming the wrong line.
+            .filter(|editor| editor.read(cx).buffer().read(cx).is_singleton())
             .map(|editor| editor.downgrade());
         self.refresh(cx);
         cx.notify();
@@ -283,8 +286,7 @@ mod tests {
             )
         });
 
-        // Attach the indicator before any blame data exists; it should show
-        // nothing yet.
+        // Attach the indicator before any blame data exists.
         let indicator = cx.new(|cx| BlameIndicator::new(cx));
         indicator.update_in(cx, |indicator, window, cx| {
             indicator.set_active_pane_item(Some(&editor as &dyn ItemHandle), window, cx);
@@ -315,7 +317,6 @@ mod tests {
             })
             .expect("row 0 should have a blame entry");
 
-        // Anchor to the fixture so the comparison below can't pass vacuously.
         assert_eq!(expected.author.as_deref(), Some("Alice"));
 
         // The fixture commit is decades old, so the relative phrasing is stable.
@@ -328,7 +329,6 @@ mod tests {
             );
         });
 
-        // Disabling the setting clears the indicator via its settings observer.
         cx.update(|_, cx| {
             SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings(cx, |settings| {

--- a/crates/git_ui/src/blame_indicator.rs
+++ b/crates/git_ui/src/blame_indicator.rs
@@ -14,6 +14,8 @@ use workspace::{HideStatusItem, StatusItemView, item::ItemHandle};
 
 use crate::commit_tooltip::blame_entry_relative_timestamp;
 
+const UPDATE_DEBOUNCE: Duration = Duration::from_millis(50);
+
 pub struct BlameIndicator {
     active_editor: Option<WeakEntity<Editor>>,
     current_blame: Option<SharedString>,
@@ -36,26 +38,22 @@ impl BlameIndicator {
         }
     }
 
-    fn on_editor_event(
-        &mut self,
-        _editor: Entity<Editor>,
-        event: &editor::EditorEvent,
-        cx: &mut Context<Self>,
-    ) {
-        if let editor::EditorEvent::SelectionsChanged { .. } = event {
-            // Debounce so rapid cursor movement doesn't run a blame lookup per
-            // keystroke; replacing the task drops the previous timer.
-            self.blame_update = cx.spawn(async move |this, cx| {
-                cx.background_executor()
-                    .timer(Duration::from_millis(50))
-                    .await;
-                this.update(cx, |this, cx| {
-                    this.update_blame(cx);
+    fn on_editor_changed(&mut self, _editor: Entity<Editor>, cx: &mut Context<Self>) {
+        // The editor notifies on every change (cursor movement, edits, blame
+        // data arriving, even cursor blink); debounce so a burst runs one
+        // blame lookup, and only re-render when the text actually changed.
+        // Replacing the task drops the previous timer.
+        self.blame_update = cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(UPDATE_DEBOUNCE).await;
+            this.update(cx, |this, cx| {
+                let previous_blame = this.current_blame.clone();
+                this.update_blame(cx);
+                if this.current_blame != previous_blame {
                     cx.notify();
-                })
-                .ok();
-            });
-        }
+                }
+            })
+            .ok();
+        });
     }
 
     fn refresh(&mut self, cx: &mut Context<Self>) {
@@ -66,7 +64,7 @@ impl BlameIndicator {
             .and_then(|editor| editor.upgrade());
 
         if let Some(editor) = editor.filter(|_| enabled) {
-            self._observe_active_editor = Some(cx.subscribe(&editor, Self::on_editor_event));
+            self._observe_active_editor = Some(cx.observe(&editor, Self::on_editor_changed));
             self.update_blame(cx);
         } else {
             self._observe_active_editor = None;
@@ -285,8 +283,17 @@ mod tests {
             )
         });
 
-        // `GitBlame` defers entry generation until the editor is focused, and
-        // focus listeners only fire on a draw of an active window — neither of
+        // Attach the indicator before any blame data exists; it should show
+        // nothing yet.
+        let indicator = cx.new(|cx| BlameIndicator::new(cx));
+        indicator.update_in(cx, |indicator, window, cx| {
+            indicator.set_active_pane_item(Some(&editor as &dyn ItemHandle), window, cx);
+        });
+        indicator.read_with(cx, |indicator, _| {
+            assert_eq!(indicator.current_blame, None);
+        });
+
+        // Focus listeners only fire on a draw of an active window — neither of
         // which test windows do on their own.
         editor.update_in(cx, |editor, window, cx| {
             window.activate_window();
@@ -298,7 +305,9 @@ mod tests {
         });
         cx.run_until_parked();
 
-        let indicator = cx.new(|cx| BlameIndicator::new(cx));
+        // The indicator's lookup sits behind a debounce timer, and test time
+        // is virtual — advance it explicitly.
+        cx.executor().advance_clock(UPDATE_DEBOUNCE);
 
         let expected = editor
             .update(cx, |editor, cx| {
@@ -308,10 +317,6 @@ mod tests {
 
         // Anchor to the fixture so the comparison below can't pass vacuously.
         assert_eq!(expected.author.as_deref(), Some("Alice"));
-
-        indicator.update_in(cx, |indicator, window, cx| {
-            indicator.set_active_pane_item(Some(&editor as &dyn ItemHandle), window, cx);
-        });
 
         // The fixture commit is decades old, so the relative phrasing is stable.
         let relative = blame_entry_relative_timestamp(&expected);

--- a/crates/git_ui/src/blame_indicator.rs
+++ b/crates/git_ui/src/blame_indicator.rs
@@ -252,15 +252,14 @@ mod tests {
             )],
         );
 
-        // The feature is off by default; turn it on before opening the editor.
+        // Inline blame is disabled to prove the status bar setting starts
+        // blame on its own.
         cx.update(|cx| {
             SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings(cx, |settings| {
-                    let blame = settings
-                        .git
-                        .get_or_insert_default()
-                        .status_bar_blame
-                        .get_or_insert_default();
+                    let git = settings.git.get_or_insert_default();
+                    git.inline_blame.get_or_insert_default().enabled = Some(false);
+                    let blame = git.status_bar_blame.get_or_insert_default();
                     blame.enabled = Some(true);
                     blame.show_commit_summary = Some(true);
                 });
@@ -286,11 +285,16 @@ mod tests {
             )
         });
 
-        // Populate the editor's blame through the public toggle, then let it load.
-        // The editor must be focused: `GitBlame` defers entry generation while blurred.
+        // `GitBlame` defers entry generation until the editor is focused, and
+        // focus listeners only fire on a draw of an active window — neither of
+        // which test windows do on their own.
         editor.update_in(cx, |editor, window, cx| {
+            window.activate_window();
             window.focus(&editor.focus_handle(cx), cx);
-            editor.toggle_git_blame(&git::Blame, window, cx);
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
         });
         cx.run_until_parked();
 
@@ -302,16 +306,14 @@ mod tests {
             })
             .expect("row 0 should have a blame entry");
 
-        // Anchor to the fixture so the comparison below can't pass vacuously if
-        // the lookup returns a wrong-but-consistent entry.
+        // Anchor to the fixture so the comparison below can't pass vacuously.
         assert_eq!(expected.author.as_deref(), Some("Alice"));
 
         indicator.update_in(cx, |indicator, window, cx| {
             indicator.set_active_pane_item(Some(&editor as &dyn ItemHandle), window, cx);
         });
 
-        // The fixture commit is years old, so its relative phrasing is stable between
-        // the indicator's render and this assertion.
+        // The fixture commit is decades old, so the relative phrasing is stable.
         let relative = blame_entry_relative_timestamp(&expected);
 
         indicator.read_with(cx, |indicator, _| {

--- a/crates/git_ui/src/blame_indicator.rs
+++ b/crates/git_ui/src/blame_indicator.rs
@@ -1,0 +1,40 @@
+use gpui::{App, Context, IntoElement, ParentElement, Render, Styled, Window};
+use project::project_settings::ProjectSettings;
+use settings::Settings as _;
+use ui::{Label, h_flex, prelude::*};
+use workspace::{HideStatusItem, StatusItemView, item::ItemHandle};
+
+pub struct BlameIndicator;
+
+impl Render for BlameIndicator {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let row = h_flex().gap_2().min_w_0().overflow_x_hidden();
+
+        if !ProjectSettings::get_global(cx).git.status_bar_blame.enabled {
+            return row.hidden();
+        }
+
+        row.child(Label::new("blame").size(LabelSize::Small))
+    }
+}
+
+impl StatusItemView for BlameIndicator {
+    fn set_active_pane_item(
+        &mut self,
+        _active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
+
+    fn hide_setting(&self, _: &App) -> Option<HideStatusItem> {
+        Some(HideStatusItem::new(|settings| {
+            settings
+                .git
+                .get_or_insert_default()
+                .status_bar_blame
+                .get_or_insert_default()
+                .enabled = Some(false);
+        }))
+    }
+}

--- a/crates/git_ui/src/blame_indicator.rs
+++ b/crates/git_ui/src/blame_indicator.rs
@@ -94,12 +94,10 @@ impl BlameIndicator {
             .status_bar_blame
             .show_commit_summary;
 
-        self.current_blame = entry
-            .filter(|entry| !entry.sha.is_zero())
-            .map(|entry| {
-                let relative = blame_entry_relative_timestamp(&entry);
-                Self::format_blame(&entry, &relative, show_summary)
-            });
+        self.current_blame = entry.filter(|entry| !entry.sha.is_zero()).map(|entry| {
+            let relative = blame_entry_relative_timestamp(&entry);
+            Self::format_blame(&entry, &relative, show_summary)
+        });
     }
 
     fn format_blame(entry: &BlameEntry, relative: &str, show_summary: bool) -> SharedString {

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -30,6 +30,7 @@ use zed_actions;
 use crate::{commit_view::CommitView, git_panel::GitPanel, text_diff_view::TextDiffView};
 
 mod askpass_modal;
+mod blame_indicator;
 pub mod branch_picker;
 mod commit_modal;
 pub mod commit_tooltip;
@@ -53,6 +54,7 @@ pub mod worktree_names;
 pub mod worktree_picker;
 pub mod worktree_service;
 
+pub use blame_indicator::BlameIndicator;
 pub use conflict_view::MergeConflictIndicator;
 
 pub fn get_provider_icon(name: &str) -> IconName {

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -469,6 +469,11 @@ pub struct GitSettings {
     ///
     /// Default: on
     pub inline_blame: InlineBlameSettings,
+    /// Whether or not to show git blame data for the current line
+    /// in the status bar.
+    ///
+    /// Default: { enabled: false }
+    pub status_bar_blame: StatusBarBlameSettings,
     /// Git blame settings.
     pub blame: BlameSettings,
     /// Which information to show in the branch picker.
@@ -548,6 +553,19 @@ pub struct InlineBlameSettings {
     /// Whether to show commit summary as part of the inline blame.
     ///
     /// Default: false
+    pub show_commit_summary: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct StatusBarBlameSettings {
+    /// Whether or not to show git blame data for the current line
+    /// as an item in the status bar.
+    ///
+    /// Default: false
+    pub enabled: bool,
+    /// Whether to show commit summary as part of the status bar blame.
+    ///
+    /// Default: true
     pub show_commit_summary: bool,
 }
 
@@ -667,6 +685,13 @@ impl Settings for ProjectSettings {
                     padding: inline.padding.unwrap(),
                     min_column: inline.min_column.unwrap(),
                     show_commit_summary: inline.show_commit_summary.unwrap(),
+                }
+            },
+            status_bar_blame: {
+                let status_bar = git.status_bar_blame.unwrap();
+                StatusBarBlameSettings {
+                    enabled: status_bar.enabled.unwrap(),
+                    show_commit_summary: status_bar.show_commit_summary.unwrap(),
                 }
             },
             blame: {

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -533,6 +533,11 @@ pub struct GitSettings {
     ///
     /// Default: on
     pub inline_blame: Option<InlineBlameSettings>,
+    /// Whether or not to show git blame data for the current line
+    /// in the status bar.
+    ///
+    /// Default: { enabled: false }
+    pub status_bar_blame: Option<StatusBarBlameSettings>,
     /// Git blame settings.
     pub blame: Option<BlameSettings>,
     /// Which information to show in the branch picker.
@@ -641,6 +646,21 @@ pub struct InlineBlameSettings {
     /// Whether to show commit summary as part of the inline blame.
     ///
     /// Default: false
+    pub show_commit_summary: Option<bool>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[serde(rename_all = "snake_case")]
+pub struct StatusBarBlameSettings {
+    /// Whether or not to show git blame data for the current line
+    /// as an item in the status bar.
+    ///
+    /// Default: false
+    pub enabled: Option<bool>,
+    /// Whether to show commit summary as part of the status bar blame.
+    ///
+    /// Default: true
     pub show_commit_summary: Option<bool>,
 }
 

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7543,6 +7543,66 @@ fn version_control_page() -> SettingsPage {
         ]
     }
 
+    fn status_bar_git_blame_section() -> [SettingsPageItem; 3] {
+        [
+            SettingsPageItem::SectionHeader("Status Bar Git Blame"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Enabled",
+                description: "Show Git blame data for the current line as an item in the status bar.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("git.status_bar_blame.enabled"),
+                    pick: |settings_content| {
+                        settings_content
+                            .git
+                            .as_ref()?
+                            .status_bar_blame
+                            .as_ref()?
+                            .enabled
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .git
+                            .get_or_insert_default()
+                            .status_bar_blame
+                            .get_or_insert_default()
+                            .enabled = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Show Commit Summary",
+                description: "Show commit summary as part of the status bar blame.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("git.status_bar_blame.show_commit_summary"),
+                    pick: |settings_content| {
+                        settings_content
+                            .git
+                            .as_ref()?
+                            .status_bar_blame
+                            .as_ref()?
+                            .show_commit_summary
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .git
+                            .get_or_insert_default()
+                            .status_bar_blame
+                            .get_or_insert_default()
+                            .show_commit_summary = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+        ]
+    }
+
     fn git_blame_view_section() -> [SettingsPageItem; 2] {
         [
             SettingsPageItem::SectionHeader("Git Blame View"),
@@ -7672,6 +7732,7 @@ fn version_control_page() -> SettingsPage {
             git_integration_section(),
             git_gutter_section(),
             inline_git_blame_section(),
+            status_bar_git_blame_section(),
             git_blame_view_section(),
             branch_picker_section(),
             git_hunks_section(),

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -591,7 +591,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             cx.new(|_| go_to_line::cursor_position::CursorPosition::new(workspace));
         let line_ending_indicator =
             cx.new(|_| line_ending_selector::LineEndingIndicator::default());
-        let blame_indicator = cx.new(|_| git_ui::BlameIndicator);
+        let blame_indicator = cx.new(|cx| git_ui::BlameIndicator::new(cx));
         let merge_conflict_indicator =
             cx.new(|cx| git_ui::MergeConflictIndicator::new(workspace, cx));
         workspace.status_bar().update(cx, |status_bar, cx| {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -591,6 +591,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             cx.new(|_| go_to_line::cursor_position::CursorPosition::new(workspace));
         let line_ending_indicator =
             cx.new(|_| line_ending_selector::LineEndingIndicator::default());
+        let blame_indicator = cx.new(|_| git_ui::BlameIndicator);
         let merge_conflict_indicator =
             cx.new(|cx| git_ui::MergeConflictIndicator::new(workspace, cx));
         workspace.status_bar().update(cx, |status_bar, cx| {
@@ -607,6 +608,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             status_bar.add_right_item(line_ending_indicator, window, cx);
             status_bar.add_right_item(vim_mode_indicator, window, cx);
             status_bar.add_right_item(cursor_position, window, cx);
+            status_bar.add_right_item(blame_indicator, window, cx);
             status_bar.add_right_item(image_info, window, cx);
         });
 

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -38,6 +38,10 @@ The Git Panel shows a flat list of changed files by default. To see files organi
 
 Zed shows Git blame information on the current line. To turn this off or add a delay before it appears, go to **Version Control > Inline Git Blame**.
 
+#### Status Bar Blame
+
+Zed can also show blame information for the current line in the status bar. This is off by default. To turn it on, go to **Version Control > Status Bar Git Blame**.
+
 #### Hiding the Gutter Indicators
 
 The colored bars in the gutter that show added, modified, and deleted lines can be hidden. Go to **Version Control > Git Gutter** and set **Visibility** to "Hide".


### PR DESCRIPTION
## Context

#12133 asks for the GitLens option of showing blame for the current line in the status bar to make the editor less cluttered.

This adds that as an opt-in status bar item showing `Author, time - summary` for the current line, same format as the inline blame (minus the SHA). The status bar blame is hidden in multibuffers/diff views, uncommitted lines show nothing. Click actions, tooltips, and keybindings are left as follow-ups.

```json
{
  "git": {
    "status_bar_blame": {
      "enabled": true,
      "show_commit_summary": true
    }
  }
}
```

## Screenshots

<img width="1583" height="1036" alt="blame_indicator" src="https://github.com/user-attachments/assets/6a9a4045-ade9-416d-b244-b56a1ec41e5b" />

<img width="1583" height="1036" alt="blame_indicator_short" src="https://github.com/user-attachments/assets/6494610b-fcd2-4fd1-9af9-c6ad74e5c295" />

<img width="1012" height="862" alt="blame_settings" src="https://github.com/user-attachments/assets/61667cd9-6e10-4d48-93b4-d1be84be076e" />

##  Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #12133

Release Notes:

- Added an opt-in `git.status_bar_blame` setting to show blame for the current line in the status bar.