### PR TITLE
file_finder: Add include_ignored parameter to Toggle action

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -110,7 +110,14 @@ impl FileFinder {
         workspace.register_action(
             |workspace, action: &workspace::ToggleFileFinder, window, cx| {
                 let Some(file_finder) = workspace.active_modal::<Self>(cx) else {
-                    Self::open(workspace, action.separate_history, window, cx).detach();
+                    Self::open(
+                        workspace,
+                        action.separate_history,
+                        action.include_ignored,
+                        window,
+                        cx,
+                    )
+                    .detach();
                     return;
                 };
 
@@ -127,6 +134,7 @@ impl FileFinder {
     fn open(
         workspace: &mut Workspace,
         separate_history: bool,
+        include_ignored: Option<bool>,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) -> Task<()> {
@@ -179,6 +187,7 @@ impl FileFinder {
                             currently_opened_path,
                             history_items.collect(),
                             separate_history,
+                            include_ignored,
                             window,
                             cx,
                         );
@@ -962,6 +971,7 @@ impl FileFinderDelegate {
         currently_opened_path: Option<FoundPath>,
         history_items: Vec<FoundPath>,
         separate_history: bool,
+        include_ignored: Option<bool>,
         window: &mut Window,
         cx: &mut Context<FileFinder>,
     ) -> Self {
@@ -991,7 +1001,7 @@ impl FileFinderDelegate {
             filter_popover_menu_handle: PopoverMenuHandle::default(),
             split_popover_menu_handle: PopoverMenuHandle::default(),
             focus_handle: cx.focus_handle(),
-            include_ignored: FileFinderSettings::get_global(cx).include_ignored,
+            include_ignored: include_ignored.or(FileFinderSettings::get_global(cx).include_ignored),
             include_ignored_refresh: Task::ready(()),
         }
     }

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -1102,14 +1102,35 @@ async fn test_toggle_action_include_ignored_param(cx: &mut TestAppContext) {
         cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
     let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
 
-    for include_ignored in [Some(true), Some(false), None] {
+    let cases = [
+        (None, Some(true), Some(true)),
+        (None, Some(false), Some(false)),
+        (None, None, None),
+        (Some(true), Some(false), Some(false)),
+        (Some(false), Some(true), Some(true)),
+        (Some(true), None, Some(true)),
+    ];
+    for (setting, action_param, expected) in cases {
+        cx.update(|_, cx| {
+            let settings = *FileFinderSettings::get_global(cx);
+            FileFinderSettings::override_global(
+                FileFinderSettings {
+                    include_ignored: setting,
+                    ..settings
+                },
+                cx,
+            );
+        });
         cx.dispatch_action(ToggleFileFinder {
             separate_history: false,
-            include_ignored,
+            include_ignored: action_param,
         });
         let picker = active_file_picker(&workspace, cx);
         picker.update(cx, |picker, _| {
-            assert_eq!(picker.delegate.include_ignored, include_ignored);
+            assert_eq!(
+                picker.delegate.include_ignored, expected,
+                "setting: {setting:?}, action param: {action_param:?}"
+            );
         });
         cx.dispatch_action(menu::Cancel);
     }

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -1095,6 +1095,27 @@ async fn test_ignored_root_with_file_inclusions_repro(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_toggle_action_include_ignored_param(cx: &mut TestAppContext) {
+    let app_state = init_test(cx);
+    let project = Project::test(app_state.fs.clone(), [], cx).await;
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+    let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+    for include_ignored in [Some(true), Some(false), None] {
+        cx.dispatch_action(ToggleFileFinder {
+            separate_history: false,
+            include_ignored,
+        });
+        let picker = active_file_picker(&workspace, cx);
+        picker.update(cx, |picker, _| {
+            assert_eq!(picker.delegate.include_ignored, include_ignored);
+        });
+        cx.dispatch_action(menu::Cancel);
+    }
+}
+
+#[gpui::test]
 async fn test_ignored_root(cx: &mut TestAppContext) {
     let app_state = init_test(cx);
     app_state
@@ -4476,6 +4497,7 @@ fn open_file_picker(
 ) -> Entity<Picker<FileFinderDelegate>> {
     cx.dispatch_action(ToggleFileFinder {
         separate_history: true,
+        include_ignored: None,
     });
     active_file_picker(workspace, cx)
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -468,7 +468,6 @@ actions!(
 pub struct ToggleFileFinder {
     #[serde(default)]
     pub separate_history: bool,
-    /// When set, overrides the `file_finder.include_ignored` setting for this invocation.
     #[serde(default)]
     pub include_ignored: Option<bool>,
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -468,6 +468,9 @@ actions!(
 pub struct ToggleFileFinder {
     #[serde(default)]
     pub separate_history: bool,
+    /// When set, overrides the `file_finder.include_ignored` setting for this invocation.
+    #[serde(default)]
+    pub include_ignored: Option<bool>,
 }
 
 /// Opens a new terminal in the center.

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -446,16 +446,6 @@ TBD: Centered layout related settings
   },
 ```
 
-The `include_ignored` value can also be overridden per-binding using the `file_finder::Toggle` action, which lets you open the file finder with ignored files pre-included regardless of the global setting:
-
-```json [keymap]
-{
-  "bindings": {
-    "ctrl-shift-o": ["file_finder::Toggle", { "include_ignored": true }]
-  }
-}
-```
-
 ## Project Panel
 
 Project panel can be shown/hidden with {#action project_panel::ToggleFocus} ({#kb project_panel::ToggleFocus}) or with {#action pane::RevealInProjectPanel} ({#kb pane::RevealInProjectPanel}).

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -446,6 +446,16 @@ TBD: Centered layout related settings
   },
 ```
 
+The `include_ignored` value can also be overridden per-binding using the `file_finder::Toggle` action, which lets you open the file finder with ignored files pre-included regardless of the global setting:
+
+```json [keymap]
+{
+  "bindings": {
+    "ctrl-shift-o": ["file_finder::Toggle", { "include_ignored": true }]
+  }
+}
+```
+
 ## Project Panel
 
 Project panel can be shown/hidden with {#action project_panel::ToggleFocus} ({#kb project_panel::ToggleFocus}) or with {#action pane::RevealInProjectPanel} ({#kb pane::RevealInProjectPanel}).


### PR DESCRIPTION
# Objective

Allow keybindings to open the file finder with ignored files pre-included, regardless of the global `file_finder.include_ignored` setting:

```json
  {
    "bindings": {
      "ctrl-shift-o": ["file_finder::Toggle", { "include_ignored": true }]
    }
  }
```

Closes https://github.com/zed-industries/zed/discussions/42575

## Solution

- Describe the solution used to achieve the objective above.

## Testing

- Did you test these changes? If so, how?
   manually locally and a unit test.
- Are there any parts that need more testing?
  no
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
   no
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  macOS

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---

Release Notes:

- Added `include_ignored` parameter to `file_finder::Toggle` action, allowing keybindings to open the file finder with ignored files pre-included.
