### PR TITLE
git_panel: Add undo actions to change sections

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6422,6 +6422,8 @@ impl GitPanel {
         let toggle_state = self.header_state(header.header);
         let section = header.header;
         let weak = cx.weak_entity();
+        let restore_tracked_files = weak.clone();
+        let trash_untracked_files = weak.clone();
 
         h_flex()
             .id(id)
@@ -6442,10 +6444,60 @@ impl GitPanel {
                     .size(LabelSize::Small),
             )
             .child(
-                Checkbox::new(checkbox_id, toggle_state)
-                    .disabled(!has_write_access)
-                    .fill()
-                    .elevation(ElevationIndex::Surface),
+                h_flex()
+                    .gap_1()
+                    .when(section == Section::Tracked, |this| {
+                        this.child(
+                            IconButton::new(("restore-tracked-files", ix), IconName::Undo)
+                                .icon_size(IconSize::Small)
+                                .icon_color(Color::Muted)
+                                .aria_label("Discard Tracked Changes")
+                                .disabled(!has_write_access)
+                                .tooltip(Tooltip::for_action_title(
+                                    "Discard Tracked Changes",
+                                    &RestoreTrackedFiles,
+                                ))
+                                .on_click(move |_, window, cx| {
+                                    restore_tracked_files
+                                        .update(cx, |this, cx| {
+                                            this.restore_tracked_files(
+                                                &RestoreTrackedFiles,
+                                                window,
+                                                cx,
+                                            );
+                                            cx.stop_propagation();
+                                        })
+                                        .log_err();
+                                }),
+                        )
+                    })
+                    .when(section == Section::New, |this| {
+                        this.child(
+                            IconButton::new(("trash-untracked-files", ix), IconName::Undo)
+                                .icon_size(IconSize::Small)
+                                .icon_color(Color::Muted)
+                                .aria_label("Trash Untracked Files")
+                                .disabled(!has_write_access)
+                                .tooltip(Tooltip::for_action_title(
+                                    "Trash Untracked Files",
+                                    &TrashUntrackedFiles,
+                                ))
+                                .on_click(move |_, window, cx| {
+                                    trash_untracked_files
+                                        .update(cx, |this, cx| {
+                                            this.clean_all(&TrashUntrackedFiles, window, cx);
+                                            cx.stop_propagation();
+                                        })
+                                        .log_err();
+                                }),
+                        )
+                    })
+                    .child(
+                        Checkbox::new(checkbox_id, toggle_state)
+                            .disabled(!has_write_access)
+                            .fill()
+                            .elevation(ElevationIndex::Surface),
+                    ),
             )
             .on_click(move |_, window, cx| {
                 if !has_write_access {


### PR DESCRIPTION
# Objective

- Make the existing discard and trash actions easier to discover and access directly from the Git panel's change sections.

## Solution

- Add an undo icon button to the Tracked section header that invokes the existing **Discard Tracked Changes** flow.
- Add a matching undo icon button to the Untracked section header that invokes the existing **Trash Untracked Files** flow.
- Reuse the existing confirmation and error-handling paths, disable the actions for read-only repositories, and expose action-aware tooltips and accessibility labels.
- Use the same muted icon color as the Git panel's **View Diff** control.

## Testing

- `cargo check -p git_ui`
- `./script/clippy -p git_ui`
- Manually verified the Tracked section action renders in the Git panel.
- Reviewers can create tracked and untracked changes, then use each section-header undo button to verify the existing confirmation prompts and actions.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

**Git panel undo action buttons**
<img width="361" height="260" alt="Screenshot 2026-07-02 at 7 36 11 PM" src="https://github.com/user-attachments/assets/43b9004d-39c4-4a51-bea2-2e2f0f3bf1f0" />

---

Release Notes:

- Improved the Git panel with section-level actions to discard tracked changes and trash untracked files.