### PR TITLE
bedrock: Fix Claude Sonnet 5 and Fable 5 routing outside US regions

### DIFF
--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -765,11 +765,9 @@ impl Model {
 
             // EU region inference profiles
             (
-                Self::ClaudeFable5
-                | Self::ClaudeOpus4_8
+                Self::ClaudeOpus4_8
                 | Self::ClaudeOpus4_7
                 | Self::ClaudeOpus4_6
-                | Self::ClaudeSonnet5
                 | Self::ClaudeSonnet4_6
                 | Self::ClaudeSonnet4_5
                 | Self::ClaudeSonnet4
@@ -810,6 +808,11 @@ impl Model {
                 | Self::Nova2Lite,
                 "apac",
             ) => Ok(format!("{}.{}", region_group, model_id)),
+
+            // Models that require an inference profile (no on-demand direct invocation)
+            // and only have US and global profiles. Fall back to the global profile
+            // when no regional profile is available.
+            (Self::ClaudeFable5 | Self::ClaudeSonnet5, _) => Ok(format!("global.{}", model_id)),
 
             // Default: use model ID directly
             _ => Ok(model_id.into()),
@@ -876,13 +879,29 @@ mod tests {
             Model::ClaudeOpus4_8.cross_region_inference_id("eu-west-1", false)?,
             "eu.anthropic.claude-opus-4-8"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_inference_profile_only_models_fall_back_to_global() -> anyhow::Result<()> {
+        // Claude Fable 5 and Claude Sonnet 5 cannot be invoked with on-demand
+        // throughput and only have US and global inference profiles, so regions
+        // without a regional profile must fall back to the global profile.
         assert_eq!(
             Model::ClaudeFable5.cross_region_inference_id("eu-west-1", false)?,
-            "eu.anthropic.claude-fable-5"
+            "global.anthropic.claude-fable-5"
         );
         assert_eq!(
             Model::ClaudeSonnet5.cross_region_inference_id("eu-west-1", false)?,
-            "eu.anthropic.claude-sonnet-5"
+            "global.anthropic.claude-sonnet-5"
+        );
+        assert_eq!(
+            Model::ClaudeFable5.cross_region_inference_id("ap-southeast-2", false)?,
+            "global.anthropic.claude-fable-5"
+        );
+        assert_eq!(
+            Model::ClaudeSonnet5.cross_region_inference_id("ap-northeast-1", false)?,
+            "global.anthropic.claude-sonnet-5"
         );
         Ok(())
     }

--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -809,9 +809,6 @@ impl Model {
                 "apac",
             ) => Ok(format!("{}.{}", region_group, model_id)),
 
-            // Models that require an inference profile (no on-demand direct invocation)
-            // and only have US and global profiles. Fall back to the global profile
-            // when no regional profile is available.
             (Self::ClaudeFable5 | Self::ClaudeSonnet5, _) => Ok(format!("global.{}", model_id)),
 
             // Default: use model ID directly
@@ -884,9 +881,6 @@ mod tests {
 
     #[test]
     fn test_inference_profile_only_models_fall_back_to_global() -> anyhow::Result<()> {
-        // Claude Fable 5 and Claude Sonnet 5 cannot be invoked with on-demand
-        // throughput and only have US and global inference profiles, so regions
-        // without a regional profile must fall back to the global profile.
         assert_eq!(
             Model::ClaudeFable5.cross_region_inference_id("eu-west-1", false)?,
             "global.anthropic.claude-fable-5"


### PR DESCRIPTION
Follow-up to #60360 and #59016 (cc @NeelChotai @bennetbo).

Claude Sonnet 5 and Claude Fable 5 cannot be invoked with on-demand throughput — AWS requires an inference profile, and only `us.*` and `global.*` profiles exist for these models ([Sonnet 5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-sonnet-5.html), [Fable 5 model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html)).

For users in EU/APAC regions without `allow_global` enabled, Zed generated profile IDs like `eu.anthropic.claude-sonnet-5`, which fail with:

```
ResourceNotFoundException: Model not found.
```

And falling back to the bare model ID isn't an option either, since direct invocation fails with:

```
Invocation of model ID anthropic.claude-fable-5 with on-demand throughput isn't supported.
Retry your request with the ID or ARN of an inference profile that contains this model.
```

Confirmed against the live AWS API — only `us.*` and `global.*` profiles exist:

```
❯ aws bedrock list-inference-profiles --region eu-west-1 \
    --query "inferenceProfileSummaries[?contains(inferenceProfileId, 'sonnet-5') || contains(inferenceProfileId, 'fable')].[inferenceProfileId,status]" \
    --output table
------------------------------------------------
|             ListInferenceProfiles            |
+------------------------------------+---------+
|  global.anthropic.claude-sonnet-5  |  ACTIVE |
|  global.anthropic.claude-fable-5   |  ACTIVE |
+------------------------------------+---------+
```

This change removes both models from the EU match arm and routes them through the global inference profile when no regional profile is available. US regions continue to use the `us.*` profile. Verified working from `eu-west-1`.

Note: this means requests from non-US regions route through the global profile, which may dispatch inference to any supported AWS region. That's inherent to how AWS exposes these models — there is no EU-resident option today.

Release Notes:

- Fixed Claude Sonnet 5 and Claude Fable 5 failing on Amazon Bedrock in non-US regions.