### PR TITLE
project_symbols: Add preview to project symbols picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13477,7 +13477,6 @@ dependencies = [
 name = "picker_preview"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "editor",
  "gpui",
  "language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14126,6 +14126,7 @@ dependencies = [
  "lsp",
  "ordered-float 2.10.1",
  "picker",
+ "picker_preview",
  "project",
  "release_channel",
  "semver",

--- a/crates/picker/src/preview.rs
+++ b/crates/picker/src/preview.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use gpui::{AnyElement, App, Entity, IntoElement, Window};
 use language::{Anchor, Buffer, HighlightedText};
+use project::Symbol;
 
 /// The editor-agnostic interface a [`Picker`](crate::Picker) uses to drive its
 /// preview.
@@ -67,6 +68,13 @@ pub enum PreviewSource {
     /// Used by pickers (like the text picker) that already hold the matched
     /// buffer.
     Buffer(Entity<Buffer>),
+    /// The buffer is identified by a project symbol; the preview opens it and
+    /// highlights the symbol's range.
+    ///
+    /// Used by pickers (like the project symbols picker) that only know the
+    /// matched symbol. The highlight is derived from the symbol once its buffer
+    /// loads, so callers don't supply a [`MatchLocation`].
+    Symbol(Symbol),
     /// No buffer to show; display this message centered in the preview instead.
     ///
     /// Used by pickers that have a selection without a previewable buffer (like
@@ -115,6 +123,17 @@ impl Update {
         Self {
             source: PreviewSource::Buffer(buffer),
             match_location: Some(highlight),
+        }
+    }
+
+    /// Preview the buffer for `symbol`, highlighting and scrolling to its range.
+    ///
+    /// The buffer is opened and the highlight derived by the preview once the
+    /// buffer loads.
+    pub fn from_symbol(symbol: Symbol) -> Self {
+        Self {
+            source: PreviewSource::Symbol(symbol),
+            match_location: None,
         }
     }
 }

--- a/crates/picker_preview/Cargo.toml
+++ b/crates/picker_preview/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/picker_preview.rs"
 doctest = false
 
 [dependencies]
-anyhow.workspace = true
+
 editor.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/picker_preview/src/picker_preview.rs
+++ b/crates/picker_preview/src/picker_preview.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use gpui::{
     Action, AnyElement, App, AppContext as _, Context, Entity, IntoElement, Pixels, StyledText,
-    Task, TaskExt as _, Window, px,
+    Task, Window, px,
 };
 use language::{Bias, Buffer, HighlightedText, HighlightedTextBuilder, ToPoint};
 use picker::{
@@ -14,6 +14,7 @@ use project::{Project, Symbol};
 use rope::Point;
 use settings::Settings;
 use ui::{ActiveTheme, Color, div, prelude::*, v_flex};
+use util::ResultExt as _;
 use util::rel_path::RelPath;
 
 use editor::{Editor, EditorSettings, RowHighlightOptions, display_map::HighlightKey};
@@ -61,6 +62,8 @@ struct EditorPreview {
     /// When set show a text message instead of a preview
     message: Option<HighlightedText>,
     preview_editor: Entity<Editor>,
+    /// Store the load preview task so we have only one at the time
+    pending_update: Task<()>,
 }
 
 impl EditorPreview {
@@ -100,6 +103,7 @@ impl EditorPreview {
             preview_editor,
             current_path: None,
             message: None,
+            pending_update: Task::ready(()),
         };
         this.clear(); // picker starts with no results.
         this
@@ -155,15 +159,16 @@ impl EditorPreview {
             }
         });
 
-        cx.spawn_in(window, async move |this, cx| {
-            let buffer = open_task.await?;
+        self.pending_update = cx.spawn_in(window, async move |this, cx| {
+            let Some(buffer) = open_task.await.log_err() else {
+                return;
+            };
             this.update_in(cx, |this, window, cx| {
                 this.update_from_buffer(buffer, highlight, window, cx);
                 cx.notify();
-            })?;
-            anyhow::Ok(())
-        })
-        .detach_and_log_err(cx);
+            })
+            .ok();
+        });
     }
 
     fn update_from_symbol(&mut self, symbol: Symbol, window: &mut Window, cx: &mut Context<Self>) {
@@ -171,8 +176,10 @@ impl EditorPreview {
             project.open_buffer_for_symbol(&symbol, cx)
         });
 
-        cx.spawn_in(window, async move |this, cx| {
-            let buffer = open_task.await?;
+        self.pending_update = cx.spawn_in(window, async move |this, cx| {
+            let Some(buffer) = open_task.await.log_err() else {
+                return;
+            };
             this.update_in(cx, |this, window, cx| {
                 let snapshot = buffer.read(cx).text_snapshot();
                 let start = snapshot.clip_point_utf16(symbol.range.start, Bias::Left);
@@ -184,10 +191,9 @@ impl EditorPreview {
                 };
                 this.update_from_buffer(buffer, Some(highlight), window, cx);
                 cx.notify();
-            })?;
-            anyhow::Ok(())
-        })
-        .detach_and_log_err(cx);
+            })
+            .ok();
+        });
     }
 
     fn update_from_buffer(

--- a/crates/picker_preview/src/picker_preview.rs
+++ b/crates/picker_preview/src/picker_preview.rs
@@ -6,11 +6,11 @@ use gpui::{
     Action, AnyElement, App, AppContext as _, Context, Entity, IntoElement, Pixels, StyledText,
     Task, TaskExt as _, Window, px,
 };
-use language::{Buffer, HighlightedText, HighlightedTextBuilder, ToPoint};
+use language::{Bias, Buffer, HighlightedText, HighlightedTextBuilder, ToPoint};
 use picker::{
     MatchLocation, PreviewBackend, PreviewLayout, PreviewSource, PreviewUpdate, ToMultiBuffer,
 };
-use project::Project;
+use project::{Project, Symbol};
 use rope::Point;
 use settings::Settings;
 use ui::{ActiveTheme, Color, div, prelude::*, v_flex};
@@ -125,6 +125,9 @@ impl EditorPreview {
                 self.update_from_buffer(buffer, highlight, window, cx);
                 cx.notify();
             }
+            PreviewSource::Symbol(symbol) => {
+                self.update_from_symbol(symbol, window, cx);
+            }
             PreviewSource::Message(message) => {
                 self.message = Some(message);
                 cx.notify();
@@ -156,6 +159,30 @@ impl EditorPreview {
             let buffer = open_task.await?;
             this.update_in(cx, |this, window, cx| {
                 this.update_from_buffer(buffer, highlight, window, cx);
+                cx.notify();
+            })?;
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
+    }
+
+    fn update_from_symbol(&mut self, symbol: Symbol, window: &mut Window, cx: &mut Context<Self>) {
+        let open_task = self.project.update(cx, |project, cx| {
+            project.open_buffer_for_symbol(&symbol, cx)
+        });
+
+        cx.spawn_in(window, async move |this, cx| {
+            let buffer = open_task.await?;
+            this.update_in(cx, |this, window, cx| {
+                let snapshot = buffer.read(cx).text_snapshot();
+                let start = snapshot.clip_point_utf16(symbol.range.start, Bias::Left);
+                let end = snapshot.clip_point_utf16(symbol.range.end, Bias::Left);
+                let highlight = MatchLocation {
+                    anchor_range: snapshot.anchor_before(start)..snapshot.anchor_after(end),
+                    range: snapshot.point_utf16_to_offset(start)
+                        ..snapshot.point_utf16_to_offset(end),
+                };
+                this.update_from_buffer(buffer, Some(highlight), window, cx);
                 cx.notify();
             })?;
             anyhow::Ok(())

--- a/crates/project_symbols/Cargo.toml
+++ b/crates/project_symbols/Cargo.toml
@@ -19,6 +19,7 @@ fuzzy.workspace = true
 gpui.workspace = true
 ordered-float.workspace = true
 picker.workspace = true
+picker_preview.workspace = true
 project.workspace = true
 serde_json.workspace = true
 settings.workspace = true

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -5,7 +5,7 @@ use gpui::{
     TextStyle, WeakEntity, Window, relative,
 };
 use ordered_float::OrderedFloat;
-use picker::{Picker, PickerDelegate};
+use picker::{Picker, PickerDelegate, PreviewUpdate};
 use project::{Project, Symbol, lsp_store::SymbolLocation};
 use settings::Settings;
 use std::{cmp::Reverse, sync::Arc};
@@ -25,8 +25,9 @@ pub fn init(cx: &mut App) {
                     let project = workspace.project().clone();
                     let handle = cx.entity().downgrade();
                     workspace.toggle_modal(window, cx, move |window, cx| {
-                        let delegate = ProjectSymbolsDelegate::new(handle, project);
-                        Picker::uniform_list(delegate, window, cx)
+                        let delegate = ProjectSymbolsDelegate::new(handle, project.clone());
+                        let preview = picker_preview::editor_preview(project, window, cx);
+                        Picker::uniform_list_with_preview(delegate, preview, window, cx)
                     })
                 },
             );
@@ -185,6 +186,12 @@ impl PickerDelegate for ProjectSymbolsDelegate {
         _cx: &mut Context<Picker<Self>>,
     ) {
         self.selected_match_index = ix;
+    }
+
+    fn try_get_preview_data_for_match(&self, _cx: &App) -> Option<PreviewUpdate> {
+        let candidate_id = self.matches.get(self.selected_match_index)?.candidate_id;
+        let symbol = self.symbols.get(candidate_id)?.clone();
+        Some(PreviewUpdate::from_symbol(symbol))
     }
 
     fn update_matches(


### PR DESCRIPTION
Candidate fix for #59822.

Adds a live preview pane to the project symbols picker, matching the file finder and project search pickers. When the selection moves, the selected symbol's file is shown in the preview with its declaration line highlighted and vertically centered.

## Changes
- `project_symbols`: construct the picker with `uniform_list_with_preview`; asynchronously open the buffer for the selected symbol (cached by candidate id, cleared on each new query) and implement `try_get_preview_data_for_match` to return the buffer plus the symbol's anchor range.
- `picker`: add a public `refresh_preview` so a delegate can push preview data once a buffer finishes opening asynchronously (the symbol buffer is not available synchronously, unlike text search which already holds open buffers).


#### Before
<img width="1725" height="712" alt="image" src="https://github.com/user-attachments/assets/21dcd7d6-7cc4-4de8-ab7d-2f1ce143e814" />

##### After
<img width="1725" height="712" alt="image" src="https://github.com/user-attachments/assets/db981db8-0a61-43bc-9838-c01b7bdbbf78" />

Can turn preview pane off by clicking at the bottom button!

## AI disclosure
AI was used for understanding the codebase and formatting this PR.

Release Notes:

- Added a preview pane to the project symbols picker