### PR TITLE
sidebar: Display a new thread button in the archive view

### DIFF
--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -133,6 +133,7 @@ pub enum ThreadsArchiveViewEvent {
     Activate { thread: ThreadMetadata },
     CancelRestore { thread_id: ThreadId },
     Import,
+    NewThread,
 }
 
 impl EventEmitter<ThreadsArchiveViewEvent> for ThreadsArchiveView {}
@@ -961,6 +962,14 @@ impl ThreadsArchiveView {
             .child(
                 h_flex()
                     .gap_1()
+                    .child(
+                        IconButton::new("new-thread", IconName::Plus)
+                            .icon_size(IconSize::Small)
+                            .tooltip(Tooltip::text("Start New Agent Thread"))
+                            .on_click(cx.listener(|_this, _, _, cx| {
+                                cx.emit(ThreadsArchiveViewEvent::NewThread);
+                            })),
+                    )
                     .child(
                         IconButton::new("thread-import", IconName::Download)
                             .icon_size(IconSize::Small)

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -7672,6 +7672,12 @@ impl Sidebar {
                 ThreadsArchiveViewEvent::Import => {
                     this.show_thread_import_modal("thread_history", window, cx);
                 }
+                ThreadsArchiveViewEvent::NewThread => {
+                    this.show_thread_list(window, cx);
+                    if let Some(workspace) = this.active_workspace(cx) {
+                        this.create_new_entry(&workspace, window, cx);
+                    }
+                }
             },
         );
 


### PR DESCRIPTION
Sometimes, landing in the archive view at first, particularly after importing ACP threads, can be confusing as there's not an immediately available "create new thread" button users can click on.

Release Notes:

- N/A
