### PR TITLE
format on save: javascript docs

### DIFF
--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -15,6 +15,22 @@ JavaScript support is available natively in Zed.
 ## Code formatting
 
 Formatting on save is disabled by default for JavaScript.
+
+To turn `format-on-save` on, you can enable the setting globally or for `JavaScript` or `TypeScript` specifically.
+
+```json [settings]
+{
+  "languages": {
+    "JavaScript": {
+      "format_on_save": "on"
+    },
+    "TypeScript": {
+      "format_on_save": "on"
+    }
+  }
+}
+```
+
 Many JavaScript projects use command-line code-formatting tools, such as [Prettier](https://prettier.io/).
 You can use one of these tools by specifying an _external_ code formatter for JavaScript in your settings.
 See [the configuration docs](../reference/all-settings.md) for more information.

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -14,8 +14,8 @@ JavaScript support is available natively in Zed.
 
 ## Code formatting
 
-Formatting on save is enabled by default for JavaScript, using TypeScript's built-in code formatting.
-But many JavaScript projects use other command-line code-formatting tools, such as [Prettier](https://prettier.io/).
+Formatting on save is disabled by default for JavaScript.
+Many JavaScript projects use command-line code-formatting tools, such as [Prettier](https://prettier.io/).
 You can use one of these tools by specifying an _external_ code formatter for JavaScript in your settings.
 See [the configuration docs](../reference/all-settings.md) for more information.
 


### PR DESCRIPTION
# Objective

JavaScript docs for default `format-on-save` settings are out of date.

Small docs followup to https://github.com/zed-industries/zed/pull/59710

## Solution

Change docs to say that JavaScript format-on-save is now off by default.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A