### PR TITLE
Remember last directory in the open project/file dialog

### DIFF
--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -1623,6 +1623,7 @@ impl MessageEditor {
             directories: false,
             multiple: true,
             prompt: Some("Select Images".into()),
+            directory: None,
         });
 
         window

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -1240,6 +1240,7 @@ impl ProjectPickerDelegate {
             directories: true,
             multiple: false,
             prompt: None,
+            directory: None,
         });
         cx.spawn_in(window, async move |this, cx| {
             let Ok(Ok(Some(paths))) = paths_receiver.await else {

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -114,6 +114,7 @@ pub fn init(cx: &mut App) {
                         directories: true,
                         multiple: false,
                         prompt: None,
+                        directory: None,
                     },
                     DirectoryLister::Local(
                         workspace.project().clone(),

--- a/crates/git_ui/src/clone.rs
+++ b/crates/git_ui/src/clone.rs
@@ -19,6 +19,7 @@ pub fn clone_and_open(
         directories: true,
         multiple: false,
         prompt: Some("Select as Repository Destination".into()),
+        directory: None,
     });
 
     window

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -1128,6 +1128,7 @@ mod tests {
                 directories: true,
                 multiple: true,
                 prompt: None,
+                directory: None,
             })
         });
         assert!(cx.did_prompt_for_paths());
@@ -1153,6 +1154,7 @@ mod tests {
                 files: true,
                 directories: false,
                 multiple: false,
+                directory: None,
                 prompt: None,
             })
         });

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1755,6 +1755,8 @@ pub struct PathPromptOptions {
     pub multiple: bool,
     /// The prompt to show to a user when selecting a path
     pub prompt: Option<SharedString>,
+    /// The directory the dialog should initially display, if known.
+    pub directory: Option<PathBuf>,
 }
 
 /// What kind of prompt styling to show

--- a/crates/gpui_linux/src/linux/platform.rs
+++ b/crates/gpui_linux/src/linux/platform.rs
@@ -346,16 +346,28 @@ impl<P: LinuxClient + 'static> Platform for LinuxPlatform<P> {
                     "Open File"
                 };
 
-                let request = match ashpd::desktop::file_chooser::OpenFileRequest::default()
+                let request_builder = ashpd::desktop::file_chooser::OpenFileRequest::default()
                     .identifier(identifier.await)
                     .modal(true)
                     .title(title)
                     .accept_label(options.prompt.as_ref().map(gpui::SharedString::as_str))
                     .multiple(options.multiple)
-                    .directory(options.directories)
-                    .send()
-                    .await
-                {
+                    .directory(options.directories);
+
+                let request_builder = match options.directory.as_deref() {
+                    Some(directory) => match request_builder.current_folder(directory) {
+                        Ok(request_builder) => request_builder,
+                        Err(error) => {
+                            let _ = done_tx.send(Err(anyhow!(
+                                "failed to set initial folder for open dialog: {error}"
+                            )));
+                            return;
+                        }
+                    },
+                    None => request_builder,
+                };
+
+                let request = match request_builder.send().await {
                     Ok(request) => request,
                     Err(err) => {
                         let result = match err {

--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -736,6 +736,13 @@ impl Platform for MacPlatform {
 
                     panel.setCanCreateDirectories(true.to_objc());
                     panel.setResolvesAliases_(false.to_objc());
+
+                    if let Some(directory) = options.directory {
+                        let path = ns_string(directory.to_string_lossy().as_ref());
+                        let url = NSURL::fileURLWithPath_isDirectory_(nil, path, true.to_objc());
+                        panel.setDirectoryURL(url);
+                    }
+
                     let done_tx = Cell::new(Some(done_tx));
                     let block = ConcreteBlock::new(move |response: NSModalResponse| {
                         let result = if response == NSModalResponse::NSModalResponseOk {

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -1152,6 +1152,23 @@ fn file_open_dialog(
             folder_dialog.SetOkButtonLabel(&HSTRING::from(prompt))?;
         }
 
+        if let Some(directory) = options.directory.as_ref()
+            && !directory.as_os_str().is_empty()
+            && let Some(full_path) = directory
+                .canonicalize()
+                .context("failed to canonicalize directory")
+                .log_err()
+        {
+            let full_path = SanitizedPath::new(&full_path);
+            let full_path_string = full_path.to_string();
+            let path_item: IShellItem =
+                SHCreateItemFromParsingName(&HSTRING::from(full_path_string), None)?;
+            folder_dialog
+                .SetFolder(&path_item)
+                .context("failed to set dialog folder")
+                .log_err();
+        }
+
         if folder_dialog.Show(window).is_err() {
             // User cancelled
             return Ok(None);

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3405,6 +3405,7 @@ impl ProjectPanel {
             directories: true,
             multiple: false,
             prompt: Some("Download".into()),
+            directory: None,
         });
 
         let fs = self.fs.clone();

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -300,6 +300,7 @@ pub fn init(cx: &mut App) {
                     directories: true,
                     multiple: false,
                     prompt: None,
+                    directory: None,
                 },
                 DirectoryLister::Local(
                     workspace.project().clone(),
@@ -2074,6 +2075,7 @@ fn open_local_project(
                 directories: true,
                 multiple: true,
                 prompt: None,
+                directory: None,
             },
             DirectoryLister::Local(
                 workspace.project().clone(),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -725,11 +725,15 @@ fn prompt_and_open_paths(
 pub fn prompt_for_open_path_and_open(
     workspace: &mut Workspace,
     app_state: Arc<AppState>,
-    options: PathPromptOptions,
+    mut options: PathPromptOptions,
     create_new_window: bool,
     window: &mut Window,
     cx: &mut Context<Workspace>,
 ) {
+    if options.directory.is_none() {
+        options.directory = last_open_dialog_directory(workspace, cx);
+    }
+    let kvp = db::kvp::KeyValueStore::global(cx);
     let paths = workspace.prompt_for_open_path(
         options,
         DirectoryLister::Local(workspace.project().clone(), app_state.fs.clone()),
@@ -741,6 +745,21 @@ pub fn prompt_for_open_path_and_open(
         let Some(paths) = paths.await.log_err().flatten() else {
             return;
         };
+        // Remember the directory containing the selection so the next dialog
+        // opens beside it (e.g. next to sibling project directories).
+        if let Some(directory) = paths
+            .first()
+            .and_then(|path| path.parent())
+            .map(|parent| parent.to_string_lossy().into_owned())
+            .filter(|directory| !directory.is_empty())
+        {
+            cx.background_spawn(async move {
+                kvp.write_kvp(LAST_OPEN_DIRECTORY_KEY.to_string(), directory)
+                    .await
+                    .log_err();
+            })
+            .detach();
+        }
         if !create_new_window {
             if let Some(handle) = multi_workspace_handle {
                 if let Some(task) = handle
@@ -766,6 +785,38 @@ pub fn prompt_for_open_path_and_open(
     .detach();
 }
 
+const LAST_OPEN_DIRECTORY_KEY: &str = "last_open_directory";
+
+/// Determines which directory the system "open" dialog should start in:
+/// the directory the user last opened from, falling back to the parent of a
+/// visible worktree root (so sibling projects are visible) and finally the
+/// home directory.
+fn last_open_dialog_directory(workspace: &Workspace, cx: &App) -> Option<PathBuf> {
+    if let Some(stored) = db::kvp::KeyValueStore::global(cx)
+        .read_kvp(LAST_OPEN_DIRECTORY_KEY)
+        .log_err()
+        .flatten()
+        .filter(|directory| !directory.is_empty())
+    {
+        return Some(PathBuf::from(stored));
+    }
+
+    workspace
+        .most_recent_active_path(cx)
+        .and_then(|path| path.parent().map(Path::to_path_buf))
+        .or_else(|| {
+            workspace
+                .project()
+                .read(cx)
+                .visible_worktrees(cx)
+                .find_map(|worktree| {
+                    let worktree = worktree.read(cx);
+                    worktree.as_local()?.abs_path().parent().map(Path::to_path_buf)
+                })
+        })
+        .or_else(std::env::home_dir)
+}
+
 pub fn init(app_state: Arc<AppState>, cx: &mut App) {
     component::init();
     theme_preview::init(cx);
@@ -783,6 +834,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut App) {
                     directories: true,
                     multiple: true,
                     prompt: None,
+                    directory: None,
                 },
                 action.create_new_window.unwrap_or_else(|| {
                     matches!(
@@ -803,6 +855,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut App) {
                     directories,
                     multiple: true,
                     prompt: None,
+                    directory: None,
                 },
                 true,
                 cx,
@@ -3865,6 +3918,7 @@ impl Workspace {
                 directories: true,
                 multiple: true,
                 prompt: None,
+                directory: None,
             },
             DirectoryLister::Project(self.project.clone()),
             window,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -946,6 +946,7 @@ fn register_actions(
                     directories: true,
                     multiple: true,
                     prompt: None,
+                    directory: None,
                 },
                 action.create_new_window.unwrap_or_else(|| {
                     matches!(
@@ -967,6 +968,7 @@ fn register_actions(
                     directories,
                     multiple: true,
                     prompt: None,
+                    directory: None,
                 },
                 true,
                 window,
@@ -989,6 +991,7 @@ fn register_actions(
                     directories: true,
                     multiple: true,
                     prompt: None,
+                    directory: None,
                 },
                 DirectoryLister::Project(workspace.project().clone()),
                 window,


### PR DESCRIPTION
The native "open" dialog (`workspace::Open` / `prompt_for_paths`) never received a starting directory, so it always opened at the OS default. When opening projects, users had to re-navigate from scratch every time to reach a sibling project directory.

The save dialog (`prompt_for_new_path`) already takes and uses a `directory` argument on every platform; this brings the open dialog to parity.

## Changes

- Add a `directory: Option<PathBuf>` field to `PathPromptOptions` and honor it in the macOS (`setDirectoryURL`), Linux (ashpd `current_folder`), and Windows (`SetFolder`) open-dialog implementations, mirroring the existing save-dialog code.
- In `prompt_for_open_path_and_open`, resolve the starting directory as: the directory last opened from (persisted via `KEY_VALUE_STORE`), falling back to the parent of the most-recent active file, then the parent of a visible worktree root (so sibling projects are visible), then the home directory.
- Persist the parent of the selected path back to the store after a successful open.

This benefits every open-dialog entry point (the File menu, the "Open Project" empty-state buttons, etc.), since they all share `prompt_for_paths`. The extension-directory picker, recent-projects "open folder", and file-attachment pickers are intentionally left unchanged (they pass `directory: None`).

## Testing

Built and `clippy`-clean on Linux (`workspace`, `gpui_linux`). The macOS and Windows changes are mechanical mirrors of the adjacent save-dialog implementations and were not built locally — relying on CI for those targets.

Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Improved the system file/folder open dialog to start at the directory you last opened from.
