### PR TITLE
git_graph: Selectable commit message in detail panel

### DIFF
--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -19,12 +19,13 @@ use git::{
 use gpui::{
     Action, Anchor, AnyElement, App, Bounds, ClickEvent, ClipboardItem, DefiniteLength,
     DismissEvent, DragMoveEvent, ElementId, Empty, Entity, EventEmitter, FocusHandle, Focusable,
-    Hsla, MouseButton, MouseDownEvent, PathBuilder, Pixels, Point, ScrollStrategy,
+    Hsla, MouseButton, MouseDownEvent, PathBuilder, Pixels, Point, ScrollHandle, ScrollStrategy,
     ScrollWheelEvent, SharedString, Subscription, Task, TextStyleRefinement,
     UniformListScrollHandle, WeakEntity, Window, actions, anchored, deferred, point, prelude::*,
     px, uniform_list,
 };
 use language::line_diff;
+use markdown::{Markdown, MarkdownElement};
 use menu::{Cancel, SelectFirst, SelectLast, SelectNext, SelectPrevious};
 use picker::{Picker, PickerDelegate};
 use project::{
@@ -57,6 +58,7 @@ use ui::{
     prelude::*, render_redistributable_columns_resize_handles, render_table_header,
     table_row::TableRow,
 };
+use util::{ResultExt, debug_panic};
 use workspace::{
     ModalView, Workspace,
     item::{Item, ItemEvent, TabTooltipContent},
@@ -1322,6 +1324,12 @@ struct GitGraphContextMenu {
     _subscription: Subscription,
 }
 
+struct DetailPanelCommitMessage {
+    sha: Oid,
+    message: Entity<Markdown>,
+    scroll_handle: ScrollHandle,
+}
+
 pub struct GitGraph {
     focus_handle: FocusHandle,
     search_state: SearchState,
@@ -1339,6 +1347,8 @@ pub struct GitGraph {
     selected_commit_diff: Option<CommitDiff>,
     selected_commit_diff_stats: Option<(usize, usize)>,
     _commit_diff_task: Option<Task<()>>,
+    selected_commit_message: Option<DetailPanelCommitMessage>,
+    _selected_commit_message_task: Option<Task<()>>,
     commit_details_split_state: Entity<SplitState>,
     repo_id: RepositoryId,
     changed_files_scroll_handle: UniformListScrollHandle,
@@ -1559,6 +1569,8 @@ impl GitGraph {
             graph_canvas_bounds: Rc::new(Cell::new(None)),
             selected_commit_diff: None,
             selected_commit_diff_stats: None,
+            selected_commit_message: None,
+            _selected_commit_message_task: None,
             log_source,
             log_order,
             commit_details_split_state: cx.new(|_cx| SplitState::new()),
@@ -2179,13 +2191,16 @@ impl GitGraph {
             return;
         };
 
-        let sha = commit.data.sha.to_string();
-
         let Some(repository) = self.get_repository(cx) else {
             return;
         };
 
-        let diff_receiver = repository.update(cx, |repo, _| repo.load_commit_diff(sha));
+        let commit_message_handle = commit.data.sha;
+        let diff_handle = commit.data.sha.to_string();
+
+        self.load_selected_commit_message(cx, &commit_message_handle, &repository);
+
+        let diff_receiver = repository.update(cx, |repo, _| repo.load_commit_diff(diff_handle));
 
         self._commit_diff_task = Some(cx.spawn(async move |this, cx| {
             if let Ok(Ok(diff)) = diff_receiver.await {
@@ -2200,6 +2215,70 @@ impl GitGraph {
         }));
 
         cx.emit(ItemEvent::Edit);
+        cx.notify();
+    }
+
+    fn load_selected_commit_message(
+        &mut self,
+        cx: &mut Context<'_, Self>,
+        sha: &Oid,
+        repository: &Entity<Repository>,
+    ) {
+        if self
+            .selected_commit_message
+            .as_ref()
+            .is_some_and(|old| old.sha == *sha)
+        {
+            return;
+        }
+
+        self._selected_commit_message_task = None;
+        match repository.update(cx, |repo, cx| {
+            repo.fetch_commit_data(*sha, true, cx).clone()
+        }) {
+            CommitDataState::Loaded(commit_data) => {
+                self.set_selected_commit_message(cx, commit_data.sha, commit_data.message.clone());
+            }
+            CommitDataState::Loading(Some(receiver)) => {
+                self._selected_commit_message_task = Some(cx.spawn(async move |this, cx| {
+                    if let Ok(commit_data) = receiver.await {
+                        this.update(cx, |this, cx| {
+                            this.set_selected_commit_message(
+                                cx,
+                                commit_data.sha,
+                                commit_data.message.clone(),
+                            );
+                        })
+                        .log_err();
+                    }
+                }))
+            }
+            _ => {
+                debug_panic!(
+                    "fetch_commit_data(_, true, _) failed to return either Loaded(data) or Loading(receiver)"
+                );
+            }
+        };
+    }
+
+    fn set_selected_commit_message(
+        &mut self,
+        cx: &mut Context<'_, GitGraph>,
+        sha: Oid,
+        message: SharedString,
+    ) {
+        let languages = self
+            .workspace
+            .read_with(cx, |workspace, cx| {
+                workspace.project().read(cx).languages().clone()
+            })
+            .log_err();
+        self.selected_commit_message = Some(DetailPanelCommitMessage {
+            sha,
+            message: cx.new(|cx| Markdown::new(message, languages, None, cx)),
+            scroll_handle: ScrollHandle::new(),
+        });
+        self._selected_commit_message_task = None;
         cx.notify();
     }
 
@@ -2815,15 +2894,13 @@ impl GitGraph {
             .copied()
             .unwrap_or_else(|| accent_colors.0.first().copied().unwrap_or_default());
 
-        // todo(git graph): We should use the full commit message here
-        let (author_name, author_email, commit_timestamp, commit_message) = match &data {
+        let (author_name, author_email, commit_timestamp) = match &data {
             CommitDataState::Loaded(data) => (
                 data.author_name.clone(),
                 data.author_email.clone(),
                 Some(data.commit_timestamp),
-                data.subject.clone(),
             ),
-            CommitDataState::Loading(_) => ("Loading…".into(), "".into(), None, "Loading…".into()),
+            CommitDataState::Loading(_) => ("Loading…".into(), "".into(), None),
         };
 
         let date_string = commit_timestamp
@@ -2917,6 +2994,8 @@ impl GitGraph {
                                     this.selected_entry_idx = None;
                                     this.selected_commit_diff = None;
                                     this.selected_commit_diff_stats = None;
+                                    this.selected_commit_message = None;
+                                    this._selected_commit_message_task = None;
                                     this.changed_files_expanded_dirs.clear();
                                     this._commit_diff_task = None;
                                     cx.notify();
@@ -3091,7 +3170,7 @@ impl GitGraph {
                     ),
             )
             .child(Divider::horizontal())
-            .child(div().p_2().child(Label::new(commit_message)))
+            .child(self.render_commit_message(window, cx))
             .child(Divider::horizontal())
             .child(
                 v_flex()
@@ -3720,6 +3799,56 @@ impl GitGraph {
                         cx.stop_propagation();
                     }))
                     .on_drag(DraggedSplitHandle, |_, _, _, cx| cx.new(|_| gpui::Empty)),
+            )
+            .into_any_element()
+    }
+
+    fn render_commit_message(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let Some(DetailPanelCommitMessage {
+            message,
+            scroll_handle,
+            ..
+        }) = self.selected_commit_message.as_ref()
+        else {
+            return Empty.into_any_element();
+        };
+
+        let message_lines = message.read_with(cx, |m, _| m.source().lines().count());
+        let message_style = editor::hover_markdown_style(window, cx);
+        let expanded_height = window.line_height() * 12.min(message_lines);
+
+        v_flex()
+            .py_2()
+            .pl_2()
+            .w_full()
+            .gap_1()
+            .child(
+                h_flex().w_full().child(
+                    div()
+                        .flex_1()
+                        .min_w_0()
+                        // using a calculated `h` here rather than `max_h`
+                        // because `max_h` prevents Taffy from correctly calculating
+                        // the width of the container and so the markdown element
+                        // will render at its full width, overflowing. `h` appears
+                        // to provide enough info to Taffy that it can correctly
+                        // calculate the width.
+                        .h(expanded_height)
+                        .child(
+                            div()
+                                .id("commit-message")
+                                .text_sm()
+                                .size_full()
+                                .overflow_y_scroll()
+                                .track_scroll(scroll_handle)
+                                .child(MarkdownElement::new(message.clone(), message_style)),
+                        )
+                        .vertical_scrollbar_for(scroll_handle, window, cx),
+                ),
             )
             .into_any_element()
     }
@@ -7031,5 +7160,177 @@ mod tests {
             Some("v1.0".into())
         );
         assert_eq!(GitGraph::ref_name_from_decoration("HEAD"), None);
+    }
+
+    #[gpui::test]
+    async fn test_commit_message_rendered_as_markdown(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            Path::new("/project"),
+            json!({ ".git": {}, "file.txt": "content" }),
+        )
+        .await;
+
+        let commit_sha = Oid::from_bytes(&[1; 20]).unwrap();
+        let commits = vec![Arc::new(InitialGraphCommitData {
+            sha: commit_sha,
+            parents: smallvec![],
+            ref_names: vec!["HEAD -> main".into()],
+        })];
+        fs.set_graph_commits(Path::new("/project/.git"), commits);
+        fs.set_commit_data(
+            Path::new("/project/.git"),
+            [(
+                CommitData {
+                    sha: commit_sha,
+                    parents: smallvec![],
+                    author_name: "Author".into(),
+                    author_email: "author@example.com".into(),
+                    commit_timestamp: 1_700_000_000,
+                    subject: "Fix crash".into(),
+                    message: "Fix crash\n\nThis fixes a crash that occurred when...".into(),
+                },
+                false,
+            )],
+        );
+
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        cx.run_until_parked();
+
+        let repository = project.read_with(cx, |project, cx| {
+            project
+                .active_repository(cx)
+                .expect("should have a repository")
+        });
+
+        let (multi_workspace, cx) = cx.add_window_view(|window, cx| {
+            workspace::MultiWorkspace::test_new(project.clone(), window, cx)
+        });
+        let workspace_weak =
+            multi_workspace.read_with(&*cx, |multi, _| multi.workspace().downgrade());
+
+        let git_graph = cx.new_window_entity(|window, cx| {
+            GitGraph::new(
+                repository.read(cx).id,
+                project.read(cx).git_store().clone(),
+                workspace_weak,
+                None,
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        // Select the commit to trigger loading the commit message
+        git_graph.update_in(cx, |graph, window, cx| {
+            graph.select_first(&menu::SelectFirst, window, cx);
+        });
+        cx.run_until_parked();
+
+        // Verify the commit message was loaded as markdown
+        git_graph.read_with(&*cx, |graph, app| {
+            let message = graph
+                .selected_commit_message
+                .as_ref()
+                .expect("selected_commit_message should be Some");
+            assert_eq!(message.sha, commit_sha);
+            let source = message.message.read_with(app, |m, _| m.source().to_owned());
+            assert!(source.contains("Fix crash"));
+            assert!(source.contains("This fixes a crash"));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_commit_message_not_reloaded_for_same_sha(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            Path::new("/project"),
+            json!({ ".git": {}, "file.txt": "content" }),
+        )
+        .await;
+
+        let commit_sha = Oid::from_bytes(&[1; 20]).unwrap();
+        let commits = vec![Arc::new(InitialGraphCommitData {
+            sha: commit_sha,
+            parents: smallvec![],
+            ref_names: vec!["HEAD -> main".into()],
+        })];
+        fs.set_graph_commits(Path::new("/project/.git"), commits);
+        fs.set_commit_data(
+            Path::new("/project/.git"),
+            [(
+                CommitData {
+                    sha: commit_sha,
+                    parents: smallvec![],
+                    author_name: "Author".into(),
+                    author_email: "author@example.com".into(),
+                    commit_timestamp: 1_700_000_000,
+                    subject: "Fix crash".into(),
+                    message: "Fix crash\n\nBody text.".into(),
+                },
+                false,
+            )],
+        );
+
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        cx.run_until_parked();
+
+        let repository = project.read_with(cx, |project, cx| {
+            project
+                .active_repository(cx)
+                .expect("should have a repository")
+        });
+
+        let (multi_workspace, cx) = cx.add_window_view(|window, cx| {
+            workspace::MultiWorkspace::test_new(project.clone(), window, cx)
+        });
+        let workspace_weak =
+            multi_workspace.read_with(&*cx, |multi, _| multi.workspace().downgrade());
+
+        let git_graph = cx.new_window_entity(|window, cx| {
+            GitGraph::new(
+                repository.read(cx).id,
+                project.read(cx).git_store().clone(),
+                workspace_weak,
+                None,
+                window,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        // Select the commit to load the message
+        git_graph.update_in(cx, |graph, window, cx| {
+            graph.select_first(&menu::SelectFirst, window, cx);
+        });
+        cx.run_until_parked();
+
+        // Verify message is loaded
+        let message_entity_id = git_graph.read_with(&*cx, |graph, _| {
+            graph
+                .selected_commit_message
+                .as_ref()
+                .map(|m| m.message.entity_id())
+        });
+        assert!(message_entity_id.is_some());
+
+        // Select the same commit again to trigger the early-return logic
+        git_graph.update_in(cx, |graph, window, cx| {
+            graph.select_first(&menu::SelectFirst, window, cx);
+        });
+        cx.run_until_parked();
+
+        // Verify the message entity is the same (not replaced)
+        git_graph.read_with(&*cx, |graph, _| {
+            let new_entity_id = graph
+                .selected_commit_message
+                .as_ref()
+                .map(|m| m.message.entity_id());
+            assert_eq!(message_entity_id, new_entity_id);
+        });
     }
 }

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -2255,7 +2255,7 @@ impl GitGraph {
             }
             _ => {
                 debug_panic!(
-                    "fetch_commit_data(_, true, _) failed to return either Loaded(data) or Loading(receiver)"
+                    "Fetched commit data asynchronously, but was not given a listener or cached commit data."
                 );
             }
         };
@@ -3817,44 +3817,35 @@ impl GitGraph {
             return Empty.into_any_element();
         };
 
-        let message_lines = message.read_with(cx, |m, _| m.source().lines().count());
         let message_style = editor::hover_markdown_style(window, cx);
         let rem_size = window.rem_size();
         let line_height = message_style
             .base_text_style
             .line_height_in_pixels(rem_size);
-        // TODO: How to handle commit messages that have fewer than 12 lines, but the
-        // lines are very long, i.e. how to account for reflow.
-        let expanded_height = line_height * 12.min(message_lines);
 
-        v_flex()
+        div()
+            // Using grid over flexbox because the structure of this side
+            // panel prvents taffy from calculating a concrete width correctly,
+            // which causes problems with text reflow when using flexbox.
+            // grid, on the other hand, doesn't appear to give taffy the same
+            // problems.
+            .grid()
             .py_2()
             .pl_2()
             .w_full()
             .gap_1()
+            .grid_cols(1)
+            // Value of 12 taken from ./commit_view.rs:725
+            .max_h(line_height * 12.)
             .child(
-                h_flex().w_full().child(
-                    div()
-                        .flex_1()
-                        .min_w_0()
-                        // using a calculated `h` here rather than `max_h`
-                        // because `max_h` prevents Taffy from correctly calculating
-                        // the width of the container and so the markdown element
-                        // will render at its full width, overflowing. `h` appears
-                        // to provide enough info to Taffy that it can correctly
-                        // calculate the width.
-                        .h(expanded_height)
-                        .child(
-                            div()
-                                .id("commit-message")
-                                .text_sm()
-                                .size_full()
-                                .overflow_y_scroll()
-                                .track_scroll(scroll_handle)
-                                .child(MarkdownElement::new(message.clone(), message_style)),
-                        )
-                        .vertical_scrollbar_for(scroll_handle, window, cx),
-                ),
+                div()
+                    .id("commit-message")
+                    .text_sm()
+                    .size_full()
+                    .overflow_y_scroll()
+                    .track_scroll(scroll_handle)
+                    .child(MarkdownElement::new(message.clone(), message_style))
+                    .vertical_scrollbar_for(scroll_handle, window, cx),
             )
             .into_any_element()
     }

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -3819,7 +3819,13 @@ impl GitGraph {
 
         let message_lines = message.read_with(cx, |m, _| m.source().lines().count());
         let message_style = editor::hover_markdown_style(window, cx);
-        let expanded_height = window.line_height() * 12.min(message_lines);
+        let rem_size = window.rem_size();
+        let line_height = message_style
+            .base_text_style
+            .line_height_in_pixels(rem_size);
+        // TODO: How to handle commit messages that have fewer than 12 lines, but the
+        // lines are very long, i.e. how to account for reflow.
+        let expanded_height = line_height * 12.min(message_lines);
 
         v_flex()
             .py_2()


### PR DESCRIPTION
# Objective

Fixes #57766 

Allow users to select and copy the text of commit messages from the git graph details panel.

## Solution

Implements selectable commit message in the detail panel using `MarkdownElement`s a la `commit_view`.

### Affordances considered and abandoned:

- "copy message" and/or "copy subject" buttons, but the UI here is already pretty tight and I don't feel confident enough in my design chops or familiarity with Zed to propose bigger UI changes here.

- Default-collapsed message with expand button, a la `commit_view`. The use-case of this panel is to get the gist of a commit while moving somewhat quickly through the graph. One might argue that the subject line alone is enough for that, but often it isn't and the thought of having to constantly expand commit messages rather than making the message immediately visible with scroll felt like it would produce a repetitious experience.

## Testing

- Adds two unit tests to verify that selection works and is idempotent

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Video demonstrating the functionality:
https://github.com/user-attachments/assets/b910aaa3-2db2-4da8-904b-21b270677ca9

---

Release Notes:

- Show full commit message as markdown in details panel of the git graph
