### PR TITLE
Fix opaque handling for Wayland layer-shell surfaces

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -404,8 +404,9 @@ impl WaylandWindowState {
     }
 
     pub fn is_transparent(&self) -> bool {
-        self.decorations == WindowDecorations::Client
-            || self.background_appearance != WindowBackgroundAppearance::Opaque
+        self.background_appearance != WindowBackgroundAppearance::Opaque
+            || (self.decorations == WindowDecorations::Client
+                && !matches!(self.surface_state, WaylandSurfaceState::LayerShell(_)))
     }
 
     fn update_subpixel_layout(&mut self) {
@@ -1621,10 +1622,9 @@ fn update_window(mut state: RefMut<WaylandWindowState>) {
     );
 
     // Note that rounded corners make this rectangle API hard to work with.
-    // As this is common when using CSD, let's just disable this API.
-    if state.background_appearance == WindowBackgroundAppearance::Opaque
-        && state.decorations == WindowDecorations::Server
-    {
+    // As this is common when using CSD, avoid this API for normal
+    // client-decorated windows. Layer-shell surfaces do not have CSD chrome.
+    if opaque {
         // Promise the compositor that this region of the window surface
         // contains no transparent pixels. This allows the compositor to skip
         // updating whatever is behind the surface for better performance.


### PR DESCRIPTION
Treat opaque layer-shell surfaces as non-transparent even though they do not use server-side decorations.

This keeps renderer transparency, Wayland opaque regions, and CSD rounded-corner handling aligned, while preserving transparent behavior for normal client-decorated windows.

# Objective

Fix opaque handling for Wayland layer-shell surfaces.

Layer-shell surfaces do not use server-side decorations, so the previous Wayland opacity logic treated them like normal client-decorated windows. This prevented opaque layer-shell surfaces from using the non-transparent renderer path and from advertising an opaque region to the compositor.

## Solution

- Treat opaque layer-shell surfaces as non-transparent in the Wayland window state.
- Reuse the computed opacity state when setting the Wayland opaque region.
- Keep normal client-decorated windows on the transparent path, because CSD rounded corners make rectangular opaque regions unsafe.

## Testing

- Verified that `crates/gpui_linux/src/linux/wayland/window.rs` has no IDE linter diagnostics.
- This change was not manually tested on a Wayland compositor.

Reviewers can test this on Linux Wayland by opening an opaque layer-shell surface and confirming that it renders correctly while still preserving transparency for normal client-decorated windows.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Improved Wayland layer-shell opacity handling for opaque surfaces.