### PR TITLE
gpui: Make `with_element_opacity` and `element_opacity` public

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3251,7 +3251,13 @@ impl Window {
         result
     }
 
-    pub(crate) fn with_element_opacity<R>(
+    /// Executes the given closure with an additional element opacity multiplier.
+    ///
+    /// This is used to implement inherited opacity for custom elements that paint directly
+    /// via window APIs.
+    ///
+    /// This method should only be called during the prepaint or paint phase of element drawing.
+    pub fn with_element_opacity<R>(
         &mut self,
         opacity: Option<f32>,
         f: impl FnOnce(&mut Self) -> R,
@@ -3363,7 +3369,7 @@ impl Window {
     /// Obtain the current element opacity. This method should only be called during the
     /// prepaint phase of element drawing.
     #[inline]
-    pub(crate) fn element_opacity(&self) -> f32 {
+    pub fn element_opacity(&self) -> f32 {
         self.invalidator.debug_assert_paint_or_prepaint();
         self.element_opacity
     }


### PR DESCRIPTION
# Objective

Make the 2 APIs public, so that user can set the opacity in paint phase
- `with_element_opacity`
- `element_opacity`

## Problem I face

In `gpui-component`'s editor component. If I set the code editor status to `disabled`, under the hood it [sets the opacity of the input to 0.5](https://github.com/longbridge/gpui-component/blob/57a5bae0577a328ef862c0469765717ceb727b6d/crates/ui/src/input/input.rs#L383), the opacity is applied to both editor gutter and text content, hence user can see through gutter to see the text content. The expected behavior is the opacity shouldn't be applied to gutter. 

I thought about 3 approaches to this problem.

**1. If code editor is disabled, don't set the `opacity` and render a overlay on the text content.**
This approach doesn't fix the issue from root, more of a patch.

**2. If code editor is disabled, apply the opacity to all sub elements except gutter**
This approach would adds many tedious changes to the editor rendering logic, as there are input prefix/suffix elements.etc.

**3. If code editor is disabled, skip applying the opacity to gutter**
This approach is correct one to me. As gutter must not have transparency, we don't apply opacity to it. For this approach to work, we need an API to read the current opacity from `window` and paint element with opacity.

## Solution

Make APIs `with_element_opacity` and `element_opacity` public. I hope making the 2 API public would help others if they need a way to set the opacity in the paint phase.

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
