### PR TITLE
project_panel: Add File/Folder and Collapse All buttons

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5496,22 +5496,22 @@ impl ProjectPanel {
             .flex_none()
             .items_center()
             .gap_1()
-            .when(!is_read_only, |this| {
-                this.child(
-                    action_button("new-file", IconName::Plus)
-                        .tooltip(Tooltip::for_action_title("New File", &NewFile))
-                        .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
-                            this.new_file(&NewFile, window, cx);
-                        })),
-                )
-                .child(
-                    action_button("new-folder", IconName::FolderAdd)
-                        .tooltip(Tooltip::for_action_title("New Folder", &NewDirectory))
-                        .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
-                            this.new_directory(&NewDirectory, window, cx);
-                        })),
-                )
-            })
+            .child(
+                action_button("new-file", IconName::Plus)
+                    .disabled(is_read_only)
+                    .tooltip(Tooltip::for_action_title("New File", &NewFile))
+                    .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
+                        this.new_file(&NewFile, window, cx);
+                    })),
+            )
+            .child(
+                action_button("new-folder", IconName::FolderAdd)
+                    .disabled(is_read_only)
+                    .tooltip(Tooltip::for_action_title("New Folder", &NewDirectory))
+                    .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
+                        this.new_directory(&NewDirectory, window, cx);
+                    })),
+            )
             .child(
                 action_button("collapse-all", IconName::ListCollapse)
                     .tooltip(Tooltip::for_action_title(

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -61,7 +61,8 @@ use std::{
 };
 use theme_settings::ThemeSettings;
 use ui::{
-    ContextMenu, DecoratedIcon, IconDecoration, IconDecorationKind, IndentGuideColors,
+    ContextMenu, DecoratedIcon, IconButtonShape, IconDecoration, IconDecorationKind,
+    IndentGuideColors,
     IndentGuideLayout, Indicator, KeyBinding, ListItem, ListItemSpacing, ProjectEmptyState,
     ScrollAxes, ScrollableHandle, Scrollbars, StickyCandidate, Tooltip, WithScrollbar, prelude::*,
 };
@@ -158,6 +159,7 @@ pub struct ProjectPanel {
     // We keep track of the mouse down state on entries so we don't flash the UI
     // in case a user clicks to open a file.
     mouse_down: bool,
+    is_hovered: bool,
     hover_expand_task: Option<Task<()>>,
     previous_drag_position: Option<Point<Pixels>>,
     sticky_items_count: usize,
@@ -850,6 +852,7 @@ impl ProjectPanel {
                 diagnostic_summary_update: Task::ready(()),
                 scroll_handle,
                 mouse_down: false,
+                is_hovered: false,
                 hover_expand_task: None,
                 previous_drag_position: None,
                 sticky_items_count: 0,
@@ -1460,6 +1463,7 @@ impl ProjectPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.discard_edit_state(window, cx);
         let roots = self.all_worktree_roots(cx);
         self.collapse_worktree_roots(roots, window, cx);
     }
@@ -2181,8 +2185,14 @@ impl ProjectPanel {
             if let Some(mut entry) = worktree.entry_for_id(new_entry_id) {
                 loop {
                     if entry.is_dir() {
-                        if let Err(ix) = expanded_dir_ids.binary_search(&entry.id) {
-                            expanded_dir_ids.insert(ix, entry.id);
+                        for ancestor in entry.path.ancestors() {
+                            if let Some(ancestor_entry) = worktree.entry_for_path(ancestor)
+                                && ancestor_entry.is_dir()
+                                && let Err(ix) =
+                                    expanded_dir_ids.binary_search(&ancestor_entry.id)
+                            {
+                                expanded_dir_ids.insert(ix, ancestor_entry.id);
+                            }
                         }
                         directory_id = entry.id;
                         break;
@@ -5464,6 +5474,56 @@ impl ProjectPanel {
         false
     }
 
+    fn render_root_actions(
+        &self,
+        entry_id: ProjectEntryId,
+        is_sticky: bool,
+        cx: &Context<Self>,
+    ) -> impl IntoElement {
+        let is_read_only = self.project.read(cx).is_read_only(cx);
+        let action_button = move |name: &str, icon: IconName| {
+            let id = SharedString::from(format!(
+                "project-panel-action-{}-{}-{name}",
+                if is_sticky { "sticky" } else { "row" },
+                entry_id.to_usize(),
+            ));
+            IconButton::new(id, icon)
+                .shape(IconButtonShape::Square)
+                .icon_size(IconSize::Small)
+                .icon_color(Color::Muted)
+        };
+        h_flex()
+            .flex_none()
+            .items_center()
+            .gap_1()
+            .when(!is_read_only, |this| {
+                this.child(
+                    action_button("new-file", IconName::Plus)
+                        .tooltip(Tooltip::for_action_title("New File", &NewFile))
+                        .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
+                            this.new_file(&NewFile, window, cx);
+                        })),
+                )
+                .child(
+                    action_button("new-folder", IconName::FolderAdd)
+                        .tooltip(Tooltip::for_action_title("New Folder", &NewDirectory))
+                        .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
+                            this.new_directory(&NewDirectory, window, cx);
+                        })),
+                )
+            })
+            .child(
+                action_button("collapse-all", IconName::ListCollapse)
+                    .tooltip(Tooltip::for_action_title(
+                        "Collapse All Entries",
+                        &CollapseAllEntries,
+                    ))
+                    .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
+                        this.collapse_all_entries(&CollapseAllEntries, window, cx);
+                    })),
+            )
+    }
+
     fn render_entry(
         &self,
         entry_id: ProjectEntryId,
@@ -5510,6 +5570,7 @@ impl ProjectPanel {
         let path = details.path.clone();
 
         let depth = details.depth;
+        let is_root_dir = depth == 0 && kind.is_dir();
         let worktree_id = details.worktree_id;
 
         let bg_color = if is_marked {
@@ -5943,7 +6004,8 @@ impl ProjectPanel {
                     .when(
                         canonical_path.is_some()
                             || diagnostic_count.is_some()
-                            || git_indicator.is_some(),
+                            || git_indicator.is_some()
+                            || is_root_dir,
                         |this| {
                             let symlink_element = canonical_path.map(|path| {
                                 div()
@@ -6001,6 +6063,16 @@ impl ProjectPanel {
                                         this.child(git_indicator)
                                     })
                                     .when_some(symlink_element, |this, el| this.child(el))
+                                    .when(
+                                        is_root_dir
+                                            && (self.is_hovered
+                                                || self.state.edit_state.is_some()),
+                                        |this| {
+                                            this.child(self.render_root_actions(
+                                                entry_id, is_sticky, cx,
+                                            ))
+                                        },
+                                    )
                                     .into_any_element(),
                             )
                         },
@@ -7297,6 +7369,18 @@ impl Render for ProjectPanel {
                                 }),
                         )
                         .size_full(),
+                )
+                .child(
+                    div()
+                        .id("project-panel-hover-tracker")
+                        .absolute()
+                        .size_full()
+                        .on_hover(cx.listener(|this, hovered: &bool, _window, cx| {
+                            if this.is_hovered != *hovered {
+                                this.is_hovered = *hovered;
+                                cx.notify();
+                            }
+                        })),
                 )
                 .custom_scrollbars(
                     {

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -4106,6 +4106,138 @@ async fn test_collapse_all_entries_with_collapsed_root(cx: &mut gpui::TestAppCon
 }
 
 #[gpui::test]
+async fn test_create_entry_expands_collapsed_ancestors(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "a": {
+                "b": {
+                    "file.txt": "",
+                },
+            },
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, |workspace, window, cx| {
+        let panel = ProjectPanel::new(workspace, window, cx);
+        workspace.add_panel(panel.clone(), window, cx);
+        panel
+    });
+    cx.run_until_parked();
+
+    // Reveal the nested directory
+    toggle_expand_dir(&panel, "root/a", cx);
+    toggle_expand_dir(&panel, "root/a/b", cx);
+    cx.run_until_parked();
+
+    // Collapse the whole tree
+    panel.update_in(cx, |panel, window, cx| {
+        panel.collapse_all_entries(&CollapseAllEntries, window, cx);
+    });
+    cx.run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &["v root", "    > a"],
+        "Nested directories are collapsed before creating the new entry"
+    );
+
+    // Target the still-collapsed nested directory and create a folder inside it
+    select_path(&panel, "root/a/b", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.new_directory(&NewDirectory, window, cx);
+    });
+    cx.run_until_parked();
+    panel
+        .update_in(cx, |panel, window, cx| {
+            panel.filename_editor.update(cx, |editor, cx| {
+                editor.set_text("new_dir", window, cx);
+            });
+            panel.confirm_edit(true, window, cx).unwrap()
+        })
+        .await
+        .unwrap();
+    cx.run_until_parked();
+
+    // The collapsed ancestor chain must auto-expand so the new entry is revealed
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "v root",
+            "    v a",
+            "        v b",
+            "            v new_dir  <== selected",
+            "              file.txt",
+        ],
+        "Creating inside a collapsed directory expands its ancestors and reveals the new entry"
+    );
+}
+
+#[gpui::test]
+async fn test_collapse_all_cancels_in_progress_edit(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "dir1": {
+                "file.txt": "",
+            },
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(window.into(), cx);
+    let panel = workspace.update_in(cx, |workspace, window, cx| {
+        let panel = ProjectPanel::new(workspace, window, cx);
+        workspace.add_panel(panel.clone(), window, cx);
+        panel
+    });
+    cx.run_until_parked();
+
+    toggle_expand_dir(&panel, "root/dir1", cx);
+    select_path(&panel, "root/dir1", cx);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.new_file(&NewFile, window, cx);
+    });
+    cx.run_until_parked();
+    panel.read_with(cx, |panel, _| {
+        assert!(panel.state.edit_state.is_some(), "create prompt is open");
+    });
+
+    // Collapsing while the prompt is open cancels it rather than stranding the edit row
+    panel.update_in(cx, |panel, window, cx| {
+        panel.collapse_all_entries(&CollapseAllEntries, window, cx);
+    });
+    cx.run_until_parked();
+    panel.read_with(cx, |panel, _| {
+        assert!(panel.state.edit_state.is_none(), "create prompt is cancelled");
+    });
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &["v root", "    > dir1"],
+        "Collapsing cancels the in-progress create and leaves a cleanly collapsed tree"
+    );
+}
+
+#[gpui::test]
 async fn test_collapse_all_entries_with_invisible_worktree(cx: &mut gpui::TestAppContext) {
     init_test_with_editor(cx);
 


### PR DESCRIPTION
# Objective
Closes: #6880 by implementing VS Code-like project panel buttons to create folders and collapse them

## Solution
Adds VS Code / Cursor–style quick-action buttons to the project panel. When the cursor is over the panel, the root worktree row reveals three icon buttons on its right side:

- **New File** (`Plus` icon) → `project_panel::NewFile`
- **New Folder** (`FolderAdd` icon) → `project_panel::NewDirectory`
- **Collapse All** (`ListCollapse` icon) → `project_panel::CollapseAllEntries`


## Implementation details:
- Added an `is_hovered` state. This is different from `group_hover`. The other way, `visible_on_hover`, did not work well. It only checked if the mouse was moving, so if you scrolled without moving the mouse the buttons would disappear. It also had a problem with the sticky header at the top: the header was blocking the way, so the buttons did not show up.
To fix this we track a flag on an overlay that is on top of everything and does not block anything. This overlay is never hidden by the header, so it always works. The buttons show up correctly when you first see them and they stay that way when you scroll

- Buttons stay visible during a create/rename prompt (`edit_state.is_some()`) so they do not disappear if the cursor leaves the panel mid-naming

- All three reuse existing actions/handlers; the buttons are only a new entry point. New File/Folder are disabled (via `IconButton::disabled`) when the project is read-only
- Creating inside a collapsed tree now reveals the new entry: `add_entry` previously only marked the immediate target directory as expanded, so a create inside a nested folder in a collapsed tree stayed hidden. It now expands the full ancestor chain of the target directory
- Collapse All cancels an in-progress create/rename: because the buttons stay visible during a naming prompt, Collapse All could be triggered mid-create, stranding the in-progress entry under a collapsed parent. `collapse_all_entries` now discards the pending edit first

## Testing

### Added tests
- `test_create_entry_expands_collapsed_ancestors`: collapses a nested tree, creates a directory inside a still-collapsed nested folder, and asserts the ancestor chain auto-expands and the new entry is revealed
- `test_collapse_all_cancels_in_progress_edit`: opens a create prompt, runs Collapse All, and asserts the edit is cancelled and the tree collapses cleanly

### Manual tests

- Buttons reveal on panel hover, hide when the cursor leaves the panel, and stay visible while scrolling with the cursor in the panel (including over the sticky root header)
- Buttons stay visible while a create/rename prompt is open even if the cursor leaves the panel


## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


<details>
  <summary>Click to view showcase</summary>

## Screenshots
**Before:**
<img width="462" height="60" alt="image" src="https://github.com/user-attachments/assets/f3cc76c1-4ad6-4a3f-8a0c-e8121e78e052" />

**After:**
<img width="470" height="61" alt="image" src="https://github.com/user-attachments/assets/8541598f-0f26-4613-83b6-a3f3e73169ec" />


## Video
https://github.com/user-attachments/assets/5d0bcacb-219f-4135-9975-c50480f08418

</details>

---

Release Notes:

- Added VS Code-like New File/Folder and Collapse All buttons to the project panel
