### PR TITLE
agent: Persist edit tracking so thread diff stats survive a restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "pretty_assertions",
  "project",
  "rand 0.9.4",
+ "serde",
  "serde_json",
  "settings",
  "telemetry",

--- a/crates/action_log/Cargo.toml
+++ b/crates/action_log/Cargo.toml
@@ -25,6 +25,7 @@ futures.workspace = true
 gpui.workspace = true
 language.workspace = true
 project.workspace = true
+serde.workspace = true
 telemetry.workspace = true
 text.workspace = true
 util.workspace = true

--- a/crates/action_log/src/action_log.rs
+++ b/crates/action_log/src/action_log.rs
@@ -9,6 +9,7 @@ use gpui::{
 };
 use language::{Anchor, Buffer, BufferEvent, Point, ToOffset, ToPoint};
 use project::{Project, ProjectItem, lsp_store::OpenLspBufferHandle};
+use serde::{Deserialize, Serialize};
 use std::{
     cmp,
     ops::Range,
@@ -62,6 +63,29 @@ pub struct ActionLog {
     last_reject_undo: Option<LastRejectUndo>,
     /// Tracks the last time files were read by the agent, to detect external modifications
     file_read_times: HashMap<PathBuf, MTime>,
+}
+
+/// A serializable snapshot of a single tracked buffer's edit state, used to
+/// persist the agent's unreviewed edits across reloads of a thread (see
+/// [`ActionLog::serialize`] and [`ActionLog::restore_edit`]).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SerializedEdit {
+    /// Absolute path of the edited file, used to reopen the buffer on restore.
+    pub abs_path: PathBuf,
+    /// The original ("diff base") contents the agent's edits are measured
+    /// against. Diffing this against the current file contents reproduces the
+    /// unreviewed edits and diff stats.
+    pub diff_base: String,
+    pub status: SerializedEditStatus,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum SerializedEditStatus {
+    Created {
+        existing_file_content: Option<String>,
+    },
+    Modified,
+    Deleted,
 }
 
 impl ActionLog {
@@ -1025,6 +1049,99 @@ impl ActionLog {
         DiffStats::all_files(self.changed_buffers(cx), cx)
     }
 
+    /// Serializes the edit state of every tracked buffer that currently has
+    /// unreviewed edits, so it can be persisted alongside the thread and later
+    /// restored with [`ActionLog::restore_edit`]. Buffers without a local file
+    /// path are skipped, since they can't be reopened on restore.
+    pub fn serialize(&self, cx: &App) -> Vec<SerializedEdit> {
+        self.tracked_buffers
+            .iter()
+            .filter(|(_, tracked)| tracked.has_edits(cx))
+            .filter_map(|(buffer, tracked)| {
+                let buffer = buffer.read(cx);
+                let abs_path = buffer.file()?.as_local()?.abs_path(cx);
+                let status = match &tracked.status {
+                    TrackedBufferStatus::Created {
+                        existing_file_content,
+                    } => SerializedEditStatus::Created {
+                        existing_file_content: existing_file_content
+                            .as_ref()
+                            .map(|content| content.to_string()),
+                    },
+                    TrackedBufferStatus::Modified => SerializedEditStatus::Modified,
+                    TrackedBufferStatus::Deleted => SerializedEditStatus::Deleted,
+                };
+                Some(SerializedEdit {
+                    abs_path,
+                    diff_base: tracked.diff_base.to_string(),
+                    status,
+                })
+            })
+            .collect()
+    }
+
+    /// Restores edit tracking for a buffer from previously [`serialize`]d state,
+    /// reinstating the original `diff_base` so the agent's unreviewed edits and
+    /// diff stats reappear after the thread is reloaded. The diff is recomputed
+    /// against the buffer's current contents.
+    ///
+    /// [`serialize`]: ActionLog::serialize
+    pub fn restore_edit(
+        &mut self,
+        buffer: Entity<Buffer>,
+        diff_base: String,
+        status: SerializedEditStatus,
+        cx: &mut Context<Self>,
+    ) {
+        let status = match status {
+            SerializedEditStatus::Created {
+                existing_file_content,
+            } => TrackedBufferStatus::Created {
+                existing_file_content: existing_file_content.map(Rope::from),
+            },
+            SerializedEditStatus::Modified => TrackedBufferStatus::Modified,
+            SerializedEditStatus::Deleted => TrackedBufferStatus::Deleted,
+        };
+
+        let open_lsp_handle = self.project.update(cx, |project, cx| {
+            project.register_buffer_with_language_servers(&buffer, cx)
+        });
+        let text_snapshot = buffer.read(cx).text_snapshot();
+        let language = buffer.read(cx).language().cloned();
+        let language_registry = buffer.read(cx).language_registry();
+        let diff = cx.new(|cx| {
+            BufferDiff::new(&text_snapshot, language, language_registry, cx)
+        });
+        let (diff_update_tx, diff_update_rx) = mpsc::unbounded();
+        let tracked_buffer = TrackedBuffer {
+            buffer: buffer.clone(),
+            diff_base: Rope::from(diff_base),
+            unreviewed_edits: Patch::default(),
+            snapshot: text_snapshot,
+            status,
+            version: buffer.read(cx).version(),
+            diff,
+            diff_update: diff_update_tx,
+            _open_lsp_handle: open_lsp_handle,
+            _maintain_diff: cx.spawn({
+                let buffer = buffer.clone();
+                async move |this, cx| {
+                    Self::maintain_diff(this, buffer, diff_update_rx, cx)
+                        .await
+                        .ok();
+                }
+            }),
+            _subscription: cx.subscribe(&buffer, Self::handle_buffer_event),
+        };
+        self.tracked_buffers.insert(buffer.clone(), tracked_buffer);
+        // Recompute the diff (and therefore the unreviewed edits) against the
+        // buffer's current contents. Treated as an agent change so the
+        // difference from `diff_base` is preserved as unreviewed.
+        if let Some(tracked_buffer) = self.tracked_buffers.get(&buffer) {
+            tracked_buffer.schedule_diff_update(ChangeAuthor::Agent, cx);
+        }
+    }
+
     /// Iterate over buffers changed since last read or edited by the model
     pub fn stale_buffers<'a>(&'a self, cx: &'a App) -> impl Iterator<Item = &'a Entity<Buffer>> {
         self.tracked_buffers
@@ -1333,6 +1450,206 @@ mod tests {
             let settings_store = SettingsStore::test(cx);
             cx.set_global(settings_store);
         });
+    }
+
+    #[gpui::test]
+    async fn test_serialize_and_restore_edits(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/dir"), json!({"file": "abc\ndef\nghi\njkl\nmno"}))
+            .await;
+        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+        let file_path = project
+            .read_with(cx, |project, cx| project.find_project_path("dir/file", cx))
+            .unwrap();
+        let buffer = project
+            .update(cx, |project, cx| project.open_buffer(file_path, cx))
+            .await
+            .unwrap();
+
+        cx.update(|cx| {
+            action_log.update(cx, |log, cx| log.buffer_read(buffer.clone(), cx));
+            buffer.update(cx, |buffer, cx| {
+                buffer
+                    .edit([(Point::new(1, 1)..Point::new(1, 2), "E")], None, cx)
+                    .unwrap()
+            });
+            buffer.update(cx, |buffer, cx| {
+                buffer
+                    .edit([(Point::new(4, 2)..Point::new(4, 3), "O")], None, cx)
+                    .unwrap()
+            });
+            action_log.update(cx, |log, cx| log.buffer_edited(buffer.clone(), cx));
+        });
+        cx.run_until_parked();
+
+        let original_stats = action_log.read_with(cx, |log, cx| log.diff_stats(cx));
+        assert!(
+            original_stats.lines_added > 0 || original_stats.lines_removed > 0,
+            "the agent's edits should produce a non-empty diff"
+        );
+        let original_hunks = unreviewed_hunks(&action_log, cx);
+
+        // Simulate persisting the thread and reloading it into a fresh action
+        // log: the serialized edits should reproduce the same diff and stats.
+        let serialized = action_log.read_with(cx, |log, cx| log.serialize(cx));
+        assert_eq!(
+            serialized.len(),
+            1,
+            "the one edited buffer should serialize"
+        );
+
+        let restored_log = cx.new(|_| ActionLog::new(project.clone()));
+        for edit in serialized {
+            let buffer = project
+                .update(cx, |project, cx| {
+                    project.open_local_buffer(&edit.abs_path, cx)
+                })
+                .await
+                .unwrap();
+            restored_log.update(cx, |log, cx| {
+                log.restore_edit(buffer, edit.diff_base, edit.status, cx)
+            });
+        }
+        cx.run_until_parked();
+
+        let restored_stats = restored_log.read_with(cx, |log, cx| log.diff_stats(cx));
+        assert_eq!(
+            (restored_stats.lines_added, restored_stats.lines_removed),
+            (original_stats.lines_added, original_stats.lines_removed),
+            "restored diff stats should match the originals"
+        );
+        assert_eq!(
+            unreviewed_hunks(&restored_log, cx),
+            original_hunks,
+            "restored unreviewed hunks should match the originals"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_serialize_and_restore_created_file(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/dir"), json!({})).await;
+        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+        let file_path = project
+            .read_with(cx, |project, cx| project.find_project_path("dir/file", cx))
+            .unwrap();
+        let buffer = project
+            .update(cx, |project, cx| project.open_buffer(file_path, cx))
+            .await
+            .unwrap();
+
+        cx.update(|cx| {
+            action_log.update(cx, |log, cx| log.buffer_created(buffer.clone(), cx));
+            buffer.update(cx, |buffer, cx| buffer.set_text("lorem\nipsum\n", cx));
+            action_log.update(cx, |log, cx| log.buffer_edited(buffer.clone(), cx));
+        });
+        project
+            .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        let original_stats = action_log.read_with(cx, |log, cx| log.diff_stats(cx));
+        assert!(
+            original_stats.lines_added > 0,
+            "creating a file should register added lines"
+        );
+        let original_hunks = unreviewed_hunks(&action_log, cx);
+
+        let serialized = action_log.read_with(cx, |log, cx| log.serialize(cx));
+        assert_eq!(serialized.len(), 1);
+        assert!(
+            matches!(serialized[0].status, SerializedEditStatus::Created { .. }),
+            "a created file should serialize with Created status"
+        );
+
+        let restored_log = cx.new(|_| ActionLog::new(project.clone()));
+        for edit in serialized {
+            let buffer = project
+                .update(cx, |project, cx| {
+                    project.open_local_buffer(&edit.abs_path, cx)
+                })
+                .await
+                .unwrap();
+            restored_log.update(cx, |log, cx| {
+                log.restore_edit(buffer, edit.diff_base, edit.status, cx)
+            });
+        }
+        cx.run_until_parked();
+
+        let restored_stats = restored_log.read_with(cx, |log, cx| log.diff_stats(cx));
+        assert_eq!(
+            (restored_stats.lines_added, restored_stats.lines_removed),
+            (original_stats.lines_added, original_stats.lines_removed),
+            "restored diff stats should match the originals"
+        );
+        assert_eq!(unreviewed_hunks(&restored_log, cx), original_hunks);
+    }
+
+    #[gpui::test]
+    async fn test_serialize_and_restore_deleted_file(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/dir"), json!({"file": "abc\ndef\nghi\n"}))
+            .await;
+        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+        let file_path = project
+            .read_with(cx, |project, cx| project.find_project_path("dir/file", cx))
+            .unwrap();
+        let buffer = project
+            .update(cx, |project, cx| project.open_buffer(file_path, cx))
+            .await
+            .unwrap();
+
+        cx.update(|cx| {
+            action_log.update(cx, |log, cx| log.buffer_read(buffer.clone(), cx));
+            action_log.update(cx, |log, cx| log.will_delete_buffer(buffer.clone(), cx));
+        });
+        cx.run_until_parked();
+
+        let original_stats = action_log.read_with(cx, |log, cx| log.diff_stats(cx));
+        assert!(
+            original_stats.lines_removed > 0,
+            "deleting the file's contents should register removed lines"
+        );
+        let original_hunks = unreviewed_hunks(&action_log, cx);
+
+        let serialized = action_log.read_with(cx, |log, cx| log.serialize(cx));
+        assert_eq!(serialized.len(), 1);
+        assert!(
+            matches!(serialized[0].status, SerializedEditStatus::Deleted),
+            "a deleted file should serialize with Deleted status"
+        );
+
+        let restored_log = cx.new(|_| ActionLog::new(project.clone()));
+        for edit in serialized {
+            let buffer = project
+                .update(cx, |project, cx| {
+                    project.open_local_buffer(&edit.abs_path, cx)
+                })
+                .await
+                .unwrap();
+            restored_log.update(cx, |log, cx| {
+                log.restore_edit(buffer, edit.diff_base, edit.status, cx)
+            });
+        }
+        cx.run_until_parked();
+
+        let restored_stats = restored_log.read_with(cx, |log, cx| log.diff_stats(cx));
+        assert_eq!(
+            (restored_stats.lines_added, restored_stats.lines_removed),
+            (original_stats.lines_added, original_stats.lines_removed),
+            "restored diff stats should match the originals"
+        );
+        assert_eq!(unreviewed_hunks(&restored_log, cx), original_hunks);
     }
 
     #[gpui::test(iterations = 10)]

--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -83,6 +83,10 @@ pub struct DbThread {
     pub ui_scroll_position: Option<SerializedScrollPosition>,
     #[serde(default)]
     pub sandboxed_terminal_temp_dir: Option<PathBuf>,
+    /// Persisted edit-tracking state (the agent's unreviewed edits) so diff
+    /// stats and the keep/reject review survive reloading the thread.
+    #[serde(default)]
+    pub action_log: Vec<action_log::SerializedEdit>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -133,6 +137,7 @@ impl SharedThread {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            action_log: Vec::new(),
         }
     }
 
@@ -317,6 +322,7 @@ impl DbThread {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            action_log: Vec::new(),
         })
     }
 }
@@ -768,6 +774,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            action_log: Vec::new(),
         }
     }
 

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -3333,6 +3333,89 @@ async fn test_cumulative_token_usage(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_action_log_restored_from_db(cx: &mut TestAppContext) {
+    let ThreadTest {
+        thread,
+        project_context,
+        fs,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+
+    fs.insert_file(
+        path!("/test/file.txt"),
+        "line one\nline two\n".as_bytes().to_vec(),
+    )
+    .await;
+
+    let project = thread.read_with(cx, |thread, _| thread.project().clone());
+    let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/test/file.txt"), cx)
+        })
+        .await
+        .unwrap();
+
+    cx.update(|cx| {
+        action_log.update(cx, |log, cx| log.buffer_read(buffer.clone(), cx));
+        buffer.update(cx, |buffer, cx| {
+            buffer
+                .edit([(0usize..0, "inserted line\n")], None, cx)
+                .unwrap()
+        });
+        action_log.update(cx, |log, cx| log.buffer_edited(buffer.clone(), cx));
+    });
+    cx.run_until_parked();
+
+    let original_stats = action_log.read_with(cx, |log, cx| log.diff_stats(cx));
+    assert!(
+        original_stats.lines_added > 0,
+        "the inserted line should register as an added line"
+    );
+
+    // Persisting the thread should carry the edit, and reloading it should
+    // reconstruct the same diff stats from the saved diff base.
+    let db_thread = thread.read_with(cx, |thread, cx| thread.to_db(cx)).await;
+    assert_eq!(
+        db_thread.action_log.len(),
+        1,
+        "the edited buffer should be persisted with the thread"
+    );
+
+    cx.update(|cx| {
+        LanguageModelRegistry::test(cx);
+    });
+    let restored = cx.update(|cx| {
+        let thread = thread.read(cx);
+        let project = thread.project.clone();
+        let context_server_registry = thread.context_server_registry.clone();
+        let templates = thread.templates.clone();
+        cx.new(|cx| {
+            Thread::from_db(
+                acp::SessionId::new("restored"),
+                db_thread,
+                project,
+                project_context.clone(),
+                context_server_registry,
+                templates,
+                cx,
+            )
+        })
+    });
+    // `from_db` reopens the buffer and restores its edit tracking in the
+    // background, so let that task settle before checking the stats.
+    cx.run_until_parked();
+
+    let restored_stats =
+        restored.read_with(cx, |thread, cx| thread.action_log().read(cx).diff_stats(cx));
+    assert_eq!(
+        (restored_stats.lines_added, restored_stats.lines_removed),
+        (original_stats.lines_added, original_stats.lines_removed),
+        "the reloaded thread should reproduce the original diff stats"
+    );
+}
+
+#[gpui::test]
 async fn test_cumulative_token_usage_keeps_accounted_usage_monotonic(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
     let fake_model = model.as_fake();

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1692,6 +1692,35 @@ impl Thread {
 
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
 
+        // Reopening buffers is async, so restore the persisted edit tracking in
+        // the background. Best-effort: files that can no longer be opened (e.g.
+        // moved or deleted since the thread was saved) are skipped.
+        let serialized_edits = db_thread.action_log;
+        if !serialized_edits.is_empty() {
+            cx.spawn({
+                let action_log = action_log.downgrade();
+                let project = project.downgrade();
+                async move |_thread, cx| {
+                    for edit in serialized_edits {
+                        let Ok(open_task) = project.update(cx, |project, cx| {
+                            project.open_local_buffer(&edit.abs_path, cx)
+                        }) else {
+                            continue;
+                        };
+                        let Some(buffer) = open_task.await.log_err() else {
+                            continue;
+                        };
+                        action_log
+                            .update(cx, |action_log, cx| {
+                                action_log.restore_edit(buffer, edit.diff_base, edit.status, cx);
+                            })
+                            .ok();
+                    }
+                }
+            })
+            .detach();
+        }
+
         Self {
             id,
             prompt_id: PromptId::new(),
@@ -1768,6 +1797,7 @@ impl Thread {
                 }
             }),
             sandboxed_terminal_temp_dir: self.sandboxed_terminal_temp_dir.clone(),
+            action_log: self.action_log.read(cx).serialize(cx),
         };
 
         cx.background_spawn(async move {

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -168,6 +168,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            action_log: Vec::new(),
         }
     }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -10954,6 +10954,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            action_log: Vec::new(),
         };
 
         let thread_store = cx.update(|cx| ThreadStore::global(cx));

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -1852,6 +1852,7 @@ mod tests {
             draft_prompt: None,
             ui_scroll_position: None,
             sandboxed_terminal_temp_dir: None,
+            action_log: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

The agent thread list's diff stats ("Edits") are derived from a thread's in-memory `ActionLog`, which records the original "diff base" contents the agent's edits are measured against. This state was never persisted, so after restarting Zed, `Thread::from_db` started with an empty action log and every thread showed zero edits — even though the changes were still on disk.

This persists each edited buffer's diff base and status alongside the thread (`DbThread`) and rehydrates them when the thread is reloaded:

- `ActionLog::serialize` captures every tracked buffer that currently has unreviewed edits (`abs_path`, `diff_base`, status). Buffers without a local file path are skipped.
- `ActionLog::restore_edit` rebuilds a tracked buffer from that state, reinstating the saved `diff_base` and recomputing the diff against the file's current contents.
- `Thread::to_db` serializes the live action log into a new `#[serde(default)]` field on `DbThread` (no SQL migration needed — `DbThread` is serde + zstd).
- `Thread::from_db` spawns a best-effort background task that reopens each saved file and calls `restore_edit`. Files that can't be reopened are skipped.

Because the diff is recomputed against current disk contents, reverting changes outside Zed correctly results in fewer/no edits after restore, and the keep/reject review continues to work.

## Notes

The sidebar only displays diff stats for threads that are currently open; this change makes the stats reappear once a thread is loaded/opened after restart. Showing last-known stats for closed threads without opening them would be a complementary follow-up.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed agent thread diff stats (edits) disappearing after restarting Zed
