### PR TITLE
agent_servers: Fix ACP terminal scrollback memory leak

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3615,7 +3615,9 @@ impl AcpThread {
                 status,
             } => {
                 if let Some(entity) = self.terminals.get(&terminal_id) {
-                    entity.update(cx, |_term, cx| {
+                    entity.update(cx, |term, cx| {
+                        term.inner()
+                            .update(cx, |inner, cx| inner.release_scrollback(cx));
                         cx.notify();
                     });
                 } else {
@@ -3882,6 +3884,87 @@ mod tests {
         assert!(
             content.contains("pre-exit data"),
             "expected pre-exit data to render, got: {content}"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_acp_terminal_releases_scrollback_on_exit(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let connection = Rc::new(FakeAgentConnection::new());
+
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(project, PathList::new(&[Path::new(path!("/test"))]), cx)
+            })
+            .await
+            .unwrap();
+
+        let terminal_id = acp::TerminalId::new(uuid::Uuid::new_v4().to_string());
+
+        let lower = cx.new(|cx| {
+            let builder = ::terminal::TerminalBuilder::new_display_only(
+                ::terminal::terminal_settings::CursorShape::default(),
+                ::terminal::terminal_settings::AlternateScroll::On,
+                None,
+                0,
+                cx.background_executor(),
+                PathStyle::local(),
+            );
+            builder.subscribe(cx)
+        });
+
+        thread.update(cx, |thread, cx| {
+            thread.on_terminal_provider_event(
+                TerminalProviderEvent::Created {
+                    terminal_id: terminal_id.clone(),
+                    label: "release-test".to_string(),
+                    cwd: None,
+                    output_byte_limit: None,
+                    terminal: lower.clone(),
+                },
+                cx,
+            );
+        });
+
+        // Write enough output to push scrollback past the viewport
+        thread.update(cx, |thread, cx| {
+            thread.on_terminal_provider_event(
+                TerminalProviderEvent::Output {
+                    terminal_id: terminal_id.clone(),
+                    data: "x\n".repeat(2000).into_bytes(),
+                },
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        let before = lower.read_with(cx, |term, _| term.total_lines());
+        assert!(
+            before > 1000,
+            "expected ~2000 lines of scrollback (got {before})"
+        );
+
+        // Exit is what should trigger release_scrollback in on_terminal_provider_event
+        thread.update(cx, |thread, cx| {
+            thread.on_terminal_provider_event(
+                TerminalProviderEvent::Exit {
+                    terminal_id: terminal_id.clone(),
+                    status: acp::TerminalExitStatus::new().exit_code(0),
+                },
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        let after = lower.read_with(cx, |term, _| term.total_lines());
+        assert!(
+            after < 50,
+            "release_scrollback should leave only viewport rows (got {after}, before={before})"
         );
     }
 

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -3637,6 +3637,53 @@ mod tests {
             "session should be removed after final close"
         );
     }
+
+    #[gpui::test]
+    async fn test_create_acp_display_terminal_caps_scroll_history(cx: &mut gpui::TestAppContext) {
+        let (
+            connection,
+            project,
+            _load_coumt,
+            _close_count,
+            _load_session_updates,
+            _load_session_gate,
+            _keep_agent_alive,
+        ) = connect_fake_agent(cx).await;
+
+        let session_id = acp::SessionId::new("session-cap-test");
+        let work_dirs = util::path_list::PathList::new(&[std::path::Path::new("/a")]);
+
+        let thread = cx
+            .update(|cx| {
+                connection
+                    .clone()
+                    .load_session(session_id, project, work_dirs, None, cx)
+            })
+            .await
+            .expect("load_session failed");
+
+        cx.run_until_parked();
+
+        let terminal = thread.update(cx, |_thread, cx| {
+            create_acp_display_terminal(util::paths::PathStyle::local(), cx)
+        });
+
+        let payload = "x\n".repeat(MAX_SCROLL_HISTORY_LINES * 5).into_bytes();
+
+        terminal.update(cx, |terminal, cx| terminal.write_output(&payload, cx));
+
+        cx.run_until_parked();
+
+        let total = terminal.read_with(cx, |term, _| term.total_lines());
+        let cap = MAX_SCROLL_HISTORY_LINES;
+
+        assert!(
+            total <= cap + 100,
+            "total_lines={} exceeded cap={} + slack — scroll history not capped",
+            total,
+            cap
+        );
+    }
 }
 
 fn mcp_servers_for_project(project: &Entity<Project>, cx: &App) -> Vec<acp::McpServer> {
@@ -4072,6 +4119,10 @@ fn handle_session_notification(
     }
 }
 
+// Mirror of terminal_view::TerminalView::MAX_EMBEDDED_LINES. Not imported
+// because adding terminal_view as a dep breaks workspace's test build.
+const MAX_SCROLL_HISTORY_LINES: usize = 1_000;
+
 fn create_acp_display_terminal(
     path_style: PathStyle,
     cx: &mut Context<AcpThread>,
@@ -4080,7 +4131,7 @@ fn create_acp_display_terminal(
         TerminalBuilder::new_display_only(
             CursorShape::default(),
             AlternateScroll::On,
-            None,
+            Some(MAX_SCROLL_HISTORY_LINES),
             0,
             cx.background_executor(),
             path_style,

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -32,10 +32,13 @@ use task::{Shell, ShellBuilder, SpawnInTerminal};
 use thiserror::Error;
 use util::ResultExt as _;
 use util::path_list::PathList;
+use util::paths::PathStyle;
 use util::process::Child;
 
 use anyhow::{Context as _, Result};
-use gpui::{App, AppContext as _, AsyncApp, Entity, SharedString, Subscription, Task, WeakEntity};
+use gpui::{
+    App, AppContext as _, AsyncApp, Context, Entity, SharedString, Subscription, Task, WeakEntity,
+};
 
 use acp_thread::{AcpThread, AuthRequired, LoadError, TerminalProviderEvent};
 use terminal::TerminalBuilder;
@@ -3982,15 +3985,10 @@ fn handle_session_notification(
 
                     thread
                         .update(cx, |thread, cx| {
-                            let builder = TerminalBuilder::new_display_only(
-                                CursorShape::default(),
-                                AlternateScroll::On,
-                                None,
-                                0,
-                                cx.background_executor(),
+                            let lower = create_acp_display_terminal(
                                 thread.project().read(cx).path_style(cx),
+                                cx,
                             );
-                            let lower = cx.new(|cx| builder.subscribe(cx));
                             thread.on_terminal_provider_event(
                                 TerminalProviderEvent::Created {
                                     terminal_id,
@@ -4072,6 +4070,23 @@ fn handle_session_notification(
             }
         }
     }
+}
+
+fn create_acp_display_terminal(
+    path_style: PathStyle,
+    cx: &mut Context<AcpThread>,
+) -> Entity<terminal::Terminal> {
+    cx.new(|cx| {
+        TerminalBuilder::new_display_only(
+            CursorShape::default(),
+            AlternateScroll::On,
+            None,
+            0,
+            cx.background_executor(),
+            path_style,
+        )
+        .subscribe(cx)
+    })
 }
 
 fn handle_create_terminal(

--- a/crates/terminal/src/alacritty.rs
+++ b/crates/terminal/src/alacritty.rs
@@ -798,6 +798,11 @@ pub(super) fn clear_saved_screen(term: &mut Term<ZedListener>) {
     }
 }
 
+pub(super) fn release_scrollback(term: &mut Term<ZedListener>) {
+    term.grid_mut().clear_history();
+    term.grid_mut().truncate();
+}
+
 pub(super) fn make_content(term: &Term<ZedListener>, last_content: &Content) -> Content {
     let content = term.renderable_content();
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -62,11 +62,11 @@ use crate::alacritty::{
     AlacrittyTermConfig, AlacrittyTermLock, HyperlinkMatch, PtySender, RegexSearches,
     append_text_to_term, apply_config, clear_saved_screen, content_text, display_offset,
     display_only_term_config, find_from_terminal_point, full_content_range, last_non_empty_lines,
-    make_content, new_term, open_pty, pty_options, pty_term_config, resize, screen_lines,
-    scroll_display, scroll_to_point, search_matches, selection_text, set_default_cursor_style,
-    set_selection as set_term_selection, spawn_event_loop, toggle_vi_mode as toggle_term_vi_mode,
-    total_lines, update_selection as update_term_selection, update_selection_to_vi_cursor,
-    update_vi_cursor_for_scroll, vi_goto_point, vi_motion,
+    make_content, new_term, open_pty, pty_options, pty_term_config, release_scrollback, resize,
+    screen_lines, scroll_display, scroll_to_point, search_matches, selection_text,
+    set_default_cursor_style, set_selection as set_term_selection, spawn_event_loop,
+    toggle_vi_mode as toggle_term_vi_mode, total_lines, update_selection as update_term_selection,
+    update_selection_to_vi_cursor, update_vi_cursor_for_scroll, vi_goto_point, vi_motion,
 };
 use crate::mappings::colors::to_vte_rgb;
 use crate::mappings::keys::to_esc_str;
@@ -1772,6 +1772,12 @@ impl Terminal {
 
     pub fn clear(&mut self) {
         self.events.push_back(InternalEvent::Clear)
+    }
+
+    pub fn release_scrollback(&mut self, cx: &mut Context<Self>) {
+        let mut term = self.term.lock();
+        release_scrollback(&mut term);
+        cx.emit(Event::Wakeup);
     }
 
     pub fn scroll_line_up(&mut self) {


### PR DESCRIPTION
# Objective

ACP agents (Cursor, Claude Code, Codex, etc.) spin up a display-only `terminal::Terminal` for each bash tool call. This compounds into two issues:

1. Each terminal allocates alacritty's default 10,000-row grid (~7 MB), but the embedded view caps display at 1,000 lines (`TerminalView::MAX_EMBEDDED_LINES`). The remaining 9,000 rows are never visible.
2. After the tool call exits, its grid memory is never released.

Closes #57099

## Solution

1. Pass `Some(MAX_SCROLL_HISTORY_LINES)` instead of `None` for `max_scroll_history_lines` when creating the display-only terminal in `agent_servers::acp::create_acp_display_terminal`, where `MAX_SCROLL_HISTORY_LINES` matches `TerminalView::MAX_EMBEDDED_LINES`.

2. Add `Terminal::release_scrollback` called from the `Exit` branch of the `on_terminal_provider_event`. It drops the alacritty grid scrollback rows.

## Testing

- `cargo nextest run -p agent_servers test_create_acp_display_terminal_caps_scroll_history` passes.
- `cargo nextest run -p acp_thread test_acp_terminal_releases_scrollback_on_exit` passes.
- `./script/clippy` clean.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed memory leak in ACP agent terminals