### PR TITLE
Fix Helix select-to-line-start/end dropping the character under the cursor

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -2949,6 +2949,31 @@ mod test {
         cx.assert_state("Theˇ \nfox jumps over", Mode::HelixNormal);
     }
 
+    // Regression test for https://github.com/zed-industries/zed/issues/58983
+    // Executing the editor action directly (as from the command palette) in Helix
+    // select mode must keep the character under the block cursor selected, matching
+    // Helix's `gh`/`gl` motions. Previously the raw action moved only the selection
+    // head and dropped the anchored character.
+    #[gpui::test]
+    async fn test_helix_select_line_boundary_actions(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        // SelectToBeginningOfLine includes the char the cursor started on.
+        cx.set_state("hello ˇworld", Mode::HelixNormal);
+        cx.simulate_keystrokes("v");
+        cx.assert_state("hello «wˇ»orld", Mode::HelixSelect);
+        cx.dispatch_action(editor::actions::SelectToBeginningOfLine::default());
+        cx.assert_state("«ˇhello w»orld", Mode::HelixSelect);
+
+        // SelectToEndOfLine lands on the last char of the line.
+        cx.set_state("hello ˇworld", Mode::HelixNormal);
+        cx.simulate_keystrokes("v");
+        cx.assert_state("hello «wˇ»orld", Mode::HelixSelect);
+        cx.dispatch_action(editor::actions::SelectToEndOfLine::default());
+        cx.assert_state("hello «worldˇ»", Mode::HelixSelect);
+    }
+
     #[gpui::test]
     async fn test_helix_select_mode_motion_multiple_cursors(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -982,6 +982,39 @@ impl Vim {
                 },
             );
 
+            // In Helix select mode the cursor is a one-character-wide selection, so
+            // selecting to a line boundary must keep the anchored character selected.
+            // The raw editor actions only move the selection head and drop it, so we
+            // route through the Helix motions (the same path as `gh`/`gl`). This fires
+            // however the action is invoked — keybinding or command palette. Other
+            // modes keep the editor's default behavior.
+            Vim::action(
+                editor,
+                cx,
+                |vim, action: &editor::actions::SelectToBeginningOfLine, window, cx| {
+                    if vim.mode == Mode::HelixSelect {
+                        vim.motion(Motion::StartOfLine { display_lines: false }, window, cx);
+                    } else {
+                        vim.update_editor(cx, |_, editor, cx| {
+                            editor.select_to_beginning_of_line(action, window, cx);
+                        });
+                    }
+                },
+            );
+            Vim::action(
+                editor,
+                cx,
+                |vim, action: &editor::actions::SelectToEndOfLine, window, cx| {
+                    if vim.mode == Mode::HelixSelect {
+                        vim.motion(Motion::EndOfLine { display_lines: false }, window, cx);
+                    } else {
+                        vim.update_editor(cx, |_, editor, cx| {
+                            editor.select_to_end_of_line(action, window, cx);
+                        });
+                    }
+                },
+            );
+
             normal::register(editor, cx);
             insert::register(editor, cx);
             helix::register(editor, cx);


### PR DESCRIPTION
Helix select mode treats the cursor like a one-wide selection, so selecting to the start of a line should keep the char under the cursor. Right now it doesn't: `editor::SelectToBeginningOfLine` (and the end-of-line one) only move the selection head and drop that char. You can repro it straight from the command palette, no keybind needed, which is what the issue does.

Helix's own `gh`/`gl` motions get this right because they run through `helix_select_motion`, which keeps the anchored char. The raw editor actions skip that and use the plain editor selection model, so the char falls out.

Fix is to have vim intercept those two editor actions, same as it already does for `editor::actions::Paste`. In Helix select mode they go through the Helix motion so the anchor sticks, and every other mode just falls through to the editor like before. Since it hooks the action itself and not a key, it works from the palette too.

I kept it to begin/end-of-line since that's what the issue is about. The word/paragraph/document selects have the same problem imo, so lmk if you want those too. idk if you'd rather keep this one small, tbh begin/end already covers the reported case.

## Before / After



https://github.com/user-attachments/assets/5742c076-1ead-4af2-a8ac-f1e924202e59




**After** — the character stays selected:



https://github.com/user-attachments/assets/e89fa7d2-6697-4091-9391-c82e1eea10a1


Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #58983

Release Notes:

- Fixed Helix select mode not keeping the character under the cursor when selecting to the start or end of a line (e.g. `editor::SelectToBeginningOfLine` from the command palette).
