### PR TITLE
Make agent worktree path resolution deterministic and prefix-optional

### DIFF
--- a/crates/agent/src/tools/diagnostics_tool.rs
+++ b/crates/agent/src/tools/diagnostics_tool.rs
@@ -43,8 +43,7 @@ type Result<T, E = String> = core::result::Result<T, E>;
 pub struct DiagnosticsToolInput {
     /// The path to get diagnostics for. If not provided, returns a project-wide summary.
     ///
-    /// This path should never be absolute, and the first component
-    /// of the path should always be a root directory in a project.
+    /// In a single-root project, give the path relative to the root. In a multi-root project, prefix it with the root directory's name (an unprefixed path falls back to the first root). Absolute paths within a project root also work.
     ///
     /// <example>
     /// If the project has the following root directories:

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -37,7 +37,7 @@ const DEFAULT_UI_TEXT: &str = "Editing file";
 pub struct EditFileToolInput {
     /// The full path of the file to edit in the project.
     ///
-    /// WARNING: When specifying which file path need changing, you MUST start each path with one of the project's root directories, unless it's a global agent skill under `~/.agents/skills`.
+    /// In a single-root project, give the path relative to the root. In a multi-root project, prefix it with the root directory's name — an unprefixed path falls back to the first root, which may not be the file you mean. Absolute paths within a project root also work. For a global agent skill, give a path under `~/.agents/skills`.
     ///
     /// The following examples assume we have two root directories in the project:
     /// - /a/b/backend
@@ -46,7 +46,7 @@ pub struct EditFileToolInput {
     /// <example>
     /// `backend/src/main.rs`
     ///
-    /// Notice how the file path starts with `backend`. Without that, the path would be ambiguous and the call would fail!
+    /// Notice how the file path starts with `backend`. Without it, an unprefixed path resolves against the first root directory, which may not be the one you intend.
     /// </example>
     ///
     /// <example>

--- a/crates/agent/src/tools/grep_tool.rs
+++ b/crates/agent/src/tools/grep_tool.rs
@@ -205,17 +205,12 @@ impl AgentTool for GrepTool {
                     continue;
                 }
 
-                let (Some((path, project_path)), mut parse_status) =
+                let (Some(project_path), mut parse_status) =
                     buffer.read_with(cx, |buffer, cx| {
                         (
-                            buffer.file().map(|file| {
-                                (
-                                    file.full_path(cx),
-                                    ProjectPath {
-                                        worktree_id: file.worktree_id(cx),
-                                        path: file.path().clone(),
-                                    },
-                                )
+                            buffer.file().map(|file| ProjectPath {
+                                worktree_id: file.worktree_id(cx),
+                                path: file.path().clone(),
                             }),
                             buffer.parse_status(),
                         )
@@ -233,10 +228,17 @@ impl AgentTool for GrepTool {
                     continue;
                 }
 
-                let abs_path = project
-                    .read_with(cx, |project, cx| project.absolute_path(&project_path, cx))
-                    .ok()
-                    .flatten();
+                // Drop the root-name prefix when there's a single visible
+                // worktree, so the model isn't fed a redundant prefix (#35893).
+                let Ok((path, abs_path)) = project.read_with(cx, |project, cx| {
+                    let path_style = project.path_style(cx);
+                    let path = project
+                        .short_full_path_for_project_path(&project_path, cx)
+                        .unwrap_or_else(|| project_path.path.display(path_style).to_string());
+                    (path, project.absolute_path(&project_path, cx))
+                }) else {
+                    continue;
+                };
 
                 while *parse_status.borrow() != ParseStatus::Idle {
                     parse_status.changed().await.map_err(|e| e.to_string())?;
@@ -301,8 +303,7 @@ impl AgentTool for GrepTool {
                     }
 
                     if !file_header_written {
-                        writeln!(output, "\n## Matches in {}", path.display())
-                            .ok();
+                        writeln!(output, "\n## Matches in {path}").ok();
                         file_header_written = true;
                     }
 
@@ -329,7 +330,7 @@ impl AgentTool for GrepTool {
                     if let Some(abs_path) = &abs_path {
                         content.push(acp::ToolCallContent::Content(acp::Content::new(
                             acp::ContentBlock::ResourceLink(acp::ResourceLink::new(
-                                format!("{}#{}", path.display(), line_label),
+                                format!("{path}#{line_label}"),
                                 format!("file://{}#{}", abs_path.display(), line_label),
                             )),
                         )));
@@ -614,7 +615,7 @@ mod tests {
         let alpha_uri = format!("file://{}#L1", path!("/root/src/alpha.txt"));
         assert!(
             links.iter().any(|link| {
-                link.name.replace('\\', "/") == "root/src/alpha.txt#L1"
+                link.name.replace('\\', "/") == "src/alpha.txt#L1"
                     && link.uri.replace('\\', "/") == alpha_uri.replace('\\', "/")
             }),
             "missing clickable link for alpha.txt, got: {links:?}"
@@ -623,7 +624,7 @@ mod tests {
         let beta_uri = format!("file://{}#L1", path!("/root/beta.txt"));
         assert!(
             links.iter().any(|link| {
-                link.name.replace('\\', "/") == "root/beta.txt#L1"
+                link.name.replace('\\', "/") == "beta.txt#L1"
                     && link.uri.replace('\\', "/") == beta_uri.replace('\\', "/")
             }),
             "missing clickable link for beta.txt, got: {links:?}"
@@ -805,7 +806,7 @@ mod tests {
         let expected = r#"
             Found 1 matches:
 
-            ## Matches in root/test_syntax.rs
+            ## Matches in test_syntax.rs
 
             ### fn top_level_function › L1-3
             ```
@@ -834,7 +835,7 @@ mod tests {
         let expected = r#"
             Found 1 matches:
 
-            ## Matches in root/test_syntax.rs
+            ## Matches in test_syntax.rs
 
             ### mod feature_module › pub mod nested_module › pub fn nested_function › L10-14
             ```
@@ -865,7 +866,7 @@ mod tests {
         let expected = r#"
             Found 1 matches:
 
-            ## Matches in root/test_syntax.rs
+            ## Matches in test_syntax.rs
 
             ### mod feature_module › pub mod nested_module › pub fn nested_function › L7-14
             ```
@@ -900,7 +901,7 @@ mod tests {
         let expected = r#"
             Found 1 matches:
 
-            ## Matches in root/test_syntax.rs
+            ## Matches in test_syntax.rs
 
             ### impl MyStruct › fn method_with_block › L26-28
             ```
@@ -930,7 +931,7 @@ mod tests {
         let expected = r#"
             Found 1 matches:
 
-            ## Matches in root/test_syntax.rs
+            ## Matches in test_syntax.rs
 
             ### impl MyStruct › fn long_function › L31-41
             ```
@@ -970,7 +971,7 @@ mod tests {
         let expected = r#"
             Found 1 matches:
 
-            ## Matches in root/test_syntax.rs
+            ## Matches in test_syntax.rs
 
             ### impl MyStruct › fn long_function › L41-45
             ```

--- a/crates/agent/src/tools/list_directory_tool.rs
+++ b/crates/agent/src/tools/list_directory_tool.rs
@@ -22,9 +22,9 @@ use util::markdown::MarkdownInlineCode;
 /// The only supported path outside the project is `~/.agents/skills` or a descendant, for global agent skills.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ListDirectoryToolInput {
-    /// The fully-qualified path of the directory to list in the project.
+    /// The path of the directory to list in the project.
     ///
-    /// This path should never be absolute, and the first component of the path should always be a root directory in a project, unless it's a global agent skill directory under `~/.agents/skills`.
+    /// In a single-root project, give the path relative to the root. In a multi-root project, prefix it with the root directory's name (an unprefixed path falls back to the first root). Absolute paths within a project root also work. For a global agent skill directory, give a path under `~/.agents/skills`.
     ///
     /// <example>
     /// If the project has the following root directories:
@@ -122,6 +122,10 @@ impl ListDirectoryTool {
         let worktree_settings = WorktreeSettings::get(Some(project_path.into()), cx);
         let worktree_snapshot = worktree.read(cx).snapshot();
         let worktree_root_name = worktree.read(cx).root_name();
+        // Drop the root-name prefix when there's a single visible worktree, so the
+        // model isn't fed (and confused by) a redundant prefix (#35893). Mirrors
+        // `Project::short_full_path_for_project_path`.
+        let prefix_root_name = project.read(cx).visible_worktrees(cx).take(2).count() >= 2;
 
         let Some(entry) = worktree_snapshot.entry_for_path(&project_path.path) else {
             return Err(anyhow!("Path not found: {}", input_path));
@@ -149,10 +153,17 @@ impl ListDirectoryTool {
                 continue;
             }
 
-            let full_path = worktree_root_name
-                .join(&entry.path)
-                .display(worktree_snapshot.path_style())
-                .into_owned();
+            let full_path = if prefix_root_name {
+                worktree_root_name
+                    .join(&entry.path)
+                    .display(worktree_snapshot.path_style())
+                    .into_owned()
+            } else {
+                entry
+                    .path
+                    .display(worktree_snapshot.path_style())
+                    .into_owned()
+            };
             if entry.is_dir() {
                 folders.push(full_path);
             } else {
@@ -410,12 +421,12 @@ mod tests {
             output,
             platform_paths(indoc! {"
                 # Folders:
-                project/src
-                project/tests
+                src
+                tests
 
                 # Files:
-                project/Cargo.toml
-                project/README.md
+                Cargo.toml
+                README.md
             "})
         );
 
@@ -437,12 +448,12 @@ mod tests {
             output,
             platform_paths(indoc! {"
                 # Folders:
-                project/src/models
-                project/src/utils
+                src/models
+                src/utils
 
                 # Files:
-                project/src/lib.rs
-                project/src/main.rs
+                src/lib.rs
+                src/main.rs
             "})
         );
 
@@ -462,7 +473,7 @@ mod tests {
             .unwrap();
         assert!(!output.contains("# Folders:"));
         assert!(output.contains("# Files:"));
-        assert!(output.contains(&platform_paths("project/tests/integration_test.rs")));
+        assert!(output.contains(&platform_paths("tests/integration_test.rs")));
     }
 
     #[gpui::test]

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -159,9 +159,9 @@ use crate::{AgentTool, ToolCallEventStream, ToolInput, outline};
 /// The only supported path outside the project is `~/.agents/skills` or a descendant, for global agent skills.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ReadFileToolInput {
-    /// The relative path of the file to read.
+    /// The path of the file to read.
     ///
-    /// This path should never be absolute, and the first component of the path should always be a root directory in a project, unless it's a global agent skill under `~/.agents/skills`.
+    /// In a single-root project, give the path relative to the root. In a multi-root project, prefix it with the root directory's name (an unprefixed path falls back to the first root). Absolute paths within a project root also work. For a global agent skill, give a path under `~/.agents/skills`.
     ///
     /// <example>
     /// If the project has the following root directories:
@@ -870,8 +870,8 @@ mod test {
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
         let tool = Arc::new(ReadFileTool::new(project, action_log, true));
 
-        // The tool schema says the first component must be the worktree root name,
-        // so "foo/test.txt" means test.txt at the root of the "foo" worktree.
+        // A path beginning with a worktree root name binds to that worktree, so
+        // "foo/test.txt" means test.txt at the root of the "foo" worktree.
         let result = cx
             .update(|cx| {
                 let input = ReadFileToolInput {

--- a/crates/agent/src/tools/write_file_tool.rs
+++ b/crates/agent/src/tools/write_file_tool.rs
@@ -28,7 +28,7 @@ const DEFAULT_UI_TEXT: &str = "Writing file";
 pub struct WriteFileToolInput {
     /// The full path of the file to create or overwrite in the project.
     ///
-    /// WARNING: When specifying which file path need changing, you MUST start each path with one of the project's root directories, unless it's a global agent skill under `~/.agents/skills`.
+    /// In a single-root project, give the path relative to the root. In a multi-root project, prefix it with the root directory's name — an unprefixed path falls back to the first root, which may not be the file you mean. Absolute paths within a project root also work. For a global agent skill, give a path under `~/.agents/skills`.
     ///
     /// The following examples assume we have two root directories in the project:
     /// - /a/b/backend
@@ -37,7 +37,7 @@ pub struct WriteFileToolInput {
     /// <example>
     /// `backend/src/main.rs`
     ///
-    /// Notice how the file path starts with `backend`. Without that, the path would be ambiguous and the call would fail!
+    /// Notice how the file path starts with `backend`. Without it, an unprefixed path resolves against the first root directory, which may not be the one you intend.
     /// </example>
     ///
     /// <example>

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5058,15 +5058,21 @@ impl Project {
             // resolution stays stable as files are created and deleted. When
             // visible worktrees share a root name, the first wins; the others are
             // reachable by absolute path.
+            let mut had_root_name_prefix = false;
             for worktree in worktree_store.visible_worktrees(cx) {
                 let worktree = worktree.read(cx);
-                if let Ok(relative_path) = path.strip_prefix(worktree.root_name().as_std_path())
-                    && let Ok(rel_path) = RelPath::new(relative_path, path_style)
-                {
-                    return Some(ProjectPath {
-                        worktree_id: worktree.id(),
-                        path: rel_path.into_arc(),
-                    });
+                if let Ok(relative_path) = path.strip_prefix(worktree.root_name().as_std_path()) {
+                    // The path is owned by this worktree's namespace even if it
+                    // then escapes via `..`; in that case we must not fall through
+                    // to the relative fallback below and silently re-anchor it
+                    // inside the worktree.
+                    had_root_name_prefix = true;
+                    if let Ok(rel_path) = RelPath::new(relative_path, path_style) {
+                        return Some(ProjectPath {
+                            worktree_id: worktree.id(),
+                            path: rel_path.into_arc(),
+                        });
+                    }
                 }
             }
 
@@ -5083,6 +5089,24 @@ impl Project {
                         path: entry.path.clone(),
                     });
                 }
+            }
+
+            // Third pass: the path has no root-name prefix and matched no existing
+            // entry, so bind it as a worktree-relative path against the first
+            // visible worktree. This lets a model resolve a not-yet-created file
+            // when it omits the root-name prefix (#35893), matching the first-wins
+            // resolution used elsewhere. Paths that began with a root name are
+            // excluded so a root-prefixed `..` escape stays unresolved rather than
+            // being re-anchored inside the worktree. `RelPath::new` still rejects
+            // unprefixed paths that escape past the root.
+            if !had_root_name_prefix
+                && let Some(worktree) = worktree_store.visible_worktrees(cx).next()
+                && let Ok(rel_path) = RelPath::new(path, path_style)
+            {
+                return Some(ProjectPath {
+                    worktree_id: worktree.read(cx).id(),
+                    path: rel_path.into_arc(),
+                });
             }
         }
 
@@ -6827,6 +6851,50 @@ mod find_project_path_tests {
             assert_ne!(
                 absolute.worktree_id, first_id,
                 "absolute path should reach the second worktree"
+            );
+        });
+    }
+
+    /// A path that omits the worktree root name and matches no existing entry
+    /// still resolves against the first visible worktree, so a model can write a
+    /// not-yet-created file without prefixing the root name (#35893).
+    #[gpui::test]
+    async fn test_find_project_path_resolves_unprefixed_new_file(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(Path::new("/zero"), json!({ "src": { "main.rs": "" } }))
+            .await;
+
+        let project = Project::test(fs.clone(), [Path::new("/zero")], cx).await;
+
+        project.read_with(cx, |project, cx| {
+            let worktree_id = project
+                .visible_worktrees(cx)
+                .next()
+                .expect("one worktree")
+                .read(cx)
+                .id();
+
+            // Unprefixed, not-yet-created file resolves to the worktree.
+            let new_file = project
+                .find_project_path("src/new_file.rs", cx)
+                .expect("unprefixed new file resolves");
+            assert_eq!(new_file.worktree_id, worktree_id);
+            assert_eq!(new_file.path.as_unix_str(), "src/new_file.rs");
+
+            // The root-name-prefixed form resolves to the same place.
+            let prefixed = project
+                .find_project_path("zero/src/new_file.rs", cx)
+                .expect("prefixed new file resolves");
+            assert_eq!(prefixed, new_file);
+
+            // A root-name-prefixed path that escapes the worktree via `..` must
+            // not be silently re-anchored inside the worktree by the fallback.
+            assert_eq!(
+                project.find_project_path("zero/../other", cx),
+                None,
+                "escaping path should stay unresolved"
             );
         });
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5053,41 +5053,34 @@ impl Project {
                 }
             }
         } else {
-            // First pass: for each worktree, try two interpretations of the path and
-            // return whichever finds an existing entry first:
-            //   (a) Strip the worktree root name as a prefix.
-            //   (b) Treat the path as a literal worktree-relative path.
+            // First pass: if the path begins with a worktree's root name, bind it
+            // to that worktree regardless of whether the entry exists, so
+            // resolution stays stable as files are created and deleted. When
+            // visible worktrees share a root name, the first wins; the others are
+            // reachable by absolute path.
             for worktree in worktree_store.visible_worktrees(cx) {
                 let worktree = worktree.read(cx);
                 if let Ok(relative_path) = path.strip_prefix(worktree.root_name().as_std_path())
                     && let Ok(rel_path) = RelPath::new(relative_path, path_style)
-                    && let Some(entry) = worktree.entry_for_path(&rel_path)
                 {
                     return Some(ProjectPath {
                         worktree_id: worktree.id(),
-                        path: entry.path.clone(),
+                        path: rel_path.into_arc(),
                     });
                 }
+            }
+
+            // Second pass: the path didn't start with a root name, so treat it as
+            // a literal worktree-relative path and return the first worktree that
+            // contains it.
+            for worktree in worktree_store.visible_worktrees(cx) {
+                let worktree = worktree.read(cx);
                 if let Ok(rel_path) = RelPath::new(path, path_style)
                     && let Some(entry) = worktree.entry_for_path(&rel_path)
                 {
                     return Some(ProjectPath {
                         worktree_id: worktree.id(),
                         path: entry.path.clone(),
-                    });
-                }
-            }
-
-            // Second pass: strip the worktree root name prefix without requiring the
-            // entry to exist, to allow resolving paths that don't exist yet.
-            for worktree in worktree_store.visible_worktrees(cx) {
-                let worktree_root_name = worktree.read(cx).root_name();
-                if let Ok(relative_path) = path.strip_prefix(worktree_root_name.as_std_path())
-                    && let Ok(path) = RelPath::new(relative_path, path_style)
-                {
-                    return Some(ProjectPath {
-                        worktree_id: worktree.read(cx).id(),
-                        path: path.into_arc(),
                     });
                 }
             }
@@ -6765,4 +6758,76 @@ fn provide_inline_values(
     }
 
     variables
+}
+
+#[cfg(test)]
+mod find_project_path_tests {
+    use crate::Project;
+    use fs::FakeFs;
+    use gpui::TestAppContext;
+    use serde_json::json;
+    use settings::SettingsStore;
+    use std::path::Path;
+
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+    }
+
+    /// When visible worktrees share a root name, resolving by that name binds to
+    /// the first worktree regardless of where the file exists, and the others
+    /// stay reachable by absolute path.
+    #[gpui::test]
+    async fn test_find_project_path_is_stable_across_same_named_worktrees(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(Path::new("/a/project1"), json!({ "shared.txt": "from a" }))
+            .await;
+        fs.insert_tree(
+            Path::new("/b/project1"),
+            json!({ "only_in_b.txt": "from b" }),
+        )
+        .await;
+
+        let project = Project::test(
+            fs.clone(),
+            [Path::new("/a/project1"), Path::new("/b/project1")],
+            cx,
+        )
+        .await;
+
+        project.read_with(cx, |project, cx| {
+            let worktrees: Vec<_> = project.visible_worktrees(cx).collect();
+            assert_eq!(worktrees.len(), 2, "expected two same-named worktrees");
+            let first_id = worktrees[0].read(cx).id();
+
+            // A file present only in the second worktree, a new file, and a file
+            // present in the first all resolve to the first worktree by bare name.
+            let only_in_b = project
+                .find_project_path("project1/only_in_b.txt", cx)
+                .expect("bare path resolves");
+            let new_file = project
+                .find_project_path("project1/new_file.txt", cx)
+                .expect("bare path resolves");
+            let existing = project
+                .find_project_path("project1/shared.txt", cx)
+                .expect("bare path resolves");
+
+            assert_eq!(only_in_b.worktree_id, first_id);
+            assert_eq!(new_file.worktree_id, first_id);
+            assert_eq!(existing.worktree_id, first_id);
+
+            // The shadowed second worktree is still reachable by absolute path.
+            let absolute = project
+                .find_project_path(Path::new("/b/project1/only_in_b.txt"), cx)
+                .expect("absolute path resolves");
+            assert_ne!(
+                absolute.worktree_id, first_id,
+                "absolute path should reach the second worktree"
+            );
+        });
+    }
 }


### PR DESCRIPTION
# Objective

Two related problems made the agent's path handling confusing:

1. **Non-deterministic resolution.** `find_project_path` resolved a relative path by returning whichever worktree happened to contain the entry, only falling back to the first worktree by root name when the entry existed nowhere. The result depended on filesystem state: the same bare path could "flip" between same-named worktrees as files were created and deleted, and it disagreed with the terminal's `cd`.
2. **Redundant root prefix.** In single-root projects the path tools always prefixed output with the worktree root name, so the model was fed (and confused by) a prefix it then echoed back into later tool calls.

Addresses #35893; part of #58839.

Tangentially related to #59864; the two don't depend on each other and either can land first.

## Solution

Organized into two layered commits for your reviewing pleasure:

**Deterministic resolution** (`find_project_path`):

- A path that begins with a worktree root name binds to the first such worktree regardless of whether the entry exists, so resolution stays stable as files come and go. Same-named worktrees resolve first-wins; the others remain reachable by absolute path.
- A new fallback binds an unprefixed, not-yet-existing path to the first visible worktree, so a model that omits the root name can still create files. A root-name-prefixed path that escapes via `..` is left unresolved rather than re-anchored inside the worktree.

**Prefix-optional presentation:**

- `list_directory` and `grep` drop the root-name prefix when there's a single visible worktree, mirroring `short_full_path_for_project_path` (already used by `read_file`/edit titles). Multi-root output keeps the prefix for disambiguation.
- The `read_file`, `write_file`, `edit_file`, `list_directory`, and `diagnostics` path descriptions are updated to match: the root-name prefix is optional in a single-root project, an unprefixed path in a multi-root project falls back to the first root, and absolute paths within a root are accepted. The old text wrongly claimed paths must start with a root name and could never be absolute.

## Testing

- `cargo test -p project find_project_path` (stability across same-named worktrees, unprefixed new-file resolution, `..` escape rejection)
- `cargo test -p action_log` (29 tests; heavy `find_project_path` user)
- `cargo test -p agent --lib` for the affected tools (`read_file`, `write_file`, `edit_file`, `list_directory`, `grep`), including updated single-root output expectations
- `./script/clippy -p project -p agent`
- Have not built a zed executable or tested the changes with a live agent.
- `find_project_path` is used project-wide, not just by agent tools. The absolute-path branch is unchanged; the relative branch's precedence changed so that all root-name-prefixed matches now win over any literal-relative match, and an unprefixed multi-root path now resolves to the first root (first-wins) instead of returning `None`. Reviewers may want to sanity-check non-agent callers.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Suggested .rules additions

This trap caused a safety regression mid-development (a `..` escape was silently re-anchored inside a worktree) and is non-obvious. Suggest `crates/project/.rules`:

> `RelPath::new` normalizes `.`/`..` components (it pops parent dirs) and only errors when `..` escapes past the root. When resolving a path that begins with a worktree root name, strip the root name as a *literal* prefix before calling `RelPath::new`. If you normalize the whole path first, a root-prefixed escape like `root/../outside` collapses to an in-worktree path and is silently re-anchored inside the worktree instead of being rejected.

---

Release Notes:

- Improved agent path handling: single-root projects no longer show a redundant worktree-name prefix, and worktree paths resolve consistently regardless of whether the file exists yet (#35893)
