### PR TITLE
agent_ui: Fix favorite model button not showing for unselected models

### DIFF
--- a/crates/agent_ui/src/ui/model_selector_components.rs
+++ b/crates/agent_ui/src/ui/model_selector_components.rs
@@ -144,11 +144,6 @@ impl RenderOnce for ModelSelectorListItem {
             .when_some(self.disabled, |this, disabled_reason| {
                 this.disabled(true)
                     .tooltip(Tooltip::text(disabled_reason.0))
-                    .end_slot(
-                        div()
-                            .pr_2()
-                            .child(Icon::new(IconName::Info).color(Color::Muted)),
-                    )
             })
             .child(
                 h_flex()
@@ -182,13 +177,17 @@ impl RenderOnce for ModelSelectorListItem {
                         this.child(Chip::new(cost_info).tooltip(Tooltip::text(tooltip_text)))
                     }),
             )
-            .when(self.is_selected, |this| {
-                this.end_slot(
-                    div()
-                        .pr_2()
-                        .child(Icon::new(IconName::Check).color(Color::Accent)),
-                )
-            })
+            .end_slot(
+                h_flex()
+                    .pr_2()
+                    .gap_1p5()
+                    .when(self.is_selected, |this| {
+                        this.child(Icon::new(IconName::Check).color(Color::Accent))
+                    })
+                    .when(is_disabled, |this| {
+                        this.child(Icon::new(IconName::Info).color(Color::Muted))
+                    }),
+            )
             .when(!is_disabled, |this| {
                 this.end_slot_on_hover(div().pr_1p5().when_some(self.on_toggle_favorite, {
                     |this, handle_click| {


### PR DESCRIPTION
Release Notes:

- Fixed an issue where adding a model as a favorite was not possible for all models but the currently selected one (preview only).
