### PR TITLE
Revert "gpui: Fix title bar clicks being delayed on macOS 27 (#58947)"

### DIFF
--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -292,15 +292,6 @@ unsafe fn build_classes() {
                 sel!(characterIndexForPoint:),
                 character_index_for_point as extern "C" fn(&Object, Sel, NSPoint) -> u64,
             );
-
-            // Undocumented SPI, also implemented by Chromium's content view. This
-            // lets full size content windows mark our Metal view as app owned title
-            // bar content, avoiding AppKit's title bar click-delay behavior.
-            decl.add_method(
-                sel!(_opaqueRectForWindowMoveWhenInTitlebar),
-                opaque_rect_for_window_move_when_in_titlebar
-                    as extern "C" fn(&Object, Sel) -> NSRect,
-            );
             decl.register()
         };
         BLURRED_VIEW_CLASS = {
@@ -2850,25 +2841,6 @@ extern "C" fn accepts_first_mouse(this: &Object, _: Sel, _: id) -> BOOL {
     let mut lock = window_state.as_ref().lock();
     lock.first_mouse = true;
     YES
-}
-
-extern "C" fn opaque_rect_for_window_move_when_in_titlebar(this: &Object, _: Sel) -> NSRect {
-    unsafe {
-        let window: id = msg_send![this, window];
-        if window == nil {
-            return NSRect::new(NSPoint::new(0., 0.), NSSize::new(0., 0.));
-        }
-
-        let style_mask: NSWindowStyleMask = msg_send![window, styleMask];
-        if style_mask.contains(NSWindowStyleMask::NSFullSizeContentViewWindowMask) {
-            // Declare the entire view as opaque content for window move purposes
-            // when using a custom titlebar, so AppKit doesn't wait for double click
-            // disambiguation before delivering clicks to titlebar controls.
-            msg_send![this, bounds]
-        } else {
-            NSRect::new(NSPoint::new(0., 0.), NSSize::new(0., 0.))
-        }
-    }
 }
 
 extern "C" fn character_index_for_point(this: &Object, _: Sel, position: NSPoint) -> u64 {


### PR DESCRIPTION
This reverts commit c8554b46e78985931b0709a3d024462924e39c8d.

Reverting this because it broke dragging the settings UI window.

Closes https://github.com/zed-industries/zed/issues/59163

Release Notes:

- Fixed not being able to drag the settings UI window on macOS.