### PR TITLE
agent_ui: Fix padding for editor

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4073,7 +4073,7 @@ impl ThreadView {
         let fills_container = !has_messages || editor_expanded;
 
         h_flex()
-            .p_2()
+            .py_2()
             .bg(editor_bg_color)
             .justify_center()
             .on_action(cx.listener(Self::handle_message_editor_move_up))
@@ -4092,6 +4092,7 @@ impl ThreadView {
                     .when_some(max_content_width, |this, max_w| this.flex_basis(max_w))
                     .when(max_content_width.is_none(), |this| this.w_full())
                     .when(fills_container, |this| this.h_full())
+                    .px_2()
                     .flex_shrink_1()
                     .flex_grow_0()
                     .justify_between()


### PR DESCRIPTION
# Objective

Fixes #59498 

Original issue mentioned problem with the alignment of text entered into the agent editor compared with the thread title when in full expanded mode. I was able to reproduce issue both in expanded mode and also when resizing while not in expanded mode by dragging panel wide enough. After more investigation, it seemed that all of the contents within the editor (text entered, bottom row of elements) were not properly aligned on both the left and right sides with other content in the agent panel.

## Solution

Moved horizontal padding to inner div that uses `max_content_width` in `render_message_editor` so that it is calculated as expected as part of the max width of the content.

- Dropped horizontal padding, keep vertical padding on outer `h_flex` div. Changed `.p_2()` to `.py_2()` here .
- Added horizontal padding back to first child `v_flex` div that uses `max_content_width`. Added `.px_2()` here.

After changes, elements within the editor are aligned on both the left and right sides with the messages within the message history and the contents of the title bar.

## Testing

I tested the fix on Linux visually, no tests were added due to the small amount of changes and the strictly visual nature of the issue.

<details>
   <summary>Self-Review Checklist</summary>

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments (**no unsafe blocks added**)
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior (**no tests added**)
- [x] Performance impact has been considered and is acceptable

</details>

## Showcase

<details>
  <summary>Before/After empty convo</summary>

### Before

<img width="946" height="551" alt="before-maximized" src="https://github.com/user-attachments/assets/27805f8c-9a04-40b3-a808-5dc3a548a0b8" />

### After

<img width="948" height="554" alt="after-maximized" src="https://github.com/user-attachments/assets/4f557aa8-d8ce-44c4-8278-35df203ca434" />

</details>

<details>
  <summary>Before/After existing convo</summary>

### Before

<img width="950" height="555" alt="before-with-convo" src="https://github.com/user-attachments/assets/82ea6b04-bca7-48fd-ab11-3414855afec8" />

### After

<img width="950" height="555" alt="after-with-convo" src="https://github.com/user-attachments/assets/2f2f394a-6d78-4650-9ddf-e760841a2635" />

</details>


## Note

- A similar issue also seems to apply to the activity bar within `render_activity_bar`, but it's less jarring, and this is also my first PR, so I'm leaving it alone.

---

Release Notes:

- N/A