### PR TITLE
Migrate missed pickers to new width system

### DIFF
--- a/crates/agent_ui/src/agent_configuration/tool_picker.rs
+++ b/crates/agent_ui/src/agent_configuration/tool_picker.rs
@@ -25,7 +25,14 @@ impl ToolPicker {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx).modal(false));
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx)
+                .modal(false)
+                .initial_width(rems(34.))
+                .minimum_results_width(rems(34.))
+                .height(rems(24.))
+                .no_vertical_padding()
+        });
         Self { picker }
     }
 
@@ -34,7 +41,14 @@ impl ToolPicker {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let picker = cx.new(|cx| Picker::list(delegate, window, cx).modal(false));
+        let picker = cx.new(|cx| {
+            Picker::list(delegate, window, cx)
+                .modal(false)
+                .initial_width(rems(34.))
+                .minimum_results_width(rems(34.))
+                .height(rems(24.))
+                .no_vertical_padding()
+        });
         Self { picker }
     }
 }
@@ -49,7 +63,7 @@ impl Focusable for ToolPicker {
 
 impl Render for ToolPicker {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(34.)).child(self.picker.clone())
+        v_flex().child(self.picker.clone())
     }
 }
 

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -50,8 +50,12 @@ pub fn language_model_selector(
             .minimum_results_width(rems(20.))
             .height(rems(20.))
             .no_vertical_padding()
+            .modal(false)
     } else {
-        Picker::list(delegate, window, cx).show_scrollbar(true)
+        Picker::list(delegate, window, cx)
+            .show_scrollbar(true)
+            .minimum_results_width(rems(20.))
+            .initial_width(rems(20.))
     }
 }
 

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -1135,6 +1135,10 @@ impl ProjectPickerModal {
             Picker::list(delegate, window, cx)
                 .list_measure_all()
                 .modal(false)
+                .initial_width(rems(34.))
+                .minimum_results_width(rems(34.))
+                .height(rems(24.))
+                .no_vertical_padding()
         });
 
         let picker_focus_handle = picker.focus_handle(cx);
@@ -1188,7 +1192,6 @@ impl Render for ProjectPickerModal {
         v_flex()
             .key_context("ProjectPickerModal")
             .elevation_3(cx)
-            .w(rems(34.))
             .on_action(cx.listener(|this, _: &workspace::Open, window, cx| {
                 this.picker.update(cx, |picker, cx| {
                     picker.delegate.open_local_folder(window, cx)

--- a/crates/collab_ui/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui/src/collab_panel/channel_modal.rs
@@ -66,6 +66,10 @@ impl ChannelModal {
                 cx,
             )
             .modal(false)
+            .initial_width(rems(34.))
+            .minimum_results_width(rems(34.))
+            .height(rems(24.))
+            .no_vertical_padding()
         });
 
         Self {
@@ -146,7 +150,6 @@ impl Render for ChannelModal {
             .on_action(cx.listener(Self::toggle_mode))
             .on_action(cx.listener(Self::dismiss))
             .elevation_3(cx)
-            .w(rems(34.))
             .child(
                 v_flex()
                     .px_2()

--- a/crates/collab_ui/src/collab_panel/contact_finder.rs
+++ b/crates/collab_ui/src/collab_panel/contact_finder.rs
@@ -21,7 +21,14 @@ impl ContactFinder {
             potential_contacts: Arc::from([]),
             selected_index: 0,
         };
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx).modal(false));
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx)
+                .modal(false)
+                .initial_width(rems(34.))
+                .minimum_results_width(rems(34.))
+                .height(rems(24.))
+                .no_vertical_padding()
+        });
 
         Self { picker }
     }
@@ -48,7 +55,6 @@ impl Render for ContactFinder {
                     .child(h_flex().child(Label::new("Invite new contacts"))),
             )
             .child(self.picker.clone())
-            .w(rems(34.))
     }
 }
 

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -127,7 +127,7 @@ impl CommandPalette {
         let picker = cx.new(|cx| {
             let picker = Picker::uniform_list(delegate, window, cx)
                 .initial_width(rems(34.))
-                .minimum_results_width(rems(30.))
+                .minimum_results_width(rems(34.))
                 .height(rems(24.))
                 .no_vertical_padding();
             picker.set_query(query, window, cx);

--- a/crates/debugger_ui/src/attach_modal.rs
+++ b/crates/debugger_ui/src/attach_modal.rs
@@ -104,6 +104,10 @@ impl AttachModal {
                 cx,
             )
             .modal(modal)
+            .initial_width(rems(34.))
+            .minimum_results_width(rems(34.))
+            .height(rems(24.))
+            .no_vertical_padding()
         });
         Self {
             _subscription: cx.subscribe(&picker, |_, _, _, cx| {
@@ -119,7 +123,6 @@ impl Render for AttachModal {
         v_flex()
             .key_context("AttachModal")
             .track_focus(&self.focus_handle(cx))
-            .w(rems(34.))
             .child(self.picker.clone())
     }
 }

--- a/crates/encoding_selector/src/encoding_selector.rs
+++ b/crates/encoding_selector/src/encoding_selector.rs
@@ -6,7 +6,7 @@ use encoding_rs::Encoding;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{
     App, AppContext, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
-    InteractiveElement, ParentElement, Render, Styled, Task, WeakEntity, Window, actions,
+    InteractiveElement, ParentElement, Render, Task, WeakEntity, Window, actions,
 };
 use language::Buffer;
 use picker::{Picker, PickerDelegate};
@@ -95,7 +95,13 @@ impl EncodingSelector {
 
     fn new(buffer: Entity<Buffer>, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let delegate = EncodingSelectorDelegate::new(cx.entity().downgrade(), buffer);
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx)
+                .initial_width(gpui::rems(34.))
+                .minimum_results_width(gpui::rems(34.))
+                .height(gpui::rems(24.))
+                .no_vertical_padding()
+        });
         Self { picker }
     }
 }
@@ -104,7 +110,6 @@ impl Render for EncodingSelector {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl gpui::IntoElement {
         v_flex()
             .key_context("EncodingSelector")
-            .w(gpui::rems(34.))
             .child(self.picker.clone())
     }
 }

--- a/crates/extensions_ui/src/extension_version_selector.rs
+++ b/crates/extensions_ui/src/extension_version_selector.rs
@@ -30,7 +30,7 @@ impl Focusable for ExtensionVersionSelector {
 
 impl Render for ExtensionVersionSelector {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(34.)).child(self.picker.clone())
+        v_flex().child(self.picker.clone())
     }
 }
 
@@ -40,7 +40,13 @@ impl ExtensionVersionSelector {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx)
+                .initial_width(rems(34.))
+                .minimum_results_width(rems(34.))
+                .height(rems(24.))
+                .no_vertical_padding()
+        });
         Self { picker }
     }
 }

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -171,6 +171,7 @@ impl FileFinder {
         let project = delegate.project.clone();
         let picker = cx.new(|cx| {
             let picker = Picker::uniform_list_with_preview(delegate, project, window, cx)
+                .minimum_results_width(gpui::rems(34.))
                 .height(gpui::rems(24.))
                 .no_vertical_padding();
             // The dedicated file finder width setting has been removed in favor of

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -108,7 +108,13 @@ impl CommitTagPicker {
             tag_names,
             selected_index: 0,
         };
-        let picker = cx.new(|cx| Picker::nonsearchable_uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::nonsearchable_uniform_list(delegate, window, cx)
+                .initial_width(COMMIT_TAG_LIST_WIDTH_IN_REMS)
+                .minimum_results_width(COMMIT_TAG_LIST_WIDTH_IN_REMS)
+                .height(rems(24.))
+                .no_vertical_padding()
+        });
         Self { picker }
     }
 }
@@ -124,9 +130,7 @@ impl Focusable for CommitTagPicker {
 
 impl Render for CommitTagPicker {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex()
-            .w(COMMIT_TAG_LIST_WIDTH_IN_REMS)
-            .child(self.picker.clone())
+        v_flex().child(self.picker.clone())
     }
 }
 

--- a/crates/git_ui/src/picker_prompt.rs
+++ b/crates/git_ui/src/picker_prompt.rs
@@ -4,8 +4,7 @@ use fuzzy::{StringMatch, StringMatchCandidate};
 use core::cmp;
 use gpui::{
     App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, ParentElement, Render, SharedString, Styled, Subscription, Task, WeakEntity,
-    Window, rems,
+    IntoElement, ParentElement, Render, SharedString, Subscription, Task, WeakEntity, Window, rems,
 };
 use picker::{Picker, PickerDelegate};
 use std::sync::Arc;
@@ -15,7 +14,6 @@ use workspace::{ModalView, Workspace};
 
 pub struct PickerPrompt {
     pub picker: Entity<Picker<PickerPromptDelegate>>,
-    rem_width: f32,
     _subscription: Subscription,
 }
 
@@ -57,11 +55,16 @@ impl PickerPrompt {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx)
+                .initial_width(rems(rem_width))
+                .minimum_results_width(rems(rem_width))
+                .height(rems(24.))
+                .no_vertical_padding()
+        });
         let _subscription = cx.subscribe(&picker, |_, _, _, cx| cx.emit(DismissEvent));
         Self {
             picker,
-            rem_width,
             _subscription,
         }
     }
@@ -78,7 +81,6 @@ impl Focusable for PickerPrompt {
 impl Render for PickerPrompt {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
-            .w(rems(self.rem_width))
             .child(self.picker.clone())
             .on_mouse_down_out(cx.listener(|this, _, window, cx| {
                 this.picker.update(cx, |this, cx| {

--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -129,6 +129,7 @@ impl WorktreePicker {
                 .list_measure_all()
                 .show_scrollbar(true)
                 .modal(false)
+                .initial_width(rems(34.))
                 .minimum_results_width(rems(34.))
                 .height(rems(20.))
                 .no_vertical_padding()
@@ -243,7 +244,6 @@ impl Render for WorktreePicker {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
             .key_context("WorktreePicker")
-            .w(rems(34.))
             .elevation_3(cx)
             .child(self.picker.clone())
             .on_modifiers_changed(cx.listener(Self::handle_modifiers_changed))

--- a/crates/language_selector/src/language_selector.rs
+++ b/crates/language_selector/src/language_selector.rs
@@ -6,7 +6,7 @@ use editor::Editor;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{
     App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, ParentElement,
-    Render, Styled, TaskExt, WeakEntity, Window, actions,
+    Render, TaskExt, WeakEntity, Window, actions,
 };
 use language::{Buffer, LanguageMatcher, LanguageName, LanguageRegistry};
 use open_path_prompt::file_finder_settings::FileFinderSettings;
@@ -83,7 +83,13 @@ impl LanguageSelector {
             current_language_name,
         );
 
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx)
+                .initial_width(rems(34.))
+                .minimum_results_width(rems(34.))
+                .height(rems(24.))
+                .no_vertical_padding()
+        });
         Self { picker }
     }
 }
@@ -92,7 +98,6 @@ impl Render for LanguageSelector {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
             .key_context("LanguageSelector")
-            .w(rems(34.))
             .child(self.picker.clone())
     }
 }

--- a/crates/line_ending_selector/src/line_ending_selector.rs
+++ b/crates/line_ending_selector/src/line_ending_selector.rs
@@ -65,14 +65,20 @@ impl LineEndingSelector {
         let line_ending = buffer.read(cx).line_ending();
         let delegate =
             LineEndingSelectorDelegate::new(cx.entity().downgrade(), buffer, project, line_ending);
-        let picker = cx.new(|cx| Picker::nonsearchable_uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::nonsearchable_uniform_list(delegate, window, cx)
+                .initial_width(rems(34.))
+                .minimum_results_width(rems(34.))
+                .height(rems(24.))
+                .no_vertical_padding()
+        });
         Self { picker }
     }
 }
 
 impl Render for LineEndingSelector {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(34.)).child(self.picker.clone())
+        v_flex().child(self.picker.clone())
     }
 }
 

--- a/crates/onboarding/src/base_keymap_picker.rs
+++ b/crates/onboarding/src/base_keymap_picker.rs
@@ -61,14 +61,20 @@ impl BaseKeymapSelector {
         window: &mut Window,
         cx: &mut Context<BaseKeymapSelector>,
     ) -> Self {
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx)
+                .initial_width(rems(34.))
+                .minimum_results_width(rems(34.))
+                .height(rems(24.))
+                .no_vertical_padding()
+        });
         Self { picker }
     }
 }
 
 impl Render for BaseKeymapSelector {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(34.)).child(self.picker.clone())
+        v_flex().child(self.picker.clone())
     }
 }
 

--- a/crates/picker/src/popover_menu.rs
+++ b/crates/picker/src/popover_menu.rs
@@ -36,6 +36,7 @@ where
         anchor: Anchor,
         cx: &mut App,
     ) -> Self {
+        picker.update(cx, |picker, _| picker.is_modal = false);
         Self {
             _subscriptions: vec![cx.subscribe(&picker, |picker, &DismissEvent, cx| {
                 picker.update(cx, |_, cx| cx.emit(DismissEvent));

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -404,7 +404,10 @@ impl ProjectPicker {
 
         let picker = cx.new(|cx| {
             let picker = Picker::uniform_list(delegate, window, cx)
+                .initial_width(rems(34.))
                 .minimum_results_width(rems(34.))
+                .height(rems(24.))
+                .no_vertical_padding()
                 .modal(false);
             picker.set_query(&home_dir.to_string(), window, cx);
             picker

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -55,6 +55,9 @@ impl SidebarRecentProjects {
                 Picker::list(delegate, window, cx)
                     .list_measure_all()
                     .show_scrollbar(true)
+                    .initial_width(rems(18.))
+                    .minimum_results_width(rems(18.))
+                    .modal(false)
             });
 
             let picker_focus_handle = picker.focus_handle(cx);

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -484,6 +484,7 @@ where
                 .minimum_results_width(rems(34.))
                 .height(rems(24.))
                 .no_vertical_padding()
+                .modal(false)
         });
 
         PopoverMenu::new("kernel-switcher")

--- a/crates/search/src/text_finder.rs
+++ b/crates/search/src/text_finder.rs
@@ -9,7 +9,7 @@ use picker::Picker;
 
 use project::ProjectPath;
 use text::Anchor;
-use ui::Window;
+use ui::{Rems, Window};
 use workspace::{DismissDecision, ModalView, Workspace};
 
 mod delegate;
@@ -223,7 +223,10 @@ impl TextFinder {
 
     fn new(delegate: Delegate, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let project = delegate.project(cx).clone();
-        let picker = cx.new(|cx| Picker::list_with_preview(delegate, project, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::list_with_preview(delegate, project, window, cx)
+                .minimum_results_width(Rems(20.0))
+        });
         let picker_weak = picker.downgrade();
         let picker_focus_handle = picker.focus_handle(cx);
         picker.update(cx, |picker, cx| {

--- a/crates/settings_profile_selector/src/settings_profile_selector.rs
+++ b/crates/settings_profile_selector/src/settings_profile_selector.rs
@@ -42,7 +42,7 @@ impl Focusable for SettingsProfileSelector {
 
 impl Render for SettingsProfileSelector {
     fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(22.)).child(self.picker.clone())
+        v_flex().child(self.picker.clone())
     }
 }
 
@@ -52,7 +52,13 @@ impl SettingsProfileSelector {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx)
+                .initial_width(rems(22.))
+                .minimum_results_width(rems(22.))
+                .height(rems(24.))
+                .no_vertical_padding()
+        });
         Self { picker }
     }
 }

--- a/crates/settings_ui/src/components/font_picker.rs
+++ b/crates/settings_ui/src/components/font_picker.rs
@@ -183,4 +183,5 @@ pub fn font_picker(
         .minimum_results_width(rems_from_px(210.))
         .height(rems(18.))
         .no_vertical_padding()
+        .modal(false)
 }

--- a/crates/settings_ui/src/components/icon_theme_picker.rs
+++ b/crates/settings_ui/src/components/icon_theme_picker.rs
@@ -196,4 +196,5 @@ pub fn icon_theme_picker(
         .minimum_results_width(rems_from_px(210.))
         .height(rems(18.))
         .no_vertical_padding()
+        .modal(false)
 }

--- a/crates/settings_ui/src/components/ollama_model_picker.rs
+++ b/crates/settings_ui/src/components/ollama_model_picker.rs
@@ -207,6 +207,7 @@ pub fn render_ollama_model_picker(
                     .minimum_results_width(rems_from_px(210.))
                     .height(rems(18.))
                     .no_vertical_padding()
+                    .modal(false)
             }))
         })
         .anchor(gpui::Anchor::TopLeft)

--- a/crates/settings_ui/src/components/theme_picker.rs
+++ b/crates/settings_ui/src/components/theme_picker.rs
@@ -181,4 +181,5 @@ pub fn theme_picker(
         .minimum_results_width(rems_from_px(210.))
         .height(rems(18.))
         .no_vertical_padding()
+        .modal(false)
 }

--- a/crates/snippets_ui/src/snippets_ui.rs
+++ b/crates/snippets_ui/src/snippets_ui.rs
@@ -111,7 +111,13 @@ impl ScopeSelector {
         let delegate =
             ScopeSelectorDelegate::new(workspace, cx.entity().downgrade(), language_registry);
 
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx)
+                .initial_width(rems(34.))
+                .minimum_results_width(rems(34.))
+                .height(rems(24.))
+                .no_vertical_padding()
+        });
 
         Self { picker }
     }
@@ -129,7 +135,7 @@ impl Focusable for ScopeSelector {
 
 impl Render for ScopeSelector {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(34.)).child(self.picker.clone())
+        v_flex().child(self.picker.clone())
     }
 }
 

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -176,6 +176,8 @@ impl TabSwitcher {
                 } else {
                     Picker::nonsearchable_list(delegate, window, cx)
                 }
+                .initial_width(rems(PANEL_WIDTH_REMS))
+                .minimum_results_width(rems(PANEL_WIDTH_REMS))
             }),
             init_modifiers,
         }

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -149,6 +149,10 @@ impl TasksModal {
                 cx,
             )
             .modal(is_modal)
+            .initial_width(rems(34.))
+            .minimum_results_width(rems(34.))
+            .height(rems(24.))
+            .no_vertical_padding()
         });
         let mut _subscriptions = [
             cx.subscribe(&picker, |_, _, _: &DismissEvent, cx| {
@@ -211,7 +215,6 @@ impl Render for TasksModal {
     ) -> impl gpui::prelude::IntoElement {
         v_flex()
             .key_context("TasksModal")
-            .w(rems(34.))
             .child(self.picker.clone())
     }
 }

--- a/crates/theme_selector/src/icon_theme_selector.rs
+++ b/crates/theme_selector/src/icon_theme_selector.rs
@@ -45,7 +45,11 @@ impl IconThemeSelector {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx)
+                .initial_width(rems(34.))
+                .minimum_results_width(rems(34.))
+        });
         Self { picker }
     }
 }

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -119,7 +119,11 @@ impl ThemeSelector {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx)
+                .initial_width(rems(34.))
+                .minimum_results_width(rems(34.))
+        });
         Self { picker }
     }
 }

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -112,7 +112,9 @@ impl AddToolchainState {
             let (lister, rx) = Self::create_path_browser_delegate(project.clone(), cx);
             let path_style = project.read(cx).path_style(cx);
             let picker = cx.new(|cx| {
-                let picker = Picker::uniform_list(lister, window, cx);
+                let picker = Picker::uniform_list(lister, window, cx)
+                    .initial_width(rems(34.))
+                    .minimum_results_width(rems(34.));
                 let mut worktree_root = worktree_root_path.to_string_lossy().into_owned();
                 worktree_root.push_str(path_style.primary_separator());
                 picker.set_query(&worktree_root, window, cx);
@@ -232,7 +234,9 @@ impl AddToolchainState {
                             let (delegate, rx) =
                                 Self::create_path_browser_delegate(this.project.clone(), cx);
                             picker.update(cx, |picker, cx| {
-                                *picker = Picker::uniform_list(delegate, window, cx);
+                                *picker = Picker::uniform_list(delegate, window, cx)
+                                    .initial_width(rems(34.))
+                                    .minimum_results_width(rems(34.));
                                 picker.set_query(path.to_string_lossy().as_ref(), window, cx);
                             });
                             *input_state = Self::wait_for_path(rx, window, cx);
@@ -684,6 +688,8 @@ impl ToolchainSelector {
                     cx,
                 );
                 Picker::uniform_list(delegate, window, cx)
+                    .initial_width(rems(34.))
+                    .minimum_results_width(rems(34.))
             });
             let picker_focus_handle = picker.focus_handle(cx);
             picker.update(cx, |picker, _| {


### PR DESCRIPTION
# Objective

- Fixes #59643.

## Problems

- Initial and minimum width was not migrated for all pickers.
- Some pickers had their width still determined by their wrapper. 
- Some pickers where not modals but did not have modal false set.

## Solution
- Migrate the pickers we missed.
- Remove the width being set on the div's wrapping the pickers.
- Set modal false on the missed pickers.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
