### PR TITLE
call: Log LiveKit connection info refresh outcomes in retry loop

### DIFF
--- a/crates/call/src/call_impl/room.rs
+++ b/crates/call/src/call_impl/room.rs
@@ -1855,8 +1855,19 @@ fn spawn_room_connection(
                 return;
             };
             match rejoin.await {
-                Ok(Some(new_connection_info)) => connection_info = new_connection_info,
-                Ok(None) => {}
+                Ok(Some(new_connection_info)) => {
+                    log::info!(
+                        "refreshed LiveKit connection info (token changed: {})",
+                        new_connection_info.token != connection_info.token
+                    );
+                    connection_info = new_connection_info;
+                }
+                Ok(None) => {
+                    log::warn!(
+                        "server returned no fresh LiveKit connection info; \
+                         retrying with the existing token"
+                    );
+                }
                 Err(error) => {
                     log::error!("failed to refresh LiveKit connection info: {error:#}");
                 }


### PR DESCRIPTION
Follow-up to #59195. While verifying that fix against prod we hit a log that couldn't distinguish "retrying with a fresh token that is still revoked" from "silently retrying with the same dead token because the server returned no connection info" (e.g. a collab deploy predating #59195). Make the retry loop self-diagnosing:

- Warn when `RejoinRoomResponse` carries no `live_kit_connection_info`, since the loop then reuses the existing token.
- On refresh, log whether the token actually changed.

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)