### PR TITLE
agent: Add comfortable/compact density setting for the thread list

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1231,6 +1231,17 @@
     //
     // Default: true
     "show_merge_conflict_indicator": true,
+    // The display density of the agent panel's thread history.
+    //
+    // 1. Show the timestamp in each thread's metadata row:
+    //    "comfortable"
+    // 2. Render each thread on a single line: the timestamp is hidden until
+    //    hovered (then shown to the left of the thread's actions) and diff
+    //    stats are pinned to the right of the title:
+    //    "compact"
+    //
+    // Default: comfortable
+    "thread_history_density": "comfortable",
   },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -606,6 +606,7 @@ mod tests {
             show_merge_conflict_indicator: true,
             sidebar_side: Default::default(),
             thinking_display: Default::default(),
+            thread_history_density: Default::default(),
         }
     }
 

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -18,8 +18,8 @@ use serde::{Deserialize, Serialize};
 use settings::{
     DockPosition, DockSide, LanguageModelParameters, LanguageModelSelection,
     NotifyWhenAgentWaiting, PlaySoundWhenAgentDone, RegisterSetting, Settings, SettingsContent,
-    SettingsStore, SidebarDockPosition, SidebarSide, ThinkingBlockDisplay, ToolPermissionMode,
-    update_settings_file, update_settings_file_with_completion,
+    SettingsStore, SidebarDockPosition, SidebarSide, ThinkingBlockDisplay, ThreadHistoryDensity,
+    ToolPermissionMode, update_settings_file, update_settings_file_with_completion,
 };
 use util::ResultExt as _;
 
@@ -237,6 +237,7 @@ pub struct AgentSettings {
     pub message_editor_min_lines: usize,
     pub show_turn_stats: bool,
     pub show_merge_conflict_indicator: bool,
+    pub thread_history_density: ThreadHistoryDensity,
     pub tool_permissions: ToolPermissions,
     pub sandbox_permissions: SandboxPermissions,
 }
@@ -768,6 +769,7 @@ impl Settings for AgentSettings {
             message_editor_min_lines: agent.message_editor_min_lines.unwrap(),
             show_turn_stats: agent.show_turn_stats.unwrap(),
             show_merge_conflict_indicator: agent.show_merge_conflict_indicator.unwrap(),
+            thread_history_density: agent.thread_history_density.unwrap(),
             tool_permissions: compile_tool_permissions(agent.tool_permissions),
             sandbox_permissions: compile_sandbox_permissions(agent.sandbox_permissions),
         }
@@ -1519,6 +1521,34 @@ mod tests {
         };
         assert_eq!(user_layout.agent_dock, Some(DockPosition::Left));
         assert_eq!(user_layout.project_panel_dock, Some(DockSide::Left));
+    }
+
+    #[gpui::test]
+    fn test_thread_history_density(cx: &mut gpui::App) {
+        let store = SettingsStore::test(cx);
+        cx.set_global(store);
+        project::DisableAiSettings::register(cx);
+        AgentSettings::register(cx);
+
+        // Defaults to comfortable when the user hasn't set it.
+        assert_eq!(
+            AgentSettings::get_global(cx).thread_history_density,
+            ThreadHistoryDensity::Comfortable
+        );
+
+        // Parses an explicit "compact" value.
+        SettingsStore::update_global(cx, |store, cx| {
+            store
+                .set_user_settings(
+                    r#"{ "agent": { "thread_history_density": "compact" } }"#,
+                    cx,
+                )
+                .unwrap();
+        });
+        assert_eq!(
+            AgentSettings::get_global(cx).thread_history_density,
+            ThreadHistoryDensity::Compact
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -973,6 +973,7 @@ mod tests {
             show_merge_conflict_indicator: true,
             sidebar_side: Default::default(),
             thinking_display: Default::default(),
+            thread_history_density: Default::default(),
         };
 
         cx.update(|cx| {

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -613,8 +613,10 @@ impl ThreadsArchiveView {
 
                 let focus_handle = self.focus_handle.clone();
 
-                let timestamp =
-                    format_history_entry_timestamp(thread.created_at.unwrap_or(thread.updated_at));
+                let density = AgentSettings::get_global(cx).thread_history_density;
+                let timestamp: SharedString =
+                    format_history_entry_timestamp(thread.created_at.unwrap_or(thread.updated_at))
+                        .into();
 
                 let icon_from_external_svg = self
                     .agent_server_store
@@ -659,6 +661,8 @@ impl ThreadsArchiveView {
                         this.custom_icon_from_external_svg(svg)
                     })
                     .timestamp(timestamp)
+                    .compact(density == settings::ThreadHistoryDensity::Compact)
+                    .show_workspace_name(true)
                     .highlight_positions(highlight_positions.clone())
                     .project_paths(thread.folder_paths().paths_owned())
                     .worktrees(worktrees)

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -188,6 +188,31 @@ pub struct AutoCompactSettingsContent {
     pub threshold: Option<AutoCompactThreshold>,
 }
 
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ThreadHistoryDensity {
+    /// Show the timestamp in each thread's metadata row.
+    #[default]
+    Comfortable,
+    /// Render each thread on a single line: the timestamp is hidden until the
+    /// thread is hovered (then shown to the left of its actions) and diff stats
+    /// are pinned to the right of the title.
+    Compact,
+}
+
 #[with_fallible_options]
 #[derive(Clone, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, Default)]
 pub struct AgentSettingsContent {
@@ -324,6 +349,12 @@ pub struct AgentSettingsContent {
     ///
     /// Default: true
     pub show_merge_conflict_indicator: Option<bool>,
+    /// The display density of the agent panel's thread history. In `compact`
+    /// mode, thread timestamps are only shown on hover (to the left of the
+    /// thread's actions) instead of in each thread's metadata row.
+    ///
+    /// Default: comfortable
+    pub thread_history_density: Option<ThreadHistoryDensity>,
     /// Per-tool permission rules for granular control over which tool actions
     /// require confirmation.
     ///

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8144,6 +8144,29 @@ fn ai_page() -> SettingsPage {
                 metadata: None,
                 files: USER,
             }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Thread History Density",
+                description: "The display density of the agent panel's thread history. 'Comfortable' shows the timestamp in each thread's metadata row. 'Compact' renders each thread on a single line: the timestamp is hidden until hovered (then shown to the left of the thread's actions) and diff stats are pinned to the right of the title.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("agent.thread_history_density"),
+                    pick: |settings_content| {
+                        settings_content
+                            .agent
+                            .as_ref()?
+                            .thread_history_density
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .agent
+                            .get_or_insert_default()
+                            .thread_history_density = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
         ]);
 
         items.extend([

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -591,6 +591,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::NotifyWhenAgentWaiting>(render_dropdown)
         .add_basic_renderer::<settings::PlaySoundWhenAgentDone>(render_dropdown)
         .add_basic_renderer::<settings::ThinkingBlockDisplay>(render_dropdown)
+        .add_basic_renderer::<settings::ThreadHistoryDensity>(render_dropdown)
         .add_basic_renderer::<settings::ImageFileSizeUnit>(render_dropdown)
         .add_basic_renderer::<settings::StatusStyle>(render_dropdown)
         .add_basic_renderer::<settings::EncodingDisplayOptions>(render_dropdown)

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -6113,6 +6113,8 @@ impl Sidebar {
             format_history_entry_timestamp(Self::thread_display_time(&thread.metadata)).into()
         };
 
+        let density = AgentSettings::get_global(cx).thread_history_density;
+
         let is_remote = thread.workspace.is_remote(cx);
 
         let worktrees = apply_worktree_label_mode(
@@ -6144,6 +6146,7 @@ impl Sidebar {
             })
             .worktrees(worktrees)
             .timestamp(timestamp)
+            .compact(density == settings::ThreadHistoryDensity::Compact)
             .highlight_positions(thread.highlight_positions.to_vec())
             .title_generating(title_generating)
             .notified(has_notification)
@@ -6442,7 +6445,9 @@ impl Sidebar {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let id = ElementId::from(format!("terminal-{}", terminal.metadata.terminal_id));
-        let timestamp = format_history_entry_timestamp(terminal.metadata.created_at);
+        let density = AgentSettings::get_global(cx).thread_history_density;
+        let timestamp: SharedString =
+            format_history_entry_timestamp(terminal.metadata.created_at).into();
         let is_hovered = self.hovered_thread_index == Some(ix);
         let color = cx.theme().colors();
         let sidebar_bg = color
@@ -6471,6 +6476,7 @@ impl Sidebar {
             .is_remote(is_remote)
             .worktrees(worktrees)
             .timestamp(timestamp)
+            .compact(density == settings::ThreadHistoryDensity::Compact)
             .notified(terminal.has_notification)
             .highlight_positions(highlight_positions)
             .selected(is_active)

--- a/crates/ui/src/components/ai/thread_item.rs
+++ b/crates/ui/src/components/ai/thread_item.rs
@@ -45,6 +45,8 @@ pub struct ThreadItem {
     title_generating: bool,
     highlight_positions: Vec<usize>,
     timestamp: SharedString,
+    compact: bool,
+    show_workspace_name: bool,
     notified: bool,
     status: AgentThreadStatus,
     selected: bool,
@@ -80,6 +82,8 @@ impl ThreadItem {
             title_generating: false,
             highlight_positions: Vec::new(),
             timestamp: "".into(),
+            compact: false,
+            show_workspace_name: false,
             notified: false,
             status: AgentThreadStatus::default(),
             selected: false,
@@ -103,6 +107,23 @@ impl ThreadItem {
 
     pub fn timestamp(mut self, timestamp: impl Into<SharedString>) -> Self {
         self.timestamp = timestamp.into();
+        self
+    }
+
+    /// Renders the item as a single line: project/worktree metadata is hidden,
+    /// diff stats are pinned to the right (always visible when present), and the
+    /// timestamp is only shown on hover to the left of the action slot.
+    pub fn compact(mut self, compact: bool) -> Self {
+        self.compact = compact;
+        self
+    }
+
+    /// In compact mode, shows the thread's workspace (worktree) name on the
+    /// right of the row. This is intended for lists that aren't already grouped
+    /// by workspace (e.g. the thread history view), where the workspace would
+    /// otherwise only be discoverable via the hover tooltip.
+    pub fn show_workspace_name(mut self, show_workspace_name: bool) -> Self {
+        self.show_workspace_name = show_workspace_name;
         self
     }
 
@@ -365,10 +386,12 @@ impl RenderOnce for ThreadItem {
         } else if highlight_positions.is_empty() {
             Label::new(title)
                 .when_some(self.title_label_color, |label, color| label.color(color))
+                .when(self.hovered || self.compact, |label| label.truncate())
                 .into_any_element()
         } else {
             HighlightedLabel::new(title, highlight_positions)
                 .when_some(self.title_label_color, |label, color| label.color(color))
+                .when(self.hovered || self.compact, |label| label.truncate())
                 .into_any_element()
         };
 
@@ -395,26 +418,67 @@ impl RenderOnce for ThreadItem {
         let has_project_paths = project_paths.is_some();
         let has_timestamp = !self.timestamp.is_empty();
         let timestamp = self.timestamp;
+        let compact = self.compact;
+        // In compact mode the item is a single line: the timestamp moves next to
+        // the action slot on hover and the diff stats are pinned to the right of
+        // the title (always visible). In comfortable mode both live in the
+        // metadata row below the title.
+        let timestamp_in_action_row = has_timestamp && compact;
+        let show_timestamp_in_metadata = has_timestamp && !compact;
+        // The diff stat element can only be rendered once, so build it up front
+        // and place it in whichever row applies for the current mode.
+        let diff_stat = has_diff_stats
+            .then(|| DiffStat::new(diff_stat_id, added_count, removed_count).into_any_element());
+        let (title_row_diff_stat, metadata_diff_stat) = if compact {
+            (diff_stat, None)
+        } else {
+            (None, diff_stat)
+        };
 
         let show_tooltip = matches!(
             self.status,
             AgentThreadStatus::Error | AgentThreadStatus::WaitingForConfirmation
         );
 
-        let linked_worktrees: Vec<ThreadItemWorktreeInfo> = self
+        // In compact mode each thread is a single line with no metadata row, so
+        // the workspace a thread belongs to would otherwise only be discoverable
+        // by hovering for the tooltip. When requested (lists that aren't grouped
+        // by workspace, such as the thread history view), surface the worktree
+        // name(s) inline on the right of the row so the workspace is identifiable
+        // at a glance.
+        let compact_workspace_label: Option<SharedString> = if compact && self.show_workspace_name {
+            let mut names: Vec<&str> = Vec::new();
+            for worktree in &self.worktrees {
+                if let Some(name) = worktree.worktree_name.as_ref() {
+                    if !names.contains(&name.as_ref()) {
+                        names.push(name.as_ref());
+                    }
+                }
+            }
+            (!names.is_empty()).then(|| SharedString::from(names.join(", ")))
+        } else {
+            None
+        };
+
+        // Worktree/branch information is surfaced as hover text (a tooltip) on
+        // the whole row rather than as an inline chip in the metadata row.
+        let worktree_tooltip_entries: Vec<(Option<SharedString>, Option<SharedString>)> = self
             .worktrees
             .into_iter()
             .filter(|wt| wt.kind == WorktreeKind::Linked)
             .filter(|wt| wt.worktree_name.is_some() || wt.branch_name.is_some())
+            .map(|wt| (wt.worktree_name, wt.branch_name))
             .collect();
 
-        let has_worktree = !linked_worktrees.is_empty();
+        let has_worktree = !worktree_tooltip_entries.is_empty();
 
-        let has_metadata = has_project_name
-            || has_project_paths
-            || has_worktree
-            || has_diff_stats
-            || has_timestamp;
+        // In compact mode the item is rendered as a single line, so the metadata
+        // row (project, diff stats, timestamp) is suppressed entirely.
+        let has_metadata = !compact
+            && (has_project_name
+                || has_project_paths
+                || has_diff_stats
+                || show_timestamp_in_metadata);
 
         v_flex()
             .id(self.id.clone())
@@ -449,27 +513,67 @@ impl RenderOnce for ThreadItem {
                             .child(icon)
                             .child(title_label),
                     )
-                    .when(self.is_truncated, |this| this.child(gradient_overlay))
-                    .when(self.hovered, |this| {
-                        this.when_some(self.action_slot, |this, slot| {
-                            let overlay = GradientFade::new(base_bg, hover_bg, hover_bg)
-                                .width(px(120.0))
-                                .right(px(8.))
-                                .gradient_stop(0.90)
-                                .group_name("thread-item");
-
-                            this.child(
-                                h_flex()
-                                    .relative()
-                                    .pr_1p5()
-                                    .child(overlay)
-                                    .child(slot)
-                                    .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                                        cx.stop_propagation()
-                                    }),
-                            )
-                        })
-                    }),
+                    // While hovered (or in compact mode) the title truncates with
+                    // an ellipsis (see `title_label`), so the fade gradient would
+                    // be redundant and could bleed over the right-hand cluster.
+                    .when(self.is_truncated && !self.hovered && !compact, |this| {
+                        this.child(gradient_overlay)
+                    })
+                    .child(
+                        h_flex()
+                            .flex_none()
+                            .gap_2()
+                            // In compact mode the workspace name is shown on
+                            // the right so the thread's project is identifiable
+                            // at a glance, in both the resting and hovered states.
+                            .when_some(compact_workspace_label, |this, label| {
+                                this.child(
+                                    div().max_w_24().child(
+                                        Label::new(label)
+                                            .size(LabelSize::Small)
+                                            .color(Color::Muted)
+                                            .truncate(),
+                                    ),
+                                )
+                            })
+                            // In compact mode the diff stats are pinned to the
+                            // right of the title and stay visible at all times.
+                            .when_some(title_row_diff_stat, |this, diff_stat| this.child(diff_stat))
+                            .when(self.hovered, |this| {
+                                this.when_some(self.action_slot, |this, slot| {
+                                    this.child(
+                                        h_flex()
+                                            .relative()
+                                            .pr_1p5()
+                                            .gap_1p5()
+                                            // The fade gradient hides title text
+                                            // bleeding behind the actions; in
+                                            // compact mode the title already
+                                            // truncates, so it isn't needed.
+                                            .when(!compact, |this| {
+                                                this.child(
+                                                    GradientFade::new(base_bg, hover_bg, hover_bg)
+                                                        .width(px(120.0))
+                                                        .right(px(8.))
+                                                        .gradient_stop(0.90)
+                                                        .group_name("thread-item"),
+                                                )
+                                            })
+                                            .when(timestamp_in_action_row, |this| {
+                                                this.child(
+                                                    Label::new(timestamp.clone())
+                                                        .size(LabelSize::Small)
+                                                        .color(Color::Muted),
+                                                )
+                                            })
+                                            .child(slot)
+                                            .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                                                cx.stop_propagation()
+                                            }),
+                                    )
+                                })
+                            }),
+                    ),
             )
             .when(has_metadata, |this| {
                 this.child(
@@ -483,109 +587,36 @@ impl RenderOnce for ThreadItem {
                                 ),
                             )
                         })
-                        .when(
-                            has_project_name || has_project_paths || has_worktree,
-                            |this| {
-                                this.when_some(self.project_name, |this, name| {
-                                    this.child(
-                                        Label::new(name).size(LabelSize::Small).color(Color::Muted),
-                                    )
-                                })
-                                .when(
-                                    has_project_name && (has_project_paths || has_worktree),
-                                    |this| this.child(dot_separator()),
+                        .when(has_project_name || has_project_paths, |this| {
+                            this.when_some(self.project_name, |this, name| {
+                                this.child(
+                                    Label::new(name).size(LabelSize::Small).color(Color::Muted),
                                 )
-                                .when_some(project_paths, |this, paths| {
+                            })
+                            .when(has_project_name && has_project_paths, |this| {
+                                this.child(dot_separator())
+                            })
+                            .when_some(
+                                project_paths,
+                                |this, paths| {
                                     this.child(
                                         Label::new(paths)
                                             .size(LabelSize::Small)
                                             .color(Color::Muted),
                                     )
-                                })
-                                .when(has_project_paths && has_worktree, |this| {
-                                    this.child(dot_separator())
-                                })
-                                .children(
-                                    linked_worktrees.into_iter().map(|wt| {
-                                        let worktree_label = wt.worktree_name.clone().map(|name| {
-                                            if wt.highlight_positions.is_empty() {
-                                                Label::new(name)
-                                                    .size(LabelSize::Small)
-                                                    .color(Color::Muted)
-                                                    .truncate()
-                                                    .into_any_element()
-                                            } else {
-                                                HighlightedLabel::new(
-                                                    name,
-                                                    wt.highlight_positions.clone(),
-                                                )
-                                                .size(LabelSize::Small)
-                                                .color(Color::Muted)
-                                                .truncate()
-                                                .into_any_element()
-                                            }
-                                        });
-
-                                        // When only the branch is shown, lead with a branch icon;
-                                        // otherwise keep the worktree icon (which "covers" both the
-                                        // worktree and any accompanying branch).
-                                        let chip_icon = if wt.worktree_name.is_none()
-                                            && wt.branch_name.is_some()
-                                        {
-                                            IconName::GitBranch
-                                        } else {
-                                            IconName::GitWorktree
-                                        };
-
-                                        let branch_label = wt.branch_name.map(|branch| {
-                                            Label::new(branch)
-                                                .size(LabelSize::Small)
-                                                .color(Color::Muted)
-                                                .truncate()
-                                                .into_any_element()
-                                        });
-
-                                        let show_separator =
-                                            worktree_label.is_some() && branch_label.is_some();
-
-                                        h_flex()
-                                            .min_w_0()
-                                            .gap_0p5()
-                                            .child(
-                                                Icon::new(chip_icon)
-                                                    .size(IconSize::XSmall)
-                                                    .color(Color::Muted),
-                                            )
-                                            .when_some(worktree_label, |this, label| {
-                                                this.child(label)
-                                            })
-                                            .when(show_separator, |this| {
-                                                this.child(
-                                                    Label::new("/")
-                                                        .size(LabelSize::Small)
-                                                        .color(separator_color)
-                                                        .flex_shrink_0(),
-                                                )
-                                            })
-                                            .when_some(branch_label, |this, label| {
-                                                this.child(label)
-                                            })
-                                    }),
-                                )
-                            },
-                        )
+                                },
+                            )
+                        })
                         .when(
-                            (has_project_name || has_project_paths || has_worktree)
-                                && (has_diff_stats || has_timestamp),
+                            (has_project_name || has_project_paths)
+                                && (has_diff_stats || show_timestamp_in_metadata),
                             |this| this.child(dot_separator()),
                         )
-                        .when(has_diff_stats, |this| {
-                            this.child(DiffStat::new(diff_stat_id, added_count, removed_count))
-                        })
-                        .when(has_diff_stats && has_timestamp, |this| {
+                        .when_some(metadata_diff_stat, |this, diff_stat| this.child(diff_stat))
+                        .when(has_diff_stats && show_timestamp_in_metadata, |this| {
                             this.child(dot_separator())
                         })
-                        .when(has_timestamp, |this| {
+                        .when(show_timestamp_in_metadata, |this| {
                             this.child(
                                 Label::new(timestamp.clone())
                                     .size(LabelSize::Small)
@@ -616,6 +647,47 @@ impl RenderOnce for ThreadItem {
                         .child(Label::new("Waiting for Confirmation"))
                         .into_any_element(),
                     _ => gpui::Empty.into_any_element(),
+                }))
+            })
+            // When there's no status tooltip, surface worktree/branch info on hover.
+            .when(!show_tooltip && has_worktree, |this| {
+                this.tooltip(Tooltip::element(move |_, _| {
+                    v_flex()
+                        .gap_0p5()
+                        .children(worktree_tooltip_entries.iter().map(
+                            |(worktree_name, branch_name)| {
+                                let chip_icon = if worktree_name.is_none() && branch_name.is_some()
+                                {
+                                    IconName::GitBranch
+                                } else {
+                                    IconName::GitWorktree
+                                };
+                                h_flex()
+                                    .gap_1()
+                                    .child(
+                                        Icon::new(chip_icon)
+                                            .size(IconSize::XSmall)
+                                            .color(Color::Muted),
+                                    )
+                                    .when_some(worktree_name.clone(), |this, name| {
+                                        this.child(Label::new(name).size(LabelSize::Small))
+                                    })
+                                    .when(
+                                        worktree_name.is_some() && branch_name.is_some(),
+                                        |this| {
+                                            this.child(
+                                                Label::new("/")
+                                                    .size(LabelSize::Small)
+                                                    .color(Color::Muted),
+                                            )
+                                        },
+                                    )
+                                    .when_some(branch_name.clone(), |this, branch| {
+                                        this.child(Label::new(branch).size(LabelSize::Small))
+                                    })
+                            },
+                        ))
+                        .into_any_element()
                 }))
             })
             .when_some(self.on_click, |this, on_click| this.on_click(on_click))
@@ -959,6 +1031,54 @@ impl Component for ThreadItem {
                             .icon(IconName::AiClaude)
                             .timestamp("6h")
                             .hovered(true)
+                            .action_slot(
+                                IconButton::new("delete", IconName::Trash)
+                                    .icon_size(IconSize::Small)
+                                    .icon_color(Color::Muted),
+                            ),
+                    )
+                    .into_any_element(),
+            ),
+            single_example(
+                "Compact (workspace on right)",
+                container()
+                    .child(
+                        ThreadItem::new("ti-10", "Compact thread showing its workspace")
+                            .icon(IconName::AiClaude)
+                            .compact(true)
+                            .show_workspace_name(true)
+                            .timestamp("15m")
+                            .worktrees(vec![ThreadItemWorktreeInfo {
+                                worktree_name: Some("zed".into()),
+                                full_path: "/projects/zed".into(),
+                                highlight_positions: Vec::new(),
+                                kind: WorktreeKind::Main,
+                                branch_name: Some("main".into()),
+                            }])
+                            .added(12)
+                            .removed(3),
+                    )
+                    .into_any_element(),
+            ),
+            single_example(
+                "Compact (hovered)",
+                container()
+                    .child(
+                        ThreadItem::new("ti-11", "Hovering reveals timestamp and actions")
+                            .icon(IconName::AiClaude)
+                            .compact(true)
+                            .show_workspace_name(true)
+                            .timestamp("15m")
+                            .hovered(true)
+                            .worktrees(vec![ThreadItemWorktreeInfo {
+                                worktree_name: Some("zed".into()),
+                                full_path: "/projects/zed".into(),
+                                highlight_positions: Vec::new(),
+                                kind: WorktreeKind::Main,
+                                branch_name: Some("main".into()),
+                            }])
+                            .added(12)
+                            .removed(3)
                             .action_slot(
                                 IconButton::new("delete", IconName::Trash)
                                     .icon_size(IconSize::Small)


### PR DESCRIPTION
## Summary

Adds an `agent.thread_history_density` setting (`comfortable` by default, or `compact`) that controls how threads are laid out in the agent panel's thread list, with a matching dropdown in the settings UI.

- **Comfortable** (default, unchanged): timestamp and diff stats live in a metadata row below each thread's title.
- **Compact**: each thread renders on a single line — the timestamp is hidden until hover (then shown to the left of the row's actions), diff stats are pinned to the right of the title, and the title truncates with an ellipsis.
- Worktree/branch info moves to a hover tooltip in both modes (previously an inline chip).
- In the **thread history view**, where threads aren't grouped by workspace, the workspace name is shown on the right of each compact row (resting and hovered) so the thread's project is identifiable at a glance.

Applies to the sidebar thread list, terminal entries, and the archived-threads view.

## Screenshots

Compact mode:
<img width="1648" height="1196" alt="Screenshot 2026-06-10 at 4 38 52 PM" src="https://github.com/user-attachments/assets/9dcdbb62-53f6-4137-829a-de5fa5303b83" />

Comfortable mode on: No change from before
<img width="1604" height="1152" alt="Screenshot 2026-06-10 at 4 45 15 PM" src="https://github.com/user-attachments/assets/48cc7278-739a-44ae-bd46-d49e0b2ec307" />

"Show Thread History" page in compact mode, shows workspace name inline
<img width="1604" height="1152" alt="Screenshot 2026-06-10 at 4 38 47 PM" src="https://github.com/user-attachments/assets/94a54f09-8e31-4db1-9508-6a23850e1a8f" />

New thread density setting:
<img width="1082" height="913" alt="Screenshot 2026-06-10 at 4 39 00 PM" src="https://github.com/user-attachments/assets/0a14cd2e-bd89-4327-8d1a-a91815a18ae4" />

Compact mode timestamp appears on hover:
<img width="1648" height="1196" alt="Screenshot 2026-06-10 at 4 38 55 PM" src="https://github.com/user-attachments/assets/d07aa3b8-ff06-4ab3-9aba-900982173cdd" />



Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Added an `agent.thread_history_density` setting to show the agent panel thread list in a comfortable or compact layout
