### PR TITLE
agent: Rebuild AWS Bedrock client on expired credential error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9792,7 +9792,6 @@ dependencies = [
  "ai_onboarding",
  "anthropic",
  "anyhow",
- "async-lock",
  "aws-config",
  "aws-credential-types",
  "aws_http_client",

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/language_models.rs"
 
 [dependencies]
 ai_onboarding.workspace = true
-async-lock.workspace = true
 anthropic = { workspace = true, features = ["schemars"] }
 anyhow.workspace = true
 aws-config = { workspace = true, features = ["behavior-version-latest"] }

--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -2,7 +2,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::{Context as _, Result, anyhow};
-use async_lock::OnceCell;
 use aws_config::stalled_stream_protection::StalledStreamProtectionConfig;
 use aws_config::{BehaviorVersion, Region};
 use aws_credential_types::{Credentials, Token};
@@ -441,7 +440,6 @@ impl BedrockLanguageModelProvider {
             http_client: self.http_client.clone(),
             handle: self.handle.clone(),
             state: self.state.clone(),
-            client: OnceCell::new(),
             request_limiter: RateLimiter::new(4),
         })
     }
@@ -544,71 +542,63 @@ struct BedrockModel {
     model: Model,
     http_client: AwsHttpClient,
     handle: tokio::runtime::Handle,
-    client: OnceCell<BedrockClient>,
     state: Entity<State>,
     request_limiter: RateLimiter,
 }
 
 impl BedrockModel {
-    fn get_or_init_client(&self, cx: &AsyncApp) -> anyhow::Result<&BedrockClient> {
-        self.client
-            .get_or_try_init_blocking(|| {
-                let (auth, endpoint, region) = cx.read_entity(&self.state, |state, _cx| {
-                    let endpoint = state.settings.as_ref().and_then(|s| s.endpoint.clone());
-                    let region = state.get_region();
-                    (state.auth.clone(), endpoint, region)
-                });
+    fn build_client(&self, cx: &AsyncApp) -> BedrockClient {
+        let (auth, endpoint, region) = cx.read_entity(&self.state, |state, _cx| {
+            let endpoint = state.settings.as_ref().and_then(|s| s.endpoint.clone());
+            let region = state.get_region();
+            (state.auth.clone(), endpoint, region)
+        });
 
-                let mut config_builder = aws_config::defaults(BehaviorVersion::latest())
-                    .stalled_stream_protection(StalledStreamProtectionConfig::disabled())
-                    .http_client(self.http_client.clone())
-                    .region(Region::new(region))
-                    .timeout_config(TimeoutConfig::disabled());
+        let mut config_builder = aws_config::defaults(BehaviorVersion::latest())
+            .stalled_stream_protection(StalledStreamProtectionConfig::disabled())
+            .http_client(self.http_client.clone())
+            .region(Region::new(region))
+            .timeout_config(TimeoutConfig::disabled());
 
-                if let Some(endpoint_url) = endpoint
-                    && !endpoint_url.is_empty()
-                {
-                    config_builder = config_builder.endpoint_url(endpoint_url);
+        if let Some(endpoint_url) = endpoint
+            && !endpoint_url.is_empty()
+        {
+            config_builder = config_builder.endpoint_url(endpoint_url);
+        }
+
+        match auth {
+            Some(BedrockAuth::Automatic) | None => {
+                // Use default AWS credential provider chain
+            }
+            Some(BedrockAuth::NamedProfile { profile_name })
+            | Some(BedrockAuth::SingleSignOn { profile_name }) => {
+                if !profile_name.is_empty() {
+                    config_builder = config_builder.profile_name(profile_name);
                 }
+            }
+            Some(BedrockAuth::IamCredentials {
+                access_key_id,
+                secret_access_key,
+                session_token,
+            }) => {
+                let aws_creds = Credentials::new(
+                    access_key_id,
+                    secret_access_key,
+                    session_token,
+                    None,
+                    "zed-bedrock-provider",
+                );
+                config_builder = config_builder.credentials_provider(aws_creds);
+            }
+            Some(BedrockAuth::ApiKey { api_key }) => {
+                config_builder = config_builder
+                    .auth_scheme_preference(["httpBearerAuth".into()]) // https://github.com/smithy-lang/smithy-rs/pull/4241
+                    .token_provider(Token::new(api_key, None));
+            }
+        }
 
-                match auth {
-                    Some(BedrockAuth::Automatic) | None => {
-                        // Use default AWS credential provider chain
-                    }
-                    Some(BedrockAuth::NamedProfile { profile_name })
-                    | Some(BedrockAuth::SingleSignOn { profile_name }) => {
-                        if !profile_name.is_empty() {
-                            config_builder = config_builder.profile_name(profile_name);
-                        }
-                    }
-                    Some(BedrockAuth::IamCredentials {
-                        access_key_id,
-                        secret_access_key,
-                        session_token,
-                    }) => {
-                        let aws_creds = Credentials::new(
-                            access_key_id,
-                            secret_access_key,
-                            session_token,
-                            None,
-                            "zed-bedrock-provider",
-                        );
-                        config_builder = config_builder.credentials_provider(aws_creds);
-                    }
-                    Some(BedrockAuth::ApiKey { api_key }) => {
-                        config_builder = config_builder
-                            .auth_scheme_preference(["httpBearerAuth".into()]) // https://github.com/smithy-lang/smithy-rs/pull/4241
-                            .token_provider(Token::new(api_key, None));
-                    }
-                }
-
-                let config = self.handle.block_on(config_builder.load());
-
-                anyhow::Ok(BedrockClient::new(&config))
-            })
-            .context("initializing Bedrock client")?;
-
-        self.client.get().context("Bedrock client not initialized")
+        let config = self.handle.block_on(config_builder.load());
+        BedrockClient::new(&config)
     }
 
     fn stream_completion(
@@ -619,14 +609,7 @@ impl BedrockModel {
         'static,
         Result<BoxStream<'static, Result<BedrockStreamingResponse, anyhow::Error>>, BedrockError>,
     > {
-        let Ok(runtime_client) = self
-            .get_or_init_client(cx)
-            .cloned()
-            .context("Bedrock client not initialized")
-        else {
-            return futures::future::ready(Err(BedrockError::Other(anyhow!("App state dropped"))))
-                .boxed();
-        };
+        let runtime_client = self.build_client(cx);
         let extra_headers = self.state.read_with(cx, |_, cx| {
             AllLanguageModelSettings::get_global(cx)
                 .bedrock


### PR DESCRIPTION
# Objective

- Zed requires a full quit and restart after the Bedrock credentials expire when using named_profile authentication. This PR should remove the need to do the full quit and restart.
- Fixes #50953
- Step toward future auto refresh token hook: https://github.com/zed-industries/zed/discussions/45707

## Solution

Currently, the bedrock client reads from `~/.aws/credentials` and is the client cached indefinitely. This PR allows clearing the cached client on an expired credential error. This allows the existing agent retry process to build a fresh client fetching fresh credentials from `~/.aws/credentials` while retrying the request.

## Testing

- Did you test these changes? If so, how?
There is no real framework to test the bedrock specific behavior.
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
1. Configure with bedrock agent with `"authentication_method": "named_profile"`.
2. Have a valid token for named profile on startup. Agent requests should execute.
3. Expire token. Agent requests should attempt to retry.
4. Regenerate token. Agent retries or subsequent requests should succeed.

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---

Release Notes:

- Improved AWS Bedrock expired token handling with named_profile
