### PR TITLE
markdown: Pair backticks per code span

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -34,8 +34,7 @@ use language::{
     tree_sitter_python,
 };
 use language_settings::Formatter;
-use languages::markdown_lang;
-use languages::rust_lang;
+use languages::{markdown_inline_lang, markdown_lang, rust_lang};
 use lsp::{CompletionParams, DEFAULT_LSP_REQUEST_TIMEOUT};
 use multi_buffer::{IndentGuide, MultiBuffer, MultiBufferOffset, MultiBufferOffsetUtf16, PathKey};
 use parking_lot::Mutex;
@@ -38407,8 +38406,16 @@ async fn test_select_delimiters(cx: &mut TestAppContext) {
 #[gpui::test]
 async fn test_select_delimiters_in_markdown(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
+
+    let language_registry = Arc::new(language::LanguageRegistry::test(cx.executor()));
+    language_registry.add(markdown_lang());
+    language_registry.add(markdown_inline_lang());
     let mut cx = EditorTestContext::new(cx).await;
-    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_lang()), cx));
+
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language_registry(language_registry);
+        buffer.set_language(Some(markdown_lang()), cx);
+    });
 
     // Inside.
     assert_select_delimiters(
@@ -38465,6 +38472,12 @@ async fn test_select_delimiters_in_markdown(cx: &mut TestAppContext) {
         r#"This is hello, ˇworld!."#,
         &mut cx,
     );
+    assert_select_delimiters(
+        false,
+        r#"this is `my great` and `my stˇring`"#,
+        r#"this is `my great` and `«my stringˇ»`"#,
+        &mut cx,
+    );
 
     // Around.
     assert_select_delimiters(
@@ -38483,6 +38496,22 @@ async fn test_select_delimiters_in_markdown(cx: &mut TestAppContext) {
         true,
         r#"This is `hello, ˇworld!`."#,
         r#"This is «`hello, world!`ˇ»."#,
+        &mut cx,
+    );
+    assert_select_delimiters(
+        true,
+        r#"this is `my great` and `my stˇring`"#,
+        r#"this is `my great` and «`my string`ˇ»"#,
+        &mut cx,
+    );
+
+    // Even though backticks are symmetric characters, a cursor between two code
+    // spans should not update the selection when attempting to select inside
+    // delimiters.
+    assert_select_delimiters(
+        false,
+        r#"this is `my great` andˇ `my string`"#,
+        r#"this is `my great` andˇ `my string`"#,
         &mut cx,
     );
 }

--- a/crates/grammars/src/markdown-inline/brackets.scm
+++ b/crates/grammars/src/markdown-inline/brackets.scm
@@ -1,0 +1,6 @@
+; Match backticks within their `code_span` node so the delimiters are always
+; paired per span and never across two separate spans.
+((code_span
+  (code_span_delimiter) @open
+  (code_span_delimiter) @close)
+  (#set! rainbow.exclude))

--- a/crates/grammars/src/markdown/brackets.scm
+++ b/crates/grammars/src/markdown/brackets.scm
@@ -11,10 +11,6 @@
   "\"" @close)
   (#set! rainbow.exclude))
 
-(("`" @open
-  "`" @close)
-  (#set! rainbow.exclude))
-
 (("'" @open
   "'" @close)
   (#set! rainbow.exclude))

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2869,7 +2869,7 @@ fn test_language_at_with_hidden_languages(cx: &mut App) {
 
         let language_registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
         language_registry.add(markdown_lang());
-        language_registry.add(Arc::new(markdown_inline_lang()));
+        language_registry.add(markdown_inline_lang());
 
         let mut buffer = Buffer::local(text, cx);
         buffer.set_language_registry(language_registry.clone());
@@ -2911,7 +2911,7 @@ fn test_language_at_for_markdown_code_block(cx: &mut App) {
 
         let language_registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
         language_registry.add(markdown_lang());
-        language_registry.add(Arc::new(markdown_inline_lang()));
+        language_registry.add(markdown_inline_lang());
         language_registry.add(rust_lang());
 
         let mut buffer = Buffer::local(text, cx);
@@ -4090,19 +4090,6 @@ fn c_lang() -> Arc<Language> {
         .with_outline_query(include_str!("../../grammars/src/c/outline.scm"))
         .unwrap(),
     )
-}
-
-pub fn markdown_inline_lang() -> Language {
-    Language::new(
-        LanguageConfig {
-            name: "Markdown-Inline".into(),
-            hidden: true,
-            ..LanguageConfig::default()
-        },
-        Some(tree_sitter_md::INLINE_LANGUAGE.into()),
-    )
-    .with_highlights_query("(emphasis) @emphasis")
-    .unwrap()
 }
 
 fn get_tree_sexp(buffer: &Entity<Buffer>, cx: &mut gpui::TestAppContext) -> String {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1640,6 +1640,32 @@ pub fn markdown_lang() -> Arc<Language> {
     Arc::new(language)
 }
 
+#[doc(hidden)]
+#[cfg(any(test, feature = "test-support"))]
+pub fn markdown_inline_lang() -> Arc<Language> {
+    use std::borrow::Cow;
+
+    let language = Language::new(
+        LanguageConfig {
+            name: "Markdown-Inline".into(),
+            hidden: true,
+            ..LanguageConfig::default()
+        },
+        Some(tree_sitter_md::INLINE_LANGUAGE.into()),
+    )
+    .with_queries(LanguageQueries {
+        brackets: Some(Cow::from(include_str!(
+            "../../grammars/src/markdown-inline/brackets.scm"
+        ))),
+        highlights: Some(Cow::from(include_str!(
+            "../../grammars/src/markdown-inline/highlights.scm"
+        ))),
+        ..LanguageQueries::default()
+    })
+    .expect("Could not parse markdown-inline queries");
+    Arc::new(language)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
-    LanguageConfig, LanguageMatcher, LanguageQueries, buffer_tests::markdown_inline_lang,
-    markdown_lang, rust_lang,
+    LanguageConfig, LanguageMatcher, LanguageQueries, markdown_inline_lang, markdown_lang,
+    rust_lang,
 };
 use gpui::App;
 use pretty_assertions::assert_eq;
@@ -184,7 +184,7 @@ fn test_syntax_map_layers_for_range(cx: &mut App) {
 fn test_syntax_map_languages_match_layers_for_range(cx: &mut App) {
     let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
     let markdown = markdown_lang();
-    let markdown_inline = Arc::new(markdown_inline_lang());
+    let markdown_inline = markdown_inline_lang();
     registry.add(markdown.clone());
     registry.add(markdown_inline);
     registry.add(rust_lang());
@@ -265,7 +265,7 @@ fn test_syntax_map_languages_match_layers_for_range(cx: &mut App) {
 fn test_dynamic_language_injection(cx: &mut App) {
     let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
     let markdown = markdown_lang();
-    let markdown_inline = Arc::new(markdown_inline_lang());
+    let markdown_inline = markdown_inline_lang();
     registry.add(markdown.clone());
     registry.add(markdown_inline.clone());
     registry.add(rust_lang());
@@ -1340,7 +1340,7 @@ fn test_edit_sequence(language_name: &str, steps: &[&str], cx: &mut App) -> (Buf
     registry.add(Arc::new(html_lang()));
     registry.add(Arc::new(erb_lang()));
     registry.add(markdown_lang());
-    registry.add(Arc::new(markdown_inline_lang()));
+    registry.add(markdown_inline_lang());
 
     let language = registry
         .language_for_name(language_name)


### PR DESCRIPTION
# Objective

The `editor: select inside delimiters` and `editor: select around delimiters` actions (and bracket matching generally) could select the text between two separate inline code spans in Markdown. The Markdown block grammar exposes backticks as a flat run of sibling tokens, so the brackets query paired the closing backtick of one code span with the opening backtick of the next, producing a pair that spans unrelated content.

## Solution

In order to fix this for inline code blocks (or code spans), this commit updates the bracket definitions for markdown-inline grammar, ensuring that delimiters are now grouped per span and cannot pair across spans, as well as dropping the flat block-level backtick pattern from the markdown grammar.

Since single and double quotes have no equivalent node in Markdown (they are not CommonMark constructs), the analogous quote case is left as a known, Markdown-only limitation.

## Testing

These changes have both been manually tested as well as new test assertions have been added specifically for the multiple code span per line scenario when dealing with Markdown.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Select Inside/Around Delimiters • Before</summary>

  https://github.com/user-attachments/assets/ca988bbc-2225-48ca-9aa7-a5b9be0b481c
</details>

<details>
  <summary>Select Inside/Around Delimiters • After</summary>

  https://github.com/user-attachments/assets/2a3fb4f4-7518-464a-bee5-6908348381a5
</details>

---

Release Notes:

- Fixed `editor: select inside delimiters` and `editor: select around delimiters` for inline code blocks in Markdown Markdown

