### PR TITLE
remote: Connect GitHub Codespaces from remote projects

### DIFF
--- a/crates/project/src/trusted_worktrees.rs
+++ b/crates/project/src/trusted_worktrees.rs
@@ -167,6 +167,9 @@ impl From<RemoteConnectionOptions> for RemoteHostLocation {
                 wsl.user.map(SharedString::new),
                 SharedString::new(wsl.distro_name),
             ),
+            RemoteConnectionOptions::Codespace(codespace) => {
+                (None, SharedString::new(codespace.name))
+            }
             RemoteConnectionOptions::Docker(docker_connection_options) => (
                 Some(SharedString::new(docker_connection_options.name)),
                 SharedString::new(docker_connection_options.container_id),

--- a/crates/recent_projects/src/codespace_picker.rs
+++ b/crates/recent_projects/src/codespace_picker.rs
@@ -1,0 +1,228 @@
+use std::sync::Arc;
+
+use gpui::{EventEmitter, SharedString, Task};
+use picker::Picker;
+use remote::CodespaceConnectionOptions;
+use ui::{
+    App, Context, HighlightedLabel, Icon, IconName, ListItem, ParentElement, Styled, Toggleable,
+    Window, h_flex, v_flex,
+};
+use util::ResultExt as _;
+
+#[derive(Clone, Debug)]
+pub struct CodespaceSelected {
+    pub codespace: CodespaceConnectionOptions,
+}
+
+#[derive(Clone, Debug)]
+pub struct CodespacePickerDismissed;
+
+pub(crate) struct CodespacePickerDelegate {
+    selected_index: usize,
+    codespaces: Option<Vec<CodespaceConnectionOptions>>,
+    matches: Vec<fuzzy_nucleo::StringMatch>,
+    query: String,
+    fetch_started: bool,
+    fetch_error: Option<String>,
+}
+
+impl CodespacePickerDelegate {
+    pub fn new() -> Self {
+        Self {
+            selected_index: 0,
+            codespaces: None,
+            matches: Vec::new(),
+            query: String::new(),
+            fetch_started: false,
+            fetch_error: None,
+        }
+    }
+
+    pub fn selected_codespace(&self) -> Option<CodespaceConnectionOptions> {
+        let matched = self.matches.get(self.selected_index)?;
+        self.codespaces.as_ref()?.get(matched.candidate_id).cloned()
+    }
+
+    fn rebuild_matches(&mut self) {
+        use fuzzy_nucleo::StringMatchCandidate;
+        use ordered_float::OrderedFloat;
+
+        let Some(codespaces) = &self.codespaces else {
+            return;
+        };
+
+        let candidates = codespaces
+            .iter()
+            .enumerate()
+            .map(|(id, codespace)| StringMatchCandidate::new(id, codespace.name.clone()))
+            .collect::<Vec<_>>();
+
+        let query = self.query.trim_start();
+        let case = fuzzy_nucleo::Case::smart_if_uppercase_in(query);
+        self.matches = fuzzy_nucleo::match_strings(
+            &candidates,
+            query,
+            case,
+            fuzzy_nucleo::LengthPenalty::On,
+            100,
+        );
+        self.matches
+            .sort_unstable_by_key(|matched| matched.candidate_id);
+
+        self.selected_index = self
+            .matches
+            .iter()
+            .enumerate()
+            .rev()
+            .max_by_key(|(_, matched)| OrderedFloat(matched.score))
+            .map(|(index, _)| index)
+            .unwrap_or(0);
+    }
+}
+
+impl EventEmitter<CodespaceSelected> for Picker<CodespacePickerDelegate> {}
+
+impl EventEmitter<CodespacePickerDismissed> for Picker<CodespacePickerDelegate> {}
+
+impl picker::PickerDelegate for CodespacePickerDelegate {
+    type ListItem = ListItem;
+
+    fn name() -> &'static str {
+        "codespace-picker"
+    }
+
+    fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(
+        &mut self,
+        ix: usize,
+        _window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) {
+        self.selected_index = ix;
+        cx.notify();
+    }
+
+    fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        Arc::from("Search GitHub Codespaces")
+    }
+
+    fn update_matches(
+        &mut self,
+        query: String,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> Task<()> {
+        self.query = query;
+
+        if self.codespaces.is_some() || self.fetch_error.is_some() {
+            self.rebuild_matches();
+            return Task::ready(());
+        }
+
+        if self.fetch_started {
+            return Task::ready(());
+        }
+
+        self.fetch_started = true;
+        cx.spawn_in(window, async move |picker, cx| {
+            let result = remote::list_codespaces().await;
+            picker
+                .update(cx, |picker, cx| {
+                    match result {
+                        Ok(codespaces) => picker.delegate.codespaces = Some(codespaces),
+                        Err(error) => {
+                            picker.delegate.fetch_error = Some(format!("{error:#}"));
+                            log::error!("failed to list GitHub Codespaces: {error:#}");
+                        }
+                    }
+                    picker.delegate.rebuild_matches();
+                    cx.notify();
+                })
+                .log_err();
+        })
+    }
+
+    fn confirm(&mut self, _secondary: bool, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        if let Some(codespace) = self.selected_codespace() {
+            cx.emit(CodespaceSelected { codespace });
+        }
+    }
+
+    fn dismissed(&mut self, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        cx.emit(CodespacePickerDismissed);
+    }
+
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        if let Some(error) = &self.fetch_error {
+            Some(error.clone().into())
+        } else if self.fetch_started && self.codespaces.is_none() {
+            Some("Loading GitHub Codespaces...".into())
+        } else {
+            Some("No GitHub Codespaces found".into())
+        }
+    }
+
+    fn render_match(
+        &self,
+        ix: usize,
+        selected: bool,
+        _: &mut Window,
+        _: &mut Context<Picker<Self>>,
+    ) -> Option<Self::ListItem> {
+        let matched = self.matches.get(ix)?;
+        let codespace = self.codespaces.as_ref()?.get(matched.candidate_id)?;
+        let name = codespace.name.clone();
+        let name_len = name.len();
+        let positions = matched
+            .positions
+            .iter()
+            .copied()
+            .filter(|position| *position < name_len)
+            .collect::<Vec<_>>();
+
+        Some(
+            ListItem::new(ix)
+                .toggle_state(selected)
+                .inset(true)
+                .spacing(ui::ListItemSpacing::Sparse)
+                .child(
+                    h_flex()
+                        .flex_grow_1()
+                        .gap_3()
+                        .child(Icon::new(IconName::Server))
+                        .child(v_flex().child(HighlightedLabel::new(name, positions))),
+                ),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn codespace() -> CodespaceConnectionOptions {
+        CodespaceConnectionOptions {
+            name: "octocat-hello-123".to_string(),
+        }
+    }
+
+    fn selected_for_query(query: &str) -> Option<CodespaceConnectionOptions> {
+        let mut delegate = CodespacePickerDelegate::new();
+        delegate.codespaces = Some(vec![codespace()]);
+        delegate.query = query.to_string();
+        delegate.rebuild_matches();
+        delegate.selected_codespace()
+    }
+
+    #[test]
+    fn matches_codespaces_by_name() {
+        assert_eq!(selected_for_query("octocat-hello"), Some(codespace()));
+    }
+}

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -1,3 +1,4 @@
+mod codespace_picker;
 mod dev_container_suggest;
 pub mod disconnected_overlay;
 mod remote_connections;

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -2031,6 +2031,7 @@ pub(crate) fn icon_for_remote_connection(options: Option<&RemoteConnectionOption
         Some(options) => match options {
             RemoteConnectionOptions::Ssh(_) => IconName::Server,
             RemoteConnectionOptions::Wsl(_) => IconName::Linux,
+            RemoteConnectionOptions::Codespace(_) => IconName::Server,
             RemoteConnectionOptions::Docker(_) => IconName::Box,
             #[cfg(any(test, feature = "test-support"))]
             RemoteConnectionOptions::Mock(_) => IconName::Server,

--- a/crates/recent_projects/src/remote_connections.rs
+++ b/crates/recent_projects/src/remote_connections.rs
@@ -317,6 +317,9 @@ pub async fn open_remote_project(
                             match connection_options {
                                 RemoteConnectionOptions::Ssh(_) => "Failed to connect over SSH",
                                 RemoteConnectionOptions::Wsl(_) => "Failed to connect to WSL",
+                                RemoteConnectionOptions::Codespace(_) => {
+                                    "Failed to connect to GitHub Codespace"
+                                }
                                 RemoteConnectionOptions::Docker(_) => {
                                     "Failed to connect to Dev Container"
                                 }
@@ -378,6 +381,9 @@ pub async fn open_remote_project(
                             match connection_options {
                                 RemoteConnectionOptions::Ssh(_) => "Failed to connect over SSH",
                                 RemoteConnectionOptions::Wsl(_) => "Failed to connect to WSL",
+                                RemoteConnectionOptions::Codespace(_) => {
+                                    "Failed to connect to GitHub Codespace"
+                                }
                                 RemoteConnectionOptions::Docker(_) => {
                                     "Failed to connect to Dev Container"
                                 }

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -408,6 +408,10 @@ impl ProjectPicker {
             RemoteConnectionOptions::Wsl(connection) => ProjectPickerData::Wsl {
                 distro_name: connection.distro_name.clone().into(),
             },
+            RemoteConnectionOptions::Codespace(connection) => ProjectPickerData::Ssh {
+                connection_string: connection.name.clone().into(),
+                nickname: None,
+            },
             RemoteConnectionOptions::Docker(_) => ProjectPickerData::Ssh {
                 // Not implemented as a project picker at this time
                 connection_string: "".into(),

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -67,7 +67,6 @@ pub struct RemoteServerProjects {
     _subscriptions: Vec<Subscription>,
     allow_dismissal: bool,
 }
-
 struct CreateRemoteServer {
     address_editor: Entity<Editor>,
     address_error: Option<SharedString>,
@@ -89,7 +88,6 @@ impl CreateRemoteServer {
         }
     }
 }
-
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum DevContainerCreationProgress {
     SelectingConfig,
@@ -113,6 +111,41 @@ impl CreateRemoteDevContainer {
             back_entry,
             progress,
         }
+    }
+}
+
+struct AddCodespace {
+    picker: Entity<Picker<crate::codespace_picker::CodespacePickerDelegate>>,
+}
+
+impl AddCodespace {
+    fn new(window: &mut Window, cx: &mut Context<RemoteServerProjects>) -> Self {
+        use crate::codespace_picker::{
+            CodespacePickerDelegate, CodespacePickerDismissed, CodespaceSelected,
+        };
+
+        let delegate = CodespacePickerDelegate::new();
+        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx).embedded());
+
+        cx.subscribe_in(
+            &picker,
+            window,
+            |this, _, _: &CodespaceSelected, window, cx| {
+                this.confirm(&menu::Confirm, window, cx);
+            },
+        )
+        .detach();
+
+        cx.subscribe_in(
+            &picker,
+            window,
+            |this, _, _: &CodespacePickerDismissed, window, cx| {
+                this.cancel(&menu::Cancel, window, cx);
+            },
+        )
+        .detach();
+
+        Self { picker }
     }
 }
 
@@ -457,38 +490,39 @@ impl ProjectPicker {
                     let (paths, paths_with_positions) =
                         determine_paths_with_positions(&remote_connection, paths).await;
 
-                    cx.update(|_, cx| {
-                        let fs = app_state.fs.clone();
-                        update_settings_file(fs, cx, {
-                            let paths = paths
-                                .iter()
-                                .map(|path| path.to_string_lossy().into_owned())
-                                .collect();
-                            move |settings, _| match index {
-                                ServerIndex::Ssh(index) => {
-                                    if let Some(server) = settings
-                                        .remote
-                                        .ssh_connections
-                                        .as_mut()
-                                        .and_then(|connections| connections.get_mut(index.0))
-                                    {
-                                        server.projects.insert(RemoteProject { paths });
-                                    };
+                    if !matches!(index, ServerIndex::Transient) {
+                        cx.update(|_, cx| {
+                            let fs = app_state.fs.clone();
+                            update_settings_file(fs, cx, {
+                                let paths = paths
+                                    .iter()
+                                    .map(|path| path.to_string_lossy().into_owned())
+                                    .collect();
+                                move |settings, _| match index {
+                                    ServerIndex::Ssh(index) => {
+                                        if let Some(server) =
+                                            settings.remote.ssh_connections.as_mut().and_then(
+                                                |connections| connections.get_mut(index.0),
+                                            )
+                                        {
+                                            server.projects.insert(RemoteProject { paths });
+                                        };
+                                    }
+                                    ServerIndex::Wsl(index) => {
+                                        if let Some(server) =
+                                            settings.remote.wsl_connections.as_mut().and_then(
+                                                |connections| connections.get_mut(index.0),
+                                            )
+                                        {
+                                            server.projects.insert(RemoteProject { paths });
+                                        };
+                                    }
+                                    ServerIndex::Transient => {}
                                 }
-                                ServerIndex::Wsl(index) => {
-                                    if let Some(server) = settings
-                                        .remote
-                                        .wsl_connections
-                                        .as_mut()
-                                        .and_then(|connections| connections.get_mut(index.0))
-                                    {
-                                        server.projects.insert(RemoteProject { paths });
-                                    };
-                                }
-                            }
-                        });
-                    })
-                    .log_err();
+                            });
+                        })
+                        .log_err();
+                    }
 
                     let window = if create_new_window {
                         let options = cx
@@ -613,6 +647,7 @@ impl std::fmt::Display for WslServerIndex {
 enum ServerIndex {
     Ssh(SshServerIndex),
     Wsl(WslServerIndex),
+    Transient,
 }
 impl From<SshServerIndex> for ServerIndex {
     fn from(index: SshServerIndex) -> Self {
@@ -624,7 +659,6 @@ impl From<WslServerIndex> for ServerIndex {
         Self::Wsl(index)
     }
 }
-
 #[derive(Clone)]
 struct ProjectEntry {
     project: RemoteProject,
@@ -799,6 +833,7 @@ enum Mode {
     ProjectPicker(Entity<ProjectPicker>),
     CreateRemoteServer(CreateRemoteServer),
     CreateRemoteDevContainer(CreateRemoteDevContainer),
+    AddCodespace(AddCodespace),
     #[cfg(target_os = "windows")]
     AddWslDistro(AddWslDistro),
 }
@@ -815,6 +850,7 @@ impl Mode {
 enum RemoteMatch {
     AddServer,
     AddDevContainer,
+    AddCodespace,
     AddWsl,
     Separator,
     ServerHeader {
@@ -901,6 +937,7 @@ impl RemoteServerPickerDelegate {
         let mut matches = Vec::new();
         if self.query.trim().is_empty() {
             matches.push(RemoteMatch::AddServer);
+            matches.push(RemoteMatch::AddCodespace);
             if has_open_project && is_local {
                 matches.push(RemoteMatch::AddDevContainer);
             }
@@ -1162,6 +1199,14 @@ impl PickerDelegate for RemoteServerPickerDelegate {
                     })
                     .ok();
             }
+            RemoteMatch::AddCodespace => {
+                remote_server_projects
+                    .update(cx, |this, cx| {
+                        this.mode = Mode::AddCodespace(AddCodespace::new(window, cx));
+                        cx.notify();
+                    })
+                    .ok();
+            }
             RemoteMatch::AddWsl => {
                 #[cfg(target_os = "windows")]
                 remote_server_projects
@@ -1270,6 +1315,12 @@ impl PickerDelegate for RemoteServerPickerDelegate {
             RemoteMatch::AddDevContainer => {
                 Some(self.render_action_item(ix, IconName::Plus, "Connect Dev Container", selected))
             }
+            RemoteMatch::AddCodespace => Some(self.render_action_item(
+                ix,
+                IconName::Plus,
+                "Connect GitHub Codespace",
+                selected,
+            )),
             RemoteMatch::AddWsl => {
                 Some(self.render_action_item(ix, IconName::Plus, "Add WSL Distro", selected))
             }
@@ -1913,6 +1964,13 @@ impl RemoteServerProjects {
                 let distro = delegate.selected_distro().unwrap();
                 self.connect_wsl_distro(state.picker.clone(), distro, window, cx);
             }
+            Mode::AddCodespace(state) => {
+                let delegate = &state.picker.read(cx).delegate;
+                let Some(codespace) = delegate.selected_codespace() else {
+                    return;
+                };
+                self.create_remote_project(ServerIndex::Transient, codespace.into(), window, cx);
+            }
         }
     }
 
@@ -2071,6 +2129,7 @@ impl RemoteServerProjects {
             ServerIndex::Wsl(server) => {
                 self.delete_wsl_project(server, project, cx);
             }
+            ServerIndex::Transient => {}
         }
     }
 
@@ -2576,6 +2635,24 @@ impl RemoteServerProjects {
             })
     }
 
+    fn render_add_codespace(
+        &self,
+        state: &AddCodespace,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        state.picker.update(cx, |picker, cx| {
+            picker.focus_handle(cx).focus(window, cx);
+        });
+
+        v_flex()
+            .id("add-codespace")
+            .overflow_hidden()
+            .size_full()
+            .flex_1()
+            .child(state.picker.clone())
+    }
+
     fn render_view_options(
         &mut self,
         options: ViewServerOptionsState,
@@ -3070,6 +3147,7 @@ impl Focusable for RemoteServerProjects {
         match &self.mode {
             Mode::Default => self.default_picker.focus_handle(cx),
             Mode::ProjectPicker(picker) => picker.focus_handle(cx),
+            Mode::AddCodespace(state) => state.picker.focus_handle(cx),
             _ => self.focus_handle.clone(),
         }
     }
@@ -3107,6 +3185,9 @@ impl Render for RemoteServerProjects {
                     .into_any_element(),
                 Mode::EditNickname(state) => self
                     .render_edit_nickname(state, window, cx)
+                    .into_any_element(),
+                Mode::AddCodespace(state) => self
+                    .render_add_codespace(state, window, cx)
                     .into_any_element(),
                 #[cfg(target_os = "windows")]
                 Mode::AddWslDistro(state) => self

--- a/crates/remote/src/remote.rs
+++ b/crates/remote/src/remote.rs
@@ -15,6 +15,7 @@ pub use remote_client::{
 pub use remote_identity::{
     RemoteConnectionIdentity, remote_connection_identity, same_remote_connection_identity,
 };
+pub use transport::codespace::{CodespaceConnectionOptions, list_codespaces};
 pub use transport::docker::DockerConnectionOptions;
 pub use transport::ssh::{SshConnectionOptions, SshPortForwardOption};
 pub use transport::wsl::WslConnectionOptions;

--- a/crates/remote/src/remote_client.rs
+++ b/crates/remote/src/remote_client.rs
@@ -1,10 +1,11 @@
 #[cfg(any(test, feature = "test-support"))]
 use crate::transport::mock::ConnectGuard;
 use crate::{
-    SshConnectionOptions,
+    CodespaceConnectionOptions, SshConnectionOptions,
     protocol::MessageId,
     proxy::ProxyLaunchError,
     transport::{
+        codespace::codespace_ssh_connection,
         docker::{DockerConnectionOptions, DockerExecConnection},
         ssh::SshRemoteConnection,
         wsl::{WslConnectionOptions, WslRemoteConnection},
@@ -1271,6 +1272,20 @@ impl ConnectionPool {
                                 .await
                                 .map(|connection| Arc::new(connection) as Arc<dyn RemoteConnection>)
                         }
+                        RemoteConnectionOptions::Codespace(opts) => {
+                            delegate
+                                .set_status(Some("Generating Codespaces SSH configuration"), cx);
+                            let ssh_connection = codespace_ssh_connection(&opts).await?;
+                            SshRemoteConnection::new_with_reported_connection_options(
+                                ssh_connection.ssh_options,
+                                RemoteConnectionOptions::Codespace(opts),
+                                ssh_connection.ssh_config_dir,
+                                delegate,
+                                cx,
+                            )
+                            .await
+                            .map(|connection| Arc::new(connection) as Arc<dyn RemoteConnection>)
+                        }
                         RemoteConnectionOptions::Docker(opts) => {
                             DockerExecConnection::new(opts, delegate, cx)
                                 .await
@@ -1322,6 +1337,7 @@ impl ConnectionPool {
 pub enum RemoteConnectionOptions {
     Ssh(SshConnectionOptions),
     Wsl(WslConnectionOptions),
+    Codespace(CodespaceConnectionOptions),
     Docker(DockerConnectionOptions),
     #[cfg(any(test, feature = "test-support"))]
     Mock(crate::transport::mock::MockConnectionOptions),
@@ -1335,6 +1351,7 @@ impl RemoteConnectionOptions {
                 .clone()
                 .unwrap_or_else(|| opts.host.to_string()),
             RemoteConnectionOptions::Wsl(opts) => opts.distro_name.clone(),
+            RemoteConnectionOptions::Codespace(opts) => opts.name.clone(),
             RemoteConnectionOptions::Docker(opts) => {
                 if opts.use_podman {
                     format!("[podman] {}", opts.name)
@@ -1353,6 +1370,7 @@ impl RemoteConnectionOptions {
         match self {
             RemoteConnectionOptions::Ssh(_) => "ssh",
             RemoteConnectionOptions::Wsl(_) => "wsl",
+            RemoteConnectionOptions::Codespace(_) => "codespace",
             RemoteConnectionOptions::Docker(opts) => {
                 if opts.use_podman {
                     "podman"
@@ -1408,6 +1426,13 @@ mod tests {
             "wsl"
         );
         assert_eq!(
+            RemoteConnectionOptions::Codespace(CodespaceConnectionOptions {
+                name: "octocat-hello-123".to_string(),
+            })
+            .connection_type(),
+            "codespace"
+        );
+        assert_eq!(
             RemoteConnectionOptions::Docker(DockerConnectionOptions {
                 use_podman: false,
                 ..Default::default()
@@ -1423,6 +1448,15 @@ mod tests {
             .connection_type(),
             "podman"
         );
+    }
+
+    #[test]
+    fn test_codespace_display_name_uses_name() {
+        let options = RemoteConnectionOptions::Codespace(CodespaceConnectionOptions {
+            name: "octocat-hello-123".to_string(),
+        });
+
+        assert_eq!(options.display_name(), "octocat-hello-123");
     }
 
     #[gpui::test]
@@ -1566,6 +1600,12 @@ impl From<SshConnectionOptions> for RemoteConnectionOptions {
 impl From<WslConnectionOptions> for RemoteConnectionOptions {
     fn from(opts: WslConnectionOptions) -> Self {
         RemoteConnectionOptions::Wsl(opts)
+    }
+}
+
+impl From<CodespaceConnectionOptions> for RemoteConnectionOptions {
+    fn from(opts: CodespaceConnectionOptions) -> Self {
+        RemoteConnectionOptions::Codespace(opts)
     }
 }
 

--- a/crates/remote/src/remote_identity.rs
+++ b/crates/remote/src/remote_identity.rs
@@ -17,13 +17,18 @@ pub enum RemoteConnectionIdentity {
         distro_name: String,
         user: Option<String>,
     },
+    Codespace {
+        name: String,
+    },
     Docker {
         container_id: String,
         name: String,
         remote_user: String,
     },
     #[cfg(any(test, feature = "test-support"))]
-    Mock { id: u64 },
+    Mock {
+        id: u64,
+    },
 }
 
 impl RemoteConnectionIdentity {
@@ -46,6 +51,7 @@ impl RemoteConnectionIdentity {
                 user.as_deref().unwrap_or_default(),
                 distro_name
             ),
+            Self::Codespace { name } => format!("codespace:{name}"),
             Self::Docker {
                 container_id,
                 name,
@@ -68,6 +74,9 @@ impl From<&RemoteConnectionOptions> for RemoteConnectionIdentity {
             RemoteConnectionOptions::Wsl(options) => Self::Wsl {
                 distro_name: options.distro_name.clone(),
                 user: options.user.clone(),
+            },
+            RemoteConnectionOptions::Codespace(options) => Self::Codespace {
+                name: options.name.clone(),
             },
             RemoteConnectionOptions::Docker(options) => Self::Docker {
                 container_id: options.container_id.clone(),
@@ -162,6 +171,18 @@ mod tests {
         });
 
         assert!(!same_remote_connection_identity(Some(&left), Some(&right),));
+    }
+
+    #[test]
+    fn codespace_identity_uses_name() {
+        let left = RemoteConnectionOptions::Codespace(crate::CodespaceConnectionOptions {
+            name: "octocat-hello-123".to_string(),
+        });
+        let right = RemoteConnectionOptions::Codespace(crate::CodespaceConnectionOptions {
+            name: "octocat-hello-123".to_string(),
+        });
+
+        assert!(same_remote_connection_identity(Some(&left), Some(&right),));
     }
 
     #[test]

--- a/crates/remote/src/transport.rs
+++ b/crates/remote/src/transport.rs
@@ -14,6 +14,7 @@ use gpui::{AppContext as _, AsyncApp, Task};
 use rpc::proto::Envelope;
 use util::command::Child;
 
+pub mod codespace;
 pub mod docker;
 #[cfg(any(test, feature = "test-support"))]
 pub mod mock;

--- a/crates/remote/src/transport/codespace.rs
+++ b/crates/remote/src/transport/codespace.rs
@@ -1,0 +1,83 @@
+use anyhow::{Context as _, Result};
+use util::command::Stdio;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct CodespaceConnectionOptions {
+    pub name: String,
+}
+
+pub async fn list_codespaces() -> Result<Vec<CodespaceConnectionOptions>> {
+    let output = run_gh_command(
+        &["codespace", "list", "--json", "name"],
+        "list GitHub Codespaces",
+    )
+    .await?;
+    parse_codespace_list(&output)
+}
+
+async fn run_gh_command(args: &[&str], context: &str) -> Result<String> {
+    let mut command = util::command::new_command("gh");
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let output = command
+        .output()
+        .await
+        .with_context(|| format!("failed to run `gh` to {context}"))?;
+    anyhow::ensure!(
+        output.status.success(),
+        "`gh` failed to {context}: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+pub(crate) fn parse_codespace_list(output: &str) -> Result<Vec<CodespaceConnectionOptions>> {
+    serde_json::from_str(output).context("parsing `gh codespace list` output")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_codespace_list_output() {
+        let output = r#"[
+            {
+                "name": "octocat-hello-123"
+            }
+        ]"#;
+
+        assert_eq!(
+            parse_codespace_list(output).unwrap(),
+            vec![CodespaceConnectionOptions {
+                name: "octocat-hello-123".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn parses_empty_codespace_list_output() {
+        assert!(parse_codespace_list("[]").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parses_codespace_list_with_missing_optional_fields() {
+        let output = r#"[{ "name": "octocat-hello-123" }]"#;
+
+        assert_eq!(
+            parse_codespace_list(output).unwrap(),
+            vec![CodespaceConnectionOptions {
+                name: "octocat-hello-123".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_codespace_list_output() {
+        assert!(parse_codespace_list("not json").is_err());
+    }
+}

--- a/crates/remote/src/transport/codespace.rs
+++ b/crates/remote/src/transport/codespace.rs
@@ -1,9 +1,50 @@
+use crate::transport::ssh::{SshConnectionHost, SshConnectionOptions};
 use anyhow::{Context as _, Result};
+use smol::fs;
+use tempfile::TempDir;
 use util::command::Stdio;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CodespaceConnectionOptions {
     pub name: String,
+}
+
+pub(crate) struct CodespaceSshConnection {
+    pub(crate) ssh_options: SshConnectionOptions,
+    pub(crate) ssh_config_dir: TempDir,
+}
+
+pub(crate) async fn codespace_ssh_connection(
+    connection_options: &CodespaceConnectionOptions,
+) -> Result<CodespaceSshConnection> {
+    log::info!("Connecting to GitHub Codespace {}", connection_options.name);
+    let ssh_config = generate_ssh_config(&connection_options.name).await?;
+    let host = parse_codespace_ssh_host(&ssh_config)?;
+
+    let ssh_config_dir = tempfile::Builder::new()
+        .prefix("zed-codespace-ssh-config")
+        .tempdir()?;
+    let ssh_config_path = ssh_config_dir.path().join("config");
+    fs::write(&ssh_config_path, ssh_config)
+        .await
+        .with_context(|| {
+            format!(
+                "writing Codespaces SSH config to {}",
+                ssh_config_path.display()
+            )
+        })?;
+
+    Ok(CodespaceSshConnection {
+        ssh_options: SshConnectionOptions {
+            host: SshConnectionHost::from(host),
+            args: Some(vec![
+                "-F".to_string(),
+                ssh_config_path.display().to_string(),
+            ]),
+            ..Default::default()
+        },
+        ssh_config_dir,
+    })
 }
 
 pub async fn list_codespaces() -> Result<Vec<CodespaceConnectionOptions>> {
@@ -13,6 +54,20 @@ pub async fn list_codespaces() -> Result<Vec<CodespaceConnectionOptions>> {
     )
     .await?;
     parse_codespace_list(&output)
+}
+
+async fn generate_ssh_config(codespace_name: &str) -> Result<String> {
+    run_gh_command(
+        &[
+            "codespace",
+            "ssh",
+            "--config",
+            "--codespace",
+            codespace_name,
+        ],
+        "generate Codespaces SSH configuration",
+    )
+    .await
 }
 
 async fn run_gh_command(args: &[&str], context: &str) -> Result<String> {
@@ -37,6 +92,32 @@ async fn run_gh_command(args: &[&str], context: &str) -> Result<String> {
 
 pub(crate) fn parse_codespace_list(output: &str) -> Result<Vec<CodespaceConnectionOptions>> {
     serde_json::from_str(output).context("parsing `gh codespace list` output")
+}
+
+fn parse_codespace_ssh_host(output: &str) -> Result<String> {
+    let mut host = None;
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let mut parts = line.splitn(2, char::is_whitespace);
+        let Some(key) = parts.next() else {
+            continue;
+        };
+        let Some(value) = parts.next() else {
+            continue;
+        };
+        if key.to_ascii_lowercase().as_str() == "host" {
+            if let Some(host_name) = value.trim().split_whitespace().find(|host_name| {
+                !host_name.is_empty() && !host_name.contains('*') && !host_name.contains('?')
+            }) {
+                host = Some(host_name.to_string());
+            }
+        }
+    }
+    host.context("Codespaces SSH config did not include Host")
 }
 
 #[cfg(test)]
@@ -79,5 +160,45 @@ mod tests {
     #[test]
     fn rejects_malformed_codespace_list_output() {
         assert!(parse_codespace_list("not json").is_err());
+    }
+
+    #[test]
+    fn parses_codespace_ssh_config() {
+        let config = r#"
+            Host cs.octocat-hello-123.main
+              User codespace
+              ProxyCommand gh cs ssh -c octocat-hello-123 --stdio -- -i /home/me/.ssh/codespaces.auto
+              UserKnownHostsFile=/dev/null
+              StrictHostKeyChecking no
+              LogLevel quiet
+              ControlMaster auto
+              IdentityFile /home/me/.ssh/codespaces.auto
+        "#;
+
+        assert_eq!(
+            parse_codespace_ssh_host(config).unwrap(),
+            "cs.octocat-hello-123.main"
+        );
+    }
+
+    #[test]
+    fn ignores_wildcard_codespace_ssh_hosts() {
+        let config = r#"
+            Host *
+              StrictHostKeyChecking no
+
+            Host cs.octocat-hello-123.main
+              User codespace
+        "#;
+
+        assert_eq!(
+            parse_codespace_ssh_host(config).unwrap(),
+            "cs.octocat-hello-123.main"
+        );
+    }
+
+    #[test]
+    fn rejects_incomplete_codespace_ssh_config() {
+        assert!(parse_codespace_ssh_host("User codespace").is_err());
     }
 }

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -50,6 +50,8 @@ pub(crate) struct SshRemoteConnection {
     ssh_shell_kind: ShellKind,
     ssh_default_system_shell: String,
     _temp_dir: TempDir,
+    _extra_temp_dir: Option<TempDir>,
+    reported_connection_options: Option<RemoteConnectionOptions>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -292,7 +294,9 @@ impl RemoteConnection for SshRemoteConnection {
     }
 
     fn connection_options(&self) -> RemoteConnectionOptions {
-        RemoteConnectionOptions::Ssh(self.socket.connection_options.clone())
+        self.reported_connection_options
+            .clone()
+            .unwrap_or_else(|| RemoteConnectionOptions::Ssh(self.socket.connection_options.clone()))
     }
 
     fn shell(&self) -> String {
@@ -779,6 +783,8 @@ impl SshRemoteConnection {
             master_process: Mutex::new(master_process_option),
             killed: AtomicBool::new(false),
             _temp_dir: temp_dir,
+            _extra_temp_dir: None,
+            reported_connection_options: None,
             remote_binary_path: None,
             ssh_path_style,
             ssh_platform,
@@ -795,6 +801,19 @@ impl SshRemoteConnection {
                 .await?,
         );
 
+        Ok(this)
+    }
+
+    pub(crate) async fn new_with_reported_connection_options(
+        connection_options: SshConnectionOptions,
+        reported_connection_options: RemoteConnectionOptions,
+        extra_temp_dir: TempDir,
+        delegate: Arc<dyn RemoteClientDelegate>,
+        cx: &mut AsyncApp,
+    ) -> Result<Self> {
+        let mut this = Self::new(connection_options, delegate, cx).await?;
+        this.reported_connection_options = Some(reported_connection_options);
+        this._extra_temp_dir = Some(extra_temp_dir);
         Ok(this)
     }
 

--- a/crates/remote_connection/src/remote_connection.rs
+++ b/crates/remote_connection/src/remote_connection.rs
@@ -240,6 +240,9 @@ impl RemoteConnectionModal {
             RemoteConnectionOptions::Wsl(options) => {
                 (options.distro_name.clone(), None, true, false)
             }
+            RemoteConnectionOptions::Codespace(options) => {
+                (options.name.clone(), None, false, false)
+            }
             RemoteConnectionOptions::Docker(options) => (options.name.clone(), None, false, true),
             #[cfg(any(test, feature = "test-support"))]
             RemoteConnectionOptions::Mock(options) => {

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -608,6 +608,7 @@ impl TitleBar {
                 IconName::Server,
             ),
             RemoteConnectionOptions::Wsl(_) => (None, "Remote Project", IconName::Linux),
+            RemoteConnectionOptions::Codespace(_) => (None, "Remote Project", IconName::Server),
             RemoteConnectionOptions::Docker(_dev_container_connection) => {
                 (None, "Dev Container", IconName::Box)
             }

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -29,8 +29,9 @@ use project::{
 
 use language::{LanguageName, Toolchain, ToolchainScope};
 use remote::{
-    DockerConnectionOptions, RemoteConnectionIdentity, RemoteConnectionOptions,
-    SshConnectionOptions, WslConnectionOptions, remote_connection_identity,
+    CodespaceConnectionOptions, DockerConnectionOptions, RemoteConnectionIdentity,
+    RemoteConnectionOptions, SshConnectionOptions, WslConnectionOptions,
+    remote_connection_identity,
 };
 use serde::{Deserialize, Serialize};
 use sqlez::{
@@ -1697,6 +1698,13 @@ impl WorkspaceDb {
                 name = Some(identity_name);
                 user = Some(remote_user);
             }
+            RemoteConnectionIdentity::Codespace {
+                name: identity_name,
+            } => {
+                kind = RemoteConnectionKind::Codespace;
+                name = Some(identity_name);
+                user = None;
+            }
             #[cfg(any(test, feature = "test-support"))]
             RemoteConnectionIdentity::Mock { id } => {
                 kind = RemoteConnectionKind::Ssh;
@@ -1988,6 +1996,9 @@ impl WorkspaceDb {
                     remote_env,
                 }))
             }
+            RemoteConnectionKind::Codespace => Some(RemoteConnectionOptions::Codespace(
+                CodespaceConnectionOptions { name: name? },
+            )),
         }
     }
 
@@ -4204,6 +4215,37 @@ mod tests {
             .unwrap();
 
         assert_eq!(connection_id, same_connection_id);
+    }
+
+    #[gpui::test]
+    async fn test_get_or_create_codespace_project_round_trip() {
+        let db = WorkspaceDb::open_test_db("test_get_or_create_codespace_project_round_trip").await;
+
+        let options = RemoteConnectionOptions::Codespace(CodespaceConnectionOptions {
+            name: "octocat-hello-123".to_string(),
+        });
+
+        let connection_id = db
+            .get_or_create_remote_connection(options.clone())
+            .await
+            .unwrap();
+
+        let same_connection_id = db
+            .get_or_create_remote_connection(RemoteConnectionOptions::Codespace(
+                CodespaceConnectionOptions {
+                    name: "octocat-hello-123".to_string(),
+                },
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(connection_id, same_connection_id);
+        assert_eq!(
+            db.remote_connection(connection_id).unwrap(),
+            RemoteConnectionOptions::Codespace(CodespaceConnectionOptions {
+                name: "octocat-hello-123".to_string(),
+            })
+        );
     }
 
     #[gpui::test]

--- a/crates/workspace/src/persistence/model.rs
+++ b/crates/workspace/src/persistence/model.rs
@@ -37,6 +37,7 @@ pub(crate) enum RemoteConnectionKind {
     Ssh,
     Wsl,
     Docker,
+    Codespace,
 }
 
 #[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
@@ -162,6 +163,7 @@ impl RemoteConnectionKind {
             RemoteConnectionKind::Ssh => "ssh",
             RemoteConnectionKind::Wsl => "wsl",
             RemoteConnectionKind::Docker => "docker",
+            RemoteConnectionKind::Codespace => "codespace",
         }
     }
 
@@ -170,6 +172,7 @@ impl RemoteConnectionKind {
             "ssh" => Some(Self::Ssh),
             "wsl" => Some(Self::Wsl),
             "docker" => Some(Self::Docker),
+            "codespace" => Some(Self::Codespace),
             _ => None,
         }
     }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -9722,6 +9722,9 @@ pub fn workspace_windows_for_location(
                     // The WSL username is not consistently populated in the workspace location, so ignore it for now.
                     a.distro_name == b.distro_name
                 }
+                (RemoteConnectionOptions::Codespace(a), RemoteConnectionOptions::Codespace(b)) => {
+                    a.name == b.name
+                }
                 (RemoteConnectionOptions::Docker(a), RemoteConnectionOptions::Docker(b)) => {
                     a.container_id == b.container_id
                 }

--- a/docs/src/remote-development.md
+++ b/docs/src/remote-development.md
@@ -117,6 +117,18 @@ To open a local folder inside a WSL container, use the `projects: open in wsl` a
 
 To open a folder that's already located inside of a WSL container, use the `projects: open wsl` action and select the WSL distribution. The distribution will be added to the `Remote Projects` window where you will be able to open the folder.
 
+## GitHub Codespaces Support
+
+Zed can connect to existing GitHub Codespaces from the Remote Projects dialog. Choose "Connect GitHub Codespace", select a Codespace from the list, and Zed will use the authenticated `gh` CLI to generate an SSH configuration for that Codespace.
+
+Prerequisites:
+
+- Install the [GitHub CLI](https://cli.github.com/) and sign in with `gh auth login`.
+- Create or start from an existing Codespace. Zed does not create, delete, rebuild, or stop Codespaces.
+- Ensure the Codespace dev container includes an SSH server, which is required by `gh codespace ssh`.
+
+When connecting, Zed runs `gh codespace list` to find Codespaces and `gh codespace ssh --config` to generate a temporary OpenSSH config. After that, Codespaces use the same SSH remote development path as other SSH servers, including terminals, tasks, proxying, port forwarding, and reconnect behavior. If the selected Codespace is stopped, `gh` may auto-start it during connection.
+
 ## Port forwarding
 
 If you'd like to be able to connect to ports on your remote server from your local machine, you can configure port forwarding in your settings file. This is particularly useful for developing websites so you can load the site in your browser while working.


### PR DESCRIPTION
# Objective

- Add support for connecting Zed to existing GitHub Codespaces from the Remote Projects dialog.
- Build on the request in https://github.com/zed-industries/zed/discussions/47184.
- Keep the first version scoped to existing Codespaces discovered through the authenticated GitHub CLI. This does not create, delete, rebuild, or stop Codespaces.

## Solution

- Add remote transport helpers for `gh codespace list --limit 100 --json name` and `gh codespace ssh --config --codespace <name>`.
- Add `RemoteConnectionOptions::Codespace` and thread it through remote display names, identities, persistence, trusted worktrees, title bar labeling, and connection setup.
- Reuse Zed's existing SSH remote path by generating a temporary OpenSSH config from `gh codespace ssh --config` and passing it to `SshRemoteConnection` with `-F`.
- Add an `Add GitHub Codespace` entry to Remote Projects with a picker that handles loading, empty, and error states from `gh`.
- Treat selected Codespaces as transient remote projects so they are not written into SSH or WSL settings as configured servers.
- Document the GitHub CLI and SSH-server prerequisites in the remote development docs.

## Testing

- `cargo fmt --all -- --check`
- `git diff --check upstream/main...HEAD`
- `./script/clippy`
- Previously built the current branch with `cargo build -p zed --profile release-fast`.
- Manually launched the current Windows build with an authenticated `gh` session and verified Remote Projects -> Add GitHub Codespace loads a real Codespace from `gh codespace list`.

I have not yet completed an end-to-end connection into a Codespace. I also captured a real-environment demo recording locally and will upload it before marking this PR ready for review.

## Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

TODO before ready-for-review: upload the real-environment recording showing Remote Projects -> Add GitHub Codespace -> Codespaces picker with an authenticated `gh` CLI.

## Draft Status

This is an AI-assisted initial implementation. Automated checks pass, but it still needs careful human review before being marked ready. The current draft is intended to get feedback on the integration approach and scope.

Release Notes:

- Added support for connecting to existing GitHub Codespaces from Remote Projects.