### PR TITLE
Support inline git blame in diff views

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -105,7 +105,7 @@ pub use element::{
     CursorLayout, EditorElement, HighlightedRange, HighlightedRangeLine, PointForPosition,
     render_breadcrumb_text,
 };
-pub use git::blame::BlameRenderer;
+pub use git::blame::{BlameRenderer, BlameRevisions};
 pub(crate) use git::{DiffHunkKey, StoredReviewComment};
 use git::{
     DiffReviewDragState, DiffReviewOverlay, InlineBlamePopover, render_diff_hunk_controls,
@@ -1075,6 +1075,7 @@ pub struct Editor {
     show_git_blame_inline: bool,
     show_git_blame_inline_delay_task: Option<Task<()>>,
     git_blame_inline_enabled: bool,
+    blame_revisions: git::blame::BlameRevisions,
     render_diff_hunk_controls: RenderDiffHunkControlsFn,
     buffer_serialization: Option<BufferSerialization>,
     show_selection_menu: Option<bool>,
@@ -2291,6 +2292,7 @@ impl Editor {
             custom_context_menu: None,
             show_git_blame_gutter: false,
             show_git_blame_inline: false,
+            blame_revisions: git::blame::BlameRevisions::default(),
             show_selection_menu: None,
             show_git_blame_inline_delay_task: None,
             git_blame_inline_enabled: full_mode

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -30605,9 +30605,16 @@ async fn test_hide_pending_blame_popover_when_modal_opens(cx: &mut TestAppContex
     });
 
     editor.update_in(cx, |editor, _, cx| {
-        editor.blame = Some(
-            cx.new(|cx| GitBlame::new(editor.buffer.clone(), project.clone(), false, true, cx)),
-        );
+        editor.blame = Some(cx.new(|cx| {
+            GitBlame::new(
+                editor.buffer.clone(),
+                project.clone(),
+                false,
+                true,
+                crate::BlameRevisions::default(),
+                cx,
+            )
+        }));
         editor.show_blame_popover(
             buffer_id,
             &::git::blame::BlameEntry {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2005,6 +2005,16 @@ impl EditorElement {
         }
 
         let editor = self.editor.read(cx);
+
+        // Added/modified rows are the change being viewed; their blame is noise.
+        if editor.blame_revisions.hide_blame_on_added_rows
+            && row_info
+                .diff_status
+                .is_some_and(|status| !status.is_deleted())
+        {
+            return None;
+        }
+
         let blame = editor.blame.clone()?;
         let padding = {
             const INLINE_ACCEPT_SUGGESTION_EM_WIDTHS: f32 = 14.;

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -1606,6 +1606,10 @@ impl Editor {
     /// This respects the user's inline-blame setting: it only restarts an
     /// already-running blame so the new revisions take effect. Toggling blame on
     /// later will also pick these revisions up.
+    pub fn blame_revisions(&self) -> &blame::BlameRevisions {
+        &self.blame_revisions
+    }
+
     pub fn set_blame_revisions(
         &mut self,
         revisions: blame::BlameRevisions,

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -1630,7 +1630,6 @@ impl Editor {
     pub(super) fn render_git_blame_inline(&self, window: &Window, cx: &App) -> bool {
         self.show_git_blame_inline
             && (self.focus_handle.is_focused(window) || self.inline_blame_popover.is_some())
-            && !self.newest_selection_head_on_empty_line(cx)
             && self.has_blame_entries(cx)
     }
 
@@ -1993,14 +1992,6 @@ impl Editor {
             .is_some_and(|blame| blame.read(cx).has_generated_entries())
     }
 
-    fn newest_selection_head_on_empty_line(&self, cx: &App) -> bool {
-        let cursor_anchor = self.selections.newest_anchor().head();
-
-        let snapshot = self.buffer.read(cx).snapshot(cx);
-        let buffer_row = MultiBufferRow(cursor_anchor.to_point(&snapshot).row);
-
-        snapshot.line_len(buffer_row) == 0
-    }
     fn hunk_after_position(
         &mut self,
         snapshot: &EditorSnapshot,

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -1598,6 +1598,27 @@ impl Editor {
         }
     }
 
+    /// Configures which revisions inline git blame uses in a diff view (project
+    /// diff or commit view): the revision used for each main buffer, and the
+    /// revision used for the diff base text so deleted lines show the commit that
+    /// last touched them.
+    ///
+    /// This respects the user's inline-blame setting: it only restarts an
+    /// already-running blame so the new revisions take effect. Toggling blame on
+    /// later will also pick these revisions up.
+    pub fn set_blame_revisions(
+        &mut self,
+        revisions: blame::BlameRevisions,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.blame_revisions = revisions;
+        if self.git_blame_inline_enabled {
+            self.start_git_blame_inline(false, window, cx);
+        }
+        cx.notify();
+    }
+
     pub(super) fn render_git_blame_gutter(&self, cx: &App) -> bool {
         !self.mode().is_minimap() && self.show_git_blame_gutter && self.has_blame_entries(cx)
     }
@@ -1781,8 +1802,17 @@ impl Editor {
             let focused = self.focus_handle(cx).contains_focused(window, cx);
 
             let project = project.clone();
-            let blame = cx
-                .new(|cx| GitBlame::new(self.buffer.clone(), project, user_triggered, focused, cx));
+            let revisions = self.blame_revisions.clone();
+            let blame = cx.new(|cx| {
+                GitBlame::new(
+                    self.buffer.clone(),
+                    project,
+                    user_triggered,
+                    focused,
+                    revisions,
+                    cx,
+                )
+            });
             self.blame_subscription =
                 Some(cx.observe_in(&blame, window, |_, _, _, cx| cx.notify()));
             self.blame = Some(blame);

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -71,6 +71,41 @@ struct GitBlameBuffer {
     commit_details: HashMap<Oid, ParsedCommitMessage>,
 }
 
+/// Controls which revisions a [`GitBlame`] blames against. The default blames
+/// the working-tree contents of each buffer, which is what normal editors want.
+///
+/// Diff views (project diff, commit view) use this to additionally blame the
+/// diff base text (so deleted lines show the commit that last touched them), and
+/// to blame the main buffer against a historical revision.
+#[derive(Clone, Debug, Default)]
+pub struct BlameRevisions {
+    /// When `true`, also compute blame for each buffer's diff base text, keyed by
+    /// the base text buffer's id, so deleted lines can show inline blame.
+    pub blame_base_text: bool,
+    /// Revision used to blame diff base text. `None` defaults to `HEAD`.
+    pub base_text_revision: Option<git::repository::BlameRevision>,
+    /// Revision used to blame the main buffer content. `None` blames the
+    /// working-tree contents (piped to git blame via stdin).
+    pub buffer_revision: Option<git::repository::BlameRevision>,
+}
+
+/// A pending blame computation for a single buffer (a main buffer or a diff base
+/// text). Resolves to the target buffer id, its snapshot, an edit subscription,
+/// the blame result, and the remote url used to parse commit metadata.
+type BlameTargetFuture = std::pin::Pin<
+    Box<
+        dyn std::future::Future<
+                Output = (
+                    BufferId,
+                    BufferSnapshot,
+                    text::Subscription<usize>,
+                    Result<Option<Blame>>,
+                    Option<String>,
+                ),
+            > + Send,
+    >,
+>;
+
 pub struct GitBlame {
     project: Entity<Project>,
     multi_buffer: WeakEntity<MultiBuffer>,
@@ -79,6 +114,7 @@ pub struct GitBlame {
     focused: bool,
     changed_while_blurred: bool,
     user_triggered: bool,
+    revisions: BlameRevisions,
     regenerate_on_edit_task: Task<Result<()>>,
     _regenerate_subscriptions: Vec<Subscription>,
 }
@@ -194,6 +230,7 @@ impl GitBlame {
         project: Entity<Project>,
         user_triggered: bool,
         focused: bool,
+        revisions: BlameRevisions,
         cx: &mut Context<Self>,
     ) -> Self {
         let multi_buffer_subscription = cx.subscribe(
@@ -250,6 +287,7 @@ impl GitBlame {
             multi_buffer: multi_buffer.downgrade(),
             buffers: HashMap::default(),
             user_triggered,
+            revisions,
             focused,
             changed_while_blurred: false,
             task: Task::ready(Ok(())),
@@ -505,6 +543,8 @@ impl GitBlame {
             })
             .unwrap_or_default();
         let project = self.project.downgrade();
+        let revisions = self.revisions.clone();
+        let multi_buffer = self.multi_buffer.clone();
 
         self.task = cx.spawn(async move |this, cx| {
             let mut all_results = Vec::new();
@@ -514,38 +554,98 @@ impl GitBlame {
                 let span = ztracing::debug_span!("for each chunk of buffers");
                 let _enter = span.enter();
                 let blame = cx.update(|cx| {
-                    buffers
-                        .iter()
-                        .map(|buffer| {
-                            let buffer = buffer.upgrade().context("buffer was dropped")?;
-                            let project = project.upgrade().context("project was dropped")?;
-                            let id = buffer.read(cx).remote_id();
-                            let snapshot = buffer.read(cx).snapshot();
-                            let buffer_edits = buffer.update(cx, |buffer, _| buffer.subscribe());
+                    let mut blame_futures: Vec<BlameTargetFuture> = Vec::new();
+                    for buffer in buffers {
+                        let buffer = buffer.upgrade().context("buffer was dropped")?;
+                        let project = project.upgrade().context("project was dropped")?;
+                        let id = buffer.read(cx).remote_id();
+                        let snapshot = buffer.read(cx).snapshot();
+                        let buffer_edits = buffer.update(cx, |buffer, _| buffer.subscribe());
 
-                            let repository = project
-                                .read(cx)
-                                .git_store()
-                                .read(cx)
-                                .repository_and_path_for_buffer_id(id, cx);
-
-                            let remote_url = repository
-                                .as_ref()
-                                .and_then(|(repo, _)| repo.read(cx).default_remote_url());
-
-                            let blame_buffer = if repository.is_some() {
-                                project.update(cx, |project, cx| {
-                                    project.blame_buffer(&buffer, None, cx)
+                        // Resolve the repository and path for this buffer. Buffers
+                        // registered in the project resolve by id; synthetic
+                        // buffers (e.g. the commit view's historical blobs) are
+                        // not in the buffer store, so fall back to resolving via
+                        // their project path.
+                        let repository = {
+                            let git_store = project.read(cx).git_store().clone();
+                            let git_store = git_store.read(cx);
+                            git_store
+                                .repository_and_path_for_buffer_id(id, cx)
+                                .or_else(|| {
+                                    let project_path = buffer.read(cx).project_path(cx)?;
+                                    git_store
+                                        .repository_and_path_for_project_path(&project_path, cx)
                                 })
-                            } else {
-                                Task::ready(Ok(None))
+                        };
+
+                        let remote_url = repository
+                            .as_ref()
+                            .and_then(|(repo, _)| repo.read(cx).default_remote_url());
+
+                        // Blame for the main buffer: either at a specific revision
+                        // (commit view) or against the working-tree contents.
+                        let main_blame: Task<Result<Option<Blame>>> =
+                            match (&repository, &revisions.buffer_revision) {
+                                (Some((repo, repo_path)), Some(revision)) => {
+                                    let receiver = repo.update(cx, |repo, _| {
+                                        repo.blame_path(repo_path.clone(), revision.clone())
+                                    });
+                                    cx.background_spawn(async move {
+                                        let blame =
+                                            receiver.await.map_err(|e| anyhow::anyhow!(e))?;
+                                        blame.map(Some)
+                                    })
+                                }
+                                (Some(_), None) => project.update(cx, |project, cx| {
+                                    project.blame_buffer(&buffer, None, cx)
+                                }),
+                                (None, _) => Task::ready(Ok(None)),
                             };
 
-                            Ok(async move {
-                                (id, snapshot, buffer_edits, blame_buffer.await, remote_url)
-                            })
-                        })
-                        .collect::<Result<Vec<_>>>()
+                        {
+                            let remote_url = remote_url.clone();
+                            blame_futures.push(Box::pin(async move {
+                                (id, snapshot, buffer_edits, main_blame.await, remote_url)
+                            }));
+                        }
+
+                        // Blame for the diff base text, so deleted lines show the
+                        // commit that last touched them in diff views.
+                        if revisions.blame_base_text
+                            && let Some((repo, repo_path)) = repository
+                            && let Some(diff) = multi_buffer
+                                .upgrade()
+                                .and_then(|multi_buffer| multi_buffer.read(cx).diff_for(id))
+                        {
+                            let base_buffer = diff.read(cx).base_text_buffer().clone();
+                            let base_id = base_buffer.read(cx).remote_id();
+                            let base_snapshot = base_buffer.read(cx).snapshot();
+                            let base_edits =
+                                base_buffer.update(cx, |buffer, _| buffer.subscribe());
+                            let revision = revisions.base_text_revision.clone().unwrap_or_else(
+                                || git::repository::BlameRevision::Revision("HEAD".to_string()),
+                            );
+                            let receiver = repo.update(cx, |repo, _| {
+                                repo.blame_path(repo_path.clone(), revision)
+                            });
+                            let base_blame: Task<Result<Option<Blame>>> =
+                                cx.background_spawn(async move {
+                                    let blame = receiver.await.map_err(|e| anyhow::anyhow!(e))?;
+                                    blame.map(Some)
+                                });
+                            blame_futures.push(Box::pin(async move {
+                                (
+                                    base_id,
+                                    base_snapshot,
+                                    base_edits,
+                                    base_blame.await,
+                                    remote_url,
+                                )
+                            }));
+                        }
+                    }
+                    Result::<_>::Ok(blame_futures)
                 })?;
                 let provider_registry =
                     cx.update(|cx| GitHostingProviderRegistry::default_global(cx));
@@ -791,7 +891,16 @@ mod tests {
             .unwrap();
         let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
 
-        let blame = cx.new(|cx| GitBlame::new(buffer.clone(), project.clone(), true, true, cx));
+        let blame = cx.new(|cx| {
+            GitBlame::new(
+                buffer.clone(),
+                project.clone(),
+                true,
+                true,
+                BlameRevisions::default(),
+                cx,
+            )
+        });
 
         let event = project.next_event(cx).await;
         assert_eq!(
@@ -864,7 +973,16 @@ mod tests {
             })
         });
 
-        let blame = cx.new(|cx| GitBlame::new(buffer.clone(), project.clone(), true, true, cx));
+        let blame = cx.new(|cx| {
+            GitBlame::new(
+                buffer.clone(),
+                project.clone(),
+                true,
+                true,
+                BlameRevisions::default(),
+                cx,
+            )
+        });
 
         cx.executor().run_until_parked();
 
@@ -940,7 +1058,16 @@ mod tests {
         let buffer_id = buffer.read_with(cx, |buffer, _| buffer.remote_id());
         let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
 
-        let git_blame = cx.new(|cx| GitBlame::new(buffer.clone(), project, false, true, cx));
+        let git_blame = cx.new(|cx| {
+            GitBlame::new(
+                buffer.clone(),
+                project,
+                false,
+                true,
+                BlameRevisions::default(),
+                cx,
+            )
+        });
 
         cx.executor().run_until_parked();
 
@@ -1012,6 +1139,133 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_blame_base_text_at_revision(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/my-repo"),
+            json!({
+                ".git": {},
+                "file.txt": "AAA\nCCC\n",
+            }),
+        )
+        .await;
+
+        // HEAD has an extra line (BBB) that was deleted in the working tree, so
+        // the diff base text contains all three lines.
+        fs.set_head_for_repo(
+            Path::new(path!("/my-repo/.git")),
+            &[("file.txt", "AAA\nBBB\nCCC\n".to_owned())],
+            "deadbeef",
+        );
+
+        // Working-tree blame (no revision).
+        fs.set_blame_for_repo(
+            Path::new(path!("/my-repo/.git")),
+            vec![(
+                repo_path("file.txt"),
+                Blame {
+                    entries: vec![blame_entry("aaaaaa", 0..1), blame_entry("cccccc", 1..2)],
+                    ..Default::default()
+                },
+            )],
+        );
+
+        // Blame of the committed (HEAD) content, used for the diff base text.
+        fs.set_blame_for_repo_at_revision(
+            Path::new(path!("/my-repo/.git")),
+            "HEAD",
+            vec![(
+                repo_path("file.txt"),
+                Blame {
+                    entries: vec![
+                        blame_entry("aaaaaa", 0..1),
+                        blame_entry("bbbbbb", 1..2),
+                        blame_entry("cccccc", 2..3),
+                    ],
+                    ..Default::default()
+                },
+            )],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/my-repo").as_ref()], cx).await;
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/my-repo/file.txt"), cx)
+            })
+            .await
+            .unwrap();
+        let main_buffer_id = buffer.read_with(cx, |buffer, _| buffer.remote_id());
+
+        let uncommitted_diff = project
+            .update(cx, |project, cx| {
+                project.open_uncommitted_diff(buffer.clone(), cx)
+            })
+            .await
+            .unwrap();
+        let base_text_buffer_id = uncommitted_diff
+            .read_with(cx, |diff, cx| diff.base_text_buffer().read(cx).remote_id());
+
+        let multi_buffer = cx.new(|cx| {
+            let mut multi_buffer = MultiBuffer::singleton(buffer.clone(), cx);
+            multi_buffer.add_diff(uncommitted_diff.clone(), cx);
+            multi_buffer.set_all_diff_hunks_expanded(cx);
+            multi_buffer
+        });
+
+        let git_blame = cx.new(|cx| {
+            GitBlame::new(
+                multi_buffer.clone(),
+                project,
+                false,
+                true,
+                BlameRevisions {
+                    blame_base_text: true,
+                    base_text_revision: None,
+                    buffer_revision: None,
+                },
+                cx,
+            )
+        });
+
+        cx.executor().run_until_parked();
+
+        git_blame.update(cx, |blame, cx| {
+            // A working-tree line still resolves against the working-tree blame.
+            assert_eq!(
+                blame
+                    .blame_for_rows(
+                        &[RowInfo {
+                            buffer_id: Some(main_buffer_id),
+                            buffer_row: Some(0),
+                            ..Default::default()
+                        }],
+                        cx
+                    )
+                    .next(),
+                Some(Some((main_buffer_id, blame_entry("aaaaaa", 0..1))))
+            );
+
+            // A deleted line (base text row 1, "BBB") resolves against the
+            // committed (HEAD) blame, showing the commit that last touched it.
+            assert_eq!(
+                blame
+                    .blame_for_rows(
+                        &[RowInfo {
+                            buffer_id: Some(base_text_buffer_id),
+                            buffer_row: Some(1),
+                            ..Default::default()
+                        }],
+                        cx
+                    )
+                    .next(),
+                Some(Some((base_text_buffer_id, blame_entry("bbbbbb", 1..2))))
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_blame_for_rows_with_edits(cx: &mut gpui::TestAppContext) {
         init_test(cx);
 
@@ -1051,7 +1305,16 @@ mod tests {
         let buffer_id = buffer.read_with(cx, |buffer, _| buffer.remote_id());
         let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
 
-        let git_blame = cx.new(|cx| GitBlame::new(buffer.clone(), project, false, true, cx));
+        let git_blame = cx.new(|cx| {
+            GitBlame::new(
+                buffer.clone(),
+                project,
+                false,
+                true,
+                BlameRevisions::default(),
+                cx,
+            )
+        });
 
         cx.executor().run_until_parked();
 
@@ -1218,7 +1481,16 @@ mod tests {
             .unwrap();
         let mbuffer = cx.new(|cx| MultiBuffer::singleton(buffer.clone(), cx));
 
-        let git_blame = cx.new(|cx| GitBlame::new(mbuffer.clone(), project, false, true, cx));
+        let git_blame = cx.new(|cx| {
+            GitBlame::new(
+                mbuffer.clone(),
+                project,
+                false,
+                true,
+                BlameRevisions::default(),
+                cx,
+            )
+        });
         cx.executor().run_until_parked();
         git_blame.update(cx, |blame, cx| blame.check_invariants(cx));
 

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -17,7 +17,7 @@ use markdown::Markdown;
 use multi_buffer::{MultiBuffer, RowInfo};
 use project::{
     Project, ProjectItem as _, ProjectPath,
-    git_store::{GitStoreEvent, Repository},
+    git_store::{GitStore, GitStoreEvent, Repository},
 };
 use smallvec::SmallVec;
 use std::{sync::Arc, time::Duration};
@@ -71,22 +71,35 @@ struct GitBlameBuffer {
     commit_details: HashMap<Oid, ParsedCommitMessage>,
 }
 
-/// Controls which revisions a [`GitBlame`] blames against. The default blames
-/// the working-tree contents of each buffer, which is what normal editors want.
+/// Controls which revisions a [`GitBlame`] blames against.
 ///
-/// Diff views (project diff, commit view) use this to additionally blame the
-/// diff base text (so deleted lines show the commit that last touched them), and
-/// to blame the main buffer against a historical revision.
-#[derive(Clone, Debug, Default)]
+/// The default suits regular editors and diff views alike: the main buffer is
+/// blamed against the working tree, deleted lines (the diff base text) are
+/// blamed at `HEAD`, and inline blame is hidden on added rows. Diff views adjust
+/// the revisions to point at the commit being viewed.
+#[derive(Clone, Debug)]
 pub struct BlameRevisions {
-    /// When `true`, also compute blame for each buffer's diff base text, keyed by
-    /// the base text buffer's id, so deleted lines can show inline blame.
+    /// Also blame each buffer's diff base text, keyed by the base text buffer's
+    /// id, so deleted lines can show the commit that last touched them.
     pub blame_base_text: bool,
     /// Revision used to blame diff base text. `None` defaults to `HEAD`.
     pub base_text_revision: Option<git::repository::BlameRevision>,
     /// Revision used to blame the main buffer content. `None` blames the
     /// working-tree contents (piped to git blame via stdin).
     pub buffer_revision: Option<git::repository::BlameRevision>,
+    /// Suppress inline blame on added/modified rows (the new side of a diff).
+    pub hide_blame_on_added_rows: bool,
+}
+
+impl Default for BlameRevisions {
+    fn default() -> Self {
+        Self {
+            blame_base_text: true,
+            base_text_revision: None,
+            buffer_revision: None,
+            hide_blame_on_added_rows: true,
+        }
+    }
 }
 
 /// A pending blame computation for a single buffer (a main buffer or a diff base
@@ -576,30 +589,19 @@ impl GitBlame {
                         let snapshot = buffer.read(cx).snapshot();
                         let buffer_edits = buffer.update(cx, |buffer, _| buffer.subscribe());
 
-                        // Resolve the repository and path for this buffer. Buffers
-                        // registered in the project resolve by id; synthetic
-                        // buffers (e.g. the commit view's historical blobs) are
-                        // not in the buffer store, so fall back to resolving via
-                        // their project path.
+                        // Resolve the repository and path for this buffer
+                        // (registered buffer, synthetic buffer with a file, or
+                        // a fileless diff base-text buffer).
                         let repository = {
                             let git_store = project.read(cx).git_store().clone();
                             let git_store = git_store.read(cx);
-                            git_store
-                                .repository_and_path_for_buffer_id(id, cx)
-                                .or_else(|| {
-                                    // Synthetic buffers (e.g. the commit view's
-                                    // historical blobs) aren't in the buffer store and
-                                    // report a `Historic` disk state, so
-                                    // `Buffer::project_path` returns `None`. Build the
-                                    // project path straight from the file instead.
-                                    let file = buffer.read(cx).file()?;
-                                    let project_path = ProjectPath {
-                                        worktree_id: file.worktree_id(cx),
-                                        path: file.path().clone(),
-                                    };
-                                    git_store
-                                        .repository_and_path_for_project_path(&project_path, cx)
-                                })
+                            resolve_repository_and_path(
+                                git_store,
+                                multi_buffer.upgrade().as_ref(),
+                                &buffer,
+                                id,
+                                cx,
+                            )
                         };
 
                         let remote_url = repository
@@ -610,8 +612,6 @@ impl GitBlame {
                             repositories.push((id, repo.clone()));
                         }
 
-                        // Blame for the main buffer: either at a specific revision
-                        // (commit view) or against the working-tree contents.
                         let main_blame: Task<Result<Option<Blame>>> =
                             match (&repository, &revisions.buffer_revision) {
                                 (Some((repo, repo_path)), Some(revision)) => {
@@ -637,8 +637,8 @@ impl GitBlame {
                             }));
                         }
 
-                        // Blame for the diff base text, so deleted lines show the
-                        // commit that last touched them in diff views.
+                        // Blame the diff base text so deleted lines show the
+                        // commit that last touched them.
                         if revisions.blame_base_text
                             && let Some((repo, repo_path)) = repository
                             && let Some(diff) = multi_buffer
@@ -646,31 +646,30 @@ impl GitBlame {
                                 .and_then(|multi_buffer| multi_buffer.read(cx).diff_for(id))
                         {
                             let base_buffer = diff.read(cx).base_text_buffer().clone();
-                            let base_id = base_buffer.read(cx).remote_id();
                             let base_snapshot = base_buffer.read(cx).snapshot();
-                            let base_edits =
-                                base_buffer.update(cx, |buffer, _| buffer.subscribe());
-                            repositories.push((base_id, repo.clone()));
-                            let revision = revisions.base_text_revision.clone().unwrap_or_else(
-                                || git::repository::BlameRevision::Revision("HEAD".to_string()),
-                            );
-                            let receiver = repo.update(cx, |repo, _| {
-                                repo.blame_path(repo_path.clone(), revision)
-                            });
-                            let base_blame: Task<Result<Option<Blame>>> =
-                                cx.background_spawn(async move {
-                                    let blame = receiver.await.map_err(|e| anyhow::anyhow!(e))?;
-                                    blame.map(Some)
+                            // An empty base text (e.g. a newly added file) has no
+                            // committed revision to blame against.
+                            if base_snapshot.len() > 0 {
+                                let base_id = base_buffer.read(cx).remote_id();
+                                let base_edits =
+                                    base_buffer.update(cx, |buffer, _| buffer.subscribe());
+                                repositories.push((base_id, repo.clone()));
+                                let revision = revisions.base_text_revision.clone().unwrap_or(
+                                    git::repository::BlameRevision::Revision("HEAD".to_string()),
+                                );
+                                let receiver = repo.update(cx, |repo, _| {
+                                    repo.blame_path(repo_path.clone(), revision)
                                 });
-                            blame_futures.push(Box::pin(async move {
-                                (
-                                    base_id,
-                                    base_snapshot,
-                                    base_edits,
-                                    base_blame.await,
-                                    remote_url,
-                                )
-                            }));
+                                let base_blame: Task<Result<Option<Blame>>> =
+                                    cx.background_spawn(async move {
+                                        let blame =
+                                            receiver.await.map_err(|e| anyhow::anyhow!(e))?;
+                                        blame.map(Some)
+                                    });
+                                blame_futures.push(Box::pin(async move {
+                                    (base_id, base_snapshot, base_edits, base_blame.await, remote_url)
+                                }));
+                            }
                         }
                     }
                     Result::<_>::Ok((blame_futures, repositories))
@@ -790,6 +789,44 @@ impl GitBlame {
 }
 
 const REGENERATE_ON_EDIT_DEBOUNCE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Resolves the repository and repo-relative path used to blame `buffer`,
+/// covering buffers registered in the project, synthetic buffers that carry a
+/// file (the commit view's historical blobs), and fileless diff base-text
+/// buffers (the left side of a split diff, resolved via the inverted diff's
+/// main buffer).
+fn resolve_repository_and_path(
+    git_store: &GitStore,
+    multi_buffer: Option<&Entity<MultiBuffer>>,
+    buffer: &Entity<language::Buffer>,
+    id: BufferId,
+    cx: &App,
+) -> Option<(Entity<Repository>, git::repository::RepoPath)> {
+    if let Some(result) = git_store.repository_and_path_for_buffer_id(id, cx) {
+        return Some(result);
+    }
+    if let Some(result) = repository_for_buffer_file(git_store, buffer, cx) {
+        return Some(result);
+    }
+    let main_buffer = multi_buffer?.read(cx).main_buffer_for_inverted_diff(id)?;
+    let main_id = main_buffer.read(cx).remote_id();
+    git_store
+        .repository_and_path_for_buffer_id(main_id, cx)
+        .or_else(|| repository_for_buffer_file(git_store, &main_buffer, cx))
+}
+
+fn repository_for_buffer_file(
+    git_store: &GitStore,
+    buffer: &Entity<language::Buffer>,
+    cx: &App,
+) -> Option<(Entity<Repository>, git::repository::RepoPath)> {
+    let file = buffer.read(cx).file()?;
+    let project_path = ProjectPath {
+        worktree_id: file.worktree_id(cx),
+        path: file.path().clone(),
+    };
+    git_store.repository_and_path_for_project_path(&project_path, cx)
+}
 
 fn build_blame_entry_sum_tree(entries: Vec<BlameEntry>, max_row: u32) -> SumTree<GitBlameEntry> {
     let mut current_row = 0;
@@ -1255,6 +1292,7 @@ mod tests {
                     blame_base_text: true,
                     base_text_revision: None,
                     buffer_revision: None,
+                    hide_blame_on_added_rows: false,
                 },
                 cx,
             )

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -667,7 +667,13 @@ impl GitBlame {
                                         blame.map(Some)
                                     });
                                 blame_futures.push(Box::pin(async move {
-                                    (base_id, base_snapshot, base_edits, base_blame.await, remote_url)
+                                    (
+                                        base_id,
+                                        base_snapshot,
+                                        base_edits,
+                                        base_blame.await,
+                                        remote_url,
+                                    )
                                 }));
                             }
                         }
@@ -1272,8 +1278,8 @@ mod tests {
             })
             .await
             .unwrap();
-        let base_text_buffer_id = uncommitted_diff
-            .read_with(cx, |diff, cx| diff.base_text_buffer().read(cx).remote_id());
+        let base_text_buffer_id =
+            uncommitted_diff.read_with(cx, |diff, cx| diff.base_text_buffer().read(cx).remote_id());
 
         let multi_buffer = cx.new(|cx| {
             let mut multi_buffer = MultiBuffer::singleton(buffer.clone(), cx);

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -614,16 +614,12 @@ impl GitBlame {
 
                         let main_blame: Task<Result<Option<Blame>>> =
                             match (&repository, &revisions.buffer_revision) {
-                                (Some((repo, repo_path)), Some(revision)) => {
-                                    let receiver = repo.update(cx, |repo, _| {
-                                        repo.blame_path(repo_path.clone(), revision.clone())
-                                    });
-                                    cx.background_spawn(async move {
-                                        let blame =
-                                            receiver.await.map_err(|e| anyhow::anyhow!(e))?;
-                                        blame.map(Some)
-                                    })
-                                }
+                                (Some((repo, repo_path)), Some(revision)) => blame_path_at_revision(
+                                    repo,
+                                    repo_path.clone(),
+                                    revision.clone(),
+                                    cx,
+                                ),
                                 (Some(_), None) => project.update(cx, |project, cx| {
                                     project.blame_buffer(&buffer, None, cx)
                                 }),
@@ -657,15 +653,8 @@ impl GitBlame {
                                 let revision = revisions.base_text_revision.clone().unwrap_or(
                                     git::repository::BlameRevision::Revision("HEAD".to_string()),
                                 );
-                                let receiver = repo.update(cx, |repo, _| {
-                                    repo.blame_path(repo_path.clone(), revision)
-                                });
-                                let base_blame: Task<Result<Option<Blame>>> =
-                                    cx.background_spawn(async move {
-                                        let blame =
-                                            receiver.await.map_err(|e| anyhow::anyhow!(e))?;
-                                        blame.map(Some)
-                                    });
+                                let base_blame =
+                                    blame_path_at_revision(&repo, repo_path, revision, cx);
                                 blame_futures.push(Box::pin(async move {
                                     (
                                         base_id,
@@ -795,6 +784,19 @@ impl GitBlame {
 }
 
 const REGENERATE_ON_EDIT_DEBOUNCE_INTERVAL: Duration = Duration::from_secs(2);
+
+fn blame_path_at_revision(
+    repository: &Entity<Repository>,
+    repo_path: git::repository::RepoPath,
+    revision: git::repository::BlameRevision,
+    cx: &mut App,
+) -> Task<Result<Option<Blame>>> {
+    let receiver = repository.update(cx, |repo, _| repo.blame_path(repo_path, revision));
+    cx.background_spawn(async move {
+        let blame = receiver.await.map_err(|e| anyhow::anyhow!(e))?;
+        blame.map(Some)
+    })
+}
 
 /// Resolves the repository and repo-relative path used to blame `buffer`,
 /// covering buffers registered in the project, synthetic buffers that carry a

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -322,17 +322,17 @@ impl GitBlame {
     }
 
     pub fn repository(&self, cx: &App, id: BufferId) -> Option<Entity<Repository>> {
-        // Prefer the repository resolved during blame generation, which also
-        // covers diff base text and synthetic buffers that aren't registered in
-        // the project (and so can't be resolved by buffer id).
+        // Prefer the repository resolved during blame generation, which covers
+        // the diff base text of a unified diff (not an excerpt buffer, so it
+        // can't be resolved on demand below).
         if let Some(repository) = self.repositories.get(&id) {
             return Some(repository.clone());
         }
-        self.project
-            .read(cx)
-            .git_store()
-            .read(cx)
-            .repository_and_path_for_buffer_id(id, cx)
+        let multi_buffer = self.multi_buffer.upgrade()?;
+        let buffer = multi_buffer.read(cx).buffer(id)?;
+        let git_store = self.project.read(cx).git_store().clone();
+        let git_store = git_store.read(cx);
+        resolve_repository_and_path(git_store, Some(&multi_buffer), &buffer, id, cx)
             .map(|(repo, _)| repo)
     }
 

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -16,7 +16,7 @@ use language::{Bias, BufferSnapshot, Edit};
 use markdown::Markdown;
 use multi_buffer::{MultiBuffer, RowInfo};
 use project::{
-    Project, ProjectItem as _,
+    Project, ProjectItem as _, ProjectPath,
     git_store::{GitStoreEvent, Repository},
 };
 use smallvec::SmallVec;
@@ -110,6 +110,11 @@ pub struct GitBlame {
     project: Entity<Project>,
     multi_buffer: WeakEntity<MultiBuffer>,
     buffers: HashMap<BufferId, GitBlameBuffer>,
+    /// Repository resolved for each blamed buffer (main buffers and diff base
+    /// text buffers). Base-text and synthetic buffers aren't registered in the
+    /// project, so callers like the blame popover can't resolve their
+    /// repository by id; this map lets them.
+    repositories: HashMap<BufferId, Entity<Repository>>,
     task: Task<Result<()>>,
     focused: bool,
     changed_while_blurred: bool,
@@ -286,6 +291,7 @@ impl GitBlame {
             project,
             multi_buffer: multi_buffer.downgrade(),
             buffers: HashMap::default(),
+            repositories: HashMap::default(),
             user_triggered,
             revisions,
             focused,
@@ -303,6 +309,12 @@ impl GitBlame {
     }
 
     pub fn repository(&self, cx: &App, id: BufferId) -> Option<Entity<Repository>> {
+        // Prefer the repository resolved during blame generation, which also
+        // covers diff base text and synthetic buffers that aren't registered in
+        // the project (and so can't be resolved by buffer id).
+        if let Some(repository) = self.repositories.get(&id) {
+            return Some(repository.clone());
+        }
         self.project
             .read(cx)
             .git_store()
@@ -549,12 +561,14 @@ impl GitBlame {
         self.task = cx.spawn(async move |this, cx| {
             let mut all_results = Vec::new();
             let mut all_errors = Vec::new();
+            let mut all_repositories: Vec<(BufferId, Entity<Repository>)> = Vec::new();
 
             for buffers in buffers_to_blame.chunks(4) {
                 let span = ztracing::debug_span!("for each chunk of buffers");
                 let _enter = span.enter();
-                let blame = cx.update(|cx| {
+                let (blame, repositories) = cx.update(|cx| {
                     let mut blame_futures: Vec<BlameTargetFuture> = Vec::new();
+                    let mut repositories: Vec<(BufferId, Entity<Repository>)> = Vec::new();
                     for buffer in buffers {
                         let buffer = buffer.upgrade().context("buffer was dropped")?;
                         let project = project.upgrade().context("project was dropped")?;
@@ -573,7 +587,16 @@ impl GitBlame {
                             git_store
                                 .repository_and_path_for_buffer_id(id, cx)
                                 .or_else(|| {
-                                    let project_path = buffer.read(cx).project_path(cx)?;
+                                    // Synthetic buffers (e.g. the commit view's
+                                    // historical blobs) aren't in the buffer store and
+                                    // report a `Historic` disk state, so
+                                    // `Buffer::project_path` returns `None`. Build the
+                                    // project path straight from the file instead.
+                                    let file = buffer.read(cx).file()?;
+                                    let project_path = ProjectPath {
+                                        worktree_id: file.worktree_id(cx),
+                                        path: file.path().clone(),
+                                    };
                                     git_store
                                         .repository_and_path_for_project_path(&project_path, cx)
                                 })
@@ -582,6 +605,10 @@ impl GitBlame {
                         let remote_url = repository
                             .as_ref()
                             .and_then(|(repo, _)| repo.read(cx).default_remote_url());
+
+                        if let Some((repo, _)) = &repository {
+                            repositories.push((id, repo.clone()));
+                        }
 
                         // Blame for the main buffer: either at a specific revision
                         // (commit view) or against the working-tree contents.
@@ -623,6 +650,7 @@ impl GitBlame {
                             let base_snapshot = base_buffer.read(cx).snapshot();
                             let base_edits =
                                 base_buffer.update(cx, |buffer, _| buffer.subscribe());
+                            repositories.push((base_id, repo.clone()));
                             let revision = revisions.base_text_revision.clone().unwrap_or_else(
                                 || git::repository::BlameRevision::Revision("HEAD".to_string()),
                             );
@@ -645,8 +673,9 @@ impl GitBlame {
                             }));
                         }
                     }
-                    Result::<_>::Ok(blame_futures)
+                    Result::<_>::Ok((blame_futures, repositories))
                 })?;
+                all_repositories.extend(repositories);
                 let provider_registry =
                     cx.update(|cx| GitHostingProviderRegistry::default_global(cx));
                 let (results, errors) = cx
@@ -703,6 +732,8 @@ impl GitBlame {
 
             this.update(cx, |this, cx| {
                 this.buffers.clear();
+                this.repositories.clear();
+                this.repositories.extend(all_repositories);
                 for (id, snapshot, buffer_edits, entries, commit_details) in all_results {
                     let Some(entries) = entries else {
                         continue;

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -635,6 +635,23 @@ impl SplittableEditor {
             editor.set_render_diff_hunk_controls(render_diff_hunk_controls, cx);
         });
 
+        // The left side renders the diff base content, so blame it at the right
+        // side's base revision (`None` means HEAD).
+        let rhs_blame_revisions = self.rhs_editor.read(cx).blame_revisions().clone();
+        if rhs_blame_revisions.blame_base_text {
+            let lhs_blame_revisions = crate::BlameRevisions {
+                blame_base_text: false,
+                base_text_revision: None,
+                buffer_revision: Some(rhs_blame_revisions.base_text_revision.unwrap_or(
+                    git::repository::BlameRevision::Revision("HEAD".to_string()),
+                )),
+                hide_blame_on_added_rows: false,
+            };
+            lhs_editor.update(cx, |editor, cx| {
+                editor.set_blame_revisions(lhs_blame_revisions, window, cx);
+            });
+        }
+
         let mut subscriptions = vec![cx.subscribe_in(
             &lhs_editor,
             window,

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -425,6 +425,24 @@ struct LhsEditor {
 }
 
 impl SplittableEditor {
+    fn lhs_blame_revisions(
+        rhs_blame_revisions: &crate::BlameRevisions,
+    ) -> Option<crate::BlameRevisions> {
+        rhs_blame_revisions
+            .blame_base_text
+            .then(|| crate::BlameRevisions {
+                blame_base_text: false,
+                base_text_revision: None,
+                buffer_revision: Some(
+                    rhs_blame_revisions
+                        .base_text_revision
+                        .clone()
+                        .unwrap_or(git::repository::BlameRevision::Revision("HEAD".to_string())),
+                ),
+                hide_blame_on_added_rows: false,
+            })
+    }
+
     pub fn rhs_editor(&self) -> &Entity<Editor> {
         &self.rhs_editor
     }
@@ -468,6 +486,31 @@ impl SplittableEditor {
         });
         self.update_editors(cx, |editor, cx| {
             editor.set_render_diff_hunk_controls(empty_controls.clone(), cx);
+        });
+    }
+
+    pub fn set_blame_revisions(
+        &self,
+        revisions: crate::BlameRevisions,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.rhs_editor.update(cx, |editor, cx| {
+            editor.set_blame_revisions(revisions, window, cx);
+        });
+        self.sync_lhs_blame_revisions(window, cx);
+    }
+
+    fn sync_lhs_blame_revisions(&self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(lhs) = &self.lhs else {
+            return;
+        };
+        let rhs_blame_revisions = self.rhs_editor.read(cx).blame_revisions().clone();
+        let Some(lhs_blame_revisions) = Self::lhs_blame_revisions(&rhs_blame_revisions) else {
+            return;
+        };
+        lhs.editor.update(cx, |editor, cx| {
+            editor.set_blame_revisions(lhs_blame_revisions, window, cx);
         });
     }
 
@@ -644,23 +687,6 @@ impl SplittableEditor {
             });
         });
 
-        // The left side renders the diff base content, so blame it at the right
-        // side's base revision (`None` means HEAD).
-        let rhs_blame_revisions = self.rhs_editor.read(cx).blame_revisions().clone();
-        if rhs_blame_revisions.blame_base_text {
-            let lhs_blame_revisions = crate::BlameRevisions {
-                blame_base_text: false,
-                base_text_revision: None,
-                buffer_revision: Some(rhs_blame_revisions.base_text_revision.unwrap_or(
-                    git::repository::BlameRevision::Revision("HEAD".to_string()),
-                )),
-                hide_blame_on_added_rows: false,
-            };
-            lhs_editor.update(cx, |editor, cx| {
-                editor.set_blame_revisions(lhs_blame_revisions, window, cx);
-            });
-        }
-
         let mut subscriptions = vec![cx.subscribe_in(
             &lhs_editor,
             window,
@@ -787,6 +813,7 @@ impl SplittableEditor {
         });
 
         self.lhs = Some(lhs);
+        self.sync_lhs_blame_revisions(window, cx);
 
         self.sync_lhs_for_paths(all_paths, cx);
 

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -635,6 +635,15 @@ impl SplittableEditor {
             editor.set_render_diff_hunk_controls(render_diff_hunk_controls, cx);
         });
 
+        // The lhs editor is created lazily here, after the splittable editor was
+        // added to the workspace, so it needs the workspace wired up itself (for
+        // e.g. the blame popover).
+        workspace.update(cx, |workspace, cx| {
+            lhs_editor.update(cx, |lhs_editor, cx| {
+                lhs_editor.added_to_workspace(workspace, window, cx);
+            });
+        });
+
         // The left side renders the diff base content, so blame it at the right
         // side's base revision (`None` means HEAD).
         let rhs_blame_revisions = self.rhs_editor.read(cx).blame_revisions().clone();

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -66,6 +66,8 @@ pub struct FakeGitRepositoryState {
     pub merge_base_contents: HashMap<RepoPath, Oid>,
     pub oids: HashMap<Oid, String>,
     pub blames: HashMap<RepoPath, Blame>,
+    /// Blame keyed by `(revision, path)`, used when blaming a specific revision.
+    pub blames_by_revision: HashMap<(String, RepoPath), Blame>,
     pub current_branch_name: Option<String>,
     pub branches: HashSet<String>,
     /// List of remotes, keys are names and values are URLs
@@ -89,6 +91,7 @@ impl FakeGitRepositoryState {
             index_contents: Default::default(),
             unmerged_paths: Default::default(),
             blames: Default::default(),
+            blames_by_revision: Default::default(),
             current_branch_name: Default::default(),
             branches: Default::default(),
             simulated_index_write_error_message: Default::default(),
@@ -955,13 +958,30 @@ impl GitRepository for FakeGitRepository {
         path: RepoPath,
         _content: Rope,
         _line_ending: LineEnding,
+        revision: Option<git::repository::BlameRevision>,
     ) -> BoxFuture<'_, Result<git::blame::Blame>> {
+        let revision = revision.map(|revision| match revision {
+            git::repository::BlameRevision::Revision(revision) => revision,
+            git::repository::BlameRevision::MergeBaseWithHead { base_ref } => {
+                format!("merge-base:{base_ref}")
+            }
+        });
         self.with_state_async(false, move |state| {
-            state
-                .blames
-                .get(&path)
-                .with_context(|| format!("failed to get blame for {:?}", path))
-                .cloned()
+            if let Some(revision) = revision {
+                state
+                    .blames_by_revision
+                    .get(&(revision.clone(), path.clone()))
+                    .with_context(|| {
+                        format!("failed to get blame for {:?} at {:?}", path, revision)
+                    })
+                    .cloned()
+            } else {
+                state
+                    .blames
+                    .get(&path)
+                    .with_context(|| format!("failed to get blame for {:?}", path))
+                    .cloned()
+            }
         })
     }
 

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2263,6 +2263,25 @@ impl FakeFs {
         .unwrap();
     }
 
+    pub fn set_blame_for_repo_at_revision(
+        &self,
+        dot_git: &Path,
+        revision: &str,
+        blames: Vec<(RepoPath, git::blame::Blame)>,
+    ) {
+        self.with_git_state(dot_git, true, |state| {
+            state
+                .blames_by_revision
+                .retain(|(rev, _), _| rev != revision);
+            state.blames_by_revision.extend(
+                blames
+                    .into_iter()
+                    .map(|(path, blame)| ((revision.to_string(), path), blame)),
+            );
+        })
+        .unwrap();
+    }
+
     pub fn set_graph_commits(&self, dot_git: &Path, commits: Vec<Arc<InitialGraphCommitData>>) {
         self.with_git_state(dot_git, true, |state| {
             state.graph_commits = commits;

--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -25,8 +25,9 @@ impl Blame {
         path: &RepoPath,
         content: &Rope,
         line_ending: LineEnding,
+        revision: Option<&str>,
     ) -> Result<Self> {
-        let mut entries = run_git_blame(git, path, content, line_ending).await?;
+        let mut entries = run_git_blame(git, path, content, line_ending, revision).await?;
 
         let mut unique_shas = HashSet::default();
 
@@ -53,11 +54,22 @@ async fn run_git_blame(
     path: &RepoPath,
     contents: &Rope,
     line_ending: LineEnding,
+    revision: Option<&str>,
 ) -> Result<Vec<BlameEntry>> {
+    // When a revision is provided, blame the committed blob at that revision
+    // directly. Otherwise, blame the working-tree contents that are piped in via
+    // stdin (`--contents -`), which lets us blame unsaved/uncommitted changes.
     let mut child = {
         let span = ztracing::debug_span!("spawning git-blame command", path = path.as_unix_str());
         let _enter = span.enter();
-        git.build_command(&["blame", "--incremental", "--contents", "-", "--"])
+        let mut command = git.build_command(&["blame", "--incremental"]);
+        if let Some(revision) = revision {
+            command.arg(revision);
+        } else {
+            command.arg("--contents").arg("-");
+        }
+        command
+            .arg("--")
             .arg(path.as_unix_str())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -80,11 +92,18 @@ async fn run_git_blame(
         .take()
         .context("failed to get stderr from git blame command")?;
 
+    let writes_contents = revision.is_none();
     let write_stdin = async move {
-        for chunk in text::chunks_with_line_ending(contents, line_ending) {
-            stdin.write_all(chunk.as_bytes()).await?;
+        if writes_contents {
+            for chunk in text::chunks_with_line_ending(contents, line_ending) {
+                stdin.write_all(chunk.as_bytes()).await?;
+            }
+            stdin.flush().await?;
         }
-        stdin.flush().await.map_err(Into::into)
+        // Dropping stdin closes the pipe, which is required so that git blame
+        // does not wait for further input when blaming a committed revision.
+        drop(stdin);
+        Result::<()>::Ok(())
     };
 
     let read_stdout = async move {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -775,6 +775,18 @@ impl LogSource {
     }
 }
 
+/// Identifies which revision a blame should be computed against.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BlameRevision {
+    /// A concrete revision: a sha, ref name, or any expression git understands
+    /// (e.g. `HEAD`, `abc123^`).
+    Revision(String),
+    /// The merge base of `HEAD` and `base_ref`. Used to blame the base text of a
+    /// `--merge-base` diff, so deleted lines are attributed against the actual
+    /// fork point rather than the tip of `base_ref`.
+    MergeBaseWithHead { base_ref: String },
+}
+
 pub struct SearchCommitArgs {
     pub query: SharedString,
     pub case_sensitive: bool,
@@ -926,6 +938,7 @@ pub trait GitRepository: Send + Sync {
         path: RepoPath,
         content: Rope,
         line_ending: LineEnding,
+        revision: Option<BlameRevision>,
     ) -> BoxFuture<'_, Result<crate::blame::Blame>>;
 
     /// Returns the absolute path to the repository. For worktrees, this will be the path to the
@@ -2217,13 +2230,35 @@ impl GitRepository for RealGitRepository {
         path: RepoPath,
         content: Rope,
         line_ending: LineEnding,
+        revision: Option<BlameRevision>,
     ) -> BoxFuture<'_, Result<crate::blame::Blame>> {
         let git = self.git_binary_in_worktree();
 
         self.executor
             .spawn(async move {
                 let git = git?;
-                crate::blame::Blame::for_path(&git, &path, &content, line_ending).await
+                // Resolve the requested revision to a concrete revision string.
+                // `MergeBaseWithHead` requires an extra `git merge-base` call so
+                // we attribute base-text lines against the actual fork point.
+                let revision = match revision {
+                    None => None,
+                    Some(BlameRevision::Revision(revision)) => Some(revision),
+                    Some(BlameRevision::MergeBaseWithHead { base_ref }) => {
+                        let output = git
+                            .run(&["merge-base", "HEAD", base_ref.as_str()])
+                            .await
+                            .context("computing merge base for blame")?;
+                        Some(output.trim().to_string())
+                    }
+                };
+                crate::blame::Blame::for_path(
+                    &git,
+                    &path,
+                    &content,
+                    line_ending,
+                    revision.as_deref(),
+                )
+                .await
             })
             .boxed()
     }

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -291,8 +291,7 @@ impl CommitView {
         // lines (the diff base text) at the parent commit, so each line shows the
         // commit that introduced it rather than "not committed yet".
         let buffer_revision = git::repository::BlameRevision::Revision(commit_sha.to_string());
-        let base_text_revision =
-            git::repository::BlameRevision::Revision(format!("{commit_sha}^"));
+        let base_text_revision = git::repository::BlameRevision::Revision(format!("{commit_sha}^"));
         editor
             .read(cx)
             .rhs_editor()

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -2,7 +2,7 @@ use anyhow::{Context as _, Result};
 use buffer_diff::BufferDiff;
 use collections::HashMap;
 use editor::{
-    Addon, Editor, EditorEvent, EditorSettings, MultiBuffer, SplittableEditor,
+    Addon, BlameRevisions, Editor, EditorEvent, EditorSettings, MultiBuffer, SplittableEditor,
     hover_markdown_style, multibuffer_context_lines,
 };
 use futures_lite::future::yield_now;
@@ -286,6 +286,28 @@ impl CommitView {
             editor
         });
         let commit_sha = Arc::<str>::from(commit.sha.as_ref());
+
+        // Blame the commit's content at the commit itself, and blame deleted
+        // lines (the diff base text) at the parent commit, so each line shows the
+        // commit that introduced it rather than "not committed yet".
+        let buffer_revision = git::repository::BlameRevision::Revision(commit_sha.to_string());
+        let base_text_revision =
+            git::repository::BlameRevision::Revision(format!("{commit_sha}^"));
+        editor
+            .read(cx)
+            .rhs_editor()
+            .clone()
+            .update(cx, |primary_editor, cx| {
+                primary_editor.set_blame_revisions(
+                    BlameRevisions {
+                        blame_base_text: true,
+                        base_text_revision: Some(base_text_revision),
+                        buffer_revision: Some(buffer_revision),
+                    },
+                    window,
+                    cx,
+                );
+            });
 
         let first_worktree_id = project
             .read(cx)

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -292,22 +292,18 @@ impl CommitView {
         // commit that introduced it rather than "not committed yet".
         let buffer_revision = git::repository::BlameRevision::Revision(commit_sha.to_string());
         let base_text_revision = git::repository::BlameRevision::Revision(format!("{commit_sha}^"));
-        editor
-            .read(cx)
-            .rhs_editor()
-            .clone()
-            .update(cx, |primary_editor, cx| {
-                primary_editor.set_blame_revisions(
-                    BlameRevisions {
-                        blame_base_text: true,
-                        base_text_revision: Some(base_text_revision),
-                        buffer_revision: Some(buffer_revision),
-                        hide_blame_on_added_rows: true,
-                    },
-                    window,
-                    cx,
-                );
-            });
+        editor.update(cx, |editor, cx| {
+            editor.set_blame_revisions(
+                BlameRevisions {
+                    blame_base_text: true,
+                    base_text_revision: Some(base_text_revision),
+                    buffer_revision: Some(buffer_revision),
+                    hide_blame_on_added_rows: true,
+                },
+                window,
+                cx,
+            );
+        });
 
         let first_worktree_id = project
             .read(cx)

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -303,6 +303,7 @@ impl CommitView {
                         blame_base_text: true,
                         base_text_revision: Some(base_text_revision),
                         buffer_revision: Some(buffer_revision),
+                        hide_blame_on_added_rows: true,
                     },
                     window,
                     cx,

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -8,7 +8,7 @@ use anyhow::{Context as _, Result, anyhow};
 use buffer_diff::{BufferDiff, DiffHunkSecondaryStatus};
 use collections::HashMap;
 use editor::{
-    Addon, Editor, EditorEvent, EditorSettings, SelectionEffects, SplittableEditor,
+    Addon, BlameRevisions, Editor, EditorEvent, EditorSettings, SelectionEffects, SplittableEditor,
     actions::{GoToHunk, GoToPreviousHunk, SendReviewToAgent},
     multibuffer_context_lines,
     scroll::Autoscroll,
@@ -543,6 +543,30 @@ impl ProjectDiff {
         let editor_subscription = cx.subscribe_in(&editor, window, Self::handle_editor_event);
 
         let primary_editor = editor.read(cx).rhs_editor().clone();
+
+        // Blame deleted lines against the diff base so they show the commit that
+        // last touched them, instead of nothing. Working-tree lines keep using
+        // the default working-tree blame.
+        let base_text_revision = match branch_diff.read(cx).diff_base() {
+            // `None` defaults to `HEAD`, which is the base text in this mode.
+            DiffBase::Head => None,
+            // The base text is the merge base of `HEAD` and `base_ref`, so blame
+            // it there rather than at the tip of `base_ref`.
+            DiffBase::Merge { base_ref } => Some(git::repository::BlameRevision::MergeBaseWithHead {
+                base_ref: base_ref.to_string(),
+            }),
+        };
+        primary_editor.update(cx, |primary_editor, cx| {
+            primary_editor.set_blame_revisions(
+                BlameRevisions {
+                    blame_base_text: true,
+                    base_text_revision,
+                    buffer_revision: None,
+                },
+                window,
+                cx,
+            );
+        });
         let review_comment_subscription =
             cx.subscribe(&primary_editor, |this, _editor, event: &EditorEvent, cx| {
                 if let EditorEvent::ReviewCommentsChanged { total_count } = event {

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -562,6 +562,7 @@ impl ProjectDiff {
                     blame_base_text: true,
                     base_text_revision,
                     buffer_revision: None,
+                    hide_blame_on_added_rows: true,
                 },
                 window,
                 cx,

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -93,6 +93,34 @@ pub struct ProjectDiff {
 }
 
 impl ProjectDiff {
+    fn blame_revisions_for_diff_base(diff_base: &DiffBase) -> BlameRevisions {
+        let (base_text_revision, hide_blame_on_added_rows) = match diff_base {
+            DiffBase::Head => (None, true),
+            DiffBase::Merge { base_ref } => {
+                (
+                    Some(git::repository::BlameRevision::MergeBaseWithHead {
+                        base_ref: base_ref.to_string(),
+                    }),
+                    false,
+                )
+            }
+        };
+        BlameRevisions {
+            blame_base_text: true,
+            base_text_revision,
+            buffer_revision: None,
+            hide_blame_on_added_rows,
+        }
+    }
+
+    fn sync_blame_revisions(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let blame_revisions =
+            Self::blame_revisions_for_diff_base(self.branch_diff.read(cx).diff_base());
+        self.editor.update(cx, |editor, cx| {
+            editor.set_blame_revisions(blame_revisions, window, cx);
+        });
+    }
+
     pub(crate) fn register(workspace: &mut Workspace, cx: &mut Context<Workspace>) {
         workspace.register_action(Self::deploy);
         workspace.register_action(Self::deploy_branch_diff);
@@ -543,31 +571,6 @@ impl ProjectDiff {
         let editor_subscription = cx.subscribe_in(&editor, window, Self::handle_editor_event);
 
         let primary_editor = editor.read(cx).rhs_editor().clone();
-
-        // Blame deleted lines against the diff base so they show the commit that
-        // last touched them, instead of nothing. Working-tree lines keep using
-        // the default working-tree blame.
-        let base_text_revision = match branch_diff.read(cx).diff_base() {
-            // `None` defaults to `HEAD`, which is the base text in this mode.
-            DiffBase::Head => None,
-            // The base text is the merge base of `HEAD` and `base_ref`, so blame
-            // it there rather than at the tip of `base_ref`.
-            DiffBase::Merge { base_ref } => Some(git::repository::BlameRevision::MergeBaseWithHead {
-                base_ref: base_ref.to_string(),
-            }),
-        };
-        primary_editor.update(cx, |primary_editor, cx| {
-            primary_editor.set_blame_revisions(
-                BlameRevisions {
-                    blame_base_text: true,
-                    base_text_revision,
-                    buffer_revision: None,
-                    hide_blame_on_added_rows: true,
-                },
-                window,
-                cx,
-            );
-        });
         let review_comment_subscription =
             cx.subscribe(&primary_editor, |this, _editor, event: &EditorEvent, cx| {
                 if let EditorEvent::ReviewCommentsChanged { total_count } = event {
@@ -587,6 +590,7 @@ impl ProjectDiff {
                     })
                 }
                 BranchDiffEvent::DiffBaseChanged => {
+                    this.sync_blame_revisions(window, cx);
                     this.pending_scroll.take();
                     this._task = window.spawn(cx, {
                         let this = cx.weak_entity();
@@ -631,7 +635,7 @@ impl ProjectDiff {
             async |cx| Self::refresh(this, cx).await
         });
 
-        Self {
+        let mut this = Self {
             project,
             workspace: workspace.downgrade(),
             branch_diff,
@@ -646,7 +650,9 @@ impl ProjectDiff {
                 branch_diff_subscription,
                 Subscription::join(editor_subscription, review_comment_subscription),
             ),
-        }
+        };
+        this.sync_blame_revisions(window, cx);
+        this
     }
 
     pub fn diff_base<'a>(&'a self, cx: &'a App) -> &'a DiffBase {
@@ -3132,6 +3138,116 @@ mod tests {
 
         assert_eq!(active_base_ref, "origin/main");
         assert_eq!(base_refs, vec!["origin/main", "topic"]);
+    }
+
+    #[gpui::test]
+    async fn test_branch_diff_updates_blame_revisions_when_diff_base_changes(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "a.txt": "changed",
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        let diff = cx
+            .update(|window, cx| {
+                let Some(repository) = project.read(cx).active_repository(cx) else {
+                    return Task::ready(Err(anyhow!("No active repository")));
+                };
+                ProjectDiff::new_with_branch_base(
+                    project.clone(),
+                    workspace,
+                    "origin/main".into(),
+                    repository,
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        diff.update_in(cx, |diff, window, cx| {
+            diff.editor.update(cx, |editor, cx| {
+                editor.split(window, cx);
+            });
+        });
+        cx.run_until_parked();
+
+        let (rhs_blame_revisions, lhs_blame_revisions) = diff.read_with(cx, |diff, cx| {
+            let editor = diff.editor.read(cx);
+            let rhs_blame_revisions = editor.rhs_editor().read(cx).blame_revisions().clone();
+            let lhs_blame_revisions = editor
+                .lhs_editor()
+                .unwrap()
+                .read(cx)
+                .blame_revisions()
+                .clone();
+            (rhs_blame_revisions, lhs_blame_revisions)
+        });
+
+        assert_eq!(
+            rhs_blame_revisions.base_text_revision,
+            Some(git::repository::BlameRevision::MergeBaseWithHead {
+                base_ref: "origin/main".to_string(),
+            })
+        );
+        assert!(!rhs_blame_revisions.hide_blame_on_added_rows);
+        assert_eq!(
+            lhs_blame_revisions.buffer_revision,
+            Some(git::repository::BlameRevision::MergeBaseWithHead {
+                base_ref: "origin/main".to_string(),
+            })
+        );
+
+        diff.update(cx, |diff, cx| {
+            diff.branch_diff.update(cx, |branch_diff, cx| {
+                branch_diff.set_diff_base(
+                    DiffBase::Merge {
+                        base_ref: "topic".into(),
+                    },
+                    cx,
+                );
+            });
+        });
+        cx.run_until_parked();
+
+        let (rhs_blame_revisions, lhs_blame_revisions) = diff.read_with(cx, |diff, cx| {
+            let editor = diff.editor.read(cx);
+            let rhs_blame_revisions = editor.rhs_editor().read(cx).blame_revisions().clone();
+            let lhs_blame_revisions = editor
+                .lhs_editor()
+                .unwrap()
+                .read(cx)
+                .blame_revisions()
+                .clone();
+            (rhs_blame_revisions, lhs_blame_revisions)
+        });
+
+        assert_eq!(
+            rhs_blame_revisions.base_text_revision,
+            Some(git::repository::BlameRevision::MergeBaseWithHead {
+                base_ref: "topic".to_string(),
+            })
+        );
+        assert!(!rhs_blame_revisions.hide_blame_on_added_rows);
+        assert_eq!(
+            lhs_blame_revisions.buffer_revision,
+            Some(git::repository::BlameRevision::MergeBaseWithHead {
+                base_ref: "topic".to_string(),
+            })
+        );
     }
 
     #[gpui::test]

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -2243,6 +2243,16 @@ impl MultiBuffer {
         self.diffs.get(&buffer_id).map(|state| state.diff.clone())
     }
 
+    /// For an inverted diff (the left side of a split diff), returns the main
+    /// buffer paired with the given fileless base-text buffer, so callers can
+    /// resolve a repository/path for it (e.g. inline blame).
+    pub fn main_buffer_for_inverted_diff(
+        &self,
+        base_text_buffer_id: BufferId,
+    ) -> Option<Entity<language::Buffer>> {
+        self.diffs.get(&base_text_buffer_id)?.main_buffer.clone()
+    }
+
     pub fn expand_diff_hunks(&mut self, ranges: Vec<Range<Anchor>>, cx: &mut Context<Self>) {
         self.expand_or_collapse_diff_hunks(ranges, true, cx);
     }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1518,7 +1518,7 @@ impl GitStore {
                 .map_err(|err| anyhow::anyhow!(err))?;
             match repository_state {
                 RepositoryState::Local(LocalRepositoryState { backend, .. }) => backend
-                    .blame(repo_path.clone(), content, line_ending)
+                    .blame(repo_path.clone(), content, line_ending, None)
                     .await
                     .with_context(|| format!("Failed to blame {:?}", repo_path.as_ref()))
                     .map(Some),
@@ -5620,6 +5620,36 @@ impl Repository {
                         author_email: resp.author_email.into(),
                         author_name: resp.author_name.into(),
                     })
+                }
+            }
+        })
+    }
+
+    /// Blames a path at a specific revision, reading the committed blob directly.
+    ///
+    /// Unlike [`GitStore::blame_buffer`], this does not depend on a registered
+    /// buffer, so it can be used to blame diff base text (deleted lines) and the
+    /// synthetic buffers used by the commit view.
+    pub fn blame_path(
+        &mut self,
+        repo_path: RepoPath,
+        revision: git::repository::BlameRevision,
+    ) -> oneshot::Receiver<Result<Blame>> {
+        self.send_job("blame_path", None, move |git_repo, _cx| async move {
+            match git_repo {
+                RepositoryState::Local(LocalRepositoryState { backend, .. }) => backend
+                    .blame(
+                        repo_path.clone(),
+                        text::Rope::default(),
+                        text::LineEnding::Unix,
+                        Some(revision),
+                    )
+                    .await
+                    .with_context(|| format!("Failed to blame {:?}", repo_path.as_ref())),
+                RepositoryState::Remote(_) => {
+                    anyhow::bail!(
+                        "blaming a specific revision is not supported for remote projects"
+                    )
                 }
             }
         })


### PR DESCRIPTION
Enable inline git blame in the project diff and commit view so that deleted lines show the commit that last touched them instead of empty.

# Objective

**This allows users to recursively trace the history of a line upward from the commit view and project diff. It can also serve as the foundation for implementing GitLens-style line history in the future.**

More info: #60036.

## Solution

This PR extends inline git blame to diff-based editors by allowing blame to target revision-backed diff content instead of only the working-tree buffer. 

Summary:
- Add revision-aware blame support in the git / project layers so a path can be blamed at a specific revision.
- Introduce `BlameRevision`, including direct revision targets and merge-base-based blame for branch diffs.
- Add editor-side `BlameRevisions` so main-buffer blame and diff base-text blame can be configured independently.
- Extend `GitBlame` to generate blame for both the primary buffer and diff base text, while preserving repository resolution for those blamed buffers.
- Wire this into `project_diff` and `commit_view`:
  - in project diff, deleted lines are blamed against the diff base revision;
  - in commit view, the visible content is blamed at the commit itself and the base text at its parent.
- Apply the same blame-revision model to the left-hand side of split diffs so base-side content can render inline blame correctly.
- Refine inline blame presentation in diff views by suppressing blame on added/modified rows and keeping the signal focused on deleted/base content.

Note that we have these behaviour changes:

| View | Before | After |
|---|---|---|
| Regular editor / working-tree content | Inline blame only applied to working-tree content. | Unchanged: inline blame continues to work for working-tree content. |
| Project Diff (`DiffBase::Head`, uncommitted changes) | Deleted lines did not show correct inline blame. | Deleted lines now show inline blame from `HEAD`; added/modified lines remain hidden. |
| Branch Diff (`DiffBase::Merge`, branch vs branch) | Deleted lines did not show correct inline blame, and added lines had no inline blame. | Deleted lines now show inline blame from `merge-base(HEAD, base_ref)`; added/modified lines also show inline blame. |
| Commit View | Historical diff content did not show correct inline blame, especially on deleted lines. | The visible content is blamed at the commit itself, and deleted lines are blamed at the parent commit; added lines remain hidden. |
| Split Diff left-hand side (base side) | The base side did not reliably show inline blame. | The base side now shows inline blame using the corresponding base revision and stays in sync when the diff base changes. |

## Testing

Unit test and manually e2e test on built macOS app. (My own built https://github.com/gaojunran/zed/actions/runs/28517639234)
Screenshots:
<img width="721" height="206" alt="image" src="https://github.com/user-attachments/assets/17051e35-3e30-43f4-8932-3179bbd3e994" />
<img width="536" height="132" alt="image" src="https://github.com/user-attachments/assets/6067978f-f9a7-46d7-8c3e-c090db907390" />



## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable
