### PR TITLE
git_ui: Fix create pull request for remotes with no provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7381,6 +7381,7 @@ dependencies = [
  "itertools 0.14.0",
  "language",
  "language_model",
+ "linkify",
  "log",
  "markdown",
  "menu",

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -38,6 +38,7 @@ gpui.workspace = true
 itertools.workspace = true
 language.workspace = true
 language_model.workspace = true
+linkify.workspace = true
 log.workspace = true
 markdown.workspace = true
 menu.workspace = true

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4392,26 +4392,27 @@ impl GitPanel {
                         .size(IconSize::Small)
                         .color(Color::Muted),
                 );
-                match (style, is_push) {
-                    (Toast | ToastWithLog { .. }, true) => {
+                match style {
+                    PushPrLink { link } => this.action("Create Pull Request", move |_, cx| {
+                        cx.open_url(&link);
+                    }),
+                    Toast | ToastWithLog { .. } if is_push => {
                         this.action("Create Pull Request", move |window, cx| {
                             window
                                 .dispatch_action(Box::new(zed_actions::git::CreatePullRequest), cx);
                         })
                     }
-                    (Toast, false) => this,
-                    (ToastWithLog { output }, false) => {
-                        this.action("View Log", move |window, cx| {
-                            let output = output.clone();
-                            let output =
-                                format!("stdout:\n{}\nstderr:\n{}", output.stdout, output.stderr);
-                            workspace_weak
-                                .update(cx, move |workspace, cx| {
-                                    open_output(operation, workspace, &output, window, cx)
-                                })
-                                .ok();
-                        })
-                    }
+                    Toast => this,
+                    ToastWithLog { output } => this.action("View Log", move |window, cx| {
+                        let output = output.clone();
+                        let output =
+                            format!("stdout:\n{}\nstderr:\n{}", output.stdout, output.stderr);
+                        workspace_weak
+                            .update(cx, move |workspace, cx| {
+                                open_output(operation, workspace, &output, window, cx)
+                            })
+                            .ok();
+                    }),
                 }
                 .dismiss_button(true)
             });

--- a/crates/git_ui/src/remote_output.rs
+++ b/crates/git_ui/src/remote_output.rs
@@ -1,6 +1,7 @@
 use anyhow::Context as _;
 
 use git::repository::{Remote, RemoteCommandOutput};
+use linkify::{LinkFinder, LinkKind};
 use ui::SharedString;
 use util::ResultExt as _;
 
@@ -21,9 +22,19 @@ impl RemoteAction {
     }
 }
 
+#[derive(Debug)]
 pub enum SuccessStyle {
     Toast,
-    ToastWithLog { output: RemoteCommandOutput },
+    ToastWithLog {
+        output: RemoteCommandOutput,
+    },
+    /// A push whose stderr contained a link to create or view a pull/merge
+    /// request. Opening this URL directly avoids relying on a hosting provider
+    /// being registered for the remote, which is not the case for every host
+    /// (e.g. self-hosted GitLab instances behind a private domain).
+    PushPrLink {
+        link: String,
+    },
 }
 
 pub struct SuccessMessage {
@@ -123,13 +134,44 @@ pub fn format_output(action: &RemoteAction, output: RemoteCommandOutput) -> Succ
                     style: SuccessStyle::Toast,
                 }
             } else {
-                SuccessMessage {
-                    message: format!("Pushed {} to {}", branch_name, remote_ref.name),
-                    style: SuccessStyle::ToastWithLog { output },
-                }
+                // Many hosting providers print a link to create or view a pull/merge
+                // request in the push output (prefixed with `remote:`). Prefer that
+                // link when present: it is produced by the server itself, so it works
+                // for any host regardless of whether Zed has a matching provider.
+                let link = extract_pull_request_link(&output.stderr);
+                let message = format!("Pushed {} to {}", branch_name, remote_ref.name);
+                let style = match link {
+                    Some(link) => SuccessStyle::PushPrLink { link },
+                    None => SuccessStyle::ToastWithLog { output },
+                };
+                SuccessMessage { message, style }
             }
         }
     }
+}
+
+/// Extracts a pull/merge request link from a push command's stderr, if any.
+///
+/// Hosting providers surface these links on lines prefixed with `remote:`
+/// (e.g. GitHub's "Create a pull request for ... on GitHub by visiting:"
+/// followed by the URL, or GitLab's "To create a merge request for ..., visit:").
+/// We only inspect `remote:` lines so that unrelated URLs printed earlier in
+/// the output (such as OpenSSH's post-quantum warning linking to openssh.com)
+/// are not picked up.
+fn extract_pull_request_link(stderr: &str) -> Option<String> {
+    let finder = LinkFinder::new();
+    stderr.lines().find_map(|line| {
+        let trimmed = line.trim_start();
+        trimmed
+            .strip_prefix("remote:")
+            .and_then(|rest| {
+                finder
+                    .links(rest)
+                    .find(|link| *link.kind() == LinkKind::Url)
+                    .map(|link| link.as_str().trim().to_string())
+            })
+            .filter(|link| !link.is_empty())
+    })
 }
 
 #[cfg(test)]
@@ -162,7 +204,10 @@ mod tests {
 
         let msg = format_output(&action, output);
 
-        assert!(matches!(msg.style, SuccessStyle::ToastWithLog { .. }));
+        let SuccessStyle::PushPrLink { link } = &msg.style else {
+            panic!("Expected PushPrLink variant, got {:?}", msg.style);
+        };
+        assert_eq!(link, "https://example.com/test/test/pull/new/test");
         assert_eq!(msg.message, "Pushed test_branch to test_remote");
     }
 
@@ -191,7 +236,13 @@ mod tests {
 
         let msg = format_output(&action, output);
 
-        assert!(matches!(msg.style, SuccessStyle::ToastWithLog { .. }));
+        let SuccessStyle::PushPrLink { link } = &msg.style else {
+            panic!("Expected PushPrLink variant, got {:?}", msg.style);
+        };
+        assert_eq!(
+            link,
+            "https://example.com/test/test/-/merge_requests/new?merge_request%5Bsource_branch%5D=test"
+        );
         assert_eq!(msg.message, "Pushed test_branch to test_remote");
     }
 
@@ -224,7 +275,11 @@ mod tests {
 
         let msg = format_output(&action, output);
 
-        assert!(matches!(msg.style, SuccessStyle::ToastWithLog { .. }));
+        let SuccessStyle::PushPrLink { link } = &msg.style else {
+            panic!("Expected PushPrLink variant, got {:?}", msg.style);
+        };
+        // The openssh.com URL on a non-`remote:` line must be ignored.
+        assert_eq!(link, "https://example.com/test/test/-/merge_requests/99999");
         assert_eq!(msg.message, "Pushed test_branch to test_remote");
     }
 
@@ -257,5 +312,43 @@ mod tests {
         } else {
             panic!("Expected ToastWithLog variant");
         }
+    }
+
+    /// Regression test for an internal GitLab host with no registered provider:
+    /// the create-merge-request URL printed by the server must still be picked
+    /// up from stderr so the toast can open it directly, instead of failing
+    /// with "Unsupported remote URL".
+    #[test]
+    fn test_push_internal_host_merge_request_link() {
+        let action = RemoteAction::Push(
+            SharedString::new_static("dtm-harness"),
+            Remote {
+                name: SharedString::new_static("origin"),
+            },
+        );
+
+        let output = RemoteCommandOutput {
+            stdout: String::new(),
+            stderr: indoc! {"
+                remote:
+                remote: To create a merge request for dtm-harness, visit:
+                remote:   https://git.woa.com/ybtm-client/dtm-harness/-/merge_requests/new?merge_request%5Bsource_branch%5D=dtm-harness
+                remote:
+                To git.woa.com:ybtm-client/dtm-harness.git
+                 * [new branch]      dtm-harness -> dtm-harness
+                "}
+            .to_string(),
+        };
+
+        let msg = format_output(&action, output);
+
+        let SuccessStyle::PushPrLink { link } = &msg.style else {
+            panic!("Expected PushPrLink variant, got {:?}", msg.style);
+        };
+        assert_eq!(
+            link,
+            "https://git.woa.com/ybtm-client/dtm-harness/-/merge_requests/new?merge_request%5Bsource_branch%5D=dtm-harness"
+        );
+        assert_eq!(msg.message, "Pushed dtm-harness to origin");
     }
 }


### PR DESCRIPTION
## Summary

The post-push toast's "Create Pull Request" button regressed in #53913: it now always dispatches the `git::CreatePullRequest` action, which parses the remote URL through the `GitHostingProviderRegistry`. For remotes whose host has no registered provider (e.g. internal GitLab instances such as `git.woa.com`), `parse_git_remote_url` returns `None` and the button fails with:

> Unsupported remote URL: git@git.woa.com:ybtm-client/dtm-harness.git

## Root cause

Before #53913, the "Create Pull Request" button only appeared when git's push output contained a create-PR/MR link (e.g. GitLab's `remote: To create a merge request for ..., visit: <url>`), and clicking it opened that URL directly via `cx.open_url(&link)` — no remote-URL parsing, so it worked for any host.

#53913 changed the button to always appear and to dispatch `git::CreatePullRequest`, which routes through `create_pull_request()` → `git::parse_git_remote_url()`. That walks Zed's hosting-provider registry, and no provider matches hosts like `git.woa.com` (an internal GitLab instance; GitLab's self-hosted detection requires `host.contains("gitlab")`). So `parse_git_remote_url` returns `None` and the error is surfaced to the user.

## Fix

Restore the stderr-link path alongside the new always-show button, preferring git's own output when present:

- **`remote_output.rs`**: re-added a `PushPrLink { link }` `SuccessStyle` variant and an `extract_pull_request_link` helper that scans only `remote:`-prefixed lines (so unrelated links such as OpenSSH's post-quantum warning are ignored). This works for any host because the server produces the URL itself.
- **`git_panel.rs`**: when `PushPrLink` is produced, the "Create Pull Request" button opens that URL directly; otherwise it falls back to dispatching `CreatePullRequest` (the provider-based path, for known hosts without a stderr link). The `ToastWithLog` "View Log" fallback for non-push actions is preserved.
- Re-added the `linkify` dependency to `git_ui`.

## Testing

- Updated the three existing push tests to assert `PushPrLink` with the correct extracted URLs.
- Added `test_push_internal_host_merge_request_link` — a regression guard mirroring the reported `git.woa.com` scenario.
- All 116 `git_ui` lib tests pass; `./script/clippy -p git_ui` and `cargo fmt` are clean.

Release Notes:

- Fixed the "Create Pull Request" button on the post-push toast failing with "Unsupported remote URL" for remotes whose host has no registered git hosting provider (e.g. internal GitLab instances).