### PR TITLE
cloud_api_types: Remove unused `AcceptTermsOfServiceResponse` type

### DIFF
--- a/crates/cloud_api_types/src/cloud_api_types.rs
+++ b/crates/cloud_api_types/src/cloud_api_types.rs
@@ -71,11 +71,6 @@ pub struct OrganizationEditPredictionConfiguration {
     pub is_feedback_enabled: bool,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct AcceptTermsOfServiceResponse {
-    pub user: AuthenticatedUser,
-}
-
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct LlmToken(pub String);
 


### PR DESCRIPTION
This PR removes the `AcceptTermsOfServiceResponse` struct, as it is no longer used.

Release Notes:

- N/A