### PR TITLE
fix/linked images clickable

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1185,7 +1185,7 @@ pub struct MarkdownElement {
     markdown: Entity<Markdown>,
     style: MarkdownStyle,
     code_block_renderer: CodeBlockRenderer,
-    on_url_click: Option<Box<dyn Fn(SharedString, &mut Window, &mut App)>>,
+    on_url_click: Option<Rc<dyn Fn(SharedString, &mut Window, &mut App)>>,
     code_span_link: Option<CodeSpanLinkCallback>,
     on_source_click: Option<SourceClickCallback>,
     on_checkbox_toggle: Option<CheckboxToggleCallback>,
@@ -1244,7 +1244,7 @@ impl MarkdownElement {
         mut self,
         handler: impl Fn(SharedString, &mut Window, &mut App) + 'static,
     ) -> Self {
-        self.on_url_click = Some(Box::new(handler));
+        self.on_url_click = Some(Rc::new(handler));
         self
     }
 
@@ -1345,16 +1345,40 @@ impl MarkdownElement {
         builder.modify_current_div(|el| el.flex().flex_row().flex_wrap().items_start());
 
         let image_element = {
-            let mut wrapper = div().min_w_0();
-            if let Some(link) = (builder.link_depth > 0)
+            let wrapper = div()
+                .id(("markdown-image-link", range.start))
+                .min_w_0();
+            let wrapper = if let Some(link) = (builder.link_depth > 0)
                 .then(|| builder.rendered_links.last())
                 .flatten()
+                && !self.style.prevent_mouse_interaction
             {
                 let url = link.destination_url.clone();
-                wrapper = wrapper
+                let markdown = self.markdown.clone();
+                let url_click = self.on_url_click.clone();
+                wrapper
                     .cursor_pointer()
-                    .on_click(move |_, _, cx| cx.open_url(&url));
-            }
+                    .on_click({
+                        let url = url.clone();
+                        let url_click = url_click.clone();
+                        move |_, window, cx| {
+                            if let Some(ref on_url_click) = url_click {
+                                on_url_click(url.clone(), window, cx);
+                            } else {
+                                cx.open_url(&url);
+                            }
+                        }
+                    })
+                    .capture_any_mouse_down(move |event, _window, cx| {
+                        if event.button == MouseButton::Right {
+                            markdown.update(cx, |md, _| {
+                                md.capture_for_context_menu(Some(url.clone()))
+                            });
+                        }
+                    })
+            } else {
+                wrapper
+            };
             wrapper.child(
                 img(source)
                     .id(("markdown-image", range.start))

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1333,16 +1333,28 @@ impl MarkdownElement {
     ) {
         builder.modify_current_div(|el| el.flex().flex_row().flex_wrap().items_start());
 
-        let image_element = div().min_w_0().child(
-            img(source)
-                .id(("markdown-image", range.start))
-                .min_w_0()
-                .max_w_full()
-                .rounded_md()
-                .when_some(height, |this, height| this.h(height))
-                .when_some(width, |this, width| this.w(width))
-                .with_fallback(move || image_fallback_element(dest_url.clone(), alt_text.clone())),
-        );
+        let image_element = {
+            let mut wrapper = div().min_w_0();
+            if let Some(link) = (builder.link_depth > 0)
+                .then(|| builder.rendered_links.last())
+                .flatten()
+            {
+                let url = link.destination_url.clone();
+                wrapper = wrapper
+                    .cursor_pointer()
+                    .on_click(move |_, _, cx| cx.open_url(&url));
+            }
+            wrapper.child(
+                img(source)
+                    .id(("markdown-image", range.start))
+                    .min_w_0()
+                    .max_w_full()
+                    .rounded_md()
+                    .when_some(height, |this, height| this.h(height))
+                    .when_some(width, |this, width| this.w(width))
+                    .with_fallback(move || image_fallback_element(dest_url.clone(), alt_text.clone())),
+            )
+        };
 
         builder.push_image_child(image_element);
     }


### PR DESCRIPTION
- **Preserve terminal spinners in thread titles (#57983)**
- **dev_container: Respect runServices for Docker Compose (#56293)**
- **ci: Remove garnix substitutor (#58033)**
- **ci: Reinstate run-nix label in addition to run-bundling (#58034)**
- **component_preview: Clean up `Component` trait (#57731)**
- **edit_prediction: Skip cloud Zeta requests when not signed in (#57615)**
- **lsp: Fix duplicate workspace/didChangeConfiguration notifications (#56853)**
- **nix: Fix dev shell on Darwin (#58032)**
- **Remove unused --nc flag and nc crate (#55962)**
- **agent: Batch streaming edit operations (#58037)**
- **Revert "Improve ChatGPT subscription response resilience" (#58035)**
- **editor: Extract `header` and `mouse` out of `element.rs` (#57472)**
- **Remove rules library (#58067)**
- **agent: Do not render diagnostics in diff (#58052)**
- **nix: Go around a linker issue on Darwin (#58070)**
- **gpui: Add item_is_above_viewport and item_is_below_viewport APIs to ListState (#58061)**
- **Duplicate Bot: Reduce noise (#58074)**
- **Add handoff feature flag (#58024)**
- **Bump `convert_case` to v0.11.0 (#58000)**
- **agent_ui: Show permission popover when inline prompt is above the viewport (#58081)**
- **Enable gain normalization on collab (#58036)**
- **git_ui: Do not include git commit prompt twice (#58062)**
- **agent_ui: Remove unused rule APIs (#58080)**
- **scheduler: Add spawn_dedicated for single-threaded actors with !Send state (#57609)**
- **Add new area labels to track mapping (#58083)**
- **x_ai: Add support for specifying reasoning effort (#58078)**
- **Fix task modal fallback when LSP tasks are empty (#58090)**
- **Bump urllib3 to v2.7.0 (#58092)**
- **git_ui: Open file diffs from git panel (#56152)**
- **Update dependency requests to v2.33.0 [SECURITY] (#58093)**
- **gpui: Support prompt_for_paths in TestPlatform (#58139)**
- **Limit editor rendering to visible clipped rows (#58132)**
- **Improve performance of `create_highlight_endpoints` (#58119)**
- **Do not play join sound in large meetings (#54337)**
- **Fix json! empty-string highlighting in Rust (#55126)**
- **keymap_editor: Fix create keybinding button clipping out of editor (#54708)**
- **Remove stale SSH LSP log entries after server restarts (#55299)**
- **vim: Support matching bracket motion in multibuffers (#54634)**
- **Honor anchored patterns in .git/info/exclude (#57779)**
- **git_ui: Update section header checkboxes immediately on stage/unstage all (#57148)**
- **Fix grammatical errors throughout the documentation (#58183)**
- **git: Suppress blame errors outside Git repositories (#56348)**
- **git_ui: Fix commit view avatar being squished when gutter line numbers are disabled (#57913)**
- **git: Implement compare with branch action (#57886)**
- **git_ui: Add setting for custom commit message instructions (#58188)**
- **git: Prefer main over master when detecting default branch (#57398)**
- **file_finder: Allow opening files without dismissing the finder (#57258)**
- **gpui: Allow chaining `flex_grow()` and `flex_shrink()` with custom factors (#58142)**
- **git_ui: Fix stale loading message in git history pane (#58133)**
- **Shorten explanation when edit predictions are disabled for a language (#54808)**
- **lsp: Register available LSP adapters locally when in remote development (#54915)**
- **project: Treat replacement literally when dealing non-ASCII text search (#56123)**
- **diagnostics: Show source and code on related diagnostics (#56147)**
- **python: Sync built-in highlights with Python 3.15 (#57562)**
- **python: Stop falling back to `conda activate base` for nameless toolchains (#56785)**
- **gpui: Fix stuck tooltips after mouse leaves origin (#58134)**
- **project: Scope terminal toolchain lookup to the terminal's worktree (#56787)**
- **editor: Fix missing background highlights in multibuffer find-all-references (#55863)**
- **worktree: Fix linked worktree git dir event handling (#57782)**
- **markdown: Fix text selection position in centered/right-aligned markdown table cells (#57283)**
- **editor: Add toggle breadcrumb action (#57970)**
- **git_graph: Exclude non-standard refs (#54291)**
- **workspace: Treat remote roots as directories (#54733)**
- **gpui: Allow repositioning macOS traffic lights at runtime (#58169)**
- **agent_ui: Add some more improvements to the draft UX (#57692)**
- **Notify on slack when new label is created (#58224)**
- **agent_ui: Remove the staff-only gate on fast mode toggle (#57914)**
- **terminal: Enable copy and paste in edit menu (#58111)**
- **editor: Fix newline outdent when tab size is greater than current indent size (#58221)**
- **git_store: Coalesce refresh pathspecs (#56406)**
- **project: Add fuzzy search in remote projects dialogue (#54143)**
- **Load project skills through worktree buffers (#58094)**
- **Add context compaction markers (#58089)**
- **terminal: Add backend-neutral terminal types (#57483)**
- **python: Fix splat parameter highlighting (#58136)**
- **Gate sandboxed terminal tempdir to local projects (#58240)**
- **agent: Respect compaction boundaries in request windows (#58241)**
- **acp: Handle reasoning effort shortcuts (#58223)**
- **Allow symlinked global skill directories (#58095)**
- **docs: Document external agent thread imports (#58242)**
- **Change .join("") to .concat() (#58200)**
- **Render the first character as the icon in a terminal thread (#58251)**
- **languages: Respect `devEngines` package manager for package scripts (#58113)**
- **Support ex: in vim modelines (#58121)**
- **Recognize shell-script as shell in modelines (#58124)**
- **ep: Jump example capture (#58236)**
- **agent: Add terminal output head and tail options (#58257)**
- **Align prefix parsing, smart-select characters (#58267)**
- **Symlink scan option (#53646)**
- **agent: Enable terminal output controls for everyone (#58271)**
- **collab: Use avatar URLs returned from Cloud (#58265)**
- **git_ui: Render commit message as markdown (#58274)**
- **gpui: Add bare bones benchmark framework (#58191)**
- **git_ui: Add split controls to commit view (#58163)**
- **recent_projects: Improve label truncation (#58279)**
- **Fix rules-to-skills migration (#58278)**
- **Add create_thread and list_agents_and_models agent tools (#57987)**
- **git: Further extract gitlib2 dependencies (#58280)**
- **Add granular per-path write permissions for the agent terminal sandbox (#57972)**
- **editor: Fix `DisplayMap::highlight_text` not always sorting its ranges (#58260)**
- **Remove git2 (libgit2) dependency (#53453)**
- **agent_ui: Fix crash when filtering tools in the agent profile tool picker (#58299)**
- **docs: Update agent server extension documentation (#58306)**
- **git_ui: Trim surrounding whitespace from new branch names (#58151)**
- **git_ui: Prepare review action with owned base ref directly (#58156)**
- **acp: Indicate when agent is downloading (#57710)**
- **Document Pro threshold billing behavior (#58320)**
- **Log worst hanging tasks and actions (#57835)**
- **agent_ui: Improve draft threads for worktrees (#58268)**
- **mermaid: Fix stack overflow when laying out deeply nested subgraphs (#58325)**
- **language_models: Support custom HTTP headers for provider requests (#55246)**
- **file_finder: Fix path duplication when opening non-project files with a filter (#54944)**
- **language: Support emitting multiple runnables from a single tree-sitter match (#57276)**
- **language_models: Remove retired GPT-5.2 and GPT-5.3-Codex from ChatGPT Subscription (#58340)**
- **mermaid_render: Remove spurious debug assert (#58341)**
- **agent: Implement compaction (experimental) (#58315)**
- **acp: Update agent-client-protocol sdk to 0.13.1 (#58308)**
- **Remove audio denoiser crate (#57923)**
- **fs: Avoid resolving symlinks when trashing (#58339)**
- **git_ui: Add total diff stats to git panel (#58018)**
- **Improve sandbox write-path handling (#58283)**
- **editor: Reduce redundant invalidations (#56234)**
- **git_ui: Move `git_graph` into `git_ui` (#57503)**
- **Fix traffic light padding on macOS SDK 26+ builds (#58245)**
- **git_ui: Fix scroll in commit view header (#58360)**
- **agent_ui: Improve sandbox write-path authorization UI (#58358)**
- **agent_ui: Add selection to terminal thread (#57301)**
- **editor: Stop re-requesting hover and definitions for the same position (#58244)**
- **title_bar: Expose the panel layout toggle as actions (#58281)**
- **agent_ui: Restore hover previews for image mentions (#58165)**
- **git: Fix a regression introduced with removing gitlib2 dep (#58359)**
- **git_ui: Fix Enter key selecting branch in commit modal branch picker (#58366)**
- **helix: Fix paste crash (#58373)**
- **agent_panel: Fix mention pasting crash  (#58375)**
- **gpui: Anchor IME candidate window to the start of the visual line (#55876)**
- **cloud_api_client: Add a few helpers for response handling (#58346)**
- **ep: Editable context collectors and metrics (#58400)**
- **go: Fix table test detection in large files (#57277)**
- **Add AI Policy to CONTRIBUTING.md (#58397)**
- **agent_ui: Cache cross-channel thread import check off the render loop (#58402)**
- **vim: Fix increment/decrement for negative numbers without gaps (#58327)**
- **Fix panic in uncommitted_diffs_for_events (#58410)**
- **agent: Improve compaction UI (#58409)**
- **ep: Make retrieved context limit configurable (#58405)**
- **ep: Back off Zeta requests after Cloud timeout (#58394)**
- **Clear LLM token and model list on sign out (#57724)**
- **markdown: Update merman renderer to 0.6 (#57967)**
- **git_ui: Make git_ui call support optional (#58413)**
- **sidebar: Add right-click menu to thread items (#58232)**
- **theme_selector: Mark the active theme with a check icon (#58404)**
- **mermaid: The other half of #57967 (#58419)**
- **Stop stalebot from nagging on the same issues (#58418)**
- **settings_ui: Make skills page UI more consistent with others (#58425)**
- **Bump Zed to v1.7.0 (#58427)**
- **agent: Fix compaction limit (#58431)**
- **agent: Fix a UTF-8 boundary panic in the agent streaming parser (#58432)**
- **Fix jump capture (#58430)**
- **Fix update version button stuck on "Downloading" step (#58435)**
- **Only notify slack on confirmed and common P0/P1s (#58399)**
- **Document Billing Manager role (#58447)**
- **collab: Only access `github_user_id` and `github_login` columns in tests (#58457)**
- **Add Gerrit icon for Chromium hosting provider (#57713)**
- **Fix external tool call locations (#58367)**
- **Improve markdown preview styles (#58465)**
- **ep: Add accepted and explicit reject fetching (#58434)**
- **collab: Add a warning about modifying database schema files (#58468)**
- **danger: Require attestation that database schema migrations have been applied (#58469)**
- **ci: Add merge queue trigger to danger workflow (#58467)**
- **git_graph: Add tree view for commit changed files (#58198)**
- **Fix hang detection crash when foreground stats are missing (#58464)**
- **Use button component for Mermaid block controls (#58473)**
- **danger: Fix typo (#58475)**
- **extension_ci: Bump extension CLI version to `ca0fd8d` (#58476)**
- **sidebar: Ensure plus icon button stays visible when menu is open (#58482)**
- **tab_switcher: Select first buffer in the list when a query is enabled (#58424)**
- **gpui: Make tooltip show delay configurable (#58291)**
- **gpui: Fix cursor styles not applying to panel-backed windows (#58493)**
- **tab_switcher: Show full file names without truncation (#58483)**
- **Disable `csharp-ls` by default (#58507)**
- **Hide markdown code block scrollbar when wrapped (#58472)**
- **ep: Skip commits containing submodules / gitlinks (#58519)**
- **ep: Add an option to filter context by type when evaluating (#58523)**
- **extension_api: Remove x86 support (#58259)**
- **Fix lost error messages when listing OpenRouter models (#58502)**
- **agent_ui: Fix panic when restoring an agent terminal in a remote project (#58533)**
- **Fix infinite loop when inferring outline body range (#58536)**
- **git_ui: Disable CommitView diff hunk controls (#58514)**
- **ep: Cap identifiers for LSP context retriever (#58539)**
- **agent: Accumulate and persist cumulative token usage for threads (#58378)**
- **ep: Add BM25 context retriever (#58526)**
- **Rename Stash tab to Stashes (#58505)**
- **Hide Always Allow option for agent skills edits (#58463)**
- **editor: Fix panic on newline below with a cursor on deleted diff hunk (#58542)**
- **collab: Remove writes to `github_user_id` and `github_login` (#58474)**
- **Restructure AI docs (#57614)**
- **Refresh OpenRouter models after setting API key (#58551)**
- **worktree_picker: Add section for open in this window (#58555)**
- **Restore access to old threads that mention rules (#58560)**
- **ep: Minor changes to evaluate context retrieval (#58572)**
- **Add note about extension API changes to the contributing guidelines (#58369)**
- **docs: Clarify Project Search runs on Enter (#58545)**
- **grammars: Stop treating `fish` modelines as Shell Script (#58550)**
- **Fix some overcomputation in the project diff (#57859)**
- **ep: Improve trigger granularity (#58561)**
- **Remove double-click handling from git panel filenames (#58594)**
- **Add action to toggle block quotes in Markdown (#58383)**
- **Add auto-surround support for tilde in Markdown (#58614)**
- **Handle bracketed ellipsis title prefixes (#58269)**
- **Speed up collab test a bit by doing less repeated work in multi iteration tests (#53490)**
- **agent_ui: Improve thread import UX (#57791)**
- **editor: Reduce number of language server requests in go to definition (#58429)**
- **Fix symlinked root rename event handling (#58624)**
- **editor: Don't bypass show_edit_predictions when navigating diagnostics (#56055)**
- **project_panel: Do not ignore first focus clicks on items (#58562)**
- **Add `envrc` to Shell Script `path_suffixes` (#58573)**
- **acp: Support raw agent registry binaries (#58579)**
- **Add meta signals to the community PR board (#58635)**
- **Use no-op hasher for TypeId hashing (#58629)**
- **Prevent auto-restart of language servers after Stop All Servers (#51468)**
- **project: Normalize line endings in textual project search (#58628)**
- **Restore the focused workspace after quitting (#58392)**
- **Agent: Improved auto scroll location when using read-file tool (#58640)**
- **Correctly handle file links in markdown and agent threads (#56024)**
- **recent_projects: Fix recent project picker icons (#57940)**
- **Add upvotes to the community PR board (#58645)**
- **agent_ui: Inherit source agent without draft content (#58636)**
- **agent_skills: Instruct agent not to include unrelated instructions in `/create-skill` (#58599)**
- **editor: Only compute word-diff highlights for visible rows (#58639)**
- **settings_ui: Disable settings overridden by current organization (#58326)**
- **sidebar: Add small refinements to the header design (#58661)**
- **Fix macOS system font fallback cascade append (#58020)**
- **Disable the IME on linux/wayland when text input is unexpected (#58237)**
- **Split out Windows in community PR area-track mapping (#58671)**
- **project: Fix spurious git diff for symlinked files (#58655)**
- **Remove experimental microphone gain normalization option (#58677)**
- **helix: Fix line selection after undoing delete (#55365)**
- **sidebar: Debounce `Sidebar::update_entries` (#57803)**
- **acp: Enable ACP session usage and deletion features (#58680)**
- **Fix split diff stale scroll anchor crash (#58688)**
- **Fix agent permission row flicker when scrolled away from a tall plan (#58689)**
- **workspace: Update window title when switching active workspace (#58401)**
- **text: Preserve structural sharing when rebuilding the fragment tree (#58681)**
- **title_bar: Improve design for call controls (#58691)**
- **agent: Warn about long skill descriptions (#58356)**
- **settings_ui: Allow changing settings scope inside sub-pages (#58698)**
- **sidebar: Hide collapse affordances in project header upon searching (#58696)**
- **python: Fix Python exception highlighting (#58176)**
- **Add indentation rules for GLSL syntax (#58520)**
- **glsl: Bump to v0.2.4 (#58704)**
- **git: Fix add safe directory button doing nothing (#58705)**
- **worktree: Don't eagerly remove watchers (#58692)**
- **Clarify panel dock defaults depend on layout in docs (#58654)**
- **Add Sourcehut icon for Sourcehut hosting provider (#58668)**
- **Fix Wayland IME handling with multiple windows (#58712)**
- **Stream git blame parsing (#58733)**
- **opencode: Model updates (#58743)**
- **extension: Perform compilation tasks in parallel (#55160)**
- **Typed workspace errors (#57649)**
- **extension_ci: Bump extension CLI version to `9ee3c50` (#58785)**
- **Use `SHORT_SHA_LENGTH` for all shortened commit SHAs (#58741)**
- **remote: Do not swallow ssh errors (#58780)**
- **agent: Don't offer feature-flag-gated tools in agent profiles (#58581)**
- **auto_update: Offload update installation to background thread (#58767)**
- **Fix SSH askpass on Windows by invoking `cli.exe` directly (#52491)**
- **Fix profiler breaking concurrent tests (#58813)**
- **agent: Remove experimental plan and title agent tools (#58824)**
- **Remove accidentally committed empty file (#58825)**
- **linux: Fix Wayland clipboard reads blocking indefinitely (#58826)**
- **ep: Show empty predictions in rate predictions modal (#58829)**
- **ep: Disable diagnostic based jumps (#58832)**
- **collab: Update test database schema (#58670)**
- **outline: Switch the outline search to use fuzzy_nucleo (#56477)**
- **Change "Ok" to "OK" in UI (#58744)**
- **settings_ui: Move skills management into settings UI (#58701)**
- **Fix error prompt darkened background exceeding window boundaries on Linux (#57608)**
- **Fix `TestScheduler::spawn_dedicated` leaking due to cycle (#58802)**
- **Improve warning display UI related to skills (#58838)**
- **Fix Sourcehut icon SVG (#58852)**
- **git_ui: Fix panic when splitting a pane containing a commit view (#58853)**
- **Include icon guidelines in PR templates and contribution docs (#58855)**
- **Fix stale Git UI on reftable repositories on Linux (#58719)**
- **git_ui: Add `Add to .git/info/exclude` option to context menus (#57044)**
- **Use unstable sorts if deduplicating (#58751)**
- **lsp: Bound the incoming language server message queue (#58867)**
- **lsp: Fix retained notification subscriptions leaking dropped language servers (#58866)**
- **image_viewer: Reveal images in file manager from keyboard shortcut (#56438)**
- **Make sure we display keybindings on gutter menu (#58856)**
- **Limit top context identifiers and diagnostics (#58870)**
- **gpui: Free atlas tile space when removing tiles (#58874)**
- **editor: Show format selections for cursor ranges (#56571)**
- **Fix indentations for expressions in C/C++ (#58740)**
- **Fix Deno test task example quoting (#58774)**
- **git_ui: Pass the clicked ref to git graph custom commands (#58781)**
- **Add built-in /compact slash command to the native agent (#58663)**
- **Add auto_compact agent settings (#58883)**
- **agent: Improve compaction UX (#58913)**
- **Enable handoff feature flag by default for staff (#58891)**
- **cloud_api_client: Always pass up an organization ID when creating an LLM token (#58872)**
- **agent: Fix handoff feature flag tests (#58916)**
- **Make `zed://` links clickable in terminal (#58910)**
- **editor: Register toggle inline values action (#58921)**
- **thread_view: Add refinements to compaction UI design (#58926)**
- **agent: Hide token usage after running `/compact` (#58937)**
- **ep: LSP telemetry (#58925)**
- **project: Re-resolve recent tasks against current editor context (#57380)**
- **ep: Add more options to control split point (#58943)**
- **Disable profiler with feature (#58942)**
- **Add Claude Fable 5 to Anthropic BYOK (#58945)**
- **Link data retention consent callout to Anthropic's policy article (#58949)**
- **gpui: Fix title bar clicks being delayed on macOS 27 (#58947)**
- **cloud_api_client: Key the cached LlmApiToken by organization (#58915)**
- **Pin workflow actions and service images to immutable SHAs (#58964)**
- **title_bar: Always show organization list in user menu (#58965)**
- **Refactor `BufferDiff` to allow multiple diffs to share the same base text buffer (#58266)**
- **gpui: Document standalone app setup (#58766)**
- **Update notify to v9.0.0-rc.4 (#58944)**
- **Document provider safety retention for designated Zed-hosted models (#58967)**
- **Fix miscellaneous typos (#58979)**
- **git_graph: Fix infinite loading for empty repos (#58959)**
- **Remove outdated TODO comment (#58985)**
- **Add telemetry for context compaction (#58928)**
- **Bench app context phase 2 (#58202)**
- **Escape control characters in syntax tree view (#59012)**
- **agent: Fix race where compaction would be marked as cancelled (#59014)**
- **Remove handoff feature flag and un-gate compaction (#58931)**
- **Stop rendering native slash commands as user messages (#58935)**
- **Allow opening a new window by default (#58805)**
- **debugger: Fix running ignored Rust tests in nested modules (#54787)**
- **docs: Compaction (#59029)**
- **docs: Add csharp-ls to C# docs (#59028)**
- **Return typed completion errors from Cloud provider (#58997)**
- **git_ui: Add button to remove open worktrees from the window in the worktree picker (#58996)**
- **Disable commit title width limit by default (#58960)**
- **client: Format the whole error chain on failure to connect to Cloud (#59035)**
- **Document `auto_update_extensions` setting (#58954)**
- **Remove dormant and disabled GitHub Actions workflows (#58975)**
- **Bump notify to fix a hang when watching or unwatching paths (#59047)**
- **Bump Zed to v1.8.0 (#59048)**
- **agent: Add thread history import telemetry (#59050)**
- **Fix not being able to scroll sidebar when the mouse is hovering a header (#59054)**
- **Add supports_disabling_thinking to Cloud model listings (#58980)**
- **docs: Remove Alpine, clean up glibc guidance, minor wording fixes (#56674)**
- **zed: Hide log file actions when logging to stdout (#57114)**
- **agent_ui: Keep pending subagent edits when regenerating a prompt (#59060)**
- **agent: Flush thread content to database on app quit (#58962)**
- **Enforce adding a message to extension CLI bumps (#58786)**
- **Improve `didChangeWatchedFiles` handler performance (#59078)**
- **editor: Expand the gutter width to contain new timestamp format (#59008)**
- **editor: Don't treat scheme-prefixed text as a URL when pasting in Markdown (#59071)**
- **tab_switcher: Middle-truncate long picker filenames (#59072)**
- **workspace: Add command to reset pane sizes (#59046)**
- **Add action to select inside enclosing brackets (#59005)**
- **gpui: Fix list scroll events being reverted by pending scroll (#59002)**
- **Fix shadow and gradient artifacts on transparent windows (#58981)**
- **Fix "Loading Commit History..." message stuck on empty repositories (#58649)**
- **acp_thread: Preserve waiting tool call status on updates (#58537)**
- **Fix ACP permission dialog keyboard shortcuts not working (#58365)**
- **sidebar: Display a new thread button in the archive view (#59114)**
- **thread_view: Fix the thinking toggle button (#59111)**
- **Fixes for AI docs (#58969)**
- **Fix file descriptor leak when process spawning failed on macOS (#59128)**
- **agent_ui: Show placeholder title in agent panel empty-state toolbar (#59126)**
- **gpui_macos: Initialize fallback fonts with primary font weight and style (#56771)**
- **Iterate on placeholder copywriting for branch and worktree pickers (#59130)**
- **repl: Add notebook cell stop button (#57093)**
- **gpui: Add `alpha` method to `Rgba` (#52125)**
- **Fix two random bugs in macOS process spawning (#59133)**
- **Persist dev container suggestion dismissal across git worktrees (#58576)**
- **gpui: Add builder API for BoxShadow (#57743)**
- **mermaid_render: Fix overlapping text in diagrams with long labels (#59140)**
- **agent_ui: Iterate on title display on the toolbar (#59162)**
- **Update Pull Request template (#59062)**
- **language_models: Add Anthropic-compatible provider support in settings (#50381)**
- **Allow editing queued message by pressing up in an empty editor (#58807)**
- **workspace: Fix overflow in error popup (#59185)**
- **editor: Fix columnar selection alignment on rows with multi-byte chars (#57097)**
- **multi_buffer: Don't eagerly clone `BufferSnapshot` in `range_to_buffer_ranges` (#59190)**
- **audio: Fix phantom presence in channels (#59195)**
- **gpui_macos: Fix traffic light hitbox after repositioning (#58534)**
- **ci: Fix caching of release jobs (by having it in the first place) (#59200)**
- **Patch async-process to allow reusing their reaper (#59156)**
- **repl: Show kernel error on notebook cell instead of hanging (#59137)**
- **editor: Align split buffer headers with scrollbar layout (#53782)**
- **call: Log LiveKit connection info refresh outcomes in retry loop (#59205)**
- **Revert "gpui: Fix title bar clicks being delayed on macOS 27 (#58947)" (#59214)**
- **Allow Prettier to read the .editorconfig files of the project when formatting from within Zed (#59149)**
- **agent_ui: Remove dead link in agent menu (#59232)**
- **client: Link to appropriate documentation for Preview and Nightly (#59234)**
- **recent_projects: Close remote projects window on button press (#58889)**
- **agent_ui: Match project name in archive-view search (#58214)**
- **agent_ui: Truncate long model names in config option selector (#57808)**
- **markdown_preview: Improve heading spacing (#59291)**
- **extension_ui: Hide agent servers from chips (#59231)**
- **component_preview: Fix example rendering no text or icons (#59241)**
- **file_finder: Adjust list item design (#59164)**
- **gpui_macos: Warn when falling back to NoopTextSystem (#59247)**
- **editor: Fix splitting brackets inside line comments (#59260)**
- **dev_container: Expand bare $VAR in addition to ${VAR} in Dockerfiles (#59280)**
- **agent: Fix shell hang on shell syntax errors with terminal tool usage (#59270)**
- **dev_container: Support the classic Docker builder via a setting (#59288)**
- **git: Do not run `git stash list` on every file save (#59042)**
- **git: Reduce number of spawned git processes when retrieving remote URLs (#59053)**
- **git: Reduce number of spawned git processes when retrieving default branch (#59087)**
- **agent_ui: Insert dropped file links at the cursor (#55127)**
- **editor: Fix blocks not appearing or lingering when anchored past a soft wrap (#59018)**
- **docs: document llvm-objcopy --strip-debug step when self-building remote_server (#57655)**
- **Fix incorrect mask in BufferChunks::next (#57544)**
- **git_ui: Always display "Create Pull Request" button on push toast (#53913)**
- **recent_projects: Show keybindings in action button tooltips (#59030)**
- **Fix ghost project when selecting remote project group (#59272)**
- **Edit name of Gemini 3.1 Flash Lite to Gemini 3.1 Flash-Lite to better match Google's official documentation (#59322)**
- **git: Reduce amount of git commands when checking for pushed commits (#59069)**
- **git: Optimize git HEAD state resolution (#59044)**
- **acp_thread: Fix compaction button stuck at loading state on error (#59161)**
- **util: Use job objects to reap spawned process trees on Windows (#58885)**
- **Anchor sticky scroll to symbol name rows (#56333)**
- **editor: Show file icon in breadcrumbs when tab bar is hidden (#56267)**
- **extensions_ui: Add `RebuildDevExtension` action (#55173)**
- **settings: Fix command aliases json schema (#57812)**
- **agent_ui: Fix reporting of 401/403 errors (#59119)**
- **agent: Don't pass back the diff on successful edits (#59335)**
- **http_proxy: Add hostname allowlist policy types (#59217)**
- **Show command in sandbox permission prompts (#59362)**
- **http_proxy: Add upstream proxy configuration (#59222)**
- **http_proxy: Add the allowlisting proxy server (#59223)**
- **sidebar: Fix click flicker on empty draft thread (#59342)**
- **sandbox: Replace allow_network bool with a NetworkAccess enum (#59218)**
- **Add member to community champions list (#59386)**
- **agent: Model sandbox network escalation as a host allowlist (#59219)**
- **livekit: Preserve tokens on channel rejoin (#59388)**
- **acp_thread: Enforce the network allowlist via an in-process proxy (#59220)**
- **Make unrestricted sandbox network access explicit (#59385)**
- **agent_ui: Show commands in sandbox permission prompts (#59391)**
- **git_ui: Resolve worktree picker remove-from-window clicks by path (#59084)**
- **settings_ui: Fix reset to default not clearing focused input fields (#59395)**
- **git_ui: Add View File action to Git Panel (#59383)**
- **project_panel: Select the whole folder name when renaming (#59390)**
- **Update `merman` tag SHA (#59360)**
- **agent: Sanboxing on linux (#58355)**
- **Duplicate Bot: Update retired Claude model (#59424)**
- **PR board: Stop touching archived items (#59428)**
- **Support provider-side compaction in the language model clients (#59145)**
- **Remove gpui's dependency on `async-process` (#59358)**
- **git: Fix `.git` directory being removed from watcher when excluded via `file_scan_exclusions` (#57895)**
- **git: Avoid unnecessary git repo rescans when unrelated git files change (#59318)**
- **agent: Address review follow-ups for quit-time thread flush (#59079)**
- **Include changed paths in remote UpdatedEntries events (#58157)**
- **ci: Revalidate zed.dev after release (#59422)**
- **Settings UI agent providers (#58876)**
- **Duplicate Bot: Switch to structured tool output for Claude (#59432)**
- **Prevent archival of manually-created worktrees (#58275)**
- **markdown_preview: Restore preview panes on workspace reload (#56972)**
- **Fix copy shortcut in macOS notebook cells (#59431)**
- **Ping on slack when a community-related workflow fails (#59435)**
- **markdown: Render soft breaks as line breaks in agent markdown (#57376)**
- **agent: Better sandboxing UI (#59437)**
- **ep: Store rejected patch as prediction (#59440)**
- **Qwen prompt format (#59150)**
- **editor: Refresh active debug line highlight on theme change (#59274)**
- **sidebar: Add submenu to create a worktree (#59341)**
- **Add terminal thread init command (#59374)**
- **Fix project grouping for Git repo subdirectories (#57998)**
- **editor: Speed up multi cursor editing (#58510)**
- **editor: Reuse display-map cursors when converting word diffs (#58658)**
- **editor: Add SelectInsideDelimiters and SelectAroundDelimiters actions (#53789)**
- **Refactor editor's select inside/around delimiter actions (#59472)**
- **markdown: Optimize `paint_search_highlights` (#59473)**
- **agent: Account for max_output_tokens in compaction threshold (#59469)**
- **Add agent sandbox permissions settings page (#59448)**
- **ci: Publish static bubblewrap in releases (#59488)**
- **Periodically log memory usage (#58999)**
- **language_models: Clear speed for OpenAI-compatible providers that don't support fast mode (#59496)**
- **a11y: Settings UI (#59429)**
- **Add harden-runner in audit mode to run_tests Linux jobs (#59446)**
- **Move the crash handler process spawn to a background thread (#58881)**
- **markdown: Add debug_asserts for search result ordering (#59483)**
- **open_path_prompt: Cancel in-flight tasks when dialog is dismissed (#59423)**
- **Bump `alacritty_terminal` repo SHA (#59445)**
- **Add Windows terminal sandboxing via WSL (#58971)**
- **Make images inside markdown links clickable**
- **markdown: Make linked images clickable**
