### PR TITLE
collab: Add `username` to `User`

### DIFF
--- a/crates/client/src/test.rs
+++ b/crates/client/src/test.rs
@@ -236,14 +236,15 @@ pub fn parse_authorization_header(req: &Request<AsyncBody>) -> Option<Credential
 
 pub fn make_get_authenticated_user_response(
     user_id: i32,
-    github_login: String,
+    username: String,
 ) -> GetAuthenticatedUserResponse {
     GetAuthenticatedUserResponse {
         user: AuthenticatedUser {
             id: user_id,
             metrics_id: format!("metrics-id-{user_id}"),
+            username: username.clone(),
             avatar_url: "".to_string(),
-            github_login,
+            github_login: username,
             name: None,
             is_staff: false,
             accepted_tos_at: None,

--- a/crates/cloud_api_types/src/cloud_api_types.rs
+++ b/crates/cloud_api_types/src/cloud_api_types.rs
@@ -38,6 +38,7 @@ pub struct GetAuthenticatedUserResponse {
 pub struct AuthenticatedUser {
     pub id: i32,
     pub metrics_id: String,
+    pub username: String,
     pub avatar_url: String,
     pub github_login: String,
     pub name: Option<String>,

--- a/crates/cloud_api_types/src/internal_api.rs
+++ b/crates/cloud_api_types/src/internal_api.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct User {
     pub id: String,
     pub legacy_user_id: i32,
+    pub username: String,
     pub github_login: String,
     pub avatar_url: String,
     pub name: Option<String>,

--- a/crates/collab/src/auth.rs
+++ b/crates/collab/src/auth.rs
@@ -68,6 +68,7 @@ pub async fn validate_header<B>(mut req: Request<B>, next: Next<B>) -> impl Into
 
         let user = User {
             id: UserId(response_body.user.id),
+            username: response_body.user.username,
             github_login: response_body.user.github_login,
             avatar_url: response_body.user.avatar_url,
             name: response_body.user.name,

--- a/crates/collab/src/entities/user.rs
+++ b/crates/collab/src/entities/user.rs
@@ -3,6 +3,7 @@ use crate::db::UserId;
 #[derive(Debug, Clone)]
 pub struct User {
     pub id: UserId,
+    pub username: String,
     pub github_login: String,
     pub avatar_url: String,
     pub name: Option<String>,

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -163,6 +163,7 @@ impl Principal {
         match &self {
             Principal::User(user) => {
                 span.record("user_id", user.id.0);
+                span.record("username", &user.username);
                 span.record("login", &user.github_login);
             }
         }
@@ -290,7 +291,7 @@ impl Debug for Session {
         let mut result = f.debug_struct("Session");
         match &self.principal {
             Principal::User(user) => {
-                result.field("user", &user.github_login);
+                result.field("user", &user.username);
             }
         }
         result.field("connection_id", &self.connection_id).finish()

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -2684,6 +2684,7 @@ async fn get_users(
         .into_iter()
         .map(|user| proto::User {
             id: user.id.to_proto(),
+            username: user.username,
             avatar_url: user.avatar_url,
             github_login: user.github_login,
             name: user.name,
@@ -2722,6 +2723,7 @@ async fn fuzzy_search_users(
         .filter(|user| user.id != session.user_id())
         .map(|user| proto::User {
             id: user.id.to_proto(),
+            username: user.username,
             avatar_url: user.avatar_url,
             github_login: user.github_login,
             name: user.name,
@@ -4178,6 +4180,7 @@ impl From<User> for proto::User {
     fn from(user: User) -> Self {
         Self {
             id: user.id.to_proto(),
+            username: user.username,
             avatar_url: user.avatar_url,
             github_login: user.github_login,
             name: user.name,

--- a/crates/collab/src/services/user_service.rs
+++ b/crates/collab/src/services/user_service.rs
@@ -282,6 +282,7 @@ mod fake_user_service {
                 user_id,
                 User {
                     id: user_id,
+                    // For the purposes of the tests we treat these as interchangeable.
                     username: params.github_login.clone(),
                     avatar_url: format!("https://github.com/{}.png?size=128", params.github_login),
                     github_login: params.github_login,

--- a/crates/collab/src/services/user_service.rs
+++ b/crates/collab/src/services/user_service.rs
@@ -211,6 +211,7 @@ impl From<internal_api::User> for User {
     fn from(user: internal_api::User) -> Self {
         Self {
             id: UserId(user.legacy_user_id),
+            username: user.username,
             avatar_url: user.avatar_url,
             github_login: user.github_login,
             name: user.name,
@@ -281,6 +282,7 @@ mod fake_user_service {
                 user_id,
                 User {
                     id: user_id,
+                    username: params.github_login.clone(),
                     avatar_url: format!("https://github.com/{}.png?size=128", params.github_login),
                     github_login: params.github_login,
                     name: name.map(|name| name.to_string()),

--- a/crates/proto/proto/core.proto
+++ b/crates/proto/proto/core.proto
@@ -9,6 +9,7 @@ message PeerId {
 message User {
   reserved 4;
   uint64 id = 1;
+  string username = 6;
   string github_login = 2;
   string avatar_url = 3;
   optional string name = 5;


### PR DESCRIPTION
This PR adds the `username` field to `User` and `proto::User`.

Closes CLO-949.

Release Notes:

- N/A
