### PR TITLE
language_models: Add stream idle timeout for ChatGPT subscription requests

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -4039,6 +4039,65 @@ async fn test_send_retry_on_error(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_send_retry_on_http_send_error(cx: &mut TestAppContext) {
+    let ThreadTest { thread, model, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    let mut events = thread
+        .update(cx, |thread, cx| {
+            thread.send(UserMessageId::new(), ["Hello!"], cx)
+        })
+        .expect("thread send should start");
+    cx.run_until_parked();
+
+    // An HttpSend error is what a stream idle timeout surfaces as (e.g. the
+    // ChatGPT subscription provider's Codex backend going silent).
+    fake_model.send_last_completion_stream_error(LanguageModelCompletionError::HttpSend {
+        provider: LanguageModelProviderName::new("OpenAI"),
+        error: anyhow::anyhow!("no data received within 300s"),
+    });
+    fake_model.end_last_completion_stream();
+
+    cx.executor().advance_clock(crate::thread::BASE_RETRY_DELAY);
+    cx.run_until_parked();
+
+    fake_model.send_last_completion_stream_text_chunk("Recovered!");
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let mut retry_events = Vec::new();
+    while let Some(Ok(event)) = events.next().await {
+        match event {
+            ThreadEvent::Retry(retry_status) => {
+                retry_events.push(retry_status);
+            }
+            ThreadEvent::Stop(..) => break,
+            _ => {}
+        }
+    }
+
+    assert_eq!(retry_events.len(), 1);
+    assert!(matches!(
+        retry_events[0],
+        acp_thread::RetryStatus { attempt: 1, .. }
+    ));
+    thread.read_with(cx, |thread, _cx| {
+        assert_eq!(
+            thread.to_markdown(),
+            indoc! {"
+                ## User
+
+                Hello!
+
+                ## Assistant
+
+                Recovered!
+            "}
+        )
+    });
+}
+
+#[gpui::test]
 async fn test_send_retry_finishes_tool_calls_on_error(cx: &mut TestAppContext) {
     let ThreadTest { thread, model, .. } = setup(cx, TestModel::Fake).await;
     let fake_model = model.as_fake();

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -15,12 +15,15 @@ use language_model::{
     LanguageModelProviderName, LanguageModelProviderState, LanguageModelRequest,
     LanguageModelToolChoice, RateLimiter,
 };
-use open_ai::{ReasoningEffort, responses::stream_response};
+use open_ai::{
+    ReasoningEffort,
+    responses::{StreamIdleTimeout, stream_response_with_idle_timeout},
+};
 use rand::RngCore as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use ui::{ConfiguredApiCard, prelude::*};
 use url::form_urlencoded;
 use util::ResultExt as _;
@@ -38,6 +41,25 @@ const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 
 const CREDENTIALS_KEY: &str = "https://chatgpt.com/backend-api/codex";
 const TOKEN_REFRESH_BUFFER_MS: u64 = 5 * 60 * 1000;
+
+/// The Codex backend sometimes accepts a connection but never sends response
+/// headers, or goes silent mid-stream, leaving the request hanging forever
+/// (Zed has no read timeout, only a connect timeout). Treat a stream with no
+/// activity for this long as dead so the agent's retry logic can take over.
+///
+/// This matches the default `stream_idle_timeout_ms` (5 minutes) that
+/// OpenAI's Codex CLI uses for this same backend. Don't make this
+/// significantly more aggressive than the first-party client: response
+/// headers can legitimately take a long time to arrive while the model
+/// reasons, which is how a 10-second header timeout caused the #58035 revert
+/// of #57891.
+const CODEX_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Bounds the OAuth token refresh request, which otherwise has no timeout and
+/// can hang a completion request forever before it even starts. The token
+/// endpoint is a plain POST, so this can be much tighter than the stream
+/// idle timeout while still being generous.
+const TOKEN_REFRESH_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct CodexCredentials {
@@ -521,15 +543,23 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
             let extra_headers = CustomHeaders::new(header_pairs);
 
             let access_token = creds.access_token.clone();
+            let background_executor = cx.background_executor().clone();
             request_limiter
                 .stream(async move {
-                    stream_response(
+                    let idle_timeout = StreamIdleTimeout {
+                        duration: CODEX_STREAM_IDLE_TIMEOUT,
+                        make_timer: Arc::new(move |duration| {
+                            background_executor.timer(duration).boxed()
+                        }),
+                    };
+                    stream_response_with_idle_timeout(
                         http_client.as_ref(),
                         PROVIDER_NAME.0.as_str(),
                         CODEX_BASE_URL,
                         &access_token,
                         responses_request,
                         &extra_headers,
+                        Some(idle_timeout),
                     )
                     .await
                     .map_err(LanguageModelCompletionError::from)
@@ -581,7 +611,20 @@ async fn get_fresh_credentials(
 
     let shared_task = cx
         .spawn(async move |cx| {
-            let result = refresh_token(&http_client_clone, &refresh_token_value).await;
+            // Bound the refresh request so a hung token endpoint can't stall
+            // completion requests indefinitely.
+            let timeout = cx.background_executor().timer(TOKEN_REFRESH_TIMEOUT);
+            let result = {
+                let mut refresh =
+                    std::pin::pin!(refresh_token(&http_client_clone, &refresh_token_value).fuse());
+                let mut timeout = std::pin::pin!(timeout.fuse());
+                futures::select_biased! {
+                    result = refresh => result,
+                    _ = timeout => Err(RefreshError::Transient(anyhow!(
+                        "timed out refreshing ChatGPT subscription token after {TOKEN_REFRESH_TIMEOUT:?}"
+                    ))),
+                }
+            };
 
             match result {
                 Ok(refreshed) => {
@@ -1108,6 +1151,7 @@ mod tests {
     use super::*;
     use gpui::TestAppContext;
     use http_client::FakeHttpClient;
+    use language_model::{LanguageModelRequestMessage, Role};
     use parking_lot::Mutex;
     use std::future::Future;
     use std::pin::Pin;
@@ -1184,6 +1228,75 @@ mod tests {
             "expires_in": 3600
         })
         .to_string()
+    }
+
+    /// A response body that never produces any data, simulating a Codex
+    /// backend connection that goes silent.
+    struct StalledBody;
+
+    impl futures::AsyncRead for StalledBody {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+            _buf: &mut [u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            std::task::Poll::Pending
+        }
+    }
+
+    #[gpui::test]
+    async fn test_stream_completion_times_out_when_stream_stalls(cx: &mut TestAppContext) {
+        // The server sends response headers but then no data, ever.
+        let http_client = FakeHttpClient::create(move |_request| async move {
+            Ok(http_client::Response::builder()
+                .status(200)
+                .body(http_client::AsyncBody::from_reader(StalledBody))?)
+        });
+
+        let state = cx.new(|_cx| State {
+            credentials: Some(make_fresh_credentials()),
+            sign_in_task: None,
+            refresh_task: None,
+            load_task: None,
+            credentials_provider: Arc::new(FakeCredentialsProvider::new()),
+            auth_generation: 0,
+            last_auth_error: None,
+        });
+
+        let model = OpenAiSubscribedLanguageModel {
+            id: LanguageModelId::from(ChatGptModel::Gpt55.id().to_string()),
+            model: ChatGptModel::Gpt55,
+            state,
+            http_client,
+            request_limiter: RateLimiter::new(4),
+        };
+        let request = LanguageModelRequest {
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec!["Hello".into()],
+                cache: false,
+                reasoning_details: None,
+            }],
+            ..Default::default()
+        };
+
+        let mut stream = model
+            .stream_completion(request, &cx.to_async())
+            .await
+            .expect("request should start streaming");
+
+        let next_event = cx.executor().spawn(async move { stream.next().await });
+        cx.executor()
+            .advance_clock(CODEX_STREAM_IDLE_TIMEOUT + Duration::from_secs(1));
+
+        let event = next_event.await;
+        assert!(
+            matches!(
+                event,
+                Some(Err(LanguageModelCompletionError::HttpSend { .. }))
+            ),
+            "expected a retryable HttpSend error, got {event:?}"
+        );
     }
 
     #[gpui::test]

--- a/crates/language_models/src/provider/vercel_ai_gateway.rs
+++ b/crates/language_models/src/provider/vercel_ai_gateway.rs
@@ -332,6 +332,12 @@ fn map_open_ai_error(error: open_ai::RequestError) -> LanguageModelCompletionErr
                 retry_after,
             )
         }
+        open_ai::RequestError::StreamIdleTimeout { timeout, .. } => {
+            LanguageModelCompletionError::HttpSend {
+                provider: PROVIDER_NAME,
+                error: anyhow::anyhow!("no data received within {timeout:?}"),
+            }
+        }
         open_ai::RequestError::Other(error) => LanguageModelCompletionError::Other(error),
     }
 }

--- a/crates/open_ai/Cargo.toml
+++ b/crates/open_ai/Cargo.toml
@@ -30,4 +30,5 @@ strum.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+http_client = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -718,7 +718,13 @@ impl OpenAiResponseEventMapper {
         events.flat_map(move |event| {
             futures::stream::iter(match event {
                 Ok(event) => self.map_event(event),
-                Err(error) => vec![Err(LanguageModelCompletionError::from(anyhow!(error)))],
+                // Preserve typed `RequestError`s (e.g. stream idle timeouts)
+                // so they're classified correctly for retry purposes instead
+                // of falling into the generic `Other` bucket.
+                Err(error) => vec![Err(match error.downcast::<crate::RequestError>() {
+                    Ok(request_error) => LanguageModelCompletionError::from(request_error),
+                    Err(error) => LanguageModelCompletionError::from(error),
+                })],
             })
         })
     }

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -12,7 +12,7 @@ use http_client::{
 pub use language_model_core::ReasoningEffort;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{convert::TryFrom, future::Future};
+use std::{convert::TryFrom, future::Future, time::Duration};
 use strum::EnumIter;
 use thiserror::Error;
 
@@ -685,6 +685,8 @@ pub enum RequestError {
         body: String,
         headers: HeaderMap<HeaderValue>,
     },
+    #[error("no data received from {provider}'s API within {timeout:?}")]
+    StreamIdleTimeout { provider: String, timeout: Duration },
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -904,6 +906,10 @@ impl From<RequestError> for language_model_core::LanguageModelCompletionError {
 
                 Self::from_http_status(provider.into(), status_code, body, retry_after)
             }
+            RequestError::StreamIdleTimeout { provider, timeout } => Self::HttpSend {
+                provider: provider.into(),
+                error: anyhow!("no data received within {timeout:?}"),
+            },
             RequestError::Other(e) => Self::Other(e),
         }
     }

--- a/crates/open_ai/src/responses.rs
+++ b/crates/open_ai/src/responses.rs
@@ -1,12 +1,106 @@
 use anyhow::{Result, anyhow};
-use futures::{AsyncBufReadExt, AsyncReadExt, StreamExt, io::BufReader, stream::BoxStream};
+use futures::{
+    AsyncBufReadExt, AsyncReadExt, FutureExt, Stream, StreamExt, future::BoxFuture, io::BufReader,
+    stream::BoxStream,
+};
 use http_client::{
     AsyncBody, CustomHeaders, HttpClient, Method, Request as HttpRequest, RequestBuilderExt,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use crate::{ReasoningEffort, RequestError, Role, ServiceTier, ToolChoice};
+
+/// Activity-based timeout for `stream_response_with_idle_timeout`, mirroring
+/// the `stream_idle_timeout` behavior of OpenAI's Codex CLI: the timer covers
+/// the window from sending the request until response headers arrive, and is
+/// then reset every time a stream event arrives. If no activity occurs within
+/// `duration`, the request fails with [`RequestError::StreamIdleTimeout`].
+pub struct StreamIdleTimeout {
+    pub duration: Duration,
+    /// Creates a future that resolves after the given duration. Callers
+    /// provide this so that this crate doesn't depend on a specific executor
+    /// (e.g. GPUI's `BackgroundExecutor::timer`, which is also controllable
+    /// from tests).
+    pub make_timer: Arc<dyn Fn(Duration) -> BoxFuture<'static, ()> + Send + Sync>,
+}
+
+impl StreamIdleTimeout {
+    fn timer(&self) -> BoxFuture<'static, ()> {
+        (self.make_timer)(self.duration)
+    }
+
+    fn error(&self, provider_name: &str) -> RequestError {
+        RequestError::StreamIdleTimeout {
+            provider: provider_name.to_owned(),
+            timeout: self.duration,
+        }
+    }
+}
+
+/// Wraps a stream of SSE events, failing it with
+/// [`RequestError::StreamIdleTimeout`] if no event arrives within the
+/// configured duration. The timer is reset every time an event arrives.
+struct IdleTimeoutStream {
+    provider_name: String,
+    inner: BoxStream<'static, Result<StreamEvent>>,
+    idle_timeout: StreamIdleTimeout,
+    timer: BoxFuture<'static, ()>,
+    timed_out: bool,
+}
+
+impl IdleTimeoutStream {
+    fn new(
+        provider_name: String,
+        inner: BoxStream<'static, Result<StreamEvent>>,
+        idle_timeout: StreamIdleTimeout,
+    ) -> Self {
+        let timer = idle_timeout.timer();
+        Self {
+            provider_name,
+            inner,
+            idle_timeout,
+            timer,
+            timed_out: false,
+        }
+    }
+}
+
+impl Stream for IdleTimeoutStream {
+    type Item = Result<StreamEvent>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.timed_out {
+            return Poll::Ready(None);
+        }
+        match this.inner.poll_next_unpin(cx) {
+            Poll::Ready(item) => {
+                this.timer = this.idle_timeout.timer();
+                Poll::Ready(item)
+            }
+            Poll::Pending => match this.timer.poll_unpin(cx) {
+                Poll::Ready(()) => {
+                    this.timed_out = true;
+                    log::error!(
+                        "No data received from {}'s API within {:?}; treating the stream as dead",
+                        this.provider_name,
+                        this.idle_timeout.duration,
+                    );
+                    let error = this.idle_timeout.error(&this.provider_name);
+                    Poll::Ready(Some(Err(anyhow::Error::new(error))))
+                }
+                Poll::Pending => Poll::Pending,
+            },
+        }
+    }
+}
 
 #[derive(Serialize, Debug)]
 pub struct Request {
@@ -443,6 +537,27 @@ pub async fn stream_response(
     request: Request,
     extra_headers: &CustomHeaders,
 ) -> Result<BoxStream<'static, Result<StreamEvent>>, RequestError> {
+    stream_response_with_idle_timeout(
+        client,
+        provider_name,
+        api_url,
+        api_key,
+        request,
+        extra_headers,
+        None,
+    )
+    .await
+}
+
+pub async fn stream_response_with_idle_timeout(
+    client: &dyn HttpClient,
+    provider_name: &str,
+    api_url: &str,
+    api_key: &str,
+    request: Request,
+    extra_headers: &CustomHeaders,
+    idle_timeout: Option<StreamIdleTimeout>,
+) -> Result<BoxStream<'static, Result<StreamEvent>>, RequestError> {
     let uri = format!("{api_url}/responses");
     let is_streaming = request.stream;
     let request = HttpRequest::builder()
@@ -456,11 +571,25 @@ pub async fn stream_response(
         ))
         .map_err(|e| RequestError::Other(e.into()))?;
 
-    let mut response = client.send(request).await?;
+    // The Codex backend doesn't send response headers until the model starts
+    // producing output, so this window can legitimately last as long as the
+    // model thinks. The idle timeout must therefore be generous (see the
+    // 10-second header timeout regression in #57891/#58035).
+    let mut response = match &idle_timeout {
+        Some(idle_timeout) => {
+            let mut send = std::pin::pin!(client.send(request).fuse());
+            let mut timer = std::pin::pin!(idle_timeout.timer().fuse());
+            futures::select_biased! {
+                response = send => response?,
+                _ = timer => return Err(idle_timeout.error(provider_name)),
+            }
+        }
+        None => client.send(request).await?,
+    };
     if response.status().is_success() {
         if is_streaming {
             let reader = BufReader::new(response.into_body());
-            Ok(reader
+            let events = reader
                 .lines()
                 .filter_map(|line| async move {
                     match line {
@@ -487,14 +616,27 @@ pub async fn stream_response(
                         Err(error) => Some(Err(anyhow!(error))),
                     }
                 })
-                .boxed())
+                .boxed();
+            Ok(match idle_timeout {
+                Some(idle_timeout) => {
+                    IdleTimeoutStream::new(provider_name.to_owned(), events, idle_timeout).boxed()
+                }
+                None => events,
+            })
         } else {
             let mut body = String::new();
-            response
-                .body_mut()
-                .read_to_string(&mut body)
-                .await
-                .map_err(|e| RequestError::Other(e.into()))?;
+            let read = response.body_mut().read_to_string(&mut body);
+            match &idle_timeout {
+                Some(idle_timeout) => {
+                    let mut read = std::pin::pin!(read.fuse());
+                    let mut timer = std::pin::pin!(idle_timeout.timer().fuse());
+                    futures::select_biased! {
+                        result = read => result.map_err(|e| RequestError::Other(e.into()))?,
+                        _ = timer => return Err(idle_timeout.error(provider_name)),
+                    }
+                }
+                None => read.await.map_err(|e| RequestError::Other(e.into()))?,
+            };
 
             match serde_json::from_str::<ResponseSummary>(&body) {
                 Ok(response_summary) => {
@@ -606,5 +748,180 @@ pub async fn stream_response(
             body,
             headers: response.headers().clone(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_client::FakeHttpClient;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Returns a timer factory whose timers never fire for the first
+    /// `fire_from_call` calls and fire immediately afterwards. Useful for
+    /// deterministically controlling when the idle timeout elapses.
+    fn timer_factory(
+        fire_from_call: usize,
+    ) -> Arc<dyn Fn(Duration) -> BoxFuture<'static, ()> + Send + Sync> {
+        let calls = Arc::new(AtomicUsize::new(0));
+        Arc::new(move |_duration| {
+            let call = calls.fetch_add(1, Ordering::SeqCst);
+            if call >= fire_from_call {
+                futures::future::ready(()).boxed()
+            } else {
+                futures::future::pending().boxed()
+            }
+        })
+    }
+
+    fn idle_timeout(
+        make_timer: Arc<dyn Fn(Duration) -> BoxFuture<'static, ()> + Send + Sync>,
+    ) -> StreamIdleTimeout {
+        StreamIdleTimeout {
+            duration: Duration::from_secs(300),
+            make_timer,
+        }
+    }
+
+    fn test_request() -> Request {
+        Request {
+            model: "gpt-test".into(),
+            instructions: None,
+            input: Vec::new(),
+            include: Vec::new(),
+            stream: true,
+            temperature: None,
+            top_p: None,
+            max_output_tokens: None,
+            parallel_tool_calls: None,
+            tool_choice: None,
+            tools: Vec::new(),
+            prompt_cache_key: None,
+            reasoning: None,
+            store: None,
+            service_tier: None,
+        }
+    }
+
+    fn assert_idle_timeout_error(error: &anyhow::Error) {
+        match error.downcast_ref::<RequestError>() {
+            Some(RequestError::StreamIdleTimeout { .. }) => {}
+            other => panic!("expected StreamIdleTimeout, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn idle_timeout_stream_fails_when_stream_stalls() {
+        futures::executor::block_on(async {
+            // One event arrives, then the stream stalls forever. The initial
+            // timer (call 0) never fires; the reset timer (call 1) fires
+            // immediately, simulating the idle window elapsing after the
+            // first event.
+            let inner = futures::stream::iter(vec![Ok(StreamEvent::Unknown)])
+                .chain(futures::stream::pending())
+                .boxed();
+            let mut stream = IdleTimeoutStream::new(
+                "test-provider".to_owned(),
+                inner,
+                idle_timeout(timer_factory(1)),
+            );
+
+            assert!(matches!(stream.next().await, Some(Ok(_))));
+            let error = stream
+                .next()
+                .await
+                .expect("expected an error item")
+                .expect_err("expected the stream to fail");
+            assert_idle_timeout_error(&error);
+            assert!(
+                stream.next().await.is_none(),
+                "stream should end after timing out"
+            );
+        });
+    }
+
+    #[test]
+    fn idle_timeout_stream_prefers_data_over_timer() {
+        futures::executor::block_on(async {
+            // Even with timers that fire immediately, available events are
+            // always delivered first.
+            let inner = futures::stream::iter(vec![
+                Ok(StreamEvent::Unknown),
+                Ok(StreamEvent::Unknown),
+                Ok(StreamEvent::Unknown),
+            ])
+            .boxed();
+            let mut stream = IdleTimeoutStream::new(
+                "test-provider".to_owned(),
+                inner,
+                idle_timeout(timer_factory(0)),
+            );
+
+            for _ in 0..3 {
+                assert!(matches!(stream.next().await, Some(Ok(_))));
+            }
+            assert!(stream.next().await.is_none());
+        });
+    }
+
+    #[test]
+    fn stream_response_times_out_when_no_response_headers_arrive() {
+        futures::executor::block_on(async {
+            // The server accepts the request but never sends response headers.
+            let client = FakeHttpClient::create(move |_request| async move {
+                std::future::pending::<()>().await;
+                Err(anyhow!("unreachable"))
+            });
+
+            let result = stream_response_with_idle_timeout(
+                &*client,
+                "test-provider",
+                "https://test.example",
+                "test-key",
+                test_request(),
+                &CustomHeaders::default(),
+                Some(idle_timeout(timer_factory(0))),
+            )
+            .await;
+
+            match result {
+                Err(RequestError::StreamIdleTimeout { .. }) => {}
+                other => panic!("expected StreamIdleTimeout, got {:?}", other.map(|_| ())),
+            }
+        });
+    }
+
+    #[test]
+    fn stream_response_succeeds_when_headers_arrive_before_timeout() {
+        futures::executor::block_on(async {
+            let client = FakeHttpClient::create(move |_request| async move {
+                let body = concat!(
+                    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"status\":\"completed\"}}\n",
+                    "\n",
+                    "data: [DONE]\n",
+                );
+                Ok(http_client::Response::builder()
+                    .status(200)
+                    .body(AsyncBody::from(body))?)
+            });
+
+            let stream = stream_response_with_idle_timeout(
+                &*client,
+                "test-provider",
+                "https://test.example",
+                "test-key",
+                test_request(),
+                &CustomHeaders::default(),
+                // The initial timer never fires; timers created after events
+                // arrive fire immediately, but events are always preferred.
+                Some(idle_timeout(timer_factory(1))),
+            )
+            .await
+            .expect("request should succeed");
+
+            let events = stream.collect::<Vec<_>>().await;
+            assert_eq!(events.len(), 1);
+            assert!(matches!(events[0], Ok(StreamEvent::Completed { .. })));
+        });
     }
 }


### PR DESCRIPTION
ChatGPT subscription (Codex backend) requests can stall — the server accepts the connection but never sends response headers, or goes silent mid-stream — and Zed would wait forever, leaving the agent stuck on a loading spinner with no error and no retry, since Zed's HTTP client only has a connect timeout. This adds an activity-based idle timeout to those requests: a timer covers the window from sending the request until response headers arrive, and is then reset every time a stream event arrives. If nothing happens for 5 minutes, the request fails with a retryable `HttpSend` error so the agent's existing backoff/retry logic takes over. The OAuth token refresh request gets a similar (60s) bound, since it could hang a turn the same way before the completion request even started.

This has some history: #57891 attempted to fix the same stall with a 10-second response-header timeout, and was reverted in #58035 after reports of GPT models abruptly stopping mid-turn. The problem was that the Codex backend doesn't send response headers until the model starts producing output, so at high reasoning effort healthy requests routinely take longer than 10 seconds to first byte, and the timeout was killing them on every attempt. (OpenCode shipped the same 10s default around the same time and hit the same regression: anomalyco/opencode#29548.) An idle timeout sidesteps that failure mode because it only needs to bound *silence* rather than time-to-first-byte plus thinking time, so it can be generous. The 5-minute value matches the `stream_idle_timeout_ms` default that OpenAI's own Codex CLI uses against this same backend ([codex-rs/core/src/model_provider_info.rs](https://github.com/openai/codex/blob/9a8730f3/codex-rs/core/src/model_provider_info.rs)), and is also the default `headersTimeout` that Node's undici applies (300s) — i.e. the bound OpenCode effectively ran with before their regression (see anomalyco/opencode#15555). Notably, the complaints about the Codex CLI's 5-minute default run in the *too slow* direction (openai/codex#17003), not the false-positive direction, which is good evidence this won't cut off healthy long thinks.

The timeout is only wired up for the ChatGPT subscription provider for now, since that's where the stalls have been reported (#57636).

Closes AI-317

Release Notes:

- Fixed the agent getting stuck loading indefinitely when a ChatGPT subscription request stalls; stalled requests now time out after 5 minutes of inactivity and retry automatically.
