### PR TITLE
Add an optional word count to the status bar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1785,6 +1785,10 @@
     "active_language_button": true,
     // Whether to show the cursor position button in the status bar.
     "cursor_position_button": true,
+    // Whether to show the word count in the status bar. When enabled, the word
+    // count of the current document is shown next to the cursor position, and
+    // the word count of the current selection is shown when text is selected.
+    "word_count_button": false,
     // Whether to show active line endings button in the status bar.
     "line_endings_button": false,
     // Control when to show the active encoding in the status bar.

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -1,6 +1,6 @@
 use editor::{Editor, EditorEvent, MBTextSummary, MultiBufferSnapshot};
 use gpui::{App, Entity, FocusHandle, Focusable, Styled, Subscription, Task, WeakEntity};
-use settings::{RegisterSetting, Settings};
+use settings::{RegisterSetting, Settings, SettingsStore};
 use std::{fmt::Write, num::NonZeroU32, time::Duration};
 use text::{Point, Selection};
 use ui::{
@@ -14,16 +14,40 @@ use workspace::{HideStatusItem, StatusBarSettings, StatusItemView, Workspace, it
 pub(crate) struct SelectionStats {
     pub lines: usize,
     pub characters: usize,
+    pub words: usize,
     pub selections: usize,
 }
 
 pub struct CursorPosition {
     position: Option<UserCaretPosition>,
     selected_count: SelectionStats,
+    document_words: usize,
+    active_editor: Option<WeakEntity<Editor>>,
     context: Option<FocusHandle>,
     workspace: WeakEntity<Workspace>,
     update_position: Task<()>,
+    update_document_words: Task<()>,
     _observe_active_editor: Option<Subscription>,
+    _observe_settings: Subscription,
+}
+
+/// Counts words as maximal runs of non-whitespace characters, matching the
+/// behavior of `wc -w`. The `in_word` state is carried across chunk boundaries
+/// so that a word split across two chunks is not double counted.
+fn count_words<'a>(chunks: impl Iterator<Item = &'a str>) -> usize {
+    let mut words = 0;
+    let mut in_word = false;
+    for chunk in chunks {
+        for character in chunk.chars() {
+            if character.is_whitespace() {
+                in_word = false;
+            } else if !in_word {
+                in_word = true;
+                words += 1;
+            }
+        }
+    }
+    words
 }
 
 /// A position in the editor, where user's caret is located at.
@@ -67,14 +91,24 @@ impl UserCaretPosition {
 }
 
 impl CursorPosition {
-    pub fn new(workspace: &Workspace) -> Self {
+    pub fn new(workspace: &Workspace, cx: &mut Context<Self>) -> Self {
+        // Recompute the document word count when the relevant setting is toggled
+        // so the status bar reflects the change immediately.
+        let observe_settings = cx.observe_global::<SettingsStore>(|cursor_position, cx| {
+            cursor_position.update_document_words(None, cx);
+            cx.notify();
+        });
         Self {
             position: None,
             context: None,
             selected_count: Default::default(),
+            document_words: 0,
+            active_editor: None,
             workspace: workspace.weak_handle(),
             update_position: Task::ready(()),
+            update_document_words: Task::ready(()),
             _observe_active_editor: None,
+            _observe_settings: observe_settings,
         }
     }
 
@@ -109,6 +143,8 @@ impl CursorPosition {
                                 cursor_position.context = None;
                             }
                             editor::EditorMode::Full { .. } => {
+                                let word_count_enabled =
+                                    StatusBarSettings::get_global(cx).word_count_button;
                                 let mut last_selection = None::<Selection<Point>>;
                                 let snapshot = editor.display_snapshot(cx);
                                 if snapshot.buffer_snapshot().excerpts().count() > 0 {
@@ -120,6 +156,13 @@ impl CursorPosition {
                                         );
                                         cursor_position.selected_count.characters +=
                                             selection_summary.chars;
+                                        if word_count_enabled {
+                                            cursor_position.selected_count.words += count_words(
+                                                snapshot
+                                                    .buffer_snapshot()
+                                                    .text_for_range(selection.start..selection.end),
+                                            );
+                                        }
                                         if selection.end != selection.start {
                                             cursor_position.selected_count.lines +=
                                                 (selection.end.row - selection.start.row) as usize;
@@ -154,38 +197,84 @@ impl CursorPosition {
         });
     }
 
-    fn write_position(&self, text: &mut String, cx: &App) {
-        if self.selected_count
-            <= (SelectionStats {
-                selections: 1,
-                ..Default::default()
-            })
-        {
-            // Do not write out anything if we have just one empty selection.
+    fn update_document_words(&mut self, debounce: Option<Duration>, cx: &mut Context<Self>) {
+        if !StatusBarSettings::get_global(cx).word_count_button {
+            if self.document_words != 0 {
+                self.document_words = 0;
+                cx.notify();
+            }
             return;
         }
+        let Some(editor) = self.active_editor.clone() else {
+            return;
+        };
+        self.update_document_words = cx.spawn(async move |cursor_position, cx| {
+            if let Some(debounce) = debounce {
+                cx.background_executor().timer(debounce).await;
+            }
+            let words = editor.update(cx, |editor, cx| {
+                let snapshot = editor.buffer().read(cx).snapshot(cx);
+                count_words(snapshot.text_for_range(Point::zero()..snapshot.max_point()))
+            });
+            if let Ok(words) = words {
+                cursor_position
+                    .update(cx, |cursor_position, cx| {
+                        if cursor_position.document_words != words {
+                            cursor_position.document_words = words;
+                            cx.notify();
+                        }
+                    })
+                    .ok();
+            }
+        });
+    }
+
+    fn write_position(&self, text: &mut String, cx: &App) {
+        let format = LineIndicatorFormat::get(None, cx);
+        let is_short_format = format == &LineIndicatorFormat::Short;
+        let word_count_enabled = StatusBarSettings::get_global(cx).word_count_button;
+
         let SelectionStats {
             lines,
             characters,
+            words,
             selections,
         } = self.selected_count;
-        let format = LineIndicatorFormat::get(None, cx);
-        let is_short_format = format == &LineIndicatorFormat::Short;
-        let lines = (lines > 1).then_some((lines, "line"));
-        let selections = (selections > 1).then_some((selections, "selection"));
-        let characters = (characters > 0).then_some((characters, "character"));
-        if (None, None, None) == (characters, selections, lines) {
-            // Nothing to display.
+        let has_selection = characters > 0 || lines > 0 || selections > 1;
+
+        let mut entries: Vec<(usize, &'static str)> = Vec::new();
+        if has_selection {
+            if selections > 1 {
+                entries.push((selections, "selection"));
+            }
+            if lines > 1 {
+                entries.push((lines, "line"));
+            }
+            if word_count_enabled {
+                entries.push((words, "word"));
+            }
+            if characters > 0 {
+                entries.push((characters, "character"));
+            }
+        } else if word_count_enabled {
+            // With no active selection, show the whole document's word count.
+            entries.push((self.document_words, "word"));
+        }
+
+        if entries.is_empty() {
             return;
         }
+
         write!(text, " (").unwrap();
         let mut wrote_once = false;
-        for (count, name) in [selections, lines, characters].into_iter().flatten() {
+        for (count, name) in entries {
             if wrote_once {
                 write!(text, ", ").unwrap();
             }
             let name = if is_short_format { &name[..1] } else { name };
-            let plural_suffix = if count > 1 && !is_short_format {
+            // Use a plural suffix for any count that isn't exactly one, so that a
+            // zero document word count reads as "0 words" rather than "0 word".
+            let plural_suffix = if count != 1 && !is_short_format {
                 "s"
             } else {
                 ""
@@ -259,6 +348,9 @@ impl Render for CursorPosition {
 }
 
 const UPDATE_DEBOUNCE: Duration = Duration::from_millis(50);
+// The document word count requires scanning the whole buffer, so coalesce rapid
+// edits (e.g. while typing) behind a slightly longer debounce.
+const WORD_COUNT_DEBOUNCE: Duration = Duration::from_millis(250);
 
 impl StatusItemView for CursorPosition {
     fn set_active_pane_item(
@@ -268,6 +360,7 @@ impl StatusItemView for CursorPosition {
         cx: &mut Context<Self>,
     ) {
         if let Some(editor) = active_pane_item.and_then(|item| item.act_as::<Editor>(cx)) {
+            self.active_editor = Some(editor.downgrade());
             self._observe_active_editor = Some(cx.subscribe_in(
                 &editor,
                 window,
@@ -279,12 +372,18 @@ impl StatusItemView for CursorPosition {
                         window,
                         cx,
                     ),
+                    EditorEvent::BufferEdited => {
+                        cursor_position.update_document_words(Some(WORD_COUNT_DEBOUNCE), cx)
+                    }
                     _ => {}
                 },
             ));
             self.update_position(&editor, None, window, cx);
+            self.update_document_words(None, cx);
         } else {
             self.position = None;
+            self.active_editor = None;
+            self.document_words = 0;
             self._observe_active_editor = None;
         }
 

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -291,6 +291,11 @@ impl CursorPosition {
     }
 
     #[cfg(test)]
+    pub(crate) fn document_words(&self) -> usize {
+        self.document_words
+    }
+
+    #[cfg(test)]
     pub(crate) fn position(&self) -> Option<UserCaretPosition> {
         self.position
     }

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -353,7 +353,7 @@ mod tests {
     use super::*;
     use cursor_position::{CursorPosition, SelectionStats, UserCaretPosition};
     use editor::actions::{MoveRight, MoveToBeginning, SelectAll};
-    use gpui::{TestAppContext, VisualTestContext};
+    use gpui::{TestAppContext, UpdateGlobal, VisualTestContext};
     use indoc::indoc;
     use language::Capability;
     use multi_buffer::{MultiBuffer, PathKey};
@@ -604,6 +604,101 @@ mod tests {
                     .read(cx)
                     .selection_stats(),
                 "After selecting a text with multibyte unicode characters, the character count should be correct"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_word_count(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            settings::SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings
+                        .status_bar
+                        .get_or_insert_default()
+                        .word_count_button = Some(true);
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/dir"),
+            json!({
+                "a.md": "the quick brown fox\njumps over"
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        workspace.update_in(cx, |workspace, window, cx| {
+            let cursor_position = cx.new(|cx| CursorPosition::new(workspace, cx));
+            workspace.status_bar().update(cx, |status_bar, cx| {
+                status_bar.add_right_item(cursor_position, window, cx);
+            });
+        });
+
+        let worktree_id = workspace.update(cx, |workspace, cx| {
+            workspace.project().update(cx, |project, cx| {
+                project.worktrees(cx).next().unwrap().read(cx).id()
+            })
+        });
+        let _buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/dir/a.md"), cx)
+            })
+            .await
+            .unwrap();
+        let editor = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_path((worktree_id, rel_path("a.md")), None, true, window, cx)
+            })
+            .await
+            .unwrap()
+            .downcast::<Editor>()
+            .unwrap();
+
+        cx.executor().advance_clock(Duration::from_millis(300));
+        cx.run_until_parked();
+        workspace.update(cx, |workspace, cx| {
+            let cursor_position = workspace
+                .status_bar()
+                .read(cx)
+                .item_of_type::<CursorPosition>()
+                .expect("missing cursor position item");
+            assert_eq!(
+                cursor_position.read(cx).document_words(),
+                6,
+                "The whole document word count should be reported when nothing is selected"
+            );
+            assert_eq!(
+                cursor_position.read(cx).selection_stats().words,
+                0,
+                "No words should be counted as selected initially"
+            );
+        });
+
+        editor.update_in(cx, |editor, window, cx| {
+            editor.select_all(&SelectAll, window, cx)
+        });
+        cx.executor().advance_clock(Duration::from_millis(300));
+        cx.run_until_parked();
+        workspace.update(cx, |workspace, cx| {
+            assert_eq!(
+                workspace
+                    .status_bar()
+                    .read(cx)
+                    .item_of_type::<CursorPosition>()
+                    .expect("missing cursor position item")
+                    .read(cx)
+                    .selection_stats()
+                    .words,
+                6,
+                "Selecting the whole document should count every word in the selection"
             );
         });
     }

--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -539,7 +539,7 @@ mod tests {
             cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
         let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
         workspace.update_in(cx, |workspace, window, cx| {
-            let cursor_position = cx.new(|_| CursorPosition::new(workspace));
+            let cursor_position = cx.new(|cx| CursorPosition::new(workspace, cx));
             workspace.status_bar().update(cx, |status_bar, cx| {
                 status_bar.add_right_item(cursor_position, window, cx);
             });
@@ -571,6 +571,7 @@ mod tests {
                 &SelectionStats {
                     lines: 0,
                     characters: 0,
+                    words: 0,
                     selections: 1,
                 },
                 workspace
@@ -592,6 +593,7 @@ mod tests {
                 &SelectionStats {
                     lines: 1,
                     characters: 3,
+                    words: 0,
                     selections: 1,
                 },
                 workspace
@@ -625,7 +627,7 @@ mod tests {
             cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
         let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
         workspace.update_in(cx, |workspace, window, cx| {
-            let cursor_position = cx.new(|_| CursorPosition::new(workspace));
+            let cursor_position = cx.new(|cx| CursorPosition::new(workspace, cx));
             workspace.status_bar().update(cx, |status_bar, cx| {
                 status_bar.add_right_item(cursor_position, window, cx);
             });
@@ -704,7 +706,7 @@ mod tests {
             cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
         let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
         workspace.update_in(cx, |workspace, window, cx| {
-            let cursor_position = cx.new(|_| CursorPosition::new(workspace));
+            let cursor_position = cx.new(|cx| CursorPosition::new(workspace, cx));
             workspace.status_bar().update(cx, |status_bar, cx| {
                 status_bar.add_right_item(cursor_position, window, cx);
             });

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -789,6 +789,7 @@ impl VsCodeSettings {
             show_active_file: None,
             active_language_button: None,
             cursor_position_button: None,
+            word_count_button: None,
             line_endings_button: None,
             active_encoding_button: None,
         })

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -509,6 +509,10 @@ pub struct StatusBarSettingsContent {
     ///
     /// Default: true
     pub cursor_position_button: Option<bool>,
+    /// Whether to show the word count in the status bar.
+    ///
+    /// Default: false
+    pub word_count_button: Option<bool>,
     /// Whether to show active line endings button in the status bar.
     ///
     /// Default: false

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3810,6 +3810,29 @@ fn window_and_layout_page() -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
+                title: "Word Count Button",
+                description: "Show the word count in the status bar.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("status_bar.word_count_button"),
+                    pick: |settings_content| {
+                        settings_content
+                            .status_bar
+                            .as_ref()?
+                            .word_count_button
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .status_bar
+                            .get_or_insert_default()
+                            .word_count_button = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
                 title: "Line Endings Button",
                 description: "Show the active line endings button in the status bar.",
                 field: Box::new(SettingField {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3718,7 +3718,7 @@ fn search_and_files_page() -> SettingsPage {
 }
 
 fn window_and_layout_page() -> SettingsPage {
-    fn status_bar_section() -> [SettingsPageItem; 11] {
+    fn status_bar_section() -> [SettingsPageItem; 12] {
         [
             SettingsPageItem::SectionHeader("Status Bar"),
             SettingsPageItem::SettingItem(SettingItem {

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -161,6 +161,7 @@ pub struct StatusBarSettings {
     pub show_active_file: bool,
     pub active_language_button: bool,
     pub cursor_position_button: bool,
+    pub word_count_button: bool,
     pub line_endings_button: bool,
     pub active_encoding_button: EncodingDisplayOptions,
 }
@@ -173,6 +174,7 @@ impl Settings for StatusBarSettings {
             show_active_file: status_bar.show_active_file.unwrap(),
             active_language_button: status_bar.active_language_button.unwrap(),
             cursor_position_button: status_bar.cursor_position_button.unwrap(),
+            word_count_button: status_bar.word_count_button.unwrap(),
             line_endings_button: status_bar.line_endings_button.unwrap(),
             active_encoding_button: status_bar.active_encoding_button.unwrap(),
         }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -595,7 +595,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
         });
 
         let cursor_position =
-            cx.new(|_| go_to_line::cursor_position::CursorPosition::new(workspace));
+            cx.new(|cx| go_to_line::cursor_position::CursorPosition::new(workspace, cx));
         let line_ending_indicator =
             cx.new(|_| line_ending_selector::LineEndingIndicator::default());
         let merge_conflict_indicator =


### PR DESCRIPTION
Adds a `status_bar.word_count_button` setting (default off). When enabled, the status bar shows the active document's word count when nothing is selected, and the selected word count alongside the existing line/character stats during a selection.

The document count only recomputes on edits, file switches, or when the setting toggles — all debounced — so there's no cost when the setting is off.

Closes #43217.

Release Notes:

- Added a `status_bar.word_count_button` setting (default off) that displays a word count in the status bar.
