### PR TITLE
agent_ui: Close search when hitting escape from message editor

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_search_bar.rs
+++ b/crates/agent_ui/src/conversation_view/thread_search_bar.rs
@@ -744,7 +744,7 @@ impl Render for ThreadSearchBar {
                     .border_color(theme.border)
                     .bg(theme.editor_background)
                     .rounded_md()
-                    .child(div().flex_1().child(render_query_input(
+                    .child(div().px_1().flex_1().child(render_query_input(
                         &self.query_editor,
                         in_error_state,
                         cx,
@@ -814,7 +814,7 @@ impl Render for ThreadSearchBar {
 
         v_flex()
             .w_full()
-            .p_2()
+            .p_1p5()
             .bg(theme.panel_background)
             .border_b_1()
             .border_color(theme.border.opacity(0.6))

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -1079,7 +1079,11 @@ impl ThreadView {
         match event {
             MessageEditorEvent::Send => self.send(window, cx),
             MessageEditorEvent::SendImmediately => self.interrupt_and_send(window, cx),
-            MessageEditorEvent::Cancel => self.cancel_generation(cx),
+            MessageEditorEvent::Cancel => {
+                if !self.close_thread_search(window, cx) {
+                    self.cancel_generation(cx);
+                }
+            }
             MessageEditorEvent::Focus => {
                 self.cancel_editing(&Default::default(), window, cx);
             }
@@ -6321,6 +6325,27 @@ impl ThreadView {
         }
     }
 
+    /// Hides the thread search bar, clears its highlights, and returns focus to
+    /// the message editor. Returns `true` if the search bar was visible.
+    pub(crate) fn close_thread_search(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if !self.thread_search_visible {
+            return false;
+        }
+
+        if let Some(bar) = self.thread_search_bar.clone() {
+            bar.update(cx, |bar, cx| bar.clear_highlights(cx));
+        }
+
+        self.thread_search_visible = false;
+        self.message_editor.focus_handle(cx).focus(window, cx);
+        cx.notify();
+        true
+    }
+
     pub(crate) fn toggle_search(
         &mut self,
         _: &crate::ToggleSearch,
@@ -10993,27 +11018,15 @@ impl Render for ThreadView {
             }))
             .on_action(cx.listener(
                 |this, _: &super::thread_search_bar::DismissThreadSearch, window, cx| {
-                    if let Some(bar) = this.thread_search_bar.clone() {
-                        bar.update(cx, |bar, cx| bar.clear_highlights(cx));
-                    }
-                    this.thread_search_visible = false;
-                    this.message_editor.focus_handle(cx).focus(window, cx);
-                    cx.notify();
+                    this.close_thread_search(window, cx);
                 },
             ))
             // Esc can arrive as `editor::Cancel` from the query editor.
             .on_action(
                 cx.listener(|this, _: &editor::actions::Cancel, window, cx| {
-                    if !this.thread_search_visible {
+                    if !this.close_thread_search(window, cx) {
                         cx.propagate();
-                        return;
                     }
-                    if let Some(bar) = this.thread_search_bar.clone() {
-                        bar.update(cx, |bar, cx| bar.clear_highlights(cx));
-                    }
-                    this.thread_search_visible = false;
-                    this.message_editor.focus_handle(cx).focus(window, cx);
-                    cx.notify();
                 }),
             )
             .on_action(cx.listener(


### PR DESCRIPTION
This PR makes the search-closing behavior consistent with regular buffers, where hitting escape when focused in the message editor will close it (before it cancels the message). Also, made the whole search bar height match the toolbar for perfect grid alignment.

Release Notes:

- Agent: Fixed the closing behavior of the in-thread search by enabling `escape` to close it when focused in the message editor.
