### PR TITLE
terminal_view: Use ASCII ellipsis in "New" tooltip for consistency with workspace pane

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -158,7 +158,7 @@ impl TerminalPanel {
                         PopoverMenu::new("terminal-tab-bar-popover-menu")
                             .trigger_with_tooltip(
                                 IconButton::new("plus", IconName::Plus).icon_size(IconSize::Small),
-                                Tooltip::text("New…"),
+                                Tooltip::text("New..."),
                             )
                             .anchor(Anchor::TopRight)
                             .with_handle(pane.new_item_context_menu_handle.clone())


### PR DESCRIPTION
## Objective

The terminal panel's "New" button tooltip used a Unicode ellipsis character (`…`), while the similar tooltip in the workspace pane (`crates/workspace/src/pane.rs`) used three ASCII dots (`...`).

This makes them consistent.

## Solution

Replaced the Unicode ellipsis `…` with three ASCII periods `...` in the terminal panel tooltip.

## Testing

Ran with `cargo run` and tooltip appears correctly.

## Self-Review Checklist:

- [x] Reviewed my own diff for quality, security, and reliability
- [x] No unsafe blocks
- [x] No performance impact
- [x] No new tests (trivial string change)

Release Notes:

- N/A
