### PR TITLE
settings_ui: Avoid unsafe section concatenation

### DIFF
--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -30,17 +30,13 @@ const DEFAULT_AUDIO_INPUT: AudioInputDeviceName = AudioInputDeviceName(None);
 const DEFAULT_EMPTY_AUDIO_INPUT: Option<&AudioInputDeviceName> = Some(&DEFAULT_AUDIO_INPUT);
 
 macro_rules! concat_sections {
-    (@vec, $($arr:expr),+ $(,)?) => {{
-        let iter = std::iter::empty::<SettingsPageItem>()$(.chain($arr))+;
-        let (lower_bound, upper_bound) = iter.size_hint();
-        let mut out = Vec::with_capacity(upper_bound.unwrap_or(lower_bound));
-        out.extend(iter);
-        out
-    }};
+    (@vec, $($arr:expr),+ $(,)?) => {
+        std::iter::empty::<SettingsPageItem>()$(.chain($arr))+.collect::<Vec<_>>()
+    };
 
-    ($($arr:expr),+ $(,)?) => {{
+    ($($arr:expr),+ $(,)?) => {
         concat_sections!(@vec, $($arr),+).into_boxed_slice()
-    }};
+    };
 }
 
 pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -31,34 +31,15 @@ const DEFAULT_EMPTY_AUDIO_INPUT: Option<&AudioInputDeviceName> = Some(&DEFAULT_A
 
 macro_rules! concat_sections {
     (@vec, $($arr:expr),+ $(,)?) => {{
-        let total_len = 0_usize $(+ $arr.len())+;
-        let mut out = Vec::with_capacity(total_len);
-
-        $(
-            out.extend($arr);
-        )+
-
+        let iter = std::iter::empty::<SettingsPageItem>()$(.chain($arr))+;
+        let (lower_bound, upper_bound) = iter.size_hint();
+        let mut out = Vec::with_capacity(upper_bound.unwrap_or(lower_bound));
+        out.extend(iter);
         out
     }};
 
     ($($arr:expr),+ $(,)?) => {{
-        let total_len = 0_usize $(+ $arr.len())+;
-
-        let mut out: Box<[std::mem::MaybeUninit<_>]> = Box::new_uninit_slice(total_len);
-
-        let mut index = 0usize;
-        $(
-            let array = $arr;
-            for item in array {
-                out[index].write(item);
-                index += 1;
-            }
-        )+
-
-        debug_assert_eq!(index, total_len);
-
-        // SAFETY: we wrote exactly `total_len` elements.
-        unsafe { out.assume_init() }
+        concat_sections!(@vec, $($arr),+).into_boxed_slice()
     }};
 }
 


### PR DESCRIPTION
Routes settings section concatenation through a chained iterator `collect` instead of manually initializing a boxed slice with `MaybeUninit`. The `collect` preallocates from the iterator's size hint, and the macro still evaluates each section expression exactly once.

Release Notes:

- N/A