### PR TITLE
git_ui: Keep view options menu state fresh

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -67,9 +67,11 @@ use settings::{
     update_settings_file,
 };
 use smallvec::SmallVec;
+use std::cell::Cell;
 use std::future::Future;
 use std::ops::Range;
 use std::path::Path;
+use std::rc::Rc;
 use std::{sync::Arc, time::Duration, usize};
 use strum::{IntoEnumIterator, VariantNames};
 use theme_settings::ThemeSettings;
@@ -163,7 +165,8 @@ enum TrashCancel {
     Cancel,
 }
 
-struct GitMenuState {
+#[derive(Clone, Copy)]
+struct GitPanelViewOptionsMenuState {
     sort_by: GitPanelSortBy,
     group_by: GitPanelGroupBy,
     tree_view: bool,
@@ -208,74 +211,111 @@ fn git_panel_context_menu(
 
 fn git_panel_view_options_menu(
     focus_handle: FocusHandle,
-    state: GitMenuState,
     window: &mut Window,
     cx: &mut App,
 ) -> Entity<ContextMenu> {
-    ContextMenu::build(window, cx, move |context_menu, _, _| {
+    let view_options_menu_state = Rc::new(Cell::new(GitPanelViewOptionsMenuState {
+        sort_by: GitPanelSettings::get_global(cx).sort_by,
+        group_by: GitPanelSettings::get_global(cx).group_by,
+        tree_view: GitPanelSettings::get_global(cx).tree_view,
+    }));
+
+    ContextMenu::build_persistent(window, cx, move |context_menu, _, _| {
+        let state = view_options_menu_state.get();
+
         context_menu
-            .context(focus_handle)
+            .context(focus_handle.clone())
             .header("View")
-            .item(
+            .item({
+                let view_options_menu_state = view_options_menu_state.clone();
                 ContextMenuEntry::new("List")
                     .toggle(IconPosition::End, !state.tree_view)
                     .handler(move |window, cx| {
                         if state.tree_view {
+                            view_options_menu_state.set(GitPanelViewOptionsMenuState {
+                                tree_view: false,
+                                ..state
+                            });
                             window.dispatch_action(Box::new(ToggleTreeView), cx);
                         }
-                    }),
-            )
-            .item(
+                    })
+            })
+            .item({
+                let view_options_menu_state = view_options_menu_state.clone();
                 ContextMenuEntry::new("Tree")
                     .toggle(IconPosition::End, state.tree_view)
                     .handler(move |window, cx| {
                         if !state.tree_view {
+                            view_options_menu_state.set(GitPanelViewOptionsMenuState {
+                                tree_view: true,
+                                ..state
+                            });
                             window.dispatch_action(Box::new(ToggleTreeView), cx);
                         }
-                    }),
-            )
+                    })
+            })
             .when(!state.tree_view, |this| {
                 this.separator()
                     .header("Sort By")
-                    .item(
+                    .item({
+                        let view_options_menu_state = view_options_menu_state.clone();
                         ContextMenuEntry::new("Path")
                             .toggle(IconPosition::End, state.sort_by == GitPanelSortBy::Path)
                             .handler(move |window, cx| {
                                 if !state.tree_view {
+                                    view_options_menu_state.set(GitPanelViewOptionsMenuState {
+                                        sort_by: GitPanelSortBy::Path,
+                                        ..state
+                                    });
                                     window.dispatch_action(Box::new(SetSortByPath), cx);
                                 }
-                            }),
-                    )
-                    .item(
+                            })
+                    })
+                    .item({
+                        let view_options_menu_state = view_options_menu_state.clone();
                         ContextMenuEntry::new("Name")
                             .toggle(IconPosition::End, state.sort_by == GitPanelSortBy::Name)
                             .handler(move |window, cx| {
                                 if !state.tree_view {
+                                    view_options_menu_state.set(GitPanelViewOptionsMenuState {
+                                        sort_by: GitPanelSortBy::Name,
+                                        ..state
+                                    });
                                     window.dispatch_action(Box::new(SetSortByName), cx);
                                 }
-                            }),
-                    )
+                            })
+                    })
             })
             .separator()
             .header("Group By")
-            .item(
+            .item({
+                let view_options_menu_state = view_options_menu_state.clone();
                 ContextMenuEntry::new("None")
                     .toggle(IconPosition::End, state.group_by == GitPanelGroupBy::None)
                     .handler(move |window, cx| {
                         if state.group_by != GitPanelGroupBy::None {
+                            view_options_menu_state.set(GitPanelViewOptionsMenuState {
+                                group_by: GitPanelGroupBy::None,
+                                ..state
+                            });
                             window.dispatch_action(Box::new(SetGroupByNone), cx);
                         }
-                    }),
-            )
-            .item(
+                    })
+            })
+            .item({
+                let view_options_menu_state = view_options_menu_state.clone();
                 ContextMenuEntry::new("Status")
                     .toggle(IconPosition::End, state.group_by == GitPanelGroupBy::Status)
                     .handler(move |window, cx| {
                         if state.group_by != GitPanelGroupBy::Status {
+                            view_options_menu_state.set(GitPanelViewOptionsMenuState {
+                                group_by: GitPanelGroupBy::Status,
+                                ..state
+                            });
                             window.dispatch_action(Box::new(SetGroupByStatus), cx);
                         }
-                    }),
-            )
+                    })
+            })
     })
 }
 
@@ -4465,11 +4505,6 @@ impl GitPanel {
             .menu(move |window, cx| {
                 Some(git_panel_view_options_menu(
                     focus_handle.clone(),
-                    GitMenuState {
-                        sort_by: GitPanelSettings::get_global(cx).sort_by,
-                        group_by: GitPanelSettings::get_global(cx).group_by,
-                        tree_view: GitPanelSettings::get_global(cx).tree_view,
-                    },
                     window,
                     cx,
                 ))


### PR DESCRIPTION
# Objective

- Keep the Git panel view options menu open when changing view, sort, or group options.
- Make the open menu reflect the selected option immediately, including showing the Sort By section as soon as List view is selected.

## Solution

- Use a persistent context menu for the Git panel view options menu so selecting an item rebuilds the menu instead of dismissing it.
- Track the open menu's view options state locally with `GitPanelViewOptionsMenuState` so checkmarks and conditional sections update before the settings file change is observed.
- Continue dispatching the existing Git panel actions so persisted settings and panel updates keep using the current code path.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

- N/A

---

Release Notes:

- Fixed Git Panel view options menu selections updating only after reopening the menu.