### PR TITLE
workspace: Use remote host's path style when validating trust scope

### DIFF
--- a/crates/workspace/src/security_modal.rs
+++ b/crates/workspace/src/security_modal.rs
@@ -512,9 +512,10 @@ fn validate_trust_scope(
         return Err("Enter a folder to trust".into());
     }
     let expanded = match (trimmed.strip_prefix('~'), home_dir) {
-        (Some(rest), Some(home_dir)) => {
-            home_dir.join(rest.strip_prefix(std::path::MAIN_SEPARATOR).unwrap_or(rest))
-        }
+        (Some(rest), Some(home_dir)) => home_dir.join(
+            rest.strip_prefix(path_style.primary_separator())
+                .unwrap_or(rest),
+        ),
         _ => PathBuf::from(trimmed),
     };
     if !util::paths::is_absolute(&expanded.to_string_lossy(), path_style) {

--- a/crates/workspace/src/security_modal.rs
+++ b/crates/workspace/src/security_modal.rs
@@ -22,6 +22,8 @@ use ui::{
 };
 use ui_input::InputField;
 
+use util::paths::PathStyle;
+
 use crate::{DismissDecision, ModalView, ToggleWorktreeSecurity};
 
 pub struct SecurityModal {
@@ -387,7 +389,12 @@ impl SecurityModal {
             return Ok(None);
         };
         let typed = self.trust_path_input.read(cx).text(cx);
-        validate_trust_scope(&typed, &project, self.home_dir.as_deref()).map(Some)
+        let path_style = self
+            .worktree_store
+            .upgrade()
+            .map(|store| store.read(cx).path_style())
+            .unwrap_or_else(PathStyle::local);
+        validate_trust_scope(&typed, &project, self.home_dir.as_deref(), path_style).map(Some)
     }
 
     fn trust_and_dismiss(&mut self, cx: &mut Context<Self>) {
@@ -498,6 +505,7 @@ fn validate_trust_scope(
     typed: &str,
     project: &Path,
     home_dir: Option<&Path>,
+    path_style: PathStyle,
 ) -> Result<PathBuf, SharedString> {
     let trimmed = typed.trim();
     if trimmed.is_empty() {
@@ -509,7 +517,7 @@ fn validate_trust_scope(
         }
         _ => PathBuf::from(trimmed),
     };
-    if !expanded.is_absolute() {
+    if !util::paths::is_absolute(&expanded.to_string_lossy(), path_style) {
         return Err("Enter an absolute folder path".into());
     }
     if !project.starts_with(&expanded) {
@@ -525,39 +533,44 @@ mod tests {
     #[test]
     fn accepts_ancestor_or_equal() {
         let project = Path::new("/Users/me/dev/delta/wt/t1");
+        let style = PathStyle::Posix;
         assert_eq!(
-            validate_trust_scope("/Users/me/dev/delta/wt", project, None).unwrap(),
+            validate_trust_scope("/Users/me/dev/delta/wt", project, None, style).unwrap(),
             PathBuf::from("/Users/me/dev/delta/wt"),
         );
         // Equal to the project itself is allowed.
         assert_eq!(
-            validate_trust_scope("/Users/me/dev/delta/wt/t1", project, None).unwrap(),
+            validate_trust_scope("/Users/me/dev/delta/wt/t1", project, None, style).unwrap(),
             PathBuf::from("/Users/me/dev/delta/wt/t1"),
         );
         // A distant ancestor is allowed.
-        assert!(validate_trust_scope("/Users/me/dev", project, None).is_ok());
+        assert!(validate_trust_scope("/Users/me/dev", project, None, style).is_ok());
     }
 
     #[test]
     fn rejects_non_ancestor_relative_or_empty() {
         let project = Path::new("/Users/me/dev/delta/wt/t1");
-        assert!(validate_trust_scope("/Users/other", project, None).is_err());
-        assert!(validate_trust_scope("relative/path", project, None).is_err());
-        assert!(validate_trust_scope("   ", project, None).is_err());
+        let style = PathStyle::Posix;
+        assert!(validate_trust_scope("/Users/other", project, None, style).is_err());
+        assert!(validate_trust_scope("relative/path", project, None, style).is_err());
+        assert!(validate_trust_scope("   ", project, None, style).is_err());
         // Deeper than the project is not an ancestor.
-        assert!(validate_trust_scope("/Users/me/dev/delta/wt/t1/sub", project, None).is_err());
+        assert!(
+            validate_trust_scope("/Users/me/dev/delta/wt/t1/sub", project, None, style).is_err()
+        );
     }
 
     #[test]
     fn expands_leading_tilde() {
         let home = Path::new("/Users/me");
         let project = Path::new("/Users/me/dev/wt/t1");
+        let style = PathStyle::Posix;
         assert_eq!(
-            validate_trust_scope("~/dev/wt", project, Some(home)).unwrap(),
+            validate_trust_scope("~/dev/wt", project, Some(home), style).unwrap(),
             PathBuf::from("/Users/me/dev/wt"),
         );
         assert_eq!(
-            validate_trust_scope("~", project, Some(home)).unwrap(),
+            validate_trust_scope("~", project, Some(home), style).unwrap(),
             PathBuf::from("/Users/me"),
         );
     }


### PR DESCRIPTION
# Objective

Zed supports trusting all projects under a given directory. However, when a local Windows client connects to a remote Linux server, the trust scope input rejects valid directories with the error "Enter an absolute folder path", even though the path is correct.
<img width="681" height="374" alt="image" src="https://github.com/user-attachments/assets/87f084fb-1213-4594-96cb-3de81f4789aa" />

The root cause is in the `validate_trust_scope` function:
https://github.com/zed-industries/zed/blob/53e4d34a71f61f13572919c04335e9da838623e6/crates/workspace/src/security_modal.rs#L497-L519
which uses `Path::is_absolute()` to check whether the entered path is absolute. On Windows, this method only considers paths with a drive letter as absolute, so Unix-style paths like `/home/user` are never recognized. When doing cross-platform remote development, valid trust scopes are incorrectly rejected.
## Solution
The `util::paths` crate already provides a helper for this situation:
https://github.com/zed-industries/zed/blob/53e4d34a71f61f13572919c04335e9da838623e6/crates/util/src/paths.rs#L575-L586
The fix
- Adds a `path_style: PathStyle` parameter to `validate_trust_scope` and uses `util::paths::is_absolute()` in place of `Path::is_absolute()`.
- The call site in `edited_trust_scope` retrieves the path style from the worktree store, which already tracks whether a connection is local or remote and the remote host's path convention.

The associated unit tests were updated for the new function signature.

## Testing

Built and tested locally; `cargo test -p workspace` passed.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed the "Folder to trust" input rejecting valid folder paths when connecting to a remote host that uses a different path style than the local machine.
