### PR TITLE
status_bar: Show AI credit usage for active LLM provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ai_credit_status"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "client",
+ "cloud_api_types",
+ "cloud_llm_client",
+ "copilot_chat",
+ "futures 0.3.32",
+ "gpui",
+ "http_client",
+ "language_model",
+ "pretty_assertions",
+ "project",
+ "serde",
+ "serde_json",
+ "settings",
+ "theme",
+ "ui",
+ "util",
+ "workspace",
+ "zed_actions",
+]
+
+[[package]]
 name = "ai_onboarding"
 version = "0.1.0"
 dependencies = [
@@ -22919,6 +22945,7 @@ dependencies = [
  "agent_settings",
  "agent_skills",
  "agent_ui",
+ "ai_credit_status",
  "anyhow",
  "ashpd",
  "askpass",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/agent_skills",
     "crates/agent_ui",
     "crates/ai_onboarding",
+    "crates/ai_credit_status",
     "crates/anthropic",
     "crates/askpass",
     "crates/assets",
@@ -276,6 +277,7 @@ agent_settings = { path = "crates/agent_settings" }
 agent_skills = { path = "crates/agent_skills" }
 agent_ui = { path = "crates/agent_ui" }
 ai_onboarding = { path = "crates/ai_onboarding" }
+ai_credit_status = { path = "crates/ai_credit_status" }
 anthropic = { path = "crates/anthropic" }
 askpass = { path = "crates/askpass" }
 assets = { path = "crates/assets" }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1016,6 +1016,15 @@
     // For example: typing `:wave:` gets replaced with `👋`.
     "auto_replace_emoji_shortcode": true,
   },
+  "ai_credit_status": {
+    // Whether to show AI credit usage for the active provider in the status bar.
+    "enabled": true,
+    // How often to refresh credit usage data, in seconds.
+    "refresh_seconds": 60,
+    // Optional monthly budget in USD used as the 100% mark for providers that
+    // do not expose remaining credits directly.
+    "monthly_budget_usd": null
+  },
   "agent": {
     // Whether the inline assistant should use streaming tools, when available
     "inline_assistant_use_streaming_tools": true,

--- a/crates/ai_credit_status/Cargo.toml
+++ b/crates/ai_credit_status/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "ai_credit_status"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/ai_credit_status.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+chrono.workspace = true
+client.workspace = true
+cloud_api_types.workspace = true
+cloud_llm_client.workspace = true
+copilot_chat.workspace = true
+futures.workspace = true
+gpui.workspace = true
+http_client.workspace = true
+language_model.workspace = true
+project.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+settings.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
+zed_actions.workspace = true
+
+[dev-dependencies]
+gpui = { workspace = true, features = ["test-support"] }
+pretty_assertions.workspace = true

--- a/crates/ai_credit_status/src/ai_credit_settings.rs
+++ b/crates/ai_credit_status/src/ai_credit_settings.rs
@@ -1,0 +1,19 @@
+use settings::{RegisterSetting, Settings, SettingsContent};
+
+#[derive(Debug, Clone, PartialEq, RegisterSetting)]
+pub struct AiCreditStatusSettings {
+    pub enabled: bool,
+    pub refresh_seconds: u64,
+    pub monthly_budget_usd: Option<f32>,
+}
+
+impl Settings for AiCreditStatusSettings {
+    fn from_settings(content: &SettingsContent) -> Self {
+        let settings = content.ai_credit_status.clone().unwrap_or_default();
+        Self {
+            enabled: settings.enabled.unwrap_or(true),
+            refresh_seconds: settings.refresh_seconds.unwrap_or(60),
+            monthly_budget_usd: settings.monthly_budget_usd,
+        }
+    }
+}

--- a/crates/ai_credit_status/src/ai_credit_status.rs
+++ b/crates/ai_credit_status/src/ai_credit_status.rs
@@ -1,0 +1,13 @@
+mod fetch;
+mod ai_credit_settings;
+mod status_item;
+
+pub use ai_credit_settings::AiCreditStatusSettings;
+pub use status_item::AiCreditStatusItem;
+
+use gpui::App;
+use settings::Settings;
+
+pub fn init(cx: &mut App) {
+    AiCreditStatusSettings::register(cx);
+}

--- a/crates/ai_credit_status/src/fetch.rs
+++ b/crates/ai_credit_status/src/fetch.rs
@@ -1,0 +1,462 @@
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use chrono::{Datelike, Utc};
+use client::{Client, UserStore, zed_urls};
+use copilot_chat::CopilotChat;
+use futures::AsyncReadExt as _;
+use gpui::{App, AsyncApp, Entity};
+use http_client::{AsyncBody, HttpClient, Method, Request};
+use language_model::{
+    ANTHROPIC_PROVIDER_ID, LanguageModelProviderId, LanguageModelRegistry, OPEN_AI_PROVIDER_ID,
+    ZED_CLOUD_PROVIDER_ID,
+};
+
+const COPILOT_CHAT_PROVIDER_ID: LanguageModelProviderId =
+    LanguageModelProviderId::new("copilot_chat");
+const OPENROUTER_PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("openrouter");
+const MISTRAL_PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("mistral");
+use project::DisableAiSettings;
+use serde::Deserialize;
+use settings::Settings;
+use theme::ActiveTheme;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreditSnapshot {
+    pub provider_label: String,
+    pub used_ratio: f32,
+    pub label: String,
+    pub tooltip: String,
+    pub account_url: Option<String>,
+}
+
+pub fn active_provider_id(cx: &App) -> Option<LanguageModelProviderId> {
+    if DisableAiSettings::get_global(cx).disable_ai {
+        return None;
+    }
+
+    LanguageModelRegistry::read_global(cx)
+        .default_model()
+        .map(|model| model.model.provider_id())
+}
+
+pub async fn fetch_credit_snapshot(
+    provider_id: LanguageModelProviderId,
+    user_store: Entity<UserStore>,
+    client: Arc<Client>,
+    monthly_budget_usd: Option<f32>,
+    cx: &AsyncApp,
+) -> Result<CreditSnapshot> {
+    if provider_id == ZED_CLOUD_PROVIDER_ID {
+        return fetch_zed_hosted(user_store, client, cx).await;
+    }
+
+    if provider_id == COPILOT_CHAT_PROVIDER_ID {
+        return fetch_copilot(client.http_client(), cx).await;
+    }
+
+    if provider_id == OPENROUTER_PROVIDER_ID {
+        return fetch_openrouter(client.http_client()).await;
+    }
+
+    if provider_id == OPEN_AI_PROVIDER_ID {
+        return fetch_openai(client.http_client(), monthly_budget_usd).await;
+    }
+
+    if provider_id == ANTHROPIC_PROVIDER_ID {
+        return fetch_anthropic(client.http_client(), monthly_budget_usd).await;
+    }
+
+    if provider_id == MISTRAL_PROVIDER_ID {
+        return fetch_mistral(client.http_client(), monthly_budget_usd).await;
+    }
+
+    anyhow::bail!("Unsupported provider: {}", provider_id)
+}
+
+fn zed_hosted_snapshot(
+    usage: cloud_llm_client::TokenSpendUsage,
+    cx: &App,
+) -> CreditSnapshot {
+    let limit = usage.limit_cents.max(1) as f32;
+    let spent = usage.spent_cents as f32;
+    CreditSnapshot {
+        provider_label: "Zed Pro".to_string(),
+        used_ratio: (spent / limit).clamp(0.0, 1.0),
+        label: format!(
+            "${:.2}/${:.2}",
+            spent / 100.0,
+            usage.limit_cents as f32 / 100.0
+        ),
+        tooltip: format!(
+            "Zed Pro token spend: ${:.2} of ${:.2} monthly limit",
+            spent / 100.0,
+            usage.limit_cents as f32 / 100.0
+        ),
+        account_url: Some(zed_urls::account_url(cx)),
+    }
+}
+
+async fn fetch_zed_hosted(
+    user_store: Entity<UserStore>,
+    _client: Arc<Client>,
+    cx: &AsyncApp,
+) -> Result<CreditSnapshot> {
+    if let Some(snapshot) = cx.update(|cx| {
+        user_store
+            .read(cx)
+            .token_spend_usage()
+            .map(|usage| zed_hosted_snapshot(usage, cx))
+    }) {
+        return Ok(snapshot);
+    }
+
+    let refresh = cx.update(|cx| {
+        user_store.update(cx, |store, cx| store.refresh_authenticated_user(cx))
+    });
+    refresh
+        .await
+        .context("failed to refresh Zed account usage")?;
+
+    cx.update(|cx| {
+        user_store
+            .read(cx)
+            .token_spend_usage()
+            .map(|usage| zed_hosted_snapshot(usage, cx))
+    })
+    .ok_or_else(|| anyhow::anyhow!("Zed Pro token spend is not available from your account yet"))
+}
+
+async fn fetch_copilot(http: Arc<dyn HttpClient>, cx: &AsyncApp) -> Result<CreditSnapshot> {
+    let oauth_token = cx
+        .update(|cx| {
+            CopilotChat::global(cx)
+                .and_then(|chat| chat.read(cx).oauth_token().map(str::to_string))
+                .or_else(resolve_github_token)
+        })
+        .ok_or_else(|| anyhow::anyhow!("Sign in to GitHub Copilot to view usage"))?;
+
+    #[derive(Debug, Deserialize)]
+    struct CopilotUserResponse {
+        #[allow(dead_code)]
+        copilot_plan: Option<String>,
+        quota_reset_date: Option<String>,
+        quota_snapshots: Option<QuotaSnapshots>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct QuotaSnapshots {
+        premium_interactions: Option<QuotaSnapshot>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct QuotaSnapshot {
+        percent_remaining: Option<f64>,
+        quota_remaining: Option<f64>,
+        entitlement: Option<f64>,
+        unlimited: Option<bool>,
+    }
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("https://api.github.com/copilot_internal/user")
+        .header("Authorization", format!("Bearer {oauth_token}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "zed-ai-credit-status")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .body(AsyncBody::default())?;
+
+    let mut response = http.send(request).await?;
+    let mut body = String::new();
+    response.body_mut().read_to_string(&mut body).await?;
+
+    if !response.status().is_success() {
+        anyhow::bail!("GitHub Copilot usage request failed: {}", body);
+    }
+
+    let parsed: CopilotUserResponse = serde_json::from_str(&body)?;
+    let premium = parsed
+        .quota_snapshots
+        .and_then(|snapshots| snapshots.premium_interactions)
+        .context("No Copilot premium quota data available")?;
+
+    if premium.unlimited.unwrap_or(false) {
+        return Ok(CreditSnapshot {
+            provider_label: "Copilot".to_string(),
+            used_ratio: 0.0,
+            label: "Premium included".to_string(),
+            tooltip: "GitHub Copilot premium requests are included with your plan".to_string(),
+            account_url: Some("https://github.com/settings/copilot".into()),
+        });
+    }
+
+    let percent_remaining = premium.percent_remaining.unwrap_or(100.0) as f32;
+    let used_ratio = ((100.0 - percent_remaining) / 100.0).clamp(0.0, 1.0);
+    let label = match (premium.quota_remaining, premium.entitlement) {
+        (Some(remaining), Some(total)) if total > 0.0 => {
+            format!("{:.0}% ({:.0}/{:.0})", used_ratio * 100.0, total - remaining, total)
+        }
+        _ => format!("{:.0}%", used_ratio * 100.0),
+    };
+
+    let reset = parsed
+        .quota_reset_date
+        .map(|date| format!("\nResets {date}"))
+        .unwrap_or_default();
+
+    Ok(CreditSnapshot {
+        provider_label: "Copilot".to_string(),
+        used_ratio,
+        label,
+        tooltip: format!(
+            "GitHub Copilot premium requests: {:.0}% used{reset}",
+            used_ratio * 100.0
+        ),
+        account_url: Some("https://github.com/settings/copilot".into()),
+    })
+}
+
+async fn fetch_openrouter(http: Arc<dyn HttpClient>) -> Result<CreditSnapshot> {
+    let api_key = std::env::var("OPENROUTER_API_KEY")
+        .context("Set OPENROUTER_API_KEY to view OpenRouter credits")?;
+
+    #[derive(Debug, Deserialize)]
+    struct KeyResponse {
+        data: KeyData,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct KeyData {
+        limit: Option<f64>,
+        limit_remaining: Option<f64>,
+        usage: f64,
+    }
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("https://openrouter.ai/api/v1/key")
+        .header("Authorization", format!("Bearer {api_key}"))
+        .body(AsyncBody::default())?;
+
+    let mut response = http.send(request).await?;
+    let mut body = String::new();
+    response.body_mut().read_to_string(&mut body).await?;
+
+    if !response.status().is_success() {
+        anyhow::bail!("OpenRouter usage request failed: {}", body);
+    }
+
+    let parsed: KeyResponse = serde_json::from_str(&body)?;
+    let data = parsed.data;
+
+    if let (Some(limit), Some(remaining)) = (data.limit, data.limit_remaining) {
+        if limit > 0.0 {
+            let used = (limit - remaining).max(0.0);
+            let used_ratio = (used / limit).clamp(0.0, 1.0) as f32;
+            return Ok(CreditSnapshot {
+                provider_label: "OpenRouter".to_string(),
+                used_ratio,
+                label: format!("${:.2}/${:.2}", used, limit),
+                tooltip: format!(
+                    "OpenRouter credits: ${:.2} used of ${:.2} limit (${:.2} total usage)",
+                    used, limit, data.usage
+                ),
+                account_url: Some("https://openrouter.ai/settings/credits".into()),
+            });
+        }
+    }
+
+    Ok(CreditSnapshot {
+        provider_label: "OpenRouter".to_string(),
+        used_ratio: 0.0,
+        label: format!("${:.2} used", data.usage),
+        tooltip: format!("OpenRouter total usage: ${:.2}", data.usage),
+        account_url: Some("https://openrouter.ai/settings/credits".into()),
+    })
+}
+
+async fn fetch_openai(
+    http: Arc<dyn HttpClient>,
+    monthly_budget_usd: Option<f32>,
+) -> Result<CreditSnapshot> {
+    let api_key =
+        std::env::var("OPENAI_API_KEY").context("Set OPENAI_API_KEY to view OpenAI usage")?;
+    let budget = monthly_budget_usd
+        .filter(|budget| *budget > 0.0)
+        .context("Set ai_credit_status.monthly_budget_usd to track OpenAI usage")?;
+
+    let now = Utc::now();
+    let start = format!("{}-{:02}-01", now.year(), now.month());
+
+    #[derive(Debug, Deserialize)]
+    struct UsageResponse {
+        total_usage: Option<f64>,
+    }
+
+    let uri = format!(
+        "https://api.openai.com/v1/usage?start_date={start}&end_date={start}"
+    );
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .body(AsyncBody::default())?;
+
+    let mut response = http.send(request).await?;
+    let mut body = String::new();
+    response.body_mut().read_to_string(&mut body).await?;
+
+    if !response.status().is_success() {
+        anyhow::bail!("OpenAI usage request failed: {}", body);
+    }
+
+    let parsed: UsageResponse = serde_json::from_str(&body)?;
+    let spent_usd = parsed.total_usage.unwrap_or(0.0) / 100.0;
+    let used_ratio = (spent_usd / budget as f64).clamp(0.0, 1.0) as f32;
+
+    Ok(CreditSnapshot {
+        provider_label: "OpenAI".to_string(),
+        used_ratio,
+        label: format!("${:.2}/${:.2}", spent_usd, budget),
+        tooltip: format!(
+            "OpenAI usage this month: ${:.2} of ${:.2} configured budget",
+            spent_usd, budget
+        ),
+        account_url: Some("https://platform.openai.com/usage".into()),
+    })
+}
+
+async fn fetch_anthropic(
+    http: Arc<dyn HttpClient>,
+    monthly_budget_usd: Option<f32>,
+) -> Result<CreditSnapshot> {
+    let api_key = std::env::var("ANTHROPIC_API_KEY")
+        .context("Set ANTHROPIC_API_KEY to view Anthropic usage")?;
+    let budget = monthly_budget_usd
+        .filter(|budget| *budget > 0.0)
+        .context("Set ai_credit_status.monthly_budget_usd to track Anthropic usage")?;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("https://api.anthropic.com/v1/models")
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .body(AsyncBody::default())?;
+
+    let mut response = http.send(request).await?;
+    if !response.status().is_success() {
+        let mut body = String::new();
+        response.body_mut().read_to_string(&mut body).await?;
+        anyhow::bail!("Anthropic request failed: {}", body);
+    }
+
+    // Anthropic does not expose remaining credits on standard API keys. Surface
+    // configured budget guidance until a billing endpoint is available.
+    Ok(CreditSnapshot {
+        provider_label: "Anthropic".to_string(),
+        used_ratio: 0.0,
+        label: format!("Budget ${:.2}", budget),
+        tooltip: format!(
+            "Anthropic does not expose remaining credits via API. \
+             Configure ai_credit_status.monthly_budget_usd (${:.2}) and check \
+             https://console.anthropic.com/settings/billing for actual spend.",
+            budget
+        ),
+        account_url: Some("https://console.anthropic.com/settings/billing".into()),
+    })
+}
+
+async fn fetch_mistral(
+    http: Arc<dyn HttpClient>,
+    monthly_budget_usd: Option<f32>,
+) -> Result<CreditSnapshot> {
+    let api_key =
+        std::env::var("MISTRAL_API_KEY").context("Set MISTRAL_API_KEY to view Mistral usage")?;
+    let budget = monthly_budget_usd
+        .filter(|budget| *budget > 0.0)
+        .context("Set ai_credit_status.monthly_budget_usd to track Mistral usage")?;
+
+    let request = Request::builder()
+        .method(Method::GET)
+        .uri("https://api.mistral.ai/v1/models")
+        .header("Authorization", format!("Bearer {api_key}"))
+        .body(AsyncBody::default())?;
+
+    let mut response = http.send(request).await?;
+    if !response.status().is_success() {
+        let mut body = String::new();
+        response.body_mut().read_to_string(&mut body).await?;
+        anyhow::bail!("Mistral request failed: {}", body);
+    }
+
+    Ok(CreditSnapshot {
+        provider_label: "Mistral".to_string(),
+        used_ratio: 0.0,
+        label: format!("Budget ${:.2}", budget),
+        tooltip: format!(
+            "Mistral does not expose remaining credits via API. \
+             Configure ai_credit_status.monthly_budget_usd (${:.2}) and check \
+             https://console.mistral.ai/billing for actual spend.",
+            budget
+        ),
+        account_url: Some("https://console.mistral.ai/billing".into()),
+    })
+}
+
+fn resolve_github_token() -> Option<String> {
+    for key in [
+        "GITHUB_TOKEN",
+        "COPILOT_USAGE_TOKEN",
+        copilot_chat::COPILOT_OAUTH_ENV_VAR,
+        copilot_chat::GITHUB_COPILOT_OAUTH_ENV_VAR,
+        "GH_TOKEN",
+    ] {
+        if let Ok(token) = std::env::var(key) {
+            let token = token.trim();
+            if !token.is_empty() {
+                return Some(token.to_string());
+            }
+        }
+    }
+    None
+}
+
+pub fn usage_color(used_ratio: f32, cx: &App) -> gpui::Hsla {
+    let ratio = used_ratio.clamp(0.0, 1.0);
+    let status = cx.theme().status();
+    if ratio < 0.25 {
+        status.success
+    } else if ratio < 0.50 {
+        status.warning
+    } else if ratio < 0.75 {
+        status.modified
+    } else {
+        status.error
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::TestAppContext;
+
+    use super::*;
+
+    #[gpui::test]
+    fn usage_color_escalates_with_ratio(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            assert_eq!(
+                usage_color(0.1, cx),
+                cx.theme().status().success
+            );
+            assert_eq!(
+                usage_color(0.4, cx),
+                cx.theme().status().warning
+            );
+            assert_eq!(
+                usage_color(0.6, cx),
+                cx.theme().status().modified
+            );
+            assert_eq!(usage_color(0.9, cx), cx.theme().status().error);
+        });
+    }
+}

--- a/crates/ai_credit_status/src/status_item.rs
+++ b/crates/ai_credit_status/src/status_item.rs
@@ -1,0 +1,248 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use client::{Client, UserStore};
+use gpui::{Action, App, Context, Empty, Entity, FocusHandle, Subscription, Task, Window, px};
+use language_model::{Event as LanguageModelEvent, LanguageModelRegistry};
+use project::DisableAiSettings;
+use settings::Settings;
+use ui::{Label, LabelSize, ProgressBar, Tooltip, prelude::*};
+use workspace::{HideStatusItem, ItemHandle, StatusItemView};
+use zed_actions::OpenSettingsAt;
+
+use crate::fetch::{
+    CreditSnapshot, active_provider_id, fetch_credit_snapshot, usage_color,
+};
+use crate::ai_credit_settings::AiCreditStatusSettings;
+
+pub struct AiCreditStatusItem {
+    snapshot: Option<CreditSnapshot>,
+    error_message: Option<String>,
+    user_store: Entity<UserStore>,
+    client: Arc<Client>,
+    _subscriptions: Vec<Subscription>,
+    refresh_task: Option<Task<()>>,
+    pane_item_focus_handle: Option<FocusHandle>,
+}
+
+impl AiCreditStatusItem {
+    pub fn new(user_store: Entity<UserStore>, client: Arc<Client>, cx: &mut Context<Self>) -> Self {
+        let mut this = Self {
+            snapshot: None,
+            error_message: None,
+            user_store,
+            client,
+            _subscriptions: Vec::new(),
+            refresh_task: None,
+            pane_item_focus_handle: None,
+        };
+
+        this._subscriptions.push(cx.observe_global::<settings::SettingsStore>(|_, cx| {
+            cx.notify();
+        }));
+        this._subscriptions
+            .push(cx.subscribe(&LanguageModelRegistry::global(cx), |_, _, event, cx| {
+                if matches!(event, LanguageModelEvent::DefaultModelChanged) {
+                    cx.notify();
+                }
+            }));
+        this._subscriptions.push(cx.observe(&this.user_store, |_, _, cx| {
+            cx.notify();
+        }));
+
+        this.schedule_refresh(cx);
+        this
+    }
+
+    fn schedule_refresh(&mut self, cx: &mut Context<Self>) {
+        let settings = AiCreditStatusSettings::get_global(cx);
+        if !settings.enabled || DisableAiSettings::get_global(cx).disable_ai {
+            self.snapshot = None;
+            self.error_message = None;
+            self.refresh_task = None;
+            return;
+        }
+
+        if active_provider_id(cx).is_none() {
+            self.snapshot = None;
+            self.error_message = Some("No active AI provider".into());
+            return;
+        }
+
+        let user_store = self.user_store.clone();
+        let client = self.client.clone();
+
+        self.refresh_task = Some(cx.spawn(async move |this, cx| {
+            loop {
+                let (enabled, monthly_budget_usd, refresh_seconds) = cx.update(|cx| {
+                    let settings = AiCreditStatusSettings::get_global(cx);
+                    (
+                        settings.enabled && !DisableAiSettings::get_global(cx).disable_ai,
+                        settings.monthly_budget_usd,
+                        settings.refresh_seconds.max(15),
+                    )
+                });
+
+                if !enabled {
+                    if this
+                        .update(cx, |this, cx| {
+                            this.snapshot = None;
+                            this.error_message = None;
+                            cx.notify();
+                        })
+                        .is_err()
+                    {
+                        break;
+                    }
+                    break;
+                }
+
+                let provider_id = cx.update(|cx| active_provider_id(cx));
+                if let Some(provider_id) = provider_id {
+                    match fetch_credit_snapshot(
+                        provider_id,
+                        user_store.clone(),
+                        client.clone(),
+                        monthly_budget_usd,
+                        cx,
+                    )
+                    .await
+                    {
+                        Ok(snapshot) => {
+                            if this
+                                .update(cx, |this, cx| {
+                                    this.snapshot = Some(snapshot);
+                                    this.error_message = None;
+                                    cx.notify();
+                                })
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Err(error) => {
+                            if this
+                                .update(cx, |this, cx| {
+                                    this.snapshot = None;
+                                    this.error_message = Some(error.to_string());
+                                    cx.notify();
+                                })
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                    }
+                } else if this
+                    .update(cx, |this, cx| {
+                        this.snapshot = None;
+                        this.error_message = Some("No active AI provider".into());
+                        cx.notify();
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+
+                cx.background_executor()
+                    .timer(Duration::from_secs(refresh_seconds))
+                    .await;
+            }
+
+        }));
+    }
+}
+
+impl Render for AiCreditStatusItem {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let settings = AiCreditStatusSettings::get_global(cx);
+        if !settings.enabled || DisableAiSettings::get_global(cx).disable_ai {
+            return Empty.into_any_element();
+        }
+
+        let Some(snapshot) = self.snapshot.clone() else {
+            let message = self
+                .error_message
+                .clone()
+                .unwrap_or_else(|| "Loading AI credit usage…".into());
+
+            return div()
+                .id("ai-credit-status-loading")
+                .child(
+                    Label::new(message)
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                )
+                .into_any_element();
+        };
+
+        let percent = (snapshot.used_ratio * 100.0).round() as u32;
+        let bar_color = usage_color(snapshot.used_ratio, cx);
+        let tooltip = snapshot.tooltip.clone();
+        let account_url = snapshot.account_url.clone();
+
+        h_flex()
+            .id("ai-credit-status")
+            .gap_1()
+            .items_center()
+            .max_w(px(180.))
+            .child(
+                div().w(px(96.)).child(
+                    ProgressBar::new(
+                        "ai-credit-usage",
+                        snapshot.used_ratio * 100.0,
+                        100.0,
+                        cx,
+                    )
+                    .fg_color(bar_color),
+                ),
+            )
+            .child(
+                Label::new(format!("{percent}%"))
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+            )
+            .child(
+                Label::new(snapshot.label)
+                    .size(LabelSize::Small)
+                    .color(Color::Muted)
+                    .truncate(),
+            )
+            .tooltip(Tooltip::text(tooltip))
+            .on_click(cx.listener(move |_, _, window, cx| {
+                if let Some(url) = account_url.clone() {
+                    cx.open_url(&url);
+                } else {
+                    window.dispatch_action(
+                        OpenSettingsAt {
+                            path: "agent".into(),
+                            target: None,
+                        }
+                        .boxed_clone(),
+                        cx,
+                    );
+                }
+            }))
+            .into_any_element()
+    }
+}
+
+impl StatusItemView for AiCreditStatusItem {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.pane_item_focus_handle = active_pane_item.map(|item| item.item_focus_handle(cx));
+    }
+
+    fn hide_setting(&self, _cx: &App) -> Option<HideStatusItem> {
+        Some(HideStatusItem::new(|settings| {
+            settings
+                .ai_credit_status
+                .get_or_insert_with(Default::default)
+                .enabled = Some(false);
+        }))
+    }
+}

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -843,6 +843,39 @@ impl UserStore {
         self.edit_prediction_usage
     }
 
+    pub fn token_spend_usage(&self) -> Option<cloud_llm_client::TokenSpendUsage> {
+        self.plan_info
+            .as_ref()
+            .and_then(|plan| plan.usage.token_spend_cents.clone())
+    }
+
+    pub fn refresh_authenticated_user(&self, cx: &mut Context<Self>) -> Task<Result<()>> {
+        if self.client.upgrade().is_none() {
+            return Task::ready(Err(anyhow::anyhow!("client dropped")));
+        }
+
+        cx.spawn(async move |this, cx| {
+            let (cloud_client, system_id) = cx
+                .update(|cx| {
+                    this.read_with(cx, |this, _| {
+                        this.client.upgrade().map(|client| {
+                            let system_id = client.telemetry().system_id().map(|id| id.to_string());
+                            (client.cloud_client(), system_id)
+                        })
+                    })
+                })?
+                .ok_or_else(|| anyhow::anyhow!("client dropped"))?;
+
+            let response = cloud_client.get_authenticated_user(system_id).await?;
+            cx.update(|cx| {
+                this.update(cx, |this, cx| {
+                    this.update_authenticated_user(response, cx);
+                })
+            })?;
+            Ok(())
+        })
+    }
+
     pub fn update_edit_prediction_usage(
         &mut self,
         usage: EditPredictionUsage,

--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -335,6 +335,16 @@ pub struct ListModelsResponse {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct CurrentUsage {
     pub edit_predictions: UsageData,
+    /// Monthly hosted LLM token spend in cents (including included credit).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_spend_cents: Option<TokenSpendUsage>,
+}
+
+/// Monthly token spend relative to the user's spend limit.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TokenSpendUsage {
+    pub spent_cents: u32,
+    pub limit_cents: u32,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -631,6 +631,10 @@ impl CopilotChat {
         self.oauth_token.is_some()
     }
 
+    pub fn oauth_token(&self) -> Option<&str> {
+        self.oauth_token.as_deref()
+    }
+
     pub fn models(&self) -> Option<&[Model]> {
         self.models.as_deref()
     }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -174,6 +174,7 @@ impl VsCodeSettings {
         SettingsContent {
             agent: self.agent_settings_content(),
             agent_servers: None,
+            ai_credit_status: None,
             audio: None,
             auto_update: None,
             base_keymap: Some(BaseKeymapContent::VSCode),

--- a/crates/settings_content/src/ai_credit_status.rs
+++ b/crates/settings_content/src/ai_credit_status.rs
@@ -1,0 +1,21 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use settings_macros::{MergeFrom, with_fallible_options};
+
+#[with_fallible_options]
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, PartialEq)]
+pub struct AiCreditStatusSettingsContent {
+    /// Whether to show AI credit usage in the status bar.
+    ///
+    /// Default: true
+    pub enabled: Option<bool>,
+    /// How often to refresh credit usage data, in seconds.
+    ///
+    /// Default: 60
+    pub refresh_seconds: Option<u64>,
+    /// Optional monthly budget in USD used as the 100% mark for providers that
+    /// do not expose remaining credits directly (e.g. OpenAI, Anthropic, Mistral).
+    ///
+    /// Default: null
+    pub monthly_budget_usd: Option<f32>,
+}

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -1,5 +1,6 @@
 mod action;
 mod agent;
+mod ai_credit_status;
 mod editor;
 mod extension;
 mod fallible_options;
@@ -15,6 +16,7 @@ mod workspace;
 
 pub use action::{ActionName, ActionWithArguments, CommandAliasTarget};
 pub use agent::*;
+pub use ai_credit_status::*;
 pub use editor::*;
 pub use extension::*;
 pub use fallible_options::*;
@@ -145,6 +147,9 @@ pub struct SettingsContent {
 
     pub agent: Option<AgentSettingsContent>,
     pub agent_servers: Option<AllAgentServersSettings>,
+
+    /// Settings for the AI credit usage indicator in the status bar.
+    pub ai_credit_status: Option<AiCreditStatusSettingsContent>,
 
     /// Configuration of audio in Zed.
     pub audio: Option<AudioSettingsContent>,

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -70,6 +70,7 @@ agent-client-protocol.workspace = true
 agent_settings.workspace = true
 agent_skills.workspace = true
 agent_ui = { workspace = true, features = ["audio"] }
+ai_credit_status.workspace = true
 anyhow.workspace = true
 askpass.workspace = true
 assets.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -735,6 +735,7 @@ fn main() {
         image_viewer::init(cx);
         repl::notebook::init(cx);
         diagnostics::init(cx);
+        ai_credit_status::init(cx);
 
         audio::init(cx);
         workspace::init(app_state.clone(), cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -598,6 +598,13 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             cx.new(|_| go_to_line::cursor_position::CursorPosition::new(workspace));
         let line_ending_indicator =
             cx.new(|_| line_ending_selector::LineEndingIndicator::default());
+        let ai_credit_status = cx.new(|cx| {
+            ai_credit_status::AiCreditStatusItem::new(
+                app_state.user_store.clone(),
+                app_state.client.clone(),
+                cx,
+            )
+        });
         let merge_conflict_indicator =
             cx.new(|cx| git_ui::MergeConflictIndicator::new(workspace, cx));
         workspace.status_bar().update(cx, |status_bar, cx| {
@@ -608,6 +615,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             status_bar.add_left_item(merge_conflict_indicator, window, cx);
             status_bar.add_left_item(activity_indicator, window, cx);
             status_bar.add_right_item(edit_prediction_ui, window, cx);
+            status_bar.add_right_item(ai_credit_status, window, cx);
             status_bar.add_right_item(active_buffer_encoding, window, cx);
             status_bar.add_right_item(active_buffer_language, window, cx);
             status_bar.add_right_item(active_toolchain_language, window, cx);

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -61,6 +61,7 @@
 - [Parallel Agents](./ai/parallel-agents.md)
 - [Inline Assistant](./ai/inline-assistant.md)
 - [LLM Providers](./ai/llm-providers.md)
+  - [AI Credit Status](./ai/ai-credit-status.md)
   - [Use API Access](./ai/use-api-access.md)
   - [Use an Existing Subscription](./ai/use-an-existing-subscription.md)
   - [Use a Gateway](./ai/use-a-gateway.md)

--- a/docs/src/ai/ai-credit-status.md
+++ b/docs/src/ai/ai-credit-status.md
@@ -1,0 +1,50 @@
+# AI Credit Status
+
+Zed can show how much AI credit or quota you have used for your **active LLM provider** directly in the status bar.
+
+## Status bar indicator
+
+When enabled, a compact progress bar appears on the right side of the status bar. It reflects usage from 0% to 100% with color bands:
+
+- 0–25%: green
+- 25–50%: yellow
+- 50–75%: orange
+- 75–100%: red
+
+Hover for details, or click to open the provider billing page when available.
+
+## Settings
+
+Configure under `ai_credit_status` in your settings file:
+
+```json
+"ai_credit_status": {
+  "enabled": true,
+  "refresh_seconds": 60,
+  "monthly_budget_usd": null
+}
+```
+
+- `enabled`: show or hide the indicator
+- `refresh_seconds`: polling interval (minimum 15 seconds)
+- `monthly_budget_usd`: optional budget used as the 100% mark for OpenAI, Anthropic, and Mistral when the provider API does not expose remaining credits
+
+You can hide the indicator from the status bar context menu via **Hide Button**.
+
+## Supported providers
+
+| Provider | Data source |
+| --- | --- |
+| Zed Pro (hosted models) | Zed account token spend (when exposed by the cloud API) |
+| GitHub Copilot Chat | GitHub Copilot internal usage API |
+| OpenRouter | OpenRouter `/api/v1/key` |
+| OpenAI | OpenAI usage API + optional `monthly_budget_usd` |
+| Anthropic | Validates API key; configure `monthly_budget_usd` and check the Anthropic console for spend |
+| Mistral | Validates API key; configure `monthly_budget_usd` and check the Mistral console for spend |
+
+The indicator follows whichever provider is selected as the default model in Agent settings.
+
+## Related discussions
+
+- [Surfacing Token Count and API Billing info](https://github.com/zed-industries/zed/discussions/56161)
+- [Token Spend progress bar on account page](https://github.com/zed-industries/zed/discussions/41148)


### PR DESCRIPTION
## Summary

- Add a built-in status bar item that shows AI credit/quota usage for the **active LLM provider**
- Horizontal progress bar with green → yellow → orange → red color bands (0–100% usage)
- Provider fetchers for Zed Pro, GitHub Copilot Chat, OpenRouter, OpenAI, Anthropic, and Mistral
- New `ai_credit_status` settings: `enabled`, `refresh_seconds`, optional `monthly_budget_usd`

Related discussions:

- https://github.com/zed-industries/zed/discussions/56161
- https://github.com/zed-industries/zed/discussions/41148

## Design notes

- Follows the active default model from Agent settings
- Zed Pro usage requires `token_spend_cents` in `/client/users/me` (client-side parsing added; server field may need coordination)
- BYOK providers without remaining-credit APIs use optional `monthly_budget_usd` as the 100% mark

## Test plan

- [ ] Enable `ai_credit_status.enabled` and confirm the bar appears on the right side of the status bar
- [ ] Switch Agent default model between Zed Pro, Copilot, and OpenRouter and verify the indicator updates
- [ ] Confirm color bands at ~10%, 40%, 60%, and 90% usage (or mock values)
- [ ] Hover tooltip shows provider details; click opens billing/account URL when available
- [ ] Hide via status bar context menu **Hide Button**
- [ ] Set `monthly_budget_usd` and verify OpenAI usage label when `OPENAI_API_KEY` is configured
- [ ] Run `cargo check -p ai_credit_status`


Made with [Cursor](https://cursor.com)