### PR TITLE
ep: Collect editable context in settled

### DIFF
--- a/crates/cloud_api_types/src/cloud_api_types.rs
+++ b/crates/cloud_api_types/src/cloud_api_types.rs
@@ -162,6 +162,8 @@ pub struct SettledEditPredictionSampleData {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub buffer_diagnostics: Vec<zeta_prompt::ActiveBufferDiagnostic>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub editable_context: Vec<zeta_prompt::EditableContextFile>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub future_edit_history_events: Vec<Arc<zeta_prompt::Event>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub navigation_history: Vec<EditPredictionRecentFile>,

--- a/crates/edit_prediction/src/capture_prediction_context.rs
+++ b/crates/edit_prediction/src/capture_prediction_context.rs
@@ -4,6 +4,7 @@ use crate::{
     zeta,
 };
 use anyhow::Result;
+use edit_prediction_context::EditableContextFile;
 use gpui::{Context, Entity, Task};
 use language::{Buffer, Point, ToPoint as _};
 use project::Project;
@@ -16,6 +17,7 @@ pub(crate) struct CapturedPredictionContext {
     pub(crate) revision: Option<String>,
     pub(crate) uncommitted_diff: Option<String>,
     pub(crate) buffer_diagnostics: Vec<zeta_prompt::ActiveBufferDiagnostic>,
+    pub(crate) editable_context: Vec<EditableContextFile>,
 }
 
 pub(crate) fn capture_prediction_context(
@@ -25,6 +27,7 @@ pub(crate) fn capture_prediction_context(
     stored_events: Vec<StoredEvent>,
     repository_url: Option<String>,
     revision: Option<String>,
+    editable_context_task: Task<Result<Vec<EditableContextFile>>>,
     cx: &mut Context<EditPredictionStore>,
 ) -> Option<Task<Result<CapturedPredictionContext>>> {
     let snapshot = buffer.read(cx).snapshot();
@@ -74,12 +77,20 @@ pub(crate) fn capture_prediction_context(
             cursor_anchor.to_point(&snapshot).row,
             100,
         );
+        let editable_context = match editable_context_task.await {
+            Ok(editable_context) => editable_context,
+            Err(error) => {
+                log::debug!("failed to capture editable context: {error:?}");
+                Vec::new()
+            }
+        };
 
         Ok(CapturedPredictionContext {
             repository_url,
             revision,
             uncommitted_diff,
             buffer_diagnostics,
+            editable_context,
         })
     }))
 }

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -21,7 +21,9 @@ use collections::{HashMap, HashSet};
 use copilot::{Copilot, Reinstall, SignIn, SignOut};
 use credentials_provider::CredentialsProvider;
 use db::kvp::{Dismissable, KeyValueStore};
-use edit_prediction_context::{RelatedExcerptStore, RelatedExcerptStoreEvent, RelatedFile};
+use edit_prediction_context::{
+    EditableContextFile, RelatedExcerptStore, RelatedExcerptStoreEvent, RelatedFile,
+};
 use edit_prediction_types::EditPredictionRequestTrigger;
 use feature_flags::{FeatureFlag, FeatureFlagAppExt as _, PresenceFlag, register_feature_flag};
 use futures::{
@@ -56,7 +58,6 @@ use std::env;
 use std::rc::Rc;
 use text::{AnchorRangeExt, Edit};
 use workspace::{AppState, Workspace};
-#[cfg(feature = "cli-support")]
 use zeta_prompt::ContextSource;
 use zeta_prompt::{ZetaFormat, ZetaPromptInput};
 
@@ -2076,6 +2077,7 @@ impl EditPredictionStore {
                                     editable_path: sample_data.editable_path,
                                     editable_offset_range: sample_data.editable_offset_range,
                                     buffer_diagnostics: context.buffer_diagnostics,
+                                    editable_context: context.editable_context,
                                     future_edit_history_events: sample_data
                                         .future_edit_history_events,
                                     navigation_history: sample_data
@@ -2795,6 +2797,14 @@ impl EditPredictionStore {
             EditPredictionModel::Zeta => {
                 let context_task = can_collect_data
                     .then(|| {
+                        let editable_context_task = self.collect_editable_context(
+                            inputs.project.clone(),
+                            inputs.buffer.clone(),
+                            inputs.position,
+                            Vec::new(),
+                            vec![ContextSource::CurrentFile, ContextSource::EditHistory],
+                            cx,
+                        );
                         capture_prediction_context(
                             inputs.project.clone(),
                             inputs.buffer.clone(),
@@ -2802,6 +2812,7 @@ impl EditPredictionStore {
                             stored_events,
                             repository_url.clone(),
                             revision,
+                            editable_context_task,
                             cx,
                         )
                     })
@@ -2978,7 +2989,6 @@ impl EditPredictionStore {
             });
     }
 
-    #[cfg(feature = "cli-support")]
     pub fn collect_editable_context(
         &mut self,
         project: Entity<Project>,
@@ -2987,7 +2997,7 @@ impl EditPredictionStore {
         oracle_paths: Vec<Arc<Path>>,
         context_sources: Vec<ContextSource>,
         cx: &mut Context<Self>,
-    ) -> Task<anyhow::Result<Vec<RelatedFile>>> {
+    ) -> Task<anyhow::Result<Vec<EditableContextFile>>> {
         use edit_prediction_context::{EditHistoryContextEntry, collect_editable_context};
 
         let buffers_by_id = project.read(cx).opened_buffers(cx).into_iter().fold(

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -3514,6 +3514,17 @@ async fn test_edit_prediction_settled_sends_sample_data_after_quiescence(cx: &mu
                 snippet_buffer_row_range: 0..0,
                 diagnostic_range_in_snippet: 0..0,
             }],
+            editable_context: vec![zeta_prompt::EditableContextFile {
+                path: Path::new("foo.md").into(),
+                max_row: 60,
+                excerpts: vec![zeta_prompt::EditableContextExcerpt {
+                    row_range: 0..2,
+                    text: "line 0\nline 1\n".into(),
+                    order: 0,
+                    context_source: zeta_prompt::ContextSource::CurrentFile,
+                }],
+                in_open_source_repo: true,
+            }],
         },
         Some(boundary),
         VecDeque::from([RecentFile {
@@ -3553,6 +3564,7 @@ async fn test_edit_prediction_settled_sends_sample_data_after_quiescence(cx: &mu
             revision: None,
             uncommitted_diff: None,
             buffer_diagnostics: Vec::new(),
+            editable_context: Vec::new(),
         },
         Some(boundary),
         VecDeque::new(),
@@ -3617,6 +3629,14 @@ async fn test_edit_prediction_settled_sends_sample_data_after_quiescence(cx: &mu
     assert_eq!(sample_data.editable_path.as_ref(), Path::new("foo.md"));
     assert_eq!(sample_data.editable_offset_range, editable_offset_range);
     assert_eq!(sample_data.buffer_diagnostics.len(), 1);
+    assert_eq!(sample_data.editable_context.len(), 1);
+    let editable_context = &sample_data.editable_context[0];
+    assert_eq!(editable_context.path.as_ref(), Path::new("foo.md"));
+    assert_eq!(editable_context.excerpts.len(), 1);
+    assert_eq!(
+        editable_context.excerpts[0].context_source,
+        zeta_prompt::ContextSource::CurrentFile
+    );
     assert_eq!(sample_data.future_edit_history_events.len(), 4);
     assert_eq!(sample_data.navigation_history.len(), 1);
     assert_eq!(sample_data.edit_events_before_quiescence, 5);
@@ -3700,6 +3720,7 @@ async fn test_edit_prediction_settled_sample_data_requires_observing_all_events_
             revision: None,
             uncommitted_diff: None,
             buffer_diagnostics: Vec::new(),
+            editable_context: Vec::new(),
         },
         Some(boundary_observed),
         VecDeque::new(),
@@ -3731,6 +3752,7 @@ async fn test_edit_prediction_settled_sample_data_requires_observing_all_events_
             revision: None,
             uncommitted_diff: None,
             buffer_diagnostics: Vec::new(),
+            editable_context: Vec::new(),
         },
         Some(boundary_missed),
         VecDeque::new(),
@@ -3784,6 +3806,7 @@ async fn test_edit_prediction_settled_drops_future_events_when_their_oss_status_
             revision: None,
             uncommitted_diff: None,
             buffer_diagnostics: Vec::new(),
+            editable_context: Vec::new(),
         },
         None,
         VecDeque::new(),

--- a/crates/edit_prediction_cli/src/retrieve_context.rs
+++ b/crates/edit_prediction_cli/src/retrieve_context.rs
@@ -177,7 +177,24 @@ pub async fn run_context_retrieval(
                     cx,
                 )
             })
-            .await?;
+            .await?
+            .into_iter()
+            .map(|file| zeta_prompt::RelatedFile {
+                path: file.path,
+                max_row: file.max_row,
+                excerpts: file
+                    .excerpts
+                    .into_iter()
+                    .map(|excerpt| zeta_prompt::RelatedExcerpt {
+                        row_range: excerpt.row_range,
+                        text: excerpt.text,
+                        order: excerpt.order,
+                        context_source: excerpt.context_source,
+                    })
+                    .collect(),
+                in_open_source_repo: file.in_open_source_repo,
+            })
+            .collect();
         merge_context_files(&mut context_files, editable_context);
     }
 

--- a/crates/edit_prediction_context/src/edit_prediction_context.rs
+++ b/crates/edit_prediction_context/src/edit_prediction_context.rs
@@ -32,7 +32,9 @@ pub use editable_context::{
     EditHistoryContextEntry, collect_editable_context, limit_retrieved_context_to_bytes,
 };
 
-pub use zeta_prompt::{ContextSource, RelatedExcerpt, RelatedFile};
+pub use zeta_prompt::{
+    ContextSource, EditableContextExcerpt, EditableContextFile, RelatedExcerpt, RelatedFile,
+};
 
 const IDENTIFIER_LINE_COUNT: u32 = 3;
 const MAX_CONTEXT_IDENTIFIER_COUNT: usize = 32;

--- a/crates/edit_prediction_context/src/editable_context.rs
+++ b/crates/edit_prediction_context/src/editable_context.rs
@@ -9,7 +9,7 @@ use std::{
 };
 use text::Anchor;
 use util::{paths::PathStyle, rel_path::RelPath};
-use zeta_prompt::{ContextSource, RelatedExcerpt, RelatedFile};
+use zeta_prompt::{ContextSource, EditableContextExcerpt, EditableContextFile, RelatedFile};
 
 use crate::{
     bm25_context::{Bm25ContextCandidate, collect_bm25_context},
@@ -51,7 +51,7 @@ pub async fn collect_editable_context(
     oracle_paths: Vec<Arc<Path>>,
     context_sources: Vec<ContextSource>,
     cx: &mut AsyncApp,
-) -> anyhow::Result<Vec<RelatedFile>> {
+) -> anyhow::Result<Vec<EditableContextFile>> {
     let mut ranges_by_buffer = RangesByBuffer::default();
 
     if context_sources.contains(&ContextSource::CursorExcerpt) {
@@ -196,7 +196,10 @@ pub fn limit_retrieved_context_to_bytes(
         .collect()
 }
 
-fn uncovered_excerpt_bytes(excerpt: &RelatedExcerpt, covered_ranges: &[Range<u32>]) -> usize {
+fn uncovered_excerpt_bytes(
+    excerpt: &zeta_prompt::RelatedExcerpt,
+    covered_ranges: &[Range<u32>],
+) -> usize {
     let mut bytes = 0;
 
     for (row, line) in (excerpt.row_range.start..).zip(excerpt.text.split_inclusive('\n')) {
@@ -616,7 +619,7 @@ fn related_file_for_ranges(
     buffer: &Entity<Buffer>,
     ranges: Vec<EditableContextRange>,
     cx: &App,
-) -> Option<RelatedFile> {
+) -> Option<EditableContextFile> {
     let buffer = buffer.read(cx);
     let snapshot = buffer.snapshot();
     let file = snapshot.file()?;
@@ -632,7 +635,7 @@ fn related_file_for_ranges(
 
     let mut excerpts = ranges
         .into_iter()
-        .map(|range| RelatedExcerpt {
+        .map(|range| EditableContextExcerpt {
             row_range: range.range.start.row..range.range.end.row,
             text: snapshot
                 .text_for_range(range.range)
@@ -644,7 +647,7 @@ fn related_file_for_ranges(
         .collect::<Vec<_>>();
     excerpts.sort_by_key(|excerpt| excerpt.order);
 
-    Some(RelatedFile {
+    Some(EditableContextFile {
         path,
         max_row: snapshot.max_point().row,
         excerpts,

--- a/crates/zeta_prompt/src/zeta_prompt.rs
+++ b/crates/zeta_prompt/src/zeta_prompt.rs
@@ -268,6 +268,25 @@ pub enum ContextSource {
     OracleFile,
 }
 
+#[derive(Clone, Debug, PartialEq, Hash, Serialize, Deserialize)]
+pub struct EditableContextFile {
+    pub path: Arc<Path>,
+    pub max_row: u32,
+    pub excerpts: Vec<EditableContextExcerpt>,
+    #[serde(default)]
+    pub in_open_source_repo: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Hash, Serialize, Deserialize)]
+pub struct EditableContextExcerpt {
+    pub row_range: Range<u32>,
+    pub text: Arc<str>,
+    #[serde(default)]
+    pub order: usize,
+    #[serde(default)]
+    pub context_source: ContextSource,
+}
+
 pub fn prompt_input_contains_special_tokens(input: &ZetaPromptInput, format: ZetaFormat) -> bool {
     special_tokens_for_format(format).iter().any(|token| {
         if let Some(line_token) = token.strip_suffix('\n') {


### PR DESCRIPTION
# Objective

Collect editable context in settled edit-prediction samples so offline training/evaluation can use the same contextual signal available at prediction time.

## Solution

- Add editable context to settled sample payloads.
- Capture current-file and edit-history context alongside the existing settled sample data.
- Keep context collection best-effort so sample upload is not blocked by context failures.

## Testing

- Added settled-sample test coverage for editable context capture.
- GitHub CI is still pending.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
