### PR TITLE
git_ui: Re-render Git Panel when language model registry updates

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -44,8 +44,8 @@ use gpui::{
 use itertools::Itertools;
 use language::{Buffer, File};
 use language_model::{
-    CompletionIntent, ConfiguredModel, LanguageModelRegistry, LanguageModelRequest,
-    LanguageModelRequestMessage, Role, Event as LanguageModelEvent,
+    CompletionIntent, ConfiguredModel, Event as LanguageModelEvent, LanguageModelRegistry,
+    LanguageModelRequest, LanguageModelRequestMessage, Role,
 };
 use menu;
 use multi_buffer::ExcerptBoundaryInfo;

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -7562,6 +7562,7 @@ mod tests {
             let settings_store = SettingsStore::test(cx);
             cx.set_global(settings_store);
             theme_settings::init(LoadThemes::JustBase, cx);
+            language_model::init(cx);
             editor::init(cx);
             crate::init(cx);
         });

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -45,7 +45,7 @@ use itertools::Itertools;
 use language::{Buffer, File};
 use language_model::{
     CompletionIntent, ConfiguredModel, LanguageModelRegistry, LanguageModelRequest,
-    LanguageModelRequestMessage, Role,
+    LanguageModelRequestMessage, Role, Event as LanguageModelEvent,
 };
 use menu;
 use multi_buffer::ExcerptBoundaryInfo;
@@ -807,6 +807,20 @@ impl GitPanel {
                     cx.notify();
                 }
             });
+
+            let registry = LanguageModelRegistry::global(cx);
+            cx.subscribe(&registry, |_, _, event, cx| match event {
+                LanguageModelEvent::CommitMessageModelChanged
+                | LanguageModelEvent::DefaultModelChanged
+                | LanguageModelEvent::ProviderStateChanged(_)
+                | LanguageModelEvent::AddedProvider(_)
+                | LanguageModelEvent::RemovedProvider(_)
+                | LanguageModelEvent::ProvidersChanged => {
+                    cx.notify();
+                }
+                _ => {}
+            })
+            .detach();
 
             cx.subscribe_in(
                 &git_store,


### PR DESCRIPTION
Fixes the "Generate git commit message" wand button being permanently disabled on startup. Subscribes the Git Panel to language model registry events so that it automatically re-renders once the asynchronous model fetches complete.

Closes #55451.

## Suggested .rules additions

### GPUI Views and Global State Registries

* If a view (like `GitPanel`) reads from a global state registry (like `LanguageModelRegistry`) during rendering, it must subscribe/observe that registry's events and call `cx.notify()` to re-render when the state updates (such as when models finish loading asynchronously).

Release Notes:

- Fixed the git commit message generation button showing as permanently disabled when models load after startup.