### PR TITLE
Fix expanded commit editor

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -5295,8 +5295,9 @@ impl GitPanel {
                                 div()
                                     .pt_2()
                                     .px_2()
-                                    .cursor_text()
+                                    .h_full()
                                     .flex_grow_1()
+                                    .cursor_text()
                                     .on_action(|&zed_actions::editor::MoveUp, _, cx| {
                                         cx.stop_propagation();
                                     })


### PR DESCRIPTION
This is a simple follow-up to #60331, the commit message in the expanded view got messed up and was being shrunken and centered instead of taking up the full height of the git panel.

All it needed was a `.h_full()`:

<details>
  <summary>Click to view showcase</summary>

### Before
<img width="652" height="758" alt="file-6d7f3fd7a5de8cff5ea44c0dfbaf0ac5" src="https://github.com/user-attachments/assets/85dca75c-7528-4876-9154-0145272c5029" />

### After
<img width="662" height="761" alt="file-268420a52e7b967fc09d10007d6aa1e5" src="https://github.com/user-attachments/assets/f39ea70b-d0a9-40e6-bb20-20cd3508ad66" />

</details>

@danilo-leal 

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] ~~Tests cover the new/changed behavior~~
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A