### PR TITLE
agent_ui: Use the thread title for agent notifications

### DIFF
--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -2694,8 +2694,9 @@ impl ConversationView {
         let root_work_dirs = root_thread.work_dirs().cloned();
         let root_title = root_thread.title();
 
-        // TODO: Change this once we have title summarization for external agents.
-        let title = self.agent.agent_id().0;
+        let title = root_title
+            .clone()
+            .unwrap_or_else(|| self.agent.agent_id().0);
 
         match settings.notify_when_agent_waiting {
             NotifyWhenAgentWaiting::PrimaryScreen => {


### PR DESCRIPTION
The agent-waiting notification heading was hardcoded to the agent id, showing "claude acp" for external agents. Use the thread's own title, which external agents now provide via session info updates, and fall back to the agent id only for threads that aren't titled yet.

# Objective

- External agent notifications were just headed generically I.e. "claude acp". There was a TODO in the code to use the thread name, so that it's clear which thread actually produced the notification.

## Solution

- Use the thread name, seems it was inscope in the code already from a previous change.

## Testing

Tested manually by triggering a notification and seeing the thread name instead of acp-claude.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior - this code path wasn't tested and doesn't seem like it needs it, but willing to be corrected.
- [x] Performance impact has been considered and is acceptable

Release Notes:

- agent: Include thread title in notification when Zed is not focused
