### PR TITLE
Refresh git state on bare .git events

### DIFF
--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -12416,7 +12416,10 @@ async fn test_bare_dot_git_changed_event_refreshes_git_state(cx: &mut gpui::Test
 
     repository.read_with(cx, |repository, _| {
         assert_eq!(
-            repository.head_commit.as_ref().map(|commit| commit.sha.as_ref()),
+            repository
+                .head_commit
+                .as_ref()
+                .map(|commit| commit.sha.as_ref()),
             Some("old-sha")
         );
         assert_eq!(
@@ -12447,7 +12450,10 @@ async fn test_bare_dot_git_changed_event_refreshes_git_state(cx: &mut gpui::Test
 
     repository.read_with(cx, |repository, _| {
         assert_eq!(
-            repository.head_commit.as_ref().map(|commit| commit.sha.as_ref()),
+            repository
+                .head_commit
+                .as_ref()
+                .map(|commit| commit.sha.as_ref()),
             Some("new-sha")
         );
         assert_eq!(repository.status_for_path(&repo_path("file.txt")), None);

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -12387,6 +12387,74 @@ async fn test_file_status(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_bare_dot_git_changed_event_refreshes_git_state(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/repo"),
+        json!({
+            ".git": {},
+            "file.txt": "new contents",
+        }),
+    )
+    .await;
+
+    let dot_git = Path::new(path!("/repo/.git"));
+    fs.set_head_for_repo(dot_git, &[("file.txt", "old contents".into())], "old-sha");
+    fs.set_index_for_repo(dot_git, &[("file.txt", "old contents".into())]);
+
+    let project = Project::test(fs.clone(), [path!("/repo").as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+    cx.run_until_parked();
+
+    let repository = project.read_with(cx, |project, cx| {
+        project.repositories(cx).values().next().unwrap().clone()
+    });
+
+    repository.read_with(cx, |repository, _| {
+        assert_eq!(
+            repository.head_commit.as_ref().map(|commit| commit.sha.as_ref()),
+            Some("old-sha")
+        );
+        assert_eq!(
+            repository
+                .status_for_path(&repo_path("file.txt"))
+                .map(|entry| entry.status),
+            Some(StatusCode::Modified.worktree())
+        );
+    });
+
+    fs.with_git_state(dot_git, false, |state| {
+        state
+            .head_contents
+            .insert(repo_path("file.txt"), "new contents".into());
+        state
+            .index_contents
+            .insert(repo_path("file.txt"), "new contents".into());
+        state.refs.insert("HEAD".into(), "new-sha".into());
+    })
+    .unwrap();
+    fs.emit_fs_event(dot_git, Some(PathEventKind::Changed));
+
+    cx.run_until_parked();
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+    cx.run_until_parked();
+
+    repository.read_with(cx, |repository, _| {
+        assert_eq!(
+            repository.head_commit.as_ref().map(|commit| commit.sha.as_ref()),
+            Some("new-sha")
+        );
+        assert_eq!(repository.status_for_path(&repo_path("file.txt")), None);
+    });
+}
+
+#[gpui::test]
 #[ignore]
 async fn test_ignored_dirs_events(cx: &mut gpui::TestAppContext) {
     init_test(cx);

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4532,6 +4532,14 @@ impl BackgroundScanner {
                         skip_ix(&mut ranges_to_drop, ix);
                         continue;
                     }
+
+                    if !dot_git_abs_paths.contains(&dot_git_abs_path) {
+                        log::debug!(
+                            "detected update within git repo at {dot_git_abs_path:?}: {abs_path:?}"
+                        );
+                        dot_git_abs_paths.push(dot_git_abs_path);
+                    }
+
                     if is_dot_git {
                         log::debug!(
                             "ignoring event {abs_path:?} for .git directory itself (kind: {:?})",
@@ -4539,13 +4547,6 @@ impl BackgroundScanner {
                         );
                         skip_ix(&mut ranges_to_drop, ix);
                         continue;
-                    }
-
-                    if !dot_git_abs_paths.contains(&dot_git_abs_path) {
-                        log::debug!(
-                            "detected update within git repo at {dot_git_abs_path:?}: {abs_path:?}"
-                        );
-                        dot_git_abs_paths.push(dot_git_abs_path);
                     }
                 }
 

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -4357,12 +4357,11 @@ async fn test_dot_git_dir_event_does_not_suppress_children(
 
     let dot_git = project_dir.join(DOT_GIT);
 
-    // Case 1: Events for .git AND .git/index.lock should NOT emit UpdatedGitRepositories
+    // Case 1: Event for .git/index.lock only should NOT emit UpdatedGitRepositories
     // (index.lock is in the skipped files list)
     {
         let mut events = cx.events(&worktree);
         fs.pause_events();
-        fs.emit_fs_event(dot_git.clone(), Some(PathEventKind::Changed));
         fs.emit_fs_event(dot_git.join("index.lock"), Some(PathEventKind::Created));
         fs.unpause_events_and_flush();
         executor.run_until_parked();
@@ -4374,7 +4373,7 @@ async fn test_dot_git_dir_event_does_not_suppress_children(
         );
     }
 
-    // Case 2: Event for just .git (bare directory event) should NOT emit UpdatedGitRepositories
+    // Case 2: Event for just .git (bare directory event) should emit UpdatedGitRepositories
     {
         let mut events = cx.events(&worktree);
         fs.pause_events();
@@ -4384,8 +4383,8 @@ async fn test_dot_git_dir_event_does_not_suppress_children(
 
         let got_git_update = drain_git_repo_updates(&mut events);
         assert!(
-            !got_git_update,
-            "should NOT emit UpdatedGitRepositories for a bare .git directory event"
+            got_git_update,
+            "should emit UpdatedGitRepositories for a bare .git directory event"
         );
     }
 


### PR DESCRIPTION
# Objective

Fix stale Git state in Zed when repository metadata changes are reported only as a bare `.git` directory event.

On macOS, file watcher events can be coalesced such that Git operations only surface as a `Changed` event for the `.git` directory itself, rather than individual events for files like `.git/index` or `.git/HEAD`. Zed previously ignored bare `.git` directory events before scheduling a Git metadata refresh, which could leave the Git panel showing stale changes or an outdated history even though `git status` / `git log` reflected the latest state.

## Solution

Treat meaningful bare `.git` directory events as Git repository updates before skipping them from normal worktree scanning.

This preserves the existing behavior of not scanning `.git` as regular project content, while still notifying the Git repository tracking path that repository metadata may have changed. As a result, Git state such as `HEAD` and file statuses are refreshed when `.git` itself is the only watcher event.

Updated the existing worktree test expectations so bare `.git` events now trigger `UpdatedGitRepositories`, while skipped files like `.git/index.lock` still do not.

Added a test covering the full project/Git path:

- repo initially has old `HEAD` and a modified file status
- fake Git state is updated to represent a commit
- only a bare `.git Changed` event is emitted
- Zed refreshes the repository snapshot, observes the new `HEAD`, and clears the stale file status

## Testing

The new tests cover the full project/Git path scenario described above. It fails without the fix and passes with the fix. Unfortunately, i was unable to reproduce the issue deterministically enough to test it end to end.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed stale Git panel state after repository metadata changes.