### PR TITLE
Unify git merge URL, both for command and output toast action

### DIFF
--- a/crates/git_hosting_providers/src/providers/bitbucket.rs
+++ b/crates/git_hosting_providers/src/providers/bitbucket.rs
@@ -10,6 +10,7 @@ use itertools::Itertools as _;
 use regex::Regex;
 use serde::Deserialize;
 use url::Url;
+use urlencoding::encode;
 
 use git::{
     BuildCommitPermalinkParams, BuildPermalinkParams, GitHostingProvider, ParsedGitRemote,
@@ -253,6 +254,32 @@ impl GitHostingProvider for Bitbucket {
                 .as_deref(),
         );
         permalink
+    }
+
+    fn build_create_pull_request_url(
+        &self,
+        remote: &ParsedGitRemote,
+        source_branch: &str,
+    ) -> Option<Url> {
+        let ParsedGitRemote { owner, repo } = remote;
+        if self.is_self_hosted() {
+            let mut url = self
+                .base_url()
+                .join(&format!("projects/{owner}/repos/{repo}/pull-requests"))
+                .ok()?;
+            url.set_query(Some(&format!(
+                "create&sourceBranch={}",
+                encode(&format!("refs/heads/{source_branch}"))
+            )));
+            Some(url)
+        } else {
+            let mut url = self
+                .base_url()
+                .join(&format!("{owner}/{repo}/pull-requests/new"))
+                .ok()?;
+            url.set_query(Some(&format!("source={}", encode(source_branch))));
+            Some(url)
+        }
     }
 
     fn extract_pull_request(&self, remote: &ParsedGitRemote, message: &str) -> Option<PullRequest> {
@@ -587,6 +614,42 @@ mod tests {
         assert_eq!(
             pr.url.as_str(),
             "https://bitbucket.company.com/projects/zed-industries/repos/zed/pull-requests/123"
+        );
+    }
+
+    #[test]
+    fn test_build_bitbucket_create_pull_request_url() {
+        let remote = ParsedGitRemote {
+            owner: "zed-industries".into(),
+            repo: "zed".into(),
+        };
+
+        let bitbucket = Bitbucket::public_instance();
+        let url = bitbucket
+            .build_create_pull_request_url(&remote, "feature/new-feature")
+            .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://bitbucket.org/zed-industries/zed/pull-requests/new?source=feature%2Fnew-feature"
+        );
+    }
+
+    #[test]
+    fn test_build_bitbucket_self_hosted_create_pull_request_url() {
+        let remote = ParsedGitRemote {
+            owner: "zed-industries".into(),
+            repo: "zed".into(),
+        };
+
+        let bitbucket =
+            Bitbucket::from_remote_url("https://bitbucket.company.com/zed-industries/zed.git")
+                .unwrap();
+        let url = bitbucket
+            .build_create_pull_request_url(&remote, "feature/new-feature")
+            .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "https://bitbucket.company.com/projects/zed-industries/repos/zed/pull-requests?create&sourceBranch=refs%2Fheads%2Ffeature%2Fnew-feature"
         );
     }
 }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3238,65 +3238,70 @@ impl GitPanel {
     }
 
     pub fn create_pull_request(&self, window: &mut Window, cx: &mut Context<Self>) {
-        let result = (|| -> anyhow::Result<()> {
-            let repo = self
-                .active_repository
-                .clone()
-                .ok_or_else(|| anyhow::anyhow!("No active repository"))?;
-
-            let (branch, remote_origin, remote_upstream) = {
-                let repository = repo.read(cx);
-                (
-                    repository.branch.clone(),
-                    repository.remote_origin_url.clone(),
-                    repository.remote_upstream_url.clone(),
-                )
-            };
-
-            let branch = branch.ok_or_else(|| anyhow::anyhow!("No active branch"))?;
-            let source_branch = branch
-                .upstream
-                .as_ref()
-                .filter(|upstream| matches!(upstream.tracking, UpstreamTracking::Tracked(_)))
-                .and_then(|upstream| upstream.branch_name())
-                .ok_or_else(|| anyhow::anyhow!("No remote configured for repository"))?;
-            let source_branch = source_branch.to_string();
-
-            let remote_url = branch
-                .upstream
-                .as_ref()
-                .and_then(|upstream| match upstream.remote_name() {
-                    Some("upstream") => remote_upstream.as_deref(),
-                    Some(_) => remote_origin.as_deref(),
-                    None => None,
-                })
-                .or(remote_origin.as_deref())
-                .or(remote_upstream.as_deref())
-                .ok_or_else(|| anyhow::anyhow!("No remote configured for repository"))?;
-            let remote_url = remote_url.to_string();
-
-            let provider_registry = GitHostingProviderRegistry::global(cx);
-            let Some((provider, parsed_remote)) =
-                git::parse_git_remote_url(provider_registry, &remote_url)
-            else {
-                return Err(anyhow::anyhow!("Unsupported remote URL: {}", remote_url));
-            };
-
-            let Some(url) = provider.build_create_pull_request_url(&parsed_remote, &source_branch)
-            else {
-                return Err(anyhow::anyhow!("Unable to construct pull request URL"));
-            };
-
-            cx.open_url(url.as_str());
-            Ok(())
-        })();
-
-        if let Err(err) = result {
-            log::error!("Error while creating pull request {:?}", err);
-            cx.defer_in(window, |panel, _window, cx| {
-                panel.show_error_toast("create pull request", err, cx);
-            });
+        match self.create_pull_request_url(cx) {
+            Ok(url) => cx.open_url(&url),
+            Err(err) => {
+                log::error!("Error while creating pull request {:?}", err);
+                cx.defer_in(window, |panel, _window, cx| {
+                    panel.show_error_toast("create pull request", err, cx);
+                });
+            }
         }
+    }
+
+    /// Builds the "create pull request" URL for the current branch from the
+    /// repository's git hosting provider. Used both by the `CreatePullRequest`
+    /// command and the post-push toast (which falls back to the link git
+    /// printed if this fails).
+    fn create_pull_request_url(&self, cx: &App) -> anyhow::Result<String> {
+        let repo = self
+            .active_repository
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("No active repository"))?;
+
+        let (branch, remote_origin, remote_upstream) = {
+            let repository = repo.read(cx);
+            (
+                repository.branch.clone(),
+                repository.remote_origin_url.clone(),
+                repository.remote_upstream_url.clone(),
+            )
+        };
+
+        let branch = branch.ok_or_else(|| anyhow::anyhow!("No active branch"))?;
+        let source_branch = branch
+            .upstream
+            .as_ref()
+            .filter(|upstream| matches!(upstream.tracking, UpstreamTracking::Tracked(_)))
+            .and_then(|upstream| upstream.branch_name())
+            .ok_or_else(|| anyhow::anyhow!("No remote configured for repository"))?;
+        let source_branch = source_branch.to_string();
+
+        let remote_url = branch
+            .upstream
+            .as_ref()
+            .and_then(|upstream| match upstream.remote_name() {
+                Some("upstream") => remote_upstream.as_deref(),
+                Some(_) => remote_origin.as_deref(),
+                None => None,
+            })
+            .or(remote_origin.as_deref())
+            .or(remote_upstream.as_deref())
+            .ok_or_else(|| anyhow::anyhow!("No remote configured for repository"))?;
+        let remote_url = remote_url.to_string();
+
+        let provider_registry = GitHostingProviderRegistry::global(cx);
+        let Some((provider, parsed_remote)) =
+            git::parse_git_remote_url(provider_registry, &remote_url)
+        else {
+            return Err(anyhow::anyhow!("Unsupported remote URL: {}", remote_url));
+        };
+
+        let url = provider
+            .build_create_pull_request_url(&parsed_remote, &source_branch)
+            .ok_or_else(|| anyhow::anyhow!("Unable to construct pull request URL"))?;
+
+        Ok(url.to_string())
     }
 
     fn askpass_delegate(
@@ -4133,6 +4138,7 @@ impl GitPanel {
             return;
         };
 
+        let git_panel = cx.weak_entity();
         workspace.update(cx, |workspace, cx| {
             let SuccessMessage { message, style } = remote_output::format_output(&action, info);
             let workspace_weak = cx.weak_entity();
@@ -4162,13 +4168,37 @@ impl GitPanel {
                                 })
                                 .ok();
                         }),
-                    PushPrLink { text, link } => this
+                    CreatePullRequest {
+                        label,
+                        fallback_url,
+                    } => this
                         .icon(
                             Icon::new(IconName::GitBranch)
                                 .size(IconSize::Small)
                                 .color(Color::Muted),
                         )
-                        .action(text, move |_, cx| cx.open_url(&link)),
+                        .action(label, move |_, cx| {
+                            let fallback_url = fallback_url.clone();
+                            git_panel
+                                .update(cx, |panel, cx| {
+                                    // Prefer the provider-built URL (matching the
+                                    // `git: create pull request` command); use the
+                                    // link git printed if that can't be built.
+                                    let url = panel
+                                        .create_pull_request_url(cx)
+                                        .log_err()
+                                        .unwrap_or(fallback_url);
+                                    cx.open_url(&url);
+                                })
+                                .ok();
+                        }),
+                    OpenLink { label, link } => this
+                        .icon(
+                            Icon::new(IconName::GitBranch)
+                                .size(IconSize::Small)
+                                .color(Color::Muted),
+                        )
+                        .action(label, move |_, cx| cx.open_url(&link)),
                 }
                 .dismiss_button(true)
             });

--- a/crates/git_ui/src/remote_output.rs
+++ b/crates/git_ui/src/remote_output.rs
@@ -22,10 +22,31 @@ impl RemoteAction {
     }
 }
 
+/// Returns the first URL printed on a `remote:` line of git's output.
+fn find_remote_link(stderr: &str) -> Option<String> {
+    let finder = LinkFinder::new();
+    stderr
+        .lines()
+        .filter(|line| line.trim_start().starts_with("remote:"))
+        .find_map(|line| {
+            finder
+                .links(line)
+                .find(|link| *link.kind() == LinkKind::Url)
+                .map(|link| link.as_str().to_string())
+        })
+}
+
 pub enum SuccessStyle {
     Toast,
     ToastWithLog { output: RemoteCommandOutput },
-    PushPrLink { text: String, link: String },
+    /// The push created a branch for which a new pull/merge request can be
+    /// opened. The button triggers the same `CreatePullRequest` action as the
+    /// command palette, deriving the URL from the git hosting provider, and
+    /// falls back to `fallback_url` (the link git printed) if that fails.
+    CreatePullRequest { label: String, fallback_url: String },
+    /// The push references an existing merge request; follow the link git
+    /// printed since there is nothing to create.
+    OpenLink { label: String, link: String },
 }
 
 pub struct SuccessMessage {
@@ -128,32 +149,41 @@ pub fn format_output(action: &RemoteAction, output: RemoteCommandOutput) -> Succ
             let style = if output.stderr.ends_with("Everything up-to-date\n") {
                 Some(SuccessStyle::Toast)
             } else if output.stderr.contains("\nremote: ") {
-                let pr_hints = [
+                // Hints git prints after a push. The "create" hints are handled
+                // by the canonical `CreatePullRequest` action (which builds the
+                // URL from the hosting provider), keeping git's link only as a
+                // fallback. The "view" hint points at an already-existing merge
+                // request, which we can only reach via the link git gave us.
+                const CREATE_HINTS: &[(&str, &str)] = &[
                     ("Create a pull request", "Create Pull Request"), // GitHub
                     ("Create pull request", "Create Pull Request"),   // Bitbucket
                     ("create a merge request", "Create Merge Request"), // GitLab
-                    ("View merge request", "View Merge Request"),     // GitLab
                 ];
-                pr_hints
+                const VIEW_HINTS: &[(&str, &str)] = &[
+                    ("View merge request", "View Merge Request"), // GitLab
+                ];
+
+                if let Some((_, label)) = CREATE_HINTS
                     .iter()
                     .find(|(indicator, _)| output.stderr.contains(indicator))
-                    .and_then(|(_, mapped)| {
-                        let finder = LinkFinder::new();
-
-                        output
-                            .stderr
-                            .lines()
-                            .filter(|line| line.trim_start().starts_with("remote:"))
-                            .find_map(|line| {
-                                finder
-                                    .links(line)
-                                    .find(|link| *link.kind() == LinkKind::Url)
-                                    .map(|link| SuccessStyle::PushPrLink {
-                                        text: mapped.to_string(),
-                                        link: link.as_str().to_string(),
-                                    })
-                            })
+                {
+                    find_remote_link(&output.stderr).map(|link| {
+                        SuccessStyle::CreatePullRequest {
+                            label: label.to_string(),
+                            fallback_url: link,
+                        }
                     })
+                } else if let Some((_, label)) = VIEW_HINTS
+                    .iter()
+                    .find(|(indicator, _)| output.stderr.contains(indicator))
+                {
+                    find_remote_link(&output.stderr).map(|link| SuccessStyle::OpenLink {
+                        label: label.to_string(),
+                        link,
+                    })
+                } else {
+                    None
+                }
             } else {
                 None
             };
@@ -195,11 +225,15 @@ mod tests {
 
         let msg = format_output(&action, output);
 
-        if let SuccessStyle::PushPrLink { text: hint, link } = &msg.style {
-            assert_eq!(hint, "Create Pull Request");
-            assert_eq!(link, "https://example.com/test/test/pull/new/test");
+        if let SuccessStyle::CreatePullRequest {
+            label,
+            fallback_url,
+        } = &msg.style
+        {
+            assert_eq!(label, "Create Pull Request");
+            assert_eq!(fallback_url, "https://example.com/test/test/pull/new/test");
         } else {
-            panic!("Expected PushPrLink variant");
+            panic!("Expected CreatePullRequest variant");
         }
     }
 
@@ -228,14 +262,18 @@ mod tests {
 
         let msg = format_output(&action, output);
 
-        if let SuccessStyle::PushPrLink { text, link } = &msg.style {
-            assert_eq!(text, "Create Merge Request");
+        if let SuccessStyle::CreatePullRequest {
+            label,
+            fallback_url,
+        } = &msg.style
+        {
+            assert_eq!(label, "Create Merge Request");
             assert_eq!(
-                link,
+                fallback_url,
                 "https://example.com/test/test/-/merge_requests/new?merge_request%5Bsource_branch%5D=test"
             );
         } else {
-            panic!("Expected PushPrLink variant");
+            panic!("Expected CreatePullRequest variant");
         }
     }
 
@@ -268,11 +306,11 @@ mod tests {
 
         let msg = format_output(&action, output);
 
-        if let SuccessStyle::PushPrLink { text, link } = &msg.style {
-            assert_eq!(text, "View Merge Request");
+        if let SuccessStyle::OpenLink { label, link } = &msg.style {
+            assert_eq!(label, "View Merge Request");
             assert_eq!(link, "https://example.com/test/test/-/merge_requests/99999");
         } else {
-            panic!("Expected PushPrLink variant");
+            panic!("Expected OpenLink variant");
         }
     }
 

--- a/crates/git_ui/src/remote_output.rs
+++ b/crates/git_ui/src/remote_output.rs
@@ -38,15 +38,23 @@ fn find_remote_link(stderr: &str) -> Option<String> {
 
 pub enum SuccessStyle {
     Toast,
-    ToastWithLog { output: RemoteCommandOutput },
+    ToastWithLog {
+        output: RemoteCommandOutput,
+    },
     /// The push created a branch for which a new pull/merge request can be
     /// opened. The button triggers the same `CreatePullRequest` action as the
     /// command palette, deriving the URL from the git hosting provider, and
     /// falls back to `fallback_url` (the link git printed) if that fails.
-    CreatePullRequest { label: String, fallback_url: String },
+    CreatePullRequest {
+        label: String,
+        fallback_url: String,
+    },
     /// The push references an existing merge request; follow the link git
     /// printed since there is nothing to create.
-    OpenLink { label: String, link: String },
+    OpenLink {
+        label: String,
+        link: String,
+    },
 }
 
 pub struct SuccessMessage {
@@ -167,11 +175,9 @@ pub fn format_output(action: &RemoteAction, output: RemoteCommandOutput) -> Succ
                     .iter()
                     .find(|(indicator, _)| output.stderr.contains(indicator))
                 {
-                    find_remote_link(&output.stderr).map(|link| {
-                        SuccessStyle::CreatePullRequest {
-                            label: label.to_string(),
-                            fallback_url: link,
-                        }
+                    find_remote_link(&output.stderr).map(|link| SuccessStyle::CreatePullRequest {
+                        label: label.to_string(),
+                        fallback_url: link,
                     })
                 } else if let Some((_, label)) = VIEW_HINTS
                     .iter()


### PR DESCRIPTION
Until now the command `git: create pull request` created its own (very nice) url to create a pull request while the the toast action after pushing used the url the git log provided (which is much less precise)

This PR routes the toast action through the same PR link creation as the command (and only falls back to the git log url if something failed)

---

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

~Closes #ISSUE~

Release Notes:

- Improved behavior of Merge/Pull Request button on push toast
