### PR TITLE
sidebar: Add configurable thread list grouping, metadata display, and filtering

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1021,6 +1021,18 @@
     "flexible": true,
     // Where to position the threads sidebar. Can be 'left' or 'right'.
     "sidebar_side": "left",
+    // How threads in the agent sidebar's thread list are grouped. Can be
+    // 'workspace', 'updated', or 'status'.
+    "thread_group_by": "workspace",
+    // Controls which metadata is shown for each thread in the sidebar's thread list.
+    "thread_list_display": {
+      // Whether to show each thread's last-updated timestamp.
+      "show_timestamp": true,
+      // Whether to show the git branch / linked-worktree chips for each thread.
+      "show_branch": true,
+      // Whether to show the diff stats (added/removed line counts) for each thread.
+      "show_diff_stats": true,
+    },
     // Default width when the agent panel is docked to the left or right.
     "default_width": 640,
     // Default height when the agent panel is docked to the bottom.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1033,6 +1033,16 @@
       // Whether to show the diff stats (added/removed line counts) for each thread.
       "show_diff_stats": true,
     },
+    // Which threads are shown in the sidebar's thread list (the "Filter by" menu).
+    // Empty lists mean no filtering is applied.
+    "thread_filter": {
+      // Restrict the list to threads matching any of these statuses. Each entry
+      // can be 'running', 'needs_attention', 'completed', or 'error'.
+      "status": [],
+      // Restrict the list to threads from any of these sources. Each entry can
+      // be 'zed' or 'external'.
+      "source": [],
+    },
     // Default width when the agent panel is docked to the left or right.
     "default_width": 640,
     // Default height when the agent panel is docked to the bottom.

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -611,6 +611,7 @@ mod tests {
                 show_branch: true,
                 show_diff_stats: true,
             },
+            thread_filter: Default::default(),
             thinking_display: Default::default(),
         }
     }

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -605,6 +605,12 @@ mod tests {
             show_turn_stats: false,
             show_merge_conflict_indicator: true,
             sidebar_side: Default::default(),
+            thread_group_by: Default::default(),
+            thread_list_display: agent_settings::ThreadListDisplaySettings {
+                show_timestamp: true,
+                show_branch: true,
+                show_diff_stats: true,
+            },
             thinking_display: Default::default(),
         }
     }

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -19,7 +19,8 @@ use settings::{
     DockPosition, DockSide, LanguageModelParameters, LanguageModelSelection,
     NotifyWhenAgentWaiting, PlaySoundWhenAgentDone, RegisterSetting, Settings, SettingsContent,
     SettingsStore, SidebarDockPosition, SidebarSide, ThinkingBlockDisplay, ThreadGroupBy,
-    ToolPermissionMode, update_settings_file, update_settings_file_with_completion,
+    ThreadSourceFilter, ThreadStatusFilter, ToolPermissionMode, update_settings_file,
+    update_settings_file_with_completion,
 };
 use util::ResultExt as _;
 
@@ -179,6 +180,12 @@ pub struct ThreadListDisplaySettings {
     pub show_diff_stats: bool,
 }
 
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ThreadFilterSettings {
+    pub status: Vec<ThreadStatusFilter>,
+    pub source: Vec<ThreadSourceFilter>,
+}
+
 fn parse_auto_compact_threshold(raw: &str) -> anyhow::Result<AutoCompactThreshold> {
     let trimmed = raw.trim();
     if let Some(percent) = trimmed.strip_suffix('%') {
@@ -217,6 +224,7 @@ pub struct AgentSettings {
     pub sidebar_side: SidebarDockPosition,
     pub thread_group_by: ThreadGroupBy,
     pub thread_list_display: ThreadListDisplaySettings,
+    pub thread_filter: ThreadFilterSettings,
     pub default_width: Pixels,
     pub default_height: Pixels,
     pub max_content_width: Option<Pixels>,
@@ -734,6 +742,13 @@ impl Settings for AgentSettings {
                     show_timestamp: display.show_timestamp.unwrap(),
                     show_branch: display.show_branch.unwrap(),
                     show_diff_stats: display.show_diff_stats.unwrap(),
+                }
+            },
+            thread_filter: {
+                let filter = agent.thread_filter.unwrap_or_default();
+                ThreadFilterSettings {
+                    status: filter.status.unwrap_or_default(),
+                    source: filter.source.unwrap_or_default(),
                 }
             },
             default_width: px(agent.default_width.unwrap()),
@@ -1511,6 +1526,50 @@ mod tests {
         assert!(!display.show_timestamp);
         assert!(display.show_branch);
         assert!(display.show_diff_stats);
+    }
+
+    #[gpui::test]
+    fn test_thread_filter_settings(cx: &mut gpui::App) {
+        let store = SettingsStore::test(cx);
+        cx.set_global(store);
+        project::DisableAiSettings::register(cx);
+        AgentSettings::register(cx);
+
+        // Defaults: grouping is by workspace and no filters are active.
+        let settings = AgentSettings::get_global(cx);
+        assert_eq!(settings.thread_group_by, ThreadGroupBy::Workspace);
+        assert!(settings.thread_filter.status.is_empty());
+        assert!(settings.thread_filter.source.is_empty());
+
+        // A user override (mirroring what the "Group & Filter Threads" menu
+        // writes) persists the grouping and the active filters.
+        SettingsStore::update_global(cx, |store, cx| {
+            store
+                .set_user_settings(
+                    r#"{
+                        "agent": {
+                            "thread_group_by": "status",
+                            "thread_filter": {
+                                "status": ["running", "needs_attention"],
+                                "source": ["external"]
+                            }
+                        }
+                    }"#,
+                    cx,
+                )
+                .unwrap();
+        });
+
+        let settings = AgentSettings::get_global(cx);
+        assert_eq!(settings.thread_group_by, ThreadGroupBy::Status);
+        assert_eq!(
+            settings.thread_filter.status,
+            vec![ThreadStatusFilter::Running, ThreadStatusFilter::NeedsAttention]
+        );
+        assert_eq!(
+            settings.thread_filter.source,
+            vec![ThreadSourceFilter::External]
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -18,8 +18,8 @@ use serde::{Deserialize, Serialize};
 use settings::{
     DockPosition, DockSide, LanguageModelParameters, LanguageModelSelection,
     NotifyWhenAgentWaiting, PlaySoundWhenAgentDone, RegisterSetting, Settings, SettingsContent,
-    SettingsStore, SidebarDockPosition, SidebarSide, ThinkingBlockDisplay, ToolPermissionMode,
-    update_settings_file, update_settings_file_with_completion,
+    SettingsStore, SidebarDockPosition, SidebarSide, ThinkingBlockDisplay, ThreadGroupBy,
+    ToolPermissionMode, update_settings_file, update_settings_file_with_completion,
 };
 use util::ResultExt as _;
 
@@ -172,6 +172,13 @@ pub struct AutoCompactSettings {
     pub threshold: AutoCompactThreshold,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ThreadListDisplaySettings {
+    pub show_timestamp: bool,
+    pub show_branch: bool,
+    pub show_diff_stats: bool,
+}
+
 fn parse_auto_compact_threshold(raw: &str) -> anyhow::Result<AutoCompactThreshold> {
     let trimmed = raw.trim();
     if let Some(percent) = trimmed.strip_suffix('%') {
@@ -208,6 +215,8 @@ pub struct AgentSettings {
     pub dock: DockPosition,
     pub flexible: bool,
     pub sidebar_side: SidebarDockPosition,
+    pub thread_group_by: ThreadGroupBy,
+    pub thread_list_display: ThreadListDisplaySettings,
     pub default_width: Pixels,
     pub default_height: Pixels,
     pub max_content_width: Option<Pixels>,
@@ -718,6 +727,15 @@ impl Settings for AgentSettings {
             button: agent.button.unwrap(),
             dock: agent.dock.unwrap(),
             sidebar_side: agent.sidebar_side.unwrap(),
+            thread_group_by: agent.thread_group_by.unwrap(),
+            thread_list_display: {
+                let display = agent.thread_list_display.unwrap();
+                ThreadListDisplaySettings {
+                    show_timestamp: display.show_timestamp.unwrap(),
+                    show_branch: display.show_branch.unwrap(),
+                    show_diff_stats: display.show_diff_stats.unwrap(),
+                }
+            },
             default_width: px(agent.default_width.unwrap()),
             default_height: px(agent.default_height.unwrap()),
             max_content_width: if agent.limit_content_width.unwrap() {
@@ -1464,6 +1482,35 @@ mod tests {
         let content: ToolPermissionsContent = serde_json::from_value(json_deny).unwrap();
         let permissions = compile_tool_permissions(Some(content));
         assert_eq!(permissions.default, ToolPermissionMode::Deny);
+    }
+
+    #[gpui::test]
+    fn test_thread_list_display_settings(cx: &mut gpui::App) {
+        let store = SettingsStore::test(cx);
+        cx.set_global(store);
+        project::DisableAiSettings::register(cx);
+        AgentSettings::register(cx);
+
+        // Defaults: every metadata field is shown.
+        let display = AgentSettings::get_global(cx).thread_list_display;
+        assert!(display.show_timestamp);
+        assert!(display.show_branch);
+        assert!(display.show_diff_stats);
+
+        // A user override flips a single field, leaving the others at default.
+        SettingsStore::update_global(cx, |store, cx| {
+            store
+                .set_user_settings(
+                    r#"{ "agent": { "thread_list_display": { "show_timestamp": false } } }"#,
+                    cx,
+                )
+                .unwrap();
+        });
+
+        let display = AgentSettings::get_global(cx).thread_list_display;
+        assert!(!display.show_timestamp);
+        assert!(display.show_branch);
+        assert!(display.show_diff_stats);
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -972,6 +972,12 @@ mod tests {
             show_turn_stats: false,
             show_merge_conflict_indicator: true,
             sidebar_side: Default::default(),
+            thread_group_by: Default::default(),
+            thread_list_display: agent_settings::ThreadListDisplaySettings {
+                show_timestamp: true,
+                show_branch: true,
+                show_diff_stats: true,
+            },
             thinking_display: Default::default(),
         };
 

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -978,6 +978,7 @@ mod tests {
                 show_branch: true,
                 show_diff_stats: true,
             },
+            thread_filter: Default::default(),
             thinking_display: Default::default(),
         };
 

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -59,6 +59,9 @@ impl Column for ThreadId {
 
 const THREAD_REMOTE_CONNECTION_MIGRATION_KEY: &str = "thread-metadata-remote-connection-backfill";
 const THREAD_ID_MIGRATION_KEY: &str = "thread-metadata-thread-id-backfill";
+/// Key under which the set of pinned thread ids is persisted (as a JSON array)
+/// in the global key-value store.
+const PINNED_THREADS_KEY: &str = "agent-pinned-threads";
 
 /// List all sidebar thread metadata from an arbitrary SQLite connection.
 ///
@@ -503,6 +506,9 @@ pub struct ThreadMetadataStore {
     threads_by_paths: HashMap<PathList, HashSet<ThreadId>>,
     threads_by_main_paths: HashMap<PathList, HashSet<ThreadId>>,
     threads_by_session: HashMap<acp::SessionId, ThreadId>,
+    /// Thread ids the user has pinned to the top of the sidebar. Persisted to
+    /// the key-value store under [`PINNED_THREADS_KEY`].
+    pinned: HashSet<ThreadId>,
     reload_task: Option<Shared<Task<()>>>,
     conversation_subscriptions: HashMap<gpui::EntityId, Subscription>,
     pending_thread_ops_tx: async_channel::Sender<DbOperation>,
@@ -880,6 +886,67 @@ impl ThreadMetadataStore {
         self.in_flight_archives.remove(&thread_id);
     }
 
+    /// Whether the given thread is pinned to the top of the sidebar.
+    pub fn is_pinned(&self, thread_id: &ThreadId) -> bool {
+        self.pinned.contains(thread_id)
+    }
+
+    /// Whether any thread is currently pinned.
+    pub fn has_pinned(&self) -> bool {
+        !self.pinned.is_empty()
+    }
+
+    /// Pins or unpins a thread, persisting the change to the key-value store.
+    pub fn set_pinned(&mut self, thread_id: ThreadId, pinned: bool, cx: &mut Context<Self>) {
+        let changed = if pinned {
+            self.pinned.insert(thread_id)
+        } else {
+            self.pinned.remove(&thread_id)
+        };
+        if !changed {
+            return;
+        }
+        self.persist_pinned(cx);
+        cx.notify();
+    }
+
+    /// Toggles the pinned state of a thread.
+    pub fn toggle_pinned(&mut self, thread_id: ThreadId, cx: &mut Context<Self>) {
+        let pinned = !self.is_pinned(&thread_id);
+        self.set_pinned(thread_id, pinned, cx);
+    }
+
+    fn load_pinned(&mut self, cx: &mut Context<Self>) {
+        let kvp = KeyValueStore::global(cx);
+        cx.spawn(async move |this, cx| {
+            let Some(raw) = kvp.read_kvp(PINNED_THREADS_KEY).log_err().flatten() else {
+                return;
+            };
+            let Some(ids) = serde_json::from_str::<HashSet<ThreadId>>(&raw).log_err() else {
+                return;
+            };
+            this.update(cx, |this, cx| {
+                this.pinned = ids;
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn persist_pinned(&self, cx: &mut Context<Self>) {
+        let kvp = KeyValueStore::global(cx);
+        let Some(serialized) = serde_json::to_string(&self.pinned).log_err() else {
+            return;
+        };
+        cx.spawn(async move |_, _| {
+            kvp.write_kvp(PINNED_THREADS_KEY.to_string(), serialized)
+                .await
+                .log_err();
+        })
+        .detach();
+    }
+
     /// Returns `true` if any unarchived thread other than `thread_id`
     /// references `path` in its folder paths. Used to determine whether a
     /// worktree can safely be removed from disk.
@@ -1241,6 +1308,7 @@ impl ThreadMetadataStore {
             threads_by_paths: HashMap::default(),
             threads_by_main_paths: HashMap::default(),
             threads_by_session: HashMap::default(),
+            pinned: HashSet::default(),
             reload_task: None,
             conversation_subscriptions: HashMap::default(),
             pending_thread_ops_tx: tx,
@@ -1248,6 +1316,7 @@ impl ThreadMetadataStore {
             _db_operations_task,
         };
         let _ = this.reload(cx);
+        this.load_pinned(cx);
         this
     }
 

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -1,3 +1,4 @@
+use std::rc::Rc;
 use std::sync::Arc;
 
 use fuzzy_nucleo::{StringMatch, StringMatchCandidate, match_strings};
@@ -28,11 +29,19 @@ pub struct SidebarRecentProjects {
     _subscription: Subscription,
 }
 
+/// Invoked when a recent project is chosen from the popover. Receives the
+/// selected project's [`ProjectGroupKey`]. When provided to
+/// [`SidebarRecentProjects::popover`], it replaces the default behavior (which
+/// simply opens/activates the project), letting callers do something else with
+/// the selected workspace, such as creating a new thread in it.
+pub type OnConfirmWorkspace = Rc<dyn Fn(ProjectGroupKey, &mut Window, &mut App)>;
+
 impl SidebarRecentProjects {
     pub fn popover(
         workspace: WeakEntity<Workspace>,
         window_project_groups: Vec<ProjectGroupKey>,
         _focus_handle: FocusHandle,
+        on_confirm: Option<OnConfirmWorkspace>,
         window: &mut Window,
         cx: &mut App,
     ) -> Entity<Self> {
@@ -44,6 +53,7 @@ impl SidebarRecentProjects {
             let delegate = SidebarRecentProjectsDelegate {
                 workspace,
                 window_project_groups,
+                on_confirm,
                 workspaces: Vec::new(),
                 filtered_workspaces: Vec::new(),
                 selected_index: 0,
@@ -113,6 +123,7 @@ impl Render for SidebarRecentProjects {
 pub struct SidebarRecentProjectsDelegate {
     workspace: WeakEntity<Workspace>,
     window_project_groups: Vec<ProjectGroupKey>,
+    on_confirm: Option<OnConfirmWorkspace>,
     workspaces: Vec<RecentWorkspace>,
     filtered_workspaces: Vec<StringMatch>,
     selected_index: usize,
@@ -239,6 +250,13 @@ impl PickerDelegate for SidebarRecentProjectsDelegate {
         let Some(recent_workspace) = self.workspaces.get(hit.candidate_id) else {
             return;
         };
+
+        if let Some(on_confirm) = self.on_confirm.clone() {
+            let key = recent_workspace.project_group_key();
+            on_confirm(key, window, cx);
+            cx.emit(DismissEvent);
+            return;
+        }
 
         let Some(workspace) = self.workspace.upgrade() else {
             return;

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -71,6 +71,34 @@ pub enum ThinkingBlockDisplay {
     AlwaysCollapsed,
 }
 
+/// How threads in the agent sidebar's thread list are grouped.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ThreadGroupBy {
+    /// Group threads by the workspace (project group) they belong to.
+    #[default]
+    Workspace,
+    /// Group threads by when they were last updated (Today, Yesterday, This
+    /// Week, etc.). This matches the dedicated thread history view.
+    Updated,
+    /// Group threads by their current status (running, waiting, completed,
+    /// etc.).
+    Status,
+}
+
 /// Threshold at which agent auto-compaction runs. See
 /// [`AutoCompactSettingsContent::threshold`] for the accepted formats.
 ///
@@ -188,6 +216,26 @@ pub struct AutoCompactSettingsContent {
     pub threshold: Option<AutoCompactThreshold>,
 }
 
+/// Controls which metadata is shown for each thread in the agent sidebar's
+/// thread list.
+#[with_fallible_options]
+#[derive(Clone, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, Default)]
+pub struct ThreadListDisplaySettingsContent {
+    /// Whether to show each thread's last-updated timestamp.
+    ///
+    /// Default: true
+    pub show_timestamp: Option<bool>,
+    /// Whether to show the git branch / linked-worktree chips for each thread.
+    ///
+    /// Default: true
+    pub show_branch: Option<bool>,
+    /// Whether to show the diff stats (added/removed line counts) for each
+    /// thread.
+    ///
+    /// Default: true
+    pub show_diff_stats: Option<bool>,
+}
+
 #[with_fallible_options]
 #[derive(Clone, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, Default)]
 pub struct AgentSettingsContent {
@@ -211,6 +259,13 @@ pub struct AgentSettingsContent {
     ///
     /// Default: left
     pub sidebar_side: Option<SidebarDockPosition>,
+    /// How threads in the agent sidebar's thread list are grouped.
+    ///
+    /// Default: workspace
+    pub thread_group_by: Option<ThreadGroupBy>,
+    /// Controls which metadata is shown for each thread in the sidebar's
+    /// thread list.
+    pub thread_list_display: Option<ThreadListDisplaySettingsContent>,
     /// Default width in pixels when the agent panel is docked to the left or right.
     ///
     /// Default: 640
@@ -349,6 +404,10 @@ impl AgentSettingsContent {
 
     pub fn set_sidebar_side(&mut self, position: SidebarDockPosition) {
         self.sidebar_side = Some(position);
+    }
+
+    pub fn set_thread_group_by(&mut self, group_by: ThreadGroupBy) {
+        self.thread_group_by = Some(group_by);
     }
 
     pub fn set_flexible_size(&mut self, flexible: bool) {

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -99,6 +99,51 @@ pub enum ThreadGroupBy {
     Status,
 }
 
+/// A status category the agent sidebar's thread list can be filtered to (see
+/// the "Filter by" menu). Multiple may be active at once.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ThreadStatusFilter {
+    /// Threads that are currently running.
+    Running,
+    /// Threads waiting on the user (e.g. tool confirmation).
+    NeedsAttention,
+    /// Threads that have finished.
+    Completed,
+    /// Threads that ended in an error.
+    Error,
+}
+
+/// A thread source the agent sidebar's thread list can be filtered to (see the
+/// "Filter by" menu). Multiple may be active at once.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ThreadSourceFilter {
+    /// Threads created by the built-in Zed agent.
+    Zed,
+    /// Threads created by external agents.
+    External,
+}
+
+/// Persisted state of the agent sidebar's "Filter by" menu. An empty (or
+/// missing) list for a category means that category is not filtered.
+#[with_fallible_options]
+#[derive(Clone, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, Default)]
+pub struct ThreadFilterSettingsContent {
+    /// Restrict the thread list to threads matching any of these statuses.
+    ///
+    /// Default: []
+    pub status: Option<Vec<ThreadStatusFilter>>,
+    /// Restrict the thread list to threads from any of these sources.
+    ///
+    /// Default: []
+    pub source: Option<Vec<ThreadSourceFilter>>,
+}
+
 /// Threshold at which agent auto-compaction runs. See
 /// [`AutoCompactSettingsContent::threshold`] for the accepted formats.
 ///
@@ -266,6 +311,9 @@ pub struct AgentSettingsContent {
     /// Controls which metadata is shown for each thread in the sidebar's
     /// thread list.
     pub thread_list_display: Option<ThreadListDisplaySettingsContent>,
+    /// Which threads are shown in the sidebar's thread list (the "Filter by"
+    /// menu). Empty lists mean no filtering is applied.
+    pub thread_filter: Option<ThreadFilterSettingsContent>,
     /// Default width in pixels when the agent panel is docked to the left or right.
     ///
     /// Default: 640
@@ -408,6 +456,14 @@ impl AgentSettingsContent {
 
     pub fn set_thread_group_by(&mut self, group_by: ThreadGroupBy) {
         self.thread_group_by = Some(group_by);
+    }
+
+    pub fn set_thread_status_filter(&mut self, status: Vec<ThreadStatusFilter>) {
+        self.thread_filter.get_or_insert_default().status = Some(status);
+    }
+
+    pub fn set_thread_source_filter(&mut self, source: Vec<ThreadSourceFilter>) {
+        self.thread_filter.get_or_insert_default().source = Some(source);
     }
 
     pub fn set_flexible_size(&mut self, flexible: bool) {

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -40,7 +40,7 @@ use menu::{
 };
 use notifications::status_toast::StatusToast;
 use project::{AgentId, AgentRegistryStore, Event as ProjectEvent, WorktreeId};
-use recent_projects::sidebar_recent_projects::SidebarRecentProjects;
+use recent_projects::sidebar_recent_projects::{OnConfirmWorkspace, SidebarRecentProjects};
 use remote::{RemoteConnectionOptions, same_remote_connection_identity};
 use ui::utils::platform_title_bar_height;
 
@@ -891,6 +891,7 @@ pub struct Sidebar {
     view: SidebarView,
     restoring_tasks: HashMap<agent_ui::ThreadId, Task<()>>,
     recent_projects_popover_handle: PopoverMenuHandle<SidebarRecentProjects>,
+    new_thread_popover_handle: PopoverMenuHandle<SidebarRecentProjects>,
     project_header_menu_handles: HashMap<usize, PopoverMenuHandle<ContextMenu>>,
     project_header_new_thread_menu_handles: HashMap<usize, PopoverMenuHandle<ContextMenu>>,
     project_header_menu_ix: Option<usize>,
@@ -1042,6 +1043,7 @@ impl Sidebar {
             view: SidebarView::default(),
             restoring_tasks: HashMap::new(),
             recent_projects_popover_handle: PopoverMenuHandle::default(),
+            new_thread_popover_handle: PopoverMenuHandle::default(),
             project_header_menu_handles: HashMap::new(),
             project_header_new_thread_menu_handles: HashMap::new(),
             project_header_menu_ix: None,
@@ -1453,7 +1455,13 @@ impl Sidebar {
                 |options, window, cx| connect_remote(active_workspace, options, window, cx),
                 &[],
                 None,
-                OpenMode::Activate,
+                // Add (don't activate) so the freshly opened workspace isn't
+                // revealed with its restored last thread while we await the
+                // open. `create_new_entry` below activates the workspace and
+                // creates the new entry in one synchronous block, so the user
+                // lands directly on the new thread without a flash of the
+                // previously active one.
+                OpenMode::Add,
                 window,
                 cx,
             )
@@ -7388,6 +7396,7 @@ impl Sidebar {
                         ws.clone(),
                         window_project_groups.clone(),
                         focus_handle.clone(),
+                        None,
                         window,
                         cx,
                     )
@@ -8266,26 +8275,80 @@ impl Sidebar {
             .child(self.render_recent_projects_button(cx))
     }
 
-    /// The sidebar's single new-thread action, shown to the right of the
-    /// thread search box. The section-based grouping modes
-    /// (updated/status) don't have a meaningful per-group target,
-    /// so this creates a thread in the active workspace. The per-group `+` on
-    /// project headers remains for the workspace grouping, where a group is a
-    /// real container.
+    /// The `+` button shown to the right of the thread search box. It opens the
+    /// same recent-projects popover as the "Add Project" button in the sidebar's
+    /// bottom bar, letting the user pick (or open) the workspace they want to
+    /// start a thread in. The per-group `+` on project headers remains for the
+    /// workspace grouping, where a group is a real container.
     fn render_global_new_thread_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let focus_handle = self.focus_handle.clone();
-        IconButton::new("sidebar-new-thread", IconName::Plus)
-            .icon_size(IconSize::Small)
-            .selected_style(ButtonStyle::Tinted(TintColor::Accent))
-            .tooltip(move |_, cx| {
-                Tooltip::for_action_in("Start New Agent Thread", &NewThread, &focus_handle, cx)
-            })
-            .on_click(cx.listener(|this, _, window, cx| {
-                if let Some(workspace) = this.active_workspace(cx) {
-                    this.selection = None;
-                    this.create_new_entry(&workspace, window, cx);
+
+        let multi_workspace = self.multi_workspace.upgrade();
+
+        let workspace = multi_workspace
+            .as_ref()
+            .map(|mw| mw.read(cx).workspace().downgrade());
+
+        let menu_focus_handle = workspace
+            .as_ref()
+            .and_then(|ws| ws.upgrade())
+            .map(|w| w.read(cx).focus_handle(cx))
+            .unwrap_or_else(|| cx.focus_handle());
+
+        let window_project_groups: Vec<ProjectGroupKey> = multi_workspace
+            .as_ref()
+            .map(|mw| mw.read(cx).project_group_keys())
+            .unwrap_or_default();
+
+        let popover_handle = self.new_thread_popover_handle.clone();
+
+        let this = cx.weak_entity();
+        let on_confirm: OnConfirmWorkspace = Rc::new(move |key, window, cx| {
+            this.update(cx, |sidebar, cx| {
+                sidebar.selection = None;
+                if let Some(workspace) = sidebar.workspace_for_group(&key, cx) {
+                    sidebar.create_new_entry(&workspace, window, cx);
+                } else {
+                    sidebar.open_workspace_and_create_entry(
+                        &key,
+                        NewEntryTarget::LastCreatedKind,
+                        window,
+                        cx,
+                    );
                 }
-            }))
+            })
+            .ok();
+        });
+
+        PopoverMenu::new("sidebar-new-thread-menu")
+            .with_handle(popover_handle)
+            .menu(move |window, cx| {
+                let on_confirm = on_confirm.clone();
+                workspace.as_ref().map(|ws| {
+                    SidebarRecentProjects::popover(
+                        ws.clone(),
+                        window_project_groups.clone(),
+                        menu_focus_handle.clone(),
+                        Some(on_confirm),
+                        window,
+                        cx,
+                    )
+                })
+            })
+            .trigger_with_tooltip(
+                IconButton::new("sidebar-new-thread", IconName::Plus)
+                    .icon_size(IconSize::Small)
+                    .selected_style(ButtonStyle::Tinted(TintColor::Accent)),
+                move |_, cx| {
+                    Tooltip::for_action_in(
+                        "Start New Agent Thread",
+                        &NewThread,
+                        &focus_handle,
+                        cx,
+                    )
+                },
+            )
+            .anchor(gpui::Anchor::TopRight)
     }
 
     fn render_group_by_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -107,7 +107,7 @@ const MAX_WIDTH: Pixels = px(800.0);
 
 /// In the workspace grouping mode, each project group shows at most this many
 /// rows before a "See more" row is shown to reveal the rest.
-const GROUP_THREAD_LIMIT: usize = 5;
+const GROUP_THREAD_LIMIT: usize = 2;
 
 #[derive(Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 enum SerializedSidebarView {
@@ -129,6 +129,50 @@ enum ThreadListDisplayField {
     Timestamp,
     Branch,
     DiffStats,
+}
+
+/// A status category the thread list can be filtered to (see the "Filter by"
+/// menu). Multiple may be active at once.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum ThreadStatusFilter {
+    Running,
+    NeedsAttention,
+    Completed,
+    Error,
+}
+
+/// A thread source the thread list can be filtered to (see the "Filter by"
+/// menu). Multiple may be active at once.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum ThreadSourceFilter {
+    Zed,
+    External,
+}
+
+const ALL_STATUS_FILTERS: &[ThreadStatusFilter] = &[
+    ThreadStatusFilter::Running,
+    ThreadStatusFilter::NeedsAttention,
+    ThreadStatusFilter::Completed,
+    ThreadStatusFilter::Error,
+];
+
+const ALL_SOURCE_FILTERS: &[ThreadSourceFilter] =
+    &[ThreadSourceFilter::Zed, ThreadSourceFilter::External];
+
+fn thread_status_filter_label(filter: ThreadStatusFilter) -> &'static str {
+    match filter {
+        ThreadStatusFilter::Running => "Running",
+        ThreadStatusFilter::NeedsAttention => "Needs Attention",
+        ThreadStatusFilter::Completed => "Completed",
+        ThreadStatusFilter::Error => "Error",
+    }
+}
+
+fn thread_source_filter_label(filter: ThreadSourceFilter) -> &'static str {
+    match filter {
+        ThreadSourceFilter::Zed => "Zed Agent",
+        ThreadSourceFilter::External => "External Agents",
+    }
 }
 
 #[derive(Default, Serialize, Deserialize)]
@@ -544,7 +588,14 @@ impl From<TerminalEntry> for ListEntry {
 
 #[derive(Default)]
 struct SidebarContents {
+    /// The rendered entries: workspace groups truncated to
+    /// [`GROUP_THREAD_LIMIT`] with "See more" rows. Used for rendering,
+    /// selection, and keyboard navigation.
     entries: Vec<ListEntry>,
+    /// Every entry, untruncated. Used by consumers that must see all threads
+    /// regardless of "See more" truncation (the thread switcher and thread
+    /// cycling).
+    all_entries: Vec<ListEntry>,
     notified_threads: HashSet<agent_ui::ThreadId>,
     notified_terminals: HashSet<TerminalId>,
     project_header_indices: Vec<usize>,
@@ -827,6 +878,11 @@ pub struct Sidebar {
     /// Workspace groups the user has expanded past [`GROUP_THREAD_LIMIT`] via
     /// the "See more" row. Groups not in this set are truncated.
     groups_showing_all: HashSet<ProjectGroupKey>,
+    /// Active status filters (see the "Filter by" menu). Empty means no status
+    /// filtering. Ephemeral (not persisted across restarts).
+    status_filter: HashSet<ThreadStatusFilter>,
+    /// Active source filters. Empty means no source filtering. Ephemeral.
+    source_filter: HashSet<ThreadSourceFilter>,
     view: SidebarView,
     restoring_tasks: HashMap<agent_ui::ThreadId, Task<()>>,
     recent_projects_popover_handle: PopoverMenuHandle<SidebarRecentProjects>,
@@ -975,6 +1031,8 @@ impl Sidebar {
             draft_kinds: HashMap::new(),
             collapsed_sections: HashSet::new(),
             groups_showing_all: HashSet::new(),
+            status_filter: HashSet::new(),
+            source_filter: HashSet::new(),
             view: SidebarView::default(),
             restoring_tasks: HashMap::new(),
             recent_projects_popover_handle: PopoverMenuHandle::default(),
@@ -2006,6 +2064,14 @@ impl Sidebar {
                 }
             }
 
+            // Apply the active status/source filters (no-op when none are set).
+            // Filtered-out rows are simply hidden from the list.
+            if self.has_active_filter() {
+                threads.retain(|thread| self.thread_matches_filter(thread));
+                let terminal_matches = self.terminal_matches_filter();
+                terminals.retain(|_| terminal_matches);
+            }
+
             // Pull pinned threads out of this group (outside of search) so they
             // surface in the top "Pinned" section instead of being truncated,
             // bucketed into a section, or hidden by collapse.
@@ -2187,26 +2253,16 @@ impl Sidebar {
                     continue;
                 }
 
-                if mode_uses_sections(group_by) {
-                    // Section modes regroup every thread below, so emit them
-                    // all here without truncation.
-                    Self::push_entries_by_display_time(
-                        &mut entries,
-                        terminals,
-                        threads,
-                        &mut current_session_ids,
-                        &mut current_thread_ids,
-                    );
-                } else {
-                    self.push_group_entries_truncated(
-                        group_key,
-                        &mut entries,
-                        terminals,
-                        threads,
-                        &mut current_session_ids,
-                        &mut current_thread_ids,
-                    );
-                }
+                // Emit every row here; workspace-group truncation ("See more")
+                // is applied as a post-pass so the untruncated list remains
+                // available for the thread switcher and cycling.
+                Self::push_entries_by_display_time(
+                    &mut entries,
+                    terminals,
+                    threads,
+                    &mut current_session_ids,
+                    &mut current_thread_ids,
+                );
             }
         }
 
@@ -2230,12 +2286,18 @@ impl Sidebar {
         // Prepend the collected pinned threads as a "Pinned" section at the
         // very top. A no-op when nothing is pinned, so the default layout (and
         // existing tests) are unaffected.
-        let (entries, project_header_indices) = self.prepend_pinned_section(
+        let (all_entries, _) = self.prepend_pinned_section(
             pinned_entries,
             entries,
             project_header_indices,
             &notified_threads,
         );
+
+        // The full (untruncated) list feeds the thread switcher and cycling;
+        // the rendered list truncates each workspace group to
+        // `GROUP_THREAD_LIMIT` with a "See more" row.
+        let (entries, project_header_indices) =
+            self.truncate_workspace_groups(&all_entries, group_by);
 
         notified_threads.retain(|id| current_thread_ids.contains(id));
 
@@ -2248,6 +2310,7 @@ impl Sidebar {
 
         self.contents = SidebarContents {
             entries,
+            all_entries,
             notified_threads,
             notified_terminals,
             project_header_indices,
@@ -3543,6 +3606,65 @@ impl Sidebar {
     /// truncation).
     fn show_all_in_group(&mut self, key: &ProjectGroupKey, cx: &mut Context<Self>) {
         if self.groups_showing_all.insert(key.clone()) {
+            self.update_entries(cx);
+        }
+    }
+
+    /// Whether any status or source filter is active.
+    fn has_active_filter(&self) -> bool {
+        !self.status_filter.is_empty() || !self.source_filter.is_empty()
+    }
+
+    /// Whether a thread passes the active status/source filters.
+    fn thread_matches_filter(&self, thread: &ThreadEntry) -> bool {
+        if !self.status_filter.is_empty() {
+            let category = match thread.status {
+                AgentThreadStatus::Running => ThreadStatusFilter::Running,
+                AgentThreadStatus::WaitingForConfirmation => ThreadStatusFilter::NeedsAttention,
+                AgentThreadStatus::Error => ThreadStatusFilter::Error,
+                AgentThreadStatus::Completed => ThreadStatusFilter::Completed,
+            };
+            if !self.status_filter.contains(&category) {
+                return false;
+            }
+        }
+        if !self.source_filter.is_empty() {
+            let source = if thread.metadata.agent_id.as_ref() == ZED_AGENT_ID.as_ref() {
+                ThreadSourceFilter::Zed
+            } else {
+                ThreadSourceFilter::External
+            };
+            if !self.source_filter.contains(&source) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Whether a terminal passes the active filters. Terminals are treated as
+    /// running processes for the status filter and are not source-filtered.
+    fn terminal_matches_filter(&self) -> bool {
+        self.status_filter.is_empty() || self.status_filter.contains(&ThreadStatusFilter::Running)
+    }
+
+    fn toggle_status_filter(&mut self, filter: ThreadStatusFilter, cx: &mut Context<Self>) {
+        if !self.status_filter.remove(&filter) {
+            self.status_filter.insert(filter);
+        }
+        self.update_entries(cx);
+    }
+
+    fn toggle_source_filter(&mut self, filter: ThreadSourceFilter, cx: &mut Context<Self>) {
+        if !self.source_filter.remove(&filter) {
+            self.source_filter.insert(filter);
+        }
+        self.update_entries(cx);
+    }
+
+    fn clear_filters(&mut self, cx: &mut Context<Self>) {
+        if self.has_active_filter() {
+            self.status_filter.clear();
+            self.source_filter.clear();
             self.update_entries(cx);
         }
     }
@@ -6247,61 +6369,78 @@ impl Sidebar {
         }
     }
 
-    /// Pushes a workspace group's rows, truncating to [`GROUP_THREAD_LIMIT`]
-    /// with a trailing "See more" row unless the group has been expanded by the
-    /// user. Every row (visible or hidden) is still registered in the current
-    /// id sets so notification state is preserved.
-    fn push_group_entries_truncated(
+    /// Produces the rendered entry list by truncating each workspace project
+    /// group to [`GROUP_THREAD_LIMIT`] rows, appending a "See more" row for the
+    /// remainder. Groups the user has expanded (and the group containing the
+    /// active thread) are shown in full. Section-grouping modes and the Pinned
+    /// section are never truncated.
+    ///
+    /// Returns the truncated entries and their header indices (for sticky
+    /// headers).
+    fn truncate_workspace_groups(
         &self,
-        group_key: &ProjectGroupKey,
-        entries: &mut Vec<ListEntry>,
-        terminals: Vec<TerminalEntry>,
-        threads: Vec<Arc<ThreadEntry>>,
-        current_session_ids: &mut HashSet<acp::SessionId>,
-        current_thread_ids: &mut HashSet<agent_ui::ThreadId>,
-    ) {
-        let mut rows: Vec<ListEntry> = terminals
-            .into_iter()
-            .map(ListEntry::Terminal)
-            .chain(threads.into_iter().map(ListEntry::Thread))
-            .collect();
-        rows.sort_by_key(|entry| std::cmp::Reverse(list_entry_display_time(entry)));
+        entries: &[ListEntry],
+        group_by: ThreadGroupBy,
+    ) -> (Vec<ListEntry>, Vec<usize>) {
+        if mode_uses_sections(group_by) {
+            let out = entries.to_vec();
+            let indices = list_entry_header_indices(&out);
+            return (out, indices);
+        }
 
-        for entry in &rows {
-            if let ListEntry::Thread(thread) = entry {
-                if let Some(session_id) = &thread.metadata.session_id {
-                    current_session_ids.insert(session_id.clone());
+        let mut out: Vec<ListEntry> = Vec::with_capacity(entries.len());
+        let mut ix = 0;
+        while ix < entries.len() {
+            match &entries[ix] {
+                ListEntry::ProjectHeader { key, .. } => {
+                    let key = key.clone();
+                    out.push(entries[ix].clone());
+                    ix += 1;
+
+                    let start = ix;
+                    while ix < entries.len()
+                        && matches!(
+                            entries[ix],
+                            ListEntry::Thread(_) | ListEntry::Terminal(_)
+                        )
+                    {
+                        ix += 1;
+                    }
+                    let rows = &entries[start..ix];
+
+                    // Keep the active thread visible by not truncating the
+                    // group that contains it past the limit.
+                    let active_beyond_limit = rows
+                        .iter()
+                        .position(|entry| {
+                            self.active_entry
+                                .as_ref()
+                                .is_some_and(|active| active.matches_entry(entry))
+                        })
+                        .is_some_and(|index| index >= GROUP_THREAD_LIMIT);
+
+                    if self.groups_showing_all.contains(&key)
+                        || rows.len() <= GROUP_THREAD_LIMIT
+                        || active_beyond_limit
+                    {
+                        out.extend_from_slice(rows);
+                    } else {
+                        out.extend(rows[..GROUP_THREAD_LIMIT].iter().cloned());
+                        out.push(ListEntry::SeeMore {
+                            key,
+                            hidden_count: rows.len() - GROUP_THREAD_LIMIT,
+                        });
+                    }
                 }
-                current_thread_ids.insert(thread.metadata.thread_id);
+                other => {
+                    out.push(other.clone());
+                    ix += 1;
+                }
             }
         }
 
-        // Keep the active thread visible even if it falls past the limit by
-        // not truncating the group that contains it.
-        let active_beyond_limit = rows
-            .iter()
-            .position(|entry| {
-                self.active_entry
-                    .as_ref()
-                    .is_some_and(|active| active.matches_entry(entry))
-            })
-            .is_some_and(|index| index >= GROUP_THREAD_LIMIT);
-
-        let show_all = self.groups_showing_all.contains(group_key)
-            || rows.len() <= GROUP_THREAD_LIMIT
-            || active_beyond_limit;
-
-        if show_all {
-            entries.extend(rows);
-            return;
-        }
-
-        let hidden_count = rows.len() - GROUP_THREAD_LIMIT;
-        entries.extend(rows.into_iter().take(GROUP_THREAD_LIMIT));
-        entries.push(ListEntry::SeeMore {
-            key: group_key.clone(),
-            hidden_count,
-        });
+        let indices = list_entry_header_indices(&out);
+        (out, indices)
     }
 
     /// The sort order used by the ctrl-tab switcher
@@ -6333,7 +6472,7 @@ impl Sidebar {
         let mut current_header_key: Option<ProjectGroupKey> = None;
         let mut entries: Vec<ThreadSwitcherEntry> = self
             .contents
-            .entries
+            .all_entries
             .iter()
             .filter_map(|entry| match entry {
                 ListEntry::ProjectHeader { label, key, .. } => {
@@ -7788,7 +7927,7 @@ impl Sidebar {
     fn cycle_thread_impl(&mut self, forward: bool, window: &mut Window, cx: &mut Context<Self>) {
         let thread_indices: Vec<usize> = self
             .contents
-            .entries
+            .all_entries
             .iter()
             .enumerate()
             .filter_map(|(ix, entry)| match entry {
@@ -7804,7 +7943,7 @@ impl Sidebar {
         let current_thread_pos = self.active_entry.as_ref().and_then(|active| {
             thread_indices
                 .iter()
-                .position(|&ix| active.matches_entry(&self.contents.entries[ix]))
+                .position(|&ix| active.matches_entry(&self.contents.all_entries[ix]))
         });
 
         let next_pos = match current_thread_pos {
@@ -7820,7 +7959,7 @@ impl Sidebar {
         };
 
         let entry_ix = thread_indices[next_pos];
-        match &self.contents.entries[entry_ix] {
+        match &self.contents.all_entries[entry_ix] {
             ListEntry::Thread(thread) => {
                 let metadata = thread.metadata.clone();
                 match &thread.workspace {
@@ -8203,6 +8342,84 @@ impl Sidebar {
                             );
                         }
 
+                        // "Filter by" section: narrow the list to threads
+                        // matching the selected status and/or source.
+                        menu = menu.separator().header("Filter by");
+                        {
+                            let this = this.clone();
+                            menu = menu.submenu_with_icon(
+                                "Status",
+                                IconName::Circle,
+                                move |mut submenu, _window, submenu_cx| {
+                                    let active = this
+                                        .read_with(submenu_cx, |sidebar, _| {
+                                            sidebar.status_filter.clone()
+                                        })
+                                        .unwrap_or_default();
+                                    for &filter in ALL_STATUS_FILTERS {
+                                        let this = this.clone();
+                                        let enabled = active.contains(&filter);
+                                        submenu = submenu.toggleable_entry(
+                                            thread_status_filter_label(filter),
+                                            enabled,
+                                            IconPosition::End,
+                                            None,
+                                            move |_window, cx| {
+                                                this.update(cx, |sidebar, cx| {
+                                                    sidebar.toggle_status_filter(filter, cx);
+                                                })
+                                                .ok();
+                                            },
+                                        );
+                                    }
+                                    submenu
+                                },
+                            );
+                        }
+                        {
+                            let this = this.clone();
+                            menu = menu.submenu_with_icon(
+                                "Source",
+                                IconName::Sparkle,
+                                move |mut submenu, _window, submenu_cx| {
+                                    let active = this
+                                        .read_with(submenu_cx, |sidebar, _| {
+                                            sidebar.source_filter.clone()
+                                        })
+                                        .unwrap_or_default();
+                                    for &filter in ALL_SOURCE_FILTERS {
+                                        let this = this.clone();
+                                        let enabled = active.contains(&filter);
+                                        submenu = submenu.toggleable_entry(
+                                            thread_source_filter_label(filter),
+                                            enabled,
+                                            IconPosition::End,
+                                            None,
+                                            move |_window, cx| {
+                                                this.update(cx, |sidebar, cx| {
+                                                    sidebar.toggle_source_filter(filter, cx);
+                                                })
+                                                .ok();
+                                            },
+                                        );
+                                    }
+                                    submenu
+                                },
+                            );
+                        }
+                        if this
+                            .read_with(_cx, |sidebar, _| sidebar.has_active_filter())
+                            .unwrap_or(false)
+                        {
+                            let this = this.clone();
+                            menu = menu.entry("Clear Filters", None, move |_window, cx| {
+                                this.update(cx, |sidebar, cx| {
+                                    sidebar.clear_filters(cx);
+                                })
+                                .ok();
+                            });
+                        }
+
                         // Collapse/expand only affect the workspace-grouped list.
                         if !is_archive {
                             menu = menu.separator();
@@ -8231,6 +8448,7 @@ impl Sidebar {
             .trigger_with_tooltip(
                 IconButton::new("group-by", IconName::ListFilter)
                     .icon_size(IconSize::Small)
+                    .toggle_state(self.has_active_filter())
                     .selected_style(ButtonStyle::Tinted(TintColor::Accent)),
                 Tooltip::text("Group & Filter Threads"),
             )

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -46,7 +46,7 @@ use ui::utils::platform_title_bar_height;
 
 use serde::{Deserialize, Serialize};
 use settings::Settings as _;
-use settings::{SettingsStore, ThreadGroupBy};
+use settings::{SettingsStore, ThreadGroupBy, ThreadSourceFilter, ThreadStatusFilter};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::mem;
@@ -131,24 +131,6 @@ enum ThreadListDisplayField {
     DiffStats,
 }
 
-/// A status category the thread list can be filtered to (see the "Filter by"
-/// menu). Multiple may be active at once.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-enum ThreadStatusFilter {
-    Running,
-    NeedsAttention,
-    Completed,
-    Error,
-}
-
-/// A thread source the thread list can be filtered to (see the "Filter by"
-/// menu). Multiple may be active at once.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-enum ThreadSourceFilter {
-    Zed,
-    External,
-}
-
 const ALL_STATUS_FILTERS: &[ThreadStatusFilter] = &[
     ThreadStatusFilter::Running,
     ThreadStatusFilter::NeedsAttention,
@@ -158,6 +140,28 @@ const ALL_STATUS_FILTERS: &[ThreadStatusFilter] = &[
 
 const ALL_SOURCE_FILTERS: &[ThreadSourceFilter] =
     &[ThreadSourceFilter::Zed, ThreadSourceFilter::External];
+
+/// Reads the persisted status filters from settings into the in-memory set used
+/// for rendering and filtering.
+fn status_filter_from_settings(cx: &App) -> HashSet<ThreadStatusFilter> {
+    AgentSettings::get_global(cx)
+        .thread_filter
+        .status
+        .iter()
+        .copied()
+        .collect()
+}
+
+/// Reads the persisted source filters from settings into the in-memory set used
+/// for rendering and filtering.
+fn source_filter_from_settings(cx: &App) -> HashSet<ThreadSourceFilter> {
+    AgentSettings::get_global(cx)
+        .thread_filter
+        .source
+        .iter()
+        .copied()
+        .collect()
+}
 
 fn thread_status_filter_label(filter: ThreadStatusFilter) -> &'static str {
     match filter {
@@ -879,9 +883,10 @@ pub struct Sidebar {
     /// the "See more" row. Groups not in this set are truncated.
     groups_showing_all: HashSet<ProjectGroupKey>,
     /// Active status filters (see the "Filter by" menu). Empty means no status
-    /// filtering. Ephemeral (not persisted across restarts).
+    /// filtering. Mirrors `agent.thread_filter.status` and is persisted there.
     status_filter: HashSet<ThreadStatusFilter>,
-    /// Active source filters. Empty means no source filtering. Ephemeral.
+    /// Active source filters. Empty means no source filtering. Mirrors
+    /// `agent.thread_filter.source` and is persisted there.
     source_filter: HashSet<ThreadSourceFilter>,
     view: SidebarView,
     restoring_tasks: HashMap<agent_ui::ThreadId, Task<()>>,
@@ -980,6 +985,7 @@ impl Sidebar {
         // other settings-driven rendering) stays in sync, including changes
         // made directly in settings.json or from the group-by menu.
         cx.observe_global::<SettingsStore>(|this, cx| {
+            this.sync_filters_from_settings(cx);
             this.schedule_update_entries(false, cx);
         })
         .detach();
@@ -1031,8 +1037,8 @@ impl Sidebar {
             draft_kinds: HashMap::new(),
             collapsed_sections: HashSet::new(),
             groups_showing_all: HashSet::new(),
-            status_filter: HashSet::new(),
-            source_filter: HashSet::new(),
+            status_filter: status_filter_from_settings(cx),
+            source_filter: source_filter_from_settings(cx),
             view: SidebarView::default(),
             restoring_tasks: HashMap::new(),
             recent_projects_popover_handle: PopoverMenuHandle::default(),
@@ -3651,6 +3657,7 @@ impl Sidebar {
         if !self.status_filter.remove(&filter) {
             self.status_filter.insert(filter);
         }
+        self.persist_filters(cx);
         self.update_entries(cx);
     }
 
@@ -3658,6 +3665,7 @@ impl Sidebar {
         if !self.source_filter.remove(&filter) {
             self.source_filter.insert(filter);
         }
+        self.persist_filters(cx);
         self.update_entries(cx);
     }
 
@@ -3665,8 +3673,40 @@ impl Sidebar {
         if self.has_active_filter() {
             self.status_filter.clear();
             self.source_filter.clear();
+            self.persist_filters(cx);
             self.update_entries(cx);
         }
+    }
+
+    /// Re-syncs the in-memory filter sets from settings, e.g. after a change
+    /// made in another window or directly in settings.json.
+    fn sync_filters_from_settings(&mut self, cx: &App) {
+        self.status_filter = status_filter_from_settings(cx);
+        self.source_filter = source_filter_from_settings(cx);
+    }
+
+    /// Persists the active status/source filters to the user's settings so they
+    /// survive restarts. Filters are written in their canonical menu order for
+    /// stable, readable settings output.
+    fn persist_filters(&self, cx: &mut Context<Self>) {
+        let Some(fs) = self.workspace_fs(cx) else {
+            return;
+        };
+        let status: Vec<ThreadStatusFilter> = ALL_STATUS_FILTERS
+            .iter()
+            .copied()
+            .filter(|filter| self.status_filter.contains(filter))
+            .collect();
+        let source: Vec<ThreadSourceFilter> = ALL_SOURCE_FILTERS
+            .iter()
+            .copied()
+            .filter(|filter| self.source_filter.contains(filter))
+            .collect();
+        settings::update_settings_file(fs, cx, move |settings, _cx| {
+            let agent = settings.agent.get_or_insert_default();
+            agent.set_thread_status_filter(status);
+            agent.set_thread_source_filter(source);
+        });
     }
 
     fn toggle_collapse(

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -4847,7 +4847,20 @@ impl Sidebar {
                 self.collapsed_sections.extend(section_ids);
             }
         } else if let Some(mw) = self.multi_workspace.upgrade() {
-            if !expanded {
+            if expanded {
+                // Expanding all groups should also reveal every "See more"
+                // truncation, not just un-collapse the headers.
+                let group_keys: Vec<ProjectGroupKey> = self
+                    .contents
+                    .all_entries
+                    .iter()
+                    .filter_map(|entry| match entry {
+                        ListEntry::ProjectHeader { key, .. } => Some(key.clone()),
+                        _ => None,
+                    })
+                    .collect();
+                self.groups_showing_all.extend(group_keys);
+            } else {
                 // Collapsing all groups resets every "See more" expansion.
                 self.groups_showing_all.clear();
             }

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -22,7 +22,7 @@ use agent_ui::{
     ThreadTitleRegenerationResult, channels_with_threads, import_threads_from_other_channels,
 };
 use agent_ui::{MessageEditorEvent, StateChange, thread_worktree_archive};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Datelike, Local, NaiveDate, TimeDelta, Utc};
 use editor::Editor;
 use feature_flags::{
     AgentThreadWorktreeLabel, AgentThreadWorktreeLabelFlag, FeatureFlag, FeatureFlagAppExt as _,
@@ -46,6 +46,7 @@ use ui::utils::platform_title_bar_height;
 
 use serde::{Deserialize, Serialize};
 use settings::Settings as _;
+use settings::{SettingsStore, ThreadGroupBy};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::mem;
@@ -104,6 +105,10 @@ const DEFAULT_WIDTH: Pixels = px(300.0);
 const MIN_WIDTH: Pixels = px(200.0);
 const MAX_WIDTH: Pixels = px(800.0);
 
+/// In the workspace grouping mode, each project group shows at most this many
+/// rows before a "See more" row is shown to reveal the rest.
+const GROUP_THREAD_LIMIT: usize = 5;
+
 #[derive(Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 enum SerializedSidebarView {
     #[default]
@@ -116,6 +121,14 @@ enum SerializedSidebarView {
 enum NewEntryTarget {
     LastCreatedKind,
     Terminal,
+}
+
+/// A toggleable thread-list display option (see the "Display" menu).
+#[derive(Clone, Copy)]
+enum ThreadListDisplayField {
+    Timestamp,
+    Branch,
+    DiffStats,
 }
 
 #[derive(Default, Serialize, Deserialize)]
@@ -399,6 +412,23 @@ enum ListEntry {
         is_active: bool,
         has_threads: bool,
     },
+    /// A text section header used by the non-workspace grouping modes
+    /// (updated, status, ...). Unlike [`ListEntry::ProjectHeader`]
+    /// this is a lightweight, mode-agnostic header rendered in the
+    /// thread-history style.
+    SectionHeader {
+        /// Stable identifier used to persist this section's collapsed state.
+        id: SharedString,
+        label: SharedString,
+        is_collapsed: bool,
+        has_notifications: bool,
+    },
+    /// A "See more" row shown when a workspace group is truncated to the first
+    /// [`GROUP_THREAD_LIMIT`] rows. Clicking it reveals the rest of the group.
+    SeeMore {
+        key: ProjectGroupKey,
+        hidden_count: usize,
+    },
     Thread(Arc<ThreadEntry>),
     Terminal(TerminalEntry),
 }
@@ -426,7 +456,9 @@ impl ActivatableEntry {
                 metadata: terminal.metadata.clone(),
                 workspace: terminal.workspace.clone(),
             }),
-            ListEntry::ProjectHeader { .. } => None,
+            ListEntry::ProjectHeader { .. }
+            | ListEntry::SectionHeader { .. }
+            | ListEntry::SeeMore { .. } => None,
         }
     }
 
@@ -468,7 +500,10 @@ impl ListEntry {
     fn session_id(&self) -> Option<&acp::SessionId> {
         match self {
             ListEntry::Thread(thread_entry) => thread_entry.metadata.session_id.as_ref(),
-            ListEntry::Terminal(_) | ListEntry::ProjectHeader { .. } => None,
+            ListEntry::Terminal(_)
+            | ListEntry::ProjectHeader { .. }
+            | ListEntry::SectionHeader { .. }
+            | ListEntry::SeeMore { .. } => None,
         }
     }
 
@@ -489,6 +524,8 @@ impl ListEntry {
             ListEntry::ProjectHeader { key, .. } => multi_workspace
                 .workspaces_for_project_group(key, cx)
                 .unwrap_or_default(),
+            ListEntry::SectionHeader { .. } => Vec::new(),
+            ListEntry::SeeMore { .. } => Vec::new(),
         }
     }
 }
@@ -526,6 +563,14 @@ enum EntryShape {
         // Determines whether the "No threads yet" row is rendered (only shown when
         // `!is_collapsed && !has_threads`).
         is_collapsed: bool,
+    },
+    SectionHeader {
+        id: SharedString,
+        is_collapsed: bool,
+    },
+    SeeMore {
+        key: ProjectGroupKey,
+        hidden_count: usize,
     },
     Thread(ThreadId),
     Terminal(TerminalId),
@@ -774,6 +819,14 @@ pub struct Sidebar {
     /// that when a draft that was empty gains content again, we refresh
     /// its interaction time.
     draft_kinds: HashMap<ThreadId, DraftKind>,
+    /// Collapsed state for the text section headers used by the non-workspace
+    /// grouping modes, keyed by [`ListEntry::SectionHeader::id`]. Workspace
+    /// grouping uses the multi-workspace's own per-group collapse state
+    /// instead.
+    collapsed_sections: HashSet<SharedString>,
+    /// Workspace groups the user has expanded past [`GROUP_THREAD_LIMIT`] via
+    /// the "See more" row. Groups not in this set are truncated.
+    groups_showing_all: HashSet<ProjectGroupKey>,
     view: SidebarView,
     restoring_tasks: HashMap<agent_ui::ThreadId, Task<()>>,
     recent_projects_popover_handle: PopoverMenuHandle<SidebarRecentProjects>,
@@ -867,6 +920,14 @@ impl Sidebar {
         )
         .detach();
 
+        // Rebuild when settings change so the thread grouping mode (and any
+        // other settings-driven rendering) stays in sync, including changes
+        // made directly in settings.json or from the group-by menu.
+        cx.observe_global::<SettingsStore>(|this, cx| {
+            this.schedule_update_entries(false, cx);
+        })
+        .detach();
+
         let channels_with_threads = channels_with_threads(cx);
         cx.spawn(async move |this, cx| {
             let channels = channels_with_threads.await;
@@ -886,6 +947,7 @@ impl Sidebar {
                     this.subscribe_to_workspace(workspace, window, cx);
                 }
             }
+            this.apply_thread_group_by(AgentSettings::get_global(cx).thread_group_by, window, cx);
             this.schedule_update_entries(false, cx);
         });
 
@@ -911,6 +973,8 @@ impl Sidebar {
             pending_thread_activation: None,
             live_thread_statuses: HashMap::new(),
             draft_kinds: HashMap::new(),
+            collapsed_sections: HashSet::new(),
+            groups_showing_all: HashSet::new(),
             view: SidebarView::default(),
             restoring_tasks: HashMap::new(),
             recent_projects_popover_handle: PopoverMenuHandle::default(),
@@ -929,6 +993,17 @@ impl Sidebar {
         cx.emit(workspace::SidebarEvent::SerializeNeeded);
     }
 
+    fn is_section_collapsed(&self, id: &SharedString) -> bool {
+        self.collapsed_sections.contains(id)
+    }
+
+    fn toggle_section_collapsed(&mut self, id: &SharedString, cx: &mut Context<Self>) {
+        if !self.collapsed_sections.remove(id) {
+            self.collapsed_sections.insert(id.clone());
+        }
+        self.update_entries(cx);
+    }
+
     fn is_group_collapsed(&self, key: &ProjectGroupKey, cx: &App) -> bool {
         self.multi_workspace
             .upgrade()
@@ -940,7 +1015,12 @@ impl Sidebar {
             .unwrap_or(false)
     }
 
-    fn set_group_expanded(&self, key: &ProjectGroupKey, expanded: bool, cx: &mut Context<Self>) {
+    fn set_group_expanded(&mut self, key: &ProjectGroupKey, expanded: bool, cx: &mut Context<Self>) {
+        if !expanded {
+            // Collapsing a group resets its "See more" expansion, so reopening
+            // it returns to the truncated set.
+            self.groups_showing_all.remove(key);
+        }
         if let Some(mw) = self.multi_workspace.upgrade() {
             mw.update(cx, |mw, cx| {
                 if let Some(state) = mw.group_state_by_key_mut(key) {
@@ -1326,6 +1406,122 @@ impl Sidebar {
         .detach_and_log_err(cx);
     }
 
+    /// Regroups a flat list of thread/terminal entries into text section
+    /// headers for the non-workspace grouping modes.
+    ///
+    /// Returns the new entry list (section headers interleaved with their
+    /// entries, collapsed sections omitting their entries) along with the
+    /// indices of the section headers (used for sticky headers).
+    fn regroup_entries_into_sections(
+        &self,
+        mut flat: Vec<ListEntry>,
+        group_by: ThreadGroupBy,
+        notified_threads: &HashSet<agent_ui::ThreadId>,
+        notified_terminals: &HashSet<TerminalId>,
+    ) -> (Vec<ListEntry>, Vec<usize>) {
+        let today = Local::now().naive_local().date();
+
+        // Sort by display time (most recent first) so entries within each
+        // section are ordered by recency.
+        flat.sort_by_key(|entry| std::cmp::Reverse(list_entry_display_time(entry)));
+
+        struct Section {
+            order: u32,
+            id: SharedString,
+            label: SharedString,
+            entries: Vec<ListEntry>,
+        }
+
+        let mut sections: Vec<Section> = Vec::new();
+        let mut index_by_id: HashMap<SharedString, usize> = HashMap::new();
+
+        for entry in flat {
+            let (order, id, label) = section_descriptor_for_entry(&entry, group_by, today);
+            let section_ix = *index_by_id.entry(id.clone()).or_insert_with(|| {
+                sections.push(Section {
+                    order,
+                    id,
+                    label,
+                    entries: Vec::new(),
+                });
+                sections.len() - 1
+            });
+            sections[section_ix].entries.push(entry);
+        }
+
+        sections.sort_by_key(|section| section.order);
+
+        let mut entries: Vec<ListEntry> = Vec::new();
+        let mut header_indices: Vec<usize> = Vec::new();
+        for section in sections {
+            if section.entries.is_empty() {
+                continue;
+            }
+            let is_collapsed = self.is_section_collapsed(&section.id);
+            let has_notifications = section.entries.iter().any(|entry| match entry {
+                ListEntry::Thread(thread) => {
+                    notified_threads.contains(&thread.metadata.thread_id)
+                }
+                ListEntry::Terminal(terminal) => {
+                    notified_terminals.contains(&terminal.metadata.terminal_id)
+                }
+                _ => false,
+            });
+
+            header_indices.push(entries.len());
+            entries.push(ListEntry::SectionHeader {
+                id: section.id,
+                label: section.label,
+                is_collapsed,
+                has_notifications,
+            });
+            if !is_collapsed {
+                entries.extend(section.entries);
+            }
+        }
+
+        (entries, header_indices)
+    }
+
+    /// Prepends the already-collected pinned threads as a "Pinned" section at
+    /// the top of the list. When nothing is pinned, the input is returned
+    /// unchanged (and the header indices are left untouched).
+    fn prepend_pinned_section(
+        &self,
+        mut pinned: Vec<ListEntry>,
+        entries: Vec<ListEntry>,
+        header_indices: Vec<usize>,
+        notified_threads: &HashSet<agent_ui::ThreadId>,
+    ) -> (Vec<ListEntry>, Vec<usize>) {
+        if pinned.is_empty() {
+            return (entries, header_indices);
+        }
+
+        pinned.sort_by_key(|entry| std::cmp::Reverse(list_entry_display_time(entry)));
+
+        let id: SharedString = "pinned".into();
+        let is_collapsed = self.is_section_collapsed(&id);
+        let has_notifications = pinned.iter().any(|entry| match entry {
+            ListEntry::Thread(thread) => notified_threads.contains(&thread.metadata.thread_id),
+            _ => false,
+        });
+
+        let mut out = Vec::with_capacity(entries.len() + 1 + pinned.len());
+        out.push(ListEntry::SectionHeader {
+            id,
+            label: "Pinned".into(),
+            is_collapsed,
+            has_notifications,
+        });
+        if !is_collapsed {
+            out.extend(pinned);
+        }
+        out.extend(entries);
+
+        let header_indices = list_entry_header_indices(&out);
+        (out, header_indices)
+    }
+
     /// Rebuilds the sidebar contents from current workspace and thread state.
     ///
     /// Iterates [`MultiWorkspace::project_group_keys`] to determine project
@@ -1354,6 +1550,15 @@ impl Sidebar {
             .map(|ws| ws.read(cx).project().read(cx).agent_server_store().clone());
 
         let query = self.filter_editor.read(cx).text(cx);
+        let group_by = AgentSettings::get_global(cx).thread_group_by;
+        // The non-workspace grouping modes regroup every thread into text
+        // section headers below, so they must load threads from every project
+        // group regardless of that group's collapsed state.
+        let force_load_threads = group_by != ThreadGroupBy::Workspace;
+        // When threads are pinned we must load every group (even collapsed
+        // ones) so a pinned thread in a collapsed group can still be lifted
+        // into the top "Pinned" section.
+        let has_pinned = ThreadMetadataStore::global(cx).read(cx).has_pinned();
 
         let previous = mem::take(&mut self.contents);
 
@@ -1370,6 +1575,10 @@ impl Sidebar {
         let mut project_header_indices: Vec<usize> = Vec::new();
         let mut seen_thread_ids: HashSet<agent_ui::ThreadId> = HashSet::new();
         let mut seen_terminal_ids: HashSet<TerminalId> = HashSet::new();
+        // Pinned threads collected across all groups, surfaced in a top
+        // "Pinned" section so they bypass truncation, section grouping, and
+        // collapse. Only populated outside of search.
+        let mut pinned_entries: Vec<ListEntry> = Vec::new();
 
         let has_open_projects = workspaces
             .iter()
@@ -1543,7 +1752,8 @@ impl Sidebar {
             let label = group_key.display_name(&path_detail_map);
 
             let is_collapsed = self.is_group_collapsed(group_key, cx);
-            let should_load_threads = !is_collapsed || !query.is_empty();
+            let should_load_threads =
+                force_load_threads || has_pinned || !is_collapsed || !query.is_empty();
 
             let is_active = active_workspace
                 .as_ref()
@@ -1796,6 +2006,29 @@ impl Sidebar {
                 }
             }
 
+            // Pull pinned threads out of this group (outside of search) so they
+            // surface in the top "Pinned" section instead of being truncated,
+            // bucketed into a section, or hidden by collapse.
+            if has_pinned && query.is_empty() && !threads.is_empty() {
+                let store = ThreadMetadataStore::global(cx);
+                let store = store.read(cx);
+                let mut remaining = Vec::with_capacity(threads.len());
+                for thread in threads.drain(..) {
+                    if !thread.metadata.is_draft()
+                        && store.is_pinned(&thread.metadata.thread_id)
+                    {
+                        if let Some(session_id) = &thread.metadata.session_id {
+                            current_session_ids.insert(session_id.clone());
+                        }
+                        current_thread_ids.insert(thread.metadata.thread_id);
+                        pinned_entries.push(ListEntry::Thread(thread));
+                    } else {
+                        remaining.push(thread);
+                    }
+                }
+                threads = remaining;
+            }
+
             let has_visible_rows = !threads.is_empty() || !terminals.is_empty();
             let has_stored_thread_rows = !should_load_threads && !has_visible_rows && {
                 let store = ThreadMetadataStore::global(cx).read(cx);
@@ -1941,19 +2174,68 @@ impl Sidebar {
                     has_threads,
                 });
 
-                if is_collapsed {
+                if is_collapsed && !force_load_threads {
+                    // Register the collapsed group's threads so their
+                    // notification state is retained; pinned threads were
+                    // already pulled out above.
+                    for thread in &threads {
+                        if let Some(session_id) = &thread.metadata.session_id {
+                            current_session_ids.insert(session_id.clone());
+                        }
+                        current_thread_ids.insert(thread.metadata.thread_id);
+                    }
                     continue;
                 }
 
-                Self::push_entries_by_display_time(
-                    &mut entries,
-                    terminals,
-                    threads,
-                    &mut current_session_ids,
-                    &mut current_thread_ids,
-                );
+                if mode_uses_sections(group_by) {
+                    // Section modes regroup every thread below, so emit them
+                    // all here without truncation.
+                    Self::push_entries_by_display_time(
+                        &mut entries,
+                        terminals,
+                        threads,
+                        &mut current_session_ids,
+                        &mut current_thread_ids,
+                    );
+                } else {
+                    self.push_group_entries_truncated(
+                        group_key,
+                        &mut entries,
+                        terminals,
+                        threads,
+                        &mut current_session_ids,
+                        &mut current_thread_ids,
+                    );
+                }
             }
         }
+
+        // For the non-workspace grouping modes, discard the project headers and
+        // regroup every thread/terminal into text section headers.
+        let (entries, project_header_indices) = if mode_uses_sections(group_by) {
+            let flat: Vec<ListEntry> = entries
+                .into_iter()
+                .filter(|entry| matches!(entry, ListEntry::Thread(_) | ListEntry::Terminal(_)))
+                .collect();
+            self.regroup_entries_into_sections(
+                flat,
+                group_by,
+                &notified_threads,
+                &notified_terminals,
+            )
+        } else {
+            (entries, project_header_indices)
+        };
+
+        // Prepend the collected pinned threads as a "Pinned" section at the
+        // very top. A no-op when nothing is pinned, so the default layout (and
+        // existing tests) are unaffected.
+        let (entries, project_header_indices) = self.prepend_pinned_section(
+            pinned_entries,
+            entries,
+            project_header_indices,
+            &notified_threads,
+        );
 
         notified_threads.retain(|id| current_thread_ids.contains(id));
 
@@ -2065,6 +2347,14 @@ impl Sidebar {
                     .map(|state| !state.expanded)
                     .unwrap_or(false),
             },
+            ListEntry::SectionHeader { id, is_collapsed, .. } => EntryShape::SectionHeader {
+                id: id.clone(),
+                is_collapsed: *is_collapsed,
+            },
+            ListEntry::SeeMore { key, hidden_count } => EntryShape::SeeMore {
+                key: key.clone(),
+                hidden_count: *hidden_count,
+            },
             ListEntry::Thread(thread) => EntryShape::Thread(thread.metadata.thread_id),
             ListEntry::Terminal(terminal) => EntryShape::Terminal(terminal.metadata.terminal_id),
         })
@@ -2174,8 +2464,11 @@ impl Sidebar {
         // is_selected means the keyboard selector is here.
         let is_selected = is_focused && self.selection == Some(ix);
 
-        let is_group_header_after_first =
-            ix > 0 && matches!(entry, ListEntry::ProjectHeader { .. });
+        let is_group_header_after_first = ix > 0
+            && matches!(
+                entry,
+                ListEntry::ProjectHeader { .. } | ListEntry::SectionHeader { .. }
+            );
 
         let is_active = self
             .active_entry
@@ -2214,9 +2507,26 @@ impl Sidebar {
                     cx,
                 )
             }
+            ListEntry::SectionHeader {
+                id,
+                label,
+                is_collapsed,
+                has_notifications,
+            } => self.render_section_header(
+                ix,
+                id,
+                label,
+                *is_collapsed,
+                *has_notifications,
+                is_selected,
+                cx,
+            ),
             ListEntry::Thread(thread) => self.render_thread(ix, thread, is_active, is_selected, cx),
             ListEntry::Terminal(terminal) => {
                 self.render_terminal(ix, terminal, is_active, is_selected, cx)
+            }
+            ListEntry::SeeMore { key, hidden_count } => {
+                self.render_see_more(ix, key, *hidden_count, is_selected, cx)
             }
         };
 
@@ -3022,37 +3332,51 @@ impl Sidebar {
             return None;
         }
 
-        let ListEntry::ProjectHeader {
-            key,
-            label,
-            highlight_positions,
-            has_running_threads,
-            waiting_thread_count,
-            has_notifications,
-            is_active,
-            has_threads,
-        } = self.contents.entries.get(header_idx)?
-        else {
-            return None;
-        };
-
         let is_focused = self.focus_handle.is_focused(window);
         let is_selected = is_focused && self.selection == Some(header_idx);
 
-        let header_element = self.render_project_header(
-            header_idx,
-            true,
-            key,
-            &label,
-            &highlight_positions,
-            *has_running_threads,
-            *waiting_thread_count,
-            *has_notifications,
-            *is_active,
-            is_selected,
-            *has_threads,
-            cx,
-        );
+        let header_element = match self.contents.entries.get(header_idx)? {
+            ListEntry::ProjectHeader {
+                key,
+                label,
+                highlight_positions,
+                has_running_threads,
+                waiting_thread_count,
+                has_notifications,
+                is_active,
+                has_threads,
+            } => self.render_project_header(
+                header_idx,
+                true,
+                key,
+                label,
+                highlight_positions,
+                *has_running_threads,
+                *waiting_thread_count,
+                *has_notifications,
+                *is_active,
+                is_selected,
+                *has_threads,
+                cx,
+            ),
+            ListEntry::SectionHeader {
+                id,
+                label,
+                is_collapsed,
+                has_notifications,
+            } => self.render_section_header(
+                header_idx,
+                id,
+                label,
+                *is_collapsed,
+                *has_notifications,
+                is_selected,
+                cx,
+            ),
+            ListEntry::Thread(_) | ListEntry::Terminal(_) | ListEntry::SeeMore { .. } => {
+                return None;
+            }
+        };
 
         let top_offset = self
             .contents
@@ -3086,6 +3410,141 @@ impl Sidebar {
             .into_any_element();
 
         Some(element)
+    }
+
+    /// Renders a section header for the non-workspace grouping modes. Its size
+    /// and layout mirror [`Self::render_project_header`] so the header bar is
+    /// consistent across modes. The row toggles the section's collapsed state
+    /// when clicked.
+    ///
+    /// Unlike project headers, sections have no per-group `+`: a derived bucket
+    /// (e.g. "Yesterday" or "Completed") isn't a container you can create into,
+    /// so the sidebar's single global new-thread button is used instead.
+    fn render_section_header(
+        &self,
+        ix: usize,
+        id: &SharedString,
+        label: &SharedString,
+        is_collapsed: bool,
+        has_notifications: bool,
+        is_selected: bool,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let id_for_toggle = id.clone();
+        let group_name = SharedString::from(format!("section-header-group-{ix}"));
+        let disclosure_icon = if is_collapsed {
+            IconName::ChevronRight
+        } else {
+            IconName::ChevronDown
+        };
+
+        let color = cx.theme().colors();
+        let sidebar_base_bg = color
+            .title_bar_background
+            .blend(color.panel_background.opacity(0.25));
+        let base_bg = color.background.blend(sidebar_base_bg);
+        let hover_base = color
+            .element_active
+            .blend(color.element_background.opacity(0.2));
+        let hover_solid = base_bg.blend(hover_base);
+
+        h_flex()
+            .id(SharedString::from(format!("section-header-{ix}")))
+            .group(&group_name)
+            .cursor_pointer()
+            .relative()
+            .h(Tab::content_height(cx))
+            .w_full()
+            .pl_2()
+            .pr_1p5()
+            .justify_between()
+            .border_1()
+            .map(|this| {
+                if is_selected {
+                    this.border_color(color.border_focused)
+                } else {
+                    this.border_color(gpui::transparent_black())
+                }
+            })
+            .hover(|s| s.bg(hover_solid))
+            .child(
+                h_flex()
+                    .relative()
+                    .min_w_0()
+                    .w_full()
+                    .gap_1()
+                    .child(Label::new(label.clone()).color(Color::Muted).truncate())
+                    // Only surface a notification indicator while collapsed:
+                    // expanded sections already show per-thread status.
+                    .when(is_collapsed && has_notifications, |this| {
+                        this.child(
+                            Icon::new(IconName::Circle)
+                                .size(IconSize::Small)
+                                .color(Color::Accent),
+                        )
+                    })
+                    .child(
+                        div()
+                            .when(!is_selected, |this| this.visible_on_hover(&group_name))
+                            .child(
+                                Icon::new(disclosure_icon)
+                                    .size(IconSize::Small)
+                                    .color(Color::Muted),
+                            ),
+                    ),
+            )
+            .on_click(cx.listener(move |this, _, _window, cx| {
+                this.toggle_section_collapsed(&id_for_toggle, cx);
+            }))
+            .block_mouse_except_scroll()
+            .into_any_element()
+    }
+
+    /// Renders the "See more" row that reveals the rest of a truncated
+    /// workspace group.
+    fn render_see_more(
+        &self,
+        ix: usize,
+        key: &ProjectGroupKey,
+        hidden_count: usize,
+        is_selected: bool,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let key = key.clone();
+        let color = cx.theme().colors();
+        h_flex()
+            .id(SharedString::from(format!("see-more-{ix}")))
+            .w_full()
+            .pl_2()
+            .pr_1p5()
+            .py_0p5()
+            .cursor_pointer()
+            .border_1()
+            .map(|this| {
+                if is_selected {
+                    this.border_color(color.border_focused)
+                } else {
+                    this.border_color(gpui::transparent_black())
+                }
+            })
+            .child(
+                Label::new(format!("See {hidden_count} more"))
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+            )
+            .on_click(cx.listener(move |this, _, _window, cx| {
+                this.show_all_in_group(&key, cx);
+            }))
+            .block_mouse_except_scroll()
+            .into_any_element()
+    }
+
+    /// Reveals every thread in a workspace group (undoes the "See more"
+    /// truncation).
+    fn show_all_in_group(&mut self, key: &ProjectGroupKey, cx: &mut Context<Self>) {
+        if self.groups_showing_all.insert(key.clone()) {
+            self.update_entries(cx);
+        }
     }
 
     fn toggle_collapse(
@@ -3392,6 +3851,10 @@ impl Sidebar {
                 let key = key.clone();
                 self.toggle_collapse(&key, window, cx);
             }
+            ListEntry::SectionHeader { id, .. } => {
+                let id = id.clone();
+                self.toggle_section_collapsed(&id, cx);
+            }
             ListEntry::Thread(thread) => {
                 let metadata = thread.metadata.clone();
                 match &thread.workspace {
@@ -3419,6 +3882,10 @@ impl Sidebar {
                 let metadata = terminal.metadata.clone();
                 let workspace = terminal.workspace.clone();
                 self.activate_terminal_entry(metadata, workspace, false, window, cx);
+            }
+            ListEntry::SeeMore { key, .. } => {
+                let key = key.clone();
+                self.show_all_in_group(&key, cx);
             }
         }
     }
@@ -4110,6 +4577,16 @@ impl Sidebar {
                     cx.notify();
                 }
             }
+            Some(ListEntry::SectionHeader { id, .. }) => {
+                let id = id.clone();
+                if self.is_section_collapsed(&id) {
+                    self.toggle_section_collapsed(&id, cx);
+                } else if ix + 1 < self.contents.entries.len() {
+                    self.selection = Some(ix + 1);
+                    self.list_state.scroll_to_reveal_item(ix + 1);
+                    cx.notify();
+                }
+            }
             _ => {}
         }
     }
@@ -4130,15 +4607,33 @@ impl Sidebar {
                     self.update_entries(cx);
                 }
             }
-            Some(ListEntry::Thread(_) | ListEntry::Terminal(_)) => {
+            Some(ListEntry::SectionHeader { id, .. }) => {
+                let id = id.clone();
+                if !self.is_section_collapsed(&id) {
+                    self.toggle_section_collapsed(&id, cx);
+                }
+            }
+            Some(ListEntry::Thread(_) | ListEntry::Terminal(_) | ListEntry::SeeMore { .. }) => {
                 for i in (0..ix).rev() {
-                    if let Some(ListEntry::ProjectHeader { key, .. }) = self.contents.entries.get(i)
-                    {
-                        let key = key.clone();
-                        self.selection = Some(i);
-                        self.set_group_expanded(&key, false, cx);
-                        self.update_entries(cx);
-                        break;
+                    match self.contents.entries.get(i) {
+                        Some(ListEntry::ProjectHeader { key, .. }) => {
+                            let key = key.clone();
+                            self.selection = Some(i);
+                            self.set_group_expanded(&key, false, cx);
+                            self.update_entries(cx);
+                            break;
+                        }
+                        Some(ListEntry::SectionHeader { id, .. }) => {
+                            let id = id.clone();
+                            self.selection = Some(i);
+                            if !self.is_section_collapsed(&id) {
+                                self.toggle_section_collapsed(&id, cx);
+                            } else {
+                                cx.notify();
+                            }
+                            break;
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -4156,27 +4651,38 @@ impl Sidebar {
 
         // Find the group header for the current selection.
         let header_ix = match self.contents.entries.get(ix) {
-            Some(ListEntry::ProjectHeader { .. }) => Some(ix),
-            Some(ListEntry::Thread(_) | ListEntry::Terminal(_)) => (0..ix).rev().find(|&i| {
+            Some(ListEntry::ProjectHeader { .. } | ListEntry::SectionHeader { .. }) => Some(ix),
+            Some(
+                ListEntry::Thread(_) | ListEntry::Terminal(_) | ListEntry::SeeMore { .. },
+            ) => (0..ix).rev().find(|&i| {
                 matches!(
                     self.contents.entries.get(i),
-                    Some(ListEntry::ProjectHeader { .. })
+                    Some(ListEntry::ProjectHeader { .. } | ListEntry::SectionHeader { .. })
                 )
             }),
             None => None,
         };
 
         if let Some(header_ix) = header_ix {
-            if let Some(ListEntry::ProjectHeader { key, .. }) = self.contents.entries.get(header_ix)
-            {
-                let key = key.clone();
-                if self.is_group_collapsed(&key, cx) {
-                    self.set_group_expanded(&key, true, cx);
-                } else {
-                    self.selection = Some(header_ix);
-                    self.set_group_expanded(&key, false, cx);
+            match self.contents.entries.get(header_ix) {
+                Some(ListEntry::ProjectHeader { key, .. }) => {
+                    let key = key.clone();
+                    if self.is_group_collapsed(&key, cx) {
+                        self.set_group_expanded(&key, true, cx);
+                    } else {
+                        self.selection = Some(header_ix);
+                        self.set_group_expanded(&key, false, cx);
+                    }
+                    self.update_entries(cx);
                 }
-                self.update_entries(cx);
+                Some(ListEntry::SectionHeader { id, .. }) => {
+                    let id = id.clone();
+                    if !self.is_section_collapsed(&id) {
+                        self.selection = Some(header_ix);
+                    }
+                    self.toggle_section_collapsed(&id, cx);
+                }
+                _ => {}
             }
         }
     }
@@ -4187,12 +4693,7 @@ impl Sidebar {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(mw) = self.multi_workspace.upgrade() {
-            mw.update(cx, |mw, _cx| {
-                mw.set_all_groups_expanded(false);
-            });
-        }
-        self.update_entries(cx);
+        self.set_all_groups_expanded(false, cx);
     }
 
     fn unfold_all(
@@ -4201,9 +4702,35 @@ impl Sidebar {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(mw) = self.multi_workspace.upgrade() {
+        self.set_all_groups_expanded(true, cx);
+    }
+
+    /// Collapses or expands every group in the current view.
+    ///
+    /// The two grouping families keep their collapsed state in different
+    /// places (workspace groups in [`MultiWorkspace`] keyed by
+    /// [`ProjectGroupKey`]; sections in [`Self::collapsed_sections`] keyed by a
+    /// derived id), so this dispatches to whichever store backs the active
+    /// grouping mode. All collapse entry points (this, the keyboard actions,
+    /// header clicks) funnel through the same per-store helpers.
+    fn set_all_groups_expanded(&mut self, expanded: bool, cx: &mut Context<Self>) {
+        if mode_uses_sections(AgentSettings::get_global(cx).thread_group_by) {
+            if expanded {
+                self.collapsed_sections.clear();
+            } else {
+                let section_ids = self.contents.entries.iter().filter_map(|entry| match entry {
+                    ListEntry::SectionHeader { id, .. } => Some(id.clone()),
+                    _ => None,
+                });
+                self.collapsed_sections.extend(section_ids);
+            }
+        } else if let Some(mw) = self.multi_workspace.upgrade() {
+            if !expanded {
+                // Collapsing all groups resets every "See more" expansion.
+                self.groups_showing_all.clear();
+            }
             mw.update(cx, |mw, _cx| {
-                mw.set_all_groups_expanded(true);
+                mw.set_all_groups_expanded(expanded);
             });
         }
         self.update_entries(cx);
@@ -5697,7 +6224,9 @@ impl Sidebar {
                 }
                 ListEntry::Thread(thread) => Sidebar::thread_display_time(&thread.metadata),
                 ListEntry::Terminal(terminal) => terminal.metadata.created_at,
-                ListEntry::ProjectHeader { .. } => unreachable!(),
+                ListEntry::ProjectHeader { .. }
+                | ListEntry::SectionHeader { .. }
+                | ListEntry::SeeMore { .. } => unreachable!(),
             }
         }
 
@@ -5716,6 +6245,63 @@ impl Sidebar {
             }
             entries.push(entry);
         }
+    }
+
+    /// Pushes a workspace group's rows, truncating to [`GROUP_THREAD_LIMIT`]
+    /// with a trailing "See more" row unless the group has been expanded by the
+    /// user. Every row (visible or hidden) is still registered in the current
+    /// id sets so notification state is preserved.
+    fn push_group_entries_truncated(
+        &self,
+        group_key: &ProjectGroupKey,
+        entries: &mut Vec<ListEntry>,
+        terminals: Vec<TerminalEntry>,
+        threads: Vec<Arc<ThreadEntry>>,
+        current_session_ids: &mut HashSet<acp::SessionId>,
+        current_thread_ids: &mut HashSet<agent_ui::ThreadId>,
+    ) {
+        let mut rows: Vec<ListEntry> = terminals
+            .into_iter()
+            .map(ListEntry::Terminal)
+            .chain(threads.into_iter().map(ListEntry::Thread))
+            .collect();
+        rows.sort_by_key(|entry| std::cmp::Reverse(list_entry_display_time(entry)));
+
+        for entry in &rows {
+            if let ListEntry::Thread(thread) = entry {
+                if let Some(session_id) = &thread.metadata.session_id {
+                    current_session_ids.insert(session_id.clone());
+                }
+                current_thread_ids.insert(thread.metadata.thread_id);
+            }
+        }
+
+        // Keep the active thread visible even if it falls past the limit by
+        // not truncating the group that contains it.
+        let active_beyond_limit = rows
+            .iter()
+            .position(|entry| {
+                self.active_entry
+                    .as_ref()
+                    .is_some_and(|active| active.matches_entry(entry))
+            })
+            .is_some_and(|index| index >= GROUP_THREAD_LIMIT);
+
+        let show_all = self.groups_showing_all.contains(group_key)
+            || rows.len() <= GROUP_THREAD_LIMIT
+            || active_beyond_limit;
+
+        if show_all {
+            entries.extend(rows);
+            return;
+        }
+
+        let hidden_count = rows.len() - GROUP_THREAD_LIMIT;
+        entries.extend(rows.into_iter().take(GROUP_THREAD_LIMIT));
+        entries.push(ListEntry::SeeMore {
+            key: group_key.clone(),
+            hidden_count,
+        });
     }
 
     /// The sort order used by the ctrl-tab switcher
@@ -5755,6 +6341,12 @@ impl Sidebar {
                     current_header_key = Some(key.clone());
                     None
                 }
+                ListEntry::SectionHeader { label, .. } => {
+                    current_header_label = Some(label.clone());
+                    current_header_key = None;
+                    None
+                }
+                ListEntry::SeeMore { .. } => None,
                 ListEntry::Thread(thread) => {
                     if thread.draft == Some(DraftKind::Empty) {
                         return None;
@@ -6089,6 +6681,10 @@ impl Sidebar {
     ) -> AnyElement {
         let has_notification = self.contents.is_thread_notified(&thread.metadata.thread_id);
 
+        let display = AgentSettings::get_global(cx).thread_list_display;
+        let is_pinned = ThreadMetadataStore::global(cx)
+            .read(cx)
+            .is_pinned(&thread.metadata.thread_id);
         let title: SharedString = thread.metadata.display_title();
         let metadata = thread.metadata.clone();
         let thread_workspace = thread.workspace.clone();
@@ -6115,7 +6711,7 @@ impl Sidebar {
             .title_bar_background
             .blend(color.panel_background.opacity(0.25));
 
-        let timestamp: SharedString = if is_empty_draft {
+        let timestamp: SharedString = if is_empty_draft || !display.show_timestamp {
             SharedString::default()
         } else {
             format_history_entry_timestamp(Self::thread_display_time(&thread.metadata)).into()
@@ -6123,10 +6719,14 @@ impl Sidebar {
 
         let is_remote = thread.workspace.is_remote(cx);
 
-        let worktrees = apply_worktree_label_mode(
-            thread.worktrees.clone(),
-            cx.flag_value::<AgentThreadWorktreeLabelFlag>(),
-        );
+        let worktrees = if display.show_branch {
+            apply_worktree_label_mode(
+                thread.worktrees.clone(),
+                cx.flag_value::<AgentThreadWorktreeLabelFlag>(),
+            )
+        } else {
+            Vec::new()
+        };
 
         let (icon, icon_svg) = if is_draft {
             (IconName::Circle, None)
@@ -6155,10 +6755,10 @@ impl Sidebar {
             .highlight_positions(thread.highlight_positions.to_vec())
             .title_generating(title_generating)
             .notified(has_notification)
-            .when(thread.diff_stats.lines_added > 0, |this| {
+            .when(display.show_diff_stats && thread.diff_stats.lines_added > 0, |this| {
                 this.added(thread.diff_stats.lines_added as usize)
             })
-            .when(thread.diff_stats.lines_removed > 0, |this| {
+            .when(display.show_diff_stats && thread.diff_stats.lines_removed > 0, |this| {
                 this.removed(thread.diff_stats.lines_removed as usize)
             })
             .selected(is_selected)
@@ -6280,9 +6880,27 @@ impl Sidebar {
                     }
                 };
 
+                let pin_button = (!is_draft).then(|| {
+                    IconButton::new("pin-thread", IconName::Pin)
+                        .icon_size(IconSize::Small)
+                        .when(is_pinned, |this| this.icon_color(Color::Accent))
+                        .tooltip(Tooltip::text(if is_pinned {
+                            "Unpin Thread"
+                        } else {
+                            "Pin Thread"
+                        }))
+                        .on_click(cx.listener(move |_this, _, _window, cx| {
+                            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                                store.toggle_pinned(thread_id_for_actions, cx);
+                            });
+                        }))
+                        .into_any_element()
+                });
+
                 this.action_slot(
                     h_flex()
                         .gap_0p5()
+                        .when_some(pin_button, |this, button| this.child(button))
                         .child(rename_button)
                         .when_some(contextual_action, |this, action| this.child(action)),
                 )
@@ -6450,7 +7068,12 @@ impl Sidebar {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let id = ElementId::from(format!("terminal-{}", terminal.metadata.terminal_id));
-        let timestamp = format_history_entry_timestamp(terminal.metadata.created_at);
+        let display = AgentSettings::get_global(cx).thread_list_display;
+        let timestamp: SharedString = if display.show_timestamp {
+            format_history_entry_timestamp(terminal.metadata.created_at).into()
+        } else {
+            SharedString::default()
+        };
         let is_hovered = self.hovered_thread_index == Some(ix);
         let color = cx.theme().colors();
         let sidebar_bg = color
@@ -6459,10 +7082,14 @@ impl Sidebar {
         let metadata = terminal.metadata.clone();
         let workspace = terminal.workspace.clone();
         let focus_handle = self.focus_handle.clone();
-        let worktrees = apply_worktree_label_mode(
-            terminal.worktrees.clone(),
-            cx.flag_value::<AgentThreadWorktreeLabelFlag>(),
-        );
+        let worktrees = if display.show_branch {
+            apply_worktree_label_mode(
+                terminal.worktrees.clone(),
+                cx.flag_value::<AgentThreadWorktreeLabelFlag>(),
+            )
+        } else {
+            Vec::new()
+        };
         let is_remote = terminal.workspace.is_remote(cx);
 
         let display_title = terminal.metadata.display_title();
@@ -7222,7 +7849,9 @@ impl Sidebar {
                 let workspace = terminal.workspace.clone();
                 self.activate_terminal_entry(metadata, workspace, true, window, cx);
             }
-            ListEntry::ProjectHeader { .. } => {}
+            ListEntry::ProjectHeader { .. }
+            | ListEntry::SectionHeader { .. }
+            | ListEntry::SeeMore { .. } => {}
         }
     }
 
@@ -7353,6 +7982,7 @@ impl Sidebar {
                                 )
                             }),
                     )
+                    .child(self.render_global_new_thread_button(cx))
             })
             .when(right_window_controls, |this| {
                 this.children(Self::render_right_window_controls(window, cx))
@@ -7430,7 +8060,6 @@ impl Sidebar {
     }
 
     fn render_sidebar_bottom_bar(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
-        let is_archive = matches!(self.view, SidebarView::Archive(..));
         let on_right = self.side(cx) == SidebarSide::Right;
 
         h_flex()
@@ -7440,24 +8069,176 @@ impl Sidebar {
             .border_t_1()
             .border_color(cx.theme().colors().border)
             .child(self.render_sidebar_toggle_button(cx))
-            .child(
-                IconButton::new("history", IconName::Clock)
-                    .icon_size(IconSize::Small)
-                    .toggle_state(is_archive)
-                    .tooltip(move |_, cx| {
-                        let label = if is_archive {
-                            "Hide Thread History"
-                        } else {
-                            "Show Thread History"
-                        };
-                        Tooltip::for_action(label, &ToggleThreadHistory, cx)
-                    })
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        this.toggle_archive(&ToggleThreadHistory, window, cx);
-                    })),
-            )
+            .child(self.render_group_by_menu(cx))
             .child(div().flex_1())
             .child(self.render_recent_projects_button(cx))
+    }
+
+    /// The sidebar's single new-thread action, shown to the right of the
+    /// thread search box. The section-based grouping modes
+    /// (updated/status) don't have a meaningful per-group target,
+    /// so this creates a thread in the active workspace. The per-group `+` on
+    /// project headers remains for the workspace grouping, where a group is a
+    /// real container.
+    fn render_global_new_thread_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let focus_handle = self.focus_handle.clone();
+        IconButton::new("sidebar-new-thread", IconName::Plus)
+            .icon_size(IconSize::Small)
+            .selected_style(ButtonStyle::Tinted(TintColor::Accent))
+            .tooltip(move |_, cx| {
+                Tooltip::for_action_in("Start New Agent Thread", &NewThread, &focus_handle, cx)
+            })
+            .on_click(cx.listener(|this, _, window, cx| {
+                if let Some(workspace) = this.active_workspace(cx) {
+                    this.selection = None;
+                    this.create_new_entry(&workspace, window, cx);
+                }
+            }))
+    }
+
+    fn render_group_by_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let current = AgentSettings::get_global(cx).thread_group_by;
+        let this = cx.weak_entity();
+        let is_archive = matches!(self.view, SidebarView::Archive(..));
+
+        PopoverMenu::new("sidebar-group-by-menu")
+            .menu(move |window, cx| {
+                let this = this.clone();
+                Some(ContextMenu::build(
+                    window,
+                    cx,
+                    move |mut menu, _window, _cx| {
+                        menu = menu.header("Group by");
+                        for &mode in ALL_THREAD_GROUP_BY {
+                            let is_selected = mode == current;
+                            let icon = thread_group_by_icon(mode);
+                            let label = thread_group_by_label(mode);
+                            let this = this.clone();
+
+                            // Rendered as a custom entry so the mode's icon is
+                            // always shown on the left and the checkmark for the
+                            // active mode on the right (the built-in toggleable
+                            // entry would otherwise reuse the icon slot for the
+                            // checkmark and hide unselected icons).
+                            let render = move |_window: &mut Window, _cx: &mut App| {
+                                h_flex()
+                                    .w_full()
+                                    .gap_2()
+                                    .justify_between()
+                                    .child(
+                                        h_flex()
+                                            .gap_1p5()
+                                            .child(
+                                                Icon::new(icon)
+                                                    .size(IconSize::Small)
+                                                    .color(Color::Default),
+                                            )
+                                            .child(Label::new(label).color(Color::Default)),
+                                    )
+                                    .when(is_selected, |this| {
+                                        this.child(
+                                            Icon::new(IconName::Check)
+                                                .size(IconSize::Small)
+                                                .color(Color::Accent),
+                                        )
+                                    })
+                                    .into_any_element()
+                            };
+
+                            menu = menu.custom_entry(render, move |window, cx| {
+                                this.update(cx, |sidebar, cx| {
+                                    sidebar.set_thread_group_by(mode, window, cx);
+                                })
+                                .ok();
+                            });
+                        }
+
+                        // "Display" submenu: toggles for which per-thread
+                        // metadata is shown in the list.
+                        menu = menu.separator();
+                        {
+                            let this = this.clone();
+                            menu = menu.submenu_with_icon(
+                                "Display",
+                                IconName::Sliders,
+                                move |mut submenu, _window, submenu_cx| {
+                                    let display =
+                                        AgentSettings::get_global(submenu_cx).thread_list_display;
+                                    let fields = [
+                                        (
+                                            "Timestamp",
+                                            display.show_timestamp,
+                                            ThreadListDisplayField::Timestamp,
+                                        ),
+                                        (
+                                            "Branch",
+                                            display.show_branch,
+                                            ThreadListDisplayField::Branch,
+                                        ),
+                                        (
+                                            "Diff Stats",
+                                            display.show_diff_stats,
+                                            ThreadListDisplayField::DiffStats,
+                                        ),
+                                    ];
+                                    for (label, enabled, field) in fields {
+                                        let this = this.clone();
+                                        submenu = submenu.toggleable_entry(
+                                            label,
+                                            enabled,
+                                            IconPosition::End,
+                                            None,
+                                            move |_window, cx| {
+                                                this.update(cx, |sidebar, cx| {
+                                                    sidebar.set_thread_list_display_field(
+                                                        field, !enabled, cx,
+                                                    );
+                                                })
+                                                .ok();
+                                            },
+                                        );
+                                    }
+                                    submenu
+                                },
+                            );
+                        }
+
+                        // Collapse/expand only affect the workspace-grouped list.
+                        if !is_archive {
+                            menu = menu.separator();
+                            let collapse_handle = this.clone();
+                            menu = menu.entry("Collapse All", None, move |_window, cx| {
+                                collapse_handle
+                                    .update(cx, |sidebar, cx| {
+                                        sidebar.set_all_groups_expanded(false, cx);
+                                    })
+                                    .ok();
+                            });
+                            let expand_handle = this;
+                            menu = menu.entry("Expand All", None, move |_window, cx| {
+                                expand_handle
+                                    .update(cx, |sidebar, cx| {
+                                        sidebar.set_all_groups_expanded(true, cx);
+                                    })
+                                    .ok();
+                            });
+                        }
+
+                        menu
+                    },
+                ))
+            })
+            .trigger_with_tooltip(
+                IconButton::new("group-by", IconName::ListFilter)
+                    .icon_size(IconSize::Small)
+                    .selected_style(ButtonStyle::Tinted(TintColor::Accent)),
+                Tooltip::text("Group & Filter Threads"),
+            )
+            .anchor(gpui::Anchor::BottomLeft)
+            .offset(gpui::Point {
+                x: px(-2.0),
+                y: px(-2.0),
+            })
     }
 
     fn active_workspace(&self, cx: &App) -> Option<Entity<Workspace>> {
@@ -7611,15 +8392,20 @@ impl Sidebar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        match &self.view {
-            SidebarView::ThreadList => {
-                self.show_archive(window, cx);
-            }
-            SidebarView::Archive(_) => self.show_thread_list(window, cx),
-        }
+        // The history view is the `Updated` grouping mode; toggle between it and
+        // the default workspace grouping, keeping the persisted setting in sync.
+        let next = if AgentSettings::get_global(cx).thread_group_by == ThreadGroupBy::Updated {
+            ThreadGroupBy::Workspace
+        } else {
+            ThreadGroupBy::Updated
+        };
+        self.set_thread_group_by(next, window, cx);
     }
 
     fn show_archive(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if matches!(self.view, SidebarView::Archive(_)) {
+            return;
+        }
         let side = match self.side(cx) {
             SidebarSide::Left => "left",
             SidebarSide::Right => "right",
@@ -7695,6 +8481,271 @@ impl Sidebar {
         handle.focus(window, cx);
         self.serialize(cx);
         cx.notify();
+    }
+
+    /// Ensures the sidebar is showing the (grouped) native thread list and
+    /// rebuilds it for the requested grouping mode.
+    ///
+    /// All grouping modes now render in the native thread list: `Workspace`
+    /// uses project headers, while the other modes regroup threads into text
+    /// section headers in [`Self::rebuild_contents`].
+    fn apply_thread_group_by(
+        &mut self,
+        _group_by: ThreadGroupBy,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if matches!(self.view, SidebarView::Archive(_)) {
+            self.show_thread_list(window, cx);
+        }
+        self.schedule_update_entries(false, cx);
+    }
+
+    /// Persists the chosen grouping mode to the user's settings and switches
+    /// the view to match.
+    fn set_thread_group_by(
+        &mut self,
+        group_by: ThreadGroupBy,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let fs = self.multi_workspace.upgrade().map(|mw| {
+            mw.read(cx)
+                .workspace()
+                .read(cx)
+                .project()
+                .read(cx)
+                .fs()
+                .clone()
+        });
+        if let Some(fs) = fs {
+            settings::update_settings_file(fs, cx, move |settings, _cx| {
+                settings
+                    .agent
+                    .get_or_insert_default()
+                    .set_thread_group_by(group_by);
+            });
+        }
+
+        telemetry::event!(
+            "Agent Thread Group By Changed",
+            group_by = thread_group_by_telemetry_name(group_by)
+        );
+
+        self.apply_thread_group_by(group_by, window, cx);
+    }
+
+    /// The filesystem handle for writing user settings, derived from the active
+    /// workspace's project.
+    fn workspace_fs(&self, cx: &App) -> Option<Arc<dyn fs::Fs>> {
+        self.multi_workspace.upgrade().map(|mw| {
+            mw.read(cx)
+                .workspace()
+                .read(cx)
+                .project()
+                .read(cx)
+                .fs()
+                .clone()
+        })
+    }
+
+    /// Persists a single thread-list display toggle (e.g. show timestamp) to
+    /// the user's settings. The list rebuilds via the settings observer.
+    fn set_thread_list_display_field(
+        &self,
+        field: ThreadListDisplayField,
+        value: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(fs) = self.workspace_fs(cx) else {
+            return;
+        };
+        settings::update_settings_file(fs, cx, move |settings, _cx| {
+            let display = settings
+                .agent
+                .get_or_insert_default()
+                .thread_list_display
+                .get_or_insert_default();
+            match field {
+                ThreadListDisplayField::Timestamp => display.show_timestamp = Some(value),
+                ThreadListDisplayField::Branch => display.show_branch = Some(value),
+                ThreadListDisplayField::DiffStats => display.show_diff_stats = Some(value),
+            }
+        });
+    }
+}
+
+/// User-facing label for a thread grouping mode, shown in the group-by menu.
+fn thread_group_by_label(group_by: ThreadGroupBy) -> &'static str {
+    match group_by {
+        ThreadGroupBy::Workspace => "Workspace",
+        ThreadGroupBy::Updated => "Updated",
+        ThreadGroupBy::Status => "Status",
+    }
+}
+
+/// The icon shown next to each grouping mode in the group-by menu.
+fn thread_group_by_icon(group_by: ThreadGroupBy) -> IconName {
+    match group_by {
+        ThreadGroupBy::Workspace => IconName::Folder,
+        ThreadGroupBy::Updated => IconName::Clock,
+        ThreadGroupBy::Status => IconName::Circle,
+    }
+}
+
+/// Stable identifier for telemetry events.
+fn thread_group_by_telemetry_name(group_by: ThreadGroupBy) -> &'static str {
+    match group_by {
+        ThreadGroupBy::Workspace => "workspace",
+        ThreadGroupBy::Updated => "updated",
+        ThreadGroupBy::Status => "status",
+    }
+}
+
+/// All grouping modes, in the order they appear in the group-by menu.
+const ALL_THREAD_GROUP_BY: &[ThreadGroupBy] = &[
+    ThreadGroupBy::Workspace,
+    ThreadGroupBy::Updated,
+    ThreadGroupBy::Status,
+];
+
+/// Whether a grouping mode renders the thread list as text section headers
+/// (history style) rather than the workspace project headers.
+fn mode_uses_sections(group_by: ThreadGroupBy) -> bool {
+    matches!(
+        group_by,
+        ThreadGroupBy::Updated | ThreadGroupBy::Status
+    )
+}
+
+/// Recency buckets used by the `Updated` grouping mode. Mirrors the buckets
+/// used by the dedicated thread history view.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RecencyBucket {
+    Today,
+    Yesterday,
+    ThisWeek,
+    PastWeek,
+    Older,
+}
+
+impl RecencyBucket {
+    fn from_dates(reference: NaiveDate, date: NaiveDate) -> Self {
+        if date >= reference {
+            return RecencyBucket::Today;
+        }
+        if date == reference - TimeDelta::days(1) {
+            return RecencyBucket::Yesterday;
+        }
+        let week = date.iso_week();
+        if reference.iso_week() == week {
+            return RecencyBucket::ThisWeek;
+        }
+        if (reference - TimeDelta::weeks(1)).iso_week() == week {
+            return RecencyBucket::PastWeek;
+        }
+        RecencyBucket::Older
+    }
+
+    fn order(self) -> u32 {
+        match self {
+            RecencyBucket::Today => 0,
+            RecencyBucket::Yesterday => 1,
+            RecencyBucket::ThisWeek => 2,
+            RecencyBucket::PastWeek => 3,
+            RecencyBucket::Older => 4,
+        }
+    }
+
+    fn id(self) -> &'static str {
+        match self {
+            RecencyBucket::Today => "updated:today",
+            RecencyBucket::Yesterday => "updated:yesterday",
+            RecencyBucket::ThisWeek => "updated:this-week",
+            RecencyBucket::PastWeek => "updated:past-week",
+            RecencyBucket::Older => "updated:older",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            RecencyBucket::Today => "Today",
+            RecencyBucket::Yesterday => "Yesterday",
+            RecencyBucket::ThisWeek => "This Week",
+            RecencyBucket::PastWeek => "Past Week",
+            RecencyBucket::Older => "Older",
+        }
+    }
+}
+
+/// The time used to sort and bucket an entry in the thread list.
+fn list_entry_display_time(entry: &ListEntry) -> DateTime<Utc> {
+    match entry {
+        ListEntry::Thread(thread) if thread.draft == Some(DraftKind::Empty) => {
+            DateTime::<Utc>::MAX_UTC
+        }
+        ListEntry::Thread(thread) => Sidebar::thread_display_time(&thread.metadata),
+        ListEntry::Terminal(terminal) => terminal.metadata.created_at,
+        ListEntry::ProjectHeader { .. }
+        | ListEntry::SectionHeader { .. }
+        | ListEntry::SeeMore { .. } => DateTime::<Utc>::MIN_UTC,
+    }
+}
+
+/// The indices of all header entries (project or section headers) in a list,
+/// used for sticky-header positioning.
+fn list_entry_header_indices(entries: &[ListEntry]) -> Vec<usize> {
+    entries
+        .iter()
+        .enumerate()
+        .filter_map(|(ix, entry)| {
+            matches!(
+                entry,
+                ListEntry::ProjectHeader { .. } | ListEntry::SectionHeader { .. }
+            )
+            .then_some(ix)
+        })
+        .collect()
+}
+
+/// Computes the section an entry belongs to under the given grouping mode,
+/// returning `(sort_order, stable_id, label)`. Only called for the
+/// section-based modes (see [`mode_uses_sections`]).
+fn section_descriptor_for_entry(
+    entry: &ListEntry,
+    group_by: ThreadGroupBy,
+    today: NaiveDate,
+) -> (u32, SharedString, SharedString) {
+    match group_by {
+        ThreadGroupBy::Updated => {
+            let date = list_entry_display_time(entry)
+                .with_timezone(&Local)
+                .naive_local()
+                .date();
+            let bucket = RecencyBucket::from_dates(today, date);
+            (bucket.order(), bucket.id().into(), bucket.label().into())
+        }
+        ThreadGroupBy::Status => match entry {
+            ListEntry::Thread(thread) if thread.draft.is_some() => {
+                (3, "status:drafts".into(), "Drafts".into())
+            }
+            ListEntry::Thread(thread) => {
+                let (order, id, label) = match thread.status {
+                    AgentThreadStatus::Running => (0, "status:running", "Running"),
+                    AgentThreadStatus::WaitingForConfirmation => {
+                        (1, "status:waiting", "Needs Attention")
+                    }
+                    AgentThreadStatus::Error => (2, "status:error", "Error"),
+                    AgentThreadStatus::Completed => (4, "status:completed", "Completed"),
+                };
+                (order, id.into(), label.into())
+            }
+            ListEntry::Terminal(_) => (5, "status:terminals".into(), "Terminals".into()),
+            ListEntry::ProjectHeader { .. }
+            | ListEntry::SectionHeader { .. }
+            | ListEntry::SeeMore { .. } => (6, "status:other".into(), "Other".into()),
+        },
+        ThreadGroupBy::Workspace => (0, "".into(), SharedString::default()),
     }
 }
 
@@ -7816,18 +8867,16 @@ impl WorkspaceSidebar for Sidebar {
     fn restore_serialized_state(
         &mut self,
         state: &str,
-        window: &mut Window,
+        _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if let Some(serialized) = serde_json::from_str::<SerializedSidebar>(state).log_err() {
             if let Some(width) = serialized.width {
                 self.width = px(width).clamp(MIN_WIDTH, MAX_WIDTH);
             }
-            if serialized.active_view == SerializedSidebarView::History {
-                cx.defer_in(window, |this, window, cx| {
-                    this.show_archive(window, cx);
-                });
-            }
+            // The active view is now derived from the global `thread_group_by`
+            // setting (applied during `Sidebar::new`), so we no longer restore
+            // it from the per-window serialized state.
         }
         cx.notify();
     }

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -981,6 +981,71 @@ async fn test_collapse_and_expand_all_in_section_mode(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_status_filter_narrows_thread_list(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let (sidebar, _panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+    cx.update(|_window, cx| {
+        AgentRegistryStore::init_test_global(cx, vec![]);
+    });
+
+    // Historical threads default to the `Completed` status.
+    for (id, title) in [("t-1", "Alpha"), ("t-2", "Beta")] {
+        save_thread_metadata(
+            acp::SessionId::new(Arc::from(id)),
+            Some(title.into()),
+            chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, 0).unwrap(),
+            None,
+            None,
+            &project,
+            cx,
+        );
+    }
+    cx.run_until_parked();
+
+    let thread_count = |sidebar: &Entity<Sidebar>, cx: &mut gpui::VisualTestContext| {
+        sidebar.read_with(cx, |sidebar, _| {
+            sidebar
+                .contents
+                .entries
+                .iter()
+                .filter(|entry| matches!(entry, ListEntry::Thread(_)))
+                .count()
+        })
+    };
+
+    assert_eq!(thread_count(&sidebar, cx), 2, "both threads visible initially");
+
+    // Filtering to `Running` hides the completed threads.
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.toggle_status_filter(super::ThreadStatusFilter::Running, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        thread_count(&sidebar, cx),
+        0,
+        "completed threads are hidden when filtering to Running"
+    );
+    assert!(sidebar.read_with(cx, |sidebar, _| sidebar.has_active_filter()));
+
+    // Also allowing `Completed` brings them back.
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.toggle_status_filter(super::ThreadStatusFilter::Completed, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(thread_count(&sidebar, cx), 2);
+
+    // Clearing all filters restores the unfiltered list.
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.clear_filters(cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(thread_count(&sidebar, cx), 2);
+    assert!(!sidebar.read_with(cx, |sidebar, _| sidebar.has_active_filter()));
+}
+
+#[gpui::test]
 async fn test_workspace_group_truncates_with_see_more(cx: &mut TestAppContext) {
     let project = init_test_project_with_agent_panel("/my-project", cx).await;
     let (multi_workspace, cx) =
@@ -4432,6 +4497,8 @@ async fn test_search_narrows_visible_threads_to_matches(cx: &mut TestAppContext)
     }
     cx.run_until_parked();
 
+    // The group has more threads than the per-group limit, so it's truncated
+    // to the first two with a "See more" row.
     assert_eq!(
         visible_entries_as_strings(&sidebar, cx),
         vec![
@@ -4439,7 +4506,7 @@ async fn test_search_narrows_visible_threads_to_matches(cx: &mut TestAppContext)
             "v [my-project]",
             "  Fix crash in project panel",
             "  Add inline diff view",
-            "  Refactor settings module",
+            "  see 1 more",
         ]
     );
 
@@ -13137,7 +13204,7 @@ mod property_test {
         let mut seen: HashSet<acp::SessionId> = HashSet::default();
         let mut duplicates: Vec<(acp::SessionId, String)> = Vec::new();
 
-        for entry in &sidebar.contents.entries {
+        for entry in &sidebar.contents.all_entries {
             if let Some(session_id) = entry.session_id() {
                 if !seen.insert(session_id.clone()) {
                     let title = match entry {
@@ -13214,7 +13281,7 @@ mod property_test {
 
         let sidebar_thread_ids: HashSet<acp::SessionId> = sidebar
             .contents
-            .entries
+            .all_entries
             .iter()
             .filter_map(|entry| entry.session_id().cloned())
             .collect();

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -184,6 +184,17 @@ fn assert_remote_project_integration_sidebar_state(
                     terminal.metadata.title
                 );
             }
+            ListEntry::SectionHeader { label, .. } => {
+                panic!(
+                    "unexpected sidebar section header while simulating remote project integration flicker: label=`{}`",
+                    label
+                );
+            }
+            ListEntry::SeeMore { hidden_count, .. } => {
+                panic!(
+                    "unexpected `See more` row while simulating remote project integration flicker: hidden={hidden_count}"
+                );
+            }
         }
     }
 
@@ -571,6 +582,12 @@ fn visible_entries_as_strings(
                         };
                         format!("{} [{}]{}", icon, label, selected)
                     }
+                    ListEntry::SectionHeader {
+                        label, is_collapsed, ..
+                    } => {
+                        let icon = if *is_collapsed { ">" } else { "v" };
+                        format!("{} #{}#{}", icon, label, selected)
+                    }
                     ListEntry::Thread(thread) => {
                         let title = thread.metadata.display_title();
                         let worktree = format_linked_worktree_chips(&thread.worktrees);
@@ -598,6 +615,9 @@ fn visible_entries_as_strings(
                         let title = terminal.metadata.display_title();
                         let worktree = format_linked_worktree_chips(&terminal.worktrees);
                         format!("  {title}{worktree}{selected}")
+                    }
+                    ListEntry::SeeMore { hidden_count, .. } => {
+                        format!("  see {hidden_count} more{selected}")
                     }
                 }
             })
@@ -795,6 +815,9 @@ async fn test_serialization_round_trip(cx: &mut TestAppContext) {
 #[gpui::test]
 async fn test_restore_serialized_archive_view_does_not_panic(cx: &mut TestAppContext) {
     // A regression test to ensure that restoring a serialized archive view does not panic.
+    // The active view is now derived from the global `thread_group_by` setting rather than
+    // the per-window serialized state, so restore only needs to apply the width without
+    // panicking; selecting the `Updated` grouping mode is what switches to the archive view.
     let project = init_test_project_with_agent_panel("/my-project", cx).await;
     let (multi_workspace, cx) =
         cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
@@ -816,13 +839,417 @@ async fn test_restore_serialized_archive_view_does_not_panic(cx: &mut TestAppCon
     });
     cx.run_until_parked();
 
-    // After the deferred `show_archive` runs, the view should be Archive.
+    // Restore applies the width but no longer forces the archive view.
+    sidebar.read_with(cx, |sidebar, _cx| {
+        assert_eq!(sidebar.width, px(400.0));
+    });
+
+    // Selecting the `Updated` grouping mode regroups the native thread list
+    // into recency sections; it no longer switches to a separate archive view.
+    sidebar.update_in(cx, |sidebar, window, cx| {
+        sidebar.set_thread_group_by(settings::ThreadGroupBy::Updated, window, cx);
+    });
+    cx.run_until_parked();
+
     sidebar.read_with(cx, |sidebar, _cx| {
         assert!(
-            matches!(sidebar.view, SidebarView::Archive(_)),
-            "expected sidebar view to be Archive after restore, got ThreadList"
+            matches!(sidebar.view, SidebarView::ThreadList),
+            "all grouping modes render in the native thread list"
         );
     });
+}
+
+#[gpui::test]
+async fn test_updated_grouping_renders_section_headers(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let (sidebar, panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+
+    let connection = StubAgentConnection::new();
+    connection.set_next_prompt_updates(vec![acp::SessionUpdate::AgentMessageChunk(
+        acp::ContentChunk::new("Hi there!".into()),
+    )]);
+    open_thread_with_connection(&panel, connection, cx);
+    send_message(&panel, cx);
+
+    let session_id = active_session_id(&panel, cx);
+    save_test_thread_metadata(&session_id, &project, cx).await;
+    cx.run_until_parked();
+
+    // Switch to the `Updated` grouping mode.
+    cx.update(|_window, cx| {
+        let mut settings = AgentSettings::get_global(cx).clone();
+        settings.thread_group_by = settings::ThreadGroupBy::Updated;
+        AgentSettings::override_global(settings, cx);
+    });
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.schedule_update_entries(false, cx);
+    });
+    cx.run_until_parked();
+
+    // The saved thread is dated in 2024, so it falls into the `Older` recency
+    // section. There should be no workspace project headers in this mode.
+    let lines = visible_entries_as_strings(&sidebar, cx);
+    assert!(
+        lines.iter().any(|line| line.contains("#Older#")),
+        "expected an `Older` recency section header, got {lines:?}"
+    );
+    assert!(
+        !lines
+            .iter()
+            .any(|line| line.starts_with("v [") || line.starts_with("> [")),
+        "expected no project headers in `Updated` mode, got {lines:?}"
+    );
+
+    // Collapsing the section hides its threads.
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.toggle_section_collapsed(&"updated:older".into(), cx);
+    });
+    cx.run_until_parked();
+
+    let collapsed = visible_entries_as_strings(&sidebar, cx);
+    assert!(
+        collapsed.iter().any(|line| line.contains("> #Older#")),
+        "expected the collapsed `Older` section header, got {collapsed:?}"
+    );
+    assert_eq!(
+        collapsed.len(),
+        1,
+        "collapsing the only section should hide all of its threads, got {collapsed:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_collapse_and_expand_all_in_section_mode(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let (sidebar, panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+
+    let connection = StubAgentConnection::new();
+    connection.set_next_prompt_updates(vec![acp::SessionUpdate::AgentMessageChunk(
+        acp::ContentChunk::new("Hi there!".into()),
+    )]);
+    open_thread_with_connection(&panel, connection, cx);
+    send_message(&panel, cx);
+
+    let session_id = active_session_id(&panel, cx);
+    save_test_thread_metadata(&session_id, &project, cx).await;
+    cx.run_until_parked();
+
+    cx.update(|_window, cx| {
+        let mut settings = AgentSettings::get_global(cx).clone();
+        settings.thread_group_by = settings::ThreadGroupBy::Updated;
+        AgentSettings::override_global(settings, cx);
+    });
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.schedule_update_entries(false, cx);
+    });
+    cx.run_until_parked();
+
+    // "Collapse All" must work in section modes, not just workspace mode.
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.set_all_groups_expanded(false, cx);
+    });
+    cx.run_until_parked();
+    let collapsed = visible_entries_as_strings(&sidebar, cx);
+    assert!(
+        collapsed.iter().any(|line| line.contains("> #Older#")),
+        "expected `Collapse All` to collapse the section, got {collapsed:?}"
+    );
+    assert_eq!(
+        collapsed.len(),
+        1,
+        "expected `Collapse All` to hide every thread, got {collapsed:?}"
+    );
+
+    // "Expand All" must re-expand it.
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.set_all_groups_expanded(true, cx);
+    });
+    cx.run_until_parked();
+    let expanded = visible_entries_as_strings(&sidebar, cx);
+    assert!(
+        expanded.iter().any(|line| line.contains("v #Older#")),
+        "expected `Expand All` to expand the section, got {expanded:?}"
+    );
+    assert!(
+        expanded.len() > 1,
+        "expected `Expand All` to reveal the section's threads, got {expanded:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_workspace_group_truncates_with_see_more(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let (sidebar, _panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+    cx.update(|_window, cx| {
+        AgentRegistryStore::init_test_global(cx, vec![]);
+    });
+
+    // Create more historical threads than the per-group limit so the group is
+    // truncated. Distinct timestamps keep the order deterministic.
+    let total = GROUP_THREAD_LIMIT + 3;
+    for i in 0..total {
+        let session_id = acp::SessionId::new(Arc::from(format!("thread-{i}")));
+        let timestamp =
+            chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, i as u32).unwrap();
+        save_thread_metadata(
+            session_id,
+            Some(format!("Thread {i}").into()),
+            timestamp,
+            Some(timestamp),
+            None,
+            &project,
+            cx,
+        );
+    }
+    cx.run_until_parked();
+
+    // Only the first `GROUP_THREAD_LIMIT` threads show, plus a "See more" row.
+    let lines = visible_entries_as_strings(&sidebar, cx);
+    let thread_lines = lines
+        .iter()
+        .filter(|line| line.trim_start().starts_with("Thread "))
+        .count();
+    assert_eq!(
+        thread_lines, GROUP_THREAD_LIMIT,
+        "expected the group to be truncated to the limit, got {lines:?}"
+    );
+    let hidden = total - GROUP_THREAD_LIMIT;
+    assert!(
+        lines.iter().any(|line| line.contains(&format!("see {hidden} more"))),
+        "expected a `See more` row for the hidden threads, got {lines:?}"
+    );
+
+    // Expanding the group via "See more" reveals every thread.
+    let key = sidebar.read_with(cx, |sidebar, _cx| {
+        sidebar.contents.entries.iter().find_map(|entry| match entry {
+            ListEntry::SeeMore { key, .. } => Some(key.clone()),
+            _ => None,
+        })
+        .expect("expected a See more entry")
+    });
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.show_all_in_group(&key, cx);
+    });
+    cx.run_until_parked();
+
+    let lines = visible_entries_as_strings(&sidebar, cx);
+    let thread_lines = lines
+        .iter()
+        .filter(|line| line.trim_start().starts_with("Thread "))
+        .count();
+    assert_eq!(
+        thread_lines, total,
+        "expected all threads to show after `See more`, got {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|line| line.contains("see ")),
+        "expected the `See more` row to disappear once expanded, got {lines:?}"
+    );
+
+    // Collapsing then reopening the group resets the "See more" expansion, so
+    // it returns to the truncated set.
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.set_group_expanded(&key, false, cx);
+        sidebar.update_entries(cx);
+    });
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.set_group_expanded(&key, true, cx);
+        sidebar.update_entries(cx);
+    });
+    cx.run_until_parked();
+
+    let lines = visible_entries_as_strings(&sidebar, cx);
+    let thread_lines = lines
+        .iter()
+        .filter(|line| line.trim_start().starts_with("Thread "))
+        .count();
+    assert_eq!(
+        thread_lines, GROUP_THREAD_LIMIT,
+        "expected reopening a collapsed group to return to the truncated set, got {lines:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_pinned_threads_surface_in_pinned_section(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let (sidebar, panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+
+    let connection = StubAgentConnection::new();
+    connection.set_next_prompt_updates(vec![acp::SessionUpdate::AgentMessageChunk(
+        acp::ContentChunk::new("Hi there!".into()),
+    )]);
+    open_thread_with_connection(&panel, connection, cx);
+    send_message(&panel, cx);
+
+    let session_id = active_session_id(&panel, cx);
+    save_test_thread_metadata(&session_id, &project, cx).await;
+    cx.run_until_parked();
+
+    let thread_id = sidebar.read_with(cx, |sidebar, _cx| {
+        sidebar
+            .contents
+            .entries
+            .iter()
+            .find_map(|entry| match entry {
+                ListEntry::Thread(thread) => Some(thread.metadata.thread_id),
+                _ => None,
+            })
+            .expect("sidebar should have a thread entry")
+    });
+
+    // Pinning moves the thread into a top "Pinned" section (workspace mode).
+    cx.update(|_window, cx| {
+        ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+            store.set_pinned(thread_id, true, cx);
+        });
+    });
+    cx.run_until_parked();
+
+    let lines = visible_entries_as_strings(&sidebar, cx);
+    assert!(
+        lines.first().is_some_and(|line| line.contains("#Pinned#")),
+        "expected a `Pinned` section at the top, got {lines:?}"
+    );
+    assert!(
+        lines.len() >= 2,
+        "expected the pinned thread to appear under the Pinned section, got {lines:?}"
+    );
+
+    // Collapsing the pinned thread's workspace group must NOT remove the
+    // Pinned section (regression: collapsing the group hid the pinned thread).
+    let group_key = sidebar.read_with(cx, |sidebar, _cx| {
+        sidebar
+            .contents
+            .entries
+            .iter()
+            .find_map(|entry| match entry {
+                ListEntry::ProjectHeader { key, .. } => Some(key.clone()),
+                _ => None,
+            })
+            .expect("expected a project header")
+    });
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.set_group_expanded(&group_key, false, cx);
+        sidebar.update_entries(cx);
+    });
+    cx.run_until_parked();
+
+    let lines = visible_entries_as_strings(&sidebar, cx);
+    assert!(
+        lines.first().is_some_and(|line| line.contains("#Pinned#")),
+        "expected the Pinned section to survive collapsing the group, got {lines:?}"
+    );
+    assert!(
+        lines.len() >= 2,
+        "expected the pinned thread to remain visible after collapse, got {lines:?}"
+    );
+
+    // Unpinning removes the Pinned section.
+    cx.update(|_window, cx| {
+        ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+            store.set_pinned(thread_id, false, cx);
+        });
+    });
+    cx.run_until_parked();
+
+    let lines = visible_entries_as_strings(&sidebar, cx);
+    assert!(
+        !lines.iter().any(|line| line.contains("#Pinned#")),
+        "expected the Pinned section to disappear after unpinning, got {lines:?}"
+    );
+}
+
+#[gpui::test]
+async fn test_pinned_thread_survives_section_collapse(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let (sidebar, _panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+    cx.update(|_window, cx| {
+        AgentRegistryStore::init_test_global(cx, vec![]);
+    });
+
+    // Two historical threads (both fall in the "Older" recency bucket).
+    for i in 0..2 {
+        let session_id = acp::SessionId::new(Arc::from(format!("thread-{i}")));
+        let timestamp =
+            chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, i as u32).unwrap();
+        save_thread_metadata(
+            session_id,
+            Some(format!("Thread {i}").into()),
+            timestamp,
+            Some(timestamp),
+            None,
+            &project,
+            cx,
+        );
+    }
+    cx.run_until_parked();
+
+    // Pin one of the threads.
+    let pinned_id = sidebar.read_with(cx, |sidebar, _cx| {
+        sidebar
+            .contents
+            .entries
+            .iter()
+            .find_map(|entry| match entry {
+                ListEntry::Thread(thread) => Some(thread.metadata.thread_id),
+                _ => None,
+            })
+            .expect("expected a thread entry")
+    });
+    cx.update(|_window, cx| {
+        ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+            store.set_pinned(pinned_id, true, cx);
+        });
+    });
+
+    // Switch to the `Updated` (section) grouping mode.
+    cx.update(|_window, cx| {
+        let mut settings = AgentSettings::get_global(cx).clone();
+        settings.thread_group_by = settings::ThreadGroupBy::Updated;
+        AgentSettings::override_global(settings, cx);
+    });
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.schedule_update_entries(false, cx);
+    });
+    cx.run_until_parked();
+
+    // The pinned thread lives in the Pinned section, not the "Older" recency
+    // bucket; the unpinned thread is under "Older".
+    let lines = visible_entries_as_strings(&sidebar, cx);
+    assert!(
+        lines.first().is_some_and(|line| line.contains("#Pinned#")),
+        "expected a Pinned section at the top, got {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|line| line.contains("#Older#")),
+        "expected an Older section for the unpinned thread, got {lines:?}"
+    );
+
+    // Collapsing the "Older" recency section must NOT remove the Pinned section.
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.toggle_section_collapsed(&"updated:older".into(), cx);
+    });
+    cx.run_until_parked();
+
+    let lines = visible_entries_as_strings(&sidebar, cx);
+    assert!(
+        lines.first().is_some_and(|line| line.contains("#Pinned#")),
+        "expected the Pinned section to survive collapsing a recency section, got {lines:?}"
+    );
+    assert!(
+        lines.len() >= 2,
+        "expected the pinned thread to remain visible, got {lines:?}"
+    );
 }
 
 #[gpui::test]
@@ -4926,7 +5353,10 @@ async fn test_rename_thread_from_sidebar_updates_title_override(cx: &mut TestApp
                     thread.metadata.thread_id,
                     thread.metadata.display_title(),
                 )),
-                ListEntry::ProjectHeader { .. } | ListEntry::Terminal(_) => None,
+                ListEntry::ProjectHeader { .. }
+                | ListEntry::SectionHeader { .. }
+                | ListEntry::Terminal(_)
+                | ListEntry::SeeMore { .. } => None,
             })
             .expect("sidebar should have a thread entry")
     });
@@ -5012,7 +5442,10 @@ async fn test_rename_thread_from_sidebar_updates_title_override(cx: &mut TestApp
             .iter()
             .find_map(|entry| match entry {
                 ListEntry::Thread(thread) => Some(thread),
-                ListEntry::ProjectHeader { .. } | ListEntry::Terminal(_) => None,
+                ListEntry::ProjectHeader { .. }
+                | ListEntry::SectionHeader { .. }
+                | ListEntry::Terminal(_)
+                | ListEntry::SeeMore { .. } => None,
             })
             .expect("renamed thread should match the search");
         let title = thread.metadata.display_title();
@@ -5051,7 +5484,10 @@ async fn test_rename_selected_thread_action_renames_selected_thread(cx: &mut Tes
             .enumerate()
             .find_map(|(ix, entry)| match entry {
                 ListEntry::Thread(thread) => Some((ix, thread.metadata.thread_id)),
-                ListEntry::ProjectHeader { .. } | ListEntry::Terminal(_) => None,
+                ListEntry::ProjectHeader { .. }
+                | ListEntry::SectionHeader { .. }
+                | ListEntry::Terminal(_)
+                | ListEntry::SeeMore { .. } => None,
             })
             .expect("sidebar should have a thread entry")
     });
@@ -7099,6 +7535,17 @@ async fn test_clicking_worktree_thread_does_not_briefly_render_as_separate_proje
                     panic!(
                         "unexpected sidebar terminal while opening linked worktree thread: title=`{}`",
                         terminal.metadata.title
+                    );
+                }
+                ListEntry::SectionHeader { label, .. } => {
+                    panic!(
+                        "unexpected sidebar section header while opening linked worktree thread: label=`{}`",
+                        label
+                    );
+                }
+                ListEntry::SeeMore { hidden_count, .. } => {
+                    panic!(
+                        "unexpected `See more` row while opening linked worktree thread: hidden={hidden_count}"
                     );
                 }
             }

--- a/crates/sidebar/src/sidebar_tests.rs
+++ b/crates/sidebar/src/sidebar_tests.rs
@@ -1141,6 +1141,68 @@ async fn test_workspace_group_truncates_with_see_more(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_expand_all_reveals_see_more_truncation(cx: &mut TestAppContext) {
+    let project = init_test_project_with_agent_panel("/my-project", cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let (sidebar, _panel) = setup_sidebar_with_agent_panel(&multi_workspace, cx);
+    cx.update(|_window, cx| {
+        AgentRegistryStore::init_test_global(cx, vec![]);
+    });
+
+    // More historical threads than the per-group limit so the group is
+    // truncated with a "See more" row.
+    let total = GROUP_THREAD_LIMIT + 3;
+    for i in 0..total {
+        let session_id = acp::SessionId::new(Arc::from(format!("thread-{i}")));
+        let timestamp =
+            chrono::TimeZone::with_ymd_and_hms(&Utc, 2024, 1, 1, 0, 0, i as u32).unwrap();
+        save_thread_metadata(
+            session_id,
+            Some(format!("Thread {i}").into()),
+            timestamp,
+            Some(timestamp),
+            None,
+            &project,
+            cx,
+        );
+    }
+    cx.run_until_parked();
+
+    // Sanity check: the group starts truncated.
+    let lines = visible_entries_as_strings(&sidebar, cx);
+    let thread_lines = lines
+        .iter()
+        .filter(|line| line.trim_start().starts_with("Thread "))
+        .count();
+    assert_eq!(
+        thread_lines, GROUP_THREAD_LIMIT,
+        "expected the group to start truncated, got {lines:?}"
+    );
+
+    // "Expand All" should reveal every thread and remove the "See more" row,
+    // not just un-collapse the group header.
+    sidebar.update(cx, |sidebar, cx| {
+        sidebar.set_all_groups_expanded(true, cx);
+    });
+    cx.run_until_parked();
+
+    let lines = visible_entries_as_strings(&sidebar, cx);
+    let thread_lines = lines
+        .iter()
+        .filter(|line| line.trim_start().starts_with("Thread "))
+        .count();
+    assert_eq!(
+        thread_lines, total,
+        "expected `Expand All` to reveal every thread, got {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|line| line.contains("see ")),
+        "expected `Expand All` to remove the `See more` row, got {lines:?}"
+    );
+}
+
+#[gpui::test]
 async fn test_pinned_threads_surface_in_pinned_section(cx: &mut TestAppContext) {
     let project = init_test_project_with_agent_panel("/my-project", cx).await;
     let (multi_workspace, cx) =


### PR DESCRIPTION
# Objective

The agent panel's thread list currently always groups threads by workspace and shows a fixed set of per-thread metadata. This makes how the thread list is grouped, what metadata it shows, and how it is filtered configurable.

## Solution

Adds the following to the agent panel sidebar's thread list:

**Grouping modes** (`agent.thread_group_by`):
- `workspace` (default) — grouped by workspace/project, matching today's behavior
- `updated` — grouped by recency (Today, Yesterday, This Week, …)
- `status` — grouped by thread status

**Metadata display toggles** (`agent.thread_list_display`) — independently show/hide per-thread metadata:
- `show_timestamp` — last-updated time
- `show_branch` — git branch / linked-worktree chips
- `show_diff_stats` — added/removed line counts

**Filtering** — a "Filter by" menu to narrow the list by status (Running, Needs Attention, Completed, Error) and source (Zed Agent, External Agents). The active filters (status and source) persist across restarts via the `agent.thread_filter` setting.

**"See more" truncation** — in workspace grouping, each group shows a limited number of threads with a "See more" row to expand, while the full untruncated list remains available to the thread switcher and thread cycling.

New settings are registered in the settings UI.

## Testing

- `cargo test -p sidebar` passes (including new tests for `updated`-grouping section headers, "See more" truncation, the thread switcher seeing the untruncated list, and the sidebar property/invariant test).
- `./script/clippy -p sidebar -p agent_settings -p settings_content -p agent_ui -p settings_ui` is clean (`--deny warnings`, release, all targets).
- Manually exercised the grouping modes, display toggles, and filter menu on macOS.
- Reviewers can test by opening the agent panel, using the group-by / display / filter controls at the bottom of the thread list, and toggling the corresponding `agent.thread_group_by` / `agent.thread_list_display` settings.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Group by: Workspace
<img width="1920" height="1200" alt="Screenshot 2026-06-11 at 10 09 32 PM" src="https://github.com/user-attachments/assets/3c9a76af-a1f1-4d7d-8d7a-63805a38aeb8" />

Group by: Updated
<img width="1920" height="1200" alt="Screenshot 2026-06-11 at 10 11 54 PM" src="https://github.com/user-attachments/assets/8dfd9dd7-5949-4511-b7ba-8ef07aad1cc4" />

Group by: Status
<img width="1920" height="1200" alt="Screenshot 2026-06-11 at 10 12 28 PM" src="https://github.com/user-attachments/assets/859b725e-baa0-4c8e-9664-a49284225164" />

Filters: Status
<img width="1920" height="1200" alt="Screenshot 2026-06-11 at 10 12 58 PM" src="https://github.com/user-attachments/assets/8e776511-6658-4d40-993b-4c0bda646205" />

Filters: Source
<img width="1920" height="1200" alt="Screenshot 2026-06-11 at 10 13 10 PM" src="https://github.com/user-attachments/assets/30b883e5-71fb-4642-b609-b7a05e4693ab" />

---

Release Notes:

- Added configurable grouping, metadata display, and filtering options to the agent panel's thread list.

