### PR TITLE
command_palette: Show scrollbar in command palette

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -126,7 +126,9 @@ impl CommandPalette {
 
         let picker = cx.new(|cx| {
             // One-shot action; there's nothing to reopen.
-            let picker = Picker::uniform_list(delegate, window, cx).reopenable(false, cx);
+            let picker = Picker::uniform_list(delegate, window, cx)
+                .reopenable(false, cx)
+                .show_scrollbar(true);
             picker.set_query(query, window, cx);
             picker
         });


### PR DESCRIPTION
Enable the command palette picker scrollbar while preserving the one-shot reopen behavior.

---

Release Notes:

- N/A or Added/Fixed/Improved ...
