### PR TITLE
terminal: Swap right and middle mouse button mappings

### DIFF
--- a/crates/terminal/src/mappings/mouse.rs
+++ b/crates/terminal/src/mappings/mouse.rs
@@ -52,8 +52,8 @@ impl MouseButtonCode {
     fn from_button(e: MouseButton) -> Self {
         match e {
             gpui::MouseButton::Left => MouseButtonCode::LeftButton,
-            gpui::MouseButton::Right => MouseButtonCode::MiddleButton,
-            gpui::MouseButton::Middle => MouseButtonCode::RightButton,
+            gpui::MouseButton::Middle => MouseButtonCode::MiddleButton,
+            gpui::MouseButton::Right => MouseButtonCode::RightButton,
             gpui::MouseButton::Navigate(_) => MouseButtonCode::Other,
         }
     }


### PR DESCRIPTION
# Objective

`MouseButton::Right` was mapped to `MouseButtonCode::MiddleButton` and vice versa, causing right-click and middle-click to behave as each other in the terminal.

## Solution

Swapped the two arms of the match expression in `crates/terminal/src/mappings/mouse.rs`.

## Testing

Tested manually: opened a terminal pane, verified that right-click and middle-click now produce the correct events.

Tested on: Windows

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards (UX/UI and icon guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed right-click and middle-click being swapped in the terminal.