### PR TITLE
workspace: Add project_grouping setting to group projects by repository or worktree

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -168,6 +168,17 @@
   //  2. Open projects in a new window
   //         "default_open_behavior": "new_window"
   "default_open_behavior": "existing_window",
+  // Controls how projects are grouped in the workspace sidebar.
+  //
+  // May take 2 values:
+  //  1. Group linked Git worktrees by their shared repository:
+  //         "project_grouping": "repository"
+  //  2. Group each opened worktree root separately:
+  //         "project_grouping": "worktree"
+  //
+  // Changing this setting may require reopening workspaces or restarting Zed
+  // before all existing project groups and recent project entries reflect it.
+  "project_grouping": "repository",
   // Whether to attempt to restore previous file's state when opening it again.
   // The state is stored per pane.
   // When disabled, defaults are applied instead of the state restoration.

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -24,9 +24,13 @@ use gpui::{AppContext as _, Entity, Global, Subscription, Task, TaskExt};
 pub use project::WorktreePaths;
 use project::{AgentId, linked_worktree_short_name};
 use remote::{RemoteConnectionOptions, same_remote_connection_identity};
+use settings::Settings;
 use ui::{App, Context, SharedString, ThreadItemWorktreeInfo, WorktreeKind};
 use util::ResultExt as _;
-use workspace::{PathList, SerializedWorkspaceLocation, WorkspaceDb};
+use workspace::{
+    PathList, SerializedWorkspaceLocation, WorkspaceDb, WorkspaceSettings,
+    project_grouping_from_settings,
+};
 
 use crate::DEFAULT_THREAD_TITLE;
 
@@ -196,6 +200,9 @@ fn migrate_thread_remote_connections(cx: &mut App, migration_task: Task<anyhow::
     let workspace_db = WorkspaceDb::global(cx);
     let fs = <dyn Fs>::global(cx);
 
+    let grouping = WorkspaceSettings::get_global(cx).project_grouping;
+    let grouping = project_grouping_from_settings(grouping);
+
     cx.spawn(async move |cx| -> anyhow::Result<()> {
         migration_task.await?;
 
@@ -207,7 +214,7 @@ fn migrate_thread_remote_connections(cx: &mut App, migration_task: Task<anyhow::
         }
 
         let recent_workspaces = workspace_db
-            .recent_project_workspaces_ungrouped(fs.as_ref())
+            .recent_project_workspaces_ungrouped_with_grouping(fs.as_ref(), grouping)
             .await?;
 
         let mut local_path_lists = HashSet::<PathList>::default();

--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -41,7 +41,7 @@ use util::ResultExt;
 use util::paths::PathExt;
 use workspace::{
     CloseWindow, ModalView, PathList, RecentWorkspace, SerializedWorkspaceLocation, Workspace,
-    WorkspaceDb, WorkspaceId,
+    WorkspaceDb, WorkspaceId, WorkspaceSettings, project_grouping_from_settings,
 };
 
 use zed_actions::agents_sidebar::FocusSidebarFilter;
@@ -1148,9 +1148,11 @@ impl ProjectPickerModal {
             });
 
         let db = WorkspaceDb::global(cx);
+        let grouping = WorkspaceSettings::get_global(cx).project_grouping;
+        let grouping = project_grouping_from_settings(grouping);
         cx.spawn_in(window, async move |this, cx| {
             let workspaces = db
-                .recent_project_workspaces(fs.as_ref())
+                .recent_project_workspaces_with_grouping(fs.as_ref(), grouping)
                 .await
                 .log_err()
                 .unwrap_or_default();

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -53,7 +53,7 @@ pub use git_store::{
 };
 pub use manifest_tree::ManifestTree;
 pub use project_search::{Search, SearchResults};
-pub use worktree_store::WorktreePaths;
+pub use worktree_store::{ProjectGrouping, WorktreePaths};
 
 use anyhow::{Context as _, Result, anyhow};
 use buffer_store::{BufferStore, BufferStoreEvent};
@@ -6235,6 +6235,14 @@ impl Project {
     pub fn project_group_key(&self, cx: &App) -> ProjectGroupKey {
         ProjectGroupKey::from_project(self, cx)
     }
+
+    pub fn project_group_key_with_grouping(
+        &self,
+        grouping: ProjectGrouping,
+        cx: &App,
+    ) -> ProjectGroupKey {
+        ProjectGroupKey::from_project_with_grouping(self, grouping, cx)
+    }
 }
 
 /// Identifies a project group by a set of paths the workspaces in this group
@@ -6258,10 +6266,18 @@ impl ProjectGroupKey {
     }
 
     pub fn from_project(project: &Project, cx: &App) -> Self {
+        Self::from_project_with_grouping(project, ProjectGrouping::Repository, cx)
+    }
+
+    pub fn from_project_with_grouping(
+        project: &Project,
+        grouping: ProjectGrouping,
+        cx: &App,
+    ) -> Self {
         let paths = project.worktree_paths(cx);
         let host = project.remote_connection_options(cx);
         Self {
-            paths: paths.main_worktree_path_list().clone(),
+            paths: paths.path_list_for_grouping(grouping).clone(),
             host,
         }
     }
@@ -6270,8 +6286,16 @@ impl ProjectGroupKey {
         paths: &WorktreePaths,
         host: Option<RemoteConnectionOptions>,
     ) -> Self {
+        Self::from_worktree_paths_with_grouping(paths, host, ProjectGrouping::Repository)
+    }
+
+    pub fn from_worktree_paths_with_grouping(
+        paths: &WorktreePaths,
+        host: Option<RemoteConnectionOptions>,
+        grouping: ProjectGrouping,
+    ) -> Self {
         Self {
-            paths: paths.main_worktree_path_list().clone(),
+            paths: paths.path_list_for_grouping(grouping).clone(),
             host,
         }
     }

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -35,6 +35,15 @@ use worktree::{
 
 use crate::{ProjectPath, trusted_worktrees::TrustedWorktrees};
 
+/// Controls which path identity is used for project group keys.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProjectGrouping {
+    /// Group projects by the main Git repository they belong to.
+    Repository,
+    /// Group projects by the actual opened worktree root folder.
+    Worktree,
+}
+
 /// The current paths for a project's worktrees. Each folder path has a corresponding
 /// main worktree path at the same position. The two lists are always the
 /// same length and are modified together via `add_path` / `remove_main_path`.
@@ -96,6 +105,15 @@ impl WorktreePaths {
     /// The main worktree paths (for group key / `threads_by_main_paths` index).
     pub fn main_worktree_path_list(&self) -> &PathList {
         &self.main_paths
+    }
+
+    /// Returns the path list to use for project group keys based on the
+    /// active grouping policy.
+    pub fn path_list_for_grouping(&self, grouping: ProjectGrouping) -> &PathList {
+        match grouping {
+            ProjectGrouping::Repository => self.main_worktree_path_list(),
+            ProjectGrouping::Worktree => self.folder_path_list(),
+        }
     }
 
     /// Iterate the (main_worktree_path, folder_path) pairs in insertion order.

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -48,7 +48,8 @@ use util::{ResultExt, paths::PathExt};
 use workspace::{
     HistoryManager, ModalView, MultiWorkspace, OpenMode, OpenOptions, OpenVisible, PathList,
     RecentWorkspace, SerializedWorkspaceLocation, Workspace, WorkspaceDb, WorkspaceId,
-    notifications::DetachAndPromptErr, with_active_or_new_workspace,
+    WorkspaceSettings, notifications::DetachAndPromptErr, project_grouping_from_settings,
+    with_active_or_new_workspace,
 };
 use zed_actions::{OpenDevContainer, OpenRecent, OpenRemote};
 
@@ -124,9 +125,10 @@ pub async fn get_recent_projects(
     limit: Option<usize>,
     fs: Arc<dyn fs::Fs>,
     db: &WorkspaceDb,
+    grouping: project::ProjectGrouping,
 ) -> Vec<RecentProjectEntry> {
     let workspaces = db
-        .recent_project_workspaces(fs.as_ref())
+        .recent_project_workspaces_with_grouping(fs.as_ref(), grouping)
         .await
         .unwrap_or_default();
 
@@ -659,10 +661,12 @@ impl RecentProjects {
         // We do not want to block the UI on a potentially lengthy call to DB, so we're gonna swap
         // out workspace locations once the future runs to completion.
         let db = WorkspaceDb::global(cx);
+        let grouping = WorkspaceSettings::get_global(cx).project_grouping;
+        let grouping = project_grouping_from_settings(grouping);
         cx.spawn_in(window, async move |this, cx| {
             let Some(fs) = fs else { return };
             let workspaces = db
-                .recent_project_workspaces(fs.as_ref())
+                .recent_project_workspaces_with_grouping(fs.as_ref(), grouping)
                 .await
                 .log_err()
                 .unwrap_or_default();
@@ -2367,6 +2371,8 @@ impl RecentProjectsDelegate {
                 .upgrade()
                 .map(|ws| ws.read(cx).app_state().fs.clone());
             let db = WorkspaceDb::global(cx);
+            let grouping = WorkspaceSettings::get_global(cx).project_grouping;
+            let grouping = project_grouping_from_settings(grouping);
             cx.spawn_in(window, async move |this, cx| {
                 let Some(fs) = fs else { return };
                 let deleted_workspace_ids = db
@@ -2375,7 +2381,7 @@ impl RecentProjectsDelegate {
                     .log_err()
                     .unwrap_or_default();
                 let workspaces = db
-                    .recent_project_workspaces(fs.as_ref())
+                    .recent_project_workspaces_with_grouping(fs.as_ref(), grouping)
                     .await
                     .unwrap_or_default();
                 this.update_in(cx, move |picker, window, cx| {

--- a/crates/recent_projects/src/sidebar_recent_projects.rs
+++ b/crates/recent_projects/src/sidebar_recent_projects.rs
@@ -16,7 +16,8 @@ use ui_input::ErasedEditor;
 use util::{ResultExt, paths::PathExt};
 use workspace::{
     MultiWorkspace, OpenMode, OpenOptions, ProjectGroupKey, RecentWorkspace,
-    SerializedWorkspaceLocation, Workspace, WorkspaceDb, notifications::DetachAndPromptErr,
+    SerializedWorkspaceLocation, Workspace, WorkspaceDb, WorkspaceSettings,
+    notifications::DetachAndPromptErr, project_grouping_from_settings,
 };
 
 use zed_actions::OpenRemote;
@@ -66,10 +67,12 @@ impl SidebarRecentProjects {
                 cx.subscribe(&picker, |_this: &mut Self, _, _, cx| cx.emit(DismissEvent));
 
             let db = WorkspaceDb::global(cx);
+            let grouping = WorkspaceSettings::get_global(cx).project_grouping;
+            let grouping = project_grouping_from_settings(grouping);
             cx.spawn_in(window, async move |this, cx| {
                 let Some(fs) = fs else { return };
                 let workspaces = db
-                    .recent_project_workspaces(fs.as_ref())
+                    .recent_project_workspaces_with_grouping(fs.as_ref(), grouping)
                     .await
                     .log_err()
                     .unwrap_or_default();

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1013,6 +1013,7 @@ impl VsCodeSettings {
             centered_layout: None,
             cli_default_open_behavior: None,
             default_open_behavior: None,
+            project_grouping: None,
             close_on_file_delete: None,
             close_panel_on_toggle: None,
             command_aliases: Default::default(),

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -58,6 +58,11 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: existing_window
     pub default_open_behavior: Option<DefaultOpenBehavior>,
+    /// Controls how projects are grouped in the workspace sidebar.
+    ///
+    /// Values: repository, worktree
+    /// Default: repository
+    pub project_grouping: Option<ProjectGrouping>,
     /// Whether to attempt to restore previous file's state when opening it again.
     /// The state is stored per pane.
     /// When disabled, defaults are applied instead of the state restoration.
@@ -283,6 +288,27 @@ pub enum ActivateOnClose {
     History,
     Neighbour,
     LeftNeighbour,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectGrouping {
+    #[default]
+    Repository,
+    Worktree,
 }
 
 #[with_fallible_options]

--- a/crates/workspace/src/history_manager.rs
+++ b/crates/workspace/src/history_manager.rs
@@ -2,13 +2,14 @@ use std::{path::PathBuf, sync::Arc};
 
 use fs::Fs;
 use gpui::{AppContext, Entity, Global, MenuItem};
+use settings::Settings;
 use smallvec::SmallVec;
 use ui::{App, Context};
 use util::{ResultExt, paths::PathExt};
 
 use crate::{
     NewWindow, SerializedWorkspaceLocation, WorkspaceId, path_list::PathList,
-    persistence::WorkspaceDb,
+    persistence::WorkspaceDb, project_grouping_from_settings, workspace_settings,
 };
 
 pub fn init(fs: Arc<dyn Fs>, cx: &mut App) {
@@ -42,9 +43,11 @@ impl HistoryManager {
 
     fn init(this: Entity<HistoryManager>, fs: Arc<dyn Fs>, cx: &App) {
         let db = WorkspaceDb::global(cx);
+        let grouping = workspace_settings::WorkspaceSettings::get_global(cx).project_grouping;
+        let grouping = project_grouping_from_settings(grouping);
         cx.spawn(async move |cx| {
             let recent_folders = db
-                .recent_project_workspaces(fs.as_ref())
+                .recent_project_workspaces_with_grouping(fs.as_ref(), grouping)
                 .await
                 .unwrap_or_default()
                 .into_iter()

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -10,6 +10,7 @@ pub use project::ProjectGroupKey;
 use project::{DisableAiSettings, Project};
 use remote::RemoteConnectionOptions;
 use settings::Settings;
+use crate::workspace_settings::WorkspaceSettings;
 pub use settings::SidebarSide;
 use std::cell::Cell;
 use std::future::Future;
@@ -29,7 +30,7 @@ const SIDEBAR_RESIZE_HANDLE_SIZE: Pixels = px(6.0);
 use crate::open_remote_project_with_existing_connection;
 use crate::{
     CloseIntent, CloseWindow, DockPosition, Event as WorkspaceEvent, Item, ModalView, OpenMode,
-    Panel, Workspace, WorkspaceId, client_side_decorations,
+    Panel, Workspace, WorkspaceId, client_side_decorations, project_grouping_from_settings,
     persistence::model::MultiWorkspaceState,
 };
 
@@ -579,8 +580,13 @@ impl MultiWorkspace {
                             .project()
                             .read(cx)
                             .remote_connection_options(cx);
-                        let old_key =
-                            ProjectGroupKey::from_worktree_paths(old_worktree_paths, host);
+                        let grouping = WorkspaceSettings::get_global(cx).project_grouping;
+                        let grouping = project_grouping_from_settings(grouping);
+                        let old_key = ProjectGroupKey::from_worktree_paths_with_grouping(
+                            old_worktree_paths,
+                            host,
+                            grouping,
+                        );
                         this.handle_project_group_key_change(&workspace, &old_key, cx);
                     }
                 }

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -10,6 +10,7 @@ use project::DisableAiSettings;
 use serde_json::json;
 use settings::{Settings, SettingsStore};
 use util::path;
+use workspace_settings::{ProjectGrouping, WorkspaceSettings};
 
 fn init_test(cx: &mut TestAppContext) {
     cx.update(|cx| {
@@ -17,6 +18,14 @@ fn init_test(cx: &mut TestAppContext) {
         cx.set_global(settings_store);
         theme_settings::init(theme::LoadThemes::JustBase, cx);
         DisableAiSettings::register(cx);
+    });
+}
+
+fn set_project_grouping(grouping: ProjectGrouping, cx: &mut TestAppContext) {
+    cx.update(|cx| {
+        let mut settings = WorkspaceSettings::get_global(cx).clone();
+        settings.project_grouping = grouping;
+        WorkspaceSettings::override_global(settings, cx);
     });
 }
 
@@ -493,6 +502,275 @@ async fn test_find_or_create_workspace_uses_project_group_key_when_paths_are_mis
             main_workspace_id,
             "the active workspace should remain the main worktree workspace"
         );
+        assert_eq!(
+            PathList::new(&mw.workspace().read(cx).root_paths(cx)),
+            project_group_key.path_list().clone(),
+            "the activated workspace should use the project group key path list rather than the missing linked-worktree path"
+        );
+        assert_eq!(
+            mw.workspaces().count(),
+            1,
+            "falling back to the project group key should not create a second workspace"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_repository_mode_groups_linked_worktrees_together(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/repo",
+        json!({
+            ".git": {
+                "worktrees": {
+                    "feature": {
+                        "commondir": "../../",
+                        "HEAD": "ref: refs/heads/feature"
+                    }
+                }
+            },
+            "src": { "main.rs": "" }
+        }),
+    )
+    .await;
+    fs.insert_tree(
+        "/worktree-feature",
+        json!({
+            ".git": "gitdir: /repo/.git/worktrees/feature",
+            "src": { "main.rs": "" }
+        }),
+    )
+    .await;
+
+    let main_project = Project::test(fs.clone(), ["/repo".as_ref()], cx).await;
+    let linked_project = Project::test(fs.clone(), ["/worktree-feature".as_ref()], cx).await;
+
+    let main_key = main_project.read_with(cx, |p, cx| p.project_group_key(cx));
+    let linked_key = linked_project.read_with(cx, |p, cx| p.project_group_key(cx));
+    assert_eq!(
+        main_key, linked_key,
+        "repository mode should group linked worktree with main repo"
+    );
+    assert_eq!(
+        main_key.path_list().paths(),
+        &[PathBuf::from("/repo")],
+        "repository mode key should use main repo path"
+    );
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(main_project, window, cx));
+    multi_workspace.update_in(cx, |mw, window, cx| {
+        mw.test_add_workspace(linked_project, window, cx);
+    });
+    cx.run_until_parked();
+
+    multi_workspace.read_with(cx, |mw, _cx| {
+        let keys = mw.project_group_keys();
+        assert_eq!(
+            keys.len(),
+            1,
+            "repository mode should produce one project group for linked worktrees"
+        );
+        assert_eq!(keys[0], main_key);
+    });
+}
+
+#[gpui::test]
+async fn test_worktree_mode_separates_linked_worktrees(cx: &mut TestAppContext) {
+    init_test(cx);
+    set_project_grouping(ProjectGrouping::Worktree, cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/repo",
+        json!({
+            ".git": {
+                "worktrees": {
+                    "feature": {
+                        "commondir": "../../",
+                        "HEAD": "ref: refs/heads/feature"
+                    }
+                }
+            },
+            "src": { "main.rs": "" }
+        }),
+    )
+    .await;
+    fs.insert_tree(
+        "/worktree-feature",
+        json!({
+            ".git": "gitdir: /repo/.git/worktrees/feature",
+            "src": { "main.rs": "" }
+        }),
+    )
+    .await;
+
+    let main_project = Project::test(fs.clone(), ["/repo".as_ref()], cx).await;
+    let linked_project = Project::test(fs.clone(), ["/worktree-feature".as_ref()], cx).await;
+
+    let main_key = main_project.read_with(cx, |p, cx| {
+        p.project_group_key_with_grouping(project::ProjectGrouping::Worktree, cx)
+    });
+    let linked_key = linked_project.read_with(cx, |p, cx| {
+        p.project_group_key_with_grouping(project::ProjectGrouping::Worktree, cx)
+    });
+    assert_ne!(
+        main_key, linked_key,
+        "worktree mode should separate linked worktree from main repo"
+    );
+    assert_eq!(
+        main_key.path_list().paths(),
+        &[PathBuf::from("/repo")],
+        "main repo key should use main repo path"
+    );
+    assert_eq!(
+        linked_key.path_list().paths(),
+        &[PathBuf::from("/worktree-feature")],
+        "linked worktree key should use worktree folder path"
+    );
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(main_project, window, cx));
+    multi_workspace.update(cx, |mw, cx| {
+        mw.open_sidebar(cx);
+    });
+    cx.run_until_parked();
+    let main_workspace = multi_workspace.read_with(cx, |mw, _cx| mw.workspace().clone());
+
+    multi_workspace.update_in(cx, |mw, window, cx| {
+        let linked_workspace = mw.test_add_workspace(linked_project, window, cx);
+        mw.activate(linked_workspace, None, window, cx);
+    });
+    cx.run_until_parked();
+
+    multi_workspace.read_with(cx, |mw, cx| {
+        let keys = mw.project_group_keys();
+        assert_eq!(
+            keys.len(),
+            2,
+            "worktree mode should produce two project groups for linked worktrees"
+        );
+        let main_workspace_key = main_workspace.read(cx).project_group_key(cx);
+        assert!(
+            keys.contains(&main_workspace_key),
+            "keys should contain the main workspace key; got {keys:?}"
+        );
+        assert!(
+            keys.contains(&linked_key),
+            "keys should contain the linked worktree key; got {keys:?}"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_adding_worktree_updates_key_in_worktree_mode(cx: &mut TestAppContext) {
+    init_test(cx);
+    set_project_grouping(ProjectGrouping::Worktree, cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root_a", json!({ "file.txt": "" })).await;
+    fs.insert_tree("/root_b", json!({ "file.txt": "" })).await;
+    let project = Project::test(fs.clone(), ["/root_a".as_ref()], cx).await;
+
+    let initial_key = project.read_with(cx, |p, cx| {
+        p.project_group_key_with_grouping(project::ProjectGrouping::Worktree, cx)
+    });
+    assert_eq!(
+        initial_key.path_list().paths(),
+        &[PathBuf::from("/root_a")]
+    );
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+
+    multi_workspace.update(cx, |mw, cx| {
+        mw.open_sidebar(cx);
+    });
+    cx.run_until_parked();
+
+    project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree("/root_b", true, cx)
+        })
+        .await
+        .expect("adding worktree should succeed");
+    cx.run_until_parked();
+
+    let updated_key = project.read_with(cx, |p, cx| {
+        p.project_group_key_with_grouping(project::ProjectGrouping::Worktree, cx)
+    });
+    assert_eq!(
+        updated_key.path_list().paths(),
+        &[PathBuf::from("/root_a"), PathBuf::from("/root_b")],
+        "worktree mode key should use actual folder paths after adding worktree"
+    );
+
+    multi_workspace.read_with(cx, |mw, cx| {
+        let keys = mw.project_group_keys();
+        let workspace_key = mw.workspace().read(cx).project_group_key(cx);
+        assert_eq!(
+            workspace_key, updated_key,
+            "workspace key should match the updated worktree-mode key"
+        );
+        assert!(keys.contains(&workspace_key));
+    });
+}
+
+#[gpui::test]
+async fn test_find_or_create_workspace_worktree_mode_does_not_collapse_missing_worktree(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+    set_project_grouping(ProjectGrouping::Worktree, cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/repo",
+        json!({
+            ".git": {},
+            "src": {}
+        }),
+    )
+    .await;
+    cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+    let project = Project::test(fs.clone(), ["/repo".as_ref()], cx).await;
+    project
+        .update(cx, |project, cx| project.git_scans_complete(cx))
+        .await;
+
+    let project_group_key = project.read_with(cx, |project, cx| project.project_group_key(cx));
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+
+    let main_workspace = multi_workspace.read_with(cx, |mw, _cx| mw.workspace().clone());
+    let main_workspace_id = main_workspace.entity_id();
+
+    let workspace = multi_workspace
+        .update_in(cx, |mw, window, cx| {
+            mw.find_or_create_workspace(
+                PathList::new(&[PathBuf::from("/wt-feature-a")]),
+                None,
+                Some(project_group_key.clone()),
+                |_options, _window, _cx| Task::ready(Ok(None)),
+                &[],
+                None,
+                OpenMode::Activate,
+                window,
+                cx,
+            )
+        })
+        .await
+        .expect("opening a missing linked-worktree path should fall back to the project group key workspace");
+
+    assert_eq!(
+        workspace.entity_id(),
+        main_workspace_id,
+        "missing linked-worktree path should reuse the main worktree workspace from the project group key"
+    );
+
+    multi_workspace.read_with(cx, |mw, cx| {
         assert_eq!(
             PathList::new(&mw.workspace().read(cx).root_paths(cx)),
             project_group_key.path_list().clone(),

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -2005,9 +2005,10 @@ impl WorkspaceDb {
 
     // Returns the raw recent workspace history. Scratch workspaces (no paths) are filtered
     // out because they are restored separately by `last_session_workspace_locations`.
-    pub async fn recent_project_workspaces_ungrouped(
+    pub async fn recent_project_workspaces_ungrouped_with_grouping(
         &self,
         fs: &dyn Fs,
+        grouping: project::ProjectGrouping,
     ) -> Result<Vec<RecentWorkspace>> {
         let remote_connections = self.remote_connections()?;
         let mut result = Vec::new();
@@ -2032,7 +2033,7 @@ impl WorkspaceDb {
             }
 
             if Self::all_paths_exist_with_a_directory(paths.paths(), fs).await {
-                let identity_paths = resolve_local_workspace_identity(fs, &paths)
+                let identity_paths = resolve_local_workspace_identity(fs, &paths, grouping)
                     .await
                     .or(identity_paths_hint)
                     .unwrap_or_else(|| paths.clone());
@@ -2047,6 +2048,27 @@ impl WorkspaceDb {
         }
 
         Ok(result)
+    }
+
+    pub async fn recent_project_workspaces_ungrouped(
+        &self,
+        fs: &dyn Fs,
+    ) -> Result<Vec<RecentWorkspace>> {
+        self.recent_project_workspaces_ungrouped_with_grouping(
+            fs,
+            project::ProjectGrouping::Repository,
+        )
+        .await
+    }
+
+    pub async fn recent_project_workspaces_with_grouping(
+        &self,
+        fs: &dyn Fs,
+        grouping: project::ProjectGrouping,
+    ) -> Result<Vec<RecentWorkspace>> {
+        Ok(dedupe_recent_workspaces(
+            self.recent_project_workspaces_ungrouped_with_grouping(fs, grouping).await?,
+        ))
     }
 
     // Returns the recent project workspaces suitable for recent-project UIs.
@@ -2156,6 +2178,18 @@ impl WorkspaceDb {
         )
         .await;
         Ok(())
+    }
+
+    pub async fn last_workspace_with_grouping(
+        &self,
+        fs: &dyn Fs,
+        grouping: project::ProjectGrouping,
+    ) -> Result<Option<RecentWorkspace>> {
+        Ok(self
+            .recent_project_workspaces_with_grouping(fs, grouping)
+            .await?
+            .into_iter()
+            .next())
     }
 
     pub async fn last_workspace(&self, fs: &dyn Fs) -> Result<Option<RecentWorkspace>> {
@@ -2665,31 +2699,41 @@ impl RecentWorkspace {
     }
 }
 
-async fn resolve_local_workspace_identity(fs: &dyn Fs, paths: &PathList) -> Option<PathList> {
-    let raw_paths = paths.paths();
-    let resolved_paths = futures::future::join_all(
-        raw_paths
-            .iter()
-            .map(|path| project::git_store::resolve_git_worktree_to_main_repo(fs, path)),
-    )
-    .await;
+async fn resolve_local_workspace_identity(
+    fs: &dyn Fs,
+    paths: &PathList,
+    grouping: project::ProjectGrouping,
+) -> Option<PathList> {
+    match grouping {
+        project::ProjectGrouping::Worktree => Some(paths.clone()),
+        project::ProjectGrouping::Repository => {
+            let raw_paths = paths.paths();
+            let resolved_paths = futures::future::join_all(
+                raw_paths
+                    .iter()
+                    .map(|path| project::git_store::resolve_git_worktree_to_main_repo(fs, path)),
+            )
+            .await;
 
-    if resolved_paths.iter().all(|resolved| resolved.is_none()) {
-        return None;
+            if resolved_paths.iter().all(|resolved| resolved.is_none()) {
+                return None;
+            }
+
+            let resolved_paths: Vec<PathBuf> = raw_paths
+                .iter()
+                .zip(resolved_paths.iter())
+                .map(|(original, resolved)| {
+                    resolved
+                        .as_ref()
+                        .cloned()
+                        .unwrap_or_else(|| original.clone())
+                })
+                .collect();
+            let resolved_path_refs: Vec<&Path> =
+                resolved_paths.iter().map(PathBuf::as_path).collect();
+            Some(PathList::new(&resolved_path_refs))
+        }
     }
-
-    let resolved_paths: Vec<PathBuf> = raw_paths
-        .iter()
-        .zip(resolved_paths.iter())
-        .map(|(original, resolved)| {
-            resolved
-                .as_ref()
-                .cloned()
-                .unwrap_or_else(|| original.clone())
-        })
-        .collect();
-    let resolved_path_refs: Vec<&Path> = resolved_paths.iter().map(PathBuf::as_path).collect();
-    Some(PathList::new(&resolved_path_refs))
 }
 
 fn dedupe_recent_workspaces(
@@ -2756,6 +2800,7 @@ mod tests {
     use crate::OpenMode;
     use crate::PathList;
     use crate::ProjectGroupKey;
+    use crate::{ProjectGrouping, WorkspaceSettings};
     use crate::{
         multi_workspace::MultiWorkspace,
         persistence::{
@@ -2773,6 +2818,7 @@ mod tests {
     use project::Project;
     use remote::SshConnectionOptions;
     use serde_json::json;
+    use settings::Settings;
     use std::{thread, time::Duration};
 
     /// Creates a unique directory in a FakeFs, returning the path.
@@ -3812,9 +3858,13 @@ mod tests {
         timestamp: DateTime<Utc>,
         fs: &dyn Fs,
     ) -> RecentWorkspace {
-        let identity_paths = resolve_local_workspace_identity(fs, &paths)
-            .await
-            .unwrap_or_else(|| paths.clone());
+        let identity_paths = resolve_local_workspace_identity(
+            fs,
+            &paths,
+            project::ProjectGrouping::Repository,
+        )
+        .await
+        .unwrap_or_else(|| paths.clone());
         RecentWorkspace {
             workspace_id,
             location: SerializedWorkspaceLocation::Local,
@@ -5342,6 +5392,77 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_recent_project_workspaces_worktree_mode_separates_linked_worktrees(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let fs = fs::FakeFs::new(cx.executor());
+        let db = WorkspaceDb::open_test_db(
+            "test_recent_project_workspaces_worktree_mode_separates_linked_worktrees",
+        )
+        .await;
+
+        fs.insert_tree(
+            "/repo",
+            json!({
+                ".git": {
+                    "worktrees": {
+                        "feature": {
+                            "commondir": "../../",
+                            "HEAD": "ref: refs/heads/feature"
+                        }
+                    }
+                },
+                "src": { "main.rs": "" }
+            }),
+        )
+        .await;
+
+        fs.insert_tree(
+            "/worktree",
+            json!({
+                ".git": "gitdir: /repo/.git/worktrees/feature",
+                "src": { "main.rs": "" }
+            }),
+        )
+        .await;
+
+        db.save_workspace(workspace_with(
+            1,
+            &[Path::new("/repo")],
+            empty_pane_group(),
+            None,
+        ))
+        .await;
+        db.save_workspace(workspace_with(
+            2,
+            &[Path::new("/worktree")],
+            empty_pane_group(),
+            None,
+        ))
+        .await;
+        db.set_timestamp_for_tests(WorkspaceId(1), "2024-01-01 00:00:00".to_owned())
+            .await
+            .unwrap();
+        db.set_timestamp_for_tests(WorkspaceId(2), "2024-01-01 00:00:01".to_owned())
+            .await
+            .unwrap();
+
+        let recents = db
+            .recent_project_workspaces_with_grouping(fs.as_ref(), project::ProjectGrouping::Worktree)
+            .await
+            .unwrap();
+
+        assert_eq!(recents.len(), 2, "worktree mode should keep separate entries");
+        assert_eq!(
+            recents[0].identity_paths.paths(),
+            &[PathBuf::from("/worktree")]
+        );
+        assert_eq!(recents[1].identity_paths.paths(), &[PathBuf::from("/repo")]);
+        assert_eq!(recents[0].workspace_id, WorkspaceId(2));
+        assert_eq!(recents[1].workspace_id, WorkspaceId(1));
+    }
+
+    #[gpui::test]
     async fn test_recent_project_workspaces_preserve_reopen_paths(cx: &mut gpui::TestAppContext) {
         let fs = fs::FakeFs::new(cx.executor());
         let db =
@@ -5756,6 +5877,132 @@ mod tests {
             active_paths,
             vec![PathBuf::from("/worktree-feature")],
             "The restored active workspace should be the linked worktree project"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_restore_window_with_linked_worktree_in_worktree_mode(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        crate::tests::init_test(cx);
+
+        cx.update(|cx| {
+            let mut settings = WorkspaceSettings::get_global(cx).clone();
+            settings.project_grouping = ProjectGrouping::Worktree;
+            WorkspaceSettings::override_global(settings, cx);
+        });
+
+        let fs = fs::FakeFs::new(cx.executor());
+
+        fs.insert_tree(
+            "/repo",
+            json!({
+                ".git": {
+                    "HEAD": "ref: refs/heads/main",
+                    "worktrees": {
+                        "feature": {
+                            "commondir": "../../",
+                            "HEAD": "ref: refs/heads/feature"
+                        }
+                    }
+                },
+                "src": { "main.rs": "" }
+            }),
+        )
+        .await;
+
+        fs.insert_tree(
+            "/worktree-feature",
+            json!({
+                ".git": "gitdir: /repo/.git/worktrees/feature",
+                "src": { "lib.rs": "" }
+            }),
+        )
+        .await;
+
+        let project_main = Project::test(fs.clone(), ["/repo".as_ref()], cx).await;
+        let project_linked = Project::test(fs.clone(), ["/worktree-feature".as_ref()], cx).await;
+        cx.run_until_parked();
+
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project_main.clone(), window, cx));
+
+        multi_workspace.update(cx, |mw, cx| {
+            mw.open_sidebar(cx);
+        });
+
+        let workspace_linked = multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.test_add_workspace(project_linked.clone(), window, cx)
+        });
+
+        let tasks =
+            multi_workspace.update_in(cx, |mw, window, cx| mw.flush_all_serialization(window, cx));
+        cx.run_until_parked();
+        for task in tasks {
+            task.await;
+        }
+        cx.run_until_parked();
+
+        let active_db_id = workspace_linked.read_with(cx, |ws, _| ws.database_id());
+        assert!(active_db_id.is_some());
+
+        let session_id = multi_workspace
+            .read_with(cx, |mw, cx| mw.workspace().read(cx).session_id())
+            .unwrap();
+        let db = cx.update(|_, cx| WorkspaceDb::global(cx));
+        let session_workspaces = db
+            .last_session_workspace_locations(&session_id, None, fs.as_ref())
+            .await
+            .expect("should load session workspaces");
+
+        let multi_workspaces =
+            cx.update(|_, cx| read_serialized_multi_workspaces(session_workspaces, cx));
+        assert_eq!(multi_workspaces.len(), 1);
+
+        let serialized = &multi_workspaces[0];
+        assert_eq!(
+            serialized.active_workspace.workspace_id,
+            active_db_id.unwrap(),
+        );
+        assert_eq!(serialized.state.project_groups.len(), 2);
+
+        let restored_keys: Vec<ProjectGroupKey> = serialized
+            .state
+            .project_groups
+            .iter()
+            .cloned()
+            .map(Into::into)
+            .collect();
+        let expected_keys = vec![
+            ProjectGroupKey::new(None, PathList::new(&["/worktree-feature"])),
+            ProjectGroupKey::new(None, PathList::new(&["/repo"])),
+        ];
+        assert_eq!(
+            restored_keys, expected_keys,
+            "Serialized project group keys in worktree mode should use actual folder paths"
+        );
+
+        let app_state =
+            multi_workspace.read_with(cx, |mw, cx| mw.workspace().read(cx).app_state().clone());
+
+        let serialized_mw = multi_workspaces.into_iter().next().unwrap();
+        let restored_handle: gpui::WindowHandle<MultiWorkspace> = cx
+            .update(|_, cx| {
+                cx.spawn(async move |mut cx| {
+                    crate::restore_multiworkspace(serialized_mw, app_state, &mut cx).await
+                })
+            })
+            .await
+            .expect("restore_multiworkspace should succeed");
+
+        cx.run_until_parked();
+
+        let restored_keys: Vec<ProjectGroupKey> = restored_handle
+            .read_with(cx, |mw: &MultiWorkspace, _cx| mw.project_group_keys())
+            .unwrap();
+        assert_eq!(
+            restored_keys, expected_keys,
+            "Restored window in worktree mode should preserve separate worktree project groups"
         );
     }
 

--- a/crates/workspace/src/welcome.rs
+++ b/crates/workspace/src/welcome.rs
@@ -260,10 +260,12 @@ impl WelcomePage {
                 .upgrade()
                 .map(|ws| ws.read(cx).app_state().fs.clone());
             let db = WorkspaceDb::global(cx);
+            let grouping = WorkspaceSettings::get_global(cx).project_grouping;
+            let grouping = crate::project_grouping_from_settings(grouping);
             cx.spawn_in(window, async move |this: WeakEntity<Self>, cx| {
                 let Some(fs) = fs else { return };
                 let workspaces = db
-                    .recent_project_workspaces(fs.as_ref())
+                    .recent_project_workspaces_with_grouping(fs.as_ref(), grouping)
                     .await
                     .log_err()
                     .unwrap_or_default();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -96,8 +96,8 @@ pub use persistence::{
 use persistence::{SerializedWindowBounds, model::SerializedWorkspace};
 use postage::stream::Stream;
 use project::{
-    DirectoryLister, Project, ProjectEntryId, ProjectPath, ResolvedPath, Worktree, WorktreeId,
-    WorktreeSettings,
+    DirectoryLister, Project, ProjectEntryId, ProjectGrouping as ProjectGroupingPolicy, ProjectPath,
+    ResolvedPath, Worktree, WorktreeId, WorktreeSettings,
     debugger::{breakpoint_store::BreakpointStoreEvent, session::ThreadStatus},
     project_settings::ProjectSettings,
     toolchain_store::ToolchainStoreEvent,
@@ -155,7 +155,7 @@ use util::{
 };
 use uuid::Uuid;
 pub use workspace_settings::{
-    AutosaveSetting, BottomDockLayout, EncodingDisplayOptions, FocusFollowsMouse,
+    AutosaveSetting, BottomDockLayout, EncodingDisplayOptions, FocusFollowsMouse, ProjectGrouping,
     RestoreOnStartupBehavior, StatusBarSettings, TabBarSettings, WorkspaceSettings,
 };
 use zed_actions::{Spawn, feedback::FileBugReport, theme::ToggleMode};
@@ -1467,6 +1467,13 @@ pub enum OpenMode {
     Activate,
 }
 
+pub fn project_grouping_from_settings(value: ProjectGrouping) -> ProjectGroupingPolicy {
+    match value {
+        ProjectGrouping::Repository => ProjectGroupingPolicy::Repository,
+        ProjectGrouping::Worktree => ProjectGroupingPolicy::Worktree,
+    }
+}
+
 impl Workspace {
     pub fn new(
         workspace_id: Option<WorkspaceId>,
@@ -2153,7 +2160,11 @@ impl Workspace {
     }
 
     pub fn project_group_key(&self, cx: &App) -> ProjectGroupKey {
-        self.project.read(cx).project_group_key(cx)
+        let grouping = WorkspaceSettings::get_global(cx).project_grouping;
+        let grouping = project_grouping_from_settings(grouping);
+        self.project
+            .read(cx)
+            .project_group_key_with_grouping(grouping, cx)
     }
 
     pub fn weak_handle(&self) -> WeakEntity<Self> {
@@ -9203,8 +9214,13 @@ impl WorkspaceHandle for Entity<Workspace> {
 pub async fn last_opened_workspace_location(
     db: &WorkspaceDb,
     fs: &dyn fs::Fs,
+    cx: &mut AsyncApp,
 ) -> Option<(WorkspaceId, SerializedWorkspaceLocation, PathList)> {
-    db.last_workspace(fs)
+    let grouping = cx.update(|cx| {
+        let grouping = WorkspaceSettings::get_global(cx).project_grouping;
+        project_grouping_from_settings(grouping)
+    });
+    db.last_workspace_with_grouping(fs, grouping)
         .await
         .log_err()
         .flatten()
@@ -9314,28 +9330,39 @@ pub async fn apply_restored_multiworkspace_state(
         ..
     } = state;
 
+    let grouping = cx.update(|cx| {
+        let grouping = WorkspaceSettings::get_global(cx).project_grouping;
+        project_grouping_from_settings(grouping)
+    });
+
     if !project_groups.is_empty() {
-        // Resolve linked worktree paths to their main repo paths so
-        // stale keys from previous sessions get normalized and deduped.
+        // In repository mode, resolve linked worktree paths to their main repo
+        // paths so stale keys from previous sessions get normalized and deduped.
+        // In worktree mode, preserve the serialized project group paths as-is.
         let mut resolved_groups: Vec<SerializedProjectGroupState> = Vec::new();
         for serialized in project_groups.iter().cloned() {
             let SerializedProjectGroupState { key, expanded } = serialized.into_restored_state();
             if key.path_list().paths().is_empty() {
                 continue;
             }
-            let mut resolved_paths = Vec::new();
-            for path in key.path_list().paths() {
-                if key.host().is_none()
-                    && let Some(common_dir) =
-                        project::discover_root_repo_common_dir(path, fs.as_ref()).await
-                {
-                    let main_path = project::repo_identity_path(&common_dir);
-                    resolved_paths.push(main_path.to_path_buf());
-                } else {
-                    resolved_paths.push(path.to_path_buf());
+            let resolved = match grouping {
+                ProjectGroupingPolicy::Repository => {
+                    let mut resolved_paths = Vec::new();
+                    for path in key.path_list().paths() {
+                        if key.host().is_none()
+                            && let Some(common_dir) =
+                                project::discover_root_repo_common_dir(path, fs.as_ref()).await
+                        {
+                            let main_path = project::repo_identity_path(&common_dir);
+                            resolved_paths.push(main_path.to_path_buf());
+                        } else {
+                            resolved_paths.push(path.to_path_buf());
+                        }
+                    }
+                    ProjectGroupKey::new(key.host(), PathList::new(&resolved_paths))
                 }
-            }
-            let resolved = ProjectGroupKey::new(key.host(), PathList::new(&resolved_paths));
+                ProjectGroupingPolicy::Worktree => key,
+            };
             if !resolved_groups.iter().any(|g| g.key == resolved) {
                 resolved_groups.push(SerializedProjectGroupState {
                     key: resolved,

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -6,11 +6,11 @@ use serde::Deserialize;
 use settings::CommandAliasTarget;
 pub use settings::{
     AutosaveSetting, BottomDockLayout, EncodingDisplayOptions, InactiveOpacity,
-    PaneSplitDirectionHorizontal, PaneSplitDirectionVertical, RegisterSetting,
+    PaneSplitDirectionHorizontal, PaneSplitDirectionVertical, ProjectGrouping, RegisterSetting,
     RestoreOnStartupBehavior, Settings,
 };
 
-#[derive(RegisterSetting)]
+#[derive(Clone, RegisterSetting)]
 pub struct WorkspaceSettings {
     pub active_pane_modifiers: ActivePanelModifiers,
     pub bottom_dock_layout: settings::BottomDockLayout,
@@ -23,6 +23,7 @@ pub struct WorkspaceSettings {
     pub restore_on_startup: settings::RestoreOnStartupBehavior,
     pub cli_default_open_behavior: settings::CliDefaultOpenBehavior,
     pub default_open_behavior: settings::DefaultOpenBehavior,
+    pub project_grouping: settings::ProjectGrouping,
     pub restore_on_file_reopen: bool,
     pub drop_target_size: f32,
     pub use_system_path_prompts: bool,
@@ -104,6 +105,7 @@ impl Settings for WorkspaceSettings {
             restore_on_startup: workspace.restore_on_startup.unwrap(),
             cli_default_open_behavior: workspace.cli_default_open_behavior.unwrap(),
             default_open_behavior: workspace.default_open_behavior.unwrap(),
+            project_grouping: workspace.project_grouping.unwrap(),
             restore_on_file_reopen: workspace.restore_on_file_reopen.unwrap(),
             drop_target_size: workspace.drop_target_size.unwrap(),
             use_system_path_prompts: workspace.use_system_path_prompts.unwrap(),

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -359,9 +359,7 @@ fn main() {
 
     let (open_listener, mut open_rx) = OpenListener::new();
 
-    let failed_single_instance_check = if *zed_env_vars::ZED_STATELESS
-        || *release_channel::RELEASE_CHANNEL == ReleaseChannel::Dev
-    {
+    let failed_single_instance_check = if *zed_env_vars::ZED_STATELESS {
         false
     } else {
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -1696,7 +1694,7 @@ pub(crate) async fn restorable_workspace_locations(
 
     match restore_behavior {
         workspace::RestoreOnStartupBehavior::LastWorkspace => {
-            workspace::last_opened_workspace_location(&db, app_state.fs.as_ref())
+            workspace::last_opened_workspace_location(&db, app_state.fs.as_ref(), cx)
                 .await
                 .map(|(workspace_id, location, paths)| {
                     vec![SessionWorkspace {


### PR DESCRIPTION
Adds a new global setting `project_grouping` that controls whether projects in the workspace sidebar are grouped by the main Git repository they belong to (`repository`, default) or by the actual opened worktree root folder (`worktree`).

When set to `worktree`, separate Git worktrees no longer collapse into a single project group. This affects the workspace sidebar, recent projects, workspace restore, and agent thread metadata.

Changes:
- Added `ProjectGrouping` enum to settings and workspace settings
- Added `project::ProjectGrouping` and setting-aware `ProjectGroupKey` construction
- Updated `Workspace::project_group_key`, `MultiWorkspace` re-keying, and persistence identity resolution to respect the setting
- Made workspace restore normalization conditional so worktree-mode preserves serialized paths
- Updated recent projects, history, welcome, and agent UI call sites
- Added repository-mode and worktree-mode tests in `multi_workspace_tests.rs` and `persistence.rs`

Release Notes:

- Added a `project_grouping` setting that lets users group projects by repository or by opened worktree root