### PR TITLE
git_ui: Add `signoff_by_default` config option

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1047,6 +1047,10 @@
     //
     // Default: 0
     "commit_title_max_length": 0,
+    /// Whether the commit should be signed-off by default
+    ///
+    /// Default: false
+    "signoff_by_default": false,
     // Default action when clicking a changed file in the Git panel.
     //
     // Choices: project_diff, file_diff, view_file

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1060,6 +1060,10 @@
     //
     // Default: 0
     "commit_title_max_length": 0,
+    /// Whether the commit should be signed-off by default
+    ///
+    /// Default: false
+    "signoff_by_default": false,
     // Default action when clicking a changed file in the Git panel.
     //
     // Choices: project_diff, file_diff, view_file

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -285,7 +285,7 @@ impl CommitModal {
                 move |window, cx| {
                     let git_panel = git_panel_entity.read(cx);
                     let amend_enabled = git_panel.amend_pending();
-                    let signoff_enabled = git_panel.signoff_enabled();
+                    let signoff_enabled = git_panel.signoff_should_be_enabled();
                     let skip_hooks_enabled = git_panel.skip_hooks_enabled();
                     let has_previous_commit = git_panel.head_commit(cx).is_some();
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1122,7 +1122,6 @@ impl GitPanel {
                         _ => {}
                     }
                 }
-                //TODO: medzernik - make sure it resets properly after commit to default
                 if this.signoff_enabled != was_signedoff_by_default {
                     this.signoff_enabled = signed_by_default;
                 }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -417,6 +417,8 @@ struct SerializedGitPanel {
     #[serde(default)]
     signoff_enabled: bool,
     #[serde(default)]
+    signoff_by_default: bool,
+    #[serde(default)]
     commit_messages: BTreeMap<String, SerializedCommitMessage>,
 }
 
@@ -933,6 +935,7 @@ pub struct GitPanel {
     original_commit_message: Option<String>,
     pending_commit_message_restores: BTreeMap<String, SerializedCommitMessage>,
     signoff_enabled: bool,
+    signoff_by_default: bool,
     skip_hooks_enabled: bool,
     pending_serialization: Task<()>,
     pub(crate) project: Entity<Project>,
@@ -1093,6 +1096,7 @@ impl GitPanel {
             let mut was_file_icons = GitPanelSettings::get_global(cx).file_icons;
             let mut was_folder_icons = GitPanelSettings::get_global(cx).folder_icons;
             let mut was_diff_stats = GitPanelSettings::get_global(cx).diff_stats;
+            let mut was_signedoff_by_default = GitPanelSettings::get_global(cx).signoff_by_default;
             cx.observe_global_in::<SettingsStore>(window, move |this, window, cx| {
                 let settings = GitPanelSettings::get_global(cx);
                 let sort_by = settings.sort_by;
@@ -1101,6 +1105,8 @@ impl GitPanel {
                 let file_icons = settings.file_icons;
                 let folder_icons = settings.folder_icons;
                 let diff_stats = settings.diff_stats;
+                let signed_by_default = settings.signoff_by_default;
+
                 if tree_view != was_tree_view {
                     match (&mut this.view_mode, tree_view) {
                         (GitPanelViewMode::Tree(state), false) => {
@@ -1115,6 +1121,10 @@ impl GitPanel {
                         }
                         _ => {}
                     }
+                }
+                //TODO: medzernik - make sure it resets properly after commit to default
+                if this.signoff_enabled != was_signedoff_by_default {
+                    this.signoff_enabled = signed_by_default;
                 }
 
                 let mut update_entries = false;
@@ -1135,6 +1145,7 @@ impl GitPanel {
                 was_file_icons = file_icons;
                 was_folder_icons = folder_icons;
                 was_diff_stats = diff_stats;
+                was_signedoff_by_default = signed_by_default;
             })
             .detach();
 
@@ -1235,6 +1246,7 @@ impl GitPanel {
                 original_commit_message,
                 pending_commit_message_restores,
                 signoff_enabled,
+                signoff_by_default: false,
                 skip_hooks_enabled: false,
                 pending_serialization: Task::ready(()),
                 single_staged_entry: None,
@@ -1385,6 +1397,7 @@ impl GitPanel {
     fn serialize(&mut self, cx: &mut Context<Self>) {
         let signoff_enabled = self.signoff_enabled;
         let commit_messages = self.serialized_commit_messages(cx);
+        let signoff_by_default = self.signoff_by_default;
         let kvp = KeyValueStore::global(cx);
 
         self.pending_serialization = cx.spawn(async move |git_panel, cx| {
@@ -1411,6 +1424,7 @@ impl GitPanel {
                         serde_json::to_string(&SerializedGitPanel {
                             signoff_enabled,
                             commit_messages,
+                            signoff_by_default,
                         })?,
                     )
                     .await?;
@@ -3019,6 +3033,7 @@ impl GitPanel {
             .ok();
         });
 
+        self.signoff_enabled = GitPanelSettings::get_global(cx).signoff_by_default;
         self.pending_commit = Some(task);
     }
 
@@ -7841,7 +7856,7 @@ impl GitPanel {
     }
 
     pub fn signoff_enabled(&self) -> bool {
-        self.signoff_enabled
+        self.signoff_by_default
     }
 
     pub fn skip_hooks_enabled(&self) -> bool {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -7854,7 +7854,7 @@ impl GitPanel {
         cx.notify();
     }
 
-    pub fn signoff_enabled(&self) -> bool {
+    pub fn signoff_should_be_enabled(&self) -> bool {
         self.signoff_by_default
     }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -8290,7 +8290,7 @@ impl GitPanel {
         cx.notify();
     }
 
-    pub fn signoff_enabled(&self) -> bool {
+    pub fn signoff_should_be_enabled(&self) -> bool {
         self.signoff_by_default
     }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1259,7 +1259,6 @@ impl GitPanel {
                         _ => {}
                     }
                 }
-                //TODO: medzernik - make sure it resets properly after commit to default
                 if this.signoff_enabled != was_signedoff_by_default {
                     this.signoff_enabled = signed_by_default;
                 }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -544,6 +544,8 @@ struct SerializedGitPanel {
     #[serde(default)]
     signoff_enabled: bool,
     #[serde(default)]
+    signoff_by_default: bool,
+    #[serde(default)]
     commit_messages: BTreeMap<String, SerializedCommitMessage>,
 }
 
@@ -1070,6 +1072,7 @@ pub struct GitPanel {
     original_commit_message: Option<String>,
     pending_commit_message_restores: BTreeMap<String, SerializedCommitMessage>,
     signoff_enabled: bool,
+    signoff_by_default: bool,
     skip_hooks_enabled: bool,
     pending_serialization: Task<()>,
     pub(crate) project: Entity<Project>,
@@ -1230,6 +1233,7 @@ impl GitPanel {
             let mut was_file_icons = GitPanelSettings::get_global(cx).file_icons;
             let mut was_folder_icons = GitPanelSettings::get_global(cx).folder_icons;
             let mut was_diff_stats = GitPanelSettings::get_global(cx).diff_stats;
+            let mut was_signedoff_by_default = GitPanelSettings::get_global(cx).signoff_by_default;
             cx.observe_global_in::<SettingsStore>(window, move |this, window, cx| {
                 let settings = GitPanelSettings::get_global(cx);
                 let sort_by = settings.sort_by;
@@ -1238,6 +1242,8 @@ impl GitPanel {
                 let file_icons = settings.file_icons;
                 let folder_icons = settings.folder_icons;
                 let diff_stats = settings.diff_stats;
+                let signed_by_default = settings.signoff_by_default;
+
                 if tree_view != was_tree_view {
                     match (&mut this.view_mode, tree_view) {
                         (GitPanelViewMode::Tree(state), false) => {
@@ -1252,6 +1258,10 @@ impl GitPanel {
                         }
                         _ => {}
                     }
+                }
+                //TODO: medzernik - make sure it resets properly after commit to default
+                if this.signoff_enabled != was_signedoff_by_default {
+                    this.signoff_enabled = signed_by_default;
                 }
 
                 let mut update_entries = false;
@@ -1272,6 +1282,7 @@ impl GitPanel {
                 was_file_icons = file_icons;
                 was_folder_icons = folder_icons;
                 was_diff_stats = diff_stats;
+                was_signedoff_by_default = signed_by_default;
             })
             .detach();
 
@@ -1370,6 +1381,7 @@ impl GitPanel {
                 original_commit_message,
                 pending_commit_message_restores,
                 signoff_enabled,
+                signoff_by_default: false,
                 skip_hooks_enabled: false,
                 pending_serialization: Task::ready(()),
                 single_staged_entry: None,
@@ -1520,6 +1532,7 @@ impl GitPanel {
     fn serialize(&mut self, cx: &mut Context<Self>) {
         let signoff_enabled = self.signoff_enabled;
         let commit_messages = self.serialized_commit_messages(cx);
+        let signoff_by_default = self.signoff_by_default;
         let kvp = KeyValueStore::global(cx);
 
         self.pending_serialization = cx.spawn(async move |git_panel, cx| {
@@ -1546,6 +1559,7 @@ impl GitPanel {
                         serde_json::to_string(&SerializedGitPanel {
                             signoff_enabled,
                             commit_messages,
+                            signoff_by_default,
                         })?,
                     )
                     .await?;
@@ -3344,6 +3358,7 @@ impl GitPanel {
             .ok();
         });
 
+        self.signoff_enabled = GitPanelSettings::get_global(cx).signoff_by_default;
         self.pending_commit = Some(task);
     }
 
@@ -8277,7 +8292,7 @@ impl GitPanel {
     }
 
     pub fn signoff_enabled(&self) -> bool {
-        self.signoff_enabled
+        self.signoff_by_default
     }
 
     pub fn skip_hooks_enabled(&self) -> bool {

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -34,6 +34,7 @@ pub struct GitPanelSettings {
     pub show_count_badge: bool,
     pub starts_open: bool,
     pub commit_title_max_length: usize,
+    pub signoff_by_default: bool,
     pub entry_primary_click_action: GitPanelClickBehavior,
 }
 
@@ -83,6 +84,7 @@ impl Settings for GitPanelSettings {
             show_count_badge: git_panel.show_count_badge.unwrap(),
             starts_open: git_panel.starts_open.unwrap(),
             commit_title_max_length: git_panel.commit_title_max_length.unwrap(),
+            signoff_by_default: git_panel.signoff_by_default.unwrap(),
             entry_primary_click_action: git_panel.entry_primary_click_action.unwrap(),
         }
     }

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -32,6 +32,7 @@ pub struct GitPanelSettings {
     pub show_count_badge: bool,
     pub starts_open: bool,
     pub commit_title_max_length: usize,
+    pub signoff_by_default: bool,
     pub entry_primary_click_action: GitPanelClickBehavior,
 }
 
@@ -81,6 +82,7 @@ impl Settings for GitPanelSettings {
             show_count_badge: git_panel.show_count_badge.unwrap(),
             starts_open: git_panel.starts_open.unwrap(),
             commit_title_max_length: git_panel.commit_title_max_length.unwrap(),
+            signoff_by_default: git_panel.signoff_by_default.unwrap(),
             entry_primary_click_action: git_panel.entry_primary_click_action.unwrap(),
         }
     }

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -750,6 +750,10 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: 0
     pub commit_title_max_length: Option<usize>,
+    /// Whether the commit should be signed-off by default
+    ///
+    /// Default: false
+    pub signoff_by_default: Option<bool>,
 
     /// Default action when clicking a changed file in the Git panel.
     ///

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -779,6 +779,10 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: 0
     pub commit_title_max_length: Option<usize>,
+    /// Whether the commit should be signed-off by default
+    ///
+    /// Default: false
+    pub signoff_by_default: Option<bool>,
 
     /// Default action when clicking a changed file in the Git panel.
     ///

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5931,7 +5931,7 @@ fn panels_page() -> SettingsPage {
         ]
     }
 
-    fn git_panel_section() -> [SettingsPageItem; 17] {
+    fn git_panel_section() -> [SettingsPageItem; 18] {
         [
             SettingsPageItem::SectionHeader("Git Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -6085,6 +6085,29 @@ fn panels_page() -> SettingsPage {
                     },
                     write: |settings_content, value, _| {
                         settings_content.git_panel.get_or_insert_default().tree_view = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Sign-off by default",
+                description: "Enable to automatically sign-off each commit.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("git_panel.signoff_by_default"),
+                    pick: |settings_content| {
+                        settings_content
+                            .git_panel
+                            .as_ref()?
+                            .signoff_by_default
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .git_panel
+                            .get_or_insert_default()
+                            .signoff_by_default = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -6252,6 +6252,29 @@ fn panels_page() -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
+                title: "Sign-off by default",
+                description: "Enable to automatically sign-off each commit.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("git_panel.signoff_by_default"),
+                    pick: |settings_content| {
+                        settings_content
+                            .git_panel
+                            .as_ref()?
+                            .signoff_by_default
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .git_panel
+                            .get_or_insert_default()
+                            .signoff_by_default = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
                 title: "File Icons",
                 description: "Show file icons next to the Git status icon.",
                 field: Box::new(SettingField {

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5500,7 +5500,8 @@ See the [debugger page](../debugger.md) for more information about debugging sup
     "scrollbar": {
       "show": null
     },
-    "starts_open": false
+    "starts_open": false,
+    "signedoff_by_default": false
   }
 }
 ```
@@ -5517,6 +5518,7 @@ See the [debugger page](../debugger.md) for more information about debugging sup
 - `collapse_untracked_diff`: Whether to collapse untracked files in the diff panel
 - `scrollbar`: When to show the scrollbar in the git panel
 - `starts_open`: Whether the git panel should open on startup
+- `signoff_by_default`: Whether the commit should be signed-off by default
 
 ## Git Worktree Directory
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5674,7 +5674,8 @@ See the [debugger page](../debugger.md) for more information about debugging sup
     "scrollbar": {
       "show": null
     },
-    "starts_open": false
+    "starts_open": false,
+    "signedoff_by_default": false
   }
 }
 ```
@@ -5691,6 +5692,7 @@ See the [debugger page](../debugger.md) for more information about debugging sup
 - `collapse_untracked_diff`: Whether to collapse untracked files in the diff panel
 - `scrollbar`: When to show the scrollbar in the git panel
 - `starts_open`: Whether the git panel should open on startup
+- `signoff_by_default`: Whether the commit should be signed-off by default
 
 ## Git Worktree Directory
 


### PR DESCRIPTION
# Objective

I really miss the option of being able to signoff my commits by default. This makes it possible to set the value to something and have it not reset after each commit (or rather, have it re-set to the proper default after each commit)

Please note that I'm still very much new to contributing to Zed, so if there is anything I could do better, I would love to have feedback or tips (maybe for example on how to make it also a project-specific setting :D).

EDIT: Forgot to add this
I also signedoff our commits, declaring that nor I or Stefan have used any AI in the creation of this PR.

## Solution

Me and @stefanfusko added a new config option (global). This config option should always reset the signoff check in the git panel after each commit I am fairly new to Zed contributions, so while a per-project setting would be also nice, I couldn't really figure out yet how to do that. 

## Testing

- Did you test these changes? If so, how?
Yes - I manually tested changing the default value, seeing whether it changed in the git panel, I also changed the git panel option and tested if it resets after the commit (if it differs from the global settings default).
- Are there any parts that need more testing?
I don't think so?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
1. open an empty repo
2. set the config value for signoff_by_default
3. check if it changes the checked status in the git panel
4. (optional) change the signoff option in the panel, making it differ from the general settings
5. after commiting check if the commit has the signedoff state desired, and also if the option is once again checked in the git panel.

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
N/A (macOS but this isn't platform specific)

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="947" height="273" alt="image" src="https://github.com/user-attachments/assets/08f407d3-f7e0-4800-8714-d7b7de95ece8" />


---

Release Notes:

- Added sign-off by default config option (toggle) to reset the value of git panel's signoff after commiting (and to reset the value when the panel is opened/value is set via settings)
