### PR TITLE
Replace Lowercasing With ASCII Comparisons

### DIFF
--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -432,19 +432,19 @@ impl CodegenAlternative {
             });
             self.generation = self.handle_completion(model, completion_events, cx);
         } else {
-            let stream: LocalBoxFuture<Result<LanguageModelTextStream>> =
-                if user_prompt.trim().to_lowercase() == "delete" {
-                    async { Ok(LanguageModelTextStream::default()) }.boxed_local()
-                } else {
-                    let request = self.build_request(&model, user_prompt, context_task, cx)?;
-                    cx.spawn({
-                        let model = model.clone();
-                        async move |_, cx| {
-                            Ok(model.stream_completion_text(request.await, cx).await?)
-                        }
-                    })
-                    .boxed_local()
-                };
+            let stream: LocalBoxFuture<Result<LanguageModelTextStream>> = if user_prompt
+                .trim()
+                .eq_ignore_ascii_case("delete")
+            {
+                async { Ok(LanguageModelTextStream::default()) }.boxed_local()
+            } else {
+                let request = self.build_request(&model, user_prompt, context_task, cx)?;
+                cx.spawn({
+                    let model = model.clone();
+                    async move |_, cx| Ok(model.stream_completion_text(request.await, cx).await?)
+                })
+                .boxed_local()
+            };
             self.generation =
                 self.handle_stream(model, /* strip_invalid_spans: */ true, stream, cx);
         }

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -1244,7 +1244,7 @@ RUN sed -i -E 's/((^|\s)PATH=)([^\$]*)$/\1\${{PATH:-\3}}/g' /etc/profile || true
             .iter()
             .filter_map(|mount| {
                 if let Some(mount_type) = &mount.mount_type
-                    && mount_type.to_lowercase() == "volume"
+                    && mount_type.eq_ignore_ascii_case("volume")
                     && let Some(source) = &mount.source
                 {
                     Some((
@@ -2823,7 +2823,10 @@ fn image_from_dockerfile(dockerfile_contents: String, target: &Option<String>) -
             Some(target) => {
                 let parts = from_line.split(' ').collect::<Vec<&str>>();
                 if parts.len() >= 3
-                    && parts.get(parts.len() - 2).unwrap_or(&"").to_lowercase() == "as"
+                    && parts
+                        .get(parts.len() - 2)
+                        .unwrap_or(&"")
+                        .eq_ignore_ascii_case("as")
                 {
                     parts.last().unwrap_or(&"").to_lowercase() == target.to_lowercase()
                 } else {

--- a/crates/edit_prediction/src/zeta.rs
+++ b/crates/edit_prediction/src/zeta.rs
@@ -101,14 +101,19 @@ pub fn request_prediction_with_zeta(
                 .as_ref()
                 .and_then(|settings| match settings.prompt_format {
                     EditPredictionPromptFormat::Zeta(version) => Some(version),
-                    EditPredictionPromptFormat::Infer => {
-                        match settings.model.to_ascii_lowercase().as_str() {
-                            "zeta" | "zeta1" => Some(ZetaVersion::Zeta1),
-                            "zeta2" => Some(ZetaVersion::Zeta2),
-                            "zeta2.1" => Some(ZetaVersion::Zeta2_1),
-                            _ => None,
+                    EditPredictionPromptFormat::Infer => match settings.model.as_str() {
+                        zeta1
+                            if zeta1.eq_ignore_ascii_case("zeta")
+                                || zeta1.eq_ignore_ascii_case("zeta1") =>
+                        {
+                            Some(ZetaVersion::Zeta1)
                         }
-                    }
+                        zeta2 if zeta2.eq_ignore_ascii_case("zeta2") => Some(ZetaVersion::Zeta2),
+                        zeta2_1 if zeta2_1.eq_ignore_ascii_case("zeta2.1") => {
+                            Some(ZetaVersion::Zeta2_1)
+                        }
+                        _ => None,
+                    },
                     _ => None,
                 })
                 .unwrap_or_default();

--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -412,11 +412,22 @@ impl std::str::FromStr for TeacherBackend {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "sonnet45" | "sonnet" | "claude" => Ok(TeacherBackend::Sonnet45),
-            "sonnet46" => Ok(TeacherBackend::Sonnet46),
-            "gpt52" | "gpt" | "openai" => Ok(TeacherBackend::Gpt52),
-            "v0114180editableregion" => Ok(TeacherBackend::Sonnet45),
+        match s {
+            sonnet45
+                if sonnet45.eq_ignore_ascii_case("sonnet45")
+                    || sonnet45.eq_ignore_ascii_case("sonnet")
+                    || sonnet45.eq_ignore_ascii_case("claude") =>
+            {
+                Ok(TeacherBackend::Sonnet45)
+            }
+            sonnet46 if sonnet46.eq_ignore_ascii_case("sonnet46") => Ok(TeacherBackend::Sonnet46),
+            gpt if gpt.eq_ignore_ascii_case("gpt52")
+                || gpt.eq_ignore_ascii_case("gpt")
+                || gpt.eq_ignore_ascii_case("openai") =>
+            {
+                Ok(TeacherBackend::Gpt52)
+            }
+            v0 if v0.eq_ignore_ascii_case("v0114180editableregion") => Ok(TeacherBackend::Sonnet45),
             _ => anyhow::bail!(
                 "unknown teacher backend `{s}`. Valid options: sonnet45, sonnet46, gpt52"
             ),
@@ -483,38 +494,44 @@ impl std::str::FromStr for PredictionProvider {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (provider, arg) = s.split_once(':').map_or((s, None), |(p, a)| (p, Some(a)));
 
-        let provider_lower = provider.to_lowercase();
-        match provider_lower.as_str() {
-            "mercury" => Ok(PredictionProvider::Mercury),
-            "zeta1" => Ok(PredictionProvider::Zeta1),
-            "zeta2" => {
+        match provider {
+            mercury if mercury.eq_ignore_ascii_case("mercury") => Ok(PredictionProvider::Mercury),
+            zeta1 if zeta1.eq_ignore_ascii_case("zeta1") => Ok(PredictionProvider::Zeta1),
+            zeta2 if zeta2.eq_ignore_ascii_case("zeta2") => {
                 let format = arg.map(ZetaFormat::parse).transpose()?.unwrap_or_default();
                 Ok(PredictionProvider::Zeta2(format))
             }
-            "teacher" => {
+            teacher if teacher.eq_ignore_ascii_case("teacher") => {
                 let (backend, format) = parse_teacher_args(arg)?;
                 Ok(PredictionProvider::Teacher(backend, format))
             }
-            "teacher-non-batching" | "teacher_non_batching" => {
+            tnb if tnb.eq_ignore_ascii_case("teacher-non-batching")
+                || tnb.eq_ignore_ascii_case("teacher_non_batching") =>
+            {
                 let (backend, format) = parse_teacher_args(arg)?;
                 Ok(PredictionProvider::TeacherNonBatching(backend, format))
             }
-            "teacher-multi-region" | "teacher_multi_region" => {
+            tmr if tmr.eq_ignore_ascii_case("teacher-multi-region")
+                || tmr.eq_ignore_ascii_case("teacher_multi_region") =>
+            {
                 let backend = arg
                     .map(|a| a.parse())
                     .transpose()?
                     .unwrap_or(TeacherBackend::default());
                 Ok(PredictionProvider::TeacherMultiRegion(backend))
             }
-            "teacher-multi-region-non-batching" | "teacher_multi_region_non_batching" => {
+            tmrnb
+                if tmrnb.eq_ignore_ascii_case("teacher-multi-region-non-batching")
+                    || tmrnb.eq_ignore_ascii_case("teacher_multi_region_non_batching") =>
+            {
                 let backend = arg
                     .map(|a| a.parse())
                     .transpose()?
                     .unwrap_or(TeacherBackend::default());
                 Ok(PredictionProvider::TeacherMultiRegionNonBatching(backend))
             }
-            "repair" => Ok(PredictionProvider::Repair),
-            "baseten" => {
+            repair if repair.eq_ignore_ascii_case("repair") => Ok(PredictionProvider::Repair),
+            baseten if baseten.eq_ignore_ascii_case("baseten") => {
                 let format = arg
                     .map(ZetaFormat::parse)
                     .transpose()?

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -1411,10 +1411,12 @@ impl ExtensionsPage {
         if let Some(id) = search.strip_prefix("id:") {
             self.upsells.clear();
 
-            let upsell = match id.to_lowercase().as_str() {
-                "ruff" => Some(Feature::ExtensionRuff),
-                "basedpyright" => Some(Feature::ExtensionBasedpyright),
-                "ty" => Some(Feature::ExtensionTy),
+            let upsell = match id {
+                ruff if ruff.eq_ignore_ascii_case("ruff") => Some(Feature::ExtensionRuff),
+                basedpyright if basedpyright.eq_ignore_ascii_case("basedpyright") => {
+                    Some(Feature::ExtensionBasedpyright)
+                }
+                ty if ty.eq_ignore_ascii_case("ty") => Some(Feature::ExtensionTy),
                 _ => None,
             };
 

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -286,11 +286,11 @@ pub enum ThinkingLevel {
 
 impl ThinkingLevel {
     pub fn from_effort(effort: &str) -> Option<Self> {
-        match effort.to_lowercase().as_str() {
-            "minimal" => Some(Self::Minimal),
-            "low" => Some(Self::Low),
-            "medium" => Some(Self::Medium),
-            "high" => Some(Self::High),
+        match effort {
+            minial if minial.eq_ignore_ascii_case("minimal") => Some(Self::Minimal),
+            low if low.eq_ignore_ascii_case("low") => Some(Self::Low),
+            medium if medium.eq_ignore_ascii_case("medium") => Some(Self::Medium),
+            high if high.eq_ignore_ascii_case("high") => Some(Self::High),
             _ => None,
         }
     }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1815,9 +1815,9 @@ impl PromptButton {
 
 impl From<&str> for PromptButton {
     fn from(value: &str) -> Self {
-        match value.to_lowercase().as_str() {
-            "ok" => PromptButton::Ok("OK".into()),
-            "cancel" => PromptButton::Cancel("Cancel".into()),
+        match value {
+            yes if yes.eq_ignore_ascii_case("ok") => PromptButton::Ok("OK".into()),
+            cancel if cancel.eq_ignore_ascii_case("cancel") => PromptButton::Cancel("Cancel".into()),
             _ => PromptButton::Other(SharedString::from(value.to_owned())),
         }
     }

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -2517,7 +2517,7 @@ fn get_scale_factor(
     let env_dpi = std::env::var(GPUI_X11_SCALE_FACTOR_ENV)
         .ok()
         .map(|var| {
-            if var.to_lowercase() == "randr" {
+            if var.eq_ignore_ascii_case("randr") {
                 DpiMode::Randr
             } else if let Ok(scale) = var.parse::<f32>() {
                 if valid_scale_factor(scale) {

--- a/crates/language/src/modeline.rs
+++ b/crates/language/src/modeline.rs
@@ -158,40 +158,43 @@ fn parse_emacs_key_value(part: &str, settings: &mut ModelineSettings, bare: bool
         let key = key.trim();
         let value = value.trim();
 
-        match key.to_lowercase().as_str() {
-            "mode" => {
+        match key {
+            key_name if key_name.eq_ignore_ascii_case("mode") => {
                 settings.mode = Some(value.to_string());
             }
-            "c-basic-offset" | "python-indent-offset" => {
+            key_name
+                if key_name.eq_ignore_ascii_case("c-basic-offset")
+                    || key_name.eq_ignore_ascii_case("python-indent-offset") =>
+            {
                 if let Ok(size) = value.parse::<NonZeroU32>() {
                     settings.indent_size = Some(size);
                 }
             }
-            "fill-column" => {
+            key_name if key_name.eq_ignore_ascii_case("fill-column") => {
                 if let Ok(size) = value.parse::<NonZeroU32>() {
                     settings.preferred_line_length = Some(size);
                 }
             }
-            "tab-width" => {
+            key_name if key_name.eq_ignore_ascii_case("tab-width") => {
                 if let Ok(size) = value.parse::<NonZeroU32>() {
                     settings.tab_size = Some(size);
                 }
             }
-            "indent-tabs-mode" => {
+            key_name if key_name.eq_ignore_ascii_case("indent-tabs-mode") => {
                 settings.hard_tabs = Some(value != "nil");
             }
-            "electric-indent-mode" => {
+            key_name if key_name.eq_ignore_ascii_case("electric-indent-mode") => {
                 settings.auto_indent = Some(value != "nil");
             }
-            "require-final-newline" => {
+            key_name if key_name.eq_ignore_ascii_case("require-final-newline") => {
                 settings.ensure_final_newline = Some(value != "nil");
             }
-            "show-trailing-whitespace" => {
+            key_name if key_name.eq_ignore_ascii_case("show-trailing-whitespace") => {
                 settings.show_trailing_whitespace = Some(value != "nil");
             }
-            key => settings
+            key_name => settings
                 .emacs_extra_variables
-                .push((key.to_string(), value.to_string())),
+                .push((key_name.to_string(), value.to_string())),
         }
     } else if bare {
         // Handle bare mode specification (e.g., -*- rust -*-)

--- a/crates/language_model_core/src/request.rs
+++ b/crates/language_model_core/src/request.rs
@@ -36,8 +36,8 @@ impl LanguageModelImage {
         let mut source = None;
 
         for (k, v) in obj.iter() {
-            match k.to_lowercase().as_str() {
-                "source" => source = v.as_str(),
+            match k.as_str() {
+                k if k.eq_ignore_ascii_case("source") => source = v.as_str(),
                 _ => {}
             }
         }
@@ -169,14 +169,14 @@ impl<'de> Deserialize<'de> for LanguageModelToolResultContent {
             if let (Some(type_value), Some(text_value)) =
                 (get_field(obj, "type"), get_field(obj, "text"))
                 && let Some(type_str) = type_value.as_str()
-                && type_str.to_lowercase() == "text"
+                && type_str.eq_ignore_ascii_case("text")
                 && let Some(text) = text_value.as_str()
             {
                 return Ok(Self::Text(Arc::from(text)));
             }
 
             // Check for wrapped Text variant: { "text": "..." }
-            if let Some((_key, value)) = obj.iter().find(|(k, _)| k.to_lowercase() == "text")
+            if let Some((_key, value)) = obj.iter().find(|(k, _)| k.eq_ignore_ascii_case("text"))
                 && obj.len() == 1
             {
                 if let Some(text) = value.as_str() {
@@ -185,7 +185,7 @@ impl<'de> Deserialize<'de> for LanguageModelToolResultContent {
             }
 
             // Check for wrapped Image variant: { "image": { "source": "...", "size": ... } }
-            if let Some((_key, value)) = obj.iter().find(|(k, _)| k.to_lowercase() == "image")
+            if let Some((_key, value)) = obj.iter().find(|(k, _)| k.eq_ignore_ascii_case("image"))
                 && obj.len() == 1
             {
                 if let Some(image_obj) = value.as_object()

--- a/crates/language_models/src/provider/opencode.rs
+++ b/crates/language_models/src/provider/opencode.rs
@@ -31,13 +31,15 @@ use crate::provider::open_ai::{
 };
 
 fn normalize_reasoning_effort(effort: &str) -> Option<ReasoningEffort> {
-    match effort.trim().to_ascii_lowercase().as_str() {
-        "none" => Some(ReasoningEffort::None),
-        "minimal" => Some(ReasoningEffort::Minimal),
-        "low" => Some(ReasoningEffort::Low),
-        "medium" => Some(ReasoningEffort::Medium),
-        "high" => Some(ReasoningEffort::High),
-        "max" | "xhigh" => Some(ReasoningEffort::XHigh),
+    match effort.trim() {
+        none if none.eq_ignore_ascii_case("none") => Some(ReasoningEffort::None),
+        minalmal if minalmal.eq_ignore_ascii_case("minimal") => Some(ReasoningEffort::Minimal),
+        low if low.eq_ignore_ascii_case("low") => Some(ReasoningEffort::Low),
+        medium if medium.eq_ignore_ascii_case("medium") => Some(ReasoningEffort::Medium),
+        high if high.eq_ignore_ascii_case("high") => Some(ReasoningEffort::High),
+        max if max.eq_ignore_ascii_case("max") || max.eq_ignore_ascii_case("xhigh") => {
+            Some(ReasoningEffort::XHigh)
+        }
         _ => None,
     }
 }

--- a/crates/markdown/src/html/html_minifier.rs
+++ b/crates/markdown/src/html/html_minifier.rs
@@ -279,34 +279,36 @@ where
             "p" => {
                 let omit_end = ctx.next_element().map_or(true, |node| {
                     if let NodeData::Element { name, .. } = &node.data {
-                        matches!(
-                            name.local.as_ref().to_ascii_lowercase().as_str(),
-                            "address"
-                                | "article"
-                                | "aside"
-                                | "blockquote"
-                                | "div"
-                                | "dl"
-                                | "fieldset"
-                                | "footer"
-                                | "form"
-                                | "h1"
-                                | "h2"
-                                | "h3"
-                                | "h4"
-                                | "h5"
-                                | "h6"
-                                | "header"
-                                | "hr"
-                                | "menu"
-                                | "nav"
-                                | "ol"
-                                | "p"
-                                | "pre"
-                                | "section"
-                                | "table"
-                                | "ul"
-                        )
+                        const ELEMENTS: &'static [&'static str] = &[
+                            "address",
+                            "article",
+                            "aside",
+                            "blockquote",
+                            "div",
+                            "dl",
+                            "fieldset",
+                            "footer",
+                            "form",
+                            "h1",
+                            "h2",
+                            "h3",
+                            "h4",
+                            "h5",
+                            "h6",
+                            "header",
+                            "hr",
+                            "menu",
+                            "nav",
+                            "ol",
+                            "p",
+                            "pre",
+                            "section",
+                            "table",
+                            "ul",
+                        ];
+                        ELEMENTS
+                            .iter()
+                            .any(|element| element.eq_ignore_ascii_case(name.local.as_ref()))
                     } else {
                         false
                     }

--- a/crates/markdown/src/html/html_parser.rs
+++ b/crates/markdown/src/html/html_parser.rs
@@ -603,10 +603,10 @@ fn html_style_from_html_styles(styles: HashMap<String, String>) -> Option<HtmlHi
 }
 
 fn parse_text_align(value: &str) -> Option<TextAlign> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "left" => Some(TextAlign::Left),
-        "center" => Some(TextAlign::Center),
-        "right" => Some(TextAlign::Right),
+    match value.trim() {
+        left if left.eq_ignore_ascii_case("left") => Some(TextAlign::Left),
+        center if center.eq_ignore_ascii_case("center") => Some(TextAlign::Center),
+        right if right.eq_ignore_ascii_case("right") => Some(TextAlign::Right),
         _ => None,
     }
 }

--- a/crates/markdown/src/html/html_parser.rs
+++ b/crates/markdown/src/html/html_parser.rs
@@ -556,11 +556,11 @@ fn html_style_from_html_styles(styles: HashMap<String, String>) -> Option<HtmlHi
     let mut html_style = HtmlHighlightStyle::default();
 
     if let Some(text_decoration) = styles.get("text-decoration") {
-        match text_decoration.to_lowercase().as_str() {
-            "underline" => {
+        match text_decoration.as_str() {
+            underline if underline.eq_ignore_ascii_case("underline") => {
                 html_style.underline = true;
             }
-            "line-through" => {
+            strikethrough if strikethrough.eq_ignore_ascii_case("line-through") => {
                 html_style.strikethrough = true;
             }
             _ => {}
@@ -568,11 +568,11 @@ fn html_style_from_html_styles(styles: HashMap<String, String>) -> Option<HtmlHi
     }
 
     if let Some(font_style) = styles.get("font-style") {
-        match font_style.to_lowercase().as_str() {
-            "italic" => {
+        match font_style.as_str() {
+            italic if italic.eq_ignore_ascii_case("italic") => {
                 html_style.italic = true;
             }
-            "oblique" => {
+            oblique if oblique.eq_ignore_ascii_case("oblique") => {
                 html_style.oblique = true;
             }
             _ => {}
@@ -580,11 +580,11 @@ fn html_style_from_html_styles(styles: HashMap<String, String>) -> Option<HtmlHi
     }
 
     if let Some(font_weight) = styles.get("font-weight") {
-        match font_weight.to_lowercase().as_str() {
-            "bold" => {
+        match font_weight.as_str() {
+            bold if bold.eq_ignore_ascii_case("bold") => {
                 html_style.weight = FontWeight::BOLD;
             }
-            "lighter" => {
+            lighter if lighter.eq_ignore_ascii_case("lighter") => {
                 html_style.weight = FontWeight::THIN;
             }
             _ => {

--- a/crates/recent_projects/src/ssh_config.rs
+++ b/crates/recent_projects/src/ssh_config.rs
@@ -99,8 +99,9 @@ fn split_keyword_and_value(line: &str) -> Option<(&str, &str)> {
 }
 
 fn is_git_provider_domain(host: &str) -> bool {
-    let host = host.to_ascii_lowercase();
-    FILTERED_GIT_PROVIDER_HOSTNAMES.contains(&host.as_str())
+    FILTERED_GIT_PROVIDER_HOSTNAMES
+        .iter()
+        .any(|h| h.eq_ignore_ascii_case(host))
 }
 
 #[cfg(test)]

--- a/crates/zlog/src/filter.rs
+++ b/crates/zlog/src/filter.rs
@@ -111,15 +111,20 @@ pub fn refresh_from_settings(settings: &HashMap<String, String>) {
 
 fn level_filter_from_str(level_str: &str) -> Option<log::LevelFilter> {
     use log::LevelFilter::*;
-    let level = match level_str.to_ascii_lowercase().as_str() {
-        "" => Trace,
-        "trace" => Trace,
-        "debug" => Debug,
-        "info" => Info,
-        "warn" => Warn,
-        "error" => Error,
-        "off" => Off,
-        "disable" | "no" | "none" | "disabled" => {
+    let level = match level_str {
+        none if none.is_ascii() => Trace,
+        trace if trace.eq_ignore_ascii_case("trace") => Trace,
+        debug if debug.eq_ignore_ascii_case("debug") => Debug,
+        info if info.eq_ignore_ascii_case("info") => Info,
+        warn if warn.eq_ignore_ascii_case("warn") => Warn,
+        error if error.eq_ignore_ascii_case("error") => Error,
+        off if off.eq_ignore_ascii_case("off") => Off,
+        disable
+            if disable.eq_ignore_ascii_case("disable")
+                || disable.eq_ignore_ascii_case("no")
+                || disable.eq_ignore_ascii_case("none")
+                || disable.eq_ignore_ascii_case("disabled") =>
+        {
             crate::warn!(
                 "Invalid log level \"{level_str}\", to disable logging set to \"off\". Defaulting to \"off\"."
             );


### PR DESCRIPTION
# Objective

- Remove unnecessary temporary lowercase allocations from several ASCII-only case-insensitive comparisons.

## Solution

- Replaced `to_lowercase()` / `to_ascii_lowercase()`-based matching with direct `eq_ignore_ascii_case()` 

## How to review

- For the first commit, I think is fine, since all method are `ascii_lowercase`
- For the second commit, I choose some path I think is fine to use `eq_ignore_ascii....`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Improved performance by avoiding temporary lowercase allocations in several ASCII case-insensitive comparisons.
