### PR TITLE
Route subagents by task complexity

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1066,6 +1066,20 @@
       // Whether thinking is enabled.
       "enable_thinking": false,
     },
+    // The fixed model to use for subagents spawned via the `spawn_agent` tool.
+    // When unset, subagents can be routed with `model_registry`; otherwise they inherit the parent model.
+    "subagent_model": null,
+    // Model metadata used to route spawned subagents by task complexity.
+    // Tiers are derived from `intelligence_score`: 0-40 is boot, 41-70 is mid, and 71-100 is heavy.
+    "model_registry": [
+      // {
+      //   "provider": "zed.dev",
+      //   "model": "claude-sonnet-4",
+      //   "intelligence_score": 72,
+      //   "cost_per_1m_input_tokens": 3,
+      //   "cost_per_1m_output_tokens": 15
+      // }
+    ],
     // Additional parameters for language model requests. When making a request to a model, parameters will be taken
     // from the last entry in this list that matches the model's provider and name. In each entry, both provider
     // and model are optional, so that you can specify parameters for either one.

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1,5 +1,6 @@
 mod db;
 mod legacy_thread;
+mod model_router;
 mod native_agent_server;
 pub mod outline;
 mod pattern_extraction;
@@ -2992,6 +2993,7 @@ impl NativeThreadEnvironment {
     pub(crate) fn create_subagent_thread(
         &self,
         label: String,
+        task_profile: Option<model_router::SubagentTaskProfile>,
         cx: &mut App,
     ) -> Result<Rc<dyn SubagentHandle>> {
         let Some(parent_thread_entity) = self.thread.upgrade() else {
@@ -3009,7 +3011,7 @@ impl NativeThreadEnvironment {
         }
 
         let subagent_thread: Entity<Thread> = cx.new(|cx| {
-            let mut thread = Thread::new_subagent(&parent_thread_entity, cx);
+            let mut thread = Thread::new_subagent_for_task(&parent_thread_entity, task_profile, cx);
             thread.set_title(label.into(), cx);
             thread
         });
@@ -3192,7 +3194,18 @@ impl ThreadEnvironment for NativeThreadEnvironment {
     }
 
     fn create_subagent(&self, label: String, cx: &mut App) -> Result<Rc<dyn SubagentHandle>> {
-        self.create_subagent_thread(label, cx)
+        self.create_subagent_thread(label, None, cx)
+    }
+
+    fn create_subagent_for_task(
+        &self,
+        label: String,
+        task_complexity_score: f32,
+        cx: &mut App,
+    ) -> Result<Rc<dyn SubagentHandle>> {
+        let task_profile =
+            model_router::SubagentTaskProfile::from_complexity_score(task_complexity_score);
+        self.create_subagent_thread(label, Some(task_profile), cx)
     }
 
     fn resume_subagent(

--- a/crates/agent/src/model_router.rs
+++ b/crates/agent/src/model_router.rs
@@ -1,0 +1,340 @@
+use settings::AgentModelRegistryEntry;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum IntelligenceTier {
+    Boot,
+    Mid,
+    Heavy,
+}
+
+impl IntelligenceTier {
+    pub(crate) fn for_score(score: f32) -> Self {
+        if score <= 40.0 {
+            Self::Boot
+        } else if score <= 70.0 {
+            Self::Mid
+        } else {
+            Self::Heavy
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Boot => "boot",
+            Self::Mid => "mid",
+            Self::Heavy => "heavy",
+        }
+    }
+
+    fn contains_model_score(self, score: f32) -> bool {
+        match self {
+            Self::Boot => (0.0..=40.0).contains(&score),
+            Self::Mid => score > 40.0 && score <= 70.0,
+            Self::Heavy => score > 70.0 && score <= 100.0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct TaskComplexitySignals {
+    pub(crate) cyclomatic_complexity: Option<u32>,
+    pub(crate) dependent_count: Option<u32>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct SubagentTaskProfile {
+    complexity_score: f32,
+}
+
+impl SubagentTaskProfile {
+    pub(crate) fn for_spawn_agent(label: &str, message: &str) -> Self {
+        Self::new(score_task(label, message, TaskComplexitySignals::default()))
+    }
+
+    pub(crate) fn from_complexity_score(complexity_score: f32) -> Self {
+        Self::new(complexity_score)
+    }
+
+    fn new(complexity_score: f32) -> Self {
+        Self {
+            complexity_score: complexity_score.clamp(0.0, 100.0),
+        }
+    }
+
+    pub(crate) fn complexity_score(self) -> f32 {
+        self.complexity_score
+    }
+
+    pub(crate) fn tier(self) -> IntelligenceTier {
+        IntelligenceTier::for_score(self.complexity_score)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ModelRoutingDecision {
+    pub(crate) provider: String,
+    pub(crate) model: String,
+    pub(crate) task_complexity_score: f32,
+    pub(crate) tier: IntelligenceTier,
+    pub(crate) model_intelligence_score: f32,
+    pub(crate) cost_per_1m_tokens: f32,
+}
+
+pub(crate) fn route_model_for_task(
+    registry: &[AgentModelRegistryEntry],
+    task_profile: SubagentTaskProfile,
+) -> Option<ModelRoutingDecision> {
+    let tier = task_profile.tier();
+
+    registry
+        .iter()
+        .filter_map(|entry| {
+            let model_intelligence_score = validated_score(entry.intelligence_score)?;
+            if !tier.contains_model_score(model_intelligence_score) {
+                return None;
+            }
+
+            let cost_per_1m_tokens = total_cost_per_1m_tokens(entry)?;
+            Some(ModelCandidate {
+                entry,
+                model_intelligence_score,
+                cost_per_1m_tokens,
+            })
+        })
+        .min_by(|left, right| {
+            left.cost_per_1m_tokens
+                .total_cmp(&right.cost_per_1m_tokens)
+                .then_with(|| {
+                    left.model_intelligence_score
+                        .total_cmp(&right.model_intelligence_score)
+                })
+                .then_with(|| left.entry.provider.0.cmp(&right.entry.provider.0))
+                .then_with(|| left.entry.model.cmp(&right.entry.model))
+        })
+        .map(|candidate| ModelRoutingDecision {
+            provider: candidate.entry.provider.0.clone(),
+            model: candidate.entry.model.clone(),
+            task_complexity_score: task_profile.complexity_score(),
+            tier,
+            model_intelligence_score: candidate.model_intelligence_score,
+            cost_per_1m_tokens: candidate.cost_per_1m_tokens,
+        })
+}
+
+struct ModelCandidate<'a> {
+    entry: &'a AgentModelRegistryEntry,
+    model_intelligence_score: f32,
+    cost_per_1m_tokens: f32,
+}
+
+fn score_task(label: &str, message: &str, complexity_signals: TaskComplexitySignals) -> f32 {
+    let task_text = format!("{label}\n{message}");
+
+    if contains_tag(&task_text, "!heavy") {
+        return 90.0;
+    }
+
+    if contains_tag(&task_text, "!boot") {
+        return 20.0;
+    }
+
+    let base_score = intent_base_score(&task_text);
+    let complexity_delta = complexity_delta(complexity_signals);
+
+    (base_score + complexity_delta).min(100.0)
+}
+
+fn intent_base_score(task_text: &str) -> f32 {
+    let task_text = task_text.to_ascii_lowercase();
+
+    if contains_any(
+        &task_text,
+        &[
+            "architecture",
+            "architectural",
+            "system design",
+            "design decision",
+        ],
+    ) {
+        90.0
+    } else if contains_any(&task_text, &["algorithm", "data structure"]) {
+        80.0
+    } else if contains_any(
+        &task_text,
+        &[
+            "bug",
+            "fix",
+            "debug",
+            "crash",
+            "panic",
+            "error",
+            "failing",
+            "failure",
+            "regression",
+            "test fail",
+            "review",
+            "test",
+        ],
+    ) {
+        50.0
+    } else if contains_any(&task_text, &["refactor", "rewrite", "cleanup", "clean up"]) {
+        30.0
+    } else if contains_any(
+        &task_text,
+        &[
+            "format",
+            "formatting",
+            "import",
+            "imports",
+            "rename",
+            "boilerplate",
+        ],
+    ) {
+        20.0
+    } else {
+        50.0
+    }
+}
+
+fn complexity_delta(signals: TaskComplexitySignals) -> f32 {
+    let cyclomatic_delta = match signals.cyclomatic_complexity {
+        Some(complexity) if complexity <= 5 => 0.0,
+        Some(complexity) if complexity <= 15 => 10.0,
+        Some(_) => 20.0,
+        None => 0.0,
+    };
+
+    let dependent_delta = signals
+        .dependent_count
+        .map(|dependents| (dependents / 50) as f32 * 10.0)
+        .unwrap_or(0.0);
+
+    cyclomatic_delta + dependent_delta
+}
+
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
+}
+
+fn contains_tag(text: &str, tag: &str) -> bool {
+    text.split(|character: char| {
+        character.is_whitespace() || (character.is_ascii_punctuation() && character != '!')
+    })
+    .any(|token| token.eq_ignore_ascii_case(tag))
+}
+
+fn validated_score(score: f32) -> Option<f32> {
+    if score.is_finite() && (0.0..=100.0).contains(&score) {
+        Some(score)
+    } else {
+        None
+    }
+}
+
+fn total_cost_per_1m_tokens(entry: &AgentModelRegistryEntry) -> Option<f32> {
+    if entry.cost_per_1m_input_tokens.is_finite()
+        && entry.cost_per_1m_output_tokens.is_finite()
+        && entry.cost_per_1m_input_tokens >= 0.0
+        && entry.cost_per_1m_output_tokens >= 0.0
+    {
+        Some(entry.cost_per_1m_input_tokens + entry.cost_per_1m_output_tokens)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use settings::LanguageModelProviderSetting;
+
+    #[test]
+    fn maps_scores_to_wide_tiers() {
+        assert_eq!(IntelligenceTier::for_score(40.0), IntelligenceTier::Boot);
+        assert_eq!(IntelligenceTier::for_score(41.0), IntelligenceTier::Mid);
+        assert_eq!(IntelligenceTier::for_score(70.0), IntelligenceTier::Mid);
+        assert_eq!(IntelligenceTier::for_score(71.0), IntelligenceTier::Heavy);
+    }
+
+    #[test]
+    fn scores_tasks_from_intent_and_overrides() {
+        assert_eq!(
+            score_task(
+                "Refactor auth",
+                "Clean up this module",
+                TaskComplexitySignals::default()
+            ),
+            30.0
+        );
+        assert_eq!(
+            score_task(
+                "Debug parser",
+                "Fix failing tests",
+                TaskComplexitySignals {
+                    cyclomatic_complexity: Some(16),
+                    dependent_count: Some(100),
+                },
+            ),
+            90.0
+        );
+        assert_eq!(
+            score_task(
+                "Format imports",
+                "Run the simple pass !heavy",
+                TaskComplexitySignals::default()
+            ),
+            90.0
+        );
+        assert_eq!(
+            score_task(
+                "Architecture",
+                "Draft it with !boot",
+                TaskComplexitySignals::default()
+            ),
+            20.0
+        );
+    }
+
+    #[test]
+    fn routes_to_cheapest_model_in_task_tier() {
+        let registry = vec![
+            registry_entry("local", "expensive-boot", 30.0, 2.0, 2.0),
+            registry_entry("local", "cheap-boot", 35.0, 0.2, 0.3),
+            registry_entry("cloud", "mid", 65.0, 1.0, 2.0),
+        ];
+
+        let decision = route_model_for_task(&registry, SubagentTaskProfile::new(20.0)).unwrap();
+
+        assert_eq!(decision.provider, "local");
+        assert_eq!(decision.model, "cheap-boot");
+        assert_eq!(decision.tier, IntelligenceTier::Boot);
+        assert_eq!(decision.model_intelligence_score, 35.0);
+    }
+
+    #[test]
+    fn ignores_invalid_registry_entries() {
+        let registry = vec![
+            registry_entry("local", "invalid-score", 120.0, 0.1, 0.1),
+            registry_entry("local", "invalid-cost", 30.0, -1.0, 0.1),
+            registry_entry("cloud", "mid", 65.0, 1.0, 2.0),
+        ];
+
+        assert!(route_model_for_task(&registry, SubagentTaskProfile::new(20.0)).is_none());
+    }
+
+    fn registry_entry(
+        provider: &str,
+        model: &str,
+        intelligence_score: f32,
+        input_cost: f32,
+        output_cost: f32,
+    ) -> AgentModelRegistryEntry {
+        AgentModelRegistryEntry {
+            provider: LanguageModelProviderSetting(provider.to_string()),
+            model: model.to_string(),
+            intelligence_score,
+            cost_per_1m_input_tokens: input_cost,
+            cost_per_1m_output_tokens: output_cost,
+        }
+    }
+}

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -41,7 +41,10 @@ use reqwest_client::ReqwestClient;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use settings::{LanguageModelProviderSetting, LanguageModelSelection, Settings, SettingsStore};
+use settings::{
+    AgentModelRegistryEntry, LanguageModelProviderSetting, LanguageModelSelection, Settings,
+    SettingsStore,
+};
 use std::{
     path::Path,
     pin::Pin,
@@ -5719,6 +5722,12 @@ async fn test_subagent_thread_uses_configured_subagent_model(cx: &mut TestAppCon
         "Subagent Model",
         true,
     ));
+    let registry_model = Arc::new(FakeLanguageModel::with_id_and_thinking(
+        "fake-corp",
+        "registry-model",
+        "Registry Model",
+        false,
+    ));
 
     cx.update(|cx| {
         LanguageModelRegistry::test(cx);
@@ -5728,7 +5737,7 @@ async fn test_subagent_thread_uses_configured_subagent_model(cx: &mut TestAppCon
                 LanguageModelProviderId::from("fake-corp".to_string()),
                 LanguageModelProviderName::from("Fake Corp".to_string()),
             )
-            .with_models(vec![subagent_model.clone()]),
+            .with_models(vec![subagent_model.clone(), registry_model.clone()]),
         );
         LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
             registry.register_provider(provider, cx);
@@ -5742,6 +5751,13 @@ async fn test_subagent_thread_uses_configured_subagent_model(cx: &mut TestAppCon
             effort: Some("high".to_string()),
             speed: None,
         });
+        settings.model_registry = vec![model_registry_entry(
+            "fake-corp",
+            "registry-model",
+            30.0,
+            0.1,
+            0.1,
+        )];
         agent_settings::AgentSettings::override_global(settings, cx);
     });
 
@@ -5783,6 +5799,119 @@ async fn test_subagent_thread_uses_configured_subagent_model(cx: &mut TestAppCon
         assert!(subagent_thread.thinking_enabled());
         assert_eq!(subagent_thread.thinking_effort(), Some(&"high".to_string()));
     });
+}
+
+#[gpui::test]
+async fn test_subagent_thread_uses_model_registry_route(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/test"), json!({})).await;
+    let project = Project::test(fs, [path!("/test").as_ref()], cx).await;
+    let project_context = cx.new(|_cx| ProjectContext::default());
+    let context_server_store = project.read_with(cx, |project, _| project.context_server_store());
+    let context_server_registry =
+        cx.new(|cx| ContextServerRegistry::new(context_server_store.clone(), cx));
+    let parent_model = Arc::new(FakeLanguageModel::default());
+    let cheap_boot_model = Arc::new(FakeLanguageModel::with_id_and_thinking(
+        "fake-corp",
+        "cheap-boot-model",
+        "Cheap Boot Model",
+        false,
+    ));
+    let expensive_boot_model = Arc::new(FakeLanguageModel::with_id_and_thinking(
+        "fake-corp",
+        "expensive-boot-model",
+        "Expensive Boot Model",
+        false,
+    ));
+    let mid_model = Arc::new(FakeLanguageModel::with_id_and_thinking(
+        "fake-corp",
+        "mid-model",
+        "Mid Model",
+        false,
+    ));
+
+    cx.update(|cx| {
+        LanguageModelRegistry::test(cx);
+
+        let provider = Arc::new(
+            FakeLanguageModelProvider::new(
+                LanguageModelProviderId::from("fake-corp".to_string()),
+                LanguageModelProviderName::from("Fake Corp".to_string()),
+            )
+            .with_models(vec![
+                cheap_boot_model.clone(),
+                expensive_boot_model.clone(),
+                mid_model.clone(),
+            ]),
+        );
+        LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
+            registry.register_provider(provider, cx);
+        });
+
+        let mut settings = agent_settings::AgentSettings::get_global(cx).clone();
+        settings.subagent_model = None;
+        settings.model_registry = vec![
+            model_registry_entry("fake-corp", "expensive-boot-model", 35.0, 1.0, 2.0),
+            model_registry_entry("fake-corp", "cheap-boot-model", 30.0, 0.1, 0.2),
+            model_registry_entry("fake-corp", "mid-model", 65.0, 0.5, 0.5),
+        ];
+        agent_settings::AgentSettings::override_global(settings, cx);
+    });
+
+    let parent_thread = cx.new(|cx| {
+        Thread::new(
+            project.clone(),
+            project_context,
+            context_server_registry,
+            Templates::new(),
+            Some(parent_model.clone()),
+            cx,
+        )
+    });
+
+    let task_profile =
+        crate::model_router::SubagentTaskProfile::for_spawn_agent("Format imports", "Sort imports");
+    let subagent_thread =
+        cx.new(|cx| Thread::new_subagent_for_task(&parent_thread, Some(task_profile), cx));
+
+    subagent_thread.read_with(cx, |subagent_thread, _cx| {
+        assert_eq!(
+            subagent_thread.model().map(|model| model.id()),
+            Some(cheap_boot_model.id())
+        );
+    });
+
+    parent_thread.update(cx, |parent_thread, _cx| {
+        parent_thread.register_running_subagent(subagent_thread.downgrade());
+    });
+    parent_thread.update(cx, |parent_thread, cx| {
+        parent_thread.set_model(mid_model.clone(), cx);
+    });
+
+    subagent_thread.read_with(cx, |subagent_thread, _cx| {
+        assert_eq!(
+            subagent_thread.model().map(|model| model.id()),
+            Some(cheap_boot_model.id())
+        );
+    });
+}
+
+fn model_registry_entry(
+    provider: &str,
+    model: &str,
+    intelligence_score: f32,
+    input_cost: f32,
+    output_cost: f32,
+) -> AgentModelRegistryEntry {
+    AgentModelRegistryEntry {
+        provider: LanguageModelProviderSetting(provider.to_string()),
+        model: model.to_string(),
+        intelligence_score,
+        cost_per_1m_input_tokens: input_cost,
+        cost_per_1m_output_tokens: output_cost,
+    }
 }
 
 #[gpui::test]

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -6,6 +6,7 @@ use crate::{
     RenameTool, SandboxedTerminalTool, SpawnAgentTool, SystemPromptTemplate, Template, Templates,
     TerminalTool, ToolPermissionDecision, WebSearchTool, WriteFileTool,
     decide_permission_from_settings,
+    model_router::{ModelRoutingDecision, SubagentTaskProfile, route_model_for_task},
 };
 use acp_thread::{MentionUri, UserMessageId};
 use action_log::ActionLog;
@@ -744,6 +745,15 @@ pub trait ThreadEnvironment {
 
     fn create_subagent(&self, label: String, cx: &mut App) -> Result<Rc<dyn SubagentHandle>>;
 
+    fn create_subagent_for_task(
+        &self,
+        label: String,
+        _task_complexity_score: f32,
+        cx: &mut App,
+    ) -> Result<Rc<dyn SubagentHandle>> {
+        self.create_subagent(label, cx)
+    }
+
     fn resume_subagent(
         &self,
         _session_id: acp::SessionId,
@@ -1262,6 +1272,14 @@ impl Thread {
     }
 
     pub fn new_subagent(parent_thread: &Entity<Thread>, cx: &mut Context<Self>) -> Self {
+        Self::new_subagent_for_task(parent_thread, None, cx)
+    }
+
+    pub(crate) fn new_subagent_for_task(
+        parent_thread: &Entity<Thread>,
+        task_profile: Option<SubagentTaskProfile>,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let project = parent_thread.read(cx).project.clone();
         let project_context = parent_thread.read(cx).project_context.clone();
         let context_server_registry = parent_thread.read(cx).context_server_registry.clone();
@@ -1287,6 +1305,29 @@ impl Thread {
         if let Some(subagent_model) = AgentSettings::get_global(cx).subagent_model.clone() {
             thread.inherits_parent_model_settings = false;
             thread.apply_model_selection(&subagent_model, cx);
+        } else if let Some(task_profile) = task_profile {
+            let model_registry = AgentSettings::get_global(cx).model_registry.clone();
+            if let Some(decision) = route_model_for_task(&model_registry, task_profile) {
+                if let Some(model) = Self::resolve_model_from_routing_decision(&decision, cx) {
+                    log::debug!(
+                        "routed subagent task score {:.1} ({}) to model {}/{} with intelligence score {:.1} and cost {:.2} per 1m tokens",
+                        decision.task_complexity_score,
+                        decision.tier.as_str(),
+                        decision.provider,
+                        decision.model,
+                        decision.model_intelligence_score,
+                        decision.cost_per_1m_tokens
+                    );
+                    thread.set_model(model, cx);
+                    thread.inherits_parent_model_settings = false;
+                } else {
+                    log::warn!(
+                        "failed to resolve routed subagent model: {}/{}",
+                        decision.provider,
+                        decision.model
+                    );
+                }
+            }
         }
         thread
     }
@@ -2384,9 +2425,27 @@ impl Thread {
             provider: LanguageModelProviderId::from(selection.provider.0.clone()),
             model: LanguageModelId::from(selection.model.clone()),
         };
+        Self::resolve_model_from_selected_model(&selected, cx)
+    }
+
+    fn resolve_model_from_routing_decision(
+        decision: &ModelRoutingDecision,
+        cx: &mut Context<Self>,
+    ) -> Option<Arc<dyn LanguageModel>> {
+        let selected = SelectedModel {
+            provider: LanguageModelProviderId::from(decision.provider.clone()),
+            model: LanguageModelId::from(decision.model.clone()),
+        };
+        Self::resolve_model_from_selected_model(&selected, cx)
+    }
+
+    fn resolve_model_from_selected_model(
+        selected: &SelectedModel,
+        cx: &mut Context<Self>,
+    ) -> Option<Arc<dyn LanguageModel>> {
         LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
             registry
-                .select_model(&selected, cx)
+                .select_model(selected, cx)
                 .map(|configured| configured.model)
         })
     }

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -577,6 +577,7 @@ mod tests {
             max_content_width: Some(px(850.)),
             default_model: None,
             subagent_model: None,
+            model_registry: Vec::new(),
             inline_assistant_model: None,
             inline_assistant_use_streaming_tools: false,
             commit_message_model: None,

--- a/crates/agent/src/tools/spawn_agent_tool.rs
+++ b/crates/agent/src/tools/spawn_agent_tool.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use crate::{AgentTool, ThreadEnvironment, ToolCallEventStream, ToolInput};
+use crate::{
+    AgentTool, ThreadEnvironment, ToolCallEventStream, ToolInput, model_router::SubagentTaskProfile,
+};
 
 /// Spawn a sub-agent for a well-scoped task.
 ///
@@ -145,7 +147,13 @@ impl AgentTool for SpawnAgentTool {
                 let subagent = if let Some(session_id) = input.session_id {
                     self.environment.resume_subagent(session_id, cx)
                 } else {
-                    self.environment.create_subagent(input.label, cx)
+                    let task_profile =
+                        SubagentTaskProfile::for_spawn_agent(&input.label, &input.message);
+                    self.environment.create_subagent_for_task(
+                        input.label,
+                        task_profile.complexity_score(),
+                        cx,
+                    )
                 };
                 let subagent = subagent.map_err(|err| SpawnAgentToolOutput::Error {
                     session_id: None,

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -16,10 +16,11 @@ use project::DisableAiSettings;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockPosition, DockSide, LanguageModelParameters, LanguageModelSelection,
-    NotifyWhenAgentWaiting, PlaySoundWhenAgentDone, RegisterSetting, Settings, SettingsContent,
-    SettingsStore, SidebarDockPosition, SidebarSide, ThinkingBlockDisplay, ToolPermissionMode,
-    update_settings_file, update_settings_file_with_completion,
+    AgentModelRegistryEntry, DockPosition, DockSide, LanguageModelParameters,
+    LanguageModelSelection, NotifyWhenAgentWaiting, PlaySoundWhenAgentDone, RegisterSetting,
+    Settings, SettingsContent, SettingsStore, SidebarDockPosition, SidebarSide,
+    ThinkingBlockDisplay, ToolPermissionMode, update_settings_file,
+    update_settings_file_with_completion,
 };
 use util::ResultExt as _;
 
@@ -213,6 +214,7 @@ pub struct AgentSettings {
     pub max_content_width: Option<Pixels>,
     pub default_model: Option<LanguageModelSelection>,
     pub subagent_model: Option<LanguageModelSelection>,
+    pub model_registry: Vec<AgentModelRegistryEntry>,
     pub inline_assistant_model: Option<LanguageModelSelection>,
     pub inline_assistant_use_streaming_tools: bool,
     pub commit_message_model: Option<LanguageModelSelection>,
@@ -743,6 +745,7 @@ impl Settings for AgentSettings {
             flexible: agent.flexible.unwrap(),
             default_model: Some(agent.default_model.unwrap()),
             subagent_model: agent.subagent_model,
+            model_registry: agent.model_registry,
             inline_assistant_model: agent.inline_assistant_model,
             inline_assistant_use_streaming_tools: agent
                 .inline_assistant_use_streaming_tools

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -990,6 +990,7 @@ mod tests {
             max_content_width: Some(px(850.)),
             default_model: None,
             subagent_model: None,
+            model_registry: Vec::new(),
             inline_assistant_model: None,
             inline_assistant_use_streaming_tools: false,
             commit_message_model: None,

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -237,6 +237,9 @@ pub struct AgentSettingsContent {
     pub default_model: Option<LanguageModelSelection>,
     /// The model to use for subagents spawned via the `spawn_agent` tool. Defaults to the parent agent's model when not specified.
     pub subagent_model: Option<LanguageModelSelection>,
+    /// Model metadata used to route spawned subagents by task complexity. When empty, subagents use `subagent_model` or the parent model.
+    #[serde(default)]
+    pub model_registry: Vec<AgentModelRegistryEntry>,
     /// Favorite models to show at the top of the model selector.
     #[serde(default)]
     pub favorite_models: Vec<LanguageModelSelection>,
@@ -586,6 +589,19 @@ pub struct LanguageModelSelection {
     pub enable_thinking: bool,
     pub effort: Option<String>,
     pub speed: Option<language_model_core::Speed>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
+pub struct AgentModelRegistryEntry {
+    pub provider: LanguageModelProviderSetting,
+    pub model: String,
+    #[serde(serialize_with = "crate::serialize_f32_with_two_decimal_places")]
+    pub intelligence_score: f32,
+    #[serde(serialize_with = "crate::serialize_f32_with_two_decimal_places")]
+    pub cost_per_1m_input_tokens: f32,
+    #[serde(serialize_with = "crate::serialize_f32_with_two_decimal_places")]
+    pub cost_per_1m_output_tokens: f32,
 }
 
 #[with_fallible_options]

--- a/docs/src/ai/agent-settings.md
+++ b/docs/src/ai/agent-settings.md
@@ -38,6 +38,7 @@ Some Zed AI features have their own model or prompt settings in `settings.json`,
 - `agent.commit_message_model`
 - `agent.thread_summary_model`
 - `agent.subagent_model`
+- `agent.model_registry`
 - `agent.commit_message_instructions`
 - `agent.inline_alternatives`
 
@@ -128,6 +129,43 @@ Some AI settings are not configured in the Agent Settings panel:
 Zed supports feature-specific model settings for Inline Assistant, Git commit generation, thread summaries, and subagents. Configure these in settings when you need a different model for a specific workflow.
 
 See [LLM Providers](./llm-providers.md) for model access, and [All Settings](../reference/all-settings.md) for the complete settings reference.
+
+## Subagent Model Routing {#subagent-model-routing}
+
+By default, subagents spawned with `spawn_agent` inherit the parent thread's
+model. Set `agent.subagent_model` when every subagent should use one fixed
+model.
+
+When `agent.subagent_model` is unset, you can use `agent.model_registry` to
+route spawned subagents by task complexity. Zed scores the delegated task,
+maps it to a wide tier, and selects the cheapest configured model in that tier.
+
+```json [settings]
+{
+  "agent": {
+    "model_registry": [
+      {
+        "provider": "ollama",
+        "model": "qwen2.5-coder:0.5b",
+        "intelligence_score": 30,
+        "cost_per_1m_input_tokens": 0.01,
+        "cost_per_1m_output_tokens": 0.02
+      },
+      {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4",
+        "intelligence_score": 70,
+        "cost_per_1m_input_tokens": 3,
+        "cost_per_1m_output_tokens": 15
+      }
+    ]
+  }
+}
+```
+
+The tier bands are `0-40` for boot tasks, `41-70` for mid tasks, and `71-100`
+for heavy tasks. If no registry entry matches the task tier or the selected
+model is not configured, the subagent inherits the parent model.
 
 ## Model Temperature {#model-temperature}
 


### PR DESCRIPTION
## Summary

- Add settings-backed `agent.model_registry` metadata for subagent routing.
- Score spawned subagent tasks and select the cheapest configured model in the matching intelligence tier.
- Preserve fixed `agent.subagent_model` precedence and parent-model fallback.
- Document the new setting and add focused routing tests.

## Testing

- `cargo fmt --all`
- `cargo test -p agent model_router`
- `cargo test -p agent test_subagent_thread_uses_model_registry_route`
- `cargo test -p agent test_subagent_thread_uses_configured_subagent_model`
- `cargo test -p agent_settings test_default_json_tool_permissions_parse`
- `cargo check -p agent_ui`
- `npx prettier --check src/ai/agent-settings.md`

Release Notes:

- Added configurable subagent model routing based on task complexity tiers.