### PR TITLE
docs: Fix incorrect default values

### DIFF
--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3015,7 +3015,7 @@ Configuration for various AI model providers including API URLs and authenticati
 
 - Description: Format for line indicator in the status bar
 - Setting: `line_indicator_format`
-- Default: `"short"`
+- Default: `"long"`
 
 **Options**
 
@@ -3375,7 +3375,7 @@ Examples:
 
 - Description: The direction that you want to split panes horizontally
 - Setting: `pane_split_direction_horizontal`
-- Default: `"up"`
+- Default: `"down"`
 
 **Options**
 
@@ -3399,7 +3399,7 @@ Examples:
 
 - Description: The direction that you want to split panes vertically
 - Setting: `pane_split_direction_vertical`
-- Default: `"left"`
+- Default: `"right"`
 
 **Options**
 


### PR DESCRIPTION
# Objective

The settings reference documents three default values that no longer match the shipped defaults in [`assets/settings/default.json`](https://github.com/zed-industries/zed/blob/main/assets/settings/default.json):

- `line_indicator_format`: docs said `"short"`, actual default is `"long"` ([`default.json:2643`](https://github.com/zed-industries/zed/blob/main/assets/settings/default.json#L2643); the `LineIndicatorFormat` enum marks `Long` as `#[default]` in [`crates/settings_content/src/settings_content.rs#L1094`](https://github.com/zed-industries/zed/blob/main/crates/settings_content/src/settings_content.rs#L1094)).
- `pane_split_direction_horizontal`: docs said `"up"`, actual default is `"down"` ([`default.json:90`](https://github.com/zed-industries/zed/blob/main/assets/settings/default.json#L90)).
- `pane_split_direction_vertical`: docs said `"left"`, actual default is `"right"` ([`default.json:92`](https://github.com/zed-industries/zed/blob/main/assets/settings/default.json#L92)).

The pane split defaults were changed in #36101 ("Change default pane split directions"), which updated `default.json` but not the docs.

## Solution

Update the three `- Default:` values in `docs/src/reference/all-settings.md` to match `assets/settings/default.json`. The runtime honors these `default.json` values (e.g. [`crates/workspace/src/workspace_settings.rs`](https://github.com/zed-industries/zed/blob/main/crates/workspace/src/workspace_settings.rs#L98) `.unwrap()`s the pane split options supplied by `default.json`).

## Testing

- `cd docs && npx prettier --check src/reference/all-settings.md` passes.
- Verified each documented default now matches `assets/settings/default.json`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
