### PR TITLE
gpui: Add damage-tracking with partial redraw (WIP)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,7 +4124,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6067,7 +6067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7277,7 +7277,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7695,7 +7695,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.17",
- "windows 0.62.2",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -8730,7 +8730,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.56.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -8984,7 +8984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -11242,7 +11242,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "naga"
 version = "29.0.3"
-source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
+source = "git+https://github.com/sauliusvl/wgpu.git?rev=29b04b33e#29b04b33e38a3d9c009f93193fb04a1312ede711"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -15668,7 +15668,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -18226,7 +18226,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19153,7 +19153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb391ac70462b3097a755618fbf9c8f95ecc1eb379a414f7b46f202ed10db1f"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -20950,7 +20950,7 @@ checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 [[package]]
 name = "wgpu"
 version = "29.0.3"
-source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
+source = "git+https://github.com/sauliusvl/wgpu.git?rev=29b04b33e#29b04b33e38a3d9c009f93193fb04a1312ede711"
 dependencies = [
  "arrayvec",
  "bitflags 2.10.0",
@@ -20979,7 +20979,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "29.0.3"
-source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
+source = "git+https://github.com/sauliusvl/wgpu.git?rev=29b04b33e#29b04b33e38a3d9c009f93193fb04a1312ede711"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -21011,7 +21011,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-apple"
 version = "29.0.3"
-source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
+source = "git+https://github.com/sauliusvl/wgpu.git?rev=29b04b33e#29b04b33e38a3d9c009f93193fb04a1312ede711"
 dependencies = [
  "wgpu-hal",
 ]
@@ -21019,7 +21019,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-emscripten"
 version = "29.0.3"
-source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
+source = "git+https://github.com/sauliusvl/wgpu.git?rev=29b04b33e#29b04b33e38a3d9c009f93193fb04a1312ede711"
 dependencies = [
  "wgpu-hal",
 ]
@@ -21027,7 +21027,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
 version = "29.0.3"
-source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
+source = "git+https://github.com/sauliusvl/wgpu.git?rev=29b04b33e#29b04b33e38a3d9c009f93193fb04a1312ede711"
 dependencies = [
  "wgpu-hal",
 ]
@@ -21035,7 +21035,7 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "29.0.3"
-source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
+source = "git+https://github.com/sauliusvl/wgpu.git?rev=29b04b33e#29b04b33e38a3d9c009f93193fb04a1312ede711"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -21088,7 +21088,7 @@ dependencies = [
 [[package]]
 name = "wgpu-naga-bridge"
 version = "29.0.3"
-source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
+source = "git+https://github.com/sauliusvl/wgpu.git?rev=29b04b33e#29b04b33e38a3d9c009f93193fb04a1312ede711"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -21097,7 +21097,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "29.0.3"
-source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
+source = "git+https://github.com/sauliusvl/wgpu.git?rev=29b04b33e#29b04b33e38a3d9c009f93193fb04a1312ede711"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -831,7 +831,8 @@ which = "6.0.0"
 wasm-bindgen = "0.2.120"
 web-time = "1.1.0"
 webrtc-sys = "0.3.23"
-wgpu = { git = "https://github.com/zed-industries/wgpu.git", rev = "357a0c56e0070480ad9daea5d2eaa83150b79e88" }
+# WIP: fork with present_with_damage; revert to the zed-industries pin once upstreamed.
+wgpu = { git = "https://github.com/sauliusvl/wgpu.git", rev = "29b04b33e" }
 windows-core = "0.61"
 yaml-rust2 = "0.8"
 yawc = "0.2.5"

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -45,6 +45,7 @@ pub mod profiler;
 #[expect(missing_docs)]
 pub mod queue;
 mod scene;
+mod scene_damage;
 mod shared_uri;
 mod style;
 mod styled;
@@ -141,6 +142,7 @@ pub use profiler::*;
 pub use queue::{PriorityQueueReceiver, PriorityQueueSender};
 pub use refineable::*;
 pub use scene::*;
+pub use scene_damage::*;
 pub use shared_uri::*;
 use std::{any::Any, future::Future};
 pub use style::*;

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -660,6 +660,16 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
     fn on_button_layout_changed(&self, _callback: Box<dyn FnMut()>) {}
     fn draw(&self, scene: &Scene);
+    /// Whether the renderer consumes per-frame damage. When true, GPUI diffs
+    /// consecutive scenes and calls [`Self::draw_with_damage`].
+    fn wants_render_damage(&self) -> bool {
+        false
+    }
+    /// Like [`Self::draw`], but with the region that changed since the previous
+    /// frame. `None` means it wasn't computed, so the backend must redraw fully.
+    fn draw_with_damage(&self, scene: &Scene, _damage: Option<crate::SceneDamage>) {
+        self.draw(scene);
+    }
     fn completed_frame(&self) {}
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
     fn is_subpixel_rendering_supported(&self) -> bool;

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -481,7 +481,7 @@ pub enum PrimitiveBatch {
     Surfaces(Range<usize>),
 }
 
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
 #[expect(missing_docs)]
 pub struct Quad {
@@ -501,7 +501,7 @@ impl From<Quad> for Primitive {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
 #[expect(missing_docs)]
 pub struct Underline {
@@ -520,7 +520,7 @@ impl From<Underline> for Primitive {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
 #[expect(missing_docs)]
 pub struct Shadow {
@@ -657,7 +657,7 @@ impl Default for TransformationMatrix {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
 #[expect(missing_docs)]
 pub struct MonochromeSprite {
@@ -676,7 +676,7 @@ impl From<MonochromeSprite> for Primitive {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
 #[expect(missing_docs)]
 pub struct SubpixelSprite {
@@ -695,7 +695,7 @@ impl From<SubpixelSprite> for Primitive {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
 #[expect(missing_docs)]
 pub struct PolychromeSprite {
@@ -715,7 +715,7 @@ impl From<PolychromeSprite> for Primitive {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(missing_docs)]
 pub struct PaintSurface {
     pub order: DrawOrder,
@@ -880,7 +880,7 @@ impl From<Path<ScaledPixels>> for Primitive {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[repr(C)]
 #[expect(missing_docs)]
 pub struct PathVertex<P: Clone + Debug + Default + PartialEq> {

--- a/crates/gpui/src/scene_damage.rs
+++ b/crates/gpui/src/scene_damage.rs
@@ -1,0 +1,286 @@
+//! Diffs two consecutive `Scene`s to find the region of the framebuffer that
+//! changed, so a backend can redraw and present only that region.
+
+use crate::{Bounds, Path, Point, ScaledPixels, Scene, Size, TransformationMatrix};
+
+/// The region of the framebuffer that changed between two frames.
+#[derive(Clone, Copy, Debug)]
+pub enum SceneDamage {
+    /// Everything must be redrawn (e.g. the previous contents are invalid).
+    Full,
+    /// Only this rectangle changed, in scaled/device pixels.
+    Rect(Bounds<ScaledPixels>),
+    /// Nothing changed; the frame's presentation can be skipped.
+    Unchanged,
+}
+
+impl SceneDamage {
+    /// Computes the region of `next` that differs from `prev`. Never reports a
+    /// changed region as unchanged, but may over-report. Both scenes must be
+    /// finished (sorted).
+    pub fn between(prev: &Scene, next: &Scene) -> SceneDamage {
+        let mut acc: Option<Bounds<ScaledPixels>> = None;
+        diff_primitives(&prev.quads, &next.quads, |q| q.bounds, &mut acc);
+        diff_primitives(
+            &prev.shadows,
+            &next.shadows,
+            |s| s.bounds.dilate(s.blur_radius * 3.0),
+            &mut acc,
+        );
+        diff_primitives(&prev.underlines, &next.underlines, |u| u.bounds, &mut acc);
+        diff_primitives(
+            &prev.monochrome_sprites,
+            &next.monochrome_sprites,
+            |s| transformed_bounds(s.bounds, &s.transformation),
+            &mut acc,
+        );
+        diff_primitives(
+            &prev.subpixel_sprites,
+            &next.subpixel_sprites,
+            |s| transformed_bounds(s.bounds, &s.transformation),
+            &mut acc,
+        );
+        diff_primitives(
+            &prev.polychrome_sprites,
+            &next.polychrome_sprites,
+            |s| s.bounds,
+            &mut acc,
+        );
+        diff_paths(&prev.paths, &next.paths, &mut acc);
+
+        match acc {
+            Some(rect) => SceneDamage::Rect(rect),
+            None => SceneDamage::Unchanged,
+        }
+    }
+
+    /// Combines two damage regions into one that covers both, used to accumulate
+    /// damage across frames that failed or skipped presentation.
+    pub fn union(self, other: SceneDamage) -> SceneDamage {
+        match (self, other) {
+            (SceneDamage::Full, _) | (_, SceneDamage::Full) => SceneDamage::Full,
+            (SceneDamage::Unchanged, damage) | (damage, SceneDamage::Unchanged) => damage,
+            (SceneDamage::Rect(a), SceneDamage::Rect(b)) => SceneDamage::Rect(a.union(&b)),
+        }
+    }
+}
+
+fn union_into(acc: &mut Option<Bounds<ScaledPixels>>, b: Bounds<ScaledPixels>) {
+    *acc = Some(match acc.take() {
+        Some(a) => a.union(&b),
+        None => b,
+    });
+}
+
+fn diff_primitives<T: Copy + PartialEq>(
+    prev: &[T],
+    cur: &[T],
+    bounds_of: impl Fn(&T) -> Bounds<ScaledPixels>,
+    acc: &mut Option<Bounds<ScaledPixels>>,
+) {
+    diff_with(prev, cur, |a, b| a == b, bounds_of, acc);
+}
+
+fn diff_paths(
+    prev: &[Path<ScaledPixels>],
+    cur: &[Path<ScaledPixels>],
+    acc: &mut Option<Bounds<ScaledPixels>>,
+) {
+    diff_with(
+        prev,
+        cur,
+        |a, b| {
+            a.order == b.order
+                && &a.bounds == &b.bounds
+                && &a.color == &b.color
+                && a.vertices == b.vertices
+        },
+        |p| p.bounds,
+        acc,
+    );
+}
+
+/// Diffs two primitive slices via common-prefix / common-suffix matching, so a
+/// single inserted or removed element (e.g. a blinking cursor, which shifts
+/// every following element) only damages the changed window rather than
+/// everything after it.
+fn diff_with<T>(
+    prev: &[T],
+    cur: &[T],
+    eq: impl Fn(&T, &T) -> bool,
+    bounds_of: impl Fn(&T) -> Bounds<ScaledPixels>,
+    acc: &mut Option<Bounds<ScaledPixels>>,
+) {
+    let max_common = prev.len().min(cur.len());
+
+    let mut prefix = 0;
+    while prefix < max_common && eq(&prev[prefix], &cur[prefix]) {
+        prefix += 1;
+    }
+    if prefix == prev.len() && prefix == cur.len() {
+        return; // Identical.
+    }
+
+    // Match from the end, without overlapping the prefix in either slice.
+    let mut suffix = 0;
+    while suffix < max_common - prefix
+        && eq(&prev[prev.len() - 1 - suffix], &cur[cur.len() - 1 - suffix])
+    {
+        suffix += 1;
+    }
+
+    for p in &prev[prefix..prev.len() - suffix] {
+        union_into(acc, bounds_of(p));
+    }
+    for c in &cur[prefix..cur.len() - suffix] {
+        union_into(acc, bounds_of(c));
+    }
+}
+
+/// Axis-aligned bounds of a sprite after its transformation, so rotated sprites
+/// damage their full painted extent.
+fn transformed_bounds(
+    bounds: Bounds<ScaledPixels>,
+    transform: &TransformationMatrix,
+) -> Bounds<ScaledPixels> {
+    let rs = transform.rotation_scale;
+    let t = transform.translation;
+    let x0 = bounds.origin.x.0;
+    let y0 = bounds.origin.y.0;
+    let x1 = x0 + bounds.size.width.0;
+    let y1 = y0 + bounds.size.height.0;
+    let mut min = (f32::MAX, f32::MAX);
+    let mut max = (f32::MIN, f32::MIN);
+    for (x, y) in [(x0, y0), (x1, y0), (x0, y1), (x1, y1)] {
+        // Matches the shader: transpose(rotation_scale) * position + translation.
+        let tx = rs[0][0] * x + rs[1][0] * y + t[0];
+        let ty = rs[0][1] * x + rs[1][1] * y + t[1];
+        min.0 = min.0.min(tx);
+        min.1 = min.1.min(ty);
+        max.0 = max.0.max(tx);
+        max.1 = max.1.max(ty);
+    }
+    Bounds {
+        origin: Point {
+            x: ScaledPixels(min.0),
+            y: ScaledPixels(min.1),
+        },
+        size: Size {
+            width: ScaledPixels(max.0 - min.0),
+            height: ScaledPixels(max.1 - min.1),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ContentMask, Hsla, Quad};
+
+    fn rect(x: f32, y: f32, w: f32, h: f32) -> Bounds<ScaledPixels> {
+        Bounds {
+            origin: Point {
+                x: ScaledPixels(x),
+                y: ScaledPixels(y),
+            },
+            size: Size {
+                width: ScaledPixels(w),
+                height: ScaledPixels(h),
+            },
+        }
+    }
+
+    fn quad(bounds: Bounds<ScaledPixels>, lightness: f32) -> Quad {
+        Quad {
+            bounds,
+            content_mask: ContentMask {
+                bounds: rect(0., 0., 1000., 1000.),
+            },
+            background: Hsla {
+                h: 0.,
+                s: 0.,
+                l: lightness,
+                a: 1.,
+            }
+            .into(),
+            ..Default::default()
+        }
+    }
+
+    fn scene_of(quads: &[Quad]) -> Scene {
+        let mut scene = Scene::default();
+        for q in quads {
+            scene.insert_primitive(*q);
+        }
+        scene.finish();
+        scene
+    }
+
+    #[test]
+    fn identical_scenes_are_unchanged() {
+        let a = scene_of(&[quad(rect(0., 0., 100., 100.), 0.5)]);
+        let b = scene_of(&[quad(rect(0., 0., 100., 100.), 0.5)]);
+        assert!(matches!(
+            SceneDamage::between(&a, &b),
+            SceneDamage::Unchanged
+        ));
+    }
+
+    #[test]
+    fn changed_quad_damages_its_bounds() {
+        let unchanged = quad(rect(0., 0., 100., 100.), 0.1);
+        let before = scene_of(&[unchanged, quad(rect(200., 200., 10., 20.), 0.5)]);
+        let after = scene_of(&[unchanged, quad(rect(200., 200., 10., 20.), 0.9)]);
+        match SceneDamage::between(&before, &after) {
+            SceneDamage::Rect(damage) => assert_eq!(damage, rect(200., 200., 10., 20.)),
+            other => panic!("expected rect damage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inserted_quad_damages_only_itself() {
+        // Mirrors the cursor blinking on: one primitive appears mid-scene,
+        // shifting the index of everything after it.
+        let a = quad(rect(0., 0., 50., 50.), 0.1);
+        let cursor = quad(rect(60., 0., 2., 20.), 0.5);
+        let c = quad(rect(100., 0., 50., 50.), 0.9);
+        let before = scene_of(&[a, c]);
+        let after = scene_of(&[a, cursor, c]);
+        match SceneDamage::between(&before, &after) {
+            SceneDamage::Rect(damage) => assert_eq!(damage, rect(60., 0., 2., 20.)),
+            other => panic!("expected rect damage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn removed_quad_damages_only_itself() {
+        // The cursor blinking off.
+        let a = quad(rect(0., 0., 50., 50.), 0.1);
+        let cursor = quad(rect(60., 0., 2., 20.), 0.5);
+        let c = quad(rect(100., 0., 50., 50.), 0.9);
+        let before = scene_of(&[a, cursor, c]);
+        let after = scene_of(&[a, c]);
+        match SceneDamage::between(&before, &after) {
+            SceneDamage::Rect(damage) => assert_eq!(damage, rect(60., 0., 2., 20.)),
+            other => panic!("expected rect damage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn union_combines_damage() {
+        assert!(matches!(
+            SceneDamage::Full.union(SceneDamage::Rect(rect(0., 0., 1., 1.))),
+            SceneDamage::Full
+        ));
+        assert!(matches!(
+            SceneDamage::Unchanged.union(SceneDamage::Unchanged),
+            SceneDamage::Unchanged
+        ));
+        match SceneDamage::Rect(rect(0., 0., 10., 10.))
+            .union(SceneDamage::Rect(rect(20., 20., 10., 10.)))
+        {
+            SceneDamage::Rect(damage) => assert_eq!(damage, rect(0., 0., 30., 30.)),
+            other => panic!("expected rect damage, got {other:?}"),
+        }
+    }
+}

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1011,6 +1011,8 @@ pub struct Window {
     pub(crate) image_cache_stack: Vec<AnyImageCache>,
     pub(crate) rendered_frame: Frame,
     pub(crate) next_frame: Frame,
+    /// Damage computed for the most recent draw, consumed by `present`.
+    render_damage: Option<crate::SceneDamage>,
     next_hitbox_id: HitboxId,
     pub(crate) next_tooltip_id: TooltipId,
     pub(crate) tooltip_bounds: Option<TooltipBounds>,
@@ -1707,6 +1709,7 @@ impl Window {
             requested_autoscroll: None,
             rendered_frame: Frame::new(DispatchTree::new(cx.keymap.clone(), cx.actions.clone())),
             next_frame: Frame::new(DispatchTree::new(cx.keymap.clone(), cx.actions.clone())),
+            render_damage: None,
             next_frame_callbacks,
             next_hitbox_id: HitboxId(0),
             next_tooltip_id: TooltipId::default(),
@@ -2658,6 +2661,11 @@ impl Window {
         self.text_system().finish_frame();
         self.next_frame.finish(&mut self.rendered_frame);
 
+        // Diff against the previous frame while both still exist.
+        self.render_damage = self.platform_window.wants_render_damage().then(|| {
+            crate::SceneDamage::between(&self.rendered_frame.scene, &self.next_frame.scene)
+        });
+
         self.invalidator.set_phase(DrawPhase::Focus);
         let previous_focus_path = self.rendered_frame.focus_path();
         let previous_window_active = self.rendered_frame.window_active;
@@ -2736,7 +2744,14 @@ impl Window {
 
     #[profiling::function]
     fn present(&mut self) {
-        self.platform_window.draw(&self.rendered_frame.scene);
+        // A present without a preceding draw re-presents an unchanged scene.
+        let damage = self.render_damage.take().or_else(|| {
+            self.platform_window
+                .wants_render_damage()
+                .then_some(crate::SceneDamage::Unchanged)
+        });
+        self.platform_window
+            .draw_with_damage(&self.rendered_frame.scene, damage);
         #[cfg(feature = "input-latency-histogram")]
         self.input_latency_tracker.record_frame_presented();
         self.needs_present.set(false);

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1404,6 +1404,14 @@ impl PlatformWindow for WaylandWindow {
     }
 
     fn draw(&self, scene: &Scene) {
+        self.draw_with_damage(scene, None);
+    }
+
+    fn wants_render_damage(&self) -> bool {
+        self.borrow().renderer.damage_enabled()
+    }
+
+    fn draw_with_damage(&self, scene: &Scene, damage: Option<gpui::SceneDamage>) {
         let mut state = self.borrow_mut();
 
         if state.renderer.device_lost() {
@@ -1428,7 +1436,7 @@ impl PlatformWindow for WaylandWindow {
             return;
         }
 
-        state.renderer_presented = state.renderer.draw(scene);
+        state.renderer_presented = state.renderer.draw_with_damage(scene, damage);
 
         if state.renderer.needs_redraw() {
             state.force_render_after_recovery = true;

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -1664,6 +1664,14 @@ impl PlatformWindow for X11Window {
     }
 
     fn draw(&self, scene: &Scene) {
+        self.draw_with_damage(scene, None);
+    }
+
+    fn wants_render_damage(&self) -> bool {
+        self.0.state.borrow().renderer.damage_enabled()
+    }
+
+    fn draw_with_damage(&self, scene: &Scene, damage: Option<gpui::SceneDamage>) {
         let mut inner = self.0.state.borrow_mut();
 
         if inner.renderer.device_lost() {
@@ -1686,7 +1694,7 @@ impl PlatformWindow for X11Window {
             return;
         }
 
-        inner.renderer.draw(scene);
+        inner.renderer.draw_with_damage(scene, damage);
 
         if inner.renderer.needs_redraw() {
             inner.force_render_after_recovery = true;

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -2,8 +2,8 @@ use crate::{CompositorGpuHint, WgpuAtlas, WgpuContext};
 use bytemuck::{Pod, Zeroable};
 use gpui::{
     AtlasTextureId, Background, Bounds, DevicePixels, GpuSpecs, MonochromeSprite, Path, Point,
-    PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size, SubpixelSprite,
-    Underline, get_gamma_correction_ratios,
+    PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, SceneDamage, Shadow, Size,
+    SubpixelSprite, Underline, get_gamma_correction_ratios,
 };
 use log::warn;
 #[cfg(not(target_family = "wasm"))]
@@ -104,6 +104,22 @@ struct WgpuBindGroupLayouts {
 /// Shared GPU context reference, used to coordinate device recovery across multiple windows.
 pub type GpuContext = Rc<RefCell<Option<WgpuContext>>>;
 
+/// Clamps a damage rect to an integer scissor rect, or `None` if it's empty.
+fn rect_to_scissor(
+    rect: Bounds<ScaledPixels>,
+    width: u32,
+    height: u32,
+) -> Option<(u32, u32, u32, u32)> {
+    let x0 = (rect.origin.x.0.floor().max(0.0) as u32).min(width);
+    let y0 = (rect.origin.y.0.floor().max(0.0) as u32).min(height);
+    let x1 = ((rect.origin.x.0 + rect.size.width.0).ceil().max(0.0) as u32).min(width);
+    let y1 = ((rect.origin.y.0 + rect.size.height.0).ceil().max(0.0) as u32).min(height);
+    if x1 <= x0 || y1 <= y0 {
+        return None;
+    }
+    Some((x0, y0, x1 - x0, y1 - y0))
+}
+
 /// GPU resources that must be dropped together during device recovery.
 struct WgpuResources {
     device: Arc<wgpu::Device>,
@@ -120,6 +136,9 @@ struct WgpuResources {
     path_intermediate_view: Option<wgpu::TextureView>,
     path_msaa_texture: Option<wgpu::Texture>,
     path_msaa_view: Option<wgpu::TextureView>,
+    /// Holds the last complete frame so partial frames can `Load` it, since the
+    /// swapchain isn't preserved across present.
+    accum_texture: Option<wgpu::Texture>,
 }
 
 impl WgpuResources {
@@ -128,6 +147,7 @@ impl WgpuResources {
         self.path_intermediate_view = None;
         self.path_msaa_texture = None;
         self.path_msaa_view = None;
+        self.accum_texture = None;
     }
 }
 
@@ -158,6 +178,9 @@ pub struct WgpuRenderer {
     device_lost: std::sync::Arc<std::sync::atomic::AtomicBool>,
     surface_configured: bool,
     needs_redraw: bool,
+    damage_enabled: bool,
+    /// Damage accumulated since the last present, so skipped frames aren't lost.
+    pending_damage: SceneDamage,
 }
 
 impl WgpuRenderer {
@@ -314,6 +337,13 @@ impl WgpuRenderer {
             opaque_alpha_mode
         };
 
+        // Damage tracking copies the persistent target to the swapchain, which
+        // needs COPY_DST; fall back to full redraws otherwise.
+        let damage_enabled = surface_caps.usages.contains(wgpu::TextureUsages::COPY_DST);
+        if !damage_enabled {
+            warn!("Surface does not support COPY_DST; render damage tracking disabled");
+        }
+
         let device = Arc::clone(&context.device);
         let max_texture_size = device.limits().max_texture_dimension_2d;
 
@@ -331,7 +361,11 @@ impl WgpuRenderer {
         }
 
         let surface_config = wgpu::SurfaceConfiguration {
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            usage: if damage_enabled {
+                wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_DST
+            } else {
+                wgpu::TextureUsages::RENDER_ATTACHMENT
+            },
             format: surface_format,
             width: clamped_width.max(1),
             height: clamped_height.max(1),
@@ -463,6 +497,7 @@ impl WgpuRenderer {
             path_intermediate_view: None,
             path_msaa_texture: None,
             path_msaa_view: None,
+            accum_texture: None,
         };
 
         Ok(Self {
@@ -488,6 +523,8 @@ impl WgpuRenderer {
             device_lost: context.device_lost_flag(),
             surface_configured: true,
             needs_redraw: false,
+            damage_enabled,
+            pending_damage: SceneDamage::Full,
         })
     }
 
@@ -947,6 +984,8 @@ impl WgpuRenderer {
         let height = size.height.0 as u32;
 
         if width != self.surface_config.width || height != self.surface_config.height {
+            // Targets are recreated at the new size, so the damage baseline is stale.
+            self.pending_damage = SceneDamage::Full;
             let clamped_width = width.min(self.max_texture_size);
             let clamped_height = height.min(self.max_texture_size);
 
@@ -1017,6 +1056,25 @@ impl WgpuRenderer {
         .unwrap_or((None, None));
         resources.path_msaa_texture = path_msaa_texture;
         resources.path_msaa_view = path_msaa_view;
+
+        if self.damage_enabled {
+            let resources = self.resources_mut();
+            let accum = resources.device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("damage_accum"),
+                size: wgpu::Extent3d {
+                    width: width.max(1),
+                    height: height.max(1),
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+                view_formats: &[],
+            });
+            resources.accum_texture = Some(accum);
+        }
     }
 
     pub fn set_subpixel_layout(&mut self, is_bgr: bool) {
@@ -1079,7 +1137,25 @@ impl WgpuRenderer {
         self.max_texture_size
     }
 
+    /// Whether this renderer consumes per-frame damage regions.
+    pub fn damage_enabled(&self) -> bool {
+        self.damage_enabled
+    }
+
     pub fn draw(&mut self, scene: &Scene) -> bool {
+        self.draw_with_damage(scene, None)
+    }
+
+    pub fn draw_with_damage(&mut self, scene: &Scene, damage: Option<SceneDamage>) -> bool {
+        // Accumulate before any early return so a dropped frame's damage isn't
+        // lost. `None` means damage wasn't computed, so redraw in full.
+        let incoming = if self.damage_enabled {
+            damage.unwrap_or(SceneDamage::Full)
+        } else {
+            SceneDamage::Full
+        };
+        self.pending_damage = self.pending_damage.union(incoming);
+
         // Bail out early if the surface has been unconfigured (e.g. during
         // Android background/rotation transitions).  Attempting to acquire
         // a texture from an unconfigured surface can block indefinitely on
@@ -1106,11 +1182,45 @@ impl WgpuRenderer {
                 self.atlas.clear();
                 self.needs_redraw = true;
                 self.failed_frame_count = 0;
+                self.pending_damage = SceneDamage::Full;
                 return false;
             }
         } else {
             self.failed_frame_count = 0;
         }
+
+        if matches!(self.pending_damage, SceneDamage::Unchanged) {
+            // Identical to the last presented frame; returning false lets the
+            // platform commit so the Wayland frame-callback loop keeps running.
+            return false;
+        }
+
+        let surface_width = self.surface_config.width;
+        let surface_height = self.surface_config.height;
+        let frame_rect = match &self.pending_damage {
+            SceneDamage::Rect(rect) => *rect,
+            _ => Bounds {
+                origin: Point {
+                    x: ScaledPixels(0.0),
+                    y: ScaledPixels(0.0),
+                },
+                size: Size {
+                    width: ScaledPixels(surface_width as f32),
+                    height: ScaledPixels(surface_height as f32),
+                },
+            },
+        };
+
+        // A partial frame loads the persistent target and redraws only the
+        // damaged region; a full frame clears and redraws everything.
+        let (color_load, scissor) = match rect_to_scissor(frame_rect, surface_width, surface_height)
+        {
+            None => return false,
+            Some(sc) if sc == (0, 0, surface_width, surface_height) => {
+                (wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT), None)
+            }
+            Some(sc) => (wgpu::LoadOp::Load, Some(sc)),
+        };
 
         self.atlas.before_frame();
 
@@ -1124,6 +1234,7 @@ impl WgpuRenderer {
                 resources
                     .surface
                     .configure(&resources.device, &surface_config);
+                self.pending_damage = SceneDamage::Full;
                 return false;
             }
             wgpu::CurrentSurfaceTexture::Lost | wgpu::CurrentSurfaceTexture::Outdated => {
@@ -1132,6 +1243,7 @@ impl WgpuRenderer {
                 resources
                     .surface
                     .configure(&resources.device, &surface_config);
+                self.pending_damage = SceneDamage::Full;
                 return false;
             }
             wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded => {
@@ -1150,6 +1262,19 @@ impl WgpuRenderer {
         let frame_view = frame
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
+
+        // With damage on, render into the persistent target and copy it to the
+        // swapchain afterwards; otherwise render straight to the frame.
+        let accum_view = self
+            .resources()
+            .accum_texture
+            .as_ref()
+            .map(|t| t.create_view(&wgpu::TextureViewDescriptor::default()));
+        let target_view = if self.damage_enabled {
+            accum_view.as_ref().unwrap_or(&frame_view)
+        } else {
+            &frame_view
+        };
 
         let gamma_params = GammaParams {
             gamma_ratios: self.rendering_params.gamma_ratios,
@@ -1213,10 +1338,10 @@ impl WgpuRenderer {
                 let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                     label: Some("main_pass"),
                     color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: &frame_view,
+                        view: target_view,
                         resolve_target: None,
                         ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                            load: color_load,
                             store: wgpu::StoreOp::Store,
                         },
                         depth_slice: None,
@@ -1224,6 +1349,10 @@ impl WgpuRenderer {
                     depth_stencil_attachment: None,
                     ..Default::default()
                 });
+
+                if let Some((x, y, w, h)) = scissor {
+                    pass.set_scissor_rect(x, y, w, h);
+                }
 
                 for batch in scene.batches() {
                     let ok = match batch {
@@ -1252,7 +1381,7 @@ impl WgpuRenderer {
                             pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                                 label: Some("main_pass_continued"),
                                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                    view: &frame_view,
+                                    view: target_view,
                                     resolve_target: None,
                                     ops: wgpu::Operations {
                                         load: wgpu::LoadOp::Load,
@@ -1263,6 +1392,10 @@ impl WgpuRenderer {
                                 depth_stencil_attachment: None,
                                 ..Default::default()
                             });
+
+                            if let Some((x, y, w, h)) = scissor {
+                                pass.set_scissor_rect(x, y, w, h);
+                            }
 
                             if did_draw {
                                 self.draw_paths_from_intermediate(
@@ -1321,16 +1454,56 @@ impl WgpuRenderer {
                         self.instance_buffer_capacity
                     );
                     frame.present();
+                    self.pending_damage = SceneDamage::Unchanged;
                     return true;
                 }
                 self.grow_instance_buffer();
                 continue;
             }
 
+            // Refresh the whole swapchain image from the persistent target.
+            if self.damage_enabled {
+                if let Some(accum) = self.resources().accum_texture.as_ref() {
+                    encoder.copy_texture_to_texture(
+                        wgpu::TexelCopyTextureInfo {
+                            texture: accum,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d::ZERO,
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &frame.texture,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d::ZERO,
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        wgpu::Extent3d {
+                            width: surface_width,
+                            height: surface_height,
+                            depth_or_array_layers: 1,
+                        },
+                    );
+                }
+            }
+
             self.resources()
                 .queue
                 .submit(std::iter::once(encoder.finish()));
-            frame.present();
+
+            // Tell the compositor what changed so it only recomposites that region.
+            match scissor {
+                Some((x, y, w, h)) if self.damage_enabled => {
+                    frame.present_with_damage(&[wgpu::DamageRect {
+                        x: x as i32,
+                        y: y as i32,
+                        width: w,
+                        height: h,
+                    }]);
+                }
+                _ => frame.present(),
+            }
+
+            self.pending_damage = SceneDamage::Unchanged;
             return true;
         }
     }


### PR DESCRIPTION

# Objective

Fixes https://github.com/zed-industries/zed/issues/15166 by implementing damage tracking in gpui. 

I think there have been many issues reported about excessive GPU usage on Linux, especially with older integrated GPUs and on 4k displays, I reported it a while back [here](https://github.com/zed-industries/zed/issues/14074#issuecomment-3112989027) with many users reporting the same. The editor was essentially unusable for me on a 4k display so I even upgraded my laptop in order to continue using zed. It's smooth now because the newer GPU is only(!!) capped to ~70% gpu usage so it can handle it.

## Solution

Diff consecutive scenes to find the changed region and, on the Linux/wgpu backend, redraw and present only that region instead of the whole window.

- `SceneDamage::between` diffs two finished scenes via prefix/suffix matching so a single inserted/removed primitive (e.g. a blinking cursor) damages only its own bounds.
- The wgpu renderer renders the damaged region into a persistent target, copies it to the swapchain, and forwards the region via `present_with_damage`. Unchanged frames skip presentation entirely.
- Enabled whenever the surface supports `COPY_DST`; falls back to full redraws.

There's an attempt to implement this already in https://github.com/zed-industries/zed/pull/53932, however this branch takes a different approach: instead of bubbling up changes bottom-up from the source we compute them top-down by comparing scenes, so this should be a bit safer.

This branch depends on the [companion PR](https://github.com/zed-industries/wgpu/pull/2) of the other approach to wgpu fork for `present_with_damage`, hence the WIP.

## Testing

I've been daily driving this change for a few days and did not notice any rendering inconsistencies. The performance is dramatically better though, see the showcase section below.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

```bash
$ WAYLAND_DEBUG=1 ~/zed-damage-tracking 2>&1 | grep damage
[1639273.818] {mesa vk display queue}  -> wl_surface#28.damage_buffer(0, 0, 2147483647, 2147483647)
[1639334.894] {mesa vk display queue}  -> wl_surface#28.damage_buffer(0, 0, 2147483647, 2147483647)
[1639368.210] {mesa vk display queue}  -> wl_surface#28.damage_buffer(0, 0, 2147483647, 2147483647)
[1639395.068] {mesa vk display queue}  -> wl_surface#28.damage_buffer(0, 51, 1257, 1428)
[1639415.679] {mesa vk display queue}  -> wl_surface#28.damage_buffer(12, 1485, 1233, 33)
[1639500.865] {mesa vk display queue}  -> wl_surface#28.damage_buffer(0, 15, 1257, 1503)
[1639521.779] {mesa vk display queue}  -> wl_surface#28.damage_buffer(0, 52, 1257, 1426)
[1639549.986] {mesa vk display queue}  -> wl_surface#28.damage_buffer(0, 19, 1257, 1499)
[1639620.980] {mesa vk display queue}  -> wl_surface#28.damage_buffer(0, 52, 1257, 1426)
[1639683.850] {mesa vk display queue}  -> wl_surface#28.damage_buffer(12, 15, 1233, 1503)
[1639712.395] {mesa vk display queue}  -> wl_surface#28.damage_buffer(504, 167, 3, 34)
[1639762.844] {mesa vk display queue}  -> wl_surface#28.damage_buffer(504, 167, 3, 34)
[1639800.511] {mesa vk display queue}  -> wl_surface#28.damage_buffer(54, 16, 1120, 1496)
[1639850.917] {mesa vk display queue}  -> wl_surface#28.damage_buffer(0, 15, 1257, 1503)
[1639861.199] {mesa vk display queue}  -> wl_surface#28.damage_buffer(0, 52, 1257, 1426)
[1639937.802] {mesa vk display queue}  -> wl_surface#28.damage_buffer(504, 201, 1, 897)
```

For performance testing I open up zed with the file panel, text editor, terminal, agent panel and launch `sudo intel_gpu_top` or `htop` in the terminal panel. I then swirl the cursor around randomly.

With vanilla upstream zed I observe:

 - 50-60% GPU usage, most in Render/3D, roughly 70/30 split between zed/sway 
 - 2-3W / 12-13W power draw (gpu / package)
 - 80-90% CPU usage for the zed process

With this branch:

 - 5-10% GPU usage
 - 0.3-5 / 8-9 W power draw
 - 30-50% CPU usage for the zed process
 
---

Release Notes:

- Implement damage tracking in GPUI dramatically reducing GPU utilization