### PR TITLE
agent_ui: Fix duplicate terminal when starting a new agent thread

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2002,6 +2002,7 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.pending_terminal_spawn = Some(terminal_id);
         let terminal_working_directory = working_directory.clone();
         let init_command = Self::terminal_init_command(run_init_command, cx);
         let terminal_task = self.project.update(cx, |project, cx| {
@@ -7408,6 +7409,34 @@ mod tests {
             assert!(
                 panel.active_terminal_id().is_some(),
                 "the single initial terminal should become active"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_explicit_terminal_blocks_redundant_auto_init(cx: &mut TestAppContext) {
+        let (panel, mut cx) = setup_panel(cx).await;
+
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.last_created_entry_kind = AgentPanelEntryKind::Terminal;
+            assert!(
+                matches!(panel.base_view, BaseView::Uninitialized),
+                "precondition: the panel starts uninitialized"
+            );
+            assert!(
+                panel.pending_terminal_spawn.is_none(),
+                "precondition: no terminal spawn is in-flight yet"
+            );
+            panel.new_terminal(None, AgentThreadSource::AgentPanel, window, cx);
+            let pending = panel.pending_terminal_spawn;
+            assert!(
+                pending.is_some(),
+                "an explicit new terminal must mark a spawn in-flight"
+            );
+            panel.set_active(true, window, cx);
+            assert_eq!(
+                panel.pending_terminal_spawn, pending,
+                "activating the panel while a terminal spawn is in-flight must not schedule a second (auto-init) terminal"
             );
         });
     }


### PR DESCRIPTION
# Objective

- Fixes #58097.
- Opening a new project and clicking `+` in the agent panel to start a terminal thread creates two terminals instead of one. I am able to replicate the issue on version 1.8.0 on macOS 27

## Solution

The new-thread action creates the terminal and then focuses the agent panel. Focusing re-activates the panel (`Panel::set_active` then `ensure_thread_initialized`) before the terminal, which is spawned asynchronously, has registered. The panel still looks uninitialized at that moment, so it spawns its own "initial" terminal too, and that is the duplicate.

`spawn_terminal` now marks the spawn as in-flight (`pending_terminal_spawn`) the moment it starts, the same way the restore and initial-terminal paths already do, so the existing guard in `ensure_thread_initialized` skips the redundant terminal.

This only affected new (unrestored) projects, since existing ones restore their previous entry instead of auto-creating one. The auto-init behavior was introduced in #57150.

## Testing

- Verified in a local dev build on macOS: opening a fresh project and clicking `+` now creates one terminal, and clicking `+` again creates a second, as expected. Reopening an existing project still restores a single terminal.
- Added `test_explicit_terminal_blocks_redundant_auto_init`, which fails without the fix.
- The change is platform-agnostic (no platform-specific code); I wasn't able to test on Linux/Windows.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A (release notes removed due to revert)
