### PR TITLE
text_finder: Open match on the right column

### DIFF
--- a/crates/search/src/text_finder/delegate.rs
+++ b/crates/search/src/text_finder/delegate.rs
@@ -413,6 +413,7 @@ impl Delegate {
         };
         let path = selected_match.path.clone();
         let line_number = selected_match.line_number;
+        let column = selected_match.relative_range.start as u32;
         let Some(workspace) = self.project_search_view.read(cx).workspace.upgrade() else {
             return;
         };
@@ -426,7 +427,11 @@ impl Delegate {
                 active_editor
                     .downgrade()
                     .update_in(cx, |editor, window, cx| {
-                        editor.go_to_singleton_buffer_point(text::Point::new(row, 0), window, cx);
+                        editor.go_to_singleton_buffer_point(
+                            text::Point::new(row, column),
+                            window,
+                            cx,
+                        );
                     })
                     .log_err();
             }
@@ -753,6 +758,7 @@ impl PickerDelegate for Delegate {
 
         let path = selected_match.path.clone();
         let line_number = selected_match.line_number;
+        let column = selected_match.relative_range.start as u32;
 
         let Some(workspace) = self.project_search_view.read(cx).workspace.upgrade() else {
             return;
@@ -769,7 +775,11 @@ impl PickerDelegate for Delegate {
                 active_editor
                     .downgrade()
                     .update_in(cx, |editor, window, cx| {
-                        editor.go_to_singleton_buffer_point(text::Point::new(row, 0), window, cx);
+                        editor.go_to_singleton_buffer_point(
+                            text::Point::new(row, column),
+                            window,
+                            cx,
+                        );
                     })
                     .log_err();
             }


### PR DESCRIPTION
## Summary

When opening a result from the text finder navigate to the exact match position the same way project search already does. Previously the text finder opened the file at the start of the matched line, while project search lands the cursor on the start of the match (correct line and column).

## Solution
  
`go_to_singleton_buffer_point` now uses `SearchMatch::relative_range.start `as the column instead of 0.

## Testing

  - Manual: search in the text finder → open a result whose match starts mid-line → cursor lands on the start of the match. Verified for both opening in the current pane and opening in a split.

Release Notes:

- Improved text finder to open files at the matched column
