### PR TITLE
gpui_linux: Fix UI freeze in fullscreen on Wayland

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -308,6 +308,34 @@ impl WaylandClientStatePtr {
             .expect("The pointer should always be valid when dispatching in wayland")
     }
 
+    /// Restart the render loop of any window whose frame-callback loop has stalled.
+    ///
+    /// Drawing only happens in response to wl_surface frame callbacks, and a fullscreen
+    /// idle window stops receiving them (see `WaylandWindowStatePtr::completed_frame`),
+    /// which freezes the UI until external damage arrives. Called after each event-loop
+    /// dispatch, this kicks a single frame for every stalled window so content dirtied by
+    /// the just-processed events (input, timers, language-server updates) is drawn; a
+    /// window with nothing new to draw simply re-stalls.
+    pub fn restart_stalled_render_loops(&self) {
+        let Some(client) = self.0.upgrade() else {
+            return;
+        };
+        // Collect into an owned Vec so the client borrow is released (at this statement's
+        // `;`) before `frame()` runs: `frame()` re-enters GPUI and can borrow the client
+        // again (e.g. IME enable/disable in `update_ime_enabled`), which would be a RefCell
+        // double-borrow panic if the borrow were held across the loop.
+        let stalled_windows: Vec<WaylandWindowStatePtr> = client
+            .borrow()
+            .windows
+            .values()
+            .filter(|window| window.render_loop_stalled())
+            .cloned()
+            .collect();
+        for window in stalled_windows {
+            window.frame();
+        }
+    }
+
     pub fn get_serial(&self, kind: SerialKind) -> u32 {
         self.0.upgrade().unwrap().borrow().serial_tracker.get(kind)
     }
@@ -947,7 +975,12 @@ impl LinuxClient for WaylandClient {
             .run(
                 None,
                 &mut WaylandClientStatePtr(Rc::downgrade(&self.0)),
-                |_| {},
+                |client| {
+                    // Drive any window whose frame-callback render loop stalled while
+                    // fullscreen and idle, so content dirtied by the events just dispatched
+                    // is drawn instead of waiting for a compositor callback that won't come.
+                    client.restart_stalled_render_loops();
+                },
             )
             .log_err();
     }

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -118,6 +118,10 @@ pub struct WaylandWindowState {
     hovered: bool,
     pub(crate) force_render_after_recovery: bool,
     renderer_presented: bool,
+    /// Set when the frame-callback render loop has stalled because the window is
+    /// fullscreen and idle (see `completed_frame`). The event loop re-ignites such
+    /// windows after each dispatch (see `WaylandClientStatePtr::restart_stalled_render_loops`).
+    render_loop_stalled: bool,
     in_progress_configure: Option<InProgressConfigure>,
     resize_throttle: bool,
     in_progress_window_controls: Option<WindowControls>,
@@ -401,6 +405,7 @@ impl WaylandWindowState {
             hovered: false,
             force_render_after_recovery: false,
             renderer_presented: false,
+            render_loop_stalled: false,
             in_progress_window_controls: None,
             window_controls: WindowControls::default(),
             client_inset: None,
@@ -460,6 +465,14 @@ impl Drop for WaylandWindow {
     fn drop(&mut self) {
         let mut state = self.0.state.borrow_mut();
         let surface_id = state.surface.id();
+
+        // The window is being torn down: its GPUI window is already gone and the surface is
+        // destroyed below, but the window lingers in `WaylandClientState::windows` until the
+        // deferred `drop_window` runs. Clear the stall flag so `restart_stalled_render_loops`
+        // doesn't kick `frame()` on it in that gap, which would request a frame on the destroyed
+        // surface and log "window not found" from the now-orphaned request_frame handler.
+        state.render_loop_stalled = false;
+
         if let Some(parent) = state.parent.as_ref() {
             parent.state.borrow_mut().children.remove(&surface_id);
         }
@@ -587,6 +600,12 @@ impl WaylandWindowStatePtr {
     pub fn is_blocked(&self) -> bool {
         let state = self.state.borrow();
         !state.children.is_empty()
+    }
+
+    /// Whether this window's frame-callback render loop has stalled while fullscreen and
+    /// idle, and needs to be re-ignited from the event loop (see `completed_frame`).
+    pub fn render_loop_stalled(&self) -> bool {
+        self.state.borrow().render_loop_stalled
     }
 
     pub fn frame(&self) {
@@ -1448,6 +1467,20 @@ impl PlatformWindow for WaylandWindow {
         if !state.renderer_presented {
             state.surface.commit();
         }
+
+        // The render loop is driven by wl_surface frame callbacks: each callback draws the
+        // next frame and requests another. The compositor only delivers a callback after it
+        // repaints an output that includes this surface, and it only repaints on damage.
+        // While idle the bufferless commit above produces no damage, so the callback only
+        // keeps coming as long as something else keeps the output repainting.
+        //
+        // Fullscreen, this surface is the entire output and obscures everything else, so an
+        // idle window produces no damage anywhere, the output never repaints, and the next
+        // callback never arrives — the loop stalls until external damage (moving the cursor
+        // or the window) wakes the compositor. Flag the stall so the event loop re-ignites
+        // the loop on its next iteration (see `WaylandClientStatePtr::restart_stalled_render_loops`),
+        // letting content dirtied while stalled be drawn without waiting on the compositor.
+        state.render_loop_stalled = state.fullscreen && !state.renderer_presented;
 
         state.renderer_presented = false;
     }


### PR DESCRIPTION
Closes #[55345](https://github.com/zed-industries/zed/issues/55345)

On Wayland, the render loop is clocked by wl_surface frame callbacks: each ` wl_callback.done` draws the next frame and requests the next callback. The compositor only delivers a callback after it repaints an output that includes the surface, and it only repaints on damage. When the window is idle, the loop's keep-alive is a bufferless commit, which adds no damage, so the callback only keeps arriving while something else keeps the output repainting.

Windowed, other surfaces (status bar, background, other windows) keep the output repainting, so the parked callback is serviced incidentally. Fullscreen, the surface is the entire output and obscures everything else, so an idle window produces no damage anywhere, the output never repaints, and the next callback never arrives. The loop stalls: typing and popups mark the window dirty, but nothing draws them until external damage (moving the cursor or the window) wakes the compositor.

Detect the stall (a fullscreen window that completed a frame without presenting) and re-ignite the loop from the event loop: after each dispatch, kick a single frame for every parked window so content dirtied by the just-processed events is drawn. A window with nothing new to draw simply re-parks, so an idle fullscreen window does no work until the next event. Windowed behaviour is unchanged.

How I found it: I noticed that when rust-analyzer works, the ui is properly rendered all the time, but only when rust-analyzer actually updates the status bar right after the window load. Once it stops, regardless of what happens next, the new frames are never rendered. I thought there was some magic done about the status bar or vice versa (everything else), but that wasn't the case. It seems that:

```
status bar changes → cx.notify() → window dirty
   → next frame callback → handler sees dirty → draws → presents a real damaged buffer
   → compositor repaints the output → delivers the NEXT frame callback
   → status bar changes again → ... (loop sustains itself)
```

The key problem is that once we stop receiving the callback invocations from Wayland, we never actually drive the code that renders; we only mark as dirty. This is not sufficient, as if the compositor decides to never call you for the next frame (like during the overdraw events, or screen damage, like moving mouse cursor or rendering anything on top, etc), Zed will never render on its own and will just continue marking everything dirty with no effect.

I came up with two solutions:

1. Inefficient: always render all the frames when in full-screen mode.
2. Better: when in full-screen mode, somehow flag that we need to really render and drive the render flow, instead of waiting for us to be called.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed UI freezing in fullscreen on Wayland (e.g. Hyprland) when typing or opening popups while the editor is otherwise idle