### PR TITLE
Unify behavior of delete/cut to line boundary actions

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8977,6 +8977,15 @@ async fn test_cut_line_ends(cx: &mut TestAppContext) {
     cx.assert_editor_state(indoc! {"
         The quickˇ
         fox jumps overˇthe lazy dog"});
+
+    cx.set_state("The quick «ˇbrown» fox");
+    cx.update_editor(|e, window, cx| e.cut_to_end_of_line(&CutToEndOfLine::default(), window, cx));
+    cx.assert_editor_state("The quick ˇ");
+    assert_eq!(
+        cx.read_from_clipboard()
+            .and_then(|item| item.text().as_deref().map(str::to_string)),
+        Some("brown fox".to_string())
+    );
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3282,20 +3282,29 @@ async fn test_move_page_up_page_down(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_delete_to_beginning_of_line(cx: &mut TestAppContext) {
+async fn test_delete_to_line_boundary(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let mut cx = EditorTestContext::new(cx).await;
-    cx.set_state("one «two threeˇ» four");
-    cx.update_editor(|editor, window, cx| {
-        editor.delete_to_beginning_of_line(
-            &DeleteToBeginningOfLine {
-                stop_at_indent: false,
-            },
-            window,
-            cx,
-        );
-        assert_eq!(editor.text(cx), " four");
-    });
+
+    for selection in ["one «two threeˇ» four", "one «ˇtwo three» four"] {
+        cx.set_state(selection);
+        cx.update_editor(|editor, window, cx| {
+            editor.delete_to_beginning_of_line(
+                &DeleteToBeginningOfLine {
+                    stop_at_indent: false,
+                },
+                window,
+                cx,
+            );
+            assert_eq!(editor.text(cx), " four");
+        });
+
+        cx.set_state(selection);
+        cx.update_editor(|editor, window, cx| {
+            editor.delete_to_end_of_line(&DeleteToEndOfLine, window, cx);
+            assert_eq!(editor.text(cx), "one ");
+        });
+    }
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8978,14 +8978,18 @@ async fn test_cut_line_ends(cx: &mut TestAppContext) {
         The quickˇ
         fox jumps overˇthe lazy dog"});
 
-    cx.set_state("The quick «ˇbrown» fox");
-    cx.update_editor(|e, window, cx| e.cut_to_end_of_line(&CutToEndOfLine::default(), window, cx));
-    cx.assert_editor_state("The quick ˇ");
-    assert_eq!(
-        cx.read_from_clipboard()
-            .and_then(|item| item.text().as_deref().map(str::to_string)),
-        Some("brown fox".to_string())
-    );
+    for selection in ["The quick «brownˇ» fox", "The quick «ˇbrown» fox"] {
+        cx.set_state(selection);
+        cx.update_editor(|e, window, cx| {
+            e.cut_to_end_of_line(&CutToEndOfLine::default(), window, cx)
+        });
+        cx.assert_editor_state("The quick ˇ");
+        assert_eq!(
+            cx.read_from_clipboard()
+                .and_then(|item| item.text().as_deref().map(str::to_string)),
+            Some("brown fox".to_string())
+        );
+    }
 }
 
 #[gpui::test]

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -1168,6 +1168,12 @@ impl Editor {
             return;
         }
         self.transact(window, cx, |this, window, cx| {
+            this.change_selections(Default::default(), window, cx, |s| {
+                s.move_with(&mut |_, selection| {
+                    selection.reversed = false;
+                });
+            });
+
             this.select_to_end_of_line(
                 &SelectToEndOfLine {
                     stop_at_soft_wraps: false,

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -1141,6 +1141,12 @@ impl Editor {
             return;
         }
         self.transact(window, cx, |this, window, cx| {
+            this.change_selections(Default::default(), window, cx, |s| {
+                s.move_with(&mut |_, selection| {
+                    selection.reversed = false;
+                });
+            });
+
             this.select_to_end_of_line(
                 &SelectToEndOfLine {
                     stop_at_soft_wraps: false,


### PR DESCRIPTION
I noticed that our line deletion actions are inconsistent.

For `DeleteToBeginningOfLine`:

- `one «two threeˇ» four` -> ` four` ✅
- `one «ˇtwo three» four` -> ` four` ✅

Great, these have the same results, regardless of selection direction.

For `DeleteToEndOfLine`:

- `one «two threeˇ» four` -> ` one ` ✅
- `one «ˇtwo three» four` -> `one two three` ❌

Whoops, that second one should be the same, assuming that selection direction again shouldn't matter, as in the case of `DeleteToBeginningOfLine`.

The same issue exists for `CutToEndOfLine`:

- `The quick «brownˇ» fox` -> `The quick ` ✅
- `The quick «ˇbrown» fox` -> `The quick brown` ❌

I unified the end-of-line actions to match `DeleteToBeginningOfLine`: selection direction no longer matters, so the whole selection is always included.

---

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

Release Notes:

- Fixed `editor: delete to end of line` to behave consistently regardless of selection direction.
- Fixed `editor: cut to end of line` to behave consistently regardless of selection direction.
