### PR TITLE
PR board: Stop touching archived items

### DIFF
--- a/script/github-community-pr-board.py
+++ b/script/github-community-pr-board.py
@@ -784,6 +784,10 @@ if __name__ == "__main__":
         print(f"Skipping draft PR #{pr['number']}")
         sys.exit(0)
 
+    if pr.get("state") != "open":
+        print(f"Skipping PR #{pr['number']} (state: {pr.get('state')})")
+        sys.exit(0)
+
     print(f"Processing PR #{pr['number']}: action={action}")
 
     if action in ("labeled", "unlabeled"):


### PR DESCRIPTION
The GitHub workflow was sometimes failing when someone edited the already-merged PR that had been archived on the board because archived items can't have their fields changed. The project board fields don't need to be updated when the PR is already merged or closed.

Release Notes:

- N/A