### PR TITLE
terminal: Remove unchecked fallback PID construction

### DIFF
--- a/crates/terminal/src/alacritty.rs
+++ b/crates/terminal/src/alacritty.rs
@@ -1,5 +1,3 @@
-#[cfg(target_os = "windows")]
-use std::num::NonZeroU32;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 use std::{borrow::Cow, io, ops::RangeInclusive, path::PathBuf, sync::Arc};
@@ -73,11 +71,12 @@ impl From<&AlacrittyPty> for ProcessIdGetter {
     fn from(pty: &AlacrittyPty) -> Self {
         let child = pty.child_watcher();
         let handle = child.raw_handle();
-        let fallback_pid = child.pid().unwrap_or_else(|| unsafe {
-            NonZeroU32::new_unchecked(GetProcessId(HANDLE(handle as _)))
-        });
+        let fallback_pid = child
+            .pid()
+            .map(u32::from)
+            .unwrap_or_else(|| unsafe { GetProcessId(HANDLE(handle as _)) });
 
-        Self::new(handle as i32, u32::from(fallback_pid))
+        Self::new(handle as i32, fallback_pid)
     }
 }
 


### PR DESCRIPTION
Removes an unchecked `NonZeroU32` construction from the Windows terminal fallback PID path.

The old code did this:

- if `child.pid()` returned `Some(nonzero_pid)`, convert it to `u32` and pass it along
- if `child.pid()` returned `None`, call `GetProcessId(...)`
- `GetProcessId` can return `0` on failure
- `NonZeroU32::new_unchecked(0)` is immediate undefined behavior, because it tells Rust that a zero value is nonzero

The new code does the same thing in the successful case:

- if `child.pid()` returns `Some(nonzero_pid)`, convert it to `u32` and pass it along

But in the failure case, it keeps the value honest:

- if `GetProcessId(...)` returns `0`, preserve it as `0`
- `ProcessIdGetter` already treats `fallback_pid == 0` as "no fallback PID available" and returns `None`

So this does not change the successful PID path. It only removes an invalid unchecked nonzero assertion from the OS failure path. The optimizer is allowed to make assumptions based on values being declared nonzero, so telling it that a value cannot be zero when the OS can return zero is unsafe.

Release Notes:

- N/A
