### PR TITLE
cpp: Add capability to run C++ Catch2 tests right from the test file

### DIFF
--- a/crates/grammars/src/cpp/runnables.scm
+++ b/crates/grammars/src/cpp/runnables.scm
@@ -4,3 +4,32 @@
     declarator: (identifier) @run)) @_cpp-main
   (#eq? @run "main")
   (#set! tag cpp-main))
+
+; Catch2 TEST_CASE
+((call_expression
+  function: (identifier) @_macro
+  (#eq? @_macro "TEST_CASE")
+  arguments: (argument_list
+    .
+    (string_literal) @run @_test_name)) @_
+  (#set! tag catch2-test))
+
+; Catch2 SECTION inside a TEST_CASE.
+(_
+  (expression_statement
+    (call_expression
+      function: (identifier) @_outer_macro
+      (#eq? @_outer_macro "TEST_CASE")
+      arguments: (argument_list
+        .
+        (string_literal) @_test_name)))
+  .
+  (compound_statement
+    (expression_statement
+      (call_expression
+        function: (identifier) @_inner_macro
+        (#eq? @_inner_macro "SECTION")
+        arguments: (argument_list
+          .
+          (string_literal) @run @_section_name))))
+  (#set! tag catch2-section))

--- a/crates/languages/src/cpp.rs
+++ b/crates/languages/src/cpp.rs
@@ -22,6 +22,7 @@ pub(crate) struct CppContextProvider;
 const CATCH2_TEST_PROGRAM: &str = "CATCH2_TEST_PROGRAM";
 const CATCH2_TEST_CWD: &str = "CATCH2_TEST_CWD";
 const CATCH2_TEST_ADDITIONAL_ARGS: &str = "CATCH2_TEST_ADDITIONAL_ARGS";
+const CATCH2_TEST_BUILD_TASK: &str = "CATCH2_TEST_BUILD_TASK";
 const CATCH2_TEST_NAME_VARIABLE: VariableName = VariableName::Custom(Cow::Borrowed("_test_name"));
 const CATCH2_SECTION_NAME_VARIABLE: VariableName =
     VariableName::Custom(Cow::Borrowed("_section_name"));
@@ -40,13 +41,13 @@ impl ContextProvider for CppContextProvider {
         if let Some(raw) = variables.get(&CATCH2_TEST_NAME_VARIABLE) {
             new_vars.insert(
                 VariableName::Custom(Cow::Borrowed("CATCH2_TEST_NAME")),
-                raw.to_owned(),
+                raw.trim_matches('"').to_owned(),
             );
         }
         if let Some(raw) = variables.get(&CATCH2_SECTION_NAME_VARIABLE) {
             new_vars.insert(
                 VariableName::Custom(Cow::Borrowed("CATCH2_SECTION_NAME")),
-                raw.to_owned(),
+                raw.trim_matches('"').to_owned(),
             );
         }
 
@@ -62,14 +63,31 @@ impl ContextProvider for CppContextProvider {
         let settings = LanguageSettings::resolve(buffer.map(|b| b.read(cx)), Some(&language), cx);
         let Some(executable) = settings.tasks.variables.get(CATCH2_TEST_PROGRAM).cloned() else {
             let error_msg = format!(
-                "Catch2 test executable not configured. \
-                 Set the {CATCH2_TEST_PROGRAM} variable under \
-                 languages.C++.tasks.variables in your settings.json."
+                "<<EOF
+Catch2 tests not configured.
+Add this configuration to your settings.json:
+
+{{
+ \"languages\": {{
+   \"C++\": {{
+     \"tasks\": {{
+       \"variables\": {{
+         \"CATCH2_TEST_PROGRAM\": \"<path to test program>\",
+         \"CATCH2_TEST_CWD\": \"<path to current working directory for test execution>\",
+         \"CATCH2_TEST_ADDITIONAL_ARGS\": \"<additional arguments passed to the test program>\",
+         \"CATCH2_TEST_BUILD_TASK\": \"<build task name, to run before debug sessions>\"
+        }}
+      }}
+    }}
+  }}
+}}
+"
             );
+
             return Task::ready(Some(TaskTemplates(vec![
                 TaskTemplate {
                     label: "catch2 run test case (not configured)".to_owned(),
-                    command: "echo".to_owned(),
+                    command: "cat".to_owned(),
                     args: vec![error_msg.clone()],
                     tags: vec!["catch2-test".to_owned()],
                     ..TaskTemplate::default()
@@ -98,10 +116,21 @@ impl ContextProvider for CppContextProvider {
             .map(|s| s.split_whitespace().map(str::to_owned).collect())
             .unwrap_or_default();
 
-        let catch2_test_name =
-            VariableName::Custom(Cow::Borrowed("CATCH2_TEST_NAME")).template_value();
-        let catch2_section_name =
-            VariableName::Custom(Cow::Borrowed("CATCH2_SECTION_NAME")).template_value();
+        let build_task_env: collections::HashMap<String, String> = settings
+            .tasks
+            .variables
+            .get(CATCH2_TEST_BUILD_TASK)
+            .map(|name| {
+                let mut map = collections::HashMap::default();
+                map.insert(CATCH2_TEST_BUILD_TASK.to_owned(), name.clone());
+                map
+            })
+            .unwrap_or_default();
+
+        let catch2_test_name = VariableName::Custom(Cow::Borrowed("CATCH2_TEST_NAME"))
+            .template_value_with_whitespace();
+        let catch2_section_name = VariableName::Custom(Cow::Borrowed("CATCH2_SECTION_NAME"))
+            .template_value_with_whitespace();
 
         let mut test_args = vec![catch2_test_name.clone()];
         test_args.extend(extra_args.iter().cloned());
@@ -120,6 +149,7 @@ impl ContextProvider for CppContextProvider {
                 args: test_args,
                 tags: vec!["catch2-test".to_owned()],
                 cwd: cwd.clone(),
+                env: build_task_env.clone(),
                 ..TaskTemplate::default()
             },
             TaskTemplate {
@@ -128,6 +158,7 @@ impl ContextProvider for CppContextProvider {
                 args: section_args,
                 tags: vec!["catch2-section".to_owned()],
                 cwd: cwd.clone(),
+                env: build_task_env,
                 ..TaskTemplate::default()
             },
         ])))

--- a/crates/languages/src/cpp.rs
+++ b/crates/languages/src/cpp.rs
@@ -1,4 +1,13 @@
+use gpui::{App, Task};
+pub use language::*;
+use language::{
+    Buffer, ContextProvider, LanguageName, LanguageToolchainStore,
+    language_settings::LanguageSettings,
+};
+
 use settings::SemanticTokenRules;
+use std::{borrow::Cow, sync::Arc};
+use task::{TaskTemplate, TaskTemplates, TaskVariables, VariableName};
 
 pub(crate) fn semantic_token_rules() -> SemanticTokenRules {
     let content = grammars::get_file("cpp/semantic_token_rules.json")
@@ -8,6 +17,123 @@ pub(crate) fn semantic_token_rules() -> SemanticTokenRules {
         .expect("failed to parse cpp semantic_token_rules.json")
 }
 
+pub(crate) struct CppContextProvider;
+
+const CATCH2_TEST_PROGRAM: &str = "CATCH2_TEST_PROGRAM";
+const CATCH2_TEST_CWD: &str = "CATCH2_TEST_CWD";
+const CATCH2_TEST_ADDITIONAL_ARGS: &str = "CATCH2_TEST_ADDITIONAL_ARGS";
+const CATCH2_TEST_NAME_VARIABLE: VariableName = VariableName::Custom(Cow::Borrowed("_test_name"));
+const CATCH2_SECTION_NAME_VARIABLE: VariableName =
+    VariableName::Custom(Cow::Borrowed("_section_name"));
+
+impl ContextProvider for CppContextProvider {
+    fn build_context(
+        &self,
+        variables: &TaskVariables,
+        _location: language::ContextLocation<'_>,
+        _project_env: Option<collections::HashMap<String, String>>,
+        _toolchains: Arc<dyn LanguageToolchainStore>,
+        _cx: &mut App,
+    ) -> Task<anyhow::Result<TaskVariables>> {
+        let mut new_vars = TaskVariables::default();
+
+        if let Some(raw) = variables.get(&CATCH2_TEST_NAME_VARIABLE) {
+            new_vars.insert(
+                VariableName::Custom(Cow::Borrowed("CATCH2_TEST_NAME")),
+                raw.to_owned(),
+            );
+        }
+        if let Some(raw) = variables.get(&CATCH2_SECTION_NAME_VARIABLE) {
+            new_vars.insert(
+                VariableName::Custom(Cow::Borrowed("CATCH2_SECTION_NAME")),
+                raw.to_owned(),
+            );
+        }
+
+        Task::ready(Ok(new_vars))
+    }
+
+    fn associated_tasks(
+        &self,
+        buffer: Option<gpui::Entity<Buffer>>,
+        cx: &App,
+    ) -> Task<Option<TaskTemplates>> {
+        let language = LanguageName::new_static("C++");
+        let settings = LanguageSettings::resolve(buffer.map(|b| b.read(cx)), Some(&language), cx);
+        let Some(executable) = settings.tasks.variables.get(CATCH2_TEST_PROGRAM).cloned() else {
+            let error_msg = format!(
+                "Catch2 test executable not configured. \
+                 Set the {CATCH2_TEST_PROGRAM} variable under \
+                 languages.C++.tasks.variables in your settings.json."
+            );
+            return Task::ready(Some(TaskTemplates(vec![
+                TaskTemplate {
+                    label: "catch2 run test case (not configured)".to_owned(),
+                    command: "echo".to_owned(),
+                    args: vec![error_msg.clone()],
+                    tags: vec!["catch2-test".to_owned()],
+                    ..TaskTemplate::default()
+                },
+                TaskTemplate {
+                    label: "catch2 run section (not configured)".to_owned(),
+                    command: "echo".to_owned(),
+                    args: vec![error_msg],
+                    tags: vec!["catch2-section".to_owned()],
+                    ..TaskTemplate::default()
+                },
+            ])));
+        };
+
+        let cwd = settings
+            .tasks
+            .variables
+            .get(CATCH2_TEST_CWD)
+            .cloned()
+            .or(Some("$ZED_DIRNAME".to_owned()));
+
+        let extra_args: Vec<String> = settings
+            .tasks
+            .variables
+            .get(CATCH2_TEST_ADDITIONAL_ARGS)
+            .map(|s| s.split_whitespace().map(str::to_owned).collect())
+            .unwrap_or_default();
+
+        let catch2_test_name =
+            VariableName::Custom(Cow::Borrowed("CATCH2_TEST_NAME")).template_value();
+        let catch2_section_name =
+            VariableName::Custom(Cow::Borrowed("CATCH2_SECTION_NAME")).template_value();
+
+        let mut test_args = vec![catch2_test_name.clone()];
+        test_args.extend(extra_args.iter().cloned());
+
+        let mut section_args = vec![
+            catch2_test_name.clone(),
+            "--section".to_owned(),
+            catch2_section_name.clone(),
+        ];
+        section_args.extend(extra_args);
+
+        Task::ready(Some(TaskTemplates(vec![
+            TaskTemplate {
+                label: format!("catch2 run test case {catch2_test_name}"),
+                command: executable.clone(),
+                args: test_args,
+                tags: vec!["catch2-test".to_owned()],
+                cwd: cwd.clone(),
+                ..TaskTemplate::default()
+            },
+            TaskTemplate {
+                label: format!("catch2 run section {catch2_section_name} in {catch2_test_name}"),
+                command: executable.clone(),
+                args: section_args,
+                tags: vec!["catch2-section".to_owned()],
+                cwd: cwd.clone(),
+                ..TaskTemplate::default()
+            },
+        ])))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use gpui::{AppContext as _, BorrowAppContext, TestAppContext};
@@ -15,6 +141,83 @@ mod tests {
     use settings::SettingsStore;
     use std::num::NonZeroU32;
     use unindent::Unindent;
+
+    #[gpui::test]
+    fn test_catch2_runnable_detection(cx: &mut TestAppContext) {
+        let language = crate::language("cpp", tree_sitter_cpp::LANGUAGE.into());
+
+        let source = r#"
+            TEST_CASE("My test case") {
+                SECTION("first section") {
+                }
+                SECTION("second section") {
+                }
+            }
+        "#
+        .unindent();
+
+        let buffer = cx.new(|cx| Buffer::local(source.clone(), cx).with_language(language, cx));
+        cx.executor().run_until_parked();
+
+        let runnables: Vec<_> = buffer.update(cx, |buffer, _| {
+            buffer.snapshot().runnable_ranges(0..source.len()).collect()
+        });
+
+        // Collect (tag, extra_captures) pairs for easier assertions.
+        let mut entries: Vec<(String, Vec<(String, String)>)> = runnables
+            .iter()
+            .flat_map(|r| {
+                r.runnable.tags.iter().map(|tag| {
+                    let mut captures: Vec<(String, String)> = r
+                        .extra_captures
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
+                    captures.sort();
+                    (tag.0.to_string(), captures)
+                })
+            })
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+
+        // One catch2-test for the TEST_CASE.
+        let test_entries: Vec<_> = entries
+            .iter()
+            .filter(|(tag, _)| tag == "catch2-test")
+            .collect();
+        assert_eq!(test_entries.len(), 1);
+        assert!(
+            test_entries[0]
+                .1
+                .iter()
+                .any(|(k, v)| k == "_test_name" && v == "\"My test case\"")
+        );
+
+        // Two catch2-section entries, one per SECTION, each carrying both _section_name and _test_name.
+        let section_entries: Vec<_> = entries
+            .iter()
+            .filter(|(tag, _)| tag == "catch2-section")
+            .collect();
+        assert_eq!(section_entries.len(), 2);
+
+        let section0: Vec<(String, String)> = section_entries[0].1.clone();
+        assert_eq!(section0.len(), 4);
+        assert_eq!(section0[0].0, "_inner_macro");
+        assert_eq!(section0[1].0, "_outer_macro");
+        assert_eq!(section0[2].0, "_section_name");
+        assert_eq!(section0[3].0, "_test_name");
+        assert_eq!(section0[2].1, "\"first section\"");
+        assert_eq!(section0[3].1, "\"My test case\"");
+
+        let section1: Vec<(String, String)> = section_entries[1].1.clone();
+        assert_eq!(section1.len(), 4);
+        assert_eq!(section1[0].0, "_inner_macro");
+        assert_eq!(section1[1].0, "_outer_macro");
+        assert_eq!(section1[2].0, "_section_name");
+        assert_eq!(section1[3].0, "_test_name");
+        assert_eq!(section1[2].1, "\"second section\"");
+        assert_eq!(section1[3].1, "\"My test case\"");
+    }
 
     #[gpui::test]
     async fn test_cpp_autoindent_access_specifier(cx: &mut TestAppContext) {

--- a/crates/languages/src/cpp.rs
+++ b/crates/languages/src/cpp.rs
@@ -1,4 +1,13 @@
+use gpui::{App, Task};
+pub use language::*;
+use language::{
+    Buffer, ContextProvider, LanguageName, LanguageToolchainStore,
+    language_settings::LanguageSettings,
+};
+
 use settings::SemanticTokenRules;
+use std::{borrow::Cow, sync::Arc};
+use task::{TaskTemplate, TaskTemplates, TaskVariables, VariableName};
 
 pub(crate) fn semantic_token_rules() -> SemanticTokenRules {
     let content = grammars::get_file("cpp/semantic_token_rules.json")
@@ -8,6 +17,123 @@ pub(crate) fn semantic_token_rules() -> SemanticTokenRules {
         .expect("failed to parse cpp semantic_token_rules.json")
 }
 
+pub(crate) struct CppContextProvider;
+
+const CATCH2_TEST_PROGRAM: &str = "CATCH2_TEST_PROGRAM";
+const CATCH2_TEST_CWD: &str = "CATCH2_TEST_CWD";
+const CATCH2_TEST_ADDITIONAL_ARGS: &str = "CATCH2_TEST_ADDITIONAL_ARGS";
+const CATCH2_TEST_NAME_VARIABLE: VariableName = VariableName::Custom(Cow::Borrowed("_test_name"));
+const CATCH2_SECTION_NAME_VARIABLE: VariableName =
+    VariableName::Custom(Cow::Borrowed("_section_name"));
+
+impl ContextProvider for CppContextProvider {
+    fn build_context(
+        &self,
+        variables: &TaskVariables,
+        _location: language::ContextLocation<'_>,
+        _project_env: Option<collections::HashMap<String, String>>,
+        _toolchains: Arc<dyn LanguageToolchainStore>,
+        _cx: &mut App,
+    ) -> Task<anyhow::Result<TaskVariables>> {
+        let mut new_vars = TaskVariables::default();
+
+        if let Some(raw) = variables.get(&CATCH2_TEST_NAME_VARIABLE) {
+            new_vars.insert(
+                VariableName::Custom(Cow::Borrowed("CATCH2_TEST_NAME")),
+                raw.to_owned(),
+            );
+        }
+        if let Some(raw) = variables.get(&CATCH2_SECTION_NAME_VARIABLE) {
+            new_vars.insert(
+                VariableName::Custom(Cow::Borrowed("CATCH2_SECTION_NAME")),
+                raw.to_owned(),
+            );
+        }
+
+        Task::ready(Ok(new_vars))
+    }
+
+    fn associated_tasks(
+        &self,
+        buffer: Option<gpui::Entity<Buffer>>,
+        cx: &App,
+    ) -> Task<Option<TaskTemplates>> {
+        let language = LanguageName::new_static("C++");
+        let settings = LanguageSettings::resolve(buffer.map(|b| b.read(cx)), Some(&language), cx);
+        let Some(executable) = settings.tasks.variables.get(CATCH2_TEST_PROGRAM).cloned() else {
+            let error_msg = format!(
+                "Catch2 test executable not configured. \
+                 Set the {CATCH2_TEST_PROGRAM} variable under \
+                 languages.C++.tasks.variables in your settings.json."
+            );
+            return Task::ready(Some(TaskTemplates(vec![
+                TaskTemplate {
+                    label: "catch2 run test case (not configured)".to_owned(),
+                    command: "echo".to_owned(),
+                    args: vec![error_msg.clone()],
+                    tags: vec!["catch2-test".to_owned()],
+                    ..TaskTemplate::default()
+                },
+                TaskTemplate {
+                    label: "catch2 run section (not configured)".to_owned(),
+                    command: "echo".to_owned(),
+                    args: vec![error_msg],
+                    tags: vec!["catch2-section".to_owned()],
+                    ..TaskTemplate::default()
+                },
+            ])));
+        };
+
+        let cwd = settings
+            .tasks
+            .variables
+            .get(CATCH2_TEST_CWD)
+            .cloned()
+            .or(Some("$ZED_DIRNAME".to_owned()));
+
+        let extra_args: Vec<String> = settings
+            .tasks
+            .variables
+            .get(CATCH2_TEST_ADDITIONAL_ARGS)
+            .map(|s| s.split_whitespace().map(str::to_owned).collect())
+            .unwrap_or_default();
+
+        let catch2_test_name =
+            VariableName::Custom(Cow::Borrowed("CATCH2_TEST_NAME")).template_value();
+        let catch2_section_name =
+            VariableName::Custom(Cow::Borrowed("CATCH2_SECTION_NAME")).template_value();
+
+        let mut test_args = vec![catch2_test_name.clone()];
+        test_args.extend(extra_args.iter().cloned());
+
+        let mut section_args = vec![
+            catch2_test_name.clone(),
+            "--section".to_owned(),
+            catch2_section_name.clone(),
+        ];
+        section_args.extend(extra_args);
+
+        Task::ready(Some(TaskTemplates(vec![
+            TaskTemplate {
+                label: format!("catch2 run test case {catch2_test_name}"),
+                command: executable.clone(),
+                args: test_args,
+                tags: vec!["catch2-test".to_owned()],
+                cwd: cwd.clone(),
+                ..TaskTemplate::default()
+            },
+            TaskTemplate {
+                label: format!("catch2 run section {catch2_section_name} in {catch2_test_name}"),
+                command: executable.clone(),
+                args: section_args,
+                tags: vec!["catch2-section".to_owned()],
+                cwd: cwd.clone(),
+                ..TaskTemplate::default()
+            },
+        ])))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use gpui::{AppContext as _, BorrowAppContext, TestAppContext};
@@ -15,6 +141,83 @@ mod tests {
     use settings::SettingsStore;
     use std::num::NonZeroU32;
     use unindent::Unindent;
+
+    #[gpui::test]
+    fn test_catch2_runnable_detection(cx: &mut TestAppContext) {
+        let language = crate::language("cpp", tree_sitter_cpp::LANGUAGE.into());
+
+        let source = r#"
+            TEST_CASE("My test case") {
+                SECTION("first section") {
+                }
+                SECTION("second section") {
+                }
+            }
+        "#
+        .unindent();
+
+        let buffer = cx.new(|cx| Buffer::local(source.clone(), cx).with_language(language, cx));
+        cx.executor().run_until_parked();
+
+        let runnables: Vec<_> = buffer.update(cx, |buffer, _| {
+            buffer.snapshot().runnable_ranges(0..source.len()).collect()
+        });
+
+        // Collect (tag, extra_captures) pairs for easier assertions.
+        let mut entries: Vec<(String, Vec<(String, String)>)> = runnables
+            .iter()
+            .flat_map(|r| {
+                r.runnable.tags.iter().map(|tag| {
+                    let mut captures: Vec<(String, String)> = r
+                        .extra_captures
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect();
+                    captures.sort();
+                    (tag.0.to_string(), captures)
+                })
+            })
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+
+        // One catch2-test for the TEST_CASE.
+        let test_entries: Vec<_> = entries
+            .iter()
+            .filter(|(tag, _)| tag == "catch2-test")
+            .collect();
+        assert_eq!(test_entries.len(), 1);
+        assert!(
+            test_entries[0]
+                .1
+                .iter()
+                .any(|(k, v)| k == "_test_name" && v == "\"My test case\"")
+        );
+
+        // Two catch2-section entries, one per SECTION, each carrying both _section_name and _test_name.
+        let section_entries: Vec<_> = entries
+            .iter()
+            .filter(|(tag, _)| tag == "catch2-section")
+            .collect();
+        assert_eq!(section_entries.len(), 2);
+
+        let section0: Vec<(String, String)> = section_entries[0].1.clone();
+        assert_eq!(section0.len(), 4);
+        assert_eq!(section0[0].0, "_inner_macro");
+        assert_eq!(section0[1].0, "_outer_macro");
+        assert_eq!(section0[2].0, "_section_name");
+        assert_eq!(section0[3].0, "_test_name");
+        assert_eq!(section0[2].1, "\"first section\"");
+        assert_eq!(section0[3].1, "\"My test case\"");
+
+        let section1: Vec<(String, String)> = section_entries[1].1.clone();
+        assert_eq!(section1.len(), 4);
+        assert_eq!(section1[0].0, "_inner_macro");
+        assert_eq!(section1[1].0, "_outer_macro");
+        assert_eq!(section1[2].0, "_section_name");
+        assert_eq!(section1[3].0, "_test_name");
+        assert_eq!(section1[2].1, "\"second section\"");
+        assert_eq!(section1[3].1, "\"My test case\"");
+    }
 
     #[gpui::test]
     async fn test_cpp_autoindent_switch_case(cx: &mut TestAppContext) {

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -59,6 +59,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
 
     let bash_lsp_adapter = Arc::new(bash::BashLspAdapter::new(node.clone()));
     let c_lsp_adapter = Arc::new(c::CLspAdapter);
+    let cpp_context_provider = Arc::new(cpp::CppContextProvider);
     let css_lsp_adapter = Arc::new(css::CssLspAdapter::new(node.clone()));
     let eslint_adapter = Arc::new(eslint::EsLintLspAdapter::new(node.clone(), fs.clone()));
     let go_context_provider = Arc::new(go::GoContextProvider);
@@ -100,6 +101,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         LanguageInfo {
             name: "cpp",
             adapters: vec![c_lsp_adapter],
+            context: Some(cpp_context_provider),
             semantic_token_rules: Some(cpp::semantic_token_rules()),
             ..Default::default()
         },

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -60,6 +60,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
 
     let bash_lsp_adapter = Arc::new(bash::BashLspAdapter::new(node.clone()));
     let c_lsp_adapter = Arc::new(c::CLspAdapter);
+    let cpp_context_provider = Arc::new(cpp::CppContextProvider);
     let css_lsp_adapter = Arc::new(css::CssLspAdapter::new(node.clone()));
     let eslint_adapter = Arc::new(eslint::EsLintLspAdapter::new(node.clone(), fs.clone()));
     let go_context_provider = Arc::new(go::GoContextProvider);
@@ -101,6 +102,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         LanguageInfo {
             name: "cpp",
             adapters: vec![c_lsp_adapter],
+            context: Some(cpp_context_provider),
             semantic_token_rules: Some(cpp::semantic_token_rules()),
             ..Default::default()
         },

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -121,6 +121,7 @@ impl DapStore {
         ADD_LOCATORS.call_once(|| {
             let registry = DapRegistry::global(cx);
             registry.add_locator(Arc::new(locators::cargo::CargoLocator {}));
+            registry.add_locator(Arc::new(locators::catch2::Catch2Locator));
             registry.add_locator(Arc::new(locators::go::GoLocator {}));
             registry.add_locator(Arc::new(locators::node::NodeLocator));
             registry.add_locator(Arc::new(locators::python::PythonLocator));

--- a/crates/project/src/debugger/locators.rs
+++ b/crates/project/src/debugger/locators.rs
@@ -1,4 +1,5 @@
 pub(crate) mod cargo;
+pub(crate) mod catch2;
 pub mod go;
 pub(crate) mod node;
 pub mod python;

--- a/crates/project/src/debugger/locators/catch2.rs
+++ b/crates/project/src/debugger/locators/catch2.rs
@@ -1,0 +1,55 @@
+use anyhow::{Result, bail};
+use async_trait::async_trait;
+use dap::{DapLocator, DebugRequest, adapters::DebugAdapterName};
+use gpui::{BackgroundExecutor, SharedString};
+use task::{BuildTaskDefinition, DebugScenario, SpawnInTerminal, TaskTemplate};
+
+pub(crate) struct Catch2Locator;
+
+const CATCH2_TEST_BUILD_TASK: &str = "CATCH2_TEST_BUILD_TASK";
+
+#[async_trait]
+impl DapLocator for Catch2Locator {
+    fn name(&self) -> SharedString {
+        SharedString::new_static("catch2-locator")
+    }
+
+    async fn create_scenario(
+        &self,
+        build_config: &TaskTemplate,
+        resolved_label: &str,
+        adapter: &DebugAdapterName,
+    ) -> Option<DebugScenario> {
+        let is_catch2 = build_config
+            .tags
+            .iter()
+            .any(|tag| tag == "catch2-test" || tag == "catch2-section");
+        if !is_catch2 {
+            return None;
+        }
+
+        let config = serde_json::json!({
+            "request": "launch",
+            "program": build_config.command,
+            "args": build_config.args,
+            "cwd": build_config.cwd,
+        });
+
+        let build = build_config
+            .env
+            .get(CATCH2_TEST_BUILD_TASK)
+            .map(|name| BuildTaskDefinition::ByName(name.clone().into()));
+
+        Some(DebugScenario {
+            adapter: adapter.0.clone(),
+            label: resolved_label.to_string().into(),
+            build: build,
+            config: config,
+            tcp_connection: None,
+        })
+    }
+
+    async fn run(&self, _: SpawnInTerminal, _executor: BackgroundExecutor) -> Result<DebugRequest> {
+        bail!("Catch2 locator does not require DapLocator::run to be called");
+    }
+}


### PR DESCRIPTION
# Objective

This PR adds the capability to run or debug [Catch2](https://github.com/catchorg/Catch2) tests right from the test file.

## Solution

The implementation adds two new tree-sitter specifications. One for detecting the `TEST_CASE` macro and one for detecting the `SECTION` macro.
The detected definitions are then used to generate TaskTemplates to start the unit test binary with the test case name and section as parameters.
The TaskTemplates are then further used in a new DapLocator to run the tests in a debugger.

New configuration options:
```json
{
  "languages": {
    "C++": {
      "tasks":{
        "variables": {
          "CATCH2_TEST_PROGRAM": "<path to test program>",
          "CATCH2_TEST_CWD": "<path to current working directory for test execution>",
          "CATCH2_TEST_ADDITIONAL_ARGS": "<additional arguments passed to the test program>",
          "CATCH2_TEST_BUILD_TASK": "<build task name, to run before debug sessions>"
        }
      }
    }
  }
}
```

## Testing

I've added a new test to ensure the tree-sitter definition works correctly.
I also verified that the changes work on a project that uses Catch2.
It might be beneficial to also test how the executable is started when the play button is pressed, but I'm not sure how to do that.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>
Play button is shown next to TEST_CASE and SECTION:
<img width="609" height="435" alt="image" src="https://github.com/user-attachments/assets/96f49914-6360-472d-bf25-90d1052dacb9" />

Running a TEST_CASE:
<img width="610" height="574" alt="image" src="https://github.com/user-attachments/assets/f197ea24-10f2-4be1-868f-716ddf235661" />

Running a SECTION within a TEST_CASE:
<img width="610" height="574" alt="image" src="https://github.com/user-attachments/assets/6e86d70a-a814-470a-9dfd-c5e77a900af7" />

</details>

---

Release Notes:

- cpp: Add ability to run Catch2 tests from the editor
