### PR TITLE
workspace: Fix panic when discarding a draft workspace

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -1228,7 +1228,9 @@ impl MultiWorkspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Workspace>>> {
-        if let Some(workspace) = self.workspace_for_paths(&paths, host.as_ref(), cx) {
+        if let Some(workspace) =
+            self.workspace_for_paths_excluding(&paths, host.as_ref(), excluding, cx)
+        {
             self.activate(workspace.clone(), source_workspace, window, cx);
             return Task::ready(Ok(workspace));
         }

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -507,6 +507,67 @@ async fn test_find_or_create_workspace_uses_project_group_key_when_paths_are_mis
 }
 
 #[gpui::test]
+async fn test_remove_fallback_via_find_or_create_skips_removed_workspaces(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/root_a", json!({ "file.txt": "" })).await;
+    let project_a = Project::test(fs.clone(), ["/root_a".as_ref()], cx).await;
+    let project_b = Project::test(fs, ["/root_a".as_ref()], cx).await;
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project_a, window, cx));
+
+    let workspace_a = multi_workspace.read_with(cx, |mw, _cx| mw.workspace().clone());
+    let workspace_b = multi_workspace.update_in(cx, |mw, window, cx| {
+        mw.test_add_workspace(project_b, window, cx)
+    });
+    cx.run_until_parked();
+
+    multi_workspace.update_in(cx, |mw, window, cx| {
+        mw.activate(workspace_a.clone(), None, window, cx);
+    });
+
+    let removed = multi_workspace
+        .update_in(cx, |mw, window, cx| {
+            let excluded = vec![workspace_a.clone()];
+            mw.remove(
+                excluded.clone(),
+                move |this, window, cx| {
+                    this.find_or_create_workspace(
+                        PathList::new(&[PathBuf::from("/root_a")]),
+                        None,
+                        None,
+                        |_options, _window, _cx| Task::ready(Ok(None)),
+                        &excluded,
+                        None,
+                        OpenMode::Activate,
+                        window,
+                        cx,
+                    )
+                },
+                window,
+                cx,
+            )
+        })
+        .await
+        .expect("removing the active workspace should succeed");
+    assert!(removed, "the workspace should have been removed");
+
+    multi_workspace.read_with(cx, |mw, _cx| {
+        assert_eq!(
+            mw.workspace().entity_id(),
+            workspace_b.entity_id(),
+            "the non-excluded workspace should become active"
+        );
+        assert!(
+            mw.workspaces()
+                .all(|workspace| workspace.entity_id() != workspace_a.entity_id()),
+            "the removed workspace should be gone"
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_find_or_create_local_workspace_reuses_active_workspace_after_sidebar_open(
     cx: &mut TestAppContext,
 ) {


### PR DESCRIPTION
To reproduce:

1. Open a git project with the agent sidebar, ideally with no other threads in the sidebar.
2. Create a thread in a new git worktree and type into it without sending.
3. While still in that worktree workspace, hit New Thread. The parked draft must now be the last activatable entry in the sidebar.
4. Hover the parked draft → click Discard Draft
5. 💥

Release Notes:

- Fixed a panic when discarding a draft workspace.