### PR TITLE
grammars: Add semantic token rule for Python constants

### DIFF
--- a/crates/grammars/src/python/semantic_token_rules.json
+++ b/crates/grammars/src/python/semantic_token_rules.json
@@ -11,5 +11,10 @@
   {
     "token_type": "builtinConstant",
     "style": ["constant.builtin"]
+  },
+  {
+    "token_type": "variable",
+    "token_modifiers": ["readonly"],
+    "style": ["constant"]
   }
 ]


### PR DESCRIPTION
# Objective

In Python, using variables in all uppercase letters signals that the variable is a constant. In Zed's built-in Python grammar, this convention is respected. Similarly, the `ty` language server has a rule for this:

https://github.com/astral-sh/ruff/blob/e39ded7e89f503d892217364f924b38362fb9a66/crates/ty_ide/src/semantic_tokens.rs#L264-L267

https://github.com/astral-sh/ruff/blob/e39ded7e89f503d892217364f924b38362fb9a66/crates/ty_ide/src/semantic_tokens.rs#L356-L358

It returns a `"readonly"` token modifier if an item is determined to be a constant. However, this specific modifier is not currently respected in Zed. Consequently, when using `ty` as the language server (which is expected to be a common setup in the near future, similar to `ruff` and `uv`), and enable semantic token highlighting, these constants are highlighted as normal variables.

## Solution

- Added a new semantic token rule in `crates/grammars/src/python/semantic_token_rules.json` to provide highlighting for constants.

## Testing

- This change primarily affects the UI and has been tested locally. A before-and-after comparison is provided below in the Showcase section.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>

| Before | After |
| :---: | :---: |
| <img width="441" height="208" alt="highlight_before" src="https://github.com/user-attachments/assets/64cc28ba-32b6-4620-a212-8f7d43f54821" /> | <img width="441" height="208" alt="highlight_after" src="https://github.com/user-attachments/assets/133919fd-03c8-4f6c-9bf9-9efa2610f050" /> |
| <img width="498" height="145" alt="highlight_tree_before" src="https://github.com/user-attachments/assets/b79f4036-65e4-4e4e-b0e9-e653529e114d" /> | <img width="498" height="145" alt="highlight_tree_after" src="https://github.com/user-attachments/assets/e0c3ae74-46b4-4d06-895b-51da69d410c5" /> |
</details>

---

Release Notes:

- Improved semantic highlighting for Python constants when using the `ty` language server.
