### PR TITLE
Iterate on placeholder copywriting for branch and worktree pickers

### DIFF
--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -1050,11 +1050,7 @@ impl PickerDelegate for BranchListDelegate {
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
         match self.state {
             PickerState::List | PickerState::NewRemote | PickerState::NewBranch => {
-                if self.is_select_only() {
-                    "Select branch…"
-                } else {
-                    "Switch branch…"
-                }
+                "Switch or type to create a branch…"
             }
             PickerState::CreateRemote(_) => "Enter a name for this remote…",
         }

--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -764,7 +764,7 @@ impl PickerDelegate for WorktreePickerDelegate {
     type ListItem = AnyElement;
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
-        "Select a worktree…".into()
+        "Select or type to create a worktree…".into()
     }
 
     fn editor_position(&self) -> PickerEditorPosition {


### PR DESCRIPTION
This change is motivated by user feedback where we saw some confusion where they didn't know that you could create either a worktree or branch through simply typing in their respective picker's editor. Hopefully, this new placeholder in each of them will help communicate that.

Release Notes:

- Improved placeholder copywriting in both the branch and worktree pickers to communicate it's possible to type-to-create each.
