### PR TITLE
text_finder: Allow horizontal scrolling in editor preview

### DIFF
--- a/crates/picker/src/preview/render.rs
+++ b/crates/picker/src/preview/render.rs
@@ -72,7 +72,7 @@ impl EditorPreview {
                     .id("picker-preview-editor")
                     .absolute()
                     .inset_0()
-                    .occlude()
+                    .block_mouse_except_scroll()
                     .on_click(|_, window, cx| {
                         window.dispatch_action(ToMultiBuffer.boxed_clone(), cx);
                     }),


### PR DESCRIPTION
## Summary

The picker's editor preview forbids vertical and horizontal scrolling. `occlude()` blocks **all** mouse interaction including scroll wheel/trackpad events. As a result, lines wider than the preview pane ran off the right edge with no way to read them.

## Solution

Switch the overlay from `occlude()` to `block_mouse_except_scroll()`. Since the editor only forbids vertical scroll (there is no horizontal equivalent), this enables horizontal scrolling while keeping the vertical view pinned to the fixed excerpt around the match.

## Testing

- Manual: open the text finder / file finder preview on a file with long lines and scroll left/right and the view doesn't scroll vertically.

## Release Notes:

- Improved the picker preview to allow horizontal scrolling of long lines
