### PR TITLE
Remove auto watch feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3490,7 +3490,6 @@ dependencies = [
  "collections",
  "db",
  "editor",
- "feature_flags",
  "futures 0.3.32",
  "fuzzy",
  "gpui",

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -36,7 +36,6 @@ client.workspace = true
 collections.workspace = true
 db.workspace = true
 editor.workspace = true
-feature_flags.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -11,7 +11,6 @@ use collections::{HashMap, HashSet};
 use contact_finder::ContactFinder;
 use db::kvp::KeyValueStore;
 use editor::{Editor, EditorElement, EditorStyle};
-use feature_flags::{AutoWatchFeatureFlag, FeatureFlagAppExt as _};
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{
     AnyElement, App, AsyncWindowContext, Bounds, ClickEvent, ClipboardItem, DismissEvent, Div,
@@ -2911,66 +2910,46 @@ impl CollabPanel {
         let is_auto_watching = auto_watch_state.enabled();
 
         let button = match section {
-            Section::ActiveCall => {
-                let has_auto_watch_flag = cx.has_flag::<AutoWatchFeatureFlag>();
-                let show_auto_watch = has_auto_watch_flag && is_auto_watching;
-                let show_copy = channel_link.is_some();
-
-                if show_auto_watch || show_copy {
-                    Some(
-                        h_flex()
-                            .when_some(channel_link, |this, channel_link| {
-                                this.child(
-                                    CopyButton::new("copy-channel-link", channel_link)
-                                        .visible_on_hover("section-header")
-                                        .tooltip_label("Copy Channel Link"),
-                                )
-                            })
-                            .when(has_auto_watch_flag, |this| {
-                                this.child(
-                                    IconButton::new(
-                                        "auto-watch-screens",
-                                        if is_auto_watching {
-                                            IconName::Eye
-                                        } else {
-                                            IconName::EyeOff
-                                        },
-                                    )
-                                    .icon_size(IconSize::Small)
-                                    .toggle_state(is_auto_watching)
-                                    .selected_style(match auto_watch_state {
-                                        AutoWatch::Paused => {
-                                            ButtonStyle::Tinted(TintColor::Warning)
-                                        }
-                                        _ => ButtonStyle::Tinted(TintColor::Accent),
-                                    })
-                                    .when(!is_auto_watching, |this| {
-                                        this.visible_on_hover("section-header")
-                                    })
-                                    .tooltip(Tooltip::text(match auto_watch_state {
-                                        AutoWatch::Paused => {
-                                            "Auto Watch Screens (paused while sharing)"
-                                        }
-                                        AutoWatch::Active { .. } => "Stop Auto Watching Screens",
-                                        AutoWatch::Off => "Auto Watch Screens",
-                                    }))
-                                    .on_click(cx.listener(
-                                        |this, _, window, cx| {
-                                            this.workspace
-                                                .update(cx, |workspace, cx| {
-                                                    workspace.toggle_auto_watch(window, cx)
-                                                })
-                                                .ok();
-                                        },
-                                    )),
-                                )
-                            })
-                            .into_any_element(),
+            Section::ActiveCall => Some(
+                h_flex()
+                    .when_some(channel_link, |this, channel_link| {
+                        this.child(
+                            CopyButton::new("copy-channel-link", channel_link)
+                                .visible_on_hover("section-header")
+                                .tooltip_label("Copy Channel Link"),
+                        )
+                    })
+                    .child(
+                        IconButton::new(
+                            "auto-watch-screens",
+                            if is_auto_watching {
+                                IconName::Eye
+                            } else {
+                                IconName::EyeOff
+                            },
+                        )
+                        .icon_size(IconSize::Small)
+                        .toggle_state(is_auto_watching)
+                        .selected_style(match auto_watch_state {
+                            AutoWatch::Paused => ButtonStyle::Tinted(TintColor::Warning),
+                            _ => ButtonStyle::Tinted(TintColor::Accent),
+                        })
+                        .when(!is_auto_watching, |this| {
+                            this.visible_on_hover("section-header")
+                        })
+                        .tooltip(Tooltip::text(match auto_watch_state {
+                            AutoWatch::Paused => "Auto Watch Screens (paused while sharing)",
+                            AutoWatch::Active { .. } => "Stop Auto Watching Screens",
+                            AutoWatch::Off => "Auto Watch Screens",
+                        }))
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.workspace
+                                .update(cx, |workspace, cx| workspace.toggle_auto_watch(window, cx))
+                                .ok();
+                        })),
                     )
-                } else {
-                    None
-                }
-            }
+                    .into_any_element(),
+            ),
             Section::Contacts => Some(
                 IconButton::new("add-contact", IconName::Plus)
                     .icon_size(IconSize::Small)

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -131,14 +131,6 @@ impl FeatureFlag for AgentSettingsUiFeatureFlag {
 }
 register_feature_flag!(AgentSettingsUiFeatureFlag);
 
-pub struct AutoWatchFeatureFlag;
-
-impl FeatureFlag for AutoWatchFeatureFlag {
-    const NAME: &'static str = "auto-watch-screens";
-    type Value = PresenceFlag;
-}
-register_feature_flag!(AutoWatchFeatureFlag);
-
 /// Wraps agent-run terminal commands in an OS-level sandbox where supported
 /// (currently macOS Seatbelt only). When off, terminal commands run with the
 /// agent's full ambient permissions, as they always have.


### PR DESCRIPTION
## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Added an auto-watch button to the collab panel that automatically opens other participants' screen shares while you're in a call.
