### PR TITLE
gpui_windows: Add missing windows dependency feature

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -142,7 +142,7 @@ scap = { workspace = true, optional = true }
 
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.61", features = ["Win32_Foundation"] }
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Power"] }
 
 
 [dev-dependencies]


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/59831 broke the crate from compiling standalone

---

Release Notes:

- N/A or Added/Fixed/Improved ...
