### PR TITLE
gpui: Fix rounded corners on images with object-fit cover

### DIFF
--- a/crates/gpui/examples/object_fit.rs
+++ b/crates/gpui/examples/object_fit.rs
@@ -10,12 +10,17 @@ use gpui::{
 #[cfg(not(target_family = "wasm"))]
 use reqwest_client::ReqwestClient;
 
-struct ObjectFitShowcase {
+struct Source {
+    label: &'static str,
     image: SharedString,
 }
 
+struct ObjectFitShowcase {
+    sources: Vec<Source>,
+}
+
 impl ObjectFitShowcase {
-    fn fit_demo(&self, label: &str, object_fit: ObjectFit) -> impl IntoElement {
+    fn fit_demo(image: &SharedString, label: &str, object_fit: ObjectFit) -> impl IntoElement {
         div()
             .flex()
             .flex_col()
@@ -23,7 +28,7 @@ impl ObjectFitShowcase {
             .gap_2()
             .child(label.to_string())
             .child(
-                img(self.image.clone())
+                img(image.clone())
                     .overflow_hidden()
                     .w(px(220.))
                     .h(px(140.))
@@ -31,6 +36,32 @@ impl ObjectFitShowcase {
                     .border_color(rgb(0xC0392B))
                     .rounded(px(24.))
                     .object_fit(object_fit),
+            )
+    }
+
+    fn source_row(source: &Source) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_col()
+            .items_center()
+            .gap_3()
+            .child(source.label.to_string())
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .flex_wrap()
+                    .justify_center()
+                    .gap_8()
+                    .child(Self::fit_demo(&source.image, "Fill", ObjectFit::Fill))
+                    .child(Self::fit_demo(&source.image, "Contain", ObjectFit::Contain))
+                    .child(Self::fit_demo(&source.image, "Cover", ObjectFit::Cover))
+                    .child(Self::fit_demo(
+                        &source.image,
+                        "ScaleDown",
+                        ObjectFit::ScaleDown,
+                    ))
+                    .child(Self::fit_demo(&source.image, "None", ObjectFit::None)),
             )
     }
 }
@@ -48,21 +79,9 @@ impl Render for ObjectFitShowcase {
                     .flex()
                     .flex_col()
                     .items_center()
-                    .gap_6()
+                    .gap_8()
                     .child("ObjectFit with rounded corners")
-                    .child(
-                        div()
-                            .flex()
-                            .flex_row()
-                            .flex_wrap()
-                            .justify_center()
-                            .gap_8()
-                            .child(self.fit_demo("Fill", ObjectFit::Fill))
-                            .child(self.fit_demo("Contain", ObjectFit::Contain))
-                            .child(self.fit_demo("Cover", ObjectFit::Cover))
-                            .child(self.fit_demo("ScaleDown", ObjectFit::ScaleDown))
-                            .child(self.fit_demo("None", ObjectFit::None)),
-                    ),
+                    .children(self.sources.iter().map(Self::source_row)),
             )
     }
 }
@@ -116,7 +135,24 @@ fn run_example() {
 
         cx.open_window(window_options, |_, cx| {
             cx.new(|_| ObjectFitShowcase {
-                image: "https://picsum.photos/id/237/400/200".into(),
+                sources: vec![
+                    Source {
+                        label: "Landscape source (400x200)",
+                        image: "https://picsum.photos/id/237/400/200".into(),
+                    },
+                    Source {
+                        label: "Portrait source (200x400)",
+                        image: "https://picsum.photos/id/1003/200/400".into(),
+                    },
+                    Source {
+                        label: "Square source (400x400)",
+                        image: "https://picsum.photos/id/1025/400/400".into(),
+                    },
+                    Source {
+                        label: "Small source (120x80)",
+                        image: "https://picsum.photos/id/1062/120/80".into(),
+                    },
+                ],
             })
         })
         .unwrap();

--- a/crates/gpui/examples/object_fit.rs
+++ b/crates/gpui/examples/object_fit.rs
@@ -1,0 +1,137 @@
+#![cfg_attr(target_family = "wasm", no_main)]
+
+use std::sync::Arc;
+
+use gpui::{
+    App, AppContext, Bounds, Context, KeyBinding, Menu, MenuItem, ObjectFit, Point, SharedString,
+    TitlebarOptions, Window, WindowBounds, WindowOptions, actions, div, img, prelude::*, px, rgb,
+    size,
+};
+#[cfg(not(target_family = "wasm"))]
+use reqwest_client::ReqwestClient;
+
+struct ObjectFitShowcase {
+    image: SharedString,
+}
+
+impl ObjectFitShowcase {
+    fn fit_demo(&self, label: &str, object_fit: ObjectFit) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_col()
+            .items_center()
+            .gap_2()
+            .child(label.to_string())
+            .child(
+                img(self.image.clone())
+                    .overflow_hidden()
+                    .w(px(220.))
+                    .h(px(140.))
+                    .border_2()
+                    .border_color(rgb(0xC0392B))
+                    .rounded(px(24.))
+                    .object_fit(object_fit),
+            )
+    }
+}
+
+impl Render for ObjectFitShowcase {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .id("main")
+            .bg(gpui::white())
+            .overflow_y_scroll()
+            .p_8()
+            .size_full()
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .gap_6()
+                    .child("ObjectFit with rounded corners")
+                    .child(
+                        div()
+                            .flex()
+                            .flex_row()
+                            .flex_wrap()
+                            .justify_center()
+                            .gap_8()
+                            .child(self.fit_demo("Fill", ObjectFit::Fill))
+                            .child(self.fit_demo("Contain", ObjectFit::Contain))
+                            .child(self.fit_demo("Cover", ObjectFit::Cover))
+                            .child(self.fit_demo("ScaleDown", ObjectFit::ScaleDown))
+                            .child(self.fit_demo("None", ObjectFit::None)),
+                    ),
+            )
+    }
+}
+
+actions!(object_fit, [Quit]);
+
+fn run_example() {
+    #[cfg(not(target_family = "wasm"))]
+    let app = gpui_platform::application();
+    #[cfg(target_family = "wasm")]
+    let app = gpui_platform::single_threaded_web();
+
+    app.run(move |cx: &mut App| {
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let http_client = ReqwestClient::user_agent("gpui example").unwrap();
+            cx.set_http_client(Arc::new(http_client));
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            // Safety: the web examples run single-threaded; the client is
+            // created and used exclusively on the main thread.
+            let http_client = unsafe {
+                gpui_web::FetchHttpClient::with_user_agent("gpui example")
+                    .expect("failed to create FetchHttpClient")
+            };
+            cx.set_http_client(Arc::new(http_client));
+        }
+
+        cx.activate(true);
+        cx.on_action(|_: &Quit, cx| cx.quit());
+        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
+        cx.set_menus(vec![Menu {
+            name: "Object Fit".into(),
+            items: vec![MenuItem::action("Quit", Quit)],
+            disabled: false,
+        }]);
+
+        let window_options = WindowOptions {
+            titlebar: Some(TitlebarOptions {
+                title: Some(SharedString::from("Object Fit Example")),
+                appears_transparent: false,
+                ..Default::default()
+            }),
+            window_bounds: Some(WindowBounds::Windowed(Bounds {
+                size: size(px(1200.), px(700.)),
+                origin: Point::new(px(200.), px(200.)),
+            })),
+            ..Default::default()
+        };
+
+        cx.open_window(window_options, |_, cx| {
+            cx.new(|_| ObjectFitShowcase {
+                image: "https://picsum.photos/id/237/400/200".into(),
+            })
+        })
+        .unwrap();
+    });
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn main() {
+    env_logger::init();
+    run_example();
+}
+
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn start() {
+    gpui_platform::web_init();
+    run_example();
+}

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -486,13 +486,15 @@ impl Element for Img {
                         .style
                         .object_fit
                         .get_bounds(bounds, data.size(layout_state.frame_index));
+                    let clip_bounds = new_bounds.intersect(&bounds);
                     let corner_radii = style
                         .corner_radii
                         .to_pixels(window.rem_size())
-                        .clamp_radii_for_quad_size(new_bounds.size);
+                        .clamp_radii_for_quad_size(clip_bounds.size);
                     window
                         .paint_image(
                             new_bounds,
+                            clip_bounds,
                             corner_radii,
                             data,
                             layout_state.frame_index,

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -704,6 +704,7 @@ pub struct PolychromeSprite {
     pub grayscale: bool,
     pub opacity: f32,
     pub bounds: Bounds<ScaledPixels>,
+    pub clip_bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
     pub tile: AtlasTile,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3969,6 +3969,7 @@ impl Window {
                 pad: 0,
                 grayscale: false,
                 bounds,
+                clip_bounds: bounds,
                 corner_radii: Default::default(),
                 content_mask,
                 tile,
@@ -4050,6 +4051,7 @@ impl Window {
     pub fn paint_image(
         &mut self,
         bounds: Bounds<Pixels>,
+        clip_bounds: Bounds<Pixels>,
         corner_radii: Corners<Pixels>,
         data: Arc<RenderImage>,
         frame_index: usize,
@@ -4058,6 +4060,7 @@ impl Window {
         self.invalidator.debug_assert_paint();
 
         let bounds = self.snap_bounds(bounds);
+        let clip_bounds = self.snap_bounds(clip_bounds);
         let params = RenderImageParams {
             image_id: data.id,
             frame_index,
@@ -4084,6 +4087,7 @@ impl Window {
             pad: 0,
             grayscale,
             bounds,
+            clip_bounds,
             content_mask,
             corner_radii,
             tile,

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -718,7 +718,7 @@ fragment float4 polychrome_sprite_fragment(
   float4 sample =
       atlas_texture.sample(atlas_texture_sampler, input.tile_position);
   float distance =
-      quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+      quad_sdf(input.position.xy, sprite.clip_bounds, sprite.corner_radii);
 
   float4 color = sample;
   if (sprite.grayscale) {

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1267,6 +1267,7 @@ struct PolychromeSprite {
     grayscale: u32,
     opacity: f32,
     bounds: Bounds,
+    clip_bounds: Bounds,
     content_mask: Bounds,
     corner_radii: Corners,
     tile: AtlasTile,
@@ -1302,7 +1303,7 @@ fn fs_poly_sprite(input: PolySpriteVarying) -> @location(0) vec4<f32> {
     }
 
     let sprite = b_poly_sprites[input.sprite_id];
-    let distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+    let distance = quad_sdf(input.position.xy, sprite.clip_bounds, sprite.corner_radii);
 
     var color = sample;
     if ((sprite.grayscale & 0xFFu) != 0u) {

--- a/crates/gpui_windows/src/shaders.hlsl
+++ b/crates/gpui_windows/src/shaders.hlsl
@@ -1207,6 +1207,7 @@ struct PolychromeSprite {
     uint grayscale;
     float opacity;
     Bounds bounds;
+    Bounds clip_bounds;
     Bounds content_mask;
     Corners corner_radii;
     AtlasTile tile;
@@ -1246,7 +1247,7 @@ PolychromeSpriteVertexOutput polychrome_sprite_vertex(uint vertex_id: SV_VertexI
 float4 polychrome_sprite_fragment(PolychromeSpriteFragmentInput input): SV_Target {
     PolychromeSprite sprite = poly_sprites[input.sprite_id];
     float4 sample = t_sprite.Sample(s_sprite, input.tile_position);
-    float distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+    float distance = quad_sdf(input.position.xy, sprite.clip_bounds, sprite.corner_radii);
 
     float4 color = sample;
     if ((sprite.grayscale & 0xFFu) != 0u) {


### PR DESCRIPTION
# Objective

`rounded` did not work properly on images using `ObjectFit::Cover`. The image is scaled to be larger than the element so it can cover the bounds, and the overflow was clipped to a plain rectangle, so the rounded corners were applied to the oversized image quad, outside the visible element box. FIxes #44339.

## Solution

`PolychromeSprite` now carries a `clip_bounds` field in addition to `bounds`, that shaders use to round and clip.
Done in all three renderers.

## Testing

- Tested in both Windows and MacOS. I have not been able to test in LInux but it should work too since the changes are minimal.
- Added the `object_fit` example to showcase the different `ObjectFit` options and aspect ratios.

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Performance impact has been considered and is acceptable

## Showcase

BEFORE:
<img width="1278" height="1042" alt="Screenshot 2026-06-14 at 16 37 43" src="https://github.com/user-attachments/assets/5c7417dc-86b9-4fd2-b3e1-9011b121f94f" />

AFTER:
<img width="1277" height="1035" alt="Screenshot 2026-06-14 at 16 36 30" src="https://github.com/user-attachments/assets/2a730bb1-8f72-4a26-b4ca-cc5ce0dfd968" />


---

Release Notes:

- N/A
