### PR TITLE
Only show preview line numbers if enabled by user

### DIFF
--- a/crates/picker/src/preview.rs
+++ b/crates/picker/src/preview.rs
@@ -2,12 +2,13 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use editor::{Editor, HighlightKey, MultiBuffer, RowHighlightOptions};
+use editor::{Editor, EditorSettings, HighlightKey, MultiBuffer, RowHighlightOptions};
 use gpui::{App, Task};
 use gpui::{AppContext, Context, Entity, TaskExt, Window};
 use language::{Buffer, HighlightedText, HighlightedTextBuilder, ToPoint};
 use project::Project;
 use rope::Point;
+use settings::Settings;
 use ui::{ActiveTheme, IntoElement, Pixels, px};
 use util::rel_path::RelPath;
 
@@ -148,6 +149,7 @@ impl EditorPreview {
             let capability = language::Capability::ReadWrite; // Later narrowed per buffer
             let multi_buffer = cx.new(|_| MultiBuffer::without_headers(capability));
             let mut editor = Editor::for_multibuffer(multi_buffer, None, window, cx);
+            let editor_settings = EditorSettings::get_global(cx).clone();
 
             // We want editing to happen in the multibuffer not in the modal. The editor acts
             // as one big <send to multibuffer> button.
@@ -159,8 +161,8 @@ impl EditorPreview {
             editor.disable_diagnostics(cx);
             editor.disable_expand_excerpt_buttons(cx);
             editor.disable_mouse_wheel_zoom();
-            editor.set_show_gutter(true, cx); // needed for line numbers
-            editor.set_show_line_numbers(true, cx);
+            editor.set_show_gutter(editor_settings.gutter.line_numbers, cx); // needed for line numbers
+            editor.set_show_line_numbers(editor_settings.gutter.line_numbers, cx);
             editor.set_show_breakpoints(false, cx);
             editor.set_show_bookmarks(false, cx);
             editor.set_show_code_actions(false, cx);


### PR DESCRIPTION
# Objective

- Currently, the file preview pane in pickers forces line numbers and the editor gutter to always be visible, ignoring user-configured preferences. This PR ensures the preview component respects the user's global editor layout settings.

## Solution

- Modified `EditorPreview::new` within `crates/picker/src/preview.rs`.
- Imported `EditorSettings` from the `editor` crate.
- Replaced the hardcoded `true` values for `set_show_gutter` and `set_show_line_numbers` with the user's active global configuration retrieved via `EditorSettings::get_global(cx).gutter.line_numbers`.

## Testing

- Did you test these changes? If so, how?
  - Yes, manually verified that toggling line numbers off or using relative line numbers in `settings.json` is accurately reflected inside the picker's file preview pane.
- Are there any parts that need more testing?
  - No, using the global context lookup seamlessly integrates with Zed's existing configuration lifecycle.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
  - Open your `settings.json` and change your line number preferences (e.g., set `"line_numbers": false`).
  - Bring up a picker that renders a file preview (like the project search or file finder).
  - Confirm that the preview pane's gutter and line number layout perfectly matches your active configuration.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
  - Tested on Linux.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>

### Line numbers ON

<img width="1940" height="2072" alt="preview-line-numbers-on" src="https://github.com/user-attachments/assets/db824b5e-bc29-459d-bc0c-86762d44f707" />

### Line numbers OFF

<img width="1940" height="2072" alt="preview-line-numbers-off" src="https://github.com/user-attachments/assets/48a6357e-d4b5-462b-920f-d1c20d3d27af" />

</details>

---

Release Notes:

- Preview line numbers now respect user configuration settings