### PR TITLE
agent: Truncate display name using grapheme clusters in config option selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
  "tree-sitter-md",
  "ui",
  "ui_input",
+ "unicode-segmentation",
  "unindent",
  "url",
  "util",

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -146,5 +146,6 @@ reqwest_client.workspace = true
 tempfile.workspace = true
 vim.workspace = true
 tree-sitter-md.workspace = true
+unicode-segmentation.workspace = true
 unindent.workspace = true
 terminal = { workspace = true, features = ["test-support"] }

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -108,6 +108,7 @@ theme_settings.workspace = true
 time.workspace = true
 ui.workspace = true
 ui_input.workspace = true
+unicode-segmentation.workspace = true
 url.workspace = true
 util.workspace = true
 uuid.workspace = true
@@ -146,6 +147,5 @@ reqwest_client.workspace = true
 tempfile.workspace = true
 vim.workspace = true
 tree-sitter-md.workspace = true
-unicode-segmentation.workspace = true
 unindent.workspace = true
 terminal = { workspace = true, features = ["test-support"] }

--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -11,7 +11,6 @@ use gpui::{
     App, BackgroundExecutor, Context, DismissEvent, Entity, Subscription, Task, Window, prelude::*,
 };
 use ordered_float::OrderedFloat;
-use unicode_segmentation::UnicodeSegmentation;
 use picker::popover_menu::PickerPopoverMenu;
 use picker::{Picker, PickerDelegate};
 use settings::SettingsStore;
@@ -19,6 +18,7 @@ use ui::{
     ElevationIndex, IconButton, KeyBinding, ListItem, ListItemSpacing, PopoverMenuHandle, Tooltip,
     prelude::*,
 };
+use unicode_segmentation::UnicodeSegmentation;
 use util::ResultExt as _;
 use zed_actions::agent::ToggleModelSelector;
 
@@ -365,7 +365,13 @@ impl ConfigOptionSelector {
         };
 
         let value_name = self.current_value_name();
-        let display_name = value_name.graphemes(true).take(32).collect::<String>();
+        let mut graphemes = value_name.graphemes(true);
+        let truncated = graphemes.by_ref().take(32).collect::<String>();
+        let display_name = if graphemes.next().is_some() {
+            format!("{truncated}…")
+        } else {
+            truncated
+        };
 
         Button::new(
             ElementId::Name(format!("config-option-{}", option.id.0).into()),

--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -11,6 +11,7 @@ use gpui::{
     App, BackgroundExecutor, Context, DismissEvent, Entity, Subscription, Task, Window, prelude::*,
 };
 use ordered_float::OrderedFloat;
+use unicode_segmentation::UnicodeSegmentation;
 use picker::popover_menu::PickerPopoverMenu;
 use picker::{Picker, PickerDelegate};
 use settings::SettingsStore;
@@ -364,11 +365,7 @@ impl ConfigOptionSelector {
         };
 
         let value_name = self.current_value_name();
-        let display_name = if value_name.len() > 33 {
-            format!("{}…", &value_name[..32])
-        } else {
-            value_name
-        };
+        let display_name = value_name.graphemes(true).take(32).collect::<String>();
 
         Button::new(
             ElementId::Name(format!("config-option-{}", option.id.0).into()),


### PR DESCRIPTION
This pull request updates how long configuration option names are displayed in the UI to better handle Unicode characters, ensuring that names are truncated by grapheme clusters (user-perceived characters) rather than bytes or code points. This prevents visual glitches with multi-codepoint characters like emojis or accented letters. The main changes are:

**Unicode handling improvements:**

* Added the `unicode-segmentation` crate as a workspace dependency in `Cargo.toml` to support grapheme-aware string operations.
* Updated import statements in `config_options.rs` to include `unicode_segmentation::UnicodeSegmentation`.

**UI display logic:**

* Changed the truncation logic for configuration option display names in `ConfigOptionSelector` to use `.graphemes(true).take(32)` instead of slicing bytes, ensuring proper handling of Unicode graphemes.

--- 

Release Notes:

- Agent: Made label truncation of configuration options in the agent panel more robust against non-single-byte characters like emojis and others.