### PR TITLE
editor: Fix line selection disappears when the cursor goes off screen

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8324,7 +8324,7 @@ impl Element for EditorElement {
                                     selected_buffer_ids
                                 };
 
-                                let mut selections = editor.selections.disjoint_in_range(
+                                let mut selections = editor.selections.disjoint_in_row_range(
                                     start_anchor..end_anchor,
                                     &snapshot.display_snapshot,
                                 );

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -1358,22 +1358,16 @@ mod tests {
     use settings::SettingsStore;
     use std::sync::Arc;
 
-    /// In line mode, `disjoint_in_range` selects by whole rows, so a selection sharing a queried
-    /// row must be returned even when its columns don't overlap the queried range. The non-line-mode
-    /// path compares exact offsets and would miss this case.
-    #[gpui::test]
-    fn disjoint_in_range_line_mode_matches_whole_row(cx: &mut gpui::TestAppContext) {
+    fn line_mode_snapshot(cx: &mut gpui::TestAppContext, text: &str) -> DisplaySnapshot {
         cx.update(|cx| {
             let settings = SettingsStore::test(cx);
             cx.set_global(settings);
             crate::init(cx);
         });
-
-        let text = "aaaa\nbbbbbbbb\ncccc";
         let buffer = cx.update(|cx| MultiBuffer::build_simple(text, cx));
         let display_map = cx.new(|cx| {
             DisplayMap::new(
-                buffer.clone(),
+                buffer,
                 test_font(),
                 px(14.),
                 None,
@@ -1384,24 +1378,46 @@ mod tests {
                 cx,
             )
         });
-        let snapshot = display_map.update(cx, |map, cx| map.snapshot(cx));
+        display_map.update(cx, |map, cx| map.snapshot(cx))
+    }
+
+    fn line_mode_collection(
+        offset_ranges: impl IntoIterator<Item = Range<usize>>,
+        buffer_snapshot: &MultiBufferSnapshot,
+    ) -> SelectionsCollection {
+        let selections = offset_ranges
+            .into_iter()
+            .enumerate()
+            .map(|(id, range)| {
+                selection_to_anchor_selection(
+                    Selection {
+                        id,
+                        start: MultiBufferOffset(range.start),
+                        end: MultiBufferOffset(range.end),
+                        reversed: false,
+                        goal: SelectionGoal::None,
+                    },
+                    buffer_snapshot,
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut collection = SelectionsCollection::new();
+        collection.disjoint = Arc::from(selections);
+        collection.pending = None;
+        collection.line_mode = true;
+        collection
+    }
+
+    /// In line mode, `disjoint_in_range` selects by whole rows, so a selection sharing a queried
+    /// row must be returned even when its columns don't overlap the queried range. The non-line-mode
+    /// path compares exact offsets and would miss this case.
+    #[gpui::test]
+    fn disjoint_in_range_line_mode_matches_whole_row(cx: &mut gpui::TestAppContext) {
+        let snapshot = line_mode_snapshot(cx, "aaaa\nbbbbbbbb\ncccc");
         let buffer_snapshot = snapshot.buffer_snapshot();
 
         // A selection on row 1 spanning columns 3..5 (buffer offsets 8..10).
-        let selection = selection_to_anchor_selection(
-            Selection {
-                id: 0,
-                start: MultiBufferOffset(8),
-                end: MultiBufferOffset(10),
-                reversed: false,
-                goal: SelectionGoal::None,
-            },
-            buffer_snapshot,
-        );
-        let mut collection = SelectionsCollection::new();
-        collection.disjoint = Arc::from([selection]);
-        collection.pending = None;
-        collection.line_mode = true;
+        let collection = line_mode_collection([8..10], buffer_snapshot);
 
         // Query row 1 at columns 0..1, entirely before the selection's columns.
         let range = buffer_snapshot.anchor_before(MultiBufferOffset(5))
@@ -1415,6 +1431,51 @@ mod tests {
         );
         assert_eq!(result[0].start, Point::new(1, 3));
         assert_eq!(result[0].end, Point::new(1, 5));
+    }
+
+    /// A selection on a row outside the queried row range must not be returned, even in line mode.
+    /// This guards the row-overlap boundary against becoming over-inclusive.
+    #[gpui::test]
+    fn disjoint_in_range_line_mode_excludes_other_rows(cx: &mut gpui::TestAppContext) {
+        let snapshot = line_mode_snapshot(cx, "aaaa\nbbbbbbbb\ncccc");
+        let buffer_snapshot = snapshot.buffer_snapshot();
+
+        // A selection on row 2 (buffer offsets 14..16).
+        let collection = line_mode_collection([14..16], buffer_snapshot);
+
+        // Query only row 0, two rows away from the selection.
+        let range = buffer_snapshot.anchor_before(MultiBufferOffset(0))
+            ..buffer_snapshot.anchor_before(MultiBufferOffset(1));
+        let result = collection.disjoint_in_range::<Point>(range, &snapshot);
+
+        assert!(
+            result.is_empty(),
+            "line mode should exclude a selection on a non-queried row"
+        );
+    }
+
+    /// A selection spanning multiple rows must be returned when the query touches any of those rows,
+    /// not just when the query shares the selection's start or end row.
+    #[gpui::test]
+    fn disjoint_in_range_line_mode_matches_interior_row(cx: &mut gpui::TestAppContext) {
+        let snapshot = line_mode_snapshot(cx, "aaaa\nbbbb\ncccc\ndddd");
+        let buffer_snapshot = snapshot.buffer_snapshot();
+
+        // A selection spanning row 1 column 1 through row 3 column 2 (buffer offsets 6..17).
+        let collection = line_mode_collection([6..17], buffer_snapshot);
+
+        // Query only row 2, an interior row of the selection.
+        let range = buffer_snapshot.anchor_before(MultiBufferOffset(11))
+            ..buffer_snapshot.anchor_before(MultiBufferOffset(12));
+        let result = collection.disjoint_in_range::<Point>(range, &snapshot);
+
+        assert_eq!(
+            result.len(),
+            1,
+            "line mode should include a selection whose interior row is queried"
+        );
+        assert_eq!(result[0].start, Point::new(1, 1));
+        assert_eq!(result[0].end, Point::new(3, 2));
     }
 
     #[gpui::test(iterations = 20)]

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -222,14 +222,14 @@ impl SelectionsCollection {
     {
         let buffer = snapshot.buffer_snapshot();
         let (start_ix, end_ix) = if self.line_mode {
-            let start_row = range.start.to_point(snapshot).row;
-            let end_row = range.end.to_point(snapshot).row;
+            let start_row = range.start.to_point(buffer).row;
+            let end_row = range.end.to_point(buffer).row;
             let start_ix = self
                 .disjoint
-                .partition_point(|probe| probe.end.to_point(snapshot).row < start_row);
+                .partition_point(|probe| probe.end.to_point(buffer).row < start_row);
             let end_ix = self
                 .disjoint
-                .partition_point(|probe| probe.start.to_point(snapshot).row <= end_row);
+                .partition_point(|probe| probe.start.to_point(buffer).row <= end_row);
             (start_ix, end_ix)
         } else {
             let start_ix = self

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -1358,6 +1358,65 @@ mod tests {
     use settings::SettingsStore;
     use std::sync::Arc;
 
+    /// In line mode, `disjoint_in_range` selects by whole rows, so a selection sharing a queried
+    /// row must be returned even when its columns don't overlap the queried range. The non-line-mode
+    /// path compares exact offsets and would miss this case.
+    #[gpui::test]
+    fn disjoint_in_range_line_mode_matches_whole_row(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            let settings = SettingsStore::test(cx);
+            cx.set_global(settings);
+            crate::init(cx);
+        });
+
+        let text = "aaaa\nbbbbbbbb\ncccc";
+        let buffer = cx.update(|cx| MultiBuffer::build_simple(text, cx));
+        let display_map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer.clone(),
+                test_font(),
+                px(14.),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = display_map.update(cx, |map, cx| map.snapshot(cx));
+        let buffer_snapshot = snapshot.buffer_snapshot();
+
+        // A selection on row 1 spanning columns 3..5 (buffer offsets 8..10).
+        let selection = selection_to_anchor_selection(
+            Selection {
+                id: 0,
+                start: MultiBufferOffset(8),
+                end: MultiBufferOffset(10),
+                reversed: false,
+                goal: SelectionGoal::None,
+            },
+            buffer_snapshot,
+        );
+        let mut collection = SelectionsCollection::new();
+        collection.disjoint = Arc::from([selection]);
+        collection.pending = None;
+        collection.line_mode = true;
+
+        // Query row 1 at columns 0..1, entirely before the selection's columns.
+        let range = buffer_snapshot.anchor_before(MultiBufferOffset(5))
+            ..buffer_snapshot.anchor_before(MultiBufferOffset(6));
+        let result = collection.disjoint_in_range::<Point>(range, &snapshot);
+
+        assert_eq!(
+            result.len(),
+            1,
+            "line mode should include the selection sharing the queried row"
+        );
+        assert_eq!(result[0].start, Point::new(1, 3));
+        assert_eq!(result[0].end, Point::new(1, 5));
+    }
+
     #[gpui::test(iterations = 20)]
     fn fast_and_slow_selection_resolution_match_without_collapsed_content(
         cx: &mut gpui::TestAppContext,

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -7,7 +7,7 @@ use std::{
 use gpui::Pixels;
 use itertools::{Either, Itertools as _};
 use language::{Bias, Point, PointUtf16, Selection, SelectionGoal};
-use multi_buffer::{MultiBufferDimension, MultiBufferOffset};
+use multi_buffer::{MultiBufferDimension, MultiBufferOffset, ToPoint};
 use util::post_inc;
 
 use crate::{
@@ -220,18 +220,25 @@ impl SelectionsCollection {
     where
         D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord + std::fmt::Debug,
     {
-        let start_ix = match self
-            .disjoint
-            .binary_search_by(|probe| probe.end.cmp(&range.start, snapshot.buffer_snapshot()))
-        {
-            Ok(ix) | Err(ix) => ix,
-        };
-        let end_ix = match self
-            .disjoint
-            .binary_search_by(|probe| probe.start.cmp(&range.end, snapshot.buffer_snapshot()))
-        {
-            Ok(ix) => ix + 1,
-            Err(ix) => ix,
+        let buffer = snapshot.buffer_snapshot();
+        let (start_ix, end_ix) = if self.line_mode {
+            let start_row = range.start.to_point(snapshot).row;
+            let end_row = range.end.to_point(snapshot).row;
+            let start_ix = self
+                .disjoint
+                .partition_point(|probe| probe.end.to_point(snapshot).row < start_row);
+            let end_ix = self
+                .disjoint
+                .partition_point(|probe| probe.start.to_point(snapshot).row <= end_row);
+            (start_ix, end_ix)
+        } else {
+            let start_ix = self
+                .disjoint
+                .partition_point(|probe| probe.end.cmp(&range.start, buffer).is_lt());
+            let end_ix = self
+                .disjoint
+                .partition_point(|probe| probe.start.cmp(&range.end, buffer).is_le());
+            (start_ix, end_ix)
         };
         resolve_selections_wrapping_blocks(&self.disjoint[start_ix..end_ix], snapshot).collect()
     }

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -212,6 +212,26 @@ impl SelectionsCollection {
         }
     }
 
+    pub fn disjoint_in_row_range<D>(
+        &self,
+        range: Range<Anchor>,
+        snapshot: &DisplaySnapshot,
+    ) -> Vec<Selection<D>>
+    where
+        D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord + std::fmt::Debug,
+    {
+        let buffer = snapshot.buffer_snapshot();
+        let start_row = range.start.to_point(buffer).row;
+        let end_row = range.end.to_point(buffer).row;
+        let start_ix = self
+            .disjoint
+            .partition_point(|probe| probe.end.to_point(buffer).row < start_row);
+        let end_ix = self
+            .disjoint
+            .partition_point(|probe| probe.start.to_point(buffer).row <= end_row);
+        resolve_selections_wrapping_blocks(&self.disjoint[start_ix..end_ix], snapshot).collect()
+    }
+
     pub fn disjoint_in_range<D>(
         &self,
         range: Range<Anchor>,
@@ -221,25 +241,12 @@ impl SelectionsCollection {
         D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord + std::fmt::Debug,
     {
         let buffer = snapshot.buffer_snapshot();
-        let (start_ix, end_ix) = if self.line_mode {
-            let start_row = range.start.to_point(buffer).row;
-            let end_row = range.end.to_point(buffer).row;
-            let start_ix = self
-                .disjoint
-                .partition_point(|probe| probe.end.to_point(buffer).row < start_row);
-            let end_ix = self
-                .disjoint
-                .partition_point(|probe| probe.start.to_point(buffer).row <= end_row);
-            (start_ix, end_ix)
-        } else {
-            let start_ix = self
-                .disjoint
-                .partition_point(|probe| probe.end.cmp(&range.start, buffer).is_lt());
-            let end_ix = self
-                .disjoint
-                .partition_point(|probe| probe.start.cmp(&range.end, buffer).is_le());
-            (start_ix, end_ix)
-        };
+        let start_ix = self
+            .disjoint
+            .partition_point(|probe| probe.end.cmp(&range.start, buffer).is_lt());
+        let end_ix = self
+            .disjoint
+            .partition_point(|probe| probe.start.cmp(&range.end, buffer).is_le());
         resolve_selections_wrapping_blocks(&self.disjoint[start_ix..end_ix], snapshot).collect()
     }
 
@@ -1358,7 +1365,7 @@ mod tests {
     use settings::SettingsStore;
     use std::sync::Arc;
 
-    fn line_mode_snapshot(cx: &mut gpui::TestAppContext, text: &str) -> DisplaySnapshot {
+    fn row_range_snapshot(cx: &mut gpui::TestAppContext, text: &str) -> DisplaySnapshot {
         cx.update(|cx| {
             let settings = SettingsStore::test(cx);
             cx.set_global(settings);
@@ -1381,7 +1388,7 @@ mod tests {
         display_map.update(cx, |map, cx| map.snapshot(cx))
     }
 
-    fn line_mode_collection(
+    fn row_range_collection(
         offset_ranges: impl IntoIterator<Item = Range<usize>>,
         buffer_snapshot: &MultiBufferSnapshot,
     ) -> SelectionsCollection {
@@ -1404,75 +1411,74 @@ mod tests {
         let mut collection = SelectionsCollection::new();
         collection.disjoint = Arc::from(selections);
         collection.pending = None;
-        collection.line_mode = true;
         collection
     }
 
-    /// In line mode, `disjoint_in_range` selects by whole rows, so a selection sharing a queried
-    /// row must be returned even when its columns don't overlap the queried range. The non-line-mode
-    /// path compares exact offsets and would miss this case.
+    /// `disjoint_in_row_range` selects by whole rows, so a selection sharing a queried row must be
+    /// returned even when its columns don't overlap the queried range. `disjoint_in_range` compares
+    /// exact offsets and would miss this case.
     #[gpui::test]
-    fn disjoint_in_range_line_mode_matches_whole_row(cx: &mut gpui::TestAppContext) {
-        let snapshot = line_mode_snapshot(cx, "aaaa\nbbbbbbbb\ncccc");
+    fn disjoint_in_row_range_matches_whole_row(cx: &mut gpui::TestAppContext) {
+        let snapshot = row_range_snapshot(cx, "aaaa\nbbbbbbbb\ncccc");
         let buffer_snapshot = snapshot.buffer_snapshot();
 
         // A selection on row 1 spanning columns 3..5 (buffer offsets 8..10).
-        let collection = line_mode_collection([8..10], buffer_snapshot);
+        let collection = row_range_collection([8..10], buffer_snapshot);
 
         // Query row 1 at columns 0..1, entirely before the selection's columns.
         let range = buffer_snapshot.anchor_before(MultiBufferOffset(5))
             ..buffer_snapshot.anchor_before(MultiBufferOffset(6));
-        let result = collection.disjoint_in_range::<Point>(range, &snapshot);
+        let result = collection.disjoint_in_row_range::<Point>(range, &snapshot);
 
         assert_eq!(
             result.len(),
             1,
-            "line mode should include the selection sharing the queried row"
+            "row range should include the selection sharing the queried row"
         );
         assert_eq!(result[0].start, Point::new(1, 3));
         assert_eq!(result[0].end, Point::new(1, 5));
     }
 
-    /// A selection on a row outside the queried row range must not be returned, even in line mode.
-    /// This guards the row-overlap boundary against becoming over-inclusive.
+    /// A selection on a row outside the queried row range must not be returned. This guards the
+    /// row-overlap boundary against becoming over-inclusive.
     #[gpui::test]
-    fn disjoint_in_range_line_mode_excludes_other_rows(cx: &mut gpui::TestAppContext) {
-        let snapshot = line_mode_snapshot(cx, "aaaa\nbbbbbbbb\ncccc");
+    fn disjoint_in_row_range_excludes_other_rows(cx: &mut gpui::TestAppContext) {
+        let snapshot = row_range_snapshot(cx, "aaaa\nbbbbbbbb\ncccc");
         let buffer_snapshot = snapshot.buffer_snapshot();
 
         // A selection on row 2 (buffer offsets 14..16).
-        let collection = line_mode_collection([14..16], buffer_snapshot);
+        let collection = row_range_collection([14..16], buffer_snapshot);
 
         // Query only row 0, two rows away from the selection.
         let range = buffer_snapshot.anchor_before(MultiBufferOffset(0))
             ..buffer_snapshot.anchor_before(MultiBufferOffset(1));
-        let result = collection.disjoint_in_range::<Point>(range, &snapshot);
+        let result = collection.disjoint_in_row_range::<Point>(range, &snapshot);
 
         assert!(
             result.is_empty(),
-            "line mode should exclude a selection on a non-queried row"
+            "row range should exclude a selection on a non-queried row"
         );
     }
 
     /// A selection spanning multiple rows must be returned when the query touches any of those rows,
     /// not just when the query shares the selection's start or end row.
     #[gpui::test]
-    fn disjoint_in_range_line_mode_matches_interior_row(cx: &mut gpui::TestAppContext) {
-        let snapshot = line_mode_snapshot(cx, "aaaa\nbbbb\ncccc\ndddd");
+    fn disjoint_in_row_range_matches_interior_row(cx: &mut gpui::TestAppContext) {
+        let snapshot = row_range_snapshot(cx, "aaaa\nbbbb\ncccc\ndddd");
         let buffer_snapshot = snapshot.buffer_snapshot();
 
         // A selection spanning row 1 column 1 through row 3 column 2 (buffer offsets 6..17).
-        let collection = line_mode_collection([6..17], buffer_snapshot);
+        let collection = row_range_collection([6..17], buffer_snapshot);
 
         // Query only row 2, an interior row of the selection.
         let range = buffer_snapshot.anchor_before(MultiBufferOffset(11))
             ..buffer_snapshot.anchor_before(MultiBufferOffset(12));
-        let result = collection.disjoint_in_range::<Point>(range, &snapshot);
+        let result = collection.disjoint_in_row_range::<Point>(range, &snapshot);
 
         assert_eq!(
             result.len(),
             1,
-            "line mode should include a selection whose interior row is queried"
+            "row range should include a selection whose interior row is queried"
         );
         assert_eq!(result[0].start, Point::new(1, 1));
         assert_eq!(result[0].end, Point::new(3, 2));


### PR DESCRIPTION
# Objective

When you make a line selection in a row that is long enough to multiple lines long while wrapped the selection box will disappear when the cursor (or just origin of the line selection goes off screen).


## Solution

The when you are in line selection mode the `SelectionsCollection` just enables `line_mode`, instead of storing the whole ranges of those line selections, so the Anchor of the selection is a single point. `disjoint_in_range` filters all the disjoint selections of the collection to fit inside some range, this is used to render the selection boxes on screen. `disjoint_in_range` had no special case for `line_mode` causing it to filter on the point instead of the bounds of the selection.

My fix is too add a case for `line_mode` that changes the filtering `Anchor` -> `Point` and then only filters on the row. Then use the proper bounds of the selection with that:
```rust
        let (start_ix, end_ix) = if self.line_mode {
            let start_row = range.start.to_point(buffer).row;
            let end_row = range.end.to_point(buffer).row;
            let start_ix = self
                .disjoint
                .partition_point(|probe| probe.end.to_point(buffer).row < start_row);
            let end_ix = self
                .disjoint
                .partition_point(|probe| probe.start.to_point(buffer).row <= end_row);
            (start_ix, end_ix)
        } else {
        ...
```

## Testing

Before:

https://github.com/user-attachments/assets/a443de39-53d7-4ee4-b3af-d3be99ca1fcf

After:

https://github.com/user-attachments/assets/18c1c7ef-45cc-4dc8-9a8b-241252c376ab

I also added some tests `disjoint_in_range_line_mode_matches_whole_row`, being the one that really tests this behavior. the other two are just for `disjoint_in_range`

I am using macOS 27.0 Beta (26A5368g), but I noticed this bug before upgrading.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- editor: Fixed bug where selection boxes wouldn't render when the cursor was offscreen.
