### PR TITLE
git_graph: Add setting for ref label alignment

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1020,6 +1020,13 @@
     // Default: project_diff
     "entry_primary_click_action": "project_diff",
   },
+  "git_graph": {
+    // Where to render ref labels in the Description column.
+    //
+    // Choices: left, right
+    // Default: left
+    "ref_label_alignment": "left",
+  },
   "message_editor": {
     // Whether to automatically replace emoji shortcodes with emoji characters.
     // For example: typing `:wave:` gets replaced with `👋`.

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -38,6 +38,7 @@ use search::{
     SearchOption, SearchOptions, SearchSource, SelectNextMatch, SelectPreviousMatch,
     ToggleCaseSensitive, buffer_search,
 };
+use settings::{GitGraphRefLabelAlignment, RegisterSetting, Settings};
 use smallvec::{SmallVec, smallvec};
 use std::{
     cell::Cell,
@@ -74,6 +75,20 @@ const CUSTOM_GIT_COMMANDS_DOCS_SLUG: &str = "tasks#custom-git-commands";
 // Extra vertical breathing room added to the UI line height when computing
 // the git graph's row height, so commit dots and lines have space around them.
 const ROW_VERTICAL_PADDING: Pixels = px(4.0);
+
+#[derive(Debug, Clone, PartialEq, RegisterSetting)]
+struct GitGraphSettings {
+    ref_label_alignment: GitGraphRefLabelAlignment,
+}
+
+impl Settings for GitGraphSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        let git_graph = content.git_graph.clone().unwrap();
+        Self {
+            ref_label_alignment: git_graph.ref_label_alignment.unwrap(),
+        }
+    }
+}
 
 struct CopiedState {
     copied_at: Option<Instant>,
@@ -1075,6 +1090,7 @@ impl GraphData {
 }
 
 pub fn init(cx: &mut App) {
+    GitGraphSettings::register(cx);
     workspace::register_serializable_item::<GitGraph>(cx);
 
     cx.observe_new(|workspace: &mut workspace::Workspace, _, _| {
@@ -1522,9 +1538,11 @@ impl GitGraph {
             })
         };
         let mut row_height = Self::row_height(window, cx);
+        let mut ref_label_alignment = GitGraphSettings::get_global(cx).ref_label_alignment;
 
         cx.observe_global_in::<settings::SettingsStore>(window, move |this, window, cx| {
             let new_row_height = Self::row_height(window, cx);
+            let new_ref_label_alignment = GitGraphSettings::get_global(cx).ref_label_alignment;
             if new_row_height != row_height {
                 // The `uniform_list` powering the table caches the item size
                 // from its last layout; invalidate it so it re-measures with
@@ -1533,6 +1551,11 @@ impl GitGraph {
                     state.scroll_handle.0.borrow_mut().last_item_size = None;
                 });
                 row_height = new_row_height;
+                cx.notify();
+            }
+
+            if new_ref_label_alignment != ref_label_alignment {
+                ref_label_alignment = new_ref_label_alignment;
                 cx.notify();
             }
         })
@@ -1780,6 +1803,7 @@ impl GitGraph {
 
         let row_height = Self::row_height(window, cx);
         let has_context_menu = self.has_context_menu();
+        let ref_label_alignment = GitGraphSettings::get_global(cx).ref_label_alignment;
 
         // We fetch data outside the visible viewport to avoid loading entries when
         // users scroll through the git graph
@@ -1883,6 +1907,33 @@ impl GitGraph {
                     column_label(subject)
                 };
 
+                let ref_chips = (!commit.data.ref_names.is_empty()).then(|| {
+                    h_flex()
+                        .gap_1()
+                        .flex_none()
+                        .children(commit.data.ref_names.iter().map(|name| {
+                            let is_head = Self::is_head_ref(name.as_ref(), &head_branch_name);
+                            self.render_ref_chip(name, accent_color, is_head, idx, cx)
+                        }))
+                        .into_any_element()
+                });
+
+                let subject_content = match ref_label_alignment {
+                    GitGraphRefLabelAlignment::Left => h_flex()
+                        .gap_2()
+                        .overflow_hidden()
+                        .children(ref_chips)
+                        .child(subject_label)
+                        .into_any_element(),
+                    GitGraphRefLabelAlignment::Right => h_flex()
+                        .gap_2()
+                        .overflow_hidden()
+                        .justify_between()
+                        .child(div().min_w_0().child(subject_label))
+                        .children(ref_chips)
+                        .into_any_element(),
+                };
+
                 vec![
                     div()
                         .id(ElementId::NamedInteger("commit-subject".into(), idx as u64))
@@ -1929,27 +1980,7 @@ impl GitGraph {
                                 this
                             }
                         })
-                        .child(
-                            h_flex()
-                                .gap_2()
-                                .overflow_hidden()
-                                .children((!commit.data.ref_names.is_empty()).then(|| {
-                                    h_flex().gap_1().children(commit.data.ref_names.iter().map(
-                                        |name| {
-                                            let is_head =
-                                                Self::is_head_ref(name.as_ref(), &head_branch_name);
-                                            self.render_ref_chip(
-                                                name,
-                                                accent_color,
-                                                is_head,
-                                                idx,
-                                                cx,
-                                            )
-                                        },
-                                    ))
-                                }))
-                                .child(subject_label),
-                        )
+                        .child(subject_content)
                         .into_any_element(),
                     column_label(formatted_time.into()),
                     column_label(author_name),

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -186,6 +186,7 @@ impl VsCodeSettings {
             extension: ExtensionSettingsContent::default(),
             file_finder: None,
             git: self.git_settings_content(),
+            git_graph: None,
             git_panel: self.git_panel_settings_content(),
             global_lsp_settings: skip_default(GlobalLspSettingsContent {
                 semantic_token_rules: self.semantic_token_rules(),

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -137,6 +137,9 @@ pub struct SettingsContent {
 
     pub git_panel: Option<GitPanelSettingsContent>,
 
+    /// Settings related to the git graph.
+    pub git_graph: Option<GitGraphSettingsContent>,
+
     pub tabs: Option<ItemSettingsContent>,
     pub tab_bar: Option<TabBarSettingsContent>,
     pub status_bar: Option<StatusBarSettingsContent>,
@@ -619,6 +622,38 @@ pub enum DockPosition {
     Left,
     Bottom,
     Right,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum GitGraphRefLabelAlignment {
+    /// Render ref labels before the commit subject.
+    #[default]
+    Left,
+    /// Render ref labels after the commit subject.
+    Right,
+}
+
+#[with_fallible_options]
+#[derive(Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug)]
+pub struct GitGraphSettingsContent {
+    /// Where ref labels should be rendered in the Description column.
+    ///
+    /// Default: left
+    pub ref_label_alignment: Option<GitGraphRefLabelAlignment>,
 }
 
 /// Configuration of voice calls in Zed.

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7660,6 +7660,35 @@ fn version_control_page() -> SettingsPage {
         ]
     }
 
+    fn git_graph_section() -> [SettingsPageItem; 2] {
+        [
+            SettingsPageItem::SectionHeader("Git Graph"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Ref Label Alignment",
+                description: "Where ref labels are rendered in the Description column.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("git_graph.ref_label_alignment"),
+                    pick: |settings_content| {
+                        settings_content
+                            .git_graph
+                            .as_ref()?
+                            .ref_label_alignment
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .git_graph
+                            .get_or_insert_default()
+                            .ref_label_alignment = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+        ]
+    }
+
     fn git_hunks_section() -> [SettingsPageItem; 4] {
         [
             SettingsPageItem::SectionHeader("Git Hunks"),
@@ -7725,6 +7754,7 @@ fn version_control_page() -> SettingsPage {
             inline_git_blame_section(),
             git_blame_view_section(),
             branch_picker_section(),
+            git_graph_section(),
             git_hunks_section(),
         ],
     }

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -600,6 +600,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::ThinkingBlockDisplay>(render_dropdown)
         .add_basic_renderer::<settings::ImageFileSizeUnit>(render_dropdown)
         .add_basic_renderer::<settings::StatusStyle>(render_dropdown)
+        .add_basic_renderer::<settings::GitGraphRefLabelAlignment>(render_dropdown)
         .add_basic_renderer::<settings::GitPanelClickBehavior>(render_dropdown)
         .add_basic_renderer::<settings::GitPanelSortBy>(render_dropdown)
         .add_basic_renderer::<settings::GitPanelGroupBy>(render_dropdown)


### PR DESCRIPTION
# Objective

- Ability to change the alignment of the ref labels in git graph.

## Solution

- Create a config option under a git_graph object for ref label alignment.

## Testing

- `check -p git_ui`
- `check -p settings_ui`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

- Change the alignment/position of ref labels in git graph in settings
 
 Alignment set to "right" ("left" is the default)
<img width="1624" height="1030" alt="Screenshot 2026-06-25 at 4 23 27 PM" src="https://github.com/user-attachments/assets/c416bcff-e341-4f79-8193-4631bbbf5df9" />

---

Release Notes:

- Add option to configure ref label alignment in git graph.