### PR TITLE
agent_ui: Remove dead link in agent menu

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -65,7 +65,7 @@ use anyhow::{Context as _, Result, anyhow};
 #[cfg(feature = "audio")]
 use audio::{Audio, Sound};
 use chrono::{DateTime, Utc};
-use client::{UserStore, zed_urls};
+use client::UserStore;
 use cloud_api_types::Plan;
 use collections::HashMap;
 use editor::{Editor, MultiBuffer};
@@ -5689,10 +5689,6 @@ impl AgentPanel {
                                         },
                                     );
                                 }
-
-                                menu = menu.entry("Rules Library", None, |_window, cx| {
-                                    cx.open_url(&zed_urls::rules_docs(cx));
-                                });
 
                                 menu = menu.separator();
                             }

--- a/crates/client/src/zed_urls.rs
+++ b/crates/client/src/zed_urls.rs
@@ -56,10 +56,6 @@ pub fn skills_docs(cx: &App) -> String {
     format!("{server_url}/docs/ai/skills", server_url = server_url(cx))
 }
 
-pub fn rules_docs(cx: &App) -> String {
-    format!("{server_url}/docs/ai/rules", server_url = server_url(cx))
-}
-
 /// Returns the URL to Zed's ACP registry blog post.
 pub fn acp_registry_blog(cx: &App) -> String {
     format!(


### PR DESCRIPTION
The link 404s for me on all channels, thus removing it and the context menu entry here.

Release Notes:

- Removed a dead link in the agent menu.
