### PR TITLE
settings: Allow empty EditorConfig values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -582,7 +582,7 @@ dirs = "6.0"
 documented = "0.9.1"
 dotenvy = "0.15.0"
 dunce = "1.0"
-ec4rs = "1.1"
+ec4rs = { version = "1.2", features = ["allow-empty-values"] }
 emojis = "0.6.1"
 env_logger = "0.11"
 encoding_rs = "0.8"

--- a/crates/settings/src/editorconfig_store.rs
+++ b/crates/settings/src/editorconfig_store.rs
@@ -391,3 +391,37 @@ impl EditorconfigStore {
             .unwrap_or_default()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_empty_editorconfig_values() {
+        let editorconfig = "\
+root = true
+
+[*]
+dotnet_naming_style.s_camelcase.required_prefix = s_
+dotnet_naming_style.s_camelcase.required_suffix =
+dotnet_naming_style.s_camelcase.word_separator =
+dotnet_naming_style.s_camelcase.capitalization = camel_case
+";
+
+        let editorconfig = editorconfig
+            .parse::<Editorconfig>()
+            .expect("editorconfig with empty values should parse");
+
+        assert!(editorconfig.is_root);
+        let [section] = editorconfig.sections.as_slice() else {
+            panic!("expected one section, got {}", editorconfig.sections.len());
+        };
+        assert_eq!(section.props().len(), 4);
+        assert!(section.props().iter().any(|(key, value)| {
+            key == "dotnet_naming_style.s_camelcase.required_suffix" && value.to_string().is_empty()
+        }));
+        assert!(section.props().iter().any(|(key, value)| {
+            key == "dotnet_naming_style.s_camelcase.word_separator" && value.to_string().is_empty()
+        }));
+    }
+}


### PR DESCRIPTION
# Objective

Fixes #59466.

Zed rejected valid `.editorconfig` files that use empty values, which are common in Roslyn naming style settings such as `required_suffix =` and `word_separator =`.

## Solution

Enable ec4rs's `allow-empty-values` feature for the workspace dependency so `key =` lines parse successfully.

Add a regression test that covers empty `.editorconfig` property values and confirms the parsed section keeps both empty entries.

## Testing

- `cargo fmt --all`
- `cargo test -p settings parses_empty_editorconfig_values`
- `cargo test -p settings`

Tested on macOS.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed EditorConfig files with empty values being rejected.