### PR TITLE
gpui: Park the Wayland frame loop while windows are idle

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1531,7 +1531,7 @@ impl App {
         // a frame, they would otherwise only redraw on the next window event.
         for window in self.windows.values() {
             if let Some(window) = window.as_deref() {
-                window.request_redraw_if_needed();
+                window.schedule_frame_if_needed();
             }
         }
     }

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2810,9 +2810,42 @@ impl<'a, T> Drop for GpuiBorrow<'a, T> {
 
 #[cfg(test)]
 mod test {
-    use std::{cell::RefCell, rc::Rc};
+    use std::{
+        cell::{Cell, RefCell},
+        rc::Rc,
+    };
 
-    use crate::{AppContext, TestAppContext};
+    use crate::{AppContext, Context, Empty, IntoElement, Render, TestAppContext, Window};
+
+    struct RenderCounter(Rc<Cell<usize>>);
+
+    impl Render for RenderCounter {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            self.0.set(self.0.get() + 1);
+            Empty
+        }
+    }
+
+    #[gpui::test]
+    fn async_app_refresh_flushes_refresh_effect(cx: &mut TestAppContext) {
+        let render_count = Rc::new(Cell::new(0));
+
+        let _window = cx.add_window({
+            let render_count = render_count.clone();
+            move |_, _| RenderCounter(render_count)
+        });
+
+        cx.run_until_parked();
+        let render_count_before_refresh = render_count.get();
+
+        let _refresh_task = cx.spawn(|cx| async move {
+            cx.refresh();
+        });
+
+        cx.run_until_parked();
+
+        assert_eq!(render_count.get(), render_count_before_refresh + 1);
+    }
 
     #[test]
     fn test_gpui_borrow() {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2815,7 +2815,10 @@ mod test {
         rc::Rc,
     };
 
-    use crate::{AppContext, Context, Empty, IntoElement, Render, TestAppContext, Window};
+    use crate::{
+        AppContext, Context, Empty, IntoElement, Render, TestAppContext, Window,
+        WindowBackgroundAppearance, WindowDecorations, px,
+    };
 
     struct RenderCounter(Rc<Cell<usize>>);
 
@@ -2845,6 +2848,40 @@ mod test {
         cx.run_until_parked();
 
         assert_eq!(render_count.get(), render_count_before_refresh + 1);
+    }
+
+    #[gpui::test]
+    fn surface_metadata_changes_schedule_frames(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, _| Empty);
+        let did_schedule_frame = Rc::new(Cell::new(false));
+        cx.test_window(*window).on_schedule_frame({
+            let did_schedule_frame = did_schedule_frame.clone();
+            move || did_schedule_frame.set(true)
+        });
+
+        cx.update(|cx| {
+            window
+                .update(cx, |_, window, _| {
+                    window.set_background_appearance(WindowBackgroundAppearance::Transparent);
+                    assert!(
+                        did_schedule_frame.replace(false),
+                        "setting background appearance should schedule a frame"
+                    );
+
+                    window.request_decorations(WindowDecorations::Client);
+                    assert!(
+                        did_schedule_frame.replace(false),
+                        "requesting decorations should schedule a frame"
+                    );
+
+                    window.set_client_inset(px(8.));
+                    assert!(
+                        did_schedule_frame.replace(false),
+                        "setting the client inset should schedule a frame"
+                    );
+                })
+                .unwrap();
+        });
     }
 
     #[test]

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1526,6 +1526,14 @@ impl App {
                 }
             }
         }
+
+        // Wake idle platform frame loops (Wayland) for windows that still need
+        // a frame, they would otherwise only redraw on the next window event.
+        for window in self.windows.values() {
+            if let Some(window) = window.as_deref() {
+                window.request_redraw_if_needed();
+            }
+        }
     }
 
     /// Repeatedly called during `flush_effects` to release any entities whose

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -662,9 +662,9 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_button_layout_changed(&self, _callback: Box<dyn FnMut()>) {}
     fn draw(&self, scene: &Scene);
     fn completed_frame(&self) {}
-    /// Ask for another `request_frame` callback even if the window is idle.
+    /// Schedules another `request_frame` callback even if the window is idle.
     /// A no-op on platforms whose frame loop runs continuously while visible.
-    fn request_redraw(&self) {}
+    fn schedule_frame(&self) {}
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
     fn is_subpixel_rendering_supported(&self) -> bool;
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -662,6 +662,9 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_button_layout_changed(&self, _callback: Box<dyn FnMut()>) {}
     fn draw(&self, scene: &Scene);
     fn completed_frame(&self) {}
+    /// Ask for another `request_frame` callback even if the window is idle.
+    /// A no-op on platforms whose frame loop runs continuously while visible.
+    fn request_redraw(&self) {}
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
     fn is_subpixel_rendering_supported(&self) -> bool;
 

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -33,6 +33,7 @@ pub(crate) struct TestWindowState {
     hover_status_change_callback: Option<Box<dyn FnMut(bool)>>,
     resize_callback: Option<Box<dyn FnMut(Size<Pixels>, f32)>>,
     moved_callback: Option<Box<dyn FnMut()>>,
+    schedule_frame_callback: Option<Box<dyn Fn()>>,
     input_handler: Option<PlatformInputHandler>,
     is_fullscreen: bool,
 }
@@ -85,6 +86,7 @@ impl TestWindow {
             hover_status_change_callback: None,
             resize_callback: None,
             moved_callback: None,
+            schedule_frame_callback: None,
             input_handler: None,
             is_fullscreen: false,
         })))
@@ -101,6 +103,10 @@ impl TestWindow {
         drop(lock);
         callback(size, scale_factor);
         self.0.lock().resize_callback = Some(callback);
+    }
+
+    pub fn on_schedule_frame(&self, callback: impl Fn() + 'static) {
+        self.0.lock().schedule_frame_callback = Some(Box::new(callback));
     }
 
     pub(crate) fn simulate_active_status_change(&self, active: bool) {
@@ -259,6 +265,12 @@ impl PlatformWindow for TestWindow {
     }
 
     fn on_request_frame(&self, _callback: Box<dyn FnMut(RequestFrameOptions)>) {}
+
+    fn schedule_frame(&self) {
+        if let Some(callback) = self.0.lock().schedule_frame_callback.as_ref() {
+            callback();
+        }
+    }
 
     fn on_input(&self, callback: Box<dyn FnMut(crate::PlatformInput) -> DispatchEventResult>) {
         self.0.lock().input_callback = Some(callback)

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1497,7 +1497,7 @@ impl Window {
                         // (Wayland) retry the skipped frame instead of parking.
                         handle
                             .update(&mut cx, |_, window, _| {
-                                window.platform_window.request_redraw();
+                                window.platform_window.schedule_frame();
                                 window.complete_frame();
                             })
                             .log_err();
@@ -1551,7 +1551,7 @@ impl Window {
                         // The sustain is invisible to window dirtiness, request
                         // the next frame explicitly.
                         if high_rate_input {
-                            window.platform_window.request_redraw();
+                            window.platform_window.schedule_frame();
                         }
                         window.complete_frame();
                     })
@@ -2629,12 +2629,12 @@ impl Window {
     }
 
     /// Wakes an idle platform frame loop if this window still needs a frame.
-    pub(crate) fn request_redraw_if_needed(&self) {
+    pub(crate) fn schedule_frame_if_needed(&self) {
         if self.invalidator.is_dirty()
             || self.needs_present.get()
             || !self.next_frame_callbacks.borrow().is_empty()
         {
-            self.platform_window.request_redraw();
+            self.platform_window.schedule_frame();
         }
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2428,6 +2428,7 @@ impl Window {
     /// Sets the size of an em for the base font of the application. Adjusting this value allows the
     /// UI to scale, just like zooming a web page.
     pub fn set_rem_size(&mut self, rem_size: impl Into<Pixels>) {
+        // TODO: Refresh the window when this is called outside an existing render cycle.
         self.rem_size = rem_size.into();
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1493,12 +1493,13 @@ impl Window {
                     if let Some(last_frame) = last_frame_time.get()
                         && now.duration_since(last_frame) < min_interval
                     {
-                        // Must still complete the frame on platforms that require it.
-                        // On Wayland, `surface.frame()` was already called to request the
-                        // next frame callback, so we must call `surface.commit()` (via
-                        // `complete_frame`) or the compositor won't send another callback.
+                        // Request another frame so demand-driven frame loops
+                        // (Wayland) retry the skipped frame instead of parking.
                         handle
-                            .update(&mut cx, |_, window, _| window.complete_frame())
+                            .update(&mut cx, |_, window, _| {
+                                window.platform_window.request_redraw();
+                                window.complete_frame();
+                            })
                             .log_err();
                         return;
                     }
@@ -1519,9 +1520,10 @@ impl Window {
                 // Keep presenting if input was recently arriving at a high rate (>= 60fps).
                 // Once high-rate input is detected, we sustain presentation for 1 second
                 // to prevent display underclocking during active input.
+                let high_rate_input = active.get() && input_rate_tracker.borrow().is_high_rate();
                 let needs_present = request_frame_options.require_presentation
                     || needs_present.get()
-                    || (active.get() && input_rate_tracker.borrow_mut().is_high_rate());
+                    || high_rate_input;
 
                 if invalidator.is_dirty() || request_frame_options.force_render {
                     measure("frame duration", || {
@@ -1546,6 +1548,11 @@ impl Window {
 
                 handle
                     .update(&mut cx, |_, window, _| {
+                        // The sustain is invisible to window dirtiness, request
+                        // the next frame explicitly.
+                        if high_rate_input {
+                            window.platform_window.request_redraw();
+                        }
                         window.complete_frame();
                     })
                     .log_err();
@@ -2619,6 +2626,16 @@ impl Window {
 
     fn complete_frame(&self) {
         self.platform_window.completed_frame();
+    }
+
+    /// Wakes an idle platform frame loop if this window still needs a frame.
+    pub(crate) fn request_redraw_if_needed(&self) {
+        if self.invalidator.is_dirty()
+            || self.needs_present.get()
+            || !self.next_frame_callbacks.borrow().is_empty()
+        {
+            self.platform_window.request_redraw();
+        }
     }
 
     /// Produces a new frame and assigns it to `rendered_frame`. To actually show

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -634,12 +634,12 @@ impl WaylandWindowStatePtr {
             state.awaiting_frame_callback = true;
         }
         // Otherwise the frame loop parks, costing no wake-ups until
-        // request_redraw arms the still pending frame request.
+        // schedule_frame arms the still pending frame request.
         state.redraw_requested = false;
         state.renderer_presented = false;
     }
 
-    pub fn request_redraw(&self) {
+    pub fn schedule_frame(&self) {
         let mut state = self.state.borrow_mut();
         if state.frame_in_progress {
             state.redraw_requested = true;
@@ -1483,8 +1483,8 @@ impl PlatformWindow for WaylandWindow {
         }
     }
 
-    fn request_redraw(&self) {
-        self.0.request_redraw();
+    fn schedule_frame(&self) {
+        self.0.schedule_frame();
     }
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -89,6 +89,51 @@ struct InProgressConfigure {
     tiling: Tiling,
 }
 
+#[derive(Debug, Default)]
+struct WaylandFrameScheduler {
+    // A committed wl_surface.frame callback has not fired yet.
+    awaiting_frame_callback: bool,
+    // GPUI is processing a frame callback and may commit through presentation.
+    frame_in_progress: bool,
+    // Another frame is needed after the callback currently awaited or in progress.
+    reschedule_requested: bool,
+}
+
+impl WaylandFrameScheduler {
+    fn start_frame(&mut self) {
+        self.awaiting_frame_callback = false;
+        self.frame_in_progress = true;
+        self.reschedule_requested = false;
+    }
+
+    fn finish_frame(
+        &mut self,
+        renderer_presented: bool,
+        force_render_after_recovery: bool,
+        commit: impl FnOnce(),
+    ) {
+        self.frame_in_progress = false;
+        if renderer_presented {
+            // The renderer's present committed the frame request. A bare commit
+            // on top of it can race Mesa's attach+commit and cause flickering (#54214).
+            self.awaiting_frame_callback = true;
+        } else if self.reschedule_requested || force_render_after_recovery {
+            commit();
+            self.awaiting_frame_callback = true;
+        }
+        self.reschedule_requested = false;
+    }
+
+    fn schedule_frame(&mut self, acknowledged_first_configure: bool, commit: impl FnOnce()) {
+        if self.frame_in_progress {
+            self.reschedule_requested = true;
+        } else if !self.awaiting_frame_callback && acknowledged_first_configure {
+            commit();
+            self.awaiting_frame_callback = true;
+        }
+    }
+}
+
 pub struct WaylandWindowState {
     surface_state: WaylandSurfaceState,
     acknowledged_first_configure: bool,
@@ -118,11 +163,7 @@ pub struct WaylandWindowState {
     hovered: bool,
     pub(crate) force_render_after_recovery: bool,
     renderer_presented: bool,
-    // A commit armed the pending wl_surface.frame request, so the compositor
-    // will send a frame callback once the surface is visible.
-    awaiting_frame_callback: bool,
-    frame_in_progress: bool,
-    redraw_requested: bool,
+    frame_scheduler: WaylandFrameScheduler,
     in_progress_configure: Option<InProgressConfigure>,
     resize_throttle: bool,
     in_progress_window_controls: Option<WindowControls>,
@@ -406,9 +447,7 @@ impl WaylandWindowState {
             hovered: false,
             force_render_after_recovery: false,
             renderer_presented: false,
-            awaiting_frame_callback: false,
-            frame_in_progress: false,
-            redraw_requested: false,
+            frame_scheduler: WaylandFrameScheduler::default(),
             in_progress_window_controls: None,
             window_controls: WindowControls::default(),
             client_inset: None,
@@ -599,9 +638,7 @@ impl WaylandWindowStatePtr {
 
     pub fn frame(&self) {
         let mut state = self.state.borrow_mut();
-        state.awaiting_frame_callback = false;
-        state.frame_in_progress = true;
-        state.redraw_requested = false;
+        state.frame_scheduler.start_frame();
         state.surface.frame(&state.globals.qh, state.surface.id());
         state.resize_throttle = false;
         let force_render = state.force_render_after_recovery;
@@ -619,35 +656,30 @@ impl WaylandWindowStatePtr {
         drop(cb);
 
         let mut state = self.state.borrow_mut();
-        state.frame_in_progress = false;
         if force_render && !state.renderer_presented {
             // The forced render was throttled, force it again on the next frame.
             state.force_render_after_recovery = true;
         }
-        if state.renderer_presented {
-            // The renderer's present committed the frame request from above.
-            // Never commit on top of it, a bare commit racing Mesa's
-            // attach+commit causes flickering (#54214).
-            state.awaiting_frame_callback = true;
-        } else if state.redraw_requested || state.force_render_after_recovery {
-            state.surface.commit();
-            state.awaiting_frame_callback = true;
-        }
+        let renderer_presented = state.renderer_presented;
+        let force_render_after_recovery = state.force_render_after_recovery;
+        let surface = state.surface.clone();
+        state
+            .frame_scheduler
+            .finish_frame(renderer_presented, force_render_after_recovery, || {
+                surface.commit()
+            });
         // Otherwise the frame loop parks, costing no wake-ups until
         // schedule_frame arms the still pending frame request.
-        state.redraw_requested = false;
         state.renderer_presented = false;
     }
 
     pub fn schedule_frame(&self) {
         let mut state = self.state.borrow_mut();
-        if state.frame_in_progress {
-            state.redraw_requested = true;
-        } else if !state.awaiting_frame_callback && state.acknowledged_first_configure {
-            // Arm the frame callback requested by the last frame().
-            state.surface.commit();
-            state.awaiting_frame_callback = true;
-        }
+        let acknowledged_first_configure = state.acknowledged_first_configure;
+        let surface = state.surface.clone();
+        state
+            .frame_scheduler
+            .schedule_frame(acknowledged_first_configure, || surface.commit());
     }
 
     fn update_ime_enabled(&self) {
@@ -1767,4 +1799,28 @@ fn inset_by_tiling(mut bounds: Bounds<Pixels>, inset: Pixels, tiling: Tiling) ->
     }
 
     bounds
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::WaylandFrameScheduler;
+
+    #[test]
+    fn scheduling_while_awaiting_frame_callback_is_preserved() {
+        let mut scheduler = WaylandFrameScheduler::default();
+        let commit_count = Cell::new(0);
+        let commit = || commit_count.set(commit_count.get() + 1);
+
+        scheduler.schedule_frame(true, commit);
+        assert_eq!(commit_count.get(), 1);
+
+        scheduler.schedule_frame(true, commit);
+        assert_eq!(commit_count.get(), 1);
+
+        scheduler.start_frame();
+        scheduler.finish_frame(false, false, commit);
+        assert_eq!(commit_count.get(), 2);
+    }
 }

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -118,6 +118,11 @@ pub struct WaylandWindowState {
     hovered: bool,
     pub(crate) force_render_after_recovery: bool,
     renderer_presented: bool,
+    // A commit armed the pending wl_surface.frame request, so the compositor
+    // will send a frame callback once the surface is visible.
+    awaiting_frame_callback: bool,
+    frame_in_progress: bool,
+    redraw_requested: bool,
     in_progress_configure: Option<InProgressConfigure>,
     resize_throttle: bool,
     in_progress_window_controls: Option<WindowControls>,
@@ -401,6 +406,9 @@ impl WaylandWindowState {
             hovered: false,
             force_render_after_recovery: false,
             renderer_presented: false,
+            awaiting_frame_callback: false,
+            frame_in_progress: false,
+            redraw_requested: false,
             in_progress_window_controls: None,
             window_controls: WindowControls::default(),
             client_inset: None,
@@ -591,6 +599,9 @@ impl WaylandWindowStatePtr {
 
     pub fn frame(&self) {
         let mut state = self.state.borrow_mut();
+        state.awaiting_frame_callback = false;
+        state.frame_in_progress = true;
+        state.redraw_requested = false;
         state.surface.frame(&state.globals.qh, state.surface.id());
         state.resize_throttle = false;
         let force_render = state.force_render_after_recovery;
@@ -604,6 +615,38 @@ impl WaylandWindowStatePtr {
                 ..Default::default()
             });
             self.update_ime_enabled();
+        }
+        drop(cb);
+
+        let mut state = self.state.borrow_mut();
+        state.frame_in_progress = false;
+        if force_render && !state.renderer_presented {
+            // The forced render was throttled, force it again on the next frame.
+            state.force_render_after_recovery = true;
+        }
+        if state.renderer_presented {
+            // The renderer's present committed the frame request from above.
+            // Never commit on top of it, a bare commit racing Mesa's
+            // attach+commit causes flickering (#54214).
+            state.awaiting_frame_callback = true;
+        } else if state.redraw_requested || state.force_render_after_recovery {
+            state.surface.commit();
+            state.awaiting_frame_callback = true;
+        }
+        // Otherwise the frame loop parks, costing no wake-ups until
+        // request_redraw arms the still pending frame request.
+        state.redraw_requested = false;
+        state.renderer_presented = false;
+    }
+
+    pub fn request_redraw(&self) {
+        let mut state = self.state.borrow_mut();
+        if state.frame_in_progress {
+            state.redraw_requested = true;
+        } else if !state.awaiting_frame_callback && state.acknowledged_first_configure {
+            // Arm the frame callback requested by the last frame().
+            state.surface.commit();
+            state.awaiting_frame_callback = true;
         }
     }
 
@@ -1440,16 +1483,8 @@ impl PlatformWindow for WaylandWindow {
         }
     }
 
-    fn completed_frame(&self) {
-        let mut state = self.borrow_mut();
-
-        // Work around a bug in old versions of wlroots where committing without a buffer attached
-        // can cause invalid synchronization that leads to graphical corruption.
-        if !state.renderer_presented {
-            state.surface.commit();
-        }
-
-        state.renderer_presented = false;
+    fn request_redraw(&self) {
+        self.0.request_redraw();
     }
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {


### PR DESCRIPTION
# Objective

GPUI apps on Wayland burn CPU at the display refresh rate while a window is visible (at least partially on an active output), even when nothing changes. The frame callback loop unconditionally re-arms itself: every `done` requests the next frame callback and ends in a commit, so the compositor wakes us ~60 times (or more on higher refresh rates) per second forever, only to skip drawing.

I noticed this while working on a GPUI application, and found an empty window constantly consuming CPU resources.

## Solution

- New `PlatformWindow::request_redraw()`, a no-op everywhere except Wayland.
- A Wayland frame now only commits (arming the next callback) when something was drawn or another frame is wanted, otherwise the loop parks.
- Windows that still need a frame after an effect flush call `request_redraw`, which resumes a parked loop with one bare commit. All state changes funnel through the effect flush, so no wake source is missed.
- The #54214 guard (no bare commit on a frame the renderer presented) is preserved. Idle windows now issue zero bare commits instead of 60/s.

## Testing

Measured debug build: an idle window went from 62 wakeups/s and ~2% CPU to 0 wakeups and 0% over 20s, `WAYLAND_DEBUG` shows the protocol going silent. Verified redraw-on-timer (park, wake, redraw, re-park),
continuous animation at full rate.

X11 is unaffected (tested on bspwm), and `cargo test -p gpui` and `script/clippy` still pass.

To test: run any gpui example on Wayland and watch CPU in htop (or any other system monitor).

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed idle windows waking at the display's refresh rate on Wayland
