### PR TITLE
agent: Don't pass back the diff on successful edits

### DIFF
--- a/crates/agent/src/tools/edit_session.rs
+++ b/crates/agent/src/tools/edit_session.rs
@@ -102,11 +102,7 @@ impl std::fmt::Display for EditSessionOutput {
                 if diff.is_empty() {
                     write!(f, "No edits were made.")
                 } else {
-                    write!(
-                        f,
-                        "Edited {}:\n\n```diff\n{diff}\n```",
-                        input_path.display()
-                    )
+                    write!(f, "Edited {} successfully", input_path.display())
                 }
             }
             EditSessionOutput::Error {


### PR DESCRIPTION
Previous versions of the tool required passing the diff back because the
parent agent wouldn't have known the edits applied otherwise. Given that
we adapted this to use streaming tool calls now, this is redundant
information and wastes context windows, especially for local models.

We still pass the diff in the case that only some of the edits were
applied, but in the successful case, we just let the model know that the
edit was successful.

---

Release Notes:

- agent: Improve edit tool performance with more succinct success response.
