### PR TITLE
editor: Show buffer headers through horizontal scrollbars

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -150,7 +150,7 @@ use edit_prediction_types::{
     EditPredictionGranularity, SuggestionDisplayType,
 };
 use editor_settings::{GoToDefinitionFallback, Minimap as MinimapSettings};
-use element::{LineWithInvisibles, PositionMap, ScrollbarLayout, layout_line};
+use element::{LineWithInvisibles, PositionMap, layout_line};
 use futures::{
     FutureExt,
     future::{self, Shared},
@@ -1102,16 +1102,9 @@ pub struct Editor {
     /// width available to buffer headers.
     last_right_margin: Pixels,
     /// Whether the horizontal scrollbar was laid out as visible during the last
-    /// prepaint. Unlike `last_horizontal_scrollbar_layout` (set whenever there
-    /// is horizontal overflow), this accounts for auto-hide. Used by
-    /// `SplitBufferHeadersElement` to gate repainting the hoisted horizontal
-    /// scrollbar over the buffer headers.
+    /// prepaint, accounting for auto-hide. Used by `SplitBufferHeadersElement`
+    /// to position sticky buffer headers above the scrollbar.
     last_horizontal_scrollbar_visible: bool,
-    /// The horizontal scrollbar's layout from the last prepaint, if one was
-    /// laid out.
-    /// Snapshotted so `SplitBufferHeadersElement` can paint the split pane's
-    /// horizontal scrollbars itself, above the buffer headers.
-    last_horizontal_scrollbar_layout: Option<ScrollbarLayout>,
     expect_bounds_change: Option<Bounds<Pixels>>,
     runnables: RunnableData,
     bookmark_store: Option<Entity<BookmarkStore>>,
@@ -2284,7 +2277,6 @@ impl Editor {
             last_position_map: None,
             last_right_margin: Pixels::ZERO,
             last_horizontal_scrollbar_visible: false,
-            last_horizontal_scrollbar_layout: None,
             expect_bounds_change: None,
             gutter_dimensions: GutterDimensions::default(),
             style: None,
@@ -2701,10 +2693,6 @@ impl Editor {
 
     pub(crate) fn last_horizontal_scrollbar_visible(&self) -> bool {
         self.last_horizontal_scrollbar_visible
-    }
-
-    pub(crate) fn last_horizontal_scrollbar_layout(&self) -> Option<&ScrollbarLayout> {
-        self.last_horizontal_scrollbar_layout.as_ref()
     }
 
     pub fn working_directory(&self, cx: &App) -> Option<PathBuf> {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1110,13 +1110,7 @@ pub struct Editor {
     /// laid out.
     /// Snapshotted so `SplitBufferHeadersElement` can paint the split pane's
     /// horizontal scrollbars itself, above the buffer headers.
-    /// much space to reserve for buffer headers.
     last_horizontal_scrollbar_layout: Option<ScrollbarLayout>,
-    /// When set, `EditorElement` lays out and keeps the horizontal scrollbar
-    /// interactive but skips painting it. Set by `SplitBufferHeadersElement`,
-    /// which repains it on top of the buffer headers so they show through the
-    /// translucent scrollbar.
-    suppress_horizontal_scrollbar_paint: bool,
     expect_bounds_change: Option<Bounds<Pixels>>,
     runnables: RunnableData,
     bookmark_store: Option<Entity<BookmarkStore>>,
@@ -2290,7 +2284,6 @@ impl Editor {
             last_right_margin: Pixels::ZERO,
             last_horizontal_scrollbar_visible: false,
             last_horizontal_scrollbar_layout: None,
-            suppress_horizontal_scrollbar_paint: false,
             expect_bounds_change: None,
             gutter_dimensions: GutterDimensions::default(),
             style: None,
@@ -2712,16 +2705,6 @@ impl Editor {
     #[allow(dead_code)]
     pub(crate) fn last_horizontal_scrollbar_layout(&self) -> Option<&ScrollbarLayout> {
         self.last_horizontal_scrollbar_layout.as_ref()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn suppress_horizontal_scrollbar_paint(&self) -> bool {
-        self.suppress_horizontal_scrollbar_paint
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn set_suppress_horizontal_scrollbar_paint(&mut self, suppress: bool) {
-        self.suppress_horizontal_scrollbar_paint = suppress;
     }
 
     pub fn working_directory(&self, cx: &App) -> Option<PathBuf> {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1102,9 +1102,10 @@ pub struct Editor {
     /// width available to buffer headers.
     last_right_margin: Pixels,
     /// Whether the horizontal scrollbar was laid out as visible during the last
-    /// prepaint.
-    /// Used by `SplitBufferHeadersElement` to clip buffer headers so they don't
-    /// paint over the scrollbar.
+    /// prepaint. Unlike `last_horizontal_scrollbar_layout` (set whenever there
+    /// is horizontal overflow), this accounts for auto-hide. Used by
+    /// `SplitBufferHeadersElement` to gate repainting the hoisted horizontal
+    /// scrollbar over the buffer headers.
     last_horizontal_scrollbar_visible: bool,
     /// The horizontal scrollbar's layout from the last prepaint, if one was
     /// laid out.
@@ -2702,7 +2703,6 @@ impl Editor {
         self.last_horizontal_scrollbar_visible
     }
 
-    #[allow(dead_code)]
     pub(crate) fn last_horizontal_scrollbar_layout(&self) -> Option<&ScrollbarLayout> {
         self.last_horizontal_scrollbar_layout.as_ref()
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -150,7 +150,7 @@ use edit_prediction_types::{
     EditPredictionGranularity, SuggestionDisplayType,
 };
 use editor_settings::{GoToDefinitionFallback, Minimap as MinimapSettings};
-use element::{LineWithInvisibles, PositionMap, layout_line};
+use element::{LineWithInvisibles, PositionMap, ScrollbarLayout, layout_line};
 use futures::{
     FutureExt,
     future::{self, Shared},
@@ -1106,6 +1106,17 @@ pub struct Editor {
     /// Used by `SplitBufferHeadersElement` to clip buffer headers so they don't
     /// paint over the scrollbar.
     last_horizontal_scrollbar_visible: bool,
+    /// The horizontal scrollbar's layout from the last prepaint, if one was
+    /// laid out.
+    /// Snapshotted so `SplitBufferHeadersElement` can paint the split pane's
+    /// horizontal scrollbars itself, above the buffer headers.
+    /// much space to reserve for buffer headers.
+    last_horizontal_scrollbar_layout: Option<ScrollbarLayout>,
+    /// When set, `EditorElement` lays out and keeps the horizontal scrollbar
+    /// interactive but skips painting it. Set by `SplitBufferHeadersElement`,
+    /// which repains it on top of the buffer headers so they show through the
+    /// translucent scrollbar.
+    suppress_horizontal_scrollbar_paint: bool,
     expect_bounds_change: Option<Bounds<Pixels>>,
     runnables: RunnableData,
     bookmark_store: Option<Entity<BookmarkStore>>,
@@ -2278,6 +2289,8 @@ impl Editor {
             last_position_map: None,
             last_right_margin: Pixels::ZERO,
             last_horizontal_scrollbar_visible: false,
+            last_horizontal_scrollbar_layout: None,
+            suppress_horizontal_scrollbar_paint: false,
             expect_bounds_change: None,
             gutter_dimensions: GutterDimensions::default(),
             style: None,
@@ -2694,6 +2707,21 @@ impl Editor {
 
     pub(crate) fn last_horizontal_scrollbar_visible(&self) -> bool {
         self.last_horizontal_scrollbar_visible
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn last_horizontal_scrollbar_layout(&self) -> Option<&ScrollbarLayout> {
+        self.last_horizontal_scrollbar_layout.as_ref()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn suppress_horizontal_scrollbar_paint(&self) -> bool {
+        self.suppress_horizontal_scrollbar_paint
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn set_suppress_horizontal_scrollbar_paint(&mut self, suppress: bool) {
+        self.suppress_horizontal_scrollbar_paint = suppress;
     }
 
     pub fn working_directory(&self, cx: &App) -> Option<PathBuf> {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -47,8 +47,8 @@ use gpui::{
     ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad,
     ParentElement, Pixels, ScrollHandle, ShapedLine, SharedString, Size,
     StatefulInteractiveElement, Style, Styled, StyledText, TaskExt, TextAlign, TextRun,
-    TextStyleRefinement, WeakEntity, Window, div, fill, outline, pattern_slash, point, px, quad,
-    relative, size, solid_background, transparent_black,
+    TextStyleRefinement, WeakEntity, Window, canvas, div, fill, outline, pattern_slash, point, px,
+    quad, relative, size, solid_background, transparent_black,
 };
 use itertools::Itertools;
 use language::{
@@ -5688,6 +5688,47 @@ impl EditorElement {
         }
     }
 
+    /// In split mode, the buffer headers are painted by a separate
+    /// `SplitBufferHeadersElement` drawn after the editor, which would cover
+    /// the horizontal scrollbar.
+    /// To keep the scrollbar on top, and its track see-through, matching the
+    /// vertical scrollbar, `paint_scrollbars` will skip the horizontal
+    /// scrollbar and this will schedule a deferred draw for it instead,
+    /// ensuring that it gets painted after all non-deferred content.
+    /// Can't be called directly from `paint_scrollbars` because
+    /// `Window::defer_draw` is a prepaint-only API.
+    fn defer_horizontal_scrollbar_paint(
+        &self,
+        scrollbars_layout: Option<&EditorScrollbars>,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        if self.split_side.is_some()
+            && let Some(scrollbars) = scrollbars_layout
+            && scrollbars.visible
+            && let Some(scrollbar_layout) = scrollbars.horizontal.clone()
+        {
+            let any_scrollbar_dragged = self.editor.read(cx).scroll_manager.any_scrollbar_dragged();
+            let bounds = scrollbar_layout.hitbox.bounds;
+
+            let mut element = canvas(
+                |_, _, _| (),
+                move |_, _, window, cx| {
+                    scrollbar_layout.paint_track_and_thumb(
+                        ScrollbarAxis::Horizontal,
+                        any_scrollbar_dragged,
+                        window,
+                        cx,
+                    );
+                },
+            )
+            .into_any_element();
+
+            element.layout_as_root(bounds.size.into(), window, cx);
+            window.defer_draw(element, bounds.origin, 0, None);
+        }
+    }
+
     fn paint_scrollbars(&mut self, layout: &mut EditorLayout, window: &mut Window, cx: &mut App) {
         let Some(scrollbars_layout) = layout.scrollbars_layout.take() else {
             return;
@@ -5695,8 +5736,11 @@ impl EditorElement {
         let any_scrollbar_dragged = self.editor.read(cx).scroll_manager.any_scrollbar_dragged();
 
         for (scrollbar_layout, axis) in scrollbars_layout.iter_scrollbars() {
-            let hitbox = &scrollbar_layout.hitbox;
+            // In split mode, the horizontal scrollbar is painted by
+            // `Self::defer_horizontal_scrollbar_paint` instead, to ensure it
+            // lands above buffer headers.
             let suppressed = axis == ScrollbarAxis::Horizontal && self.split_side.is_some();
+            let hitbox = &scrollbar_layout.hitbox;
 
             if scrollbars_layout.visible && !suppressed {
                 window.paint_layer(hitbox.bounds, |window| {
@@ -9235,15 +9279,11 @@ impl Element for EditorElement {
                             scrollbars_layout.visible && scrollbars_layout.horizontal.is_some()
                         });
 
-                    let horizontal_scrollbar_layout = scrollbars_layout
-                        .as_ref()
-                        .and_then(|scrollbars_layout| scrollbars_layout.horizontal.clone());
-
+                    self.defer_horizontal_scrollbar_paint(scrollbars_layout.as_ref(), window, cx);
                     self.editor.update(cx, |editor, _| {
                         editor.last_position_map = Some(position_map.clone());
                         editor.last_right_margin = right_margin;
                         editor.last_horizontal_scrollbar_visible = visible_horizontal_scrollbar;
-                        editor.last_horizontal_scrollbar_layout = horizontal_scrollbar_layout;
                     });
 
                     EditorLayout {
@@ -9654,7 +9694,7 @@ impl EditorScrollbars {
 }
 
 #[derive(Clone)]
-pub(crate) struct ScrollbarLayout {
+pub struct ScrollbarLayout {
     hitbox: Hitbox,
     visible_range: Range<ScrollOffset>,
     text_unit_size: Pixels,
@@ -9914,7 +9954,7 @@ impl ScrollbarLayout {
         }
     }
 
-    pub(crate) fn paint_track(&self, axis: ScrollbarAxis, window: &mut Window, cx: &App) {
+    fn paint_track(&self, axis: ScrollbarAxis, window: &mut Window, cx: &App) {
         let colors = cx.theme().colors();
 
         window.paint_quad(quad(
@@ -9927,7 +9967,7 @@ impl ScrollbarLayout {
         ));
     }
 
-    pub(crate) fn paint_thumb(
+    fn paint_thumb(
         &self,
         axis: ScrollbarAxis,
         any_scrollbar_dragged: bool,
@@ -9960,7 +10000,7 @@ impl ScrollbarLayout {
         }
     }
 
-    pub(crate) fn paint_track_and_thumb(
+    fn paint_track_and_thumb(
         &self,
         axis: ScrollbarAxis,
         any_scrollbar_dragged: bool,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9959,6 +9959,19 @@ impl ScrollbarLayout {
             }
         }
     }
+
+    pub(crate) fn paint_track_and_thumb(
+        &self,
+        axis: ScrollbarAxis,
+        any_scrollbar_dragged: bool,
+        window: &mut Window,
+        cx: &App,
+    ) {
+        window.paint_layer(self.hitbox.bounds, |window| {
+            self.paint_track(axis, window, cx);
+            self.paint_thumb(axis, any_scrollbar_dragged, window, cx);
+        })
+    }
 }
 
 struct MinimapLayout {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5693,10 +5693,14 @@ impl EditorElement {
             return;
         };
         let any_scrollbar_dragged = self.editor.read(cx).scroll_manager.any_scrollbar_dragged();
+        let suppress_horizontal_scrollbar =
+            self.editor.read(cx).suppress_horizontal_scrollbar_paint();
 
         for (scrollbar_layout, axis) in scrollbars_layout.iter_scrollbars() {
             let hitbox = &scrollbar_layout.hitbox;
-            if scrollbars_layout.visible {
+            let suppressed = axis == ScrollbarAxis::Horizontal && suppress_horizontal_scrollbar;
+
+            if scrollbars_layout.visible && !suppressed {
                 window.paint_layer(hitbox.bounds, |window| {
                     scrollbar_layout.paint_track(axis, window, cx);
 
@@ -9242,6 +9246,7 @@ impl Element for EditorElement {
                         editor.last_right_margin = right_margin;
                         editor.last_horizontal_scrollbar_visible = visible_horizontal_scrollbar;
                         editor.last_horizontal_scrollbar_layout = horizontal_scrollbar_layout;
+                        editor.suppress_horizontal_scrollbar_paint = false;
                     });
 
                     EditorLayout {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5693,12 +5693,10 @@ impl EditorElement {
             return;
         };
         let any_scrollbar_dragged = self.editor.read(cx).scroll_manager.any_scrollbar_dragged();
-        let suppress_horizontal_scrollbar =
-            self.editor.read(cx).suppress_horizontal_scrollbar_paint();
 
         for (scrollbar_layout, axis) in scrollbars_layout.iter_scrollbars() {
             let hitbox = &scrollbar_layout.hitbox;
-            let suppressed = axis == ScrollbarAxis::Horizontal && suppress_horizontal_scrollbar;
+            let suppressed = axis == ScrollbarAxis::Horizontal && self.split_side.is_some();
 
             if scrollbars_layout.visible && !suppressed {
                 window.paint_layer(hitbox.bounds, |window| {
@@ -9246,7 +9244,6 @@ impl Element for EditorElement {
                         editor.last_right_margin = right_margin;
                         editor.last_horizontal_scrollbar_visible = visible_horizontal_scrollbar;
                         editor.last_horizontal_scrollbar_layout = horizontal_scrollbar_layout;
-                        editor.suppress_horizontal_scrollbar_paint = false;
                     });
 
                     EditorLayout {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5697,30 +5697,8 @@ impl EditorElement {
         for (scrollbar_layout, axis) in scrollbars_layout.iter_scrollbars() {
             let hitbox = &scrollbar_layout.hitbox;
             if scrollbars_layout.visible {
-                let scrollbar_edges = match axis {
-                    ScrollbarAxis::Horizontal => Edges {
-                        top: Pixels::ZERO,
-                        right: Pixels::ZERO,
-                        bottom: Pixels::ZERO,
-                        left: Pixels::ZERO,
-                    },
-                    ScrollbarAxis::Vertical => Edges {
-                        top: Pixels::ZERO,
-                        right: Pixels::ZERO,
-                        bottom: Pixels::ZERO,
-                        left: ScrollbarLayout::BORDER_WIDTH,
-                    },
-                };
-
                 window.paint_layer(hitbox.bounds, |window| {
-                    window.paint_quad(quad(
-                        hitbox.bounds,
-                        Corners::default(),
-                        cx.theme().colors().scrollbar_track_background,
-                        scrollbar_edges,
-                        cx.theme().colors().scrollbar_track_border,
-                        BorderStyle::Solid,
-                    ));
+                    scrollbar_layout.paint_track(axis, window, cx);
 
                     if axis == ScrollbarAxis::Vertical {
                         let fast_markers =
@@ -5737,33 +5715,7 @@ impl EditorElement {
                         }
                     }
 
-                    if let Some(thumb_bounds) = scrollbar_layout.thumb_bounds {
-                        let scrollbar_thumb_color = match scrollbar_layout.thumb_state {
-                            ScrollbarThumbState::Dragging => {
-                                cx.theme().colors().scrollbar_thumb_active_background
-                            }
-                            ScrollbarThumbState::Hovered => {
-                                cx.theme().colors().scrollbar_thumb_hover_background
-                            }
-                            ScrollbarThumbState::Idle => {
-                                cx.theme().colors().scrollbar_thumb_background
-                            }
-                        };
-                        window.paint_quad(quad(
-                            thumb_bounds,
-                            Corners::default(),
-                            scrollbar_thumb_color,
-                            scrollbar_edges,
-                            cx.theme().colors().scrollbar_thumb_border,
-                            BorderStyle::Solid,
-                        ));
-
-                        if any_scrollbar_dragged {
-                            window.set_window_cursor_style(CursorStyle::Arrow);
-                        } else {
-                            window.set_cursor_style(CursorStyle::Arrow, hitbox);
-                        }
-                    }
+                    scrollbar_layout.paint_thumb(axis, any_scrollbar_dragged, window, cx);
                 })
             }
         }
@@ -9943,6 +9895,62 @@ impl ScrollbarLayout {
         }
 
         quads
+    }
+
+    fn scrollbar_edges(axis: ScrollbarAxis) -> Edges<Pixels> {
+        match axis {
+            ScrollbarAxis::Horizontal => Edges::default(),
+            ScrollbarAxis::Vertical => Edges {
+                left: Self::BORDER_WIDTH,
+                ..Default::default()
+            },
+        }
+    }
+
+    pub(crate) fn paint_track(&self, axis: ScrollbarAxis, window: &mut Window, cx: &App) {
+        let colors = cx.theme().colors();
+
+        window.paint_quad(quad(
+            self.hitbox.bounds,
+            Corners::default(),
+            colors.scrollbar_track_background,
+            Self::scrollbar_edges(axis),
+            colors.scrollbar_track_border,
+            BorderStyle::Solid,
+        ));
+    }
+
+    pub(crate) fn paint_thumb(
+        &self,
+        axis: ScrollbarAxis,
+        any_scrollbar_dragged: bool,
+        window: &mut Window,
+        cx: &App,
+    ) {
+        let colors = cx.theme().colors();
+
+        if let Some(thumb_bounds) = self.thumb_bounds {
+            let thumb_color = match self.thumb_state {
+                ScrollbarThumbState::Dragging => colors.scrollbar_thumb_active_background,
+                ScrollbarThumbState::Hovered => colors.scrollbar_thumb_hover_background,
+                ScrollbarThumbState::Idle => colors.scrollbar_thumb_background,
+            };
+
+            window.paint_quad(quad(
+                thumb_bounds,
+                Corners::default(),
+                thumb_color,
+                Self::scrollbar_edges(axis),
+                colors.scrollbar_thumb_border,
+                BorderStyle::Solid,
+            ));
+
+            if any_scrollbar_dragged {
+                window.set_window_cursor_style(CursorStyle::Arrow);
+            } else {
+                window.set_cursor_style(CursorStyle::Arrow, &self.hitbox);
+            }
+        }
     }
 }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9233,10 +9233,15 @@ impl Element for EditorElement {
                             scrollbars_layout.visible && scrollbars_layout.horizontal.is_some()
                         });
 
+                    let horizontal_scrollbar_layout = scrollbars_layout
+                        .as_ref()
+                        .and_then(|scrollbars_layout| scrollbars_layout.horizontal.clone());
+
                     self.editor.update(cx, |editor, _| {
                         editor.last_position_map = Some(position_map.clone());
                         editor.last_right_margin = right_margin;
                         editor.last_horizontal_scrollbar_visible = visible_horizontal_scrollbar;
+                        editor.last_horizontal_scrollbar_layout = horizontal_scrollbar_layout;
                     });
 
                     EditorLayout {
@@ -9647,7 +9652,7 @@ impl EditorScrollbars {
 }
 
 #[derive(Clone)]
-struct ScrollbarLayout {
+pub(crate) struct ScrollbarLayout {
     hitbox: Hitbox,
     visible_range: Range<ScrollOffset>,
     text_unit_size: Pixels,

--- a/crates/editor/src/split_editor_view.rs
+++ b/crates/editor/src/split_editor_view.rs
@@ -2,10 +2,10 @@ use std::cmp;
 
 use collections::{HashMap, HashSet};
 use gpui::{
-    AbsoluteLength, AnyElement, App, AvailableSpace, Axis, Bounds, ContentMask, Context,
-    DragMoveEvent, Element, Entity, GlobalElementId, Hsla, InspectorElementId, IntoElement,
-    LayoutId, Length, ParentElement, Pixels, StatefulInteractiveElement, Styled,
-    TextStyleRefinement, Window, div, linear_color_stop, linear_gradient, point, px, size,
+    AbsoluteLength, AnyElement, App, AvailableSpace, Bounds, ContentMask, Context, DragMoveEvent,
+    Element, Entity, GlobalElementId, Hsla, InspectorElementId, IntoElement, LayoutId, Length,
+    ParentElement, Pixels, StatefulInteractiveElement, Styled, TextStyleRefinement, Window, div,
+    linear_color_stop, linear_gradient, point, px, size,
 };
 use multi_buffer::{Anchor, ExcerptBoundaryInfo};
 use smallvec::smallvec;
@@ -355,18 +355,6 @@ impl Element for SplitBufferHeadersElement {
                 });
             });
         });
-
-        for editor in [&self.lhs_editor, &self.rhs_editor] {
-            let visible = editor.read(cx).last_horizontal_scrollbar_visible();
-            let layout = editor.read(cx).last_horizontal_scrollbar_layout();
-            let any_scrollbar_dragged = editor.read(cx).scroll_manager.any_scrollbar_dragged();
-
-            if let Some(layout) = layout
-                && visible
-            {
-                layout.paint_track_and_thumb(Axis::Horizontal, any_scrollbar_dragged, window, cx);
-            }
-        }
     }
 }
 

--- a/crates/editor/src/split_editor_view.rs
+++ b/crates/editor/src/split_editor_view.rs
@@ -396,17 +396,6 @@ impl SplitBufferHeadersElement {
             .update(cx, |editor, cx| editor.snapshot(window, cx));
         let scroll_position = snapshot.scroll_position();
 
-        // When dealing with a split editor, the [`SplitBufferHeadersElement`]
-        // is the one responsible for painting the horizontal scrollbars for
-        // each editor, so we need to suppress the pain on the editor itself.
-        self.lhs_editor.update(cx, |editor, _| {
-            editor.set_suppress_horizontal_scrollbar_paint(true);
-        });
-
-        self.rhs_editor.update(cx, |editor, _| {
-            editor.set_suppress_horizontal_scrollbar_paint(true);
-        });
-
         // Compute right margin to avoid overlapping the scrollbar
         let content_bounds = self.content_bounds(bounds, cx);
         let available_width = (content_bounds.size.width

--- a/crates/editor/src/split_editor_view.rs
+++ b/crates/editor/src/split_editor_view.rs
@@ -356,26 +356,16 @@ impl Element for SplitBufferHeadersElement {
             });
         });
 
-        let visible = self.lhs_editor.read(cx).last_horizontal_scrollbar_visible();
-        let any_scrollbar_dragged = self.lhs_editor.read(cx).scroll_manager.scrollbars_visible();
-        let layout = self.lhs_editor.read(cx).last_horizontal_scrollbar_layout();
+        for editor in [&self.lhs_editor, &self.rhs_editor] {
+            let visible = editor.read(cx).last_horizontal_scrollbar_visible();
+            let layout = editor.read(cx).last_horizontal_scrollbar_layout();
+            let any_scrollbar_dragged = editor.read(cx).scroll_manager.any_scrollbar_dragged();
 
-        if let Some(layout) = layout
-            && visible
-        {
-            layout.paint_track(Axis::Horizontal, window, cx);
-            layout.paint_thumb(Axis::Horizontal, any_scrollbar_dragged, window, cx);
-        }
-
-        let visible = self.rhs_editor.read(cx).last_horizontal_scrollbar_visible();
-        let any_scrollbar_dragged = self.rhs_editor.read(cx).scroll_manager.scrollbars_visible();
-        let layout = self.rhs_editor.read(cx).last_horizontal_scrollbar_layout();
-
-        if let Some(layout) = layout
-            && visible
-        {
-            layout.paint_track(Axis::Horizontal, window, cx);
-            layout.paint_thumb(Axis::Horizontal, any_scrollbar_dragged, window, cx);
+            if let Some(layout) = layout
+                && visible
+            {
+                layout.paint_track_and_thumb(Axis::Horizontal, any_scrollbar_dragged, window, cx);
+            }
         }
     }
 }

--- a/crates/editor/src/split_editor_view.rs
+++ b/crates/editor/src/split_editor_view.rs
@@ -2,18 +2,16 @@ use std::cmp;
 
 use collections::{HashMap, HashSet};
 use gpui::{
-    AbsoluteLength, AnyElement, App, AvailableSpace, Bounds, Context, DragMoveEvent, Element,
-    Entity, GlobalElementId, Hsla, InspectorElementId, IntoElement, LayoutId, Length,
-    ParentElement, Pixels, StatefulInteractiveElement, Styled, TextStyleRefinement, Window, div,
-    linear_color_stop, linear_gradient, point, px, size,
+    AbsoluteLength, AnyElement, App, AvailableSpace, Axis, Bounds, ContentMask, Context,
+    DragMoveEvent, Element, Entity, GlobalElementId, Hsla, InspectorElementId, IntoElement,
+    LayoutId, Length, ParentElement, Pixels, StatefulInteractiveElement, Styled,
+    TextStyleRefinement, Window, div, linear_color_stop, linear_gradient, point, px, size,
 };
 use multi_buffer::{Anchor, ExcerptBoundaryInfo};
 use smallvec::smallvec;
 use text::BufferId;
 use theme::ActiveTheme;
 use ui::{h_flex, prelude::*, v_flex};
-
-use gpui::ContentMask;
 
 use crate::{
     DisplayRow, Editor, EditorSnapshot, EditorStyle, FILE_HEADER_HEIGHT,
@@ -256,7 +254,6 @@ struct BufferHeaderLayout {
 }
 
 struct SplitBufferHeadersPrepaintState {
-    content_bounds: Bounds<Pixels>,
     sticky_header: Option<AnyElement>,
     non_sticky_headers: Vec<BufferHeaderLayout>,
 }
@@ -309,7 +306,6 @@ impl Element for SplitBufferHeadersElement {
     ) -> Self::PrepaintState {
         if bounds.size.width <= px(0.) || bounds.size.height <= px(0.) {
             return SplitBufferHeadersPrepaintState {
-                content_bounds: bounds,
                 sticky_header: None,
                 non_sticky_headers: Vec::new(),
             };
@@ -333,7 +329,7 @@ impl Element for SplitBufferHeadersElement {
         &mut self,
         _id: Option<&GlobalElementId>,
         _inspector_id: Option<&InspectorElementId>,
-        _bounds: Bounds<Pixels>,
+        bounds: Bounds<Pixels>,
         _request_layout: &mut Self::RequestLayoutState,
         prepaint: &mut Self::PrepaintState,
         window: &mut Window,
@@ -348,22 +344,39 @@ impl Element for SplitBufferHeadersElement {
 
         window.with_rem_size(rem_size, |window| {
             window.with_text_style(Some(text_style), |window| {
-                window.with_content_mask(
-                    Some(ContentMask {
-                        bounds: prepaint.content_bounds,
-                    }),
-                    |window| {
-                        for header_layout in &mut prepaint.non_sticky_headers {
-                            header_layout.element.paint(window, cx);
-                        }
+                window.with_content_mask(Some(ContentMask { bounds }), |window| {
+                    for header_layout in &mut prepaint.non_sticky_headers {
+                        header_layout.element.paint(window, cx);
+                    }
 
-                        if let Some(mut sticky_header) = prepaint.sticky_header.take() {
-                            sticky_header.paint(window, cx);
-                        }
-                    },
-                );
+                    if let Some(mut sticky_header) = prepaint.sticky_header.take() {
+                        sticky_header.paint(window, cx);
+                    }
+                });
             });
         });
+
+        let visible = self.lhs_editor.read(cx).last_horizontal_scrollbar_visible();
+        let any_scrollbar_dragged = self.lhs_editor.read(cx).scroll_manager.scrollbars_visible();
+        let layout = self.lhs_editor.read(cx).last_horizontal_scrollbar_layout();
+
+        if let Some(layout) = layout
+            && visible
+        {
+            layout.paint_track(Axis::Horizontal, window, cx);
+            layout.paint_thumb(Axis::Horizontal, any_scrollbar_dragged, window, cx);
+        }
+
+        let visible = self.rhs_editor.read(cx).last_horizontal_scrollbar_visible();
+        let any_scrollbar_dragged = self.rhs_editor.read(cx).scroll_manager.scrollbars_visible();
+        let layout = self.rhs_editor.read(cx).last_horizontal_scrollbar_layout();
+
+        if let Some(layout) = layout
+            && visible
+        {
+            layout.paint_track(Axis::Horizontal, window, cx);
+            layout.paint_thumb(Axis::Horizontal, any_scrollbar_dragged, window, cx);
+        }
     }
 }
 
@@ -457,7 +470,6 @@ impl SplitBufferHeadersElement {
         );
 
         SplitBufferHeadersPrepaintState {
-            content_bounds,
             sticky_header,
             non_sticky_headers,
         }

--- a/crates/editor/src/split_editor_view.rs
+++ b/crates/editor/src/split_editor_view.rs
@@ -396,6 +396,17 @@ impl SplitBufferHeadersElement {
             .update(cx, |editor, cx| editor.snapshot(window, cx));
         let scroll_position = snapshot.scroll_position();
 
+        // When dealing with a split editor, the [`SplitBufferHeadersElement`]
+        // is the one responsible for painting the horizontal scrollbars for
+        // each editor, so we need to suppress the pain on the editor itself.
+        self.lhs_editor.update(cx, |editor, _| {
+            editor.set_suppress_horizontal_scrollbar_paint(true);
+        });
+
+        self.rhs_editor.update(cx, |editor, _| {
+            editor.set_suppress_horizontal_scrollbar_paint(true);
+        });
+
         // Compute right margin to avoid overlapping the scrollbar
         let content_bounds = self.content_bounds(bounds, cx);
         let available_width = (content_bounds.size.width


### PR DESCRIPTION
# Objective

The changes in https://github.com/zed-industries/zed/pull/53782 fixed an issue where, on a split editor, the buffer headers would be painted above the editor's horizontal scrollbars. Since it solved the problem by applying a `ContentMask` on both of the `SplitBufferHeadersElement` prepaint and paint methods, it ended up leading to this situation where the horizontal scrollbar track did not have a see-through effect, like it already happens for the vertical scrollbars.

As such, the changes in this Pull Request tackle that issue, leading to a uniform look on both the vertical and horizontal scrollbars.

## Solution

Since this is related to the paint order and the `EditorElement` is responsible for painting the horizontal scrollbars, which always happens before the `SplitBufferHeadersElement` is painted, in order to solve this, the painting of the horizontal scrollbars had to be done after the buffer headers are painted.

Knowing this, the `EditorElement::paint_scrollbars` now takes into consideration whether it is in split mode (`self.split_side.is_some()` and the scrollbar being drawn is the horizontal one (`axis == ScrollbarAxis::Horizontal`). If that's the case, it'll skip painting the horizontal scrollbars.

The `SplitBufferHeadersElement::paint` method is now responsible for checking whether the Editor's last prepaint had a visible horizontal scrollbar and draw both editor's (left and right) horizontal scrollbars, after the buffer headers are painted. Some new methods were introduced to unify this scrollbar painting behavior, namely:

* `editor::element::ScrollbarLayout::paint_track`
* `editor::element::ScrollbarLayout::paint_thumb`
* `editor::element::ScrollbarLayout::paint_track_and_thumb`

## Testing

Testing was done by simply opening `git: diff` with changes large enough to trigger the horizontal scrollbars to be shown, ensuring that soft wrapping is disabled (`editor: toggle soft wrap`) and then scrolling until a buffer header element is drawn behind the horizontal scrollbar, noticing how we're now able to see it's content through the scrollbar's track, as shown in the screenshot in the "Showcase" section.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

| Before | After |
|--------|------|
| ![](https://github.com/user-attachments/assets/0b9feaba-0576-4523-a388-89c09a733938) | ![](https://github.com/user-attachments/assets/4550b901-e3f7-4713-b6a0-0f9a15417f3a) |
  
Notice how, before, when the horizontal scrollbar overlaps the buffer header, there's a full white background instead of the transparent one we're used to seeing in the vertical scrollbars.

With these changes, we no longer subtract the scrollbar's width from the `ContentMask` applied at paint time. This lets the buffer headers render into the scrollbar track, so now they show through.

## Known Limitations

Even though this fixes the paint issue, there's still a smaller issue with regards to hitboxes. Even though the scrollbars are only painted in the text area of the editor, it's hitbox spans the whole width of the editor, preventing clicks in the gutter and buffer header even where the scrollbar track or thumb is not painted. This is an issue that is also present without these changes, so probably not worth the effort to try and improve on.

---

Release Notes:

- Improved split editor horizontal scrollbars so buffer headers show through the scrollbar track, matching vertical scrollbars.
