### PR TITLE
editor: Add editor::CodeAction for kind-bindable code actions

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -5,6 +5,34 @@ use project::project_settings::GoToDiagnosticSeverityFilter;
 use schemars::JsonSchema;
 use util::serde::default_true;
 
+/// Runs an LSP code action by kind (e.g. `source.organizeImports`).
+#[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
+#[action(namespace = editor)]
+#[serde(deny_unknown_fields)]
+pub struct CodeAction {
+    pub kind: String,
+
+    #[serde(default)]
+    pub apply: ApplyMode,
+}
+
+/// Resolution strategy for [`CodeAction`] when the LSP returns 0, 1, or N
+/// matching actions.
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ApplyMode {
+    /// Apply the first matching action without prompting.
+    First,
+    /// Apply if exactly one matches; otherwise show the code-actions picker
+    /// filtered by `kind`. Default.
+    #[default]
+    IfSingle,
+    /// Always open the code-actions picker filtered by `kind`.
+    Never,
+    /// Apply all matching actions in one transaction.
+    All,
+}
+
 /// Selects the next occurrence of the current selection.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8000,7 +8000,57 @@ impl Editor {
         }
         let project = self.project.clone()?;
         let kind = CodeActionKind::from(action.kind.clone());
-        Some(self.perform_code_action_kind(project, kind, window, cx))
+        match action.apply {
+            ApplyMode::First => self.apply_first_code_action(project, kind, window, cx),
+            // TODO: IfSingle and Never temporarily behave as All until the
+            // kind-filtered picker lands.
+            ApplyMode::IfSingle | ApplyMode::Never | ApplyMode::All => {
+                Some(self.perform_code_action_kind(project, kind, window, cx))
+            }
+        }
+    }
+
+    fn apply_first_code_action(
+        &mut self,
+        project: Entity<Project>,
+        kind: CodeActionKind,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<Task<Result<()>>> {
+        let display_snapshot = self.display_snapshot(cx);
+        let selection = self.selections.newest_adjusted(&display_snapshot);
+        let multi_buffer = self.buffer.read(cx);
+        let (buffer, start) = multi_buffer.text_anchor_for_position(selection.start, cx)?;
+        let (end_buffer, end) = multi_buffer.text_anchor_for_position(selection.end, cx)?;
+        if buffer != end_buffer {
+            return None;
+        }
+
+        // Per the LSP spec, source.* kinds apply to the whole file; other
+        // kinds target the cursor or selection.
+        let range = if kind.as_str().starts_with("source.") {
+            let snapshot = buffer.read(cx);
+            snapshot.anchor_before(0)..snapshot.anchor_before(snapshot.len())
+        } else {
+            start..end
+        };
+
+        let actions = project.update(cx, |project, cx| {
+            project.code_actions(&buffer, range, Some(vec![kind]), cx)
+        });
+        let workspace = self.workspace()?.downgrade();
+
+        Some(cx.spawn_in(window, async move |editor, cx| {
+            let Some(action) = actions.await?.unwrap_or_default().into_iter().next() else {
+                return Ok(());
+            };
+            let title = action.lsp_action.title().to_owned();
+            let apply = project.update(cx, |project, cx| {
+                project.apply_code_action(buffer, action, true, cx)
+            });
+            let transaction = apply.await?;
+            Self::open_project_transaction(&editor, workspace, transaction, title, cx).await
+        }))
     }
 
     fn perform_code_action_kind(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8001,19 +8001,18 @@ impl Editor {
         let project = self.project.clone()?;
         let kind = CodeActionKind::from(action.kind.clone());
         match action.apply {
-            ApplyMode::First => self.apply_first_code_action(project, kind, window, cx),
-            // TODO: IfSingle and Never temporarily behave as All until the
-            // kind-filtered picker lands.
-            ApplyMode::IfSingle | ApplyMode::Never | ApplyMode::All => {
-                Some(self.perform_code_action_kind(project, kind, window, cx))
+            ApplyMode::All => Some(self.perform_code_action_kind(project, kind, window, cx)),
+            ApplyMode::First | ApplyMode::IfSingle | ApplyMode::Never => {
+                self.dispatch_code_action_by_kind(project, kind, action.apply, window, cx)
             }
         }
     }
 
-    fn apply_first_code_action(
+    fn dispatch_code_action_by_kind(
         &mut self,
         project: Entity<Project>,
         kind: CodeActionKind,
+        mode: ApplyMode,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<()>>> {
@@ -8041,15 +8040,50 @@ impl Editor {
         let workspace = self.workspace()?.downgrade();
 
         Some(cx.spawn_in(window, async move |editor, cx| {
-            let Some(action) = actions.await?.unwrap_or_default().into_iter().next() else {
+            let actions = actions.await?.unwrap_or_default();
+            if actions.is_empty() {
                 return Ok(());
+            }
+            let apply_first = match mode {
+                ApplyMode::First => true,
+                ApplyMode::IfSingle => actions.len() == 1,
+                ApplyMode::Never => false,
+                ApplyMode::All => unreachable!(),
             };
-            let title = action.lsp_action.title().to_owned();
-            let apply = project.update(cx, |project, cx| {
-                project.apply_code_action(buffer, action, true, cx)
-            });
-            let transaction = apply.await?;
-            Self::open_project_transaction(&editor, workspace, transaction, title, cx).await
+            if apply_first {
+                let action = actions.into_iter().next().expect("non-empty checked above");
+                let title = action.lsp_action.title().to_owned();
+                let apply = project.update(cx, |project, cx| {
+                    project.apply_code_action(buffer, action, true, cx)
+                });
+                let transaction = apply.await?;
+                return Self::open_project_transaction(
+                    &editor, workspace, transaction, title, cx,
+                )
+                .await;
+            }
+            let provider: Rc<dyn CodeActionProvider> = Rc::new(project);
+            let available: Rc<[AvailableCodeAction]> = actions
+                .into_iter()
+                .map(|action| AvailableCodeAction {
+                    action,
+                    provider: provider.clone(),
+                })
+                .collect();
+            editor.update(cx, |editor, cx| {
+                let contents =
+                    CodeActionContents::new(None, Some(available), Vec::new(), Default::default());
+                *editor.context_menu.borrow_mut() =
+                    Some(CodeContextMenu::CodeActions(CodeActionsMenu {
+                        buffer,
+                        actions: contents,
+                        selected_item: Default::default(),
+                        scroll_handle: UniformListScrollHandle::default(),
+                        deployed_from: None,
+                    }));
+                cx.notify();
+            })?;
+            Ok(())
         }))
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7989,6 +7989,20 @@ impl Editor {
         ))
     }
 
+    fn code_action(
+        &mut self,
+        action: &crate::actions::CodeAction,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<Task<Result<()>>> {
+        if self.read_only(cx) {
+            return None;
+        }
+        let project = self.project.clone()?;
+        let kind = CodeActionKind::from(action.kind.clone());
+        Some(self.perform_code_action_kind(project, kind, window, cx))
+    }
+
     fn perform_code_action_kind(
         &mut self,
         project: Entity<Project>,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -15662,6 +15662,231 @@ async fn test_organize_imports_manual_trigger(cx: &mut TestAppContext) {
     );
 }
 
+async fn setup_code_action_test(
+    cx: &mut TestAppContext,
+    initial_content: &str,
+) -> (
+    Entity<Editor>,
+    lsp::FakeLanguageServer,
+    &'static mut gpui::VisualTestContext,
+) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_file(path!("/file.rs"), initial_content.as_bytes().to_vec())
+        .await;
+    let project = Project::test(fs, [path!("/").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    // `into_mut` heap-allocates the visual cx so the helper can return a
+    // reference to it. Same trick `add_window_view` uses internally.
+    let cx = gpui::VisualTestContext::from_window(*window, cx).into_mut();
+
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(language::rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                code_action_provider: Some(lsp::CodeActionProviderCapability::Simple(true)),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+
+    let worktree_id = workspace.update(cx, |workspace, cx| {
+        workspace.project().update(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        })
+    });
+    let editor = workspace
+        .update_in(cx, |workspace, window, cx| {
+            workspace.open_path((worktree_id, rel_path("file.rs")), None, true, window, cx)
+        })
+        .await
+        .unwrap()
+        .downcast::<Editor>()
+        .unwrap();
+    editor.update_in(cx, |editor, window, cx| {
+        window.focus(&editor.focus_handle(cx), cx);
+    });
+    cx.executor().run_until_parked();
+    let fake_server = fake_servers.next().await.unwrap();
+    (editor, fake_server, cx)
+}
+
+fn quickfix(
+    title: &str,
+    range: lsp::Range,
+    replacement: &str,
+    uri: lsp::Uri,
+) -> lsp::CodeActionOrCommand {
+    lsp::CodeActionOrCommand::CodeAction(lsp::CodeAction {
+        title: title.into(),
+        kind: Some(lsp::CodeActionKind::QUICKFIX),
+        edit: Some(lsp::WorkspaceEdit {
+            changes: Some(
+                [(uri, vec![lsp::TextEdit::new(range, replacement.into())])]
+                    .into_iter()
+                    .collect(),
+            ),
+            ..Default::default()
+        }),
+        ..Default::default()
+    })
+}
+
+fn lsp_range(start_line: u32, start_col: u32, end_line: u32, end_col: u32) -> lsp::Range {
+    lsp::Range::new(
+        lsp::Position::new(start_line, start_col),
+        lsp::Position::new(end_line, end_col),
+    )
+}
+
+#[gpui::test]
+async fn test_code_action_first_applies_one_and_filters_by_kind(cx: &mut TestAppContext) {
+    let (editor, fake_server, cx) = setup_code_action_test(cx, "AAAA\nBBBB\n").await;
+
+    fake_server.set_request_handler::<lsp::request::CodeActionRequest, _, _>(
+        |params, _| async move {
+            // Only the kind-filtered call returns canned actions; the editor's
+            // unfiltered auto-refresh hits this handler too and gets nothing.
+            if params.context.only.as_deref() != Some(&[lsp::CodeActionKind::QUICKFIX][..]) {
+                return Ok(Some(vec![]));
+            }
+            let uri = params.text_document.uri;
+            Ok(Some(vec![
+                quickfix("first", lsp_range(0, 0, 0, 4), "FIRST", uri.clone()),
+                quickfix("second", lsp_range(1, 0, 1, 4), "SECOND", uri),
+            ]))
+        },
+    );
+
+    editor
+        .update_in(cx, |editor, window, cx| {
+            editor.code_action(
+                &crate::actions::CodeAction {
+                    kind: "quickfix".into(),
+                    apply: ApplyMode::First,
+                },
+                window,
+                cx,
+            )
+        })
+        .unwrap()
+        .await
+        .unwrap();
+
+    editor.read_with(cx, |editor, cx| {
+        assert_eq!(editor.text(cx), "FIRST\nBBBB\n");
+        assert!(editor.context_menu().borrow().is_none());
+    });
+}
+
+#[gpui::test]
+async fn test_code_action_if_single_applies_when_one_match(cx: &mut TestAppContext) {
+    let (editor, fake_server, cx) = setup_code_action_test(cx, "AAAA\n").await;
+
+    fake_server.set_request_handler::<lsp::request::CodeActionRequest, _, _>(
+        |params, _| async move {
+            let uri = params.text_document.uri;
+            Ok(Some(vec![quickfix(
+                "only",
+                lsp_range(0, 0, 0, 4),
+                "ONLY",
+                uri,
+            )]))
+        },
+    );
+
+    editor
+        .update_in(cx, |editor, window, cx| {
+            editor.code_action(
+                &crate::actions::CodeAction {
+                    kind: "quickfix".into(),
+                    apply: ApplyMode::IfSingle,
+                },
+                window,
+                cx,
+            )
+        })
+        .unwrap()
+        .await
+        .unwrap();
+
+    editor.read_with(cx, |editor, cx| {
+        assert_eq!(editor.text(cx), "ONLY\n");
+        assert!(editor.context_menu().borrow().is_none());
+    });
+}
+
+#[gpui::test]
+async fn test_code_action_if_single_opens_menu_when_multiple(cx: &mut TestAppContext) {
+    let (editor, fake_server, cx) = setup_code_action_test(cx, "AAAA\n").await;
+
+    fake_server.set_request_handler::<lsp::request::CodeActionRequest, _, _>(
+        |params, _| async move {
+            let uri = params.text_document.uri;
+            Ok(Some(vec![
+                quickfix("first", lsp_range(0, 0, 0, 4), "FIRST", uri.clone()),
+                quickfix("second", lsp_range(0, 0, 0, 4), "SECOND", uri),
+            ]))
+        },
+    );
+
+    editor
+        .update_in(cx, |editor, window, cx| {
+            editor.code_action(
+                &crate::actions::CodeAction {
+                    kind: "quickfix".into(),
+                    apply: ApplyMode::IfSingle,
+                },
+                window,
+                cx,
+            )
+        })
+        .unwrap()
+        .await
+        .unwrap();
+
+    editor.read_with(cx, |editor, cx| {
+        assert_eq!(editor.text(cx), "AAAA\n");
+        assert!(editor.context_menu().borrow().is_some());
+    });
+}
+
+#[gpui::test]
+async fn test_code_action_zero_matches_is_noop(cx: &mut TestAppContext) {
+    let (editor, fake_server, cx) = setup_code_action_test(cx, "AAAA\n").await;
+
+    fake_server.set_request_handler::<lsp::request::CodeActionRequest, _, _>(|_, _| async move {
+        Ok(Some(vec![]))
+    });
+
+    editor
+        .update_in(cx, |editor, window, cx| {
+            editor.code_action(
+                &crate::actions::CodeAction {
+                    kind: "quickfix".into(),
+                    apply: ApplyMode::IfSingle,
+                },
+                window,
+                cx,
+            )
+        })
+        .unwrap()
+        .await
+        .unwrap();
+
+    editor.read_with(cx, |editor, cx| {
+        assert_eq!(editor.text(cx), "AAAA\n");
+        assert!(editor.context_menu().borrow().is_none());
+    });
+}
+
 #[gpui::test]
 async fn test_formatter_failure_does_not_abort_subsequent_formatters(cx: &mut TestAppContext) {
     init_test(cx, |settings| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -622,6 +622,13 @@ impl EditorElement {
                 }
             });
             register_action(editor, window, |editor, action, window, cx| {
+                if let Some(task) = editor.code_action(action, window, cx) {
+                    editor.detach_and_notify_err(task, window, cx);
+                } else {
+                    cx.propagate();
+                }
+            });
+            register_action(editor, window, |editor, action, window, cx| {
                 if let Some(task) = editor.confirm_completion(action, window, cx) {
                     editor.detach_and_notify_err(task, window, cx);
                 } else {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -11223,21 +11223,7 @@ impl LspStore {
                 let buffer_id = BufferId::new(*buffer_id)?;
                 buffers.insert(this.buffer_store.read(cx).get_existing(buffer_id)?);
             }
-            let kind = match envelope.payload.kind.as_str() {
-                "" => CodeActionKind::EMPTY,
-                "quickfix" => CodeActionKind::QUICKFIX,
-                "refactor" => CodeActionKind::REFACTOR,
-                "refactor.extract" => CodeActionKind::REFACTOR_EXTRACT,
-                "refactor.inline" => CodeActionKind::REFACTOR_INLINE,
-                "refactor.rewrite" => CodeActionKind::REFACTOR_REWRITE,
-                "source" => CodeActionKind::SOURCE,
-                "source.organizeImports" => CodeActionKind::SOURCE_ORGANIZE_IMPORTS,
-                "source.fixAll" => CodeActionKind::SOURCE_FIX_ALL,
-                _ => anyhow::bail!(
-                    "Invalid code action kind {}",
-                    envelope.payload.kind.as_str()
-                ),
-            };
+            let kind = CodeActionKind::from(envelope.payload.kind);
             anyhow::Ok(this.apply_code_action_kind(buffers, kind, false, cx))
         })?;
 

--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -484,6 +484,43 @@ For language-specific inlay hint settings, refer to the documentation for each l
 
 Code actions provide quick fixes and refactoring options. Access code actions using the {#action editor::ToggleCodeActions} command or by clicking the lightbulb icon that appears next to your cursor when actions are available.
 
+#### Running code actions by kind
+
+The {#action editor::CodeAction} action runs an LSP action by kind (e.g. `quickfix`, `refactor`, `source.organizeImports`). Bind it from your keymap:
+
+```json [keymap]
+[
+  {
+    "context": "Editor",
+    "bindings": {
+      "ctrl-alt-o": [
+        "editor::CodeAction",
+        { "kind": "source.organizeImports" }
+      ],
+      "ctrl-alt-q": [
+        "editor::CodeAction",
+        { "kind": "quickfix", "apply": "first" }
+      ],
+      "ctrl-alt-r": [
+        "editor::CodeAction",
+        { "kind": "refactor", "apply": "never" }
+      ]
+    }
+  }
+]
+```
+
+The `apply` field controls what happens when the language server returns zero, one, or multiple matching actions:
+
+| `apply`     | Zero matches | One match   | Multiple matches |
+| ----------- | ------------ | ----------- | ---------------- |
+| `if_single` | no-op        | apply       | open picker      |
+| `first`     | no-op        | apply       | apply the first  |
+| `never`     | no-op        | open picker | open picker      |
+| `all`       | no-op        | apply       | apply all        |
+
+`if_single` is the default if `apply` is omitted. `source.*` kinds apply to the whole file; other kinds target the cursor or selection.
+
 ### Go To Definition and References
 
 Use these commands to navigate your codebase:


### PR DESCRIPTION
## Context

#14470 asks for a way to bind LSP code actions to keyboard shortcuts. There's the existing `editor::ToggleCodeActions` which shows the unfiltered menu, but no way to bind these to a keyboard shortcut.

This adds `editor::CodeAction { kind, apply }`. `kind` is the LSP kind string, `apply` controls what happens with `n` number of matches:

| `apply` | Zero  | One | Multiple |
| - |- |- |- |
| `if_single` | no-op | apply | open picker |
| `first` | no-op | apply | apply the first  |
| `never` | no-op | open picker | open picker |
| `all` | no-op | apply | apply all |

`if_single` is the default if `apply` is omitted.

Example configuration:

```json
{
  "context": "Editor",
  "bindings": {
    "ctrl-alt-o": ["editor::CodeAction", { "kind": "source.organizeImports", "apply": "all"  }],
    "ctrl-alt-q": ["editor::CodeAction", { "kind": "quickfix", "apply": "first" }],
    "ctrl-alt-r": ["editor::CodeAction", { "kind": "refactor", "apply": "never" }]
  }
}
```

## How to Review

Inside a project with an LSP that supports code actions (typescript-language-server worked well for me), add the keymap above and:

- With the cursor inside `const x = 1 + 2 + 3`, `ctrl-alt-r` will open the picker.
- With messy imports, `ctrl-alt-o` sorts and prunes them.
- On a line with no fixable diagnostic, any of the bindings is a silent no-op.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #14470

Release Notes:

- Added `editor::CodeAction { kind, apply }` for binding LSP actions to keyboard shortcuts.