### PR TITLE
markdown_preview: Use UI font for base font size

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -73,7 +73,7 @@
   "agent_buffer_font_size": 12,
   // The default font size for the commit editor in the git panel and commit modal.
   "git_commit_buffer_font_size": 12,
-  // The default font size for the markdown preview. Falls back to the editor font size if unset.
+  // The default font size for the markdown preview. Falls back to the UI font size if unset.
   "markdown_preview_font_size": null,
   // The font family for the markdown preview. Falls back to the UI font family if unset.
   "markdown_preview_font_family": null,

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -5399,13 +5399,13 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_editor_zoom_does_not_affect_markdown_preview(cx: &mut TestAppContext) {
+    fn test_ui_zoom_does_not_affect_markdown_preview(cx: &mut TestAppContext) {
         ensure_theme_initialized(cx);
 
         cx.update(|cx| {
             settings::SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings(cx, |settings| {
-                    settings.theme.buffer_font_size = Some(16.0.into());
+                    settings.theme.ui_font_size = Some(16.0.into());
                     settings.theme.markdown_preview_font_size = None;
                 });
             });
@@ -5416,11 +5416,9 @@ mod tests {
             let before = ThemeSettings::get_global(cx).markdown_preview_font_size(cx);
             assert_eq!(before, px(16.0));
 
-            theme_settings::increase_buffer_font_size(cx);
-            theme_settings::increase_buffer_font_size(cx);
-            theme_settings::increase_buffer_font_size(cx);
+            theme_settings::adjust_ui_font_size(cx, |size| size + px(3.0));
 
-            assert_eq!(ThemeSettings::get_global(cx).buffer_font_size(cx), px(19.0));
+            assert_eq!(ThemeSettings::get_global(cx).ui_font_size(cx), px(19.0));
             assert_eq!(
                 ThemeSettings::get_global(cx).markdown_preview_font_size(cx),
                 before
@@ -5429,13 +5427,13 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_markdown_preview_follows_buffer_font_size_setting_when_unset(cx: &mut TestAppContext) {
+    fn test_markdown_preview_follows_ui_font_size_setting_when_unset(cx: &mut TestAppContext) {
         ensure_theme_initialized(cx);
 
         cx.update(|cx| {
             settings::SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings(cx, |settings| {
-                    settings.theme.buffer_font_size = Some(20.0.into());
+                    settings.theme.ui_font_size = Some(20.0.into());
                     settings.theme.markdown_preview_font_size = None;
                 });
             });
@@ -5451,7 +5449,7 @@ mod tests {
         cx.update(|cx| {
             settings::SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings(cx, |settings| {
-                    settings.theme.buffer_font_size = Some(24.0.into());
+                    settings.theme.ui_font_size = Some(24.0.into());
                 });
             });
         });

--- a/crates/settings_content/src/theme.rs
+++ b/crates/settings_content/src/theme.rs
@@ -157,7 +157,7 @@ pub struct ThemeSettingsContent {
     /// markdown preview. Falls back to the buffer font if unset.
     pub markdown_preview_code_font_family: Option<FontFamilyName>,
     /// The font size to use for rendering in the markdown preview.
-    /// Falls back to the buffer font size if unset.
+    /// Falls back to the UI font size if unset.
     pub markdown_preview_font_size: Option<FontSize>,
     /// The theme to use for the markdown preview.
     /// Falls back to the main editor theme if unset.

--- a/crates/theme_settings/src/settings.rs
+++ b/crates/theme_settings/src/settings.rs
@@ -64,7 +64,7 @@ pub struct ThemeSettings {
     /// Falls back to the buffer font family if unset.
     markdown_preview_code_font_family: Option<SharedString>,
     /// The font size to use for rendering in the markdown preview.
-    /// Falls back to the buffer font size if unset.
+    /// Falls back to the UI font size if unset.
     markdown_preview_font_size: Option<Pixels>,
     /// The theme to use for the markdown preview.
     /// Falls back to the main editor theme if unset.
@@ -451,14 +451,14 @@ impl ThemeSettings {
 
     /// Returns the markdown preview font size.
     ///
-    /// Note: the fallback deliberately uses `self.buffer_font_size` instead of `buffer_font_size(cx)`,
-    /// so that temporary editor zoom does not also resize the markdown preview.
+    /// Note: the fallback deliberately uses `self.ui_font_size` instead of `ui_font_size(cx)`,
+    /// so that temporary UI zoom does not also resize the markdown preview.
     pub fn markdown_preview_font_size(&self, cx: &App) -> Pixels {
         cx.try_global::<MarkdownPreviewFontSize>()
             .map(|size| size.0)
             .or(self.markdown_preview_font_size)
             .map(clamp_font_size)
-            .unwrap_or_else(|| clamp_font_size(self.buffer_font_size))
+            .unwrap_or_else(|| clamp_font_size(self.ui_font_size))
     }
 
     /// Returns the buffer font size, read from the settings.


### PR DESCRIPTION
This PR makes the `markdown_preview_font_size` setting be based on the UI font size instead of the buffer UI font size. I typically use a much smaller code font than UI font, and that made reading the markdown preview super small. I don't think this will be uncommon because the dimensions between mono and non-mono typefaces are different...

Release Notes:

- Changed the markdown preview to fall back to the UI font size instead of the buffer font size when `markdown_preview_font_size` is unset.
