### PR TITLE
Add "Go to Source Definition" context menu item

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -584,6 +584,10 @@ actions!(
         GoToDeclarationSplit,
         /// Goes to the definition of the symbol at cursor.
         GoToDefinition,
+        /// Goes to the source definition of the symbol at cursor.
+        GoToSourceDefinition,
+        /// Goes to the source definition in a split pane.
+        GoToSourceDefinitionSplit,
         /// Goes to definition in a split pane.
         GoToDefinitionSplit,
         /// Goes to the next diff hunk.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1599,6 +1599,7 @@ pub enum GotoDefinitionKind {
     Declaration,
     Type,
     Implementation,
+    Source,
 }
 
 pub enum FormatTarget {
@@ -11274,6 +11275,19 @@ impl SemanticsProvider for WeakEntity<Project> {
             GotoDefinitionKind::Declaration => project.declarations(buffer, position, cx),
             GotoDefinitionKind::Type => project.type_definitions(buffer, position, cx),
             GotoDefinitionKind::Implementation => project.implementations(buffer, position, cx),
+            GotoDefinitionKind::Source => {
+                let source_task = project.source_definitions(buffer, position, cx);
+                let buffer = buffer.clone();
+                cx.spawn(async move |this, cx| {
+                    if let Ok(Some(definitions)) = source_task.await
+                        && !definitions.is_empty()
+                    {
+                        return Ok(Some(definitions));
+                    }
+                    this.update(cx, |project, cx| project.definitions(&buffer, position, cx))?
+                        .await
+                })
+            }
         })
         .ok()
     }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -27075,6 +27075,177 @@ async fn test_goto_definition_no_fallback(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_go_to_source_definition_resolves_through_vtsls(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorLspTestContext::new_typescript_with_adapter(
+        FakeLspAdapter {
+            name: "vtsls",
+            capabilities: lsp::ServerCapabilities {
+                definition_provider: Some(lsp::OneOf::Left(true)),
+                execute_command_provider: Some(lsp::ExecuteCommandOptions {
+                    commands: vec!["typescript.goToSourceDefinition".to_string()],
+                    ..lsp::ExecuteCommandOptions::default()
+                }),
+                ..lsp::ServerCapabilities::default()
+            },
+            ..FakeLspAdapter::default()
+        },
+        cx,
+    )
+    .await;
+
+    cx.set_state("functionˇ one() {}\n\nfunction two() {}\n");
+
+    let target_url = cx.buffer_lsp_url.clone();
+    let mut execute_command = cx.lsp.set_request_handler::<lsp::request::ExecuteCommand, _, _>(
+        move |params, _cx| {
+            let target_url = target_url.clone();
+            async move {
+                assert_eq!(params.command, "typescript.goToSourceDefinition");
+                assert_eq!(
+                    params.arguments.first(),
+                    Some(&serde_json::Value::String(target_url.to_string()))
+                );
+                Ok(Some(serde_json::json!([{
+                    "uri": target_url.to_string(),
+                    "range": {
+                        "start": {"line": 2, "character": 9},
+                        "end": {"line": 2, "character": 12},
+                    },
+                }])))
+            }
+        },
+    );
+
+    let _go_to_definition = cx.set_request_handler::<lsp::request::GotoDefinition, _, _>(
+        move |_, _, _| async move {
+            panic!(
+                "Should not fall back to regular Go to Definition when vtsls resolves a source definition"
+            )
+        },
+    );
+
+    let navigated = cx
+        .update_editor(|editor, window, cx| {
+            editor.go_to_source_definition(&GoToSourceDefinition, window, cx)
+        })
+        .await
+        .expect("Failed to navigate to source definition");
+    execute_command
+        .next()
+        .await
+        .expect("Should have called the vtsls goToSourceDefinition handler");
+
+    assert_eq!(navigated, Navigated::Yes);
+    cx.assert_editor_state("function one() {}\n\nfunction «twoˇ»() {}\n");
+}
+
+#[gpui::test]
+async fn test_go_to_source_definition_resolves_through_tsserver_request(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorLspTestContext::new_typescript_with_adapter(
+        FakeLspAdapter {
+            name: "typescript-language-server",
+            capabilities: lsp::ServerCapabilities {
+                definition_provider: Some(lsp::OneOf::Left(true)),
+                execute_command_provider: Some(lsp::ExecuteCommandOptions {
+                    commands: vec!["typescript.tsserverRequest".to_string()],
+                    ..lsp::ExecuteCommandOptions::default()
+                }),
+                ..lsp::ServerCapabilities::default()
+            },
+            ..FakeLspAdapter::default()
+        },
+        cx,
+    )
+    .await;
+
+    cx.set_state("functionˇ one() {}\n\nfunction two() {}\n");
+
+    let source_file = EditorLspTestContext::root_path()
+        .join("dir")
+        .join("file.ts")
+        .to_string_lossy()
+        .into_owned();
+
+    let mut execute_command = cx.lsp.set_request_handler::<lsp::request::ExecuteCommand, _, _>(
+        move |params, _cx| {
+            let source_file = source_file.clone();
+            async move {
+                assert_eq!(params.command, "typescript.tsserverRequest");
+                assert_eq!(
+                    params.arguments.first(),
+                    Some(&serde_json::Value::String(
+                        "findSourceDefinition".to_string()
+                    ))
+                );
+                Ok(Some(serde_json::json!({
+                    "body": [{
+                        "file": source_file,
+                        "start": {"line": 3, "offset": 10},
+                        "end": {"line": 3, "offset": 13},
+                    }]
+                })))
+            }
+        },
+    );
+
+    let _go_to_definition = cx.set_request_handler::<lsp::request::GotoDefinition, _, _>(
+        move |_, _, _| async move {
+            panic!(
+                "Should not fall back to regular Go to Definition when tsserver resolves a source definition"
+            )
+        },
+    );
+
+    let navigated = cx
+        .update_editor(|editor, window, cx| {
+            editor.go_to_source_definition(&GoToSourceDefinition, window, cx)
+        })
+        .await
+        .expect("Failed to navigate to source definition");
+    execute_command
+        .next()
+        .await
+        .expect("Should have called the tsserver findSourceDefinition handler");
+
+    assert_eq!(navigated, Navigated::Yes);
+    cx.assert_editor_state("function one() {}\n\nfunction «twoˇ»() {}\n");
+}
+
+#[gpui::test]
+async fn test_go_to_source_definition_falls_back_to_regular_definition(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorLspTestContext::new_typescript(
+        lsp::ServerCapabilities {
+            definition_provider: Some(lsp::OneOf::Left(true)),
+            ..lsp::ServerCapabilities::default()
+        },
+        cx,
+    )
+    .await;
+
+    cx.set_state("functionˇ one() {}\n\nfunction two() {}\n");
+
+    cx.set_request_handler::<lsp::request::GotoDefinition, _, _>(move |url, _, _| async move {
+        Ok(Some(lsp::GotoDefinitionResponse::Scalar(lsp::Location {
+            uri: url,
+            range: lsp::Range::new(lsp::Position::new(2, 9), lsp::Position::new(2, 12)),
+        })))
+    });
+
+    let navigated = cx
+        .update_editor(|editor, window, cx| {
+            editor.go_to_source_definition(&GoToSourceDefinition, window, cx)
+        })
+        .await
+        .expect("Failed to navigate via fallback");
+
+    assert_eq!(navigated, Navigated::Yes);
+    cx.assert_editor_state("function one() {}\n\nfunction «twoˇ»() {}\n");
+}
+
+#[gpui::test]
 async fn test_goto_definition_close_ranges_open_singleton(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let mut cx = EditorLspTestContext::new_rust(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -397,6 +397,16 @@ impl EditorElement {
         });
         register_action(editor, window, |editor, action, window, cx| {
             editor
+                .go_to_source_definition(action, window, cx)
+                .detach_and_log_err(cx);
+        });
+        register_action(editor, window, |editor, action, window, cx| {
+            editor
+                .go_to_source_definition_split(action, window, cx)
+                .detach_and_log_err(cx);
+        });
+        register_action(editor, window, |editor, action, window, cx| {
+            editor
                 .go_to_declaration(action, window, cx)
                 .detach_and_log_err(cx);
         });

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -1,8 +1,8 @@
 use crate::{
     Copy, CopyAndTrim, CopyPermalinkToLine, Cut, DisplayPoint, DisplaySnapshot, Editor,
     EvaluateSelectedText, FindAllReferences, GoToDeclaration, GoToDefinition, GoToImplementation,
-    GoToTypeDefinition, Paste, Rename, RevealInFileManager, RunToCursor, SelectMode,
-    SelectionEffects, SelectionExt, ToDisplayPoint, ToggleCodeActions,
+    GoToSourceDefinition, GoToTypeDefinition, Paste, Rename, RevealInFileManager, RunToCursor,
+    SelectMode, SelectionEffects, SelectionExt, ToDisplayPoint, ToggleCodeActions,
     actions::{Format, FormatSelections},
     selections_collection::SelectionsCollection,
 };
@@ -216,6 +216,18 @@ pub fn deploy_context_menu(
                         .repository_and_path_for_buffer_id(buffer_anchor.buffer_id, cx)
                         .is_some()
                 });
+        let has_source_definition = buffer
+            .anchor_to_buffer_anchor(anchor)
+            .and_then(|(_, buffer_snapshot)| {
+                editor.buffer().read(cx).buffer(buffer_snapshot.remote_id())
+            })
+            .is_some_and(|buffer| {
+                project.update(cx, |project, cx| {
+                    buffer.update(cx, |buffer, cx| {
+                        project.supports_source_definition(buffer, cx)
+                    })
+                })
+            });
 
         let evaluate_selection = window.is_action_available(&EvaluateSelectedText, cx);
         let run_to_cursor = window.is_action_available(&RunToCursor, cx);
@@ -257,6 +269,9 @@ pub fn deploy_context_menu(
                     |builder| builder.separator(),
                 )
                 .action("Go to Definition", Box::new(GoToDefinition))
+                .when(has_source_definition, |builder| {
+                    builder.action("Go to Source Definition", Box::new(GoToSourceDefinition))
+                })
                 .action("Go to Declaration", Box::new(GoToDeclaration))
                 .action("Go to Type Definition", Box::new(GoToTypeDefinition))
                 .action("Go to Implementation", Box::new(GoToImplementation))

--- a/crates/editor/src/navigation.rs
+++ b/crates/editor/src/navigation.rs
@@ -989,6 +989,24 @@ impl Editor {
         })
     }
 
+    pub fn go_to_source_definition(
+        &mut self,
+        _: &GoToSourceDefinition,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Navigated>> {
+        self.go_to_definition_of_kind(GotoDefinitionKind::Source, false, window, cx)
+    }
+
+    pub fn go_to_source_definition_split(
+        &mut self,
+        _: &GoToSourceDefinitionSplit,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Navigated>> {
+        self.go_to_definition_of_kind(GotoDefinitionKind::Source, true, window, cx)
+    }
+
     pub fn go_to_declaration(
         &mut self,
         _: &GoToDeclaration,
@@ -1651,7 +1669,9 @@ impl Editor {
             if num_locations > 1 {
                 let tab_kind = match kind {
                     Some(GotoDefinitionKind::Implementation) => "Implementations",
-                    Some(GotoDefinitionKind::Symbol) | None => "Definitions",
+                    Some(GotoDefinitionKind::Symbol) | Some(GotoDefinitionKind::Source) | None => {
+                        "Definitions"
+                    }
                     Some(GotoDefinitionKind::Declaration) => "Declarations",
                     Some(GotoDefinitionKind::Type) => "Types",
                 };

--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -51,6 +51,22 @@ impl EditorLspTestContext {
         capabilities: lsp::ServerCapabilities,
         cx: &mut gpui::TestAppContext,
     ) -> EditorLspTestContext {
+        Self::new_with_adapter(
+            language,
+            FakeLspAdapter {
+                capabilities,
+                ..Default::default()
+            },
+            cx,
+        )
+        .await
+    }
+
+    pub async fn new_with_adapter(
+        language: Language,
+        adapter: FakeLspAdapter,
+        cx: &mut gpui::TestAppContext,
+    ) -> EditorLspTestContext {
         let app_state = cx.update(AppState::test);
 
         cx.update(|cx| {
@@ -70,13 +86,7 @@ impl EditorLspTestContext {
         let project = Project::test(app_state.fs.clone(), [], cx).await;
 
         let language_registry = project.read_with(cx, |project, _| project.languages().clone());
-        let mut fake_servers = language_registry.register_fake_lsp(
-            language.name(),
-            FakeLspAdapter {
-                capabilities,
-                ..Default::default()
-            },
-        );
+        let mut fake_servers = language_registry.register_fake_lsp(language.name(), adapter);
         language_registry.add(Arc::new(language));
 
         let root = Self::root_path();
@@ -171,10 +181,29 @@ impl EditorLspTestContext {
         capabilities: lsp::ServerCapabilities,
         cx: &mut gpui::TestAppContext,
     ) -> EditorLspTestContext {
+        Self::new_with_adapter(
+            Self::typescript_language(),
+            FakeLspAdapter {
+                capabilities,
+                ..Default::default()
+            },
+            cx,
+        )
+        .await
+    }
+
+    pub async fn new_typescript_with_adapter(
+        adapter: FakeLspAdapter,
+        cx: &mut gpui::TestAppContext,
+    ) -> EditorLspTestContext {
+        Self::new_with_adapter(Self::typescript_language(), adapter, cx).await
+    }
+
+    fn typescript_language() -> Language {
         let mut word_characters: HashSet<char> = Default::default();
         word_characters.insert('$');
         word_characters.insert('#');
-        let language = Language::new(
+        Language::new(
             LanguageConfig {
                 name: "Typescript".into(),
                 matcher: LanguageMatcher {
@@ -267,9 +296,7 @@ impl EditorLspTestContext {
                 "#})),
             ..Default::default()
         })
-        .expect("Could not parse queries");
-
-        Self::new(language, capabilities, cx).await
+        .expect("Could not parse queries")
     }
 
     pub async fn new_tsx(

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4230,6 +4230,18 @@ fn should_log_lsp_request_failure(message: &str) -> bool {
     message.ends_with("content modified") || message.ends_with("server cancelled the request")
 }
 
+const SOURCE_DEFINITION_VTSLS: LanguageServerName = LanguageServerName::new_static("vtsls");
+const SOURCE_DEFINITION_VTSLS_COMMAND: &str = "typescript.goToSourceDefinition";
+const SOURCE_DEFINITION_TS_LS: LanguageServerName =
+    LanguageServerName::new_static("typescript-language-server");
+const SOURCE_DEFINITION_TS_LS_COMMAND: &str = "typescript.tsserverRequest";
+
+#[derive(Clone, Copy)]
+enum SourceDefinitionStrategy {
+    Vtsls,
+    TsServerRequest,
+}
+
 impl LspStore {
     pub fn init(client: &AnyProtoClient) {
         client.add_entity_request_handler(Self::handle_lsp_query);
@@ -6090,6 +6102,180 @@ impl LspStore {
                 })
             })?
             .await
+        })
+    }
+
+    /// Returns whether [`Self::source_definitions`] has a language server to work
+    /// with for `buffer` — i.e. whether it's worth offering "Go to Source
+    /// Definition" as an action for this buffer at all. Cheap and synchronous, so
+    /// it's safe to call when building UI (e.g. the right-click context menu).
+    pub fn supports_source_definition(&self, buffer: &Buffer, cx: &mut App) -> bool {
+        self.upstream_client().is_none() && self.find_source_definition_server(buffer, cx).is_some()
+    }
+
+    fn find_source_definition_server(
+        &self,
+        buffer: &Buffer,
+        cx: &mut App,
+    ) -> Option<(Arc<LanguageServer>, SourceDefinitionStrategy)> {
+        let local = self.as_local()?;
+        local
+            .language_servers_for_buffer(buffer, cx)
+            .find_map(|(adapter, server)| {
+                let commands = server
+                    .capabilities()
+                    .execute_command_provider
+                    .map(|options| options.commands)
+                    .unwrap_or_default();
+                if adapter.name == SOURCE_DEFINITION_VTSLS
+                    && commands.iter().any(|c| c == SOURCE_DEFINITION_VTSLS_COMMAND)
+                {
+                    Some((server.clone(), SourceDefinitionStrategy::Vtsls))
+                } else if adapter.name == SOURCE_DEFINITION_TS_LS
+                    && commands
+                        .iter()
+                        .any(|c| c == SOURCE_DEFINITION_TS_LS_COMMAND)
+                {
+                    Some((server.clone(), SourceDefinitionStrategy::TsServerRequest))
+                } else {
+                    None
+                }
+            })
+    }
+
+    /// Resolves the "source definition" of the symbol at `position`, i.e. the real
+    /// `.js`/`.ts` implementation behind an ambient `.d.ts` declaration (e.g. from a
+    /// node_modules package), which plain `textDocument/definition` can't reach.
+    ///
+    /// `vtsls` exposes this directly as the `typescript.goToSourceDefinition`
+    /// executeCommand (taking a document uri + LSP position, returning `Location[]`
+    /// already converted to LSP shape). `typescript-language-server` instead exposes
+    /// a generic `typescript.tsserverRequest` passthrough, through which we invoke
+    /// tsserver's own `findSourceDefinition` command (available since TypeScript 4.7)
+    /// with tsserver's 1-based file/line/offset args, unwrapping its
+    /// `{ success, body }` response envelope.
+    ///
+    /// Returns `Ok(None)` (rather than an error) whenever this isn't applicable —
+    /// remote/collab projects, buffers without a matching language server, or
+    /// buffers with no local file — so callers can fall back to regular
+    /// `definitions` without treating this as a failure.
+    pub fn source_definitions(
+        &mut self,
+        buffer: &Entity<Buffer>,
+        position: PointUtf16,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Option<Vec<LocationLink>>>> {
+        if self.upstream_client().is_some() {
+            return Task::ready(Ok(None));
+        }
+
+        let Some((server, strategy)) =
+            buffer.update(cx, |buffer, cx| self.find_source_definition_server(buffer, cx))
+        else {
+            return Task::ready(Ok(None));
+        };
+
+        let Some(abs_path) = File::from_dyn(buffer.read(cx).file())
+            .and_then(File::as_local)
+            .map(|file| file.abs_path(cx))
+        else {
+            return Task::ready(Ok(None));
+        };
+        let Ok(uri) = file_path_to_lsp_url(&abs_path) else {
+            return Task::ready(Ok(None));
+        };
+
+        let params = match strategy {
+            SourceDefinitionStrategy::Vtsls => lsp::ExecuteCommandParams {
+                command: SOURCE_DEFINITION_VTSLS_COMMAND.to_owned(),
+                arguments: vec![
+                    Value::String(uri.to_string()),
+                    serde_json::to_value(point_to_lsp(position)).unwrap_or(Value::Null),
+                ],
+                ..lsp::ExecuteCommandParams::default()
+            },
+            SourceDefinitionStrategy::TsServerRequest => lsp::ExecuteCommandParams {
+                command: SOURCE_DEFINITION_TS_LS_COMMAND.to_owned(),
+                arguments: vec![
+                    Value::String("findSourceDefinition".to_owned()),
+                    serde_json::json!({
+                        "file": abs_path.to_string_lossy(),
+                        "line": position.row + 1,
+                        "offset": position.column + 1,
+                    }),
+                ],
+                ..lsp::ExecuteCommandParams::default()
+            },
+        };
+
+        let request_timeout = ProjectSettings::get_global(cx)
+            .global_lsp_settings
+            .get_request_timeout();
+        let server_id = server.server_id();
+        let lsp_store = cx.entity();
+        let buffer = buffer.clone();
+
+        cx.spawn(async move |_, cx| {
+            let response = server
+                .request::<lsp::request::ExecuteCommand>(params, request_timeout)
+                .await
+                .into_response()
+                .context("source definition")?;
+
+            let locations = match strategy {
+                SourceDefinitionStrategy::Vtsls => {
+                    serde_json::from_value::<Vec<lsp::Location>>(response.unwrap_or(Value::Null))
+                        .unwrap_or_default()
+                }
+                SourceDefinitionStrategy::TsServerRequest => {
+                    let body = match response {
+                        Some(Value::Object(mut map)) => map.remove("body").unwrap_or(Value::Null),
+                        _ => Value::Null,
+                    };
+                    #[derive(serde::Deserialize)]
+                    struct TsServerLocation {
+                        line: u32,
+                        offset: u32,
+                    }
+                    #[derive(serde::Deserialize)]
+                    struct TsServerFileSpan {
+                        file: String,
+                        start: TsServerLocation,
+                        end: TsServerLocation,
+                    }
+                    serde_json::from_value::<Vec<TsServerFileSpan>>(body)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter_map(|span| {
+                            let uri = file_path_to_lsp_url(Path::new(&span.file)).ok()?;
+                            Some(lsp::Location {
+                                uri,
+                                range: lsp::Range::new(
+                                    lsp::Position::new(
+                                        span.start.line.saturating_sub(1),
+                                        span.start.offset.saturating_sub(1),
+                                    ),
+                                    lsp::Position::new(
+                                        span.end.line.saturating_sub(1),
+                                        span.end.offset.saturating_sub(1),
+                                    ),
+                                ),
+                            })
+                        })
+                        .collect()
+                }
+            };
+
+            let definitions = location_links_from_lsp(
+                Some(lsp::GotoDefinitionResponse::Array(locations)),
+                lsp_store,
+                buffer,
+                server_id,
+                false,
+                cx.clone(),
+            )
+            .await?;
+            Ok(Some(definitions))
         })
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4230,6 +4230,24 @@ impl Project {
         })
     }
 
+    pub fn source_definitions<T: ToPointUtf16>(
+        &mut self,
+        buffer: &Entity<Buffer>,
+        position: T,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Option<Vec<LocationLink>>>> {
+        let position = position.to_point_utf16(buffer.read(cx));
+        let guard = self.retain_remotely_created_models(cx);
+        let task = self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.source_definitions(buffer, position, cx)
+        });
+        cx.background_spawn(async move {
+            let result = task.await;
+            drop(guard);
+            result
+        })
+    }
+
     pub fn workspace_definitions<T: ToPointUtf16>(
         &mut self,
         buffer: &Entity<Buffer>,
@@ -6083,6 +6101,14 @@ impl Project {
         cx: &'a App,
     ) -> impl 'a + Iterator<Item = (LanguageServerId, LanguageServerName)> {
         self.lsp_store.read(cx).supplementary_language_servers()
+    }
+
+    /// Whether [`Self::source_definitions`] has a language server to work with for
+    /// `buffer` right now — used to decide whether "Go to Source Definition" is
+    /// worth offering in UI (e.g. the right-click context menu) for this buffer.
+    pub fn supports_source_definition(&self, buffer: &Buffer, cx: &mut App) -> bool {
+        self.lsp_store
+            .update(cx, |lsp_store, cx| lsp_store.supports_source_definition(buffer, cx))
     }
 
     pub fn any_language_server_supports_inlay_hints(&self, buffer: &Buffer, cx: &mut App) -> bool {


### PR DESCRIPTION

# Objective

Adds a button to the context menu that let's users navigate to the js/ts source files of symbols imported from node modules.
The other context menu items ("Go to Definition/Implenentation/...") link to the type definition file, which is not always the desired behaviour - especially while debugging code / understanding the modules behaviour.

Adds the feature requested here: https://github.com/zed-industries/zed/discussions/42617

> Disclaimer:
This was vibe coded, hope it's still considered

## Solution

`vtsls`'s `typescript.goToSourceDefinition` command or `typescript-language-server`'s tsserver passthrough (`findSourceDefinition`), depending on which server is attached, resolves the source js or ts file.
It falls back to "Go to Definition" when no source location is found. The menu entry itself only appears when a supporting language server is actually attached to the buffer.

The implementation matches VS Code's "Go to Source Definition".

## Testing

- Did you test these changes? If so, how?
Yes, manually tested the build.
- Are there any parts that need more testing?
No automated tests that check if the condition for the new context menu item is correct
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
   1. Open a typescript project
   2. Find a function imported from a node module
   3. Right click the function name and select "Go to Source Definition"
   4. You should jump to the implemented function in the JS file within node_modules
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
Mac OS silicon

## Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

---

Release Notes:

- Added "Go to Source Definition" context menu button, that links typescript symbols with its source
