### PR TITLE
project_panel: Avoid undo error when trashing non-existing file or directory

### DIFF
--- a/crates/project_panel/src/undo.rs
+++ b/crates/project_panel/src/undo.rs
@@ -153,26 +153,30 @@ enum Operation {
 }
 
 impl Operation {
-    async fn execute(self, undo_manager: &Inner, cx: &mut AsyncApp) -> Result<Change> {
+    async fn execute(self, undo_manager: &Inner, cx: &mut AsyncApp) -> Result<Option<Change>> {
         Ok(match self {
-            Operation::Trash(project_path) => {
-                let trash_entry = undo_manager.trash(&project_path, cx).await?;
-                Change::Trashed(project_path.worktree_id, trash_entry)
-            }
+            Operation::Trash(project_path) => match undo_manager.trash(&project_path, cx).await? {
+                None => None,
+                Some(trashed_entry) => {
+                    Some(Change::Trashed(project_path.worktree_id, trashed_entry))
+                }
+            },
             Operation::Rename(from, to) => {
                 undo_manager.rename(&from, &to, cx).await?;
-                Change::Renamed(from, to)
+                Some(Change::Renamed(from, to))
             }
             Operation::Restore(worktree_id, trashed_entry) => {
                 let project_path = undo_manager.restore(worktree_id, trashed_entry, cx).await?;
-                Change::Restored(project_path)
+                Some(Change::Restored(project_path))
             }
             Operation::Batch(operations) => {
-                let mut res = Vec::new();
-                for op in operations {
-                    res.push(Box::pin(op.execute(undo_manager, cx)).await?);
+                let mut batch = Vec::new();
+                for operation in operations {
+                    if let Some(change) = Box::pin(operation.execute(undo_manager, cx)).await? {
+                        batch.push(change)
+                    }
                 }
-                Change::Batched(res)
+                Some(Change::Batched(batch))
             }
         })
     }
@@ -413,14 +417,17 @@ impl Inner {
         // manual intervention would likely be needed in order to undo. As such,
         // we remove the change from the `history` even before attempting to
         // execute its inversion.
-        let undo_change = self
+        if let Some(undo_change) = self
             .history
             .remove(before_cursor)
             .expect("we can undo")
             .to_inverse()
             .execute(self, cx)
-            .await?;
-        self.history.insert(before_cursor, undo_change);
+            .await?
+        {
+            self.history.insert(before_cursor, undo_change);
+        }
+
         Ok(())
     }
 
@@ -433,15 +440,18 @@ impl Inner {
         // manual intervention would likely be needed in order to redo. As such,
         // we remove the change from the `history` even before attempting to
         // execute its inversion.
-        let redo_change = self
+        if let Some(redo_change) = self
             .history
             .remove(self.cursor)
             .expect("we can redo")
             .to_inverse()
             .execute(self, cx)
-            .await?;
-        self.history.insert(self.cursor, redo_change);
-        self.cursor += 1;
+            .await?
+        {
+            self.history.insert(self.cursor, redo_change);
+            self.cursor += 1;
+        }
+
         Ok(())
     }
 
@@ -494,28 +504,46 @@ impl Inner {
         res?.await
     }
 
-    async fn trash(&self, project_path: &ProjectPath, cx: &mut AsyncApp) -> Result<TrashedEntry> {
+    /// Attempts to trash the provided `project_path`. If the file or directory
+    /// no longer exists at the provided path, we assume it has been deleted
+    /// from the project and simply return `Ok(None)`.
+    async fn trash(
+        &self,
+        project_path: &ProjectPath,
+        cx: &mut AsyncApp,
+    ) -> Result<Option<TrashedEntry>> {
         let Some(workspace) = self.workspace.upgrade() else {
             return Err(anyhow!("Failed to obtain workspace."));
         };
 
-        workspace
-            .update(cx, |workspace, cx| {
-                workspace.project().update(cx, |project, cx| {
-                    let entry_id = project
-                        .entry_for_path(&project_path, cx)
-                        .map(|entry| entry.id)
-                        .ok_or_else(|| anyhow!("No entry for path."))?;
+        // TODO!: We can probably simplify this a bit still.
+        let task = workspace.update(cx, |workspace, cx| {
+            workspace.project().update(cx, |project, cx| {
+                let Some(entry_id) = project
+                    .entry_for_path(&project_path, cx)
+                    .map(|entry| entry.id)
+                else {
+                    return Ok(None);
+                };
 
-                    project
-                        .delete_entry(entry_id, true, cx)
-                        .ok_or_else(|| anyhow!("Worktree entry should exist"))
-                })
-            })?
-            .await
-            .and_then(|entry| {
-                entry.ok_or_else(|| anyhow!("When trashing we should always get a trashentry"))
+                project
+                    .delete_entry(entry_id, true, cx)
+                    .context("Worktree entry should exist")
+                    .map(Some)
             })
+        })?;
+
+        // No file or directory found at the provided `project_path`, assume
+        // that it was already deleted.
+        let Some(task) = task else {
+            return Ok(None);
+        };
+
+        let trashed_entry = task
+            .await?
+            .context("trashing should always yield a trashed entry")?;
+
+        Ok(Some(trashed_entry))
     }
 
     async fn restore(

--- a/crates/project_panel/src/undo.rs
+++ b/crates/project_panel/src/undo.rs
@@ -516,22 +516,12 @@ impl Inner {
             return Err(anyhow!("Failed to obtain workspace."));
         };
 
-        // TODO!: We can probably simplify this a bit still.
         let task = workspace.update(cx, |workspace, cx| {
             workspace.project().update(cx, |project, cx| {
-                let Some(entry_id) = project
-                    .entry_for_path(&project_path, cx)
-                    .map(|entry| entry.id)
-                else {
-                    return Ok(None);
-                };
-
-                project
-                    .delete_entry(entry_id, true, cx)
-                    .context("Worktree entry should exist")
-                    .map(Some)
+                let entry_id = project.entry_for_path(&project_path, cx)?.id;
+                project.delete_entry(entry_id, true, cx)
             })
-        })?;
+        });
 
         // No file or directory found at the provided `project_path`, assume
         // that it was already deleted.


### PR DESCRIPTION
This is a temporary description, while the Pull Request in in draft:

Update the way trashing is handled by the undo manager such that, the path being trashed no longer exists, we don't consider that an error and simply don't return a corresponding change.

This fixes the situation where doing the following actions could end up displaying an error to the user:

1. Create `empty.txt`
2. Delete `empty.txt`, accepting that this action can't be undone
3. Attempt to undo

---

# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, use "Fixes #X" for each issue as [described in the GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Solution

- Describe the solution used to achieve the objective above.

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

## Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---

Release Notes:

- N/A or Added/Fixed/Improved ...
