### PR TITLE
ci: Publish static bubblewrap in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -440,6 +440,74 @@ jobs:
         path: target/zed-remote-server-linux-x86_64.gz
         if-no-files-found: error
     timeout-minutes: 60
+  build_static_bwrap_linux_aarch64:
+    needs:
+    - run_tests_linux
+    - clippy_linux
+    - check_scripts
+    runs-on: namespace-profile-8x32-ubuntu-2004-arm-m4
+    steps:
+    - name: steps::cache_nix_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
+      with:
+        cache: nix
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad
+      with:
+        name: zed
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        cachixArgs: -v
+    - name: run_bundling::build_static_bwrap
+      run: nix build nixpkgs#pkgsStatic.bubblewrap -L
+    - name: run_bundling::build_static_bwrap
+      run: |
+        cp result/bin/bwrap bwrap-linux-aarch64
+        chmod 755 bwrap-linux-aarch64
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-aarch64
+        path: bwrap-linux-aarch64
+        if-no-files-found: error
+    timeout-minutes: 60
+  build_static_bwrap_linux_x86_64:
+    needs:
+    - run_tests_linux
+    - clippy_linux
+    - check_scripts
+    runs-on: namespace-profile-32x64-ubuntu-2004
+    steps:
+    - name: steps::cache_nix_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
+      with:
+        cache: nix
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad
+      with:
+        name: zed
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        cachixArgs: -v
+    - name: run_bundling::build_static_bwrap
+      run: nix build nixpkgs#pkgsStatic.bubblewrap -L
+    - name: run_bundling::build_static_bwrap
+      run: |
+        cp result/bin/bwrap bwrap-linux-x86_64
+        chmod 755 bwrap-linux-x86_64
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-x86_64
+        path: bwrap-linux-x86_64
+        if-no-files-found: error
+    timeout-minutes: 60
   bundle_mac_aarch64:
     needs:
     - run_tests_mac
@@ -641,6 +709,8 @@ jobs:
     - create_draft_release
     - bundle_linux_aarch64
     - bundle_linux_x86_64
+    - build_static_bwrap_linux_aarch64
+    - build_static_bwrap_linux_x86_64
     - bundle_mac_aarch64
     - bundle_mac_x86_64
     - bundle_windows_aarch64
@@ -661,6 +731,8 @@ jobs:
         mv ./artifacts/Zed-x86_64.dmg/Zed-x86_64.dmg release-artifacts/Zed-x86_64.dmg
         mv ./artifacts/zed-linux-aarch64.tar.gz/zed-linux-aarch64.tar.gz release-artifacts/zed-linux-aarch64.tar.gz
         mv ./artifacts/zed-linux-x86_64.tar.gz/zed-linux-x86_64.tar.gz release-artifacts/zed-linux-x86_64.tar.gz
+        mv ./artifacts/bwrap-linux-aarch64/bwrap-linux-aarch64 release-artifacts/bwrap-linux-aarch64
+        mv ./artifacts/bwrap-linux-x86_64/bwrap-linux-x86_64 release-artifacts/bwrap-linux-x86_64
         mv ./artifacts/Zed-x86_64.exe/Zed-x86_64.exe release-artifacts/Zed-x86_64.exe
         mv ./artifacts/Zed-aarch64.exe/Zed-aarch64.exe release-artifacts/Zed-aarch64.exe
         mv ./artifacts/zed-remote-server-macos-aarch64.gz/zed-remote-server-macos-aarch64.gz release-artifacts/zed-remote-server-macos-aarch64.gz
@@ -680,7 +752,7 @@ jobs:
     steps:
     - name: release::validate_release_assets
       run: |
-        EXPECTED_ASSETS='["Zed-aarch64.dmg", "Zed-x86_64.dmg", "zed-linux-aarch64.tar.gz", "zed-linux-x86_64.tar.gz", "Zed-x86_64.exe", "Zed-aarch64.exe", "zed-remote-server-macos-aarch64.gz", "zed-remote-server-macos-x86_64.gz", "zed-remote-server-linux-aarch64.gz", "zed-remote-server-linux-x86_64.gz", "zed-remote-server-windows-aarch64.zip", "zed-remote-server-windows-x86_64.zip"]'
+        EXPECTED_ASSETS='["Zed-aarch64.dmg", "Zed-x86_64.dmg", "zed-linux-aarch64.tar.gz", "zed-linux-x86_64.tar.gz", "bwrap-linux-aarch64", "bwrap-linux-x86_64", "Zed-x86_64.exe", "Zed-aarch64.exe", "zed-remote-server-macos-aarch64.gz", "zed-remote-server-macos-x86_64.gz", "zed-remote-server-linux-aarch64.gz", "zed-remote-server-linux-x86_64.gz", "zed-remote-server-windows-aarch64.zip", "zed-remote-server-windows-x86_64.zip"]'
         TAG="$GITHUB_REF_NAME"
 
         ACTUAL_ASSETS=$(gh release view "$TAG" --repo=zed-industries/zed --json assets -q '[.assets[].name]')
@@ -821,6 +893,8 @@ jobs:
     - check_scripts
     - bundle_linux_aarch64
     - bundle_linux_x86_64
+    - build_static_bwrap_linux_aarch64
+    - build_static_bwrap_linux_x86_64
     - bundle_mac_aarch64
     - bundle_mac_x86_64
     - bundle_windows_aarch64
@@ -848,6 +922,8 @@ jobs:
                 if [ "$RESULT_CHECK_SCRIPTS" == "failure" ];then FAILED_JOBS="$FAILED_JOBS check_scripts"; fi
                 if [ "$RESULT_BUNDLE_LINUX_AARCH64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_linux_aarch64"; fi
                 if [ "$RESULT_BUNDLE_LINUX_X86_64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_linux_x86_64"; fi
+                if [ "$RESULT_BUILD_STATIC_BWRAP_LINUX_AARCH64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS build_static_bwrap_linux_aarch64"; fi
+                if [ "$RESULT_BUILD_STATIC_BWRAP_LINUX_X86_64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS build_static_bwrap_linux_x86_64"; fi
                 if [ "$RESULT_BUNDLE_MAC_AARCH64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_mac_aarch64"; fi
                 if [ "$RESULT_BUNDLE_MAC_X86_64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_mac_x86_64"; fi
                 if [ "$RESULT_BUNDLE_WINDOWS_AARCH64" == "failure" ];then FAILED_JOBS="$FAILED_JOBS bundle_windows_aarch64"; fi
@@ -900,6 +976,8 @@ jobs:
         RESULT_CHECK_SCRIPTS: ${{ needs.check_scripts.result }}
         RESULT_BUNDLE_LINUX_AARCH64: ${{ needs.bundle_linux_aarch64.result }}
         RESULT_BUNDLE_LINUX_X86_64: ${{ needs.bundle_linux_x86_64.result }}
+        RESULT_BUILD_STATIC_BWRAP_LINUX_AARCH64: ${{ needs.build_static_bwrap_linux_aarch64.result }}
+        RESULT_BUILD_STATIC_BWRAP_LINUX_X86_64: ${{ needs.build_static_bwrap_linux_x86_64.result }}
         RESULT_BUNDLE_MAC_AARCH64: ${{ needs.bundle_mac_aarch64.result }}
         RESULT_BUNDLE_MAC_X86_64: ${{ needs.bundle_mac_x86_64.result }}
         RESULT_BUNDLE_WINDOWS_AARCH64: ${{ needs.bundle_windows_aarch64.result }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,11 +467,12 @@ jobs:
       run: |
         cp result/bin/bwrap bwrap-linux-aarch64
         chmod 755 bwrap-linux-aarch64
+        gzip -f --stdout --best bwrap-linux-aarch64 > bwrap-linux-aarch64.gz
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
-        name: bwrap-linux-aarch64
-        path: bwrap-linux-aarch64
+        name: bwrap-linux-aarch64.gz
+        path: bwrap-linux-aarch64.gz
         if-no-files-found: error
     timeout-minutes: 60
   build_static_bwrap_linux_x86_64:
@@ -501,11 +502,12 @@ jobs:
       run: |
         cp result/bin/bwrap bwrap-linux-x86_64
         chmod 755 bwrap-linux-x86_64
+        gzip -f --stdout --best bwrap-linux-x86_64 > bwrap-linux-x86_64.gz
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
-        name: bwrap-linux-x86_64
-        path: bwrap-linux-x86_64
+        name: bwrap-linux-x86_64.gz
+        path: bwrap-linux-x86_64.gz
         if-no-files-found: error
     timeout-minutes: 60
   bundle_mac_aarch64:
@@ -731,8 +733,8 @@ jobs:
         mv ./artifacts/Zed-x86_64.dmg/Zed-x86_64.dmg release-artifacts/Zed-x86_64.dmg
         mv ./artifacts/zed-linux-aarch64.tar.gz/zed-linux-aarch64.tar.gz release-artifacts/zed-linux-aarch64.tar.gz
         mv ./artifacts/zed-linux-x86_64.tar.gz/zed-linux-x86_64.tar.gz release-artifacts/zed-linux-x86_64.tar.gz
-        mv ./artifacts/bwrap-linux-aarch64/bwrap-linux-aarch64 release-artifacts/bwrap-linux-aarch64
-        mv ./artifacts/bwrap-linux-x86_64/bwrap-linux-x86_64 release-artifacts/bwrap-linux-x86_64
+        mv ./artifacts/bwrap-linux-aarch64.gz/bwrap-linux-aarch64.gz release-artifacts/bwrap-linux-aarch64.gz
+        mv ./artifacts/bwrap-linux-x86_64.gz/bwrap-linux-x86_64.gz release-artifacts/bwrap-linux-x86_64.gz
         mv ./artifacts/Zed-x86_64.exe/Zed-x86_64.exe release-artifacts/Zed-x86_64.exe
         mv ./artifacts/Zed-aarch64.exe/Zed-aarch64.exe release-artifacts/Zed-aarch64.exe
         mv ./artifacts/zed-remote-server-macos-aarch64.gz/zed-remote-server-macos-aarch64.gz release-artifacts/zed-remote-server-macos-aarch64.gz
@@ -752,7 +754,7 @@ jobs:
     steps:
     - name: release::validate_release_assets
       run: |
-        EXPECTED_ASSETS='["Zed-aarch64.dmg", "Zed-x86_64.dmg", "zed-linux-aarch64.tar.gz", "zed-linux-x86_64.tar.gz", "bwrap-linux-aarch64", "bwrap-linux-x86_64", "Zed-x86_64.exe", "Zed-aarch64.exe", "zed-remote-server-macos-aarch64.gz", "zed-remote-server-macos-x86_64.gz", "zed-remote-server-linux-aarch64.gz", "zed-remote-server-linux-x86_64.gz", "zed-remote-server-windows-aarch64.zip", "zed-remote-server-windows-x86_64.zip"]'
+        EXPECTED_ASSETS='["Zed-aarch64.dmg", "Zed-x86_64.dmg", "zed-linux-aarch64.tar.gz", "zed-linux-x86_64.tar.gz", "bwrap-linux-aarch64.gz", "bwrap-linux-x86_64.gz", "Zed-x86_64.exe", "Zed-aarch64.exe", "zed-remote-server-macos-aarch64.gz", "zed-remote-server-macos-x86_64.gz", "zed-remote-server-linux-aarch64.gz", "zed-remote-server-linux-x86_64.gz", "zed-remote-server-windows-aarch64.zip", "zed-remote-server-windows-x86_64.zip"]'
         TAG="$GITHUB_REF_NAME"
 
         ACTUAL_ASSETS=$(gh release view "$TAG" --repo=zed-industries/zed --json assets -q '[.assets[].name]')

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -212,11 +212,12 @@ jobs:
       run: |
         cp result/bin/bwrap bwrap-linux-aarch64
         chmod 755 bwrap-linux-aarch64
+        gzip -f --stdout --best bwrap-linux-aarch64 > bwrap-linux-aarch64.gz
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
-        name: bwrap-linux-aarch64
-        path: bwrap-linux-aarch64
+        name: bwrap-linux-aarch64.gz
+        path: bwrap-linux-aarch64.gz
         if-no-files-found: error
     timeout-minutes: 60
   build_static_bwrap_linux_x86_64:
@@ -244,11 +245,12 @@ jobs:
       run: |
         cp result/bin/bwrap bwrap-linux-x86_64
         chmod 755 bwrap-linux-x86_64
+        gzip -f --stdout --best bwrap-linux-x86_64 > bwrap-linux-x86_64.gz
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
-        name: bwrap-linux-x86_64
-        path: bwrap-linux-x86_64
+        name: bwrap-linux-x86_64.gz
+        path: bwrap-linux-x86_64.gz
         if-no-files-found: error
     timeout-minutes: 60
   bundle_mac_aarch64:
@@ -587,8 +589,8 @@ jobs:
         mv ./artifacts/Zed-x86_64.dmg/Zed-x86_64.dmg release-artifacts/Zed-x86_64.dmg
         mv ./artifacts/zed-linux-aarch64.tar.gz/zed-linux-aarch64.tar.gz release-artifacts/zed-linux-aarch64.tar.gz
         mv ./artifacts/zed-linux-x86_64.tar.gz/zed-linux-x86_64.tar.gz release-artifacts/zed-linux-x86_64.tar.gz
-        mv ./artifacts/bwrap-linux-aarch64/bwrap-linux-aarch64 release-artifacts/bwrap-linux-aarch64
-        mv ./artifacts/bwrap-linux-x86_64/bwrap-linux-x86_64 release-artifacts/bwrap-linux-x86_64
+        mv ./artifacts/bwrap-linux-aarch64.gz/bwrap-linux-aarch64.gz release-artifacts/bwrap-linux-aarch64.gz
+        mv ./artifacts/bwrap-linux-x86_64.gz/bwrap-linux-x86_64.gz release-artifacts/bwrap-linux-x86_64.gz
         mv ./artifacts/Zed-x86_64.exe/Zed-x86_64.exe release-artifacts/Zed-x86_64.exe
         mv ./artifacts/Zed-aarch64.exe/Zed-aarch64.exe release-artifacts/Zed-aarch64.exe
         mv ./artifacts/zed-remote-server-macos-aarch64.gz/zed-remote-server-macos-aarch64.gz release-artifacts/zed-remote-server-macos-aarch64.gz

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -187,6 +187,70 @@ jobs:
         path: target/zed-remote-server-linux-x86_64.gz
         if-no-files-found: error
     timeout-minutes: 60
+  build_static_bwrap_linux_aarch64:
+    needs:
+    - run_tests_linux
+    runs-on: namespace-profile-8x32-ubuntu-2004-arm-m4
+    steps:
+    - name: steps::cache_nix_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
+      with:
+        cache: nix
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad
+      with:
+        name: zed
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        cachixArgs: -v
+    - name: run_bundling::build_static_bwrap
+      run: nix build nixpkgs#pkgsStatic.bubblewrap -L
+    - name: run_bundling::build_static_bwrap
+      run: |
+        cp result/bin/bwrap bwrap-linux-aarch64
+        chmod 755 bwrap-linux-aarch64
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-aarch64
+        path: bwrap-linux-aarch64
+        if-no-files-found: error
+    timeout-minutes: 60
+  build_static_bwrap_linux_x86_64:
+    needs:
+    - run_tests_linux
+    runs-on: namespace-profile-32x64-ubuntu-2004
+    steps:
+    - name: steps::cache_nix_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
+      with:
+        cache: nix
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad
+      with:
+        name: zed
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        cachixArgs: -v
+    - name: run_bundling::build_static_bwrap
+      run: nix build nixpkgs#pkgsStatic.bubblewrap -L
+    - name: run_bundling::build_static_bwrap
+      run: |
+        cp result/bin/bwrap bwrap-linux-x86_64
+        chmod 755 bwrap-linux-x86_64
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-x86_64
+        path: bwrap-linux-x86_64
+        if-no-files-found: error
+    timeout-minutes: 60
   bundle_mac_aarch64:
     needs:
     - run_tests_linux
@@ -488,6 +552,8 @@ jobs:
     needs:
     - bundle_linux_aarch64
     - bundle_linux_x86_64
+    - build_static_bwrap_linux_aarch64
+    - build_static_bwrap_linux_x86_64
     - bundle_mac_aarch64
     - bundle_mac_x86_64
     - bundle_windows_aarch64
@@ -521,6 +587,8 @@ jobs:
         mv ./artifacts/Zed-x86_64.dmg/Zed-x86_64.dmg release-artifacts/Zed-x86_64.dmg
         mv ./artifacts/zed-linux-aarch64.tar.gz/zed-linux-aarch64.tar.gz release-artifacts/zed-linux-aarch64.tar.gz
         mv ./artifacts/zed-linux-x86_64.tar.gz/zed-linux-x86_64.tar.gz release-artifacts/zed-linux-x86_64.tar.gz
+        mv ./artifacts/bwrap-linux-aarch64/bwrap-linux-aarch64 release-artifacts/bwrap-linux-aarch64
+        mv ./artifacts/bwrap-linux-x86_64/bwrap-linux-x86_64 release-artifacts/bwrap-linux-x86_64
         mv ./artifacts/Zed-x86_64.exe/Zed-x86_64.exe release-artifacts/Zed-x86_64.exe
         mv ./artifacts/Zed-aarch64.exe/Zed-aarch64.exe release-artifacts/Zed-aarch64.exe
         mv ./artifacts/zed-remote-server-macos-aarch64.gz/zed-remote-server-macos-aarch64.gz release-artifacts/zed-remote-server-macos-aarch64.gz
@@ -559,6 +627,8 @@ jobs:
     needs:
     - bundle_linux_aarch64
     - bundle_linux_x86_64
+    - build_static_bwrap_linux_aarch64
+    - build_static_bwrap_linux_x86_64
     - bundle_mac_aarch64
     - bundle_mac_x86_64
     - bundle_windows_aarch64

--- a/.github/workflows/run_bundling.yml
+++ b/.github/workflows/run_bundling.yml
@@ -98,6 +98,66 @@ jobs:
         path: target/zed-remote-server-linux-x86_64.gz
         if-no-files-found: error
     timeout-minutes: 60
+  build_static_bwrap_linux_aarch64:
+    runs-on: namespace-profile-8x32-ubuntu-2004-arm-m4
+    steps:
+    - name: steps::cache_nix_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
+      with:
+        cache: nix
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad
+      with:
+        name: zed
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        cachixArgs: -v
+    - name: run_bundling::build_static_bwrap
+      run: nix build nixpkgs#pkgsStatic.bubblewrap -L
+    - name: run_bundling::build_static_bwrap
+      run: |
+        cp result/bin/bwrap bwrap-linux-aarch64
+        chmod 755 bwrap-linux-aarch64
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-aarch64
+        path: bwrap-linux-aarch64
+        if-no-files-found: error
+    timeout-minutes: 60
+  build_static_bwrap_linux_x86_64:
+    runs-on: namespace-profile-32x64-ubuntu-2004
+    steps:
+    - name: steps::cache_nix_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
+      with:
+        cache: nix
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: run_bundling::build_static_bwrap
+      uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad
+      with:
+        name: zed
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        cachixArgs: -v
+    - name: run_bundling::build_static_bwrap
+      run: nix build nixpkgs#pkgsStatic.bubblewrap -L
+    - name: run_bundling::build_static_bwrap
+      run: |
+        cp result/bin/bwrap bwrap-linux-x86_64
+        chmod 755 bwrap-linux-x86_64
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-x86_64
+        path: bwrap-linux-x86_64
+        if-no-files-found: error
+    timeout-minutes: 60
   bundle_mac_aarch64:
     if: |-
       (github.event.action == 'labeled' && github.event.label.name == 'run-bundling') ||

--- a/.github/workflows/run_bundling.yml
+++ b/.github/workflows/run_bundling.yml
@@ -121,11 +121,12 @@ jobs:
       run: |
         cp result/bin/bwrap bwrap-linux-aarch64
         chmod 755 bwrap-linux-aarch64
+        gzip -f --stdout --best bwrap-linux-aarch64 > bwrap-linux-aarch64.gz
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
-        name: bwrap-linux-aarch64
-        path: bwrap-linux-aarch64
+        name: bwrap-linux-aarch64.gz
+        path: bwrap-linux-aarch64.gz
         if-no-files-found: error
     timeout-minutes: 60
   build_static_bwrap_linux_x86_64:
@@ -151,11 +152,12 @@ jobs:
       run: |
         cp result/bin/bwrap bwrap-linux-x86_64
         chmod 755 bwrap-linux-x86_64
+        gzip -f --stdout --best bwrap-linux-x86_64 > bwrap-linux-x86_64.gz
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
-        name: bwrap-linux-x86_64
-        path: bwrap-linux-x86_64
+        name: bwrap-linux-x86_64.gz
+        path: bwrap-linux-x86_64.gz
         if-no-files-found: error
     timeout-minutes: 60
   bundle_mac_aarch64:

--- a/tooling/xtask/src/tasks/workflows/release.rs
+++ b/tooling/xtask/src/tasks/workflows/release.rs
@@ -2,7 +2,7 @@ use gh_workflow::{Event, Expression, Level, Push, Run, Step, Use, Workflow, ctx:
 use indoc::formatdoc;
 
 use crate::tasks::workflows::{
-    run_bundling::{bundle_linux, bundle_mac, bundle_windows, upload_artifact},
+    run_bundling::{build_static_bwrap, bundle_linux, bundle_mac, bundle_windows, upload_artifact},
     run_tests,
     runners::{self, Arch, Platform},
     steps::{
@@ -36,6 +36,14 @@ pub(crate) fn release() -> Workflow {
         linux_x86_64: bundle_linux(
             Arch::X86_64,
             None,
+            &[&linux_tests, &linux_clippy, &check_scripts],
+        ),
+        bwrap_linux_aarch64: build_static_bwrap(
+            Arch::AARCH64,
+            &[&linux_tests, &linux_clippy, &check_scripts],
+        ),
+        bwrap_linux_x86_64: build_static_bwrap(
+            Arch::X86_64,
             &[&linux_tests, &linux_clippy, &check_scripts],
         ),
         mac_aarch64: bundle_mac(
@@ -123,6 +131,8 @@ pub(crate) fn release() -> Workflow {
 pub(crate) struct ReleaseBundleJobs {
     pub linux_aarch64: NamedJob,
     pub linux_x86_64: NamedJob,
+    pub bwrap_linux_aarch64: NamedJob,
+    pub bwrap_linux_x86_64: NamedJob,
     pub mac_aarch64: NamedJob,
     pub mac_x86_64: NamedJob,
     pub windows_aarch64: NamedJob,
@@ -134,6 +144,8 @@ impl ReleaseBundleJobs {
         vec![
             &self.linux_aarch64,
             &self.linux_x86_64,
+            &self.bwrap_linux_aarch64,
+            &self.bwrap_linux_x86_64,
             &self.mac_aarch64,
             &self.mac_x86_64,
             &self.windows_aarch64,
@@ -145,6 +157,8 @@ impl ReleaseBundleJobs {
         vec![
             self.linux_aarch64,
             self.linux_x86_64,
+            self.bwrap_linux_aarch64,
+            self.bwrap_linux_x86_64,
             self.mac_aarch64,
             self.mac_x86_64,
             self.windows_aarch64,

--- a/tooling/xtask/src/tasks/workflows/release_nightly.rs
+++ b/tooling/xtask/src/tasks/workflows/release_nightly.rs
@@ -4,7 +4,7 @@ use crate::tasks::workflows::{
         ReleaseBundleJobs, create_sentry_release, download_workflow_artifacts, notify_on_failure,
         prep_release_artifacts,
     },
-    run_bundling::{bundle_linux, bundle_mac, bundle_windows},
+    run_bundling::{build_static_bwrap, bundle_linux, bundle_mac, bundle_windows},
     run_tests::run_platform_tests_no_filter,
     runners::{Arch, Platform, ReleaseChannel},
     steps::{
@@ -33,6 +33,8 @@ pub fn release_nightly() -> Workflow {
     let bundle = ReleaseBundleJobs {
         linux_aarch64: bundle_linux(Arch::AARCH64, NIGHTLY, &[&tests]),
         linux_x86_64: bundle_linux(Arch::X86_64, NIGHTLY, &[&tests]),
+        bwrap_linux_aarch64: build_static_bwrap(Arch::AARCH64, &[&tests]),
+        bwrap_linux_x86_64: build_static_bwrap(Arch::X86_64, &[&tests]),
         mac_aarch64: bundle_mac(Arch::AARCH64, NIGHTLY, &[&tests]),
         mac_x86_64: bundle_mac(Arch::X86_64, NIGHTLY, &[&tests]),
         windows_aarch64: bundle_windows(Arch::AARCH64, NIGHTLY, &[&tests]),

--- a/tooling/xtask/src/tasks/workflows/run_bundling.rs
+++ b/tooling/xtask/src/tasks/workflows/run_bundling.rs
@@ -4,7 +4,7 @@ use crate::tasks::workflows::{
     release::ReleaseBundleJobs,
     runners::{Arch, Platform, ReleaseChannel},
     steps::{FluentBuilder, IfNoFilesFound, NamedJob, UploadArtifactStep, dependant_job, named},
-    vars::{assets, bundle_envs},
+    vars::{self, assets, bundle_envs},
 };
 
 use super::{runners, steps};
@@ -15,6 +15,8 @@ pub fn run_bundling() -> Workflow {
     let bundle = ReleaseBundleJobs {
         linux_aarch64: bundle_linux(Arch::AARCH64, None, &[]),
         linux_x86_64: bundle_linux(Arch::X86_64, None, &[]),
+        bwrap_linux_aarch64: build_static_bwrap(Arch::AARCH64, &[]),
+        bwrap_linux_x86_64: build_static_bwrap(Arch::X86_64, &[]),
         mac_aarch64: bundle_mac(Arch::AARCH64, None, &[]),
         mac_x86_64: bundle_mac(Arch::X86_64, None, &[]),
         windows_aarch64: bundle_windows(Arch::AARCH64, None, &[]),
@@ -95,6 +97,49 @@ pub fn upload_artifact(path: &str) -> UploadArtifactStep {
     let name = Path::new(path).file_name().unwrap().to_str().unwrap();
     steps::upload_artifact(name, path).if_no_files_found(IfNoFilesFound::Error)
 }
+
+pub(crate) fn build_static_bwrap(arch: Arch, deps: &[&NamedJob]) -> NamedJob {
+    let artifact_name = match arch {
+        Arch::X86_64 => assets::BWRAP_LINUX_X86_64,
+        Arch::AARCH64 => assets::BWRAP_LINUX_AARCH64,
+    };
+    let copy_artifact = indoc::formatdoc! {r#"
+        cp result/bin/bwrap {artifact_name}
+        chmod 755 {artifact_name}
+    "#};
+
+    NamedJob {
+        name: format!("build_static_bwrap_linux_{arch}"),
+        job: dependant_job(deps)
+            .runs_on(arch.linux_bundler())
+            .timeout_minutes(60u32)
+            .add_step(steps::cache_nix_dependencies_namespace())
+            .add_step(
+                named::uses(
+                    "cachix",
+                    "install-nix-action",
+                    "02a151ada4993995686f9ed4f1be7cfbb229e56f", // v31
+                )
+                .add_with(("github_access_token", vars::GITHUB_TOKEN)),
+            )
+            .add_step(
+                named::uses(
+                    "cachix",
+                    "cachix-action",
+                    "0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad", // v16
+                )
+                .add_with(("name", "zed"))
+                .add_with(("authToken", vars::CACHIX_AUTH_TOKEN))
+                .add_with(("cachixArgs", "-v")),
+            )
+            .add_step(named::bash("nix build nixpkgs#pkgsStatic.bubblewrap -L"))
+            .add_step(named::bash(&copy_artifact))
+            .add_step(upload_artifact(artifact_name)),
+    }
+}
+
+// https://cloud.zed.dev/releases/nightly/latest/asset?os=linux&arch=x86_64&asset=bwrap
+
 
 pub(crate) fn bundle_linux(
     arch: Arch,

--- a/tooling/xtask/src/tasks/workflows/run_bundling.rs
+++ b/tooling/xtask/src/tasks/workflows/run_bundling.rs
@@ -103,9 +103,13 @@ pub(crate) fn build_static_bwrap(arch: Arch, deps: &[&NamedJob]) -> NamedJob {
         Arch::X86_64 => assets::BWRAP_LINUX_X86_64,
         Arch::AARCH64 => assets::BWRAP_LINUX_AARCH64,
     };
+    let binary_name = artifact_name
+        .strip_suffix(".gz")
+        .expect("static bwrap artifact name should end in .gz");
     let copy_artifact = indoc::formatdoc! {r#"
-        cp result/bin/bwrap {artifact_name}
-        chmod 755 {artifact_name}
+        cp result/bin/bwrap {binary_name}
+        chmod 755 {binary_name}
+        gzip -f --stdout --best {binary_name} > {artifact_name}
     "#};
 
     NamedJob {
@@ -137,9 +141,6 @@ pub(crate) fn build_static_bwrap(arch: Arch, deps: &[&NamedJob]) -> NamedJob {
             .add_step(upload_artifact(artifact_name)),
     }
 }
-
-// https://cloud.zed.dev/releases/nightly/latest/asset?os=linux&arch=x86_64&asset=bwrap
-
 
 pub(crate) fn bundle_linux(
     arch: Arch,

--- a/tooling/xtask/src/tasks/workflows/vars.rs
+++ b/tooling/xtask/src/tasks/workflows/vars.rs
@@ -374,8 +374,8 @@ pub mod assets {
     pub const MAC_X86_64: &str = "Zed-x86_64.dmg";
     pub const LINUX_AARCH64: &str = "zed-linux-aarch64.tar.gz";
     pub const LINUX_X86_64: &str = "zed-linux-x86_64.tar.gz";
-    pub const BWRAP_LINUX_AARCH64: &str = "bwrap-linux-aarch64";
-    pub const BWRAP_LINUX_X86_64: &str = "bwrap-linux-x86_64";
+    pub const BWRAP_LINUX_AARCH64: &str = "bwrap-linux-aarch64.gz";
+    pub const BWRAP_LINUX_X86_64: &str = "bwrap-linux-x86_64.gz";
     pub const WINDOWS_X86_64: &str = "Zed-x86_64.exe";
     pub const WINDOWS_AARCH64: &str = "Zed-aarch64.exe";
 

--- a/tooling/xtask/src/tasks/workflows/vars.rs
+++ b/tooling/xtask/src/tasks/workflows/vars.rs
@@ -374,6 +374,8 @@ pub mod assets {
     pub const MAC_X86_64: &str = "Zed-x86_64.dmg";
     pub const LINUX_AARCH64: &str = "zed-linux-aarch64.tar.gz";
     pub const LINUX_X86_64: &str = "zed-linux-x86_64.tar.gz";
+    pub const BWRAP_LINUX_AARCH64: &str = "bwrap-linux-aarch64";
+    pub const BWRAP_LINUX_X86_64: &str = "bwrap-linux-x86_64";
     pub const WINDOWS_X86_64: &str = "Zed-x86_64.exe";
     pub const WINDOWS_AARCH64: &str = "Zed-aarch64.exe";
 
@@ -390,6 +392,8 @@ pub mod assets {
             MAC_X86_64,
             LINUX_AARCH64,
             LINUX_X86_64,
+            BWRAP_LINUX_AARCH64,
+            BWRAP_LINUX_X86_64,
             WINDOWS_X86_64,
             WINDOWS_AARCH64,
             REMOTE_SERVER_MAC_AARCH64,


### PR DESCRIPTION
Adds a step to the release and run_bundling workflows to build a statically-linked bubblewrap binary and upload it

---

Release Notes:

- N/A or Added/Fixed/Improved ...
