### PR TITLE
editor: Add soft wrap mode that ignores editor width

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1518,7 +1518,9 @@
   //      "soft_wrap": "prefer_line", // (deprecated, same as "none")
   // 2. Soft wrap lines that overflow the editor.
   //      "soft_wrap": "editor_width",
-  // 3. Soft wrap lines at the preferred line length or the editor width (whichever is smaller).
+  // 3. Soft wrap lines at the preferred line length, regardless of the editor width.
+  //      "soft_wrap": "preferred_line_length",
+  // 4. Soft wrap lines at the preferred line length or the editor width (whichever is smaller).
   //      "soft_wrap": "bounded",
   "soft_wrap": "none",
   // The column at which to soft-wrap lines, for buffers where soft-wrap

--- a/crates/editor/src/config.rs
+++ b/crates/editor/src/config.rs
@@ -236,7 +236,7 @@ impl Editor {
         let settings = self.buffer.read(cx).language_settings(cx);
         if settings.show_wrap_guides {
             match self.soft_wrap_mode(cx) {
-                SoftWrap::Bounded(soft_wrap) => {
+                SoftWrap::Fixed(soft_wrap) | SoftWrap::Bounded(soft_wrap) => {
                     wrap_guides.push((soft_wrap as usize, true));
                 }
                 SoftWrap::GitDiff | SoftWrap::None | SoftWrap::EditorWidth => {}
@@ -255,6 +255,9 @@ impl Editor {
                 SoftWrap::None
             }
             language_settings::SoftWrap::EditorWidth => SoftWrap::EditorWidth,
+            language_settings::SoftWrap::PreferredLineLength => {
+                SoftWrap::Fixed(settings.preferred_line_length)
+            }
             language_settings::SoftWrap::Bounded => {
                 SoftWrap::Bounded(settings.preferred_line_length)
             }
@@ -288,7 +291,9 @@ impl Editor {
             let soft_wrap = match self.soft_wrap_mode(cx) {
                 SoftWrap::GitDiff => return,
                 SoftWrap::None => language_settings::SoftWrap::EditorWidth,
-                SoftWrap::EditorWidth | SoftWrap::Bounded(_) => language_settings::SoftWrap::None,
+                SoftWrap::EditorWidth | SoftWrap::Fixed(_) | SoftWrap::Bounded(_) => {
+                    language_settings::SoftWrap::None
+                }
             };
             self.soft_wrap_mode_override = Some(soft_wrap);
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -516,6 +516,8 @@ pub enum SoftWrap {
     None,
     /// Soft wrap lines that exceed the editor width.
     EditorWidth,
+    /// Soft wrap lines at a fixed column, regardless of the editor width.
+    Fixed(u32),
     /// Soft wrap line at the preferred line length or the editor width (whichever is smaller).
     Bounded(u32),
 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -10632,6 +10632,7 @@ fn calculate_wrap_width(
         SoftWrap::GitDiff => None,
         SoftWrap::None => Some(wrap_width_for(MAX_LINE_LEN as u32 / 2)),
         SoftWrap::EditorWidth => Some(editor_width),
+        SoftWrap::Fixed(column) => Some(wrap_width_for(column)),
         SoftWrap::Bounded(column) => Some(editor_width.min(wrap_width_for(column))),
     }
 }
@@ -12291,6 +12292,16 @@ mod tests {
         assert_eq!(
             calculate_wrap_width(SoftWrap::Bounded(200), px(400.0), em_width),
             Some(px(400.0)),
+        );
+
+        assert_eq!(
+            calculate_wrap_width(SoftWrap::Fixed(72), editor_width, em_width),
+            Some(px((72.0 * 8.0_f32).ceil())),
+        );
+        // Unlike Bounded, a narrower editor does not shrink the wrap width.
+        assert_eq!(
+            calculate_wrap_width(SoftWrap::Fixed(200), px(400.0), em_width),
+            Some(px((200.0 * 8.0_f32).ceil())),
         );
     }
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -118,6 +118,7 @@ pub(crate) fn to_settings_soft_wrap(value: language_core::SoftWrap) -> settings:
         language_core::SoftWrap::None => settings::SoftWrap::None,
         language_core::SoftWrap::PreferLine => settings::SoftWrap::PreferLine,
         language_core::SoftWrap::EditorWidth => settings::SoftWrap::EditorWidth,
+        language_core::SoftWrap::PreferredLineLength => settings::SoftWrap::PreferredLineLength,
         language_core::SoftWrap::Bounded => settings::SoftWrap::Bounded,
     }
 }

--- a/crates/language_core/src/language_config.rs
+++ b/crates/language_core/src/language_config.rs
@@ -17,8 +17,10 @@ pub enum SoftWrap {
     PreferLine,
     /// Soft wrap lines that exceed the editor width.
     EditorWidth,
+    /// Soft wrap lines at the preferred line length, regardless of the editor
+    /// width; a narrower editor scrolls horizontally instead of re-wrapping.
+    PreferredLineLength,
     /// Soft wrap line at the preferred line length or the editor width (whichever is smaller).
-    #[serde(alias = "preferred_line_length")]
     Bounded,
 }
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -613,7 +613,7 @@ impl VsCodeSettings {
             show_wrap_guides: None,
             soft_wrap: self.read_enum("editor.wordWrap", |s| match s {
                 "on" => Some(SoftWrap::EditorWidth),
-                "wordWrapColumn" => Some(SoftWrap::PreferLine),
+                "wordWrapColumn" => Some(SoftWrap::PreferredLineLength),
                 "bounded" => Some(SoftWrap::Bounded),
                 "off" => Some(SoftWrap::None),
                 _ => None,

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -413,8 +413,10 @@ pub enum SoftWrap {
     PreferLine,
     /// Soft wrap lines that exceed the editor width.
     EditorWidth,
+    /// Soft wrap lines at the preferred line length, regardless of the editor
+    /// width; a narrower editor scrolls horizontally instead of re-wrapping.
+    PreferredLineLength,
     /// Soft wrap line at the preferred line length or the editor width (whichever is smaller).
-    #[serde(alias = "preferred_line_length")]
     Bounded,
 }
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4058,7 +4058,8 @@ Positive integer values
 1. `none` to avoid wrapping generally, unless the line is too long
 2. `prefer_line` (deprecated, same as `none`)
 3. `editor_width` to wrap lines that overflow the editor width
-4. `bounded` to wrap lines at the minimum of `editor_width` and `preferred_line_length`
+4. `preferred_line_length` to wrap lines at the `preferred_line_length` column, regardless of the editor width
+5. `bounded` to wrap lines at the minimum of `editor_width` and `preferred_line_length`
 
 ## Show Wrap Guides
 


### PR DESCRIPTION
Adds a `soft_wrap` value (`preferred_line_length`) which wraps at the `preferred_line_length` regardless of the editor width. A narrower editor scrolls horizontally instead of re-wrapping.
The behaviour of `bounded` (wrap at the smaller of editor width and preferred length) is unchanged.

Why I think this mode is missing rather than new:
- #14700 asked for exactly this behavior and was closed by #16586, which added `bounded` instead.
- The docs still describe it in two places: `visual-customization.md` lists `preferred_line_length` among the `soft_wrap` values, and the Show Wrap Guides section of the settings reference says the guide shows "if `soft_wrap` is set to `preferred_line_length`". This PR makes both statements true.
- The VS Code settings importer maps `editor.wordWrap: "wordWrapColumn"` to `PreferLine`, which afaics is a deprecated alias of `none`. This PR points it at the new mode, which is what `wordWrapColumn` actually does.

<img width="300" alt="wrap-bounded" src="https://github.com/user-attachments/assets/e228dd0a-d5e3-4b74-9e16-1accec4453df" />
<img width="300" alt="wrap-preferred-line-length" src="https://github.com/user-attachments/assets/d7250f27-516a-4c78-a1a8-98130564dacd" />

Release Notes:

- Added `preferred_line_length` as a `soft_wrap` mode that wraps at the preferred line length regardless of editor width
