### PR TITLE
extension_ui: Hide agent servers from chips

### DIFF
--- a/crates/cloud_api_types/src/extension.rs
+++ b/crates/cloud_api_types/src/extension.rs
@@ -36,11 +36,12 @@ pub struct ExtensionApiManifest {
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 pub enum ExtensionProvides {
+    Languages,
     Themes,
     IconThemes,
-    Languages,
     Grammars,
     LanguageServers,
+    DebugAdapters,
     ContextServers,
     /// Deprecated
     AgentServers,
@@ -49,7 +50,6 @@ pub enum ExtensionProvides {
     /// Deprecated
     IndexedDocsProviders,
     Snippets,
-    DebugAdapters,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -1738,31 +1738,34 @@ impl Render for ExtensionsPage {
                                 this.change_provides_filter(None, cx);
                             })),
                     )
-                    .children(ExtensionProvides::iter().filter_map(|provides| {
-                        match provides {
-                            ExtensionProvides::SlashCommands
-                            | ExtensionProvides::IndexedDocsProviders => return None,
-                            _ => {}
-                        }
+                    .children(
+                        ExtensionProvides::iter()
+                            .filter(|provides| match provides {
+                                ExtensionProvides::AgentServers
+                                | ExtensionProvides::Grammars // grammars do not add anything of value to users currently
+                                | ExtensionProvides::IndexedDocsProviders
+                                | ExtensionProvides::SlashCommands => false,
+                                _ => true,
+                            })
+                            .map(|provides| {
+                                let label = extension_provides_label(provides);
+                                let button_id =
+                                    SharedString::from(format!("filter-category-{}", label));
 
-                        let label = extension_provides_label(provides);
-                        let button_id = SharedString::from(format!("filter-category-{}", label));
-
-                        Some(
-                            Button::new(button_id, label)
-                                .style(if self.provides_filter == Some(provides) {
-                                    ButtonStyle::Filled
-                                } else {
-                                    ButtonStyle::Subtle
-                                })
-                                .toggle_state(self.provides_filter == Some(provides))
-                                .on_click({
-                                    cx.listener(move |this, _event, _, cx| {
-                                        this.change_provides_filter(Some(provides), cx);
+                                Button::new(button_id, label)
+                                    .style(if self.provides_filter == Some(provides) {
+                                        ButtonStyle::Filled
+                                    } else {
+                                        ButtonStyle::Subtle
                                     })
-                                }),
-                        )
-                    })),
+                                    .toggle_state(self.provides_filter == Some(provides))
+                                    .on_click({
+                                        cx.listener(move |this, _event, _, cx| {
+                                            this.change_provides_filter(Some(provides), cx);
+                                        })
+                                    })
+                            }),
+                    ),
             )
             .child(self.render_feature_upsells(cx))
             .child(v_flex().px_4().size_full().overflow_y_hidden().map(|this| {


### PR DESCRIPTION
This fixes an issue where we would still allow users to toggle for agent servers but would not actually show them any results, since they are all suppressed.

Also slightly changes the order in which we present the provides chips: Languages is now first, and debug adapters are now further up.

Release Notes:

- Removed the agent server chip from the extension UI search filder.
