### PR TITLE
Add configurable word characters

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1489,6 +1489,11 @@
   "modeline_lines": 5,
   // What debuggers are preferred by default for all languages.
   "debuggers": [],
+  // Additional characters to treat as part of a word for word-based editor operations,
+  // such as double-click word selection.
+  //
+  // For example, add "-" to select "foo-bar" as a single word.
+  "word_characters": [],
   // Whether to enable word diff highlighting in the editor.
   //
   // When enabled, changed words within modified lines are highlighted

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1489,7 +1489,7 @@
   "modeline_lines": 5,
   // What debuggers are preferred by default for all languages.
   "debuggers": [],
-  // Additional characters to treat as part of a word for word-based editor operations,
+  // Additional characters to treat as part of a word for selection operations,
   // such as double-click word selection.
   //
   // For example, add "-" to select "foo-bar" as a single word.

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -15,7 +15,7 @@ use crate::{
     },
 };
 use buffer_diff::{BufferDiff, DiffHunkSecondaryStatus, DiffHunkStatus, DiffHunkStatusKind};
-use collections::HashMap;
+use collections::{HashMap, HashSet};
 use futures::{StreamExt, channel::oneshot};
 use gpui::{
     BackgroundExecutor, DismissEvent, Task, TaskExt, TestAppContext, UpdateGlobal,
@@ -30,6 +30,7 @@ use language::{
     LanguageToolchainStore, Override, Point,
     language_settings::{
         CompletionSettingsContent, FormatterList, LanguageSettingsContent, LspInsertMode,
+        WordCharacters,
     },
     tree_sitter_python,
 };
@@ -10593,6 +10594,26 @@ async fn test_select_next(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_select_next_uses_configured_word_characters_for_match_boundaries(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |settings| {
+        settings.defaults.word_characters =
+            Some(WordCharacters(['-'].into_iter().collect::<HashSet<_>>()));
+    });
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("ˇfoo-bar foo-bar-baz foo-bar");
+    cx.update_editor(|editor, window, cx| editor.select_next(&SelectNext::default(), window, cx))
+        .unwrap();
+    cx.assert_editor_state("«foo-barˇ» foo-bar-baz foo-bar");
+
+    cx.update_editor(|editor, window, cx| editor.select_next(&SelectNext::default(), window, cx))
+        .unwrap();
+    cx.assert_editor_state("«foo-barˇ» foo-bar-baz «foo-barˇ»");
+}
+
+#[gpui::test]
 async fn test_select_all_matches(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let mut cx = EditorTestContext::new(cx).await;
@@ -10668,6 +10689,22 @@ async fn test_select_all_matches(cx: &mut TestAppContext) {
         e.select_all_matches(&SelectAllMatches, window, cx).unwrap();
     });
     cx.assert_editor_state("«fooˇ»\n«FOOˇ»\n«Fooˇ»");
+}
+
+#[gpui::test]
+async fn test_select_all_matches_uses_configured_word_characters_for_match_boundaries(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |settings| {
+        settings.defaults.word_characters =
+            Some(WordCharacters(['-'].into_iter().collect::<HashSet<_>>()));
+    });
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("fˇoo-bar foo-bar-baz foo-bar");
+    cx.update_editor(|editor, window, cx| editor.select_all_matches(&SelectAllMatches, window, cx))
+        .unwrap();
+    cx.assert_editor_state("«foo-barˇ» foo-bar-baz «foo-barˇ»");
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2756,6 +2756,37 @@ fn test_prev_next_word_boundary(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_word_selection_motions_use_configured_word_characters(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.word_characters =
+            Some(WordCharacters(['-'].into_iter().collect::<HashSet<_>>()));
+    });
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple("foo-bar baz", cx);
+        build_editor(buffer, window, cx)
+    });
+
+    _ = editor.update(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selections| {
+            selections.select_display_ranges([
+                DisplayPoint::new(DisplayRow(0), 0)..DisplayPoint::new(DisplayRow(0), 0)
+            ])
+        });
+        editor.select_to_next_word_end(&SelectToNextWordEnd, window, cx);
+        assert_selection_ranges("«foo-barˇ» baz", editor, cx);
+
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selections| {
+            selections.select_display_ranges([
+                DisplayPoint::new(DisplayRow(0), 7)..DisplayPoint::new(DisplayRow(0), 7)
+            ])
+        });
+        editor.select_to_previous_word_start(&SelectToPreviousWordStart, window, cx);
+        assert_selection_ranges("«ˇfoo-bar» baz", editor, cx);
+    });
+}
+
+#[gpui::test]
 fn test_prev_next_word_bounds_with_soft_wrap(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -12,6 +12,7 @@ use multi_buffer::{MultiBufferOffset, MultiBufferRow, MultiBufferSnapshot};
 use serde::Deserialize;
 use workspace::searchable::Direction;
 
+use collections::HashSet;
 use std::{ops::Range, sync::Arc};
 
 /// Defines search strategy for items in `movement` module.
@@ -264,6 +265,14 @@ pub fn line_end(
 /// Returns a position of the previous word boundary, where a word character is defined as either
 /// uppercase letter, lowercase letter, '_' character or language-specific word character (like '-' in CSS).
 pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint {
+    previous_word_start_with_extra_word_characters(map, point, None)
+}
+
+pub fn previous_word_start_with_extra_word_characters(
+    map: &DisplaySnapshot,
+    point: DisplayPoint,
+    extra_word_characters: Option<&HashSet<char>>,
+) -> DisplayPoint {
     let raw_point = point.to_point(map);
     let classifier = map.buffer_snapshot().char_classifier_at(raw_point);
 
@@ -280,7 +289,9 @@ pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> Displa
         }
         is_first_iteration = false;
 
-        (classifier.kind(left) != classifier.kind(right) && !classifier.is_whitespace(right))
+        (classifier.kind_with_extra_word_characters(left, extra_word_characters)
+            != classifier.kind_with_extra_word_characters(right, extra_word_characters)
+            && !classifier.is_whitespace(right))
             || left == '\n'
     })
 }
@@ -439,6 +450,14 @@ pub fn is_subword_start(left: char, right: char, classifier: &CharClassifier) ->
 /// Returns a position of the next word boundary, where a word character is defined as either
 /// uppercase letter, lowercase letter, '_' character or language-specific word character (like '-' in CSS).
 pub fn next_word_end(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint {
+    next_word_end_with_extra_word_characters(map, point, None)
+}
+
+pub fn next_word_end_with_extra_word_characters(
+    map: &DisplaySnapshot,
+    point: DisplayPoint,
+    extra_word_characters: Option<&HashSet<char>>,
+) -> DisplayPoint {
     let raw_point = point.to_point(map);
     let classifier = map.buffer_snapshot().char_classifier_at(raw_point);
     let mut is_first_iteration = true;
@@ -454,7 +473,9 @@ pub fn next_word_end(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint
         }
         is_first_iteration = false;
 
-        (classifier.kind(left) != classifier.kind(right) && !classifier.is_whitespace(left))
+        (classifier.kind_with_extra_word_characters(left, extra_word_characters)
+            != classifier.kind_with_extra_word_characters(right, extra_word_characters)
+            && !classifier.is_whitespace(left))
             || right == '\n'
     })
 }

--- a/crates/editor/src/navigation.rs
+++ b/crates/editor/src/navigation.rs
@@ -414,10 +414,30 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let display_snapshot = self.display_snapshot(cx);
+        let buffer = display_snapshot.buffer_snapshot();
+        let word_characters = self
+            .selections
+            .all::<MultiBufferOffset>(&display_snapshot)
+            .into_iter()
+            .map(|selection| {
+                buffer
+                    .language_settings_at(selection.head(), cx)
+                    .word_characters
+                    .clone()
+            })
+            .collect::<Vec<_>>();
+        let mut word_characters = word_characters.iter();
+
         self.change_selections(Default::default(), window, cx, |s| {
             s.move_heads_with(&mut |map, head, _| {
+                let word_characters = word_characters.next();
                 (
-                    movement::previous_word_start(map, head),
+                    movement::previous_word_start_with_extra_word_characters(
+                        map,
+                        head,
+                        word_characters,
+                    ),
                     SelectionGoal::None,
                 )
             });
@@ -472,9 +492,28 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let display_snapshot = self.display_snapshot(cx);
+        let buffer = display_snapshot.buffer_snapshot();
+        let word_characters = self
+            .selections
+            .all::<MultiBufferOffset>(&display_snapshot)
+            .into_iter()
+            .map(|selection| {
+                buffer
+                    .language_settings_at(selection.head(), cx)
+                    .word_characters
+                    .clone()
+            })
+            .collect::<Vec<_>>();
+        let mut word_characters = word_characters.iter();
+
         self.change_selections(Default::default(), window, cx, |s| {
             s.move_heads_with(&mut |map, head, _| {
-                (movement::next_word_end(map, head), SelectionGoal::None)
+                let word_characters = word_characters.next();
+                (
+                    movement::next_word_end_with_extra_word_characters(map, head, word_characters),
+                    SelectionGoal::None,
+                )
             });
         })
     }

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -500,7 +500,12 @@ impl Editor {
 
             if only_carets {
                 for selection in &mut selections {
-                    let (word_range, _) = buffer.surrounding_word(selection.start, None);
+                    let settings = buffer.language_settings_at(selection.start, cx);
+                    let (word_range, _) = buffer.surrounding_word_with_extra_word_characters(
+                        selection.start,
+                        None,
+                        Some(&settings.word_characters),
+                    );
                     selection.start = word_range.start;
                     selection.end = word_range.end;
                     selection.goal = SelectionGoal::None;
@@ -677,10 +682,20 @@ impl Editor {
                 if let Some((node, _)) = buffer.syntax_ancestor(old_range.clone()) {
                     // manually select word at selection
                     if ["string_content", "inline"].contains(&node.kind()) {
-                        let (word_range, _) = buffer.surrounding_word(old_range.start, None);
+                        let settings = buffer.language_settings_at(old_range.start, cx);
+                        let (word_range, _) = buffer.surrounding_word_with_extra_word_characters(
+                            old_range.start,
+                            None,
+                            Some(&settings.word_characters),
+                        );
                         // ignore if word is already selected
                         if !word_range.is_empty() && old_range != word_range {
-                            let (last_word_range, _) = buffer.surrounding_word(old_range.end, None);
+                            let (last_word_range, _) = buffer
+                                .surrounding_word_with_extra_word_characters(
+                                    old_range.end,
+                                    None,
+                                    Some(&settings.word_characters),
+                                );
                             // only select word if start and end point belongs to same word
                             if word_range == last_word_range {
                                 selected_larger_node = true;
@@ -1266,7 +1281,12 @@ impl Editor {
                 let position = display_map
                     .clip_point(position, Bias::Left)
                     .to_offset(&display_map, Bias::Left);
-                let (range, _) = buffer.surrounding_word(position, None);
+                let settings = buffer.language_settings_at(position, cx);
+                let (range, _) = buffer.surrounding_word_with_extra_word_characters(
+                    position,
+                    None,
+                    Some(&settings.word_characters),
+                );
                 start = buffer.anchor_before(range.start);
                 end = buffer.anchor_before(range.end);
                 mode = SelectMode::Word(start..end);
@@ -1364,11 +1384,19 @@ impl Editor {
                         .clip_point(position, Bias::Left)
                         .to_offset(&display_map, Bias::Left);
                     let original_range = original_range.to_offset(buffer);
+                    let settings = buffer.language_settings_at(offset, cx);
 
-                    let head_offset = if buffer.is_inside_word(offset, None)
-                        || original_range.contains(&offset)
+                    let head_offset = if buffer.is_inside_word_with_extra_word_characters(
+                        offset,
+                        None,
+                        Some(&settings.word_characters),
+                    ) || original_range.contains(&offset)
                     {
-                        let (word_range, _) = buffer.surrounding_word(offset, None);
+                        let (word_range, _) = buffer.surrounding_word_with_extra_word_characters(
+                            offset,
+                            None,
+                            Some(&settings.word_characters),
+                        );
                         if word_range.start < original_range.start {
                             word_range.start
                         } else {
@@ -2197,7 +2225,12 @@ impl Editor {
 
             if only_carets {
                 for selection in &mut selections {
-                    let (word_range, _) = buffer.surrounding_word(selection.start, None);
+                    let settings = buffer.language_settings_at(selection.start, cx);
+                    let (word_range, _) = buffer.surrounding_word_with_extra_word_characters(
+                        selection.start,
+                        None,
+                        Some(&settings.word_characters),
+                    );
                     selection.start = word_range.start;
                     selection.end = word_range.end;
                     selection.goal = SelectionGoal::None;

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -349,9 +349,20 @@ impl Editor {
                 MultiBufferOffset(query_match.start())..MultiBufferOffset(query_match.end())
             };
 
-            let is_partial_word_match = select_next_state.wordwise
-                && (buffer.is_inside_word(offset_range.start, None)
-                    || buffer.is_inside_word(offset_range.end, None));
+            let is_partial_word_match = if select_next_state.wordwise {
+                let settings = buffer.language_settings_at(offset_range.start, cx);
+                buffer.is_inside_word_with_extra_word_characters(
+                    offset_range.start,
+                    None,
+                    Some(&settings.word_characters),
+                ) || buffer.is_inside_word_with_extra_word_characters(
+                    offset_range.end,
+                    None,
+                    Some(&settings.word_characters),
+                )
+            } else {
+                false
+            };
 
             let is_initial_selection = MultiBufferOffset(query_match.start())
                 == initial_selection.start
@@ -440,10 +451,22 @@ impl Editor {
                     let offset_range =
                         end_offset - query_match.end()..end_offset - query_match.start();
 
-                    if !select_prev_state.wordwise
-                        || (!buffer.is_inside_word(offset_range.start, None)
-                            && !buffer.is_inside_word(offset_range.end, None))
-                    {
+                    let is_partial_word_match = if select_prev_state.wordwise {
+                        let settings = buffer.language_settings_at(offset_range.start, cx);
+                        buffer.is_inside_word_with_extra_word_characters(
+                            offset_range.start,
+                            None,
+                            Some(&settings.word_characters),
+                        ) || buffer.is_inside_word_with_extra_word_characters(
+                            offset_range.end,
+                            None,
+                            Some(&settings.word_characters),
+                        )
+                    } else {
+                        false
+                    };
+
+                    if !is_partial_word_match {
                         next_selected_range = Some(offset_range);
                         break;
                     }
@@ -2157,10 +2180,22 @@ impl Editor {
                     let offset_range =
                         start_offset + query_match.start()..start_offset + query_match.end();
 
-                    if !select_next_state.wordwise
-                        || (!buffer.is_inside_word(offset_range.start, None)
-                            && !buffer.is_inside_word(offset_range.end, None))
-                    {
+                    let is_partial_word_match = if select_next_state.wordwise {
+                        let settings = buffer.language_settings_at(offset_range.start, cx);
+                        buffer.is_inside_word_with_extra_word_characters(
+                            offset_range.start,
+                            None,
+                            Some(&settings.word_characters),
+                        ) || buffer.is_inside_word_with_extra_word_characters(
+                            offset_range.end,
+                            None,
+                            Some(&settings.word_characters),
+                        )
+                    } else {
+                        false
+                    };
+
+                    if !is_partial_word_match {
                         let idx = selections
                             .partition_point(|selection| selection.end <= offset_range.start);
                         let overlaps = selections

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -4065,6 +4065,15 @@ impl BufferSnapshot {
         start: T,
         scope_context: Option<CharScopeContext>,
     ) -> (Range<usize>, Option<CharKind>) {
+        self.surrounding_word_with_extra_word_characters(start, scope_context, None)
+    }
+
+    pub fn surrounding_word_with_extra_word_characters<T: ToOffset>(
+        &self,
+        start: T,
+        scope_context: Option<CharScopeContext>,
+        extra_word_characters: Option<&HashSet<char>>,
+    ) -> (Range<usize>, Option<CharKind>) {
         let mut start = start.to_offset(self);
         let mut end = start;
         let mut next_chars = self.chars_at(start).take(128).peekable();
@@ -4072,12 +4081,21 @@ impl BufferSnapshot {
 
         let classifier = self.char_classifier_at(start).scope_context(scope_context);
         let word_kind = cmp::max(
-            prev_chars.peek().copied().map(|c| classifier.kind(c)),
-            next_chars.peek().copied().map(|c| classifier.kind(c)),
+            prev_chars
+                .peek()
+                .copied()
+                .map(|c| classifier.kind_with_extra_word_characters(c, extra_word_characters)),
+            next_chars
+                .peek()
+                .copied()
+                .map(|c| classifier.kind_with_extra_word_characters(c, extra_word_characters)),
         );
 
         for ch in prev_chars {
-            if Some(classifier.kind(ch)) == word_kind && ch != '\n' {
+            if Some(classifier.kind_with_extra_word_characters(ch, extra_word_characters))
+                == word_kind
+                && ch != '\n'
+            {
                 start -= ch.len_utf8();
             } else {
                 break;
@@ -4085,7 +4103,10 @@ impl BufferSnapshot {
         }
 
         for ch in next_chars {
-            if Some(classifier.kind(ch)) == word_kind && ch != '\n' {
+            if Some(classifier.kind_with_extra_word_characters(ch, extra_word_characters))
+                == word_kind
+                && ch != '\n'
+            {
                 end += ch.len_utf8();
             } else {
                 break;
@@ -6078,7 +6099,32 @@ impl CharClassifier {
     }
 
     pub fn kind_with(&self, c: char, ignore_punctuation: bool) -> CharKind {
+        self.kind_with_extra_word_characters_and_punctuation(c, ignore_punctuation, None)
+    }
+
+    pub fn kind_with_extra_word_characters(
+        &self,
+        c: char,
+        extra_word_characters: Option<&HashSet<char>>,
+    ) -> CharKind {
+        self.kind_with_extra_word_characters_and_punctuation(
+            c,
+            self.ignore_punctuation,
+            extra_word_characters,
+        )
+    }
+
+    fn kind_with_extra_word_characters_and_punctuation(
+        &self,
+        c: char,
+        ignore_punctuation: bool,
+        extra_word_characters: Option<&HashSet<char>>,
+    ) -> CharKind {
         if c.is_alphanumeric() || c == '_' {
+            return CharKind::Word;
+        }
+
+        if extra_word_characters.is_some_and(|characters| characters.contains(&c)) {
             return CharKind::Word;
         }
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -4153,6 +4153,24 @@ fn init_settings(cx: &mut App, f: fn(&mut AllLanguageSettingsContent)) {
     });
 }
 
+#[gpui::test]
+fn test_surrounding_word_with_extra_word_characters(cx: &mut App) {
+    let buffer = cx.new(|cx| Buffer::local("foo-bar baz", cx));
+    let snapshot = buffer.read(cx).snapshot();
+
+    assert_eq!(snapshot.surrounding_word(4, None).0, 4..7);
+    assert_eq!(
+        snapshot
+            .surrounding_word_with_extra_word_characters(
+                4,
+                None,
+                Some(&['-'].into_iter().collect())
+            )
+            .0,
+        0..7
+    );
+}
+
 #[gpui::test(iterations = 100)]
 fn test_random_chunk_bitmaps(cx: &mut App, mut rng: StdRng) {
     use util::RandomCharIter;

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -161,6 +161,8 @@ pub struct LanguageSettings {
     pub completions: CompletionSettings,
     /// Preferred debuggers for this language.
     pub debuggers: Vec<String>,
+    /// Additional characters to treat as part of a word for word-based editor operations.
+    pub word_characters: HashSet<char>,
     /// Whether to enable word diff highlighting in the editor.
     ///
     /// When enabled, changed words within modified lines are highlighted
@@ -801,6 +803,7 @@ impl settings::Settings for AllLanguageSettings {
                     lsp_insert_mode: completions.lsp_insert_mode.unwrap(),
                 },
                 debuggers: settings.debuggers.unwrap(),
+                word_characters: settings.word_characters.unwrap(),
                 word_diff_enabled: settings.word_diff_enabled.unwrap(),
             }
         }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -19,7 +19,8 @@ pub use settings::{
     AutoIndentMode, CompletionSettingsContent, EditPredictionDataCollectionChoice,
     EditPredictionPromptFormatContent, EditPredictionProvider, EditPredictionsMode, FormatOnSave,
     Formatter, FormatterList, InlayHintKind, LanguageSettingsContent, LineEndingSetting,
-    LspInsertMode, RewrapBehavior, ShowWhitespaceSetting, SoftWrap, WordsCompletionMode,
+    LspInsertMode, RewrapBehavior, ShowWhitespaceSetting, SoftWrap, WordCharacters,
+    WordsCompletionMode,
 };
 use settings::{RegisterSetting, Settings, SettingsLocation, SettingsStore, merge_from::MergeFrom};
 use shellexpand;
@@ -161,7 +162,7 @@ pub struct LanguageSettings {
     pub completions: CompletionSettings,
     /// Preferred debuggers for this language.
     pub debuggers: Vec<String>,
-    /// Additional characters to treat as part of a word for word-based editor operations.
+    /// Additional characters to treat as part of a word for selection operations.
     pub word_characters: HashSet<char>,
     /// Whether to enable word diff highlighting in the editor.
     ///
@@ -803,7 +804,7 @@ impl settings::Settings for AllLanguageSettings {
                     lsp_insert_mode: completions.lsp_insert_mode.unwrap(),
                 },
                 debuggers: settings.debuggers.unwrap(),
-                word_characters: settings.word_characters.unwrap(),
+                word_characters: settings.word_characters.unwrap().0,
                 word_diff_enabled: settings.word_diff_enabled.unwrap(),
             }
         }
@@ -931,8 +932,47 @@ pub struct JsxTagAutoCloseSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gpui::TestAppContext;
+    use gpui::{TestAppContext, UpdateGlobal};
     use util::rel_path::rel_path;
+
+    #[gpui::test]
+    fn test_language_word_characters_override_global_word_characters(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.project.all_languages.defaults.word_characters =
+                        Some(WordCharacters(['-'].into_iter().collect()));
+                    settings.project.all_languages.languages.0.insert(
+                        "Rust".into(),
+                        LanguageSettingsContent {
+                            word_characters: Some(WordCharacters(['\''].into_iter().collect())),
+                            ..Default::default()
+                        },
+                    );
+                    settings.project.all_languages.languages.0.insert(
+                        "Plain Text".into(),
+                        LanguageSettingsContent {
+                            word_characters: Some(WordCharacters(HashSet::default())),
+                            ..Default::default()
+                        },
+                    );
+                });
+            });
+
+            let global_settings = LanguageSettings::resolve(None, None, cx);
+            assert_eq!(global_settings.word_characters, ['-'].into_iter().collect());
+
+            let rust_settings =
+                LanguageSettings::resolve(None, Some(&LanguageName::new("Rust")), cx);
+            assert_eq!(rust_settings.word_characters, ['\''].into_iter().collect());
+
+            let plain_text_settings =
+                LanguageSettings::resolve(None, Some(&LanguageName::new("Plain Text")), cx);
+            assert!(plain_text_settings.word_characters.is_empty());
+        });
+    }
 
     #[gpui::test]
     fn test_edit_predictions_enabled_for_file(cx: &mut TestAppContext) {

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3998,15 +3998,27 @@ impl MultiBufferSnapshot {
         position: T,
         scope_context: Option<CharScopeContext>,
     ) -> bool {
+        self.is_inside_word_with_extra_word_characters(position, scope_context, None)
+    }
+
+    pub fn is_inside_word_with_extra_word_characters<T: ToOffset>(
+        &self,
+        position: T,
+        scope_context: Option<CharScopeContext>,
+        extra_word_characters: Option<&HashSet<char>>,
+    ) -> bool {
         let position = position.to_offset(self);
         let classifier = self
             .char_classifier_at(position)
             .scope_context(scope_context);
-        let next_char_kind = self.chars_at(position).next().map(|c| classifier.kind(c));
+        let next_char_kind = self
+            .chars_at(position)
+            .next()
+            .map(|c| classifier.kind_with_extra_word_characters(c, extra_word_characters));
         let prev_char_kind = self
             .reversed_chars_at(position)
             .next()
-            .map(|c| classifier.kind(c));
+            .map(|c| classifier.kind_with_extra_word_characters(c, extra_word_characters));
         prev_char_kind.zip(next_char_kind) == Some((CharKind::Word, CharKind::Word))
     }
 
@@ -4014,6 +4026,15 @@ impl MultiBufferSnapshot {
         &self,
         start: T,
         scope_context: Option<CharScopeContext>,
+    ) -> (Range<MultiBufferOffset>, Option<CharKind>) {
+        self.surrounding_word_with_extra_word_characters(start, scope_context, None)
+    }
+
+    pub fn surrounding_word_with_extra_word_characters<T: ToOffset>(
+        &self,
+        start: T,
+        scope_context: Option<CharScopeContext>,
+        extra_word_characters: Option<&HashSet<char>>,
     ) -> (Range<MultiBufferOffset>, Option<CharKind>) {
         let mut start = start.to_offset(self);
         let mut end = start;
@@ -4023,12 +4044,21 @@ impl MultiBufferSnapshot {
         let classifier = self.char_classifier_at(start).scope_context(scope_context);
 
         let word_kind = cmp::max(
-            prev_chars.peek().copied().map(|c| classifier.kind(c)),
-            next_chars.peek().copied().map(|c| classifier.kind(c)),
+            prev_chars
+                .peek()
+                .copied()
+                .map(|c| classifier.kind_with_extra_word_characters(c, extra_word_characters)),
+            next_chars
+                .peek()
+                .copied()
+                .map(|c| classifier.kind_with_extra_word_characters(c, extra_word_characters)),
         );
 
         for ch in prev_chars {
-            if Some(classifier.kind(ch)) == word_kind && ch != '\n' {
+            if Some(classifier.kind_with_extra_word_characters(ch, extra_word_characters))
+                == word_kind
+                && ch != '\n'
+            {
                 start -= ch.len_utf8();
             } else {
                 break;
@@ -4036,7 +4066,10 @@ impl MultiBufferSnapshot {
         }
 
         for ch in next_chars {
-            if Some(classifier.kind(ch)) == word_kind && ch != '\n' {
+            if Some(classifier.kind_with_extra_word_characters(ch, extra_word_characters))
+                == word_kind
+                && ch != '\n'
+            {
                 end += ch.len_utf8();
             } else {
                 break;

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -2199,6 +2199,28 @@ mod tests {
             cx,
         );
 
+        // word separators
+        check_vscode_import(
+            &mut store,
+            r#"{
+            }
+            "#
+            .unindent(),
+            r#"{ "editor.wordSeparators": "`~!@#$%^&*()=+[{]}\\|;:'\",.<>/? " }"#.to_owned(),
+            r#"{
+              "base_keymap": "VSCode",
+              "minimap": {
+                "show": "always"
+              },
+              "word_characters": [
+                "-"
+              ]
+            }
+            "#
+            .unindent(),
+            cx,
+        );
+
         // persist settings that were present
         check_vscode_import(
             &mut store,

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -129,12 +129,13 @@ impl VsCodeSettings {
         self.content.get(key).and_then(Value::as_str).and_then(f)
     }
 
-    fn word_characters_from_word_separators(&self) -> Option<HashSet<char>> {
+    fn word_characters_from_word_separators(&self) -> Option<WordCharacters> {
         let separators = self.read_str("editor.wordSeparators")?;
         Some(
             ('!'..='~')
                 .filter(|&c| !c.is_alphanumeric() && c != '_' && !separators.contains(c))
-                .collect(),
+                .collect::<HashSet<_>>()
+                .into(),
         )
     }
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use anyhow::{Context as _, Result, anyhow};
-use collections::HashMap;
+use collections::{HashMap, HashSet};
 use fs::Fs;
 use gpui::Rgba;
 use paths::{cursor_settings_file_paths, vscode_settings_file_paths};
@@ -127,6 +127,15 @@ impl VsCodeSettings {
 
     fn read_enum<T>(&self, key: &str, f: impl FnOnce(&str) -> Option<T>) -> Option<T> {
         self.content.get(key).and_then(Value::as_str).and_then(f)
+    }
+
+    fn word_characters_from_word_separators(&self) -> Option<HashSet<char>> {
+        let separators = self.read_str("editor.wordSeparators")?;
+        Some(
+            ('!'..='~')
+                .filter(|&c| !c.is_alphanumeric() && c != '_' && !separators.contains(c))
+                .collect(),
+        )
     }
 
     fn read_fonts(&self, key: &str) -> (Option<FontFamilyName>, Option<Vec<FontFamilyName>>) {
@@ -626,6 +635,7 @@ impl VsCodeSettings {
                         .flat_map(|n| n.as_u64().map(|n| n as usize))
                         .collect()
                 }),
+            word_characters: self.word_characters_from_word_separators(),
             word_diff_enabled: None,
         }
     }

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -116,6 +116,22 @@ impl EditPredictionProvider {
     }
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(transparent)]
+pub struct WordCharacters(pub HashSet<char>);
+
+impl merge_from::MergeFrom for WordCharacters {
+    fn merge_from(&mut self, other: &Self) {
+        *self = other.clone();
+    }
+}
+
+impl From<HashSet<char>> for WordCharacters {
+    fn from(value: HashSet<char>) -> Self {
+        Self(value)
+    }
+}
+
 /// The contents of the edit prediction settings.
 #[with_fallible_options]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
@@ -612,11 +628,11 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: []
     pub debuggers: Option<Vec<String>>,
-    /// Additional characters to treat as part of a word for word-based
-    /// editor operations, such as double-click word selection.
+    /// Additional characters to treat as part of a word for selection operations,
+    /// such as double-click word selection.
     ///
     /// Default: []
-    pub word_characters: Option<HashSet<char>>,
+    pub word_characters: Option<WordCharacters>,
     /// Whether to enable word diff highlighting in the editor.
     ///
     /// When enabled, changed words within modified lines are highlighted

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -612,6 +612,11 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: []
     pub debuggers: Option<Vec<String>>,
+    /// Additional characters to treat as part of a word for word-based
+    /// editor operations, such as double-click word selection.
+    ///
+    /// Default: []
+    pub word_characters: Option<HashSet<char>>,
     /// Whether to enable word diff highlighting in the editor.
     ///
     /// When enabled, changed words within modified lines are highlighted

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4075,8 +4075,8 @@ List of `integer` column numbers
 
 ## Word Characters
 
-- Description: Additional characters to treat as part of a word for word-based
-  editor operations, such as double-click word selection.
+- Description: Additional characters to treat as part of a word for selection
+  operations, such as double-click word selection.
 - Setting: `word_characters`
 - Default: `[]`
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -2952,6 +2952,7 @@ The following settings can be overridden for each specific language:
 - [`whitespace_map`](#whitespace-map)
 - [`soft_wrap`](#soft-wrap)
 - [`tab_size`](#tab-size)
+- [`word_characters`](#word-characters)
 - [`use_autoclose`](#use-autoclose)
 - [`always_treat_brackets_as_autoclosed`](#always-treat-brackets-as-autoclosed)
 
@@ -3267,7 +3268,6 @@ Examples:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
-
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action
@@ -4072,6 +4072,25 @@ List of `integer` column numbers
 **Options**
 
 `integer` values
+
+## Word Characters
+
+- Description: Additional characters to treat as part of a word for word-based
+  editor operations, such as double-click word selection.
+- Setting: `word_characters`
+- Default: `[]`
+
+**Options**
+
+List of single-character strings.
+
+Example:
+
+```json [settings]
+{
+  "word_characters": ["-"]
+}
+```
 
 ## Tasks
 


### PR DESCRIPTION
## Summary

Adds a `word_characters` language setting that lets users configure extra characters considered part of a word for editor selection. With:

```json
{
  "word_characters": ["-"]
}
```

double-click selection can include `foo-bar` as one word.

This uses existing language settings merging, so the setting can be defined globally or under `languages`. Language extension word characters continue to apply through the existing classifier path.

VS Code imports translate `editor.wordSeparators` into `word_characters` for ASCII punctuation that VS Code does not treat as a separator.

## Validation

- `git diff --check`
- `cargo fmt -p language -p multi_buffer -p editor -p settings -p settings_content --check`
- `npx prettier --check src/reference/all-settings.md`
- `cargo check -p settings_content --lib`
- `cargo check -p language --lib`
- `cargo test -p language test_surrounding_word_with_extra_word_characters`
- `cargo test -p settings test_vscode_import`
- `cargo check -p editor --lib`

Release Notes:

- Added `word_characters` setting for configuring word selection behavior.