### PR TITLE
gpui_linux: Suppress dead code warning on `wake_sender`

### DIFF
--- a/crates/gpui_linux/src/linux/platform.rs
+++ b/crates/gpui_linux/src/linux/platform.rs
@@ -123,6 +123,10 @@ pub(crate) struct LinuxCommon {
     pub(crate) callbacks: PlatformHandlers,
     pub(crate) signal: LoopSignal,
     pub(crate) menus: Vec<OwnedMenu>,
+    #[cfg_attr(
+        not(all(target_os = "linux", any(feature = "wayland", feature = "x11"))),
+        allow(dead_code)
+    )]
     wake_sender: Sender<()>,
     wake_listener_started: bool,
 }


### PR DESCRIPTION
This PR adds a conditional `allow(dead_code)` to the `wake_sender` field to fix this error when building Collab:

```
error: field `wake_sender` is never read
   --> crates/gpui_linux/src/linux/platform.rs:126:5
    |
116 | pub(crate) struct LinuxCommon {
    |                   ----------- field in this struct
...
126 |     wake_sender: Sender<()>,
    |     ^^^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[expect(dead_code)]` or `#[allow(dead_code)]`

error: could not compile `gpui_linux` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

https://github.com/zed-industries/zed/actions/runs/28374439219/job/84060893437

Release Notes:

- N/A
