### PR TITLE
open_ai: Fix Responses reasoning replay with store false

### DIFF
--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -482,6 +482,23 @@ mod tests {
         }
     }
 
+    fn response_request_json(
+        model: &AvailableModel,
+        request: LanguageModelRequest,
+    ) -> serde_json::Value {
+        let request = into_open_ai_response(
+            request,
+            &model.name,
+            model.capabilities.parallel_tool_calls,
+            model.capabilities.prompt_cache_key,
+            model.max_output_tokens,
+            default_thinking_reasoning_effort(model),
+            supports_none_reasoning_effort(model),
+        );
+
+        serde_json::to_value(request).unwrap()
+    }
+
     #[test]
     fn configured_reasoning_effort_supports_thinking() {
         assert_eq!(
@@ -624,16 +641,7 @@ mod tests {
             ..Default::default()
         };
 
-        let request = into_open_ai_response(
-            request,
-            &model.name,
-            model.capabilities.parallel_tool_calls,
-            model.capabilities.prompt_cache_key,
-            model.max_output_tokens,
-            default_thinking_reasoning_effort(&model),
-            supports_none_reasoning_effort(&model),
-        );
-        let serialized = serde_json::to_value(request).unwrap();
+        let serialized = response_request_json(&model, request);
 
         assert_eq!(
             serialized["reasoning"],
@@ -653,16 +661,7 @@ mod tests {
             ..Default::default()
         };
 
-        let request = into_open_ai_response(
-            request,
-            &model.name,
-            model.capabilities.parallel_tool_calls,
-            model.capabilities.prompt_cache_key,
-            model.max_output_tokens,
-            default_thinking_reasoning_effort(&model),
-            supports_none_reasoning_effort(&model),
-        );
-        let serialized = serde_json::to_value(request).unwrap();
+        let serialized = response_request_json(&model, request);
 
         assert_eq!(serialized.get("reasoning"), None);
         assert_eq!(serialized.get("include"), None);

--- a/crates/open_ai/src/completion.rs
+++ b/crates/open_ai/src/completion.rs
@@ -277,6 +277,7 @@ pub fn into_open_ai_response(
     let include = if reasoning
         .as_ref()
         .is_some_and(|reasoning| reasoning.effort != ReasoningEffort::None)
+        || (reasoning.is_none() && default_reasoning_effort.is_some())
         || input_items
             .iter()
             .any(|item| matches!(item, ResponseInputItem::Reasoning(_)))
@@ -462,10 +463,21 @@ fn append_reasoning_details_to_response_items(
 }
 
 fn push_replayed_reasoning_item(
-    reasoning_item: ResponseReasoningInputItem,
+    mut reasoning_item: ResponseReasoningInputItem,
     replayed_reasoning_item_indexes: &mut HashMap<String, usize>,
     input_items: &mut Vec<ResponseInputItem>,
 ) {
+    if reasoning_item.encrypted_content.as_deref() == Some("") {
+        reasoning_item.encrypted_content = None;
+    }
+
+    if !reasoning_item_is_replayable_with_store_false(&reasoning_item) {
+        if let Some(id) = reasoning_item.id.as_ref() {
+            remove_replayed_reasoning_item(id, replayed_reasoning_item_indexes, input_items);
+        }
+        return;
+    }
+
     if let Some(id) = reasoning_item.id.as_ref() {
         if let Some(index) = replayed_reasoning_item_indexes.get(id) {
             input_items[*index] = ResponseInputItem::Reasoning(reasoning_item);
@@ -476,6 +488,39 @@ fn push_replayed_reasoning_item(
     }
 
     input_items.push(ResponseInputItem::Reasoning(reasoning_item));
+}
+
+fn remove_replayed_reasoning_item(
+    id: &str,
+    replayed_reasoning_item_indexes: &mut HashMap<String, usize>,
+    input_items: &mut Vec<ResponseInputItem>,
+) {
+    let Some(index) = replayed_reasoning_item_indexes.remove(id) else {
+        return;
+    };
+
+    if index < input_items.len() {
+        input_items.remove(index);
+        for existing_index in replayed_reasoning_item_indexes.values_mut() {
+            if *existing_index > index {
+                *existing_index -= 1;
+            }
+        }
+    }
+}
+
+fn reasoning_item_is_replayable_with_store_false(
+    reasoning_item: &ResponseReasoningInputItem,
+) -> bool {
+    if reasoning_item
+        .encrypted_content
+        .as_deref()
+        .is_some_and(|encrypted_content| !encrypted_content.is_empty())
+    {
+        return true;
+    }
+
+    reasoning_item.id.is_none() && !reasoning_item.content.is_empty()
 }
 
 fn push_response_text_part(
@@ -1645,7 +1690,7 @@ mod tests {
     }
 
     #[test]
-    fn into_open_ai_response_replays_reasoning_without_encrypted_content() {
+    fn into_open_ai_response_drops_id_only_reasoning_without_encrypted_content() {
         let request = LanguageModelRequest {
             thread_id: None,
             prompt_id: None,
@@ -1688,16 +1733,73 @@ mod tests {
             serialized["input"],
             json!([
                 {
-                    "type": "reasoning",
-                    "id": "rs_123",
-                    "summary": [],
-                    "status": "completed"
-                },
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Done.",
+                            "annotations": []
+                        }
+                    ]
+                }
+            ])
+        );
+        assert_eq!(serialized.get("include"), None);
+    }
+
+    #[test]
+    fn into_open_ai_response_replays_self_contained_reasoning_without_id() {
+        let request = LanguageModelRequest {
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            messages: vec![LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![MessageContent::Text("Done.".into())],
+                cache: false,
+                reasoning_details: Some(Arc::new(json!({
+                    "reasoning_items": [
+                        {
+                            "summary": [],
+                            "content": [
+                                {
+                                    "type": "reasoning_text",
+                                    "text": "Complete reasoning state."
+                                }
+                            ],
+                            "encrypted_content": "",
+                            "status": "completed"
+                        }
+                    ]
+                }))),
+            }],
+            tools: Vec::new(),
+            tool_choice: None,
+            stop: Vec::new(),
+            temperature: None,
+            thinking_allowed: false,
+            thinking_effort: None,
+            speed: None,
+            compact_at_tokens: None,
+        };
+
+        let response =
+            into_open_ai_response(request, "custom-model", false, false, None, None, false);
+        let serialized = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(
+            serialized["input"],
+            json!([
                 {
                     "type": "reasoning",
-                    "id": "rs_456",
                     "summary": [],
-                    "encrypted_content": "",
+                    "content": [
+                        {
+                            "type": "reasoning_text",
+                            "text": "Complete reasoning state."
+                        }
+                    ],
                     "status": "completed"
                 },
                 {
@@ -1712,6 +1814,10 @@ mod tests {
                     ]
                 }
             ])
+        );
+        assert_eq!(
+            serialized["include"],
+            json!(["reasoning.encrypted_content"])
         );
     }
 
@@ -1749,6 +1855,10 @@ mod tests {
 
         let serialized = serde_json::to_value(&response).unwrap();
         assert_eq!(serialized.get("reasoning"), None);
+        assert_eq!(
+            serialized["include"],
+            json!(["reasoning.encrypted_content"])
+        );
     }
 
     /// `Speed::Fast` should translate to `service_tier: "priority"` on the
@@ -2131,6 +2241,85 @@ mod tests {
                 }
             ])
         );
+    }
+
+    #[test]
+    fn into_open_ai_response_removes_previous_reasoning_when_latest_duplicate_is_not_replayable() {
+        let first_reasoning_details = json!({
+            "phase": "final_answer",
+            "reasoning_items": [
+                {
+                    "id": "rs_123",
+                    "summary": [],
+                    "encrypted_content": "ENC_OLD",
+                    "status": "in_progress"
+                }
+            ]
+        });
+        let second_reasoning_details = json!({
+            "phase": "final_answer",
+            "reasoning_items": [
+                {
+                    "id": "rs_123",
+                    "summary": [],
+                    "status": "completed"
+                }
+            ]
+        });
+        let request = LanguageModelRequest {
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            messages: vec![
+                LanguageModelRequestMessage {
+                    role: Role::Assistant,
+                    content: vec![MessageContent::Text("First.".into())],
+                    cache: false,
+                    reasoning_details: Some(Arc::new(first_reasoning_details)),
+                },
+                LanguageModelRequestMessage {
+                    role: Role::Assistant,
+                    content: vec![MessageContent::Text("Second.".into())],
+                    cache: false,
+                    reasoning_details: Some(Arc::new(second_reasoning_details)),
+                },
+            ],
+            tools: Vec::new(),
+            tool_choice: None,
+            stop: Vec::new(),
+            temperature: None,
+            thinking_allowed: false,
+            thinking_effort: None,
+            speed: None,
+            compact_at_tokens: None,
+        };
+
+        let response =
+            into_open_ai_response(request, "custom-model", false, false, None, None, false);
+        let serialized = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(
+            serialized["input"],
+            json!([
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        { "type": "output_text", "text": "First.", "annotations": [] }
+                    ],
+                    "phase": "final_answer"
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        { "type": "output_text", "text": "Second.", "annotations": [] }
+                    ],
+                    "phase": "final_answer"
+                }
+            ])
+        );
+        assert_eq!(serialized.get("include"), None);
     }
 
     #[test]

--- a/docs/src/ai/use-api-access.md
+++ b/docs/src/ai/use-api-access.md
@@ -503,9 +503,11 @@ By default, OpenAI-compatible models inherit these capabilities:
 
 If a model only works with the Responses API, set `capabilities.chat_completions` to `false`. Zed will use the Responses endpoint for that model.
 
-For reasoning models (e.g. GPT-5), set `reasoning_effort` to the non-`none` effort level your endpoint supports. This enables thinking in the agent panel and tells Zed which effort to send when thinking is enabled. The provider settings UI can configure this when adding an OpenAI-compatible provider. Zed sends OpenAI-style `reasoning_effort` on chat-completions requests.
+For reasoning models (e.g. GPT-5), set `reasoning_effort` to the non-`none` effort level your endpoint supports. This enables thinking in the agent panel and tells Zed which effort to send when thinking is enabled. The provider settings UI can configure this when adding an OpenAI-compatible provider.
 
-If the model requires the Responses API for reasoning state, set `capabilities.chat_completions` to `false`:
+For Responses API reasoning models (`capabilities.chat_completions: false`), `reasoning_effort` also lets Zed request `reasoning.encrypted_content`. Zed keeps Responses requests stateless with `store: false`; encrypted reasoning state lets Zed safely continue multi-turn conversations without relying on the provider to persist prior `rs_*` reasoning item IDs. If encrypted reasoning state is unavailable for a previous turn, Zed skips replaying that reasoning item rather than sending an unresolved ID.
+
+If the model requires the Responses API for reasoning state, set `capabilities.chat_completions` to `false` and configure `reasoning_effort`:
 
 ```json [settings]
 {
@@ -535,7 +537,7 @@ If the model requires the Responses API for reasoning state, set `capabilities.c
 }
 ```
 
-Valid settings values are `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, and `"max"`. Use `"none"` in `settings.json` when you need to force reasoning off for an endpoint; the provider setup UI exposes the non-`none` values for thinking-capable models. For chat-completions endpoints that should receive prior thinking back in a dedicated `reasoning_content` field, also set `capabilities.interleaved_reasoning` to `true`. If the endpoint expects the output-token limit as `max_tokens` instead of `max_completion_tokens`, set `capabilities.max_tokens_parameter` to `true`.
+Valid `reasoning_effort` values are `"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, and `"max"`. Use `"none"` in `settings.json` when you need to force reasoning off for an endpoint; the provider setup UI exposes the non-`none` values for thinking-capable models. Zed sends OpenAI-style `reasoning_effort` on chat-completions requests. For chat-completions endpoints that should receive prior thinking back in a dedicated `reasoning_content` field, also set `capabilities.interleaved_reasoning` to `true`. If the endpoint expects the output-token limit as `max_tokens` instead of `max_completion_tokens`, set `capabilities.max_tokens_parameter` to `true`.
 
 For example, a chat-completions endpoint with the maximum OpenAI-style reasoning effort, streamed thinking, and `max_tokens` output limits can be configured as:
 


### PR DESCRIPTION
# Summary:

- Request `reasoning.encrypted_content` for stateless Responses API requests when reasoning is active/configured or replayable reasoning state is present.
- Avoid replaying unresolved ID-only `rs_*` reasoning items when using `store: false`.
- Preserve latest-item-wins semantics for duplicated reasoning IDs, including removing stale staged reasoning when the latest duplicate is not replayable.
- Document OpenAI-compatible Responses API reasoning setup and lightly consolidate related test setup.

# Background:

Zed keeps Responses API requests stateless with `store: false`. For reasoning models, providers like OpenAI do not persist prior `rs_*` reasoning item IDs in this mode, so replaying those IDs without `encrypted_content` can cause later turns to fail with item-not-found errors.

This keeps the stateless behavior but only replays reasoning state that is safe to send back: encrypted reasoning items or self-contained idless reasoning content. If encrypted reasoning state is unavailable, Zed skips the unresolved reasoning item instead of sending an invalid ID reference.

Closes #59207

# Testing:

- `cargo test -p open_ai into_open_ai_response_ --lib`
- `cargo test -p language_models open_ai_compatible --lib`
- `cargo fmt -p open_ai -- --check`
- `cargo fmt -p language_models -- --check`
- `cargo fmt -p open_ai -p language_models -- --check`
- `./script/clippy -p open_ai -p language_models`
- `git --no-pager diff --check`

Release Notes:

- Fixed OpenAI-compatible Responses API conversations failing when prior reasoning items are not persisted.
