### PR TITLE
recent_projects: Fix read ssh server index always being 0

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -3192,8 +3192,9 @@ mod create_host_tests {
         });
 
         let host_b = SharedString::from("host-b.example");
-        let new_index =
-            modal.update(cx, |modal, cx| modal.create_host_from_ssh_config(&host_b, cx));
+        let new_index = modal.update(cx, |modal, cx| {
+            modal.create_host_from_ssh_config(&host_b, cx)
+        });
         cx.run_until_parked();
 
         let connections = cx.update(|_, cx| {

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -36,10 +36,7 @@ use std::{
     borrow::Cow,
     collections::BTreeSet,
     path::PathBuf,
-    sync::{
-        Arc,
-        atomic::{self, AtomicBool, AtomicUsize},
-    },
+    sync::{Arc, atomic::AtomicBool},
 };
 
 use ui::{
@@ -2962,18 +2959,7 @@ impl RemoteServerProjects {
         ssh_config_host: &SharedString,
         cx: &mut Context<'_, Self>,
     ) -> SshServerIndex {
-        let new_ix = Arc::new(AtomicUsize::new(0));
-
-        let update_new_ix = new_ix.clone();
-        self.update_settings_file(cx, move |settings, _| {
-            update_new_ix.store(
-                settings
-                    .ssh_connections
-                    .as_ref()
-                    .map_or(0, |connections| connections.len()),
-                atomic::Ordering::Release,
-            );
-        });
+        let new_ix = RemoteSettings::get_global(cx).ssh_connections().count();
 
         self.add_ssh_server(
             SshConnectionOptions {
@@ -2983,7 +2969,7 @@ impl RemoteServerProjects {
             cx,
         );
         self.mode = Mode::default_mode(&self.ssh_config_servers, cx);
-        SshServerIndex(new_ix.load(atomic::Ordering::Acquire))
+        SshServerIndex(new_ix)
     }
 }
 
@@ -3159,5 +3145,72 @@ mod filter_tests {
 
         state.filter_sync("");
         assert!(state.filtered_servers.is_none());
+    }
+}
+
+#[cfg(test)]
+mod create_host_tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {
+        cx.update(|cx| {
+            let state = AppState::test(cx);
+            crate::init(cx);
+            editor::init(cx);
+            state
+        })
+    }
+
+    #[gpui::test]
+    async fn test_create_host_from_ssh_config_returns_new_connection_index(
+        cx: &mut TestAppContext,
+    ) {
+        let app_state = init_test(cx);
+        let fs: Arc<dyn Fs> = app_state.fs.clone();
+
+        cx.update(|cx| {
+            update_settings_file(fs.clone(), cx, |settings, _| {
+                settings.remote.ssh_connections = Some(vec![SshConnection {
+                    host: "host-a.example".to_string(),
+                    projects: BTreeSet::from_iter([RemoteProject {
+                        paths: vec!["/path/to/project-a".to_string()],
+                    }]),
+                    ..Default::default()
+                }]);
+            });
+        });
+        cx.run_until_parked();
+
+        let project = Project::test(fs.clone(), [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let modal = workspace.update_in(cx, |_workspace, window, cx| {
+            let weak = cx.weak_entity();
+            cx.new(|cx| RemoteServerProjects::new(false, fs.clone(), window, weak, cx))
+        });
+
+        let host_b = SharedString::from("host-b.example");
+        let new_index =
+            modal.update(cx, |modal, cx| modal.create_host_from_ssh_config(&host_b, cx));
+        cx.run_until_parked();
+
+        let connections = cx.update(|_, cx| {
+            RemoteSettings::get_global(cx)
+                .ssh_connections()
+                .collect::<Vec<_>>()
+        });
+
+        assert_eq!(connections.len(), 2);
+        assert_eq!(connections[0].host, "host-a.example");
+        assert_eq!(connections[1].host, "host-b.example");
+        assert_eq!(
+            connections[new_index.0].host, "host-b.example",
+            "returned index should point at the newly created host"
+        );
+
+        assert_eq!(connections[0].projects.len(), 1);
+        assert!(connections[new_index.0].projects.is_empty());
     }
 }


### PR DESCRIPTION
# Objective

Fixes https://github.com/zed-industries/zed/issues/59676

## Solution

Right now the queue / fetch logic is mixing async and sync flows. A task might append something to the queue, but the queue fetching does not respect/wait on that. Making this synchronous and in-memory fixes this.

`add_ssh_server` also appends it to the end of the queue, so we need to get the last index, not index 0.

## Testing

I manually tested it before and after by reproducing the steps in the original issue. Added a regression test afterwards.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
