### PR TITLE
Suppress `pet` log spam when opening Python projects

### DIFF
--- a/crates/zlog/src/filter.rs
+++ b/crates/zlog/src/filter.rs
@@ -42,6 +42,7 @@ const DEFAULT_FILTERS: &[(&str, log::LevelFilter)] = &[
     // usvg prints a lot of warnings on rendering an SVG with partial errors, which
     // can happen a lot with the SVG preview
     ("usvg::parser", log::LevelFilter::Error),
+    ("pet", log::LevelFilter::Warn),
 ];
 
 pub fn init_env_filter(filter: env_config::EnvFilter) {


### PR DESCRIPTION
# Objective

Zed uses `pet` to auto-discover Python virtual environments. When opening Python projects, there is a large amount of log spam from `pet` output, which is not useful:

```
2026-07-01T22:32:07+08:00 INFO  [pet::find] find_and_report_envs; search_scope=None
2026-07-01T22:32:07+08:00 INFO  [lsp] starting language server process. binary path: "/usr/bin/ty", working directory: "/home/xin/works/test/test_python", args: ["server"]
2026-07-01T22:32:07+08:00 INFO  [pet::find] locators_phase;
2026-07-01T22:32:07+08:00 INFO  [pet::find] path_search_phase;
2026-07-01T22:32:07+08:00 INFO  [pet::find] locator_find; locator=PipEnv
2026-07-01T22:32:07+08:00 INFO  [pet::find] workspace_search_phase;
2026-07-01T22:32:07+08:00 INFO  [pet::find] locator_find; locator=PyEnv
2026-07-01T22:32:07+08:00 INFO  [pet::find] locator_find; locator=Pixi
2026-07-01T22:32:07+08:00 INFO  [pet::find] locator_find; locator=Conda
2026-07-01T22:32:07+08:00 INFO  [pet::find] locator_find; locator=Uv
2026-07-01T22:32:07+08:00 INFO  [pet::find] locator_find; locator=Poetry
2026-07-01T22:32:07+08:00 INFO  [pet::find] global_virtualenvs_phase;
2026-07-01T22:32:07+08:00 INFO  [pet::find] locator_find; locator=Venv
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=[] executable_count=0
2026-07-01T22:32:07+08:00 INFO  [pet::find] locator_find; locator=VirtualEnv
2026-07-01T22:32:07+08:00 INFO  [pet::find] find_python_environments_in_workspace_folder_recursive; workspace_folder="/home/xin/works/test/test_python" workspace=/home/xin/works/test/test_python
2026-07-01T22:32:07+08:00 INFO  [pet::find] locator_find; locator=Homebrew
2026-07-01T22:32:07+08:00 INFO  [lsp] starting language server process. binary path: "/usr/bin/ruff", working directory: "/home/xin/works/test/test_python", args: ["server"]
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=[] executable_count=0
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=[] executable_count=0
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=[] executable_count=0
2026-07-01T22:32:07+08:00 INFO  [pet::find] locator_find; locator=LinuxGlobal
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=[] executable_count=0
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=[] executable_count=0
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=[] executable_count=0
2026-07-01T22:32:07+08:00 INFO  [pet::find] locator_find; locator=VirtualEnvWrapper
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=[] executable_count=0
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=["/home/xin/works/test/test_python/.venv/bin/python"] executable_count=1
2026-07-01T22:32:07+08:00 INFO  [pet::locators] identify_python_environment_using_locators; env=PythonEnv { executable: "/home/xin/works/test/test_python/.venv/bin/python", prefix: Some("/home/xin/works/test/test_python/.venv"), version: None, symlinks: None } executable=/home/xin/works/test/test_python/.venv/bin/python
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=PyEnv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Pixi
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Conda
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Uv
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=[] executable_count=0
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=[] executable_count=0
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=[] executable_count=0
2026-07-01T22:32:07+08:00 INFO  [pet::find] identify_python_executables_using_locators; executables=["/usr/bin/python", "/usr/bin/python3", "/usr/bin/python3.14"] executable_count=3
2026-07-01T22:32:07+08:00 INFO  [pet::locators] identify_python_environment_using_locators; env=PythonEnv { executable: "/usr/bin/python", prefix: None, version: None, symlinks: None } executable=/usr/bin/python
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=PyEnv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Pixi
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Conda
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Uv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Poetry
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=PipEnv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=VirtualEnvWrapper
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Venv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=VirtualEnv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Homebrew
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=LinuxGlobal
2026-07-01T22:32:07+08:00 INFO  [pet::locators] resolve_python_env; executable=/usr/bin/python
2026-07-01T22:32:07+08:00 INFO  [pet::locators] identify_python_environment_using_locators; env=PythonEnv { executable: "/usr/bin/python3", prefix: None, version: None, symlinks: None } executable=/usr/bin/python3
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=PyEnv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Pixi
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Conda
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Uv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Poetry
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=PipEnv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=VirtualEnvWrapper
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Venv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=VirtualEnv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Homebrew
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=LinuxGlobal
2026-07-01T22:32:07+08:00 INFO  [pet::locators] resolve_python_env; executable=/usr/bin/python3
2026-07-01T22:32:07+08:00 INFO  [pet::locators] identify_python_environment_using_locators; env=PythonEnv { executable: "/usr/bin/python3.14", prefix: None, version: None, symlinks: None } executable=/usr/bin/python3.14
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=PyEnv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Pixi
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Conda
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Uv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Poetry
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=PipEnv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=VirtualEnvWrapper
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Venv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=VirtualEnv
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=Homebrew
2026-07-01T22:32:07+08:00 INFO  [pet::locators] try_from_locator; locator=LinuxGlobal
2026-07-01T22:32:07+08:00 INFO  [pet::locators] resolve_python_env; executable=/usr/bin/python3.14
```


This PR is intended to remove this log spam.

## Solution

Add `pet`  to the default log filters. Now, `INFO` logs from `pet` are suppressed by default.

## Testing

Tested locally, and verified that there is no longer any `pet` log spam in the Zed logs.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


---

Release Notes:

- Improved logging by suppressing verbose Python environment discovery logs.