### PR TITLE
Git status list fix

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1315,6 +1315,19 @@ impl GitPanel {
         }
     }
 
+    /// If: `selected_entry > entry_count`
+    ///
+    /// Then: select last entry
+    ///
+    /// Assumes: git panel `entry_count` is the most relevant and won't be changed further
+    fn select_last_entry_if_out_of_bounds(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(idx) = self.selected_entry
+            && idx > self.entry_count
+        {
+            self.select_last(&menu::SelectLast, window, cx);
+        }
+    }
+
     fn focus_changes_list(
         &mut self,
         _: &FocusChanges,
@@ -3925,6 +3938,7 @@ impl GitPanel {
         }
 
         self.select_first_entry_if_none(window, cx);
+        self.select_last_entry_if_out_of_bounds(window, cx);
 
         let suggested_commit_message = self.suggest_commit_message(cx);
         let placeholder_text = suggested_commit_message.unwrap_or("Enter commit message".into());

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1315,14 +1315,15 @@ impl GitPanel {
         }
     }
 
-    /// If: `selected_entry > entry_count`
+    /// If: `selected_entry >= entries.len()`
     ///
     /// Then: select last entry
     ///
-    /// Assumes: git panel `entry_count` is the most relevant and won't be changed further
+    /// Note: `select_last` is no-op for `self.entries.last().is_none()`
+    /// that's why I don't check if it have entries at all.
     fn select_last_entry_if_out_of_bounds(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(idx) = self.selected_entry
-            && idx > self.entry_count
+            && idx >= self.entries.len()
         {
             self.select_last(&menu::SelectLast, window, cx);
         }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1315,12 +1315,6 @@ impl GitPanel {
         }
     }
 
-    /// If: `selected_entry >= entries.len()`
-    ///
-    /// Then: select last entry
-    ///
-    /// Note: `select_last` is no-op for `self.entries.last().is_none()`
-    /// that's why I don't check if it have entries at all.
     fn select_last_entry_if_out_of_bounds(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(idx) = self.selected_entry
             && idx >= self.entries.len()


### PR DESCRIPTION
Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #ISSUE

Issue:
- Create and/or modify several files.
- Go to GitPanel.
- Stage files you want to commit.
- Select last entry. You may select not last but make sure after list of entries shrinks, your selection would be "out of visible list" after.
- Commit.
- Entries will be committed and disappear.
- But it seems like `selected_entry` is not updated (or updated incorrectly) and Zed still have "hidden" selected entry of the last selected entry. So you need to `Shift-g` (in vim mode)  or some other keybinding to select last entry manually. I used `k` multiple times before I realized I can use `Shift-g` or `g g` -,-

Release Notes:

- Fixed: stale index (`selected_entry`) of git panel after .

Notes:
- I basically copied logic of function 1 line above but instead of `first_entry` I used `last_etnry`. So... It should be harmless.
- I didn't find where selection logic is tested. I tried to do something using `test_amend` as template, but... I'm afraid I won't be able to understand if I'm using testing framework correctly.
- I couldn't make tests, but I tried to "test" by hand using something like this:
<img width="358" height="487" alt="image" src="https://github.com/user-attachments/assets/8575bdcc-f59b-44f2-99e3-fe663e5e61f1" />

Flat View seems like working fine, but Tree View has some "bugs" (if we can call it like that) inherited. For example, if I stage selected file and commit it, selection jumps to the `asdjfl` instead of the file right under - `outer_file`. The same behavior in the current release.