### PR TITLE
terminal_view: add fast scroll for terminal

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -704,7 +704,13 @@ impl TerminalView {
         self.terminal.update(cx, |term, cx| {
             term.scroll_wheel(
                 event,
-                TerminalSettings::get_global(cx).scroll_multiplier.max(0.01),
+                if (event.modifiers.alt) {
+                    EditorSettings::get_global(cx)
+                        .fast_scroll_sensitivity
+                        .max(0.01)
+                } else {
+                    TerminalSettings::get_global(cx).scroll_multiplier.max(0.01)
+                },
             )
         });
     }


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, use "Fixes #X" for each issue as [described in the GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Solution

- Describe the solution used to achieve the objective above.

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Adds fast scroll for terminal when alt modifier is pressed. Reuses same scroll sensitivity from EditorSettings, not sure if that should be separate setting for terminal. 
I tested it briefly, and it did work, did not spot any regressions.

Release Notes:

- N/A
