### PR TITLE
settings_ui: Move MCP server timeout setting to MCP subpage

### DIFF
--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8420,15 +8420,30 @@ fn ai_page(cx: &App) -> SettingsPage {
         })]
     }
 
+    use feature_flags::FeatureFlagAppExt as _;
+
+    // When the agent settings UI is enabled, the context server timeout is shown
+    // inside the MCP Servers sub-page. Otherwise it remains a standalone section
+    // here so it stays reachable.
+    let agent_settings_ui_enabled = cx.has_flag::<feature_flags::AgentSettingsUiFeatureFlag>();
+
+    let mut items = concat_sections!(
+        @vec,
+        general_section(),
+        agent_configuration_section(cx),
+    );
+    if !agent_settings_ui_enabled {
+        items.extend(context_servers_section());
+    }
+    items.extend(concat_sections!(
+        @vec,
+        edit_prediction_language_settings_section(),
+        edit_prediction_display_sub_section(),
+    ));
+
     SettingsPage {
         title: "AI",
-        items: concat_sections![
-            general_section(),
-            agent_configuration_section(cx),
-            context_servers_section(),
-            edit_prediction_language_settings_section(),
-            edit_prediction_display_sub_section()
-        ],
+        items: items.into(),
     }
 }
 

--- a/crates/settings_ui/src/pages/mcp_servers_page.rs
+++ b/crates/settings_ui/src/pages/mcp_servers_page.rs
@@ -18,7 +18,7 @@ use util::ResultExt as _;
 
 use zed_actions::ExtensionCategoryFilter;
 
-use crate::SettingsWindow;
+use crate::{PROJECT, SettingField, SettingItem, SettingsPageItem, SettingsWindow, USER};
 
 pub(crate) fn render_mcp_servers_page(
     settings_window: &SettingsWindow,
@@ -40,19 +40,20 @@ pub(crate) fn render_mcp_servers_page(
         render_no_project_state(cx)
     };
 
+    let timeout_setting = render_context_server_timeout(settings_window, window, cx);
     let add_server_popover = render_add_server_popover(settings_window, window, cx);
 
     v_flex()
         .id("mcp-servers-page")
         .size_full()
         .pt_2p5()
-        .px_8()
         .pb_16()
         .track_scroll(scroll_handle)
         .overflow_y_scroll()
         .child(
             h_flex()
                 .w_full()
+                .px_8()
                 .justify_between()
                 .items_center()
                 .mb_4()
@@ -67,8 +68,32 @@ pub(crate) fn render_mcp_servers_page(
                 )
                 .child(add_server_popover),
         )
-        .child(server_list)
+        .child(div().px_8().child(server_list))
+        .child(timeout_setting)
         .into_any_element()
+}
+
+fn render_context_server_timeout(
+    settings_window: &SettingsWindow,
+    window: &mut Window,
+    cx: &mut Context<SettingsWindow>,
+) -> AnyElement {
+    let item = SettingsPageItem::SettingItem(SettingItem {
+        title: "MCP Server Timeout",
+        description: "Default timeout in seconds for MCP server tool calls.",
+        field: Box::new(SettingField {
+            organization_override: None,
+            json_path: Some("context_server_timeout"),
+            pick: |settings_content| settings_content.project.context_server_timeout.as_ref(),
+            write: |settings_content, value, _| {
+                settings_content.project.context_server_timeout = value;
+            },
+        }),
+        metadata: None,
+        files: USER | PROJECT,
+    });
+
+    item.render(settings_window, 0, false, false, window, cx)
 }
 
 fn get_context_server_store(


### PR DESCRIPTION
This moves the MCP timeout setting to the MCP subpage, instead of rendering it in a separate section called "Context Servers"

Before:

<img width="896" height="332" alt="image" src="https://github.com/user-attachments/assets/edf6e681-4bad-43f5-89b0-3e8228f74f7a" />

After:

<img width="660" height="222" alt="image" src="https://github.com/user-attachments/assets/7b2bfbea-f0c7-4419-8d06-dfc7d7f740e8" />


Release Notes:

- N/A 
