### PR TITLE
extension_rollout: Allow rollout for `extension-workflows` tag

### DIFF
--- a/.github/workflows/extension_workflow_rollout.yml
+++ b/.github/workflows/extension_workflow_rollout.yml
@@ -16,7 +16,7 @@ on:
         default: ''
 jobs:
   fetch_extension_repos:
-    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions') && github.ref == 'refs/heads/main'
+    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions') && (github.ref == 'refs/tags/extension-workflows' || github.ref == 'refs/heads/main')
     runs-on: namespace-profile-2x4-ubuntu-2404
     steps:
     - name: checkout_zed_repo
@@ -220,21 +220,18 @@ jobs:
         clean: false
         fetch-depth: 0
         token: ${{ steps.generate-token.outputs.token }}
-    - name: extension_workflow_rollout::create_rollout_tag::update_rollout_tag
-      run: |
-        if git rev-parse "extension-workflows" >/dev/null 2>&1; then
-            git tag -d "extension-workflows"
-            git push origin ":refs/tags/extension-workflows" || true
-        fi
-
-        echo "Creating new tag 'extension-workflows' at $(git rev-parse --short HEAD)"
-        git tag "extension-workflows"
-        git push origin "extension-workflows"
-      env:
-        GIT_AUTHOR_NAME: zed-zippy[bot]
-        GIT_AUTHOR_EMAIL: 234243425+zed-zippy[bot]@users.noreply.github.com
-        GIT_COMMITTER_NAME: zed-zippy[bot]
-        GIT_COMMITTER_EMAIL: 234243425+zed-zippy[bot]@users.noreply.github.com
+    - name: steps::update_tag
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+      with:
+        script: |
+          github.rest.git.updateRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'tags/extension-workflows',
+              sha: context.sha,
+              force: true
+          })
+        github-token: ${{ steps.generate-token.outputs.token }}
     timeout-minutes: 1
 defaults:
   run:

--- a/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
@@ -5,6 +5,8 @@ use indoc::formatdoc;
 use indoc::indoc;
 use serde_json::json;
 
+use crate::tasks::workflows::steps::GitRef;
+use crate::tasks::workflows::steps::RefSha;
 use crate::tasks::workflows::steps::{
     CheckoutStep, DownloadArtifactStep, IfNoFilesFound, ResultEncoding, TokenPermissions,
     UploadArtifactStep, cache_rust_dependencies_namespace,
@@ -13,8 +15,7 @@ use crate::tasks::workflows::vars::JobOutput;
 use crate::tasks::workflows::{
     runners,
     steps::{
-        self, DEFAULT_REPOSITORY_OWNER_GUARD, NamedJob, RepositoryTarget, ZippyGitIdentity,
-        generate_token, named,
+        self, DEFAULT_REPOSITORY_OWNER_GUARD, NamedJob, RepositoryTarget, generate_token, named,
     },
     vars::{self, StepOutput, WorkflowInput},
 };
@@ -155,8 +156,7 @@ fn fetch_extension_repos(filter_repos_input: &WorkflowInput) -> (NamedJob, JobOu
 
     let job = Job::default()
         .cond(Expression::new(format!(
-            "{DEFAULT_REPOSITORY_OWNER_GUARD} && github.ref == 'refs/heads/main'"
-        )))
+            "{DEFAULT_REPOSITORY_OWNER_GUARD} && (github.ref == 'refs/tags/{ROLLOUT_TAG_NAME}' || github.ref == 'refs/heads/main')")))
         .runs_on(runners::LINUX_SMALL)
         .timeout_minutes(10u32)
         .outputs([
@@ -336,19 +336,6 @@ fn create_rollout_tag(rollout_job: &NamedJob, filter_repos_input: &WorkflowInput
         steps::checkout_repo().with_full_history().with_token(token)
     }
 
-    fn update_rollout_tag() -> Step<Run> {
-        named::bash(formatdoc! {r#"
-            if git rev-parse "{ROLLOUT_TAG_NAME}" >/dev/null 2>&1; then
-                git tag -d "{ROLLOUT_TAG_NAME}"
-                git push origin ":refs/tags/{ROLLOUT_TAG_NAME}" || true
-            fi
-
-            echo "Creating new tag '{ROLLOUT_TAG_NAME}' at $(git rev-parse --short HEAD)"
-            git tag "{ROLLOUT_TAG_NAME}"
-            git push origin "{ROLLOUT_TAG_NAME}"
-        "#})
-    }
-
     let (authenticate, token) =
         generate_token(vars::ZED_ZIPPY_APP_ID, vars::ZED_ZIPPY_APP_PRIVATE_KEY)
             .for_repository(RepositoryTarget::current())
@@ -365,7 +352,12 @@ fn create_rollout_tag(rollout_job: &NamedJob, filter_repos_input: &WorkflowInput
         .timeout_minutes(1u32)
         .add_step(authenticate)
         .add_step(checkout_zed_repo(&token))
-        .add_step(update_rollout_tag().with_zippy_git_identity());
+        .add_step(steps::update_ref(
+            GitRef::Tag(ROLLOUT_TAG_NAME.to_owned()),
+            RefSha::Context,
+            &token,
+            true,
+        ));
 
     named::job(job)
 }


### PR DESCRIPTION
Also cleans up the tag update step to instead use the GitHub API for this. 

Release Notes:

- N/A