### PR TITLE
ci: Add bubblewrap manifest JSON

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -468,11 +468,19 @@ jobs:
         cp result/bin/bwrap bwrap-linux-aarch64
         chmod 755 bwrap-linux-aarch64
         gzip -f --stdout --best bwrap-linux-aarch64 > bwrap-linux-aarch64.gz
+        version=$(nix eval --raw nixpkgs#pkgsStatic.bubblewrap.version)
+        printf '{"version":"%s"}\n' "$version" > bwrap-linux-aarch64.json
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: bwrap-linux-aarch64.gz
         path: bwrap-linux-aarch64.gz
+        if-no-files-found: error
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-aarch64.json
+        path: bwrap-linux-aarch64.json
         if-no-files-found: error
     timeout-minutes: 60
   build_static_bwrap_linux_x86_64:
@@ -503,11 +511,19 @@ jobs:
         cp result/bin/bwrap bwrap-linux-x86_64
         chmod 755 bwrap-linux-x86_64
         gzip -f --stdout --best bwrap-linux-x86_64 > bwrap-linux-x86_64.gz
+        version=$(nix eval --raw nixpkgs#pkgsStatic.bubblewrap.version)
+        printf '{"version":"%s"}\n' "$version" > bwrap-linux-x86_64.json
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: bwrap-linux-x86_64.gz
         path: bwrap-linux-x86_64.gz
+        if-no-files-found: error
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-x86_64.json
+        path: bwrap-linux-x86_64.json
         if-no-files-found: error
     timeout-minutes: 60
   bundle_mac_aarch64:
@@ -735,6 +751,8 @@ jobs:
         mv ./artifacts/zed-linux-x86_64.tar.gz/zed-linux-x86_64.tar.gz release-artifacts/zed-linux-x86_64.tar.gz
         mv ./artifacts/bwrap-linux-aarch64.gz/bwrap-linux-aarch64.gz release-artifacts/bwrap-linux-aarch64.gz
         mv ./artifacts/bwrap-linux-x86_64.gz/bwrap-linux-x86_64.gz release-artifacts/bwrap-linux-x86_64.gz
+        mv ./artifacts/bwrap-linux-aarch64.json/bwrap-linux-aarch64.json release-artifacts/bwrap-linux-aarch64.json
+        mv ./artifacts/bwrap-linux-x86_64.json/bwrap-linux-x86_64.json release-artifacts/bwrap-linux-x86_64.json
         mv ./artifacts/Zed-x86_64.exe/Zed-x86_64.exe release-artifacts/Zed-x86_64.exe
         mv ./artifacts/Zed-aarch64.exe/Zed-aarch64.exe release-artifacts/Zed-aarch64.exe
         mv ./artifacts/zed-remote-server-macos-aarch64.gz/zed-remote-server-macos-aarch64.gz release-artifacts/zed-remote-server-macos-aarch64.gz
@@ -754,7 +772,7 @@ jobs:
     steps:
     - name: release::validate_release_assets
       run: |
-        EXPECTED_ASSETS='["Zed-aarch64.dmg", "Zed-x86_64.dmg", "zed-linux-aarch64.tar.gz", "zed-linux-x86_64.tar.gz", "bwrap-linux-aarch64.gz", "bwrap-linux-x86_64.gz", "Zed-x86_64.exe", "Zed-aarch64.exe", "zed-remote-server-macos-aarch64.gz", "zed-remote-server-macos-x86_64.gz", "zed-remote-server-linux-aarch64.gz", "zed-remote-server-linux-x86_64.gz", "zed-remote-server-windows-aarch64.zip", "zed-remote-server-windows-x86_64.zip"]'
+        EXPECTED_ASSETS='["Zed-aarch64.dmg", "Zed-x86_64.dmg", "zed-linux-aarch64.tar.gz", "zed-linux-x86_64.tar.gz", "bwrap-linux-aarch64.gz", "bwrap-linux-x86_64.gz", "bwrap-linux-aarch64.json", "bwrap-linux-x86_64.json", "Zed-x86_64.exe", "Zed-aarch64.exe", "zed-remote-server-macos-aarch64.gz", "zed-remote-server-macos-x86_64.gz", "zed-remote-server-linux-aarch64.gz", "zed-remote-server-linux-x86_64.gz", "zed-remote-server-windows-aarch64.zip", "zed-remote-server-windows-x86_64.zip"]'
         TAG="$GITHUB_REF_NAME"
 
         ACTUAL_ASSETS=$(gh release view "$TAG" --repo=zed-industries/zed --json assets -q '[.assets[].name]')

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -213,11 +213,19 @@ jobs:
         cp result/bin/bwrap bwrap-linux-aarch64
         chmod 755 bwrap-linux-aarch64
         gzip -f --stdout --best bwrap-linux-aarch64 > bwrap-linux-aarch64.gz
+        version=$(nix eval --raw nixpkgs#pkgsStatic.bubblewrap.version)
+        printf '{"version":"%s"}\n' "$version" > bwrap-linux-aarch64.json
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: bwrap-linux-aarch64.gz
         path: bwrap-linux-aarch64.gz
+        if-no-files-found: error
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-aarch64.json
+        path: bwrap-linux-aarch64.json
         if-no-files-found: error
     timeout-minutes: 60
   build_static_bwrap_linux_x86_64:
@@ -246,11 +254,19 @@ jobs:
         cp result/bin/bwrap bwrap-linux-x86_64
         chmod 755 bwrap-linux-x86_64
         gzip -f --stdout --best bwrap-linux-x86_64 > bwrap-linux-x86_64.gz
+        version=$(nix eval --raw nixpkgs#pkgsStatic.bubblewrap.version)
+        printf '{"version":"%s"}\n' "$version" > bwrap-linux-x86_64.json
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: bwrap-linux-x86_64.gz
         path: bwrap-linux-x86_64.gz
+        if-no-files-found: error
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-x86_64.json
+        path: bwrap-linux-x86_64.json
         if-no-files-found: error
     timeout-minutes: 60
   bundle_mac_aarch64:
@@ -591,6 +607,8 @@ jobs:
         mv ./artifacts/zed-linux-x86_64.tar.gz/zed-linux-x86_64.tar.gz release-artifacts/zed-linux-x86_64.tar.gz
         mv ./artifacts/bwrap-linux-aarch64.gz/bwrap-linux-aarch64.gz release-artifacts/bwrap-linux-aarch64.gz
         mv ./artifacts/bwrap-linux-x86_64.gz/bwrap-linux-x86_64.gz release-artifacts/bwrap-linux-x86_64.gz
+        mv ./artifacts/bwrap-linux-aarch64.json/bwrap-linux-aarch64.json release-artifacts/bwrap-linux-aarch64.json
+        mv ./artifacts/bwrap-linux-x86_64.json/bwrap-linux-x86_64.json release-artifacts/bwrap-linux-x86_64.json
         mv ./artifacts/Zed-x86_64.exe/Zed-x86_64.exe release-artifacts/Zed-x86_64.exe
         mv ./artifacts/Zed-aarch64.exe/Zed-aarch64.exe release-artifacts/Zed-aarch64.exe
         mv ./artifacts/zed-remote-server-macos-aarch64.gz/zed-remote-server-macos-aarch64.gz release-artifacts/zed-remote-server-macos-aarch64.gz

--- a/.github/workflows/run_bundling.yml
+++ b/.github/workflows/run_bundling.yml
@@ -122,11 +122,19 @@ jobs:
         cp result/bin/bwrap bwrap-linux-aarch64
         chmod 755 bwrap-linux-aarch64
         gzip -f --stdout --best bwrap-linux-aarch64 > bwrap-linux-aarch64.gz
+        version=$(nix eval --raw nixpkgs#pkgsStatic.bubblewrap.version)
+        printf '{"version":"%s"}\n' "$version" > bwrap-linux-aarch64.json
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: bwrap-linux-aarch64.gz
         path: bwrap-linux-aarch64.gz
+        if-no-files-found: error
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-aarch64.json
+        path: bwrap-linux-aarch64.json
         if-no-files-found: error
     timeout-minutes: 60
   build_static_bwrap_linux_x86_64:
@@ -153,11 +161,19 @@ jobs:
         cp result/bin/bwrap bwrap-linux-x86_64
         chmod 755 bwrap-linux-x86_64
         gzip -f --stdout --best bwrap-linux-x86_64 > bwrap-linux-x86_64.gz
+        version=$(nix eval --raw nixpkgs#pkgsStatic.bubblewrap.version)
+        printf '{"version":"%s"}\n' "$version" > bwrap-linux-x86_64.json
     - name: run_bundling::upload_artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: bwrap-linux-x86_64.gz
         path: bwrap-linux-x86_64.gz
+        if-no-files-found: error
+    - name: run_bundling::upload_artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: bwrap-linux-x86_64.json
+        path: bwrap-linux-x86_64.json
         if-no-files-found: error
     timeout-minutes: 60
   bundle_mac_aarch64:

--- a/tooling/xtask/src/tasks/workflows/run_bundling.rs
+++ b/tooling/xtask/src/tasks/workflows/run_bundling.rs
@@ -103,6 +103,10 @@ pub(crate) fn build_static_bwrap(arch: Arch, deps: &[&NamedJob]) -> NamedJob {
         Arch::X86_64 => assets::BWRAP_LINUX_X86_64,
         Arch::AARCH64 => assets::BWRAP_LINUX_AARCH64,
     };
+    let manifest_name = match arch {
+        Arch::X86_64 => assets::BWRAP_MANIFEST_LINUX_X86_64,
+        Arch::AARCH64 => assets::BWRAP_MANIFEST_LINUX_AARCH64,
+    };
     let binary_name = artifact_name
         .strip_suffix(".gz")
         .expect("static bwrap artifact name should end in .gz");
@@ -110,6 +114,8 @@ pub(crate) fn build_static_bwrap(arch: Arch, deps: &[&NamedJob]) -> NamedJob {
         cp result/bin/bwrap {binary_name}
         chmod 755 {binary_name}
         gzip -f --stdout --best {binary_name} > {artifact_name}
+        version=$(nix eval --raw nixpkgs#pkgsStatic.bubblewrap.version)
+        printf '{{"version":"%s"}}\n' "$version" > {manifest_name}
     "#};
 
     NamedJob {
@@ -138,7 +144,8 @@ pub(crate) fn build_static_bwrap(arch: Arch, deps: &[&NamedJob]) -> NamedJob {
             )
             .add_step(named::bash("nix build nixpkgs#pkgsStatic.bubblewrap -L"))
             .add_step(named::bash(&copy_artifact))
-            .add_step(upload_artifact(artifact_name)),
+            .add_step(upload_artifact(artifact_name))
+            .add_step(upload_artifact(manifest_name)),
     }
 }
 

--- a/tooling/xtask/src/tasks/workflows/vars.rs
+++ b/tooling/xtask/src/tasks/workflows/vars.rs
@@ -376,6 +376,8 @@ pub mod assets {
     pub const LINUX_X86_64: &str = "zed-linux-x86_64.tar.gz";
     pub const BWRAP_LINUX_AARCH64: &str = "bwrap-linux-aarch64.gz";
     pub const BWRAP_LINUX_X86_64: &str = "bwrap-linux-x86_64.gz";
+    pub const BWRAP_MANIFEST_LINUX_AARCH64: &str = "bwrap-linux-aarch64.json";
+    pub const BWRAP_MANIFEST_LINUX_X86_64: &str = "bwrap-linux-x86_64.json";
     pub const WINDOWS_X86_64: &str = "Zed-x86_64.exe";
     pub const WINDOWS_AARCH64: &str = "Zed-aarch64.exe";
 
@@ -394,6 +396,8 @@ pub mod assets {
             LINUX_X86_64,
             BWRAP_LINUX_AARCH64,
             BWRAP_LINUX_X86_64,
+            BWRAP_MANIFEST_LINUX_AARCH64,
+            BWRAP_MANIFEST_LINUX_X86_64,
             WINDOWS_X86_64,
             WINDOWS_AARCH64,
             REMOTE_SERVER_MAC_AARCH64,


### PR DESCRIPTION
Adds a second release asset containing a json `{ "version": "<bwrap-version>" }`

---

Release Notes:

- N/A or Added/Fixed/Improved ...
