### PR TITLE
Add default semantic token rules for C# (Roslyn) token types

### DIFF
--- a/assets/settings/default_semantic_token_rules.json
+++ b/assets/settings/default_semantic_token_rules.json
@@ -253,4 +253,75 @@
     "token_modifiers": [],
     "style": ["type.event", "type"],
   },
+  // C# (Roslyn) extended classification types
+  {
+    "token_type": "field",
+    "token_modifiers": [],
+    "style": ["property", "variable.member", "variable"],
+  },
+  {
+    "token_type": "constant",
+    "token_modifiers": [],
+    "style": ["constant"],
+  },
+  {
+    "token_type": "controlKeyword",
+    "token_modifiers": [],
+    "style": ["keyword.control", "keyword"],
+  },
+  {
+    "token_type": "delegate",
+    "token_modifiers": [],
+    "style": ["type.delegate", "type"],
+  },
+  {
+    "token_type": "extensionMethod",
+    "token_modifiers": [],
+    "style": ["function.method", "function"],
+  },
+  {
+    "token_type": "operatorOverloaded",
+    "token_modifiers": [],
+    "style": ["operator"],
+  },
+  {
+    "token_type": "recordClass",
+    "token_modifiers": [],
+    "style": ["type.class", "class", "type"],
+  },
+  {
+    "token_type": "recordStruct",
+    "token_modifiers": [],
+    "style": ["type.struct", "struct", "type"],
+  },
+  {
+    "token_type": "module",
+    "token_modifiers": [],
+    "style": ["namespace", "module"],
+  },
+  {
+    "token_type": "functionPointer",
+    "token_modifiers": [],
+    "style": ["function", "type"],
+  },
+  {
+    "token_type": "pointer",
+    "token_modifiers": [],
+    "style": ["type"],
+  },
+  {
+    "token_type": "excludedCode",
+    "token_modifiers": [],
+    "style": ["comment"],
+  },
+  {
+    "token_type": "stringVerbatim",
+    "token_modifiers": [],
+    "style": ["string"],
+  },
+  {
+    "token_type": "stringEscapeCharacter",
+    "token_modifiers": [],
+    "style": ["string.escape", "string.special", "string"],
+  },
 ]

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1796,6 +1796,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_default_semantic_token_rules_cover_roslyn_token_types() {
+        let rules: SemanticTokenRules =
+            crate::parse_json_with_comments(&crate::default_semantic_token_rules())
+                .expect("default_semantic_token_rules.json must parse");
+
+        // C# (Roslyn) reports its own extended token-type legend instead of the
+        // standard LSP types. Each of these needs a rule with a non-empty style,
+        // otherwise the tokens are dropped and C# falls back to tree-sitter-only
+        // highlighting.
+        for token_type in [
+            "field",
+            "constant",
+            "controlKeyword",
+            "delegate",
+            "extensionMethod",
+            "operatorOverloaded",
+            "recordClass",
+            "recordStruct",
+            "module",
+        ] {
+            assert!(
+                rules.rules.iter().any(|rule| {
+                    rule.token_type.as_deref() == Some(token_type) && !rule.style.is_empty()
+                }),
+                "default semantic token rules must map the C# (Roslyn) token type {token_type:?}"
+            );
+        }
+    }
+
     #[gpui::test]
     fn test_default_settings_release_channel_overrides(cx: &mut App) {
         // The test deals with overrides and should ignore the other set-ups (Preview and Stable runs)


### PR DESCRIPTION
Roslyn reports an extended token-type legend (field, controlKeyword, recordClass, extensionMethod, ...) that the default rules did not cover, so those tokens were silently dropped and C# fell back to tree-sitter-only highlighting. Map them to existing theme styles.

# Objective

Companion to #60015. This PR adds highlighting support for Roslyn's (C#) semantic token types, so C# code can be colored correctly instead of being limited to the standard LSP token set.

Zed's default semantic token rules only cover the ~24 standard LSP token types, and there's no catch-all rule. Roslyn reports a much larger, C#-specific legend (`field`, `controlKeyword`, `recordClass`, `extensionMethod`, ...), so any token whose type isn't one of those 24 is silently dropped — leaving C# fields, constants, control-flow keywords, records, etc. without semantic highlighting (a private field stays indistinguishable from a local variable).

## Solution

Add default rules in `default_semantic_token_rules.json` mapping Roslyn's C# token types to existing theme styles (with fallback chains, in the existing `// C#` section).

## Testing

- Added a test asserting the default rules parse and cover the added C# token types (guards against accidental removal).
- Verified manually on a C# project: fields, constants, control-flow keywords, records and extension methods now get semantic highlighting consistent with the theme.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>

**Before** — Roslyn's C# token types aren't mapped, so fields/keywords fall back to tree-sitter (a field looks like a plain variable):

<img width="979" height="1089" alt="Screenshot 2026-06-28 at 10 06 41" src="https://github.com/user-attachments/assets/89582f31-c827-429d-8a15-b93d2340bec9" />

**After** — fields, constants, control-flow keywords and records get semantic colors:

<img width="934" height="1032" alt="Screenshot 2026-06-28 at 09 58 15" src="https://github.com/user-attachments/assets/9af6328f-7215-4e71-b818-9aa40c85a537" />

</details>

---

Release Notes:

Improved C# semantic highlighting by mapping Roslyn's token types (fields, constants, records, control-flow keywords, and more) to theme styles.
