### PR TITLE
Do not redownload same Nightly updates over and over

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -109,12 +109,6 @@ actions!(
     ]
 );
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum VersionCheckType {
-    Sha(AppCommitSha),
-    Semantic(Version),
-}
-
 #[derive(Serialize, Debug)]
 pub struct AssetQuery<'a> {
     asset: &'a str,
@@ -130,16 +124,16 @@ pub enum AutoUpdateStatus {
     Idle,
     Checking,
     Downloading {
-        version: VersionCheckType,
+        version: Version,
         /// Download progress as a fraction in the range `0.0..=1.0`, or `None`
         /// when the total download size is not yet known.
         progress: Option<f32>,
     },
     Installing {
-        version: VersionCheckType,
+        version: Version,
     },
     Updated {
-        version: VersionCheckType,
+        version: Version,
     },
     Errored {
         error: Arc<anyhow::Error>,
@@ -800,46 +794,33 @@ impl AutoUpdater {
         installed_version: Version,
         fetched_version: String,
         status: AutoUpdateStatus,
-    ) -> Result<Option<VersionCheckType>> {
-        let parsed_fetched_version = fetched_version.parse::<Version>();
-
-        let fetched_sha = parsed_fetched_version
-            .as_ref()
-            .ok()
-            .and_then(|version| version.build.as_str().rsplit('.').next())
-            .unwrap_or(fetched_version.as_str())
-            .to_owned();
-
-        if let AutoUpdateStatus::Updated { version, .. } = status {
-            match version {
-                VersionCheckType::Sha(cached_version) => {
-                    let newer_version = (fetched_sha != cached_version.full())
-                        .then(|| VersionCheckType::Sha(AppCommitSha::new(fetched_sha)));
-                    return Ok(newer_version);
-                }
-                VersionCheckType::Semantic(cached_version) => {
-                    return Self::check_if_fetched_version_is_newer_non_nightly(
-                        cached_version,
-                        parsed_fetched_version?,
-                    );
-                }
-            }
-        }
+    ) -> Result<Option<Version>> {
+        let fetched_version = fetched_version.parse::<Version>()?;
 
         match release_channel {
             ReleaseChannel::Nightly => {
-                let should_download = app_commit_sha
-                    .ok()
-                    .flatten()
-                    .is_none_or(|sha| fetched_sha != sha);
-                let newer_version =
-                    should_download.then(|| VersionCheckType::Sha(AppCommitSha::new(fetched_sha)));
-                Ok(newer_version)
+                let should_download = if let AutoUpdateStatus::Updated { version } = status {
+                    fetched_version != version
+                } else {
+                    let fetched_sha = fetched_version.build.as_str().rsplit('.').next();
+                    app_commit_sha
+                        .ok()
+                        .flatten()
+                        .is_none_or(|sha| fetched_sha != Some(sha.as_str()))
+                };
+                Ok(should_download.then_some(fetched_version))
             }
-            _ => Self::check_if_fetched_version_is_newer_non_nightly(
-                installed_version,
-                parsed_fetched_version?,
-            ),
+            _ => {
+                let current_version = if let AutoUpdateStatus::Updated { version } = status {
+                    version
+                } else {
+                    installed_version
+                };
+                Ok(Self::check_if_fetched_version_is_newer_non_nightly(
+                    current_version,
+                    fetched_version,
+                ))
+            }
         }
     }
 
@@ -902,13 +883,11 @@ impl AutoUpdater {
     fn check_if_fetched_version_is_newer_non_nightly(
         mut installed_version: Version,
         fetched_version: Version,
-    ) -> Result<Option<VersionCheckType>> {
+    ) -> Option<Version> {
         // For non-nightly releases, ignore build and pre-release fields as they're not provided by our endpoints right now.
         installed_version.pre = semver::Prerelease::EMPTY;
         installed_version.build = semver::BuildMetadata::EMPTY;
-        let should_download = fetched_version > installed_version;
-        let newer_version = should_download.then(|| VersionCheckType::Semantic(fetched_version));
-        Ok(newer_version)
+        (fetched_version > installed_version).then_some(fetched_version)
     }
 
     pub fn set_should_show_update_notification(
@@ -1363,7 +1342,7 @@ mod tests {
         assert_eq!(
             status,
             AutoUpdateStatus::Downloading {
-                version: VersionCheckType::Semantic(semver::Version::new(0, 100, 1)),
+                version: semver::Version::new(0, 100, 1),
                 progress: None,
             }
         );
@@ -1394,7 +1373,7 @@ mod tests {
         assert_eq!(
             status,
             AutoUpdateStatus::Updated {
-                version: VersionCheckType::Semantic(semver::Version::new(0, 100, 1))
+                version: semver::Version::new(0, 100, 1)
             }
         );
         let will_restart = cx.expect_restart();
@@ -1547,10 +1526,7 @@ mod tests {
             status,
         );
 
-        assert_eq!(
-            newer_version.unwrap(),
-            Some(VersionCheckType::Semantic(fetched_version))
-        );
+        assert_eq!(newer_version.unwrap(), Some(fetched_version));
     }
 
     #[test]
@@ -1559,7 +1535,7 @@ mod tests {
         let app_commit_sha = Ok(Some("a".to_string()));
         let installed_version = semver::Version::new(1, 0, 0);
         let status = AutoUpdateStatus::Updated {
-            version: VersionCheckType::Semantic(semver::Version::new(1, 0, 1)),
+            version: semver::Version::new(1, 0, 1),
         };
         let fetched_version = semver::Version::new(1, 0, 1);
 
@@ -1580,7 +1556,7 @@ mod tests {
         let app_commit_sha = Ok(Some("a".to_string()));
         let installed_version = semver::Version::new(1, 0, 0);
         let status = AutoUpdateStatus::Updated {
-            version: VersionCheckType::Semantic(semver::Version::new(1, 0, 1)),
+            version: semver::Version::new(1, 0, 1),
         };
         let fetched_version = semver::Version::new(1, 0, 2);
 
@@ -1592,10 +1568,7 @@ mod tests {
             status,
         );
 
-        assert_eq!(
-            newer_version.unwrap(),
-            Some(VersionCheckType::Semantic(fetched_version))
-        );
+        assert_eq!(newer_version.unwrap(), Some(fetched_version));
     }
 
     #[test]
@@ -1605,13 +1578,13 @@ mod tests {
         let mut installed_version = semver::Version::new(1, 0, 0);
         installed_version.build = semver::BuildMetadata::new("a").unwrap();
         let status = AutoUpdateStatus::Idle;
-        let fetched_sha = "1.0.0+a".to_string();
+        let fetched_version = "1.0.0+a".to_string();
 
         let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            fetched_sha,
+            fetched_version,
             status,
         );
 
@@ -1624,19 +1597,19 @@ mod tests {
         let app_commit_sha = Ok(Some("a".to_string()));
         let installed_version = semver::Version::new(1, 0, 0);
         let status = AutoUpdateStatus::Idle;
-        let fetched_sha = "b".to_string();
+        let fetched_version = "1.0.0+b".to_string();
 
         let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            fetched_sha.clone(),
+            fetched_version.clone(),
             status,
         );
 
         assert_eq!(
             newer_version.unwrap(),
-            Some(VersionCheckType::Sha(AppCommitSha::new(fetched_sha)))
+            Some(fetched_version.parse().unwrap())
         );
     }
 
@@ -1647,15 +1620,15 @@ mod tests {
         let mut installed_version = semver::Version::new(1, 0, 0);
         installed_version.build = semver::BuildMetadata::new("a").unwrap();
         let status = AutoUpdateStatus::Updated {
-            version: VersionCheckType::Sha(AppCommitSha::new("b".to_string())),
+            version: "1.0.0+b".parse().unwrap(),
         };
-        let fetched_sha = "1.0.0+b".to_string();
+        let fetched_version = "1.0.0+b".to_string();
 
         let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            fetched_sha,
+            fetched_version,
             status,
         );
 
@@ -1669,21 +1642,21 @@ mod tests {
         let mut installed_version = semver::Version::new(1, 0, 0);
         installed_version.build = semver::BuildMetadata::new("a").unwrap();
         let status = AutoUpdateStatus::Updated {
-            version: VersionCheckType::Sha(AppCommitSha::new("b".to_string())),
+            version: "1.0.0+b".parse().unwrap(),
         };
-        let fetched_sha = "1.0.0+c".to_string();
+        let fetched_version = "1.0.0+c".to_string();
 
         let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            fetched_sha,
+            fetched_version.clone(),
             status,
         );
 
         assert_eq!(
             newer_version.unwrap(),
-            Some(VersionCheckType::Sha(AppCommitSha::new("c".to_string())))
+            Some(fetched_version.parse().unwrap())
         );
     }
 
@@ -1691,13 +1664,13 @@ mod tests {
     fn test_nightly_does_not_redownload_after_updating_to_fetched_version() {
         let release_channel = ReleaseChannel::Nightly;
         let installed_version = semver::Version::new(1, 0, 0);
-        let fetched_sha = "1.0.0+nightly.b".to_string();
+        let fetched_version = "1.0.0+nightly.b".to_string();
 
         let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             Ok(Some("a".to_string())),
             installed_version.clone(),
-            fetched_sha.clone(),
+            fetched_version.clone(),
             AutoUpdateStatus::Idle,
         )
         .unwrap()
@@ -1707,7 +1680,7 @@ mod tests {
             release_channel,
             Ok(Some("a".to_string())),
             installed_version,
-            fetched_sha,
+            fetched_version,
             AutoUpdateStatus::Updated {
                 version: newer_version,
             },
@@ -1722,19 +1695,19 @@ mod tests {
         let app_commit_sha = Ok(None);
         let installed_version = semver::Version::new(1, 0, 0);
         let status = AutoUpdateStatus::Idle;
-        let fetched_sha = "a".to_string();
+        let fetched_version = "1.0.0+a".to_string();
 
         let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            fetched_sha.clone(),
+            fetched_version.clone(),
             status,
         );
 
         assert_eq!(
             newer_version.unwrap(),
-            Some(VersionCheckType::Sha(AppCommitSha::new(fetched_sha)))
+            Some(fetched_version.parse().unwrap())
         );
     }
 
@@ -1745,15 +1718,15 @@ mod tests {
         let app_commit_sha = Ok(None);
         let installed_version = semver::Version::new(1, 0, 0);
         let status = AutoUpdateStatus::Updated {
-            version: VersionCheckType::Sha(AppCommitSha::new("b".to_string())),
+            version: "1.0.0+b".parse().unwrap(),
         };
-        let fetched_sha = "1.0.0+b".to_string();
+        let fetched_version = "1.0.0+b".to_string();
 
         let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            fetched_sha,
+            fetched_version,
             status,
         );
 
@@ -1767,21 +1740,21 @@ mod tests {
         let app_commit_sha = Ok(None);
         let installed_version = semver::Version::new(1, 0, 0);
         let status = AutoUpdateStatus::Updated {
-            version: VersionCheckType::Sha(AppCommitSha::new("b".to_string())),
+            version: "1.0.0+b".parse().unwrap(),
         };
-        let fetched_sha = "c".to_string();
+        let fetched_version = "1.0.0+c".to_string();
 
         let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            fetched_sha.clone(),
+            fetched_version.clone(),
             status,
         );
 
         assert_eq!(
             newer_version.unwrap(),
-            Some(VersionCheckType::Sha(AppCommitSha::new(fetched_sha)))
+            Some(fetched_version.parse().unwrap())
         );
     }
 }

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -803,16 +803,18 @@ impl AutoUpdater {
     ) -> Result<Option<VersionCheckType>> {
         let parsed_fetched_version = fetched_version.parse::<Version>();
 
+        let fetched_sha = parsed_fetched_version
+            .as_ref()
+            .ok()
+            .and_then(|version| version.build.as_str().rsplit('.').next())
+            .unwrap_or(fetched_version.as_str())
+            .to_owned();
+
         if let AutoUpdateStatus::Updated { version, .. } = status {
             match version {
                 VersionCheckType::Sha(cached_version) => {
-                    let should_download =
-                        parsed_fetched_version.as_ref().ok().is_none_or(|version| {
-                            version.build.as_str().rsplit('.').next()
-                                != Some(&cached_version.full())
-                        });
-                    let newer_version = should_download
-                        .then(|| VersionCheckType::Sha(AppCommitSha::new(fetched_version)));
+                    let newer_version = (fetched_sha != cached_version.full())
+                        .then(|| VersionCheckType::Sha(AppCommitSha::new(fetched_sha)));
                     return Ok(newer_version);
                 }
                 VersionCheckType::Semantic(cached_version) => {
@@ -829,14 +831,9 @@ impl AutoUpdater {
                 let should_download = app_commit_sha
                     .ok()
                     .flatten()
-                    .map(|sha| {
-                        parsed_fetched_version.as_ref().ok().is_none_or(|version| {
-                            version.build.as_str().rsplit('.').next() != Some(&sha)
-                        })
-                    })
-                    .unwrap_or(true);
-                let newer_version = should_download
-                    .then(|| VersionCheckType::Sha(AppCommitSha::new(fetched_version)));
+                    .is_none_or(|sha| fetched_sha != sha);
+                let newer_version =
+                    should_download.then(|| VersionCheckType::Sha(AppCommitSha::new(fetched_sha)));
                 Ok(newer_version)
             }
             _ => Self::check_if_fetched_version_is_newer_non_nightly(
@@ -1680,14 +1677,43 @@ mod tests {
             release_channel,
             app_commit_sha,
             installed_version,
-            fetched_sha.clone(),
+            fetched_sha,
             status,
         );
 
         assert_eq!(
             newer_version.unwrap(),
-            Some(VersionCheckType::Sha(AppCommitSha::new(fetched_sha)))
+            Some(VersionCheckType::Sha(AppCommitSha::new("c".to_string())))
         );
+    }
+
+    #[test]
+    fn test_nightly_does_not_redownload_after_updating_to_fetched_version() {
+        let release_channel = ReleaseChannel::Nightly;
+        let installed_version = semver::Version::new(1, 0, 0);
+        let fetched_sha = "1.0.0+nightly.b".to_string();
+
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
+            release_channel,
+            Ok(Some("a".to_string())),
+            installed_version.clone(),
+            fetched_sha.clone(),
+            AutoUpdateStatus::Idle,
+        )
+        .unwrap()
+        .expect("a newer nightly version should be available");
+
+        let next_check = AutoUpdater::check_if_fetched_version_is_newer(
+            release_channel,
+            Ok(Some("a".to_string())),
+            installed_version,
+            fetched_sha,
+            AutoUpdateStatus::Updated {
+                version: newer_version,
+            },
+        );
+
+        assert_eq!(next_check.unwrap(), None);
     }
 
     #[test]

--- a/crates/title_bar/src/update_version.rs
+++ b/crates/title_bar/src/update_version.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::anyhow;
-use auto_update::{AutoUpdateStatus, AutoUpdater, UpdateCheckType, VersionCheckType};
+use auto_update::{AutoUpdateStatus, AutoUpdater, UpdateCheckType};
 use gpui::{Empty, Render};
 use semver::Version;
 use ui::{UpdateButton, prelude::*};
@@ -42,14 +42,14 @@ impl UpdateVersion {
         let next_state = match self.status {
             AutoUpdateStatus::Idle => AutoUpdateStatus::Checking,
             AutoUpdateStatus::Checking => AutoUpdateStatus::Downloading {
-                version: VersionCheckType::Semantic(Version::new(1, 99, 0)),
+                version: Version::new(1, 99, 0),
                 progress: Some(0.5),
             },
             AutoUpdateStatus::Downloading { .. } => AutoUpdateStatus::Installing {
-                version: VersionCheckType::Semantic(Version::new(1, 99, 0)),
+                version: Version::new(1, 99, 0),
             },
             AutoUpdateStatus::Installing { .. } => AutoUpdateStatus::Updated {
-                version: VersionCheckType::Semantic(Version::new(1, 99, 0)),
+                version: Version::new(1, 99, 0),
             },
             AutoUpdateStatus::Updated { .. } => AutoUpdateStatus::Errored {
                 error: Arc::new(anyhow!("Network timeout")),
@@ -67,13 +67,8 @@ impl UpdateVersion {
         self.dismissed && self.status.is_updated()
     }
 
-    fn version_tooltip_message(version: &VersionCheckType) -> String {
-        format!("Update to Version: {}", {
-            match version {
-                VersionCheckType::Sha(sha) => sha.full(),
-                VersionCheckType::Semantic(semantic_version) => semantic_version.to_string(),
-            }
-        })
+    fn version_tooltip_message(version: &Version) -> String {
+        format!("Update to Version: {version}")
     }
 }
 
@@ -87,15 +82,15 @@ impl Render for UpdateVersion {
                 UpdateButton::checking().into_any_element()
             }
             AutoUpdateStatus::Downloading { version, progress } => {
-                let version = Self::version_tooltip_message(&version);
+                let version = Self::version_tooltip_message(version);
                 UpdateButton::downloading(version, *progress).into_any_element()
             }
             AutoUpdateStatus::Installing { version } => {
-                let version = Self::version_tooltip_message(&version);
+                let version = Self::version_tooltip_message(version);
                 UpdateButton::installing(version).into_any_element()
             }
             AutoUpdateStatus::Updated { version } => {
-                let version = Self::version_tooltip_message(&version);
+                let version = Self::version_tooltip_message(version);
                 UpdateButton::updated(version)
                     .on_click(|_, _, cx| {
                         workspace::reload(cx);
@@ -124,27 +119,25 @@ impl Render for UpdateVersion {
 }
 #[cfg(test)]
 mod tests {
-    use auto_update::VersionCheckType;
-    use release_channel::AppCommitSha;
     use semver::Version;
 
     use super::*;
 
     #[test]
     fn test_version_tooltip_message() {
-        let message = UpdateVersion::version_tooltip_message(&VersionCheckType::Semantic(
-            Version::new(1, 0, 0),
-        ));
+        let message = UpdateVersion::version_tooltip_message(&Version::new(1, 0, 0));
 
         assert_eq!(message, "Update to Version: 1.0.0");
 
-        let message = UpdateVersion::version_tooltip_message(&VersionCheckType::Sha(
-            AppCommitSha::new("14d9a4189f058d8736339b06ff2340101eaea5af".to_string()),
-        ));
+        let message = UpdateVersion::version_tooltip_message(
+            &"1.0.0+nightly.14d9a4189f058d8736339b06ff2340101eaea5af"
+                .parse()
+                .unwrap(),
+        );
 
         assert_eq!(
             message,
-            "Update to Version: 14d9a4189f058d8736339b06ff2340101eaea5af"
+            "Update to Version: 1.0.0+nightly.14d9a4189f058d8736339b06ff2340101eaea5af"
         );
     }
 }


### PR DESCRIPTION
If one gets a Nightly update but does not restart and rather dismisses the notification, the next update check will do the update again.

This is caused by the fact that the version check is done based on semver, but Nightly has the very same version that differs by the SHA only.
Adjust the Nightly update check to skip re-downloads if SHA parts of the version match also.

https://github.com/zed-industries/zed/pull/59852 does more changes, this PR extracts the part I am sure about.

Release Notes:

- N/A