### PR TITLE
Fix window dragging on Windows

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -377,8 +377,8 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut App) -> WindowO
         focus: false,
         show: false,
         kind: WindowKind::Normal,
-        // Zed handles window movement itself, so disable AppKit's titlebar dragging.
-        is_movable: false,
+        // Zed handles window movement itself, so disable AppKit's titlebar dragging on macOS.
+        is_movable: !cfg!(target_os = "macos"),
         display_id: display.map(|display| display.id()),
         window_background: cx.theme().window_background_appearance(),
         app_id: Some(app_id.to_owned()),


### PR DESCRIPTION
# Objective

Recently, a bug was introduced in the Windows nightly builds where the Zed window cannot be dragged around. The preview build does not have this issue. By checking out commits between these two builds and testing them (a manual binary search), I identified that #59836 introduced this regression.

According to the PR description of #59836, the change was intended to fix a macOS-specific issue by setting `is_movable` to `false`. However, this change had the side effect of breaking window dragging on Windows.

## Solution

Make the `is_movable` configuration platform-dependent: keep it `false` on macOS to preserve the fix, but keep it `true` on Windows and other platforms.

## Testing

Manually tested the fix locally on Windows, and the window can now be dragged normally.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed the Zed window could not be dragged on Windows.
