### PR TITLE
gpui_windows: Harden DirectWrite and DirectX text rendering

### DIFF
--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -1524,8 +1524,17 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
             unsafe { std::slice::from_raw_parts(glyphrun.glyphAdvances, glyph_count) };
         let glyph_offsets =
             unsafe { std::slice::from_raw_parts(glyphrun.glyphOffsets, glyph_count) };
-        let cluster_map =
-            unsafe { std::slice::from_raw_parts(desc.clusterMap, desc.stringLength as usize) };
+        let cluster_map = if desc.clusterMap.is_null() {
+            if desc.stringLength != 0 {
+                return Err(Error::new(
+                    E_INVALIDARG,
+                    "DirectWrite returned a null cluster map",
+                ));
+            }
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(desc.clusterMap, desc.stringLength as usize) }
+        };
 
         let cluster_analyzer = ClusterAnalyzer::new(cluster_map, glyph_count);
         let mut utf16_idx = desc.textPosition as usize;

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -67,6 +67,12 @@ struct GPUState {
     blend_state: ID3D11BlendState,
     vertex_shader: ID3D11VertexShader,
     pixel_shader: ID3D11PixelShader,
+    // The thread that created this `GPUState`. The color-glyph rasterizer drives the *shared* D3D11
+    // immediate context (`Map`/`Unmap`/`Draw`/`CopyResource`) that `DirectXRenderer` and
+    // `DirectXAtlas` also use. An immediate `ID3D11DeviceContext` is not thread-safe, so all of that
+    // must happen on the single UI thread. We record the owning thread here to assert the invariant
+    // in debug builds.
+    owner_thread: std::thread::ThreadId,
 }
 
 struct DirectWriteState {
@@ -158,6 +164,7 @@ impl GPUState {
             blend_state,
             vertex_shader,
             pixel_shader,
+            owner_thread: std::thread::current().id(),
         })
     }
 }
@@ -881,6 +888,18 @@ impl DirectWriteState {
         params: &RenderGlyphParams,
         glyph_bounds: Bounds<DevicePixels>,
     ) -> Result<Vec<u8>> {
+        // INVARIANT: the code below drives the *shared* D3D11 immediate context
+        // (`Map`/`Unmap`/`Draw`/`CopyResource`), which `DirectXRenderer` and `DirectXAtlas` also
+        // touch. An immediate `ID3D11DeviceContext` is not thread-safe, so this must run on the
+        // single UI thread that created the `GPUState`. Giving the emoji rasterizer its own
+        // device/immediate context would lift this constraint (see the PR description); until then,
+        // assert we are on the owning thread in debug builds.
+        debug_assert_eq!(
+            std::thread::current().id(),
+            self.gpu_state.owner_thread,
+            "color glyph rasterization must run on the GPUState owner thread; \
+             the D3D11 immediate context is not thread-safe",
+        );
         let bitmap_size = glyph_bounds.size;
         let subpixel_shift = params
             .subpixel_variant

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -1174,6 +1174,10 @@ impl DirectWriteState {
             };
         }
 
+        // Release the mapping now that the rows have been copied out; leaving `staging_texture`
+        // mapped would leak the mapping and keep the resource pinned for later reuse.
+        unsafe { device_context.Unmap(&staging_texture, 0) };
+
         // Convert from premultiplied to straight alpha
         for chunk in rasterized.chunks_exact_mut(4) {
             let b = chunk[0] as f32;

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -608,7 +608,7 @@ impl DirectWriteState {
             }
 
             let mut runs = Vec::new();
-            let renderer_context = RendererContext {
+            let mut renderer_context = RendererContext {
                 text_system: self,
                 components,
                 index_converter: StringIndexConverter::new(text),
@@ -616,7 +616,7 @@ impl DirectWriteState {
                 width: 0.0,
             };
             text_layout.Draw(
-                Some((&raw const renderer_context).cast::<c_void>()),
+                Some((&raw mut renderer_context).cast::<c_void>().cast_const()),
                 &components.text_renderer.0,
                 0.0,
                 0.0,

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -1519,21 +1519,33 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
 
         let color_font = unsafe { font_face.IsColorFont().as_bool() };
 
-        let glyph_ids = unsafe { std::slice::from_raw_parts(glyphrun.glyphIndices, glyph_count) };
-        let glyph_advances =
-            unsafe { std::slice::from_raw_parts(glyphrun.glyphAdvances, glyph_count) };
-        let glyph_offsets =
-            unsafe { std::slice::from_raw_parts(glyphrun.glyphOffsets, glyph_count) };
-        let cluster_map = if desc.clusterMap.is_null() {
-            if desc.stringLength != 0 {
-                return Err(Error::new(
-                    E_INVALIDARG,
-                    "DirectWrite returned a null cluster map",
-                ));
-            }
-            &[]
-        } else {
-            unsafe { std::slice::from_raw_parts(desc.clusterMap, desc.stringLength as usize) }
+        let glyph_ids = unsafe {
+            slice_from_nullable(
+                glyphrun.glyphIndices,
+                glyph_count,
+                "DirectWrite returned a null glyph indices array",
+            )?
+        };
+        let glyph_advances = unsafe {
+            slice_from_nullable(
+                glyphrun.glyphAdvances,
+                glyph_count,
+                "DirectWrite returned a null glyph advances array",
+            )?
+        };
+        let glyph_offsets = unsafe {
+            slice_from_nullable(
+                glyphrun.glyphOffsets,
+                glyph_count,
+                "DirectWrite returned a null glyph offsets array",
+            )?
+        };
+        let cluster_map = unsafe {
+            slice_from_nullable(
+                desc.clusterMap,
+                desc.stringLength as usize,
+                "DirectWrite returned a null cluster map",
+            )?
         };
 
         let cluster_analyzer = ClusterAnalyzer::new(cluster_map, glyph_count);
@@ -1611,6 +1623,29 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
             E_NOTIMPL,
             "DrawInlineObject unimplemented",
         ))
+    }
+}
+
+/// Interprets an optional DirectWrite array pointer as a slice, treating a
+/// null pointer with a zero length as an empty slice. A null pointer with a
+/// nonzero length fails with `null_error_message`.
+///
+/// # Safety
+///
+/// When `ptr` is non-null, the caller must guarantee that it points to a valid
+/// array of at least `len` elements that outlives the returned slice.
+unsafe fn slice_from_nullable<'a, T>(
+    ptr: *const T,
+    len: usize,
+    null_error_message: &str,
+) -> windows::core::Result<&'a [T]> {
+    if ptr.is_null() {
+        if len != 0 {
+            return Err(Error::new(E_INVALIDARG, null_error_message));
+        }
+        Ok(&[])
+    } else {
+        Ok(unsafe { std::slice::from_raw_parts(ptr, len) })
     }
 }
 

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -67,12 +67,6 @@ struct GPUState {
     blend_state: ID3D11BlendState,
     vertex_shader: ID3D11VertexShader,
     pixel_shader: ID3D11PixelShader,
-    // The thread that created this `GPUState`. The color-glyph rasterizer drives the *shared* D3D11
-    // immediate context (`Map`/`Unmap`/`Draw`/`CopyResource`) that `DirectXRenderer` and
-    // `DirectXAtlas` also use. An immediate `ID3D11DeviceContext` is not thread-safe, so all of that
-    // must happen on the single UI thread. We record the owning thread here to assert the invariant
-    // in debug builds.
-    owner_thread: std::thread::ThreadId,
 }
 
 struct DirectWriteState {
@@ -164,7 +158,6 @@ impl GPUState {
             blend_state,
             vertex_shader,
             pixel_shader,
-            owner_thread: std::thread::current().id(),
         })
     }
 }
@@ -890,16 +883,8 @@ impl DirectWriteState {
     ) -> Result<Vec<u8>> {
         // INVARIANT: the code below drives the *shared* D3D11 immediate context
         // (`Map`/`Unmap`/`Draw`/`CopyResource`), which `DirectXRenderer` and `DirectXAtlas` also
-        // touch. An immediate `ID3D11DeviceContext` is not thread-safe, so this must run on the
-        // single UI thread that created the `GPUState`. Giving the emoji rasterizer its own
-        // device/immediate context would lift this constraint (see the PR description); until then,
-        // assert we are on the owning thread in debug builds.
-        debug_assert_eq!(
-            std::thread::current().id(),
-            self.gpu_state.owner_thread,
-            "color glyph rasterization must run on the GPUState owner thread; \
-             the D3D11 immediate context is not thread-safe",
-        );
+        // touch. An immediate `ID3D11DeviceContext` is not thread-safe, so this must only run on
+        // the main UI thread (which it always is; text rasterization never leaves that thread).
         let bitmap_size = glyph_bounds.size;
         let subpixel_shift = params
             .subpixel_variant

--- a/crates/gpui_windows/src/directx_atlas.rs
+++ b/crates/gpui_windows/src/directx_atlas.rs
@@ -282,6 +282,24 @@ impl DirectXAtlasTexture {
         bounds: Bounds<DevicePixels>,
         bytes: &[u8],
     ) {
+        // `UpdateSubresource` reads `row_pitch * height` bytes from `bytes` based on the
+        // `D3D11_BOX` below. If the caller hands us a slice shorter than that, the driver would
+        // over-read past the end of the source buffer (potentially by multiple megabytes), so bail
+        // out instead. This is a first-insert path rather than a per-frame one, so the check is
+        // effectively free.
+        let row_bytes = bounds.size.width.to_bytes(self.bytes_per_pixel as u8) as usize;
+        let expected = row_bytes * bounds.size.height.0.max(0) as usize;
+        if bytes.len() < expected {
+            log::error!(
+                "DirectXAtlasTexture::upload: source slice is {} bytes but the {}x{} region \
+                 requires {} bytes; skipping upload to avoid a driver over-read",
+                bytes.len(),
+                bounds.size.width.0,
+                bounds.size.height.0,
+                expected,
+            );
+            return;
+        }
         unsafe {
             device_context.UpdateSubresource(
                 &self.texture,

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -191,6 +191,8 @@ impl DirectXRenderer {
         update_buffer(
             device_context,
             self.globals.global_params_buffer.as_ref().unwrap(),
+            // `global_params_buffer` is allocated to hold exactly one `GlobalParams`.
+            1,
             &[GlobalParams {
                 gamma_ratios: self.font_info.gamma_ratios,
                 viewport_size: [resources.viewport.Width, resources.viewport.Height],
@@ -1031,7 +1033,7 @@ impl<T> PipelineState<T> {
             self.view = view;
             self.buffer_size = new_buffer_size;
         }
-        update_buffer(device_context, &self.buffer, data)
+        update_buffer(device_context, &self.buffer, self.buffer_size, data)
     }
 
     fn draw(
@@ -1535,8 +1537,20 @@ fn create_buffer_view_range(
 fn update_buffer<T>(
     device_context: &ID3D11DeviceContext,
     buffer: &ID3D11Buffer,
+    capacity: usize,
     data: &[T],
 ) -> Result<()> {
+    // `copy_nonoverlapping` below writes `data.len()` elements of `T` into the mapped buffer, which
+    // was allocated with room for `capacity` elements. Writing past that would corrupt GPU memory
+    // beyond the end of the buffer. Callers are responsible for the capacity invariant (dynamic
+    // pipeline buffers grow before reaching this point), so a debug assertion is enough to catch a
+    // regression without paying for a COM `GetDesc` query on this per-frame path.
+    debug_assert!(
+        data.len() <= capacity,
+        "update_buffer: {} elements exceed buffer capacity of {}",
+        data.len(),
+        capacity,
+    );
     unsafe {
         let mut dest = std::mem::zeroed();
         device_context.Map(buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, Some(&mut dest))?;

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -191,8 +191,6 @@ impl DirectXRenderer {
         update_buffer(
             device_context,
             self.globals.global_params_buffer.as_ref().unwrap(),
-            // `global_params_buffer` is allocated to hold exactly one `GlobalParams`.
-            1,
             &[GlobalParams {
                 gamma_ratios: self.font_info.gamma_ratios,
                 viewport_size: [resources.viewport.Width, resources.viewport.Height],
@@ -1033,7 +1031,7 @@ impl<T> PipelineState<T> {
             self.view = view;
             self.buffer_size = new_buffer_size;
         }
-        update_buffer(device_context, &self.buffer, self.buffer_size, data)
+        update_buffer(device_context, &self.buffer, data)
     }
 
     fn draw(
@@ -1537,20 +1535,8 @@ fn create_buffer_view_range(
 fn update_buffer<T>(
     device_context: &ID3D11DeviceContext,
     buffer: &ID3D11Buffer,
-    capacity: usize,
     data: &[T],
 ) -> Result<()> {
-    // `copy_nonoverlapping` below writes `data.len()` elements of `T` into the mapped buffer, which
-    // was allocated with room for `capacity` elements. Writing past that would corrupt GPU memory
-    // beyond the end of the buffer. Callers are responsible for the capacity invariant (dynamic
-    // pipeline buffers grow before reaching this point), so a debug assertion is enough to catch a
-    // regression without paying for a COM `GetDesc` query on this per-frame path.
-    debug_assert!(
-        data.len() <= capacity,
-        "update_buffer: {} elements exceed buffer capacity of {}",
-        data.len(),
-        capacity,
-    );
     unsafe {
         let mut dest = std::mem::zeroed();
         device_context.Map(buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, Some(&mut dest))?;


### PR DESCRIPTION
This hardens the Windows text rendering path in gpui_windows against undefined behavior and out-of-bounds access. DirectWrite hands back glyph-run arrays (glyph indices, advances, offsets) and cluster maps as raw pointers that may be null; these are now interpreted through a shared `slice_from_nullable` helper that treats a null pointer with zero length as an empty slice and returns `E_INVALIDARG` when a null pointer arrives with a nonzero length, instead of constructing a slice from a null pointer. It also fixes a provenance bug: the renderer context passed to `IDWriteTextLayout::Draw` was derived via `&raw const` from a non-mut binding, but the `DrawGlyphRun` callback recovers that pointer and writes through it, which is undefined behavior under Stacked/Tree Borrows; the binding is now `mut` and the pointer is derived from `&raw mut` so its provenance matches the write (codegen is unchanged).

On the DirectX side, the atlas upload is now bounded by the source slice length so a mismatched destination region cannot read past the end of the source, and the color-glyph staging texture is unmapped after readback so the mapping is no longer leaked and the resource pinned. The color-glyph rasterizer drives the shared, non-thread-safe D3D11 immediate context that `DirectXRenderer` and `DirectXAtlas` also use, so it must stay on the main UI thread — which it always is today; a comment documents that invariant.

Since gpui_windows is a Windows-only crate, it cannot be compiled on non-Windows hosts, so Windows CI is the compile gate for these changes.

Release Notes:

- N/A