### PR TITLE
project_panel: Add expand/collapse folder buttons to root entries

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -929,6 +929,7 @@
       "left": "project_panel::CollapseSelectedEntry",
       "ctrl-left": "project_panel::CollapseAllEntries",
       "right": "project_panel::ExpandSelectedEntry",
+      "ctrl-right": "project_panel::ExpandAllEntries",
       "new": "project_panel::NewFile",
       "ctrl-n": "project_panel::NewFile",
       "alt-new": "project_panel::NewDirectory",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -986,6 +986,7 @@
       "left": "project_panel::CollapseSelectedEntry",
       "cmd-left": "project_panel::CollapseAllEntries",
       "right": "project_panel::ExpandSelectedEntry",
+      "cmd-right": "project_panel::ExpandAllEntries",
       "cmd-n": "project_panel::NewFile",
       "cmd-d": "project_panel::Duplicate",
       "alt-cmd-n": "project_panel::NewDirectory",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -930,6 +930,7 @@
       "left": "project_panel::CollapseSelectedEntry",
       "ctrl-left": "project_panel::CollapseAllEntries",
       "right": "project_panel::ExpandSelectedEntry",
+      "ctrl-right": "project_panel::ExpandAllEntries",
       "ctrl-n": "project_panel::NewFile",
       "alt-n": "project_panel::NewDirectory",
       "ctrl-x": "project_panel::Cut",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -861,6 +861,8 @@
     "diagnostic_badges": false,
     // Whether to show the git status indicator next to file names in the project panel.
     "git_status_indicator": false,
+    // Whether to show expand/collapse all buttons at the top of the project panel.
+    "show_expand_collapse_buttons": true,
     // Whether to enable drag-and-drop operations in the project panel.
     "drag_and_drop": true,
     // Whether to hide the root entry when only one folder is open in the window;

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -60,10 +60,11 @@ use std::{
 };
 use theme_settings::ThemeSettings;
 use ui::{
-    Color, ContextMenu, ContextMenuEntry, DecoratedIcon, Icon, IconDecoration, IconDecorationKind,
-    IndentGuideColors, IndentGuideLayout, Indicator, KeyBinding, Label, LabelSize, ListItem,
-    ListItemSpacing, ProjectEmptyState, ScrollAxes, ScrollableHandle, Scrollbars, StickyCandidate,
-    Tooltip, WithScrollbar, prelude::*, v_flex,
+    Color, ContextMenu, ContextMenuEntry, DecoratedIcon, Icon, IconButton, IconDecoration,
+    IconDecorationKind, IconName, IconSize, IndentGuideColors, IndentGuideLayout, Indicator,
+    KeyBinding, Label, LabelSize, ListItem, ListItemSpacing, ProjectEmptyState, ScrollAxes,
+    ScrollableHandle, Scrollbars, StickyCandidate, Tooltip, WithScrollbar, prelude::*,
+    v_flex,
 };
 use util::{
     ResultExt, TakeUntilExt, TryFutureExt,
@@ -341,6 +342,8 @@ actions!(
         CollapseSelectedEntryAndChildren,
         /// Collapses all entries in the project tree.
         CollapseAllEntries,
+        /// Expands all entries in the project tree.
+        ExpandAllEntries,
         /// Creates a new directory.
         NewDirectory,
         /// Creates a new file.
@@ -495,6 +498,14 @@ pub fn init(cx: &mut App) {
             if let Some(panel) = workspace.panel::<ProjectPanel>(cx) {
                 panel.update(cx, |panel, cx| {
                     panel.collapse_all_entries(action, window, cx);
+                });
+            }
+        });
+
+        workspace.register_action(|workspace, action: &ExpandAllEntries, window, cx| {
+            if let Some(panel) = workspace.panel::<ProjectPanel>(cx) {
+                panel.update(cx, |panel, cx| {
+                    panel.expand_all_entries(action, window, cx);
                 });
             }
         });
@@ -1473,6 +1484,35 @@ impl ProjectPanel {
                     None => *expanded_entries = Default::default(),
                 };
             });
+
+        self.update_visible_entries(None, false, false, window, cx);
+        cx.notify();
+    }
+
+    fn expand_all_entries(
+        &mut self,
+        _: &ExpandAllEntries,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let project = self.project.read(cx);
+
+        for worktree in project.visible_worktrees(cx) {
+            let worktree = worktree.read(cx);
+            let worktree_id = worktree.id();
+            let worktree_snapshot = worktree.snapshot();
+
+            let mut directory_ids: Vec<ProjectEntryId> = worktree_snapshot
+                .entries(false, 0)
+                .filter(|entry| entry.is_dir())
+                .map(|entry| entry.id)
+                .collect();
+            directory_ids.sort();
+
+            self.state
+                .expanded_dir_ids
+                .insert(worktree_id, directory_ids);
+        }
 
         self.update_visible_entries(None, false, false, window, cx);
         cx.notify();
@@ -5848,7 +5888,8 @@ impl ProjectPanel {
                     .when(
                         canonical_path.is_some()
                             || diagnostic_count.is_some()
-                            || git_indicator.is_some(),
+                            || git_indicator.is_some()
+                            || (details.depth == 0 && settings.show_expand_collapse_buttons),
                         |this| {
                             let symlink_element = canonical_path.map(|path| {
                                 div()
@@ -5872,6 +5913,71 @@ impl ProjectPanel {
                                     .gap_1()
                                     .flex_none()
                                     .pr_3()
+                                    .when(details.depth == 0 && settings.show_expand_collapse_buttons, |this| {
+                                        let worktree_proto = details.worktree_id.to_proto();
+                                        let entry_proto = entry_id.to_proto();
+                                        this.child(
+                                            IconButton::new(
+                                                format!("collapse-all-{worktree_proto}-{entry_proto}"),
+                                                IconName::ListCollapse,
+                                            )
+                                                .icon_size(IconSize::Small)
+                                                .tooltip(Tooltip::text("Collapse Folder"))
+                                                .on_click(cx.listener({
+                                                    let worktree_id = details.worktree_id;
+                                                    move |this, _, window, cx| {
+                                                        this.collapse_all_for_entry(
+                                                            worktree_id,
+                                                            entry_id,
+                                                            cx,
+                                                        );
+                                                        if let Some(expanded_dir_ids) =
+                                                            this.state.expanded_dir_ids.get_mut(&worktree_id)
+                                                        {
+                                                            if let Err(ix) =
+                                                                expanded_dir_ids.binary_search(&entry_id)
+                                                            {
+                                                                expanded_dir_ids.insert(ix, entry_id);
+                                                            }
+                                                        }
+                                                        this.update_visible_entries(
+                                                            None,
+                                                            false,
+                                                            false,
+                                                            window,
+                                                            cx,
+                                                        );
+                                                        cx.notify();
+                                                    }
+                                                })),
+                                        )
+                                        .child(
+                                            IconButton::new(
+                                                format!("expand-all-{worktree_proto}-{entry_proto}"),
+                                                IconName::ListTree,
+                                            )
+                                                .icon_size(IconSize::Small)
+                                                .tooltip(Tooltip::text("Expand Folder"))
+                                                .on_click(cx.listener({
+                                                    let worktree_id = details.worktree_id;
+                                                    move |this, _, window, cx| {
+                                                        this.expand_all_for_entry(
+                                                            worktree_id,
+                                                            entry_id,
+                                                            cx,
+                                                        );
+                                                        this.update_visible_entries(
+                                                            None,
+                                                            false,
+                                                            false,
+                                                            window,
+                                                            cx,
+                                                        );
+                                                        cx.notify();
+                                                    }
+                                                })),
+                                        )
+                                    })
                                     .when_some(diagnostic_count, |this, count| {
                                         this.when(count.error_count > 0, |this| {
                                             this.child(
@@ -6761,6 +6867,7 @@ impl Render for ProjectPanel {
                 .on_action(cx.listener(Self::expand_selected_entry))
                 .on_action(cx.listener(Self::collapse_selected_entry))
                 .on_action(cx.listener(Self::collapse_all_entries))
+                .on_action(cx.listener(Self::expand_all_entries))
                 .on_action(cx.listener(Self::collapse_selected_entry_and_children))
                 .on_action(cx.listener(Self::open))
                 .on_action(cx.listener(Self::open_permanent))

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -38,6 +38,7 @@ pub struct ProjectPanelSettings {
     pub sort_order: ProjectPanelSortOrder,
     pub diagnostic_badges: bool,
     pub git_status_indicator: bool,
+    pub show_expand_collapse_buttons: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -145,6 +146,7 @@ impl Settings for ProjectPanelSettings {
             sort_order: project_panel.sort_order.unwrap(),
             diagnostic_badges: project_panel.diagnostic_badges.unwrap(),
             git_status_indicator: project_panel.git_status_indicator.unwrap(),
+            show_expand_collapse_buttons: project_panel.show_expand_collapse_buttons.unwrap(),
         }
     }
 }

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -8395,6 +8395,349 @@ async fn test_collapse_all_for_root_noop_on_non_root(cx: &mut gpui::TestAppConte
 }
 
 #[gpui::test]
+async fn test_expand_all_entries(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/project_root",
+        json!({
+            "dir_1": {
+                "nested_dir": {
+                    "file_a.py": "# File contents",
+                    "file_b.py": "# File contents",
+                    "file_c.py": "# File contents",
+                },
+                "file_1.py": "# File contents",
+                "file_2.py": "# File contents",
+                "file_3.py": "# File contents",
+            },
+            "dir_2": {
+                "file_1.py": "# File contents",
+                "file_2.py": "# File contents",
+                "file_3.py": "# File contents",
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/project_root".as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.collapse_all_entries(&CollapseAllEntries, window, cx)
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["v project_root", "    > dir_1", "    > dir_2",]
+    );
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.expand_all_entries(&ExpandAllEntries, window, cx)
+    });
+    cx.executor().run_until_parked();
+
+    let entries = visible_entries_as_strings(&panel, 0..20, cx);
+    assert_eq!(entries.len(), 13, "should show all 13 entries");
+    assert!(entries[0].starts_with("v project_root"), "root expanded");
+    assert!(entries[1].contains("v dir_1"), "dir_1 expanded");
+    assert!(entries[2].contains("v nested_dir"), "nested_dir expanded");
+    assert!(entries.iter().any(|e| e.contains("file_a.py")), "file_a visible");
+    assert!(entries.iter().any(|e| e.contains("file_c.py")), "file_c visible");
+    assert!(entries.iter().any(|e| e.contains("v dir_2")), "dir_2 expanded");
+    assert!(!entries.iter().any(|e| e.contains("> ")), "no collapsed dirs");
+}
+
+#[gpui::test]
+async fn test_expand_all_entries_multiple_worktrees(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    let worktree_content = json!({
+        "dir_1": {
+            "file_1.py": "# File contents",
+        },
+        "dir_2": {
+            "file_1.py": "# File contents",
+        }
+    });
+
+    fs.insert_tree("/project_root_1", worktree_content.clone())
+        .await;
+    fs.insert_tree("/project_root_2", worktree_content).await;
+
+    let project = Project::test(
+        fs.clone(),
+        ["/project_root_1".as_ref(), "/project_root_2".as_ref()],
+        cx,
+    )
+    .await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.collapse_all_entries(&CollapseAllEntries, window, cx)
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["> project_root_1", "> project_root_2",]
+    );
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.expand_all_entries(&ExpandAllEntries, window, cx)
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "v project_root_1",
+            "    v dir_1",
+            "          file_1.py",
+            "    v dir_2",
+            "          file_1.py",
+            "v project_root_2",
+            "    v dir_1",
+            "          file_1.py",
+            "    v dir_2",
+            "          file_1.py",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_expand_all_entries_via_window_dispatch(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    let worktree_content = json!({
+        "dir_1": {
+            "file_1.py": "# File contents",
+        },
+        "dir_2": {
+            "file_1.py": "# File contents",
+        }
+    });
+
+    fs.insert_tree("/project_root_1", worktree_content.clone())
+        .await;
+    fs.insert_tree("/project_root_2", worktree_content).await;
+
+    let project = Project::test(
+        fs.clone(),
+        ["/project_root_1".as_ref(), "/project_root_2".as_ref()],
+        cx,
+    )
+    .await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    cx.update(|_, cx| {
+        let settings = *ProjectPanelSettings::get_global(cx);
+        ProjectPanelSettings::override_global(
+            ProjectPanelSettings {
+                auto_reveal_entries: false,
+                ..settings
+            },
+            cx,
+        );
+    });
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.collapse_all_entries(&CollapseAllEntries, window, cx)
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["> project_root_1", "> project_root_2",]
+    );
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.expand_all_entries(&ExpandAllEntries, window, cx);
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "v project_root_1",
+            "    v dir_1",
+            "          file_1.py",
+            "    v dir_2",
+            "          file_1.py",
+            "v project_root_2",
+            "    v dir_1",
+            "          file_1.py",
+            "    v dir_2",
+            "          file_1.py",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_per_worktree_expand(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    let worktree_content = json!({
+        "dir_1": {
+            "file_1.py": "# File contents",
+        },
+        "dir_2": {
+            "file_1.py": "# File contents",
+        }
+    });
+
+    fs.insert_tree("/project_root_1", worktree_content.clone())
+        .await;
+    fs.insert_tree("/project_root_2", worktree_content).await;
+
+    let project = Project::test(
+        fs.clone(),
+        ["/project_root_1".as_ref(), "/project_root_2".as_ref()],
+        cx,
+    )
+    .await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.collapse_all_entries(&CollapseAllEntries, window, cx)
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["> project_root_1", "> project_root_2",]
+    );
+
+    let root2_entry = find_project_entry(&panel, "project_root_2", cx).unwrap();
+    panel.update_in(cx, |panel, window, cx| {
+        let worktree_id = panel
+            .project
+            .read(cx)
+            .worktree_id_for_entry(root2_entry, cx)
+            .unwrap();
+        panel.expand_all_for_entry(worktree_id, root2_entry, cx);
+        panel.update_visible_entries(None, false, false, window, cx);
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "> project_root_1",
+            "v project_root_2",
+            "    v dir_1",
+            "          file_1.py",
+            "    v dir_2",
+            "          file_1.py",
+        ]
+    );
+}
+
+#[gpui::test]
+async fn test_per_worktree_collapse(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    let worktree_content = json!({
+        "dir_1": {
+            "file_1.py": "# File contents",
+        },
+        "dir_2": {
+            "file_1.py": "# File contents",
+        }
+    });
+
+    fs.insert_tree("/project_root_1", worktree_content.clone())
+        .await;
+    fs.insert_tree("/project_root_2", worktree_content).await;
+
+    let project = Project::test(
+        fs.clone(),
+        ["/project_root_1".as_ref(), "/project_root_2".as_ref()],
+        cx,
+    )
+    .await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, ProjectPanel::new);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.expand_all_entries(&ExpandAllEntries, window, cx)
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "v project_root_1",
+            "    v dir_1",
+            "          file_1.py",
+            "    v dir_2",
+            "          file_1.py",
+            "v project_root_2",
+            "    v dir_1",
+            "          file_1.py",
+            "    v dir_2",
+            "          file_1.py",
+        ]
+    );
+
+    let root1_entry = find_project_entry(&panel, "project_root_1", cx).unwrap();
+    panel.update_in(cx, |panel, window, cx| {
+        let worktree_id = panel
+            .project
+            .read(cx)
+            .worktree_id_for_entry(root1_entry, cx)
+            .unwrap();
+        panel.collapse_all_for_entry(worktree_id, root1_entry, cx);
+        if let Some(expanded_dir_ids) = panel.state.expanded_dir_ids.get_mut(&worktree_id) {
+            if let Err(ix) = expanded_dir_ids.binary_search(&root1_entry) {
+                expanded_dir_ids.insert(ix, root1_entry);
+            }
+        }
+        panel.update_visible_entries(None, false, false, window, cx);
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "v project_root_1",
+            "    > dir_1",
+            "    > dir_2",
+            "v project_root_2",
+            "    v dir_1",
+            "          file_1.py",
+            "    v dir_2",
+            "          file_1.py",
+        ]
+    );
+}
+
+#[gpui::test]
 async fn test_create_entries_without_selection(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -838,6 +838,7 @@ impl VsCodeSettings {
             auto_open: None,
             diagnostic_badges: None,
             git_status_indicator: None,
+            show_expand_collapse_buttons: None,
         };
 
         if let (Some(false), Some(false)) = (

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -820,6 +820,10 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: false
     pub git_status_indicator: Option<bool>,
+    /// Whether to show the expand all and collapse all buttons in the project panel.
+    ///
+    /// Default: true
+    pub show_expand_collapse_buttons: Option<bool>,
 }
 
 #[derive(

--- a/docs/src/project-panel.md
+++ b/docs/src/project-panel.md
@@ -17,7 +17,8 @@ status bar.
 Use the arrow keys to move through entries. {#kb
 project_panel::ExpandSelectedEntry} expands a directory and {#kb
 project_panel::CollapseSelectedEntry} collapses it. {#kb
-project_panel::CollapseAllEntries} collapses every directory at once. Press {#kb
+project_panel::CollapseAllEntries} collapses every directory at once. {#kb
+project_panel::ExpandAllEntries} expands every directory at once. Press {#kb
 project_panel::Open} or click to preview a selected file, without giving it a
 permanent tab. Editing the file or double-clicking it promotes it to a permanent tab.
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4959,6 +4959,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
     "sort_mode": "directories_first",
     "hide_root": false,
     "hide_hidden": false,
+    "show_expand_collapse_buttons": true,
     "starts_open": true,
     "auto_open": {
       "on_create": true,
@@ -5326,6 +5327,20 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 - `on_create`: Whether to automatically open newly created files in the editor.
 - `on_paste`: Whether to automatically open files after pasting or duplicating them.
 - `on_drop`: Whether to automatically open files dropped from external sources.
+
+### Expand / Collapse Buttons
+
+- Description: Whether to show expand all and collapse all buttons on the project panel root entries.
+- Setting: `show_expand_collapse_buttons`
+- Default:
+
+```json [settings]
+{
+  "project_panel": {
+    "show_expand_collapse_buttons": true
+  }
+}
+```
 
 ## Agent
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -487,7 +487,9 @@ Project panel can be shown/hidden with {#action project_panel::ToggleFocus} ({#k
     // this also affects how file paths appear in the file finder history.
     "hide_root": false,
     // Whether to hide the hidden entries in the project panel.
-    "hide_hidden": false
+    "hide_hidden": false,
+    // Whether to show expand/collapse all buttons on root entries.
+    "show_expand_collapse_buttons": true
   }
 ```
 


### PR DESCRIPTION
Add inline expand (ListTree) and collapse (ListCollapse) IconButtons to each worktree root entry's end_slot, next to diagnostic badges and git indicators.

- Per-worktree behavior: each root entry's buttons affect only that worktree
- Expand calls expand_all_for_entry, collapse calls collapse_all_for_entry with root re-added to keep it visible
- Add show_expand_collapse_buttons setting (default true)
- Add cmd-right/ctrl-right keybinding for global ExpandAllEntries action
- Update docs: project-panel.md, all-settings.md, visual-customization.md

# Objective

The project panel had no discoverable way to expand or collapse all entries in the file tree. The only ways were keyboard shortcuts (`cmd-left` for collapse all) or the right-click context menu. Users coming from VS Code and IntelliJ expect toolbar buttons for expand/collapse all.

This PR is a minimal subset of #47237 (which implemented a full action bar with many buttons but was closed). I'm starting small (just expand/collapse) with the intent to follow up with additional buttons in subsequent PRs.

## Solution

- Add `ExpandAllEntries` action + handler + `expand_all_entries()` method
- Add two `IconButton`s (`ListCollapse` / `ListTree`) to each root entry's `end_slot`, next to diagnostic badges and git indicators
- **Per-worktree behavior**: each root entry's buttons affect only that worktree, clicking expand on the second root expands only that folder's subtree
- Expand calls `expand_all_for_entry(worktree_id, root_entry_id)` to recursively expand all directories under that root
- Collapse calls `collapse_all_for_entry` then re-adds the root entry to `expanded_dir_ids` so the root stays visible
- Add `show_expand_collapse_buttons` setting (default `true`) to `ProjectPanelSettings`
- Add `cmd-right` / `ctrl-right` keybinding for `ExpandAllEntries` (global), mirroring the existing `cmd-left` for `CollapseAllEntries`
- Buttons are fully unique per worktree (element IDs include `worktree_id` to avoid collisions across multi-folder workspaces)

## Testing

- Added 5 GPUI tests in `project_panel_tests.rs`:
  - `test_expand_all_entries`: single worktree
  - `test_expand_all_entries_multiple_worktrees`: global expand across worktrees
  - `test_expand_all_entries_via_window_dispatch`: action dispatch path
  - `test_per_worktree_expand`: expand only the clicked worktree
  - `test_per_worktree_collapse`: collapse only the clicked worktree, keep root visible
- Ran `cargo test -p project_panel`: 104 pass
- Ran `./script/clippy`: clean

**Manual testing for reviewers:**

1. Open a project with nested directories and open the Project Panel
2. Confirm expand (tree icon) and collapse (list icon) buttons appear on the right side of each root entry row
3. Click expand, confirm all directories under that root expand
4. Click collapse, confirm children collapse but the root stays visible
5. Open a multi-folder workspace (two root entries). Click expand on the second root, confirm only that folder expands, not the first
6. Press `cmd-right` (or `ctrl-right`), confirm all worktrees expand globally
7. Set `"show_expand_collapse_buttons": false` in settings, confirm the buttons disappear

Tested on macOS only. Linux and Windows should behave the same since there is no platform-specific code.

## Questions for reviewers

I put the buttons inline on each root entry row (reusing the existing `end_slot`) rather than a dedicated toolbar above the tree (#47237 took the toolbar approach). This saves vertical space and keeps the buttons near the content they affect. Is the inline approach preferred, or should I reconsider a dedicated toolbar?

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

https://github.com/user-attachments/assets/b94a9224-a847-4a8e-8135-5a7468f358d4

---

Release Notes:

- Added expand and collapse buttons to the project panel root entries.