### PR TITLE
Fix picker preview for matches far down in files

### DIFF
--- a/crates/picker/src/preview.rs
+++ b/crates/picker/src/preview.rs
@@ -253,7 +253,8 @@ impl EditorPreview {
 
         const MIN_LINE_HEIGHT_PX: Pixels = px(6.0);
         const MARGIN: u32 = 2; // scrolling can offset things;
-        let max_rows = (window.viewport_size().height / MIN_LINE_HEIGHT_PX).ceil() as u32 + MARGIN;
+        let max_visible_rows =
+            (window.viewport_size().height / MIN_LINE_HEIGHT_PX).ceil() as u32 + MARGIN;
 
         self.preview_editor.update(cx, |editor, cx| {
             let focus_row = highlight
@@ -264,8 +265,7 @@ impl EditorPreview {
                         .to_point(&buffer.read(cx).text_snapshot())
                         .row
                 })
-                .unwrap_or_default()
-                .min(max_rows);
+                .unwrap_or_default();
 
             let multi_buffer = editor.buffer().clone();
             multi_buffer.update(cx, |multi_buffer, cx| {
@@ -273,7 +273,7 @@ impl EditorPreview {
                 multi_buffer.set_excerpts_for_buffer(
                     buffer,
                     [Point::new(focus_row, 0)..Point::new(focus_row, 0)],
-                    max_rows,
+                    max_visible_rows,
                     cx,
                 );
             });


### PR DESCRIPTION
Fixes picker previews for matches far down in a file by building the excerpt around the actual matched row instead of clamping it to the preview height estimate.

### Before

<img width="1858" height="1192" alt="Screenshot 2026-06-19 at 6 03 03 PM" src="https://github.com/user-attachments/assets/fcbed7c4-22d6-4481-a263-522bb48c656f" />

### After

<img width="2057" height="1128" alt="Screenshot 2026-06-19 at 6 05 02 PM" src="https://github.com/user-attachments/assets/f88db8e2-8687-4f79-8085-bca50de09ce9" />

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
