### PR TITLE
languages: Add ability to add Go test build tags

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -643,6 +643,8 @@ const GO_TABLE_TEST_CASE_NAME_TASK_VARIABLE: VariableName =
 const GO_SUITE_NAME_TASK_VARIABLE: VariableName =
     VariableName::Custom(Cow::Borrowed("GO_SUITE_NAME"));
 
+const GO_TEST_BUILD_TAGS_STR: &str = "GO_TEST_BUILD_TAGS";
+
 impl ContextProvider for GoContextProvider {
     fn build_context(
         &self,
@@ -727,7 +729,11 @@ impl ContextProvider for GoContextProvider {
         )))
     }
 
-    fn associated_tasks(&self, _: Option<Entity<Buffer>>, _: &App) -> Task<Option<TaskTemplates>> {
+    fn associated_tasks(
+        &self,
+        buffer: Option<Entity<Buffer>>,
+        cx: &App,
+    ) -> Task<Option<TaskTemplates>> {
         let package_cwd = if GO_PACKAGE_TASK_VARIABLE.template_value() == "." {
             None
         } else {
@@ -735,7 +741,27 @@ impl ContextProvider for GoContextProvider {
         };
         let module_cwd = Some(GO_MODULE_ROOT_TASK_VARIABLE.template_value());
 
-        Task::ready(Some(TaskTemplates(vec![
+        let settings = LanguageSettings::resolve(
+            buffer.map(|buffer| buffer.read(cx)),
+            Some(&LanguageName::new("Go")),
+            cx,
+        );
+        // Tags only — the user supplies tag names via `GO_TEST_BUILD_TAGS`, we build the `-tags=` flag.
+        let build_tags_arg = settings
+            .tasks
+            .variables
+            .get(GO_TEST_BUILD_TAGS_STR)
+            .map(|tags| {
+                let normalized = tags
+                    .split(|c: char| c.is_whitespace() || c == ',')
+                    .filter(|tag| !tag.is_empty())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                format!("-tags={normalized}")
+            })
+            .filter(|arg| arg != "-tags=");
+
+        let mut templates = vec![
             TaskTemplate {
                 label: format!(
                     "go test {} -v -run Test{}/{}",
@@ -909,7 +935,19 @@ impl ContextProvider for GoContextProvider {
                 cwd: module_cwd,
                 ..TaskTemplate::default()
             },
-        ])))
+        ];
+
+        if let Some(build_tags_arg) = build_tags_arg {
+            for template in &mut templates {
+                if template.command == "go"
+                    && template.args.first().map(String::as_str) == Some("test")
+                {
+                    template.args.insert(1, build_tags_arg.clone());
+                }
+            }
+        }
+
+        Task::ready(Some(TaskTemplates(templates)))
     }
 
     fn runnable_resolver(&self) -> Option<Arc<dyn RunnableResolver>> {
@@ -1984,5 +2022,80 @@ mod tests {
         let input_with_double_quotes = r#"`test with "double quotes"`"#;
         let result = extract_subtest_name(input_with_double_quotes);
         assert_eq!(result, Some(r#"test_with_\"double_quotes\""#.to_string()));
+    }
+
+    fn set_go_task_variables(cx: &mut gpui::App, variables: &[(&str, &str)]) {
+        use gpui::BorrowAppContext;
+        use settings::{LanguageSettingsContent, LanguageTaskSettingsContent, SettingsStore};
+
+        let variables: collections::HashMap<String, String> = variables
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect();
+        let test_settings = SettingsStore::test(cx);
+        cx.set_global(test_settings);
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |content| {
+                content.project.all_languages.languages.0.insert(
+                    "Go".into(),
+                    LanguageSettingsContent {
+                        tasks: Some(LanguageTaskSettingsContent {
+                            variables: Some(variables),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    async fn test_go_build_tags_injected_into_test_tasks(cx: &mut TestAppContext) {
+        let templates = cx
+            .update(|cx| {
+                set_go_task_variables(cx, &[(GO_TEST_BUILD_TAGS_STR, "integration e2e")]);
+                GoContextProvider.associated_tasks(None, cx)
+            })
+            .await
+            .unwrap();
+
+        for template in &templates.0 {
+            let is_go_test = template.command == "go"
+                && template.args.first().map(String::as_str) == Some("test");
+            if is_go_test {
+                assert_eq!(
+                    template.args.get(1).map(String::as_str),
+                    Some("-tags=integration,e2e"),
+                    "expected build tags right after `test` for task {:?}",
+                    template.label
+                );
+            } else {
+                assert!(
+                    !template.args.iter().any(|arg| arg.starts_with("-tags=")),
+                    "non-test task should not receive build tags: {:?}",
+                    template.label
+                );
+            }
+        }
+    }
+
+    #[gpui::test]
+    async fn test_go_build_tags_blank_value_not_injected(cx: &mut TestAppContext) {
+        let templates = cx
+            .update(|cx| {
+                set_go_task_variables(cx, &[(GO_TEST_BUILD_TAGS_STR, " , ")]);
+                GoContextProvider.associated_tasks(None, cx)
+            })
+            .await
+            .unwrap();
+
+        for template in &templates.0 {
+            assert!(
+                !template.args.iter().any(|arg| arg.starts_with("-tags=")),
+                "blank build tags should add no flag: {:?}",
+                template.label
+            );
+        }
     }
 }

--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -111,6 +111,26 @@ You can override the default code lens settings in your `settings.json`:
 
 See [gopls code lenses documentation](https://go.dev/gopls/codelenses) for more information.
 
+## Build Tags
+
+To run tests that are guarded by [build constraints](https://pkg.go.dev/cmd/go#hdr-Build_constraints) (e.g. `//go:build integration`), set the `GO_TEST_BUILD_TAGS` task variable. Zed adds the listed tags as `-tags=...` to every `go test` task it generates:
+
+```json [settings]
+{
+  "languages": {
+    "Go": {
+      "tasks": {
+        "variables": {
+          "GO_TEST_BUILD_TAGS": "integration,e2e"
+        }
+      }
+    }
+  }
+}
+```
+
+List only the tag names (comma or space separated); Zed builds the `-tags` flag for you. This applies to all `go test` tasks (including `go test ./...`) but not to `go run` or `go generate`.
+
 ## Debugging
 
 Zed supports zero-configuration debugging of Go tests and entry points (`func main`) using Delve. Run {#action debugger::Start} ({#kb debugger::Start}) to see a contextual list of these preconfigured debug tasks.


### PR DESCRIPTION
# Objective

Fixes https://github.com/zed-industries/zed/issues/46449

Go projects often guard tests behind [build constraints](https://pkg.go.dev/cmd/go#hdr-Build_constraints) (e.g. `//go:build integration`). Such tests fail to run unless `-tags=...` is passed to `go test`. Until now, build tags could only be set for **debugging** (`buildFlags` in `.zed/debug.json`) and for **gopls analysis** (`lsp.gopls.settings.build.buildFlags`), but **not** for the regular `go test` tasks that Zed runs from code lenses or the task modal. This PR closes that gap.

## Solution

Reuse the existing per-language `tasks.variables` mechanism (the same approach Rust uses for `RUST_TARGET_DIR`), so no changes to the shared settings crates are needed.

- `GoContextProvider::associated_tasks` now reads the `GO_TEST_BUILD_TAGS` task variable, normalizes the comma/space-separated tag names, and builds a single `-tags=<tags>` argument.
- That argument is injected right after `test` into every generated `go test` task (plain `go test`, `go test ./...`, subtests, table tests, testify suites, examples, benchmarks, fuzz). `go run` / `go generate` tasks are intentionally left untouched.
- A blank/whitespace-only value produces no flag.

Users only supply tag names; Zed builds the flag:

```json
{
  "languages": {
    "Go": {
      "tasks": {
        "variables": { "GO_TEST_BUILD_TAGS": "integration,e2e" }
      }
    }
  }
}
```

## Testing
- Added two `#[gpui::test]` cases in `crates/languages/src/go.rs` (there was previously no coverage for `associated_tasks`):
  - tags are injected as `-tags=integration,e2e` immediately after `test` for every `go test` task, and are absent from `go run` / `go generate` tasks;
  - a blank value adds no `-tags=` flag.
- `cargo test -p languages go::tests` — 18 passed.
- `./script/clippy -p languages` — clean.
- Manually verified in Zed: with the setting present, running a test produced `go test -tags=integration -run ^TestX$ ...`; removing the setting dropped the flag.

## Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (There are no unsafe blocks)
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines) (There are no UX/UI changes)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Release Notes:
- Added support for configuring Go build tags for test runs via the `GO_TEST_BUILD_TAGS` task variable.
