### PR TITLE
Fix delayed titlebar clicks on macOS 27 Beta

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1494,7 +1494,12 @@ pub struct WindowOptions {
     /// The kind of window to create
     pub kind: WindowKind,
 
-    /// Whether the window should be movable by the user
+    /// Whether the window should be movable by the user.
+    ///
+    /// On macOS 27, custom titlebar windows that implement their own drag behavior
+    /// with [`Window::start_window_move`] should set this to `false`; otherwise
+    /// AppKit can treat the titlebar region as system-owned and delay clicks
+    /// while disambiguating titlebar double-clicks.
     pub is_movable: bool,
 
     /// Whether the window should be resizable by the user

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -377,7 +377,8 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut App) -> WindowO
         focus: false,
         show: false,
         kind: WindowKind::Normal,
-        is_movable: true,
+        // Zed handles window movement itself, so disable AppKit's titlebar dragging.
+        is_movable: false,
         display_id: display.map(|display| display.id()),
         window_background: cx.theme().window_background_appearance(),
         app_id: Some(app_id.to_owned()),


### PR DESCRIPTION
## Summary

macOS 27 Beta delays clicks in titlebar regions while AppKit determines whether a gesture should become a drag, single click, or double click. Zed's main workspace windows render a custom titlebar that already handles window movement via `Window::start_window_move`, so they do not need AppKit's native movable-titlebar behavior.

This sets `is_movable` to `false` for the main `MultiWorkspace` windows and documents the `WindowOptions::is_movable` caveat for GPUI users with custom titlebars.

## Background

The previous fix for this, #58947, used AppKit's private `_opaqueRectForWindowMoveWhenInTitlebar` SPI to mark GPUI's full-size content view as app-owned titlebar content. That fixed delayed titlebar clicks, but was later reverted in #59214 because it also affected windows that rely on AppKit's native titlebar dragging, like the settings window.

This PR takes a narrower approach by only changing Zed's main custom-titlebar windows. Those windows already implement dragging explicitly via `Window::start_window_move`, so disabling AppKit's native movable-titlebar behavior fixes the macOS 27 Beta click delay without affecting other window types.

Release Notes:

- Fixed delayed clicks in the custom titlebar on macOS 27 Beta.
