### PR TITLE
Duplicate Bot: Update retired Claude model

### DIFF
--- a/script/github-check-new-issue-for-duplicates.py
+++ b/script/github-check-new-issue-for-duplicates.py
@@ -180,7 +180,7 @@ def call_claude(api_key, system, user_content, max_tokens=1024):
             "content-type": "application/json",
         },
         json={
-            "model": "claude-sonnet-4-20250514",
+            "model": "claude-sonnet-4-6",
             "max_tokens": max_tokens,
             "temperature": 0.0,
             "system": system,


### PR DESCRIPTION
claude-sonnet-4-20250514 was retired by Anthropic on June 15, 2026, causing the "Comment on potential duplicate bug/crash reports" workflow to fail with a 404 from /v1/messages on the first call_claude invocation.

Switch to the recommended replacement, claude-sonnet-4-6.

Release Notes:
- N/A
