### PR TITLE
sqlez: Harden SQLite FFI (bind lengths, null handles, statement visibility)

### DIFF
--- a/crates/sqlez/src/connection.rs
+++ b/crates/sqlez/src/connection.rs
@@ -87,6 +87,13 @@ impl Connection {
                 self.sqlite3,
                 CString::new("main")?.as_ptr(),
             );
+            // `sqlite3_backup_init` returns null on error (e.g. the same connection is used as
+            // both source and destination). The null check inside `sqlite3_backup_step` only
+            // exists under a SQLite build flag, so guard against the null handle ourselves.
+            if backup.is_null() {
+                destination.last_error()?;
+                anyhow::bail!("sqlite3_backup_init failed");
+            }
             sqlite3_backup_step(backup, -1);
             sqlite3_backup_finish(backup);
             destination.last_error()

--- a/crates/sqlez/src/connection.rs
+++ b/crates/sqlez/src/connection.rs
@@ -192,6 +192,13 @@ impl Connection {
 
                 return Some((err_msg, offset as usize + sub_statement_correction));
             }
+            // Several `sqlite3_prepare_v2` failure paths (OOM, shared-cache schema lock, TOOBIG)
+            // return a code other than the plain syntax-error code while leaving `*pzTail` unset
+            // (still null). The syntax-error branch above won't fire in those cases, so guard
+            // against calling `CStr::from_ptr` on a null pointer here.
+            if remaining_sql_ptr.is_null() {
+                return None;
+            }
             remaining_sql = unsafe { CStr::from_ptr(remaining_sql_ptr) };
             alter_table = None;
         }

--- a/crates/sqlez/src/connection.rs
+++ b/crates/sqlez/src/connection.rs
@@ -27,12 +27,18 @@ impl Connection {
         };
 
         unsafe {
-            sqlite3_open_v2(
+            let result = sqlite3_open_v2(
                 CString::new(uri)?.as_ptr(),
                 &mut connection.sqlite3,
                 flags,
                 ptr::null(),
             );
+
+            // On allocation failure `sqlite3_open_v2` leaves the handle null. Every call below
+            // dereferences it, so bail out before touching the handle.
+            if connection.sqlite3.is_null() {
+                anyhow::bail!("sqlite3_open_v2 failed to allocate a connection (code {result})");
+            }
 
             // Turn on extended error codes
             sqlite3_extended_result_codes(connection.sqlite3, 1);

--- a/crates/sqlez/src/statement.rs
+++ b/crates/sqlez/src/statement.rs
@@ -11,7 +11,7 @@ use crate::connection::Connection;
 pub struct Statement<'a> {
     /// vector of pointers to the raw SQLite statement objects.
     /// it holds the actual prepared statements that will be executed.
-    pub raw_statements: Vec<*mut sqlite3_stmt>,
+    pub(crate) raw_statements: Vec<*mut sqlite3_stmt>,
     /// Index of the current statement being executed from the `raw_statements` vector.
     current_statement: usize,
     /// A reference to the database connection.

--- a/crates/sqlez/src/statement.rs
+++ b/crates/sqlez/src/statement.rs
@@ -133,10 +133,10 @@ impl<'a> Statement<'a> {
     pub fn bind_blob(&self, index: i32, blob: &[u8]) -> Result<()> {
         let index = index as c_int;
         let blob_pointer = blob.as_ptr() as *const _;
-        let len = blob.len() as c_int;
+        let len = blob.len() as u64;
 
         self.bind_index_with(index, &|raw_statement| unsafe {
-            sqlite3_bind_blob(*raw_statement, index, blob_pointer, len, SQLITE_TRANSIENT());
+            sqlite3_bind_blob64(*raw_statement, index, blob_pointer, len, SQLITE_TRANSIENT());
         })
     }
 
@@ -217,10 +217,17 @@ impl<'a> Statement<'a> {
     pub fn bind_text(&self, index: i32, text: &str) -> Result<()> {
         let index = index as c_int;
         let text_pointer = text.as_ptr() as *const _;
-        let len = text.len() as c_int;
+        let len = text.len() as u64;
 
         self.bind_index_with(index, &|raw_statement| unsafe {
-            sqlite3_bind_text(*raw_statement, index, text_pointer, len, SQLITE_TRANSIENT());
+            sqlite3_bind_text64(
+                *raw_statement,
+                index,
+                text_pointer,
+                len,
+                SQLITE_TRANSIENT(),
+                SQLITE_UTF8 as u8,
+            );
         })
     }
 

--- a/crates/sqlez/src/thread_safe_connection.rs
+++ b/crates/sqlez/src/thread_safe_connection.rs
@@ -38,9 +38,6 @@ pub struct ThreadSafeConnection {
     connections: Arc<ThreadLocal<Connection>>,
 }
 
-unsafe impl Send for ThreadSafeConnection {}
-unsafe impl Sync for ThreadSafeConnection {}
-
 pub struct ThreadSafeConnectionBuilder<M: Migrator + 'static = ()> {
     db_initialize_query: Option<&'static str>,
     write_queue_constructor: Option<WriteQueueConstructor>,


### PR DESCRIPTION
This hardens the sqlez crate's SQLite FFI boundary. Bind operations now pass 64-bit lengths to SQLite rather than truncating them to a 32-bit c_int, so large blob and text values keep their correct length. The raw statement pointers are narrowed to pub(crate) visibility so code outside the crate can't reach into them. The FFI wrappers for sql_has_syntax_error, backup_main, and open_with_flags now check for null handles returned by SQLite before dereferencing them, avoiding undefined behavior on those error paths. Finally, the manual Send/Sync impls on ThreadSafeConnection are removed, since they were redundant with what its field types already provide.

Release Notes:

- N/A