### PR TITLE
Restore remote binary dev build output

### DIFF
--- a/crates/remote/src/transport.rs
+++ b/crates/remote/src/transport.rs
@@ -279,6 +279,7 @@ async fn build_remote_server_from_source(
         let output = command
             .kill_on_drop(true)
             .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
             .output()
             .await?;
         anyhow::ensure!(


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/46695

cargo outputs to stderr, so if we do not inherit it, we do not see it, yet this can be useful to understand what broke and see the progress.
I am not sure if there was a reason to remove it, hence creating the PR to discuss — want to add at least a comment there for the future if we decide to keep things as is.

Before:

<img width="1731" height="1022" alt="before" src="https://github.com/user-attachments/assets/92bb0969-e495-41b0-8cac-1f85a83440a0" />

After:
<img width="1728" height="1086" alt="after" src="https://github.com/user-attachments/assets/c733fb8b-adbe-44dc-84a5-48e2c9e63a38" />

Release Notes:

- N/A