### PR TITLE
Fix compaction happening too early for chatgpt_subscribed

### DIFF
--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -322,15 +322,17 @@ impl ChatGptModel {
     }
 
     fn max_token_count(&self) -> u64 {
-        // All Codex-supported models share the backend's 272K input cap, even
-        // when the raw model exposes a larger context window via the public
-        // API (e.g. gpt-5.4 has max_context_window 1M, but the Codex backend
-        // caps it at 272K). Source: openai/codex models-manager/models.json.
+        // All Codex-supported models use a 272K context window in the Codex
+        // backend, even when the raw model exposes a larger context window via the
+        // public API (e.g. gpt-5.4 has max_context_window 1M, but Codex uses
+        // context_window 272K). Source: openai/codex models-manager/models.json.
         272_000
     }
 
     fn max_output_tokens(&self) -> Option<u64> {
-        Some(128_000)
+        // Codex model metadata does not expose a max output token cap for these
+        // models. Source: openai/codex models-manager/models.json.
+        None
     }
 
     fn supports_images(&self) -> bool {


### PR DESCRIPTION
# Objective
 
Fixes auto-compaction for ChatGPT Subscription / Codex-backed GPT models by treating the Codex `context_window` as the usable context budget instead of reserving an inferred `128k` output budget.
 
- Fixes #59555 

## Solution

Zed previously reported `max_output_tokens = 128_000` for `openai_subscribed` models. Generic agent code subtracts `max_output_tokens` from `max_token_count` when computing the effective input budget, so `openai_subscribed` models ended up with:

- `max_token_count = 272_000`
- `max_output_tokens = 128_000`
- effective compaction budget = `144_000`
- default `90%` threshold = `129_600`

## Testing

Tested with a heavy prompt to confirm that the auto compaction is indeed now triggered at 90% (default) 

<img width="385" height="183" alt="image" src="https://github.com/user-attachments/assets/da569152-f687-4366-868a-a6559b948ce5" />

This made Zed compact around the halfway point of the actual Codex context window.

Codex model metadata exposes `context_window = 272000` and does not expose a `max_output_tokens` cap. Codex also compacts against the context window directly, rather than subtracting an output reservation. The subscribed backend also rejects the `max_output_tokens` request parameter, so Zed already omits it when serializing requests.

This change makes `openai_subscribed` report no known max output token cap, which matches also that split token display is disabled for these models.


## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

---

Release Notes:

- agent: Fix compaction happening too early when using the ChatGPT subscription provider.
