### PR TITLE
Provide Zed Data Dir as a TaskVariable

### DIFF
--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -18,7 +18,7 @@ use language::{
     language_settings::LanguageSettings,
 };
 use lsp::{LanguageServerId, LanguageServerName};
-use paths::{debug_task_file_name, task_file_name};
+use paths::{debug_task_file_name, extensions_dir, task_file_name};
 use settings::{InvalidSettingsError, parse_json_with_comments};
 use task::{
     DebugScenario, ResolvedTask, SharedTaskContext, TaskContext, TaskHook, TaskId, TaskTemplate,
@@ -1124,6 +1124,11 @@ impl ContextProvider for BasicContextProvider {
         if let Some(language) = buffer.language() {
             task_variables.insert(VariableName::Language, language.name().to_string());
         }
+
+        task_variables.insert(
+            VariableName::ExtensionWorkDir,
+            extensions_dir().join("work").to_string_lossy().into_owned(),
+        );
 
         Task::ready(Ok(task_variables))
     }

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -195,6 +195,8 @@ pub enum VariableName {
     GitRepositoryPath,
     /// Name of the Git ref (branch, remote ref, or tag) associated with the task context.
     GitRef,
+    /// Absolute path of the Zed extensions work directory
+    ExtensionWorkDir,
     /// Custom variable, provided by the plugin or other external source.
     /// Will be printed with `CUSTOM_` prefix to avoid potential conflicts with other variables.
     Custom(Cow<'static, str>),
@@ -236,6 +238,7 @@ impl FromStr for VariableName {
             "GIT_REPOSITORY_NAME" => Self::GitRepositoryName,
             "GIT_REPOSITORY_PATH" => Self::GitRepositoryPath,
             "GIT_REF" => Self::GitRef,
+            "EXTENSION_WORK_DIR" => Self::ExtensionWorkDir,
             _ => {
                 if let Some(custom_name) =
                     without_prefix.strip_prefix(ZED_CUSTOM_VARIABLE_NAME_PREFIX)
@@ -277,6 +280,7 @@ impl std::fmt::Display for VariableName {
             Self::GitRepositoryName => write!(f, "{ZED_VARIABLE_NAME_PREFIX}GIT_REPOSITORY_NAME"),
             Self::GitRepositoryPath => write!(f, "{ZED_VARIABLE_NAME_PREFIX}GIT_REPOSITORY_PATH"),
             Self::GitRef => write!(f, "{ZED_VARIABLE_NAME_PREFIX}GIT_REF"),
+            Self::ExtensionWorkDir => write!(f, "{ZED_VARIABLE_NAME_PREFIX}EXTENSION_WORK_DIR"),
             Self::Custom(s) => write!(
                 f,
                 "{ZED_VARIABLE_NAME_PREFIX}{ZED_CUSTOM_VARIABLE_NAME_PREFIX}{s}"

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -98,6 +98,7 @@ These variables allow you to pull information from the current editor and use it
 - `ZED_WORKTREE_ROOT`: absolute path to the root of the current worktree. (e.g. `/Users/my-user/path/to/project`)
 - `ZED_MAIN_GIT_WORKTREE`: absolute path to the main git worktree's working directory. For normal checkouts this equals `ZED_WORKTREE_ROOT`; for linked git worktrees this is the original repository's working directory.
 - `ZED_CUSTOM_RUST_PACKAGE`: (Rust-specific) name of the parent package of $ZED_FILE source file.
+- `ZED_EXTENSION_WORK_DIR`: the absolute path to the Zed extension work directory
 
 To use a variable in a task, prefix it with a dollar sign (`$`):
 


### PR DESCRIPTION
## Problem
For extensions providing tasks (like the ones that are exposed as the little play buttons next to e.g. test methods) it is extremely difficult to impossible to do non-trivial things in a platform-agnostic way, because the programming model is polyglot-shell-script-in-a-json-string. 
 
## Solution

The primary goal of this PR is to give extension-provided tasks access to the extension working directory (`$ZED_EXTENSION_WORK_DIR/my_extension`) so they can dispatch the logic to provided scripts/binaries, which allows for a much more reasonable programming model.

It does so by providing the resolved extension work dir (`paths::extensions_dir()/work`)  as a TaskVariable, so scripts don't have to make guesses and/or duplicate code in above mentioned polyglot-shell-scripts-in-json-string kind of ways in order to dispatch their tasks correctly.

## Context

I work primarily on the Java extension. 
https://github.com/zed-extensions/java/issues/94 is the issue that this would solve specifically for me
https://github.com/zed-extensions/java/pull/274 contains some of our discussions on the subject
https://github.com/zed-industries/zed/pull/45932 is a much more general approach at this, that would unlock more things to be done with extensions but means changes to the extension api, which comes with dangers and problems

Release Notes:

- Added `$ZED_EXTENSION_WORK_DIR` Task Variable
