### PR TITLE
editor: Stop C/C++ preprocessor directives from breaking folds

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2323,10 +2323,7 @@ impl DisplaySnapshot {
                         .is_some_and(|scope| {
                             matches!(
                                 scope.override_name(),
-                                Some("string")
-                                    | Some("comment")
-                                    | Some("comment.inclusive")
-                                    | Some("preproc")
+                                Some("string") | Some("comment") | Some("preproc")
                             )
                         });
                     if in_string_or_comment_or_preproc_scope

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2318,15 +2318,18 @@ impl DisplaySnapshot {
                 if !line_indent.is_line_blank()
                     && line_indent.raw_len() <= start_line_indent.raw_len()
                 {
-                    let in_string_or_comment_scope = snapshot
+                    let in_string_or_comment_or_preproc_scope = snapshot
                         .language_scope_at(Point::new(row, 0))
                         .is_some_and(|scope| {
                             matches!(
                                 scope.override_name(),
-                                Some("string") | Some("comment") | Some("comment.inclusive")
+                                Some("string")
+                                    | Some("comment")
+                                    | Some("comment.inclusive")
+                                    | Some("preproc")
                             )
                         });
-                    if in_string_or_comment_scope
+                    if in_string_or_comment_or_preproc_scope
                         && let Some(end) = foldable_node_end
                         && Point::new(row, 0).to_offset(snapshot) < end
                     {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1682,6 +1682,40 @@ async fn test_fold_with_unindented_multiline_block_comment_includes_closing_brac
 }
 
 #[gpui::test]
+async fn test_fold_with_column_zero_preprocessor_directives(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language(
+            Some(languages::language("c", tree_sitter_c::LANGUAGE.into())),
+            cx,
+        )
+    });
+
+    cx.set_state(indoc! {"
+        ˇvoid foo(void) {
+            int a = 1;
+        #if DEBUG
+            int b = 2;
+        #endif
+            int c = 3;
+        }
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.fold_at_level(&FoldAtLevel(1), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            indoc! {"
+                void foo(void) {⋯}
+            "},
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_fold_preserves_top_level_comments_between_python_classes(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/grammars/src/c/overrides.scm
+++ b/crates/grammars/src/c/overrides.scm
@@ -1,3 +1,17 @@
 (comment) @comment.inclusive
 
 (string_literal) @string
+
+[
+  "#define"
+  "#elif"
+  "#elifdef"
+  "#elifndef"
+  "#else"
+  "#endif"
+  "#if"
+  "#ifdef"
+  "#ifndef"
+  "#include"
+  (preproc_directive)
+] @preproc.inclusive

--- a/crates/grammars/src/cpp/overrides.scm
+++ b/crates/grammars/src/cpp/overrides.scm
@@ -1,3 +1,17 @@
 (comment) @comment.inclusive
 
 (string_literal) @string
+
+[
+  "#define"
+  "#elif"
+  "#elifdef"
+  "#elifndef"
+  "#else"
+  "#endif"
+  "#if"
+  "#ifdef"
+  "#ifndef"
+  "#include"
+  (preproc_directive)
+] @preproc.inclusive


### PR DESCRIPTION
# Objective

Fixes #58799

When LSP folding ranges are disabled, ident-based fold ranges in C/C++ were exiting early at zero column preprocessor directives (like `#if` and `#endif`), leading to the fold only collapsing the function until the first directive.

## Solution

The fold loop in `DisplayMapSnapshot::crease_for_buffer_row` already handles zero column content for multi-line strings and block comments. This PR extends that to include `preproc` directives. Additionally, this PR adds a new `@preproc.inclusive` capture in `crates/grammars/src/{c, cpp}/overrides.scm`.

## Testing

Added `test_fold_with_column_zero_preprocessor_directives` in `crates/editor/src/editor_tests.rs`. It asserts that folding a C function containing `#if`/`#endif` collapses the entire function.

Manual reproduction can be done using the following `.c` file:

```c
void foo(void) {
    int a = 1;
#if DEBUG
    int b = 2;
#endif
    int c = 3;
}
```

Click the fold arrow next to `void foo(void) {`.

- Before: fold stops at `#if DEBUG`, only the first two lines collapse.
- After: the entire function collapses to `void foo(void) {⋯}`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Side note

While adding `Some("preproc")`, I noticed that there's a branch for `Some("comment.inclusive")`. It looks like `Grammar::with_override_query` in `crates/language_core/src/grammar.rs` strips `.inclusive` from capture names, which would mean that the `Some("comment.inclusive")` branch in `DisplayMapSnapshot::crease_for_buffer_row` never matches. I wasn't completely sure, so I left it as-is. If my observation is correct, I'm more than happy to remove it in a follow-up commit.

---

Release Notes:

- Fixed C/C++ code folding when encountering zero-indent preprocessor directives.