### PR TITLE
worktree: Service path-prefix scans on the scan worker pool

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1321,6 +1321,18 @@ pub struct FakeFs {
 }
 
 #[cfg(feature = "test-support")]
+struct ReadDirBlock {
+    state: Arc<Mutex<FakeFsState>>,
+}
+
+#[cfg(feature = "test-support")]
+impl Drop for ReadDirBlock {
+    fn drop(&mut self) {
+        self.state.lock().read_dir_block = None;
+    }
+}
+
+#[cfg(feature = "test-support")]
 struct FakeFsState {
     root: FakeFsEntry,
     next_inode: u64,
@@ -1337,6 +1349,11 @@ struct FakeFsState {
     trash: Vec<(TrashedEntry, FakeFsEntry)>,
     file_to_create_before_watch_add: Option<(PathBuf, PathBuf)>,
     remove_dir_errors: std::collections::HashMap<PathBuf, String>,
+    read_dir_block: Option<(
+        PathBuf,
+        async_channel::Sender<()>,
+        async_channel::Receiver<()>,
+    )>,
 }
 
 #[cfg(feature = "test-support")]
@@ -1657,6 +1674,7 @@ impl FakeFs {
                 trash: Vec::new(),
                 file_to_create_before_watch_add: None,
                 remove_dir_errors: Default::default(),
+                read_dir_block: None,
             })),
         });
 
@@ -2498,6 +2516,22 @@ impl FakeFs {
         self.state.lock().read_dir_call_count
     }
 
+    pub async fn with_read_dir_blocked<R>(
+        &self,
+        prefix: impl AsRef<Path>,
+        body: impl Future<Output = R>,
+    ) -> R {
+        let _block = {
+            let prefix = normalize_path(prefix.as_ref());
+            let (tx, rx) = async_channel::unbounded();
+            self.state.lock().read_dir_block = Some((prefix, tx, rx));
+            ReadDirBlock {
+                state: self.state.clone(),
+            }
+        };
+        body.await
+    }
+
     pub fn watched_paths(&self) -> Vec<PathBuf> {
         let state = self.state.lock();
         state
@@ -3111,6 +3145,17 @@ impl Fs for FakeFs {
     ) -> Result<Pin<Box<dyn Send + Stream<Item = Result<PathBuf>>>>> {
         self.simulate_random_delay().await;
         let path = normalize_path(path);
+
+        let blocker = self
+            .state
+            .lock()
+            .read_dir_block
+            .as_ref()
+            .and_then(|(prefix, _tx, rx)| path.starts_with(prefix).then(|| rx.clone()));
+        if let Some(rx) = blocker {
+            rx.recv().await.ok();
+        }
+
         let mut state = self.state.lock();
         state.read_dir_call_count += 1;
         let entry = state.entry(&path)?;

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4958,8 +4958,15 @@ impl BackgroundScanner {
 
     /// Drains a queue of scan jobs across the available workers, loading their
     /// directories in parallel.
-    ///
     async fn drain_scan_jobs(&self, scan_jobs_rx: async_channel::Receiver<ScanJob>) {
+        if self
+            .status_updates_tx
+            .unbounded_send(ScanState::Started)
+            .is_err()
+        {
+            return;
+        }
+
         self.executor
             .scoped_priority(Priority::Low, |scope| {
                 for _ in 0..self.executor.num_cpus() {
@@ -4970,6 +4977,7 @@ impl BackgroundScanner {
                             {
                                 log::error!("error scanning directory {:?}: {}", job.abs_path, err);
                             }
+                            self.send_status_update(true, SmallVec::new(), &[]).await;
                         }
                     });
                 }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4911,7 +4911,12 @@ impl BackgroundScanner {
                                 // directories, language-server file watchers, project search)
                                 // here, so they aren't starved while the main loop is busy in a
                                 // long-running rescan.
-                                path_prefix_request = self.path_prefixes_to_scan_rx.recv().fuse() => {
+                                path_prefix_request = async {
+                                    if self.phase == BackgroundScannerPhase::InitialScan {
+                                        std::future::pending::<()>().await;
+                                    }
+                                    self.path_prefixes_to_scan_rx.recv().await
+                                }.fuse() => {
                                     let Ok(request) = path_prefix_request else { break };
                                     if !self.process_path_prefix_request(request, true).await {
                                         return;

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -270,6 +270,7 @@ struct BackgroundScannerState {
     scanned_dirs: HashSet<ProjectEntryId>,
     watched_dir_abs_paths_by_entry_id: HashMap<ProjectEntryId, Arc<Path>>,
     path_prefixes_to_scan: HashSet<Arc<RelPath>>,
+    prefix_scans_in_flight: HashMap<Arc<RelPath>, SmallVec<[barrier::Sender; 1]>>,
     paths_to_scan: HashMap<Arc<RelPath>, usize>,
     /// The ids of all of the entries that were removed from the snapshot
     /// as part of the current update. These entry ids may be re-used
@@ -1215,6 +1216,7 @@ impl LocalWorktree {
                         watched_dir_abs_paths_by_entry_id: Default::default(),
                         scanning_enabled,
                         path_prefixes_to_scan: Default::default(),
+                        prefix_scans_in_flight: Default::default(),
                         paths_to_scan: Default::default(),
                         removed_entries: Default::default(),
                         changed_paths: Default::default(),
@@ -4334,52 +4336,77 @@ impl BackgroundScanner {
         request: PathPrefixScanRequest,
         scanning: bool,
     ) -> bool {
-        if self
-            .state
-            .lock()
-            .await
-            .path_prefixes_to_scan
-            .contains(&request.path)
-        {
-            return self.send_status_update(scanning, request.done, &[]).await;
+        let PathPrefixScanRequest { path, done } = request;
+
+        let owns_crawl = {
+            let mut state = self.state.lock().await;
+            if let Some(waiters) = state.prefix_scans_in_flight.get_mut(&path) {
+                // A crawl of this prefix is already running; wait on it rather than
+                // crawling the same subtree again. This barrier fires when the
+                // owning crawl finishes and the in-flight entry is removed.
+                waiters.extend(done);
+                return true;
+            }
+            let already_loaded = state.path_prefixes_to_scan.contains(&path);
+            if !already_loaded {
+                state
+                    .prefix_scans_in_flight
+                    .insert(path.clone(), SmallVec::new());
+            }
+            !already_loaded
+        };
+
+        if !owns_crawl {
+            return self.send_status_update(scanning, done, &[]).await;
         }
 
-        log::trace!("adding path prefix {:?}", request.path);
+        let alive = self.load_path_prefix(&path, done, scanning).await;
 
-        let did_scan = self
-            .forcibly_load_paths(std::slice::from_ref(&request.path))
-            .await;
+        self.state.lock().await.prefix_scans_in_flight.remove(&path);
+
+        alive
+    }
+
+    async fn load_path_prefix(
+        &self,
+        path: &Arc<RelPath>,
+        done: SmallVec<[barrier::Sender; 1]>,
+        scanning: bool,
+    ) -> bool {
+        log::trace!("adding path prefix {:?}", path);
+
+        let did_scan = self.forcibly_load_paths(std::slice::from_ref(path)).await;
         if !did_scan {
-            return self.send_status_update(scanning, request.done, &[]).await;
+            return self.send_status_update(scanning, done, &[]).await;
         }
 
         let (root_path, abs_path) = {
             let mut state = self.state.lock().await;
-            state.path_prefixes_to_scan.insert(request.path.clone());
+            state.path_prefixes_to_scan.insert(path.clone());
             (
                 state.snapshot.abs_path.clone(),
-                state.snapshot.absolutize(&request.path),
+                state.snapshot.absolutize(path),
             )
         };
 
         let Some(abs_path) = self.fs.canonicalize(&abs_path).await.log_err() else {
-            return self.send_status_update(scanning, request.done, &[]).await;
+            return self.send_status_update(scanning, done, &[]).await;
         };
         let root_canonical_path = self.fs.canonicalize(root_path.as_path()).await;
         let root_canonical_path = match &root_canonical_path {
-            Ok(path) => SanitizedPath::new(path),
+            Ok(canonical) => SanitizedPath::new(canonical),
             Err(err) => {
                 log::error!("failed to canonicalize root path {root_path:?}: {err:#}");
-                return self.send_status_update(scanning, request.done, &[]).await;
+                return self.send_status_update(scanning, done, &[]).await;
             }
         };
 
         let (scan_job_tx, scan_job_rx) = async_channel::unbounded();
-        self.with_scan(scanning, request.done, &[], async {
+        self.with_scan(scanning, done, &[], async {
             self.reload_entries_for_paths(
                 &root_path,
                 root_canonical_path,
-                std::slice::from_ref(&request.path),
+                std::slice::from_ref(path),
                 vec![abs_path],
                 Some(scan_job_tx.clone()),
             )

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4824,6 +4824,7 @@ impl BackgroundScanner {
 
     async fn forcibly_load_paths(&self, paths: &[Arc<RelPath>]) -> bool {
         let (scan_job_tx, scan_job_rx) = async_channel::unbounded();
+        let mut own_paths_to_scan = Vec::new();
         {
             let mut state = self.state.lock().await;
             let root_path = state.snapshot.abs_path.clone();
@@ -4850,6 +4851,7 @@ impl BackgroundScanner {
                             )
                             .await;
                         state.paths_to_scan.insert(path.clone());
+                        own_paths_to_scan.push(path.clone());
                         break;
                     }
                 }
@@ -4860,7 +4862,11 @@ impl BackgroundScanner {
             self.scan_dir(&job).await.log_err();
         }
 
-        !mem::take(&mut self.state.lock().await.paths_to_scan).is_empty()
+        let mut state = self.state.lock().await;
+        for path in &own_paths_to_scan {
+            state.paths_to_scan.remove(path);
+        }
+        !own_paths_to_scan.is_empty()
     }
 
     async fn scan_dirs(

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4193,13 +4193,8 @@ impl BackgroundScanner {
 
         // Perform an initial scan of the directory.
         drop(scan_job_tx);
-        self.with_scan(
-            false,
-            SmallVec::new(),
-            &[],
-            self.scan_dirs(true, scan_job_rx),
-        )
-        .await;
+        self.with_scan(self.scan_dirs(true, scan_job_rx)).await;
+        self.send_status_update(false, SmallVec::new(), &[]).await;
 
         if self.defer_watch {
             let (events, watcher) = self
@@ -4294,27 +4289,18 @@ impl BackgroundScanner {
         }
     }
 
-    async fn with_scan(
-        &self,
-        scanning: bool,
-        done: SmallVec<[barrier::Sender; 1]>,
-        event_roots: &[EventRoot],
-        scan: impl Future<Output = ()>,
-    ) -> bool {
+    async fn with_scan(&self, scan: impl Future<Output = ()>) {
         {
             let mut state = self.state.lock().await;
             state.snapshot.scan_id += 1;
             state.scans_in_flight += 1;
         }
         scan.await;
-        {
-            let mut state = self.state.lock().await;
-            state.scans_in_flight -= 1;
-            if state.scans_in_flight == 0 {
-                state.snapshot.completed_scan_id = state.snapshot.scan_id;
-            }
+        let mut state = self.state.lock().await;
+        state.scans_in_flight -= 1;
+        if state.scans_in_flight == 0 {
+            state.snapshot.completed_scan_id = state.snapshot.scan_id;
         }
-        self.send_status_update(scanning, done, event_roots).await
     }
 
     async fn process_scan_request(&self, mut request: ScanRequest, scanning: bool) -> bool {
@@ -4344,19 +4330,15 @@ impl BackgroundScanner {
             })
             .collect::<Vec<_>>();
 
-        self.with_scan(
-            scanning,
-            request.done,
-            &[],
-            self.reload_entries_for_paths(
-                &root_path,
-                &root_canonical_path,
-                &request.relative_paths,
-                abs_paths,
-                None,
-            ),
-        )
-        .await
+        self.with_scan(self.reload_entries_for_paths(
+            &root_path,
+            &root_canonical_path,
+            &request.relative_paths,
+            abs_paths,
+            None,
+        ))
+        .await;
+        self.send_status_update(scanning, request.done, &[]).await
     }
 
     async fn process_path_prefix_request(
@@ -4366,46 +4348,38 @@ impl BackgroundScanner {
     ) -> bool {
         let PathPrefixScanRequest { path, done } = request;
 
-        let owns_crawl = {
-            let mut state = self.state.lock().await;
-            if let Some(waiters) = state.prefix_scans_in_flight.get_mut(&path) {
-                // A crawl of this prefix is already running; wait on it rather than
-                // crawling the same subtree again. This barrier fires when the
-                // owning crawl finishes and the in-flight entry is removed.
-                waiters.extend(done);
-                return true;
-            }
-            let already_loaded = state.path_prefixes_to_scan.contains(&path);
-            if !already_loaded {
-                state
-                    .prefix_scans_in_flight
-                    .insert(path.clone(), SmallVec::new());
-            }
-            !already_loaded
-        };
-
-        if !owns_crawl {
-            return self.send_status_update(scanning, done, &[]).await;
+        enum Outcome {
+            Waiting,
+            AlreadyLoaded(SmallVec<[barrier::Sender; 1]>),
+            Crawl,
         }
 
-        let alive = self.load_path_prefix(&path, done, scanning).await;
+        let outcome = {
+            let mut state = self.state.lock().await;
+            if let Some(waiters) = state.prefix_scans_in_flight.get_mut(&path) {
+                waiters.extend(done);
+                Outcome::Waiting
+            } else if state.path_prefixes_to_scan.contains(&path) {
+                Outcome::AlreadyLoaded(done)
+            } else {
+                state.prefix_scans_in_flight.insert(path.clone(), done);
+                Outcome::Crawl
+            }
+        };
 
-        self.state.lock().await.prefix_scans_in_flight.remove(&path);
-
-        alive
+        match outcome {
+            Outcome::Waiting => true,
+            Outcome::AlreadyLoaded(done) => self.send_status_update(scanning, done, &[]).await,
+            Outcome::Crawl => self.load_path_prefix(&path, scanning).await,
+        }
     }
 
-    async fn load_path_prefix(
-        &self,
-        path: &Arc<RelPath>,
-        done: SmallVec<[barrier::Sender; 1]>,
-        scanning: bool,
-    ) -> bool {
+    async fn load_path_prefix(&self, path: &Arc<RelPath>, scanning: bool) -> bool {
         log::trace!("adding path prefix {:?}", path);
 
         let did_scan = self.forcibly_load_paths(std::slice::from_ref(path)).await;
         if !did_scan {
-            return self.send_status_update(scanning, done, &[]).await;
+            return self.notify_prefix_waiters(path, scanning).await;
         }
 
         let (root_path, abs_path) = {
@@ -4418,19 +4392,19 @@ impl BackgroundScanner {
         };
 
         let Some(abs_path) = self.fs.canonicalize(&abs_path).await.log_err() else {
-            return self.send_status_update(scanning, done, &[]).await;
+            return self.notify_prefix_waiters(path, scanning).await;
         };
         let root_canonical_path = self.fs.canonicalize(root_path.as_path()).await;
         let root_canonical_path = match &root_canonical_path {
             Ok(canonical) => SanitizedPath::new(canonical),
             Err(err) => {
                 log::error!("failed to canonicalize root path {root_path:?}: {err:#}");
-                return self.send_status_update(scanning, done, &[]).await;
+                return self.notify_prefix_waiters(path, scanning).await;
             }
         };
 
         let (scan_job_tx, scan_job_rx) = async_channel::unbounded();
-        self.with_scan(scanning, done, &[], async {
+        self.with_scan(async {
             self.reload_entries_for_paths(
                 &root_path,
                 root_canonical_path,
@@ -4442,7 +4416,19 @@ impl BackgroundScanner {
             drop(scan_job_tx);
             self.drain_scan_jobs(scan_job_rx).await;
         })
-        .await
+        .await;
+        self.notify_prefix_waiters(path, scanning).await
+    }
+
+    async fn notify_prefix_waiters(&self, path: &Arc<RelPath>, scanning: bool) -> bool {
+        let done = self
+            .state
+            .lock()
+            .await
+            .prefix_scans_in_flight
+            .remove(path)
+            .unwrap_or_default();
+        self.send_status_update(scanning, done, &[]).await
     }
 
     fn normalized_events_for_worktree(
@@ -4801,7 +4787,7 @@ impl BackgroundScanner {
             }
         }
 
-        self.with_scan(false, SmallVec::new(), &relative_paths, async {
+        self.with_scan(async {
             let (scan_job_tx, scan_job_rx) = async_channel::unbounded();
             if !relative_paths.is_empty() {
                 log::debug!(
@@ -4849,6 +4835,8 @@ impl BackgroundScanner {
             }
         })
         .await;
+        self.send_status_update(false, SmallVec::new(), &relative_paths)
+            .await;
     }
 
     async fn update_global_gitignore(&self, abs_path: &Path) {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -80,6 +80,34 @@ use crate::ignore::IgnoreKind;
 
 pub const FS_WATCH_LATENCY: Duration = Duration::from_millis(100);
 
+struct ProgressThrottle {
+    update_count: AtomicUsize,
+}
+
+impl ProgressThrottle {
+    fn new() -> Self {
+        Self {
+            update_count: AtomicUsize::new(0),
+        }
+    }
+
+    fn try_claim(&self, last_seen: &mut usize) -> bool {
+        match self
+            .update_count
+            .compare_exchange(*last_seen, *last_seen + 1, SeqCst, SeqCst)
+        {
+            Ok(_) => {
+                *last_seen += 1;
+                true
+            }
+            Err(count) => {
+                *last_seen = count;
+                false
+            }
+        }
+    }
+}
+
 /// A set of local or remote files that are being opened as part of a project.
 /// Responsible for tracking related FS (for local)/collab (for remote) events and corresponding updates.
 /// Stores git repositories data and the diagnostics for the file(s).
@@ -4914,7 +4942,7 @@ impl BackgroundScanner {
             return;
         }
 
-        let progress_update_count = AtomicUsize::new(0);
+        let progress = ProgressThrottle::new();
         self.executor
             .scoped_priority(Priority::Low, |scope| {
                 for _ in 0..self.executor.num_cpus() {
@@ -4954,20 +4982,9 @@ impl BackgroundScanner {
                                 // to ensure that only one of the workers sends a progress update after
                                 // the update interval elapses.
                                 _ = progress_update_timer => {
-                                    match progress_update_count.compare_exchange(
-                                        last_progress_update_count,
-                                        last_progress_update_count + 1,
-                                        SeqCst,
-                                        SeqCst
-                                    ) {
-                                        Ok(_) => {
-                                            last_progress_update_count += 1;
-                                            self.send_status_update(true, SmallVec::new(), &[])
-                                                .await;
-                                        }
-                                        Err(count) => {
-                                            last_progress_update_count = count;
-                                        }
+                                    if progress.try_claim(&mut last_progress_update_count) {
+                                        self.send_status_update(true, SmallVec::new(), &[])
+                                            .await;
                                     }
                                     progress_update_timer.set(self.progress_timer(enable_progress_updates).fuse());
                                 }
@@ -4999,17 +5016,33 @@ impl BackgroundScanner {
             return;
         }
 
+        let progress = ProgressThrottle::new();
         self.executor
             .scoped_priority(Priority::Low, |scope| {
                 for _ in 0..self.executor.num_cpus() {
                     scope.spawn(async {
-                        while let Ok(job) = scan_jobs_rx.recv().await {
-                            if let Err(err) = self.scan_dir(&job).await
-                                && job.path.is_empty()
-                            {
-                                log::error!("error scanning directory {:?}: {}", job.abs_path, err);
+                        let mut last_progress_update_count = 0;
+                        let progress_update_timer = self.executor.timer(FS_WATCH_LATENCY).fuse();
+                        futures::pin_mut!(progress_update_timer);
+
+                        loop {
+                            select_biased! {
+                                _ = progress_update_timer => {
+                                    if progress.try_claim(&mut last_progress_update_count) {
+                                        self.send_status_update(true, SmallVec::new(), &[]).await;
+                                    }
+                                    progress_update_timer.set(self.executor.timer(FS_WATCH_LATENCY).fuse());
+                                }
+
+                                job = scan_jobs_rx.recv().fuse() => {
+                                    let Ok(job) = job else { break };
+                                    if let Err(err) = self.scan_dir(&job).await
+                                        && job.path.is_empty()
+                                    {
+                                        log::error!("error scanning directory {:?}: {}", job.abs_path, err);
+                                    }
+                                }
                             }
-                            self.send_status_update(true, SmallVec::new(), &[]).await;
                         }
                     });
                 }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -270,7 +270,7 @@ struct BackgroundScannerState {
     scanned_dirs: HashSet<ProjectEntryId>,
     watched_dir_abs_paths_by_entry_id: HashMap<ProjectEntryId, Arc<Path>>,
     path_prefixes_to_scan: HashSet<Arc<RelPath>>,
-    paths_to_scan: HashSet<Arc<RelPath>>,
+    paths_to_scan: HashMap<Arc<RelPath>, usize>,
     /// The ids of all of the entries that were removed from the snapshot
     /// as part of the current update. These entry ids may be re-used
     /// if the same inode is discovered at a new path, or if the given
@@ -4850,7 +4850,7 @@ impl BackgroundScanner {
                                 self.fs.as_ref(),
                             )
                             .await;
-                        state.paths_to_scan.insert(path.clone());
+                        *state.paths_to_scan.entry(path.clone()).or_insert(0) += 1;
                         own_paths_to_scan.push(path.clone());
                         break;
                     }
@@ -4864,7 +4864,12 @@ impl BackgroundScanner {
 
         let mut state = self.state.lock().await;
         for path in &own_paths_to_scan {
-            state.paths_to_scan.remove(path);
+            if let Some(count) = state.paths_to_scan.get_mut(path) {
+                *count -= 1;
+                if *count == 0 {
+                    state.paths_to_scan.remove(path);
+                }
+            }
         }
         !own_paths_to_scan.is_empty()
     }
@@ -5864,7 +5869,7 @@ impl BackgroundScanner {
             || state.scanned_dirs.contains(&entry.id) // If we've ever scanned it, keep scanning
             || state
                 .paths_to_scan
-                .iter()
+                .keys()
                 .any(|p| p.starts_with(&entry.path))
             || state
                 .path_prefixes_to_scan

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -279,6 +279,7 @@ struct BackgroundScannerState {
     changed_paths: Vec<Arc<RelPath>>,
     prev_snapshot: Snapshot,
     scanning_enabled: bool,
+    scans_in_flight: usize,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1217,6 +1218,7 @@ impl LocalWorktree {
                         paths_to_scan: Default::default(),
                         removed_entries: Default::default(),
                         changed_paths: Default::default(),
+                        scans_in_flight: 0,
                     }),
                     phase: BackgroundScannerPhase::InitialScan,
                     share_private_files,
@@ -4133,7 +4135,6 @@ impl BackgroundScanner {
         let (scan_job_tx, scan_job_rx) = async_channel::unbounded();
         {
             let mut state = self.state.lock().await;
-            state.snapshot.scan_id += 1;
             if let Some(mut root_entry) = state.snapshot.root_entry().cloned() {
                 let ignore_stack = state
                     .snapshot
@@ -4162,13 +4163,13 @@ impl BackgroundScanner {
 
         // Perform an initial scan of the directory.
         drop(scan_job_tx);
-        self.scan_dirs(true, scan_job_rx).await;
-        {
-            let mut state = self.state.lock().await;
-            state.snapshot.completed_scan_id = state.snapshot.scan_id;
-        }
-
-        self.send_status_update(false, SmallVec::new(), &[]).await;
+        self.with_scan(
+            false,
+            SmallVec::new(),
+            &[],
+            self.scan_dirs(true, scan_job_rx),
+        )
+        .await;
 
         if self.defer_watch {
             let (events, watcher) = self
@@ -4241,32 +4242,9 @@ impl BackgroundScanner {
 
                 path_prefix_request = self.path_prefixes_to_scan_rx.recv().fuse() => {
                     let Ok(request) = path_prefix_request else { break };
-
-                    if self.state.lock().await.path_prefixes_to_scan.contains(&request.path) {
-                        self.send_status_update(false, request.done, &[]).await;
-                        continue;
+                    if !self.process_path_prefix_request(request, false).await {
+                        return;
                     }
-
-                    log::trace!("adding path prefix {:?}", request.path);
-
-                    let did_scan = self.forcibly_load_paths(std::slice::from_ref(&request.path)).await;
-                    if did_scan {
-                        let abs_path =
-                        {
-                            let mut state = self.state.lock().await;
-                            state.path_prefixes_to_scan.insert(request.path.clone());
-                            state.snapshot.absolutize(&request.path)
-                        };
-
-                        if let Some(abs_path) = self.fs.canonicalize(&abs_path).await.log_err() {
-                            self.process_events(vec![PathEvent {
-                                path: abs_path,
-                                kind: Some(fs::PathEventKind::Changed),
-                            }])
-                            .await;
-                        }
-                    }
-                    self.send_status_update(false, request.done, &[]).await;
                 }
 
                 paths = fs_events_rx.next().fuse() => {
@@ -4284,6 +4262,29 @@ impl BackgroundScanner {
                 }
             }
         }
+    }
+
+    async fn with_scan(
+        &self,
+        scanning: bool,
+        done: SmallVec<[barrier::Sender; 1]>,
+        event_roots: &[EventRoot],
+        scan: impl Future<Output = ()>,
+    ) -> bool {
+        {
+            let mut state = self.state.lock().await;
+            state.snapshot.scan_id += 1;
+            state.scans_in_flight += 1;
+        }
+        scan.await;
+        {
+            let mut state = self.state.lock().await;
+            state.scans_in_flight -= 1;
+            if state.scans_in_flight == 0 {
+                state.snapshot.completed_scan_id = state.snapshot.scan_id;
+            }
+        }
+        self.send_status_update(scanning, done, event_roots).await
     }
 
     async fn process_scan_request(&self, mut request: ScanRequest, scanning: bool) -> bool {
@@ -4313,25 +4314,80 @@ impl BackgroundScanner {
             })
             .collect::<Vec<_>>();
 
+        self.with_scan(
+            scanning,
+            request.done,
+            &[],
+            self.reload_entries_for_paths(
+                &root_path,
+                &root_canonical_path,
+                &request.relative_paths,
+                abs_paths,
+                None,
+            ),
+        )
+        .await
+    }
+
+    async fn process_path_prefix_request(
+        &self,
+        request: PathPrefixScanRequest,
+        scanning: bool,
+    ) -> bool {
+        if self
+            .state
+            .lock()
+            .await
+            .path_prefixes_to_scan
+            .contains(&request.path)
         {
-            let mut state = self.state.lock().await;
-            let is_idle = state.snapshot.completed_scan_id == state.snapshot.scan_id;
-            state.snapshot.scan_id += 1;
-            if is_idle {
-                state.snapshot.completed_scan_id = state.snapshot.scan_id;
-            }
+            return self.send_status_update(scanning, request.done, &[]).await;
         }
 
-        self.reload_entries_for_paths(
-            &root_path,
-            &root_canonical_path,
-            &request.relative_paths,
-            abs_paths,
-            None,
-        )
-        .await;
+        log::trace!("adding path prefix {:?}", request.path);
 
-        self.send_status_update(scanning, request.done, &[]).await
+        let did_scan = self
+            .forcibly_load_paths(std::slice::from_ref(&request.path))
+            .await;
+        if !did_scan {
+            return self.send_status_update(scanning, request.done, &[]).await;
+        }
+
+        let (root_path, abs_path) = {
+            let mut state = self.state.lock().await;
+            state.path_prefixes_to_scan.insert(request.path.clone());
+            (
+                state.snapshot.abs_path.clone(),
+                state.snapshot.absolutize(&request.path),
+            )
+        };
+
+        let Some(abs_path) = self.fs.canonicalize(&abs_path).await.log_err() else {
+            return self.send_status_update(scanning, request.done, &[]).await;
+        };
+        let root_canonical_path = self.fs.canonicalize(root_path.as_path()).await;
+        let root_canonical_path = match &root_canonical_path {
+            Ok(path) => SanitizedPath::new(path),
+            Err(err) => {
+                log::error!("failed to canonicalize root path {root_path:?}: {err:#}");
+                return self.send_status_update(scanning, request.done, &[]).await;
+            }
+        };
+
+        let (scan_job_tx, scan_job_rx) = async_channel::unbounded();
+        self.with_scan(scanning, request.done, &[], async {
+            self.reload_entries_for_paths(
+                &root_path,
+                root_canonical_path,
+                std::slice::from_ref(&request.path),
+                vec![abs_path],
+                Some(scan_job_tx.clone()),
+            )
+            .await;
+            drop(scan_job_tx);
+            self.drain_scan_jobs(scan_job_rx).await;
+        })
+        .await
     }
 
     fn normalized_events_for_worktree(
@@ -4690,58 +4746,54 @@ impl BackgroundScanner {
             }
         }
 
-        self.state.lock().await.snapshot.scan_id += 1;
-
-        let (scan_job_tx, scan_job_rx) = async_channel::unbounded();
-        if !relative_paths.is_empty() {
-            log::debug!(
-                "will update project paths {:?}",
-                relative_paths
+        self.with_scan(false, SmallVec::new(), &relative_paths, async {
+            let (scan_job_tx, scan_job_rx) = async_channel::unbounded();
+            if !relative_paths.is_empty() {
+                log::debug!(
+                    "will update project paths {:?}",
+                    relative_paths
+                        .iter()
+                        .map(|event_root| &event_root.path)
+                        .collect::<Vec<_>>()
+                );
+            }
+            self.reload_entries_for_paths(
+                &root_path,
+                &root_canonical_path,
+                &relative_paths
                     .iter()
-                    .map(|event_root| &event_root.path)
-                    .collect::<Vec<_>>()
-            );
-        }
-        self.reload_entries_for_paths(
-            &root_path,
-            &root_canonical_path,
-            &relative_paths
-                .iter()
-                .map(|event_root| event_root.path.clone())
-                .collect::<Vec<_>>(),
-            events
-                .into_iter()
-                .map(|event| event.path)
-                .collect::<Vec<_>>(),
-            Some(scan_job_tx.clone()),
-        )
-        .await;
+                    .map(|event_root| event_root.path.clone())
+                    .collect::<Vec<_>>(),
+                events
+                    .into_iter()
+                    .map(|event| event.path)
+                    .collect::<Vec<_>>(),
+                Some(scan_job_tx.clone()),
+            )
+            .await;
 
-        let affected_repo_roots = if !dot_git_abs_paths.is_empty() {
-            self.update_git_repositories(dot_git_abs_paths).await
-        } else {
-            Vec::new()
-        };
+            let affected_repo_roots = if !dot_git_abs_paths.is_empty() {
+                self.update_git_repositories(dot_git_abs_paths).await
+            } else {
+                Vec::new()
+            };
 
-        {
-            let mut ignores_to_update = self.ignores_needing_update().await;
-            ignores_to_update.extend(affected_repo_roots);
-            let ignores_to_update = self.order_ignores(ignores_to_update).await;
-            let snapshot = self.state.lock().await.snapshot.clone();
-            self.update_ignore_statuses_for_paths(scan_job_tx, snapshot, ignores_to_update)
-                .await;
-            self.scan_dirs(false, scan_job_rx).await;
-        }
+            {
+                let mut ignores_to_update = self.ignores_needing_update().await;
+                ignores_to_update.extend(affected_repo_roots);
+                let ignores_to_update = self.order_ignores(ignores_to_update).await;
+                let snapshot = self.state.lock().await.snapshot.clone();
+                self.update_ignore_statuses_for_paths(scan_job_tx, snapshot, ignores_to_update)
+                    .await;
+                self.scan_dirs(false, scan_job_rx).await;
+            }
 
-        {
             let mut state = self.state.lock().await;
-            state.snapshot.completed_scan_id = state.snapshot.scan_id;
             for (_, entry) in mem::take(&mut state.removed_entries) {
                 state.scanned_dirs.remove(&entry.id);
             }
-        }
-        self.send_status_update(false, SmallVec::new(), &relative_paths)
-            .await;
+        })
+        .await;
     }
 
     async fn update_global_gitignore(&self, abs_path: &Path) {
@@ -4844,6 +4896,17 @@ impl BackgroundScanner {
                                     }
                                 }
 
+                                // Likewise service path-prefix requests (expanding gitignored
+                                // directories, language-server file watchers, project search)
+                                // here, so they aren't starved while the main loop is busy in a
+                                // long-running rescan.
+                                path_prefix_request = self.path_prefixes_to_scan_rx.recv().fuse() => {
+                                    let Ok(request) = path_prefix_request else { break };
+                                    if !self.process_path_prefix_request(request, true).await {
+                                        return;
+                                    }
+                                }
+
                                 // Send periodic progress updates to the worktree. Use an atomic counter
                                 // to ensure that only one of the workers sends a progress update after
                                 // the update interval elapses.
@@ -4874,6 +4937,27 @@ impl BackgroundScanner {
                                             log::error!("error scanning directory {:?}: {}", job.abs_path, err);
                                         }
                                 }
+                            }
+                        }
+                    });
+                }
+            })
+            .await;
+    }
+
+    /// Drains a queue of scan jobs across the available workers, loading their
+    /// directories in parallel.
+    ///
+    async fn drain_scan_jobs(&self, scan_jobs_rx: async_channel::Receiver<ScanJob>) {
+        self.executor
+            .scoped_priority(Priority::Low, |scope| {
+                for _ in 0..self.executor.num_cpus() {
+                    scope.spawn(async {
+                        while let Ok(job) = scan_jobs_rx.recv().await {
+                            if let Err(err) = self.scan_dir(&job).await
+                                && job.path.is_empty()
+                            {
+                                log::error!("error scanning directory {:?}: {}", job.abs_path, err);
                             }
                         }
                     });

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -1963,6 +1963,81 @@ async fn test_duplicate_concurrent_path_prefix_requests_scan_subtree_once(cx: &m
     );
 }
 
+#[gpui::test(iterations = 200)]
+async fn test_coalesced_path_prefix_completion_implies_visibility(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.executor().set_num_cpus(8);
+
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".gitignore": "dup\nheavy\n",
+            "dup": {
+                "a": { "b": { "file.txt": "contents" } },
+            },
+            "heavy": {
+                "a": { "a1.js": "a1" },
+            },
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    // Load "heavy" so a later rescan of it has something to re-crawl.
+    tree.update(cx, |tree, cx| tree.load_file(rel_path("heavy/a/a1.js"), cx))
+        .await
+        .unwrap();
+
+    // Block "heavy"'s `read_dir` calls so the rescan below parks mid-flight,
+    // keeping scan workers busy long enough for the duplicate "dup" requests to
+    // land on distinct workers and coalesce onto a single in-flight crawl.
+    fs.with_read_dir_blocked("/root/heavy", async {
+        fs.emit_fs_event("/root/heavy", Some(PathEventKind::Rescan));
+        cx.executor().run_until_parked();
+
+        let mut completion_receivers = (0..8)
+            .map(|_| {
+                tree.update(cx, |tree, _| {
+                    tree.as_local()
+                        .unwrap()
+                        .add_path_prefix_to_scan(rel_path("dup").into())
+                })
+            })
+            .collect::<Vec<_>>();
+
+        // Awaiting each completion drives the executor, but the moment a barrier
+        // resolves the scanned entries must already be applied to the snapshot.
+        for receiver in &mut completion_receivers {
+            receiver.recv().await;
+            tree.read_with(cx, |tree, _| {
+                assert!(
+                    tree.entry_for_path(rel_path("dup/a/b/file.txt")).is_some(),
+                    "a coalesced path-prefix request reported completion before its \
+                     scanned entries were visible on the foreground worktree"
+                );
+            });
+        }
+    })
+    .await;
+
+    cx.executor().run_until_parked();
+}
+
 #[gpui::test]
 async fn test_path_prefix_expansion_reports_incremental_progress(cx: &mut TestAppContext) {
     init_test(cx);

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -1857,6 +1857,110 @@ async fn test_duplicate_concurrent_path_prefix_requests_do_not_lose_each_other(
     });
 }
 
+#[gpui::test(iterations = 50)]
+async fn test_duplicate_concurrent_path_prefix_requests_scan_subtree_once(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.executor().set_num_cpus(8);
+
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".gitignore": "heavy\nsolo\ndup\n",
+            "heavy": {
+                "a": { "a1.js": "a1" },
+            },
+            "solo": {
+                "a": { "b": { "file.txt": "contents" } },
+            },
+            "dup": {
+                "a": { "b": { "file.txt": "contents" } },
+            },
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    // Load "heavy" so a later rescan of it has something to re-crawl.
+    tree.update(cx, |tree, cx| tree.load_file(rel_path("heavy/a/a1.js"), cx))
+        .await
+        .unwrap();
+
+    // Baseline: expand a single gitignored subtree (no rescan in flight) and
+    // record how many directory reads one full crawl of an identical subtree costs.
+    let prev_read_dir_count = fs.read_dir_call_count();
+    let mut solo_scan = tree.update(cx, |tree, _| {
+        tree.as_local()
+            .unwrap()
+            .add_path_prefix_to_scan(rel_path("solo").into())
+    });
+    solo_scan.recv().await;
+    cx.executor().run_until_parked();
+    let solo_reads = fs.read_dir_call_count() - prev_read_dir_count;
+
+    // Now fire eight identical requests for "dup" while a rescan of "heavy" is
+    // parked mid-flight, so the duplicates land on distinct idle scan workers
+    // concurrently. With dedup, exactly one of them crawls the subtree.
+    let mut scans = fs
+        .with_read_dir_blocked("/root/heavy", async {
+            fs.emit_fs_event("/root/heavy", Some(PathEventKind::Rescan));
+            cx.executor().run_until_parked();
+
+            let prev_read_dir_count = fs.read_dir_call_count();
+            let completion_receivers = (0..8)
+                .map(|_| {
+                    tree.update(cx, |tree, _| {
+                        tree.as_local()
+                            .unwrap()
+                            .add_path_prefix_to_scan(rel_path("dup").into())
+                    })
+                })
+                .collect::<Vec<_>>();
+            cx.executor().run_until_parked();
+
+            let mut completion_receivers = completion_receivers;
+            for scan in &mut completion_receivers {
+                scan.recv().await;
+            }
+            cx.executor().run_until_parked();
+
+            let dup_reads = fs.read_dir_call_count() - prev_read_dir_count;
+
+            tree.read_with(cx, |tree, _| {
+                assert!(
+                    tree.entry_for_path(rel_path("dup/a/b/file.txt")).is_some(),
+                    "dup subtree was never loaded"
+                );
+            });
+
+            (completion_receivers, dup_reads)
+        })
+        .await;
+
+    cx.executor().run_until_parked();
+
+    let (_completion_receivers, dup_reads) = &mut scans;
+    assert!(
+        *dup_reads <= solo_reads,
+        "eight concurrent duplicate requests crawled the subtree {dup_reads} times \
+         (one crawl costs {solo_reads}); without dedup they would each crawl it (~8x)"
+    );
+}
+
 #[gpui::test]
 async fn test_path_prefix_expansion_reports_incremental_progress(cx: &mut TestAppContext) {
     init_test(cx);

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -1663,7 +1663,7 @@ async fn test_path_prefix_scan_is_not_starved_by_rescan(cx: &mut TestAppContext)
 
     // Suspend the rescan mid-flight, then emit a watcher "lost sync" rescan for that subtree.
     // The scanner's main loop is now parked, waiting on the blocked read.
-    let mut done = fs
+    let mut scan = fs
         .with_read_dir_blocked("/root/heavy", async {
             fs.emit_fs_event("/root/heavy", Some(PathEventKind::Rescan));
             cx.executor().run_until_parked();
@@ -1689,7 +1689,7 @@ async fn test_path_prefix_scan_is_not_starved_by_rescan(cx: &mut TestAppContext)
         })
         .await;
 
-    done.recv().await;
+    scan.recv().await;
     cx.executor().run_until_parked();
 }
 
@@ -1737,12 +1737,12 @@ async fn test_concurrent_path_prefix_requests_do_not_lose_each_other(cx: &mut Te
         .unwrap();
 
     // Block "heavy"'s `read_dir` calls so the rescan below parks mid-flight.
-    let mut dones = fs
+    let mut scans = fs
         .with_read_dir_blocked("/root/heavy", async {
             fs.emit_fs_event("/root/heavy", Some(PathEventKind::Rescan));
             cx.executor().run_until_parked();
 
-            let dones: Vec<_> = (0..num_dirs)
+            let completion_receivers: Vec<_> = (0..num_dirs)
                 .map(|i| {
                     tree.update(cx, |tree, _| {
                         tree.as_local()
@@ -1752,12 +1752,12 @@ async fn test_concurrent_path_prefix_requests_do_not_lose_each_other(cx: &mut Te
                 })
                 .collect();
             cx.executor().run_until_parked();
-            dones
+            completion_receivers
         })
         .await;
 
-    for done in &mut dones {
-        done.recv().await;
+    for scan in &mut scans {
+        scan.recv().await;
     }
     cx.executor().run_until_parked();
 
@@ -1772,7 +1772,7 @@ async fn test_concurrent_path_prefix_requests_do_not_lose_each_other(cx: &mut Te
     }
 }
 
-#[gpui::test(iterations = 50)]
+#[gpui::test(iterations = 200)]
 async fn test_duplicate_concurrent_path_prefix_requests_do_not_lose_each_other(
     cx: &mut TestAppContext,
 ) {
@@ -1783,13 +1783,18 @@ async fn test_duplicate_concurrent_path_prefix_requests_do_not_lose_each_other(
     fs.insert_tree(
         "/root",
         json!({
-            ".gitignore": "dir\n",
+            ".gitignore": "dir\nheavy\n",
             "dir": {
                 "sub": {
                     "subsub": {
-                        "file.txt": "contents"
+                        "subsubsub": {
+                            "file.txt": "contents"
+                        }
                     }
                 }
+            },
+            "heavy": {
+                "a": { "a1.js": "a1" }
             },
         }),
     )
@@ -1810,30 +1815,44 @@ async fn test_duplicate_concurrent_path_prefix_requests_do_not_lose_each_other(
     cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
         .await;
 
-    // Fire the exact same path-prefix request multiple times back to back,
-    // without yielding in between, so several copies can be picked up by
-    // distinct idle scan workers concurrently.
-    let mut dones: Vec<_> = (0..4)
-        .map(|_| {
-            tree.update(cx, |tree, _| {
-                tree.as_local()
-                    .unwrap()
-                    .add_path_prefix_to_scan(rel_path("dir/sub/subsub").into())
-            })
-        })
-        .collect();
-    cx.executor().run_until_parked();
+    // Load "heavy" so a later rescan of it has something to re-crawl.
+    tree.update(cx, |tree, cx| tree.load_file(rel_path("heavy/a/a1.js"), cx))
+        .await
+        .unwrap();
 
-    for done in &mut dones {
-        done.recv().await;
+    // Block "heavy"'s `read_dir` calls so the rescan below parks mid-flight.
+    let mut scans = fs
+        .with_read_dir_blocked("/root/heavy", async {
+            fs.emit_fs_event("/root/heavy", Some(PathEventKind::Rescan));
+            cx.executor().run_until_parked();
+
+            // Fire the exact same path-prefix request multiple times back to
+            // back, without yielding in between, so several copies can be
+            // picked up by distinct idle scan workers concurrently.
+            let completion_receivers = (0..8)
+                .map(|_| {
+                    tree.update(cx, |tree, _| {
+                        tree.as_local()
+                            .unwrap()
+                            .add_path_prefix_to_scan(rel_path("dir/sub/subsub/subsubsub").into())
+                    })
+                })
+                .collect::<Vec<_>>();
+            cx.executor().run_until_parked();
+            completion_receivers
+        })
+        .await;
+
+    for scan in &mut scans {
+        scan.recv().await;
     }
     cx.executor().run_until_parked();
 
     tree.read_with(cx, |tree, _| {
         assert!(
-            tree.entry_for_path(rel_path("dir/sub/subsub/file.txt"))
+            tree.entry_for_path(rel_path("dir/sub/subsub/subsubsub/file.txt"))
                 .is_some(),
-            "dir/sub/subsub was starved by a duplicate concurrent path-prefix request"
+            "dir/sub/subsub/subsubsub was starved by a duplicate concurrent path-prefix request"
         );
     });
 }

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -10,7 +10,9 @@ use postage::stream::Stream;
 use pretty_assertions::assert_eq;
 use rand::prelude::*;
 use rpc::{AnyProtoClient, NoopProtoClient, proto};
-use worktree::{Entry, EntryKind, Event, PathChange, Worktree, WorktreeModelHandle};
+use worktree::{
+    Entry, EntryKind, Event, FS_WATCH_LATENCY, PathChange, Worktree, WorktreeModelHandle,
+};
 
 use serde_json::json;
 use settings::{SettingsStore, WorktreeId};
@@ -2003,10 +2005,14 @@ async fn test_path_prefix_expansion_reports_incremental_progress(cx: &mut TestAp
             });
             cx.executor().run_until_parked();
 
-            // The expansion as a whole has not completed (it's still parked on
-            // "expand/slow"), but the periodic progress updates from
-            // `drain_scan_jobs` should already have pushed "expand/fast"'s
-            // contents to the foreground.
+            // The expansion is now parked on the blocked "expand/slow" read, with
+            // "expand" and "expand/fast" already crawled. Advancing past the
+            // progress interval lets a free worker emit a periodic progress
+            // update, which should push "expand/fast"'s contents to the
+            // foreground before the expansion as a whole completes.
+            cx.executor().advance_clock(FS_WATCH_LATENCY * 2);
+            cx.executor().run_until_parked();
+
             tree.read_with(cx, |tree, _| {
                 assert!(
                     tree.entry_for_path(rel_path("expand/fast/file.txt"))

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -1693,6 +1693,151 @@ async fn test_path_prefix_scan_is_not_starved_by_rescan(cx: &mut TestAppContext)
     cx.executor().run_until_parked();
 }
 
+#[gpui::test(iterations = 50)]
+async fn test_concurrent_path_prefix_requests_do_not_lose_each_other(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.executor().set_num_cpus(8);
+
+    let num_dirs = 6;
+    let mut root = serde_json::Map::new();
+    let mut gitignore = String::new();
+    for i in 0..num_dirs {
+        root.insert(
+            format!("dir{i}"),
+            json!({ "sub": { "file.txt": "contents" } }),
+        );
+        gitignore.push_str(&format!("dir{i}\n"));
+    }
+    gitignore.push_str("heavy\n");
+    root.insert(".gitignore".to_string(), json!(gitignore));
+    root.insert("heavy".to_string(), json!({ "a": { "a1.js": "a1" } }));
+
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree("/root", serde_json::Value::Object(root))
+        .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    // Load "heavy" so a later rescan of it has something to re-crawl.
+    tree.update(cx, |tree, cx| tree.load_file(rel_path("heavy/a/a1.js"), cx))
+        .await
+        .unwrap();
+
+    // Block "heavy"'s `read_dir` calls so the rescan below parks mid-flight.
+    let mut dones = fs
+        .with_read_dir_blocked("/root/heavy", async {
+            fs.emit_fs_event("/root/heavy", Some(PathEventKind::Rescan));
+            cx.executor().run_until_parked();
+
+            let dones: Vec<_> = (0..num_dirs)
+                .map(|i| {
+                    tree.update(cx, |tree, _| {
+                        tree.as_local()
+                            .unwrap()
+                            .add_path_prefix_to_scan(rel_path(&format!("dir{i}/sub")).into())
+                    })
+                })
+                .collect();
+            cx.executor().run_until_parked();
+            dones
+        })
+        .await;
+
+    for done in &mut dones {
+        done.recv().await;
+    }
+    cx.executor().run_until_parked();
+
+    for i in 0..num_dirs {
+        tree.read_with(cx, |tree, _| {
+            assert!(
+                tree.entry_for_path(rel_path(&format!("dir{i}/sub/file.txt")))
+                    .is_some(),
+                "dir{i}/sub was starved by a concurrent path-prefix request and never loaded"
+            );
+        });
+    }
+}
+
+#[gpui::test(iterations = 50)]
+async fn test_duplicate_concurrent_path_prefix_requests_do_not_lose_each_other(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    cx.executor().set_num_cpus(8);
+
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".gitignore": "dir\n",
+            "dir": {
+                "sub": {
+                    "subsub": {
+                        "file.txt": "contents"
+                    }
+                }
+            },
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    // Fire the exact same path-prefix request multiple times back to back,
+    // without yielding in between, so several copies can be picked up by
+    // distinct idle scan workers concurrently.
+    let mut dones: Vec<_> = (0..4)
+        .map(|_| {
+            tree.update(cx, |tree, _| {
+                tree.as_local()
+                    .unwrap()
+                    .add_path_prefix_to_scan(rel_path("dir/sub/subsub").into())
+            })
+        })
+        .collect();
+    cx.executor().run_until_parked();
+
+    for done in &mut dones {
+        done.recv().await;
+    }
+    cx.executor().run_until_parked();
+
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("dir/sub/subsub/file.txt"))
+                .is_some(),
+            "dir/sub/subsub was starved by a duplicate concurrent path-prefix request"
+        );
+    });
+}
+
 #[gpui::test]
 async fn test_dirs_no_longer_ignored(cx: &mut TestAppContext) {
     init_test(cx);

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -1617,6 +1617,83 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_path_prefix_scan_is_not_starved_by_rescan(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".gitignore": "heavy\nlight\n",
+            "heavy": {
+                "a": { "a1.js": "a1" },
+                "b": { "b1.js": "b1" },
+                "c": { "c1.js": "c1" },
+            },
+            "light": {
+                "x.js": "",
+            },
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    // Load the heavy gitignored subtree so a later rescan will re-crawl it.
+    tree.update(cx, |tree, cx| tree.load_file(rel_path("heavy/a/a1.js"), cx))
+        .await
+        .unwrap();
+
+    // "light" has not been loaded yet.
+    tree.read_with(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("light/x.js")).is_none());
+    });
+
+    // Suspend the rescan mid-flight, then emit a watcher "lost sync" rescan for that subtree.
+    // The scanner's main loop is now parked, waiting on the blocked read.
+    let mut done = fs
+        .with_read_dir_blocked("/root/heavy", async {
+            fs.emit_fs_event("/root/heavy", Some(PathEventKind::Rescan));
+            cx.executor().run_until_parked();
+
+            // While the rescan is suspended, ask the scanner to load a different,
+            // new gitignored subtree. This must be serviced by a free scan worker
+            // rather than waiting for the blocked rescan to complete.
+            let done = tree.update(cx, |tree, _| {
+                tree.as_local()
+                    .unwrap()
+                    .add_path_prefix_to_scan(rel_path("light").into())
+            });
+            cx.executor().run_until_parked();
+
+            tree.read_with(cx, |tree, _| {
+                assert!(
+                    tree.entry_for_path(rel_path("light/x.js")).is_some(),
+                    "path-prefix scan was starved by the in-flight rescan"
+                );
+            });
+
+            done
+        })
+        .await;
+
+    done.recv().await;
+    cx.executor().run_until_parked();
+}
+
+#[gpui::test]
 async fn test_dirs_no_longer_ignored(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.background_executor.clone());

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -1929,6 +1929,131 @@ async fn test_path_prefix_expansion_reports_incremental_progress(cx: &mut TestAp
 }
 
 #[gpui::test]
+async fn test_path_prefix_expansion_registers_nested_git_repository(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".gitignore": "vendor\n",
+            "vendor": {
+                "pkg": {
+                    ".git": {},
+                    "lib.rs": "",
+                },
+            },
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    // The gitignored "vendor" directory hasn't been expanded yet, so the
+    // repository nested inside it is not yet known.
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.as_local().unwrap().repositories().is_empty(),
+            "nested repo should not be known before the gitignored dir is expanded"
+        );
+    });
+
+    // Force-expand the gitignored subtree that contains the nested repository.
+    // This path no longer routes through `process_events`, so this guards
+    // against a regression in `scan_dir`'s inline `.git` detection.
+    let mut done = tree.update(cx, |tree, _| {
+        tree.as_local()
+            .unwrap()
+            .add_path_prefix_to_scan(rel_path("vendor/pkg").into())
+    });
+    done.recv().await;
+    cx.executor().run_until_parked();
+
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("vendor/pkg/lib.rs")).is_some(),
+            "the force-expanded gitignored subtree should be loaded"
+        );
+        pretty_assertions::assert_eq!(
+            tree.as_local().unwrap().repositories(),
+            vec![Path::new("/root/vendor/pkg").into()],
+            "a git repository nested inside a force-expanded gitignored directory \
+             should be registered"
+        );
+    });
+}
+
+#[gpui::test(iterations = 100)]
+async fn test_path_prefix_request_during_initial_scan_is_not_lost(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.executor().set_num_cpus(8);
+
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".gitignore": "ignored\n",
+            // "a" is a normal (non-ignored) directory; "a/ignored" is gitignored.
+            "a": {
+                "ignored": {
+                    "sub": {
+                        "file.txt": "contents",
+                    },
+                },
+            },
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    // Queue a path-prefix expansion before the initial scan has had a chance to
+    // run. The request must not be silently dropped just because that ancestor
+    // isn't loaded yet.
+    let mut done = tree.update(cx, |tree, _| {
+        tree.as_local()
+            .unwrap()
+            .add_path_prefix_to_scan(rel_path("a/ignored/sub").into())
+    });
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+    done.recv().await;
+    cx.executor().run_until_parked();
+
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("a/ignored/sub/file.txt"))
+                .is_some(),
+            "a path-prefix request issued during the initial scan was dropped because \
+             its ancestor directory had not been loaded yet"
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_dirs_no_longer_ignored(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.background_executor.clone());

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -1858,6 +1858,77 @@ async fn test_duplicate_concurrent_path_prefix_requests_do_not_lose_each_other(
 }
 
 #[gpui::test]
+async fn test_path_prefix_expansion_reports_incremental_progress(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".gitignore": "expand\n",
+            "expand": {
+                "fast": { "file.txt": "contents" },
+                "slow": { "file.txt": "contents" },
+            },
+        }),
+    )
+    .await;
+
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    // Block only "expand/slow", so "expand" and "expand/fast" can be fully
+    // listed and loaded while "expand/slow" is still stuck mid-scan.
+    let mut done = fs
+        .with_read_dir_blocked("/root/expand/slow", async {
+            let done = tree.update(cx, |tree, _| {
+                tree.as_local()
+                    .unwrap()
+                    .add_path_prefix_to_scan(rel_path("expand").into())
+            });
+            cx.executor().run_until_parked();
+
+            // The expansion as a whole has not completed (it's still parked on
+            // "expand/slow"), but the periodic progress updates from
+            // `drain_scan_jobs` should already have pushed "expand/fast"'s
+            // contents to the foreground.
+            tree.read_with(cx, |tree, _| {
+                assert!(
+                    tree.entry_for_path(rel_path("expand/fast/file.txt"))
+                        .is_some(),
+                    "expand/fast should already be visible to the foreground before the whole \
+                     expansion finishes, via drain_scan_jobs's periodic progress updates"
+                );
+            });
+
+            done
+        })
+        .await;
+
+    done.recv().await;
+    cx.executor().run_until_parked();
+
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("expand/slow/file.txt"))
+                .is_some(),
+            "expand/slow should be loaded once the expansion fully completes"
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_dirs_no_longer_ignored(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.background_executor.clone());


### PR DESCRIPTION
This PR lets path-prefix scans also be serviced by the scan worker pool, not just the scanner's main loop. So a request can be handled concurrently by a free worker while a rescan is in flight, instead of waiting behind it in the main loop.

Because scans can now overlap, the old pattern of "bump `scan_id` -> set `completed_scan_id = scan_id`" pattern has been replaced by a single `with_scan` wrapper plus a `scans_in_flight` counter. `completed_scan_id` only advances when the last in-flight scan finishes.

This PR also deduplicates and coalesces path-prefix requests to reduce some wasted effort, and path-prefix crawl no longer routes through `process_events` which helps abate the problem identified by @Dnreikronos in https://github.com/zed-industries/zed/issues/58678#issuecomment-4692555480.

Closes https://github.com/zed-industries/zed/issues/58678.

---

Release Notes:

- Fixed `.gitignore`'d directories sometimes failing to expand (or expanding slowly) in the project panel while a large worktree was being rescanned
