### PR TITLE
Disable one-time code autofill in Zed text inputs

### DIFF
--- a/crates/zed/resources/info/Permissions.plist
+++ b/crates/zed/resources/info/Permissions.plist
@@ -22,3 +22,5 @@
 <string>An application in Zed wants to use speech recognition.</string>
 <key>NSRemindersUsageDescription</key>
 <string>An application in Zed wants to use your reminders.</string>
+<key>NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac</key>
+<true/>


### PR DESCRIPTION
Closes #46899
Closes #55666

## Summary

- Set `NSAutoFillRequiresTextContentTypeForOneTimeCodeOnMac` in the macOS Info.plist fragments
- Prevent macOS 26 Security Code AutoFill from appearing in regular Zed text inputs unless explicitly annotated as one-time-code fields

## Testing

- Not run; Info.plist-only change

Release Notes:

- Fixed macOS showing one-time-code AutoFill suggestions in regular Zed text inputs.