### PR TITLE
Fix local JSON schema path handling on Windows

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -30,6 +30,7 @@ use std::{
     sync::Arc,
 };
 use task::{TaskTemplate, TaskTemplates, VariableName};
+use url::Url;
 use util::{
     ResultExt, archive::extract_zip, fs::remove_matching, maybe, merge_json_value_into,
     paths::PathStyle, rel_path::RelPath,
@@ -359,13 +360,17 @@ fn worktree_root(delegate: &Arc<dyn LspAdapterDelegate>, settings: Option<Value>
             continue;
         }
 
-        *url = delegate
-            .resolve_relative_path(url.clone().into())
-            .to_string_lossy()
-            .into_owned();
+        let path = delegate.resolve_relative_path(url.clone().into());
+        if let Some(file_url) = file_path_to_schema_url(&path) {
+            *url = file_url;
+        }
     }
 
     Some(Value::Object(settings_map))
+}
+
+fn file_path_to_schema_url(path: &Path) -> Option<String> {
+    Url::from_file_path(path).ok().map(|url| url.to_string())
 }
 
 fn json_schema_proxy_settings(proxy: Option<String>) -> Option<Value> {
@@ -400,9 +405,34 @@ async fn get_cached_server_binary(
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use serde_json::json;
 
-    use super::json_schema_proxy_settings;
+    use super::{file_path_to_schema_url, json_schema_proxy_settings};
+
+    #[cfg(unix)]
+    #[test]
+    fn test_file_path_to_schema_url_converts_unix_absolute_path() {
+        assert_eq!(
+            file_path_to_schema_url(Path::new("/worktree/schema.json")),
+            Some("file:///worktree/schema.json".to_string())
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_file_path_to_schema_url_converts_windows_absolute_path() {
+        assert_eq!(
+            file_path_to_schema_url(Path::new(r"C:\worktree\schema.json")),
+            Some("file:///C:/worktree/schema.json".to_string())
+        );
+    }
+
+    #[test]
+    fn test_file_path_to_schema_url_ignores_relative_path() {
+        assert_eq!(file_path_to_schema_url(Path::new("schema.json")), None);
+    }
 
     #[test]
     fn test_json_schema_proxy_settings_includes_proxy() {


### PR DESCRIPTION
# Objective

Fixes local JSON schema path handling on Windows, closes #58503.

## Solution

Encode path in `file:///` URI.

https://github.com/zed-industries/zed/pull/59635/changes#diff-2be740eec736280b7b1bc728b63a9cf9854e5f99d96e49fc26d69f5b69382addR363-R375

## Testing

- [x] Added tests for Linux and Windows.

  https://github.com/zed-industries/zed/pull/59635/changes#diff-2be740eec736280b7b1bc728b63a9cf9854e5f99d96e49fc26d69f5b69382addR414-R435

- [x] Ran `languages` tests. Excluded db tests because my env does not have the service.

  ```shell
  cargo test --workspace -p languages -- --skip db_tests::
  ```

  Only failure is `extension_store_test::test_extension_store_with_test_extension`, which timed out on my machine, presumably because of poor internet connection.

- [x] Verified [Windows build](https://github.com/PRO-2684/zed/actions/runs/27871537190) manually. Screenshot available at "Showcase" section.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

This image showcases the fix:

<img width="3199" height="1333" alt="image" src="https://github.com/user-attachments/assets/0034df47-8a76-49e9-9651-628dd4347bb4" />

---

Release Notes:

- Fixed local JSON schema path handling on Windows