### PR TITLE
agent_ui: Surface saved terminal tool output after restart

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -5874,6 +5874,88 @@ mod tests {
         });
     }
 
+    /// Regression test for the `update_fields` fallback that the fix for
+    /// issue #57230 relies on: after a thread restart, `Thread::replay`
+    /// emits a `ToolCall` (no content / no `raw_output`) followed by a
+    /// `ToolCallUpdate` containing only the saved `raw_output`. This
+    /// fallback turns that `raw_output` into displayable markdown content
+    /// so `tool_call.content` is non-empty for the UI — which in turn lets
+    /// the agent panel decide the call is collapsible and show a
+    /// disclosure widget for the saved output.
+    #[gpui::test]
+    async fn test_raw_output_update_populates_content_when_empty(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(project, PathList::new(&[Path::new(path!("/test"))]), cx)
+            })
+            .await
+            .unwrap();
+
+        let tool_call_id = acp::ToolCallId::new("replayed-terminal-tool-call");
+        let saved_output = "```\ntotal 0\ndrwxr-xr-x  2 user user  64 Jan  1 00:00 .\n```";
+
+        thread.update(cx, |thread, cx| {
+            // Initial ToolCall event, as emitted by `Thread::replay` via
+            // `send_tool_call`: kind/title/raw_input but no content and no
+            // raw_output.
+            thread
+                .handle_session_update(
+                    acp::SessionUpdate::ToolCall(
+                        acp::ToolCall::new(tool_call_id.clone(), "ls -al")
+                            .kind(acp::ToolKind::Execute)
+                            .raw_input(json!({ "command": "ls -al" })),
+                    ),
+                    cx,
+                )
+                .unwrap();
+
+            // Followed by the status + raw_output update emitted at the end
+            // of `replay_tool_call` for tools that don't implement `replay`
+            // (e.g. the terminal tool).
+            thread
+                .handle_session_update(
+                    acp::SessionUpdate::ToolCallUpdate(acp::ToolCallUpdate::new(
+                        tool_call_id.clone(),
+                        acp::ToolCallUpdateFields::new()
+                            .status(acp::ToolCallStatus::Completed)
+                            .raw_output(json!(saved_output)),
+                    )),
+                    cx,
+                )
+                .unwrap();
+
+            let tool_call = thread
+                .entries
+                .iter()
+                .find_map(|entry| match entry {
+                    AgentThreadEntry::ToolCall(call) if call.id == tool_call_id => Some(call),
+                    _ => None,
+                })
+                .expect("replayed tool call should be present");
+
+            assert!(
+                !tool_call.content.is_empty(),
+                "raw_output should be converted to displayable content so the tool block has \
+                 expand/collapse controls after replay (issue #57230)"
+            );
+
+            let ToolCallContent::ContentBlock(ContentBlock::Markdown { markdown }) =
+                &tool_call.content[0]
+            else {
+                panic!(
+                    "expected markdown content block from raw_output, got: {:?}",
+                    tool_call.content[0]
+                );
+            };
+            assert_eq!(markdown.read(cx).source(), saved_output);
+        });
+    }
+
     /// Tests that restoring a checkpoint properly cleans up terminals that were
     /// created after that checkpoint, and cancels any in-progress generation.
     ///

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -2305,6 +2305,124 @@ async fn test_terminal_tool_cancellation_captures_output(cx: &mut TestAppContext
     verify_thread_recovery(&thread, &fake_model, cx).await;
 }
 
+/// The fix for #57230 depends on `Thread::replay` emitting, for tools without
+/// a `replay` impl (like the terminal tool), a `ToolCall` event followed by a
+/// `ToolCallUpdate` carrying the persisted `raw_output` — the update is what
+/// `acp_thread::ToolCall::update_fields` turns back into displayable content.
+/// `test_mcp_tool_result_displayed_when_server_disconnected` covers only the
+/// tool-not-found branch of `replay_tool_call`; this covers the tool-found
+/// branch, running the real `TerminalTool` end to end, and ties the persisted
+/// output to what the UI failure indicator recovers via
+/// `parse_failed_exit_code`.
+#[gpui::test]
+async fn test_terminal_tool_output_replayed_after_restart(cx: &mut TestAppContext) {
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    // A terminal whose command exits immediately with a nonzero code.
+    let environment = Rc::new(cx.update(|cx| {
+        FakeThreadEnvironment::default().with_terminal(
+            FakeTerminalHandle::new_with_immediate_exit(cx, 128).with_output(
+                acp::TerminalOutputResponse::new("fatal: oops".to_string(), false)
+                    .exit_status(acp::TerminalExitStatus::new().exit_code(128)),
+            ),
+        )
+    }));
+
+    let mut events = thread
+        .update(cx, |thread, cx| {
+            thread.add_tool(crate::TerminalTool::new(
+                thread.project().clone(),
+                environment,
+            ));
+            thread.send(UserMessageId::new(), ["run a command"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "terminal_tool_1".into(),
+            name: TerminalTool::NAME.into(),
+            raw_input: r#"{"command": "false", "cd": "."}"#.into(),
+            input: json!({"command": "false", "cd": "."}),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+
+    // Approve the command at the permission prompt. Responding explicitly
+    // (instead of overriding the permission settings) keeps the test
+    // deterministic across scheduler seeds: a settings-global override can
+    // race the async settings load in `setup` and get clobbered.
+    let tool_call_auth = next_tool_call_authorization(&mut events).await;
+    tool_call_auth
+        .response
+        .send(acp_thread::SelectedPermissionOutcome::new(
+            acp::PermissionOptionId::new("allow"),
+            acp::PermissionOptionKind::AllowOnce,
+        ))
+        .unwrap();
+    cx.run_until_parked();
+
+    // After the tool completes, the model continues with a new completion
+    // request that includes the tool result; finish the turn.
+    fake_model.send_last_completion_stream_text_chunk("The command failed.");
+    fake_model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+
+    // Replay the thread (this is what happens when loading a saved thread).
+    let mut replay_events = thread.update(cx, |thread, cx| thread.replay(cx));
+
+    let mut saw_tool_call = false;
+    let mut raw_output_update = None;
+    while let Some(event) = replay_events.next().await {
+        match event.unwrap() {
+            ThreadEvent::ToolCall(tool_call) => {
+                assert_eq!(tool_call.tool_call_id.to_string(), "terminal_tool_1");
+                assert_eq!(tool_call.kind, acp::ToolKind::Execute);
+                saw_tool_call = true;
+            }
+            ThreadEvent::ToolCallUpdate(acp_thread::ToolCallUpdate::UpdateFields(update))
+                if update.fields.raw_output.is_some() =>
+            {
+                assert_eq!(update.tool_call_id.to_string(), "terminal_tool_1");
+                assert!(
+                    saw_tool_call,
+                    "raw_output update must follow the ToolCall event, or \
+                     `update_fields` has no tool call to repopulate"
+                );
+                raw_output_update = Some(update);
+            }
+            _ => {}
+        }
+    }
+
+    let update = raw_output_update.expect("replay should emit an update carrying raw_output");
+    // A nonzero exit code is not an error result for the terminal tool.
+    assert_eq!(update.fields.status, Some(acp::ToolCallStatus::Completed));
+
+    let saved_output = update
+        .fields
+        .raw_output
+        .as_ref()
+        .and_then(|output| output.as_str())
+        .expect("terminal tool output should be persisted as a string");
+    assert!(
+        saved_output.contains("fatal: oops"),
+        "saved output should contain the terminal output, got: {saved_output}"
+    );
+    assert_eq!(
+        crate::parse_failed_exit_code(saved_output),
+        Some(128),
+        "the UI failure indicator should recover the exit code from the \
+         persisted output, got: {saved_output}"
+    );
+}
+
 #[gpui::test]
 async fn test_cancellation_aware_tool_responds_to_cancellation(cx: &mut TestAppContext) {
     // This test verifies that tools which properly handle cancellation via

--- a/crates/agent/src/tools/terminal_tool.rs
+++ b/crates/agent/src/tools/terminal_tool.rs
@@ -585,6 +585,23 @@ fn select_terminal_output_lines(output: &str, selection: TerminalOutputSelection
     }
 }
 
+/// Recovers the exit code that [`process_content`] records in the persisted
+/// output string of a failed command. The terminal tool's output is a plain
+/// string, so after a thread is reloaded from disk this sentinel is the only
+/// remaining failure signal; the UI uses it to restore the failure indicator
+/// on replayed terminal cards.
+pub fn parse_failed_exit_code(output: &str) -> Option<i32> {
+    let head = match output.find("\n\n") {
+        Some(end) => &output[..end],
+        None => output,
+    };
+    head.strip_prefix("Command \"")?;
+    let marker = "\" failed with exit code ";
+    // `rfind`, because the command itself may contain the marker text.
+    let code = &head[head.rfind(marker)? + marker.len()..];
+    code.strip_suffix('.')?.parse().ok()
+}
+
 fn process_content(
     output: acp::TerminalOutputResponse,
     command: &str,
@@ -1232,6 +1249,35 @@ mod tests {
             "Expected failure message, got: {}",
             result
         );
+    }
+
+    #[test]
+    fn test_parse_failed_exit_code_round_trips_process_content() {
+        let failed = |output: &str, command: &str, exit_code: u32| {
+            process_content(
+                acp::TerminalOutputResponse::new(output.to_string(), false)
+                    .exit_status(acp::TerminalExitStatus::new().exit_code(exit_code)),
+                command,
+                false,
+                false,
+                TerminalOutputSelection::default(),
+            )
+        };
+
+        assert_eq!(
+            parse_failed_exit_code(&failed("error output", "false", 137)),
+            Some(137)
+        );
+        assert_eq!(parse_failed_exit_code(&failed("", "false", 1)), Some(1));
+        // Quotes in the command must not break the parse.
+        assert_eq!(
+            parse_failed_exit_code(&failed("oops", "echo \"a b\" && false", 2)),
+            Some(2)
+        );
+        // Success and non-terminal-shaped outputs carry no exit code.
+        assert_eq!(parse_failed_exit_code(&failed("fine", "true", 0)), None);
+        assert_eq!(parse_failed_exit_code("Command executed successfully."), None);
+        assert_eq!(parse_failed_exit_code("arbitrary tool output"), None);
     }
 
     #[test]

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -7292,6 +7292,22 @@ impl ThreadView {
         })
     }
 
+    /// Tooltip for the failure indicator on terminal cards rendered without a
+    /// live terminal (replayed, auto-denied, or from external agents). The
+    /// exit code, when it survived in the persisted output, beats the coarser
+    /// status.
+    fn terminal_failure_tooltip(
+        saved_exit_code: Option<i32>,
+        status: &ToolCallStatus,
+    ) -> String {
+        match (saved_exit_code, status) {
+            (Some(exit_code), _) => format!("Exited with code {exit_code}"),
+            (None, ToolCallStatus::Canceled) => "Canceled".to_string(),
+            (None, ToolCallStatus::Rejected) => "Rejected".to_string(),
+            (None, _) => "Failed".to_string(),
+        }
+    }
+
     fn render_tool_call(
         &self,
         active_session_id: &acp::SessionId,
@@ -7608,13 +7624,113 @@ impl ThreadView {
             })
             .map(|this| {
                 if is_terminal_tool {
-                    this.child(self.render_collapsible_command(
+                    // `render_tool_call` only handles `Execute`-kind tool calls
+                    // when there's no live `Terminal` entity in `content` —
+                    // i.e. when the thread was reloaded from disk and the
+                    // saved output was reconstructed as markdown from
+                    // `raw_output`. The live-terminal path is
+                    // `render_terminal_tool_call`. Without an explicit
+                    // disclosure here, the saved output is reachable only by
+                    // expanding `expanded_tool_calls` for this id, which
+                    // never happens because no `NewTerminal` view event
+                    // fires for a replayed call (issue #57230).
+                    // A nonzero exit code isn't an error result for the
+                    // terminal tool; after a reload it only survives as a
+                    // sentinel in the saved output text, so recover it from
+                    // there to restore the live card's failure indicator.
+                    let saved_exit_code = tool_call
+                        .raw_output
+                        .as_ref()
+                        .and_then(|output| output.as_str())
+                        .and_then(agent::parse_failed_exit_code);
+                    let has_header =
+                        is_collapsible || failed_or_canceled || saved_exit_code.is_some();
+                    let command_block = self.render_collapsible_command(
                         card_header_id.clone(),
-                        true,
+                        // Keep the "Run Command" preview label only while the
+                        // command hasn't produced a result (e.g. awaiting
+                        // confirmation); once there is one, the header row
+                        // below replaces it, mirroring the live card.
+                        !has_header,
                         tool_call.label.clone(),
                         window,
                         cx,
-                    ))
+                    );
+                    if !has_header {
+                        return this.child(command_block);
+                    }
+                    let disclosure = is_collapsible.then(|| {
+                        let id = tool_call.id.clone();
+                        Disclosure::new(("expand-output", entry_ix), is_open)
+                            .opened_icon(IconName::ChevronUp)
+                            .closed_icon(IconName::ChevronDown)
+                            .visible_on_hover(&card_header_id)
+                            .on_click(cx.listener(
+                                move |this: &mut Self, _, _, cx: &mut Context<Self>| {
+                                    if is_open {
+                                        this.expanded_tool_calls.remove(&id);
+                                    } else {
+                                        this.expanded_tool_calls.insert(id.clone());
+                                    }
+                                    cx.notify();
+                                },
+                            ))
+                    });
+                    let failure_indicator = (failed_or_canceled || saved_exit_code.is_some())
+                        .then(|| {
+                            let tooltip = Self::terminal_failure_tooltip(
+                                saved_exit_code,
+                                &tool_call.status,
+                            );
+                            div()
+                                .id(("terminal-tool-error-code-indicator", entry_ix))
+                                .child(
+                                    Icon::new(IconName::Close)
+                                        .size(IconSize::Small)
+                                        .color(Color::Error),
+                                )
+                                .tooltip(Tooltip::text(tooltip))
+                        });
+                    // The terminal tool's `cd` input is the closest surviving
+                    // analog of the live card's working-dir header label. Other
+                    // `Execute` tools (e.g. external ACP agents) have no `cd`.
+                    let working_dir = tool_call
+                        .raw_input
+                        .as_ref()
+                        .and_then(|input| input.get("cd"))
+                        .and_then(|cd| cd.as_str())
+                        .filter(|cd| !cd.is_empty())
+                        .map_or_else(|| "Ran command".to_string(), |cd| cd.to_string());
+                    let header = h_flex()
+                        .id(("replayed-terminal-header", entry_ix))
+                        .pt_1()
+                        .pl_1p5()
+                        .pr_1()
+                        .flex_none()
+                        .gap_1()
+                        .justify_between()
+                        .child(
+                            div()
+                                .id(("command-target-path", entry_ix))
+                                .w_full()
+                                .max_w_full()
+                                .overflow_x_scroll()
+                                .child(
+                                    Label::new(working_dir)
+                                        .buffer_font(cx)
+                                        .size(LabelSize::XSmall)
+                                        .color(Color::Muted),
+                                ),
+                        )
+                        .children(disclosure)
+                        .children(failure_indicator);
+                    this.child(
+                        v_flex()
+                            .group(&card_header_id)
+                            .bg(self.tool_card_header_bg(cx))
+                            .child(header)
+                            .child(command_block),
+                    )
                 } else {
                     this.child(
                         h_flex()
@@ -10931,6 +11047,42 @@ mod tests {
     use serde_json::json;
     use util::path;
     use workspace::MultiWorkspace;
+
+    /// The failure indicator on terminal cards without a live terminal
+    /// (replayed after restart, auto-denied, or from external ACP agents)
+    /// must always offer a tooltip: the exit code recovered from the
+    /// persisted output when available, else a status-based fallback
+    /// (issue #57230 follow-up: external-agent failures showed no tooltip).
+    #[test]
+    fn test_terminal_failure_tooltip() {
+        // Native terminal tool failure, exit code recovered from the
+        // persisted output sentinel by `agent::parse_failed_exit_code`.
+        let saved_output = "Command \"false\" failed with exit code 128.\n\n```\nfatal: oops\n```";
+        let exit_code = agent::parse_failed_exit_code(saved_output);
+        assert_eq!(exit_code, Some(128));
+        assert_eq!(
+            ThreadView::terminal_failure_tooltip(exit_code, &ToolCallStatus::Failed),
+            "Exited with code 128"
+        );
+
+        // Output not produced by the native terminal tool (e.g. Claude Code
+        // reporting "Exit code 2" in its own format): no code recovered,
+        // fall back to the status.
+        let foreign = agent::parse_failed_exit_code("Exit code 2");
+        assert_eq!(foreign, None);
+        assert_eq!(
+            ThreadView::terminal_failure_tooltip(foreign, &ToolCallStatus::Failed),
+            "Failed"
+        );
+        assert_eq!(
+            ThreadView::terminal_failure_tooltip(None, &ToolCallStatus::Canceled),
+            "Canceled"
+        );
+        assert_eq!(
+            ThreadView::terminal_failure_tooltip(None, &ToolCallStatus::Rejected),
+            "Rejected"
+        );
+    }
 
     fn native_command(name: &str) -> acp::AvailableCommand {
         acp::AvailableCommand::new(name, "").meta(acp_thread::meta_with_command_category(


### PR DESCRIPTION
# Objective

Fixes #57230: after restarting Zed, terminal tool calls in a reloaded thread showed only the command, and the output persisted in `threads.db` was unreachable (no expand/collapse controls).

## Solution & Showcase

**Before**: when a thread was reloaded, `Thread::replay` recreated each terminal tool call without its live `Terminal` entity, so rendering fell through to the generic tool-call path (`render_tool_call`), which never offered a way to open the output that `acp_thread` had already reconstructed from the persisted `raw_output`.

<img width="696" height="134" alt="image" src="https://github.com/user-attachments/assets/1e509f6f-b3a7-4e91-818c-24b283c84179" />
<br/>
<br/>

**After**: once such a call has a result, the PR renders a header row above the command block that mirrors the UX of the live terminal card (behavior, label and icon position):

[Expand replayed terminal tool output.webm](https://github.com/user-attachments/assets/4c783b6b-8f33-499d-bbad-c42c6e35451e)

- **Working directory** on the left (instead of the static "Run Command" label). Calls with no `cd` (e.g. external ACP agents) show "Ran command" instead.
- **Expand/collapse chevron** revealed on hover.
- **Failure indicator** (red ✕ with an "Exited with code N" tooltip). Nonzero exit codes are recovered from the persisted output string with a new new `agent::parse_failed_exit_code` helper.

Differences from the live cards:
1. Replayed cards intentionally start collapsed regardless of the `expand_terminal_card` setting, to mirror the current UX of agent threads after Zed restarts. Later we might add auto-expansion during [in-thread search](https://github.com/zed-industries/zed/pull/57231), or an UX affordance to expand all.
2. There's a thin border around replayed output, coming from the markdown fenced code block. Signals a static snapshot rather than a live terminal, so I decided to keep it.

The PR also serves two more paths that had the same unreachable-output bug:
1. `Execute`-kind calls that never get a terminal entity, i.e. commands denied by the user or auto-denied by the permission layer (due to containing `$VAR` substitutions, for example)

[User-denied command.webm](https://github.com/user-attachments/assets/5049ca4a-6475-4815-a973-2edf46e5f888)

2. External ACP agents that report command output as plain content blocks.

## Testing

Automated tests:

- `acp_thread`: regression test for the `update_fields` raw-output fallback the UI depends on (`test_raw_output_update_populates_content_when_empty`).
- `agent`: round-trip test for `parse_failed_exit_code` against `process_content`.

<details>
  <summary>Manual test plan, all pass</summary>

Summary: replayed cards start collapsed; chevron and copy button appear on hover; output expands/collapses on click; failed commands show the red ✕ with the exit-code tooltip.

### Setup

1. In the agent panel, start a thread and send this prompt:
```
We're testing Zed's terminal output handling. Please run the following commands using the termnal tool:
- A successful command with output (e.g. `ls -al`)
- A successful command without output (e.g. `true`)
- A failing command (e.g. `false` → exit 1, or a `git add nonexistent.xyz` → exit 128)
- A command containing a shell variable (e.g. run `echo $HOME` verbatim)
- A long multi-line command (heredoc-style or `&&`-chained across lines)
- A command the user is likely to dent (e.g. `rm ~/nonexistent-file`).
```
2. Restart Zed (same `--user-data-dir`), reopen the same thread.

### Replayed cards (after restart)

#### T-001 — Replayed cards start collapsed

**Status:** ✅ PASS pre-restructure 2026-06-11; ✅ re-verify

**Repro:** Reload the thread. Every terminal card shows the command but no output. This holds even with `agent.expand_terminal_card: true` (default) in settings (that setting only auto-expands live terminals as they are created).


#### T-002 — Header shows working dir, not "Run Command"

**Status:** ✅ PASS 2026-06-12

**Repro:** Each replayed terminal card has a header row above the command, showing the working directory (the tool's `cd` input) on the left — matching live cards. "Run Command" must not appear on any card that has a result.


#### T-003 — Chevron appears on hover, top-right of the header row

**Status:** ✅ PASS 2026-06-12

**Repro:** Mouse over a replayed card. The expand/collapse chevron fades in at the top-right of the header row — same position as live cards. The copy button appears on the command row below it.


#### T-004 — Click chevron: expand and collapse

**Status:** ✅ PASS 2026-06-12

**Repro:** Click the chevron → saved output renders below the command (markdown code block). Click again → collapses. State persists while scrolling the thread (virtualized list re-renders).


#### T-005 — Copy button copies unfenced command

**Status:**  ✅ PASS 2026-06-12

**Repro:** Hover the command row, click copy. Pasted text is the bare command — no ``` fences.


#### T-006 — Failed command: red ✕ with exit-code tooltip

**Status:** ✅ PASS 2026-06-12

**Repro:** On the replayed card of the failing command, a red ✕ shows at the right of the header row (next to the chevron, same position as live). Hovering it shows "Exited with code N". Expanding shows the saved output including the failure sentinel text.


#### T-007 — Auto-denied `$VAR` command after restart

**Status:** ✅ PASS 2026-06-12

**Repro:** The auto-denied command's card shows a red ✕ (status Failed; no exit-code tooltip — it never ran). Expanding shows the denial message ("…does not allow shell substitutions…").


#### T-008 — Long multi-line command layout

**Status:** ✅ PASS 2026-06-12

**Repro:** The multi-line command card renders without layout breakage; long working-dir paths scroll horizontally in the header instead of wrapping or pushing the chevron/✕ out of view.


### Live cards (same session, no restart needed)

#### T-009 — Live terminal cards unaffected

**Status:** ✅ PASS 2026-06-12

**Repro:** In the reloaded thread, ask the agent to run another command. The new card uses the live terminal rendering: working-dir header, real terminal view on expand, stop button while running, elapsed time. Compare side by side with a replayed card.


#### T-010 — Awaiting-confirmation preview unchanged

**Status:** ✅ PASS 2026-06-12

**Repro:** With confirm-mode permissions, trigger a command needing approval. While waiting, the card shows the "Run Command" preview label (no header row, no chevron). After approval it becomes a live terminal card.


#### T-011 — Auto-denied `$VAR` command in a live session

**Status:** ✅ PASS 2026-06-12

**Repro:** Same as T-007 but observed live, without restarting: the denied call renders as a static card (no terminal) with a red ✕.


### Edge cases

#### T-012 — User-stopped command after restart

**Status:** ✅ PASS 2026-06-12

**Repro:** Stop a long-running command via the stop button. After restart, its card shows output text ("the user intentionally interrupted this command…" / "…timed out…") but **no ✕** — the persisted result is not an error and carries no exit code. Document, don't try to fix.


#### T-013 — User-timed-out command after restart

**Status:** ✅ PASS 2026-06-12

**Repro:** Let a long-running command hit a `timeout_ms`. After restart, its card shows output text ("Command …timed out…") but **no ✕** — the persisted result is not an error and carries no exit code. Document, don't try to fix.


#### T-014 — Empty-output success after restart

**Status:** ✅ PASS 2026-06-12

**Repro:** Run `true` (no output). After restart the card's saved output is "Command executed successfully." — chevron present, expanding shows that text.


#### T-015 — Themes

**Status:** ✅ PASS 2026-06-12

**Repro:** Quick pass in light + dark themes: header bg, chevron hover, red ✕ legible; card border visible but not jarring.


#### T-016 — External ACP agent: "Ran command" fallback label

**Status:** ✅ PASS 2026-06-12 (Claude Code)

**Repro:** In a thread driven by an external ACP agent (e.g. Claude Code / Gemini CLI) that reports `Execute`-kind tool calls as plain content blocks (no embedded terminal), completed command cards show a "Ran command" header label (past tense — no `cd` input to display) with the chevron, and the output expands on click.

**Notes:** Claude Code also produces genuine live-terminal cards (it creates embedded ACP terminals for some commands without passing a `cwd`), which render via the unchanged live path and show its pre-existing "current directory" fallback label — out of this PR's scope. The label "jumping" between "Ran command" and "current directory" within one thread reflects those two mechanisms, not a bug in this change.


#### T-017 — ✕ tooltip fallback when no exit code is recoverable

**Status:** ✅ PASS 2026-06-13 (fix shipped 2026-06-12; regression-guarded by `test_terminal_failure_tooltip`)

**Repro:** Hover the red ✕ on failed cards whose saved output is not the native terminal tool's failure sentinel:
1. An auto-denied `$VAR` command (live or replayed) → tooltip "Failed".
2. A failed command in an external ACP agent thread (e.g. Claude Code's "Exit code 2" format) → tooltip "Failed".
4. Reject a command at the confirmation prompt → tooltip "Failed". (Not "Rejected": the deny click sets a transient `Rejected` status, but the denial becomes an error tool result whose final `Failed` status update overwrites it — that's what is recorded and replayed. The expanded output still shows "Permission to run tool denied by user".)

A tooltip must appear in every case; "Exited with code N" still wins whenever the native sentinel is present (T-006). For comparison, release v1.7.2 shows no ✕ and no tooltip at all on these cards, live or replayed.

</details>

- **Are there any parts that need more testing?** Can't really think of any.
- **How can other people (reviewers) test your changes? Is there anything specific they need to know?** See the manual test plan above.
- **If relevant, what platforms did you test these changes on, and are there any important ones you can't test?** Verified on Linux (dev build). Haven't tested on macOS or Windows.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed showing terminal tool output in agent threads after restart
