### PR TITLE
gpui_macos: Warn when falling back to NoopTextSystem

### DIFF
--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -194,7 +194,14 @@ impl MacPlatform {
         let text_system = Arc::new(crate::MacTextSystem::new());
 
         #[cfg(not(feature = "font-kit"))]
-        let text_system = Arc::new(gpui::NoopTextSystem::new());
+        let text_system = {
+            if !headless {
+                log::warn!(
+                    "gpui_macos was compiled without the `font-kit` feature, so no text will be rendered."
+                );
+            }
+            Arc::new(gpui::NoopTextSystem::new())
+        };
 
         let keyboard_layout = MacKeyboardLayout::new();
         let keyboard_mapper = Rc::new(MacKeyboardMapper::new(keyboard_layout.id()));


### PR DESCRIPTION
# Objective

Without the `font-kit` feature, `MacPlatform` silently substitutes `gpui::NoopTextSystem`, which accepts fonts and resolves font ids but rasterizes every glyph to an empty bitmap.

I hit this with the `component_preview` example https://github.com/zed-industries/zed/pull/59241.

## Solution

Log a warning at startup in `MacPlatform::new()` when falling back to `NoopTextSystem`. Skipped in headless mode, where no text is expected to render and the fallback is a reasonable configuration.

## Testing

Checked as part of https://github.com/zed-industries/zed/pull/59241

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)

## Showcase

It just render as like without any error:
<img width="1312" height="945" alt="cp_pr1_before" src="https://github.com/user-attachments/assets/f5faf3c0-9523-4c5f-9756-e65cbaf3456f" />


---

Release Notes:

- N/A or Added/Fixed/Improved ...
