### PR TITLE
git_ui: Add configure and docs links to commit message tooltip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7368,6 +7368,7 @@ dependencies = [
  "async-channel 2.5.0",
  "buffer_diff",
  "call",
+ "client",
  "collections",
  "component",
  "ctor",

--- a/crates/client/src/zed_urls.rs
+++ b/crates/client/src/zed_urls.rs
@@ -69,6 +69,10 @@ pub fn skills_docs(cx: &App) -> String {
     format!("{docs_url}/ai/skills", docs_url = docs_url(cx))
 }
 
+pub fn llm_provider_docs(cx: &App) -> String {
+    format!("{docs_url}/ai/llm-providers", docs_url = docs_url(cx))
+}
+
 /// Returns the URL to Zed's ACP registry blog post.
 pub fn acp_registry_blog(cx: &App) -> String {
     format!(

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -23,14 +23,15 @@ askpass.workspace = true
 async-channel.workspace = true
 buffer_diff.workspace = true
 call = { workspace = true, optional = true }
+client.workspace = true
 collections.workspace = true
 component.workspace = true
 db.workspace = true
 editor.workspace = true
 file_icons.workspace = true
 fs.workspace = true
-futures.workspace = true
 futures-lite.workspace = true
+futures.workspace = true
 fuzzy.workspace = true
 fuzzy_nucleo.workspace = true
 git.workspace = true
@@ -50,8 +51,8 @@ prompt_store.workspace = true
 proto.workspace = true
 rand.workspace = true
 release_channel.workspace = true
-remote_connection.workspace = true
 remote.workspace = true
+remote_connection.workspace = true
 schemars.workspace = true
 search.workspace = true
 serde.workspace = true
@@ -67,6 +68,7 @@ theme.workspace = true
 theme_settings.workspace = true
 time.workspace = true
 time_format.workspace = true
+tracing.workspace = true
 ui.workspace = true
 ui_input.workspace = true
 util.workspace = true
@@ -75,7 +77,6 @@ workspace.workspace = true
 zed_actions.workspace = true
 zeroize.workspace = true
 ztracing.workspace = true
-tracing.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
@@ -91,12 +92,12 @@ indoc.workspace = true
 pretty_assertions.workspace = true
 project = { workspace = true, features = ["test-support"] }
 rand.workspace = true
+remote_connection = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }
 task.workspace = true
 unindent.workspace = true
 workspace = { workspace = true, features = ["test-support"] }
 zlog.workspace = true
-remote_connection = { workspace = true, features = ["test-support"] }
 
 [package.metadata.cargo-machete]
 ignored = ["tracing"]

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4787,8 +4787,7 @@ impl GitPanel {
                 this.generate_commit_message(cx);
             }));
 
-        // let button = if can_commit && has_commit_model_configuration_error {
-        let button = if true {
+        let button = if can_commit && has_commit_model_configuration_error {
             button.hoverable_tooltip(move |_window, cx| {
                 cx.new(|_| GenerateCommitMessageConfigurationTooltip).into()
             })

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4774,34 +4774,38 @@ impl GitPanel {
 
         let editor_focus_handle = self.commit_editor.focus_handle(cx);
 
-        Some(
-            IconButton::new("generate-commit-message", IconName::AiEdit)
-                .shape(ui::IconButtonShape::Square)
-                .icon_color(if has_commit_model_configuration_error {
-                    Color::Disabled
+        let button = IconButton::new("generate-commit-message", IconName::AiEdit)
+            .shape(ui::IconButtonShape::Square)
+            .icon_color(if has_commit_model_configuration_error {
+                Color::Disabled
+            } else {
+                Color::Muted
+            })
+            .disabled(!can_commit || has_commit_model_configuration_error)
+            .on_click(cx.listener(move |this, _event, _window, cx| {
+                this.generate_commit_message(cx);
+            }));
+
+        let button = if can_commit && has_commit_model_configuration_error {
+            button.hoverable_tooltip(move |_window, cx| {
+                cx.new(|_| GenerateCommitMessageConfigurationTooltip).into()
+            })
+        } else {
+            button.tooltip(move |_window, cx| {
+                if !can_commit {
+                    Tooltip::simple("No Changes to Commit", cx)
                 } else {
-                    Color::Muted
-                })
-                .tooltip(move |_window, cx| {
-                    if !can_commit {
-                        Tooltip::simple("No Changes to Commit", cx)
-                    } else if has_commit_model_configuration_error {
-                        Tooltip::simple("Configure an LLM provider to generate commit messages", cx)
-                    } else {
-                        Tooltip::for_action_in(
-                            "Generate Commit Message",
-                            &git::GenerateCommitMessage,
-                            &editor_focus_handle,
-                            cx,
-                        )
-                    }
-                })
-                .disabled(!can_commit || has_commit_model_configuration_error)
-                .on_click(cx.listener(move |this, _event, _window, cx| {
-                    this.generate_commit_message(cx);
-                }))
-                .into_any_element(),
-        )
+                    Tooltip::for_action_in(
+                        "Generate Commit Message",
+                        &git::GenerateCommitMessage,
+                        &editor_focus_handle,
+                        cx,
+                    )
+                }
+            })
+        };
+
+        Some(button.into_any_element())
     }
 
     pub(crate) fn render_co_authors(&self, cx: &Context<Self>) -> Option<AnyElement> {
@@ -7154,6 +7158,57 @@ impl GitPanel {
         if self.amend_pending {
             self.load_last_commit_message(cx);
         }
+    }
+}
+
+struct GenerateCommitMessageConfigurationTooltip;
+
+impl Render for GenerateCommitMessageConfigurationTooltip {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        ui::tooltip_container(cx, |container, _cx| {
+            container
+                .flex_shrink_0()
+                .w(rems_from_px(288.))
+                .min_h(rems_from_px(72.))
+                .justify_between()
+                .child(v_flex().flex_1().w_full().child(Label::new(
+                    "Configure an LLM provider to generate commit messages",
+                )))
+                .child(
+                    h_flex()
+                        .pt_1()
+                        .gap_2()
+                        .items_end()
+                        .w_full()
+                        .child(
+                            ButtonLike::new("configure-commit-message-provider")
+                                .size(ButtonSize::None)
+                                .child(
+                                    Label::new("Configure Provider")
+                                        .size(LabelSize::Small)
+                                        .color(Color::Accent)
+                                        .underline(),
+                                )
+                                .on_click(|_, window, cx| {
+                                    window.dispatch_action(
+                                        zed_actions::OpenSettingsAt {
+                                            path: "llm_providers".to_string(),
+                                            target: None,
+                                        }
+                                        .boxed_clone(),
+                                        cx,
+                                    );
+                                }),
+                        )
+                        .child(
+                            ui::ButtonLink::new(
+                                "See Docs",
+                                "https://zed.dev/docs/ai/llm-providers",
+                            )
+                            .label_size(LabelSize::Small),
+                        ),
+                )
+        })
     }
 }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -13,6 +13,7 @@ use crate::{
 use agent_settings::{AgentSettings, UserAgentsMd};
 use anyhow::Context as _;
 use askpass::AskPassDelegate;
+use client::zed_urls;
 use collections::{BTreeMap, HashMap, HashSet};
 use db::kvp::KeyValueStore;
 use editor::{Editor, EditorElement, EditorMode, MultiBuffer, MultiBufferOffset, SizingBehavior};
@@ -4786,7 +4787,8 @@ impl GitPanel {
                 this.generate_commit_message(cx);
             }));
 
-        let button = if can_commit && has_commit_model_configuration_error {
+        // let button = if can_commit && has_commit_model_configuration_error {
+        let button = if true {
             button.hoverable_tooltip(move |_window, cx| {
                 cx.new(|_| GenerateCommitMessageConfigurationTooltip).into()
             })
@@ -7167,28 +7169,18 @@ impl Render for GenerateCommitMessageConfigurationTooltip {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         ui::tooltip_container(cx, |container, _cx| {
             container
-                .flex_shrink_0()
-                .w(rems_from_px(288.))
-                .min_h(rems_from_px(72.))
-                .justify_between()
-                .child(v_flex().flex_1().w_full().child(Label::new(
-                    "Configure an LLM provider to generate commit messages",
-                )))
+                .gap_1p5()
+                .child(Label::new(
+                    "Configure an LLM provider to generate commit messages.",
+                ))
                 .child(
                     h_flex()
-                        .pt_1()
-                        .gap_2()
-                        .items_end()
-                        .w_full()
+                        .gap_1()
                         .child(
-                            ButtonLike::new("configure-commit-message-provider")
-                                .size(ButtonSize::None)
-                                .child(
-                                    Label::new("Configure Provider")
-                                        .size(LabelSize::Small)
-                                        .color(Color::Accent)
-                                        .underline(),
-                                )
+                            Button::new("configure-commit-message-provider", "Configure Provider")
+                                .style(ButtonStyle::Filled)
+                                .layer(ElevationIndex::ModalSurface)
+                                .label_size(LabelSize::Small)
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(
                                         zed_actions::OpenSettingsAt {
@@ -7201,11 +7193,17 @@ impl Render for GenerateCommitMessageConfigurationTooltip {
                                 }),
                         )
                         .child(
-                            ui::ButtonLink::new(
-                                "See Docs",
-                                "https://zed.dev/docs/ai/llm-providers",
-                            )
-                            .label_size(LabelSize::Small),
+                            Button::new("llm-provider-docs", "See Docs")
+                                .style(ButtonStyle::OutlinedGhost)
+                                .end_icon(
+                                    Icon::new(IconName::ArrowUpRight)
+                                        .color(Color::Muted)
+                                        .size(IconSize::Small),
+                                )
+                                .label_size(LabelSize::Small)
+                                .on_click(move |_, _, cx| {
+                                    cx.open_url(&zed_urls::llm_provider_docs(cx))
+                                }),
                         ),
                 )
         })

--- a/crates/ui/src/components/button/icon_button.rs
+++ b/crates/ui/src/components/button/icon_button.rs
@@ -124,6 +124,17 @@ impl IconButton {
 
         self
     }
+
+    /// Use the given callback to construct a new tooltip view when the mouse hovers over this
+    /// button. The tooltip itself is also hoverable and won't disappear when the user moves the
+    /// mouse into the tooltip, allowing it to contain interactive elements like links or buttons.
+    pub fn hoverable_tooltip(
+        mut self,
+        tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static,
+    ) -> Self {
+        self.base = self.base.hoverable_tooltip(tooltip);
+        self
+    }
 }
 
 impl Disableable for IconButton {


### PR DESCRIPTION
When no LLM provider is configured, hovering the disabled "Generate Commit Message" button in the git panel/commit modal previously showed a plain, non-interactive tooltip with no way to act on it.

This tooltip now includes two links:
- **Configure Provider** — jumps directly to the "LLM Providers" settings sub-page.
- **See Docs** — opens `https://zed.dev/docs/ai/llm-providers`.

Also adds `IconButton::hoverable_tooltip`, mirroring the existing `.tooltip(...)` forwarding, since `IconButton` didn't previously expose the underlying `ButtonLike::hoverable_tooltip` capability needed for interactive tooltip content.

Release Notes:

- Improved the commit message tooltip to link directly to LLM provider settings and documentation when no provider is configured.
