### PR TITLE
Address potential UB in unsafe blocks

### DIFF
--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -9,7 +9,7 @@ use cocoa::{
 use gpui::{
     AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, MonochromeSprite, PaintSurface,
     Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
-    Surface, Underline, point, size,
+    Underline, point, size,
 };
 #[cfg(any(test, feature = "test-support"))]
 use image::RgbaImage;
@@ -1522,7 +1522,7 @@ impl MetalRenderer {
                 .unwrap();
 
             align_offset(instance_offset);
-            let next_offset = *instance_offset + mem::size_of::<Surface>();
+            let next_offset = *instance_offset + mem::size_of::<SurfaceBounds>();
             if next_offset > instance_buffer.size {
                 return false;
             }

--- a/crates/gpui_macos/src/open_type.rs
+++ b/crates/gpui_macos/src/open_type.rs
@@ -79,10 +79,9 @@ fn generate_feature_array(features: &FontFeatures) -> CFMutableArrayRef {
         let feature_array = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
         for (tag, value) in features.tag_value_list() {
             let keys = [kCTFontOpenTypeFeatureTag, kCTFontOpenTypeFeatureValue];
-            let values = [
-                CFString::new(tag).as_CFTypeRef(),
-                CFNumber::from(*value as i32).as_CFTypeRef(),
-            ];
+            let tag_string = CFString::new(tag);
+            let value_number = CFNumber::from(*value as i32);
+            let values = [tag_string.as_CFTypeRef(), value_number.as_CFTypeRef()];
             let dict = CFDictionaryCreate(
                 kCFAllocatorDefault,
                 &keys as *const _ as _,
@@ -91,7 +90,6 @@ fn generate_feature_array(features: &FontFeatures) -> CFMutableArrayRef {
                 &kCFTypeDictionaryKeyCallBacks,
                 &kCFTypeDictionaryValueCallBacks,
             );
-            values.into_iter().for_each(|value| CFRelease(value));
             CFArrayAppendValue(feature_array, dict as _);
             CFRelease(dict as _);
         }

--- a/crates/gpui_macos/src/pasteboard.rs
+++ b/crates/gpui_macos/src/pasteboard.rs
@@ -1,4 +1,3 @@
-use core::slice;
 use std::ffi::{CStr, c_void};
 use std::path::PathBuf;
 
@@ -96,7 +95,6 @@ impl Pasteboard {
             let types: id = self.inner.types();
             if msg_send![types, containsObject: ut_type.inner()] {
                 self.data_for_type(ut_type.inner_mut()).map(|bytes| {
-                    let bytes = bytes.to_vec();
                     let id = hash(&bytes);
 
                     ClipboardItem {
@@ -119,17 +117,12 @@ impl Pasteboard {
             }
 
             let data = self.inner.dataForType(string_type);
-            let text_bytes: &[u8] = if data == nil {
+            if data == nil {
                 return None;
-            } else if data.bytes().is_null() {
-                // https://developer.apple.com/documentation/foundation/nsdata/1410616-bytes?language=objc
-                // "If the length of the NSData object is 0, this property returns nil."
-                &[]
-            } else {
-                slice::from_raw_parts(data.bytes() as *mut u8, data.length() as usize)
-            };
+            }
+            let text_bytes = nsdata_to_vec(data);
 
-            let text = String::from_utf8_lossy(text_bytes).to_string();
+            let text = String::from_utf8_lossy(&text_bytes).to_string();
             let metadata = self
                 .data_for_type(self.text_hash_type)
                 .and_then(|hash_bytes| {
@@ -138,7 +131,7 @@ impl Pasteboard {
                     let metadata = self.data_for_type(self.metadata_type)?;
 
                     if hash == ClipboardString::text_hash(&text) {
-                        String::from_utf8(metadata.to_vec()).ok()
+                        String::from_utf8(metadata).ok()
                     } else {
                         None
                     }
@@ -148,16 +141,13 @@ impl Pasteboard {
         }
     }
 
-    unsafe fn data_for_type(&self, kind: id) -> Option<&[u8]> {
+    unsafe fn data_for_type(&self, kind: id) -> Option<Vec<u8>> {
         unsafe {
             let data = self.inner.dataForType(kind);
             if data == nil {
                 None
             } else {
-                Some(slice::from_raw_parts(
-                    data.bytes() as *mut u8,
-                    data.length() as usize,
-                ))
+                Some(nsdata_to_vec(data))
             }
         }
     }
@@ -251,6 +241,17 @@ impl Pasteboard {
 
             self.inner
                 .setData_forType(bytes, Into::<UTType>::into(image.format).inner_mut());
+        }
+    }
+}
+
+unsafe fn nsdata_to_vec(data: id) -> Vec<u8> {
+    unsafe {
+        let bytes = data.bytes();
+        if bytes.is_null() {
+            Vec::new()
+        } else {
+            std::slice::from_raw_parts(bytes as *const u8, data.length() as usize).to_vec()
         }
     }
 }

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1086,7 +1086,7 @@ impl MacWindow {
                 return None;
             }
 
-            if msg_send![main_window, isKindOfClass: WINDOW_CLASS] {
+            if is_window_class(main_window) {
                 let handle = get_window_state(&*main_window).lock().handle;
                 Some(handle)
             } else {
@@ -1104,7 +1104,7 @@ impl MacWindow {
             let mut window_handles = Vec::new();
             for i in 0..count {
                 let window: id = msg_send![windows, objectAtIndex:i];
-                if msg_send![window, isKindOfClass: WINDOW_CLASS] {
+                if is_window_class(window) {
                     let handle = get_window_state(&*window).lock().handle;
                     window_handles.push(handle);
                 }
@@ -1675,7 +1675,7 @@ impl PlatformWindow for MacWindow {
             let mut result = Vec::new();
             for i in 0..count {
                 let window: id = msg_send![windows, objectAtIndex:i];
-                if msg_send![window, isKindOfClass: WINDOW_CLASS] {
+                if is_window_class(window) {
                     let handle = get_window_state(&*window).lock().handle;
                     let title: id = msg_send![window, title];
                     let title = SharedString::from(title.to_str().to_string());
@@ -1910,9 +1910,20 @@ fn get_scale_factor(native_window: id) -> f32 {
 
 /// Returns whether `window` is one of GPUI's managed windows.
 unsafe fn is_gpui_window(window: id) -> bool {
+    unsafe { is_window_class(window) || is_panel_class(window) }
+}
+
+unsafe fn is_window_class(window: id) -> bool {
     unsafe {
-        msg_send![window, isKindOfClass: WINDOW_CLASS]
-            || msg_send![window, isKindOfClass: PANEL_CLASS]
+        let result: BOOL = msg_send![window, isKindOfClass: WINDOW_CLASS];
+        result == YES
+    }
+}
+
+unsafe fn is_panel_class(window: id) -> bool {
+    unsafe {
+        let result: BOOL = msg_send![window, isKindOfClass: PANEL_CLASS];
+        result == YES
     }
 }
 
@@ -2790,6 +2801,7 @@ extern "C" fn attributed_substring_for_proposed_range(
         let selected_text = input_handler.text_for_range(range.clone(), &mut adjusted)?;
         if let Some(adjusted) = adjusted
             && adjusted != range
+            && !actual_range.is_null()
         {
             unsafe { (actual_range as *mut NSRange).write(NSRange::from(adjusted)) };
         }

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -1524,8 +1524,11 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
             unsafe { std::slice::from_raw_parts(glyphrun.glyphAdvances, glyph_count) };
         let glyph_offsets =
             unsafe { std::slice::from_raw_parts(glyphrun.glyphOffsets, glyph_count) };
-        let cluster_map =
-            unsafe { std::slice::from_raw_parts(desc.clusterMap, desc.stringLength as usize) };
+        let cluster_map = if desc.clusterMap.is_null() {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(desc.clusterMap, desc.stringLength as usize) }
+        };
 
         let cluster_analyzer = ClusterAnalyzer::new(cluster_map, glyph_count);
         let mut utf16_idx = desc.textPosition as usize;

--- a/crates/gpui_windows/src/platform.rs
+++ b/crates/gpui_windows/src/platform.rs
@@ -800,13 +800,15 @@ impl Platform for WindowsPlatform {
                 Ok(None)
             } else {
                 let username: String = unsafe { (*credentials).UserName.to_string()? };
-                let credential_blob = unsafe {
-                    std::slice::from_raw_parts(
-                        (*credentials).CredentialBlob,
-                        (*credentials).CredentialBlobSize as usize,
-                    )
+                let password = unsafe {
+                    let size = (*credentials).CredentialBlobSize as usize;
+                    match std::ptr::NonNull::new((*credentials).CredentialBlob) {
+                        Some(credential_blob) => {
+                            std::slice::from_raw_parts(credential_blob.as_ptr(), size).to_vec()
+                        }
+                        None => Vec::new(),
+                    }
                 };
-                let password = credential_blob.to_vec();
                 unsafe { CredFree(credentials as *const _ as _) };
                 Ok(Some((username, password)))
             }

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -550,10 +550,9 @@ impl WindowsWindow {
 
 impl rwh::HasWindowHandle for WindowsWindow {
     fn window_handle(&self) -> std::result::Result<rwh::WindowHandle<'_>, rwh::HandleError> {
-        let raw = rwh::Win32WindowHandle::new(unsafe {
-            NonZeroIsize::new_unchecked(self.0.hwnd.0 as isize)
-        })
-        .into();
+        let hwnd =
+            NonZeroIsize::new(self.0.hwnd.0 as isize).ok_or(rwh::HandleError::Unavailable)?;
+        let raw = rwh::Win32WindowHandle::new(hwnd).into();
         Ok(unsafe { rwh::WindowHandle::borrow_raw(raw) })
     }
 }
@@ -1531,8 +1530,12 @@ fn set_window_composition_attribute(hwnd: HWND, color: Option<Color>, state: u32
             .log_err()
         {
             let func_name = PCSTR::from_raw(c"SetWindowCompositionAttribute".as_ptr() as *const u8);
+            let Some(raw_set_window_composition_attribute) = GetProcAddress(user32, func_name)
+            else {
+                return;
+            };
             let set_window_composition_attribute: SetWindowCompositionAttributeType =
-                std::mem::transmute(GetProcAddress(user32, func_name));
+                std::mem::transmute(raw_set_window_composition_attribute);
             let mut color = color.unwrap_or_default();
             let is_acrylic = state == 4;
             if is_acrylic && color.3 == 0 {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -42,23 +42,7 @@ macro_rules! concat_sections {
     }};
 
     ($($arr:expr),+ $(,)?) => {{
-        let total_len = 0_usize $(+ $arr.len())+;
-
-        let mut out: Box<[std::mem::MaybeUninit<_>]> = Box::new_uninit_slice(total_len);
-
-        let mut index = 0usize;
-        $(
-            let array = $arr;
-            for item in array {
-                out[index].write(item);
-                index += 1;
-            }
-        )+
-
-        debug_assert_eq!(index, total_len);
-
-        // SAFETY: we wrote exactly `total_len` elements.
-        unsafe { out.assume_init() }
+        concat_sections!(@vec, $($arr),+).into_boxed_slice()
     }};
 }
 

--- a/crates/sqlez/src/statement.rs
+++ b/crates/sqlez/src/statement.rs
@@ -133,10 +133,10 @@ impl<'a> Statement<'a> {
     pub fn bind_blob(&self, index: i32, blob: &[u8]) -> Result<()> {
         let index = index as c_int;
         let blob_pointer = blob.as_ptr() as *const _;
-        let len = blob.len() as c_int;
+        let len = blob.len() as u64;
 
         self.bind_index_with(index, &|raw_statement| unsafe {
-            sqlite3_bind_blob(*raw_statement, index, blob_pointer, len, SQLITE_TRANSIENT());
+            sqlite3_bind_blob64(*raw_statement, index, blob_pointer, len, SQLITE_TRANSIENT());
         })
     }
 
@@ -217,10 +217,17 @@ impl<'a> Statement<'a> {
     pub fn bind_text(&self, index: i32, text: &str) -> Result<()> {
         let index = index as c_int;
         let text_pointer = text.as_ptr() as *const _;
-        let len = text.len() as c_int;
+        let len = text.len() as u64;
 
         self.bind_index_with(index, &|raw_statement| unsafe {
-            sqlite3_bind_text(*raw_statement, index, text_pointer, len, SQLITE_TRANSIENT());
+            sqlite3_bind_text64(
+                *raw_statement,
+                index,
+                text_pointer,
+                len,
+                SQLITE_TRANSIENT(),
+                SQLITE_UTF8 as u8,
+            );
         })
     }
 

--- a/crates/terminal/src/alacritty.rs
+++ b/crates/terminal/src/alacritty.rs
@@ -1,5 +1,3 @@
-#[cfg(target_os = "windows")]
-use std::num::NonZeroU32;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 use std::{borrow::Cow, io, ops::RangeInclusive, path::PathBuf, sync::Arc};
@@ -73,11 +71,12 @@ impl From<&AlacrittyPty> for ProcessIdGetter {
     fn from(pty: &AlacrittyPty) -> Self {
         let child = pty.child_watcher();
         let handle = child.raw_handle();
-        let fallback_pid = child.pid().unwrap_or_else(|| unsafe {
-            NonZeroU32::new_unchecked(GetProcessId(HANDLE(handle as _)))
-        });
+        let fallback_pid = child
+            .pid()
+            .map(u32::from)
+            .unwrap_or_else(|| unsafe { GetProcessId(HANDLE(handle as _)) });
 
-        Self::new(handle as i32, u32::from(fallback_pid))
+        Self::new(handle as i32, fallback_pid)
     }
 }
 


### PR DESCRIPTION
Addresses the low-hanging unsafe-code hardening items from the audit by replacing unchecked niche construction in terminal and Windows window handles, checking nullable Windows FFI outputs before transmuting or slicing them, using SQLite’s 64-bit bind APIs, keeping CoreText feature objects alive until CoreFoundation retains them, copying macOS pasteboard data before exposing it, decoding Objective-C BOOL results explicitly, fixing the Metal instance-buffer size guard to use SurfaceBounds, delegating settings section concatenation to the safe Vec path, and adding a compile-time LayoutId representation guard.

Release Notes:

- N/A
