### PR TITLE
vim: Fix Helix cursor position when deleting to end of line

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -2340,7 +2340,6 @@ mod test {
         );
     }
 
-    // Regression test for https://github.com/zed-industries/zed/issues/58702.
     // Deleting a selection that ends at the last non-newline character should
     // leave the cursor on the newline (matching Helix), not clamp it onto the
     // character to the left of the selection.
@@ -3011,7 +3010,7 @@ mod test {
         cx.assert_state("ˇ\nfox jumps over", Mode::HelixNormal);
 
         // same from the middle of a line — the cursor rests on the trailing
-        // newline, matching Helix and the whole-line case above (see #58702)
+        // newline, matching Helix and the whole-line case above.
         cx.set_state("The ˇquick brown\nfox jumps over", Mode::HelixNormal);
         cx.simulate_keystrokes("v g l d");
         cx.assert_state("The ˇ\nfox jumps over", Mode::HelixNormal);

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -2340,6 +2340,32 @@ mod test {
         );
     }
 
+    // Regression test for https://github.com/zed-industries/zed/issues/58702.
+    // Deleting a selection that ends at the last non-newline character should
+    // leave the cursor on the newline (matching Helix), not clamp it onto the
+    // character to the left of the selection.
+    #[gpui::test]
+    async fn test_delete_to_end_of_line_keeps_cursor_on_newline(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        cx.set_state(
+            indoc! {"
+            ab«cdefgˇ»
+            hij"},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("d");
+
+        cx.assert_state(
+            indoc! {"
+            abˇ
+            hij"},
+            Mode::HelixNormal,
+        );
+    }
+
     // #[gpui::test]
     // async fn test_delete_character_end_of_buffer(cx: &mut gpui::TestAppContext) {
     //     let mut cx = VimTestContext::new(cx, true).await;
@@ -2984,11 +3010,11 @@ mod test {
         cx.simulate_keystrokes("v g l d");
         cx.assert_state("ˇ\nfox jumps over", Mode::HelixNormal);
 
-        // same from the middle of a line — cursor lands on the last
-        // remaining character (the space) after delete
+        // same from the middle of a line — the cursor rests on the trailing
+        // newline, matching Helix and the whole-line case above (see #58702)
         cx.set_state("The ˇquick brown\nfox jumps over", Mode::HelixNormal);
         cx.simulate_keystrokes("v g l d");
-        cx.assert_state("Theˇ \nfox jumps over", Mode::HelixNormal);
+        cx.assert_state("The ˇ\nfox jumps over", Mode::HelixNormal);
     }
 
     #[gpui::test]

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -695,8 +695,9 @@ impl Vim {
                 }
                 editor.delete_selections_with_linked_edits(window, cx);
 
-                // Fixup cursor position after the deletion
-                editor.set_clip_at_line_ends(true, cx);
+                // Fixup cursor position after the deletion. Helix keeps the
+                // cursor on the trailing newline, so only clip in Vim modes.
+                editor.set_clip_at_line_ends(!vim.mode.is_helix(), cx);
                 editor.change_selections(Default::default(), window, cx, |s| {
                     s.move_with(&mut |map, selection| {
                         let mut cursor = selection.head().to_point(map);


### PR DESCRIPTION
## Why / What

Fixes #58702.

In Helix mode the block cursor is a one-character selection that can rest on the
trailing newline at the end of a line. When you select to the end of a line
(excluding the newline) and press `d`, Helix leaves the cursor on the newline.
Zed instead clamped the cursor onto the character immediately to the left of the
deleted selection.

The shared `visual_delete` always re-clipped the post-deletion cursor at line
ends (`set_clip_at_line_ends(true)`), which is correct for Vim normal mode but
contradicts Helix mode, where `Vim::clip_at_line_ends()` is `false`. This also
made Helix inconsistent with itself: deleting a whole line left the cursor on the
newline, but deleting to the end of a non-empty line clamped it onto the previous
character. The fix honors the active mode's clip policy, so Helix keeps the
cursor on the newline.

## Testing

- Added `test_delete_to_end_of_line_keeps_cursor_on_newline` reproducing #58702.
- Corrected `test_helix_select_end_of_line`; its mid-line assertion had captured
  the pre-fix (clamped) cursor position. Its whole-line assertion already
  expected the cursor on the newline, so the test is now internally consistent.
- `cargo test -p vim`: 540 passed, 0 failed.
- Vim visual-mode delete is unchanged (`is_helix()` is false for Vim modes).

Release Notes:

- Fixed Helix mode placing the cursor on the wrong character after deleting a selection that ends at the end of a line.
