### PR TITLE
Disable window corner rounding when tiled

### DIFF
--- a/crates/platform_title_bar/src/platform_title_bar.rs
+++ b/crates/platform_title_bar/src/platform_title_bar.rs
@@ -263,13 +263,11 @@ impl Render for PlatformTitleBar {
                 Decorations::Server => el,
                 Decorations::Client { tiling, .. } => el
                     .when(
-                        !(tiling.top || tiling.right)
-                            && !(sidebar.open && sidebar.side == SidebarSide::Right),
+                        !tiling.is_tiled() && !(sidebar.open && sidebar.side == SidebarSide::Right),
                         |el| el.rounded_tr(theme::CLIENT_SIDE_DECORATION_ROUNDING),
                     )
                     .when(
-                        !(tiling.top || tiling.left)
-                            && !(sidebar.open && sidebar.side == SidebarSide::Left),
+                        !tiling.is_tiled() && !(sidebar.open && sidebar.side == SidebarSide::Left),
                         |el| el.rounded_tl(theme::CLIENT_SIDE_DECORATION_ROUNDING),
                     )
                     // this border is to avoid a transparent gap in the rounded corners

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -119,13 +119,11 @@ impl Render for StatusBar {
                 Decorations::Server => el,
                 Decorations::Client { tiling, .. } => el
                     .when(
-                        !(tiling.bottom || tiling.right)
-                            && !(sidebar.open && sidebar.side == SidebarSide::Right),
+                        !tiling.is_tiled() && !(sidebar.open && sidebar.side == SidebarSide::Right),
                         |el| el.rounded_br(CLIENT_SIDE_DECORATION_ROUNDING),
                     )
                     .when(
-                        !(tiling.bottom || tiling.left)
-                            && !(sidebar.open && sidebar.side == SidebarSide::Left),
+                        !tiling.is_tiled() && !(sidebar.open && sidebar.side == SidebarSide::Left),
                         |el| el.rounded_bl(CLIENT_SIDE_DECORATION_ROUNDING),
                     )
                     // This border is to avoid a transparent gap in the rounded corners

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -10693,10 +10693,10 @@ pub fn client_side_decorations(
         Decorations::Client { tiling } => tiling,
     };
     let corner_tiling = Tiling {
-        top: tiling.top || border_radius_tiling.top,
-        bottom: tiling.bottom || border_radius_tiling.bottom,
-        left: tiling.left || border_radius_tiling.left,
-        right: tiling.right || border_radius_tiling.right,
+        top: tiling.is_tiled() || border_radius_tiling.top,
+        bottom: tiling.is_tiled() || border_radius_tiling.bottom,
+        left: tiling.is_tiled() || border_radius_tiling.left,
+        right: tiling.is_tiled() || border_radius_tiling.right,
     };
 
     match decorations {


### PR DESCRIPTION
# Objective

Zed rounds one corner when a window is tiled to the sides of the viewport. This behavior seems unintended. For comparison, Brave Browser and Firefox do not do this. Having completely square corners when a window is tiled is likely the expected behavior for most users.

Should fix at least partially #14110.

## Solution

Basically, prevent rounding the corners if the window is tiled.

## Testing

I have tested visually on Linux/KDE.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Click to view showcase</summary>


### No Rounded Corners If Tiled (Results)

<img width="3839" height="2073" alt="zed-no-rounded-corners-if-tiled" src="https://github.com/user-attachments/assets/37bd2185-29f4-4fb3-8656-4084273bee0a" />

<img width="301" height="155" alt="zed-no-rounded-corners-if-tiled-zoom" src="https://github.com/user-attachments/assets/b604a1a3-5097-4d87-a067-2193984168ff" />

### Original Behavior 

<img width="3839" height="2069" alt="zed-rounded-corner-if-tiled" src="https://github.com/user-attachments/assets/37b1fcf1-df48-4511-a229-af8f4e2f3cee" />

<img width="297" height="187" alt="zed-rounded-corner-if-tiled-zoom" src="https://github.com/user-attachments/assets/de7b0aed-551b-4c23-8585-96ed21af35f9" />

</details>

---

Release Notes:

- Disable window corner rounding when tiled
