### PR TITLE
ci: Fix bwrap jobs on `run_bundling`

### DIFF
--- a/.github/workflows/run_bundling.yml
+++ b/.github/workflows/run_bundling.yml
@@ -99,6 +99,9 @@ jobs:
         if-no-files-found: error
     timeout-minutes: 60
   build_static_bwrap_linux_aarch64:
+    if: |-
+      (github.event.action == 'labeled' && github.event.label.name == 'run-bundling') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-bundling'))
     runs-on: namespace-profile-8x32-ubuntu-2004-arm-m4
     steps:
     - name: steps::cache_nix_dependencies_namespace
@@ -130,6 +133,9 @@ jobs:
         if-no-files-found: error
     timeout-minutes: 60
   build_static_bwrap_linux_x86_64:
+    if: |-
+      (github.event.action == 'labeled' && github.event.label.name == 'run-bundling') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'run-bundling'))
     runs-on: namespace-profile-32x64-ubuntu-2004
     steps:
     - name: steps::cache_nix_dependencies_namespace

--- a/tooling/xtask/src/tasks/workflows/run_bundling.rs
+++ b/tooling/xtask/src/tasks/workflows/run_bundling.rs
@@ -114,7 +114,7 @@ pub(crate) fn build_static_bwrap(arch: Arch, deps: &[&NamedJob]) -> NamedJob {
 
     NamedJob {
         name: format!("build_static_bwrap_linux_{arch}"),
-        job: dependant_job(deps)
+        job: bundle_job(deps)
             .runs_on(arch.linux_bundler())
             .timeout_minutes(60u32)
             .add_step(steps::cache_nix_dependencies_namespace())


### PR DESCRIPTION
This fixes an issue where the bwrap bundle jobs were not guarded properly and thus showed up as `cancelled` in the job list for PRs from external contributors, causing the CI to show as failed on a PR (e.g. https://github.com/zed-industries/zed/actions/runs/28028544741/job/82963972185?pr=59758)

Release Notes:

- N/A
