### PR TITLE
Fix recent projects footer overflowing

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -705,7 +705,7 @@ impl RecentProjects {
                 ProjectPickerStyle::Modal,
             );
 
-            Self::new(delegate, fs, 34., window, cx)
+            Self::new(delegate, fs, 42., window, cx)
         })
     }
 


### PR DESCRIPTION
The width of the recent projects picker was set too small. When selecting an item that is already opened an additional action (remove current window) appears that overflows. This sets the width such that that no longer occurs.

fixes: #59847

Release Notes:

- N/A (bug on preview only)
