### PR TITLE
git: Reduce number of spawned git processes when retrieving remote URLs

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -221,18 +221,6 @@ impl GitRepository for FakeGitRepository {
         })
     }
 
-    fn remote_url(&self, name: &str) -> BoxFuture<'_, Option<String>> {
-        let name = name.to_string();
-        let fut = self.with_state_async(false, move |state| {
-            state
-                .remotes
-                .get(&name)
-                .context("remote not found")
-                .cloned()
-        });
-        async move { fut.await.ok() }.boxed()
-    }
-
     fn remote_urls(&self) -> BoxFuture<'_, HashMap<String, String>> {
         let fut = self.with_state_async(false, |state| Ok(state.remotes.clone()));
         async move { fut.await.unwrap_or_default() }.boxed()

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -233,6 +233,11 @@ impl GitRepository for FakeGitRepository {
         async move { fut.await.ok() }.boxed()
     }
 
+    fn remote_urls(&self) -> BoxFuture<'_, HashMap<String, String>> {
+        let fut = self.with_state_async(false, |state| Ok(state.remotes.clone()));
+        async move { fut.await.unwrap_or_default() }.boxed()
+    }
+
     fn diff_tree(&self, _request: DiffTreeType) -> BoxFuture<'_, Result<TreeDiff>> {
         let mut entries = HashMap::default();
         self.with_state_async(false, |state| {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -800,6 +800,9 @@ pub trait GitRepository: Send + Sync {
     /// Returns the URL of the remote with the given name.
     fn remote_url(&self, name: &str) -> BoxFuture<'_, Option<String>>;
 
+    /// Returns the URL of all remotes.
+    fn remote_urls(&self) -> BoxFuture<'_, HashMap<String, String>>;
+
     /// Resolve a list of refs to SHAs.
     fn revparse_batch(&self, revs: Vec<String>) -> BoxFuture<'_, Result<Vec<Option<String>>>>;
 
@@ -1707,6 +1710,25 @@ impl GitRepository for RealGitRepository {
                 } else {
                     Some(url.to_string())
                 }
+            })
+            .boxed()
+    }
+
+    fn remote_urls(&self) -> BoxFuture<'_, HashMap<String, String>> {
+        let git = self.git_binary();
+        self.executor
+            .spawn(async move {
+                let mut urls = HashMap::default();
+                if let Ok(stdout) = git.run(&["remote", "-v"]).await {
+                    for line in stdout.lines() {
+                        if let Some(line) = line.strip_suffix(" (fetch)")
+                            && let Some((name, url)) = line.split_once(char::is_whitespace)
+                        {
+                            urls.insert(name.to_string(), url.trim_start().to_string());
+                        }
+                    }
+                }
+                urls
             })
             .boxed()
     }
@@ -5199,5 +5221,54 @@ mod tests {
                 })
                 .boxed()
         }
+    }
+
+    #[gpui::test]
+    async fn test_remote_urls(cx: &mut TestAppContext) {
+        disable_git_global_config();
+        cx.executor().allow_parking();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_dir = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+
+        git_init_repo(&repo_dir);
+
+        let repo = RealGitRepository::new(
+            &repo_dir.join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        let git = repo.git_binary();
+        git.run(&[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/zed-industries/zed.git",
+        ])
+        .await
+        .unwrap();
+        git.run(&[
+            "remote",
+            "add",
+            "upstream",
+            "/Users/user/My Projects/upstream.git",
+        ])
+        .await
+        .unwrap();
+
+        let remote_urls = repo.remote_urls().await;
+        assert_eq!(remote_urls.len(), 2);
+        assert_eq!(
+            remote_urls.get("origin").unwrap(),
+            "https://github.com/zed-industries/zed.git"
+        );
+        assert_eq!(
+            remote_urls.get("upstream").unwrap(),
+            "/Users/user/My Projects/upstream.git"
+        );
     }
 }

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -798,7 +798,11 @@ pub trait GitRepository: Send + Sync {
     ) -> BoxFuture<'_, anyhow::Result<()>>;
 
     /// Returns the URL of the remote with the given name.
-    fn remote_url(&self, name: &str) -> BoxFuture<'_, Option<String>>;
+    fn remote_url(&self, name: &str) -> BoxFuture<'_, Option<String>> {
+        let name = name.to_string();
+        let fut = self.remote_urls();
+        async move { fut.await.remove(&name) }.boxed()
+    }
 
     /// Returns the URL of all remotes.
     fn remote_urls(&self) -> BoxFuture<'_, HashMap<String, String>>;
@@ -1686,30 +1690,6 @@ impl GitRepository for RealGitRepository {
                 }
 
                 Ok(())
-            })
-            .boxed()
-    }
-
-    fn remote_url(&self, name: &str) -> BoxFuture<'_, Option<String>> {
-        let git = self.git_binary();
-        let name = name.to_owned();
-        self.executor
-            .spawn(async move {
-                let output = git
-                    .build_command(&["remote", "get-url", &name])
-                    .output()
-                    .await
-                    .log_err()?;
-                if !output.status.success() {
-                    return None;
-                }
-                let url = String::from_utf8(output.stdout).ok()?;
-                let url = url.trim();
-                if url.is_empty() {
-                    None
-                } else {
-                    Some(url.to_string())
-                }
             })
             .boxed()
     }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -9914,8 +9914,9 @@ async fn compute_snapshot(
         .filter(|wt| wt.path != *work_directory_abs_path)
         .collect();
 
-    let remote_origin_url = backend.remote_url("origin").await;
-    let remote_upstream_url = backend.remote_url("upstream").await;
+    let mut remote_urls = backend.remote_urls().await;
+    let remote_origin_url = remote_urls.remove("origin");
+    let remote_upstream_url = remote_urls.remove("upstream");
 
     log::debug!("fetched remotes");
 


### PR DESCRIPTION
Currently Zed fetches remote URLs by sequentially calling `git remote get-url origin` and `git remote get-url upstream`.
This PR introduces a new `remote_urls` function which uses `git remote -v` to retrieve all remote fetch URLs with a single git process.

Followup on #59042 and #59042 in the hope to reduce the amount of spawned git processes.

Probably best to review both commits separately.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Improved performance of listing git remotes
