### PR TITLE
editor: Fix splitting brackets inside line comments

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4665,6 +4665,43 @@ async fn test_newline_comments_with_multiple_delimiters(cx: &mut TestAppContext)
 }
 
 #[gpui::test]
+async fn test_newline_comments_with_brackets(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(4)
+    });
+    let language = Arc::new(Language::new(
+        LanguageConfig {
+            line_comments: vec!["// ".into()],
+            brackets: BracketPairConfig {
+                pairs: vec![BracketPair {
+                    start: "(".to_string(),
+                    end: ")".to_string(),
+                    close: false,
+                    surround: false,
+                    newline: true,
+                }],
+                ..BracketPairConfig::default()
+            },
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    {
+        let mut cx = EditorTestContext::new(cx).await;
+        cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
+        cx.set_state(indoc! {"
+        // (ˇ)
+    "});
+        cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+        cx.assert_editor_state(indoc! {"
+        // (
+        // ˇ)
+    "})
+    }
+}
+
+#[gpui::test]
 async fn test_newline_comments_repl_separators(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.tab_size = NonZeroU32::new(4)

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -578,8 +578,9 @@ impl Editor {
                                 },
                                 prevent_auto_indent: false,
                             };
+                            let mut delimiter = None;
 
-                            let comment_delimiter = maybe!({
+                            if let Some(comment_delimiter) = maybe!({
                                 if !selection_is_empty {
                                     return None;
                                 }
@@ -593,9 +594,16 @@ impl Editor {
                                     &buffer,
                                     language,
                                 );
-                            });
-
-                            let doc_delimiter = maybe!({
+                            }) {
+                                delimiter = Some(comment_delimiter);
+                                if let NewlineConfig::Newline {
+                                    extra_line_additional_indent,
+                                    ..
+                                } = &mut newline_config
+                                {
+                                    *extra_line_additional_indent = None;
+                                }
+                            } else if let Some(doc_delimiter) = maybe!({
                                 if !selection_is_empty {
                                     return None;
                                 }
@@ -610,9 +618,9 @@ impl Editor {
                                     language,
                                     &mut newline_config,
                                 );
-                            });
-
-                            let list_delimiter = maybe!({
+                            }) {
+                                delimiter = Some(doc_delimiter);
+                            } else if let Some(list_delimiter) = maybe!({
                                 if !selection_is_empty {
                                     return None;
                                 }
@@ -627,12 +635,11 @@ impl Editor {
                                     language,
                                     &mut newline_config,
                                 );
-                            });
+                            }) {
+                                delimiter = Some(list_delimiter);
+                            }
 
-                            (
-                                comment_delimiter.or(doc_delimiter).or(list_delimiter),
-                                newline_config,
-                            )
+                            (delimiter, newline_config)
                         } else {
                             (
                                 None,


### PR DESCRIPTION
# Objective

Closes #59229

When adding a newline, Zed has a bit of intelligence to do more work than just inserting a `\n`. For comment lines, it simply extends the comment:
```rust
Before
// This is a comment, ˇThis is another comment


After
// This is a comment, 
// ˇThis is another comment
```
And when the cursor is inside bracket pairs, Zed inserts another newline to move the closing bracket to a new line:
```rust
Before
fn main() {ˇ}


After
fn main() {
    ˇ
}
```
However, when we have a comment line with the cursor inside a bracket pair,  both mechanisms apply, resulting in an unintended state where the closing bracket is kicked out of the comment:
```rust
Before
// {ˇ}

After
// {
// ˇ
}
```

We definitely do not need the bracket extension rule when we are adding a newline inside comments. We want comment lines inside brackets to be split like this:
```rust
// {
// ˇ}
```

## Solution

- Disable Bracket Extra Newline in Comments: When a line comment delimiter is detected, we override the default  `newline_config`  to set `extra_line_additional_indent`  to  `None` .
- Avoid Rule Conflicts (Short-circuiting): The three newline customization helpers (line comment, block comment, and list item) are mutually exclusive. I refactored their execution from a sequential list into an  `if let Some ... else if let Some`  branch. This prevents subsequent rules from having side effects on `newline_config`  when a match has already occurred.

## Testing

A new test named `test_newline_comments_with_brackets` is introduced in `crates/editor/src/editor_tests.rs`, All tests in the `editor` crate were verified using  `cargo test -p editor` .

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed an issue where splitting brackets inside line comments inserted an extra line and broke the comment formatting
