### PR TITLE
agent_ui: Fix opening the profile configuration modal from picker

### DIFF
--- a/assets/keymaps/specific-overrides-macos.json
+++ b/assets/keymaps/specific-overrides-macos.json
@@ -11,6 +11,12 @@
     "use_key_equivalents": true,
     "bindings": {
       "cmd-shift-a": "picker::ToggleActionsMenu",
+    },
+  },
+  {
+    "context": "(Picker && with_preview) > Editor",
+    "use_key_equivalents": true,
+    "bindings": {
       "cmd-alt-p": "picker::TogglePreview",
       "cmd-alt-right": "picker::SetPreviewRight",
       "cmd-alt-down": "picker::SetPreviewBelow",

--- a/assets/keymaps/specific-overrides.json
+++ b/assets/keymaps/specific-overrides.json
@@ -10,6 +10,11 @@
     "context": "Picker > Editor",
     "bindings": {
       "ctrl-shift-a": "picker::ToggleActionsMenu",
+    },
+  },
+  {
+    "context": "(Picker && with_preview) > Editor",
+    "bindings": {
       "ctrl-alt-p": "picker::TogglePreview",
       "ctrl-alt-right": "picker::SetPreviewRight",
       "ctrl-alt-down": "picker::SetPreviewBelow",

--- a/crates/picker/src/render.rs
+++ b/crates/picker/src/render.rs
@@ -1,4 +1,4 @@
-use gpui::canvas;
+use gpui::{KeyContext, canvas};
 use settings::Settings;
 use theme_settings::ThemeSettings;
 use ui::{
@@ -89,8 +89,15 @@ impl<D: PickerDelegate> Picker<D> {
 
         let editor_position = self.delegate.editor_position();
         let picker_bounds = self.picker_bounds.clone();
+
+        let mut key_context = KeyContext::default();
+        key_context.add("Picker");
+        if self.preview.is_some() {
+            key_context.add("with_preview");
+        }
+
         let menu = v_flex()
-            .key_context("Picker")
+            .key_context(key_context)
             .relative()
             .map(|this| {
                 self.shape.apply_results_size(


### PR DESCRIPTION
Release Notes:

- Agent: Fixed a bug where trying to open the profile configuration modal through the picker in the agent panel's message editor wouldn't work through the keybinding.
