### PR TITLE
grammars: Highlight inline HTML comments in Markdown

### DIFF
--- a/crates/grammars/src/grammars.rs
+++ b/crates/grammars/src/grammars.rs
@@ -106,3 +106,44 @@ pub fn load_queries(name: &str) -> LanguageQueries {
     }
     result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Context as _;
+    use tree_sitter::StreamingIterator as _;
+
+    #[test]
+    fn highlights_inline_markdown_comments() -> anyhow::Result<()> {
+        let source = "before <!-- hidden note --> <span>after</span>";
+        let language = tree_sitter_md::INLINE_LANGUAGE.into();
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language)?;
+        let tree = parser
+            .parse(source, None)
+            .context("failed to parse inline Markdown")?;
+        let highlights = load_queries("markdown-inline")
+            .highlights
+            .context("missing inline Markdown highlights query")?;
+        let query = tree_sitter::Query::new(&language, &highlights)?;
+        let comment_capture_index = query
+            .capture_index_for_name("comment")
+            .context("missing comment capture")?;
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), source.as_bytes());
+        let mut comments = Vec::new();
+
+        while let Some(query_match) = matches.next() {
+            comments.extend(
+                query_match
+                    .captures
+                    .iter()
+                    .filter(|capture| capture.index == comment_capture_index)
+                    .map(|capture| &source[capture.node.byte_range()]),
+            );
+        }
+
+        assert_eq!(comments, ["<!-- hidden note -->"]);
+        Ok(())
+    }
+}

--- a/crates/grammars/src/markdown-inline/highlights.scm
+++ b/crates/grammars/src/markdown-inline/highlights.scm
@@ -4,6 +4,9 @@
 
 (code_span) @text.literal.markup
 
+((html_tag) @comment
+  (#match? @comment "^<!--"))
+
 (strikethrough) @strikethrough.markup
 
 [


### PR DESCRIPTION
## Summary

- highlight inline HTML comments in Markdown with the theme's comment style
- leave other inline HTML tags unaffected
- add regression coverage for the Markdown-inline highlight query

## Root cause

The Markdown-inline grammar exposes comments and ordinary inline HTML as the same `html_tag` node. The existing highlight query did not distinguish comments by their source text, so `<!-- ... -->` received no comment capture inside paragraphs.

This change adds a query predicate that applies `@comment` only when an `html_tag` starts with `<!--`.

## Validation

- `rustup run stable rustfmt --edition 2024 --check crates/grammars/src/grammars.rs`
- `git diff --check`
- parsed inline Markdown containing both `<!-- hidden note -->` and `<span>after</span>` with the updated query and verified that only the comment received the `comment` capture

Release Notes:

- Improved Markdown syntax highlighting for inline HTML comments.
