### PR TITLE
extensions_ui: Hide empty Agent Servers category

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -1740,7 +1740,8 @@ impl Render for ExtensionsPage {
                     )
                     .children(ExtensionProvides::iter().filter_map(|provides| {
                         match provides {
-                            ExtensionProvides::SlashCommands
+                            ExtensionProvides::AgentServers
+                            | ExtensionProvides::SlashCommands
                             | ExtensionProvides::IndexedDocsProviders => return None,
                             _ => {}
                         }


### PR DESCRIPTION
Self-Review Checklist:

Follow-up to https://github.com/zed-industries/zed/pull/57133. Probably just missed this, but if we have finally deprecated “Agent Servers” (ACP extensions) then it should just be hidden altogether. Ran into this while looking at https://github.com/zed-industries/zed/issues/58956.

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- Hide “Agent Servers” category from Extensions
