### PR TITLE
component_preview: Fix example rendering no text or icons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3622,10 +3622,13 @@ name = "component_preview"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assets",
  "client",
  "collections",
  "component",
  "db",
+ "editor",
+ "env_logger 0.11.8",
  "fs",
  "gpui",
  "gpui_platform",

--- a/crates/component_preview/Cargo.toml
+++ b/crates/component_preview/Cargo.toml
@@ -40,7 +40,10 @@ uuid.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]
-gpui_platform = { workspace = true, features = ["screen-capture"] }
+assets.workspace = true
+editor.workspace = true
+env_logger.workspace = true
+gpui_platform = { workspace = true, features = ["screen-capture", "font-kit", "wayland", "x11"] }
 
 [[example]]
 name = "component_preview"

--- a/crates/component_preview/examples/component_preview.rs
+++ b/crates/component_preview/examples/component_preview.rs
@@ -1,6 +1,7 @@
 //! Component Preview Example
 //!
 //! Run with: `cargo run -p component_preview --example component_preview"`
+use assets::Assets;
 use fs::RealFs;
 use gpui::{AppContext as _, Bounds, KeyBinding, WindowBounds, WindowOptions, actions, size};
 
@@ -16,20 +17,28 @@ use workspace::{AppState, Workspace, WorkspaceStore};
 
 use component_preview::{ComponentPreview, init};
 
-actions!(zed, [Quit]);
+actions!(component_preview, [Quit]);
 
 fn quit(_: &Quit, cx: &mut App) {
     cx.quit();
 }
 
 fn main() {
-    gpui_platform::application().run(|cx| {
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Warn)
+        .init();
+
+    gpui_platform::application().with_assets(Assets).run(|cx| {
         component::init();
 
         cx.on_action(quit);
         cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
         let version = release_channel::AppVersion::load(env!("CARGO_PKG_VERSION"), None, None);
         release_channel::init(version, cx);
+        cx.set_global(db::AppDatabase::new());
+        Assets
+            .load_fonts(cx)
+            .expect("Failed to load embedded fonts");
 
         let http_client =
             ReqwestClient::user_agent("component_preview").expect("Failed to create HTTP client");
@@ -68,6 +77,7 @@ fn main() {
         AppState::set_global(app_state.clone(), cx);
 
         workspace::init(app_state.clone(), cx);
+        editor::init(cx);
         init(app_state.clone(), cx);
 
         let size = size(px(1200.), px(800.));


### PR DESCRIPTION
`cargo run -p component_preview --example component_preview` does not work.
On current main it panics at startup:

```
thread 'main' panicked at crates/gpui/src/action.rs:296:13:
Action with name `zed::Quit` already registered
```

With that panic fixed, the window opens but renders no text and no icons (see Showcase below).s

## Solution

Root cause for the blank window: `component_preview` package resolves `gpui_platform` with just `"screen-capture"`.

On macOS the missing `font-kit` feature makes `MacPlatform` fall back to `gpui::NoopTextSystem`, as mentiond also in README (or CONTRIBUTE) file.

On Linux the missing `wayland`/`x11` features leave no windowing backend at all.

list of changes:

- Enable the same `gpui_platform` features as the `zed` binary.
- Attach `Assets` and load the embedded fonts.
- Initialize `env_logger` so platform warnings reach the terminal.
- Fix three startup panics: move the example's `Quit` action to the  `component_preview` namespace.

## Testing

Tested on macOS/Linux, not tested on Windows. I use Parallel VMs.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)

## Showcase

Before:
<img width="1312" height="945" alt="cp_pr1_before" src="https://github.com/user-attachments/assets/4611596f-6775-4863-bd4a-5f4d8c642e35" />

After:
<img width="1312" height="945" alt="cp_pr1_after" src="https://github.com/user-attachments/assets/8f8082e6-c8cd-48f5-946a-032ce8186d30" />

---

Release Notes:

- N/A
