### PR TITLE
worktree: Watch parent directory for single-file worktrees

### DIFF
--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -27,7 +27,7 @@ use buffer_diff::{
 use collections::{BTreeSet, HashMap, HashSet};
 use encoding_rs;
 use fs::{FakeFs, PathEventKind};
-use futures::{StreamExt, future};
+use futures::{FutureExt as _, StreamExt, future};
 use git::{
     GitHostingProviderRegistry,
     repository::{RepoPath, repo_path},
@@ -6531,6 +6531,101 @@ async fn test_dirty_buffer_reloads_after_undo(cx: &mut gpui::TestAppContext) {
         );
         assert!(!buffer.is_dirty());
     });
+}
+
+#[cfg(target_os = "linux")]
+#[gpui::test]
+async fn test_single_file_buffer_reloads_after_undoing_external_atomic_save(
+    cx: &mut gpui::TestAppContext,
+) {
+    init_test(cx);
+    cx.executor().allow_parking();
+
+    let dir = TempTree::new(json!({
+        "file.txt": "version 1",
+    }));
+    let file_path = dir.path().join("file.txt");
+
+    let project = Project::test(
+        Arc::new(RealFs::new(None, cx.executor())),
+        [file_path.as_path()],
+        cx,
+    )
+    .await;
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(file_path.as_path(), cx)
+        })
+        .await
+        .unwrap();
+
+    atomic_replace_file(&file_path, "version 2 from external tool");
+    wait_for_buffer_text(
+        &buffer,
+        "version 2 from external tool",
+        Duration::from_secs(3),
+        cx,
+    )
+    .await;
+
+    buffer.update(cx, |buffer, cx| {
+        buffer.undo(cx);
+    });
+    project
+        .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))
+        .await
+        .unwrap();
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "version 1");
+        assert!(!buffer.is_dirty());
+    });
+
+    atomic_replace_file(&file_path, "version 3 from external tool");
+    wait_for_buffer_text(
+        &buffer,
+        "version 3 from external tool",
+        Duration::from_secs(3),
+        cx,
+    )
+    .await;
+
+    buffer.read_with(cx, |buffer, _| {
+        assert!(!buffer.is_dirty());
+    });
+}
+
+#[cfg(target_os = "linux")]
+fn atomic_replace_file(path: &Path, contents: &str) {
+    let temp_path = path.with_extension("tmp");
+    std::fs::write(&temp_path, contents).unwrap();
+    std::fs::rename(temp_path, path).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+async fn wait_for_buffer_text(
+    buffer: &Entity<Buffer>,
+    expected_text: &str,
+    timeout: Duration,
+    cx: &mut gpui::TestAppContext,
+) {
+    let timeout = cx.executor().timer(timeout).fuse();
+    futures::pin_mut!(timeout);
+    loop {
+        if buffer.read_with(cx, |buffer, _| buffer.text() == expected_text) {
+            return;
+        }
+
+        futures::select_biased! {
+            _ = cx.background_executor.timer(Duration::from_millis(20)).fuse() => {
+                cx.executor().run_until_parked();
+            }
+            _ = timeout => {
+                let actual_text = buffer.read_with(cx, |buffer, _| buffer.text());
+                panic!("buffer text never became {expected_text:?}; actual text: {actual_text:?}");
+            }
+        }
+    }
 }
 
 #[gpui::test]

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1185,19 +1185,24 @@ impl LocalWorktree {
         let (scan_states_tx, mut scan_states_rx) = mpsc::unbounded();
         let background_scanner = cx.background_spawn({
             let abs_path = snapshot.abs_path.as_path().to_path_buf();
+            let is_single_file = snapshot.snapshot.root_dir().is_none();
             let background = cx.background_executor().clone();
             async move {
-                let defer_watch =
-                    force_defer_watch || (scanning_enabled && fs::requires_poll_watcher(&abs_path));
+                let requires_poll_watcher =
+                    scanning_enabled && fs::requires_poll_watcher(&abs_path);
+                let defer_watch = force_defer_watch || (scanning_enabled && requires_poll_watcher);
 
                 let (events, watcher) = if scanning_enabled && !defer_watch {
-                    fs.watch(&abs_path, FS_WATCH_LATENCY).await
+                    let (events, watcher) = fs.watch(&abs_path, FS_WATCH_LATENCY).await;
+                    if is_single_file && !requires_poll_watcher {
+                        watch_single_file_parent(watcher.as_ref(), &abs_path);
+                    }
+                    (events, watcher)
                 } else {
                     (Box::pin(stream::pending()) as _, Arc::new(NullWatcher) as _)
                 };
                 let fs_case_sensitive = fs.is_case_sensitive().await;
 
-                let is_single_file = snapshot.snapshot.root_dir().is_none();
                 let mut scanner = BackgroundScanner {
                     fs,
                     fs_case_sensitive,
@@ -2339,6 +2344,18 @@ impl RemoteWorktree {
         })
     }
 }
+
+#[cfg(target_os = "linux")]
+fn watch_single_file_parent(watcher: &dyn Watcher, path: &Path) {
+    if let Some(parent) = path.parent() {
+        // Inotify file watches follow the inode and stop reporting after an
+        // atomic replace; the parent watch keeps tracking the path by name.
+        watcher.add(parent).log_err();
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn watch_single_file_parent(_watcher: &dyn Watcher, _path: &Path) {}
 
 impl Snapshot {
     pub fn new(
@@ -4176,6 +4193,9 @@ impl BackgroundScanner {
                 .watch(root_abs_path.as_path(), FS_WATCH_LATENCY)
                 .await;
             self.watcher = watcher;
+            if self.is_single_file && !fs::requires_poll_watcher(root_abs_path.as_path()) {
+                watch_single_file_parent(self.watcher.as_ref(), root_abs_path.as_path());
+            }
             fs_events_rx = Box::pin(events.map(|events| events.into_iter().collect()));
 
             let state = self.state.lock().await;


### PR DESCRIPTION
# Objective

Fix a Linux file watcher bug for single-file worktrees opened as a standalone file.

The reported flow is:

1. An external tool atomically saves the file.
2. Zed receives the change and reloads the buffer.
3. The user presses Ctrl-Z in Zed until the buffer returns to the original clean contents, then saves it.
4. The external tool atomically saves the file again.
5. Zed no longer reports or reloads the external change.

On Linux, Zed was watching the standalone file path directly. Native inotify file watches attach to an inode, not just the pathname. The first external atomic save replaces the file with a new inode, so the existing file watch can keep following the old, replaced inode. After the user undoes back to the original clean state and saves, Zed still believes the buffer is synchronized, but the next external atomic save is missed because the watcher is no longer tracking the live path.

## Solution

When using the native Linux watcher for a single-file worktree, also watch the file's parent directory. Directory events track changes by filename, so atomic replacements continue to produce events for the standalone file even after its inode changes.

Install the same parent watch when a deferred watcher is created after the initial scan. Poll watchers are left unchanged because they already track paths by polling instead of relying on an inotify inode watch.

## Testing

- cargo -q test -p project test_single_file_buffer_reloads_after_undoing_external_atomic_save -- --nocapture
- ./script/clippy -p worktree -p project --test integration
- cargo fmt --check
- git diff --check

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed single-file worktrees on Linux not reloading after external atomic saves.