### PR TITLE
Update prost to 0.12 and compile protos with protox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
  "rustix-openpty",
  "serde",
  "signal-hook",
- "unicode-width",
+ "unicode-width 0.2.2",
  "vte",
  "windows-sys 0.59.0",
 ]
@@ -727,7 +727,7 @@ checksum = "c86cd1c51b95d71dde52bca69ed225008f6ff4c8cc825b08042aa1ef823e1980"
 dependencies = [
  "anstyle",
  "memchr",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1417,7 +1417,7 @@ dependencies = [
  "smol",
  "tempfile",
  "util",
- "which 6.0.3",
+ "which",
  "workspace",
  "zlog",
 ]
@@ -3371,7 +3371,7 @@ checksum = "ba7a06c0b31fff5ff2e1e7d37dbf940864e2a974b336e1a2938d10af6e8fb283"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3454,7 +3454,7 @@ dependencies = [
  "project",
  "prometheus",
  "prompt_store",
- "prost 0.9.0",
+ "prost",
  "rand 0.9.4",
  "recent_projects",
  "release_channel",
@@ -3712,7 +3712,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -5804,7 +5804,7 @@ dependencies = [
  "ui_input",
  "unicode-script",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unindent",
  "url",
  "util",
@@ -7192,7 +7192,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7971,7 +7971,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
- "which 6.0.3",
+ "which",
 ]
 
 [[package]]
@@ -8307,15 +8307,6 @@ checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "hash32",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -10238,7 +10229,7 @@ dependencies = [
  "livekit-runtime",
  "log",
  "parking_lot",
- "prost 0.12.6",
+ "prost",
  "semver",
  "serde",
  "serde_json",
@@ -10259,7 +10250,7 @@ dependencies = [
  "log",
  "parking_lot",
  "pbjson-types",
- "prost 0.12.6",
+ "prost",
  "rand 0.9.4",
  "reqwest 0.12.24",
  "rustls-native-certs 0.6.3",
@@ -10283,7 +10274,7 @@ dependencies = [
  "parking_lot",
  "pbjson",
  "pbjson-types",
- "prost 0.12.6",
+ "prost",
  "serde",
  "thiserror 1.0.69",
  "tokio",
@@ -10306,9 +10297,10 @@ dependencies = [
  "async-trait",
  "jsonwebtoken",
  "log",
- "prost 0.9.0",
- "prost-build 0.9.0",
- "prost-types 0.9.0",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "protox",
  "serde",
  "zed-reqwest",
 ]
@@ -10972,7 +10964,7 @@ dependencies = [
  "serde_json",
  "svgtypes 0.11.0",
  "thiserror 2.0.17",
- "unicode-width",
+ "unicode-width 0.2.2",
  "url",
 ]
 
@@ -10989,6 +10981,28 @@ dependencies = [
  "log",
  "objc",
  "paste",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -11460,7 +11474,7 @@ dependencies = [
  "smol",
  "util",
  "watch",
- "which 6.0.3",
+ "which",
 ]
 
 [[package]]
@@ -12704,8 +12718,8 @@ checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
 dependencies = [
  "heck 0.4.1",
  "itertools 0.11.0",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
@@ -12718,8 +12732,8 @@ dependencies = [
  "chrono",
  "pbjson",
  "pbjson-build",
- "prost 0.12.6",
- "prost-build 0.12.6",
+ "prost",
+ "prost-build",
  "serde",
 ]
 
@@ -14006,7 +14020,7 @@ dependencies = [
  "util",
  "watch",
  "wax",
- "which 6.0.3",
+ "which",
  "worktree",
  "zed_credentials_provider",
  "zeroize",
@@ -14190,42 +14204,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
-dependencies = [
- "bytes 1.11.1",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes 1.11.1",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
-dependencies = [
- "bytes 1.11.1",
- "heck 0.3.3",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost 0.9.0",
- "prost-types 0.9.0",
- "regex",
- "tempfile",
- "which 4.4.2",
+ "prost-derive",
 ]
 
 [[package]]
@@ -14242,24 +14226,11 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.6",
- "prost-types 0.12.6",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.117",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -14276,13 +14247,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.9.0"
+name = "prost-reflect"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+checksum = "6f5eec97d5d34bdd17ad2db2219aabf46b054c6c41bd5529767c9ce55be5898f"
 dependencies = [
- "bytes 1.11.1",
- "prost 0.9.0",
+ "logos",
+ "miette",
+ "once_cell",
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
@@ -14291,7 +14265,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost 0.12.6",
+ "prost",
 ]
 
 [[package]]
@@ -14299,8 +14273,9 @@ name = "proto"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "prost 0.9.0",
- "prost-build 0.9.0",
+ "prost",
+ "prost-build",
+ "protox",
  "serde",
 ]
 
@@ -14321,6 +14296,33 @@ version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protox"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac532509cee918d40f38c3e12f8ef9230f215f017d54de7dd975015538a42ce7"
+dependencies = [
+ "bytes 1.11.1",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6c33f43516fe397e2f930779d720ca12cd057f7da4cd6326a0ef78d69dee96"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
  "thiserror 1.0.69",
 ]
 
@@ -15058,7 +15060,7 @@ dependencies = [
  "log",
  "parking_lot",
  "paths",
- "prost 0.9.0",
+ "prost",
  "release_channel",
  "rpc",
  "schemars 1.0.4",
@@ -15072,7 +15074,7 @@ dependencies = [
  "thiserror 2.0.17",
  "urlencoding",
  "util",
- "which 6.0.3",
+ "which",
 ]
 
 [[package]]
@@ -19735,6 +19737,12 @@ checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -19885,7 +19893,7 @@ dependencies = [
  "url",
  "util_macros",
  "walkdir",
- "which 6.0.3",
+ "which",
  "windows 0.61.3",
 ]
 
@@ -21154,18 +21162,6 @@ dependencies = [
  "log",
  "raw-window-handle",
  "web-sys",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -702,9 +702,10 @@ profiling = "1"
 proptest = { git = "https://github.com/proptest-rs/proptest", rev = "3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b", features = ["attr-macro"] }
 proptest-derive = "0.8.0"
 proxyvars = "0.2"
-prost = "0.9"
-prost-build = "0.9"
-prost-types = "0.9"
+prost = "0.12"
+prost-build = "0.12"
+prost-types = "0.12"
+protox = "0.6"
 pollster = "0.4.0"
 pulldown-cmark = { version = "0.13.0", default-features = false }
 quick-xml = "0.38"

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -134,7 +134,7 @@ impl ActivityIndicator {
                             let status = match &status_update.status {
                                 Some(proto::status_update::Status::Binary(binary_status)) => {
                                     if let Some(binary_status) =
-                                        proto::ServerBinaryStatus::from_i32(*binary_status)
+                                        proto::ServerBinaryStatus::try_from(*binary_status).ok()
                                     {
                                         let binary_status = match binary_status {
                                             proto::ServerBinaryStatus::None => BinaryStatus::None,
@@ -168,7 +168,7 @@ impl ActivityIndicator {
                                 }
                                 Some(proto::status_update::Status::Health(health_status)) => {
                                     if let Some(health) =
-                                        proto::ServerHealth::from_i32(*health_status)
+                                        proto::ServerHealth::try_from(*health_status).ok()
                                     {
                                         let health = match health {
                                             proto::ServerHealth::Ok => ServerHealth::Ok,

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -863,7 +863,7 @@ impl ChannelStore {
                 );
             }
             for membership in message.payload.channel_memberships {
-                if let Some(role) = ChannelRole::from_i32(membership.role) {
+                if let Some(role) = ChannelRole::try_from(membership.role).ok() {
                     this.channel_states
                         .entry(ChannelId(membership.channel_id))
                         .or_default()

--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -620,7 +620,7 @@ impl Database {
     ) -> Result<TransactionGuard<Vec<ConnectionId>>> {
         let project_id = ProjectId::from_proto(update.project_id);
         let kind = match update.kind {
-            Some(kind) => proto::LocalSettingsKind::from_i32(kind)
+            Some(kind) => proto::LocalSettingsKind::try_from(kind).ok()
                 .with_context(|| format!("unknown worktree settings kind: {kind}"))?,
             None => proto::LocalSettingsKind::Settings,
         };

--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -620,7 +620,8 @@ impl Database {
     ) -> Result<TransactionGuard<Vec<ConnectionId>>> {
         let project_id = ProjectId::from_proto(update.project_id);
         let kind = match update.kind {
-            Some(kind) => proto::LocalSettingsKind::try_from(kind).ok()
+            Some(kind) => proto::LocalSettingsKind::try_from(kind)
+                .ok()
                 .with_context(|| format!("unknown worktree settings kind: {kind}"))?,
             None => proto::LocalSettingsKind::Settings,
         };

--- a/crates/dap/src/proto_conversions.rs
+++ b/crates/dap/src/proto_conversions.rs
@@ -55,7 +55,7 @@ impl ProtoConversion for dap_types::Scope {
     fn from_proto(payload: Self::ProtoType) -> Self {
         let presentation_hint = payload
             .presentation_hint
-            .and_then(DapScopePresentationHint::from_i32);
+            .and_then(|hint| DapScopePresentationHint::try_from(hint).ok());
         Self {
             name: payload.name,
             presentation_hint: presentation_hint.map(ScopePresentationHint::from_proto),
@@ -222,7 +222,7 @@ impl ProtoConversion for dap_types::Source {
             source_reference: payload.source_reference,
             presentation_hint: payload
                 .presentation_hint
-                .and_then(DapSourcePresentationHint::from_i32)
+                .and_then(|hint| DapSourcePresentationHint::try_from(hint).ok())
                 .map(dap_types::SourcePresentationHint::from_proto),
             origin: payload.origin,
             sources: Some(Vec::<dap_types::Source>::from_proto(payload.sources)),
@@ -401,7 +401,7 @@ impl ProtoConversion for dap_types::OutputEvent {
         Self {
             category: payload
                 .category
-                .and_then(proto::DapOutputCategory::from_i32)
+                .and_then(|category| proto::DapOutputCategory::try_from(category).ok())
                 .map(OutputEventCategory::from_proto),
             output: payload.output,
             variables_reference: payload.variables_reference,
@@ -410,7 +410,7 @@ impl ProtoConversion for dap_types::OutputEvent {
             column: payload.column.map(|column| column as u64),
             group: payload
                 .group
-                .and_then(proto::DapOutputEventGroup::from_i32)
+                .and_then(|group| proto::DapOutputEventGroup::try_from(group).ok())
                 .map(OutputEventGroup::from_proto),
             data: None,
             location_reference: None,

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -615,7 +615,7 @@ fn deserialize_anchor(anchor: proto::EditorAnchor, buffer: &MultiBufferSnapshot)
         let text_anchor = language::proto::deserialize_anchor(anchor)?;
         buffer.anchor_in_buffer(text_anchor)
     } else {
-        match proto::Bias::from_i32(anchor.bias)? {
+        match proto::Bias::try_from(anchor.bias).ok()? {
             proto::Bias::Left => Some(Anchor::Min),
             proto::Bias::Right => Some(Anchor::Max),
         }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1024,7 +1024,9 @@ impl Buffer {
         let buffer = TextBuffer::new(replica_id, buffer_id, message.base_text);
         let mut this = Self::build(buffer, file, capability);
         this.text.set_line_ending(proto::deserialize_line_ending(
-            rpc::proto::LineEnding::try_from(message.line_ending).ok().context("missing line_ending")?,
+            rpc::proto::LineEnding::try_from(message.line_ending)
+                .ok()
+                .context("missing line_ending")?,
         ));
         this.saved_version = proto::deserialize_version(&message.saved_version);
         this.saved_mtime = message.saved_mtime.map(|time| time.into());

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1024,7 +1024,7 @@ impl Buffer {
         let buffer = TextBuffer::new(replica_id, buffer_id, message.base_text);
         let mut this = Self::build(buffer, file, capability);
         this.text.set_line_ending(proto::deserialize_line_ending(
-            rpc::proto::LineEnding::from_i32(message.line_ending).context("missing line_ending")?,
+            rpc::proto::LineEnding::try_from(message.line_ending).ok().context("missing line_ending")?,
         ));
         this.saved_version = proto::deserialize_version(&message.saved_version);
         this.saved_mtime = message.saved_mtime.map(|time| time.into());

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -332,7 +332,8 @@ pub fn deserialize_operation(message: proto::Operation) -> Result<crate::Operati
                     selections: Arc::from(selections),
                     line_mode: message.line_mode,
                     cursor_shape: deserialize_cursor_shape(
-                        proto::CursorShape::from_i32(message.cursor_shape)
+                        proto::CursorShape::try_from(message.cursor_shape)
+                            .ok()
                             .context("Missing cursor shape")?,
                     ),
                 }
@@ -364,7 +365,8 @@ pub fn deserialize_operation(message: proto::Operation) -> Result<crate::Operati
                         value: message.lamport_timestamp,
                     },
                     line_ending: deserialize_line_ending(
-                        proto::LineEnding::from_i32(message.line_ending)
+                        proto::LineEnding::try_from(message.line_ending)
+                            .ok()
                             .context("missing line_ending")?,
                     ),
                 }
@@ -446,7 +448,9 @@ pub fn deserialize_diagnostics(
                 range: deserialize_anchor(diagnostic.start?)?..deserialize_anchor(diagnostic.end?)?,
                 diagnostic: Diagnostic {
                     source: diagnostic.source,
-                    severity: match proto::diagnostic::Severity::from_i32(diagnostic.severity)? {
+                    severity: match proto::diagnostic::Severity::try_from(diagnostic.severity)
+                        .ok()?
+                    {
                         proto::diagnostic::Severity::Error => DiagnosticSeverity::ERROR,
                         proto::diagnostic::Severity::Warning => DiagnosticSeverity::WARNING,
                         proto::diagnostic::Severity::Information => DiagnosticSeverity::INFORMATION,
@@ -465,9 +469,11 @@ pub fn deserialize_diagnostics(
                     is_unnecessary: diagnostic.is_unnecessary,
                     underline: diagnostic.underline,
                     registration_id: diagnostic.registration_id.map(SharedString::from),
-                    source_kind: match proto::diagnostic::SourceKind::from_i32(
+                    source_kind: match proto::diagnostic::SourceKind::try_from(
                         diagnostic.source_kind,
-                    )? {
+                    )
+                    .ok()?
+                    {
                         proto::diagnostic::SourceKind::Pulled => DiagnosticSourceKind::Pulled,
                         proto::diagnostic::SourceKind::Pushed => DiagnosticSourceKind::Pushed,
                         proto::diagnostic::SourceKind::Other => DiagnosticSourceKind::Other,
@@ -490,7 +496,7 @@ pub fn deserialize_anchor(anchor: proto::Anchor) -> Option<Anchor> {
         replica_id: ReplicaId::new(anchor.replica_id as u16),
         value: anchor.timestamp,
     };
-    let bias = match proto::Bias::from_i32(anchor.bias)? {
+    let bias = match proto::Bias::try_from(anchor.bias).ok()? {
         proto::Bias::Left => Bias::Left,
         proto::Bias::Right => Bias::Right,
     };

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -914,7 +914,7 @@ impl LspButton {
                     let Some(name) = name.as_ref() else {
                         return;
                     };
-                    if let Some(binary_status) = proto::ServerBinaryStatus::from_i32(*binary_status)
+                    if let Some(binary_status) = proto::ServerBinaryStatus::try_from(*binary_status).ok()
                     {
                         let binary_status = match binary_status {
                             proto::ServerBinaryStatus::None => BinaryStatus::None,
@@ -943,7 +943,7 @@ impl LspButton {
                     };
                 }
                 Some(proto::status_update::Status::Health(health_status)) => {
-                    if let Some(health) = proto::ServerHealth::from_i32(*health_status) {
+                    if let Some(health) = proto::ServerHealth::try_from(*health_status).ok() {
                         let health = match health {
                             proto::ServerHealth::Ok => ServerHealth::Ok,
                             proto::ServerHealth::Warning => ServerHealth::Warning,

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -914,7 +914,8 @@ impl LspButton {
                     let Some(name) = name.as_ref() else {
                         return;
                     };
-                    if let Some(binary_status) = proto::ServerBinaryStatus::try_from(*binary_status).ok()
+                    if let Some(binary_status) =
+                        proto::ServerBinaryStatus::try_from(*binary_status).ok()
                     {
                         let binary_status = match binary_status {
                             proto::ServerBinaryStatus::None => BinaryStatus::None,

--- a/crates/livekit_api/Cargo.toml
+++ b/crates/livekit_api/Cargo.toml
@@ -25,6 +25,7 @@ serde.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
+protox.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["prost-types"]

--- a/crates/livekit_api/build.rs
+++ b/crates/livekit_api/build.rs
@@ -1,4 +1,4 @@
-fn main() -> std::io::Result<()> {
+fn main() {
     println!("cargo:rerun-if-changed=vendored/protocol");
     // Compile the descriptor set with protox (a pure-Rust protobuf compiler) so
     // building Zed doesn't require a system `protoc` binary.
@@ -6,8 +6,9 @@ fn main() -> std::io::Result<()> {
         ["vendored/protocol/livekit_room.proto"],
         ["vendored/protocol"],
     )
-    .map_err(|err| std::io::Error::other(err.to_string()))?;
+    .unwrap();
     prost_build::Config::new()
         .type_attribute("SendDataResponse", "#[allow(clippy::empty_docs)]")
         .compile_fds(file_descriptors)
+        .unwrap();
 }

--- a/crates/livekit_api/build.rs
+++ b/crates/livekit_api/build.rs
@@ -1,9 +1,13 @@
-fn main() {
+fn main() -> std::io::Result<()> {
+    println!("cargo:rerun-if-changed=vendored/protocol");
+    // Compile the descriptor set with protox (a pure-Rust protobuf compiler) so
+    // building Zed doesn't require a system `protoc` binary.
+    let file_descriptors = protox::compile(
+        ["vendored/protocol/livekit_room.proto"],
+        ["vendored/protocol"],
+    )
+    .map_err(|err| std::io::Error::other(err.to_string()))?;
     prost_build::Config::new()
         .type_attribute("SendDataResponse", "#[allow(clippy::empty_docs)]")
-        .compile_protos(
-            &["vendored/protocol/livekit_room.proto"],
-            &["vendored/protocol"],
-        )
-        .unwrap();
+        .compile_fds(file_descriptors)
 }

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -1479,7 +1479,7 @@ impl BufferStore {
         let version = deserialize_version(&envelope.payload.version);
         let mtime = envelope.payload.mtime.clone().map(|time| time.into());
         let line_ending = deserialize_line_ending(
-            proto::LineEnding::from_i32(envelope.payload.line_ending)
+            proto::LineEnding::try_from(envelope.payload.line_ending).ok()
                 .context("missing line ending")?,
         );
         this.update(&mut cx, |this, cx| {

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -1479,7 +1479,8 @@ impl BufferStore {
         let version = deserialize_version(&envelope.payload.version);
         let mtime = envelope.payload.mtime.clone().map(|time| time.into());
         let line_ending = deserialize_line_ending(
-            proto::LineEnding::try_from(envelope.payload.line_ending).ok()
+            proto::LineEnding::try_from(envelope.payload.line_ending)
+                .ok()
                 .context("missing line ending")?,
         );
         this.update(&mut cx, |this, cx| {

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -1032,7 +1032,7 @@ impl Breakpoint {
 
     fn from_proto(breakpoint: client::proto::Breakpoint) -> Option<Self> {
         Some(Self {
-            state: match proto::BreakpointState::from_i32(breakpoint.state) {
+            state: match proto::BreakpointState::try_from(breakpoint.state).ok() {
                 Some(proto::BreakpointState::Disabled) => BreakpointState::Disabled,
                 None | Some(proto::BreakpointState::Enabled) => BreakpointState::Enabled,
             },

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4095,7 +4095,7 @@ impl BufferGitState {
     ) {
         use proto::update_diff_bases::Mode;
 
-        let Some(mode) = Mode::from_i32(message.mode) else {
+        let Some(mode) = Mode::try_from(message.mode).ok() else {
             return;
         };
 
@@ -8543,7 +8543,7 @@ impl Repository {
                             buffer_id: buffer_id.to_proto(),
                         })
                         .await?;
-                    let mode = Mode::from_i32(response.mode).context("Invalid mode")?;
+                    let mode = Mode::try_from(response.mode).ok().context("Invalid mode")?;
                     let bases = match mode {
                         Mode::IndexMatchesHead => DiffBasesChange::SetBoth(response.committed_text),
                         Mode::IndexAndHead => DiffBasesChange::SetEach {
@@ -10086,7 +10086,7 @@ fn status_from_proto(
     use proto::git_file_status::Variant;
 
     let Some(variant) = status.and_then(|status| status.variant) else {
-        let code = proto::GitStatus::from_i32(simple_status)
+        let code = proto::GitStatus::try_from(simple_status).ok()
             .with_context(|| format!("Invalid git status code: {simple_status}"))?;
         let result = match code {
             proto::GitStatus::Added => TrackedStatus {
@@ -10120,7 +10120,7 @@ fn status_from_proto(
         Variant::Unmerged(unmerged) => {
             let [first_head, second_head] =
                 [unmerged.first_head, unmerged.second_head].map(|head| {
-                    let code = proto::GitStatus::from_i32(head)
+                    let code = proto::GitStatus::try_from(head).ok()
                         .with_context(|| format!("Invalid git status code: {head}"))?;
                     let result = match code {
                         proto::GitStatus::Added => UnmergedStatusCode::Added,
@@ -10140,7 +10140,7 @@ fn status_from_proto(
         Variant::Tracked(tracked) => {
             let [index_status, worktree_status] = [tracked.index_status, tracked.worktree_status]
                 .map(|status| {
-                    let code = proto::GitStatus::from_i32(status)
+                    let code = proto::GitStatus::try_from(status).ok()
                         .with_context(|| format!("Invalid git status code: {status}"))?;
                     let result = match code {
                         proto::GitStatus::Modified => StatusCode::Modified,

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -10086,7 +10086,8 @@ fn status_from_proto(
     use proto::git_file_status::Variant;
 
     let Some(variant) = status.and_then(|status| status.variant) else {
-        let code = proto::GitStatus::try_from(simple_status).ok()
+        let code = proto::GitStatus::try_from(simple_status)
+            .ok()
             .with_context(|| format!("Invalid git status code: {simple_status}"))?;
         let result = match code {
             proto::GitStatus::Added => TrackedStatus {
@@ -10120,7 +10121,8 @@ fn status_from_proto(
         Variant::Unmerged(unmerged) => {
             let [first_head, second_head] =
                 [unmerged.first_head, unmerged.second_head].map(|head| {
-                    let code = proto::GitStatus::try_from(head).ok()
+                    let code = proto::GitStatus::try_from(head)
+                        .ok()
                         .with_context(|| format!("Invalid git status code: {head}"))?;
                     let result = match code {
                         proto::GitStatus::Added => UnmergedStatusCode::Added,
@@ -10140,7 +10142,8 @@ fn status_from_proto(
         Variant::Tracked(tracked) => {
             let [index_status, worktree_status] = [tracked.index_status, tracked.worktree_status]
                 .map(|status| {
-                    let code = proto::GitStatus::try_from(status).ok()
+                    let code = proto::GitStatus::try_from(status)
+                        .ok()
                         .with_context(|| format!("Invalid git status code: {status}"))?;
                     let result = match code {
                         proto::GitStatus::Modified => StatusCode::Modified,

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -4213,7 +4213,9 @@ impl GetDocumentDiagnostics {
 
         Ok(lsp::Diagnostic {
             range: language::range_to_lsp(range)?,
-            severity: match proto::lsp_diagnostic::Severity::try_from(diagnostic.severity).ok().unwrap()
+            severity: match proto::lsp_diagnostic::Severity::try_from(diagnostic.severity)
+                .ok()
+                .unwrap()
             {
                 proto::lsp_diagnostic::Severity::Error => Some(lsp::DiagnosticSeverity::ERROR),
                 proto::lsp_diagnostic::Severity::Warning => Some(lsp::DiagnosticSeverity::WARNING),

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1679,7 +1679,7 @@ impl LspCommand for GetDocumentHighlights {
             buffer
                 .update(&mut cx, |buffer, _| buffer.wait_for_anchors([start, end]))
                 .await?;
-            let kind = match proto::document_highlight::Kind::from_i32(highlight.kind) {
+            let kind = match proto::document_highlight::Kind::try_from(highlight.kind).ok() {
                 Some(proto::document_highlight::Kind::Text) => DocumentHighlightKind::TEXT,
                 Some(proto::document_highlight::Kind::Read) => DocumentHighlightKind::READ,
                 Some(proto::document_highlight::Kind::Write) => DocumentHighlightKind::WRITE,
@@ -4204,7 +4204,7 @@ impl GetDocumentDiagnostics {
         let tags = diagnostic
             .tags
             .into_iter()
-            .filter_map(|tag| match proto::LspDiagnosticTag::from_i32(tag) {
+            .filter_map(|tag| match proto::LspDiagnosticTag::try_from(tag).ok() {
                 Some(proto::LspDiagnosticTag::Unnecessary) => Some(lsp::DiagnosticTag::UNNECESSARY),
                 Some(proto::LspDiagnosticTag::Deprecated) => Some(lsp::DiagnosticTag::DEPRECATED),
                 _ => None,
@@ -4213,7 +4213,7 @@ impl GetDocumentDiagnostics {
 
         Ok(lsp::Diagnostic {
             range: language::range_to_lsp(range)?,
-            severity: match proto::lsp_diagnostic::Severity::from_i32(diagnostic.severity).unwrap()
+            severity: match proto::lsp_diagnostic::Severity::try_from(diagnostic.severity).ok().unwrap()
             {
                 proto::lsp_diagnostic::Severity::Error => Some(lsp::DiagnosticSeverity::ERROR),
                 proto::lsp_diagnostic::Severity::Warning => Some(lsp::DiagnosticSeverity::WARNING),

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -12485,7 +12485,7 @@ impl LspStore {
         Ok(CoreCompletion {
             replace_range: old_replace_start..old_replace_end,
             new_text: completion.new_text,
-            source: match proto::completion::Source::from_i32(completion.source) {
+            source: match proto::completion::Source::try_from(completion.source).ok() {
                 Some(proto::completion::Source::Custom) => CompletionSource::Custom,
                 Some(proto::completion::Source::Lsp) => CompletionSource::Lsp {
                     insert_range,
@@ -12557,7 +12557,7 @@ impl LspStore {
             .end
             .and_then(deserialize_anchor)
             .context("invalid end")?;
-        let lsp_action = match proto::code_action::Kind::from_i32(action.kind) {
+        let lsp_action = match proto::code_action::Kind::try_from(action.kind).ok() {
             Some(proto::code_action::Kind::Action) => {
                 LspAction::Action(serde_json::from_slice(&action.lsp_action)?)
             }
@@ -14469,7 +14469,7 @@ impl LanguageServerLogType {
         use proto::rpc_message;
         match log_type {
             proto::language_server_log::LogType::Log(message_type) => Self::Log(
-                match LogLevel::from_i32(message_type.level).unwrap_or(LogLevel::Log) {
+                match LogLevel::try_from(message_type.level).ok().unwrap_or(LogLevel::Log) {
                     LogLevel::Error => MessageType::ERROR,
                     LogLevel::Warning => MessageType::WARNING,
                     LogLevel::Info => MessageType::INFO,
@@ -14480,7 +14480,7 @@ impl LanguageServerLogType {
                 verbose_info: trace_message.verbose_info,
             },
             proto::language_server_log::LogType::Rpc(message) => Self::Rpc {
-                received: match rpc_message::Kind::from_i32(message.kind)
+                received: match rpc_message::Kind::try_from(message.kind).ok()
                     .unwrap_or(rpc_message::Kind::Received)
                 {
                     rpc_message::Kind::Received => true,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -14469,7 +14469,10 @@ impl LanguageServerLogType {
         use proto::rpc_message;
         match log_type {
             proto::language_server_log::LogType::Log(message_type) => Self::Log(
-                match LogLevel::try_from(message_type.level).ok().unwrap_or(LogLevel::Log) {
+                match LogLevel::try_from(message_type.level)
+                    .ok()
+                    .unwrap_or(LogLevel::Log)
+                {
                     LogLevel::Error => MessageType::ERROR,
                     LogLevel::Warning => MessageType::WARNING,
                     LogLevel::Info => MessageType::INFO,
@@ -14480,7 +14483,8 @@ impl LanguageServerLogType {
                 verbose_info: trace_message.verbose_info,
             },
             proto::language_server_log::LogType::Rpc(message) => Self::Rpc {
-                received: match rpc_message::Kind::try_from(message.kind).ok()
+                received: match rpc_message::Kind::try_from(message.kind)
+                    .ok()
                     .unwrap_or(rpc_message::Kind::Received)
                 {
                     rpc_message::Kind::Received => true,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5580,7 +5580,7 @@ impl Project {
         mut cx: AsyncApp,
     ) -> Result<()> {
         let toggled_log_kind =
-            match proto::toggle_lsp_logs::LogType::from_i32(envelope.payload.log_type)
+            match proto::toggle_lsp_logs::LogType::try_from(envelope.payload.log_type).ok()
                 .context("invalid log type")?
             {
                 proto::toggle_lsp_logs::LogType::Log => LogKind::Logs,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5580,7 +5580,8 @@ impl Project {
         mut cx: AsyncApp,
     ) -> Result<()> {
         let toggled_log_kind =
-            match proto::toggle_lsp_logs::LogType::try_from(envelope.payload.log_type).ok()
+            match proto::toggle_lsp_logs::LogType::try_from(envelope.payload.log_type)
+                .ok()
                 .context("invalid log type")?
             {
                 proto::toggle_lsp_logs::LogType::Log => LogKind::Logs,

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -1042,7 +1042,8 @@ impl SettingsObserver {
         mut cx: AsyncApp,
     ) -> anyhow::Result<()> {
         let kind = match envelope.payload.kind {
-            Some(kind) => proto::LocalSettingsKind::try_from(kind).ok()
+            Some(kind) => proto::LocalSettingsKind::try_from(kind)
+                .ok()
                 .with_context(|| format!("unknown kind {kind}"))?,
             None => proto::LocalSettingsKind::Settings,
         };

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -1042,7 +1042,7 @@ impl SettingsObserver {
         mut cx: AsyncApp,
     ) -> anyhow::Result<()> {
         let kind = match envelope.payload.kind {
-            Some(kind) => proto::LocalSettingsKind::from_i32(kind)
+            Some(kind) => proto::LocalSettingsKind::try_from(kind).ok()
                 .with_context(|| format!("unknown kind {kind}"))?,
             None => proto::LocalSettingsKind::Settings,
         };

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -23,5 +23,6 @@ serde.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
+protox.workspace = true
 
 [dev-dependencies]

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -1,10 +1,12 @@
-fn main() {
+fn main() -> std::io::Result<()> {
     println!("cargo:rerun-if-changed=proto");
-    let mut build = prost_build::Config::new();
-    build
+    // Compile the descriptor set with protox (a pure-Rust protobuf compiler) so
+    // building Zed doesn't require a system `protoc` binary.
+    let file_descriptors = protox::compile(["proto/zed.proto"], ["proto"])
+        .map_err(|err| std::io::Error::other(err.to_string()))?;
+    prost_build::Config::new()
         .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
         .type_attribute("ProjectPath", "#[derive(Hash, Eq)]")
         .type_attribute("Anchor", "#[derive(Hash, Eq)]")
-        .compile_protos(&["proto/zed.proto"], &["proto"])
-        .unwrap();
+        .compile_fds(file_descriptors)
 }

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -1,12 +1,12 @@
-fn main() -> std::io::Result<()> {
+fn main() {
     println!("cargo:rerun-if-changed=proto");
     // Compile the descriptor set with protox (a pure-Rust protobuf compiler) so
     // building Zed doesn't require a system `protoc` binary.
-    let file_descriptors = protox::compile(["proto/zed.proto"], ["proto"])
-        .map_err(|err| std::io::Error::other(err.to_string()))?;
+    let file_descriptors = protox::compile(["proto/zed.proto"], ["proto"]).unwrap();
     prost_build::Config::new()
         .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
         .type_attribute("ProjectPath", "#[derive(Hash, Eq)]")
         .type_attribute("Anchor", "#[derive(Hash, Eq)]")
         .compile_fds(file_descriptors)
+        .unwrap();
 }

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -847,7 +847,8 @@ impl HeadlessProject {
                 .map(|global_log_store| global_log_store.0.clone())
                 .context("lsp logs store is missing")?;
             let toggled_log_kind =
-                match proto::toggle_lsp_logs::LogType::try_from(envelope.payload.log_type).ok()
+                match proto::toggle_lsp_logs::LogType::try_from(envelope.payload.log_type)
+                    .ok()
                     .context("invalid log type")?
                 {
                     proto::toggle_lsp_logs::LogType::Log => LogKind::Logs,

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -847,7 +847,7 @@ impl HeadlessProject {
                 .map(|global_log_store| global_log_store.0.clone())
                 .context("lsp logs store is missing")?;
             let toggled_log_kind =
-                match proto::toggle_lsp_logs::LogType::from_i32(envelope.payload.log_type)
+                match proto::toggle_lsp_logs::LogType::try_from(envelope.payload.log_type).ok()
                     .context("invalid log type")?
                 {
                     proto::toggle_lsp_logs::LogType::Log => LogKind::Logs,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6446,7 +6446,9 @@ impl Workspace {
             anyhow::bail!("no id for view");
         };
         let id = ViewId::from_proto(id)?;
-        let panel_id = view.panel_id.and_then(proto::PanelId::from_i32);
+        let panel_id = view
+            .panel_id
+            .and_then(|id| proto::PanelId::try_from(id).ok());
 
         let pane = this.update(cx, |this, _cx| {
             let state = this


### PR DESCRIPTION
### Summary 

Updates `prost` from 0.9 to 0.12 across the workspace and switches the `proto` and `livekit_api` build scripts to compile their `.proto` files with [protox](https://crates.io/crates/protox), a pure-Rust protobuf compiler.

### Why

- `prost` 0.9's `prost-derive` pulls in `syn` 1, which costs ~14–23s on clean builds. Moving to 0.12 (which uses `syn` 2) removes that consumer and unifies us on the single `prost` 0.12.x already pulled in by the livekit crates, dropping a duplicate prost stack.
- `prost-build` 0.11+ no longer bundles `protoc`, so a plain upgrade would require every developer and CI runner to install a `protoc` binary. Using `protox` instead keeps the build fully self-contained — no external tooling on dev machines or CI images.

### Notes

- Incremental builds are unaffected: protox only runs when a `.proto` file changes, and its crates compile once and are cached.
- Verified a clean `cargo build -p zed` succeeds, and that the build works with `protoc` unavailable.

Release Notes:

- N/A