### PR TITLE
gpui: Fix web examples build

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -157,13 +157,13 @@ env_logger.workspace = true
 gpui_platform = { workspace = true, features = ["font-kit", "wayland", "x11"] }
 gpui_util = { workspace = true }
 lyon = { version = "1.0", features = ["extra"] }
-proptest = { workspace = true }
 rand.workspace = true
 scheduler = { workspace = true, features = ["test-support"] }
 unicode-segmentation = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 http_client = { workspace = true, features = ["test-support"] }
+proptest = { workspace = true }
 reqwest_client = { workspace = true, features = ["test-support"] }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]

--- a/crates/gpui/examples/a11y.rs
+++ b/crates/gpui/examples/a11y.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(target_family = "wasm", no_main)]
+
 //! Accessibility (AccessKit) demo app.
 //!
 //! Run with: `cargo run -p gpui --example a11y`


### PR DESCRIPTION
# Objective

fix `cargo xtask web-examples --no-serve` error.

## Solution

Building GPUI web examples for wasm failed because gpui's ordinary dev-dependencies were included in the wasm build graph. That pulled in proptest's default fork/timeout support, which depends on wait-timeout. wait-timeout does not support wasm32-unknown-unknown, so compilation failed.

The a11y example also had a wasm_bindgen start function but was missing the wasm no_main crate attribute, so Rust still expected a normal main function and emitted E0601.

Move gpui's proptest dev-dependency behind the non-wasm target so web example builds do not include native-only test timeout support. Add the wasm no_main crate attribute to the a11y example.

Verified with:

```
cargo tree --target wasm32-unknown-unknown -p gpui -i wait-timeout
cargo xtask web-examples --no-serve
```

---

Release Notes:

- N/A or Added/Fixed/Improved ...
