### PR TITLE
Fix stale disk-based diagnostics after editing an open file outside Zed

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4673,6 +4673,22 @@ impl LspStore {
             self.detect_language_for_buffer(&buffer, cx);
         }
 
+        // A clean reload means the buffer now matches the file on disk, so treat
+        // it like a save for the language servers. Disk-based diagnostics (e.g.
+        // rust-analyzer's `cargo check`/flycheck, which only re-runs on
+        // `textDocument/didSave`) otherwise stay stale until the next manual
+        // save when a file is edited outside the editor.
+        // https://github.com/zed-industries/zed/issues/59041
+        //
+        // Gating on `!is_dirty()` skips reload conflicts and restored unsaved
+        // buffers, which must not masquerade as a save. Read-only buffers (e.g.
+        // dependency sources opened via go-to-definition) report `is_dirty() ==
+        // false` unconditionally and still notify here, which is correct: their
+        // on-disk content changed and should be re-diagnosed.
+        if !buffer.read(cx).is_dirty() {
+            self.on_buffer_saved(buffer.clone(), cx);
+        }
+
         let buffer_id = buffer.read(cx).remote_id();
         let task = self.pull_diagnostics_for_buffer(buffer, cx);
         self.buffer_reload_tasks.insert(buffer_id, task);

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -4124,6 +4124,99 @@ async fn test_diagnostic_summaries_cleared_on_buffer_reload(cx: &mut gpui::TestA
     );
 }
 
+// Regression test for https://github.com/zed-industries/zed/issues/59041:
+// when an open file is edited outside the editor, the buffer reloads and the
+// language server must be told about the save so disk-based diagnostics (e.g.
+// rust-analyzer's flycheck, which only re-runs on `didSave`) refresh instead of
+// going stale until the next manual save.
+#[gpui::test]
+async fn test_external_reload_notifies_language_server_of_save(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({ "main.rs": "fn main() { let x = 5_f64 > 5; }" }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+
+    let save_count = Arc::new(atomic::AtomicUsize::new(0));
+    let closure_save_count = save_count.clone();
+    let mut fake_servers = language_registry.register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: lsp::ServerCapabilities {
+                text_document_sync: Some(lsp::TextDocumentSyncCapability::Options(
+                    lsp::TextDocumentSyncOptions {
+                        save: Some(lsp::TextDocumentSyncSaveOptions::Supported(true)),
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            },
+            initializer: Some(Box::new(move |fake_server| {
+                let save_count = closure_save_count.clone();
+                fake_server.handle_notification::<lsp::notification::DidSaveTextDocument, _>(
+                    move |_, _| {
+                        save_count.fetch_add(1, atomic::Ordering::SeqCst);
+                    },
+                );
+            })),
+            ..Default::default()
+        },
+    );
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(path!("/dir/main.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let _fake_server = fake_servers.next().await.unwrap();
+    cx.executor().run_until_parked();
+
+    // A clean buffer edited outside the editor reloads, and that reload should
+    // be reported to the server as a save so flycheck re-runs.
+    let saves_before = save_count.load(atomic::Ordering::SeqCst);
+    fs.save(
+        path!("/dir/main.rs").as_ref(),
+        &"fn main() { let x = 5_f64 > 5_f64; }".into(),
+        LineEnding::Unix,
+    )
+    .await
+    .unwrap();
+    cx.executor().run_until_parked();
+    assert_eq!(
+        save_count.load(atomic::Ordering::SeqCst),
+        saves_before + 1,
+        "a clean external reload should notify the language server of a save"
+    );
+
+    // With unsaved local edits, the buffer must not auto-reload nor report a
+    // phantom save: the in-memory contents no longer match disk.
+    buffer.update(cx, |buffer, cx| buffer.edit([(0..0, "// wip\n")], None, cx));
+    cx.executor().run_until_parked();
+    let saves_before_dirty = save_count.load(atomic::Ordering::SeqCst);
+    fs.save(
+        path!("/dir/main.rs").as_ref(),
+        &"fn main() {}".into(),
+        LineEnding::Unix,
+    )
+    .await
+    .unwrap();
+    cx.executor().run_until_parked();
+    assert_eq!(
+        save_count.load(atomic::Ordering::SeqCst),
+        saves_before_dirty,
+        "a dirty buffer must not be reloaded or reported as saved on external change"
+    );
+}
+
 #[gpui::test]
 async fn test_edits_from_lsp2_with_past_version(cx: &mut gpui::TestAppContext) {
     init_test(cx);


### PR DESCRIPTION
what / why

editing an open file outside zed left stale diagnostics sitting there. the buffer reloads and the new text reaches the server via didChange, but disk-based diagnostics (ra's cargo check / flycheck) only re-run on didSave, which never got sent. so the old error sticks around until you manually save. python/ty isn't affected, it has no separate on-save check.

fix

on a clean reload (buffer now matches disk) notify the language servers of a save, the same path ctrl-s takes. that kicks off flycheck again and the stale diagnostics clear themselves. gated on !is_dirty() so reload conflicts and restored-but-unsaved buffers don't fake a save.

perf

nothing extra on the editing hot path. a manual save still fires exactly one didSave (the worktree reconciles its own write, no phantom reload). only added cost is one flycheck per clean external reload, which is the point anyway, and it's scoped to open + clean buffers and debounced by ra.

Self-Review Checklist:

- [x] Unsafe blocks (if any) have justifying comments
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Closes #59041

Release Notes:

- fixed stale disk-based diagnostics (e.g. rust-analyzer's cargo check) sticking around after an open file is edited outside zed
