### PR TITLE
Add Guild Board automation

### DIFF
--- a/.github/workflows/guild-board-automation.yml
+++ b/.github/workflows/guild-board-automation.yml
@@ -1,0 +1,80 @@
+# Zed Guild Board (#74): cleanup, stale-nudge, shipped-weekly, and event-driven automation.
+
+name: Guild Board Automation
+
+on:
+  issues:
+    types: [labeled, assigned]
+  schedule:
+    - cron: "0 8 * * *"       # daily 08:00 UTC: cleanup + stale-nudge
+    - cron: "0 14 * * 5"      # friday 14:00 UTC (~9am ET): shipped-weekly only
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "cleanup | stale-nudge | shipped-weekly"
+        required: true
+        type: choice
+        options: [cleanup, stale-nudge, shipped-weekly]
+
+permissions:
+  contents: read
+  issues: write
+  discussions: write
+
+concurrency:
+  group: guild-board-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: github.repository == 'zed-industries/zed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+        id: app-token
+        with:
+          app-id: ${{ secrets.ZED_COMMUNITY_BOT_APP_ID }}
+          private-key: ${{ secrets.ZED_COMMUNITY_BOT_PRIVATE_KEY }}
+          owner: zed-industries
+
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          sparse-checkout: script/guild-board-automation.py
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - run: pip install requests
+
+      - name: Resolve mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            echo "mode=event" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "mode=${{ inputs.mode }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.schedule }}" = "0 14 * * 5" ]; then
+            echo "mode=shipped-weekly" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=cleanup" >> "$GITHUB_OUTPUT"
+            echo "also_nudge=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - run: python script/guild-board-automation.py
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROJECT_NUMBER: "74"
+          GUILD_TEAM_SLUG: "zed-guild"
+          DISCUSSION_CATEGORY_ID: ${{ secrets.GUILD_DISCUSSION_CATEGORY_ID }}
+          MODE: ${{ steps.mode.outputs.mode }}
+
+      - if: steps.mode.outputs.also_nudge == 'true'
+        run: python script/guild-board-automation.py
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROJECT_NUMBER: "74"
+          GUILD_TEAM_SLUG: "zed-guild"
+          MODE: stale-nudge

--- a/script/guild-board-automation.py
+++ b/script/guild-board-automation.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Zed Guild Board (#74): cleanup, stale-nudge, shipped-weekly, repro/assignment events."""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+GITHUB_API = "https://api.github.com"
+OWNER = "zed-industries"
+REPO = "zed"
+MAX_RETRIES = 3
+RETRY_DELAY = 5
+
+SHIPPED_STATUS = "Shipped by Guild"
+IN_PROGRESS_STATUS = "In Progress"
+STALE_DAYS = 14
+
+# Labels that exist in zed-industries/zed as of 2026-06-24
+REPRO_LABELS = {
+    "state:reproducible": "Reproduced",
+    "state:unactionable": "Cannot Reproduce",
+}
+
+
+def graphql(query, variables):
+    for attempt in range(MAX_RETRIES + 1):
+        r = requests.post(
+            f"{GITHUB_API}/graphql",
+            headers=HEADERS,
+            json={"query": query, "variables": variables},
+        )
+        if r.status_code in (502, 503, 504) and attempt < MAX_RETRIES:
+            time.sleep(RETRY_DELAY)
+            continue
+        r.raise_for_status()
+        data = r.json()
+        if "errors" in data:
+            raise RuntimeError(f"GraphQL: {data['errors']}")
+        return data["data"]
+
+
+def rest_post(path, body):
+    r = requests.post(f"{GITHUB_API}/{path}", headers=HEADERS, json=body)
+    r.raise_for_status()
+    return r.json()
+
+
+def fetch_project(number):
+    data = graphql("""
+        query($owner: String!, $number: Int!) {
+          organization(login: $owner) {
+            projectV2(number: $number) {
+              id
+              fields(first: 50) {
+                nodes {
+                  ... on ProjectV2Field { id name dataType }
+                  ... on ProjectV2SingleSelectField { id name options { id name } }
+                }
+              }
+            }
+          }
+        }
+    """, {"owner": OWNER, "number": number})
+    project = data["organization"]["projectV2"]
+    if not project:
+        print(
+            f"Could not fetch project #{number}. "
+            "Check that your token has read:project (classic) or "
+            "Organization Projects: Read and write (fine-grained) scope."
+        )
+        sys.exit(1)
+    return project
+
+
+def list_project_items(project_id):
+    cursor = None
+    while True:
+        data = graphql("""
+            query($pid: ID!, $cursor: String) {
+              node(id: $pid) {
+                ... on ProjectV2 {
+                  items(first: 100, after: $cursor) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      id
+                      isArchived
+                      fieldValues(first: 20) {
+                        nodes {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            field { ... on ProjectV2SingleSelectField { name } }
+                            name
+                          }
+                          ... on ProjectV2ItemFieldDateValue {
+                            field { ... on ProjectV2Field { name } }
+                            date
+                          }
+                        }
+                      }
+                      content {
+                        __typename
+                        ... on Issue {
+                          id number state closed closedAt
+                          assignees(first: 10) { nodes { login } }
+                          labels(first: 30) { nodes { name } }
+                          timelineItems(last: 1, itemTypes: [CROSS_REFERENCED_EVENT]) {
+                            nodes {
+                              ... on CrossReferencedEvent {
+                                source { __typename ... on PullRequest { number state } }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        """, {"pid": project_id, "cursor": cursor})
+        page = data["node"]["items"]
+        yield from page["nodes"]
+        if not page["pageInfo"]["hasNextPage"]:
+            return
+        cursor = page["pageInfo"]["endCursor"]
+
+
+def set_field(project, item_id, field_name, option_name):
+    field = next((f for f in project["fields"]["nodes"] if f.get("name") == field_name), None)
+    if not field:
+        print(f"Field '{field_name}' missing, skipping")
+        return
+    option = next((o for o in field.get("options", []) if o["name"] == option_name), None)
+    if not option:
+        print(f"Option '{option_name}' missing in '{field_name}', skipping")
+        return
+    graphql("""
+        mutation($pid: ID!, $iid: ID!, $fid: ID!, $oid: String!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $pid, itemId: $iid, fieldId: $fid,
+            value: { singleSelectOptionId: $oid }
+          }) { projectV2Item { id } }
+        }
+    """, {"pid": project["id"], "iid": item_id, "fid": field["id"], "oid": option["id"]})
+    print(f"Set '{field_name}' = '{option_name}' on {item_id}")
+
+
+def add_comment(issue_number, body):
+    rest_post(f"repos/{OWNER}/{REPO}/issues/{issue_number}/comments", {"body": body})
+    print(f"Commented on #{issue_number}")
+
+
+def is_guild_member(login):
+    slug = os.environ.get("GUILD_TEAM_SLUG", "zed-guild")
+    r = requests.get(
+        f"{GITHUB_API}/orgs/{OWNER}/teams/{slug}/members/{login}",
+        headers=HEADERS,
+    )
+    return r.status_code == 204
+
+
+def find_item(project_id, content_node_id):
+    data = graphql("""
+        query($cid: ID!) {
+          node(id: $cid) {
+            ... on Issue {
+              projectItems(first: 50) {
+                nodes { id project { id } }
+              }
+            }
+          }
+        }
+    """, {"contentId": content_node_id})
+    for item in data["node"]["projectItems"]["nodes"]:
+        if item["project"]["id"] == project_id:
+            return item["id"]
+    return None
+
+
+def run_cleanup(project_number):
+    project = fetch_project(project_number)
+    shipped = 0
+    for item in list_project_items(project["id"]):
+        if item.get("isArchived"):
+            continue
+        content = item.get("content") or {}
+        if content.get("__typename") != "Issue":
+            continue
+        if content.get("state") != "CLOSED":
+            continue
+        current_status = next(
+            (fv.get("name") for fv in item.get("fieldValues", {}).get("nodes", [])
+             if fv.get("field", {}).get("name") == "Status"), None)
+        if current_status == SHIPPED_STATUS:
+            continue
+        assignees = [a["login"] for a in content.get("assignees", {}).get("nodes", [])]
+        if not any(is_guild_member(a) for a in assignees):
+            continue
+        set_field(project, item["id"], "Status", SHIPPED_STATUS)
+        shipped += 1
+    print(f"Cleanup: {shipped} marked shipped")
+
+
+def run_stale_nudge(project_number):
+    project = fetch_project(project_number)
+    now = datetime.now(timezone.utc)
+    nudged = 0
+    for item in list_project_items(project["id"]):
+        if item.get("isArchived"):
+            continue
+        content = item.get("content") or {}
+        if content.get("__typename") != "Issue" or content.get("state") != "OPEN":
+            continue
+        assignees = [a["login"] for a in content.get("assignees", {}).get("nodes", [])]
+        if not assignees:
+            continue
+        has_pr = any(
+            (tl.get("source") or {}).get("__typename") == "PullRequest"
+            and (tl.get("source") or {}).get("state") == "OPEN"
+            for tl in content.get("timelineItems", {}).get("nodes", []))
+        if has_pr:
+            continue
+        assigned_date = next(
+            (fv.get("date") for fv in item.get("fieldValues", {}).get("nodes", [])
+             if fv.get("field", {}).get("name") == "Assigned Date"), None)
+        if not assigned_date:
+            continue
+        days = (now - datetime.fromisoformat(assigned_date).replace(tzinfo=timezone.utc)).days
+        if days < STALE_DAYS:
+            continue
+        assignee_list = ", ".join(f"@{a}" for a in assignees)
+        add_comment(content["number"],
+            f"Hey {assignee_list}, this issue has been assigned for "
+            f"{days} days with no linked PR yet. If you're still working on it, "
+            f"no action needed. If you're no longer planning to pick this up, "
+            f"feel free to unassign yourself so another Guild member can grab it. "
+            f"(This check runs once every two weeks.)")
+        nudged += 1
+    print(f"Stale nudge: {nudged} issues nudged")
+
+
+def run_event(project_number):
+    event_name = os.environ["GITHUB_EVENT_NAME"]
+    with open(os.environ["GITHUB_EVENT_PATH"]) as f:
+        event = json.load(f)
+    if event_name != "issues":
+        print(f"Ignoring event: {event_name}")
+        return
+    action = event["action"]
+    issue = event["issue"]
+    if action == "labeled":
+        handle_label(event, issue, project_number)
+    elif action == "assigned":
+        handle_assignment(event, issue, project_number)
+
+
+def run_shipped_weekly(project_number):
+    project = fetch_project(project_number)
+    now = datetime.now(timezone.utc)
+    week_ago = now - timedelta(days=7)
+    shipped = []
+    for item in list_project_items(project["id"]):
+        if item.get("isArchived"):
+            continue
+        content = item.get("content") or {}
+        if content.get("__typename") != "Issue":
+            continue
+        status = next(
+            (fv.get("name") for fv in item.get("fieldValues", {}).get("nodes", [])
+             if fv.get("field", {}).get("name") == "Status"), None)
+        if status != SHIPPED_STATUS:
+            continue
+        closed_at = content.get("closedAt")
+        if not closed_at:
+            continue
+        closed_dt = datetime.fromisoformat(closed_at.replace("Z", "+00:00"))
+        if closed_dt < week_ago:
+            continue
+        assignees = [a["login"] for a in content.get("assignees", {}).get("nodes", [])]
+        shipped.append({
+            "number": content["number"],
+            "title": content["title"],
+            "assignees": assignees,
+        })
+    if not shipped:
+        print("Nothing shipped this week, skipping discussion post.")
+        return
+    week_str = now.strftime("%b %d, %Y")
+    title = f"Shipped by the Guild - Week of {week_str}"
+    lines = [f"Here's what the Zed Guild shipped this week:\n"]
+    for item in shipped:
+        credit = ", ".join(f"@{a}" for a in item["assignees"]) if item["assignees"] else "unassigned"
+        lines.append(f"- #{item['number']} {item['title']} ({credit})")
+    lines.append(f"\n{len(shipped)} issue{'s' if len(shipped) != 1 else ''} shipped. Nice work.")
+    body = "\n".join(lines)
+    category_id = os.environ.get("DISCUSSION_CATEGORY_ID")
+    if not category_id:
+        print("DISCUSSION_CATEGORY_ID not set, printing instead:\n")
+        print(f"# {title}\n\n{body}")
+        return
+    repo_id = graphql("""
+        query($owner: String!, $name: String!) {
+          repository(owner: $owner, name: $name) { id }
+        }
+    """, {"owner": OWNER, "name": REPO})["repository"]["id"]
+    graphql("""
+        mutation($repoId: ID!, $catId: ID!, $title: String!, $body: String!) {
+          createDiscussion(input: {
+            repositoryId: $repoId, categoryId: $catId,
+            title: $title, body: $body
+          }) { discussion { url } }
+        }
+    """, {"repoId": repo_id, "catId": category_id, "title": title, "body": body})
+    print(f"Posted discussion: {title}")
+
+
+def handle_label(event, issue, project_number):
+    label_name = event["label"]["name"]
+    if label_name not in REPRO_LABELS:
+        return
+    project = fetch_project(project_number)
+    item_id = find_item(project["id"], issue["node_id"])
+    if not item_id:
+        print(f"Issue #{issue['number']} not on board, skipping repro tracking")
+        return
+    repro_value = REPRO_LABELS[label_name]
+    set_field(project, item_id, "Repro Status", repro_value)
+    print(f"Repro by {event['sender']['login']}: {repro_value} on #{issue['number']}")
+
+
+def handle_assignment(event, issue, project_number):
+    assignee = event["assignee"]["login"]
+    if not is_guild_member(assignee):
+        print(f"{assignee} not in guild team, skipping")
+        return
+    project = fetch_project(project_number)
+    item_id = find_item(project["id"], issue["node_id"])
+    if not item_id:
+        print(f"Issue #{issue['number']} not on board")
+        return
+    set_field(project, item_id, "Status", IN_PROGRESS_STATUS)
+    date_field = next(
+        (f for f in project["fields"]["nodes"]
+         if f.get("name") == "Assigned Date" and f.get("dataType") == "DATE"), None)
+    if date_field:
+        graphql("""
+            mutation($pid: ID!, $iid: ID!, $fid: ID!, $date: Date!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $pid, itemId: $iid, fieldId: $fid,
+                value: { date: $date }
+              }) { projectV2Item { id } }
+            }
+        """, {"pid": project["id"], "iid": item_id, "fid": date_field["id"],
+              "date": datetime.now(timezone.utc).strftime("%Y-%m-%d")})
+        print(f"Stamped Assigned Date on #{issue['number']}")
+
+
+if __name__ == "__main__":
+    HEADERS = {
+        "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    project_number = int(os.environ.get("PROJECT_NUMBER", "74"))
+    mode = os.environ.get("MODE", "event")
+    {"cleanup": run_cleanup, "stale-nudge": run_stale_nudge, "event": run_event,
+     "shipped-weekly": run_shipped_weekly}.get(
+        mode, lambda _: (print(f"Unknown mode: {mode}"), sys.exit(1))
+    )(project_number)


### PR DESCRIPTION
# Objective

Automate the Zed Guild project board (#74) to reduce manual board management across all three guild tracks (Repro Team, Bug Bashers, Feature Shippers).

Currently, board status updates, stale issue tracking, and shipped-item visibility are all manual. This adds a GitHub Action that handles the repetitive parts so guild program staff can focus on mentorship and review.

## Solution

One Python script (`script/guild-board-automation.py`) and one workflow file (`.github/workflows/guild-board-automation.yml`) running in four modes:

- cleanup (daily cron): walks the board, finds closed issues where the assignee is a `zed-guild` team member, sets their Status to "Shipped by Guild." Non-guild closures are left untouched.
- stale-nudge (daily cron): finds open issues assigned >14 days with no linked PR, posts a single comment asking if the contributor is still working on it or wants to unassign. Runs once per issue every two weeks.
- shipped-weekly (Friday cron): collects everything marked "Shipped by Guild" in the last 7 days, posts a GitHub Discussion with issue links and @mentions.
- event (webhook on `issues.labeled` and `issues.assigned`): when `state:reproducible` or `state:unactionable` is added to a board issue, stamps the Repro Status field. When a guild team member self-assigns, sets Status to "In Progress" and writes today's date to the Assigned Date field.

Uses the existing `ZED_COMMUNITY_BOT` GitHub App for auth, same as the community PR board.

### Prerequisites before merging

Three custom fields need to be created on project board #74:
- Status: add "In Progress" and "Shipped by Guild" options (keep any existing options)
- Repro Status: single-select with "Reproduced" and "Cannot Reproduce"
- Assigned Date: date type

One new repo secret:
- `GUILD_DISCUSSION_CATEGORY_ID`: the GraphQL node ID of the discussion category for Friday posts

One app permission addition:
- `ZED_COMMUNITY_BOT` needs `Discussions: Read and write`

## Testing

- Tested all four modes locally against real issue data from the repo (7 issues across all three guild tracks: bug basher assignment, repro label stamping, stale nudge, cleanup of closed issues, feature shipper assignment, shipped-by-guild marking).
- Verified cleanup only credits guild team members by checking assignee against the Teams membership API.
- Verified stale-nudge skips issues with linked open PRs and issues without an Assigned Date field.
- Verified shipped-weekly gracefully prints to stdout when `DISCUSSION_CATEGORY_ID` is not set.
- Label names (`state:reproducible`, `state:unactionable`) verified against the actual repo label list.
- Not tested: live webhook delivery in the zed repo (requires merge). Can be validated post-merge by manually triggering via `workflow_dispatch` with each mode.
- Platform: macOS locally, targets `ubuntu-latest` in CI.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments — **N/A (Python, no unsafe blocks)**
- [ ] The content adheres to Zed's UI standards — **N/A (no UI changes)**
- [ ] Tests cover the new/changed behavior — local dry-run testing against real issue data, no automated test suite (follows the pattern of `github-community-pr-board.py` which also has no test suite)
- [x] Performance impact has been considered and is acceptable — daily crons paginate the board at 100 items/request, event-driven runs touch one issue. Guild board is small (~50 items).

---

Release Notes:

- N/A
