### PR TITLE
git_ui: Add option to skip pre-commit hook

### DIFF
--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -104,6 +104,8 @@ actions!(
         Amend,
         /// Enable the --signoff option.
         Signoff,
+        /// Skips the pre-commit hook when committing.
+        SkipPreCommitHook,
         /// Cancels the current git operation.
         Cancel,
         /// Expands the commit message editor.

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -457,6 +457,7 @@ impl Upstream {
 pub struct CommitOptions {
     pub amend: bool,
     pub signoff: bool,
+    pub skip_pre_commit_hook: bool,
     pub allow_empty: bool,
 }
 

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -4,7 +4,7 @@ use crate::git_panel::{
 };
 use crate::git_panel_settings::GitPanelSettings;
 use git::repository::CommitOptions;
-use git::{Amend, Commit, GenerateCommitMessage, Signoff};
+use git::{Amend, Commit, GenerateCommitMessage, Signoff, SkipPreCommitHook};
 use project::DisableAiSettings;
 use settings::Settings;
 use ui::{
@@ -283,6 +283,7 @@ impl CommitModal {
                     let git_panel = git_panel_entity.read(cx);
                     let amend_enabled = git_panel.amend_pending();
                     let signoff_enabled = git_panel.signoff_enabled();
+                    let skip_pre_commit_hook_enabled = git_panel.skip_pre_commit_hook_enabled();
                     let has_previous_commit = git_panel.head_commit(cx).is_some();
 
                     Some(ContextMenu::build(window, cx, |context_menu, _, _| {
@@ -322,6 +323,24 @@ impl CommitModal {
                                     }
                                 },
                             )
+                            .toggleable_entry(
+                                "Skip Pre-commit Hook (--no-verify)",
+                                skip_pre_commit_hook_enabled,
+                                IconPosition::Start,
+                                Some(Box::new(SkipPreCommitHook)),
+                                {
+                                    let git_panel = git_panel_entity.clone();
+                                    move |window, cx| {
+                                        git_panel.update(cx, |git_panel, cx| {
+                                            git_panel.toggle_skip_pre_commit_hook_enabled(
+                                                &SkipPreCommitHook,
+                                                window,
+                                                cx,
+                                            );
+                                        })
+                                    }
+                                },
+                            )
                     }))
                 }
             })
@@ -342,6 +361,7 @@ impl CommitModal {
             active_repo,
             is_amend_pending,
             is_signoff_enabled,
+            is_skip_pre_commit_hook_enabled,
             workspace,
         ) = self.git_panel.update(cx, |git_panel, cx| {
             let (can_commit, tooltip) = git_panel.configure_commit_button(cx);
@@ -351,6 +371,7 @@ impl CommitModal {
             let active_repo = git_panel.active_repository.clone();
             let is_amend_pending = git_panel.amend_pending();
             let is_signoff_enabled = git_panel.signoff_enabled();
+            let is_skip_pre_commit_hook_enabled = git_panel.skip_pre_commit_hook_enabled();
             (
                 can_commit,
                 tooltip,
@@ -360,6 +381,7 @@ impl CommitModal {
                 active_repo,
                 is_amend_pending,
                 is_signoff_enabled,
+                is_skip_pre_commit_hook_enabled,
                 git_panel.workspace.clone(),
             )
         });
@@ -447,6 +469,7 @@ impl CommitModal {
                                         CommitOptions {
                                             amend: is_amend_pending,
                                             signoff: is_signoff_enabled,
+                                            skip_pre_commit_hook: is_skip_pre_commit_hook_enabled,
                                             allow_empty: false,
                                         },
                                         window,
@@ -463,9 +486,14 @@ impl CommitModal {
                                             tooltip,
                                             Some(&git::Commit),
                                             format!(
-                                                "git commit{}{}",
+                                                "git commit{}{}{}",
                                                 if is_amend_pending { " --amend" } else { "" },
-                                                if is_signoff_enabled { " --signoff" } else { "" }
+                                                if is_signoff_enabled { " --signoff" } else { "" },
+                                                if is_skip_pre_commit_hook_enabled {
+                                                    " --no-verify"
+                                                } else {
+                                                    ""
+                                                }
                                             ),
                                             &focus_handle.clone(),
                                             cx,

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -36,7 +36,10 @@ use git::repository::{
 };
 use git::stash::GitStash;
 use git::status::{DiffStat, StageStatus};
-use git::{Amend, Commit, Signoff, ToggleStaged, repository::RepoPath, status::FileStatus};
+use git::{
+    Amend, Commit, Signoff, SkipPreCommitHook, ToggleStaged, repository::RepoPath,
+    status::FileStatus,
+};
 use git::{
     ExpandCommitEditor, GitHostingProviderRegistry, GitRemote, RestoreTrackedFiles, StageAll,
     StashAll, StashApply, StashPop, ToggleFillCommitEditor, TrashUntrackedFiles, UnstageAll,
@@ -923,6 +926,7 @@ pub struct GitPanel {
     original_commit_message: Option<String>,
     pending_commit_message_restores: BTreeMap<String, SerializedCommitMessage>,
     signoff_enabled: bool,
+    skip_pre_commit_hook_enabled: bool,
     pending_serialization: Task<()>,
     pub(crate) project: Entity<Project>,
     scroll_handle: UniformListScrollHandle,
@@ -1224,6 +1228,7 @@ impl GitPanel {
                 original_commit_message,
                 pending_commit_message_restores,
                 signoff_enabled,
+                skip_pre_commit_hook_enabled: false,
                 pending_serialization: Task::ready(()),
                 single_staged_entry: None,
                 single_tracked_entry: None,
@@ -2778,6 +2783,7 @@ impl GitPanel {
                 CommitOptions {
                     amend: self.amend_pending,
                     signoff: self.signoff_enabled,
+                    skip_pre_commit_hook: self.skip_pre_commit_hook_enabled,
                     allow_empty: false,
                 },
                 window,
@@ -2986,6 +2992,7 @@ impl GitPanel {
                             this.original_commit_message = None;
                             this.serialize(cx);
                         }
+                        this.set_skip_pre_commit_hook_enabled(false, cx);
                     }
                     Err(e) => this.show_error_toast("commit", e, cx),
                 }
@@ -5353,6 +5360,7 @@ impl GitPanel {
                 let has_previous_commit = self.head_commit(cx).is_some();
                 let amend = self.amend_pending();
                 let signoff = self.signoff_enabled;
+                let skip_pre_commit_hook = self.skip_pre_commit_hook_enabled;
 
                 move |window, cx| {
                     Some(ContextMenu::build(window, cx, |context_menu, _, _| {
@@ -5384,6 +5392,15 @@ impl GitPanel {
                                 IconPosition::Start,
                                 Some(Box::new(Signoff)),
                                 move |window, cx| window.dispatch_action(Box::new(Signoff), cx),
+                            )
+                            .toggleable_entry(
+                                "Skip Pre-commit Hook (--no-verify)",
+                                skip_pre_commit_hook,
+                                IconPosition::Start,
+                                Some(Box::new(SkipPreCommitHook)),
+                                move |window, cx| {
+                                    window.dispatch_action(Box::new(SkipPreCommitHook), cx)
+                                },
                             )
                     }))
                 }
@@ -5823,6 +5840,7 @@ impl GitPanel {
         let commit_tooltip_focus_handle = self.commit_editor.focus_handle(cx);
         let amend = self.amend_pending();
         let signoff = self.signoff_enabled;
+        let skip_pre_commit_hook = self.skip_pre_commit_hook_enabled;
 
         let label_color = if self.pending_commit.is_some() {
             Color::Disabled
@@ -5858,6 +5876,7 @@ impl GitPanel {
                                         CommitOptions {
                                             amend,
                                             signoff,
+                                            skip_pre_commit_hook,
                                             allow_empty: false,
                                         },
                                         window,
@@ -5875,9 +5894,14 @@ impl GitPanel {
                                     tooltip,
                                     Some(&git::Commit),
                                     format!(
-                                        "git commit{}{}",
+                                        "git commit{}{}{}",
                                         if amend { " --amend" } else { "" },
-                                        if signoff { " --signoff" } else { "" }
+                                        if signoff { " --signoff" } else { "" },
+                                        if skip_pre_commit_hook {
+                                            " --no-verify"
+                                        } else {
+                                            ""
+                                        }
                                     ),
                                     &handle.clone(),
                                     cx,
@@ -7737,6 +7761,24 @@ impl GitPanel {
         self.set_signoff_enabled(!self.signoff_enabled, cx);
     }
 
+    pub fn skip_pre_commit_hook_enabled(&self) -> bool {
+        self.skip_pre_commit_hook_enabled
+    }
+
+    pub fn set_skip_pre_commit_hook_enabled(&mut self, value: bool, cx: &mut Context<Self>) {
+        self.skip_pre_commit_hook_enabled = value;
+        cx.notify();
+    }
+
+    pub fn toggle_skip_pre_commit_hook_enabled(
+        &mut self,
+        _: &SkipPreCommitHook,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.set_skip_pre_commit_hook_enabled(!self.skip_pre_commit_hook_enabled, cx);
+    }
+
     pub async fn load(
         workspace: WeakEntity<Workspace>,
         mut cx: AsyncWindowContext,
@@ -7925,6 +7967,7 @@ impl Render for GitPanel {
                     .on_action(cx.listener(GitPanel::on_commit))
                     .on_action(cx.listener(GitPanel::on_amend))
                     .on_action(cx.listener(GitPanel::toggle_signoff_enabled))
+                    .on_action(cx.listener(GitPanel::toggle_skip_pre_commit_hook_enabled))
                     .on_action(cx.listener(Self::stage_all))
                     .on_action(cx.listener(Self::unstage_all))
                     .on_action(cx.listener(Self::stage_selected))

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3101,6 +3101,7 @@ impl GitStore {
                     CommitOptions {
                         amend: options.amend,
                         signoff: options.signoff,
+                        skip_pre_commit_hook: options.skip_pre_commit_hook,
                         allow_empty: options.allow_empty,
                     },
                     askpass,
@@ -7407,13 +7408,19 @@ impl Repository {
         let askpass_delegates = self.askpass_delegates.clone();
         let askpass_id = util::post_inc(&mut self.latest_askpass_id);
 
-        let rx = self.run_hook(RunHook::PreCommit, cx);
+        let run_hook = if options.skip_pre_commit_hook {
+            None
+        } else {
+            Some(self.run_hook(RunHook::PreCommit, cx))
+        };
 
         self.send_job(
             "commit",
             Some("git commit".into()),
             move |git_repo, _cx| async move {
-                rx.await??;
+                if let Some(rx) = run_hook {
+                    rx.await??;
+                }
 
                 match git_repo {
                     RepositoryState::Local(LocalRepositoryState {
@@ -7443,6 +7450,7 @@ impl Repository {
                                     amend: options.amend,
                                     signoff: options.signoff,
                                     allow_empty: options.allow_empty,
+                                    skip_pre_commit_hook: options.skip_pre_commit_hook,
                                 }),
                                 askpass_id,
                             })
@@ -9935,7 +9943,7 @@ mod tests {
     use super::*;
     use crate::Project;
     use fs::{FakeFs, Fs};
-    use git::repository::{RepoPath, repo_path};
+    use git::repository::{RealGitRepository, RepoPath, repo_path};
     use gpui::TestAppContext;
     use gpui::proptest::prelude::*;
     use rand::{SeedableRng, rngs::StdRng};
@@ -9948,6 +9956,168 @@ mod tests {
             let settings_store = SettingsStore::test(cx);
             cx.set_global(settings_store);
         });
+    }
+
+    #[allow(clippy::disallowed_methods)]
+    #[track_caller]
+    fn git_command(working_directory: &Path, arguments: &[&str]) {
+        let output = std::process::Command::new("git")
+            .args(arguments)
+            .current_dir(working_directory)
+            .env("GIT_CONFIG_GLOBAL", "")
+            .env("GIT_CONFIG_SYSTEM", "")
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "test@zed.dev")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "test@zed.dev")
+            .output()
+            .expect("failed to run git command");
+        assert!(
+            output.status.success(),
+            "git command failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn test_commit_environment() -> Arc<HashMap<String, String>> {
+        Arc::new(HashMap::from_iter([
+            ("GIT_CONFIG_GLOBAL".to_string(), "".to_string()),
+            ("GIT_CONFIG_SYSTEM".to_string(), "".to_string()),
+            ("GIT_AUTHOR_NAME".to_string(), "test".to_string()),
+            ("GIT_AUTHOR_EMAIL".to_string(), "test@zed.dev".to_string()),
+            ("GIT_COMMITTER_NAME".to_string(), "test".to_string()),
+            (
+                "GIT_COMMITTER_EMAIL".to_string(),
+                "test@zed.dev".to_string(),
+            ),
+            ("GIT_ASKPASS".to_string(), "false".to_string()),
+        ]))
+    }
+
+    fn test_commit_options(skip_pre_commit_hook: bool) -> CommitOptions {
+        CommitOptions {
+            amend: false,
+            signoff: false,
+            skip_pre_commit_hook,
+            allow_empty: true,
+        }
+    }
+
+    fn test_repository_with_failing_pre_commit_hook(
+        cx: &mut TestAppContext,
+    ) -> (Entity<Repository>, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repo_dir = temp_dir.path().to_path_buf();
+        git_command(&repo_dir, &["init", "-b", "main"]);
+        git_command(&repo_dir, &["commit", "--allow-empty", "-m", "Initial"]);
+
+        let hooks_dir = repo_dir.join(".git/hooks");
+        std::fs::write(
+            hooks_dir.join("pre-commit"),
+            "#!/bin/sh\necho pre-commit hook failed >&2\nexit 1\n",
+        )
+        .unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let hook_path = hooks_dir.join("pre-commit");
+            let mut permissions = std::fs::metadata(&hook_path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(hook_path, permissions).unwrap();
+        }
+
+        let backend = RealGitRepository::new(
+            &repo_dir.join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+        backend.set_trusted(true);
+
+        let state = Task::ready(Ok(LocalRepositoryState {
+            fs: FakeFs::new(cx.executor()),
+            backend: Arc::new(backend),
+            environment: test_commit_environment(),
+        }))
+        .shared();
+
+        let repository = cx.update(|cx| {
+            cx.new(|cx| {
+                let snapshot = RepositorySnapshot::empty(
+                    RepositoryId(1),
+                    Arc::from(repo_dir.as_path()),
+                    Some(Arc::from(repo_dir.join(".git").as_path())),
+                    Some(Arc::from(repo_dir.join(".git").as_path())),
+                    Some(Arc::from(repo_dir.join(".git").as_path())),
+                    PathStyle::local(),
+                );
+                let (job_sender, worker_task) =
+                    Repository::spawn_local_git_worker(state.clone(), cx);
+
+                Repository {
+                    this: cx.weak_entity(),
+                    snapshot,
+                    commit_message_buffer: None,
+                    git_store: WeakEntity::new_invalid(),
+                    paths_needing_status_update: Vec::new(),
+                    job_sender,
+                    _worker_task: worker_task,
+                    active_jobs: HashMap::default(),
+                    job_debug_queue: job_debug_queue::GitJobDebugQueue::new(),
+                    pending_ops: SumTree::default(),
+                    job_id: 0,
+                    askpass_delegates: Arc::default(),
+                    latest_askpass_id: 0,
+                    repository_state: cx
+                        .spawn(async move |_, _| Ok(RepositoryState::Local(state.await?)))
+                        .shared(),
+                    initial_graph_data: HashMap::default(),
+                    commit_data_handler: CommitDataHandlerState::Closed,
+                    commit_data: HashMap::default(),
+                }
+            })
+        });
+
+        (repository, temp_dir)
+    }
+
+    #[gpui::test]
+    async fn test_commit_can_skip_pre_commit_hook(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.executor().allow_parking();
+
+        {
+            let (repository, _temp_dir) = test_repository_with_failing_pre_commit_hook(cx);
+            let result = repository.update(cx, |repository, cx| {
+                repository.commit(
+                    "Commit".into(),
+                    None,
+                    test_commit_options(false),
+                    AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+                    cx,
+                )
+            });
+            cx.run_until_parked();
+            assert!(result.await.unwrap().is_err());
+        }
+
+        {
+            let (repository, _temp_dir) = test_repository_with_failing_pre_commit_hook(cx);
+            let result = repository.update(cx, |repository, cx| {
+                repository.commit(
+                    "Commit".into(),
+                    None,
+                    test_commit_options(true),
+                    AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+                    cx,
+                )
+            });
+            cx.run_until_parked();
+            result.await.unwrap().unwrap();
+        }
     }
 
     #[gpui::test]

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -393,6 +393,7 @@ message Commit {
     bool amend = 1;
     bool signoff = 2;
     bool allow_empty = 3;
+    bool skip_pre_commit_hook = 4;
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a transient Git panel option to skip Zed’s explicit pre-commit hook when committing from the UI.

The option appears in the commit split-button menu next to `Amend` and `Signoff`, and is available in both the Git panel and commit modal.

## Details

Zed currently runs the pre-commit hook explicitly before committing, then invokes the raw `git commit` command with `--no-verify` to avoid running hooks twice.

This change keeps that low-level behavior unchanged. When the new option is enabled, Zed skips only its explicit `RunHook::PreCommit` step for that commit.

The option is intentionally transient:

- Defaults to disabled
- Is not serialized with Git panel state
- Resets after a successful commit
- Remains enabled after failure so the commit can be retried

## Related

Related to #56318 and #56321, but narrower in scope: this adds a per-commit UI option rather than a persistent setting.

Does not address full Git hook support such as `commit-msg` or `prepare-commit-msg`; see #44926.

## Testing

- `cargo fmt`
- `cargo test -p project test_commit_can_skip_pre_commit_hook`
- `cargo test -p git_ui test_amend`
- `cargo check -p git_ui -p project -p git`
- `git diff --check`
- Manual: launched a local Zed build and verified the option can commit in a repository with a failing pre-commit hook

## Suggested .rules additions

- Git panel commits run Zed’s explicit pre-commit hook before invoking raw `git commit --no-verify`; changes to hook behavior should usually target the explicit hook path, not remove the raw `--no-verify`.

Release Notes:

- Added a Git panel option to skip the pre-commit hook when committing from the UI.

## Screenshots / Recording
<img width="352" height="1055" alt="skip pre-commit" src="https://github.com/user-attachments/assets/92f0acf8-e136-4f79-8abc-10e9d835ee26" />
