### PR TITLE
gpui_macos: Harden platform, display, and Metal surface FFI

### DIFF
--- a/crates/gpui_macos/src/display.rs
+++ b/crates/gpui_macos/src/display.rs
@@ -7,7 +7,9 @@ use cocoa::{
 };
 use core_foundation::base::CFRelease;
 use core_foundation::uuid::{CFUUIDGetUUIDBytes, CFUUIDRef};
-use core_graphics::display::{CGDirectDisplayID, CGDisplayBounds, CGGetActiveDisplayList};
+use core_graphics::display::{
+    CGDirectDisplayID, CGDisplayBounds, CGGetActiveDisplayList, CGMainDisplayID,
+};
 use gpui::{Bounds, DisplayId, Pixels, PlatformDisplay, point, px, size};
 use objc::{msg_send, sel, sel_impl};
 use uuid::Uuid;
@@ -35,6 +37,12 @@ impl MacDisplay {
         // https://chromium.googlesource.com/chromium/src/+/66.0.3359.158/ui/display/mac/screen_mac.mm#56
         unsafe {
             let screens = NSScreen::screens(nil);
+            // On a headless machine `NSScreen.screens` is empty; indexing it
+            // would raise an NSRangeException that unwinds through Rust. Fall
+            // back to the main display id in that case.
+            if NSArray::count(screens) == 0 {
+                return Self(CGMainDisplayID());
+            }
             let screen = cocoa::foundation::NSArray::objectAtIndex(screens, 0);
             let device_description = NSScreen::deviceDescription(screen);
             let screen_number_key: id = ns_string("NSScreenNumber");

--- a/crates/gpui_macos/src/gpui_macos.rs
+++ b/crates/gpui_macos/src/gpui_macos.rs
@@ -63,6 +63,12 @@ impl BoolExt for bool {
 }
 
 trait NSStringExt {
+    /// # Safety
+    ///
+    /// The returned `&str` borrows the receiver's internal UTF-8 buffer, which
+    /// is owned by the (typically autoreleased) `NSString`. The result must not
+    /// outlive the receiver's autorelease scope; callers should copy it (for
+    /// example with `to_string`) before that scope ends.
     unsafe fn to_str(&self) -> &str;
 }
 

--- a/crates/gpui_macos/src/metal_atlas.rs
+++ b/crates/gpui_macos/src/metal_atlas.rs
@@ -270,7 +270,11 @@ fn point_from_etagere(value: etagere::Point) -> Point<DevicePixels> {
 #[derive(Deref, DerefMut)]
 struct AssertSend<T>(T);
 
-unsafe impl<T> Send for AssertSend<T> {}
+// Implemented only for the concrete Metal types actually stored in an
+// AssertSend, rather than as a blanket impl over all `T`, so that a future
+// `AssertSend<SomethingNotThreadSafe>` cannot silently become `Send`.
+unsafe impl Send for AssertSend<Device> {}
+unsafe impl Send for AssertSend<metal::Texture> {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -16,7 +16,8 @@ use image::RgbaImage;
 
 use core_foundation::base::TCFType;
 use core_video::{
-    metal_texture::CVMetalTextureGetTexture, metal_texture_cache::CVMetalTextureCache,
+    metal_texture::{CVMetalTexture, CVMetalTextureGetTexture},
+    metal_texture_cache::CVMetalTextureCache,
     pixel_buffer::kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
 };
 use foreign_types::{ForeignType, ForeignTypeRef};
@@ -482,13 +483,16 @@ impl MetalRenderer {
                 self.draw_primitives(scene, &mut instance_buffer, drawable, viewport_size);
 
             match command_buffer {
-                Ok(command_buffer) => {
+                Ok((command_buffer, surface_textures)) => {
                     let instance_buffer_pool = self.instance_buffer_pool.clone();
                     let instance_buffer = Cell::new(Some(instance_buffer));
                     let block = ConcreteBlock::new(move |_| {
                         if let Some(instance_buffer) = instance_buffer.take() {
                             instance_buffer_pool.lock().release(instance_buffer);
                         }
+                        // Release the video-frame CVMetalTextures only after the
+                        // GPU has finished sampling them.
+                        let _ = &surface_textures;
                     });
                     let block = block.copy();
                     command_buffer.add_completed_handler(&block);
@@ -555,13 +559,16 @@ impl MetalRenderer {
                 self.draw_primitives(scene, &mut instance_buffer, drawable, viewport_size);
 
             match command_buffer {
-                Ok(command_buffer) => {
+                Ok((command_buffer, surface_textures)) => {
                     let instance_buffer_pool = self.instance_buffer_pool.clone();
                     let instance_buffer = Cell::new(Some(instance_buffer));
                     let block = ConcreteBlock::new(move |_| {
                         if let Some(instance_buffer) = instance_buffer.take() {
                             instance_buffer_pool.lock().release(instance_buffer);
                         }
+                        // Release the video-frame CVMetalTextures only after the
+                        // GPU has finished sampling them.
+                        let _ = &surface_textures;
                     });
                     let block = block.copy();
                     command_buffer.add_completed_handler(&block);
@@ -661,13 +668,16 @@ impl MetalRenderer {
                 self.draw_primitives_to_texture(scene, &mut instance_buffer, &target_texture, size);
 
             match command_buffer {
-                Ok(command_buffer) => {
+                Ok((command_buffer, surface_textures)) => {
                     let instance_buffer_pool = self.instance_buffer_pool.clone();
                     let instance_buffer = Cell::new(Some(instance_buffer));
                     let block = ConcreteBlock::new(move |_| {
                         if let Some(instance_buffer) = instance_buffer.take() {
                             instance_buffer_pool.lock().release(instance_buffer);
                         }
+                        // Release the video-frame CVMetalTextures only after the
+                        // GPU has finished sampling them.
+                        let _ = &surface_textures;
                     });
                     let block = block.copy();
                     command_buffer.add_completed_handler(&block);
@@ -783,13 +793,16 @@ impl MetalRenderer {
                 self.draw_primitives_to_texture(scene, &mut instance_buffer, &target_texture, size);
 
             match command_buffer {
-                Ok(command_buffer) => {
+                Ok((command_buffer, surface_textures)) => {
                     let instance_buffer_pool = self.instance_buffer_pool.clone();
                     let instance_buffer = Cell::new(Some(instance_buffer));
                     let block = ConcreteBlock::new(move |_| {
                         if let Some(instance_buffer) = instance_buffer.take() {
                             instance_buffer_pool.lock().release(instance_buffer);
                         }
+                        // Release the video-frame CVMetalTextures only after the
+                        // GPU has finished sampling them.
+                        let _ = &surface_textures;
                     });
                     let block = block.copy();
                     command_buffer.add_completed_handler(&block);
@@ -825,7 +838,7 @@ impl MetalRenderer {
         instance_buffer: &mut InstanceBuffer,
         drawable: &metal::MetalDrawableRef,
         viewport_size: Size<DevicePixels>,
-    ) -> Result<metal::CommandBuffer> {
+    ) -> Result<(metal::CommandBuffer, Vec<CVMetalTexture>)> {
         self.draw_primitives_to_texture(scene, instance_buffer, drawable.texture(), viewport_size)
     }
 
@@ -835,11 +848,15 @@ impl MetalRenderer {
         instance_buffer: &mut InstanceBuffer,
         texture: &metal::TextureRef,
         viewport_size: Size<DevicePixels>,
-    ) -> Result<metal::CommandBuffer> {
+    ) -> Result<(metal::CommandBuffer, Vec<CVMetalTexture>)> {
         let command_queue = self.command_queue.clone();
         let command_buffer = command_queue.new_command_buffer();
         let alpha = if self.opaque { 1. } else { 0. };
         let mut instance_offset = 0;
+        // Collects the CVMetalTextures wrapping the video surfaces drawn this
+        // frame so their lifetime can be extended to GPU completion by the
+        // caller's completed handler.
+        let mut surface_textures = Vec::new();
 
         let mut command_encoder = new_command_encoder_for_texture(
             command_buffer,
@@ -931,6 +948,7 @@ impl MetalRenderer {
                     &mut instance_offset,
                     viewport_size,
                     command_encoder,
+                    &mut surface_textures,
                 ),
                 PrimitiveBatch::SubpixelSprites { .. } => unreachable!(),
             };
@@ -959,7 +977,7 @@ impl MetalRenderer {
             });
         }
 
-        Ok(command_buffer.to_owned())
+        Ok((command_buffer.to_owned(), surface_textures))
     }
 
     fn draw_paths_to_intermediate(
@@ -1473,6 +1491,7 @@ impl MetalRenderer {
         instance_offset: &mut usize,
         viewport_size: Size<DevicePixels>,
         command_encoder: &metal::RenderCommandEncoderRef,
+        surface_textures: &mut Vec<CVMetalTexture>,
     ) -> bool {
         command_encoder.set_render_pipeline_state(&self.surfaces_pipeline_state);
         command_encoder.set_vertex_buffer(
@@ -1561,6 +1580,13 @@ impl MetalRenderer {
 
             command_encoder.draw_primitives(metal::MTLPrimitiveType::Triangle, 0, 6);
             *instance_offset = next_offset;
+
+            // Keep the CVMetalTextures alive until the GPU finishes sampling
+            // them. The texture cache recycles the backing IOSurface once these
+            // handles are released, so they must outlive command buffer
+            // completion (handled by the caller's completed handler).
+            surface_textures.push(y_texture);
+            surface_textures.push(cb_cr_texture);
         }
         true
     }

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -87,7 +87,7 @@ impl InstanceBufferPool {
         // The draw functions align each offset up to a 256-byte boundary before
         // computing a pointer into the buffer, so the buffer size must itself be
         // a multiple of 256 for that pointer arithmetic to stay in bounds.
-        debug_assert!(self.buffer_size % 256 == 0);
+        debug_assert!(self.buffer_size.is_multiple_of(256));
         let buffer = self.buffers.pop().unwrap_or_else(|| {
             let options = if unified_memory {
                 MTLResourceOptions::StorageModeShared

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -9,7 +9,7 @@ use cocoa::{
 use gpui::{
     AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, MonochromeSprite, PaintSurface,
     Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
-    Surface, Underline, point, size,
+    Underline, point, size,
 };
 #[cfg(any(test, feature = "test-support"))]
 use image::RgbaImage;
@@ -1522,7 +1522,7 @@ impl MetalRenderer {
                 .unwrap();
 
             align_offset(instance_offset);
-            let next_offset = *instance_offset + mem::size_of::<Surface>();
+            let next_offset = *instance_offset + mem::size_of::<SurfaceBounds>();
             if next_offset > instance_buffer.size {
                 return false;
             }

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -1542,7 +1542,8 @@ impl MetalRenderer {
             // CVMetalTextureGetTexture can return null (e.g. if the texture
             // cache failed to wrap the plane); constructing a TextureRef from
             // null would be undefined behavior, so skip the surface instead.
-            let y_texture_ptr = unsafe { CVMetalTextureGetTexture(y_texture.as_concrete_TypeRef()) };
+            let y_texture_ptr =
+                unsafe { CVMetalTextureGetTexture(y_texture.as_concrete_TypeRef()) };
             let cb_cr_texture_ptr =
                 unsafe { CVMetalTextureGetTexture(cb_cr_texture.as_concrete_TypeRef()) };
             if y_texture_ptr.is_null() || cb_cr_texture_ptr.is_null() {

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -83,6 +83,10 @@ impl InstanceBufferPool {
         device: &metal::Device,
         unified_memory: bool,
     ) -> InstanceBuffer {
+        // The draw functions align each offset up to a 256-byte boundary before
+        // computing a pointer into the buffer, so the buffer size must itself be
+        // a multiple of 256 for that pointer arithmetic to stay in bounds.
+        debug_assert!(self.buffer_size % 256 == 0);
         let buffer = self.buffers.pop().unwrap_or_else(|| {
             let options = if unified_memory {
                 MTLResourceOptions::StorageModeShared
@@ -1081,14 +1085,13 @@ impl MetalRenderer {
         );
 
         let shadow_bytes_len = mem::size_of_val(shadows);
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-
         let next_offset = *instance_offset + shadow_bytes_len;
         if next_offset > instance_buffer.size {
             return false;
         }
 
+        let buffer_contents =
+            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
         unsafe {
             ptr::copy_nonoverlapping(
                 shadows.as_ptr() as *const u8,
@@ -1144,14 +1147,13 @@ impl MetalRenderer {
         );
 
         let quad_bytes_len = mem::size_of_val(quads);
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-
         let next_offset = *instance_offset + quad_bytes_len;
         if next_offset > instance_buffer.size {
             return false;
         }
 
+        let buffer_contents =
+            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
         unsafe {
             ptr::copy_nonoverlapping(quads.as_ptr() as *const u8, buffer_contents, quad_bytes_len);
         }
@@ -1293,14 +1295,13 @@ impl MetalRenderer {
         );
 
         let underline_bytes_len = mem::size_of_val(underlines);
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-
         let next_offset = *instance_offset + underline_bytes_len;
         if next_offset > instance_buffer.size {
             return false;
         }
 
+        let buffer_contents =
+            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
         unsafe {
             ptr::copy_nonoverlapping(
                 underlines.as_ptr() as *const u8,
@@ -1334,9 +1335,6 @@ impl MetalRenderer {
         align_offset(instance_offset);
 
         let sprite_bytes_len = mem::size_of_val(sprites);
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-
         let next_offset = *instance_offset + sprite_bytes_len;
         if next_offset > instance_buffer.size {
             return false;
@@ -1375,6 +1373,8 @@ impl MetalRenderer {
         );
         command_encoder.set_fragment_texture(SpriteInputIndex::AtlasTexture as u64, Some(&texture));
 
+        let buffer_contents =
+            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
         unsafe {
             ptr::copy_nonoverlapping(
                 sprites.as_ptr() as *const u8,
@@ -1441,14 +1441,13 @@ impl MetalRenderer {
         command_encoder.set_fragment_texture(SpriteInputIndex::AtlasTexture as u64, Some(&texture));
 
         let sprite_bytes_len = mem::size_of_val(sprites);
-        let buffer_contents =
-            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
-
         let next_offset = *instance_offset + sprite_bytes_len;
         if next_offset > instance_buffer.size {
             return false;
         }
 
+        let buffer_contents =
+            unsafe { (instance_buffer.metal_buffer.contents() as *mut u8).add(*instance_offset) };
         unsafe {
             ptr::copy_nonoverlapping(
                 sprites.as_ptr() as *const u8,

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -1539,6 +1539,17 @@ impl MetalRenderer {
                 )
                 .unwrap();
 
+            // CVMetalTextureGetTexture can return null (e.g. if the texture
+            // cache failed to wrap the plane); constructing a TextureRef from
+            // null would be undefined behavior, so skip the surface instead.
+            let y_texture_ptr = unsafe { CVMetalTextureGetTexture(y_texture.as_concrete_TypeRef()) };
+            let cb_cr_texture_ptr =
+                unsafe { CVMetalTextureGetTexture(cb_cr_texture.as_concrete_TypeRef()) };
+            if y_texture_ptr.is_null() || cb_cr_texture_ptr.is_null() {
+                log::error!("CVMetalTextureGetTexture returned null; skipping surface");
+                continue;
+            }
+
             align_offset(instance_offset);
             let next_offset = *instance_offset + mem::size_of::<SurfaceBounds>();
             if next_offset > instance_buffer.size {
@@ -1555,14 +1566,11 @@ impl MetalRenderer {
                 mem::size_of_val(&texture_size) as u64,
                 &texture_size as *const Size<DevicePixels> as *const _,
             );
-            // let y_texture = y_texture.get_texture().unwrap().
             command_encoder.set_fragment_texture(SurfaceInputIndex::YTexture as u64, unsafe {
-                let texture = CVMetalTextureGetTexture(y_texture.as_concrete_TypeRef());
-                Some(metal::TextureRef::from_ptr(texture as *mut _))
+                Some(metal::TextureRef::from_ptr(y_texture_ptr as *mut _))
             });
             command_encoder.set_fragment_texture(SurfaceInputIndex::CbCrTexture as u64, unsafe {
-                let texture = CVMetalTextureGetTexture(cb_cr_texture.as_concrete_TypeRef());
-                Some(metal::TextureRef::from_ptr(texture as *mut _))
+                Some(metal::TextureRef::from_ptr(cb_cr_texture_ptr as *mut _))
             });
 
             unsafe {

--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -1462,7 +1462,9 @@ unsafe fn ns_url_to_path(url: id) -> Result<PathBuf> {
         if absolute_string.is_null() {
             "<null>".to_string()
         } else {
-            CStr::from_ptr(absolute_string).to_string_lossy().into_owned()
+            CStr::from_ptr(absolute_string)
+                .to_string_lossy()
+                .into_owned()
         }
     });
     Ok(PathBuf::from(OsStr::from_bytes(unsafe {

--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -1188,6 +1188,12 @@ impl Platform for MacPlatform {
 unsafe fn path_from_objc(path: id) -> PathBuf {
     let len = msg_send![path, lengthOfBytesUsingEncoding: NSUTF8StringEncoding];
     let bytes = unsafe { path.UTF8String() as *const u8 };
+    // `UTF8String` can return null; building a slice from null is undefined
+    // behavior, so treat that as an empty path.
+    if bytes.is_null() {
+        log::error!("NSString UTF8String returned null; using empty path");
+        return PathBuf::new();
+    }
     let path = str::from_utf8(unsafe { slice::from_raw_parts(bytes, len) }).unwrap();
     PathBuf::from(path)
 }
@@ -1358,7 +1364,15 @@ extern "C" fn open_urls(this: &mut Object, _: Sel, _: id, urls: id) {
         (0..urls.count())
             .filter_map(|i| {
                 let url = urls.objectAtIndex(i);
-                match CStr::from_ptr(url.absoluteString().UTF8String() as *mut c_char).to_str() {
+                // `absoluteString` is nullable, and `UTF8String` on nil yields
+                // null; constructing a CStr from null would be undefined
+                // behavior, so skip the entry.
+                let string = url.absoluteString().UTF8String() as *const c_char;
+                if string.is_null() {
+                    log::error!("skipping url with null absoluteString");
+                    return None;
+                }
+                match CStr::from_ptr(string).to_str() {
                     Ok(string) => Some(string.to_string()),
                     Err(err) => {
                         log::error!("error converting path to string: {}", err);
@@ -1444,7 +1458,12 @@ extern "C" fn handle_dock_menu(this: &mut Object, _: Sel, _: id) -> id {
 unsafe fn ns_url_to_path(url: id) -> Result<PathBuf> {
     let path: *mut c_char = msg_send![url, fileSystemRepresentation];
     anyhow::ensure!(!path.is_null(), "url is not a file path: {}", unsafe {
-        CStr::from_ptr(url.absoluteString().UTF8String()).to_string_lossy()
+        let absolute_string = url.absoluteString().UTF8String();
+        if absolute_string.is_null() {
+            "<null>".to_string()
+        } else {
+            CStr::from_ptr(absolute_string).to_string_lossy().into_owned()
+        }
     });
     Ok(PathBuf::from(OsStr::from_bytes(unsafe {
         CStr::from_ptr(path).to_bytes()

--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -448,7 +448,7 @@ impl MacPlatform {
                     match menu_type {
                         SystemMenuType::Services => {
                             let app: id = msg_send![APP_CLASS, sharedApplication];
-                            app.setServicesMenu_(item);
+                            app.setServicesMenu_(submenu);
                         }
                     }
 

--- a/crates/gpui_macos/src/screen_capture.rs
+++ b/crates/gpui_macos/src/screen_capture.rs
@@ -129,8 +129,6 @@ impl ScreenCaptureSource for MacScreenCaptureSource {
             let _: () = msg_send![configuration, release];
             let _: () = msg_send![delegate, release];
 
-            let (tx, rx) = oneshot::channel();
-
             let mut error: id = nil;
             let _: () = msg_send![stream, addStreamOutput:output type:SCStreamOutputTypeScreen sampleHandlerQueue:0 error:&mut error as *mut id];
             if error != nil {

--- a/crates/gpui_macos/src/screen_capture.rs
+++ b/crates/gpui_macos/src/screen_capture.rs
@@ -54,6 +54,13 @@ impl ScreenCaptureSource for MacScreenCaptureSource {
         let (display_id, size) = unsafe {
             let display_id: CGDirectDisplayID = msg_send![self.sc_display, displayID];
             let display_mode_ref = CGDisplayCopyDisplayMode(display_id);
+            // CGDisplayCopyDisplayMode returns null for a disconnected display;
+            // passing that to the CGDisplayMode* functions would dereference
+            // null inside CoreGraphics.
+            anyhow::ensure!(
+                !display_mode_ref.is_null(),
+                "no display mode for display {display_id}"
+            );
             let width = CGDisplayModeGetPixelWidth(display_mode_ref);
             let height = CGDisplayModeGetPixelHeight(display_mode_ref);
             CGDisplayModeRelease(display_mode_ref);
@@ -82,6 +89,14 @@ impl ScreenCaptureSource for MacScreenCaptureSource {
         _foreground_executor: &ForegroundExecutor,
         frame_callback: Box<dyn Fn(ScreenCaptureFrame) + Send>,
     ) -> oneshot::Receiver<Result<Box<dyn ScreenCaptureStream>>> {
+        let (tx, rx) = oneshot::channel();
+        let meta = match self.metadata() {
+            Ok(meta) => meta,
+            Err(error) => {
+                tx.send(Err(error)).ok();
+                return rx;
+            }
+        };
         unsafe {
             let stream: id = msg_send![class!(SCStream), alloc];
             let filter: id = msg_send![class!(SCContentFilter), alloc];
@@ -104,7 +119,6 @@ impl ScreenCaptureSource for MacScreenCaptureSource {
                 Box::into_raw(Box::new(frame_callback)) as *mut c_void,
             );
 
-            let meta = self.metadata().unwrap();
             let _: id = msg_send![configuration, setWidth: meta.resolution.width.0 as i64];
             let _: id = msg_send![configuration, setHeight: meta.resolution.height.0 as i64];
             let stream: id = msg_send![stream, initWithFilter:filter configuration:configuration delegate:delegate];


### PR DESCRIPTION
This hardens several unsafe FFI paths in `gpui_macos`. On the Metal rendering side, surface buffer sizing now derives its allocation math from `SurfaceBounds`, and the instance-buffer pointer arithmetic is bounded by the capacity check so writes can no longer run past the end of the buffer. The `CVMetalTexture` backing a rendered surface is kept alive until the GPU signals completion rather than being dropped early, and `CVMetalTextureGetTexture` is null-checked before the returned texture is wrapped, avoiding a use-after-free and a null dereference during rendering.

On the platform and display side, screen-capture metadata guards against a null `CGDisplayMode`, display enumeration falls back to the main display when no `NSScreen`s are reported (as can happen while displays are being disconnected), and the `AssertSend` `Send` impl is narrowed to the concrete Metal types it is actually used with. NSString-to-Rust conversions now null-check `UTF8String` before constructing a `CStr` or slice, the Services menu is wired up by passing the submenu to `setServicesMenu:` rather than the menu item, and the lifetime safety of `NSStringExt::to_str` is documented.

Release Notes:

- Fixed potential crashes and video corruption when displays are disconnected or during screen sharing on macOS
