### PR TITLE
solo_diff_view: Add git action to open file diff and other improvements

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2798,6 +2798,7 @@ impl EditorElement {
     ) -> Vec<Option<AnyElement>> {
         let include_fold_statuses = EditorSettings::get_global(cx).gutter.folds
             && snapshot.mode.is_full()
+            && snapshot.display_snapshot.companion_snapshot().is_none()
             && self.editor.read(cx).buffer_kind(cx) == ItemBufferKind::Singleton;
         if include_fold_statuses {
             row_infos

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -115,6 +115,8 @@ actions!(
         Init,
         /// Opens all modified files in the editor.
         OpenModifiedFiles,
+        /// Opens the current file in a solo diff view.
+        OpenFileDiff,
         /// Clones a repository.
         Clone,
         ViewCommit,

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -17,7 +17,7 @@ use git::{
 };
 use gpui::{
     App, ClipboardItem, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
-    SharedString, Subscription, Task, TaskExt, Window,
+    SharedString, Subscription, Task, TaskExt, WeakEntity, Window,
 };
 use menu::{Cancel, Confirm};
 use project::git_store::Repository;
@@ -292,8 +292,22 @@ pub fn init(cx: &mut App) {
         workspace.register_action(|workspace, _: &git::OpenModifiedFiles, window, cx| {
             open_modified_files(workspace, window, cx);
         });
-        workspace.register_action(|workspace, _: &git::OpenFileDiff, window, cx| {
-            open_file_diff(workspace, window, cx);
+        workspace.register_action_renderer(|div, workspace, _window, cx| {
+            div.when_some(
+                file_diff_entry(workspace, cx),
+                |div, (entry, repository)| {
+                    let workspace = workspace.weak_handle();
+                    div.on_action(move |_: &git::OpenFileDiff, window, cx| {
+                        open_file_diff(
+                            entry.clone(),
+                            repository.clone(),
+                            workspace.clone(),
+                            window,
+                            cx,
+                        );
+                    })
+                },
+            )
         });
         workspace.register_action(|workspace, _: &git::RenameBranch, window, cx| {
             rename_current_branch(workspace, window, cx);
@@ -314,18 +328,28 @@ pub fn init(cx: &mut App) {
 }
 
 fn open_file_diff(
-    workspace: &mut Workspace,
+    entry: GitStatusEntry,
+    repository: Entity<Repository>,
+    workspace: WeakEntity<Workspace>,
     window: &mut Window,
-    cx: &mut Context<Workspace>,
+    cx: &mut App,
 ) {
-    let Some(project_path) = workspace
-        .active_item(cx)
-        .and_then(|item| item.project_path(cx))
-    else {
-        return;
-    };
+    window.defer(cx, {
+        let workspace = workspace.clone();
+        move |window, cx| {
+            SoloDiffView::open_or_focus(entry, repository, workspace.clone(), window, cx)
+                .detach_and_notify_err(workspace, window, cx);
+        }
+    });
+}
 
-    let Some((entry, repository)) = workspace
+fn file_diff_entry(
+    workspace: &Workspace,
+    cx: &App,
+) -> Option<(GitStatusEntry, Entity<Repository>)> {
+    let project_path = workspace.active_item(cx)?.project_path(cx)?;
+
+    workspace
         .project()
         .read(cx)
         .repositories(cx)
@@ -345,18 +369,6 @@ fn open_file_diff(
                 repository.clone(),
             ))
         })
-    else {
-        return;
-    };
-
-    let workspace = workspace.weak_handle();
-    window.defer(cx, {
-        let workspace = workspace.clone();
-        move |window, cx| {
-            SoloDiffView::open_or_focus(entry, repository, workspace.clone(), window, cx)
-                .detach_and_notify_err(workspace, window, cx);
-        }
-    });
 }
 
 fn open_modified_files(

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -24,10 +24,18 @@ use project::git_store::Repository;
 use project_diff::ProjectDiff;
 use time::OffsetDateTime;
 use ui::prelude::*;
-use workspace::{ModalView, OpenMode, Workspace, notifications::DetachAndPromptErr};
+use workspace::{
+    ModalView, OpenMode, Workspace,
+    notifications::{DetachAndPromptErr, NotifyTaskExt},
+};
 use zed_actions;
 
-use crate::{commit_view::CommitView, git_panel::GitPanel, text_diff_view::TextDiffView};
+use crate::{
+    commit_view::CommitView,
+    git_panel::{GitPanel, GitStatusEntry},
+    solo_diff_view::SoloDiffView,
+    text_diff_view::TextDiffView,
+};
 
 mod askpass_modal;
 pub mod branch_picker;
@@ -284,6 +292,9 @@ pub fn init(cx: &mut App) {
         workspace.register_action(|workspace, _: &git::OpenModifiedFiles, window, cx| {
             open_modified_files(workspace, window, cx);
         });
+        workspace.register_action(|workspace, _: &git::OpenFileDiff, window, cx| {
+            open_file_diff(workspace, window, cx);
+        });
         workspace.register_action(|workspace, _: &git::RenameBranch, window, cx| {
             rename_current_branch(workspace, window, cx);
         });
@@ -300,6 +311,52 @@ pub fn init(cx: &mut App) {
         );
     })
     .detach();
+}
+
+fn open_file_diff(
+    workspace: &mut Workspace,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let Some(project_path) = workspace
+        .active_item(cx)
+        .and_then(|item| item.project_path(cx))
+    else {
+        return;
+    };
+
+    let Some((entry, repository)) = workspace
+        .project()
+        .read(cx)
+        .repositories(cx)
+        .values()
+        .find_map(|repository| {
+            let repo_path = repository
+                .read(cx)
+                .project_path_to_repo_path(&project_path, cx)?;
+            let status_entry = repository.read(cx).status_for_path(&repo_path)?;
+            Some((
+                GitStatusEntry {
+                    repo_path,
+                    status: status_entry.status,
+                    staging: status_entry.status.staging(),
+                    diff_stat: status_entry.diff_stat,
+                },
+                repository.clone(),
+            ))
+        })
+    else {
+        return;
+    };
+
+    let workspace = workspace.weak_handle();
+    window.defer(cx, {
+        let workspace = workspace.clone();
+        move |window, cx| {
+            SoloDiffView::open_or_focus(entry, repository, workspace.clone(), window, cx)
+                .detach_and_notify_err(workspace, window, cx);
+        }
+    });
 }
 
 fn open_modified_files(

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -334,12 +334,9 @@ fn open_file_diff(
     window: &mut Window,
     cx: &mut App,
 ) {
-    window.defer(cx, {
-        let workspace = workspace.clone();
-        move |window, cx| {
-            SoloDiffView::open_or_focus(entry, repository, workspace.clone(), window, cx)
-                .detach_and_notify_err(workspace, window, cx);
-        }
+    window.defer(cx, move |window, cx| {
+        SoloDiffView::open_or_focus(entry, repository, workspace.clone(), window, cx)
+            .detach_and_notify_err(workspace, window, cx);
     });
 }
 

--- a/crates/git_ui/src/solo_diff_view.rs
+++ b/crates/git_ui/src/solo_diff_view.rs
@@ -659,6 +659,7 @@ impl Render for SoloDiffGitToolbar {
                 DiffStat::new("solo-diff-stat", stat.added as usize, stat.deleted as usize)
                     .into_any_element()
             }))
+            .child(Divider::vertical())
             .child(
                 h_group_sm()
                     .when(button_states.selection, |el| {
@@ -746,7 +747,7 @@ impl Render for SoloDiffGitToolbar {
             .child(vertical_divider())
             .child(
                 h_group_sm()
-                    .child(
+                    .child(if button_states.stage_file {
                         Button::new("stage-file", "Stage File")
                             .tooltip(Tooltip::for_action_title_in(
                                 "Stage file",
@@ -756,9 +757,8 @@ impl Render for SoloDiffGitToolbar {
                             .disabled(!button_states.stage_file)
                             .on_click(
                                 cx.listener(|this, _, window, cx| this.stage_file(window, cx)),
-                            ),
-                    )
-                    .child(
+                            )
+                    } else {
                         Button::new("unstage-file", "Unstage File")
                             .tooltip(Tooltip::for_action_title_in(
                                 "Unstage file",
@@ -768,9 +768,8 @@ impl Render for SoloDiffGitToolbar {
                             .disabled(!button_states.unstage_file)
                             .on_click(
                                 cx.listener(|this, _, window, cx| this.unstage_file(window, cx)),
-                            ),
-                    )
-                    .child(Divider::vertical())
+                            )
+                    })
                     .child(
                         Button::new("commit", "Commit")
                             .tooltip(Tooltip::for_action_title_in(


### PR DESCRIPTION
# Objective

- Polish the solo diff review UI by reducing redundant controls and hiding inactive fold controls in split diff views.

## Solution

- Collapse the solo diff header's `Stage File` / `Unstage File` actions into one button that shows the action relevant to the file's current staging state.
- Stop reserving fold gutter space and rendering fold crease toggles for editors with companion snapshots, matching the existing LHS split diff behavior.

## Testing

- `cargo fmt --check`
- `cargo check -p git_ui`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before, the solo diff header showed both file-level staging actions at once, and the RHS split diff gutter could show fold arrows that did not work in that view. After this change, the header shows the relevant file-level staging action and split companion panes no longer show inactive fold controls.

Release Notes:

- Improved solo diff controls by showing the relevant file staging action and hiding inactive fold toggles in split diffs.
