### PR TITLE
ollama: Don't abort entire model fetch if one model's details fail to load

### DIFF
--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use collections::{HashMap, HashSet, IndexMap};
 use gpui::{Entity, SharedString, Task};
-use language_model::LanguageModelProviderId;
+use language_model::{DisabledReason, LanguageModelProviderId};
 use project::{AgentId, Project};
 use serde::{Deserialize, Serialize};
 use std::{any::Any, error::Error, fmt, path::PathBuf, rc::Rc};
@@ -493,6 +493,7 @@ pub struct AgentModelInfo {
     pub icon: Option<AgentModelIcon>,
     pub is_latest: bool,
     pub cost: Option<SharedString>,
+    pub disabled: Option<DisabledReason>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1064,6 +1065,7 @@ mod test_support {
                     icon: Some(AgentModelIcon::Named(ui::IconName::ZedAssistant)),
                     is_latest: false,
                     cost: None,
+                    disabled: None,
                 })),
             }
         }

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -310,6 +310,7 @@ impl LanguageModels {
             }),
             is_latest: model.is_latest(),
             cost: model.model_cost_info().map(|cost| cost.to_shared_string()),
+            disabled: model.is_disabled(),
         }
     }
 
@@ -5545,6 +5546,7 @@ mod internal_tests {
                         ui::IconName::ZedAssistant
                     )),
                     is_latest: false,
+                    disabled: None,
                     cost: None,
                 }]
             )])

--- a/crates/agent_ui/src/model_selector.rs
+++ b/crates/agent_ui/src/model_selector.rs
@@ -266,6 +266,7 @@ impl PickerDelegate for ModelPickerDelegate {
     fn confirm(&mut self, _secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
         if let Some(ModelPickerEntry::Model(model_info, _)) =
             self.filtered_entries.get(self.selected_index)
+            && model_info.disabled.is_none()
         {
             self.selector
                 .select_model(model_info.id.clone(), cx)
@@ -331,6 +332,7 @@ impl PickerDelegate for ModelPickerDelegate {
                                     Some(AgentModelIcon::Named(icon)) => this.icon(*icon),
                                     None => this,
                                 })
+                                .disabled(model_info.disabled.clone())
                                 .is_selected(is_selected)
                                 .is_focused(selected)
                                 .is_latest(model_info.is_latest)
@@ -506,6 +508,7 @@ mod tests {
                             description: None,
                             icon: None,
                             is_latest: false,
+                            disabled: None,
                             cost: None,
                         })
                         .collect::<Vec<_>>(),
@@ -613,6 +616,7 @@ mod tests {
                     description: None,
                     icon: None,
                     is_latest: false,
+                    disabled: None,
                     cost: None,
                 },
                 AgentModelInfo {
@@ -621,6 +625,7 @@ mod tests {
                     description: None,
                     icon: None,
                     is_latest: false,
+                    disabled: None,
                     cost: None,
                 },
             ];
@@ -805,6 +810,7 @@ mod tests {
                 description: None,
                 icon: None,
                 is_latest: false,
+                disabled: None,
                 cost: None,
             },
             acp_thread::AgentModelInfo {
@@ -813,6 +819,7 @@ mod tests {
                 description: None,
                 icon: None,
                 is_latest: false,
+                disabled: None,
                 cost: None,
             },
         ]);
@@ -855,6 +862,7 @@ mod tests {
                 description: None,
                 icon: None,
                 is_latest: false,
+                disabled: None,
                 cost: None,
             },
             acp_thread::AgentModelInfo {
@@ -863,6 +871,7 @@ mod tests {
                 description: None,
                 icon: None,
                 is_latest: false,
+                disabled: None,
                 cost: None,
             },
         ]);

--- a/crates/agent_ui/src/ui/model_selector_components.rs
+++ b/crates/agent_ui/src/ui/model_selector_components.rs
@@ -1,4 +1,5 @@
 use gpui::{Action, ClickEvent, FocusHandle, prelude::*};
+use language_model::DisabledReason;
 use ui::{Chip, ElevationIndex, KeyBinding, ListItem, ListItemSpacing, Tooltip, prelude::*};
 use zed_actions::agent::ToggleModelSelector;
 
@@ -52,6 +53,7 @@ pub struct ModelSelectorListItem {
     is_focused: bool,
     is_latest: bool,
     is_favorite: bool,
+    disabled: Option<DisabledReason>,
     on_toggle_favorite: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
     cost_info: Option<SharedString>,
 }
@@ -66,6 +68,7 @@ impl ModelSelectorListItem {
             is_focused: false,
             is_latest: false,
             is_favorite: false,
+            disabled: None,
             on_toggle_favorite: None,
             cost_info: None,
         }
@@ -83,6 +86,11 @@ impl ModelSelectorListItem {
 
     pub fn is_selected(mut self, is_selected: bool) -> Self {
         self.is_selected = is_selected;
+        self
+    }
+
+    pub fn disabled(mut self, disabled: Option<DisabledReason>) -> Self {
+        self.disabled = disabled;
         self
     }
 
@@ -117,8 +125,12 @@ impl ModelSelectorListItem {
 
 impl RenderOnce for ModelSelectorListItem {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let is_disabled = self.disabled.is_some();
+
         let model_icon_color = if self.is_selected {
             Color::Accent
+        } else if is_disabled {
+            Color::Disabled
         } else {
             Color::Muted
         };
@@ -129,6 +141,15 @@ impl RenderOnce for ModelSelectorListItem {
             .inset(true)
             .spacing(ListItemSpacing::Sparse)
             .toggle_state(self.is_focused)
+            .when_some(self.disabled, |this, disabled_reason| {
+                this.disabled(true)
+                    .tooltip(Tooltip::text(disabled_reason.0))
+                    .end_slot(
+                        div()
+                            .pr_2()
+                            .child(Icon::new(IconName::Info).color(Color::Muted)),
+                    )
+            })
             .child(
                 h_flex()
                     .w_full()
@@ -143,7 +164,11 @@ impl RenderOnce for ModelSelectorListItem {
                             .size(IconSize::Small),
                         )
                     })
-                    .child(Label::new(self.title).truncate())
+                    .child(
+                        Label::new(self.title)
+                            .when(is_disabled, |this| this.color(Color::Disabled))
+                            .truncate(),
+                    )
                     .when(self.is_latest, |parent| parent.child(Chip::new("Latest")))
                     .when_some(self.cost_info, |this, cost_info| {
                         let tooltip_text = if cost_info.ends_with('×') {
@@ -157,26 +182,34 @@ impl RenderOnce for ModelSelectorListItem {
                         this.child(Chip::new(cost_info).tooltip(Tooltip::text(tooltip_text)))
                     }),
             )
-            .end_slot(div().pr_2().when(self.is_selected, |this| {
-                this.child(Icon::new(IconName::Check).color(Color::Accent))
-            }))
-            .end_slot_on_hover(div().pr_1p5().when_some(self.on_toggle_favorite, {
-                |this, handle_click| {
-                    let (icon, color, tooltip) = if is_favorite {
-                        (IconName::StarFilled, Color::Accent, "Unfavorite Model")
-                    } else {
-                        (IconName::Star, Color::Default, "Favorite Model")
-                    };
-                    this.child(
-                        IconButton::new(("toggle-favorite", self.index), icon)
-                            .layer(ElevationIndex::ElevatedSurface)
-                            .icon_color(color)
-                            .icon_size(IconSize::Small)
-                            .tooltip(Tooltip::text(tooltip))
-                            .on_click(move |event, window, cx| (handle_click)(event, window, cx)),
-                    )
-                }
-            }))
+            .when(self.is_selected, |this| {
+                this.end_slot(
+                    div()
+                        .pr_2()
+                        .child(Icon::new(IconName::Check).color(Color::Accent)),
+                )
+            })
+            .when(!is_disabled, |this| {
+                this.end_slot_on_hover(div().pr_1p5().when_some(self.on_toggle_favorite, {
+                    |this, handle_click| {
+                        let (icon, color, tooltip) = if is_favorite {
+                            (IconName::StarFilled, Color::Accent, "Unfavorite Model")
+                        } else {
+                            (IconName::Star, Color::Default, "Favorite Model")
+                        };
+                        this.child(
+                            IconButton::new(("toggle-favorite", self.index), icon)
+                                .layer(ElevationIndex::ElevatedSurface)
+                                .icon_color(color)
+                                .icon_size(IconSize::Small)
+                                .tooltip(Tooltip::text(tooltip))
+                                .on_click(move |event, window, cx| {
+                                    (handle_click)(event, window, cx)
+                                }),
+                        )
+                    }
+                }))
+            })
     }
 }
 

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -24,6 +24,15 @@ pub fn init(cx: &mut App) {
     registry::init(cx);
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DisabledReason(pub SharedString);
+
+impl DisabledReason {
+    pub fn new(reason: impl Into<SharedString>) -> Self {
+        Self(reason.into())
+    }
+}
+
 pub struct LanguageModelTextStream {
     pub message_id: Option<String>,
     pub stream: BoxStream<'static, Result<String, LanguageModelCompletionError>>,
@@ -56,6 +65,11 @@ pub trait LanguageModel: Send + Sync {
     /// Returns whether this model is the "latest", so we can highlight it in the UI.
     fn is_latest(&self) -> bool {
         false
+    }
+
+    /// Whether the model is currently disabled and, if so, why this is the case.
+    fn is_disabled(&self) -> Option<DisabledReason> {
+        None
     }
 
     /// Whether requests to this model require the user to consent to the

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -7,11 +7,12 @@ use futures::{Stream, TryFutureExt, stream};
 use gpui::{AnyView, App, AsyncApp, Context, CursorStyle, Entity, Task, TaskExt};
 use http_client::{CustomHeaders, HttpClient};
 use language_model::{
-    ApiKeyState, AuthenticateError, EnvVar, IconOrSvg, LanguageModel, LanguageModelCompletionError,
-    LanguageModelCompletionEvent, LanguageModelId, LanguageModelName, LanguageModelProvider,
-    LanguageModelProviderId, LanguageModelProviderName, LanguageModelProviderState,
-    LanguageModelRequest, LanguageModelRequestTool, LanguageModelToolChoice, LanguageModelToolUse,
-    LanguageModelToolUseId, MessageContent, RateLimiter, Role, StopReason, TokenUsage, env_var,
+    ApiKeyState, AuthenticateError, DisabledReason, EnvVar, IconOrSvg, LanguageModel,
+    LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelId, LanguageModelName,
+    LanguageModelProvider, LanguageModelProviderId, LanguageModelProviderName,
+    LanguageModelProviderState, LanguageModelRequest, LanguageModelRequestTool,
+    LanguageModelToolChoice, LanguageModelToolUse, LanguageModelToolUseId, MessageContent,
+    RateLimiter, Role, StopReason, TokenUsage, env_var,
 };
 use menu;
 use ollama::{
@@ -139,34 +140,42 @@ impl State {
                     let extra_headers = extra_headers.clone();
                     async move {
                         let name = model.name.as_str();
-                        let model = show_model(
+
+                        show_model(
                             http_client.as_ref(),
                             &api_url,
                             api_key.as_deref(),
                             name,
                             &extra_headers,
                         )
-                        .await?;
-                        let ollama_model = ollama::Model::new(
-                            name,
-                            None,
-                            model.context_length,
-                            Some(model.supports_tools()),
-                            Some(model.supports_vision()),
-                            Some(model.supports_thinking()),
-                        );
-                        Ok(ollama_model)
+                        .await
+                        .map_or_else(
+                            |error| {
+                                ollama::Model::new_disabled(
+                                    name,
+                                    format!("Failed to fetch model from API: {error}",),
+                                )
+                            },
+                            |model| {
+                                ollama::Model::new(
+                                    name,
+                                    model.context_length,
+                                    Some(model.supports_tools()),
+                                    Some(model.supports_vision()),
+                                    Some(model.supports_thinking()),
+                                )
+                            },
+                        )
                     }
                 });
 
             // Rate-limit capability fetches
             // since there is an arbitrary number of models available
-            let results: Vec<Result<_>> = futures::stream::iter(tasks)
+            let mut ollama_models: Vec<_> = futures::stream::iter(tasks)
                 .buffer_unordered(5)
                 .collect()
                 .await;
 
-            let mut ollama_models = skip_failed_models(results);
             ollama_models.sort_by(|a, b| a.name.cmp(&b.name));
 
             this.update(cx, |this, cx| {
@@ -307,6 +316,7 @@ impl LanguageModelProvider for OllamaLanguageModelProvider {
             .map(|model| {
                 Arc::new(OllamaLanguageModel {
                     id: LanguageModelId::from(model.name.clone()),
+                    disabled: model.disabled.as_ref().map(|d| DisabledReason::new(d)),
                     model,
                     http_client: self.http_client.clone(),
                     request_limiter: RateLimiter::new(4),
@@ -349,6 +359,7 @@ pub struct OllamaLanguageModel {
     http_client: Arc<dyn HttpClient>,
     request_limiter: RateLimiter,
     state: Entity<State>,
+    disabled: Option<DisabledReason>,
 }
 
 impl OllamaLanguageModel {
@@ -507,6 +518,10 @@ impl LanguageModel for OllamaLanguageModel {
 
     fn telemetry_id(&self) -> String {
         format!("ollama/{}", self.model.id())
+    }
+
+    fn is_disabled(&self) -> Option<DisabledReason> {
+        self.disabled.clone()
     }
 
     fn max_token_count(&self) -> u64 {
@@ -1062,23 +1077,6 @@ impl Render for ConfigurationView {
     }
 }
 
-/// Keeps only the models whose `show_model` request succeeded, logging and
-/// dropping the rest. A single model failing (e.g. a cloud model that was
-/// retired but is still listed by `/api/tags`) shouldn't take down the whole
-/// list - see https://github.com/zed-industries/zed/issues/37815.
-fn skip_failed_models(results: Vec<Result<ollama::Model>>) -> Vec<ollama::Model> {
-    let mut ollama_models = Vec::with_capacity(results.len());
-    for result in results {
-        match result {
-            Ok(model) => ollama_models.push(model),
-            Err(err) => {
-                log::warn!("Failed to fetch Ollama model details, skipping it: {err}");
-            }
-        }
-    }
-    ollama_models
-}
-
 fn merge_settings_into_models(
     models: &mut HashMap<String, ollama::Model>,
     available_models: &[AvailableModel],
@@ -1105,6 +1103,7 @@ fn merge_settings_into_models(
                     supports_tools: setting_model.supports_tools,
                     supports_vision: setting_model.supports_images,
                     supports_thinking: setting_model.supports_thinking,
+                    disabled: None,
                 },
             );
         }
@@ -1142,6 +1141,7 @@ mod tests {
                 supports_tools: None,
                 supports_vision: None,
                 supports_thinking: None,
+                disabled: None,
             },
         );
         models.insert(
@@ -1154,6 +1154,7 @@ mod tests {
                 supports_tools: None,
                 supports_vision: None,
                 supports_thinking: None,
+                disabled: None,
             },
         );
 
@@ -1198,49 +1199,5 @@ mod tests {
             "3b model should have its own display_name"
         );
         assert_eq!(model_3b.max_tokens, 6000);
-    }
-
-    fn fake_model(name: &str) -> ollama::Model {
-        ollama::Model {
-            name: name.to_string(),
-            display_name: None,
-            max_tokens: 4096,
-            keep_alive: None,
-            supports_tools: None,
-            supports_vision: None,
-            supports_thinking: None,
-        }
-    }
-
-    #[test]
-    fn test_skip_failed_models_keeps_successful_ones() {
-        // Regression test for https://github.com/zed-industries/zed/issues/37815
-        // A single model failing `show_model` (e.g. a retired Ollama Cloud model
-        // still listed by `/api/tags`) used to abort the whole fetch via
-        // `collect::<Result<Vec<_>>>()?`, leaving `fetched_models` permanently
-        // empty and the provider permanently "unauthenticated".
-        let results: Vec<Result<ollama::Model>> = vec![
-            Ok(fake_model("llama3.2")),
-            Err(anyhow!(
-                "qwen3-vl:235b-instruct was retired at 2026-06-16 00:00:00 -0700 PDT"
-            )),
-            Ok(fake_model("qwen3:8b")),
-        ];
-
-        let models = skip_failed_models(results);
-
-        assert_eq!(
-            models.iter().map(|m| m.name.as_str()).collect::<Vec<_>>(),
-            vec!["llama3.2", "qwen3:8b"],
-            "the failing model should be skipped, not abort the whole list"
-        );
-    }
-
-    #[test]
-    fn test_skip_failed_models_all_failed_returns_empty() {
-        let results: Vec<Result<ollama::Model>> =
-            vec![Err(anyhow!("connection refused")), Err(anyhow!("timeout"))];
-
-        assert!(skip_failed_models(results).is_empty());
     }
 }

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -161,13 +161,12 @@ impl State {
 
             // Rate-limit capability fetches
             // since there is an arbitrary number of models available
-            let mut ollama_models: Vec<_> = futures::stream::iter(tasks)
+            let results: Vec<Result<_>> = futures::stream::iter(tasks)
                 .buffer_unordered(5)
-                .collect::<Vec<Result<_>>>()
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>>>()?;
+                .collect()
+                .await;
 
+            let mut ollama_models = skip_failed_models(results);
             ollama_models.sort_by(|a, b| a.name.cmp(&b.name));
 
             this.update(cx, |this, cx| {
@@ -1063,6 +1062,23 @@ impl Render for ConfigurationView {
     }
 }
 
+/// Keeps only the models whose `show_model` request succeeded, logging and
+/// dropping the rest. A single model failing (e.g. a cloud model that was
+/// retired but is still listed by `/api/tags`) shouldn't take down the whole
+/// list - see https://github.com/zed-industries/zed/issues/37815.
+fn skip_failed_models(results: Vec<Result<ollama::Model>>) -> Vec<ollama::Model> {
+    let mut ollama_models = Vec::with_capacity(results.len());
+    for result in results {
+        match result {
+            Ok(model) => ollama_models.push(model),
+            Err(err) => {
+                log::warn!("Failed to fetch Ollama model details, skipping it: {err}");
+            }
+        }
+    }
+    ollama_models
+}
+
 fn merge_settings_into_models(
     models: &mut HashMap<String, ollama::Model>,
     available_models: &[AvailableModel],
@@ -1182,5 +1198,49 @@ mod tests {
             "3b model should have its own display_name"
         );
         assert_eq!(model_3b.max_tokens, 6000);
+    }
+
+    fn fake_model(name: &str) -> ollama::Model {
+        ollama::Model {
+            name: name.to_string(),
+            display_name: None,
+            max_tokens: 4096,
+            keep_alive: None,
+            supports_tools: None,
+            supports_vision: None,
+            supports_thinking: None,
+        }
+    }
+
+    #[test]
+    fn test_skip_failed_models_keeps_successful_ones() {
+        // Regression test for https://github.com/zed-industries/zed/issues/37815
+        // A single model failing `show_model` (e.g. a retired Ollama Cloud model
+        // still listed by `/api/tags`) used to abort the whole fetch via
+        // `collect::<Result<Vec<_>>>()?`, leaving `fetched_models` permanently
+        // empty and the provider permanently "unauthenticated".
+        let results: Vec<Result<ollama::Model>> = vec![
+            Ok(fake_model("llama3.2")),
+            Err(anyhow!(
+                "qwen3-vl:235b-instruct was retired at 2026-06-16 00:00:00 -0700 PDT"
+            )),
+            Ok(fake_model("qwen3:8b")),
+        ];
+
+        let models = skip_failed_models(results);
+
+        assert_eq!(
+            models.iter().map(|m| m.name.as_str()).collect::<Vec<_>>(),
+            vec!["llama3.2", "qwen3:8b"],
+            "the failing model should be skipped, not abort the whole list"
+        );
+    }
+
+    #[test]
+    fn test_skip_failed_models_all_failed_returns_empty() {
+        let results: Vec<Result<ollama::Model>> =
+            vec![Err(anyhow!("connection refused")), Err(anyhow!("timeout"))];
+
+        assert!(skip_failed_models(results).is_empty());
     }
 }

--- a/crates/ollama/src/ollama.rs
+++ b/crates/ollama/src/ollama.rs
@@ -21,6 +21,7 @@ pub struct Model {
     pub supports_tools: Option<bool>,
     pub supports_vision: Option<bool>,
     pub supports_thinking: Option<bool>,
+    pub disabled: Option<String>,
 }
 
 fn get_max_tokens(_name: &str) -> u64 {
@@ -31,7 +32,6 @@ fn get_max_tokens(_name: &str) -> u64 {
 impl Model {
     pub fn new(
         name: &str,
-        display_name: Option<&str>,
         max_tokens: Option<u64>,
         supports_tools: Option<bool>,
         supports_vision: Option<bool>,
@@ -39,14 +39,26 @@ impl Model {
     ) -> Self {
         Self {
             name: name.to_owned(),
-            display_name: display_name
-                .map(ToString::to_string)
-                .or_else(|| name.strip_suffix(":latest").map(ToString::to_string)),
+            display_name: name.strip_suffix(":latest").map(ToString::to_string),
             max_tokens: max_tokens.unwrap_or_else(|| get_max_tokens(name)),
             keep_alive: Some(KeepAlive::indefinite()),
             supports_tools,
             supports_vision,
             supports_thinking,
+            disabled: None,
+        }
+    }
+
+    pub fn new_disabled(name: &str, reason: String) -> Self {
+        Self {
+            name: name.to_owned(),
+            display_name: name.strip_suffix(":latest").map(ToString::to_string),
+            max_tokens: get_max_tokens(name),
+            keep_alive: Some(KeepAlive::indefinite()),
+            supports_tools: None,
+            supports_vision: None,
+            supports_thinking: None,
+            disabled: Some(reason),
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #37815.

`State::fetch_models()` calls `/api/tags` to list models, then calls `/api/show` for **every** model in that list to get its capabilities, collecting the results with `collect::<Result<Vec<_>>>()?`. If `/api/show` errors for even one model, the whole batch fails and `fetched_models` is never populated. Since `is_authenticated()` is defined as `!self.fetched_models.is_empty()`, this means a single bad model permanently breaks both authentication state and the model picker for the entire Ollama provider - with no error surfaced anywhere (not the UI, not the logs), which matches the reports in #37815 of "Connect does nothing" / "no logs, no nothing".

I hit this myself: I had a stale local reference to an Ollama Cloud model that had been retired server-side. `/api/show` for that one model returned `410 Gone`, which silently broke Connect and the model picker for every other model too. Removing the retired model with `ollama rm` fixed it immediately, which confirmed the root cause.

## Fix

Instead of aborting the whole fetch on the first error, skip individual models that fail `/api/show` and log a warning, keeping the rest. Extracted this into a small `skip_failed_models` helper so it's unit-testable without mocking HTTP.

## Disclosure

I used Claude (Anthropic's Claude Code) to help track down this root cause (tracing through `fetch_models`/`is_authenticated` in this file) and draft the fix + tests below. I reviewed and understand the change - it's a small, targeted fix to a single function plus two unit tests for the new helper.

## Test plan

- [x] `cargo check -p language_models` passes
- [x] `cargo test -p language_models --lib ollama::` - all 3 tests pass (the 2 new ones plus the existing `test_merge_settings_preserves_display_names_for_similar_models`, unaffected by this change)
- [x] `cargo fmt -p language_models -- --check` - no diff

## Release Notes

Release Notes:

- Fixed Ollama models silently failing to show up in the model picker (and "Connect" appearing to do nothing) when a single model's details couldn't be fetched, e.g. a retired Ollama Cloud model
