### PR TITLE
Fix not being able to scroll sidebar when the mouse is hovering a header

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -2442,7 +2442,7 @@ impl Sidebar {
                     }
                 }),
             )
-            .occlude();
+            .block_mouse_except_scroll();
 
         if !is_collapsed && !has_threads {
             v_flex()


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed a bug that prevented scrolling the sidebar when the mouse was positioned over a project header.