### PR TITLE
gpui: Add outline style support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22761,7 +22761,7 @@ dependencies = [
 
 [[package]]
 name = "zed"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "acp_thread",
  "acp_tools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22761,7 +22761,7 @@ dependencies = [
 
 [[package]]
 name = "zed"
-version = "1.19.1"
+version = "1.19.2"
 dependencies = [
  "acp_thread",
  "acp_tools",

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -3848,6 +3848,7 @@ impl Thread {
             return Task::ready(None).shared();
         };
         let mut request = LanguageModelRequest {
+            thread_id: Some(self.id.to_string()),
             intent: Some(CompletionIntent::ThreadContextSummarization),
             temperature: AgentSettings::temperature_for_model(&model, cx),
             ..Default::default()
@@ -3936,7 +3937,7 @@ impl Thread {
         log::debug!("Generating title with model: {:?}", model.name());
 
         let temperature = AgentSettings::temperature_for_model(&model, cx);
-        let request = build_thread_title_request(&self.messages, temperature);
+        let request = build_thread_title_request(&self.id, &self.messages, temperature);
 
         let title_generation = cx.spawn(async move |_this, cx| {
             stream_thread_title(model, request, cx)
@@ -4855,10 +4856,12 @@ fn retained_user_request_messages_before(
 }
 
 pub fn build_thread_title_request(
+    thread_id: &acp::SessionId,
     messages: &[Arc<Message>],
     temperature: Option<f32>,
 ) -> LanguageModelRequest {
     let mut request = LanguageModelRequest {
+        thread_id: Some(thread_id.to_string()),
         intent: Some(CompletionIntent::ThreadSummarization),
         temperature,
         ..Default::default()
@@ -6939,6 +6942,7 @@ mod tests {
     #[gpui::test]
     async fn test_thread_summary_request_uses_compacted_history(cx: &mut TestAppContext) {
         let (thread, _event_stream) = setup_thread_for_test(cx).await;
+        let thread_id = thread.read_with(cx, |thread, _| thread.id().to_string());
         let summary_model = Arc::new(FakeLanguageModel::default());
 
         let summary_task = cx.update(|cx| {
@@ -6968,6 +6972,10 @@ mod tests {
         cx.run_until_parked();
 
         let summary_request = summary_model.pending_completions().pop().unwrap();
+        assert_eq!(
+            summary_request.thread_id.as_deref(),
+            Some(thread_id.as_str())
+        );
         assert_eq!(
             summary_request.intent,
             Some(CompletionIntent::ThreadContextSummarization)
@@ -7002,8 +7010,10 @@ mod tests {
             agent_text_message("after assistant"),
         ];
 
-        let request = build_thread_title_request(&messages, Some(0.2));
+        let request =
+            build_thread_title_request(&acp::SessionId::new("thread-id"), &messages, Some(0.2));
 
+        assert_eq!(request.thread_id.as_deref(), Some("thread-id"));
         assert_eq!(request.intent, Some(CompletionIntent::ThreadSummarization));
         assert_eq!(request.temperature, Some(0.2));
         assert_eq!(

--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -497,6 +497,7 @@ impl CodegenAlternative {
             .context("generating content prompt")?;
 
         let temperature = AgentSettings::temperature_for_model(model, cx);
+        let session_id = self.session_id.to_string();
 
         let tool_choice = model
             .supports_tool_choice(LanguageModelToolChoice::Any)
@@ -544,7 +545,7 @@ impl CodegenAlternative {
             ];
 
             LanguageModelRequest {
-                thread_id: None,
+                thread_id: Some(session_id),
                 prompt_id: None,
                 intent: Some(CompletionIntent::InlineAssist),
                 tools,
@@ -609,6 +610,7 @@ impl CodegenAlternative {
             .context("generating content prompt")?;
 
         let temperature = AgentSettings::temperature_for_model(model, cx);
+        let session_id = self.session_id.to_string();
 
         Ok(cx.spawn(async move |_cx| {
             let mut request_message = LanguageModelRequestMessage {
@@ -625,7 +627,7 @@ impl CodegenAlternative {
             request_message.content.push(prompt.into());
 
             LanguageModelRequest {
-                thread_id: None,
+                thread_id: Some(session_id),
                 prompt_id: None,
                 intent: Some(CompletionIntent::InlineAssist),
                 tools: Vec::new(),

--- a/crates/agent_ui/src/terminal_inline_assistant.rs
+++ b/crates/agent_ui/src/terminal_inline_assistant.rs
@@ -244,6 +244,7 @@ impl TerminalInlineAssistant {
         )?;
 
         let temperature = AgentSettings::temperature_for_model(&model, cx);
+        let session_id = assist.codegen.read(cx).session_id().to_string();
 
         let mention_set = prompt_editor.read(cx).mention_set().clone();
         let load_context_task = load_context(&mention_set, cx);
@@ -263,7 +264,7 @@ impl TerminalInlineAssistant {
             request_message.content.push(prompt.into());
 
             LanguageModelRequest {
-                thread_id: None,
+                thread_id: Some(session_id),
                 prompt_id: None,
                 intent: Some(CompletionIntent::TerminalInlineAssist),
                 messages: vec![request_message],

--- a/crates/ai_onboarding/src/ai_onboarding.rs
+++ b/crates/ai_onboarding/src/ai_onboarding.rs
@@ -167,13 +167,13 @@ impl ZedAiOnboarding {
             .gap_1()
             .child(Headline::new("Welcome to Zed AI"))
             .child(
-                Label::new("Sign in to try Zed Pro free for 14 days.")
+                Label::new("Sign in to try GPT Luna. Your 14 days begin when you start the trial.")
                     .color(Color::Muted)
                     .mb_2(),
             )
             .child(PlanDefinitions.sign_in_upsell())
             .child(
-                Button::new("sign_in", "Try Zed Pro for Free")
+                Button::new("sign_in", "Sign In to Try GPT Luna")
                     .disabled(signing_in)
                     .full_width()
                     .style(ButtonStyle::Tinted(ui::TintColor::Accent))
@@ -300,7 +300,7 @@ impl ZedAiOnboarding {
             .child(Self::pro_trial_stamp(cx))
             .child(Headline::new("Welcome to the Zed Pro Trial"))
             .child(
-                Label::new("Here's what you get for the next 14 days:")
+                Label::new("Included for 14 days from when your trial started:")
                     .color(Color::Muted)
                     .mb_2(),
             )

--- a/crates/ai_onboarding/src/plan_definitions.rs
+++ b/crates/ai_onboarding/src/plan_definitions.rs
@@ -17,17 +17,17 @@ impl PlanDefinitions {
     pub fn sign_in_upsell(&self) -> impl IntoElement {
         List::new()
             .child(ListBulletItem::new("Unlimited edit predictions"))
-            .child(ListBulletItem::new("$20 of tokens in Zed agent"))
+            .child(ListBulletItem::new("$5 of GPT Luna"))
             .child(ListBulletItem::new("No credit card required"))
     }
 
     pub fn pro_trial(&self, period: bool) -> impl IntoElement {
         List::new()
-            .child(ListBulletItem::new("$20 of tokens in Zed agent"))
+            .child(ListBulletItem::new("$5 of GPT Luna"))
             .child(ListBulletItem::new("Unlimited edit predictions"))
             .when(period, |this| {
                 this.child(ListBulletItem::new(
-                    "Try it out for 14 days, no credit card required",
+                    "14 days from trial start, no credit card required",
                 ))
             })
     }

--- a/crates/dev_container/src/devcontainer_json.rs
+++ b/crates/dev_container/src/devcontainer_json.rs
@@ -4,6 +4,7 @@ use crate::{command_json::CommandRunner, devcontainer_api::DevContainerError};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json_lenient::Value;
 use util::command::Command;
+use util::redact::is_valid_environment_name;
 
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
 #[serde(untagged)]
@@ -285,7 +286,28 @@ impl DevContainer {
         ))
     }
 
+    pub(crate) fn validate_environment_names(&self) -> Result<(), DevContainerError> {
+        for (property, environment) in [
+            ("containerEnv", self.container_env.as_ref()),
+            ("remoteEnv", self.remote_env.as_ref()),
+        ] {
+            if environment.is_some_and(|environment| {
+                environment
+                    .keys()
+                    .any(|name| !is_valid_environment_name(name))
+            }) {
+                return Err(DevContainerError::DevContainerValidationFailed(format!(
+                    "{property} contains an invalid environment variable name"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
     pub(crate) fn validate_devcontainer_contents(&self) -> Result<(), DevContainerError> {
+        self.validate_environment_names()?;
+
         match self.build_type() {
             DevContainerBuildType::Image(_) => Ok(()),
             DevContainerBuildType::Dockerfile(_) => {
@@ -1716,6 +1738,37 @@ mod test {
                     .to_string()
             ))
         );
+    }
+
+    #[test]
+    fn should_reject_invalid_environment_names() {
+        for (json, property) in [
+            (
+                r#"{"image":"ubuntu","containerEnv":{"":"secret"}}"#,
+                "containerEnv",
+            ),
+            (
+                r#"{"image":"ubuntu","containerEnv":{"NAME=VALUE":"secret"}}"#,
+                "containerEnv",
+            ),
+            (
+                r#"{"image":"ubuntu","remoteEnv":{"LINE\nBREAK":"secret"}}"#,
+                "remoteEnv",
+            ),
+            (
+                r#"{"image":"ubuntu","remoteEnv":{"NAME\u0000NUL":"secret"}}"#,
+                "remoteEnv",
+            ),
+        ] {
+            let devcontainer = deserialize_devcontainer_json(json).expect("valid JSON");
+
+            assert_eq!(
+                devcontainer.validate_environment_names(),
+                Err(DevContainerError::DevContainerValidationFailed(format!(
+                    "{property} contains an invalid environment variable name"
+                )))
+            );
+        }
     }
 
     #[test]

--- a/crates/dev_container/src/devcontainer_manifest.rs
+++ b/crates/dev_container/src/devcontainer_manifest.rs
@@ -2731,6 +2731,9 @@ pub(crate) async fn spawn_dev_container(
     .await?;
 
     devcontainer_manifest.parse_nonremote_vars()?;
+    devcontainer_manifest
+        .dev_container()
+        .validate_environment_names()?;
 
     log::debug!("Checking for existing container");
     if let Some(devcontainer) = devcontainer_manifest

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5754,20 +5754,21 @@ impl Editor {
                             .collect::<String>();
 
                         if !line_text_after_indent.is_empty() {
-                            let block_prefix = language_scope
+                            let block_prefixes = language_scope
                                 .block_comment()
-                                .map(|c| c.prefix.as_ref())
-                                .filter(|p| !p.is_empty());
-                            let doc_prefix = language_scope
-                                .documentation_comment()
-                                .map(|c| c.prefix.as_ref())
-                                .filter(|p| !p.is_empty());
+                                .into_iter()
+                                .chain(language_scope.documentation_comment())
+                                .filter(|comment| {
+                                    language_scope.override_name() == Some("comment")
+                                        && !comment.prefix.is_empty()
+                                        && !line_text_after_indent.starts_with(comment.end.as_ref())
+                                })
+                                .map(|comment| comment.prefix.as_ref());
                             let comment_prefixes = language_scope
                                 .line_comment_prefixes()
                                 .iter()
                                 .map(|p| p.as_ref())
-                                .chain(block_prefix)
-                                .chain(doc_prefix)
+                                .chain(block_prefixes)
                                 .map(|prefix| (prefix, false));
                             let all_prefixes = comment_prefixes.chain(
                                 language_scope

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -23,7 +23,7 @@ use gpui::{
     BackgroundExecutor, DismissEvent, Task, TaskExt, TestAppContext, UpdateGlobal,
     VisualTestContext, WindowBounds, WindowOptions, div,
 };
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
 use language::{
     BracketPair, BracketPairConfig,
     Capability::{Read, ReadOnly, ReadWrite},
@@ -7038,22 +7038,8 @@ async fn test_join_lines_strips_comment_prefix(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     {
-        let language = Arc::new(Language::new(
-            LanguageConfig {
-                line_comments: vec!["// ".into(), "/// ".into()],
-                documentation_comment: Some(BlockCommentConfig {
-                    start: "/*".into(),
-                    end: "*/".into(),
-                    prefix: "* ".into(),
-                    tab_size: 1,
-                }),
-                ..LanguageConfig::default()
-            },
-            None,
-        ));
-
         let mut cx = EditorTestContext::new(cx).await;
-        cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
+        cx.update_buffer(|buffer, cx| buffer.set_language(Some(rust_lang()), cx));
 
         // Strips the comment prefix (with trailing space) from the joined-in line.
         cx.set_state(indoc! {"
@@ -7117,22 +7103,30 @@ async fn test_join_lines_strips_comment_prefix(cx: &mut TestAppContext) {
 
         // Strips block comment body prefix (`* `) from the joined-in line.
         cx.set_state(indoc! {"
+            /*
              * ˇfoo
              * bar
+             */
         "});
         cx.update_editor(|e, window, cx| e.join_lines(&JoinLines, window, cx));
         cx.assert_editor_state(indoc! {"
+            /*
              * fooˇ bar
+             */
         "});
 
         // Strips bare block comment body prefix (`*` without trailing space).
         cx.set_state(indoc! {"
+            /*
              * ˇfoo
              *
+             */
         "});
         cx.update_editor(|e, window, cx| e.join_lines(&JoinLines, window, cx));
         cx.assert_editor_state(indoc! {"
+            /*
              * fooˇ
+             */
         "});
     }
 
@@ -7205,6 +7199,92 @@ async fn test_join_lines_strips_comment_prefix(cx: &mut TestAppContext) {
         cx.assert_editor_state(indoc! {"
             - fooˇbar
         "});
+    }
+}
+
+#[gpui::test]
+async fn test_join_lines_preserves_rust_operators(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(rust_lang()), cx));
+
+    for insert_whitespace in [true, false] {
+        let separator = if insert_whitespace { " " } else { "" };
+        for indent in ["", "    ", "\t"] {
+            for (first_line, next_line) in [
+                ("let value =", "*pointer;"),
+                ("let value =", "* pointer;"),
+                ("let value =", "**pointer;"),
+                ("let value =", "*指针;"),
+                ("let value = 2", "* 3;"),
+                ("let value = \"text", "*text\";"),
+                ("let value = r#\"text", "*text\"#;"),
+            ] {
+                cx.set_state(&formatdoc! {"
+                    fn main() {{
+                        {first_line}ˇ
+                    {indent}{next_line}
+                    }}"});
+                cx.update_editor(|editor, window, cx| {
+                    editor.join_lines_impl(insert_whitespace, window, cx)
+                });
+                cx.assert_editor_state(&formatdoc! {"
+                    fn main() {{
+                        {first_line}ˇ{separator}{next_line}
+                    }}"});
+            }
+        }
+    }
+}
+
+#[gpui::test]
+async fn test_join_lines_rust_block_comments(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(rust_lang()), cx));
+
+    for insert_whitespace in [true, false] {
+        let separator = if insert_whitespace { " " } else { "" };
+        for start in ["/*", "/**", "/*!"] {
+            for next_line in ["* bar", "*bar"] {
+                cx.set_state(&formatdoc! {"
+                    {start}
+                     * fooˇ
+                     {next_line}
+                     */"});
+                cx.update_editor(|editor, window, cx| {
+                    editor.join_lines_impl(insert_whitespace, window, cx)
+                });
+                cx.assert_editor_state(&formatdoc! {"
+                    {start}
+                     * fooˇ{separator}bar
+                     */"});
+            }
+
+            cx.set_state(&formatdoc! {"
+                {start}
+                 * fooˇ
+                 *
+                 */"});
+            cx.update_editor(|editor, window, cx| {
+                editor.join_lines_impl(insert_whitespace, window, cx)
+            });
+            cx.assert_editor_state(&formatdoc! {"
+                {start}
+                 * fooˇ
+                 */"});
+
+            cx.set_state(&formatdoc! {"
+                {start}
+                 * fooˇ
+                 */"});
+            cx.update_editor(|editor, window, cx| {
+                editor.join_lines_impl(insert_whitespace, window, cx)
+            });
+            cx.assert_editor_state(&formatdoc! {"
+                {start}
+                 * fooˇ{separator}*/"});
+        }
     }
 }
 

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -219,6 +219,10 @@ name = "shadow"
 path = "examples/shadow.rs"
 
 [[example]]
+name = "outline"
+path = "examples/outline.rs"
+
+[[example]]
 name = "svg"
 path = "examples/svg/svg.rs"
 

--- a/crates/gpui/examples/outline.rs
+++ b/crates/gpui/examples/outline.rs
@@ -1,0 +1,244 @@
+#![cfg_attr(target_family = "wasm", no_main)]
+
+use gpui::{
+    App, Bounds, Context, Div, SharedString, Window, WindowBounds, WindowOptions, div, hsla,
+    prelude::*, px, relative, rgb, size,
+};
+use gpui_platform::application;
+
+struct OutlineExample {}
+
+impl OutlineExample {
+    /// A square swatch with a small border, used as the base for outline demos.
+    fn square() -> Div {
+        div()
+            .size_16()
+            .bg(rgb(0xffffff))
+            .border_1()
+            .border_color(hsla(0.0, 0.0, 0.0, 0.1))
+    }
+
+    /// A rounded swatch, to show the outline tracking corner radii.
+    fn rounded() -> Div {
+        div()
+            .size_16()
+            .bg(rgb(0xffffff))
+            .rounded(px(8.))
+            .border_1()
+            .border_color(hsla(0.0, 0.0, 0.0, 0.1))
+    }
+}
+
+fn example(label: impl Into<SharedString>, example: impl IntoElement) -> impl IntoElement {
+    let label = label.into();
+
+    div()
+        .flex()
+        .flex_col()
+        .justify_center()
+        .items_center()
+        .w(relative(1. / 6.))
+        .border_r_1()
+        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .justify_center()
+                .flex_1()
+                .py_12()
+                .child(example),
+        )
+        .child(
+            div()
+                .w_full()
+                .border_t_1()
+                .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+                .p_1()
+                .flex()
+                .items_center()
+                .child(label),
+        )
+}
+
+fn row(children: Vec<impl IntoElement + 'static>) -> Div {
+    div()
+        .border_b_1()
+        .border_color(hsla(0.0, 0.0, 0.0, 1.0))
+        .flex()
+        .w_full()
+        .children(children)
+}
+
+impl Render for OutlineExample {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let outline = gpui::blue();
+
+        div()
+            .id("outline-example")
+            .overflow_y_scroll()
+            .bg(rgb(0xffffff))
+            .size_full()
+            .text_xs()
+            .child(
+                div().flex().flex_col().w_full().children(vec![
+                    // Increasing outline widths.
+                    row(vec![
+                        example(
+                            "Width 0",
+                            OutlineExample::square().outline_0().outline_color(outline),
+                        ),
+                        example(
+                            "Width 1",
+                            OutlineExample::square().outline_1().outline_color(outline),
+                        ),
+                        example(
+                            "Width 2",
+                            OutlineExample::square().outline_2().outline_color(outline),
+                        ),
+                        example(
+                            "Width 4",
+                            OutlineExample::square().outline_4().outline_color(outline),
+                        ),
+                        example(
+                            "Width 8",
+                            OutlineExample::square().outline_8().outline_color(outline),
+                        ),
+                    ]),
+                    // Increasing offsets (outline floats further from the box).
+                    row(vec![
+                        example(
+                            "Offset 0",
+                            OutlineExample::square()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset_0(),
+                        ),
+                        example(
+                            "Offset 2",
+                            OutlineExample::square()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset_2(),
+                        ),
+                        example(
+                            "Offset 4",
+                            OutlineExample::square()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset_4(),
+                        ),
+                        example(
+                            "Offset 8",
+                            OutlineExample::square()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset_8(),
+                        ),
+                        example(
+                            "Offset -4",
+                            OutlineExample::square()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset(px(-4.)),
+                        ),
+                    ]),
+                    // Styles: solid (default), dashed, and none.
+                    row(vec![
+                        example(
+                            "Solid",
+                            OutlineExample::square()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset_2(),
+                        ),
+                        example(
+                            "Dashed",
+                            OutlineExample::square()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset_2()
+                                .outline_dashed(),
+                        ),
+                        example(
+                            "None",
+                            OutlineExample::square()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset_2()
+                                .outline_0(),
+                        ),
+                    ]),
+                    // Rounded corners: the outline grows its radius to stay parallel.
+                    row(vec![
+                        example(
+                            "Rounded 0",
+                            OutlineExample::rounded()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset_0(),
+                        ),
+                        example(
+                            "Rounded +2",
+                            OutlineExample::rounded()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset_2(),
+                        ),
+                        example(
+                            "Rounded +8",
+                            OutlineExample::rounded()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset_8(),
+                        ),
+                        example(
+                            "Rounded dashed",
+                            OutlineExample::rounded()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset_4()
+                                .outline_dashed(),
+                        ),
+                        // A negative offset larger than the corner radius clamps the
+                        // outline radius to 0, so the corners render square.
+                        example(
+                            "Rounded -12",
+                            OutlineExample::rounded()
+                                .outline_2()
+                                .outline_color(outline)
+                                .outline_offset(px(-12.)),
+                        ),
+                    ]),
+                ]),
+            )
+    }
+}
+
+fn run_example() {
+    application().run(|cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(1000.0), px(700.0)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |_, cx| cx.new(|_| OutlineExample {}),
+        )
+        .unwrap();
+
+        cx.activate(true);
+    });
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn main() {
+    run_example();
+}
+
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn start() {
+    gpui_platform::web_init();
+    run_example();
+}

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -2346,7 +2346,14 @@ impl Interactivity {
             }
 
             let rem_size = window.rem_size();
-            let padding = style.padding.to_pixels(bounds.size.into(), rem_size);
+            // Taffy lays the box out with the padding snapped to the device pixel
+            // grid (`to_taffy`); recomputed unsnapped, e.g. py_1 at a fractional
+            // rem size, it exceeds `bounds` and leaves the box scrollable by the
+            // sub-pixel difference.
+            let padding = style
+                .padding
+                .to_pixels(bounds.size.into(), rem_size)
+                .map(|edge| window.pixel_snap(*edge));
             let padding_size = size(padding.left + padding.right, padding.top + padding.bottom);
             // The floating point values produced by Taffy and ours often vary
             // slightly after ~5 decimal places. This can lead to cases where after
@@ -5163,6 +5170,48 @@ mod tests {
             .unwrap();
 
         assert_eq!(focused, Some(item_b.id));
+    }
+
+    #[gpui::test]
+    fn test_fractional_padding_does_not_make_a_fitting_container_scrollable(
+        cx: &mut TestAppContext,
+    ) {
+        struct PaddedContainer {
+            scroll_handle: ScrollHandle,
+        }
+
+        impl Render for PaddedContainer {
+            fn render(
+                &mut self,
+                _window: &mut Window,
+                _cx: &mut Context<Self>,
+            ) -> impl IntoElement {
+                // 4.25px of padding snaps to 4px in layout, so a 42px child
+                // fits the 50px box exactly.
+                div().size_full().child(
+                    div()
+                        .id("container")
+                        .h(px(50.))
+                        .w(px(100.))
+                        .py(px(4.25))
+                        .overflow_y_scroll()
+                        .track_scroll(&self.scroll_handle)
+                        .child(div().w_full().h(px(42.))),
+                )
+            }
+        }
+
+        let scroll_handle = ScrollHandle::new();
+        let window: AnyWindowHandle = cx
+            .add_window({
+                let scroll_handle = scroll_handle.clone();
+                move |_, _| PaddedContainer { scroll_handle }
+            })
+            .into();
+        cx.update_window(window, |_, window, cx| window.draw(cx).clear(cx))
+            .unwrap();
+
+        assert_eq!(scroll_handle.max_offset().y, px(0.));
     }
 
     struct ContentSizedGrid;

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -280,6 +280,18 @@ pub struct Style {
     /// The border style of this element
     pub border_style: BorderStyle,
 
+    /// The outline width of this element
+    pub outline_width: AbsoluteLength,
+
+    /// The outline color of this element
+    pub outline_color: Option<Hsla>,
+
+    /// The outline style of this element
+    pub outline_style: BorderStyle,
+
+    /// The outline offset of this element
+    pub outline_offset: AbsoluteLength,
+
     /// The radius of the corners of this element
     #[refineable]
     pub corner_radii: Corners<AbsoluteLength>,
@@ -751,6 +763,32 @@ impl Style {
             ));
         }
 
+        if self.is_outline_visible() {
+            let outline_width = self.outline_width.to_pixels(rem_size);
+            let outline_offset = self.outline_offset.to_pixels(rem_size);
+            let expand = outline_offset + outline_width;
+            let outline_bounds = bounds.dilate(expand);
+            // Grow each non-zero corner so the outline tracks rounded corners; square stays square.
+            let zero = px(0.);
+            let outline_radii = corner_radii.map(|radius| {
+                if *radius > zero {
+                    (*radius + expand).max(zero)
+                } else {
+                    zero
+                }
+            });
+            let mut background = self.outline_color.unwrap_or_default();
+            background.a = 0.;
+            window.paint_quad(quad(
+                outline_bounds,
+                outline_radii,
+                background,
+                Edges::all(outline_width),
+                self.outline_color.unwrap_or_default(),
+                self.outline_style,
+            ));
+        }
+
         #[cfg(debug_assertions)]
         if self.debug_below {
             cx.remove_global::<DebugBelow>();
@@ -761,6 +799,12 @@ impl Style {
         self.border_color
             .is_some_and(|color| !color.is_transparent())
             && self.border_widths.any(|length| !length.is_zero())
+    }
+
+    fn is_outline_visible(&self) -> bool {
+        self.outline_color
+            .is_some_and(|color| !color.is_transparent())
+            && !self.outline_width.is_zero()
     }
 }
 
@@ -800,6 +844,10 @@ impl Default for Style {
             background: None,
             border_color: None,
             border_style: BorderStyle::default(),
+            outline_width: AbsoluteLength::default(),
+            outline_color: None,
+            outline_style: BorderStyle::default(),
+            outline_offset: AbsoluteLength::default(),
             corner_radii: Corners::default(),
             box_shadow: Default::default(),
             text: TextStyleRefinement::default(),

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 pub use gpui_macros::{
     border_style_methods, box_shadow_style_methods, cursor_style_methods, margin_style_methods,
-    overflow_style_methods, padding_style_methods, position_style_methods,
+    outline_style_methods, overflow_style_methods, padding_style_methods, position_style_methods,
     visibility_style_methods,
 };
 const ELLIPSIS: SharedString = SharedString::new_static("…");
@@ -31,6 +31,7 @@ pub trait Styled: Sized {
     gpui_macros::overflow_style_methods!();
     gpui_macros::cursor_style_methods!();
     gpui_macros::border_style_methods!();
+    gpui_macros::outline_style_methods!();
     gpui_macros::box_shadow_style_methods!();
 
     /// Sets the display type of the element to `block`.
@@ -499,6 +500,12 @@ pub trait Styled: Sized {
     /// Sets the border style of the element.
     fn border_dashed(mut self) -> Self {
         self.style().border_style = Some(BorderStyle::Dashed);
+        self
+    }
+
+    /// Sets the outline style of the element to dashed.
+    fn outline_dashed(mut self) -> Self {
+        self.style().outline_style = Some(BorderStyle::Dashed);
         self
     }
 

--- a/crates/gpui_macros/src/derive_inspector_reflection.rs
+++ b/crates/gpui_macros/src/derive_inspector_reflection.rs
@@ -273,6 +273,11 @@ fn try_expand_macro(macro_item: &syn::TraitItemMacro) -> Option<Vec<TraitItem>> 
             let expanded = crate::styles::border_style_methods(TokenStream::from(tokens));
             parse_expanded_items(expanded)
         }
+        "gpui_macros::outline_style_methods" | "outline_style_methods" => {
+            let tokens = macro_item.mac.tokens.clone();
+            let expanded = crate::styles::outline_style_methods(TokenStream::from(tokens));
+            parse_expanded_items(expanded)
+        }
         "gpui_macros::box_shadow_style_methods" | "box_shadow_style_methods" => {
             let tokens = macro_item.mac.tokens.clone();
             let expanded = crate::styles::box_shadow_style_methods(TokenStream::from(tokens));

--- a/crates/gpui_macros/src/gpui_macros.rs
+++ b/crates/gpui_macros/src/gpui_macros.rs
@@ -142,6 +142,12 @@ pub fn border_style_methods(input: TokenStream) -> TokenStream {
     styles::border_style_methods(input)
 }
 
+/// Generates methods for outline styles.
+#[proc_macro]
+pub fn outline_style_methods(input: TokenStream) -> TokenStream {
+    styles::outline_style_methods(input)
+}
+
 /// Generates methods for box shadow styles.
 #[proc_macro]
 pub fn box_shadow_style_methods(input: TokenStream) -> TokenStream {

--- a/crates/gpui_macros/src/styles.rs
+++ b/crates/gpui_macros/src/styles.rs
@@ -381,6 +381,56 @@ pub fn border_style_methods(input: TokenStream) -> TokenStream {
     output.into()
 }
 
+pub fn outline_style_methods(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as StyleableMacroInput);
+    let visibility = input.method_visibility;
+
+    let mut methods = Vec::new();
+
+    for outline_style_prefix in outline_prefixes() {
+        methods.push(generate_custom_value_setter(
+            visibility.clone(),
+            outline_style_prefix.prefix,
+            quote! { AbsoluteLength },
+            &outline_style_prefix.fields,
+            outline_style_prefix.doc_string_prefix,
+        ));
+
+        for outline_style_suffix in outline_suffixes() {
+            methods.push(generate_predefined_setter(
+                visibility.clone(),
+                outline_style_prefix.prefix,
+                outline_style_suffix.suffix,
+                &outline_style_prefix.fields,
+                &outline_style_suffix.width_tokens,
+                false,
+                &format!(
+                    "{prefix}\n\n{suffix}",
+                    prefix = outline_style_prefix.doc_string_prefix,
+                    suffix = outline_style_suffix.doc_string_suffix,
+                ),
+            ));
+        }
+    }
+
+    let output = quote! {
+        /// Sets the outline color of the element.
+        /// [Docs](https://tailwindcss.com/docs/outline-color)
+        #visibility fn outline_color<C>(mut self, outline_color: C) -> Self
+        where
+            C: Into<gpui::Hsla>,
+            Self: Sized,
+        {
+            self.style().outline_color = Some(outline_color.into());
+            self
+        }
+
+        #(#methods)*
+    };
+
+    output.into()
+}
+
 pub fn box_shadow_style_methods(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as StyleableMacroInput);
     let visibility = input.method_visibility;
@@ -523,6 +573,18 @@ struct BorderStylePrefix {
 }
 
 struct BorderStyleSuffix {
+    suffix: &'static str,
+    width_tokens: TokenStream2,
+    doc_string_suffix: &'static str,
+}
+
+struct OutlineStylePrefix {
+    prefix: &'static str,
+    fields: Vec<TokenStream2>,
+    doc_string_prefix: &'static str,
+}
+
+struct OutlineStyleSuffix {
     suffix: &'static str,
     width_tokens: TokenStream2,
     doc_string_suffix: &'static str,
@@ -1412,6 +1474,51 @@ fn border_suffixes() -> Vec<BorderStyleSuffix> {
             suffix: "32",
             width_tokens: quote! { px(32.) },
             doc_string_suffix: "32px",
+        },
+    ]
+}
+
+fn outline_prefixes() -> Vec<OutlineStylePrefix> {
+    vec![
+        OutlineStylePrefix {
+            prefix: "outline",
+            fields: vec![quote! { outline_width }],
+            doc_string_prefix: "Sets the outline width of the element. The outline is drawn outside the element's box and does not affect layout. [Docs](https://tailwindcss.com/docs/outline-width)",
+        },
+        OutlineStylePrefix {
+            prefix: "outline_offset",
+            fields: vec![quote! { outline_offset }],
+            doc_string_prefix: "Sets the space between the outline and the element's border edge. [Docs](https://tailwindcss.com/docs/outline-offset)",
+        },
+    ]
+}
+
+fn outline_suffixes() -> Vec<OutlineStyleSuffix> {
+    vec![
+        OutlineStyleSuffix {
+            suffix: "0",
+            width_tokens: quote! { px(0.) },
+            doc_string_suffix: "0px",
+        },
+        OutlineStyleSuffix {
+            suffix: "1",
+            width_tokens: quote! { px(1.) },
+            doc_string_suffix: "1px",
+        },
+        OutlineStyleSuffix {
+            suffix: "2",
+            width_tokens: quote! { px(2.) },
+            doc_string_suffix: "2px",
+        },
+        OutlineStyleSuffix {
+            suffix: "4",
+            width_tokens: quote! { px(4.) },
+            doc_string_suffix: "4px",
+        },
+        OutlineStyleSuffix {
+            suffix: "8",
+            width_tokens: quote! { px(8.) },
+            doc_string_suffix: "8px",
         },
     ]
 }

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -450,7 +450,9 @@ fn zed_ai_description(
         Some(Plan::ZedPro) => {
             "You have access to Zed's hosted models through your Pro subscription."
         }
-        Some(Plan::ZedProTrial) => "You have access to Zed's hosted models through your Pro trial.",
+        Some(Plan::ZedProTrial) => {
+            "Your Pro trial includes $5 of GPT Luna and unlimited edit predictions for 14 days from trial start."
+        }
         Some(Plan::ZedStudent) => {
             "You have access to Zed's hosted models through your Student subscription."
         }
@@ -466,7 +468,7 @@ fn zed_ai_description(
         }
         Some(Plan::ZedFree) | None => {
             if eligible_for_trial {
-                "Subscribe for access to Zed's hosted models. Start with a 14 day free trial."
+                "Start a free trial with $5 of GPT Luna and unlimited edit predictions for 14 days from trial start."
             } else {
                 "Subscribe for access to Zed's hosted models."
             }
@@ -498,7 +500,7 @@ impl RenderOnce for ZedAiConfiguration {
                 .on_click(|_, _, cx| cx.open_url(&zed_urls::account_url(cx)))
                 .into_any_element()
         } else if self.plan.is_none() || self.eligible_for_trial {
-            Button::new("start_trial", "Start 14-day Free Pro Trial")
+            Button::new("start_trial", "Start Free Trial")
                 .when(!self.compact, |this| {
                     this.full_width().label_size(LabelSize::Small)
                 })

--- a/crates/language_models/src/provider/opencode.rs
+++ b/crates/language_models/src/provider/opencode.rs
@@ -64,7 +64,8 @@ const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new(
 
 const API_KEY_ENV_VAR_NAME: &str = "OPENCODE_API_KEY";
 static API_KEY_ENV_VAR: LazyLock<EnvVar> = env_var!(API_KEY_ENV_VAR_NAME);
-pub(crate) const RESERVED_HEADER_NAMES: &[&str] = &["x-opencode-session"];
+const OPENCODE_SESSION_HEADER_NAME: &str = "x-opencode-session";
+pub(crate) const RESERVED_HEADER_NAMES: &[&str] = &[OPENCODE_SESSION_HEADER_NAME];
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct OpenCodeSettings {
@@ -326,9 +327,11 @@ impl HttpClient for InjectHeaderClient {
     fn user_agent(&self) -> Option<&http::HeaderValue> {
         self.inner.user_agent()
     }
+
     fn proxy(&self) -> Option<&http_client::Url> {
         self.inner.proxy()
     }
+
     fn send(
         &self,
         mut req: http::Request<AsyncBody>,
@@ -337,6 +340,15 @@ impl HttpClient for InjectHeaderClient {
             .insert(self.name.clone(), self.value.clone());
         self.inner.send(req)
     }
+}
+
+// Standalone requests do not have a conversation ID, but OpenCode requires a
+// non-empty session header.
+fn opencode_session_header_value(thread_id: Option<&str>) -> http::HeaderValue {
+    thread_id
+        .filter(|thread_id| !thread_id.is_empty())
+        .and_then(|thread_id| http::HeaderValue::from_str(thread_id).ok())
+        .unwrap_or_else(|| http::HeaderValue::from(rand::random::<u64>()))
 }
 
 impl OpenCodeLanguageModel {
@@ -633,17 +645,11 @@ impl LanguageModel for OpenCodeLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
-        let http_client = if let Some(ref thread_id) = request.thread_id
-            && let Ok(value) = http::HeaderValue::from_str(thread_id)
-        {
-            Arc::new(InjectHeaderClient {
-                inner: self.http_client.clone(),
-                name: http::HeaderName::from_static("x-opencode-session"),
-                value,
-            })
-        } else {
-            self.http_client.clone()
-        };
+        let http_client: Arc<dyn HttpClient> = Arc::new(InjectHeaderClient {
+            inner: self.http_client.clone(),
+            name: http::HeaderName::from_static(OPENCODE_SESSION_HEADER_NAME),
+            value: opencode_session_header_value(request.thread_id.as_deref()),
+        });
         let extra_headers = self.custom_headers(cx);
 
         match self.model.protocol(self.subscription) {
@@ -981,6 +987,136 @@ impl Render for ConfigurationView {
                 .child(subscription_toggles)
                 .children(no_subscriptions_warning)
                 .into_any()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_client::{FakeHttpClient, Response};
+    use language_model::{LanguageModelRequestMessage, MessageContent, Role};
+    use parking_lot::Mutex;
+
+    #[test]
+    fn test_opencode_session_header_uses_thread_id() {
+        let value = opencode_session_header_value(Some("thread-123"));
+
+        assert_eq!(value, "thread-123");
+    }
+
+    #[test]
+    fn test_opencode_session_header_without_thread_id() {
+        let value = opencode_session_header_value(None);
+
+        assert_generated_session_id(&value);
+    }
+
+    #[test]
+    fn test_opencode_session_header_with_empty_thread_id() {
+        let value = opencode_session_header_value(Some(""));
+
+        assert_generated_session_id(&value);
+    }
+
+    #[test]
+    fn test_opencode_session_header_with_invalid_thread_id() {
+        let value = opencode_session_header_value(Some("thread\n123"));
+
+        assert_generated_session_id(&value);
+    }
+
+    #[gpui::test]
+    async fn test_stream_completion_sends_session_header_without_thread_id(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let captured_header = Arc::new(Mutex::new(None));
+        let http_client = FakeHttpClient::create({
+            let captured_header = captured_header.clone();
+            move |request| {
+                let captured_header = captured_header.clone();
+                async move {
+                    *captured_header.lock() =
+                        Some(request.headers().get(OPENCODE_SESSION_HEADER_NAME).cloned());
+                    Ok(Response::builder().status(200).body(AsyncBody::from(
+                        "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+                    ))?)
+                }
+            }
+        });
+        let provider = cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            OpenCodeLanguageModelProvider::new(http_client, Arc::new(TestCredentialsProvider), cx)
+        });
+        let store_key = provider.state.update(cx, |state, cx| {
+            state.set_api_key(Some("test-key".to_string()), cx)
+        });
+        store_key.await.unwrap();
+        let model =
+            provider.create_language_model(opencode::Model::default(), OpenCodeSubscription::Go);
+        let request = LanguageModelRequest {
+            thread_id: None,
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![MessageContent::Text("Hello".to_string())],
+                cache: false,
+                reasoning_details: None,
+            }],
+            ..Default::default()
+        };
+
+        let stream = model
+            .stream_completion(request, &cx.to_async())
+            .await
+            .unwrap();
+        drop(stream);
+
+        let captured_header = captured_header
+            .lock()
+            .take()
+            .expect("request should reach the http client")
+            .expect("request should carry the session header");
+        assert_generated_session_id(&captured_header);
+    }
+
+    fn assert_generated_session_id(value: &http::HeaderValue) {
+        value
+            .to_str()
+            .unwrap()
+            .parse::<u64>()
+            .expect("generated session id should be a u64");
+    }
+
+    struct TestCredentialsProvider;
+
+    impl CredentialsProvider for TestCredentialsProvider {
+        fn read_credentials<'a>(
+            &'a self,
+            _url: &'a str,
+            _cx: &'a AsyncApp,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<Option<(String, Vec<u8>)>>> + 'a>,
+        > {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn write_credentials<'a>(
+            &'a self,
+            _url: &'a str,
+            _username: &'a str,
+            _password: &'a [u8],
+            _cx: &'a AsyncApp,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + 'a>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn delete_credentials<'a>(
+            &'a self,
+            _url: &'a str,
+            _cx: &'a AsyncApp,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + 'a>> {
+            Box::pin(async { Ok(()) })
         }
     }
 }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -146,7 +146,7 @@ use util::{
     paths::{PathStyle, SanitizedPath, UrlExt},
     post_inc,
     redact::redact_command,
-    rel_path::RelPath,
+    rel_path::{RelPath, RelPathBuf},
     union_json_value_into,
 };
 
@@ -9684,15 +9684,6 @@ impl LspStore {
             let abs_path = abs_path
                 .to_file_path_ext(path_style)
                 .map_err(|()| anyhow!("can't convert URI to path"))?;
-
-            let fs = lsp_store.update(cx, |lsp_store, _cx| {
-                lsp_store.as_local().map(|local| local.fs.clone())
-            })?;
-            let abs_path = if let Some(fs) = fs {
-                fs.canonicalize(&abs_path).await.unwrap_or(abs_path)
-            } else {
-                abs_path
-            };
             let p = abs_path.clone();
             let yarn_worktree = lsp_store
                 .update(cx, move |lsp_store, cx| match lsp_store.as_local() {
@@ -9713,11 +9704,16 @@ impl LspStore {
                 } else {
                     (Arc::<Path>::from(abs_path.as_path()), None)
                 };
-            let worktree = lsp_store.update(cx, |lsp_store, cx| {
-                lsp_store.worktree_store.update(cx, |worktree_store, cx| {
-                    worktree_store.find_worktree(&worktree_root_target, cx)
-                })
-            })?;
+            let worktree = if known_relative_path.is_some() {
+                lsp_store.read_with(cx, |lsp_store, cx| {
+                    lsp_store
+                        .worktree_store
+                        .read(cx)
+                        .find_worktree(&worktree_root_target, cx)
+                })?
+            } else {
+                find_worktree_for_lsp_path(&lsp_store, &abs_path, cx).await?
+            };
             let (worktree, relative_path, source_ws) = if let Some(result) = worktree {
                 let relative_path = known_relative_path.unwrap_or_else(|| result.1.clone());
                 (result.0, relative_path, None)
@@ -14003,6 +13999,101 @@ fn lsp_ranges_conflict(a: &lsp::Range, b: &lsp::Range) -> bool {
 
 fn lsp_ranges_overlap(a: &lsp::Range, b: &lsp::Range) -> bool {
     a.start < b.end && b.start < a.end
+}
+
+async fn find_worktree_for_lsp_path(
+    lsp_store: &WeakEntity<LspStore>,
+    abs_path: &Path,
+    cx: &mut AsyncApp,
+) -> Result<Option<(Entity<Worktree>, Arc<RelPath>)>> {
+    let (fs, worktree) = lsp_store.read_with(cx, |lsp_store, cx| {
+        (
+            lsp_store.as_local().map(|local| local.fs.clone()),
+            lsp_store
+                .worktree_store
+                .read(cx)
+                .find_worktree(abs_path, cx),
+        )
+    })?;
+    match worktree {
+        Some((worktree, relative_path)) => {
+            let relative_path =
+                normalize_lsp_relative_path(&worktree, abs_path, relative_path, cx).await?;
+            Ok(Some((worktree, relative_path)))
+        }
+        None => {
+            let Some(fs) = fs else {
+                return Ok(None);
+            };
+            let Ok(canonical_path) = fs.canonicalize(abs_path).await else {
+                return Ok(None);
+            };
+            lsp_store.read_with(cx, |lsp_store, cx| {
+                lsp_store
+                    .worktree_store
+                    .read(cx)
+                    .find_worktree(&canonical_path, cx)
+            })
+        }
+    }
+}
+
+async fn normalize_lsp_relative_path(
+    worktree: &Entity<Worktree>,
+    abs_path: &Path,
+    relative_path: Arc<RelPath>,
+    cx: &mut AsyncApp,
+) -> Result<Arc<RelPath>> {
+    let Some((fs, snapshot, worktree_root)) = worktree.read_with(cx, |worktree, _| {
+        let local_worktree = worktree.as_local()?;
+        if local_worktree.fs_is_case_sensitive() {
+            return None;
+        }
+        Some((
+            local_worktree.fs().clone(),
+            worktree.snapshot(),
+            worktree.abs_path(),
+        ))
+    }) else {
+        return Ok(relative_path);
+    };
+    if snapshot.entry_for_path(&relative_path).is_some() {
+        return Ok(relative_path);
+    }
+
+    let mut normalized_path = RelPathBuf::new();
+    let mut components = relative_path.components();
+    while let Some(component) = components.next() {
+        let mut exact_path = normalized_path.clone();
+        exact_path.push_component(component)?;
+        if snapshot.entry_for_path(&exact_path).is_some() {
+            normalized_path = exact_path;
+            continue;
+        }
+        let case_insensitive_match = snapshot
+            .child_entries(&normalized_path)
+            .find(|entry| {
+                entry
+                    .path
+                    .file_name()
+                    .is_some_and(|name| name.eq_ignore_ascii_case(component))
+            })
+            .map(|entry| entry.path.to_rel_path_buf());
+        let Some(matched_path) = case_insensitive_match else {
+            if let Ok(canonical_path) = fs.canonicalize(abs_path).await
+                && let Ok(canonical_root) = fs.canonicalize(&worktree_root).await
+                && let Ok(canonical_relative_path) = canonical_path.strip_prefix(&canonical_root)
+                && let Ok(canonical_relative_path) =
+                    RelPath::new(canonical_relative_path, PathStyle::local())
+            {
+                return Ok(canonical_relative_path.into_arc());
+            }
+            exact_path.push(components.rest());
+            return Ok(Arc::from(exact_path));
+        };
+        normalized_path = matched_path;
+    }
+    Ok(Arc::from(normalized_path))
 }
 
 fn subscribe_to_binary_statuses(

--- a/crates/project/tests/integration/lsp_store.rs
+++ b/crates/project/tests/integration/lsp_store.rs
@@ -1,15 +1,15 @@
 use std::{
-    path::Path,
+    path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, Instant},
 };
 
 use collections::HashMap;
-use fs::FakeFs;
+use fs::{FakeFs, Fs};
 use futures::StreamExt;
-use gpui::TestAppContext;
-use language::{CodeLabel, FakeLspAdapter, HighlightId, rust_lang};
-use lsp::{LanguageServerName, Uri};
+use gpui::{Entity, TestAppContext};
+use language::{Buffer, CodeLabel, FakeLspAdapter, HighlightId, LocalFile, rust_lang};
+use lsp::{LanguageServerId, LanguageServerName, Uri};
 use parking_lot::Mutex;
 use project::{
     Project,
@@ -161,6 +161,117 @@ async fn test_open_buffer_via_lsp_case_variant_no_duplicate(cx: &mut TestAppCont
             .collect();
         assert_eq!(entries, vec!["", "src", "src/main.rs"]);
     });
+}
+
+#[gpui::test]
+async fn test_open_buffer_via_lsp_preserves_external_symlink_path(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.executor().allow_parking();
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/shared"),
+        json!({ "pkg": { "def.rs": "pub fn def() {}" } }),
+    )
+    .await;
+    fs.insert_tree(
+        path!("/project"),
+        json!({ "src": { "main.rs": "fn main() {}" } }),
+    )
+    .await;
+    fs.create_symlink(
+        path!("/project/pkg").as_ref(),
+        PathBuf::from(path!("/shared/pkg")),
+    )
+    .await
+    .unwrap();
+
+    let (project, server_id) =
+        project_with_rust_server(fs, path!("/project"), path!("/project/src/main.rs"), cx).await;
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_via_lsp(
+                Uri::from_file_path(path!("/project/pkg/def.rs")).unwrap(),
+                server_id,
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    assert_eq!(
+        buffer_paths(&buffer, cx),
+        (
+            "pkg/def.rs".to_string(),
+            PathBuf::from(path!("/project/pkg/def.rs"))
+        )
+    );
+    assert_eq!(
+        worktree_roots(&project, cx),
+        vec![PathBuf::from(path!("/project"))]
+    );
+}
+
+#[gpui::test]
+async fn test_open_buffer_via_lsp_case_variant_in_unscanned_dir(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.executor().allow_parking();
+
+    let fs = FakeFs::new(cx.executor());
+    fs.set_case_sensitive(false);
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".gitignore": "ignored\n",
+            "src": { "main.rs": "fn main() {}" },
+            "ignored": { "lib.rs": "pub fn lib() {}" },
+        }),
+    )
+    .await;
+
+    let (project, server_id) =
+        project_with_rust_server(fs, path!("/root"), path!("/root/src/main.rs"), cx).await;
+    assert_eq!(
+        worktree_entries(&project, cx),
+        vec!["", ".gitignore", "ignored", "src", "src/main.rs"]
+    );
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_via_lsp(
+                Uri::from_file_path(path!("/root/IGNORED/LIB.rs")).unwrap(),
+                server_id,
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    assert_eq!(
+        buffer_paths(&buffer, cx),
+        (
+            "ignored/lib.rs".to_string(),
+            PathBuf::from(path!("/root/ignored/lib.rs"))
+        )
+    );
+    assert_eq!(
+        worktree_roots(&project, cx),
+        vec![PathBuf::from(path!("/root"))]
+    );
+    assert_eq!(
+        worktree_entries(&project, cx),
+        vec![
+            "",
+            ".gitignore",
+            "ignored",
+            "ignored/lib.rs",
+            "src",
+            "src/main.rs"
+        ]
+    );
 }
 
 #[test]
@@ -672,4 +783,64 @@ async fn test_initialization_options_contributions_without_own_options(cx: &mut 
         sent_initialization_options.lock().take(),
         Some(Some(contribution)),
     );
+}
+
+async fn project_with_rust_server(
+    fs: Arc<FakeFs>,
+    root: &str,
+    first_file: &str,
+    cx: &mut TestAppContext,
+) -> (Entity<Project>, LanguageServerId) {
+    let project = Project::test(fs, [root.as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let mut fake_servers = language_registry.register_fake_lsp("Rust", FakeLspAdapter::default());
+
+    project
+        .update(cx, |project, cx| {
+            project.open_local_buffer_with_lsp(first_file, cx)
+        })
+        .await
+        .unwrap();
+    fake_servers.next().await.unwrap();
+    cx.run_until_parked();
+
+    let server_id = project.read_with(cx, |project, cx| {
+        project
+            .lsp_store()
+            .read(cx)
+            .language_server_statuses()
+            .next()
+            .unwrap()
+            .0
+    });
+    (project, server_id)
+}
+
+fn buffer_paths(buffer: &Entity<Buffer>, cx: &TestAppContext) -> (String, PathBuf) {
+    buffer.read_with(cx, |buffer, cx| {
+        let file = File::from_dyn(buffer.file()).unwrap();
+        (file.path.as_unix_str().to_string(), file.abs_path(cx))
+    })
+}
+
+fn worktree_roots(project: &Entity<Project>, cx: &TestAppContext) -> Vec<PathBuf> {
+    project.read_with(cx, |project, cx| {
+        project
+            .worktrees(cx)
+            .map(|worktree| worktree.read(cx).abs_path().to_path_buf())
+            .collect()
+    })
+}
+
+fn worktree_entries(project: &Entity<Project>, cx: &TestAppContext) -> Vec<String> {
+    project.read_with(cx, |project, cx| {
+        let worktree = project.worktrees(cx).next().unwrap();
+        worktree
+            .read(cx)
+            .snapshot()
+            .entries(true, 0)
+            .map(|entry| entry.path.as_unix_str().to_string())
+            .collect()
+    })
 }

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -7,6 +7,7 @@ use parking_lot::Mutex;
 use release_channel::{AppCommitSha, AppVersion, ReleaseChannel};
 use semver::Version as SemanticVersion;
 use std::collections::BTreeMap;
+use std::fmt::Write;
 use std::time::Instant;
 use std::{
     path::{Path, PathBuf},
@@ -14,6 +15,7 @@ use std::{
 };
 use util::ResultExt;
 use util::command::Stdio;
+use util::redact::{is_valid_environment_name, redact_command};
 use util::shell::ShellKind;
 use util::{
     paths::{PathStyle, RemotePathBuf},
@@ -512,13 +514,47 @@ impl DockerExecConnection {
             command.arg(arg.as_ref());
         }
         let output = command.output().await?;
-        log::debug!("{:?}: {:?}", command, output);
-        anyhow::ensure!(
-            output.status.success(),
-            "failed to run command {command:?}: {}",
-            String::from_utf8_lossy(&output.stderr)
+        log::debug!(
+            "{}: {:?}",
+            redact_arguments(self.docker_cli(), subcommand, args),
+            output.status
         );
+        if !output.status.success() {
+            anyhow::bail!(docker_command_error(
+                self.docker_cli(),
+                subcommand,
+                args,
+                &String::from_utf8_lossy(&output.stderr),
+            ));
+        }
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+
+    fn docker_exec_arguments(
+        &self,
+        inner_program: &str,
+        working_directory: Option<&str>,
+        env: &HashMap<String, String>,
+        program_args: &[impl AsRef<str>],
+    ) -> Vec<String> {
+        let mut args = match working_directory {
+            Some(dir) => vec!["-w".to_string(), dir.to_string()],
+            None => vec![],
+        };
+
+        args.push("-u".to_string());
+        args.push(self.connection_options.remote_user.clone());
+
+        push_environment(&mut args, &self.connection_options.remote_env);
+        push_environment(&mut args, env);
+
+        args.push(self.connection_options.container_id.clone());
+        args.push(inner_program.to_string());
+
+        for arg in program_args {
+            args.push(arg.as_ref().to_owned());
+        }
+        args
     }
 
     async fn run_docker_exec(
@@ -528,30 +564,7 @@ impl DockerExecConnection {
         env: &HashMap<String, String>,
         program_args: &[impl AsRef<str>],
     ) -> Result<String> {
-        let mut args = match working_directory {
-            Some(dir) => vec!["-w".to_string(), dir.to_string()],
-            None => vec![],
-        };
-
-        args.push("-u".to_string());
-        args.push(self.connection_options.remote_user.clone());
-
-        for (k, v) in self.connection_options.remote_env.iter() {
-            args.push("-e".to_string());
-            args.push(format!("{k}={v}"));
-        }
-
-        for (k, v) in env.iter() {
-            args.push("-e".to_string());
-            args.push(format!("{k}={v}"));
-        }
-
-        args.push(self.connection_options.container_id.clone());
-        args.push(inner_program.to_string());
-
-        for arg in program_args {
-            args.push(arg.as_ref().to_owned());
-        }
+        let args = self.docker_exec_arguments(inner_program, working_directory, env, program_args);
         self.run_docker_command("exec", args.as_ref()).await
     }
 
@@ -674,10 +687,7 @@ impl RemoteConnection for DockerExecConnection {
 
         let mut docker_args = vec!["exec".to_string()];
 
-        for (k, v) in self.connection_options.remote_env.iter() {
-            docker_args.push("-e".to_string());
-            docker_args.push(format!("{k}={v}"));
-        }
+        push_environment(&mut docker_args, &self.connection_options.remote_env);
         for env_var in ["RUST_LOG", "RUST_BACKTRACE", "ZED_GENERATE_MINIDUMPS"] {
             if let Some(value) = std::env::var(env_var).ok() {
                 docker_args.push("-e".to_string());
@@ -815,15 +825,8 @@ impl RemoteConnection for DockerExecConnection {
             docker_args.push(parsed_working_dir);
         }
 
-        for (k, v) in self.connection_options.remote_env.iter() {
-            docker_args.push("-e".to_string());
-            docker_args.push(format!("{k}={v}"));
-        }
-
-        for (k, v) in env.iter() {
-            docker_args.push("-e".to_string());
-            docker_args.push(format!("{k}={v}"));
-        }
+        push_environment(&mut docker_args, &self.connection_options.remote_env);
+        push_environment(&mut docker_args, env);
 
         match interactive {
             Interactive::Yes => docker_args.push("-it".to_string()),
@@ -875,5 +878,213 @@ impl RemoteConnection for DockerExecConnection {
 
     fn default_system_shell(&self) -> String {
         String::from("/bin/sh")
+    }
+}
+
+fn push_environment<'a>(
+    args: &mut Vec<String>,
+    environment: impl IntoIterator<Item = (&'a String, &'a String)>,
+) {
+    for (name, value) in environment {
+        if !is_valid_environment_name(name) {
+            log::warn!("Skipping environment variable with invalid name");
+            continue;
+        }
+        args.push("-e".to_string());
+        args.push(format!("{name}={value}"));
+    }
+}
+
+fn redact_arguments(docker_cli: &str, subcommand: &str, args: &[impl AsRef<str>]) -> String {
+    let mut redacted = format!("{docker_cli:?} {subcommand:?}");
+    let mut next_argument_is_environment = false;
+
+    for arg in args {
+        let arg = arg.as_ref();
+        let argument = if next_argument_is_environment {
+            next_argument_is_environment = false;
+            redact_environment(arg)
+        } else if arg == "-e" {
+            next_argument_is_environment = true;
+            arg.to_string()
+        } else {
+            redact_command(arg)
+        };
+        write!(redacted, " {argument:?}").ok();
+    }
+
+    redacted
+}
+
+fn docker_command_error(
+    docker_cli: &str,
+    subcommand: &str,
+    args: &[impl AsRef<str>],
+    stderr: &str,
+) -> String {
+    format!(
+        "failed to run command {}: {}",
+        redact_arguments(docker_cli, subcommand, args),
+        redact_command(stderr)
+    )
+}
+
+fn redact_environment(assignment: &str) -> String {
+    match assignment.split_once('=') {
+        Some((name, _)) => format!("{name}=<redacted>"),
+        None => assignment.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_forwarded_env() {
+        let connection = connection(&[
+            ("DATABASE_URL", "postgres://user:password@host/db"),
+            ("GH_TOKEN", "ghp_supersecret"),
+            ("PATH", "/usr/bin"),
+            ("lowercase_token", "secret"),
+        ]);
+
+        assert_eq!(
+            redacted_docker_exec(&connection, &[], &["-c", "echo hi"]),
+            concat!(
+                "\"docker\" \"exec\" \"-w\" \"/workspace\" \"-u\" \"user\"",
+                " \"-e\" \"DATABASE_URL=<redacted>\" \"-e\" \"GH_TOKEN=<redacted>\"",
+                " \"-e\" \"PATH=<redacted>\" \"-e\" \"lowercase_token=<redacted>\"",
+                " \"container_id\" \"sh\" \"-c\" \"echo hi\""
+            )
+        );
+    }
+
+    #[test]
+    fn preserves_argument_boundaries_and_escapes_control_characters() {
+        let connection = connection(&[]);
+
+        assert_eq!(
+            redacted_docker_exec(&connection, &[], &["-c", "first argument\nsecond argument"]),
+            concat!(
+                "\"docker\" \"exec\" \"-w\" \"/workspace\" \"-u\" \"user\"",
+                " \"container_id\" \"sh\" \"-c\" \"first argument\\nsecond argument\""
+            )
+        );
+    }
+
+    #[test]
+    fn redacts_assignments_in_command_arguments() {
+        assert_eq!(
+            redact_arguments(
+                "docker",
+                "exec",
+                &["container_id", "sh", "-c", "GH_TOKEN=ghp_supersecret run"]
+            ),
+            concat!(
+                "\"docker\" \"exec\" \"container_id\" \"sh\" \"-c\"",
+                " \"GH_TOKEN=\\\"[REDACTED]\\\" run\""
+            )
+        );
+    }
+
+    #[test]
+    fn redacts_failure_message() {
+        let connection = connection(&[("API_KEY", "remote-secret")]);
+        let env = [("COMMAND_SECRET".to_string(), "command-secret".to_string())]
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        let args = connection.docker_exec_arguments("sh", None, &env, &["-c", "echo hi"]);
+
+        assert_eq!(
+            docker_command_error(
+                connection.docker_cli(),
+                "exec",
+                &args,
+                "sh: 1: /usr/local/cargo/bin/zed-remote-server: not found\nGH_TOKEN=ghp_supersecret run",
+            ),
+            concat!(
+                "failed to run command \"docker\" \"exec\" \"-u\" \"user\"",
+                " \"-e\" \"API_KEY=<redacted>\" \"-e\" \"COMMAND_SECRET=<redacted>\"",
+                " \"container_id\" \"sh\" \"-c\" \"echo hi\"",
+                ": sh: 1: /usr/local/cargo/bin/zed-remote-server: not found\nGH_TOKEN=\"[REDACTED]\" run"
+            )
+        );
+    }
+
+    #[test]
+    fn skips_invalid_env_names() {
+        let connection = connection(&[
+            ("", "empty"),
+            ("NAME=VALUE", "equals"),
+            ("LINE\nBREAK", "newline"),
+            ("NAME\0NUL", "nul"),
+            ("GH_TOKEN", "ghp_supersecret"),
+        ]);
+        let env = HashMap::default();
+        let program_args = Vec::<&str>::new();
+        let args = connection.docker_exec_arguments("sh", None, &env, &program_args);
+
+        assert_eq!(
+            args,
+            vec![
+                "-u",
+                "user",
+                "-e",
+                "GH_TOKEN=ghp_supersecret",
+                "container_id",
+                "sh"
+            ]
+        );
+    }
+
+    #[test]
+    fn uses_podman_cli() {
+        let mut connection = connection(&[("GH_TOKEN", "ghp_supersecret")]);
+        connection.connection_options.use_podman = true;
+
+        assert_eq!(
+            redacted_docker_exec(&connection, &[], &[]),
+            concat!(
+                "\"podman\" \"exec\" \"-w\" \"/workspace\" \"-u\" \"user\"",
+                " \"-e\" \"GH_TOKEN=<redacted>\" \"container_id\" \"sh\""
+            )
+        );
+    }
+
+    fn connection(remote_env: &[(&str, &str)]) -> DockerExecConnection {
+        DockerExecConnection {
+            proxy_process: Mutex::new(None),
+            remote_dir_for_server: "/tmp/zed".to_string(),
+            remote_binary_relpath: None,
+            connection_options: DockerConnectionOptions {
+                name: "container".to_string(),
+                container_id: "container_id".to_string(),
+                remote_user: "user".to_string(),
+                upload_binary_over_docker_exec: false,
+                use_podman: false,
+                remote_env: remote_env
+                    .iter()
+                    .map(|(key, value)| (key.to_string(), value.to_string()))
+                    .collect(),
+            },
+            remote_platform: None,
+            os_version: None,
+            path_style: None,
+            shell: "/bin/sh".to_string(),
+        }
+    }
+
+    fn redacted_docker_exec(
+        connection: &DockerExecConnection,
+        env: &[(&str, &str)],
+        program_args: &[&str],
+    ) -> String {
+        let env = env
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect::<HashMap<_, _>>();
+        let args = connection.docker_exec_arguments("sh", Some("/workspace"), &env, program_args);
+        redact_arguments(connection.docker_cli(), "exec", &args)
     }
 }

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -3847,7 +3847,11 @@ impl Sidebar {
                     anyhow::bail!("Thread not found in database");
                 };
 
-                let request = agent::build_thread_title_request(&db_thread.messages, temperature);
+                let request = agent::build_thread_title_request(
+                    &session_id,
+                    &db_thread.messages,
+                    temperature,
+                );
                 let title =
                     SharedString::from(agent::stream_thread_title(model, request, cx).await?);
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1289,6 +1289,13 @@ impl TerminalView {
         self.clear_bell(cx);
         self.pause_cursor_blinking(window, cx);
 
+        if event.prefer_character_input
+            && event.keystroke.key_char.is_some()
+            && !self.terminal.read(cx).vi_mode_enabled()
+        {
+            return;
+        }
+
         if self.process_keystroke(&event.keystroke, cx) {
             cx.stop_propagation();
         }
@@ -2170,7 +2177,7 @@ fn first_project_directory(workspace: &Workspace, cx: &App) -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::{TestAppContext, VisualTestContext};
+    use gpui::{TestAppContext, UpdateGlobal, VisualTestContext};
     use project::{Entry, Project, ProjectPath, Worktree};
     use remote::RemoteClient;
     use std::path::{Path, PathBuf};
@@ -2341,6 +2348,70 @@ mod tests {
             terminal.update(&mut cx, |terminal, _| terminal.take_input_log()),
             vec![vec![0x11]],
             "ctrl-q in a focused terminal should send 0x11 to the PTY, not trigger zed::Quit",
+        );
+    }
+
+    #[gpui::test]
+    async fn altgr_character_input_is_not_swallowed_as_meta_sequence(cx: &mut TestAppContext) {
+        let (project, _workspace, window_handle) = init_test_with_window(cx).await;
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.terminal.get_or_insert_default().option_as_meta = Some(true);
+                });
+            });
+        });
+        let (_pane, terminal, _terminal_view) =
+            add_display_only_terminal(&project, window_handle, true, cx);
+
+        let mut cx = VisualTestContext::from_window(window_handle.into(), cx);
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        cx.run_until_parked();
+
+        let mut altgr_a = Keystroke::parse("ctrl-alt-a").unwrap();
+        altgr_a.key_char = Some("ą".to_string());
+
+        let propagate = cx.update(|window, cx| {
+            window
+                .dispatch_event(
+                    gpui::PlatformInput::KeyDown(KeyDownEvent {
+                        keystroke: altgr_a.clone(),
+                        is_held: false,
+                        prefer_character_input: true,
+                    }),
+                    cx,
+                )
+                .propagate
+        });
+        assert!(
+            propagate,
+            "a keystroke that produced a character must propagate so the platform can commit the text",
+        );
+        assert_eq!(
+            terminal.update(&mut cx, |terminal, _| terminal.take_input_log()),
+            Vec::<Vec<u8>>::new(),
+            "AltGr-produced characters must not be sent as meta escape sequences",
+        );
+
+        let propagate = cx.update(|window, cx| {
+            window
+                .dispatch_event(
+                    gpui::PlatformInput::KeyDown(KeyDownEvent {
+                        keystroke: altgr_a,
+                        is_held: false,
+                        prefer_character_input: false,
+                    }),
+                    cx,
+                )
+                .propagate
+        });
+        assert!(!propagate);
+        assert_eq!(
+            terminal.update(&mut cx, |terminal, _| terminal.take_input_log()),
+            vec![b"\x1b\x01".to_vec()],
+            "ctrl-alt-a without character input preference is still sent as meta ctrl-a",
         );
     }
 

--- a/crates/util/src/redact.rs
+++ b/crates/util/src/redact.rs
@@ -20,6 +20,13 @@ pub fn should_redact(env_var_name: &str) -> bool {
         .any(|suffix| env_var_name.ends_with(suffix))
 }
 
+pub fn is_valid_environment_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|character| character != '=' && !character.is_control())
+}
+
 /// Redact a string which could include a command with environment variables
 pub fn redact_command(command: &str) -> String {
     REDACT_REGEX

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -26,7 +26,7 @@ use util::{path, test::marked_text_ranges};
 pub use vim_test_context::*;
 
 use gpui::VisualTestContext;
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
 use project::FakeFs;
 use search::BufferSearchBar;
 use search::{ProjectSearchView, project_search};
@@ -619,6 +619,84 @@ async fn test_join_lines(cx: &mut gpui::TestAppContext) {
       twothreefourˇfive
       six
       "});
+}
+
+#[perf]
+#[gpui::test]
+async fn test_join_lines_rust_dereference(cx: &mut gpui::TestAppContext) {
+    let mut cx = VimTestContext::new(cx, true).await;
+
+    for dereference in ["*value.get()", "* value.get()"] {
+        let initial = formatdoc! {"
+            ˇlet another_value = unsafe {{
+             {dereference}
+            }};"};
+        let joined = formatdoc! {"
+            let another_value = unsafe {{ˇ {dereference}
+            }};"};
+        let fully_joined = format!("let another_value = unsafe {{ {dereference}ˇ }};");
+
+        for keystrokes in [
+            "shift-j",
+            "1 shift-j",
+            "2 shift-j",
+            "v j shift-j",
+            "shift-v j shift-j",
+            "j v k shift-j",
+            "j shift-v k shift-j",
+        ] {
+            cx.assert_binding_normal(keystrokes, &initial, &joined);
+        }
+
+        for keystrokes in [
+            "3 shift-j",
+            "v 2 j shift-j",
+            "shift-v 2 j shift-j",
+            "2 j v 2 k shift-j",
+            "2 j shift-v 2 k shift-j",
+        ] {
+            cx.assert_binding_normal(keystrokes, &initial, &fully_joined);
+        }
+    }
+}
+
+#[perf]
+#[gpui::test]
+async fn test_join_lines_rust_dereference_without_whitespace(cx: &mut gpui::TestAppContext) {
+    let mut cx = VimTestContext::new(cx, true).await;
+
+    for dereference in ["*value.get()", "* value.get()"] {
+        let initial = formatdoc! {"
+            ˇlet another_value = unsafe {{
+            {dereference}
+            }};"};
+        let joined = formatdoc! {"
+            let another_value = unsafe {{ˇ{dereference}
+            }};"};
+        let fully_joined = format!("let another_value = unsafe {{{dereference}ˇ}};");
+
+        for keystrokes in [
+            "g shift-j",
+            "1 g shift-j",
+            "2 g shift-j",
+            "v j g shift-j",
+            "shift-v j g shift-j",
+            "j v k g shift-j",
+            "j shift-v k g shift-j",
+        ] {
+            cx.assert_binding_normal(keystrokes, &initial, &joined);
+        }
+
+        for keystrokes in [
+            "3 g shift-j",
+            "v 2 j g shift-j",
+            "shift-v 2 j g shift-j",
+            "2 j v 2 k g shift-j",
+            "2 j shift-v 2 k g shift-j",
+        ] {
+            cx.assert_binding_normal(keystrokes, &initial, &fully_joined);
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -2,7 +2,7 @@
 description = "The fast, collaborative code editor."
 edition.workspace = true
 name = "zed"
-version = "1.19.0"
+version = "1.19.1"
 publish.workspace = true
 license = "GPL-3.0-or-later"
 authors = ["Zed Team <hi@zed.dev>"]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -2,7 +2,7 @@
 description = "The fast, collaborative code editor."
 edition.workspace = true
 name = "zed"
-version = "1.19.1"
+version = "1.19.2"
 publish.workspace = true
 license = "GPL-3.0-or-later"
 authors = ["Zed Team <hi@zed.dev>"]

--- a/crates/zed/RELEASE_CHANNEL
+++ b/crates/zed/RELEASE_CHANNEL
@@ -1,1 +1,1 @@
-preview
+stable

--- a/crates/zed/RELEASE_CHANNEL
+++ b/crates/zed/RELEASE_CHANNEL
@@ -1,1 +1,1 @@
-dev
+preview

--- a/docs/src/account/plans-and-pricing.md
+++ b/docs/src/account/plans-and-pricing.md
@@ -27,7 +27,7 @@ Zed is free to use. You can configure AI agents with your own API keys via [Use 
 
 ### Zed Pro {#pro}
 
-Zed Pro includes access to all hosted AI models and Edit Predictions. The plan includes $5 of monthly token credit; usage beyond that is billed at the rates listed on [Zed-Hosted Models](./zed-hosted-models.md). A trial of Zed Pro includes $20 of credit, usable for 14 days.
+Zed Pro includes access to all hosted AI models and Edit Predictions. The plan includes $5 of monthly token credit; usage beyond that is billed at the rates listed on [Zed-Hosted Models](./zed-hosted-models.md). A [trial of Zed Pro](#trials) includes $5 of GPT Luna and unlimited Edit Predictions for 14 days from when you start the trial.
 
 For details on billing and payment, see [Individual Billing](./billing.md).
 
@@ -65,4 +65,6 @@ On Zed Business, administrators set a pre-tax org-wide spend limit from the Data
 
 ### Trials {#trials}
 
-Trials automatically convert to Zed Free when they end. Trials do not include access to Anthropic's Opus models. No cancellation is needed to prevent conversion to Zed Pro.
+Trials include $5 of GPT Luna and unlimited Edit Predictions for 14 days from when you start the trial. Trial hosted-model access is limited to GPT Luna. Zed and Delta share the same $5 trial balance. No credit card is required.
+
+Trials automatically convert to Zed Free when they end. No cancellation is needed to prevent conversion to Zed Pro.

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -2014,6 +2014,41 @@ While other options may be changed at a runtime and should be placed under `sett
 }
 ```
 
+## Focus Follows Mouse
+
+- Description: Whether the focused panel follows the mouse location.
+- Setting: `focus_follows_mouse`
+- Default:
+
+```json [settings]
+{
+  "focus_follows_mouse": {
+    "enabled": false,
+    "debounce_ms": 250
+  }
+}
+```
+
+### Enabled
+
+- Description: Whether hovering over a dock or pane moves focus to it.
+- Setting: `enabled`
+- Default: `false`
+
+**Options**
+
+`boolean` values
+
+### Debounce
+
+- Description: How long the mouse must hover over a panel before it is focused, in milliseconds.
+- Setting: `debounce_ms`
+- Default: `250`
+
+**Options**
+
+Non-negative `integer` values
+
 ## Format On Save {#format-on-save}
 
 - Description: Whether or not to perform a buffer format before saving.


### PR DESCRIPTION
# Objective

GPUI has `border_*` and `box_shadow_*` methods but no CSS-style outline. Unlike borders,
outlines are drawn outside the element's box and don't affect layout, which makes them
handy for focus rings and emphasis.

## Solution

Add `outline_*` methods to `Styled`, mirroring the `border_*` API and Tailwind:
`outline_color`, `outline_{0,1,2,4,8}` (width), `outline_offset_*`, and `outline_dashed`.

The outline is painted outside the element bounds in `Style::paint`. With rounded corners,
the outline radius grows with the offset; a negative offset past the radius clamps to square.

An `outline` example demonstrates the behavior.

## Testing

- Ran the new `outline` example (`cargo run -p gpui --example outline`) and visually
  verified widths, colors, positive/negative offsets, dashed style, and the
  rounded-corner / square-corner edge cases.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards (UX/UI and icon guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>

<img width="989" height="830" alt="image" src="https://github.com/user-attachments/assets/d3999d9e-3f21-43a0-929f-b2165be616cc" />

</details>

```
cargo run -p gpui --example outline
```

---

Release Notes:

- Added `outline` style methods to GPUI's `Styled` trait
