### PR TITLE
vim: Update anchor used for LSP operations

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3133,16 +3133,16 @@ impl Editor {
         self.cursor_offset_on_selection = set_cursor_offset_on_selection;
     }
 
-    /// Returns the anchor to use as the rename target for a selection.
+    /// Returns the anchor to use as the target of symbol operations (rename,
+    /// go to definition, find references, hover, etc.) for a selection.
     ///
     /// In selection-based modes, like vim's visual mode and helix, the rendered
     /// block cursor sits one position to the left of the selection's head,
     /// since the head is the exclusive end of a forward selection. Using the
-    /// head
-    /// directly would place the rename one character past the symbol, for
+    /// head directly would target one character past the symbol, for
     /// example, trailing whitespace, so for a non-empty forward selection we
     /// shift one point left to land back on the symbol under the cursor.
-    fn rename_target_anchor(&self, selection: &Selection<Anchor>, cx: &mut App) -> Anchor {
+    fn symbol_target_anchor(&self, selection: &Selection<Anchor>, cx: &mut App) -> Anchor {
         let head = selection.head();
 
         if self.cursor_offset_on_selection
@@ -3500,9 +3500,9 @@ impl Editor {
         }
 
         let provider = self.semantics_provider.clone()?;
-        let buffer = self.buffer.read(cx);
         let newest_selection = self.selections.newest_anchor().clone();
-        let cursor_position = newest_selection.head();
+        let cursor_position = self.symbol_target_anchor(&newest_selection, cx);
+        let buffer = self.buffer.read(cx);
         let (cursor_buffer, cursor_buffer_position) =
             buffer.text_anchor_for_position(cursor_position, cx)?;
         let (tail_buffer, tail_buffer_position) =
@@ -7709,7 +7709,7 @@ impl Editor {
         }
         let provider = self.semantics_provider.clone()?;
         let selection = self.selections.newest_anchor().clone();
-        let cursor = self.rename_target_anchor(&selection, cx);
+        let cursor = self.symbol_target_anchor(&selection, cx);
         let (cursor_buffer, cursor_buffer_position) =
             self.buffer.read(cx).text_anchor_for_position(cursor, cx)?;
         let (tail_buffer, cursor_buffer_position_end) = self

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -40,7 +40,8 @@ pub const HOVER_POPOVER_GAP: Pixels = px(10.);
 
 /// Bindable action which uses the most recent selection head to trigger a hover
 pub fn hover(editor: &mut Editor, _: &Hover, window: &mut Window, cx: &mut Context<Editor>) {
-    let head = editor.selections.newest_anchor().head();
+    let selection = editor.selections.newest_anchor().clone();
+    let head = editor.symbol_target_anchor(&selection, cx);
     show_hover(editor, head, true, window, cx);
 }
 

--- a/crates/editor/src/navigation.rs
+++ b/crates/editor/src/navigation.rs
@@ -1142,8 +1142,8 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<()>>> {
-        let selection = self.selections.newest_anchor();
-        let head = selection.head();
+        let selection = self.selections.newest_anchor().clone();
+        let head = self.symbol_target_anchor(&selection, cx);
 
         let multi_buffer = self.buffer.read(cx);
 
@@ -1243,12 +1243,13 @@ impl Editor {
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<Navigated>>> {
         let always_open_multibuffer = action.always_open_multibuffer;
-        let selection = self.selections.newest_anchor();
+        let selection = self.selections.newest_anchor().clone();
+        let target = self.symbol_target_anchor(&selection, cx);
         let multi_buffer = self.buffer.read(cx);
         let multi_buffer_snapshot = multi_buffer.snapshot(cx);
         let selection_offset = selection.map(|anchor| anchor.to_offset(&multi_buffer_snapshot));
         let selection_point = selection.map(|anchor| anchor.to_point(&multi_buffer_snapshot));
-        let head = selection_offset.head();
+        let head = target.to_offset(&multi_buffer_snapshot);
 
         let head_anchor = multi_buffer_snapshot.anchor_at(
             head,
@@ -2234,10 +2235,8 @@ impl Editor {
         let Some(provider) = self.semantics_provider.clone() else {
             return Task::ready(Ok(Navigated::No));
         };
-        let head = self
-            .selections
-            .newest::<MultiBufferOffset>(&self.display_snapshot(cx))
-            .head();
+        let selection = self.selections.newest_anchor().clone();
+        let head = self.symbol_target_anchor(&selection, cx);
         let buffer = self.buffer.read(cx);
         let Some((buffer, head)) = buffer.text_anchor_for_position(head, cx) else {
             return Task::ready(Ok(Navigated::No));

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -4379,4 +4379,43 @@ mod test {
 
         cx.assert_state("const after = 2; console.log(afterˇ)", Mode::HelixNormal);
     }
+
+    #[gpui::test]
+    async fn test_helix_go_to_definition_uses_visible_cursor_position(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let mut cx = VimTestContext::new_typescript(cx).await;
+        cx.enable_helix();
+
+        cx.set_state(
+            "const before = 2; console.log(«beforeˇ»)",
+            Mode::HelixNormal,
+        );
+
+        let expected_position = cx.to_lsp(MultiBufferOffset(
+            "const before = 2; console.log(befor".len(),
+        ));
+        let def_range = cx.lsp_range("const «beforeˇ» = 2; console.log(before)");
+        let mut definition_request = cx.set_request_handler::<lsp::request::GotoDefinition, _, _>(
+            move |url, params, _| async move {
+                assert_eq!(
+                    params.text_document_position_params.position,
+                    expected_position
+                );
+                Ok(Some(lsp::GotoDefinitionResponse::Scalar(lsp::Location {
+                    uri: url,
+                    range: def_range,
+                })))
+            },
+        );
+
+        cx.simulate_keystrokes("g d");
+        definition_request.next().await.unwrap();
+        cx.run_until_parked();
+
+        cx.assert_state(
+            "const «beforeˇ» = 2; console.log(before)",
+            Mode::HelixNormal,
+        );
+    }
 }


### PR DESCRIPTION
# Objective

Followup to #55542 , ensuring that we apply the same anchor calculation logic when performing hover, go to definition, go to declaration, go to type definition, go to implementation, find all references, go to reference, hover and document highlights.

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, use "Fixes #X" for each issue as [described in the GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Solution

In helix and vim visual modes, the head of a forward selection is its exclusive end, so it sits one position past the rendered block cursor. Operations targeting the symbol under the cursor queried the head directly and could miss the symbol entirely, for example, landing in the whitespace after a `w` motion.

The changes in #55542 fixed this for the case when renaming a symbol, but there's other places where `Selection::head` was still being used.

hover, go to definition, go to declaration, go to type definition, go to implementation, find all references, go to reference, hover and document highlights.

## Testing

Tested both manually as well as introduced a new test for the go to definition case – `vim::helix::test::test_helix_go_to_definition_uses_visible_cursor_position` .

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Go To Definition • Before</summary>

  https://github.com/user-attachments/assets/02b8ab0f-7a60-478e-9436-19c773004115
</details>

<details>
  <summary>Go To Definition • After</summary>

  https://github.com/user-attachments/assets/f7899a5b-3309-4bec-8dc4-28c1a3185e20
</details>

---

Release Notes:

- Improved LSP symbol operations (go to definition, find all references, hover, etc.) missing the symbol under the visible selection in Helix mode.

