### PR TITLE
editor: Fix movement mismatch between minimap thumb and cursor

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1505,6 +1505,7 @@ impl EditorElement {
             minimap_line_height,
             minimap_scroll_top,
             max_scroll_top: total_editor_lines,
+            visible_editor_lines,
         })
     }
 
@@ -6378,17 +6379,13 @@ impl EditorElement {
             }
 
             let minimap_axis = ScrollbarAxis::Vertical;
-            let pixels_per_line = Pixels::from(
-                ScrollPixelOffset::from(minimap_hitbox.size.height) / layout.max_scroll_top,
-            )
-            .min(layout.minimap_line_height);
-
-            let mut mouse_position = window.mouse_position();
 
             window.on_mouse_event({
                 let editor = self.editor.clone();
 
                 let minimap_hitbox = minimap_hitbox.clone();
+
+                let mut mouse_position = window.mouse_position();
 
                 move |event: &MouseMoveEvent, phase, window, cx| {
                     if phase == DispatchPhase::Capture {
@@ -6399,6 +6396,22 @@ impl EditorElement {
                         if event.pressed_button == Some(MouseButton::Left)
                             && editor.scroll_manager.is_dragging_minimap()
                         {
+                            let Some(thumb_bounds) = layout.thumb_layout.thumb_bounds else {
+                                return;
+                            };
+
+                            let max_thumb_moving_distance =
+                                minimap_hitbox.size.height - thumb_bounds.size.height;
+                            // `max_scroll_top` means the total lines of the editor (file).
+                            let non_visible_editor_lines =
+                                (layout.max_scroll_top - layout.visible_editor_lines).max(1.);
+
+                            let pixels_per_line = Pixels::from(
+                                ScrollPixelOffset::from(max_thumb_moving_distance)
+                                    / non_visible_editor_lines,
+                            )
+                            .min(layout.minimap_line_height);
+
                             let old_position = mouse_position.along(minimap_axis);
                             let new_position = event.position.along(minimap_axis);
                             if (minimap_hitbox.origin.along(minimap_axis)
@@ -10067,6 +10080,7 @@ struct MinimapLayout {
     pub minimap_line_height: Pixels,
     pub thumb_border_style: MinimapThumbBorder,
     pub max_scroll_top: ScrollOffset,
+    pub visible_editor_lines: f64,
 }
 
 impl MinimapLayout {


### PR DESCRIPTION
# Objective

Fixes #44824

This bug results from an incorrect mathematical derivation of the `pixels_per_line` calculation formula. The correct derivation is given below. All variables and functions referenced here are defined in `crates/editor/src/element.rs`.

In `MinimapLayout::calculate_minimap_top_offset`, the `minimap_scroll_top` used in `EditorElement::layout_minimap` is calculated as:

```math
minimap\_scroll\_top = \frac{scroll\_position}{document\_lines - visible\_editor\_lines} * (document\_lines - visible\_minimap\_lines)
```

`ScrollbarLayout::thumb_bounds` calculates the actual thumb position as:

```math
thumb\_position = content\_offset + visible\_range\_start * text\_unit\_size
```

The `content_offset` is calculated as:

```math
content\_offset = -minimap\_scroll\_top * minimap\_line\_height
```

The `visible_range_start` is `visible_range.start`, which equals `scroll_position` based on this expression `let visible_range = scroll_position..scroll_position + text_units_per_page;` in `ScrollbarLayout::new_with_hitbox_and_track_length`.

The `text_unit_size` is calculated as:

```math
text\_unit\_size = \frac{track\_length - thumb\_size}{total\_text\_units - text\_units\_per\_page}
```

It can be proved that `text_unit_size` always equals `minimap_line_height` when `ScrollbarLayout::for_minimap` calls `ScrollbarLayout::new_with_hitbox_and_track_length`. To avoid making the PR description too long, the proof process is omitted because it is cumbersome.

Therefore, the formula can be simplified as:

```math
thumb\_position = (1 - \frac{document\_lines - visible\_minimap\_lines}{document\_lines - visible\_editor\_lines}) * scroll\_position * minimap\_line\_height
```

Now we rewrite `scroll_position` and `thumb_position` using their increments:

```math
\Delta scroll\_position = \frac{\Delta mouse\_position}{pixels\_per\_line}
```

and

```math
\Delta thumb\_position
```

Then, the formula becomes:

```math
\Delta thumb\_position = (1 - \frac{document\_lines - visible\_minimap\_lines}{document\_lines - visible\_editor\_lines}) * \frac{\Delta mouse\_position}{pixels\_per\_line} * minimap\_line\_height
```

To make the thumb follow the mouse movement, `Δthumb_position` must exactly equal `Δmouse_position`, so we can cancel out them on both sides of the equation:

```math
pixels\_per\_line = \frac{(visible\_minimap\_lines - visible\_editor\_lines) * minimap\_line\_height}{document\_lines - visible\_editor\_lines}
```

Note that `visible_minimap_lines * minimap_line_height` equals the height of the minimap hitbox (which also equals the height of the editor), and `visible_editor_lines * minimap_line_height` equals the height of the thumb.

Finally, this formula can be rewritten as:

```math
pixels\_per\_line = \frac{minimap\_hitbox\_height - minimap\_thumb\_height}{document\_lines - visible\_editor\_lines}
```

The `document_lines` in the formula corresponds to `total_editor_lines` in the implementation. This value is stored in the `max_scroll_top` field of `MinimapLayout`.

## Solution

Replace the previous incorrect calculation formula with the correct one.

## Testing

This fix was successfully built and tested on Windows.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

The following recording shows the unexpected behavior (note the thumb position in the minimap scrollbar):

https://github.com/user-attachments/assets/c4acae7d-6ce5-41a8-bac9-38c709663ec2

The following recording shows the expected behavior:

https://github.com/user-attachments/assets/4b08852d-584d-4a13-b6d3-de4e684f983c

Release Notes:

- Fixed movement mismatch between minimap thumb and cursor.
