### PR TITLE
languages: Factor out function for constructing asset names for Python language servers

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -269,6 +269,24 @@ pub struct TyLspAdapter {
     fs: Arc<dyn Fs>,
 }
 
+fn build_asset_name_with_prefix(
+    prefix: &str,
+    arch_server_name: &str,
+) -> Result<(String, String)> {
+    let arch = match consts::ARCH {
+        "x86" => "i686",
+        _ => consts::ARCH,
+    };
+    let os = arch_server_name;
+    let suffix = match consts::OS {
+        "windows" => "zip",
+        _ => "tar.gz",
+    };
+    let asset_name = format!("{prefix}-{arch}-{os}.{suffix}");
+    let asset_stem = format!("{prefix}-{arch}-{os}");
+    Ok((asset_stem, asset_name))
+}
+
 #[cfg(target_os = "macos")]
 impl TyLspAdapter {
     const GITHUB_ASSET_KIND: AssetKind = AssetKind::TarGz;
@@ -301,18 +319,7 @@ impl TyLspAdapter {
     }
 
     fn build_asset_name() -> Result<(String, String)> {
-        let arch = match consts::ARCH {
-            "x86" => "i686",
-            _ => consts::ARCH,
-        };
-        let os = Self::ARCH_SERVER_NAME;
-        let suffix = match consts::OS {
-            "windows" => "zip",
-            _ => "tar.gz",
-        };
-        let asset_name = format!("ty-{arch}-{os}.{suffix}");
-        let asset_stem = format!("ty-{arch}-{os}");
-        Ok((asset_stem, asset_name))
+        build_asset_name_with_prefix("ty", Self::ARCH_SERVER_NAME)
     }
 }
 
@@ -2464,18 +2471,7 @@ impl RuffLspAdapter {
     }
 
     fn build_asset_name() -> Result<(String, String)> {
-        let arch = match consts::ARCH {
-            "x86" => "i686",
-            _ => consts::ARCH,
-        };
-        let os = Self::ARCH_SERVER_NAME;
-        let suffix = match consts::OS {
-            "windows" => "zip",
-            _ => "tar.gz",
-        };
-        let asset_name = format!("ruff-{arch}-{os}.{suffix}");
-        let asset_stem = format!("ruff-{arch}-{os}");
-        Ok((asset_stem, asset_name))
+        build_asset_name_with_prefix("ruff", Self::ARCH_SERVER_NAME)
     }
 }
 


### PR DESCRIPTION
# Objective

- `crates/languages/src/python.rs` contained two byte-for-byte duplicate `build_asset_name` functions: one on `TyLspAdapter` (line ~303) and one on `RuffLspAdapter` (line ~2466). The only difference was the `"ty"` vs `"ruff"` literal in two `format!` calls. This is a maintenance burden — any fix to asset naming logic must be applied in two places.

## Testing

- Ran `./script/clippy -p languages` — clean (no warnings, release profile, all targets/features).
- Ran `cargo test -p languages` — 85 passed; 0 failed; 0 ignored.
- No new tests added: behavior is unchanged; existing `python::tests::*` cover the surrounding code paths.
- Reviewers can re-run the same commands to verify. No platform-specific behavior changed (the OS/arch matching logic is identical to before).

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Improved internal code sharing between Ty and Ruff LSP adapters
