### PR TITLE
gpui_macos: Guard window-procedure BOOL decoding and nullable text-input ranges

### DIFF
--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -89,7 +89,7 @@ unsafe fn build_classes() {
             );
             decl.add_method(
                 sel!(applicationShouldHandleReopen:hasVisibleWindows:),
-                should_handle_reopen as extern "C" fn(&mut Object, Sel, id, bool),
+                should_handle_reopen as extern "C" fn(&mut Object, Sel, id, BOOL) -> BOOL,
             );
             decl.add_method(
                 sel!(applicationWillTerminate:),
@@ -1269,8 +1269,13 @@ unsafe fn register_system_wake_observer(observer: id) {
     }
 }
 
-extern "C" fn should_handle_reopen(this: &mut Object, _: Sel, _: id, has_open_windows: bool) {
-    if !has_open_windows {
+extern "C" fn should_handle_reopen(
+    this: &mut Object,
+    _: Sel,
+    _: id,
+    has_open_windows: BOOL,
+) -> BOOL {
+    if has_open_windows == NO {
         let platform = unsafe { get_mac_platform(this) };
         let mut lock = platform.0.lock();
         if let Some(mut callback) = lock.reopen.take() {
@@ -1279,6 +1284,8 @@ extern "C" fn should_handle_reopen(this: &mut Object, _: Sel, _: id, has_open_wi
             platform.0.lock().reopen.get_or_insert(callback);
         }
     }
+    // GPUI handles reopen itself, so AppKit should not perform any default handling.
+    NO
 }
 
 extern "C" fn will_terminate(this: &mut Object, _: Sel, _: id) {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -2799,10 +2799,13 @@ extern "C" fn attributed_substring_for_proposed_range(
         let mut adjusted: Option<Range<usize>> = None;
 
         let selected_text = input_handler.text_for_range(range.clone(), &mut adjusted)?;
+        // Apple documents `actualRange` as `NSRangePointer?` and says it can be `NULL`.
+        // https://developer.apple.com/documentation/appkit/nstextinputclient/attributedsubstring(forproposedrange:actualrange:)
         if let Some(adjusted) = adjusted
             && adjusted != range
+            && let Some(actual_range) = NonNull::new(actual_range as *mut NSRange)
         {
-            unsafe { (actual_range as *mut NSRange).write(NSRange::from(adjusted)) };
+            unsafe { actual_range.write(NSRange::from(adjusted)) };
         }
         unsafe {
             let string: id = msg_send![class!(NSAttributedString), alloc];

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1086,7 +1086,7 @@ impl MacWindow {
                 return None;
             }
 
-            if msg_send![main_window, isKindOfClass: WINDOW_CLASS] {
+            if is_window_class(main_window) {
                 let handle = get_window_state(&*main_window).lock().handle;
                 Some(handle)
             } else {
@@ -1104,7 +1104,7 @@ impl MacWindow {
             let mut window_handles = Vec::new();
             for i in 0..count {
                 let window: id = msg_send![windows, objectAtIndex:i];
-                if msg_send![window, isKindOfClass: WINDOW_CLASS] {
+                if is_window_class(window) {
                     let handle = get_window_state(&*window).lock().handle;
                     window_handles.push(handle);
                 }
@@ -1675,7 +1675,7 @@ impl PlatformWindow for MacWindow {
             let mut result = Vec::new();
             for i in 0..count {
                 let window: id = msg_send![windows, objectAtIndex:i];
-                if msg_send![window, isKindOfClass: WINDOW_CLASS] {
+                if is_window_class(window) {
                     let handle = get_window_state(&*window).lock().handle;
                     let title: id = msg_send![window, title];
                     let title = SharedString::from(title.to_str().to_string());
@@ -1910,9 +1910,20 @@ fn get_scale_factor(native_window: id) -> f32 {
 
 /// Returns whether `window` is one of GPUI's managed windows.
 unsafe fn is_gpui_window(window: id) -> bool {
+    unsafe { is_window_class(window) || is_panel_class(window) }
+}
+
+unsafe fn is_window_class(window: id) -> bool {
     unsafe {
-        msg_send![window, isKindOfClass: WINDOW_CLASS]
-            || msg_send![window, isKindOfClass: PANEL_CLASS]
+        let result: BOOL = msg_send![window, isKindOfClass: WINDOW_CLASS];
+        result == YES
+    }
+}
+
+unsafe fn is_panel_class(window: id) -> bool {
+    unsafe {
+        let result: BOOL = msg_send![window, isKindOfClass: PANEL_CLASS];
+        result == YES
     }
 }
 


### PR DESCRIPTION
Several Objective-C interop points in the macOS window and platform code read or returned values with the wrong ABI, which is undefined behavior. This hardens three of them.

The window-enumeration paths decoded `isKindOfClass:` results directly as a Rust `bool`, but the method returns an ObjC `BOOL` (a signed char on x86_64), so any value other than 0 or 1 is UB. These checks now decode the `BOOL` explicitly, factored into `is_window_class` and `is_panel_class` helpers.

The `applicationShouldHandleReopen:hasVisibleWindows:` delegate was declared as taking a Rust `bool` and returning nothing, but AppKit passes a `BOOL` and expects a `BOOL` in return. Reading the argument as `bool` was UB, and returning nothing left AppKit reading an undefined value from the return register. It now takes and returns `BOOL`, and explicitly returns `NO` since GPUI handles reopen itself.

Finally, `attributedSubstringForProposedRange:actualRange:` wrote through the `actualRange` out-pointer unconditionally, but Apple documents it as nullable (`NSRangePointer?`). The write is now guarded with `NonNull::new`, so a null pointer is skipped rather than dereferenced.

Release Notes:

- Fixed potential crashes in window handling and text input on macOS
