### PR TITLE
solo_diff_view: Show changes only by default

### DIFF
--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -601,9 +601,9 @@ impl SplittableEditor {
             return;
         }
 
-        let is_rhs_singleton = self.rhs_multibuffer.read(cx).is_singleton();
+        let rhs_has_headers = self.rhs_multibuffer.read(cx).snapshot(cx).show_headers();
         let lhs_multibuffer = cx.new(|cx| {
-            let mut multibuffer = if is_rhs_singleton {
+            let mut multibuffer = if !rhs_has_headers {
                 MultiBuffer::without_headers(Capability::ReadOnly)
             } else {
                 MultiBuffer::new(Capability::ReadOnly)

--- a/crates/git_ui/src/solo_diff_view.rs
+++ b/crates/git_ui/src/solo_diff_view.rs
@@ -204,7 +204,8 @@ impl SoloDiffView {
         diff.read(cx)
             .snapshot(cx)
             .hunks_intersecting_range(
-                Anchor::min_for_buffer(buffer.remote_id())..Anchor::max_for_buffer(buffer.remote_id()),
+                Anchor::min_for_buffer(buffer.remote_id())
+                    ..Anchor::max_for_buffer(buffer.remote_id()),
                 buffer,
             )
             .map(|diff_hunk| diff_hunk.buffer_range.to_point(buffer))
@@ -488,7 +489,11 @@ impl Item for SoloDiffView {
                     .into(),
                 highlights: Vec::new(),
             }],
-            Some(theme_settings::ThemeSettings::get_global(cx).buffer_font.clone()),
+            Some(
+                theme_settings::ThemeSettings::get_global(cx)
+                    .buffer_font
+                    .clone(),
+            ),
         ))
     }
 

--- a/crates/git_ui/src/solo_diff_view.rs
+++ b/crates/git_ui/src/solo_diff_view.rs
@@ -14,8 +14,8 @@ use gpui::{
     Action, AnyElement, App, AppContext as _, Context, Entity, EventEmitter, FocusHandle,
     Focusable, IntoElement, Render, Subscription, Task, WeakEntity, Window,
 };
-use language::{Buffer, HighlightedText};
-use multi_buffer::MultiBuffer;
+use language::{Anchor, Buffer, HighlightedText, OffsetRangeExt as _, Point};
+use multi_buffer::{MultiBuffer, PathKey, excerpt_context_lines};
 use project::{
     Project,
     git_store::{Repository, RepositoryId},
@@ -23,6 +23,7 @@ use project::{
 use settings::{DiffViewStyle, Settings, SettingsStore, update_settings_file};
 use std::{
     any::{Any, TypeId},
+    ops::Range,
     sync::Arc,
 };
 use ui::{
@@ -43,8 +44,10 @@ pub struct SoloDiffView {
     repository_id: RepositoryId,
     repo_path: RepoPath,
     buffer: Entity<Buffer>,
+    diff: Entity<buffer_diff::BufferDiff>,
     editor: Entity<SplittableEditor>,
     workspace: WeakEntity<Workspace>,
+    showing_full_file: bool,
     _settings_subscription: Subscription,
 }
 
@@ -129,9 +132,15 @@ impl SoloDiffView {
     ) -> Self {
         let repository_id = repository.read(cx).id;
         let multibuffer = cx.new(|cx| {
-            let mut multibuffer = MultiBuffer::singleton(buffer.clone(), cx);
-            multibuffer.add_diff(diff, cx);
-            multibuffer.set_all_diff_hunks_expanded(cx);
+            let mut multibuffer = MultiBuffer::without_headers(buffer.read(cx).capability());
+            multibuffer.set_excerpts_for_path(
+                PathKey::for_buffer(&buffer, cx),
+                buffer.clone(),
+                Self::hunk_ranges(&buffer, &diff, cx),
+                excerpt_context_lines(cx),
+                cx,
+            );
+            multibuffer.add_diff(diff.clone(), cx);
             multibuffer
         });
         let editor = cx.new(|cx| {
@@ -178,10 +187,62 @@ impl SoloDiffView {
             repository_id,
             repo_path,
             buffer,
+            diff,
             editor,
             workspace: workspace.downgrade(),
+            showing_full_file: false,
             _settings_subscription: settings_subscription,
         }
+    }
+
+    fn hunk_ranges(
+        buffer: &Entity<Buffer>,
+        diff: &Entity<buffer_diff::BufferDiff>,
+        cx: &App,
+    ) -> Vec<Range<Point>> {
+        let buffer = buffer.read(cx);
+        diff.read(cx)
+            .snapshot(cx)
+            .hunks_intersecting_range(
+                Anchor::min_for_buffer(buffer.remote_id())..Anchor::max_for_buffer(buffer.remote_id()),
+                buffer,
+            )
+            .map(|diff_hunk| diff_hunk.buffer_range.to_point(buffer))
+            .collect()
+    }
+
+    fn set_showing_full_file(&mut self, showing_full_file: bool, cx: &mut Context<Self>) {
+        if self.showing_full_file == showing_full_file {
+            return;
+        }
+
+        let ranges = if showing_full_file {
+            let buffer = self.buffer.read(cx);
+            vec![Point::zero()..buffer.max_point()]
+        } else {
+            Self::hunk_ranges(&self.buffer, &self.diff, cx)
+        };
+        let context_line_count = if showing_full_file {
+            0
+        } else {
+            excerpt_context_lines(cx)
+        };
+
+        self.editor.update(cx, |editor, cx| {
+            let path = PathKey::for_buffer(&self.buffer, cx);
+            editor.remove_excerpts_for_path(path.clone(), cx);
+            editor.update_excerpts_for_path(
+                path,
+                self.buffer.clone(),
+                ranges,
+                context_line_count,
+                self.diff.clone(),
+                cx,
+            );
+        });
+
+        self.showing_full_file = showing_full_file;
+        cx.notify();
     }
 
     fn matches(&self, repository: &Entity<Repository>, repo_path: &RepoPath, cx: &App) -> bool {
@@ -367,13 +428,15 @@ impl Item for SoloDiffView {
     ) -> Option<gpui::AnyEntity> {
         if type_id == TypeId::of::<Self>() {
             Some(self_handle.clone().into())
+        } else if type_id == TypeId::of::<SplittableEditor>() {
+            None
         } else {
             self.editor.act_as_type(type_id, cx)
         }
     }
 
     fn as_searchable(&self, _: &Entity<Self>, _: &App) -> Option<Box<dyn SearchableItemHandle>> {
-        Some(Box::new(self.editor.clone()))
+        None
     }
 
     fn for_each_project_item(
@@ -415,7 +478,18 @@ impl Item for SoloDiffView {
     }
 
     fn breadcrumbs(&self, cx: &App) -> Option<(Vec<HighlightedText>, Option<gpui::Font>)> {
-        self.editor.breadcrumbs(cx)
+        Some((
+            vec![HighlightedText {
+                text: self
+                    .repo_path
+                    .as_ref()
+                    .display(PathStyle::local())
+                    .into_owned()
+                    .into(),
+                highlights: Vec::new(),
+            }],
+            Some(theme_settings::ThemeSettings::get_global(cx).buffer_font.clone()),
+        ))
     }
 
     fn added_to_workspace(
@@ -505,6 +579,14 @@ impl SoloDiffStyleToolbar {
 
         cx.notify();
     }
+
+    fn toggle_showing_full_file(&mut self, cx: &mut Context<Self>) {
+        if let Some(solo_diff) = self.solo_diff() {
+            solo_diff.update(cx, |solo_diff, cx| {
+                solo_diff.set_showing_full_file(!solo_diff.showing_full_file, cx);
+            });
+        }
+    }
 }
 
 impl EventEmitter<ToolbarItemEvent> for SoloDiffStyleToolbar {}
@@ -532,7 +614,10 @@ impl Render for SoloDiffStyleToolbar {
         let Some(solo_diff) = self.solo_diff() else {
             return div();
         };
-        let editor_entity = solo_diff.read(cx).editor.clone();
+        let (editor_entity, showing_full_file) = {
+            let solo_diff = solo_diff.read(cx);
+            (solo_diff.editor.clone(), solo_diff.showing_full_file)
+        };
         let editor = editor_entity.read(cx);
         let diff_view_style = editor.diff_view_style();
         let is_split_set = diff_view_style == DiffViewStyle::Split;
@@ -546,6 +631,25 @@ impl Render for SoloDiffStyleToolbar {
             .h_8()
             .items_center()
             .gap_1()
+            .child(
+                IconButton::new(
+                    "solo-diff-toggle-excerpts",
+                    if showing_full_file {
+                        IconName::ChevronDownUp
+                    } else {
+                        IconName::ChevronUpDown
+                    },
+                )
+                .icon_size(IconSize::Small)
+                .tooltip(Tooltip::text(if showing_full_file {
+                    "Show Changes Only"
+                } else {
+                    "Show Full File"
+                }))
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.toggle_showing_full_file(cx);
+                })),
+            )
             .child(
                 IconButton::new("solo-diff-unified", IconName::DiffUnified)
                     .icon_size(IconSize::Small)


### PR DESCRIPTION
# Objective

- Default the solo diff view to show changed hunks with excerpted context instead of expanding the entire file.
- Closes https://github.com/zed-industries/zed/issues/59489

## Solution

- Initialize the solo diff editor with excerpts around changed hunks.
- Add a header toggle for switching between the excerpted changes-only view and the full-file view.
- Keep both sides of the split diff visually aligned when excerpts are collapsed.

## Testing

- `cargo check -p git_ui`
- `cargo test -p git_ui`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>

Changes-only default view:
<img width="1624" height="1030" alt="solo_diff_view_new_default_changes_only_view" src="https://github.com/user-attachments/assets/c6fb937e-8882-415c-8476-b9c3019c152e" />


Toggled full-file view:
<img width="1624" height="1030" alt="solo_diff_view_toggled_to_full_file_view" src="https://github.com/user-attachments/assets/3d736d00-178a-4dfa-b1ff-d3d15e33b30e" />

</details>

---

Release Notes:

- Improved solo diff view to show changed hunks by default with a toggle for viewing the full file.
