### PR TITLE
settings_ui: Fix env var name input for local MCPs

### DIFF
--- a/crates/settings_ui/src/pages/mcp_servers_page.rs
+++ b/crates/settings_ui/src/pages/mcp_servers_page.rs
@@ -1045,7 +1045,7 @@ fn render_kv_section(
                     h_flex()
                         .gap_1()
                         .items_center()
-                        .child(div().flex_1().min_w_0().child(input_box(&row.key, cx)))
+                        .child(input_box(&row.key, cx))
                         .child(
                             IconButton::new((kind.remove_id(), ix), IconName::Close)
                                 .icon_size(IconSize::Small)


### PR DESCRIPTION
I wanted to add env vars to a local MCP server from the settings UI, and notices the variable name input does not work. This fixes it.

The key input was wrapped in `div().flex_1().min_w_0()` while the value was rendered directly. A single-line editor asks for `width: 100%`, which needs a parent with a definite width to resolve against; `flex-basis: 0` together with `min-width: 0` collapses that width to zero, and a zero-width editor paints no hitbox and so never receives focus or input. Removing the wrapper so the key renders like the value (matching the equivalent inputs on the external agents form) fixes it. The key/value section is shared, so this also restores header editing for remote servers, not just env vars for local ones.

Current Nightly:

https://github.com/user-attachments/assets/f6419785-69e4-482d-9cd5-3e60abafb431

This branch:

https://github.com/user-attachments/assets/b9a85be5-208c-4779-9b48-154f08c7fd04

Release Notes:

- N/A


