### PR TITLE
Rework Git documentation IA

### DIFF
--- a/crates/docs_preprocessor/src/main.rs
+++ b/crates/docs_preprocessor/src/main.rs
@@ -188,7 +188,7 @@ fn handle_preprocessing() -> Result<()> {
     template_big_table_of_actions(&mut book);
     template_and_validate_keybindings(&mut book, &mut errors);
     template_and_validate_actions(&mut book, &mut errors);
-    template_and_validate_json_snippets(&mut book, &mut errors);
+    template_and_validate_json_snippets(&mut book, &mut errors)?;
 
     if !errors.is_empty() {
         const ANSI_RED: &str = "\x1b[31m";
@@ -379,7 +379,10 @@ fn find_binding_with_overlay(
         .or_else(|| find_binding(os, action))
 }
 
-fn template_and_validate_json_snippets(book: &mut Book, errors: &mut HashSet<PreprocessorError>) {
+fn template_and_validate_json_snippets(
+    book: &mut Book,
+    errors: &mut HashSet<PreprocessorError>,
+) -> Result<()> {
     let params = SettingsJsonSchemaParams {
         language_names: &[],
         font_names: &[],
@@ -393,7 +396,7 @@ fn template_and_validate_json_snippets(book: &mut Book, errors: &mut HashSet<Pre
     };
     let settings_schema = SettingsStore::json_schema(&params);
     let settings_validator = jsonschema::validator_for(&settings_schema)
-        .expect("failed to compile settings JSON schema");
+        .context("failed to compile settings JSON schema")?;
 
     // The keymap schema is built from the action manifest. When `actions.json`
     // is unavailable (e.g. when running outside of CI without first generating
@@ -405,7 +408,7 @@ fn template_and_validate_json_snippets(book: &mut Book, errors: &mut HashSet<Pre
             keymap_schema_for_actions(&ALL_ACTIONS.actions, &ALL_ACTIONS.schema_definitions);
         Some(
             jsonschema::validator_for(&keymap_schema)
-                .expect("failed to compile keymap JSON schema"),
+                .context("failed to compile keymap JSON schema")?,
         )
     } else {
         None
@@ -568,6 +571,8 @@ fn template_and_validate_json_snippets(book: &mut Book, errors: &mut HashSet<Pre
         };
         Ok(())
     });
+
+    Ok(())
 }
 
 /// Removes any configurable options from the stringified action if existing,

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -34,7 +34,7 @@
   - [Worktrees](./git/worktrees.md)
   - [History and Blame](./git/history-and-blame.md)
   - [Conflicts and Recovery](./git/conflicts-and-recovery.md)
-  - [GitHub and Pull Requests](./git/github-and-pull-requests.md)
+  - [Git Hosting and Pull Requests](./git/github-and-pull-requests.md)
   - [Agents and Git](./git/agents-and-git.md)
   - [Settings and Actions](./git/settings-and-actions.md)
 - [Modelines](./modelines.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,7 +26,17 @@
   - [Tasks](./tasks.md)
   - [Debugger](./debugger.md)
   - [REPL](./repl.md)
-- [Git](./git.md)
+- [Git and Review](./git.md)
+  - [Status and Changes](./git/status-and-changes.md)
+  - [Diffs and Review](./git/diffs-and-review.md)
+  - [Staging and Committing](./git/staging-and-committing.md)
+  - [Branches and Sync](./git/branches-and-sync.md)
+  - [Worktrees](./git/worktrees.md)
+  - [History and Blame](./git/history-and-blame.md)
+  - [Conflicts and Recovery](./git/conflicts-and-recovery.md)
+  - [GitHub and Pull Requests](./git/github-and-pull-requests.md)
+  - [Agents and Git](./git/agents-and-git.md)
+  - [Settings and Actions](./git/settings-and-actions.md)
 - [Modelines](./modelines.md)
 
 # Collaboration

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -47,7 +47,9 @@ You can also start a new thread from the [Threads Sidebar](./parallel-agents.md#
 
 ### Managing Multiple Threads {#multiple-threads}
 
-You can run multiple agent threads at once, each working independently with its own agent, context window, and conversation history. Open the Threads Sidebar with {#kb multi_workspace::ToggleWorkspaceSidebar} to see all your threads grouped by project. For how projects, Zed worktrees, Git worktrees, and branches fit together, see [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees). Click any thread to switch to it, or use the thread switcher ({#kb agents_sidebar::ToggleThreadSwitcher}) to cycle between recent threads without opening the sidebar.
+You can run multiple agent threads at once, each working independently with its own agent, context window, and conversation history. Open the Threads Sidebar with {#kb multi_workspace::ToggleWorkspaceSidebar} to see all your threads grouped by project. Click any thread to switch to it, or use the thread switcher ({#kb agents_sidebar::ToggleThreadSwitcher}) to cycle between recent threads without opening the sidebar.
+
+See [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees) for how project, Zed worktree, Git worktree, and branch context affect agent work.
 
 Threads you're no longer working on can be archived by hovering over them in the sidebar and clicking the archive icon, or selecting them and pressing {#kb agent::ArchiveSelectedThread}. The Thread History holds all your threads across all projects, sorted chronologically, and you can restore them at any time.
 

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -47,11 +47,11 @@ You can also start a new thread from the [Threads Sidebar](./parallel-agents.md#
 
 ### Managing Multiple Threads {#multiple-threads}
 
-You can run multiple agent threads at once, each working independently with its own agent, context window, and conversation history. Open the Threads Sidebar with {#kb multi_workspace::ToggleWorkspaceSidebar} to see all your threads grouped by project. Click any thread to switch to it, or use the thread switcher ({#kb agents_sidebar::ToggleThreadSwitcher}) to cycle between recent threads without opening the sidebar.
+You can run multiple agent threads at once, each working independently with its own agent, context window, and conversation history. Open the Threads Sidebar with {#kb multi_workspace::ToggleWorkspaceSidebar} to see all your threads grouped by project. For how projects, Zed worktrees, Git worktrees, and branches fit together, see [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees). Click any thread to switch to it, or use the thread switcher ({#kb agents_sidebar::ToggleThreadSwitcher}) to cycle between recent threads without opening the sidebar.
 
 Threads you're no longer working on can be archived by hovering over them in the sidebar and clicking the archive icon, or selecting them and pressing {#kb agent::ArchiveSelectedThread}. The Thread History holds all your threads across all projects, sorted chronologically, and you can restore them at any time.
 
-If two threads might edit the same files, you can isolate one in a new Git worktree. Use the worktree picker in the title bar to pick which worktree the agent runs in, or create a new one. See [Worktree Isolation](./parallel-agents.md#worktree-isolation) for details.
+If two threads might edit the same files, you can isolate one in a new Git worktree. Use the worktree picker in the title bar to pick which worktree the agent runs in, or create a new one. See [Worktree Isolation](./parallel-agents.md#worktree-isolation) for thread behavior and [Git Worktrees](../git/worktrees.md#worktree-context-ui) for project, worktree, and branch context.
 
 For more details on the Threads Sidebar and managing multiple projects, see [Parallel Agents](./parallel-agents.md).
 

--- a/docs/src/ai/ai-improvement.md
+++ b/docs/src/ai/ai-improvement.md
@@ -19,7 +19,7 @@ AI features in Zed include:
 - [Agent Panel](./agent-panel.md)
 - [Edit Prediction](./edit-prediction.md)
 - [Inline Assistant](./inline-assistant.md)
-- [Git commit generation](../git.md#ai-support-in-git)
+- [Git commit generation](../git/staging-and-committing.md#ai-commit-message)
 
 For the broader request path and provider data boundaries, see
 [AI Privacy](./privacy-and-security.md).

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -9,6 +9,9 @@ External Agents are agents that integrate with Zed through the [Agent Client Pro
 
 Use [Terminal Threads](./terminal-threads.md) instead when you want to run a CLI or TUI directly in a terminal-backed thread.
 
+For the Zed-side project, worktree, and branch context where a thread runs, see
+[Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees).
+
 External Agents run through their own process and provider relationship. Billing, legal terms, retention, and data handling are between you and the agent provider. Zed does not charge for External Agents.
 
 For Zed-hosted models and Zed-managed AI features, see [AI Privacy](./privacy-and-security.md) and [Feedback and Training Data](./ai-improvement.md).
@@ -56,7 +59,7 @@ Codex may support ChatGPT login, Codex API keys, OpenAI API keys, or Codex-nativ
 
 Use Gemini CLI when you want Gemini running as an ACP-integrated External Agent in Zed.
 
-Install Gemini CLI from the [ACP Registry](#registry), then start a Gemini CLI thread from the Agent Panel or Threads Sidebar. Gemini CLI owns its own authentication and may prompt you to log in with Google, Vertex AI, or another Gemini-supported flow.
+Install Gemini CLI from the [ACP Registry](#registry), then start a Gemini CLI thread from the Agent Panel or Threads Sidebar. Gemini CLI normally owns its own authentication and may prompt you to log in with Google, Vertex AI, or another Gemini-supported flow.
 
 If `GEMINI_API_KEY` or `GOOGLE_AI_API_KEY` is available to the agent process, Gemini CLI uses that key. Otherwise, if you have configured an API key for Zed's Google AI provider, Zed passes that key to Gemini CLI as `GEMINI_API_KEY`.
 

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -23,7 +23,7 @@ Agent paths decide how agentic work runs in Zed.
 - [External Agents](./external-agents.md): ACP-integrated agents that run through their own process and configuration.
 - [Terminal Threads](./terminal-threads.md): terminal-backed threads for running an agent CLI or TUI directly in Zed.
 
-The [Threads Sidebar](./parallel-agents.md#threads-sidebar) is where you organize agent work. You can run multiple agent threads and Terminal Threads at once, each using a different agent and working against different projects.
+The [Threads Sidebar](./parallel-agents.md#threads-sidebar) is where you organize agent work. You can run multiple agent threads and Terminal Threads at once, each using a different agent and working against different projects. For how projects, Zed worktrees, Git worktrees, and branches fit together, see [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees).
 
 See [Agents](./agents.md) for a comparison.
 
@@ -41,7 +41,7 @@ Zed has several AI-powered workflows:
 - [Parallel Agents](./parallel-agents.md): run multiple threads across projects and worktrees.
 - [Inline Assistant](./inline-assistant.md): transform a selection in place.
 - [Edit Prediction](./edit-prediction.md): accept AI completions while you type.
-- [Git commit generation](../git.md#ai-support-in-git): generate commit messages from the Git panel.
+- [Git commit generation](../git/staging-and-committing.md#ai-commit-message): generate commit messages from the Git panel.
 
 ## Configure AI {#configure-ai}
 

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -23,7 +23,9 @@ Agent paths decide how agentic work runs in Zed.
 - [External Agents](./external-agents.md): ACP-integrated agents that run through their own process and configuration.
 - [Terminal Threads](./terminal-threads.md): terminal-backed threads for running an agent CLI or TUI directly in Zed.
 
-The [Threads Sidebar](./parallel-agents.md#threads-sidebar) is where you organize agent work. You can run multiple agent threads and Terminal Threads at once, each using a different agent and working against different projects. For how projects, Zed worktrees, Git worktrees, and branches fit together, see [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees).
+The [Threads Sidebar](./parallel-agents.md#threads-sidebar) is where you organize agent work. You can run multiple agent threads and Terminal Threads at once, each using a different agent and working against different projects.
+
+See [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees) for how project, Zed worktree, Git worktree, and branch context affect agent work.
 
 See [Agents](./agents.md) for a comparison.
 

--- a/docs/src/ai/parallel-agents.md
+++ b/docs/src/ai/parallel-agents.md
@@ -13,7 +13,7 @@ Use **Panel Layout > Agentic** from the user menu in the title bar (or the {#act
 
 ## Threads Sidebar {#threads-sidebar}
 
-The sidebar shows your threads grouped by project. Each project gets its own section with a header. Threads appear below with their title, status indicator, and which agent is running them. Threads running in linked Git worktrees appear under the same project as their main worktree. See [Worktree Isolation](#worktree-isolation).
+The sidebar shows your threads grouped by project. Each project gets its own section with a header. Threads appear below with their title, status indicator, and which agent is running them. Threads running in linked Git worktrees appear under the same project as their main worktree. See [Worktree Isolation](#worktree-isolation) and [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees).
 
 Terminal Threads also appear as entries in the sidebar alongside agent threads, identified by a terminal icon. Click one to switch to it.
 
@@ -31,7 +31,7 @@ To remove a thread from the sidebar, you can archive it by hovering over it and 
 
 The Thread History view holds all your threads, including ones that you have archived. Toggle it with {#kb agents_sidebar::ToggleThreadHistory} or by clicking the clock icon in the sidebar bottom bar, next to the sidebar toggle.
 
-To restore a thread, open Thread History and click the thread you want to bring back. Zed moves it back to the thread list and opens it in the Agent Panel. If the thread was running in a Git worktree that was removed, Zed restores the worktree automatically.
+To restore a thread, open Thread History and click the thread you want to bring back. Zed moves it back to the thread list and opens it in the Agent Panel. If the thread was running in a Git worktree that was removed, Zed restores the saved worktree state when possible.
 
 To permanently delete a thread, open Thread History, hover over the thread, and click the trash icon. This removes the thread's conversation history and cleans up any associated worktree data. Deleted threads cannot be recovered.
 
@@ -75,15 +75,13 @@ A single project can contain multiple folders (a multi-root folder project). Age
 
 ## Worktree Isolation {#worktree-isolation}
 
-If two threads might edit the same files, start one in a new [Git worktree](../git.md#git-worktrees) to give it an isolated checkout.
+If two threads might edit the same files, start one in a new [Git worktree](../git/worktrees.md) to give it an isolated checkout.
 
-Worktrees are managed from the title bar. Click the worktree picker (to the right of the project picker) to switch between existing worktrees or create a new one. New worktrees are created in a detached HEAD state, so you won't accidentally share a branch between worktrees.
+Use the [worktree picker](../git/worktrees.md#open-worktree-picker) to create or switch linked Git worktrees, then use the [branch picker](../git/worktrees.md#choose-branch) in that checkout to choose a branch.
 
-Once you're in a new worktree, use the branch picker next to the worktree picker to create a new branch or check out an existing one. If the branch you pick is already checked out in another worktree, the current worktree stays in detached HEAD until you choose a different branch.
+After the agent finishes, review the diff and merge the changes through your normal Git workflow. See [Agents and Git](../git/agents-and-git.md) for the Git-specific review handoff.
 
-To automate setup steps whenever a new worktree is created use a [Task hook](../tasks.md#hooks). The `create_worktree` hook runs automatically after Zed creates a linked worktree, with `ZED_WORKTREE_ROOT` pointing at the new worktree and `ZED_MAIN_GIT_WORKTREE` pointing at the original repository.
-
-After the agent finishes, review the diff and merge the changes through your normal Git workflow. If the thread was running in a linked worktree and no other active threads use it, moving the thread to Thread History saves the worktree's Git state and removes it from disk. Restoring the thread from history restores the worktree.
+If the thread was running in a linked worktree and no other unarchived agent thread or Terminal Thread references it, moving the thread to Thread History may save the worktree's Git state and remove it from disk. Zed only does this for worktrees it can identify as safe to manage. If Zed saved the worktree state, restoring the thread recreates it when possible. For the project/worktree/branch model and setup hooks, see [Git Worktrees](../git/worktrees.md).
 
 ## See Also {#see-also}
 

--- a/docs/src/ai/parallel-agents.md
+++ b/docs/src/ai/parallel-agents.md
@@ -13,7 +13,9 @@ Use **Panel Layout > Agentic** from the user menu in the title bar (or the {#act
 
 ## Threads Sidebar {#threads-sidebar}
 
-The sidebar shows your threads grouped by project. Each project gets its own section with a header. Threads appear below with their title, status indicator, and which agent is running them. Threads running in linked Git worktrees appear under the same project as their main worktree. See [Worktree Isolation](#worktree-isolation) and [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees).
+The sidebar shows your threads grouped by project. Each project gets its own section with a header. Threads appear below with their title, status indicator, and which agent is running them. Threads running in linked Git worktrees appear under the same project as their main worktree. See [Worktree Isolation](#worktree-isolation).
+
+See [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees) for how project, Zed worktree, Git worktree, and branch context affect agent work.
 
 Terminal Threads also appear as entries in the sidebar alongside agent threads, identified by a terminal icon. Click one to switch to it.
 

--- a/docs/src/ai/privacy-and-security.md
+++ b/docs/src/ai/privacy-and-security.md
@@ -8,7 +8,7 @@ description: Understand how Zed handles AI prompts, code context, hosted model r
 This page explains the privacy and trust boundaries for AI features in Zed,
 including [Zed Agent](./zed-agent.md), [Edit Prediction](./edit-prediction.md),
 [Inline Assistant](./inline-assistant.md), and
-[Git commit generation](../git.md#ai-support-in-git).
+[Git commit generation](../git/staging-and-committing.md#ai-commit-message).
 
 Zed does not retain your prompts or code context by default. For
 [Zed-hosted models](../account/zed-hosted-models.md), Zed has no-training

--- a/docs/src/ai/quick-start.md
+++ b/docs/src/ai/quick-start.md
@@ -62,13 +62,13 @@ For general settings mechanics, see [Configuring Zed](../configuring-zed.md).
 
 ## Use a Specific AI Feature {#features}
 
-| If you want to...                              | Use                                                  |
-| ---------------------------------------------- | ---------------------------------------------------- |
-| Prompt agents, add context, and review changes | [Agent Panel](./agent-panel.md)                      |
-| Accept AI completions while typing             | [Edit Prediction](./edit-prediction.md)              |
-| Rewrite selected code or terminal text         | [Inline Assistant](./inline-assistant.md)            |
-| Run multiple AI tasks at once                  | [Parallel Agents](./parallel-agents.md)              |
-| Generate commit messages                       | [Git commit generation](../git.md#ai-support-in-git) |
+| Goal                                           | Use                                                                         |
+| ---------------------------------------------- | --------------------------------------------------------------------------- |
+| Prompt agents, add context, and review changes | [Agent Panel](./agent-panel.md)                                             |
+| Accept AI completions while typing             | [Edit Prediction](./edit-prediction.md)                                     |
+| Rewrite selected code or terminal text         | [Inline Assistant](./inline-assistant.md)                                   |
+| Run multiple AI tasks at once                  | [Parallel Agents](./parallel-agents.md)                                     |
+| Generate commit messages                       | [Git commit generation](../git/staging-and-committing.md#ai-commit-message) |
 
 ## Learn More {#learn-more}
 

--- a/docs/src/ai/quick-start.md
+++ b/docs/src/ai/quick-start.md
@@ -70,6 +70,9 @@ For general settings mechanics, see [Configuring Zed](../configuring-zed.md).
 | Run multiple AI tasks at once                  | [Parallel Agents](./parallel-agents.md)                                     |
 | Generate commit messages                       | [Git commit generation](../git/staging-and-committing.md#ai-commit-message) |
 
+For how projects, Zed worktrees, Git worktrees, and branches set the context
+where agent work runs, see [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees).
+
 ## Learn More {#learn-more}
 
 | If you want to...                    | Use                                                                                                                                            |

--- a/docs/src/ai/terminal-threads.md
+++ b/docs/src/ai/terminal-threads.md
@@ -15,7 +15,11 @@ Zed owns the thread surface:
 
 - the terminal-backed thread in the Threads Sidebar
 - thread grouping by project
+- the project/worktree context where the terminal opens
 - switching and organizing the terminal session alongside other threads
+
+For how projects, Zed worktrees, Git worktrees, and branches fit together, see
+[Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees).
 
 ## What the CLI Owns {#what-the-cli-owns}
 
@@ -65,6 +69,8 @@ The same `agent.notify_when_agent_waiting` and `agent.play_sound_when_agent_done
 ## Closing Terminal Threads {#closing-terminal-threads}
 
 Unlike agent threads, Terminal Threads are closed rather than archived. They do not go to Thread History. To close one, hover over it in the Threads Sidebar and click the **×** button, or select it and press {#kb agent::ArchiveSelectedThread}.
+
+If a Terminal Thread is the last reference to a Zed-managed linked Git worktree, closing it may remove that worktree workspace and delete the worktree directory from disk. Zed only does this for worktrees it can identify as safe to manage.
 
 ## CLI/TUI Setup Notes {#cli-setup}
 

--- a/docs/src/ai/terminal-threads.md
+++ b/docs/src/ai/terminal-threads.md
@@ -70,7 +70,10 @@ The same `agent.notify_when_agent_waiting` and `agent.play_sound_when_agent_done
 
 Unlike agent threads, Terminal Threads are closed rather than archived. They do not go to Thread History. To close one, hover over it in the Threads Sidebar and click the **×** button, or select it and press {#kb agent::ArchiveSelectedThread}.
 
-If a Terminal Thread is the last reference to a Zed-managed linked Git worktree, closing it may remove that worktree workspace and delete the worktree directory from disk. Zed only does this for worktrees it can identify as safe to manage.
+If a Terminal Thread is the last reference to a Zed-managed linked Git worktree,
+closing the Terminal Thread may remove that worktree from Zed and delete the
+worktree folder from disk. Zed only does this for worktrees it can identify as
+safe to manage.
 
 ## CLI/TUI Setup Notes {#cli-setup}
 

--- a/docs/src/ai/zed-agent.md
+++ b/docs/src/ai/zed-agent.md
@@ -5,7 +5,7 @@ description: Use Zed's native AI agent with Zed-configured models, tools, profil
 
 # Zed Agent
 
-Zed Agent is Zed's native agent path. It runs in the [Agent Panel](./agent-panel.md) and [Threads Sidebar](./parallel-agents.md#threads-sidebar), uses models configured through [LLM Providers](./llm-providers.md), and integrates with Zed's project, editor, terminal, and review surfaces.
+Zed Agent is Zed's native agent path. It runs in the [Agent Panel](./agent-panel.md) and [Threads Sidebar](./parallel-agents.md#threads-sidebar), uses models configured through [LLM Providers](./llm-providers.md), and integrates with Zed's project, editor, terminal, and review surfaces. For how projects, Zed worktrees, Git worktrees, and branches set the context where agent work runs, see [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees).
 
 Use Zed Agent when you want the agent to:
 

--- a/docs/src/ai/zed-agent.md
+++ b/docs/src/ai/zed-agent.md
@@ -5,7 +5,9 @@ description: Use Zed's native AI agent with Zed-configured models, tools, profil
 
 # Zed Agent
 
-Zed Agent is Zed's native agent path. It runs in the [Agent Panel](./agent-panel.md) and [Threads Sidebar](./parallel-agents.md#threads-sidebar), uses models configured through [LLM Providers](./llm-providers.md), and integrates with Zed's project, editor, terminal, and review surfaces. For how projects, Zed worktrees, Git worktrees, and branches set the context where agent work runs, see [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees).
+Zed Agent is Zed's native agent path. It runs in the [Agent Panel](./agent-panel.md) and [Threads Sidebar](./parallel-agents.md#threads-sidebar), uses models configured through [LLM Providers](./llm-providers.md), and integrates with Zed's project, editor, terminal, and review surfaces.
+
+See [Git Worktrees](../git/worktrees.md#projects-zed-worktrees-git-worktrees) for how project, Zed worktree, Git worktree, and branch context affect agent work.
 
 Use Zed Agent when you want the agent to:
 

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -1,413 +1,104 @@
 ---
-description: Zed is a text editor that supports lots of Git features
-title: Zed Editor Git integration documentation
+title: Git and Review - Zed
+description: Use Zed's Git tools to inspect status, review diffs, stage and commit changes, sync branches, browse history, and resolve conflicts.
 ---
 
-# Git
-
-Zed has built-in Git support that lets you manage version control without leaving the editor. The Git Panel shows your working tree state, staging area, and branch information. Changes you make on the command line are reflected immediately in Zed.
-
-For operations that Zed doesn't support natively, you can use the integrated terminal.
-
-## Git Panel
-
-The Git Panel shows the state of your working tree and Git's staging area.
-
-You can open the Git Panel using {#action git_panel::ToggleFocus}, or by clicking the Git icon in the status bar.
-
-In the panel you can see the state of your project at a glance: which repository and branch are active, what files have changed and the current staging state of each file.
-
-Zed monitors your repository so that changes you make on the command line are instantly reflected.
-
-### Configuration
-
-Open the Settings Editor (`Cmd+,` on macOS, `Ctrl+,` on Linux/Windows) to customize Git behavior. Settings are spread across two pages:
-
-- **Panels > Git Panel**: Panel position, tree vs flat view, status display style
-- **Version Control**: Gutter indicators, inline blame, hunk styles
-
-#### Moving the Git Panel
-
-By default, the Git Panel docks on the left. Go to **Panels > Git Panel** and change **Git Panel Dock** to move it to the right or bottom.
-
-#### Switching to Tree View
-
-The Git Panel shows a flat list of changed files by default. To see files organized by folder hierarchy instead, toggle **Tree View** in the panel's context menu, or enable it in **Panels > Git Panel**.
-
-#### Inline Blame
-
-Zed shows Git blame information on the current line. To turn this off or add a delay before it appears, go to **Version Control > Inline Git Blame**.
-
-#### Hiding the Gutter Indicators
-
-The colored bars in the gutter that show added, modified, and deleted lines can be hidden. Go to **Version Control > Git Gutter** and set **Visibility** to "Hide".
-
-#### Commit Message Line Length
-
-Zed wraps commit messages at 72 characters (a Git convention). To change this, search for "Git Commit" in Settings and adjust **Preferred Line Length**.
-
-## Project Diff
-
-You can see all of the changes captured by Git in Zed by opening the Project Diff ({#kb git::Diff}), accessible via the {#action git::Diff} action in the Command Palette or the Git Panel.
-
-All of the changes displayed in the Project Diff behave exactly the same as any other multibuffer: they are all editable excerpts of files.
-
-You can stage or unstage each hunk as well as a whole file by hitting the buttons on the tab bar or their corresponding keybindings.
-
-### Word Diff Highlighting
-
-By default, Zed highlights changed words within modified lines to make it easier to spot exactly what changed. To disable this globally, open the Settings Editor and go to **Languages & Tools > Miscellaneous**, then turn off **Word Diff Enabled**.
-
-To disable word diff for specific languages only, add this to your settings.json:
-
-```json
-{
-  "languages": {
-    "Markdown": {
-      "word_diff_enabled": false
-    }
-  }
-}
-```
-
-### Diff View Styles
-
-Zed displays diffs in two modes: **split** (side-by-side comparison) or **unified** (inline changes). Split view is the default.
-
-#### Changing the diff view
-
-Open the Settings Editor ({#kb zed::OpenSettings}) and search for "diff view style". Select either **Split** or **Unified**.
-
-To change the default, add this to your `settings.json`:
-
-```json
-{
-  "diff_view_style": "unified"
-}
-```
-
-See [Configuring Zed](./configuring-zed.md) for more about the Settings Editor.
-
-#### Split vs unified
-
-- **Split**: Shows the original and modified versions side by side. Useful for comparing file structure or reviewing large changes.
-- **Unified**: Shows changes inline with additions and deletions in a single view. Useful for focusing on specific line changes.
-
-You can switch between modes at any time. Your preference applies to [Project Diff](#project-diff), [File History](#file-history), and [Stash Diff View](#stash-diff-view). These diff views function as [multibuffers](./multibuffers.md), allowing you to edit multiple excerpts simultaneously.
-
-## File History
-
-File History shows the commit history for an individual file. Each entry displays the commit's author, timestamp, and message. Selecting a commit opens a diff view filtered to show only the changes made to that file in that commit.
-
-To view File History:
-
-- Right-click on a file in the Project Panel and select "View File History"
-- Right-click on a file in the Git Panel and select "View File History"
-- Right-click on an editor tab and select "View File History"
-- Use the Command Palette and search for "file history"
-
-## Fetch, Push, and Pull
-
-Fetch, push, or pull from your Git repository in Zed via the buttons available on the Git Panel or via the Command Palette by looking at the respective actions: {#action git::Fetch}, {#action git::Push}, and {#action git::Pull}.
-
-### Push Configuration
-
-Zed respects Git's push configuration. When pushing, Zed checks the following in order:
-
-1. `pushRemote` configured for the current branch
-2. `remote.pushDefault` in your Git config
-3. The branch's tracking remote
-
-This matches Git's standard behavior, so if you've configured `pushRemote` or `pushDefault` in your `.gitconfig` or via `git config`, Zed will use those settings.
-
-## Remotes
-
-When your repository has multiple remotes, Zed shows a remote selector in the Git Panel. Click the remote button next to push/pull to choose which remote to use for that operation.
-
-## Staging Workflow
-
-Zed has two primary staging workflows, using either the Project Diff or the panel directly.
-
-### Using the Project Diff
-
-In the Project Diff view, you can focus on each hunk and stage them individually by clicking on the tab bar buttons or via the keybindings {#action git::StageAndNext} ({#kb git::StageAndNext}).
-
-Similarly, stage all hunks at the same time with the {#action git::StageAll} ({#kb git::StageAll}) keybinding and then immediately commit with {#action git::Commit} ({#kb git::Commit}).
-
-### Using the Git Panel
-
-From the panel, you can simply type a commit message and hit the commit button, or {#action git::Commit}. This will automatically stage all tracked files (indicated by a `[·]` in the entry's checkbox) and commit them.
-
-<!-- Show a set of changes with default staged -->
-
-Entries can be staged using each individual entry's checkbox. All changes can be staged using the button at the top of the panel, or {#action git::StageAll}.
-
-To open a changed file in the editor without a diff view, right-click on the file in the Git Panel and select **View File**. Use **Open Diff** ({#kb menu::Confirm}) or **Open Diff (File)** to review changes in a diff view instead.
-
-<!-- Add media -->
-
-## Committing
-
-Zed offers two commit textareas:
-
-1. The first one is available right at the bottom of the Git Panel. Hitting {#kb git::Commit} immediately commits all of your staged changes.
-2. The second is available via the action {#action git::ExpandCommitEditor} or via hitting the {#kb git::ExpandCommitEditor} while focused in the Git Panel commit textarea.
-
-### Undoing a Commit
-
-As soon as you commit in Zed, in the Git Panel, you'll see a bar right under the commit textarea, which will show the recently submitted commit.
-In there, you can use the "Uncommit" button, which performs the `git reset HEADˆ--soft` command.
-
-### Configuring Commit Line Length
-
-By default, Zed sets the commit line length to `72` but it can be configured in your local `settings.json` file.
-
-Find more information about setting the `preferred-line-length` in the [Configuration](#configuration) section.
-
-## Branch Management
-
-### Creating and Switching Branches
-
-Create a new branch using {#action git::Branch} or switch to an existing branch using {#action git::Switch} or {#action git::CheckoutBranch}.
-
-When you are working in a [Git worktree](#git-worktrees), use the branch picker after switching to the worktree to create or check out the branch you want to use there.
-
-### Deleting Branches
-
-To delete a branch, open the branch switcher with {#action git::Switch}, find the branch you want to delete, and use the delete option. Zed will confirm before deleting to prevent accidental data loss.
-
-> **Note:** You cannot delete the branch you currently have checked out. Switch to a different branch first.
-
-## Git Worktrees
-
-Git worktrees let you keep multiple checkouts of the same repository on disk at the same time.
-This is useful when you want to work on more than one branch or task without stashing, rebuilding, or disturbing the files in your main checkout.
-
-Open the worktree picker from the title bar, next to the project picker, or by running {#action git::Worktree}.
-From the picker, you can:
-
-- Create a new linked worktree either from the current branch or default branch
-- Type a name to create a named worktree or let Zed automatically pick one for you
-- Switch the current workspace to an existing worktree
-- Open an existing worktree in a new window
-- Delete linked worktrees that are not currently open in the project
-
-### Worktree Management
-
-New worktrees are created in detached HEAD state.
-After switching to the new worktree, use the branch picker next to the worktree picker to create a new branch or check out an existing, unused branch.
-This keeps Zed from accidentally checking out the same branch in multiple worktrees.
-
-The directory used for new worktrees is controlled by the `git.worktree_directory` setting.
-By default, Zed creates worktrees under `../worktrees` relative to the repository's working directory.
-
-See [All Settings](./reference/all-settings.md#git-worktree-directory) for examples.
-
-### Init Setup
-
-To run setup steps after Zed creates a linked worktree, use the [`create_worktree` task hook](./tasks.md#hooks).
-For agent-specific workflows, see [Worktree Isolation](./ai/parallel-agents.md#worktree-isolation).
-
-### Multi-root Workspaces
-
-If your project contains multiple Git repositories (i.e., multi-root folders), Zed creates a linked worktree for each repository when creating a new worktree from the picker.
-Non-Git folders in the same project are included in the new workspace as-is.
-
-## Merge Conflicts
-
-When you encounter merge conflicts after a merge, rebase, or pull, Zed highlights the conflicting regions in your files and displays resolution buttons above each conflict.
-
-### Viewing Conflicts
-
-Conflicting files appear in the Git Panel with a warning icon. You can also see conflicts in the Project Diff view, where each conflict region is highlighted:
-
-- Changes from your current branch are highlighted in green
-- Changes from the incoming branch are highlighted in blue
-
-### Resolving Conflicts
-
-Each conflict shows three buttons:
-
-- **Use [branch-name]**: Keep the changes from one branch (shows the actual branch name, like "main")
-- **Use [other-branch]**: Keep the changes from the other branch (like "feature-branch")
-- **Use Both**: Keep both sets of changes, with your branch's changes first
-
-Click a button to resolve that conflict. The conflict markers are removed and replaced with your chosen content. After resolving all conflicts in a file, stage it and commit to complete the merge.
-
-> **Tip:** For complex conflicts that need manual editing, you can edit the file directly. Remove the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) and keep the content you want.
-
-## Stashing
-
-Git stash allows you to temporarily save your uncommitted changes and revert your working directory to a clean state. This is particularly useful when you need to quickly switch branches or pull updates without committing incomplete work.
-
-### Creating Stashes
-
-To stash all your current changes, use the {#action git::StashAll} action. This will save both staged and unstaged changes to a new stash entry and clean your working directory.
-
-### Managing Stashes
-
-Zed provides a stash picker accessible via {#action git::ViewStash} or from the Git Panel's overflow menu. From the stash picker, you can:
-
-- **View stash list**: Browse all your saved stashes with their descriptions and timestamps
-- **Open diffs**: See exactly what changes are stored in each stash
-- **Apply stashes**: Apply stash changes to your working directory while keeping the stash entry
-- **Pop stashes**: Apply stash changes and remove the stash entry from the list
-- **Drop stashes**: Delete unwanted stash entries without applying them
-
-### Quick Stash Operations
-
-For faster workflows, Zed provides direct actions to work with the most recent stash:
-
-- **Apply latest stash**: Use {#action git::StashApply} to apply the most recent stash without removing it
-- **Pop latest stash**: Use {#action git::StashPop} to apply and remove the most recent stash
-
-### Stash Diff View
-
-To view a stash's contents, select it in the stash picker and press {#kb stash_picker::ShowStashItem}. From the diff view, you can use these keybindings:
-
-| Action                               | Keybinding                   |
-| ------------------------------------ | ---------------------------- |
-| Apply stash                          | {#kb git::ApplyCurrentStash} |
-| Pop stash (apply and remove)         | {#kb git::PopCurrentStash}   |
-| Drop stash (remove without applying) | {#kb git::DropCurrentStash}  |
-
-## AI Support in Git
-
-Zed currently supports LLM-powered commit message generation.
-You can ask AI to generate a commit message by focusing on the message editor within the Git Panel and either clicking on the pencil icon in the bottom left, or reaching for the {#action git::GenerateCommitMessage}, or through the {#kb git::GenerateCommitMessage} keybinding.
-
-> Note that you need to have an LLM provider configured either via your own API keys or through Zed's hosted AI models.
-> Visit [AI Quick Start](./ai/quick-start.md) to learn how to configure AI.
-
-You can specify your preferred model for this task by adding a `commit_message_model` field to your agent settings.
-See [Feature-specific models](./ai/agent-settings.md#feature-specific-models) for more information.
-
-```json [settings]
-{
-  "agent": {
-    "commit_message_model": {
-      "provider": "anthropic",
-      "model": "claude-4-5-haiku"
-    }
-  }
-}
-```
-
-To add custom commit instructions for the model, use the global `AGENTS.md` file located `~/.config/zed/AGENTS.md` on macOS and Linux, `%APPDATA%\Zed\AGENTS.md` on Windows.
-
-To add custom instructions that apply only to commit message generation, use the `commit_message_instructions` field in your agent settings:
-
-```json [settings]
-{
-  "agent": {
-    "commit_message_instructions": "Use the Conventional Commits format: <type>(<scope>): <description>."
-  }
-}
-```
-
-These instructions are sent to the model in addition to any instruction files, such as `.rules` or `AGENTS.md`. To add instructions that apply to both commit messages and the agent more broadly, use the global `AGENTS.md` file located `~/.config/zed/AGENTS.md` on macOS and Linux, `%APPDATA%\Zed\AGENTS.md` on Windows.
-
-> Before Zed v1.4.0, this was done through the Rules Library, which has been removed.
-> See [Migrating from Rules](./ai/instructions.md#migrating-from-rules) for more information.
-
-## Git Integrations
-
-Zed integrates with popular Git hosting services to ensure that Git commit hashes and references to Issues, Pull Requests, and Merge Requests become clickable links.
-
-Zed currently supports links to the hosted versions of
-[GitHub](https://github.com),
-[GitLab](https://gitlab.com),
-[Bitbucket](https://bitbucket.org),
-[SourceHut](https://sr.ht) and
-[Codeberg](https://codeberg.org).
-
-### Self-Hosted Instances
-
-Zed automatically identifies Git hosting providers by checking for keywords in your Git remote URL. For example, if your self-hosted URL contains `gitlab`, `gitea`, or other recognized provider names, Zed will automatically register that hosting provider without any configuration needed.
-
-However, if your self-hosted Git instance URL doesn't contain identifying keywords, you can manually configure Zed to create clickable links to your instance by adding a `git_hosting_providers` setting so commit hashes and permalinks resolve to your domain:
-
-```json [settings]
-{
-  "git_hosting_providers": [
-    {
-      "provider": "gitlab",
-      "name": "Corp GitLab",
-      "base_url": "https://git.example.corp"
-    }
-  ]
-}
-```
-
-The `provider` field specifies which type of hosting service you're using. Supported `provider` values are `github`, `gitlab`, `bitbucket`, `gitea`, `forgejo`, and `sourcehut`. The `name` is optional and used as a display name for your instance, and `base_url` is the root URL of your self-hosted server.
-
-You can configure multiple custom providers if you work with several self-hosted instances.
-
-### Permalinks
-
-Zed also has a Copy Permalink feature to create a permanent link to a code snippet on your Git hosting service.
-These links are useful for sharing a specific line or range of lines in a file at a specific commit.
-Trigger this action via the [Command Palette](./getting-started.md#command-palette) (search for `permalink`),
-by creating [custom key bindings](./key-bindings.md#custom-key-bindings) for the
-`editor::CopyPermalinkToLine` or `editor::OpenPermalinkToLine` actions
-or by simply right clicking and selecting `Copy Permalink` with line(s) selected in your editor.
-
-## Diff Hunk Keyboard Shortcuts
-
-When viewing files with changes, Zed displays diff hunks that can be expanded or collapsed for detailed review:
-
-- **Expand all diff hunks**: {#action editor::ExpandAllDiffHunks} ({#kb editor::ExpandAllDiffHunks})
-- **Collapse all diff hunks**: Press `Escape` (bound to {#action editor::Cancel})
-- **Toggle selected diff hunks**: {#action editor::ToggleSelectedDiffHunks} ({#kb editor::ToggleSelectedDiffHunks})
-- **Navigate between hunks**: {#action editor::GoToHunk} and {#action editor::GoToPreviousHunk}
-
-> **Tip:** The `Escape` key is the quickest way to collapse all expanded diff hunks and return to an overview of your changes.
-
-## Action Reference
-
-| Action                                    | Keybinding                            |
-| ----------------------------------------- | ------------------------------------- |
-| {#action git::Add}                        | {#kb git::Add}                        |
-| {#action git::StageAll}                   | {#kb git::StageAll}                   |
-| {#action git::UnstageAll}                 | {#kb git::UnstageAll}                 |
-| {#action git::ToggleStaged}               | {#kb git::ToggleStaged}               |
-| {#action git::StageAndNext}               | {#kb git::StageAndNext}               |
-| {#action git::UnstageAndNext}             | {#kb git::UnstageAndNext}             |
-| {#action git::Commit}                     | {#kb git::Commit}                     |
-| {#action git::ExpandCommitEditor}         | {#kb git::ExpandCommitEditor}         |
-| {#action git::Push}                       | {#kb git::Push}                       |
-| {#action git::ForcePush}                  | {#kb git::ForcePush}                  |
-| {#action git::Pull}                       | {#kb git::Pull}                       |
-| {#action git::PullRebase}                 | {#kb git::PullRebase}                 |
-| {#action git::Fetch}                      | {#kb git::Fetch}                      |
-| {#action git::Diff}                       | {#kb git::Diff}                       |
-| {#action git::Restore}                    | {#kb git::Restore}                    |
-| {#action git::RestoreFile}                | {#kb git::RestoreFile}                |
-| {#action git::Branch}                     | {#kb git::Branch}                     |
-| {#action git::Switch}                     | {#kb git::Switch}                     |
-| {#action git::CheckoutBranch}             | {#kb git::CheckoutBranch}             |
-| {#action git::Worktree}                   | {#kb git::Worktree}                   |
-| {#action git::Blame}                      | {#kb git::Blame}                      |
-| {#action git::StashAll}                   | {#kb git::StashAll}                   |
-| {#action git::StashPop}                   | {#kb git::StashPop}                   |
-| {#action git::StashApply}                 | {#kb git::StashApply}                 |
-| {#action git::ViewStash}                  | {#kb git::ViewStash}                  |
-| {#action editor::ToggleGitBlameInline}    | {#kb editor::ToggleGitBlameInline}    |
-| {#action editor::ExpandAllDiffHunks}      | {#kb editor::ExpandAllDiffHunks}      |
-| {#action editor::ToggleSelectedDiffHunks} | {#kb editor::ToggleSelectedDiffHunks} |
-
-> Not all actions have default keybindings, but can be bound by [customizing your keymap](./key-bindings.md#user-keymaps).
-
-## Git CLI Configuration
-
-If you would like to also use Zed for your [git commit message editor](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_editor) when committing from the command line you can use `zed --wait`:
-
-```sh
-git config --global core.editor "zed --wait"
-```
-
-Or add the following to your shell environment (in `~/.zshrc`, `~/.bashrc`, etc):
-
-```sh
-export GIT_EDITOR="zed --wait"
-```
+# Git and Review
+<span id="git"></span>
+
+Zed includes Git tools for everyday version control: checking repository status,
+reviewing diffs, staging and committing, syncing branches, browsing history,
+resolving conflicts, and reviewing agent-produced changes.
+
+Use this page as the entry point. Each linked page focuses on one Git task.
+
+## Quick start {#quick-start}
+
+| Goal                                      | Go to                                                         |
+| ----------------------------------------- | ------------------------------------------------------------- |
+| See changed, staged, and conflicted files | [Status and Changes](./git/status-and-changes.md)             |
+| Review working-tree or branch diffs       | [Diffs and Review](./git/diffs-and-review.md)                 |
+| Stage, unstage, amend, uncommit, commit   | [Staging and Committing](./git/staging-and-committing.md)     |
+| Fetch, pull, push, publish, or switch     | [Branches and Sync](./git/branches-and-sync.md)               |
+| Work in multiple checkouts                | [Worktrees](./git/worktrees.md)                               |
+| Browse Git Graph, file history, or blame  | [History and Blame](./git/history-and-blame.md)               |
+| Resolve merge conflicts or recover work   | [Conflicts and Recovery](./git/conflicts-and-recovery.md)     |
+| Copy permalinks or create PR links        | [GitHub and Pull Requests](./git/github-and-pull-requests.md) |
+| Review agent changes or branch diffs      | [Agents and Git](./git/agents-and-git.md)                     |
+| Find Git settings and actions             | [Settings and Actions](./git/settings-and-actions.md)         |
+
+Open the Git Panel with {#action git_panel::ToggleFocus}, {#kb
+git_panel::ToggleFocus}, or the Git icon in the status bar. The Git Panel is
+the main entry point for repository status, staging, committing, branch sync,
+stashes, and recent commits.
+
+Open the Project Diff with {#action git::Diff} or {#kb git::Diff} when you want
+to review and edit changed hunks across the project.
+
+## What Zed supports {#supported-workflows}
+
+Zed supports these Git workflows in the editor:
+
+- Repository status, changed files, staged state, conflicts, and multi-root Git
+  projects.
+- Working-tree diffs, branch diffs, compare-with-branch, and hunk-level stage,
+  unstage, and restore actions.
+- Staging, unstaging, committing, amending the last commit, uncommitting the last
+  commit, and AI-generated commit messages.
+- Branch creation, checkout, delete, fetch, pull, pull with rebase, push, force
+  push, remote selection, and create-pull-request URLs.
+- Linked Git worktrees, including multi-root worktree creation and agent
+  worktree isolation.
+- Git Graph, commit views, file history, inline blame, and commit/file
+  permalinks.
+- Conflict region buttons, conflicted files in the Git Panel, Project Diff
+  conflict views, and stash operations.
+
+For Git operations that Zed does not expose directly, use the integrated
+[terminal](./terminal.md).
+
+## Support boundaries {#support-boundaries}
+
+Some Git-related workflows are intentionally narrow today:
+
+- Branch Diff opens a Project Diff review surface. Zed does not currently
+  support inline branch-diff hunks inside ordinary editor buffers.
+- Create Pull Request opens a host URL for creating a pull request or merge
+  request. Zed does not provide a full in-editor PR review and comment-posting
+  workflow.
+- Conflict resolution buttons help resolve conflict regions after Git reports a
+  conflict. Zed does not provide a complete merge, rebase, cherry-pick, or
+  three-way merge UI.
+- Agent setup, model configuration, and tool permissions live in the
+  [AI docs](./ai/quick-start.md). Git docs only cover how agent workflows touch
+  diffs, worktrees, and changed files.
+
+## See also {#see-also}
+
+- [Command Palette](./command-palette.md): Run Git actions by name.
+- [Keybindings](./key-bindings.md): Bind Git actions that do not have defaults.
+- [Tasks](./tasks.md#custom-git-commands): Add custom Git commands to Git
+  Graph context menus.
+
+## Moved sections {#moved-sections}
+
+Some sections from the old Git page moved into focused Git and Review pages:
+
+- <span id="git-panel"></span><span id="using-the-git-panel"></span>[Status and Changes](./git/status-and-changes.md), [Staging and Committing](./git/staging-and-committing.md), and [Settings and Actions](./git/settings-and-actions.md): Git Panel workflows and settings.
+- <span id="configuration"></span><span id="moving-the-git-panel"></span><span id="switching-to-tree-view"></span><span id="hiding-the-gutter-indicators"></span>[Settings and Actions](./git/settings-and-actions.md): Git settings, panel layout, tree view, gutter indicators, actions, and keybindings.
+- <span id="inline-blame"></span>[History and Blame](./git/history-and-blame.md#blame): Inline blame.
+- <span id="commit-message-line-length"></span><span id="committing"></span><span id="configuring-commit-line-length"></span>[Staging and Committing](./git/staging-and-committing.md#commit): Commit editor workflows.
+- <span id="project-diff"></span><span id="using-the-project-diff"></span>[Diffs and Review](./git/diffs-and-review.md#project-diff): Project Diff.
+- <span id="word-diff-highlighting"></span><span id="diff-view-styles"></span><span id="changing-the-diff-view"></span><span id="split-vs-unified"></span>[Diffs and Review](./git/diffs-and-review.md#diff-view-style): Diff view style and word diff.
+- <span id="file-history"></span>[History and Blame](./git/history-and-blame.md#file-history): File History.
+- <span id="fetch-push-and-pull"></span><span id="push-configuration"></span><span id="remotes"></span>[Branches and Sync](./git/branches-and-sync.md): Fetch, pull, push, remotes, and push configuration.
+- <span id="staging-workflow"></span>[Staging and Committing](./git/staging-and-committing.md#stage-changes): Staging workflows.
+- <span id="undoing-a-commit"></span>[Amend](./git/staging-and-committing.md#amend) and [uncommit](./git/staging-and-committing.md#uncommit): Last-commit recovery.
+- <span id="branch-management"></span><span id="creating-and-switching-branches"></span><span id="deleting-branches"></span>[Branches and Sync](./git/branches-and-sync.md#branches): Branch management.
+- <span id="git-worktrees"></span><span id="worktree-management"></span><span id="init-setup"></span><span id="multi-root-workspaces"></span>[Worktrees](./git/worktrees.md): Linked Git worktrees.
+- <span id="merge-conflicts"></span><span id="viewing-conflicts"></span><span id="resolving-conflicts"></span>[Conflicts and Recovery](./git/conflicts-and-recovery.md): Merge conflicts.
+- <span id="stashing"></span><span id="creating-stashes"></span><span id="managing-stashes"></span><span id="quick-stash-operations"></span><span id="stash-diff-view"></span>[Conflicts and Recovery](./git/conflicts-and-recovery.md#stashes): Stashes.
+- <span id="ai-support-in-git"></span>[Agents and Git](./git/agents-and-git.md) and [AI commit messages](./git/staging-and-committing.md#ai-commit-message): AI-assisted Git workflows.
+- <span id="git-integrations"></span><span id="self-hosted-instances"></span><span id="permalinks"></span>[GitHub and Pull Requests](./git/github-and-pull-requests.md): Hosting integrations and permalinks.
+- <span id="diff-hunk-keyboard-shortcuts"></span><span id="action-reference"></span>[Settings and Actions](./git/settings-and-actions.md#core-git-actions): Git actions and keyboard shortcuts.
+- <span id="git-cli-configuration"></span>[Commit from the terminal](./git/staging-and-committing.md#terminal-editor): Git CLI editor configuration.

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -4,6 +4,7 @@ description: Use Zed's Git tools to inspect status, review diffs, stage and comm
 ---
 
 # Git and Review
+
 <span id="git"></span>
 
 Zed includes Git tools for everyday version control: checking repository status,

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -15,18 +15,18 @@ Use this page as the entry point. Each linked page focuses on one Git task.
 
 ## Quick start {#quick-start}
 
-| Goal                                      | Go to                                                         |
-| ----------------------------------------- | ------------------------------------------------------------- |
-| See changed, staged, and conflicted files | [Status and Changes](./git/status-and-changes.md)             |
-| Review working-tree or branch diffs       | [Diffs and Review](./git/diffs-and-review.md)                 |
-| Stage, unstage, amend, uncommit, commit   | [Staging and Committing](./git/staging-and-committing.md)     |
-| Fetch, pull, push, publish, or switch     | [Branches and Sync](./git/branches-and-sync.md)               |
-| Work in multiple checkouts                | [Worktrees](./git/worktrees.md)                               |
-| Browse Git Graph, file history, or blame  | [History and Blame](./git/history-and-blame.md)               |
-| Resolve merge conflicts or recover work   | [Conflicts and Recovery](./git/conflicts-and-recovery.md)     |
-| Copy permalinks or create PR links        | [Git Hosting and Pull Requests](./git/github-and-pull-requests.md) |
-| Review agent changes or ask an agent to review a diff | [Agents and Git](./git/agents-and-git.md)                     |
-| Find Git settings and actions             | [Settings and Actions](./git/settings-and-actions.md)         |
+| Goal                                                  | Go to                                                              |
+| ----------------------------------------------------- | ------------------------------------------------------------------ |
+| See changed, staged, and conflicted files             | [Status and Changes](./git/status-and-changes.md)                  |
+| Review working-tree or branch diffs                   | [Diffs and Review](./git/diffs-and-review.md)                      |
+| Stage, unstage, amend, uncommit, commit               | [Staging and Committing](./git/staging-and-committing.md)          |
+| Fetch, pull, push, publish, or switch                 | [Branches and Sync](./git/branches-and-sync.md)                    |
+| Work in multiple checkouts                            | [Worktrees](./git/worktrees.md)                                    |
+| Browse Git Graph, file history, or blame              | [History and Blame](./git/history-and-blame.md)                    |
+| Resolve merge conflicts or recover work               | [Conflicts and Recovery](./git/conflicts-and-recovery.md)          |
+| Copy permalinks or create PR links                    | [Git Hosting and Pull Requests](./git/github-and-pull-requests.md) |
+| Review agent changes or ask an agent to review a diff | [Agents and Git](./git/agents-and-git.md)                          |
+| Find Git settings and actions                         | [Settings and Actions](./git/settings-and-actions.md)              |
 
 Open the Git Panel with {#action git_panel::ToggleFocus}, {#kb
 git_panel::ToggleFocus}, or the Git icon in the status bar. The Git Panel is

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -24,8 +24,8 @@ Use this page as the entry point. Each linked page focuses on one Git task.
 | Work in multiple checkouts                | [Worktrees](./git/worktrees.md)                               |
 | Browse Git Graph, file history, or blame  | [History and Blame](./git/history-and-blame.md)               |
 | Resolve merge conflicts or recover work   | [Conflicts and Recovery](./git/conflicts-and-recovery.md)     |
-| Copy permalinks or create PR links        | [GitHub and Pull Requests](./git/github-and-pull-requests.md) |
-| Review agent changes or branch diffs      | [Agents and Git](./git/agents-and-git.md)                     |
+| Copy permalinks or create PR links        | [Git Hosting and Pull Requests](./git/github-and-pull-requests.md) |
+| Review agent changes or ask an agent to review a diff | [Agents and Git](./git/agents-and-git.md)                     |
 | Find Git settings and actions             | [Settings and Actions](./git/settings-and-actions.md)         |
 
 Open the Git Panel with {#action git_panel::ToggleFocus}, {#kb
@@ -100,6 +100,6 @@ Some sections from the old Git page moved into focused Git and Review pages:
 - <span id="merge-conflicts"></span><span id="viewing-conflicts"></span><span id="resolving-conflicts"></span>[Conflicts and Recovery](./git/conflicts-and-recovery.md): Merge conflicts.
 - <span id="stashing"></span><span id="creating-stashes"></span><span id="managing-stashes"></span><span id="quick-stash-operations"></span><span id="stash-diff-view"></span>[Conflicts and Recovery](./git/conflicts-and-recovery.md#stashes): Stashes.
 - <span id="ai-support-in-git"></span>[Agents and Git](./git/agents-and-git.md) and [AI commit messages](./git/staging-and-committing.md#ai-commit-message): AI-assisted Git workflows.
-- <span id="git-integrations"></span><span id="self-hosted-instances"></span><span id="permalinks"></span>[GitHub and Pull Requests](./git/github-and-pull-requests.md): Hosting integrations and permalinks.
+- <span id="git-integrations"></span><span id="self-hosted-instances"></span><span id="permalinks"></span>[Git Hosting and Pull Requests](./git/github-and-pull-requests.md): Hosting integrations and permalinks.
 - <span id="diff-hunk-keyboard-shortcuts"></span><span id="action-reference"></span>[Settings and Actions](./git/settings-and-actions.md#core-git-actions): Git actions and keyboard shortcuts.
 - <span id="git-cli-configuration"></span>[Commit from the terminal](./git/staging-and-committing.md#terminal-editor): Git CLI editor configuration.

--- a/docs/src/git/agents-and-git.md
+++ b/docs/src/git/agents-and-git.md
@@ -1,0 +1,71 @@
+---
+title: Agents and Git - Zed
+description: Review agent changes, use branch diff context, isolate agents in Git worktrees, and generate commit messages in Zed.
+---
+
+# Agents and Git
+
+Agent workflows often create, review, and isolate Git changes. This page covers
+the Git side of those workflows. Model setup, tools, profiles, and permissions
+stay canonical in the [AI docs](../ai/quick-start.md).
+
+## Review agent changes {#review-agent-changes}
+
+After an agent edits your project, the Agent Panel shows a changed-files
+summary. Open the review view with {#action agent::OpenAgentDiff} or {#kb
+agent::OpenAgentDiff}.
+
+From the agent diff you can accept or reject individual hunks or the whole set
+of changes. The review view is separate from the normal Git index. After
+accepting changes, use [Diffs and Review](./diffs-and-review.md) and [Staging
+and Committing](./staging-and-committing.md) to stage and commit the result.
+
+If `agent.single_file_review` is enabled, agent edit diffs can also appear
+inline in individual files. While single-file review is active, the agent review
+diff temporarily overrides the buffer's normal Git diff.
+
+```json [settings]
+{
+  "agent": {
+    "single_file_review": true
+  }
+}
+```
+
+## Review a branch diff with an agent {#review-branch-diff}
+
+Use {#action git::ReviewDiff} to open an agent thread with branch-diff context.
+You can also add branch diff context from the Agent Panel message editor by
+typing `@` and choosing **Branch Diff**.
+
+Branch diff context uses the Project Diff branch comparison model. See [Branch
+Diff and Compare With Branch](./diffs-and-review.md#branch-diff) for the Git
+review surface and boundary.
+
+## Isolate agent work in a worktree {#agent-worktrees}
+
+If multiple agent threads may edit the same files, create or switch to a linked
+Git worktree before starting one of the threads. Worktrees isolate the checkout,
+branch, and working tree.
+
+Worktrees are managed from the title bar picker or {#action git::Worktree}. For
+thread-specific behavior, see [Worktree
+Isolation](../ai/parallel-agents.md#worktree-isolation).
+
+## Generate commit messages {#agent-commit-messages}
+
+AI commit message generation is a Git Panel workflow that uses your configured
+LLM provider. Use {#action git::GenerateCommitMessage} from the commit editor.
+
+See [Generate a commit message with
+AI](./staging-and-committing.md#ai-commit-message) for Git-specific settings and
+[AI Quick Start](../ai/quick-start.md) for provider setup.
+
+## See also {#see-also}
+
+- [Agent Panel](../ai/agent-panel.md): Prompt agents, add context, and review
+  changes.
+- [Parallel Agents](../ai/parallel-agents.md): Run multiple threads and isolate
+  worktrees.
+- [Diffs and Review](./diffs-and-review.md): Review Git branch and working-tree
+  diffs.

--- a/docs/src/git/branches-and-sync.md
+++ b/docs/src/git/branches-and-sync.md
@@ -58,13 +58,13 @@ Use {#action git::CreatePullRequest} to open the hosting provider's pull request
 or merge request creation URL when Zed can build one for the active branch.
 
 This is a publishing handoff to the host. Zed does not provide a full in-editor
-pull request review or comment-posting workflow. See [GitHub and Pull
+pull request review or comment-posting workflow. See [Git Hosting and Pull
 Requests](./github-and-pull-requests.md) for hosting boundaries.
 
 ## Compare branches {#compare-branches}
 
-Use {#action git::BranchDiff} to compare against the default branch, or {#action
-git::CompareWithBranch} from Project Diff to choose another base.
+Use {#action git::BranchDiff} to compare against the default branch, or
+{#action git::CompareWithBranch} from Project Diff to choose another base.
 
 See [Diffs and Review](./diffs-and-review.md#branch-diff) for the supported
 branch-diff workflow and its boundaries.
@@ -86,7 +86,7 @@ Recovery](./conflicts-and-recovery.md#stashes).
 ## See also {#see-also}
 
 - [Worktrees](./worktrees.md): Keep multiple checkouts of one repository.
-- [GitHub and Pull Requests](./github-and-pull-requests.md): Configure hosting
+- [Git Hosting and Pull Requests](./github-and-pull-requests.md): Configure hosting
   links and PR handoffs.
 - [Settings and Actions](./settings-and-actions.md): Find sync and branch
   actions.

--- a/docs/src/git/branches-and-sync.md
+++ b/docs/src/git/branches-and-sync.md
@@ -1,0 +1,92 @@
+---
+title: Git Branches and Sync - Zed
+description: Create, switch, delete, fetch, pull, push, force push, publish branches, and open pull request links from Zed.
+---
+
+# Branches and Sync
+
+Use Zed's branch and remote controls to move between branches and synchronize
+with remotes.
+
+## Create and switch branches {#branches}
+
+Open the branch picker with {#action git::Branch}, {#action git::Switch},
+{#action git::CheckoutBranch}, or the branch selector in the title bar or Git
+Panel.
+
+From the picker you can:
+
+- create a branch
+- switch to a local branch
+- check out a remote branch
+- filter remote branches
+- delete or force-delete local branches
+
+You cannot delete the branch that is currently checked out. Switch to another
+branch first.
+
+## Fetch, pull, and push {#sync}
+
+Use the Git Panel buttons or Command Palette actions:
+
+| Job                           | Action                    |
+| ----------------------------- | ------------------------- |
+| Fetch from the default remote | {#action git::Fetch}      |
+| Fetch from a chosen remote    | {#action git::FetchFrom}  |
+| Pull                          | {#action git::Pull}       |
+| Pull with rebase              | {#action git::PullRebase} |
+| Push                          | {#action git::Push}       |
+| Push to a chosen remote       | {#action git::PushTo}     |
+| Force push                    | {#action git::ForcePush}  |
+
+When a repository has multiple remotes, Zed shows a remote selector in the Git
+Panel. Use the selector to choose the remote for fetch, pull, or push variants.
+
+## Push configuration {#push-configuration}
+
+Zed follows Git's push configuration. When pushing, Zed checks:
+
+1. `pushRemote` configured for the current branch
+2. `remote.pushDefault` in your Git config
+3. the branch's tracking remote
+
+Configure these values with Git itself, for example through `git config`.
+
+## Publish and create pull request links {#publish-and-pr}
+
+Use {#action git::CreatePullRequest} to open the hosting provider's pull request
+or merge request creation URL when Zed can build one for the active branch.
+
+This is a publishing handoff to the host. Zed does not provide a full in-editor
+pull request review or comment-posting workflow. See [GitHub and Pull
+Requests](./github-and-pull-requests.md) for hosting boundaries.
+
+## Compare branches {#compare-branches}
+
+Use {#action git::BranchDiff} to compare against the default branch, or {#action
+git::CompareWithBranch} from Project Diff to choose another base.
+
+See [Diffs and Review](./diffs-and-review.md#branch-diff) for the supported
+branch-diff workflow and its boundaries.
+
+## Stash before switching {#stash-before-switching}
+
+When you need to set aside work before switching branches, use:
+
+| Job                       | Action                    |
+| ------------------------- | ------------------------- |
+| Stash all changes         | {#action git::StashAll}   |
+| Apply the latest stash    | {#action git::StashApply} |
+| Pop the latest stash      | {#action git::StashPop}   |
+| Browse and manage stashes | {#action git::ViewStash}  |
+
+For stash diff and recovery details, see [Conflicts and
+Recovery](./conflicts-and-recovery.md#stashes).
+
+## See also {#see-also}
+
+- [Worktrees](./worktrees.md): Keep multiple checkouts of one repository.
+- [GitHub and Pull Requests](./github-and-pull-requests.md): Configure hosting
+  links and PR handoffs.
+- [Settings and Actions](./settings-and-actions.md): Find sync and branch
+  actions.

--- a/docs/src/git/conflicts-and-recovery.md
+++ b/docs/src/git/conflicts-and-recovery.md
@@ -1,0 +1,79 @@
+---
+title: Git Conflicts and Recovery - Zed
+description: Resolve merge conflicts, use conflict buttons, restore hunks, and manage stashes from Zed.
+---
+
+# Conflicts and Recovery
+
+Zed helps you resolve conflict regions after Git reports a conflict and provides
+stash and restore actions for everyday recovery.
+
+## Resolve conflicts {#resolve-conflicts}
+
+When a merge, rebase, cherry-pick, or pull creates conflicts, Zed highlights
+conflict regions in the editor. Conflicted files also appear in the Git Panel
+and Project Diff.
+
+Each conflict region shows buttons for choosing content:
+
+- **Use [branch-name]** keeps one side.
+- **Use [other-branch]** keeps the other side.
+- **Use Both** keeps both sides, with your branch's changes first.
+
+After resolving all conflict regions in a file, stage the file and continue the
+Git operation.
+
+## Use the terminal for operation control {#terminal-fallback}
+
+Zed's conflict buttons resolve file contents. Zed does not provide a complete
+merge, rebase, cherry-pick, or three-way merge UI.
+
+Use the [terminal](../terminal.md) for commands such as:
+
+```sh
+git rebase --continue
+git merge --abort
+git cherry-pick --continue
+```
+
+## Restore changes {#restore}
+
+Use restore actions when you want to discard changes:
+
+| Job                                     | Action                             |
+| --------------------------------------- | ---------------------------------- |
+| Restore selected hunks                  | {#action git::Restore}             |
+| Restore selected hunks and move forward | {#action git::RestoreAndNext}      |
+| Restore a file from the Git Panel       | {#action git::RestoreFile}         |
+| Restore all tracked files               | {#action git::RestoreTrackedFiles} |
+| Move untracked files to trash           | {#action git::TrashUntrackedFiles} |
+
+Review the diff before restoring. Restore actions discard work.
+
+## Stashes {#stashes}
+
+Use stashes to set aside uncommitted work without committing it.
+
+| Job                    | Action                    |
+| ---------------------- | ------------------------- |
+| Stash all changes      | {#action git::StashAll}   |
+| Apply the latest stash | {#action git::StashApply} |
+| Pop the latest stash   | {#action git::StashPop}   |
+| Open the stash picker  | {#action git::ViewStash}  |
+
+The stash picker lets you browse stash entries, open stash diffs, apply, pop,
+and drop entries.
+
+In a stash diff view:
+
+| Action      | Keybinding                   |
+| ----------- | ---------------------------- |
+| Apply stash | {#kb git::ApplyCurrentStash} |
+| Pop stash   | {#kb git::PopCurrentStash}   |
+| Drop stash  | {#kb git::DropCurrentStash}  |
+
+## See also {#see-also}
+
+- [Status and Changes](./status-and-changes.md): Find conflicted files.
+- [Diffs and Review](./diffs-and-review.md): Review conflict diffs.
+- [Branches and Sync](./branches-and-sync.md): Sync or switch after recovery.

--- a/docs/src/git/diffs-and-review.md
+++ b/docs/src/git/diffs-and-review.md
@@ -1,0 +1,106 @@
+---
+title: Git Diffs and Review - Zed
+description: Review working-tree changes, branch diffs, single-file diffs, and agent-produced changes in Zed.
+---
+
+# Diffs and Review
+
+Zed uses editable diff surfaces for reviewing Git changes. Most diff views are
+[multibuffers](../multibuffers.md), so you can edit excerpts while reviewing.
+
+## Choose a review path {#choose-review-path}
+
+| Goal                                         | Use                                                                |
+| -------------------------------------------- | ------------------------------------------------------------------ |
+| Review all working-tree changes              | {#action git::Diff} or **Open Diff** in the Git Panel              |
+| Review one changed file                      | **Open Diff (File)** from the Git Panel file context menu          |
+| Compare your work against the default branch | {#action git::BranchDiff}                                          |
+| Compare your work against a specific branch  | {#action git::CompareWithBranch} from Project Diff                 |
+| Ask an agent to review a branch diff         | {#action git::ReviewDiff} or [Agents and Git](./agents-and-git.md) |
+| Review changes made by an agent              | [Agent change review](./agents-and-git.md#review-agent-changes)    |
+
+## Project Diff {#project-diff}
+
+Open Project Diff with {#action git::Diff} or {#kb git::Diff}. Project Diff
+shows changed hunks across the active repository.
+
+From Project Diff you can:
+
+- edit changed excerpts directly
+- stage or unstage individual hunks
+- stage or unstage all hunks
+- restore selected hunks
+- switch between split and unified diff styles
+
+Useful hunk actions:
+
+| Action                        | Keybinding                |
+| ----------------------------- | ------------------------- |
+| {#action git::StageAndNext}   | {#kb git::StageAndNext}   |
+| {#action git::UnstageAndNext} | {#kb git::UnstageAndNext} |
+| {#action git::StageAll}       | {#kb git::StageAll}       |
+| {#action git::UnstageAll}     | {#kb git::UnstageAll}     |
+| {#action git::Restore}        | {#kb git::Restore}        |
+
+## Branch Diff and Compare With Branch {#branch-diff}
+
+Use {#action git::BranchDiff} to compare the working directory against the
+repository's default branch, usually `main` or `master`.
+
+Use {#action git::CompareWithBranch} from Project Diff to choose a different
+base branch. Zed opens the branch picker, then updates Project Diff to compare
+against the selected branch.
+
+> **Note:** Branch Diff opens the Project Diff review surface. Zed does not
+> support inline branch-diff hunks in ordinary editor buffers. Editor gutter
+> indicators show working-tree changes.
+
+## Staged and unstaged review {#staged-and-unstaged-review}
+
+Zed tracks staged, unstaged, and partially staged state in the Git Panel and in
+diff hunk controls. You can stage or unstage hunks while reviewing.
+
+Zed does not support a separate PR-style review surface that shows only the
+staged commit apart from all unstaged work. Use hunk-level stage state, the Git
+Panel, and Project Diff together to verify what will be committed. For commit
+mechanics, see [Staging and Committing](./staging-and-committing.md).
+
+## Diff view style {#diff-view-style}
+
+Zed supports split and unified diff views. Split view shows old and new content
+side by side. Unified view shows changes inline.
+
+Open the Settings Editor with {#action zed::OpenSettings} and search for
+`diff_view_style`, or add:
+
+```json [settings]
+{
+  "diff_view_style": "unified"
+}
+```
+
+The setting applies to Project Diff, File History, commit views, and stash diff
+views.
+
+## Word diff highlighting {#word-diff}
+
+Zed highlights changed words inside modified lines. To disable word diff for a
+language, add:
+
+```json [settings]
+{
+  "languages": {
+    "Markdown": {
+      "word_diff_enabled": false
+    }
+  }
+}
+```
+
+## See also {#see-also}
+
+- [Status and Changes](./status-and-changes.md): Find changed files before
+  opening a diff.
+- [History and Blame](./history-and-blame.md): Review previous commits and file
+  history.
+- [Agents and Git](./agents-and-git.md): Review agent edits and branch diffs.

--- a/docs/src/git/github-and-pull-requests.md
+++ b/docs/src/git/github-and-pull-requests.md
@@ -1,0 +1,72 @@
+---
+title: GitHub and Pull Requests - Zed
+description: Configure Git hosting links, copy permalinks, and open pull request creation URLs from Zed.
+---
+
+# GitHub and Pull Requests
+
+Zed integrates with Git hosting providers for links, permalinks, commit
+references, and pull request creation handoffs.
+
+## Supported hosting links {#hosting-links}
+
+Zed recognizes common hosting providers from your Git remote URL and turns
+commit hashes, issue references, pull request references, and merge request
+references into clickable links.
+
+Built-in provider support includes GitHub, GitLab, Bitbucket, SourceHut,
+Codeberg, Gitee, Azure DevOps, Gitea, and Forgejo.
+
+## Self-hosted providers {#self-hosted}
+
+If your remote URL does not identify the provider clearly, configure
+`git_hosting_providers`:
+
+```json [settings]
+{
+  "git_hosting_providers": [
+    {
+      "provider": "gitlab",
+      "name": "Corp GitLab",
+      "base_url": "https://git.example.corp"
+    }
+  ]
+}
+```
+
+Supported `provider` values include `github`, `gitlab`, `bitbucket`, `gitea`,
+`forgejo`, and `sourcehut`. The `name` field is optional.
+
+## Permalinks {#permalinks}
+
+Use {#action editor::CopyPermalinkToLine} to copy a permanent link to the
+current line or selected line range. Use {#action editor::OpenPermalinkToLine}
+to open the hosted source link.
+
+Permalinks point at a specific commit when the hosting provider supports that
+URL format.
+
+## Create pull request links {#create-pull-request}
+
+Use {#action git::CreatePullRequest} to open the hosting provider's pull request
+or merge request creation page for the active branch when Zed can build the URL.
+
+This action is a handoff to the host. Finish the pull request or merge request
+in the browser.
+
+## PR review boundary {#pr-review-boundary}
+
+Zed does not support full in-editor pull request review. Creating a PR link,
+opening permalinks, and clicking hosted references are handoffs to the Git host;
+they are not workflows for reviewing PR files, posting review comments, or
+managing hosted PR state from Zed.
+
+For branch-level code review inside Zed, use [Branch Diff](./diffs-and-review.md#branch-diff)
+or [Agents and Git](./agents-and-git.md#review-branch-diff).
+
+## See also {#see-also}
+
+- [Branches and Sync](./branches-and-sync.md): Publish and push branches.
+- [Diffs and Review](./diffs-and-review.md): Review branch diffs in Zed.
+- [Settings and Actions](./settings-and-actions.md): Configure providers and
+  permalink actions.

--- a/docs/src/git/github-and-pull-requests.md
+++ b/docs/src/git/github-and-pull-requests.md
@@ -1,9 +1,9 @@
 ---
-title: GitHub and Pull Requests - Zed
+title: Git Hosting and Pull Requests - Zed
 description: Configure Git hosting links, copy permalinks, and open pull request creation URLs from Zed.
 ---
 
-# GitHub and Pull Requests
+# Git Hosting and Pull Requests
 
 Zed integrates with Git hosting providers for links, permalinks, commit
 references, and pull request creation handoffs.

--- a/docs/src/git/history-and-blame.md
+++ b/docs/src/git/history-and-blame.md
@@ -1,0 +1,98 @@
+---
+title: Git History and Blame - Zed
+description: Browse Git Graph, commit views, file history, inline blame, and commit permalinks in Zed.
+---
+
+# History and Blame
+
+Use Zed's history tools to inspect commits, understand why code changed, and
+share links to specific lines or commits.
+
+## Git Panel history {#git-panel-history}
+
+Open the Git Panel with {#action git_panel::ToggleFocus}, then switch to the
+History tab to see recent commits for the active repository. Select a commit to
+open its details and changed files.
+
+## Git Graph {#git-graph}
+
+Open Git Graph with {#action git_graph::Open} or from the Git Panel history
+area.
+
+Git Graph shows the commit graph for a repository. From Git Graph you can:
+
+- inspect commit metadata and changed files
+- open a commit view
+- copy a commit SHA or tag
+- search commits
+- run custom Git command tasks from a commit context menu
+
+Useful Git Graph actions:
+
+| Action                              | Keybinding                      |
+| ----------------------------------- | ------------------------------- |
+| {#action git_graph::Open}           | {#kb git_graph::Open}           |
+| {#action git_graph::OpenCommitView} | {#kb git_graph::OpenCommitView} |
+| {#action git_graph::CopyCommitSha}  | {#kb git_graph::CopyCommitSha}  |
+| {#action git_graph::FocusSearch}    | {#kb git_graph::FocusSearch}    |
+
+Use [custom Git command tasks](../tasks.md#custom-git-commands) when you want to
+add repository-specific commands to the Git Graph context menu.
+
+## File History {#file-history}
+
+File History shows commits that changed a selected file, folder, or project
+path. Open File History with {#action git::FileHistory}, or from context menus
+in:
+
+- the Project Panel
+- the Git Panel
+- an editor tab
+- an editor buffer context menu
+
+Selecting a commit opens a diff view for that path at that commit.
+
+## Blame {#blame}
+
+Use {#action git::Blame} to show Git blame for the current file. Zed also shows
+inline blame for the current line when inline blame is enabled.
+
+Open the Settings Editor and search for `inline_blame`, or configure:
+
+```json [settings]
+{
+  "git": {
+    "inline_blame": {
+      "enabled": true,
+      "delay_ms": 600,
+      "show_commit_summary": true
+    }
+  }
+}
+```
+
+Use {#action editor::ToggleGitBlameInline} to toggle inline blame.
+
+## Permalinks from history {#permalinks}
+
+Commit views and editor selections can create links to hosted source when Zed
+can identify the Git hosting provider. Use {#action
+editor::CopyPermalinkToLine} or {#action editor::OpenPermalinkToLine} from the
+editor.
+
+See [GitHub and Pull Requests](./github-and-pull-requests.md#permalinks) for
+provider support and self-hosted configuration.
+
+## Known boundaries {#boundaries}
+
+Git Graph, File History, and blame are local history tools. Zed does not support
+full pull request review, hosted issue triage, or host-specific history filters
+inside these views.
+
+## See also {#see-also}
+
+- [Diffs and Review](./diffs-and-review.md): Review current and branch changes.
+- [GitHub and Pull Requests](./github-and-pull-requests.md): Configure hosted
+  links.
+- [Settings and Actions](./settings-and-actions.md): Configure inline blame and
+  history actions.

--- a/docs/src/git/history-and-blame.md
+++ b/docs/src/git/history-and-blame.md
@@ -76,11 +76,11 @@ Use {#action editor::ToggleGitBlameInline} to toggle inline blame.
 ## Permalinks from history {#permalinks}
 
 Commit views and editor selections can create links to hosted source when Zed
-can identify the Git hosting provider. Use {#action
-editor::CopyPermalinkToLine} or {#action editor::OpenPermalinkToLine} from the
-editor.
+can identify the Git hosting provider. Use
+{#action editor::CopyPermalinkToLine} or {#action editor::OpenPermalinkToLine}
+from the editor.
 
-See [GitHub and Pull Requests](./github-and-pull-requests.md#permalinks) for
+See [Git Hosting and Pull Requests](./github-and-pull-requests.md#permalinks) for
 provider support and self-hosted configuration.
 
 ## Known boundaries {#boundaries}
@@ -92,7 +92,7 @@ inside these views.
 ## See also {#see-also}
 
 - [Diffs and Review](./diffs-and-review.md): Review current and branch changes.
-- [GitHub and Pull Requests](./github-and-pull-requests.md): Configure hosted
+- [Git Hosting and Pull Requests](./github-and-pull-requests.md): Configure hosted
   links.
 - [Settings and Actions](./settings-and-actions.md): Configure inline blame and
   history actions.

--- a/docs/src/git/settings-and-actions.md
+++ b/docs/src/git/settings-and-actions.md
@@ -1,0 +1,171 @@
+---
+title: Git Settings and Actions - Zed
+description: Find Zed Git settings, command palette actions, keybindings, Git Panel options, diff settings, and hosting provider configuration.
+---
+
+# Settings and Actions
+
+Use this page as a workflow-oriented reference for Git settings and actions.
+For generated setting details, see [All Settings](../reference/all-settings.md).
+
+## Git Panel settings {#git-panel-settings}
+
+Open the Settings Editor with {#action zed::OpenSettings} and search for
+**Git Panel**, or configure:
+
+```json [settings]
+{
+  "git_panel": {
+    "dock": "left",
+    "button": true,
+    "tree_view": false,
+    "sort_by": "path",
+    "group_by": "status",
+    "show_count_badge": false
+  }
+}
+```
+
+Common jobs:
+
+| Goal                                  | Setting or UI                           |
+| ------------------------------------- | --------------------------------------- |
+| Move the Git Panel                    | **Panels > Git Panel > Git Panel Dock** |
+| Hide the Git Panel status-bar button  | `git_panel.button`                      |
+| Group changed files by folder         | `git_panel.tree_view` or the panel menu |
+| Sort changes by path                  | `git_panel.sort_by`                     |
+| Show a badge with uncommitted changes | `git_panel.show_count_badge`            |
+
+## Version control display settings {#version-control-settings}
+
+Use the Settings Editor under **Version Control** for gutter and blame display.
+
+```json [settings]
+{
+  "git": {
+    "git_gutter": "tracked_files",
+    "hunk_style": "staged_hollow",
+    "inline_blame": {
+      "enabled": true,
+      "delay_ms": 600
+    }
+  }
+}
+```
+
+See [Status and Changes](./status-and-changes.md#editor-indicators) and [History
+and Blame](./history-and-blame.md#blame) for how these settings affect daily
+workflows.
+
+## Diff settings {#diff-settings}
+
+Use `diff_view_style` for split or unified diffs:
+
+```json [settings]
+{
+  "diff_view_style": "split"
+}
+```
+
+Use `word_diff_enabled` per language when word-level highlighting is too noisy:
+
+```json [settings]
+{
+  "languages": {
+    "Markdown": {
+      "word_diff_enabled": false
+    }
+  }
+}
+```
+
+## Worktree settings {#worktree-settings}
+
+Use `git.worktree_directory` to choose where Zed creates linked worktrees:
+
+```json [settings]
+{
+  "git": {
+    "worktree_directory": "../worktrees"
+  }
+}
+```
+
+See [Worktrees](./worktrees.md).
+
+## Hosting provider settings {#hosting-provider-settings}
+
+Use `git_hosting_providers` for self-hosted Git providers:
+
+```json [settings]
+{
+  "git_hosting_providers": [
+    {
+      "provider": "gitlab",
+      "name": "Corp GitLab",
+      "base_url": "https://git.example.corp"
+    }
+  ]
+}
+```
+
+See [GitHub and Pull Requests](./github-and-pull-requests.md).
+
+## Core Git actions {#core-git-actions}
+
+| Job                     | Action                               | Keybinding                       |
+| ----------------------- | ------------------------------------ | -------------------------------- |
+| Open Git Panel          | {#action git_panel::ToggleFocus}     | {#kb git_panel::ToggleFocus}     |
+| Open Project Diff       | {#action git::Diff}                  | {#kb git::Diff}                  |
+| Branch Diff             | {#action git::BranchDiff}            | {#kb git::BranchDiff}            |
+| Compare With Branch     | {#action git::CompareWithBranch}     | {#kb git::CompareWithBranch}     |
+| Review Diff with agent  | {#action git::ReviewDiff}            | {#kb git::ReviewDiff}            |
+| Stage all               | {#action git::StageAll}              | {#kb git::StageAll}              |
+| Unstage all             | {#action git::UnstageAll}            | {#kb git::UnstageAll}            |
+| Stage hunk and next     | {#action git::StageAndNext}          | {#kb git::StageAndNext}          |
+| Unstage hunk and next   | {#action git::UnstageAndNext}        | {#kb git::UnstageAndNext}        |
+| Commit                  | {#action git::Commit}                | {#kb git::Commit}                |
+| Amend                   | {#action git::Amend}                 | {#kb git::Amend}                 |
+| Uncommit                | {#action git::Uncommit}              | {#kb git::Uncommit}              |
+| Generate commit message | {#action git::GenerateCommitMessage} | {#kb git::GenerateCommitMessage} |
+
+## Branch, sync, and recovery actions {#branch-sync-recovery-actions}
+
+| Job                   | Action                             | Keybinding                     |
+| --------------------- | ---------------------------------- | ------------------------------ |
+| Create branch         | {#action git::Branch}              | {#kb git::Branch}              |
+| Switch branch         | {#action git::Switch}              | {#kb git::Switch}              |
+| Checkout branch       | {#action git::CheckoutBranch}      | {#kb git::CheckoutBranch}      |
+| Worktree picker       | {#action git::Worktree}            | {#kb git::Worktree}            |
+| Fetch                 | {#action git::Fetch}               | {#kb git::Fetch}               |
+| Pull                  | {#action git::Pull}                | {#kb git::Pull}                |
+| Pull with rebase      | {#action git::PullRebase}          | {#kb git::PullRebase}          |
+| Push                  | {#action git::Push}                | {#kb git::Push}                |
+| Force push            | {#action git::ForcePush}           | {#kb git::ForcePush}           |
+| Create PR URL         | {#action git::CreatePullRequest}   | {#kb git::CreatePullRequest}   |
+| Stash all             | {#action git::StashAll}            | {#kb git::StashAll}            |
+| Apply latest stash    | {#action git::StashApply}          | {#kb git::StashApply}          |
+| Pop latest stash      | {#action git::StashPop}            | {#kb git::StashPop}            |
+| View stashes          | {#action git::ViewStash}           | {#kb git::ViewStash}           |
+| Restore hunks         | {#action git::Restore}             | {#kb git::Restore}             |
+| Restore tracked files | {#action git::RestoreTrackedFiles} | {#kb git::RestoreTrackedFiles} |
+
+## History and hosting actions {#history-hosting-actions}
+
+| Job                 | Action                                 | Keybinding                         |
+| ------------------- | -------------------------------------- | ---------------------------------- |
+| File history        | {#action git::FileHistory}             | {#kb git::FileHistory}             |
+| Blame               | {#action git::Blame}                   | {#kb git::Blame}                   |
+| Toggle inline blame | {#action editor::ToggleGitBlameInline} | {#kb editor::ToggleGitBlameInline} |
+| Open Git Graph      | {#action git_graph::Open}              | {#kb git_graph::Open}              |
+| Copy permalink      | {#action editor::CopyPermalinkToLine}  | {#kb editor::CopyPermalinkToLine}  |
+| Open permalink      | {#action editor::OpenPermalinkToLine}  | {#kb editor::OpenPermalinkToLine}  |
+
+Not every action has a default keybinding. Add custom bindings in your
+[keymap](../key-bindings.md#user-keymaps).
+
+## See also {#see-also}
+
+- [All Actions](../all-actions.md): Generated action reference.
+- [All Settings](../reference/all-settings.md): Generated setting reference.
+- [Command Palette](../command-palette.md): Run actions by name.

--- a/docs/src/git/settings-and-actions.md
+++ b/docs/src/git/settings-and-actions.md
@@ -109,7 +109,7 @@ Use `git_hosting_providers` for self-hosted Git providers:
 }
 ```
 
-See [GitHub and Pull Requests](./github-and-pull-requests.md).
+See [Git Hosting and Pull Requests](./github-and-pull-requests.md).
 
 ## Core Git actions {#core-git-actions}
 

--- a/docs/src/git/staging-and-committing.md
+++ b/docs/src/git/staging-and-committing.md
@@ -24,8 +24,8 @@ To undo staging, use the matching unstage controls, {#action git::UnstageFile},
 
 ## Commit from the Git Panel {#commit}
 
-Type a commit message in the Git Panel commit editor, then use {#action
-git::Commit} or {#kb git::Commit}.
+Type a commit message in the Git Panel commit editor, then use
+{#action git::Commit} or {#kb git::Commit}.
 
 Zed commits staged changes. If tracked files have unstaged changes and nothing
 is staged, the Git Panel can stage tracked changes as part of the commit flow.
@@ -44,18 +44,18 @@ Review staged state before amending. Amend rewrites the last commit.
 
 ## Uncommit the last commit {#uncommit}
 
-After committing, the Git Panel shows the previous commit. Use {#action
-git::Uncommit} to undo the last commit while keeping its changes in the working
-directory.
+After committing, the Git Panel shows the previous commit. Use
+{#action git::Uncommit} to undo the last commit while keeping its changes in the
+working tree.
 
 This is equivalent to a soft reset of the last commit. Use the terminal for more
 advanced reset workflows.
 
 ## Generate a commit message with AI {#ai-commit-message}
 
-Focus the Git Panel commit editor, then use {#action
-git::GenerateCommitMessage}, {#kb git::GenerateCommitMessage}, or the pencil
-button to generate a commit message.
+Focus the Git Panel commit editor, then use {#action git::GenerateCommitMessage},
+{#kb git::GenerateCommitMessage}, or the pencil button to generate a commit
+message.
 
 AI commit generation requires an LLM provider. Start with [AI Quick
 Start](../ai/quick-start.md) if you have not configured one.

--- a/docs/src/git/staging-and-committing.md
+++ b/docs/src/git/staging-and-committing.md
@@ -1,0 +1,107 @@
+---
+title: Git Staging and Committing - Zed
+description: Stage, unstage, commit, amend, uncommit, and generate commit messages with Zed's Git tools.
+---
+
+# Staging and Committing
+
+Use the Git Panel and Project Diff to decide what belongs in the next commit,
+then commit from Zed without leaving the editor.
+
+## Stage changes {#stage-changes}
+
+You can stage from the Git Panel or Project Diff:
+
+| Scope      | Action                                                                    |
+| ---------- | ------------------------------------------------------------------------- |
+| One file   | Click the file checkbox in the Git Panel, or use {#action git::StageFile} |
+| One hunk   | Use hunk controls in Project Diff or {#action git::StageAndNext}          |
+| A range    | Select status entries and use {#action git::StageRange}                   |
+| Everything | Use {#action git::StageAll}                                               |
+
+To undo staging, use the matching unstage controls, {#action git::UnstageFile},
+{#action git::UnstageAndNext}, or {#action git::UnstageAll}.
+
+## Commit from the Git Panel {#commit}
+
+Type a commit message in the Git Panel commit editor, then use {#action
+git::Commit} or {#kb git::Commit}.
+
+Zed commits staged changes. If tracked files have unstaged changes and nothing
+is staged, the Git Panel can stage tracked changes as part of the commit flow.
+Untracked files must be staged before they are committed.
+
+Use {#action git::ExpandCommitEditor} or {#kb git::ExpandCommitEditor} when you
+need more space for a longer commit message.
+
+## Amend the last commit {#amend}
+
+Use {#action git::Amend} from the Git Panel when staged changes should be added
+to the previous commit. Zed loads the previous commit message while amend mode
+is active.
+
+Review staged state before amending. Amend rewrites the last commit.
+
+## Uncommit the last commit {#uncommit}
+
+After committing, the Git Panel shows the previous commit. Use {#action
+git::Uncommit} to undo the last commit while keeping its changes in the working
+directory.
+
+This is equivalent to a soft reset of the last commit. Use the terminal for more
+advanced reset workflows.
+
+## Generate a commit message with AI {#ai-commit-message}
+
+Focus the Git Panel commit editor, then use {#action
+git::GenerateCommitMessage}, {#kb git::GenerateCommitMessage}, or the pencil
+button to generate a commit message.
+
+AI commit generation requires an LLM provider. Start with [AI Quick
+Start](../ai/quick-start.md) if you have not configured one.
+
+To choose the model used for commit messages, add:
+
+```json [settings]
+{
+  "agent": {
+    "commit_message_model": {
+      "provider": "anthropic",
+      "model": "claude-4-5-haiku"
+    }
+  }
+}
+```
+
+To add instructions only for commit message generation:
+
+```json [settings]
+{
+  "agent": {
+    "commit_message_instructions": "Use the Conventional Commits format: <type>(<scope>): <description>."
+  }
+}
+```
+
+For instructions that apply to the agent more broadly, use [AI
+Instructions](../ai/instructions.md).
+
+## Commit from the terminal {#terminal-editor}
+
+To use Zed as your Git commit message editor for command-line commits:
+
+```sh
+git config --global core.editor "zed --wait"
+```
+
+Or set:
+
+```sh
+export GIT_EDITOR="zed --wait"
+```
+
+## See also {#see-also}
+
+- [Diffs and Review](./diffs-and-review.md): Review hunks before staging.
+- [Branches and Sync](./branches-and-sync.md): Push or publish after committing.
+- [Agents and Git](./agents-and-git.md): Review changes produced by agents.

--- a/docs/src/git/status-and-changes.md
+++ b/docs/src/git/status-and-changes.md
@@ -1,0 +1,97 @@
+---
+title: Git Status and Changes - Zed
+description: Use the Git Panel, editor gutter, and status indicators to understand changed, staged, untracked, and conflicted files in Zed.
+---
+
+# Status and Changes
+
+Use Zed's Git status surfaces to see what changed, what is staged, and what
+needs attention before you commit or sync.
+
+## Open the Git Panel {#open-git-panel}
+
+Open the Git Panel with {#action git_panel::ToggleFocus}, {#kb
+git_panel::ToggleFocus}, or the Git icon in the status bar.
+
+The Git Panel shows:
+
+- the active repository and branch
+- changed, untracked, staged, partially staged, and conflicted files
+- the commit editor
+- fetch, pull, push, stash, branch, history, and diff entry points
+
+Zed watches the repository, so changes made from the terminal or another Git
+tool update the panel.
+
+## Read file state {#file-state}
+
+Each changed file has a staged-state control:
+
+| State            | Meaning                                                 |
+| ---------------- | ------------------------------------------------------- |
+| Unstaged         | The file has changes that are not in the index.         |
+| Staged           | The file's current changes are ready to commit.         |
+| Partially staged | Some hunks are staged and other hunks remain unstaged.  |
+| Conflict         | Git reported a conflict that must be resolved manually. |
+
+Use the checkbox beside a file to stage or unstage that file. Use {#action
+git::StageAll} and {#action git::UnstageAll} for repository-wide changes.
+
+## Choose flat or tree view {#tree-view}
+
+The Git Panel shows a flat list by default. Open the panel menu and toggle
+**Tree View** to group changed files by directory.
+
+You can also configure this in the Settings Editor under **Panels > Git Panel**,
+or in [Settings and Actions](./settings-and-actions.md#git-panel-settings).
+
+## Review a file from status {#review-file}
+
+From a changed file in the Git Panel:
+
+- Select the file to open its diff.
+- Open the context menu and choose **View File** to open the file without a diff
+  view.
+- Open the context menu and choose **Open Diff (File)** to review only that
+  file.
+- Choose **View File History** to inspect previous commits for that path.
+
+The Project Diff is the better entry point when you want to review several
+files or hunks together. See [Diffs and Review](./diffs-and-review.md).
+
+## Use editor indicators {#editor-indicators}
+
+When a file has Git changes, Zed shows gutter indicators for added, modified,
+and deleted lines. Expand a hunk to inspect details, then stage, unstage, or
+restore the hunk.
+
+Useful hunk actions:
+
+| Action                                    | Keybinding                            |
+| ----------------------------------------- | ------------------------------------- |
+| {#action editor::ExpandAllDiffHunks}      | {#kb editor::ExpandAllDiffHunks}      |
+| {#action editor::ToggleSelectedDiffHunks} | {#kb editor::ToggleSelectedDiffHunks} |
+| {#action editor::GoToHunk}                | {#kb editor::GoToHunk}                |
+| {#action editor::GoToPreviousHunk}        | {#kb editor::GoToPreviousHunk}        |
+| {#action editor::Cancel}                  | {#kb editor::Cancel}                  |
+
+> **Note:** Editor gutter hunks show working-tree changes. Branch Diff uses the
+> Project Diff surface, not inline branch-diff hunks in ordinary editor buffers.
+
+## Multi-root projects {#multi-root-projects}
+
+If a project contains multiple Git repositories, the Git Panel lets you switch
+between repositories. Actions such as stage, commit, fetch, pull, and push apply
+to the active repository.
+
+Use the repository selector in the panel header when the file you want is in a
+different repository.
+
+## See also {#see-also}
+
+- [Diffs and Review](./diffs-and-review.md): Review working-tree and branch
+  diffs.
+- [Staging and Committing](./staging-and-committing.md): Move changes into a
+  commit.
+- [Settings and Actions](./settings-and-actions.md): Configure Git Panel and
+  gutter behavior.

--- a/docs/src/git/status-and-changes.md
+++ b/docs/src/git/status-and-changes.md
@@ -34,13 +34,14 @@ Each changed file has a staged-state control:
 | Partially staged | Some hunks are staged and other hunks remain unstaged.  |
 | Conflict         | Git reported a conflict that must be resolved manually. |
 
-Use the checkbox beside a file to stage or unstage that file. Use {#action
-git::StageAll} and {#action git::UnstageAll} for repository-wide changes.
+Use the checkbox beside a file to stage or unstage that file. Use
+{#action git::StageAll} and {#action git::UnstageAll} for repository-wide
+changes.
 
 ## Choose flat or tree view {#tree-view}
 
 The Git Panel shows a flat list by default. Open the panel menu and toggle
-**Tree View** to group changed files by directory.
+**Tree View** to group changed files by folder.
 
 You can also configure this in the Settings Editor under **Panels > Git Panel**,
 or in [Settings and Actions](./settings-and-actions.md#git-panel-settings).

--- a/docs/src/git/worktrees.md
+++ b/docs/src/git/worktrees.md
@@ -97,15 +97,15 @@ can span multiple roots, and each Git root keeps its own Git state.
 
 Zed shows project, worktree, and branch context in different places:
 
-| Surface | What it shows or controls |
-| --- | --- |
-| Project picker | The current project or recent project you are opening. |
-| Worktree picker | The linked Git worktree checkout for the current project. |
-| Branch picker | The branch or detached commit checked out in the active Git worktree. |
-| Project Panel | The roots in the current project, including multi-root folders and linked Git worktrees. |
-| Git Panel | The active Git repository. In multi-root projects, use the repository selector before staging, committing, fetching, pulling, or pushing. |
-| Threads Sidebar | Threads grouped by project. Threads in linked Git worktrees appear with the main checkout's project group. |
-| Terminal Threads | Terminal-backed threads with their own terminal working directory and shell environment. |
+| Surface          | What it shows or controls                                                                                                                 |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Project picker   | The current project or recent project you are opening.                                                                                    |
+| Worktree picker  | The linked Git worktree checkout for the current project.                                                                                 |
+| Branch picker    | The branch or detached commit checked out in the active Git worktree.                                                                     |
+| Project Panel    | The roots in the current project, including multi-root folders and linked Git worktrees.                                                  |
+| Git Panel        | The active Git repository. In multi-root projects, use the repository selector before staging, committing, fetching, pulling, or pushing. |
+| Threads Sidebar  | Threads grouped by project. Threads in linked Git worktrees appear with the main checkout's project group.                                |
+| Terminal Threads | Terminal-backed threads with their own terminal working directory and shell environment.                                                  |
 
 When you are choosing where an operation runs, use these rules:
 

--- a/docs/src/git/worktrees.md
+++ b/docs/src/git/worktrees.md
@@ -15,9 +15,9 @@ and folder roots in its [trust model](../worktree-trust.md).
 
 ## Projects, Zed worktrees, and Git worktrees {#projects-zed-worktrees-git-worktrees}
 
-A Zed project is the workspace context that owns your file tree, Git state,
-search scope, terminals, tasks, and agent threads. A project can contain one
-folder, multiple folders, or a mix of Git repositories and non-Git folders.
+A Zed project owns your file tree, Git state, search scope, terminals, tasks,
+and agent threads. A project can contain one folder, multiple folders, or a mix
+of Git repositories and non-Git folders.
 
 A Zed worktree is an opened file or folder root inside a project. That is broader
 than a Git worktree. For example, a normal folder, a single opened file, and a
@@ -40,7 +40,7 @@ From the picker you can:
 
 - create a linked worktree from the current branch or default branch
 - type a name or let Zed choose one
-- switch the current workspace to an existing worktree
+- switch the current project to an existing worktree
 - open an existing worktree in a new window
 - delete linked worktrees that are not currently open in the project
 
@@ -84,11 +84,11 @@ Use the [`create_worktree` task hook](../tasks.md#hooks) to run setup commands
 after Zed creates a linked worktree. The hook receives `ZED_WORKTREE_ROOT` for
 the new worktree and `ZED_MAIN_GIT_WORKTREE` for the original repository.
 
-## Multi-root workspaces {#multi-root-workspaces}
+## Multi-root projects {#multi-root-workspaces}
 
 If a project contains multiple Git repositories, Zed creates a linked worktree
 for each repository when you create a worktree from the picker. Non-Git folders
-in the same project are included in the new workspace as-is.
+in the same project are included in the new project context as-is.
 
 This means a Zed project is not the same thing as one Git repository. A project
 can span multiple roots, and each Git root keeps its own Git state.
@@ -97,19 +97,21 @@ can span multiple roots, and each Git root keeps its own Git state.
 
 Zed shows project, worktree, and branch context in different places:
 
-| Surface          | What it shows or controls                                                                                                                 |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Project picker   | The current project or recent project you are opening.                                                                                    |
-| Worktree picker  | The linked Git worktree checkout for the current project.                                                                                 |
-| Branch picker    | The branch or detached commit checked out in the active Git worktree.                                                                     |
-| Project Panel    | The roots in the current project, including multi-root folders and linked Git worktrees.                                                  |
-| Git Panel        | The active Git repository. In multi-root projects, use the repository selector before staging, committing, fetching, pulling, or pushing. |
-| Threads Sidebar  | Threads grouped by project. Threads in linked Git worktrees appear with the main checkout's project group.                                |
-| Terminal Threads | Terminal-backed threads with their own terminal working directory and shell environment.                                                  |
+| Surface          | Controls or shows                                      |
+| ---------------- | ------------------------------------------------------ |
+| Project picker   | Current or recent project.                             |
+| Worktree picker  | Linked Git checkout for the current project.           |
+| Branch picker    | Branch or detached commit for the active Git worktree. |
+| Project Panel    | Roots in the current project.                          |
+| Git Panel        | Active Git repository.                                 |
+| Threads Sidebar  | Thread grouping by project.                            |
+| Terminal Threads | Terminal working folder and shell environment.         |
 
 When you are choosing where an operation runs, use these rules:
 
 - Git Panel actions apply to the active repository in the Git Panel.
+- In multi-root projects, use the Git Panel repository selector before staging,
+  committing, fetching, pulling, or pushing.
 - Branch picker actions apply to the active Git worktree checkout.
 - Worktree picker actions switch, create, open, or delete linked Git worktrees for
   the current project.
@@ -119,6 +121,8 @@ When you are choosing where an operation runs, use these rules:
   created. Starting a thread from a project group in the Threads Sidebar scopes it
   to that project. Starting work in a linked Git worktree scopes edits to that
   checkout.
+- Threads in linked Git worktrees appear with the main checkout's project group
+  in the Threads Sidebar.
 - `create_worktree` task hooks run after Zed creates a linked Git worktree and
   receive `ZED_WORKTREE_ROOT` and `ZED_MAIN_GIT_WORKTREE`.
 

--- a/docs/src/git/worktrees.md
+++ b/docs/src/git/worktrees.md
@@ -1,0 +1,161 @@
+---
+title: Git Worktrees - Zed
+description: Create, switch, open, delete, and configure linked Git worktrees in Zed, including worktrees for parallel agent work.
+---
+
+# Worktrees
+
+Git worktrees let one repository have multiple checkouts on disk. In Zed, they
+are useful when you want separate branches or tasks without stashing or
+disturbing your main checkout.
+
+This page covers linked Git worktrees and how they fit with Zed projects,
+branches, terminals, and agent threads. Zed also uses "worktree" for opened file
+and folder roots in its [trust model](../worktree-trust.md).
+
+## Projects, Zed worktrees, and Git worktrees {#projects-zed-worktrees-git-worktrees}
+
+A Zed project is the workspace context that owns your file tree, Git state,
+search scope, terminals, tasks, and agent threads. A project can contain one
+folder, multiple folders, or a mix of Git repositories and non-Git folders.
+
+A Zed worktree is an opened file or folder root inside a project. That is broader
+than a Git worktree. For example, a normal folder, a single opened file, and a
+linked Git worktree can all be Zed worktrees.
+
+A linked Git worktree is a separate checkout managed by Git. It has its own
+working tree and checked-out commit or branch, while sharing Git metadata with
+the original repository.
+
+Branches are checked out inside a Git worktree. Creating or switching a Git
+worktree changes the checkout you are working in; choosing a branch changes what
+that checkout points at.
+
+## Open the worktree picker {#open-worktree-picker}
+
+Open the worktree picker from the title bar, next to the project picker, or run
+{#action git::Worktree}.
+
+From the picker you can:
+
+- create a linked worktree from the current branch or default branch
+- type a name or let Zed choose one
+- switch the current workspace to an existing worktree
+- open an existing worktree in a new window
+- delete linked worktrees that are not currently open in the project
+
+Worktree creation requires a Git repository in the current project and is not
+supported in collaborative projects.
+
+## Choose a branch after creating a worktree {#choose-branch}
+
+New worktrees are created in detached HEAD state. After switching to the new
+worktree, use the branch picker next to the worktree picker to create or check
+out a branch.
+
+If a branch is already checked out in another worktree, Zed keeps the current
+worktree detached until you choose a different branch. This avoids checking out
+the same branch in multiple worktrees.
+
+The worktree picker and branch picker are separate. Use the worktree picker to
+choose a checkout, then use the branch picker in that checkout to create,
+switch, or check out a branch.
+
+## Configure where worktrees are created {#worktree-directory}
+
+The `git.worktree_directory` setting controls where Zed creates linked
+worktrees. By default, Zed creates worktrees under `../worktrees` relative to
+the repository's working directory.
+
+```json [settings]
+{
+  "git": {
+    "worktree_directory": "../worktrees"
+  }
+}
+```
+
+See [All Settings](../reference/all-settings.md#git-worktree-directory) for the
+full setting reference.
+
+## Run setup after worktree creation {#setup-hook}
+
+Use the [`create_worktree` task hook](../tasks.md#hooks) to run setup commands
+after Zed creates a linked worktree. The hook receives `ZED_WORKTREE_ROOT` for
+the new worktree and `ZED_MAIN_GIT_WORKTREE` for the original repository.
+
+## Multi-root workspaces {#multi-root-workspaces}
+
+If a project contains multiple Git repositories, Zed creates a linked worktree
+for each repository when you create a worktree from the picker. Non-Git folders
+in the same project are included in the new workspace as-is.
+
+This means a Zed project is not the same thing as one Git repository. A project
+can span multiple roots, and each Git root keeps its own Git state.
+
+## Where worktree context appears {#worktree-context-ui}
+
+Zed shows project, worktree, and branch context in different places:
+
+| Surface | What it shows or controls |
+| --- | --- |
+| Project picker | The current project or recent project you are opening. |
+| Worktree picker | The linked Git worktree checkout for the current project. |
+| Branch picker | The branch or detached commit checked out in the active Git worktree. |
+| Project Panel | The roots in the current project, including multi-root folders and linked Git worktrees. |
+| Git Panel | The active Git repository. In multi-root projects, use the repository selector before staging, committing, fetching, pulling, or pushing. |
+| Threads Sidebar | Threads grouped by project. Threads in linked Git worktrees appear with the main checkout's project group. |
+| Terminal Threads | Terminal-backed threads with their own terminal working directory and shell environment. |
+
+When you are choosing where an operation runs, use these rules:
+
+- Git Panel actions apply to the active repository in the Git Panel.
+- Branch picker actions apply to the active Git worktree checkout.
+- Worktree picker actions switch, create, open, or delete linked Git worktrees for
+  the current project.
+- Normal terminals and Terminal Threads run commands from their terminal working
+  directory.
+- Agent threads run in the project/worktree context where the thread was
+  created. Starting a thread from a project group in the Threads Sidebar scopes it
+  to that project. Starting work in a linked Git worktree scopes edits to that
+  checkout.
+- `create_worktree` task hooks run after Zed creates a linked Git worktree and
+  receive `ZED_WORKTREE_ROOT` and `ZED_MAIN_GIT_WORKTREE`.
+
+## Where threads and terminals run {#thread-terminal-context}
+
+Agent threads and Terminal Threads run in a project/worktree context. Threads
+that run in linked Git worktrees appear under the same project group as the main
+checkout, so related work stays together in the Threads Sidebar.
+
+Terminal Threads use the terminal's working directory and shell environment.
+They are closed rather than archived into Thread History. Closing the last
+Terminal Thread reference to a Zed-managed linked Git worktree may still trigger
+safe worktree cleanup. See [Terminal Threads](../ai/terminal-threads.md) for
+Terminal Thread behavior and support boundaries.
+
+## Worktrees and agents {#worktrees-and-agents}
+
+Worktrees are useful when multiple agent threads may edit the same files. Start
+one thread in a new worktree so its edits, branch, and Git state are isolated
+from your main checkout.
+
+For thread-specific behavior, see [Worktree
+Isolation](../ai/parallel-agents.md#worktree-isolation). For the Git review
+handoff after an agent edits files, see [Agents and Git](./agents-and-git.md).
+
+When a thread uses a linked Git worktree, archiving or restoring the thread may
+save or restore that worktree's Git state. This behavior is conditional: Zed only
+cleans up worktrees it can identify as safe to manage, and Terminal Threads do
+not move to Thread History.
+
+## See also {#see-also}
+
+- [Branches and Sync](./branches-and-sync.md): Choose a branch in a worktree.
+- [Tasks](../tasks.md#hooks): Automate setup after creating a worktree.
+- [Parallel Agents](../ai/parallel-agents.md): Run threads in isolated
+  worktrees.
+- [Windows & Projects](../windows-and-projects.md): Understand Zed projects and
+  multi-root projects.
+- [Zed and trusted worktrees](../worktree-trust.md): Understand Zed's broader
+  worktree trust model.

--- a/docs/src/project-panel.md
+++ b/docs/src/project-panel.md
@@ -17,10 +17,10 @@ status bar.
 Use the arrow keys to move through entries. {#kb
 project_panel::ExpandSelectedEntry} expands a directory and {#kb
 project_panel::CollapseSelectedEntry} collapses it. {#kb
-project_panel::CollapseAllEntries} collapses every directory at once. {#kb
-project_panel::ExpandAllEntries} expands every directory at once. Press {#kb
-project_panel::Open} or click to preview a selected file, without giving it a
-permanent tab. Editing the file or double-clicking it promotes it to a permanent tab.
+project_panel::CollapseAllEntries} collapses every directory at once. Press
+{#kb project_panel::Open} or click to preview a selected file, without giving it
+a permanent tab. Editing the file or double-clicking it promotes it to a
+permanent tab.
 
 ### Auto-reveal
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -565,7 +565,7 @@ Note: Dirty files (files with unsaved changes) will not be automatically closed 
 - `"unified"`: Show changes inline with added and deleted lines stacked vertically
 - `"split"`: Display old and new versions side by side in separate panes (default)
 
-See [Git documentation](../git.md#diff-view-styles) for more details.
+See [Git documentation](../git/diffs-and-review.md#diff-view-style) for more details.
 
 ## Disable AI
 

--- a/docs/src/remote-development.md
+++ b/docs/src/remote-development.md
@@ -278,7 +278,7 @@ Note that we deliberately disallow some options (for example `-t` or `-T`) that 
 
 - [Running & Testing](./running-testing.md): Run tasks, terminal commands, and
   debugger sessions while you work remotely.
-- [Git Worktrees](./git.md#git-worktrees): Create and switch between linked
+- [Git Worktrees](./git/worktrees.md): Create and switch between linked
   Git worktrees. Zed supports the worktree picker in remote projects when the
   remote connection is active.
 - [Configuring Zed](./configuring-zed.md): Manage shared and project settings,

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -236,9 +236,9 @@ In addition to being spawned manually, tasks can be configured to run automatica
 
 The following hooks are currently supported:
 
-- `create_worktree` — runs after Zed creates a new linked Git worktree, either directly through the CLI or from the [worktree picker](./git.md#git-worktrees). The task is spawned with `ZED_WORKTREE_ROOT` pointing at the newly created worktree and `ZED_MAIN_GIT_WORKTREE` pointing at the original repository's working directory, which makes these hooks well-suited to copying untracked files (such as `.env` files) or running per-worktree setup commands.
+- `create_worktree`: Runs after Zed creates a new linked Git worktree, such as from the [worktree picker](./git/worktrees.md) or an agent worktree workflow. The task is spawned with `ZED_WORKTREE_ROOT` pointing at the newly created worktree and `ZED_MAIN_GIT_WORKTREE` pointing at the original repository's working directory, which makes these hooks well-suited to copying untracked files (such as `.env` files) or running per-worktree setup commands.
 
-Hook tasks are resolved from the same global and worktree-local `tasks.json` files as manually spawned tasks, and multiple tasks may register for the same hook; they all run when the hook fires. A hook task still benefits from the usual task configuration fields — `cwd`, `env`, `reveal`, `hide`, and so on — so you can control how much of the terminal UI is shown while it runs.
+Hook tasks are resolved from the same global and worktree-local `tasks.json` files as manually spawned tasks, and multiple tasks may register for the same hook; they all run when the hook fires. A hook task still benefits from the usual task configuration fields: `cwd`, `env`, `reveal`, `hide`, and so on. Use these fields to control how much of the terminal UI is shown while a hook task runs.
 
 ```json [tasks]
 [

--- a/docs/src/windows-and-projects.md
+++ b/docs/src/windows-and-projects.md
@@ -29,6 +29,9 @@ When you have multiple projects open:
 - Agent threads are tied to their project context
 - Your workspace layout (splits, tabs) is preserved per project
 
+For how projects, Zed worktrees, Git worktrees, and branches fit together, see
+[Git Worktrees](./git/worktrees.md#projects-zed-worktrees-git-worktrees).
+
 Think of projects in the threads sidebar like browser tabs, but for repositories.
 
 ## Opening in a New Window

--- a/docs/src/worktree-trust.md
+++ b/docs/src/worktree-trust.md
@@ -8,7 +8,7 @@ description: "Configure which folders Zed trusts for running code and extensions
 A worktree in Zed is either a directory or a single file that Zed opens as a standalone "project".
 Zed opens a worktree each time you run `zed some/path`, drag a file or directory into Zed, or open your user settings file.
 
-> Note: This is broader than a [Git worktree](./git.md#git-worktrees). A Git worktree is a linked checkout managed by Git; Zed's trust model applies to every opened file or folder root, including Git worktrees.
+> **Note:** This is broader than a [Git worktree](./git/worktrees.md). A Git worktree is a linked checkout managed by Git; Zed's trust model applies to every opened file or folder root, including Git worktrees.
 
 Every worktree opened may contain a `.zed/settings.json` file with extra configuration options that may require installing and spawning language servers or MCP servers.
 To let users choose based on their own threat model and risk tolerance, all worktrees start in Restricted Mode. Restricted Mode prevents downloading and running related items from `.zed/settings.json`. Until a worktree is trusted, Zed does not run related untrusted actions and waits for user confirmation. This gives users a chance to review project settings, MCP servers, and language servers.


### PR DESCRIPTION
## Summary

- Split the Git docs into focused pages for status, diffs, staging, branches, history, conflicts, hosting and pull requests, worktrees, settings, and agent workflows.
- Made `docs/src/git/worktrees.md` the canonical public page for how Zed projects, Zed worktrees, linked Git worktrees, branches, terminals, and agent threads relate to each other.
- Updated the AI docs to link back to that canonical worktree context instead of carrying duplicate or partial definitions.
- Preserved old `docs/src/git.md` anchors with a moved-section index so existing links into the former Git page still land somewhere useful.
- Kept roadmap, unsupported behavior, and broader feedback synthesis out of shipped docs.

## Reviewer Focus

- Docs IA: whether this split is the right shape for the Git docs, and whether the hub plus moved-section anchors are enough for readers arriving from old links.
- Git/worktree correctness: project vs. Zed worktree vs. linked Git worktree terminology, branch picker and worktree picker boundaries, multi-root behavior, and setup hooks.
- AI boundaries: agent-thread worktree isolation, archive/restore wording, Terminal Threads behavior, and External Agents provider/runtime ownership.
- Canonical placement: whether Git Worktrees is the right home for project/worktree/branch context. If that context belongs in Windows & Projects instead, treat that as the main IA question.

## Review Already Performed

- Ran piecewise adversarial reviews over IA/link integrity, Git surface correctness, AI/worktree boundaries, tasks/generated metadata, and brand/copy.
- Ran focused acceptance reviews for project/worktree/branch context and AI docs coverage.
- Ran a final docs conventions and brand-voice pass against `docs/.conventions/CONVENTIONS.md`, `docs/AGENTS.md`, and the Zed brand rubric.
- Fixed issues found during review: moved-section fragments, split action tokens, stale hosting link text, terminology drift, table scannability, Terminal Thread cleanup wording, Gemini CLI auth wording, and unsupported-workflow boundaries.

## Validation

- `script/generate-action-metadata`
- `cargo test -p docs_preprocessor`
- `npx prettier --check` on the final touched docs files
- `git diff --check`
- `mdbook build docs`

The docs build passed with existing missing-meta-description warnings only.

Release Notes:

- N/A
