### PR TITLE
git_panel: Focus back on commit editor when expanded

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -7099,7 +7099,7 @@ impl Render for GitPanel {
 
 impl Focusable for GitPanel {
     fn focus_handle(&self, cx: &App) -> gpui::FocusHandle {
-        if self.entries.is_empty() {
+        if self.entries.is_empty() || self.commit_editor_expanded {
             self.commit_editor.focus_handle(cx)
         } else {
             self.focus_handle.clone()
@@ -9888,6 +9888,47 @@ mod tests {
                 panel.commit_editor.read(cx).mode().clone(),
                 EditorMode::AutoHeight { .. }
             ));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_focus_handle(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (_project, workspace, panel, mut cx) = setup_git_panel_with_changes(
+            cx,
+            json!({
+                ".git": {},
+                "tracked": "tracked\n",
+            }),
+            &[("tracked", StatusCode::Modified)],
+        )
+        .await;
+
+        workspace.update_in(&mut cx, |workspace, window, cx| {
+            workspace.add_panel(panel.clone(), window, cx);
+        });
+
+        // With changes present and the editor not expanded, the panel's own
+        // focus handle should be returned, in order for
+        // `git_panel::ToggleFocus` to focus on the panel itself.
+        panel.update_in(&mut cx, |panel, _window, cx| {
+            assert!(!panel.entries.is_empty());
+            assert!(!panel.commit_editor_expanded);
+            assert_eq!(panel.focus_handle(cx), panel.focus_handle.clone());
+        });
+
+        // Expand the editor so we can later confirm that toggling focus
+        // actually focuses on the commit editor, seeing as it has been
+        // expanded.
+        panel.update_in(&mut cx, |panel, window, cx| {
+            panel.toggle_fill_commit_editor(&ToggleFillCommitEditor, window, cx);
+            assert!(panel.commit_editor_expanded);
+        });
+
+        cx.dispatch_action(super::ToggleFocus);
+        panel.update_in(&mut cx, |panel, window, cx| {
+            assert!(panel.commit_editor.focus_handle(cx).is_focused(window));
         });
     }
 }


### PR DESCRIPTION
Update the focus handle returned by the `GitPanel::focus_handle` method in order to ensure that, if the commit editor is currently expanded, using the `git_panel::ToggleFocus` action will correctly focus back on the expanded editor, rather than on the panel.

# Objective

When using the expanded commit editor, if one focuses away from the panel and then uses the `git panel: toggle focus` action in order to focus back on the panel, the focus will land on the panel, which is now being rendered behind the commit editor.

## Solution

Update the focus handle returned by the `GitPanel` to take into consideration whether the commit editor is expanded and, in that case, return the editor's focus handle instead.

## Testing

Tested both manually as well as through a newly introduced test – `git_ui::git_panel::tests::test_focus_handle`.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Before</summary>

  https://github.com/user-attachments/assets/0e2647f3-2835-485f-8f01-2128d2de6b8e
</details>

<details>
  <summary>After</summary>

  https://github.com/user-attachments/assets/cc77fae7-e76c-4389-82b0-f4e7ec8258d7
</details>

---

Release Notes:

- Fixed `git panel: toggle focus` to focus back on the commit editor in case it is expanded.
