### PR TITLE
fuzzy_nucleo: Add a tail proximity bonus to fix the double hits not sorted higher bonus.

### DIFF
--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -448,6 +448,55 @@ async fn test_complex_path(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_tail_proximity_bonus_prefers_shallow_cargo_toml(cx: &mut TestAppContext) {
+    let app_state = init_test(cx);
+
+    cx.update(|cx| {
+        let settings = *ProjectPanelSettings::get_global(cx);
+        ProjectPanelSettings::override_global(
+            ProjectPanelSettings {
+                hide_root: true,
+                ..settings
+            },
+            cx,
+        );
+    });
+
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/root"),
+            json!({
+                "zzz": { "zed": { "Cargo.toml": "" } },
+                "zed": { "zzz": { "Cargo.toml": "" } },
+            }),
+        )
+        .await;
+
+    let project = Project::test(app_state.fs.clone(), [path!("/root").as_ref()], cx).await;
+    let (picker, _, cx) = build_find_picker(project, cx);
+
+    picker
+        .update_in(cx, |picker, window, cx| {
+            picker
+                .delegate
+                .update_matches("zed cargo".to_string(), window, cx)
+        })
+        .await;
+
+    picker.update(cx, |picker, _| {
+        assert_eq!(
+            collect_search_matches(picker).search_paths_only(),
+            vec![
+                rel_path("zzz/zed/Cargo.toml").into(),
+                rel_path("zed/zzz/Cargo.toml").into(),
+            ],
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_row_column_numbers_query_inside_file(cx: &mut TestAppContext) {
     let app_state = init_test(cx);
 

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -448,7 +448,7 @@ async fn test_complex_path(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_tail_proximity_bonus_prefers_shallow_cargo_toml(cx: &mut TestAppContext) {
+async fn test_tail_proximity_bonus_prefers_later_match(cx: &mut TestAppContext) {
     let app_state = init_test(cx);
 
     cx.update(|cx| {

--- a/crates/fuzzy_nucleo/src/paths.rs
+++ b/crates/fuzzy_nucleo/src/paths.rs
@@ -134,6 +134,15 @@ fn get_filename_match_bonus(
     score as f64 / filename.len().max(1) as f64
 }
 
+pub const TAIL_REWARD_SCALE: f64 = 1.5;
+
+#[inline]
+fn get_tail_proximity_bonus(matched_chars: &[u32], haystack_len: u32) -> f64 {
+    let trailing: u32 = matched_chars.iter().map(|&i| haystack_len - 1 - i).sum();
+    let mean_trailing = trailing as f64 / matched_chars.len() as f64;
+    (1.0 / (1.0 + mean_trailing)) * TAIL_REWARD_SCALE
+}
+
 fn path_match_helper<'a>(
     matcher: &mut nucleo::Matcher,
     query: &Query,
@@ -193,7 +202,9 @@ fn path_match_helper<'a>(
 
         let length_penalty = candidate_buf.len() as f64 * LENGTH_PENALTY;
         let filename_bonus = get_filename_match_bonus(&candidate_buf, &query.pattern, matcher);
-        let positive = (score as f64 + filename_bonus) * case_penalty(case_mismatches);
+        let tail_proximity_bonus =
+            get_tail_proximity_bonus(&matched_chars, candidate_buf.len() as u32);
+        let positive = (score as f64 + filename_bonus + tail_proximity_bonus) * case_penalty(case_mismatches);
         let adjusted_score = positive - length_penalty;
         let positions = positions_from_sorted(&candidate_buf, &matched_chars);
 

--- a/crates/fuzzy_nucleo/src/paths.rs
+++ b/crates/fuzzy_nucleo/src/paths.rs
@@ -134,10 +134,14 @@ fn get_filename_match_bonus(
     score as f64 / filename.len().max(1) as f64
 }
 
-pub const TAIL_REWARD_SCALE: f64 = 1.5;
+const TAIL_REWARD_SCALE: f64 = 1.5;
 
 #[inline]
 fn get_tail_proximity_bonus(matched_chars: &[u32], haystack_len: u32) -> f64 {
+    debug_assert!(
+        haystack_len != 0 && matched_chars.len() != 0,
+        "This should only be called on a successful match."
+    );
     let trailing: u32 = matched_chars.iter().map(|&i| haystack_len - 1 - i).sum();
     let mean_trailing = trailing as f64 / matched_chars.len() as f64;
     (1.0 / (1.0 + mean_trailing)) * TAIL_REWARD_SCALE
@@ -202,8 +206,7 @@ fn path_match_helper<'a>(
 
         let length_penalty = candidate_buf.len() as f64 * LENGTH_PENALTY;
         let filename_bonus = get_filename_match_bonus(&candidate_buf, &query.pattern, matcher);
-        let tail_proximity_bonus =
-            get_tail_proximity_bonus(&matched_chars, candidate_buf.len() as u32);
+        let tail_proximity_bonus = get_tail_proximity_bonus(&matched_chars, haystack.len() as u32);
         let positive =
             (score as f64 + filename_bonus + tail_proximity_bonus) * case_penalty(case_mismatches);
         let adjusted_score = positive - length_penalty;

--- a/crates/fuzzy_nucleo/src/paths.rs
+++ b/crates/fuzzy_nucleo/src/paths.rs
@@ -204,7 +204,8 @@ fn path_match_helper<'a>(
         let filename_bonus = get_filename_match_bonus(&candidate_buf, &query.pattern, matcher);
         let tail_proximity_bonus =
             get_tail_proximity_bonus(&matched_chars, candidate_buf.len() as u32);
-        let positive = (score as f64 + filename_bonus + tail_proximity_bonus) * case_penalty(case_mismatches);
+        let positive =
+            (score as f64 + filename_bonus + tail_proximity_bonus) * case_penalty(case_mismatches);
         let adjusted_score = positive - length_penalty;
         let positions = positions_from_sorted(&candidate_buf, &matched_chars);
 


### PR DESCRIPTION
# Objective
Fixes #55195 

The issue is that if a path contains some part of the query multiple times, like `x/x.py` it may not outrank results like `y/x.py` (for the query `x`), despite the fact that it should.

## Solution

I added a very small bonus that rewards the proximity of the matches to the tail-end of the path, this is easy because nucleo naturally favors the tail, so the tail most match for a given query atom will be the one that is found. This bonus does need to be small, though not too small, in order to not disrupt any other scoring orders. 

The main benefit of this over a different approach like counting occurrences of an atom is speed, this approach is constant time and just overall very low overhead, but performance would be much more of a concern with other approaches. 

## Testing

All the file finder tests still pass. 

Directly showing off the difference on the case from the original issue:
<img width="944" height="1123" alt="Screenshot 2026-06-12 at 3 36 13 PM" src="https://github.com/user-attachments/assets/e4d2efdd-284f-4ef6-931f-fb7f95e801f8" />

This case shows that it *doesn't* overpower the other bonuses, like the length bonus.
<img width="944" height="1123" alt="Screenshot 2026-06-12 at 3 36 06 PM" src="https://github.com/user-attachments/assets/46dcc17d-ba28-4fc3-a119-3d5ef49785bc" />


## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


---
Release Notes:

- file_finder: Improved search results from fuzzy file search.
