### PR TITLE
Guild board assignment

### DIFF
--- a/.github/workflows/guild-board-assignment.yml
+++ b/.github/workflows/guild-board-assignment.yml
@@ -1,0 +1,45 @@
+# Zed Guild Board (#74): mark Guild-assigned issues as in progress.
+
+name: Guild Board Assignment
+
+on:
+  issues:
+    types: [assigned]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: guild-board-assignment-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: github.repository == 'zed-industries/zed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+        id: app-token
+        with:
+          app-id: ${{ secrets.ZED_COMMUNITY_BOT_APP_ID }}
+          private-key: ${{ secrets.ZED_COMMUNITY_BOT_PRIVATE_KEY }}
+          owner: zed-industries
+
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          sparse-checkout: script/guild-board-assignment.py
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - run: pip install requests
+
+      - run: python script/guild-board-assignment.py
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROJECT_NUMBER: "74"
+          GUILD_TEAM_SLUG: "zed-guild"

--- a/.github/workflows/guild-board-cleanup.yml
+++ b/.github/workflows/guild-board-cleanup.yml
@@ -1,0 +1,46 @@
+# Zed Guild Board (#74): mark closed Guild-assigned issues as shipped.
+
+name: Guild Board Cleanup
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: guild-board-cleanup
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: github.repository == 'zed-industries/zed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+        id: app-token
+        with:
+          app-id: ${{ secrets.ZED_COMMUNITY_BOT_APP_ID }}
+          private-key: ${{ secrets.ZED_COMMUNITY_BOT_PRIVATE_KEY }}
+          owner: zed-industries
+
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          sparse-checkout: script/guild-board-cleanup.py
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - run: pip install requests
+
+      - run: python script/guild-board-cleanup.py
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROJECT_NUMBER: "74"
+          GUILD_TEAM_SLUG: "zed-guild"

--- a/.github/workflows/guild-board-shipped-weekly.yml
+++ b/.github/workflows/guild-board-shipped-weekly.yml
@@ -1,0 +1,47 @@
+# Zed Guild Board (#74): post a weekly shipped summary.
+
+name: Guild Board Shipped Weekly
+
+on:
+  schedule:
+    - cron: "0 14 * * 5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+  discussions: write
+
+concurrency:
+  group: guild-board-shipped-weekly
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: github.repository == 'zed-industries/zed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+        id: app-token
+        with:
+          app-id: ${{ secrets.ZED_COMMUNITY_BOT_APP_ID }}
+          private-key: ${{ secrets.ZED_COMMUNITY_BOT_PRIVATE_KEY }}
+          owner: zed-industries
+
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          sparse-checkout: script/guild-board-shipped-weekly.py
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - run: pip install requests
+
+      - run: python script/guild-board-shipped-weekly.py
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROJECT_NUMBER: "74"
+          DISCUSSION_CATEGORY_ID: ${{ secrets.GUILD_DISCUSSION_CATEGORY_ID }}

--- a/.github/workflows/guild-board-stale-nudge.yml
+++ b/.github/workflows/guild-board-stale-nudge.yml
@@ -1,0 +1,46 @@
+# Zed Guild Board (#74): nudge stale assigned issues with no linked PR.
+
+name: Guild Board Stale Nudge
+
+on:
+  schedule:
+    - cron: "0 8 1,15 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: guild-board-stale-nudge
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: github.repository == 'zed-industries/zed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859
+        id: app-token
+        with:
+          app-id: ${{ secrets.ZED_COMMUNITY_BOT_APP_ID }}
+          private-key: ${{ secrets.ZED_COMMUNITY_BOT_PRIVATE_KEY }}
+          owner: zed-industries
+
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          sparse-checkout: script/guild-board-stale-nudge.py
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - run: pip install requests
+
+      - run: python script/guild-board-stale-nudge.py
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROJECT_NUMBER: "74"
+          GUILD_TEAM_SLUG: "zed-guild"

--- a/script/guild-board-assignment.py
+++ b/script/guild-board-assignment.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+import json
+import os
+from datetime import datetime, timezone
+
+import requests
+
+GITHUB_API = "https://api.github.com"
+OWNER = "zed-industries"
+REPO = "zed"
+IN_PROGRESS_STATUS = "In Progress"
+
+
+def graphql(query, variables):
+    response = requests.post(
+        f"{GITHUB_API}/graphql",
+        headers=HEADERS,
+        json={"query": query, "variables": variables},
+    )
+    response.raise_for_status()
+    data = response.json()
+    if "errors" in data:
+        raise RuntimeError(f"GraphQL: {data['errors']}")
+    return data["data"]
+
+
+def fetch_project(number):
+    data = graphql("""
+        query($owner: String!, $number: Int!) {
+          organization(login: $owner) {
+            projectV2(number: $number) {
+              id
+              fields(first: 50) {
+                nodes {
+                  ... on ProjectV2Field { id name dataType }
+                  ... on ProjectV2SingleSelectField { id name options { id name } }
+                }
+              }
+            }
+          }
+        }
+    """, {"owner": OWNER, "number": number})
+    project = data["organization"]["projectV2"]
+    if not project:
+        raise RuntimeError(f"Could not fetch project #{number}")
+    return project
+
+
+def find_item(project_id, content_node_id):
+    data = graphql("""
+        query($contentId: ID!) {
+          node(id: $contentId) {
+            ... on Issue {
+              projectItems(first: 50) {
+                nodes { id project { id } }
+              }
+            }
+          }
+        }
+    """, {"contentId": content_node_id})
+    for item in data["node"]["projectItems"]["nodes"]:
+        if item["project"]["id"] == project_id:
+            return item["id"]
+    return None
+
+
+def set_single_select_field(project, item_id, field_name, option_name):
+    field = next((field for field in project["fields"]["nodes"] if field.get("name") == field_name), None)
+    if not field:
+        print(f"Field '{field_name}' missing, skipping")
+        return
+    option = next((option for option in field.get("options", []) if option["name"] == option_name), None)
+    if not option:
+        print(f"Option '{option_name}' missing in '{field_name}', skipping")
+        return
+    graphql("""
+        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
+            value: { singleSelectOptionId: $optionId }
+          }) { projectV2Item { id } }
+        }
+    """, {
+        "projectId": project["id"],
+        "itemId": item_id,
+        "fieldId": field["id"],
+        "optionId": option["id"],
+    })
+    print(f"Set '{field_name}' = '{option_name}' on {item_id}")
+
+
+def set_assigned_date(project, item_id):
+    field = next(
+        (field for field in project["fields"]["nodes"]
+         if field.get("name") == "Assigned Date" and field.get("dataType") == "DATE"),
+        None,
+    )
+    if not field:
+        print("Field 'Assigned Date' missing, skipping")
+        return
+    graphql("""
+        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
+            value: { date: $date }
+          }) { projectV2Item { id } }
+        }
+    """, {
+        "projectId": project["id"],
+        "itemId": item_id,
+        "fieldId": field["id"],
+        "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+    })
+    print(f"Stamped Assigned Date on {item_id}")
+
+
+def is_guild_member(login):
+    team_slug = os.environ.get("GUILD_TEAM_SLUG", "zed-guild")
+    response = requests.get(
+        f"{GITHUB_API}/orgs/{OWNER}/teams/{team_slug}/members/{login}",
+        headers=HEADERS,
+    )
+    return response.status_code == 204
+
+
+def main():
+    if os.environ.get("GITHUB_EVENT_NAME") != "issues":
+        print("Ignoring non-issues event")
+        return
+
+    with open(os.environ["GITHUB_EVENT_PATH"]) as event_file:
+        event = json.load(event_file)
+    if event.get("action") != "assigned":
+        print(f"Ignoring issue action: {event.get('action')}")
+        return
+
+    assignee = event["assignee"]["login"]
+    if not is_guild_member(assignee):
+        print(f"{assignee} is not in the Guild team, skipping")
+        return
+
+    project = fetch_project(int(os.environ.get("PROJECT_NUMBER", "74")))
+    issue = event["issue"]
+    item_id = find_item(project["id"], issue["node_id"])
+    if not item_id:
+        print(f"Issue #{issue['number']} is not on the Guild Board")
+        return
+
+    set_single_select_field(project, item_id, "Status", IN_PROGRESS_STATUS)
+    set_assigned_date(project, item_id)
+
+
+if __name__ == "__main__":
+    HEADERS = {
+        "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    main()

--- a/script/guild-board-cleanup.py
+++ b/script/guild-board-cleanup.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+import os
+
+import requests
+
+GITHUB_API = "https://api.github.com"
+OWNER = "zed-industries"
+SHIPPED_STATUS = "Shipped by Guild"
+
+
+def graphql(query, variables):
+    response = requests.post(
+        f"{GITHUB_API}/graphql",
+        headers=HEADERS,
+        json={"query": query, "variables": variables},
+    )
+    response.raise_for_status()
+    data = response.json()
+    if "errors" in data:
+        raise RuntimeError(f"GraphQL: {data['errors']}")
+    return data["data"]
+
+
+def fetch_project(number):
+    data = graphql("""
+        query($owner: String!, $number: Int!) {
+          organization(login: $owner) {
+            projectV2(number: $number) {
+              id
+              fields(first: 50) {
+                nodes {
+                  ... on ProjectV2SingleSelectField { id name options { id name } }
+                }
+              }
+            }
+          }
+        }
+    """, {"owner": OWNER, "number": number})
+    project = data["organization"]["projectV2"]
+    if not project:
+        raise RuntimeError(f"Could not fetch project #{number}")
+    return project
+
+
+def list_project_items(project_id):
+    cursor = None
+    while True:
+        data = graphql("""
+            query($projectId: ID!, $cursor: String) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 100, after: $cursor) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      id
+                      isArchived
+                      fieldValues(first: 20) {
+                        nodes {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            field { ... on ProjectV2SingleSelectField { name } }
+                            name
+                          }
+                        }
+                      }
+                      content {
+                        __typename
+                        ... on Issue {
+                          state
+                          assignees(first: 10) { nodes { login } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        """, {"projectId": project_id, "cursor": cursor})
+        page = data["node"]["items"]
+        yield from page["nodes"]
+        if not page["pageInfo"]["hasNextPage"]:
+            return
+        cursor = page["pageInfo"]["endCursor"]
+
+
+def set_single_select_field(project, item_id, field_name, option_name):
+    field = next((field for field in project["fields"]["nodes"] if field.get("name") == field_name), None)
+    if not field:
+        print(f"Field '{field_name}' missing, skipping")
+        return
+    option = next((option for option in field.get("options", []) if option["name"] == option_name), None)
+    if not option:
+        print(f"Option '{option_name}' missing in '{field_name}', skipping")
+        return
+    graphql("""
+        mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+          updateProjectV2ItemFieldValue(input: {
+            projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
+            value: { singleSelectOptionId: $optionId }
+          }) { projectV2Item { id } }
+        }
+    """, {
+        "projectId": project["id"],
+        "itemId": item_id,
+        "fieldId": field["id"],
+        "optionId": option["id"],
+    })
+    print(f"Set '{field_name}' = '{option_name}' on {item_id}")
+
+
+_guild_cache = {}
+
+
+def is_guild_member(login):
+    if login in _guild_cache:
+        return _guild_cache[login]
+    team_slug = os.environ.get("GUILD_TEAM_SLUG", "zed-guild")
+    response = requests.get(
+        f"{GITHUB_API}/orgs/{OWNER}/teams/{team_slug}/members/{login}",
+        headers=HEADERS,
+    )
+    _guild_cache[login] = response.status_code == 204
+    return _guild_cache[login]
+
+
+def main():
+    project = fetch_project(int(os.environ.get("PROJECT_NUMBER", "74")))
+    shipped = 0
+
+    for item in list_project_items(project["id"]):
+        if item.get("isArchived"):
+            continue
+        content = item.get("content") or {}
+        if content.get("__typename") != "Issue" or content.get("state") != "CLOSED":
+            continue
+        current_status = next(
+            (field_value.get("name") for field_value in item.get("fieldValues", {}).get("nodes", [])
+             if field_value.get("field", {}).get("name") == "Status"),
+            None,
+        )
+        if current_status == SHIPPED_STATUS:
+            continue
+        assignees = [assignee["login"] for assignee in content.get("assignees", {}).get("nodes", [])]
+        if not any(is_guild_member(assignee) for assignee in assignees):
+            continue
+
+        set_single_select_field(project, item["id"], "Status", SHIPPED_STATUS)
+        shipped += 1
+
+    print(f"Cleanup: {shipped} marked shipped")
+
+
+if __name__ == "__main__":
+    HEADERS = {
+        "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    main()

--- a/script/guild-board-shipped-weekly.py
+++ b/script/guild-board-shipped-weekly.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+GITHUB_API = "https://api.github.com"
+OWNER = "zed-industries"
+REPO = "zed"
+SHIPPED_STATUS = "Shipped by Guild"
+
+
+def graphql(query, variables):
+    response = requests.post(
+        f"{GITHUB_API}/graphql",
+        headers=HEADERS,
+        json={"query": query, "variables": variables},
+    )
+    response.raise_for_status()
+    data = response.json()
+    if "errors" in data:
+        raise RuntimeError(f"GraphQL: {data['errors']}")
+    return data["data"]
+
+
+def fetch_project(number):
+    data = graphql("""
+        query($owner: String!, $number: Int!) {
+          organization(login: $owner) {
+            projectV2(number: $number) { id }
+          }
+        }
+    """, {"owner": OWNER, "number": number})
+    project = data["organization"]["projectV2"]
+    if not project:
+        raise RuntimeError(f"Could not fetch project #{number}")
+    return project
+
+
+def list_project_items(project_id):
+    cursor = None
+    while True:
+        data = graphql("""
+            query($projectId: ID!, $cursor: String) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 100, after: $cursor) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      id
+                      isArchived
+                      fieldValues(first: 20) {
+                        nodes {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            field { ... on ProjectV2SingleSelectField { name } }
+                            name
+                          }
+                        }
+                      }
+                      content {
+                        __typename
+                        ... on Issue {
+                          number
+                          title
+                          closedAt
+                          assignees(first: 10) { nodes { login } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        """, {"projectId": project_id, "cursor": cursor})
+        page = data["node"]["items"]
+        yield from page["nodes"]
+        if not page["pageInfo"]["hasNextPage"]:
+            return
+        cursor = page["pageInfo"]["endCursor"]
+
+
+def repository_id():
+    return graphql("""
+        query($owner: String!, $name: String!) {
+          repository(owner: $owner, name: $name) { id }
+        }
+    """, {"owner": OWNER, "name": REPO})["repository"]["id"]
+
+
+def post_discussion(title, body):
+    category_id = os.environ.get("DISCUSSION_CATEGORY_ID")
+    if not category_id:
+        print("DISCUSSION_CATEGORY_ID not set, printing instead:\n")
+        print(f"# {title}\n\n{body}")
+        return
+
+    graphql("""
+        mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+          createDiscussion(input: {
+            repositoryId: $repositoryId, categoryId: $categoryId,
+            title: $title, body: $body
+          }) { discussion { url } }
+        }
+    """, {
+        "repositoryId": repository_id(),
+        "categoryId": category_id,
+        "title": title,
+        "body": body,
+    })
+    print(f"Posted discussion: {title}")
+
+
+def main():
+    project = fetch_project(int(os.environ.get("PROJECT_NUMBER", "74")))
+    now = datetime.now(timezone.utc)
+    week_ago = now - timedelta(days=7)
+    shipped = []
+
+    for item in list_project_items(project["id"]):
+        if item.get("isArchived"):
+            continue
+        content = item.get("content") or {}
+        if content.get("__typename") != "Issue":
+            continue
+        status = next(
+            (field_value.get("name") for field_value in item.get("fieldValues", {}).get("nodes", [])
+             if field_value.get("field", {}).get("name") == "Status"),
+            None,
+        )
+        if status != SHIPPED_STATUS:
+            continue
+        closed_at = content.get("closedAt")
+        if not closed_at:
+            continue
+        closed_datetime = datetime.fromisoformat(closed_at.replace("Z", "+00:00"))
+        if closed_datetime < week_ago:
+            continue
+
+        shipped.append({
+            "number": content["number"],
+            "title": content["title"],
+            "assignees": [assignee["login"] for assignee in content.get("assignees", {}).get("nodes", [])],
+        })
+
+    if not shipped:
+        print("Nothing shipped this week, skipping discussion post.")
+        return
+
+    title = f"Shipped by the Guild - Week of {now.strftime('%b %d, %Y')}"
+    lines = ["Here's what the Zed Guild shipped this week:\n"]
+    for item in shipped:
+        credit = ", ".join(f"@{assignee}" for assignee in item["assignees"]) if item["assignees"] else "unassigned"
+        lines.append(f"- #{item['number']} {item['title']} ({credit})")
+    lines.append(f"\n{len(shipped)} issue{'s' if len(shipped) != 1 else ''} shipped. Nice work.")
+
+    post_discussion(title, "\n".join(lines))
+
+
+if __name__ == "__main__":
+    HEADERS = {
+        "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    main()

--- a/script/guild-board-stale-nudge.py
+++ b/script/guild-board-stale-nudge.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+import os
+from datetime import datetime, timezone
+
+import requests
+
+GITHUB_API = "https://api.github.com"
+OWNER = "zed-industries"
+REPO = "zed"
+STALE_DAYS = 14
+
+
+def graphql(query, variables):
+    response = requests.post(
+        f"{GITHUB_API}/graphql",
+        headers=HEADERS,
+        json={"query": query, "variables": variables},
+    )
+    response.raise_for_status()
+    data = response.json()
+    if "errors" in data:
+        raise RuntimeError(f"GraphQL: {data['errors']}")
+    return data["data"]
+
+
+def rest_post(path, body):
+    response = requests.post(f"{GITHUB_API}/{path}", headers=HEADERS, json=body)
+    response.raise_for_status()
+
+
+def fetch_project(number):
+    data = graphql("""
+        query($owner: String!, $number: Int!) {
+          organization(login: $owner) {
+            projectV2(number: $number) { id }
+          }
+        }
+    """, {"owner": OWNER, "number": number})
+    project = data["organization"]["projectV2"]
+    if not project:
+        raise RuntimeError(f"Could not fetch project #{number}")
+    return project
+
+
+def list_project_items(project_id):
+    cursor = None
+    while True:
+        data = graphql("""
+            query($projectId: ID!, $cursor: String) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 100, after: $cursor) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      id
+                      isArchived
+                      fieldValues(first: 20) {
+                        nodes {
+                          ... on ProjectV2ItemFieldDateValue {
+                            field { ... on ProjectV2Field { name } }
+                            date
+                          }
+                        }
+                      }
+                      content {
+                        __typename
+                        ... on Issue {
+                          number
+                          state
+                          assignees(first: 10) { nodes { login } }
+                          timelineItems(first: 20, itemTypes: [CROSS_REFERENCED_EVENT]) {
+                            nodes {
+                              ... on CrossReferencedEvent {
+                                source { __typename ... on PullRequest { state } }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        """, {"projectId": project_id, "cursor": cursor})
+        page = data["node"]["items"]
+        yield from page["nodes"]
+        if not page["pageInfo"]["hasNextPage"]:
+            return
+        cursor = page["pageInfo"]["endCursor"]
+
+
+def add_comment(issue_number, body):
+    rest_post(f"repos/{OWNER}/{REPO}/issues/{issue_number}/comments", {"body": body})
+    print(f"Commented on #{issue_number}")
+
+
+_guild_cache = {}
+
+
+def is_guild_member(login):
+    if login in _guild_cache:
+        return _guild_cache[login]
+    team_slug = os.environ.get("GUILD_TEAM_SLUG", "zed-guild")
+    response = requests.get(
+        f"{GITHUB_API}/orgs/{OWNER}/teams/{team_slug}/members/{login}",
+        headers=HEADERS,
+    )
+    _guild_cache[login] = response.status_code == 204
+    return _guild_cache[login]
+
+
+def has_recent_nudge(issue_number):
+    response = requests.get(
+        f"{GITHUB_API}/repos/{OWNER}/{REPO}/issues/{issue_number}/comments",
+        headers=HEADERS,
+        params={"per_page": 10, "direction": "desc"},
+    )
+    response.raise_for_status()
+    for comment in response.json():
+        if "This check runs twice a month" in comment.get("body", ""):
+            return True
+    return False
+
+
+def has_open_pull_request(content):
+    return any(
+        (timeline_item.get("source") or {}).get("__typename") == "PullRequest"
+        and (timeline_item.get("source") or {}).get("state") == "OPEN"
+        for timeline_item in content.get("timelineItems", {}).get("nodes", [])
+    )
+
+
+def main():
+    project = fetch_project(int(os.environ.get("PROJECT_NUMBER", "74")))
+    now = datetime.now(timezone.utc)
+    nudged = 0
+
+    for item in list_project_items(project["id"]):
+        if item.get("isArchived"):
+            continue
+        content = item.get("content") or {}
+        if content.get("__typename") != "Issue" or content.get("state") != "OPEN":
+            continue
+        assignees = [a["login"] for a in content.get("assignees", {}).get("nodes", []) if is_guild_member(a["login"])]
+        if not assignees or has_open_pull_request(content):
+            continue
+        assigned_date = next(
+            (field_value.get("date") for field_value in item.get("fieldValues", {}).get("nodes", [])
+             if field_value.get("field", {}).get("name") == "Assigned Date"),
+            None,
+        )
+        if not assigned_date:
+            continue
+        days = (now - datetime.fromisoformat(assigned_date).replace(tzinfo=timezone.utc)).days
+        if days < STALE_DAYS:
+            continue
+
+        if has_recent_nudge(content["number"]):
+            print(f"#{content['number']} already nudged recently, skipping")
+            continue
+
+        assignee_list = ", ".join(f"@{assignee}" for assignee in assignees)
+        add_comment(
+            content["number"],
+            f"Hey {assignee_list}, this issue has been assigned for "
+            f"{days} days with no linked PR yet. If you're still working on it, "
+            f"no action needed. If you're no longer planning to pick this up, "
+            f"feel free to unassign yourself so another Guild member can grab it. "
+            f"(This check runs twice a month.)",
+        )
+        nudged += 1
+
+    print(f"Stale nudge: {nudged} issues nudged")
+
+
+if __name__ == "__main__":
+    HEADERS = {
+        "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    main()


### PR DESCRIPTION
# Objective

Automate the Zed Guild Board (#74) lifecycle - assignment tracking, cleanup, stale nudging, and weekly shipped summaries, so guild members don't have to manage board status manually.

## Solution

Four GitHub Actions workflows, each with a corresponding Python script:

- **Assignment** (`guild-board-assignment`): On issue assignment, checks if the assignee is a guild member, sets the board item to "In Progress", and stamps the "Assigned Date" field.
- **Cleanup** (`guild-board-cleanup`): Runs daily at 8am UTC. Marks closed issues with guild assignees as "Shipped by Guild". Caches membership lookups to avoid redundant API calls.
- **Stale Nudge** (`guild-board-stale-nudge`): Runs on the 1st and 15th at 8am UTC. Comments on open issues assigned 14+ days with no linked PR, pinging guild assignees. Filters to guild members only and guards against duplicate comments on re-runs.
- **Shipped Weekly** (`guild-board-shipped-weekly`): Runs Fridays at 2pm UTC. Posts a GitHub Discussion summarizing issues shipped in the last 7 days with assignee credits.

All workflows use the `zed-community-bot` GitHub App token and are scoped to `zed-industries/zed`.

## Testing

- Dry-run each workflow via `workflow_dispatch` after merge

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A