### PR TITLE
gpui: Fix nested tooltip ownership

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -2193,6 +2193,11 @@ impl Interactivity {
                             } else {
                                 None
                             };
+                            if let (Some(global_id), Some(hitbox)) = (global_id, hitbox.as_ref())
+                                && self.tooltip_builder.is_some()
+                            {
+                                window.register_tooltip_owner(global_id, hitbox, Rc::new(|_| true));
+                            }
 
                             let scroll_offset =
                                 self.clamp_scroll_position(bounds, &style, window, cx);
@@ -2381,6 +2386,7 @@ impl Interactivity {
                                             }
 
                                             self.paint_mouse_listeners(
+                                                global_id,
                                                 hitbox,
                                                 element_state.as_mut(),
                                                 window,
@@ -2551,6 +2557,7 @@ impl Interactivity {
 
     fn paint_mouse_listeners(
         &mut self,
+        global_id: Option<&GlobalElementId>,
         hitbox: &Hitbox,
         element_state: Option<&mut InteractiveElementState>,
         window: &mut Window,
@@ -2945,7 +2952,9 @@ impl Interactivity {
                 });
             }
 
-            if let Some(tooltip_builder) = self.tooltip_builder.take() {
+            if let (Some(tooltip_builder), Some(tooltip_owner_id)) =
+                (self.tooltip_builder.take(), global_id.cloned())
+            {
                 let active_tooltip = element_state
                     .active_tooltip
                     .get_or_insert_with(Default::default)
@@ -2959,20 +2968,20 @@ impl Interactivity {
                 let build_tooltip = Rc::new(move |window: &mut Window, cx: &mut App| {
                     Some(((tooltip_builder.build)(window, cx), tooltip_is_hoverable))
                 });
-                // Use bounds instead of testing hitbox since this is called during prepaint.
                 let check_is_hovered_during_prepaint = Rc::new({
                     let pending_mouse_down = pending_mouse_down.clone();
-                    let source_bounds = hitbox.bounds;
+                    let tooltip_owner_id = tooltip_owner_id.clone();
                     move |window: &Window| {
                         !window.last_input_was_keyboard()
                             && pending_mouse_down.borrow().is_none()
-                            && source_bounds.contains(&window.mouse_position())
+                            && window.is_topmost_tooltip_owner_during_prepaint(&tooltip_owner_id)
                     }
                 });
                 let check_is_hovered = Rc::new({
-                    let hitbox = hitbox.clone();
                     move |window: &Window| {
-                        pending_mouse_down.borrow().is_none() && hitbox.is_hovered(window)
+                        !window.last_input_was_keyboard()
+                            && pending_mouse_down.borrow().is_none()
+                            && window.is_topmost_tooltip_owner(&tooltip_owner_id)
                     }
                 });
                 register_tooltip_mouse_handlers(
@@ -3501,13 +3510,8 @@ pub(crate) fn register_tooltip_mouse_handlers(
 ///
 /// The mouse hovering logic also relies on being called from window prepaint in order to handle the
 /// case where the element the tooltip is on is not rendered - in that case its mouse listeners are
-/// also not registered. During window prepaint, the hitbox information is not available, so
-/// `check_is_hovered_during_prepaint` is used which bases the check off of the absolute bounds of
-/// the element.
-///
-/// TODO: There's a minor bug due to the use of absolute bounds while checking during prepaint - it
-/// does not know if the hitbox is occluded. In the case where a tooltip gets displayed and then
-/// gets occluded after display, it will stick around until the mouse exits the hover bounds.
+/// also not registered. During window prepaint, `check_is_hovered_during_prepaint` checks the
+/// current frame's topmost tooltip owner instead of the rendered frame's hit-test state.
 fn handle_tooltip_mouse_move(
     active_tooltip: &Rc<RefCell<Option<ActiveTooltip>>>,
     build_tooltip: &Rc<dyn Fn(&mut Window, &mut App) -> Option<(AnyView, bool)>>,

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -4236,7 +4236,9 @@ mod tests {
 
     struct TooltipCaptureElement {
         child: AnyElement,
-        captured_active_tooltip: CapturedActiveTooltip,
+        tooltip_owner_id: ElementId,
+        tooltip_owner_capture: CapturedActiveTooltip,
+        tooltip_child: Option<(ElementId, CapturedActiveTooltip)>,
     }
 
     impl IntoElement for TooltipCaptureElement {
@@ -4292,42 +4294,78 @@ mod tests {
             cx: &mut App,
         ) {
             self.child.paint(window, cx);
-            window.with_global_id("target".into(), |global_id, window| {
+            window.with_global_id(self.tooltip_owner_id.clone(), |global_id, window| {
                 window.with_element_state::<InteractiveElementState, _>(
                     global_id,
                     |state, _window| {
                         let state = state.unwrap();
-                        *self.captured_active_tooltip.borrow_mut() =
+                        *self.tooltip_owner_capture.borrow_mut() =
                             state.active_tooltip.as_ref().map(Rc::downgrade);
                         ((), state)
                     },
                 )
             });
+            if let Some((tooltip_child_id, tooltip_child_capture)) = &self.tooltip_child {
+                window.with_element_namespace(self.tooltip_owner_id.clone(), |window| {
+                    window.with_global_id(tooltip_child_id.clone(), |global_id, window| {
+                        window.with_element_state::<InteractiveElementState, _>(
+                            global_id,
+                            |state, _window| {
+                                let state = state.unwrap();
+                                *tooltip_child_capture.borrow_mut() =
+                                    state.active_tooltip.as_ref().map(Rc::downgrade);
+                                ((), state)
+                            },
+                        )
+                    });
+                });
+            }
         }
     }
 
     struct TooltipOwner {
-        captured_active_tooltip: CapturedActiveTooltip,
+        tooltip_owner_id: ElementId,
+        tooltip_owner_capture: CapturedActiveTooltip,
+        tooltip_child: Option<(ElementId, CapturedActiveTooltip)>,
         show_delay_override: Option<Duration>,
     }
 
     impl Render for TooltipOwner {
         fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            let tooltip_child_id = self
+                .tooltip_child
+                .as_ref()
+                .map(|(tooltip_child_id, _)| tooltip_child_id.clone());
             TooltipCaptureElement {
                 child: div()
                     .size_full()
                     .child(
                         div()
-                            .id("target")
-                            .w(px(50.))
+                            .id(self.tooltip_owner_id.clone())
+                            .w(if tooltip_child_id.is_some() {
+                                px(100.)
+                            } else {
+                                px(50.)
+                            })
                             .h(px(50.))
                             .tooltip(|_, cx| cx.new(|_| TestTooltipView).into())
                             .when_some(self.show_delay_override, |this, delay| {
                                 this.tooltip_show_delay(delay)
+                            })
+                            .when_some(tooltip_child_id, |this, tooltip_child_id| {
+                                this.child(
+                                    div()
+                                        .id(tooltip_child_id)
+                                        .w(px(50.))
+                                        .h(px(50.))
+                                        .tooltip(|_, cx| cx.new(|_| TestTooltipView).into()),
+                                )
                             }),
                     )
                     .into_any_element(),
-                captured_active_tooltip: self.captured_active_tooltip.clone(),
+                tooltip_owner_id: self.tooltip_owner_id.clone(),
+                tooltip_owner_capture: self.tooltip_owner_capture.clone(),
+                tooltip_child: self.tooltip_child.clone(),
             }
         }
     }
@@ -4371,7 +4409,10 @@ mod tests {
     }
 
     fn setup_tooltip_owner_test(
+        tooltip_owner_id: ElementId,
+        tooltip_child: Option<(ElementId, CapturedActiveTooltip)>,
         show_delay_override: Option<Duration>,
+        mouse_position: Option<Point<Pixels>>,
     ) -> (
         TestAppContext,
         crate::AnyWindowHandle,
@@ -4382,7 +4423,9 @@ mod tests {
         let window = test_app.add_window({
             let captured_active_tooltip = captured_active_tooltip.clone();
             move |_, _| TooltipOwner {
-                captured_active_tooltip,
+                tooltip_owner_id,
+                tooltip_owner_capture: captured_active_tooltip,
+                tooltip_child,
                 show_delay_override,
             }
         });
@@ -4394,32 +4437,35 @@ mod tests {
             })
             .unwrap();
 
-        test_app
-            .update_window(any_window, |_, window, cx| {
-                window.dispatch_event(
-                    MouseMoveEvent {
-                        position: point(px(10.), px(10.)),
-                        modifiers: Default::default(),
-                        pressed_button: None,
-                    }
-                    .to_platform_input(),
-                    cx,
-                );
-            })
-            .unwrap();
+        if let Some(mouse_position) = mouse_position {
+            test_app
+                .update_window(any_window, |_, window, cx| {
+                    window.dispatch_event(
+                        MouseMoveEvent {
+                            position: mouse_position,
+                            modifiers: Default::default(),
+                            pressed_button: None,
+                        }
+                        .to_platform_input(),
+                        cx,
+                    );
+                })
+                .unwrap();
 
-        test_app
-            .update_window(any_window, |_, window, cx| {
-                window.draw(cx).clear(cx);
-            })
-            .unwrap();
+            test_app
+                .update_window(any_window, |_, window, cx| {
+                    window.draw(cx).clear(cx);
+                })
+                .unwrap();
+        }
 
         (test_app, any_window, captured_active_tooltip)
     }
 
     #[test]
     fn tooltip_waiting_for_show_is_released_when_its_owner_disappears() {
-        let (mut test_app, any_window, captured_active_tooltip) = setup_tooltip_owner_test(None);
+        let (mut test_app, any_window, captured_active_tooltip) =
+            setup_tooltip_owner_test("target".into(), None, None, Some(point(px(10.), px(10.))));
 
         let weak_active_tooltip = captured_active_tooltip.borrow().clone().unwrap();
         let active_tooltip = weak_active_tooltip.upgrade().unwrap();
@@ -4443,8 +4489,12 @@ mod tests {
     fn tooltip_respects_custom_show_delay() {
         let extra_delay = Duration::from_secs(1);
         let show_delay_override = DEFAULT_TOOLTIP_SHOW_DELAY + extra_delay;
-        let (mut test_app, _any_window, captured_active_tooltip) =
-            setup_tooltip_owner_test(Some(show_delay_override));
+        let (mut test_app, _any_window, captured_active_tooltip) = setup_tooltip_owner_test(
+            "target".into(),
+            None,
+            Some(show_delay_override),
+            Some(point(px(10.), px(10.))),
+        );
 
         let weak_active_tooltip = captured_active_tooltip.borrow().clone().unwrap();
         let active_tooltip = weak_active_tooltip.upgrade().unwrap();
@@ -4470,7 +4520,8 @@ mod tests {
 
     #[test]
     fn tooltip_is_released_when_its_owner_disappears() {
-        let (mut test_app, any_window, captured_active_tooltip) = setup_tooltip_owner_test(None);
+        let (mut test_app, any_window, captured_active_tooltip) =
+            setup_tooltip_owner_test("target".into(), None, None, Some(point(px(10.), px(10.))));
 
         let weak_active_tooltip = captured_active_tooltip.borrow().clone().unwrap();
         let active_tooltip = weak_active_tooltip.upgrade().unwrap();
@@ -4498,7 +4549,8 @@ mod tests {
 
     #[test]
     fn tooltip_hides_after_mouse_leaves_origin() {
-        let (mut test_app, any_window, captured_active_tooltip) = setup_tooltip_owner_test(None);
+        let (mut test_app, any_window, captured_active_tooltip) =
+            setup_tooltip_owner_test("target".into(), None, None, Some(point(px(10.), px(10.))));
 
         let weak_active_tooltip = captured_active_tooltip.borrow().clone().unwrap();
         let active_tooltip = weak_active_tooltip.upgrade().unwrap();
@@ -4528,6 +4580,129 @@ mod tests {
             .unwrap();
 
         assert!(active_tooltip.borrow().is_none());
+    }
+
+    #[test]
+    fn test_nested_tooltip_owner_hover() {
+        let captured_child_active_tooltip: CapturedActiveTooltip = Rc::new(RefCell::new(None));
+        let (mut test_app, any_window, captured_parent_active_tooltip) = setup_tooltip_owner_test(
+            "parent".into(),
+            Some(("child".into(), captured_child_active_tooltip.clone())),
+            None,
+            None,
+        );
+
+        let weak_parent_active_tooltip = captured_parent_active_tooltip.borrow().clone().unwrap();
+        let parent_active_tooltip = weak_parent_active_tooltip.upgrade().unwrap();
+        let weak_child_active_tooltip = captured_child_active_tooltip.borrow().clone().unwrap();
+        let child_active_tooltip = weak_child_active_tooltip.upgrade().unwrap();
+
+        assert!(parent_active_tooltip.borrow().is_none());
+        assert!(child_active_tooltip.borrow().is_none());
+
+        test_app
+            .update_window(any_window, |_, window, cx| {
+                window.dispatch_event(
+                    MouseMoveEvent {
+                        position: point(px(75.), px(10.)),
+                        modifiers: Default::default(),
+                        pressed_button: None,
+                    }
+                    .to_platform_input(),
+                    cx,
+                );
+            })
+            .unwrap();
+        assert!(matches!(
+            parent_active_tooltip.borrow().as_ref(),
+            Some(ActiveTooltip::WaitingForShow { .. })
+        ));
+        assert!(child_active_tooltip.borrow().is_none());
+
+        test_app
+            .dispatcher
+            .advance_clock(DEFAULT_TOOLTIP_SHOW_DELAY);
+        test_app.run_until_parked();
+
+        assert!(matches!(
+            parent_active_tooltip.borrow().as_ref(),
+            Some(ActiveTooltip::Visible { .. })
+        ));
+        assert!(child_active_tooltip.borrow().is_none());
+
+        test_app
+            .update_window(any_window, |_, window, cx| {
+                window.dispatch_event(
+                    MouseMoveEvent {
+                        position: point(px(10.), px(10.)),
+                        modifiers: Default::default(),
+                        pressed_button: None,
+                    }
+                    .to_platform_input(),
+                    cx,
+                );
+            })
+            .unwrap();
+
+        test_app
+            .update_window(any_window, |_, window, cx| {
+                window.draw(cx).clear(cx);
+            })
+            .unwrap();
+
+        assert!(parent_active_tooltip.borrow().is_none());
+        assert!(matches!(
+            child_active_tooltip.borrow().as_ref(),
+            Some(ActiveTooltip::WaitingForShow { .. })
+        ));
+
+        test_app
+            .dispatcher
+            .advance_clock(DEFAULT_TOOLTIP_SHOW_DELAY);
+        test_app.run_until_parked();
+
+        assert!(parent_active_tooltip.borrow().is_none());
+        assert!(matches!(
+            child_active_tooltip.borrow().as_ref(),
+            Some(ActiveTooltip::Visible { .. })
+        ));
+
+        test_app
+            .update_window(any_window, |_, window, cx| {
+                window.dispatch_event(
+                    MouseMoveEvent {
+                        position: point(px(75.), px(10.)),
+                        modifiers: Default::default(),
+                        pressed_button: None,
+                    }
+                    .to_platform_input(),
+                    cx,
+                );
+            })
+            .unwrap();
+
+        test_app
+            .update_window(any_window, |_, window, cx| {
+                window.draw(cx).clear(cx);
+            })
+            .unwrap();
+
+        assert!(child_active_tooltip.borrow().is_none());
+        assert!(matches!(
+            parent_active_tooltip.borrow().as_ref(),
+            Some(ActiveTooltip::WaitingForShow { .. })
+        ));
+
+        test_app
+            .dispatcher
+            .advance_clock(DEFAULT_TOOLTIP_SHOW_DELAY);
+        test_app.run_until_parked();
+
+        assert!(matches!(
+            parent_active_tooltip.borrow().as_ref(),
+            Some(ActiveTooltip::Visible { .. })
+        ));
+        assert!(child_active_tooltip.borrow().is_none());
     }
 
     struct MouseDownOutOwner {

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -1114,6 +1114,20 @@ impl Element for InteractiveText {
                 self.text
                     .prepaint(None, inspector_id, bounds, state, window, cx);
                 let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Normal);
+                if let Some(global_id) = global_id
+                    && self.tooltip_builder.is_some()
+                {
+                    let text_layout = self.text.layout().clone();
+                    window.register_tooltip_owner(
+                        global_id,
+                        &hitbox,
+                        Rc::new(move |window| {
+                            text_layout
+                                .index_for_position(window.mouse_position())
+                                .is_ok()
+                        }),
+                    );
+                }
                 (hitbox, interactive_state)
             },
         )
@@ -1209,6 +1223,7 @@ impl Element for InteractiveText {
                 });
 
                 if let Some(tooltip_builder) = self.tooltip_builder.clone() {
+                    let tooltip_owner_id = global_id.unwrap().clone();
                     let active_tooltip = interactive_state.active_tooltip.clone();
                     let build_tooltip = Rc::new({
                         let tooltip_is_hoverable = false;
@@ -1222,30 +1237,23 @@ impl Element for InteractiveText {
                         }
                     });
 
-                    // Use bounds instead of testing hitbox since this is called during prepaint.
                     let check_is_hovered_during_prepaint = Rc::new({
-                        let source_bounds = hitbox.bounds;
-                        let text_layout = text_layout.clone();
                         let pending_mouse_down = interactive_state.mouse_down_index.clone();
+                        let tooltip_owner_id = tooltip_owner_id.clone();
                         move |window: &Window| {
-                            text_layout
-                                .index_for_position(window.mouse_position())
-                                .is_ok()
-                                && source_bounds.contains(&window.mouse_position())
+                            !window.last_input_was_keyboard()
                                 && pending_mouse_down.get().is_none()
+                                && window
+                                    .is_topmost_tooltip_owner_during_prepaint(&tooltip_owner_id)
                         }
                     });
 
                     let check_is_hovered = Rc::new({
-                        let hitbox = hitbox.clone();
-                        let text_layout = text_layout.clone();
                         let pending_mouse_down = interactive_state.mouse_down_index.clone();
                         move |window: &Window| {
-                            text_layout
-                                .index_for_position(window.mouse_position())
-                                .is_ok()
-                                && hitbox.is_hovered(window)
+                            !window.last_input_was_keyboard()
                                 && pending_mouse_down.get().is_none()
+                                && window.is_topmost_tooltip_owner(&tooltip_owner_id)
                         }
                     });
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -890,6 +890,13 @@ pub(crate) struct TooltipRequest {
     tooltip: AnyTooltip,
 }
 
+#[derive(Clone)]
+pub(crate) struct TooltipOwner {
+    owner_id: GlobalElementId,
+    hitbox_id: HitboxId,
+    owns_mouse_position: Rc<dyn Fn(&Window) -> bool>,
+}
+
 pub(crate) struct DeferredDraw {
     current_view: EntityId,
     priority: usize,
@@ -917,6 +924,7 @@ pub(crate) struct Frame {
     pub(crate) deferred_draws: Vec<DeferredDraw>,
     pub(crate) input_handlers: Vec<Option<PlatformInputHandler>>,
     pub(crate) tooltip_requests: Vec<Option<TooltipRequest>>,
+    pub(crate) tooltip_owners: Vec<TooltipOwner>,
     pub(crate) cursor_styles: Vec<CursorStyleRequest>,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) debug_bounds: FxHashMap<String, Bounds<Pixels>>,
@@ -931,6 +939,7 @@ pub(crate) struct Frame {
 pub(crate) struct PrepaintStateIndex {
     hitboxes_index: usize,
     tooltips_index: usize,
+    tooltip_owners_index: usize,
     deferred_draws_index: usize,
     dispatch_tree_index: usize,
     accessed_element_states_index: usize,
@@ -963,6 +972,7 @@ impl Frame {
             deferred_draws: Vec::new(),
             input_handlers: Vec::new(),
             tooltip_requests: Vec::new(),
+            tooltip_owners: Vec::new(),
             cursor_styles: Vec::new(),
 
             #[cfg(any(test, feature = "test-support"))]
@@ -985,6 +995,7 @@ impl Frame {
         self.scene.clear();
         self.input_handlers.clear();
         self.tooltip_requests.clear();
+        self.tooltip_owners.clear();
         self.cursor_styles.clear();
         self.hitboxes.clear();
         self.window_control_hitboxes.clear();
@@ -1041,6 +1052,23 @@ impl Frame {
             hit_test.hover_hitbox_count = hit_test.ids.len();
         }
         hit_test
+    }
+
+    fn topmost_tooltip_owner<'a>(
+        &'a self,
+        hit_test: &HitTest,
+        window: &Window,
+    ) -> Option<&'a GlobalElementId> {
+        for hitbox_id in hit_test.ids.iter().take(hit_test.hover_hitbox_count) {
+            if let Some(owner) =
+                self.tooltip_owners.iter().rev().find(|owner| {
+                    owner.hitbox_id == *hitbox_id && (owner.owns_mouse_position)(window)
+                })
+            {
+                return Some(&owner.owner_id);
+            }
+        }
+        None
     }
 
     pub(crate) fn focus_path(&self) -> SmallVec<[FocusId; 8]> {
@@ -3102,6 +3130,10 @@ impl Window {
     }
 
     fn prepaint_tooltip(&mut self, cx: &mut App) -> Option<AnyElement> {
+        let mut visible_tooltip = None;
+
+        // Even when a topmost tooltip wins rendering, other active tooltip owners need
+        // to update so losing ancestors can clear their active tooltip state.
         // Use indexing instead of iteration to avoid borrowing self for the duration of the loop.
         for tooltip_request_index in (0..self.next_frame.tooltip_requests.len()).rev() {
             let Some(Some(tooltip_request)) = self
@@ -3157,17 +3189,24 @@ impl Window {
                 continue;
             }
 
-            self.with_absolute_element_offset(tooltip_bounds.origin, |window| {
-                element.prepaint(window, cx)
-            });
-
-            self.tooltip_bounds = Some(TooltipBounds {
-                id: tooltip_request.id,
-                bounds: tooltip_bounds,
-            });
-            return Some(element);
+            if visible_tooltip.is_none() {
+                visible_tooltip = Some((tooltip_request.id, tooltip_bounds, element));
+            }
         }
-        None
+
+        let Some((tooltip_id, tooltip_bounds, mut element)) = visible_tooltip else {
+            return None;
+        };
+
+        self.with_absolute_element_offset(tooltip_bounds.origin, |window| {
+            element.prepaint(window, cx)
+        });
+
+        self.tooltip_bounds = Some(TooltipBounds {
+            id: tooltip_id,
+            bounds: tooltip_bounds,
+        });
+        Some(element)
     }
 
     fn prepaint_deferred_draws(&mut self, cx: &mut App) {
@@ -3290,6 +3329,7 @@ impl Window {
         PrepaintStateIndex {
             hitboxes_index: self.next_frame.hitboxes.len(),
             tooltips_index: self.next_frame.tooltip_requests.len(),
+            tooltip_owners_index: self.next_frame.tooltip_owners.len(),
             deferred_draws_index: self.next_frame.deferred_draws.len(),
             dispatch_tree_index: self.next_frame.dispatch_tree.len(),
             accessed_element_states_index: self.next_frame.accessed_element_states.len(),
@@ -3308,6 +3348,12 @@ impl Window {
                 [range.start.tooltips_index..range.end.tooltips_index]
                 .iter_mut()
                 .map(|request| request.take()),
+        );
+        self.next_frame.tooltip_owners.extend(
+            self.rendered_frame.tooltip_owners
+                [range.start.tooltip_owners_index..range.end.tooltip_owners_index]
+                .iter()
+                .cloned(),
         );
         self.next_frame.accessed_element_states.extend(
             self.rendered_frame.accessed_element_states[range.start.accessed_element_states_index
@@ -3449,6 +3495,37 @@ impl Window {
         id
     }
 
+    pub(crate) fn register_tooltip_owner(
+        &mut self,
+        owner_id: &GlobalElementId,
+        hitbox: &Hitbox,
+        owns_mouse_position: Rc<dyn Fn(&Window) -> bool>,
+    ) {
+        self.invalidator.debug_assert_prepaint();
+        self.next_frame.tooltip_owners.push(TooltipOwner {
+            owner_id: owner_id.clone(),
+            hitbox_id: hitbox.id,
+            owns_mouse_position,
+        });
+    }
+
+    pub(crate) fn is_topmost_tooltip_owner(&self, owner_id: &GlobalElementId) -> bool {
+        self.rendered_frame
+            .topmost_tooltip_owner(&self.mouse_hit_test, self)
+            .is_some_and(|topmost_owner_id| topmost_owner_id == owner_id)
+    }
+
+    pub(crate) fn is_topmost_tooltip_owner_during_prepaint(
+        &self,
+        owner_id: &GlobalElementId,
+    ) -> bool {
+        self.invalidator.debug_assert_prepaint();
+        let hit_test = self.next_frame.hit_test(self.mouse_position);
+        self.next_frame
+            .topmost_tooltip_owner(&hit_test, self)
+            .is_some_and(|topmost_owner_id| topmost_owner_id == owner_id)
+    }
+
     /// Invoke the given function with the given content mask after intersecting it
     /// with the current mask. This method should only be called during element drawing.
     // This function is called in a highly recursive manner in editor
@@ -3535,6 +3612,9 @@ impl Window {
             self.next_frame
                 .tooltip_requests
                 .truncate(index.tooltips_index);
+            self.next_frame
+                .tooltip_owners
+                .truncate(index.tooltip_owners_index);
             self.next_frame
                 .deferred_draws
                 .truncate(index.deferred_draws_index);


### PR DESCRIPTION
### Objective

Fix tooltip hover for nested owners. When parent and child elements both have tooltips, the prepaint tooltip path could keep treating the parent as hovered because it checked raw bounds instead of the current tooltip owner under the mouse. This could make the parent tooltip briefly flash or reuse stale hover timing when moving between parent and child.

### Solution

Resolve tooltip visibility through the current frame’s topmost tooltip owner under the mouse instead of raw bounds checks. This gives child tooltip owners priority over parent owners without requiring children to occlude their parents.

### Testing

Added a test case and manually verified on macOS as well.

### Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

### Showcase

### Before

Notice that after moving back from the child (close button) to the parent (tab) shows the parent tooltip immediately, because the parent tooltip state was not fully reset while the cursor was over the child.

https://github.com/user-attachments/assets/abc455bd-f02c-41ca-939c-10585ea37b88

### After

https://github.com/user-attachments/assets/55aefcfc-6e15-4608-a751-10895f10e443

---

Release Notes:

- N/A
