### PR TITLE
agent: Rewrite simple terminal output pipes

### DIFF
--- a/crates/agent/src/tools/terminal_tool.rs
+++ b/crates/agent/src/tools/terminal_tool.rs
@@ -6,6 +6,7 @@ use project::Project;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
+use shell_command_parser::{OutputPipeBehavior, rewrite_outermost_output_pipe};
 use std::{
     path::{Path, PathBuf},
     rc::Rc,
@@ -28,7 +29,7 @@ const COMMAND_OUTPUT_LIMIT: u64 = 16 * 1024;
 ///
 /// Do not generate terminal commands that use shell substitutions or interpolations such as `$VAR`, `${VAR}`, `$(...)`, backticks, `$((...))`, `<(...)`, or `>(...)`. Resolve those values yourself before calling this tool, or ask the user for the literal value to use.
 ///
-/// Do not pipe output to `head`, `tail`, or similar output-filtering commands just to reduce what you receive. Instead, use `head_lines` and/or `tail_lines`; this keeps the terminal output visible to the user in real time while limiting only the final output sent back to you. When both are specified, the first `head_lines` lines are returned, then a blank line, then the last `tail_lines` lines. Avoid requesting too many lines, or the response may waste tokens or exceed the context window.
+/// Do not pipe output to `head`, `tail`, or similar output-filtering commands just to reduce what you receive. Instead, use `head_lines` and/or `tail_lines`; this keeps the terminal output visible to the user in real time while limiting only the final output sent back to you. When both are specified, the first `head_lines` lines are returned, then a blank line, then the last `tail_lines` lines. Avoid requesting too many lines, or the response may waste tokens or exceed the context window. If you do pipe the outermost command to `head` or `tail` anyway with only a simple line-count argument, or to bare `less`, and omit both `head_lines` and `tail_lines`, this tool will run the command without that pipe and apply the corresponding output selection when applicable.
 ///
 /// Do not use this tool for commands that run indefinitely, such as servers (like `npm run start`, `npm run dev`, `python -m http.server`, etc) or file watchers that don't terminate on their own.
 ///
@@ -69,7 +70,7 @@ pub struct TerminalToolInput {
 ///
 /// Do not generate terminal commands that use shell substitutions or interpolations such as `$VAR`, `${VAR}`, `$(...)`, backticks, `$((...))`, `<(...)`, or `>(...)`. Resolve those values first or ask the user for the literal value to use.
 ///
-/// Do not pipe output to `head`, `tail`, or similar output-filtering commands just to reduce what you receive. Instead, use `head_lines` and/or `tail_lines`; this keeps the terminal output visible to the user in real time while limiting only the final output sent back to you. When both are specified, the first `head_lines` lines are returned, then a blank line, then the last `tail_lines` lines. Avoid requesting too many lines, or the response may waste tokens or exceed the context window.
+/// Do not pipe output to `head`, `tail`, or similar output-filtering commands just to reduce what you receive. Instead, use `head_lines` and/or `tail_lines`; this keeps the terminal output visible to the user in real time while limiting only the final output sent back to you. When both are specified, the first `head_lines` lines are returned, then a blank line, then the last `tail_lines` lines. Avoid requesting too many lines, or the response may waste tokens or exceed the context window. If you do pipe the outermost command to `head` or `tail` anyway with only a simple line-count argument, or to bare `less`, and omit both `head_lines` and `tail_lines`, this tool will run the command without that pipe and apply the corresponding output selection when applicable.
 ///
 /// Do not use this tool for commands that run indefinitely, such as servers (like `npm run start`, `npm run dev`, `python -m http.server`, etc) or file watchers that don't terminate on their own.
 ///
@@ -210,6 +211,7 @@ impl From<TerminalToolInput> for TerminalToolRequest {
             },
             sandbox: None,
         }
+        .with_outermost_output_pipe_rewrite()
     }
 }
 
@@ -232,6 +234,30 @@ impl From<SandboxedTerminalToolInput> for TerminalToolRequest {
                 reason: input.reason,
             }),
         }
+        .with_outermost_output_pipe_rewrite()
+    }
+}
+
+impl TerminalToolRequest {
+    fn with_outermost_output_pipe_rewrite(mut self) -> Self {
+        if self.selection.is_enabled() {
+            return self;
+        }
+
+        if let Some(rewrite) = rewrite_outermost_output_pipe(&self.command) {
+            self.command = rewrite.command;
+            match rewrite.behavior {
+                OutputPipeBehavior::Head(line_count) => {
+                    self.selection.head_lines = Some(line_count);
+                }
+                OutputPipeBehavior::Tail(line_count) => {
+                    self.selection.tail_lines = Some(line_count);
+                }
+                OutputPipeBehavior::FullOutput => {}
+            }
+        }
+
+        self
     }
 }
 
@@ -278,7 +304,7 @@ impl AgentTool for TerminalTool {
         input: Result<Self::Input, serde_json::Value>,
         _cx: &mut App,
     ) -> SharedString {
-        terminal_initial_title(input.map(|input| input.command))
+        terminal_initial_title(input.map(TerminalToolRequest::from))
     }
 
     fn run(
@@ -316,7 +342,7 @@ impl AgentTool for SandboxedTerminalTool {
         input: Result<Self::Input, serde_json::Value>,
         _cx: &mut App,
     ) -> SharedString {
-        terminal_initial_title(input.map(|input| input.command))
+        terminal_initial_title(input.map(TerminalToolRequest::from))
     }
 
     fn run(
@@ -339,9 +365,9 @@ impl AgentTool for SandboxedTerminalTool {
     }
 }
 
-fn terminal_initial_title(input: Result<String, serde_json::Value>) -> SharedString {
-    if let Ok(command) = input {
-        command.into()
+fn terminal_initial_title(input: Result<TerminalToolRequest, serde_json::Value>) -> SharedString {
+    if let Ok(input) = input {
+        input.command.into()
     } else {
         "".into()
     }
@@ -1066,6 +1092,63 @@ mod tests {
         } else {
             String::new()
         }
+    }
+
+    #[test]
+    fn test_terminal_tool_request_rewrites_outermost_tail_pipe_to_selection() {
+        let request: TerminalToolRequest = TerminalToolInput {
+            command: "printf lines | tail -n 2".to_string(),
+            cd: ".".to_string(),
+            ..Default::default()
+        }
+        .into();
+
+        assert_eq!(request.command, "printf lines");
+        assert_eq!(request.selection.head_lines, None);
+        assert_eq!(request.selection.tail_lines, Some(2));
+    }
+
+    #[test]
+    fn test_terminal_tool_request_rewrites_outermost_head_pipe_to_selection() {
+        let request: TerminalToolRequest = SandboxedTerminalToolInput {
+            command: "printf lines | head".to_string(),
+            cd: ".".to_string(),
+            ..Default::default()
+        }
+        .into();
+
+        assert_eq!(request.command, "printf lines");
+        assert_eq!(request.selection.head_lines, Some(10));
+        assert_eq!(request.selection.tail_lines, None);
+    }
+
+    #[test]
+    fn test_terminal_tool_request_rewrites_outermost_less_pipe_to_full_output() {
+        let request: TerminalToolRequest = TerminalToolInput {
+            command: "printf lines | less".to_string(),
+            cd: ".".to_string(),
+            ..Default::default()
+        }
+        .into();
+
+        assert_eq!(request.command, "printf lines");
+        assert_eq!(request.selection.head_lines, None);
+        assert_eq!(request.selection.tail_lines, None);
+    }
+
+    #[test]
+    fn test_terminal_tool_request_keeps_pipe_when_selection_already_specified() {
+        let request: TerminalToolRequest = TerminalToolInput {
+            command: "printf lines | tail -n 2".to_string(),
+            cd: ".".to_string(),
+            head_lines: Some(5),
+            ..Default::default()
+        }
+        .into();
+
+        assert_eq!(request.command, "printf lines | tail -n 2");
+        assert_eq!(request.selection.head_lines, Some(5));
+        assert_eq!(request.selection.tail_lines, None);
     }
 
     #[test]

--- a/crates/shell_command_parser/src/shell_command_parser.rs
+++ b/crates/shell_command_parser/src/shell_command_parser.rs
@@ -20,6 +20,19 @@ pub enum TerminalCommandValidation {
     Unsupported,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutermostOutputPipe {
+    pub command: String,
+    pub behavior: OutputPipeBehavior,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputPipeBehavior {
+    Head(usize),
+    Tail(usize),
+    FullOutput,
+}
+
 pub fn extract_commands(command: &str) -> Option<Vec<String>> {
     let reader = BufReader::new(command.as_bytes());
     let options = ParserOptions::default();
@@ -113,6 +126,145 @@ pub fn validate_terminal_command(command: &str) -> TerminalCommandValidation {
         TerminalProgramValidation::Safe => TerminalCommandValidation::Safe,
         TerminalProgramValidation::Unsafe => TerminalCommandValidation::Unsafe,
         TerminalProgramValidation::Unsupported => TerminalCommandValidation::Unsupported,
+    }
+}
+
+pub fn rewrite_outermost_output_pipe(command: &str) -> Option<OutermostOutputPipe> {
+    let reader = BufReader::new(command.as_bytes());
+    let options = ParserOptions::default();
+    let source_info = SourceInfo::default();
+    let mut parser = Parser::new(reader, &options, &source_info);
+    let program = parser.parse_program().ok()?;
+
+    let pipeline = single_outermost_pipeline(&program)?;
+    if pipeline.timed.is_some() || pipeline.bang || pipeline.seq.len() < 2 {
+        return None;
+    }
+
+    let last_command = pipeline.seq.last()?;
+    let words = simple_command_words(last_command)?;
+    let behavior = output_pipe_behavior(&words)?;
+    let command = command_before_pipeline_stage(command, last_command)?;
+
+    Some(OutermostOutputPipe { command, behavior })
+}
+
+fn single_outermost_pipeline(program: &ast::Program) -> Option<&ast::Pipeline> {
+    let [complete_command] = program.complete_commands.as_slice() else {
+        return None;
+    };
+    let [compound_list_item] = complete_command.0.as_slice() else {
+        return None;
+    };
+    if !matches!(&compound_list_item.1, ast::SeparatorOperator::Sequence) {
+        return None;
+    }
+
+    let and_or_list = &compound_list_item.0;
+    if !and_or_list.additional.is_empty() {
+        return None;
+    }
+    Some(&and_or_list.first)
+}
+
+fn simple_command_words(command: &ast::Command) -> Option<Vec<String>> {
+    let ast::Command::Simple(simple_command) = command else {
+        return None;
+    };
+    if simple_command
+        .prefix
+        .as_ref()
+        .is_some_and(|prefix| !prefix.0.is_empty())
+    {
+        return None;
+    }
+
+    let mut words = vec![normalize_word(simple_command.word_or_name.as_ref()?)?];
+    if let Some(suffix) = &simple_command.suffix {
+        for item in &suffix.0 {
+            match item {
+                ast::CommandPrefixOrSuffixItem::Word(word) => words.push(normalize_word(word)?),
+                _ => return None,
+            }
+        }
+    }
+    Some(words)
+}
+
+fn output_pipe_behavior(words: &[String]) -> Option<OutputPipeBehavior> {
+    match words.first()?.as_str() {
+        "head" | "tail" => head_tail_output_behavior(words),
+        "less" => less_output_behavior(words),
+        _ => None,
+    }
+}
+
+fn head_tail_output_behavior(words: &[String]) -> Option<OutputPipeBehavior> {
+    let command = words.first()?;
+    let line_count = match words.get(1..) {
+        Some([]) => 10,
+        Some([arg]) => line_count_from_argument(arg)?,
+        Some([flag, value]) if flag == "-n" || flag == "--lines" => parse_line_count(value)?,
+        _ => return None,
+    };
+
+    match command.as_str() {
+        "head" => Some(OutputPipeBehavior::Head(line_count)),
+        "tail" => Some(OutputPipeBehavior::Tail(line_count)),
+        _ => None,
+    }
+}
+
+fn less_output_behavior(words: &[String]) -> Option<OutputPipeBehavior> {
+    match words.get(1..) {
+        Some([]) => Some(OutputPipeBehavior::FullOutput),
+        _ => None,
+    }
+}
+
+fn line_count_from_argument(argument: &str) -> Option<usize> {
+    if let Some(value) = argument.strip_prefix("--lines=") {
+        parse_line_count(value)
+    } else if let Some(value) = argument.strip_prefix("-n") {
+        if value.is_empty() {
+            None
+        } else {
+            parse_line_count(value)
+        }
+    } else if let Some(value) = argument.strip_prefix('-') {
+        parse_line_count(value)
+    } else {
+        None
+    }
+}
+
+fn parse_line_count(value: &str) -> Option<usize> {
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    value.parse().ok()
+}
+
+fn command_before_pipeline_stage(source: &str, stage: &ast::Command) -> Option<String> {
+    let stage_location = stage.location()?;
+    let stage_start = byte_index_for_character_index(source, stage_location.start.index)?;
+    let before_stage = source.get(..stage_start)?;
+    let before_pipe = before_stage.trim_end().strip_suffix('|')?.trim_end();
+    if before_pipe.is_empty() {
+        None
+    } else {
+        Some(before_pipe.to_string())
+    }
+}
+
+fn byte_index_for_character_index(text: &str, character_index: usize) -> Option<usize> {
+    if character_index == 0 {
+        return Some(0);
+    }
+    match text.char_indices().nth(character_index) {
+        Some((byte_index, _)) => Some(byte_index),
+        None if text.chars().count() == character_index => Some(text.len()),
+        None => None,
     }
 }
 
@@ -1215,6 +1367,118 @@ mod tests {
     fn test_pipe() {
         let commands = extract_commands("ls | xargs rm -rf").expect("parse failed");
         assert_eq!(commands, vec!["ls", "xargs rm -rf"]);
+    }
+
+    #[test]
+    fn test_rewrite_outermost_tail_pipe_defaults_to_ten_lines() {
+        assert_eq!(
+            rewrite_outermost_output_pipe("git --no-pager diff | tail"),
+            Some(OutermostOutputPipe {
+                command: "git --no-pager diff".to_string(),
+                behavior: OutputPipeBehavior::Tail(10),
+            })
+        );
+    }
+
+    #[test]
+    fn test_rewrite_outermost_head_pipe_with_line_count() {
+        assert_eq!(
+            rewrite_outermost_output_pipe("git --no-pager log | head -n 25"),
+            Some(OutermostOutputPipe {
+                command: "git --no-pager log".to_string(),
+                behavior: OutputPipeBehavior::Head(25),
+            })
+        );
+    }
+
+    #[test]
+    fn test_rewrite_outermost_tail_pipe_with_compact_line_counts() {
+        assert_eq!(
+            rewrite_outermost_output_pipe("rg needle | tail -20"),
+            Some(OutermostOutputPipe {
+                command: "rg needle".to_string(),
+                behavior: OutputPipeBehavior::Tail(20),
+            })
+        );
+        assert_eq!(
+            rewrite_outermost_output_pipe("rg needle | tail -n20"),
+            Some(OutermostOutputPipe {
+                command: "rg needle".to_string(),
+                behavior: OutputPipeBehavior::Tail(20),
+            })
+        );
+        assert_eq!(
+            rewrite_outermost_output_pipe("rg needle | head --lines=3"),
+            Some(OutermostOutputPipe {
+                command: "rg needle".to_string(),
+                behavior: OutputPipeBehavior::Head(3),
+            })
+        );
+    }
+
+    #[test]
+    fn test_rewrite_outermost_less_pipe_to_full_output() {
+        assert_eq!(
+            rewrite_outermost_output_pipe("git --no-pager log | less"),
+            Some(OutermostOutputPipe {
+                command: "git --no-pager log".to_string(),
+                behavior: OutputPipeBehavior::FullOutput,
+            })
+        );
+    }
+
+    #[test]
+    fn test_rewrite_outermost_output_pipe_preserves_unicode_before_pipe() {
+        assert_eq!(
+            rewrite_outermost_output_pipe("echo α | head -n 1"),
+            Some(OutermostOutputPipe {
+                command: "echo α".to_string(),
+                behavior: OutputPipeBehavior::Head(1),
+            })
+        );
+    }
+
+    #[test]
+    fn test_rewrite_outermost_output_pipe_rejects_nested_pipes() {
+        assert_eq!(
+            rewrite_outermost_output_pipe("echo $(git diff | tail)"),
+            None
+        );
+        assert_eq!(rewrite_outermost_output_pipe("(git diff | tail)"), None);
+    }
+
+    #[test]
+    fn test_rewrite_outermost_output_pipe_rejects_chained_commands() {
+        assert_eq!(
+            rewrite_outermost_output_pipe("echo setup && git diff | tail"),
+            None
+        );
+        assert_eq!(
+            rewrite_outermost_output_pipe("echo setup; git diff | tail"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_outermost_output_pipe_rejects_complex_arguments() {
+        assert_eq!(rewrite_outermost_output_pipe("rg needle | tail -f"), None);
+        assert_eq!(
+            rewrite_outermost_output_pipe("rg needle | tail log.txt"),
+            None
+        );
+        assert_eq!(
+            rewrite_outermost_output_pipe("rg needle | head -c 20"),
+            None
+        );
+        assert_eq!(
+            rewrite_outermost_output_pipe("rg needle | tail -n +20"),
+            None
+        );
+        assert_eq!(rewrite_outermost_output_pipe("rg needle | less -R"), None);
+        assert_eq!(
+            rewrite_outermost_output_pipe("rg needle | less file.txt"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
The terminal tool now conservatively recognizes simple outermost pipes to head, tail, or bare less and maps them to tool-level output handling instead of running the pipeline. This preserves full terminal output for the user while still returning a bounded subset to the model when requested.

Closes AI-131

Release Notes:

- Improved terminal tool output handling when commands are piped to head, tail, or less.
