### PR TITLE
git: Use version control colors in diff hunk line numbers

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -100,6 +100,9 @@ use workspace::{
 struct LineHighlightSpec {
     selection: bool,
     breakpoint: bool,
+    added: bool,
+    deleted: bool,
+    modified: bool,
     _active_stack_frame: bool,
 }
 
@@ -2727,12 +2730,17 @@ impl EditorElement {
 
                 let color = active_rows
                     .get(&display_row)
-                    .map(|spec| {
-                        if spec.breakpoint {
-                            cx.theme().colors().debugger_accent
-                        } else {
-                            cx.theme().colors().editor_active_line_number
+                    .map(|spec| match spec {
+                        LineHighlightSpec {
+                            breakpoint: true, ..
+                        } => cx.theme().colors().debugger_accent,
+                        LineHighlightSpec { added: true, .. } => {
+                            cx.theme().colors().version_control_added
                         }
+                        LineHighlightSpec { deleted: true, .. } => {
+                            cx.theme().colors().version_control_deleted
+                        }
+                        _ => cx.theme().colors().editor_active_line_number,
                     })
                     .unwrap_or_else(|| cx.theme().colors().editor_line_number);
                 let shaped_line =
@@ -8179,48 +8187,6 @@ impl Element for EditorElement {
                     let drag_highlight_color = colors.editor_active_line_background;
                     let drag_border_color = colors.border_focused;
 
-                    for (ix, row_info) in row_infos.iter().enumerate() {
-                        let Some(diff_status) = row_info.diff_status else {
-                            continue;
-                        };
-
-                        let diff_hunk_colors = match diff_status.kind {
-                            DiffHunkStatusKind::Added => &added_diff_hunk_colors,
-                            DiffHunkStatusKind::Deleted => &deleted_diff_hunk_colors,
-                            DiffHunkStatusKind::Modified => {
-                                debug_panic!("modified diff status for row info");
-                                continue;
-                            }
-                        };
-
-                        let hollow_highlight = LineHighlight {
-                            background: diff_hunk_colors.hollow_background.into(),
-                            border: Some(diff_hunk_colors.hollow_border),
-                            include_gutter: true,
-                            type_id: None,
-                        };
-
-                        let filled_highlight = LineHighlight {
-                            background: solid_background(diff_hunk_colors.filled_background),
-                            border: None,
-                            include_gutter: true,
-                            type_id: None,
-                        };
-
-                        let background = if self.diff_hunk_hollow(diff_status, cx) {
-                            hollow_highlight
-                        } else {
-                            filled_highlight
-                        };
-
-                        let base_display_point =
-                            DisplayPoint::new(start_row + DisplayRow(ix as u32), 0);
-
-                        highlighted_rows
-                            .entry(base_display_point.row())
-                            .or_insert(background);
-                    }
-
                     // Add diff review drag selection highlight to text area
                     if let Some(drag_state) = &self.editor.read(cx).diff_review_drag_state {
                         let range = drag_state.row_range(&snapshot.display_snapshot);
@@ -8355,6 +8321,55 @@ impl Element for EditorElement {
                             window,
                             cx,
                         );
+
+                    for (ix, row_info) in row_infos.iter().enumerate() {
+                        let Some(diff_status) = row_info.diff_status else {
+                            continue;
+                        };
+
+                        let diff_hunk_colors = match diff_status.kind {
+                            DiffHunkStatusKind::Added => &added_diff_hunk_colors,
+                            DiffHunkStatusKind::Deleted => &deleted_diff_hunk_colors,
+                            DiffHunkStatusKind::Modified => {
+                                debug_panic!("modified diff status for row info");
+                                continue;
+                            }
+                        };
+
+                        let hollow_highlight = LineHighlight {
+                            background: diff_hunk_colors.hollow_background.into(),
+                            border: Some(diff_hunk_colors.hollow_border),
+                            include_gutter: true,
+                            type_id: None,
+                        };
+
+                        let filled_highlight = LineHighlight {
+                            background: solid_background(diff_hunk_colors.filled_background),
+                            border: None,
+                            include_gutter: true,
+                            type_id: None,
+                        };
+
+                        let background = if self.diff_hunk_hollow(diff_status, cx) {
+                            hollow_highlight
+                        } else {
+                            filled_highlight
+                        };
+
+                        let base_display_point =
+                            DisplayPoint::new(start_row + DisplayRow(ix as u32), 0);
+
+                        highlighted_rows
+                            .entry(base_display_point.row())
+                            .or_insert(background);
+
+                        let spec = active_rows.entry(base_display_point.row()).or_default();
+                        match diff_status.kind {
+                            DiffHunkStatusKind::Added => spec.added = true,
+                            DiffHunkStatusKind::Deleted => spec.deleted = true,
+                            DiffHunkStatusKind::Modified => spec.modified = true,
+                        }
+                    }
 
                     // relative rows are based on newest selection, even outside the visible area
                     let current_selection_head = self.editor.update(cx, |editor, cx| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -102,7 +102,6 @@ struct LineHighlightSpec {
     breakpoint: bool,
     added: bool,
     deleted: bool,
-    modified: bool,
     _active_stack_frame: bool,
 }
 
@@ -8365,9 +8364,13 @@ impl Element for EditorElement {
 
                         let spec = active_rows.entry(base_display_point.row()).or_default();
                         match diff_status.kind {
+                            DiffHunkStatusKind::Deleted => spec.deleted = true,
                             DiffHunkStatusKind::Added => spec.added = true,
                             DiffHunkStatusKind::Deleted => spec.deleted = true,
-                            DiffHunkStatusKind::Modified => spec.modified = true,
+                            DiffHunkStatusKind::Modified => {
+                                debug_panic!("modified diff status for row info");
+                                continue;
+                            }
                         }
                     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -103,6 +103,40 @@ struct LineHighlightSpec {
     _active_stack_frame: bool,
 }
 
+enum LineNumberStyle {
+    Breakpoint,
+    DiffAdded,
+    DiffDeleted,
+    Active,
+    Inactive,
+}
+
+impl LineNumberStyle {
+    fn new(is_active: bool, is_breakpoint: bool, diff_status: Option<DiffHunkStatus>) -> Self {
+        match (
+            is_active,
+            is_breakpoint,
+            diff_status.map(|status| status.kind),
+        ) {
+            (_, true, _) => Self::Breakpoint,
+            (true, _, _) => Self::Active,
+            (_, _, Some(DiffHunkStatusKind::Added)) => Self::DiffAdded,
+            (_, _, Some(DiffHunkStatusKind::Deleted)) => Self::DiffDeleted,
+            (_, _, _) => Self::Inactive,
+        }
+    }
+
+    fn color(self, colors: &theme::ThemeColors) -> Hsla {
+        match self {
+            Self::Breakpoint => colors.debugger_accent,
+            Self::DiffAdded => colors.version_control_added,
+            Self::DiffDeleted => colors.version_control_deleted,
+            Self::Active => colors.editor_active_line_number,
+            Self::Inactive => colors.editor_line_number,
+        }
+    }
+}
+
 #[derive(Debug)]
 struct SelectionLayout {
     head: DisplayPoint,
@@ -2725,32 +2759,13 @@ impl EditorElement {
                 let number = relative_number.unwrap_or(&non_relative_number);
                 write!(&mut line_number, "{number}").unwrap();
 
-                let colors = cx.theme().colors();
                 let spec = active_rows.get(&display_row);
-                let color = match (spec, row_info.diff_status) {
-                    (
-                        Some(LineHighlightSpec {
-                            breakpoint: true, ..
-                        }),
-                        _,
-                    ) => colors.debugger_accent,
-                    (
-                        _,
-                        Some(DiffHunkStatus {
-                            kind: DiffHunkStatusKind::Added,
-                            ..
-                        }),
-                    ) => colors.version_control_added,
-                    (
-                        _,
-                        Some(DiffHunkStatus {
-                            kind: DiffHunkStatusKind::Deleted,
-                            ..
-                        }),
-                    ) => colors.version_control_deleted,
-                    (Some(_), _) => colors.editor_active_line_number,
-                    (_, _) => colors.editor_line_number,
-                };
+                let color = LineNumberStyle::new(
+                    spec.is_some(),
+                    spec.is_some_and(|spec| spec.breakpoint),
+                    row_info.diff_status,
+                )
+                .color(cx.theme().colors());
 
                 let shaped_line =
                     self.shape_line_number(SharedString::from(&line_number), color, window);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -100,8 +100,6 @@ use workspace::{
 struct LineHighlightSpec {
     selection: bool,
     breakpoint: bool,
-    added: bool,
-    deleted: bool,
     _active_stack_frame: bool,
 }
 
@@ -2727,21 +2725,33 @@ impl EditorElement {
                 let number = relative_number.unwrap_or(&non_relative_number);
                 write!(&mut line_number, "{number}").unwrap();
 
-                let color = active_rows
-                    .get(&display_row)
-                    .map(|spec| match spec {
-                        LineHighlightSpec {
+                let colors = cx.theme().colors();
+                let spec = active_rows.get(&display_row);
+                let color = match (spec, row_info.diff_status) {
+                    (
+                        Some(LineHighlightSpec {
                             breakpoint: true, ..
-                        } => cx.theme().colors().debugger_accent,
-                        LineHighlightSpec { added: true, .. } => {
-                            cx.theme().colors().version_control_added
-                        }
-                        LineHighlightSpec { deleted: true, .. } => {
-                            cx.theme().colors().version_control_deleted
-                        }
-                        _ => cx.theme().colors().editor_active_line_number,
-                    })
-                    .unwrap_or_else(|| cx.theme().colors().editor_line_number);
+                        }),
+                        _,
+                    ) => colors.debugger_accent,
+                    (
+                        _,
+                        Some(DiffHunkStatus {
+                            kind: DiffHunkStatusKind::Added,
+                            ..
+                        }),
+                    ) => colors.version_control_added,
+                    (
+                        _,
+                        Some(DiffHunkStatus {
+                            kind: DiffHunkStatusKind::Deleted,
+                            ..
+                        }),
+                    ) => colors.version_control_deleted,
+                    (Some(_), _) => colors.editor_active_line_number,
+                    (_, _) => colors.editor_line_number,
+                };
+
                 let shaped_line =
                     self.shape_line_number(SharedString::from(&line_number), color, window);
                 let scroll_top =
@@ -8186,6 +8196,48 @@ impl Element for EditorElement {
                     let drag_highlight_color = colors.editor_active_line_background;
                     let drag_border_color = colors.border_focused;
 
+                    for (ix, row_info) in row_infos.iter().enumerate() {
+                        let Some(diff_status) = row_info.diff_status else {
+                            continue;
+                        };
+
+                        let diff_hunk_colors = match diff_status.kind {
+                            DiffHunkStatusKind::Added => &added_diff_hunk_colors,
+                            DiffHunkStatusKind::Deleted => &deleted_diff_hunk_colors,
+                            DiffHunkStatusKind::Modified => {
+                                debug_panic!("modified diff status for row info");
+                                continue;
+                            }
+                        };
+
+                        let hollow_highlight = LineHighlight {
+                            background: diff_hunk_colors.hollow_background.into(),
+                            border: Some(diff_hunk_colors.hollow_border),
+                            include_gutter: true,
+                            type_id: None,
+                        };
+
+                        let filled_highlight = LineHighlight {
+                            background: solid_background(diff_hunk_colors.filled_background),
+                            border: None,
+                            include_gutter: true,
+                            type_id: None,
+                        };
+
+                        let background = if self.diff_hunk_hollow(diff_status, cx) {
+                            hollow_highlight
+                        } else {
+                            filled_highlight
+                        };
+
+                        let base_display_point =
+                            DisplayPoint::new(start_row + DisplayRow(ix as u32), 0);
+
+                        highlighted_rows
+                            .entry(base_display_point.row())
+                            .or_insert(background);
+                    }
+
                     // Add diff review drag selection highlight to text area
                     if let Some(drag_state) = &self.editor.read(cx).diff_review_drag_state {
                         let range = drag_state.row_range(&snapshot.display_snapshot);
@@ -8320,59 +8372,6 @@ impl Element for EditorElement {
                             window,
                             cx,
                         );
-
-                    for (ix, row_info) in row_infos.iter().enumerate() {
-                        let Some(diff_status) = row_info.diff_status else {
-                            continue;
-                        };
-
-                        let diff_hunk_colors = match diff_status.kind {
-                            DiffHunkStatusKind::Added => &added_diff_hunk_colors,
-                            DiffHunkStatusKind::Deleted => &deleted_diff_hunk_colors,
-                            DiffHunkStatusKind::Modified => {
-                                debug_panic!("modified diff status for row info");
-                                continue;
-                            }
-                        };
-
-                        let hollow_highlight = LineHighlight {
-                            background: diff_hunk_colors.hollow_background.into(),
-                            border: Some(diff_hunk_colors.hollow_border),
-                            include_gutter: true,
-                            type_id: None,
-                        };
-
-                        let filled_highlight = LineHighlight {
-                            background: solid_background(diff_hunk_colors.filled_background),
-                            border: None,
-                            include_gutter: true,
-                            type_id: None,
-                        };
-
-                        let background = if self.diff_hunk_hollow(diff_status, cx) {
-                            hollow_highlight
-                        } else {
-                            filled_highlight
-                        };
-
-                        let base_display_point =
-                            DisplayPoint::new(start_row + DisplayRow(ix as u32), 0);
-
-                        highlighted_rows
-                            .entry(base_display_point.row())
-                            .or_insert(background);
-
-                        let spec = active_rows.entry(base_display_point.row()).or_default();
-                        match diff_status.kind {
-                            DiffHunkStatusKind::Deleted => spec.deleted = true,
-                            DiffHunkStatusKind::Added => spec.added = true,
-                            DiffHunkStatusKind::Deleted => spec.deleted = true,
-                            DiffHunkStatusKind::Modified => {
-                                debug_panic!("modified diff status for row info");
-                                continue;
-                            }
-                        }
-                    }
 
                     // relative rows are based on newest selection, even outside the visible area
                     let current_selection_head = self.editor.update(cx, |editor, cx| {


### PR DESCRIPTION
# Objective

When diff hunks are expanded, reading the line numbers can be a little hard due to the contrast between `editor.line_number` and both `editor.diff_hunk.deleted.background` and `editor.diff_hunk.added.background`. In order to make it easier for these line numbers to stand out, the actual `version_control` colors, respective to each diff hunk, can be used to color the line number.

## Solution

Luckily, the line numbers color was already dynamically decided on `EditorElement::layout_line_numbers` depending on whether the line had a breakpoint or it was active (part of a selection). The information on whether the row for which the line was being laid out belonged to a diff hunk is also already available on the `Gutter::row_infos`.

As such, this change was easy to achieve by simply updating `EditorElement::layout_line_numbers` to take into consideration each row's `RowInfo::diff_status` and mapping each status to a `version_control` color, ignoring the `Modified` variant, as that should never happen.

## Testing

Manually tested against a repository that has added, deleted and modified changes. Differences can be seen in the `Showcase` section.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Before</summary>
  
  <img width="2744" height="2994" alt="version_control_line_numbers_before" src="https://github.com/user-attachments/assets/75d160a7-e0cc-4c9d-8fdd-4cab5cc6eefb" />
</details>

<details>
  <summary>After</summary>

  <img width="2744" height="2994" alt="version_control_line_numbers_after" src="https://github.com/user-attachments/assets/887fdb6a-34c6-4331-b750-4d3bea6fcd77" />
</details>
---

Release Notes:

- Improved line number colors in diff hunks to match the version control colors
