### PR TITLE
editor: End Emacs mark mode after region copy and kill

### DIFF
--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -343,6 +343,7 @@ impl Editor {
         }
         let item = self.cut_common(true, window, cx);
         cx.write_to_clipboard(item);
+        self.selection_mark_mode = false;
     }
 
     pub(super) fn kill_ring_cut(
@@ -365,7 +366,8 @@ impl Editor {
             });
         });
         let item = self.cut_common(false, window, cx);
-        cx.set_global(KillRing(item))
+        cx.set_global(KillRing(item));
+        self.selection_mark_mode = false;
     }
 
     pub(super) fn kill_ring_yank(
@@ -384,6 +386,7 @@ impl Editor {
             return;
         };
         self.do_paste(&text, metadata, false, window, cx);
+        self.selection_mark_mode = false;
     }
 
     pub(super) fn copy_and_trim(
@@ -395,8 +398,17 @@ impl Editor {
         self.do_copy(true, cx);
     }
 
-    pub(super) fn copy(&mut self, _: &Copy, _: &mut Window, cx: &mut Context<Self>) {
+    pub(super) fn copy(&mut self, _: &Copy, window: &mut Window, cx: &mut Context<Self>) {
         self.do_copy(false, cx);
+        if self.selection_mark_mode {
+            // Reset current selection
+            self.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                s.move_with(&mut |_, selection| {
+                    selection.collapse_to(selection.head(), SelectionGoal::None);
+                });
+            });
+            self.selection_mark_mode = false;
+        }
     }
 
     pub(super) fn diff_clipboard_with_selection(

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8934,6 +8934,42 @@ async fn test_cut_line_ends(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_clipboard_ops_end_mark_mode(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("ˇhello world");
+    cx.update_editor(|e, window, cx| {
+        e.set_mark(&SetMark, window, cx);
+        e.select_to_next_word_end(&SelectToNextWordEnd, window, cx);
+        e.copy(&Copy, window, cx);
+        assert!(!e.selection_mark_mode, "copy should end mark mode");
+    });
+    cx.assert_editor_state("helloˇ world");
+
+    cx.set_state("ˇhello world");
+    cx.update_editor(|e, window, cx| {
+        e.set_mark(&SetMark, window, cx);
+        e.cut(&Cut, window, cx);
+        assert!(!e.selection_mark_mode, "cut should end mark mode");
+    });
+
+    cx.set_state("ˇhello world");
+    cx.update_editor(|e, window, cx| {
+        e.set_mark(&SetMark, window, cx);
+        e.kill_ring_cut(&KillRingCut, window, cx);
+        assert!(!e.selection_mark_mode, "kill_ring_cut should end mark mode");
+    });
+
+    cx.set_state("ˇhello world");
+    cx.update_editor(|e, window, cx| {
+        e.set_mark(&SetMark, window, cx);
+        e.kill_ring_yank(&KillRingYank, window, cx);
+        assert!(!e.selection_mark_mode, "kill_ring_yank should end mark mode");
+    });
+}
+
+#[gpui::test]
 async fn test_clipboard(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
# Objective

Fixes #48718

When `editor::SetMark` is active and the user runs a region action (Copy, Cut, KillRingCut, KillRingYank), mark mode stayed activated. The next arrow-key movement then kept selecting text.

## Solution

Clear `selection_mark_mode` at the end of each clipboard handler. Copy also collapses the selection. The other three already collapse as a side effect of mutating the buffer.

## Testing

Added `test_clipboard_ops_end_mark_mode` covering all of the four handlers. Manually verified on macOS by setting a temporary `editor::SetMark` keybinding, reproduced the issue on `main`, then confirmed it works on this branch.

I have not tested on Windows or Linux, however the change is in the editor and as far as I know does not touch any platform-specific code. So the behavior should be the same.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed selection not ending after Copy or Cut in Emacs mark mode