### PR TITLE
acp: Remove gemini-cli workarounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,6 @@ dependencies = [
  "feature_flags",
  "fs",
  "futures 0.3.32",
- "google_ai",
  "gpui",
  "gpui_tokio",
  "http_client",
@@ -408,7 +407,6 @@ dependencies = [
  "util",
  "uuid",
  "watch",
- "zed_credentials_provider",
 ]
 
 [[package]]

--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -39,7 +39,6 @@ futures.workspace = true
 gpui.workspace = true
 feature_flags.workspace = true
 gpui_tokio = { workspace = true, optional = true }
-google_ai.workspace = true
 http_client.workspace = true
 indoc.workspace = true
 language_model.workspace = true
@@ -59,7 +58,6 @@ terminal.workspace = true
 uuid.workspace = true
 util.workspace = true
 watch.workspace = true
-zed_credentials_provider.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -41,9 +41,8 @@ use acp_thread::{AcpThread, AuthRequired, LoadError, TerminalProviderEvent};
 use terminal::TerminalBuilder;
 use terminal::terminal_settings::{AlternateScroll, CursorShape};
 
-use crate::{CURSOR_ID, GEMINI_ID};
+use crate::CURSOR_ID;
 
-pub const GEMINI_TERMINAL_AUTH_METHOD_ID: &str = "spawn-gemini-cli";
 const PARAMETERIZED_MODEL_PICKER_META_KEY: &str = "parameterizedModelPicker";
 const MAX_DEBUG_BACKLOG_MESSAGES: usize = 2000;
 
@@ -509,7 +508,6 @@ impl ConfigOptions {
 
 pub struct AcpSession {
     thread: WeakEntity<AcpThread>,
-    suppress_abort_err: bool,
     session_modes: Option<Rc<RefCell<acp::SessionModeState>>>,
     config_options: Option<ConfigOptions>,
     ref_count: usize,
@@ -802,7 +800,6 @@ impl AcpConnection {
                 .next()
                 .cloned()
         });
-        let original_command = command.clone();
         let (path, args, env) = project
             .read_with(cx, |project, cx| {
                 project.remote_client().and_then(|client| {
@@ -1039,25 +1036,7 @@ impl AcpConnection {
             None
         };
 
-        // TODO: Remove this override once Google team releases their official auth methods
-        let auth_methods = if agent_id.0.as_ref() == GEMINI_ID {
-            let mut gemini_args = original_command.args.clone();
-            gemini_args.retain(|a| a != "--experimental-acp" && a != "--acp");
-            let value = serde_json::json!({
-                "label": "gemini /auth",
-                "command": original_command.path.to_string_lossy(),
-                "args": gemini_args,
-                "env": original_command.env.unwrap_or_default(),
-            });
-            let meta = acp::Meta::from_iter([("terminal-auth".to_string(), value)]);
-            vec![acp::AuthMethod::Agent(
-                acp::AuthMethodAgent::new(GEMINI_TERMINAL_AUTH_METHOD_ID, "Login")
-                    .description("Login with your Google or Vertex AI account")
-                    .meta(meta),
-            )]
-        } else {
-            response.auth_methods
-        };
+        let auth_methods = response.auth_methods;
         let defaults = AcpConnectionDefaults::new(default_mode, default_config_options);
         let settings_subscription = cx.update({
             let agent_id = agent_id.clone();
@@ -1206,7 +1185,6 @@ impl AcpConnection {
                         session_id.clone(),
                         AcpSession {
                             thread: thread.downgrade(),
-                            suppress_abort_err: false,
                             session_modes: None,
                             config_options: None,
                             ref_count: 1,
@@ -1673,7 +1651,6 @@ impl AgentConnection for AcpConnection {
                 response.session_id,
                 AcpSession {
                     thread: thread.downgrade(),
-                    suppress_abort_err: false,
                     session_modes: modes,
                     config_options: config_options.map(ConfigOptions::new),
                     ref_count: 1,
@@ -1931,17 +1908,8 @@ impl AgentConnection for AcpConnection {
         cx: &mut App,
     ) -> Task<Result<acp::PromptResponse>> {
         let conn = self.connection.clone();
-        let sessions = self.sessions.clone();
-        let session_id = params.session_id.clone();
         cx.foreground_executor().spawn(async move {
             let result = conn.send_request(params).block_task().await;
-
-            let mut suppress_abort_err = false;
-
-            if let Some(session) = sessions.borrow_mut().get_mut(&session_id) {
-                suppress_abort_err = session.suppress_abort_err;
-                session.suppress_abort_err = false;
-            }
 
             match result {
                 Ok(response) => Ok(response),
@@ -1958,9 +1926,6 @@ impl AgentConnection for AcpConnection {
                         anyhow::bail!(err)
                     };
 
-                    // Temporary workaround until the following PR is generally available:
-                    // https://github.com/google-gemini/gemini-cli/pull/6656
-
                     #[derive(Deserialize)]
                     #[serde(deny_unknown_fields)]
                     struct ErrorDetails {
@@ -1968,16 +1933,7 @@ impl AgentConnection for AcpConnection {
                     }
 
                     match serde_json::from_value(data.clone()) {
-                        Ok(ErrorDetails { details }) => {
-                            if suppress_abort_err
-                                && (details.contains("This operation was aborted")
-                                    || details.contains("The user aborted a request"))
-                            {
-                                Ok(acp::PromptResponse::new(acp::StopReason::Cancelled))
-                            } else {
-                                Err(anyhow!(details))
-                            }
-                        }
+                        Ok(ErrorDetails { details }) => Err(anyhow!(details)),
                         Err(_) => Err(anyhow!(err)),
                     }
                 }
@@ -1986,9 +1942,6 @@ impl AgentConnection for AcpConnection {
     }
 
     fn cancel(&self, session_id: &acp::SessionId, _cx: &mut App) {
-        if let Some(session) = self.sessions.borrow_mut().get_mut(session_id) {
-            session.suppress_abort_err = true;
-        }
         let params = acp::CancelNotification::new(session_id.clone());
         self.connection.send_notification(params).log_err();
     }

--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -22,10 +22,7 @@ use std::{any::Any, rc::Rc, sync::Arc};
 pub use acp::test_support::{
     FakeAcpAgentServer, FakeAcpConnectionHarness, connect_fake_acp_connection,
 };
-pub use acp::{
-    AcpConnection, AcpDebugMessage, AcpDebugMessageContent, AcpDebugMessageDirection,
-    GEMINI_TERMINAL_AUTH_METHOD_ID,
-};
+pub use acp::{AcpConnection, AcpDebugMessage, AcpDebugMessageContent, AcpDebugMessageDirection};
 
 pub struct AgentServerDelegate {
     store: Entity<AgentServerStore>,

--- a/crates/agent_servers/src/custom.rs
+++ b/crates/agent_servers/src/custom.rs
@@ -5,7 +5,6 @@ use anyhow::{Context as _, Result};
 use collections::HashSet;
 use fs::Fs;
 use gpui::{App, AppContext as _, Entity, Task};
-use language_model::{ApiKey, EnvVar};
 use project::{
     Project,
     agent_server_store::{AgentId, AllAgentServersSettings},
@@ -14,7 +13,6 @@ use settings::{AgentConfigOptionValue, SettingsStore, update_settings_file};
 use std::{rc::Rc, sync::Arc};
 use ui::IconName;
 
-pub const GEMINI_ID: &str = "gemini";
 pub const CLAUDE_AGENT_ID: &str = "claude-acp";
 pub const CODEX_ID: &str = "codex-acp";
 pub const CURSOR_ID: &str = "cursor";
@@ -239,19 +237,11 @@ impl AgentServer for CustomAgentServer {
                         extra_env.insert("OPEN_AI_API_KEY".into(), api_key);
                     }
                 }
-                GEMINI_ID => {
-                    extra_env.insert("SURFACE".to_owned(), "zed".to_owned());
-                }
                 _ => {}
             }
         }
         let store = delegate.store.downgrade();
         cx.spawn(async move |cx| {
-            if is_registry_agent && agent_id.as_ref() == GEMINI_ID {
-                if let Some(api_key) = cx.update(api_key_for_gemini_cli).await.ok() {
-                    extra_env.insert("GEMINI_API_KEY".into(), api_key);
-                }
-            }
             let command = store
                 .update(cx, |store, cx| {
                     let agent = store.get_external_agent(&agent_id).with_context(|| {
@@ -283,23 +273,6 @@ impl AgentServer for CustomAgentServer {
     fn into_any(self: Rc<Self>) -> Rc<dyn std::any::Any> {
         self
     }
-}
-
-fn api_key_for_gemini_cli(cx: &mut App) -> Task<Result<String>> {
-    let env_var = EnvVar::new("GEMINI_API_KEY".into()).or(EnvVar::new("GOOGLE_AI_API_KEY".into()));
-    if let Some(key) = env_var.value {
-        return Task::ready(Ok(key));
-    }
-    let credentials_provider = zed_credentials_provider::global(cx);
-    let api_url = google_ai::API_URL.to_string();
-    cx.spawn(async move |cx| {
-        Ok(
-            ApiKey::load_from_system_keychain(&api_url, credentials_provider.as_ref(), cx)
-                .await?
-                .key()
-                .to_string(),
-        )
-    })
 }
 
 fn is_registry_agent(agent_id: impl Into<AgentId>, cx: &App) -> bool {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -122,7 +122,6 @@ const KNOWN_TERMINAL_AGENT_COMMANDS: &[&str] = &[
     "crush",
     "devin",
     "droid",
-    "gemini",
     "goose",
     "grok",
     "openhands",

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -1248,15 +1248,15 @@ mod tests {
 
     #[test]
     fn test_deserialize_new_external_agent_thread() {
-        let action = serde_json::from_str::<NewExternalAgentThread>(r#"{"agent":"gemini"}"#)
+        let action = serde_json::from_str::<NewExternalAgentThread>(r#"{"agent":"my-agent"}"#)
             .expect("should deserialize agent id");
-        assert_eq!(action.agent, AgentId::from("gemini"));
+        assert_eq!(action.agent, AgentId::from("my-agent"));
 
         let action = serde_json::from_str::<NewExternalAgentThread>(
-            r#"{"agent":{"custom":{"name":"gemini"}}}"#,
+            r#"{"agent":{"custom":{"name":"my-agent"}}}"#,
         )
         .expect("should deserialize legacy custom agent payload");
-        assert_eq!(action.agent, AgentId::from("gemini"));
+        assert_eq!(action.agent, AgentId::from("my-agent"));
 
         let action = serde_json::from_str::<NewExternalAgentThread>(r#"{"agent":"NativeAgent"}"#)
             .expect("should deserialize legacy native agent payload");

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -8,9 +8,9 @@ use acp_thread::{AgentConnection, Plan};
 use action_log::{ActionLog, ActionLogTelemetry, DiffStats};
 use agent::{NativeAgentServer, NoModelConfiguredError, ThreadStore};
 use agent_client_protocol::schema::v1 as acp;
+use agent_servers::AgentServer;
 #[cfg(test)]
 use agent_servers::AgentServerDelegate;
-use agent_servers::{AgentServer, GEMINI_TERMINAL_AUTH_METHOD_ID};
 use agent_settings::{AgentProfileId, AgentSettings};
 use anyhow::{Result, anyhow};
 #[cfg(feature = "audio")]
@@ -1844,7 +1844,6 @@ impl ConversationView {
                                 workspace,
                                 project,
                                 method.clone(),
-                                false,
                                 window,
                                 cx,
                             )
@@ -2006,7 +2005,6 @@ impl ConversationView {
         workspace: Entity<Workspace>,
         project: Entity<Project>,
         method: acp::AuthMethodId,
-        previous_attempt: bool,
         window: &mut Window,
         cx: &mut App,
     ) -> Task<Result<()>> {
@@ -2048,7 +2046,7 @@ impl ConversationView {
                 .await?;
 
             let success_patterns = match method.0.as_ref() {
-                "claude-login" | GEMINI_TERMINAL_AUTH_METHOD_ID => vec![
+                "claude-login" => vec![
                     "Login successful".to_string(),
                     "Type your message".to_string(),
                 ],
@@ -2101,24 +2099,6 @@ impl ConversationView {
                         }
                     }
                     _ = exit_status => {
-                        if !previous_attempt
-                            && project.read_with(cx, |project, _| project.is_via_remote_server())
-                            && method.0.as_ref() == GEMINI_TERMINAL_AUTH_METHOD_ID
-                        {
-                            return cx
-                                .update(|window, cx| {
-                                    Self::spawn_external_agent_login(
-                                        login,
-                                        workspace,
-                                        project.clone(),
-                                        method,
-                                        true,
-                                        window,
-                                        cx,
-                                    )
-                                })?
-                                .await;
-                        }
                         return Err(anyhow!("exited before logging in"));
                     }
                 }
@@ -2771,7 +2751,7 @@ impl ConversationView {
 
     fn current_model_name(&self, cx: &App) -> SharedString {
         // For native agent (Zed Agent), use the specific model name (e.g., "Claude 3.5 Sonnet")
-        // For ACP agents, use the agent name (e.g., "Claude Agent", "Gemini CLI")
+        // For ACP agents, use the agent name (e.g., "Claude Agent", "Codex CLI")
         // This provides better clarity about what refused the request
         if self.as_native_connection(cx).is_some() {
             self.root_thread_view()
@@ -2780,7 +2760,7 @@ impl ConversationView {
                 .map(|model| model.name.clone())
                 .unwrap_or_else(|| SharedString::from("The model"))
         } else {
-            // ACP agent - use the agent name (e.g., "Claude Agent", "Gemini CLI")
+            // ACP agent - use the agent name (e.g., "Claude Agent", "Codex CLI")
             self.agent.agent_id().0
         }
     }

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -10561,7 +10561,7 @@ impl ThreadView {
 
     fn current_model_name(&self, cx: &App) -> SharedString {
         // For native agent (Zed Agent), use the specific model name (e.g., "Claude 3.5 Sonnet")
-        // For ACP agents, use the agent name (e.g., "Claude Agent", "Gemini CLI")
+        // For ACP agents, use the agent name (e.g., "Claude Agent", "Codex CLI")
         // This provides better clarity about what refused the request
         if self.as_native_connection(cx).is_some() {
             self.model_selector
@@ -10570,7 +10570,7 @@ impl ThreadView {
                 .map(|model| model.name.clone())
                 .unwrap_or_else(|| SharedString::from("The model"))
         } else {
-            // ACP agent - use the agent name (e.g., "Claude Agent", "Gemini CLI")
+            // ACP agent - use the agent name (e.g., "Claude Agent", "Codex CLI")
             self.agent_id.0.clone()
         }
     }

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -336,7 +336,6 @@ impl ExtensionFilter {
 enum Feature {
     AgentClaude,
     AgentCodex,
-    AgentGemini,
     ExtensionBasedpyright,
     ExtensionRuff,
     ExtensionTailwind,
@@ -363,7 +362,6 @@ fn keywords_by_feature() -> &'static BTreeMap<Feature, Vec<&'static str>> {
                 vec!["claude", "claude code", "claude agent"],
             ),
             (Feature::AgentCodex, vec!["codex", "codex cli"]),
-            (Feature::AgentGemini, vec!["gemini", "gemini cli"]),
             (
                 Feature::ExtensionBasedpyright,
                 vec!["basedpyright", "pyright"],
@@ -1642,12 +1640,6 @@ impl ExtensionsPage {
                 Feature::AgentCodex => self.render_feature_upsell_banner(
                     "Codex CLI support is built-in to Zed!".into(),
                     "https://zed.dev/docs/ai/external-agents#codex-cli".into(),
-                    false,
-                    cx,
-                ),
-                Feature::AgentGemini => self.render_feature_upsell_banner(
-                    "Gemini CLI support is built-in to Zed!".into(),
-                    "https://zed.dev/docs/ai/external-agents#gemini-cli".into(),
                     false,
                     cx,
                 ),

--- a/crates/migrator/src/migrations/m_2025_11_20/settings.rs
+++ b/crates/migrator/src/migrations/m_2025_11_20/settings.rs
@@ -33,7 +33,7 @@ fn migrate_custom_agent_settings(
     let server_name = mat.nodes_for_capture_index(server_name_index).next()?;
     let server_name_text = &contents[server_name.byte_range()];
 
-    if matches!(server_name_text, "gemini" | "claude" | "codex") {
+    if matches!(server_name_text, "claude" | "codex") {
         return None;
     }
 

--- a/crates/migrator/src/migrations/m_2026_02_25/settings.rs
+++ b/crates/migrator/src/migrations/m_2026_02_25/settings.rs
@@ -12,10 +12,6 @@ struct BuiltinMapping {
 
 const BUILTIN_MAPPINGS: &[BuiltinMapping] = &[
     BuiltinMapping {
-        old_key: "gemini",
-        registry_key: "gemini",
-    },
-    BuiltinMapping {
         old_key: "claude",
         registry_key: "claude-acp",
     },
@@ -82,15 +78,7 @@ fn migrate_builtin_entry(
     };
 
     let has_command = old_obj.contains_key("command");
-    let ignore_system_version = old_obj
-        .get("ignore_system_version")
-        .and_then(|v| v.as_bool());
-
-    // A custom entry is needed when the user configured a custom binary
-    // or explicitly opted into using the system version via
-    // `ignore_system_version: false` (only meaningful for gemini).
-    let needs_custom = has_command
-        || (mapping.old_key == "gemini" && matches!(ignore_system_version, Some(false)));
+    let needs_custom = has_command;
 
     if needs_custom {
         let local_key = format!("{}-custom", mapping.registry_key);
@@ -112,12 +100,6 @@ fn migrate_builtin_entry(
                     custom_obj.insert("args".to_string(), args.clone());
                 }
             }
-        } else {
-            // ignore_system_version: false — the user wants the binary from $PATH
-            custom_obj.insert(
-                "command".to_string(),
-                Value::String(mapping.old_key.to_string()),
-            );
         }
 
         // Carry over all compatible fields to the custom entry.

--- a/crates/migrator/src/migrations/m_2026_02_25/settings.rs
+++ b/crates/migrator/src/migrations/m_2026_02_25/settings.rs
@@ -78,9 +78,7 @@ fn migrate_builtin_entry(
     };
 
     let has_command = old_obj.contains_key("command");
-    let needs_custom = has_command;
-
-    if needs_custom {
+    if has_command {
         let local_key = format!("{}-custom", mapping.registry_key);
 
         // Don't overwrite an existing `-custom` entry.

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -1205,8 +1205,8 @@ mod tests {
             )],
             r#"{
     "agent_servers": {
-        "gemini": {
-            "default_model": "gemini-1.5-pro"
+        "another-custom-agent": {
+            "default_model": "custom-model"
         },
         "claude": {},
         "codex": {},
@@ -1228,8 +1228,9 @@ mod tests {
             Some(
                 r#"{
     "agent_servers": {
-        "gemini": {
-            "default_model": "gemini-1.5-pro"
+        "another-custom-agent": {
+            "type": "custom",
+            "default_model": "custom-model"
         },
         "claude": {},
         "codex": {},
@@ -4082,9 +4083,6 @@ mod tests {
             )],
             r#"{
     "agent_servers": {
-        "gemini": {
-            "default_model": "gemini-2.0-flash"
-        },
         "claude": {
             "default_mode": "plan"
         },
@@ -4103,10 +4101,6 @@ mod tests {
         "claude-acp": {
             "type": "registry",
             "default_mode": "plan"
-        },
-        "gemini": {
-            "type": "registry",
-            "default_model": "gemini-2.0-flash"
         }
     }
 }"#,
@@ -4122,7 +4116,6 @@ mod tests {
             )],
             r#"{
     "agent_servers": {
-        "gemini": {},
         "claude": {},
         "codex": {}
     }
@@ -4134,9 +4127,6 @@ mod tests {
             "type": "registry"
         },
         "claude-acp": {
-            "type": "registry"
-        },
-        "gemini": {
             "type": "registry"
         }
     }
@@ -4184,89 +4174,6 @@ mod tests {
     }
 
     #[test]
-    fn test_migrate_builtin_agent_servers_gemini_with_command() {
-        assert_migrate_with_migrations(
-            &[MigrationType::Json(
-                migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
-            )],
-            r#"{
-    "agent_servers": {
-        "gemini": {
-            "command": "/opt/gemini/bin/gemini",
-            "default_model": "gemini-2.0-flash"
-        }
-    }
-}"#,
-            Some(
-                r#"{
-    "agent_servers": {
-        "gemini-custom": {
-            "type": "custom",
-            "command": "/opt/gemini/bin/gemini",
-            "default_model": "gemini-2.0-flash"
-        }
-    }
-}"#,
-            ),
-        );
-    }
-
-    #[test]
-    fn test_migrate_builtin_agent_servers_gemini_ignore_system_version_false() {
-        assert_migrate_with_migrations(
-            &[MigrationType::Json(
-                migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
-            )],
-            r#"{
-    "agent_servers": {
-        "gemini": {
-            "ignore_system_version": false,
-            "default_model": "gemini-2.0-flash"
-        }
-    }
-}"#,
-            Some(
-                r#"{
-    "agent_servers": {
-        "gemini-custom": {
-            "type": "custom",
-            "command": "gemini",
-            "default_model": "gemini-2.0-flash"
-        }
-    }
-}"#,
-            ),
-        );
-    }
-
-    #[test]
-    fn test_migrate_builtin_agent_servers_gemini_ignore_system_version_true() {
-        assert_migrate_with_migrations(
-            &[MigrationType::Json(
-                migrations::m_2026_02_25::migrate_builtin_agent_servers_to_registry,
-            )],
-            r#"{
-    "agent_servers": {
-        "gemini": {
-            "ignore_system_version": true,
-            "default_model": "gemini-2.0-flash"
-        }
-    }
-}"#,
-            Some(
-                r#"{
-    "agent_servers": {
-        "gemini": {
-            "type": "registry",
-            "default_model": "gemini-2.0-flash"
-        }
-    }
-}"#,
-            ),
-        );
-    }
-
-    #[test]
     fn test_migrate_builtin_agent_servers_already_typed_unchanged() {
         assert_migrate_with_migrations(
             &[MigrationType::Json(
@@ -4274,9 +4181,9 @@ mod tests {
             )],
             r#"{
     "agent_servers": {
-        "gemini": {
-            "type": "registry",
-            "default_model": "gemini-2.0-flash"
+        "my-custom-agent": {
+            "type": "custom",
+            "command": "/path/to/agent"
         },
         "claude-acp": {
             "type": "registry",
@@ -4455,9 +4362,9 @@ mod tests {
             )],
             r#"{
     "agent_servers": {
-        "gemini": {
-            "type": "registry",
-            "default_model": "gemini-2.0-flash"
+        "my-custom-agent": {
+            "type": "custom",
+            "command": "/path/to/agent"
         },
         "claude": {
             "default_mode": "plan"
@@ -4475,9 +4382,9 @@ mod tests {
             "type": "registry",
             "default_mode": "plan"
         },
-        "gemini": {
-            "type": "registry",
-            "default_model": "gemini-2.0-flash"
+        "my-custom-agent": {
+            "type": "custom",
+            "command": "/path/to/agent"
         }
     }
 }"#,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -3371,9 +3371,9 @@ mod tests {
         assert_eq!(
             foreground_process_command_from_argv(&[
                 "node".to_string(),
-                "/opt/homebrew/lib/node_modules/@google/gemini-cli/dist/index.js".to_string(),
+                "/opt/homebrew/lib/node_modules/qwen/dist/index.js".to_string(),
             ]),
-            Some("gemini".to_string())
+            Some("qwen".to_string())
         );
         assert_eq!(
             foreground_process_command_from_argv(&[

--- a/docs/src/ai/by-company.md
+++ b/docs/src/ai/by-company.md
@@ -35,12 +35,11 @@ For detailed setup, follow the links in the `Setup` column. This page answers ro
 
 Claude Pro and Max subscriptions are separate from Anthropic API credits. If you want Claude subscription-limit behavior, use Claude Agent or Claude Code where supported. See [Use an Existing Subscription](./use-an-existing-subscription.md#claude).
 
-## Google / Gemini / Gemini CLI {#google-gemini}
+## Google / Gemini {#google-gemini}
 
-| Path          | Support level                    | What you get                                      | Account / billing     | Setup                                                                                         |
-| ------------- | -------------------------------- | ------------------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------- |
-| Google AI API | Configured in Zed                | Gemini models through API access                  | Google AI API billing | [Use API Access](./use-api-access.md#google-ai)                                               |
-| Gemini CLI    | Hosted in Zed or run in terminal | Gemini CLI as an External Agent or native CLI/TUI | Owned by Gemini CLI   | [External Agents](./external-agents.md#gemini-cli), [Terminal Threads](./terminal-threads.md) |
+| Path          | Support level     | What you get                     | Account / billing     | Setup                                           |
+| ------------- | ----------------- | -------------------------------- | --------------------- | ----------------------------------------------- |
+| Google AI API | Configured in Zed | Gemini models through API access | Google AI API billing | [Use API Access](./use-api-access.md#google-ai) |
 
 ## GitHub / Copilot {#github-copilot}
 

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -34,7 +34,7 @@ Common External Agents include:
 
 This list is curated, not exhaustive. Open the ACP Registry in Zed for the current list of available agents.
 
-For company-specific setup paths, including Claude, Codex, Gemini, OpenCode, Copilot, Cursor, and Pi, see [AI by Company](./by-company.md).
+For company-specific setup paths, including Claude, Codex, Google AI/Gemini, OpenCode, Copilot, Cursor, and Pi, see [AI by Company](./by-company.md).
 
 ## Claude Agent {#claude-agent}
 
@@ -51,14 +51,6 @@ Use Codex when you want Codex running as an ACP-integrated External Agent in Zed
 Install Codex from the [ACP Registry](#registry), then start a Codex thread from the Agent Panel or Threads Sidebar. Codex owns its own authentication and billing. An OpenAI API key configured for [Zed Agent](./zed-agent.md) does not automatically configure Codex.
 
 Codex may support ChatGPT login, Codex API keys, OpenAI API keys, or Codex-native configuration depending on the installed version and environment. To change authentication, use the Codex thread's native login/logout flow.
-
-## Gemini CLI {#gemini-cli}
-
-Use Gemini CLI when you want Gemini running as an ACP-integrated External Agent in Zed.
-
-Install Gemini CLI from the [ACP Registry](#registry), then start a Gemini CLI thread from the Agent Panel or Threads Sidebar. Gemini CLI owns its own authentication and may prompt you to log in with Google, Vertex AI, or another Gemini-supported flow.
-
-If `GEMINI_API_KEY` or `GOOGLE_AI_API_KEY` is available to the agent process, Gemini CLI uses that key. Otherwise, if you have configured an API key for Zed's Google AI provider, Zed passes that key to Gemini CLI as `GEMINI_API_KEY`.
 
 ## OpenCode {#opencode}
 

--- a/docs/src/ai/parallel-agents.md
+++ b/docs/src/ai/parallel-agents.md
@@ -41,7 +41,7 @@ You can search your threads in history; search will fuzzy match on thread titles
 
 If you have External Agents installed, Zed will detect whether you have existing threads and invite you to import them into Zed. Once you open Thread History, you'll find an import icon button in the Thread History toolbar that lets you import threads at any time. Clicking on it opens a modal where you can select the agents whose threads you want to import.
 
-> **Note:** Thread import is subject to agent support. Some agents (such as Cursor and Gemini CLI) are not currently supported.
+> **Note:** Thread import is subject to agent support. Some agents, such as Cursor, are not currently supported.
 
 ## Running Multiple Threads {#running-multiple-threads}
 

--- a/docs/src/ai/quick-start.md
+++ b/docs/src/ai/quick-start.md
@@ -27,7 +27,7 @@ Start in the [Agent Panel](./agent-panel.md) to prompt the agent, add context, r
 
 ## Use Another Coding Agent in Zed {#agent-cli}
 
-Use this path for Claude, Codex, OpenCode, Copilot, Cursor, Pi Coding Agent, Gemini CLI, or another coding agent.
+Use this path for Claude, Codex, OpenCode, Copilot, Cursor, Pi Coding Agent, or another coding agent.
 
 | If the agent...                 | Use                                       |
 | ------------------------------- | ----------------------------------------- |


### PR DESCRIPTION
Gemini CLI is dead, so we can remove these.

Release Notes:

- N/A
