### PR TITLE
Allow hiding edit predictions status button

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1802,6 +1802,8 @@
     "cursor_position_button": true,
     // Whether to show active line endings button in the status bar.
     "line_endings_button": false,
+    // Whether to show the edit prediction button in the status bar.
+    "edit_prediction_button": true,
     // Control when to show the active encoding in the status bar.
     "active_encoding_button": "non_utf8",
   },

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -86,7 +86,7 @@ impl Render for EditPredictionButton {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         // Return empty div if AI is disabled
         if DisableAiSettings::get_global(cx).disable_ai {
-            self.popover_menu_handle.clear();
+            self.popover_menu_handle.clear(cx);
             return div().hidden();
         }
 
@@ -98,7 +98,7 @@ impl Render for EditPredictionButton {
                 let Some(copilot) = EditPredictionStore::try_global(cx)
                     .and_then(|store| store.read(cx).copilot_for_project(&self.project.upgrade()?))
                 else {
-                    self.popover_menu_handle.clear();
+                    self.popover_menu_handle.clear(cx);
                     return div().hidden();
                 };
                 let status = copilot.read(cx).status();
@@ -118,7 +118,7 @@ impl Render for EditPredictionButton {
                 };
 
                 if let Status::Error(e) = status {
-                    self.popover_menu_handle.clear();
+                    self.popover_menu_handle.clear(cx);
                     if !show_status_button {
                         return div().hidden();
                     }
@@ -398,7 +398,7 @@ impl Render for EditPredictionButton {
                 };
 
                 if edit_prediction::should_show_upsell_modal(cx) {
-                    self.popover_menu_handle.clear();
+                    self.popover_menu_handle.clear(cx);
                     if !show_status_button {
                         return div().hidden();
                     }
@@ -546,7 +546,7 @@ impl Render for EditPredictionButton {
             }
 
             EditPredictionProvider::None => {
-                self.popover_menu_handle.clear();
+                self.popover_menu_handle.clear(cx);
                 div().hidden()
             }
         }

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -37,8 +37,8 @@ use ui::{
 use util::ResultExt as _;
 
 use workspace::{
-    HideStatusItem, StatusItemView, Toast, Workspace, create_and_open_local_file, item::ItemHandle,
-    notifications::NotificationId,
+    HideStatusItem, StatusBarSettings, StatusItemView, Toast, Workspace,
+    create_and_open_local_file, item::ItemHandle, notifications::NotificationId,
 };
 use zed_actions::{OpenBrowser, OpenSettingsAt};
 
@@ -72,13 +72,25 @@ pub struct EditPredictionButton {
     project: WeakEntity<Project>,
 }
 
+fn hidden_status_popover(popover_menu: PopoverMenu<ContextMenu>) -> Div {
+    div().w(px(0.)).h(px(0.)).overflow_hidden().child(
+        popover_menu.trigger(
+            IconButton::new("edit-prediction-hidden-anchor", IconName::ZedPredict)
+                .shape(IconButtonShape::Square)
+                .alpha(0.),
+        ),
+    )
+}
+
 impl Render for EditPredictionButton {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         // Return empty div if AI is disabled
         if DisableAiSettings::get_global(cx).disable_ai {
+            self.popover_menu_handle.clear();
             return div().hidden();
         }
 
+        let show_status_button = StatusBarSettings::get_global(cx).edit_prediction_button;
         let language_settings = all_language_settings(None, cx);
 
         match language_settings.edit_predictions.provider {
@@ -86,6 +98,7 @@ impl Render for EditPredictionButton {
                 let Some(copilot) = EditPredictionStore::try_global(cx)
                     .and_then(|store| store.read(cx).copilot_for_project(&self.project.upgrade()?))
                 else {
+                    self.popover_menu_handle.clear();
                     return div().hidden();
                 };
                 let status = copilot.read(cx).status();
@@ -105,6 +118,11 @@ impl Render for EditPredictionButton {
                 };
 
                 if let Status::Error(e) = status {
+                    self.popover_menu_handle.clear();
+                    if !show_status_button {
+                        return div().hidden();
+                    }
+
                     return div().child(
                         IconButton::new("copilot-error", icon)
                             .icon_size(IconSize::Small)
@@ -141,42 +159,43 @@ impl Render for EditPredictionButton {
                 let project = self.project.clone();
                 let file = self.file.clone();
                 let language = self.language.clone();
-                div().child(
-                    PopoverMenu::new("copilot")
-                        .on_open({
-                            let file = file.clone();
-                            let language = language;
-                            let project = project.clone();
-                            Rc::new(move |_window, cx| {
-                                emit_edit_prediction_menu_opened(
-                                    "copilot", &file, &language, &project, cx,
-                                );
-                            })
+                let popover_menu = PopoverMenu::new("copilot")
+                    .on_open({
+                        let file = file.clone();
+                        let language = language;
+                        let project = project.clone();
+                        Rc::new(move |_window, cx| {
+                            emit_edit_prediction_menu_opened(
+                                "copilot", &file, &language, &project, cx,
+                            );
                         })
-                        .menu(move |window, cx| {
-                            let current_status = EditPredictionStore::try_global(cx)
-                                .and_then(|store| {
-                                    store.read(cx).copilot_for_project(&project.upgrade()?)
-                                })?
-                                .read(cx)
-                                .status();
-                            match current_status {
-                                Status::Authorized => this.update(cx, |this, cx| {
-                                    this.build_copilot_context_menu(window, cx)
-                                }),
-                                _ => this.update(cx, |this, cx| {
-                                    this.build_copilot_start_menu(window, cx)
-                                }),
-                            }
-                            .ok()
-                        })
-                        .anchor(Anchor::BottomRight)
-                        .trigger_with_tooltip(
-                            IconButton::new("copilot-icon", icon),
-                            |_window, cx| Tooltip::for_action("GitHub Copilot", &ToggleMenu, cx),
-                        )
-                        .with_handle(self.popover_menu_handle.clone()),
-                )
+                    })
+                    .menu(move |window, cx| {
+                        let current_status = EditPredictionStore::try_global(cx)
+                            .and_then(|store| {
+                                store.read(cx).copilot_for_project(&project.upgrade()?)
+                            })?
+                            .read(cx)
+                            .status();
+                        match current_status {
+                            Status::Authorized => this
+                                .update(cx, |this, cx| this.build_copilot_context_menu(window, cx)),
+                            _ => this
+                                .update(cx, |this, cx| this.build_copilot_start_menu(window, cx)),
+                        }
+                        .ok()
+                    })
+                    .anchor(Anchor::BottomRight)
+                    .with_handle(self.popover_menu_handle.clone());
+
+                if show_status_button {
+                    div().child(popover_menu.trigger_with_tooltip(
+                        IconButton::new("copilot-icon", icon),
+                        |_window, cx| Tooltip::for_action("GitHub Copilot", &ToggleMenu, cx),
+                    ))
+                } else {
+                    hidden_status_popover(popover_menu)
+                }
             }
             EditPredictionProvider::Codestral => {
                 let enabled = self.editor_enabled.unwrap_or(true);
@@ -192,30 +211,31 @@ impl Render for EditPredictionButton {
                     "Missing API key for Codestral"
                 };
 
-                div().child(
-                    PopoverMenu::new("codestral")
-                        .on_open({
-                            let file = file.clone();
-                            let language = language;
-                            let project = project;
-                            Rc::new(move |_window, cx| {
-                                emit_edit_prediction_menu_opened(
-                                    "codestral",
-                                    &file,
-                                    &language,
-                                    &project,
-                                    cx,
-                                );
-                            })
+                let popover_menu = PopoverMenu::new("codestral")
+                    .on_open({
+                        let file = file.clone();
+                        let language = language;
+                        let project = project;
+                        Rc::new(move |_window, cx| {
+                            emit_edit_prediction_menu_opened(
+                                "codestral",
+                                &file,
+                                &language,
+                                &project,
+                                cx,
+                            );
                         })
-                        .menu(move |window, cx| {
-                            this.update(cx, |this, cx| {
-                                this.build_codestral_context_menu(window, cx)
-                            })
+                    })
+                    .menu(move |window, cx| {
+                        this.update(cx, |this, cx| this.build_codestral_context_menu(window, cx))
                             .ok()
-                        })
-                        .anchor(Anchor::BottomRight)
-                        .trigger_with_tooltip(
+                    })
+                    .anchor(Anchor::BottomRight)
+                    .with_handle(self.popover_menu_handle.clone());
+
+                if show_status_button {
+                    div().child(
+                        popover_menu.trigger_with_tooltip(
                             IconButton::new("codestral-icon", IconName::AiMistral)
                                 .shape(IconButtonShape::Square)
                                 .when(!has_api_key, |this| {
@@ -238,28 +258,33 @@ impl Render for EditPredictionButton {
                                     cx,
                                 )
                             },
-                        )
-                        .with_handle(self.popover_menu_handle.clone()),
-                )
+                        ),
+                    )
+                } else {
+                    hidden_status_popover(popover_menu)
+                }
             }
             EditPredictionProvider::OpenAiCompatibleApi => {
                 let enabled = self.editor_enabled.unwrap_or(true);
                 let this = cx.weak_entity();
 
-                div().child(
-                    PopoverMenu::new("openai-compatible-api")
-                        .menu(move |window, cx| {
-                            this.update(cx, |this, cx| {
-                                this.build_edit_prediction_context_menu(
-                                    EditPredictionProvider::OpenAiCompatibleApi,
-                                    window,
-                                    cx,
-                                )
-                            })
-                            .ok()
+                let popover_menu = PopoverMenu::new("openai-compatible-api")
+                    .menu(move |window, cx| {
+                        this.update(cx, |this, cx| {
+                            this.build_edit_prediction_context_menu(
+                                EditPredictionProvider::OpenAiCompatibleApi,
+                                window,
+                                cx,
+                            )
                         })
-                        .anchor(Anchor::BottomRight)
-                        .trigger(
+                        .ok()
+                    })
+                    .anchor(Anchor::BottomRight)
+                    .with_handle(self.popover_menu_handle.clone());
+
+                if show_status_button {
+                    div().child(
+                        popover_menu.trigger(
                             IconButton::new("openai-compatible-api-icon", IconName::AiOpenAiCompat)
                                 .shape(IconButtonShape::Square)
                                 .when(!enabled, |this| {
@@ -268,28 +293,33 @@ impl Render for EditPredictionButton {
                                             cx.theme().colors().status_bar_background,
                                         ))
                                 }),
-                        )
-                        .with_handle(self.popover_menu_handle.clone()),
-                )
+                        ),
+                    )
+                } else {
+                    hidden_status_popover(popover_menu)
+                }
             }
             EditPredictionProvider::Ollama => {
                 let enabled = self.editor_enabled.unwrap_or(true);
                 let this = cx.weak_entity();
 
-                div().child(
-                    PopoverMenu::new("ollama")
-                        .menu(move |window, cx| {
-                            this.update(cx, |this, cx| {
-                                this.build_edit_prediction_context_menu(
-                                    EditPredictionProvider::Ollama,
-                                    window,
-                                    cx,
-                                )
-                            })
-                            .ok()
+                let popover_menu = PopoverMenu::new("ollama")
+                    .menu(move |window, cx| {
+                        this.update(cx, |this, cx| {
+                            this.build_edit_prediction_context_menu(
+                                EditPredictionProvider::Ollama,
+                                window,
+                                cx,
+                            )
                         })
-                        .anchor(Anchor::BottomRight)
-                        .trigger_with_tooltip(
+                        .ok()
+                    })
+                    .anchor(Anchor::BottomRight)
+                    .with_handle(self.popover_menu_handle.clone());
+
+                if show_status_button {
+                    div().child(
+                        popover_menu.trigger_with_tooltip(
                             IconButton::new("ollama-icon", IconName::AiOllama)
                                 .shape(IconButtonShape::Square)
                                 .when(!enabled, |this| {
@@ -317,9 +347,11 @@ impl Render for EditPredictionButton {
                                     cx,
                                 )
                             },
-                        )
-                        .with_handle(self.popover_menu_handle.clone()),
-                )
+                        ),
+                    )
+                } else {
+                    hidden_status_popover(popover_menu)
+                }
             }
             provider @ (EditPredictionProvider::Zed | EditPredictionProvider::Mercury) => {
                 let enabled = self.editor_enabled.unwrap_or(true);
@@ -366,6 +398,11 @@ impl Render for EditPredictionButton {
                 };
 
                 if edit_prediction::should_show_upsell_modal(cx) {
+                    self.popover_menu_handle.clear();
+                    if !show_status_button {
+                        return div().hidden();
+                    }
+
                     let tooltip_meta = if self.user_store.read(cx).current_user().is_some() {
                         "Choose a Plan"
                     } else {
@@ -489,7 +526,9 @@ impl Render for EditPredictionButton {
                     .as_ref()
                     .is_some_and(|provider| provider.is_refreshing(cx));
 
-                if is_refreshing {
+                if !show_status_button {
+                    return hidden_status_popover(popover_menu);
+                } else if is_refreshing {
                     popover_menu = popover_menu.trigger(
                         icon_button.with_animation(
                             "pulsating-label",
@@ -506,7 +545,10 @@ impl Render for EditPredictionButton {
                 div().child(popover_menu.into_any_element())
             }
 
-            EditPredictionProvider::None => div().hidden(),
+            EditPredictionProvider::None => {
+                self.popover_menu_handle.clear();
+                div().hidden()
+            }
         }
     }
 }
@@ -1354,10 +1396,12 @@ impl StatusItemView for EditPredictionButton {
     }
 
     fn hide_setting(&self, _: &App) -> Option<HideStatusItem> {
-        // This button is already gated on having a non-disabled edit
-        // prediction provider, which the user manages through provider/AI
-        // settings.
-        None
+        Some(HideStatusItem::new(|settings| {
+            settings
+                .status_bar
+                .get_or_insert_default()
+                .edit_prediction_button = Some(false);
+        }))
     }
 }
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -790,6 +790,7 @@ impl VsCodeSettings {
             active_language_button: None,
             cursor_position_button: None,
             line_endings_button: None,
+            edit_prediction_button: None,
             active_encoding_button: None,
         })
     }

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -513,6 +513,10 @@ pub struct StatusBarSettingsContent {
     ///
     /// Default: false
     pub line_endings_button: Option<bool>,
+    /// Whether to show the edit prediction button in the status bar.
+    ///
+    /// Default: true
+    pub edit_prediction_button: Option<bool>,
     /// Whether to show the active encoding button in the status bar.
     ///
     /// Default: non_utf8

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3757,7 +3757,7 @@ fn search_and_files_page() -> SettingsPage {
 }
 
 fn window_and_layout_page() -> SettingsPage {
-    fn status_bar_section() -> [SettingsPageItem; 11] {
+    fn status_bar_section() -> [SettingsPageItem; 12] {
         [
             SettingsPageItem::SectionHeader("Status Bar"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -3866,6 +3866,29 @@ fn window_and_layout_page() -> SettingsPage {
                             .status_bar
                             .get_or_insert_default()
                             .line_endings_button = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Edit Predictions Button",
+                description: "Show the edit predictions button in the status bar.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("status_bar.edit_prediction_button"),
+                    pick: |settings_content| {
+                        settings_content
+                            .status_bar
+                            .as_ref()?
+                            .edit_prediction_button
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .status_bar
+                            .get_or_insert_default()
+                            .edit_prediction_button = value;
                     },
                 }),
                 metadata: None,

--- a/crates/ui/src/components/popover_menu.rs
+++ b/crates/ui/src/components/popover_menu.rs
@@ -79,8 +79,31 @@ impl<M: ManagedView> PopoverMenuHandle<M> {
         }
     }
 
-    pub fn clear(&self) {
-        self.0.borrow_mut().take();
+    pub fn clear(&self, cx: &mut App) {
+        let Some((menu_cell, deployed_menu)) = self
+            .0
+            .borrow()
+            .as_ref()
+            .map(|state| (state.menu.clone(), state.menu.borrow().as_ref().cloned()))
+        else {
+            return;
+        };
+
+        if let Some(menu) = deployed_menu {
+            menu.update(cx, |_, cx| cx.emit(DismissEvent));
+            let this = self.clone();
+            cx.defer(move |_| {
+                let mut state = this.0.borrow_mut();
+                if state
+                    .as_ref()
+                    .is_some_and(|state| Rc::ptr_eq(&state.menu, &menu_cell))
+                {
+                    state.take();
+                }
+            });
+        } else {
+            self.0.borrow_mut().take();
+        }
     }
 
     pub fn toggle(&self, window: &mut Window, cx: &mut App) {

--- a/crates/ui/src/components/popover_menu.rs
+++ b/crates/ui/src/components/popover_menu.rs
@@ -79,6 +79,10 @@ impl<M: ManagedView> PopoverMenuHandle<M> {
         }
     }
 
+    pub fn clear(&self) {
+        self.0.borrow_mut().take();
+    }
+
     pub fn toggle(&self, window: &mut Window, cx: &mut App) {
         if let Some(state) = self.0.borrow().as_ref() {
             if state.menu.borrow().is_some() {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -15708,6 +15708,26 @@ mod tests {
         workspace.read_with(cx, |workspace, cx| {
             let visible = workspace.status_bar_visible(cx);
             assert!(visible, "Status bar should be visible by default");
+            assert!(
+                StatusBarSettings::get_global(cx).edit_prediction_button,
+                "Edit prediction status button should be visible by default"
+            );
+        });
+
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .status_bar
+                    .get_or_insert_default()
+                    .edit_prediction_button = Some(false);
+            });
+        });
+
+        workspace.read_with(cx, |_, cx| {
+            assert!(
+                !StatusBarSettings::get_global(cx).edit_prediction_button,
+                "Edit prediction status button should be hidden when disabled"
+            );
         });
 
         // Test with status bar hidden

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -162,6 +162,7 @@ pub struct StatusBarSettings {
     pub active_language_button: bool,
     pub cursor_position_button: bool,
     pub line_endings_button: bool,
+    pub edit_prediction_button: bool,
     pub active_encoding_button: EncodingDisplayOptions,
 }
 
@@ -174,6 +175,7 @@ impl Settings for StatusBarSettings {
             active_language_button: status_bar.active_language_button.unwrap(),
             cursor_position_button: status_bar.cursor_position_button.unwrap(),
             line_endings_button: status_bar.line_endings_button.unwrap(),
+            edit_prediction_button: status_bar.edit_prediction_button.unwrap(),
             active_encoding_button: status_bar.active_encoding_button.unwrap(),
         }
     }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1754,6 +1754,7 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
   "status_bar": {
     "active_language_button": true,
     "cursor_position_button": true,
+    "edit_prediction_button": true,
     "line_endings_button": false
   }
 }

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -348,6 +348,9 @@ TBD: Centered layout related settings
     // Clicking the button brings up the line-ending selector.
     // Defaults to false.
     "line_endings_button": false,
+    // Show/hide the edit predictions button.
+    // Defaults to true.
+    "edit_prediction_button": true,
     // Show/hide a button that displays the buffer's character encoding.
     // If set to "non_utf8", the button is hidden only for UTF-8 without BOM.
     // Defaults to "non_utf8".


### PR DESCRIPTION
## Summary

- Added `status_bar.edit_prediction_button` so users can hide the edit predictions status bar button without disabling edit predictions.
- Exposed the setting in defaults, schema/runtime settings, Settings UI, VS Code import fallback, and docs.
- Kept `edit_prediction::ToggleMenu` usable when the visual button is hidden by preserving a hidden popover anchor for menu-capable provider states.
- Dismissed deployed popovers before clearing stale popover handle state when edit predictions become unavailable.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test -p workspace test_status_bar_visibility`
- `cargo check -p ui -p edit_prediction_ui -p zed`
- `./script/clippy -p zed -p ui -p edit_prediction_ui -p settings_ui -p workspace -p settings -p settings_content`

## Suggested .rules additions

- For status bar items backed by `PopoverMenuHandle`, preserve action-based menu paths separately from visual button visibility, and dismiss deployed menus before clearing handle state.

Release Notes:

- Added a setting to hide the edit predictions status bar button.