### PR TITLE
Add setting for default preview layout in search and file finder

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -726,6 +726,9 @@
     "regex": false,
     // Whether to center the cursor on each search match when navigating.
     "center_on_match": false,
+    // Where to place the preview in the project search modal by default.
+    // One of: "hidden", "right", "below".
+    "preview": "hidden",
   },
   // When to populate a new search's query based on the text under the cursor.
   // This setting can take the following three values:
@@ -1432,6 +1435,9 @@
     "include_ignored": "smart",
     // Whether to include text channels in file finder results.
     "include_channels": false,
+    // Where to place the file preview in the file finder by default.
+    // One of: "hidden", "right", "below".
+    "preview": "hidden",
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -7,8 +7,8 @@ pub use settings::{
     CodeLens, CompletionDetailAlignment, CompletionMenuItemKind, CurrentLineHighlight, DelayMs,
     DiffViewStyle, DisplayIn, DocumentColorsRenderMode, DoubleClickInMultibuffer,
     GoToDefinitionFallback, GoToDefinitionScrollStrategy, MinimapThumb, MinimapThumbBorder,
-    MultiCursorModifier, ScrollBeyondLastLine, ScrollbarDiagnostics, SeedQuerySetting, ShowMinimap,
-    SnippetSortOrder,
+    MultiCursorModifier, PreviewLayoutContent, ScrollBeyondLastLine, ScrollbarDiagnostics,
+    SeedQuerySetting, ShowMinimap, SnippetSortOrder,
 };
 use settings::{RegisterSetting, RelativeLineNumbers, Settings};
 use ui::scrollbars::ShowScrollbar;
@@ -184,6 +184,8 @@ pub struct SearchSettings {
     pub regex: bool,
     /// Whether to center the cursor on each search match when navigating.
     pub center_on_match: bool,
+    /// Where to place the preview in the project search modal by default.
+    pub preview: PreviewLayoutContent,
 }
 
 impl EditorSettings {
@@ -284,6 +286,7 @@ impl Settings for EditorSettings {
                 include_ignored: search.include_ignored.unwrap(),
                 regex: search.regex.unwrap(),
                 center_on_match: search.center_on_match.unwrap(),
+                preview: search.preview.unwrap(),
             },
             auto_signature_help: editor.auto_signature_help.unwrap(),
             show_signature_help_after_edits: editor.show_signature_help_after_edits.unwrap(),

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -166,13 +166,15 @@ impl FileFinder {
     }
 
     fn new(delegate: FileFinderDelegate, window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let modal_max_width_setting = FileFinderSettings::get_global(cx).modal_max_width;
+        let settings = FileFinderSettings::get_global(cx);
+        let modal_max_width_setting = settings.modal_max_width;
+        let default_layout = settings.preview.into();
 
         let project = delegate.project.clone();
         let modal_max_width = Self::modal_max_width(modal_max_width_setting, window);
         let preview = picker_preview::editor_preview(project, window, cx);
         let picker = cx.new(|cx| {
-            Picker::uniform_list_with_preview(delegate, preview, window, cx)
+            Picker::uniform_list_with_preview(delegate, preview, default_layout, window, cx)
                 .initial_width(Rems::from_pixels(modal_max_width, window))
         });
         let picker_focus_handle = picker.focus_handle(cx);

--- a/crates/open_path_prompt/src/file_finder_settings.rs
+++ b/crates/open_path_prompt/src/file_finder_settings.rs
@@ -1,6 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::{RegisterSetting, Settings};
+use settings::{PreviewLayoutContent, RegisterSetting, Settings};
 
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq, RegisterSetting)]
 pub struct FileFinderSettings {
@@ -9,6 +9,7 @@ pub struct FileFinderSettings {
     pub skip_focus_for_active_in_search: bool,
     pub include_ignored: Option<bool>,
     pub include_channels: bool,
+    pub preview: PreviewLayoutContent,
 }
 
 impl Settings for FileFinderSettings {
@@ -25,6 +26,7 @@ impl Settings for FileFinderSettings {
                 settings::IncludeIgnoredContent::Smart => None,
             },
             include_channels: file_finder.include_channels.unwrap(),
+            preview: file_finder.preview.unwrap(),
         }
     }
 }

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -402,6 +402,7 @@ impl<D: PickerDelegate> Picker<D> {
     pub fn uniform_list_with_preview(
         delegate: D,
         preview: Arc<dyn PreviewBackend>,
+        default_layout: preview::Layout,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -412,7 +413,8 @@ impl<D: PickerDelegate> Picker<D> {
             cx,
         );
 
-        let preview = Preview::new(preview);
+        let mut preview = Preview::new(preview);
+        preview.layout = default_layout;
         Self::new(
             delegate,
             ContainerKind::UniformList,
@@ -430,6 +432,7 @@ impl<D: PickerDelegate> Picker<D> {
     pub fn list_with_preview(
         delegate: D,
         preview: Arc<dyn PreviewBackend>,
+        default_layout: preview::Layout,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -440,7 +443,8 @@ impl<D: PickerDelegate> Picker<D> {
             cx,
         );
 
-        let preview = Preview::new(preview);
+        let mut preview = Preview::new(preview);
+        preview.layout = default_layout;
         Self::new(
             delegate,
             ContainerKind::List,
@@ -496,10 +500,12 @@ impl<D: PickerDelegate> Picker<D> {
     ) -> Self {
         let element_container = Self::create_element_container(container);
         if let Some(preview) = &mut preview {
+            // A persisted layout is the user's last runtime choice and wins; otherwise
+            // fall back to the caller's configured default (already set on `preview`).
             preview.layout = persistence::load_last_preview_layout(D::name(), cx)
                 .log_err()
                 .flatten()
-                .unwrap_or_default();
+                .unwrap_or(preview.layout);
         };
         let has_preview = preview.is_some();
         let persisted_shape =
@@ -1423,6 +1429,20 @@ mod tests {
         }
     }
 
+    struct NoopPreview;
+
+    impl PreviewBackend for NoopPreview {
+        fn update(&self, _update: PreviewUpdate, _window: &mut Window, _cx: &mut App) {}
+
+        fn render(&self, _layout: PreviewLayout, _cx: &mut App) -> gpui::AnyElement {
+            gpui::Empty.into_any_element()
+        }
+
+        fn adjust_to_new_size(&self, _window: &mut Window, _cx: &mut App) {}
+
+        fn clear(&self, _cx: &mut App) {}
+    }
+
     fn init_test(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let store = settings::SettingsStore::test(cx);
@@ -1430,6 +1450,37 @@ mod tests {
             theme_settings::init(theme::LoadThemes::JustBase, cx);
             editor::init(cx);
         });
+    }
+
+    #[gpui::test]
+    async fn test_preview_opens_with_configured_default_layout(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        // With no layout persisted for this delegate, the finder opens with the
+        // layout the caller derived from its setting.
+        for layout in [
+            preview::Layout::Right,
+            preview::Layout::Below,
+            preview::Layout::Hidden,
+        ] {
+            let (picker, cx) = cx.add_window_view(|window, cx| {
+                Picker::list_with_preview(
+                    TestDelegate::new(vec![true]),
+                    Arc::new(NoopPreview),
+                    layout,
+                    window,
+                    cx,
+                )
+            });
+
+            picker.update(cx, |picker, _cx| {
+                assert_eq!(
+                    picker.preview_layout(),
+                    Some(layout),
+                    "preview should open with the configured default layout {layout:?}"
+                );
+            });
+        }
     }
 
     #[gpui::test]

--- a/crates/picker/src/preview.rs
+++ b/crates/picker/src/preview.rs
@@ -30,6 +30,16 @@ pub enum Layout {
     Right,
 }
 
+impl From<settings::PreviewLayoutContent> for Layout {
+    fn from(content: settings::PreviewLayoutContent) -> Self {
+        match content {
+            settings::PreviewLayoutContent::Hidden => Layout::Hidden,
+            settings::PreviewLayoutContent::Right => Layout::Right,
+            settings::PreviewLayoutContent::Below => Layout::Below,
+        }
+    }
+}
+
 impl Preview {
     pub fn new(content: Arc<dyn PreviewBackend>) -> Self {
         Preview {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -3791,6 +3791,7 @@ mod tests {
                 include_ignored: false,
                 regex: false,
                 center_on_match: false,
+                preview: Default::default(),
             },
             cx,
         );
@@ -3854,6 +3855,7 @@ mod tests {
                 include_ignored: false,
                 regex: false,
                 center_on_match: false,
+                preview: Default::default(),
             },
             cx,
         );
@@ -3892,6 +3894,7 @@ mod tests {
                 include_ignored: false,
                 regex: false,
                 center_on_match: false,
+                preview: Default::default(),
             },
             cx,
         );
@@ -4076,6 +4079,7 @@ mod tests {
                         include_ignored: Some(search_settings.include_ignored),
                         regex: Some(search_settings.regex),
                         center_on_match: Some(search_settings.center_on_match),
+                        preview: Some(search_settings.preview),
                     });
                 });
             });

--- a/crates/search/src/text_finder.rs
+++ b/crates/search/src/text_finder.rs
@@ -14,7 +14,7 @@ use language::Buffer;
 use picker::Picker;
 
 use project::ProjectPath;
-use settings::{Settings as _, SeedQuerySetting};
+use settings::{SeedQuerySetting, Settings as _};
 use text::Anchor;
 use ui::Window;
 use workspace::{

--- a/crates/search/src/text_finder.rs
+++ b/crates/search/src/text_finder.rs
@@ -14,7 +14,7 @@ use language::Buffer;
 use picker::Picker;
 
 use project::ProjectPath;
-use settings::SeedQuerySetting;
+use settings::{Settings as _, SeedQuerySetting};
 use text::Anchor;
 use ui::Window;
 use workspace::{
@@ -378,7 +378,9 @@ impl TextFinder {
     ) -> Self {
         let project = delegate.project(cx).clone();
         let preview = picker_preview::editor_preview(project, window, cx);
-        let picker = cx.new(|cx| Picker::list_with_preview(delegate, preview, window, cx));
+        let default_layout = editor::EditorSettings::get_global(cx).search.preview.into();
+        let picker =
+            cx.new(|cx| Picker::list_with_preview(delegate, preview, default_layout, window, cx));
         let picker_weak = picker.downgrade();
         let picker_focus_handle = picker.focus_handle(cx);
         picker.update(cx, |picker, cx| {

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -941,6 +941,8 @@ pub struct SearchSettingsContent {
     pub regex: Option<bool>,
     /// Whether to center the cursor on each search match when navigating.
     pub center_on_match: Option<bool>,
+    /// Where to place the preview in the project search modal by default.
+    pub preview: Option<crate::PreviewLayoutContent>,
 }
 
 #[with_fallible_options]

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -873,6 +873,10 @@ pub struct FileFinderSettingsContent {
     ///
     /// Default: false
     pub include_channels: Option<bool>,
+    /// Where to place the file preview by default.
+    ///
+    /// Default: hidden
+    pub preview: Option<PreviewLayoutContent>,
 }
 
 #[derive(
@@ -898,6 +902,34 @@ pub enum IncludeIgnoredContent {
     /// Be smart and search for ignored when called from a gitignored worktree
     #[default]
     Smart,
+}
+
+/// Where a preview-capable picker (the project search modal, the file finder)
+/// places its preview by default. Toggling the preview at runtime persists and
+/// overrides this until it is changed again.
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum PreviewLayoutContent {
+    /// Don't show the preview.
+    #[default]
+    Hidden,
+    /// Show the preview to the right of the results.
+    Right,
+    /// Show the preview below the results.
+    Below,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3417,7 +3417,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
 }
 
 fn search_and_files_page() -> SettingsPage {
-    fn search_section() -> [SettingsPageItem; 9] {
+    fn search_section() -> [SettingsPageItem; 10] {
         [
             SettingsPageItem::SectionHeader("Search"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -3559,6 +3559,30 @@ fn search_and_files_page() -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
+                title: "Preview",
+                description: "Where to place the preview in the project search modal by default.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("editor.search.preview"),
+                    pick: |settings_content| {
+                        settings_content
+                            .editor
+                            .search
+                            .as_ref()
+                            .and_then(|search| search.preview.as_ref())
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .editor
+                            .search
+                            .get_or_insert_default()
+                            .preview = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
                 title: "Seed Search Query From Cursor",
                 description: "When to populate a new search's query based on the text under the cursor.",
                 field: Box::new(SettingField {
@@ -3580,7 +3604,7 @@ fn search_and_files_page() -> SettingsPage {
         ]
     }
 
-    fn file_finder_section() -> [SettingsPageItem; 4] {
+    fn file_finder_section() -> [SettingsPageItem; 5] {
         [
             SettingsPageItem::SectionHeader("File Finder"),
             // todo: null by default
@@ -3644,6 +3668,22 @@ fn search_and_files_page() -> SettingsPage {
                             .file_finder
                             .get_or_insert_default()
                             .skip_focus_for_active_in_search = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Preview",
+                description: "Where to place the file preview in the file finder by default.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("file_finder.preview"),
+                    pick: |settings_content| {
+                        settings_content.file_finder.as_ref()?.preview.as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content.file_finder.get_or_insert_default().preview = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -628,6 +628,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::AutosaveSettingDiscriminants>(render_dropdown)
         .add_basic_renderer::<settings::WorkingDirectoryDiscriminants>(render_dropdown)
         .add_basic_renderer::<settings::IncludeIgnoredContent>(render_dropdown)
+        .add_basic_renderer::<settings::PreviewLayoutContent>(render_dropdown)
         .add_basic_renderer::<settings::ShowIndentGuides>(render_dropdown)
         .add_basic_renderer::<settings::ShellDiscriminants>(render_dropdown)
         .add_basic_renderer::<settings::EditPredictionsMode>(render_dropdown)


### PR DESCRIPTION
Follow-up to #8279.

The search modal and file finder already support a side/bottom preview, but it always opens hidden and has to be toggled by hand every time. This adds a setting to choose the layout each one opens with, as asked for in https://github.com/zed-industries/zed/issues/8279#issuecomment-4800802142.

Two independent settings, since I tend to want different things for "jump to file" vs "search in files":

```jsonc
"search":      { "preview": "right" },  // project search modal
"file_finder": { "preview": "below" }
```

Accepted values are `"hidden"` (default, unchanged), `"right"` and `"below"`. Both are also exposed as dropdowns in the settings UI.

Toggling the preview at runtime still persists per picker and wins over the setting, so this only decides where the preview starts when nothing has been persisted yet.

### How it works

`SearchSettings` / `FileFinderSettings` grow a `preview` field that the two modals pass into `Picker::{list,uniform_list}_with_preview`. When the picker has no persisted layout it now falls back to that value instead of always defaulting to hidden.

### Tests

Added a picker test that a preview picker opens with the configured layout when nothing is persisted (`test_preview_opens_with_configured_default_layout`).

Release Notes:

- Added `search.preview` and `file_finder.preview` settings to control whether the preview shows by default and where it is placed (`hidden`, `right`, `below`).
