### PR TITLE
Fix regression of main window dragging on Windows

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -377,8 +377,10 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut App) -> WindowO
         focus: false,
         show: false,
         kind: WindowKind::Normal,
-        // Zed handles window movement itself, so disable AppKit's titlebar dragging.
-        is_movable: false,
+        // On macOS, Zed handles window movement itself, so disable AppKit's titlebar dragging.
+        // On other platforms, `is_movable` gates native window dragging (e.g. Windows'
+        // `HTCAPTION` hit test), so it must remain `true`.
+        is_movable: cfg!(not(target_os = "macos")),
         display_id: display.map(|display| display.id()),
         window_background: cx.theme().window_background_appearance(),
         app_id: Some(app_id.to_owned()),


### PR DESCRIPTION
## Summary
This PR fixes the issue with main Zed window which cannot be moved by dragging the title bar on Windows.

## Root cause 

`is_movable: false` was set for macOS but breaks Windows
`crates/zed/src/zed.rs:381` sets `is_movable: false` for the main window, introduced by commit `ec7c11c65c` (PR #59836) to fix macOS 27 Beta titlebar click delays. The comment says "disable AppKit's titlebar dragging", but the setting applies to all platforms, including Windows.

## Why it breaks on Windows

On Windows, window dragging relies on `WM_NCHITTEST` returning `HTCAPTION`, not `start_window_move()` (which is an empty no-op on Windows - `crates/gpui/src/platform.rs:703`, never overridden in `gpui_windows`).
The hit test at `crates/gpui_windows/src/events.rs:903-904` gates `HTCAPTION` on `is_movable`:

```rust
WindowControlArea::Drag if self.is_movable => Some(HTCAPTION as _),
WindowControlArea::Drag => None,
```

Since `is_movable` is false, `HTCAPTION` is never returned, the title bar is treated as client area (`HTCLIENT`), mouse events go to gpui's `on_mouse_move` handler (`crates/platform_title_bar/src/platform_title_bar.rs:218`), which calls `window.start_window_move()`, which does nothing on Windows.

On macOS this works because `start_window_move()` IS implemented (`crates/gpui_macos/src/window.rs:1801`, using `performWindowDragWithEvent`).

## Test
The fix was successfully built and tested on Windows 11 platform.

---

Release Notes:

- N/A