### PR TITLE
docs: Add note to Windows building docs

### DIFF
--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -21,6 +21,8 @@ Clone the [Zed repository](https://github.com/zed-industries/zed).
 - Install the Windows 11 or 10 SDK for your system, and make sure at least `Windows 10 SDK version 2104 (10.0.20348.0)` is installed. You can download it from the [Windows SDK Archive](https://developer.microsoft.com/windows/downloads/windows-sdk/).
 - Install [CMake](https://cmake.org/download) (required by [a dependency](https://docs.rs/wasmtime-c-api-impl/latest/wasmtime_c_api/)). Or you can install it through Visual Studio Installer, then manually add the `bin` directory to your `PATH`, for example: `C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin`.
 
+> Starting with Visual Studio 2026 (or MSVC 14.50), you need to install optional components `MSVC Build Tools for x64/x86 (Latest)` and `C++ Spectre-mitigated libraries for x64/x86 (Latest MSVC)`, since Microsoft has decoupled the MSVC version from the Visual Studio version. The traditional naming format `MSVC v*** - VS YYYY C++ x64/x86 ...` will no longer be applicable to newer MSVC toolchain. See [this blog](https://devblogs.microsoft.com/cppblog/new-release-cadence-and-support-lifecycle-for-msvc-build-tools/) for more details.
+
 If you cannot compile Zed, make sure a Visual Studio installation includes at least the following components:
 
 ```json


### PR DESCRIPTION
# Objective

Microsoft has decoupled the MSVC version from the Visual Studio version starting with Visual Studio 2026 (see [this blog](https://devblogs.microsoft.com/cppblog/new-release-cadence-and-support-lifecycle-for-msvc-build-tools/)), meaning that the previous traditional naming conventions were obsolete. For Visual Studio 2026 (including future newer versions of VS) users, the existing docs will probably confuse them, as they cannot find out the components named like "MSVC v145 - VS 2026 C++ ..." in present Visual Studio Installer.

## Solution

Add a note next to the dependencies.

## Testing

Docs are no need to test. (Maybe?)

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
