### PR TITLE
Remove cherry-pick-bot config

### DIFF
--- a/.github/cherry-pick-bot.yml
+++ b/.github/cherry-pick-bot.yml
@@ -1,2 +1,0 @@
-enabled: true
-preservePullRequestTitle: true

--- a/script/cherry-pick
+++ b/script/cherry-pick
@@ -1,4 +1,4 @@
-# #!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 if [ "$#" -ne 3 ]; then


### PR DESCRIPTION
Although not listed on https://killedbygoogle.com/, the Google cherry-pick bot was killed some time ago and we now use our own bot for this. Thus we can safely remove the config here.

Also, fixes the shebang in the cherry-pick script.

Release Notes:

- N/A