### PR TITLE
Refine bookmark toggle action

### DIFF
--- a/crates/editor/src/bookmarks.rs
+++ b/crates/editor/src/bookmarks.rs
@@ -120,16 +120,27 @@ impl Editor {
         cx.notify();
     }
 
-    pub fn toggle_bookmark_at_row(&mut self, row: DisplayRow, cx: &mut Context<Self>) {
+    pub fn toggle_bookmark_at_row(
+        &mut self,
+        row: DisplayRow,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let display_snapshot = self.display_snapshot(cx);
         let point = display_snapshot.display_point_to_point(row.as_display_point(), Bias::Left);
         let buffer_snapshot = self.buffer.read(cx).snapshot(cx);
         let anchor = buffer_snapshot.anchor_before(point);
 
-        self.toggle_bookmark_at_anchor(anchor, cx);
+        self.toggle_bookmark_at_anchor(anchor, false, window, cx);
     }
 
-    pub fn toggle_bookmark_at_anchor(&mut self, anchor: Anchor, cx: &mut Context<Self>) {
+    pub fn toggle_bookmark_at_anchor(
+        &mut self,
+        anchor: Anchor,
+        with_label: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let buffer_snapshot = self.buffer.read(cx).snapshot(cx);
         let Some((position, _)) = buffer_snapshot.anchor_to_buffer_anchor(anchor) else {
             return;
@@ -142,9 +153,22 @@ impl Editor {
             return;
         };
 
-        bookmark_store.update(cx, |bookmark_store, cx| {
-            bookmark_store.toggle_bookmark(buffer, position, String::new(), cx);
-        });
+        let target = BookmarkTarget {
+            buffer,
+            anchor,
+            buffer_anchor: position,
+        };
+        if Self::bookmark_exists_for_target(&bookmark_store, &target, cx) {
+            bookmark_store.update(cx, |bookmark_store, cx| {
+                bookmark_store.toggle_bookmark(target.buffer, position, None, cx);
+            });
+        } else {
+            if with_label {
+                self.add_toggle_bookmark_blocks(vec![target], bookmark_store, window, cx)
+            } else {
+                self.toggle_bookmarks(vec![target], String::new(), cx);
+            }
+        }
 
         cx.notify();
     }
@@ -240,7 +264,7 @@ impl Editor {
                 "Enter bookmark label (Optional)",
                 Some(Box::new(move |label: String, _, cx| {
                     bookmark_store.update(cx, |store, cx| {
-                        store.toggle_bookmark(target.buffer, target.buffer_anchor, label, cx);
+                        store.toggle_bookmark(target.buffer, target.buffer_anchor, Some(label), cx);
                     });
                 })),
                 None,
@@ -259,7 +283,12 @@ impl Editor {
         if let Some(bookmark_store) = self.bookmark_store.clone() {
             bookmark_store.update(cx, |store, cx| {
                 for target in targets {
-                    store.toggle_bookmark(target.buffer, target.buffer_anchor, label.clone(), cx);
+                    store.toggle_bookmark(
+                        target.buffer,
+                        target.buffer_anchor,
+                        Some(label.clone()),
+                        cx,
+                    );
                 }
             });
         }

--- a/crates/editor/src/bookmarks.rs
+++ b/crates/editor/src/bookmarks.rs
@@ -108,13 +108,13 @@ impl Editor {
 
         if absent_targets.is_empty() {
             // All cursors are on existing bookmarks, remove all bookmarks.
-            self.toggle_bookmarks(exist_targets, String::new(), cx);
+            self.toggle_bookmarks(exist_targets, None, cx);
         } else if with_label {
             // Only add new ones (prompting for a label) and leave existing ones unchanged.
             self.add_toggle_bookmark_blocks(absent_targets, bookmark_store, window, cx);
         } else {
             // Only add new (unnamed) bookmarks and leave existing ones unchanged.
-            self.toggle_bookmarks(absent_targets, String::new(), cx);
+            self.toggle_bookmarks(absent_targets, None, cx);
         }
 
         cx.notify();
@@ -166,7 +166,7 @@ impl Editor {
             if with_label {
                 self.add_toggle_bookmark_blocks(vec![target], bookmark_store, window, cx)
             } else {
-                self.toggle_bookmarks(vec![target], String::new(), cx);
+                self.toggle_bookmarks(vec![target], Some(String::new()), cx);
             }
         }
 
@@ -277,18 +277,13 @@ impl Editor {
     fn toggle_bookmarks(
         &mut self,
         targets: Vec<BookmarkTarget>,
-        label: String,
+        label: Option<String>,
         cx: &mut Context<Self>,
     ) {
         if let Some(bookmark_store) = self.bookmark_store.clone() {
             bookmark_store.update(cx, |store, cx| {
                 for target in targets {
-                    store.toggle_bookmark(
-                        target.buffer,
-                        target.buffer_anchor,
-                        Some(label.clone()),
-                        cx,
-                    );
+                    store.toggle_bookmark(target.buffer, target.buffer_anchor, label.clone(), cx);
                 }
             });
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4079,8 +4079,8 @@ impl Editor {
             .size(ui::ButtonSize::None)
             .icon_color(Color::Info)
             .style(ButtonStyle::Transparent)
-            .on_click(cx.listener(move |editor, _, _window, cx| {
-                editor.toggle_bookmark_at_row(row, cx);
+            .on_click(cx.listener(move |editor, _, window, cx| {
+                editor.toggle_bookmark_at_row(row, window, cx);
             }))
             .on_right_click(cx.listener(move |editor, event: &ClickEvent, window, cx| {
                 editor.set_gutter_context_menu(row, None, event.position(), window, cx);
@@ -4371,13 +4371,29 @@ impl Editor {
                 .separator()
                 .entry(set_bookmark_msg, Some(ToggleBookmark.boxed_clone()), {
                     let weak_editor = weak_editor.clone();
-                    move |_window, cx| {
+                    move |window, cx| {
                         weak_editor
                             .update(cx, |this, cx| {
-                                this.toggle_bookmark_at_anchor(anchor, cx);
+                                this.toggle_bookmark_at_anchor(anchor, false, window, cx);
                             })
                             .log_err();
                     }
+                })
+                .when(!has_bookmark, |this| {
+                    this.entry(
+                        "Add Bookmark With Label",
+                        Some(ToggleBookmarkWithLabel.boxed_clone()),
+                        {
+                            let weak_editor = weak_editor.clone();
+                            move |window, cx| {
+                                weak_editor
+                                    .update(cx, |this, cx| {
+                                        this.toggle_bookmark_at_anchor(anchor, true, window, cx);
+                                    })
+                                    .log_err();
+                            }
+                        },
+                    )
                 })
                 .when(has_bookmark, |this| {
                     this.entry(
@@ -4529,7 +4545,9 @@ impl Editor {
                     };
 
                     match intent {
-                        GutterButtonIntent::SetBookmark => editor.toggle_bookmark_at_row(row, cx),
+                        GutterButtonIntent::SetBookmark => {
+                            editor.toggle_bookmark_at_row(row, window, cx)
+                        }
                         GutterButtonIntent::SetBreakpoint => editor.edit_breakpoint_at_anchor(
                             position,
                             Breakpoint::new_standard(),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -31028,7 +31028,7 @@ impl BookmarkTestContext {
     fn toggle_bookmarks_at_rows(&mut self, rows: &[u32]) {
         for &row in rows {
             self.move_to_row(row);
-            self.add_bookmark_with_label("");
+            self.toggle_bookmark();
         }
     }
 
@@ -31048,16 +31048,16 @@ impl BookmarkTestContext {
 }
 
 #[gpui::test]
-async fn test_bookmark_toggling(cx: &mut TestAppContext) {
+async fn test_bookmark_toggling_unlabeled(cx: &mut TestAppContext) {
     let mut ctx =
         BookmarkTestContext::new("First line\nSecond line\nThird line\nFourth line", cx).await;
 
-    ctx.add_bookmark_with_label("");
+    ctx.toggle_bookmark();
     ctx.editor
         .update_in(&mut ctx.cx, |editor: &mut Editor, window, cx| {
             editor.move_to_end(&MoveToEnd, window, cx);
         });
-    ctx.add_bookmark_with_label("");
+    ctx.toggle_bookmark();
 
     ctx.assert_bookmarked_file_count(1);
     ctx.assert_bookmark_rows(vec![0, 3]);
@@ -31076,7 +31076,43 @@ async fn test_bookmark_toggling(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_bookmark_toggling_unnamed_with_multiple_selections(cx: &mut TestAppContext) {
+async fn test_bookmark_toggling_with_label(cx: &mut TestAppContext) {
+    let mut ctx =
+        BookmarkTestContext::new("First line\nSecond line\nThird line\nFourth line", cx).await;
+
+    ctx.add_bookmark_with_label("first label");
+    ctx.assert_bookmark_labels(vec![(0, "first label")]);
+
+    ctx.toggle_bookmark_with_label();
+
+    ctx.assert_prompt_block_count(0);
+    ctx.assert_bookmarked_file_count(0);
+    ctx.assert_bookmark_rows(vec![]);
+}
+
+#[gpui::test]
+async fn test_bookmark_toggles_can_remove_each_others_bookmarks(cx: &mut TestAppContext) {
+    let mut ctx =
+        BookmarkTestContext::new("First line\nSecond line\nThird line\nFourth line", cx).await;
+
+    ctx.toggle_bookmark();
+    ctx.assert_bookmark_labels(vec![(0, "")]);
+
+    ctx.toggle_bookmark_with_label();
+    ctx.assert_prompt_block_count(0);
+    ctx.assert_bookmarked_file_count(0);
+    ctx.assert_bookmark_rows(vec![]);
+
+    ctx.add_bookmark_with_label("labeled bookmark");
+    ctx.assert_bookmark_labels(vec![(0, "labeled bookmark")]);
+
+    ctx.toggle_bookmark();
+    ctx.assert_bookmarked_file_count(0);
+    ctx.assert_bookmark_rows(vec![]);
+}
+
+#[gpui::test]
+async fn test_bookmark_toggling_unlabeled_with_multiple_selections(cx: &mut TestAppContext) {
     let mut ctx =
         BookmarkTestContext::new("First line\nSecond line\nThird line\nFourth line", cx).await;
 
@@ -31163,7 +31199,7 @@ async fn test_bookmark_toggle_deduplicates_by_row(cx: &mut TestAppContext) {
         .update_in(&mut ctx.cx, |editor: &mut Editor, window, cx| {
             editor.move_to_beginning(&MoveToBeginning, window, cx);
         });
-    ctx.add_bookmark_with_label("");
+    ctx.toggle_bookmark();
 
     ctx.assert_bookmark_rows(vec![0]);
 
@@ -31188,7 +31224,7 @@ async fn test_bookmark_survives_edits(cx: &mut TestAppContext) {
         BookmarkTestContext::new("First line\nSecond line\nThird line\nFourth line", cx).await;
 
     ctx.move_to_row(2);
-    ctx.add_bookmark_with_label("");
+    ctx.toggle_bookmark();
     ctx.assert_bookmark_rows(vec![2]);
 
     ctx.editor
@@ -31315,7 +31351,7 @@ async fn test_bookmark_navigation_lands_at_column_zero(cx: &mut TestAppContext) 
         "Cursor should be at the 11th column before toggling bookmark, got column {column_before_toggle}"
     );
 
-    ctx.add_bookmark_with_label("");
+    ctx.toggle_bookmark();
 
     ctx.editor
         .update_in(&mut ctx.cx, |editor: &mut Editor, window, cx| {
@@ -31351,7 +31387,7 @@ async fn test_bookmark_set_from_nonzero_column_toggles_off_from_column_zero(
                 cx,
             );
         });
-    ctx.add_bookmark_with_label("");
+    ctx.toggle_bookmark();
 
     ctx.assert_bookmark_rows(vec![1]);
 

--- a/crates/project/src/bookmark_store.rs
+++ b/crates/project/src/bookmark_store.rs
@@ -175,7 +175,7 @@ impl BookmarkStore {
         &mut self,
         buffer: Entity<Buffer>,
         anchor: text::Anchor,
-        label: String,
+        label: Option<String>,
         cx: &mut Context<Self>,
     ) {
         let Some(abs_path) = Self::abs_path_from_buffer(&buffer, cx) else {
@@ -206,7 +206,10 @@ impl BookmarkStore {
                 self.bookmarks.remove(&abs_path);
             }
         } else {
-            buffer_bookmarks.bookmarks.push(Bookmark { anchor, label });
+            buffer_bookmarks.bookmarks.push(Bookmark {
+                anchor,
+                label: label.unwrap_or_default(),
+            });
         }
 
         cx.notify();

--- a/crates/project/tests/integration/bookmark_store.rs
+++ b/crates/project/tests/integration/bookmark_store.rs
@@ -56,7 +56,7 @@ mod integration {
             for &row in rows {
                 let anchor = snapshot.anchor_after(text::Point::new(row, 0));
                 bookmark_store.update(cx, |store, cx| {
-                    store.toggle_bookmark(buffer.clone(), anchor, String::new(), cx);
+                    store.toggle_bookmark(buffer.clone(), anchor, None, cx);
                 });
             }
         });
@@ -75,7 +75,7 @@ mod integration {
             let snapshot = buffer.read(cx).snapshot();
             let anchor = snapshot.anchor_after(text::Point::new(row, 0));
             bookmark_store.update(cx, |store, cx| {
-                store.toggle_bookmark(buffer.clone(), anchor, label.to_string(), cx);
+                store.toggle_bookmark(buffer.clone(), anchor, Some(label.to_string()), cx);
             });
         });
     }


### PR DESCRIPTION
# Objective

- Optimize bookmark addition behavior to support both directly adding bookmarks and opening the prompt editor to input labels for bookmark creation. Details are documented in #57491

## Solution

- Add optional parameters to the original `ToggleBookmark` action. By default, a blank bookmark will be created directly, and the prompt editor will only open when parameters are provided.

## Testing

- Relevant tests have been supplemented
- Tested on Windows 10

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


---

Release Notes:

- Improved default bookmark toggling behavior
