### PR TITLE
Fix file descriptor leaks to terminal subprocesses on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7866,6 +7866,7 @@ dependencies = [
  "strum 0.27.2",
  "swash",
  "url",
+ "util",
  "uuid",
  "wayland-backend",
  "wayland-client",

--- a/crates/gpui_linux/Cargo.toml
+++ b/crates/gpui_linux/Cargo.toml
@@ -73,6 +73,7 @@ smallvec.workspace = true
 smol.workspace = true
 strum.workspace = true
 url.workspace = true
+util.workspace = true
 uuid.workspace = true
 
 # Always used

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -331,7 +331,7 @@ impl WaylandWindowState {
         options: WindowParams,
         parent: Option<WaylandWindowStatePtr>,
     ) -> anyhow::Result<Self> {
-        let renderer = {
+        let renderer = util::fd::with_new_fds_close_on_exec(|| {
             let raw_window = RawWindow {
                 window: surface.id().as_ptr().cast::<c_void>(),
                 display: surface
@@ -350,8 +350,8 @@ impl WaylandWindowState {
                 // Prefer Mailbox to avoid blocking. Falls back to FIFO if Mailbox is unsupported.
                 preferred_present_mode: Some(wgpu::PresentMode::Mailbox),
             };
-            WgpuRenderer::new(gpu_context, &raw_window, config, compositor_gpu)?
-        };
+            WgpuRenderer::new(gpu_context, &raw_window, config, compositor_gpu)
+        })?;
 
         if let WaylandSurfaceState::Xdg(ref xdg_state) = surface_state {
             if let Some(title) = options.titlebar.and_then(|titlebar| titlebar.title) {
@@ -995,7 +995,9 @@ impl WaylandWindowStatePtr {
                 state.scale = scale;
             }
             let device_bounds = state.bounds.to_device_pixels(state.scale);
-            state.renderer.update_drawable_size(device_bounds.size);
+            util::fd::with_new_fds_close_on_exec(|| {
+                state.renderer.update_drawable_size(device_bounds.size);
+            });
             (state.bounds.size, state.scale)
         };
 
@@ -1422,7 +1424,7 @@ impl PlatformWindow for WaylandWindow {
                     .display_ptr()
                     .cast::<std::ffi::c_void>(),
             };
-            match state.renderer.recover(&raw_window) {
+            match util::fd::with_new_fds_close_on_exec(|| state.renderer.recover(&raw_window)) {
                 Ok(()) => {}
                 Err(err) => {
                     log::warn!("GPU recovery failed, will retry on next frame: {err}");
@@ -1433,7 +1435,8 @@ impl PlatformWindow for WaylandWindow {
             return;
         }
 
-        state.renderer_presented = state.renderer.draw(scene);
+        state.renderer_presented =
+            util::fd::with_new_fds_close_on_exec(|| state.renderer.draw(scene));
 
         if state.renderer.needs_redraw() {
             state.force_render_after_recovery = true;

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -704,7 +704,7 @@ impl X11WindowState {
 
             xcb_flush(xcb);
 
-            let mut renderer = {
+            let mut renderer = util::fd::with_new_fds_close_on_exec(|| {
                 let raw_window = RawWindow {
                     connection: as_raw_xcb_connection::AsRawXcbConnection::as_raw_xcb_connection(
                         xcb,
@@ -724,8 +724,8 @@ impl X11WindowState {
                     transparent: false,
                     preferred_present_mode: None,
                 };
-                WgpuRenderer::new(gpu_context, &raw_window, config, compositor_gpu)?
-            };
+                WgpuRenderer::new(gpu_context, &raw_window, config, compositor_gpu)
+            })?;
 
             renderer.set_subpixel_layout(is_bgr);
 
@@ -1250,7 +1250,9 @@ impl X11WindowStatePtr {
             }
 
             let gpu_size = query_render_extent(&self.xcb, self.x_window)?;
-            state.renderer.update_drawable_size(gpu_size);
+            util::fd::with_new_fds_close_on_exec(|| {
+                state.renderer.update_drawable_size(gpu_size);
+            });
             let result = (is_resize, state.content_size(), state.scale_factor);
             if let Some(value) = state.last_sync_counter.take() {
                 check_reply(
@@ -1675,7 +1677,7 @@ impl PlatformWindow for X11Window {
                 window_id: self.0.x_window,
                 visual_id: inner.visual_id,
             };
-            match inner.renderer.recover(&raw_window) {
+            match util::fd::with_new_fds_close_on_exec(|| inner.renderer.recover(&raw_window)) {
                 Ok(()) => {}
                 Err(err) => {
                     log::warn!("GPU recovery failed, will retry on next frame: {err}");
@@ -1686,7 +1688,7 @@ impl PlatformWindow for X11Window {
             return;
         }
 
-        inner.renderer.draw(scene);
+        util::fd::with_new_fds_close_on_exec(|| inner.renderer.draw(scene));
 
         if inner.renderer.needs_redraw() {
             inner.force_render_after_recovery = true;

--- a/crates/prompt_store/src/prompt_store.rs
+++ b/crates/prompt_store/src/prompt_store.rs
@@ -218,12 +218,12 @@ impl PromptStore {
         cx.background_spawn(async move {
             std::fs::create_dir_all(&db_path)?;
 
-            let db_env = unsafe {
+            let db_env = util::fd::with_new_fds_close_on_exec(|| unsafe {
                 heed::EnvOpenOptions::new()
                     .map_size(1024 * 1024 * 1024) // 1GB
                     .max_dbs(4) // Metadata and bodies (possibly v1 of both as well)
-                    .open(db_path)?
-            };
+                    .open(&db_path)
+            })?;
 
             let mut txn = db_env.write_txn()?;
             let metadata = db_env.create_database(&mut txn, Some("metadata.v2"))?;

--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -98,11 +98,13 @@ impl PtyProcessInfo {
         // terminal (#58651). Refresh only the spawned child so that
         // `kill_child_process` works before the first foreground refresh.
         let mut system = System::new();
-        system.refresh_processes_specifics(
-            ProcessesToUpdate::Some(&[pid_getter.fallback_pid()]),
-            true,
-            process_refresh_kind,
-        );
+        util::fd::with_new_fds_close_on_exec(|| {
+            system.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[pid_getter.fallback_pid()]),
+                true,
+                process_refresh_kind,
+            );
+        });
 
         PtyProcessInfo {
             system: RwLock::new(system),
@@ -136,7 +138,13 @@ impl PtyProcessInfo {
         } else {
             &pids[..]
         };
-        system.refresh_processes_specifics(ProcessesToUpdate::Some(pids), true, self.refresh_kind);
+        util::fd::with_new_fds_close_on_exec(|| {
+            system.refresh_processes_specifics(
+                ProcessesToUpdate::Some(pids),
+                true,
+                self.refresh_kind,
+            );
+        });
         drop(system);
         RwLockReadGuard::try_map(self.system.read(), |system| system.process(pid)).ok()
     }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1194,6 +1194,14 @@ impl TerminalBuilder {
                     shell_kind.tty_escape_args(),
                 );
 
+                // Ensure no leaked fds from GPU/compositor/Wayland are inherited by the child shell.
+                #[cfg(target_os = "linux")]
+                if let Err(error) = util::fd::mark_open_fds_close_on_exec() {
+                    log::debug!(
+                        "failed to set non-standard fds close-on-exec before pty spawn: {error}"
+                    );
+                }
+
                 //Setup the pty...
                 let pty = match open_pty(&pty_options, TerminalBounds::default(), window_id) {
                     Ok(pty) => pty,

--- a/crates/util/src/fd.rs
+++ b/crates/util/src/fd.rs
@@ -1,0 +1,186 @@
+use anyhow::Result;
+
+#[cfg(target_os = "linux")]
+use std::os::fd::RawFd;
+
+/// Wraps an operation. Any file descriptors opened or transferred during it
+/// are marked `FD_CLOEXEC` so they are not inherited by child processes
+#[cfg(target_os = "linux")]
+pub fn with_new_fds_close_on_exec<T>(operation: impl FnOnce() -> T) -> T {
+    let before = open_fds_snapshot();
+    let output = operation();
+
+    if let Ok(before) = before {
+        if let Err(error) = mark_fds_changed_since(&before) {
+            log::debug!("failed to set new fds close-on-exec: {error}");
+        }
+    }
+
+    output
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn with_new_fds_close_on_exec<T>(operation: impl FnOnce() -> T) -> T {
+    operation()
+}
+
+/// Marks every currently open file descriptor (except stdin/stdout/stderr)
+/// as `FD_CLOEXEC`. Use before spawning a child process to prevent fd leaks
+/// from GPU drivers, Wayland compositor, or third-party libraries.
+#[cfg(target_os = "linux")]
+pub fn mark_open_fds_close_on_exec() -> Result<usize> {
+    let Ok(entries) = std::fs::read_dir("/proc/self/fd") else {
+        return Ok(0);
+    };
+
+    let mut updated = 0;
+    for entry in entries {
+        let entry = entry?;
+        let Some(fd) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<RawFd>().ok())
+        else {
+            continue;
+        };
+
+        if fd <= 2 {
+            continue;
+        }
+
+        if set_fd_close_on_exec(fd)? {
+            updated += 1;
+        }
+    }
+
+    Ok(updated)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn mark_open_fds_close_on_exec() -> Result<usize> {
+    Ok(0)
+}
+
+#[cfg(target_os = "linux")]
+fn set_fd_close_on_exec(fd: RawFd) -> Result<bool> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags == -1 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::EBADF) {
+            return Ok(false);
+        }
+        return Err(error.into());
+    }
+
+    if flags & libc::FD_CLOEXEC != 0 {
+        return Ok(false);
+    }
+
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) } == -1 {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::EBADF) {
+            return Ok(false);
+        }
+        return Err(error.into());
+    }
+
+    Ok(true)
+}
+
+#[cfg(target_os = "linux")]
+fn open_fds_snapshot() -> Result<std::collections::HashMap<RawFd, std::path::PathBuf>> {
+    let Ok(entries) = std::fs::read_dir("/proc/self/fd") else {
+        return Ok(std::collections::HashMap::default());
+    };
+
+    let mut snapshot = std::collections::HashMap::default();
+    for entry in entries {
+        let entry = entry?;
+        let Some(fd) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<RawFd>().ok())
+        else {
+            continue;
+        };
+        let Ok(target) = std::fs::read_link(entry.path()) else {
+            continue;
+        };
+
+        snapshot.insert(fd, target);
+    }
+
+    Ok(snapshot)
+}
+
+#[cfg(target_os = "linux")]
+fn mark_fds_changed_since(
+    before: &std::collections::HashMap<RawFd, std::path::PathBuf>,
+) -> Result<usize> {
+    let after = open_fds_snapshot()?;
+    let mut updated = 0;
+
+    for (fd, target) in after {
+        if before.get(&fd) == Some(&target) {
+            continue;
+        }
+
+        if set_fd_close_on_exec(fd)? {
+            updated += 1;
+        }
+    }
+
+    Ok(updated)
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn with_new_fds_marks_new_fd() {
+        use std::ffi::CString;
+        use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+        use std::os::unix::ffi::OsStrExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("fd-test");
+        std::fs::write(&path, b"test").unwrap();
+        let path = CString::new(path.as_os_str().as_bytes()).unwrap();
+
+        let file = super::with_new_fds_close_on_exec(|| {
+            let fd = unsafe { libc::open(path.as_ptr(), libc::O_RDONLY) };
+            assert_ne!(fd, -1, "failed to open test file");
+            unsafe { OwnedFd::from_raw_fd(fd) }
+        });
+
+        let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
+        assert_ne!(flags, -1, "failed to get fd flags");
+        assert_ne!(flags & libc::FD_CLOEXEC, 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn mark_open_fds_covers_existing_fd() {
+        use std::ffi::CString;
+        use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+        use std::os::unix::ffi::OsStrExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("fd-test-all");
+        std::fs::write(&path, b"test").unwrap();
+        let path = CString::new(path.as_os_str().as_bytes()).unwrap();
+
+        let file = unsafe {
+            let fd = libc::open(path.as_ptr(), libc::O_RDONLY);
+            assert_ne!(fd, -1, "failed to open test file");
+            OwnedFd::from_raw_fd(fd)
+        };
+
+        let before = super::mark_open_fds_close_on_exec().unwrap();
+        assert!(before >= 1);
+
+        let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
+        assert_ne!(flags, -1, "failed to get fd flags");
+        assert_ne!(flags & libc::FD_CLOEXEC, 0);
+    }
+}

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -1,6 +1,7 @@
 pub mod archive;
 pub mod command;
 pub mod disambiguate;
+pub mod fd;
 pub mod fs;
 pub mod markdown;
 pub mod path_list;


### PR DESCRIPTION
Fixes #59257

On Linux, Zed leaks open file descriptors to child processes spawned by the integrated terminal. Running `ls -al /proc/self/fd` inside a Zed terminal shows leaked fds such as:

- `data.mdb` from LMDB (prompt store)
- `/proc/<pid>/mountinfo` from sysinfo
- `/dmabuf:`, `/dev/udmabuf`, `/memfd:*dma_buf*` from GPU/Wayland

These are inherited by the shell via fork+exec because they lack `FD_CLOEXEC`.

## Changes

Adds a small `util::fd` module with two primitives:

- **`with_new_fds_close_on_exec(operation)`** — snapshots `/proc/self/fd` before/after an operation and marks any new or changed fds as `FD_CLOEXEC`. Used source-specifically around LMDB open, sysinfo refresh, and GPU renderer operations.
- **`mark_open_fds_close_on_exec()`** — marks all open fds except stdin/stdout/stderr as `FD_CLOEXEC`. Called as defense-in-depth before PTY spawn to catch any remaining unclosed fds from GPU drivers or Wayland compositor.

Both functions are no-ops on non-Linux platforms.

## Testing

- Unit tests for both fd primitives in `util/src/fd.rs`
- Manual verification: `ls -al /proc/self/fd` in Zed's integrated terminal shows only `0`, `1`, `2`, and `3 -> /proc/.../fd` (from `ls` itself)

Release Notes:

- Fixed file descriptors leaking from Zed to integrated terminal subprocesses on Linux