### PR TITLE
Allow Prettier to read the .editorconfig files of the project when formatting from within Zed

### DIFF
--- a/crates/prettier/src/prettier_server.js
+++ b/crates/prettier/src/prettier_server.js
@@ -172,7 +172,7 @@ async function handleMessage(message, prettier) {
 
     let resolvedConfig = {};
     if (params.options.filepath) {
-      resolvedConfig = (await prettier.prettier.resolveConfig(params.options.filepath)) || {};
+      resolvedConfig = (await prettier.prettier.resolveConfig(params.options.filepath, { editorconfig: true })) || {};
 
       if (params.options.ignorePath) {
         const fileInfo = await prettier.prettier.getFileInfo(params.options.filepath, {


### PR DESCRIPTION
allow Prettier to read the .editorconfig files of the project when formatting from within zed.

Prettier's API requires passing the `{ editorconfig: true }` option to read .editorconfig files. The prettier CLI uses this option by default when running but the API does not.

API Option for this: https://prettier.io/docs/api#prettierresolveconfigfileurlorpath--options

Code where the CLI of prettier defaults this to true to show this option aligns with Prettier's defaults.

- https://github.com/prettier/prettier/blob/7e374c3cd024b2bd1b5d88e005aec3718b60f1b6/src/cli/cli-options.evaluate.js#L162
- https://github.com/prettier/prettier/blob/7e374c3cd024b2bd1b5d88e005aec3718b60f1b6/src/cli/options/get-options-for-file.js#L72

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
  - No tests were found that covered running prettier directly.
- [x] Performance impact has been considered and is acceptable

Closes #10828

Release Notes:

- Allow Prettier to read the .editorconfig files of the project when formatting from within zed.
