### PR TITLE
thread_view: Fix the thinking toggle button

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4827,20 +4827,27 @@ impl ThreadView {
             }
         });
 
-        // When rendered as the right half of the split button next to the
-        // thinking toggle, only the right corners are rounded.
         let trigger = if standalone {
-            ButtonLike::new("effort-selector-trigger")
+            ButtonLike::new("effort-selector-trigger").child(
+                h_flex()
+                    .gap_1()
+                    .child(
+                        Icon::new(IconName::ThinkingMode)
+                            .size(IconSize::Small)
+                            .color(label_color),
+                    )
+                    .child(Label::new(label).size(LabelSize::Small).color(label_color))
+                    .child(Icon::new(icon).size(IconSize::XSmall).color(Color::Muted)),
+            )
         } else {
             ButtonLike::new_rounded_right("effort-selector-trigger")
+                .child(Label::new(label).size(LabelSize::Small).color(label_color))
+                .child(Icon::new(icon).size(IconSize::XSmall).color(Color::Muted))
         };
 
         PopoverMenu::new("effort-selector")
             .trigger_with_tooltip(
-                trigger
-                    .selected_style(ButtonStyle::Tinted(TintColor::Accent))
-                    .child(Label::new(label).size(LabelSize::Small).color(label_color))
-                    .child(Icon::new(icon).size(IconSize::XSmall).color(Color::Muted)),
+                trigger.selected_style(ButtonStyle::Tinted(TintColor::Accent)),
                 tooltip,
             )
             .menu(move |window, cx| {


### PR DESCRIPTION
We recently changed this given some new models (e.g., Fable) don't allow turning thinking off. In those cases, we are not rendering the split button anymore, but we should still display the thinking icon, so they look a bit more consistent.

Release Notes:

- N/A
