### PR TITLE
Add branch diff indicators mode

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2169,7 +2169,9 @@ impl Editor {
             let git_store = project.read(cx).git_store().clone();
             let project = project.clone();
             project_subscriptions.push(cx.subscribe(&git_store, move |this, _, event, cx| {
-                if let GitStoreEvent::RepositoryAdded = event {
+                if let GitStoreEvent::RepositoryAdded
+                | GitStoreEvent::BranchDiffIndicatorsChanged = event
+                {
                     this.load_diff_task = Some(
                         update_uncommitted_diff_for_buffer(
                             cx.entity(),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2169,8 +2169,8 @@ impl Editor {
             let git_store = project.read(cx).git_store().clone();
             let project = project.clone();
             project_subscriptions.push(cx.subscribe(&git_store, move |this, _, event, cx| {
-                if let GitStoreEvent::RepositoryAdded
-                | GitStoreEvent::BranchDiffIndicatorsChanged = event
+                if let GitStoreEvent::RepositoryAdded | GitStoreEvent::BranchDiffIndicatorsChanged =
+                    event
                 {
                     this.load_diff_task = Some(
                         update_uncommitted_diff_for_buffer(

--- a/crates/editor/src/git.rs
+++ b/crates/editor/src/git.rs
@@ -3127,11 +3127,20 @@ pub(super) fn update_uncommitted_diff_for_buffer(
 ) -> Task<()> {
     let mut tasks = Vec::new();
     project.update(cx, |project, cx| {
-        for buffer in buffers {
-            if project::File::from_dyn(buffer.read(cx).file()).is_some() {
-                tasks.push(project.open_uncommitted_diff(buffer.clone(), cx))
+        let git_store = project.git_store().clone();
+        git_store.update(cx, |git_store, cx| {
+            for buffer in buffers {
+                if project::File::from_dyn(buffer.read(cx).file()).is_none() {
+                    continue;
+                }
+                let buffer_id = buffer.read(cx).remote_id();
+                let task = match git_store.branch_diff_base_for_buffer(buffer_id, cx) {
+                    Some((repo, oid)) => git_store.open_diff_since(oid, buffer.clone(), repo, cx),
+                    None => git_store.open_uncommitted_diff(buffer.clone(), cx),
+                };
+                tasks.push(task);
             }
-        }
+        });
     });
     cx.spawn(async move |cx| {
         let diffs = future::join_all(tasks).await;

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -756,14 +756,9 @@ impl Item for Editor {
                 .and_then(|buffer| {
                     let buffer = buffer.read(cx);
                     let path = buffer.project_path(cx)?;
-                    let buffer_id = buffer.remote_id();
                     let project = self.project()?.read(cx);
                     let entry = project.entry_for_path(&path, cx)?;
-                    let (repo, repo_path) = project
-                        .git_store()
-                        .read(cx)
-                        .repository_and_path_for_buffer_id(buffer_id, cx)?;
-                    let status = repo.read(cx).status_for_path(&repo_path)?.status;
+                    let status = project.git_store().read(cx).project_path_git_status(&path, cx)?;
 
                     Some(entry_git_aware_label_color(
                         status.summary(),

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -758,7 +758,10 @@ impl Item for Editor {
                     let path = buffer.project_path(cx)?;
                     let project = self.project()?.read(cx);
                     let entry = project.entry_for_path(&path, cx)?;
-                    let status = project.git_store().read(cx).project_path_git_status(&path, cx)?;
+                    let status = project
+                        .git_store()
+                        .read(cx)
+                        .project_path_git_status(&path, cx)?;
 
                     Some(entry_git_aware_label_color(
                         status.summary(),

--- a/crates/git_ui/src/branch_diff_indicator.rs
+++ b/crates/git_ui/src/branch_diff_indicator.rs
@@ -1,0 +1,109 @@
+use gpui::{App, ClickEvent, Context, Empty, Entity, ParentElement as _, Subscription, Window};
+use project::{
+    Project,
+    git_store::{GitStore, GitStoreEvent},
+};
+use ui::{ButtonLike, Tooltip, prelude::*};
+use workspace::{HideStatusItem, StatusItemView, Workspace, item::ItemHandle};
+
+use crate::project_diff::ToggleBranchDiffIndicators;
+
+/// Status bar item shown only while branch-diff-indicators mode is active;
+/// clicking it turns the mode back off.
+pub struct BranchDiffIndicator {
+    project: Entity<Project>,
+    _subscription: Subscription,
+}
+
+impl BranchDiffIndicator {
+    /// Builds the indicator and subscribes to the project's git store.
+    pub fn new(workspace: &Workspace, cx: &mut Context<Self>) -> Self {
+        let project = workspace.project().clone();
+        let git_store = project.read(cx).git_store().clone();
+        let subscription = cx.subscribe(&git_store, Self::on_git_store_event);
+        Self {
+            project,
+            _subscription: subscription,
+        }
+    }
+
+    /// Re-renders when the mode is toggled so the item appears or disappears.
+    fn on_git_store_event(
+        &mut self,
+        _git_store: Entity<GitStore>,
+        event: &GitStoreEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if matches!(event, GitStoreEvent::BranchDiffIndicatorsChanged) {
+            cx.notify();
+        }
+    }
+
+    /// Turns branch-diff-indicators mode off (the item is only shown when on).
+    fn toggle_off(&mut self, _: &ClickEvent, _window: &mut Window, cx: &mut Context<Self>) {
+        let git_store = self.project.read(cx).git_store().clone();
+        git_store.update(cx, |git_store, cx| {
+            git_store.set_branch_diff_indicators_enabled(false, cx);
+        });
+    }
+}
+
+impl Render for BranchDiffIndicator {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let enabled = self
+            .project
+            .read(cx)
+            .git_store()
+            .read(cx)
+            .branch_diff_indicators_enabled();
+        if !enabled {
+            return Empty.into_any_element();
+        }
+
+        let border_color = cx.theme().colors().text_accent.opacity(0.2);
+
+        h_flex()
+            .h(rems_from_px(22.))
+            .rounded_sm()
+            .border_1()
+            .border_color(border_color)
+            .child(
+                ButtonLike::new("branch-diff-indicator")
+                    .child(
+                        h_flex()
+                            .h_full()
+                            .gap_1()
+                            .child(
+                                Icon::new(IconName::GitBranch)
+                                    .size(IconSize::Small)
+                                    .color(Color::Accent),
+                            )
+                            .child(Label::new("Branch Diff").size(LabelSize::Small)),
+                    )
+                    .tooltip(|_, cx| {
+                        Tooltip::with_meta(
+                            "Showing Branch Diff",
+                            Some(&ToggleBranchDiffIndicators),
+                            "Gutter and project panel show changes vs. the default branch. Click to turn off.",
+                            cx,
+                        )
+                    })
+                    .on_click(cx.listener(Self::toggle_off)),
+            )
+            .into_any_element()
+    }
+}
+
+impl StatusItemView for BranchDiffIndicator {
+    fn set_active_pane_item(
+        &mut self,
+        _: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        _: &mut Context<Self>,
+    ) {
+    }
+
+    fn hide_setting(&self, _: &App) -> Option<HideStatusItem> {
+        None
+    }
+}

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1195,7 +1195,9 @@ impl GitPanel {
                             .ok();
                     }
                     GitStoreEvent::RepositoryUpdated(_, _, _) => {}
-                    GitStoreEvent::JobsUpdated | GitStoreEvent::ConflictsUpdated => {}
+                    GitStoreEvent::JobsUpdated
+                    | GitStoreEvent::ConflictsUpdated
+                    | GitStoreEvent::BranchDiffIndicatorsChanged => {}
                 },
             )
             .detach();

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -5,6 +5,7 @@ use editor::{Editor, actions::DiffClipboardWithSelectionData};
 use workspace::{Toast, notifications::NotificationId};
 
 mod blame_ui;
+mod branch_diff_indicator;
 pub mod clone;
 
 use git::{
@@ -64,6 +65,7 @@ pub mod worktree_picker;
 pub mod worktree_service;
 
 pub use blame_ui::GitBlameStatus;
+pub use branch_diff_indicator::BranchDiffIndicator;
 pub use conflict_view::MergeConflictIndicator;
 
 pub fn get_provider_icon(name: &str) -> IconName {

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -90,15 +90,13 @@ impl ProjectDiff {
         workspace.register_action(|workspace, _: &Add, window, cx| {
             Self::deploy(workspace, &Diff, window, cx);
         });
-        workspace.register_action(
-            |workspace, _: &ToggleBranchDiffIndicators, _window, cx| {
-                let git_store = workspace.project().read(cx).git_store().clone();
-                git_store.update(cx, |git_store, cx| {
-                    let enabled = git_store.branch_diff_indicators_enabled();
-                    git_store.set_branch_diff_indicators_enabled(!enabled, cx);
-                });
-            },
-        );
+        workspace.register_action(|workspace, _: &ToggleBranchDiffIndicators, _window, cx| {
+            let git_store = workspace.project().read(cx).git_store().clone();
+            git_store.update(cx, |git_store, cx| {
+                let enabled = git_store.branch_diff_indicators_enabled();
+                git_store.set_branch_diff_indicators_enabled(!enabled, cx);
+            });
+        });
         workspace::register_serializable_item::<ProjectDiff>(cx);
     }
 

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -49,6 +49,10 @@ actions!(
         LeaderAndFollower,
         /// Compare with a specific branch
         CompareWithBranch,
+        /// Toggles showing the branch diff (relative to the default branch's
+        /// merge base) in the editor gutter and project panel, instead of
+        /// working changes.
+        ToggleBranchDiffIndicators,
     ]
 );
 
@@ -86,6 +90,15 @@ impl ProjectDiff {
         workspace.register_action(|workspace, _: &Add, window, cx| {
             Self::deploy(workspace, &Diff, window, cx);
         });
+        workspace.register_action(
+            |workspace, _: &ToggleBranchDiffIndicators, _window, cx| {
+                let git_store = workspace.project().read(cx).git_store().clone();
+                git_store.update(cx, |git_store, cx| {
+                    let enabled = git_store.branch_diff_indicators_enabled();
+                    git_store.set_branch_diff_indicators_enabled(!enabled, cx);
+                });
+            },
+        );
         workspace::register_serializable_item::<ProjectDiff>(cx);
     }
 

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -2748,7 +2748,7 @@ impl OutlinePanel {
                     let active_multi_buffer = active_editor.read(cx).buffer().clone();
                     let new_entries = outline_panel.new_entries_for_fs_update.clone();
                     let repo_snapshots = outline_panel.project.update(cx, |project, cx| {
-                        project.git_store().read(cx).repo_snapshots(cx)
+                        project.git_store().read(cx).display_repo_snapshots(cx)
                     });
                     let git_store = outline_panel.project.read(cx).git_store().clone();
                     new_collapsed_entries = outline_panel.collapsed_entries.clone();

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -108,7 +108,35 @@ pub struct GitStore {
     diffs: HashMap<BufferId, Entity<BufferGitState>>,
     buffer_ids_by_index_text_buffer_id: HashMap<BufferId, BufferId>,
     shared_diffs: HashMap<proto::PeerId, HashMap<BufferId, SharedDiffs>>,
+    /// When `Some`, branch-diff-indicators mode is active: the gutter and panel
+    /// show changes vs. each repo's default-branch merge base, not vs. HEAD.
+    branch_diff_indicators: Option<BranchDiffIndicators>,
     _subscriptions: Vec<Subscription>,
+}
+
+/// Per-repository state backing the branch-diff-indicators mode.
+#[derive(Default)]
+struct BranchDiffIndicators {
+    repos: HashMap<RepositoryId, RepoBranchDiff>,
+}
+
+/// One repository's merge-base diff and merged statuses for the mode.
+#[derive(Default)]
+struct RepoBranchDiff {
+    /// Resolved default branch ref (e.g. `origin/main`). `None` means the
+    /// default branch could not be resolved, so this repository degrades to
+    /// normal working-changes indicators.
+    base_ref: Option<SharedString>,
+    /// HEAD sha the current `tree_diff` was computed against, for change
+    /// detection.
+    head_sha: Option<SharedString>,
+    /// Committed changes between the merge base and HEAD. `None` while loading
+    /// or when degraded.
+    tree_diff: Option<Arc<TreeDiff>>,
+    /// Working-tree statuses merged with `tree_diff`, used to color the project
+    /// panel. `None` when degraded (panel then shows real working status).
+    merged_statuses: Option<SumTree<StatusEntry>>,
+    _refresh: Option<Task<()>>,
 }
 
 #[derive(Default)]
@@ -382,6 +410,45 @@ impl sum_tree::KeyedItem for StatusEntry {
     }
 }
 
+/// Merges a repository's working-tree statuses with its merge-base tree diff
+/// into per-path statuses relative to the merge base.
+fn build_merged_statuses(
+    snapshot: &RepositorySnapshot,
+    tree_diff: &TreeDiff,
+) -> SumTree<StatusEntry> {
+    let mut items = Vec::new();
+    let mut seen = HashSet::new();
+    for entry in snapshot.statuses_by_path.iter() {
+        seen.insert(entry.repo_path.clone());
+        let tree_status = tree_diff.entries.get(&entry.repo_path);
+        if let Some(status) = diff_buffer_list::merge_statuses(Some(entry.status), tree_status)
+            && status.has_changes()
+        {
+            items.push(StatusEntry {
+                repo_path: entry.repo_path.clone(),
+                status,
+                diff_stat: entry.diff_stat,
+            });
+        }
+    }
+    for (repo_path, tree_status) in tree_diff.entries.iter() {
+        if seen.contains(repo_path) {
+            continue;
+        }
+        if let Some(status) = diff_buffer_list::merge_statuses(None, Some(tree_status))
+            && status.has_changes()
+        {
+            items.push(StatusEntry {
+                repo_path: repo_path.clone(),
+                status,
+                diff_stat: None,
+            });
+        }
+    }
+    items.sort_by(|a, b| a.repo_path.cmp(&b.repo_path));
+    SumTree::from_iter(items, ())
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RepositoryId(pub u64);
 
@@ -598,6 +665,9 @@ pub enum GitStoreEvent {
     JobsUpdated,
     ConflictsUpdated,
     GlobalConfigurationUpdated,
+    /// The branch-diff-indicators mode was toggled, or its computed diff for
+    /// some repository changed.
+    BranchDiffIndicatorsChanged,
 }
 
 impl EventEmitter<RepositoryEvent> for Repository {}
@@ -745,6 +815,7 @@ impl GitStore {
             shared_diffs: HashMap::default(),
             diffs: HashMap::default(),
             buffer_ids_by_index_text_buffer_id: HashMap::default(),
+            branch_diff_indicators: None,
         }
     }
 
@@ -1787,7 +1858,17 @@ impl GitStore {
         cx: &App,
     ) -> Option<FileStatus> {
         let (repo, repo_path) = self.repository_and_path_for_project_path(project_path, cx)?;
-        Some(repo.read(cx).status_for_path(&repo_path)?.status)
+        let working_status = repo.read(cx).status_for_path(&repo_path).map(|s| s.status);
+        if let Some(indicators) = self.branch_diff_indicators.as_ref()
+            && let Some(state) = indicators.repos.get(&repo.read(cx).id)
+            && let Some(tree_diff) = state.tree_diff.as_ref()
+        {
+            return diff_buffer_list::merge_statuses(
+                working_status,
+                tree_diff.entries.get(&repo_path),
+            );
+        }
+        working_status
     }
 
     pub fn checkpoint(&self, cx: &mut App) -> Task<Result<GitStoreCheckpoint>> {
@@ -2166,6 +2247,29 @@ impl GitStore {
                 .ok();
             }
         }
+        if self.branch_diff_indicators.is_some() {
+            match event {
+                RepositoryEvent::HeadChanged => {
+                    let new_head = repo_snapshot
+                        .head_commit
+                        .as_ref()
+                        .map(|commit| commit.sha.clone());
+                    let old_head = self
+                        .branch_diff_indicators
+                        .as_ref()
+                        .and_then(|indicators| indicators.repos.get(&id))
+                        .and_then(|state| state.head_sha.clone());
+                    if new_head != old_head {
+                        self.refresh_branch_diff_for_repo(id, cx);
+                    }
+                }
+                RepositoryEvent::StatusesChanged => {
+                    self.rebuild_branch_merged_statuses(id, cx);
+                }
+                _ => {}
+            }
+        }
+
         cx.emit(GitStoreEvent::RepositoryUpdated(
             id,
             event.clone(),
@@ -2303,6 +2407,7 @@ impl GitStore {
                 self.repositories.insert(id, repo);
                 self.worktree_ids.insert(id, HashSet::from([worktree_id]));
                 cx.emit(GitStoreEvent::RepositoryAdded);
+                self.refresh_branch_diff_for_repo(id, cx);
                 self.active_repo_id.get_or_insert_with(|| {
                     cx.emit(GitStoreEvent::ActiveRepositoryChanged(Some(id)));
                     id
@@ -2314,6 +2419,9 @@ impl GitStore {
             if self.active_repo_id == Some(id) {
                 self.active_repo_id = None;
                 cx.emit(GitStoreEvent::ActiveRepositoryChanged(None));
+            }
+            if let Some(indicators) = self.branch_diff_indicators.as_mut() {
+                indicators.repos.remove(&id);
             }
             self.repositories.remove(&id);
             if let Some(updates_tx) = updates_tx.as_ref() {
@@ -2734,6 +2842,8 @@ impl GitStore {
                 |repo, cx| repo.apply_remote_update(update, cx)
             })?;
 
+            this.refresh_branch_diff_for_repo(id, cx);
+
             this.active_repo_id.get_or_insert_with(|| {
                 cx.emit(GitStoreEvent::ActiveRepositoryChanged(Some(id)));
                 id
@@ -2755,6 +2865,9 @@ impl GitStore {
         this.update(&mut cx, |this, cx| {
             let mut update = envelope.payload;
             let id = RepositoryId::from_proto(update.id);
+            if let Some(indicators) = this.branch_diff_indicators.as_mut() {
+                indicators.repos.remove(&id);
+            }
             this.repositories.remove(&id);
             if let Some((client, project_id)) = this.downstream_client() {
                 update.project_id = project_id.to_proto();
@@ -4218,6 +4331,170 @@ impl GitStore {
             .iter()
             .map(|(id, repo)| (*id, repo.read(cx).snapshot.clone()))
             .collect()
+    }
+
+    /// Whether branch-diff-indicators mode is currently active.
+    pub fn branch_diff_indicators_enabled(&self) -> bool {
+        self.branch_diff_indicators.is_some()
+    }
+
+    /// Turns branch-diff-indicators mode on or off, refreshing every repository.
+    pub fn set_branch_diff_indicators_enabled(
+        &mut self,
+        enabled: bool,
+        cx: &mut Context<Self>,
+    ) {
+        if enabled == self.branch_diff_indicators.is_some() {
+            return;
+        }
+        if enabled {
+            self.branch_diff_indicators = Some(BranchDiffIndicators::default());
+            let repo_ids = self.repositories.keys().copied().collect::<Vec<_>>();
+            for repo_id in repo_ids {
+                self.refresh_branch_diff_for_repo(repo_id, cx);
+            }
+        } else {
+            self.branch_diff_indicators = None;
+        }
+        cx.emit(GitStoreEvent::BranchDiffIndicatorsChanged);
+    }
+
+    /// Merge-base diff base for a buffer in this mode: `Some((repo, oid))` to
+    /// diff against blob `oid` (`None` oid = added), or `None` to use HEAD.
+    pub fn branch_diff_base_for_buffer(
+        &self,
+        buffer_id: BufferId,
+        cx: &App,
+    ) -> Option<(Entity<Repository>, Option<git::Oid>)> {
+        let indicators = self.branch_diff_indicators.as_ref()?;
+        let (repo, repo_path) = self.repository_and_path_for_buffer_id(buffer_id, cx)?;
+        let state = indicators.repos.get(&repo.read(cx).id)?;
+        let tree_diff = state.tree_diff.as_ref()?;
+        let oid = match tree_diff.entries.get(&repo_path)? {
+            TreeDiffStatus::Added => None,
+            TreeDiffStatus::Modified { old } | TreeDiffStatus::Deleted { old } => Some(*old),
+        };
+        Some((repo, oid))
+    }
+
+    /// Like `repo_snapshots`, but in this mode substitutes merge-base-relative
+    /// statuses for panel coloring. The underlying snapshots are never mutated.
+    pub fn display_repo_snapshots(&self, cx: &App) -> HashMap<RepositoryId, RepositorySnapshot> {
+        let mut snapshots = self.repo_snapshots(cx);
+        if let Some(indicators) = self.branch_diff_indicators.as_ref() {
+            for (id, snapshot) in snapshots.iter_mut() {
+                if let Some(state) = indicators.repos.get(id)
+                    && let Some(merged) = state.merged_statuses.clone()
+                {
+                    snapshot.statuses_by_path = merged;
+                }
+            }
+        }
+        snapshots
+    }
+
+    /// Resolves the default branch and reloads the merge-base tree diff for one
+    /// repository, then rebuilds its merged statuses and notifies listeners.
+    fn refresh_branch_diff_for_repo(&mut self, repo_id: RepositoryId, cx: &mut Context<Self>) {
+        if self.branch_diff_indicators.is_none() {
+            return;
+        }
+        let Some(repo) = self.repositories.get(&repo_id).cloned() else {
+            return;
+        };
+        let head_sha = repo
+            .read(cx)
+            .snapshot
+            .head_commit
+            .as_ref()
+            .map(|commit| commit.sha.clone());
+
+        let task = cx.spawn(async move |this, cx| {
+            let result = Self::load_branch_tree_diff(repo, cx).await;
+            this.update(cx, |this, cx| {
+                let Some(state) = this
+                    .branch_diff_indicators
+                    .as_mut()
+                    .and_then(|indicators| indicators.repos.get_mut(&repo_id))
+                else {
+                    return;
+                };
+                match result {
+                    Ok(Some((base_ref, tree_diff))) => {
+                        state.base_ref = Some(base_ref);
+                        state.tree_diff = Some(Arc::new(tree_diff));
+                    }
+                    Ok(None) => {
+                        state.base_ref = None;
+                        state.tree_diff = None;
+                    }
+                    Err(error) => {
+                        log::warn!("failed to compute branch diff indicators: {error:#}");
+                        state.base_ref = None;
+                        state.tree_diff = None;
+                    }
+                }
+                this.rebuild_branch_merged_statuses(repo_id, cx);
+                cx.emit(GitStoreEvent::BranchDiffIndicatorsChanged);
+            })
+            .ok();
+        });
+
+        if let Some(indicators) = self.branch_diff_indicators.as_mut() {
+            let state = indicators.repos.entry(repo_id).or_default();
+            state.head_sha = head_sha;
+            state._refresh = Some(task);
+        }
+    }
+
+    /// Resolves the repository's default branch and returns its merge-base tree
+    /// diff, or `None` when no default branch could be determined.
+    async fn load_branch_tree_diff(
+        repo: Entity<Repository>,
+        cx: &mut AsyncApp,
+    ) -> Result<Option<(SharedString, TreeDiff)>> {
+        let default_branch = repo
+            .update(cx, |repo, _| repo.default_branch(true))
+            .await??;
+        let Some(base_ref) = default_branch else {
+            return Ok(None);
+        };
+        let tree_diff = repo
+            .update(cx, |repo, cx| {
+                repo.diff_tree(
+                    DiffTreeType::MergeBase {
+                        base: base_ref.clone(),
+                        head: "HEAD".into(),
+                    },
+                    cx,
+                )
+            })
+            .await??;
+        Ok(Some((base_ref, tree_diff)))
+    }
+
+    /// Recomputes a repository's merged (working + merge-base) statuses used for
+    /// panel coloring; clears them when the repository is degraded.
+    fn rebuild_branch_merged_statuses(&mut self, repo_id: RepositoryId, cx: &App) {
+        let tree_diff = match self
+            .branch_diff_indicators
+            .as_ref()
+            .and_then(|indicators| indicators.repos.get(&repo_id))
+        {
+            Some(state) => state.tree_diff.clone(),
+            None => return,
+        };
+        let merged = tree_diff.and_then(|tree_diff| {
+            let repo = self.repositories.get(&repo_id)?;
+            Some(build_merged_statuses(&repo.read(cx).snapshot, &tree_diff))
+        });
+        if let Some(state) = self
+            .branch_diff_indicators
+            .as_mut()
+            .and_then(|indicators| indicators.repos.get_mut(&repo_id))
+        {
+            state.merged_statuses = merged;
+        }
     }
 
     fn coalesce_repo_paths(mut paths: Vec<RepoPath>) -> Vec<RepoPath> {
@@ -10023,6 +10300,134 @@ mod tests {
             assert!(
                 diff.base_text_exists(),
                 "regular file should have a git diff base"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_branch_diff_indicators_mode(cx: &mut TestAppContext) {
+        use util::rel_path::rel_path;
+
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            Path::new("/project"),
+            json!({
+                ".git": {},
+                // Working tree matches HEAD (no uncommitted changes), but differs
+                // from the merge base, so it's only visible in branch-diff mode.
+                "committed.txt": "head\n",
+            }),
+        )
+        .await;
+
+        fs.set_head_and_index_for_repo(
+            Path::new("/project/.git"),
+            &[("committed.txt", "head\n".into())],
+        );
+        fs.set_merge_base_content_for_repo(
+            Path::new("/project/.git"),
+            &[("committed.txt", "base\n".into())],
+        );
+
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+        let git_store = project.read_with(cx, |project, _| project.git_store().clone());
+
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_buffer((worktree_id, rel_path("committed.txt")), cx)
+            })
+            .await
+            .unwrap();
+        let buffer_id = buffer.read_with(cx, |buffer, _| buffer.remote_id());
+
+        // With the mode off, there is no working change, so the uncommitted diff
+        // has HEAD ("head") as its base and no branch base override.
+        let uncommitted_diff = project
+            .update(cx, |project, cx| {
+                project.open_uncommitted_diff(buffer.clone(), cx)
+            })
+            .await
+            .unwrap();
+        uncommitted_diff.read_with(cx, |diff, cx| {
+            assert_eq!(diff.base_text_string(cx).as_deref(), Some("head\n"));
+        });
+        git_store.read_with(cx, |git_store, cx| {
+            assert!(
+                git_store
+                    .branch_diff_base_for_buffer(buffer_id, cx)
+                    .is_none()
+            );
+            assert!(
+                git_store
+                    .project_path_git_status(&(worktree_id, rel_path("committed.txt")).into(), cx)
+                    .is_none()
+            );
+        });
+
+        // Enable branch-diff-indicators mode.
+        git_store.update(cx, |git_store, cx| {
+            git_store.set_branch_diff_indicators_enabled(true, cx);
+        });
+        cx.run_until_parked();
+
+        // Now the buffer diffs against the merge-base blob ("base") ...
+        let (repo, oid) = git_store
+            .read_with(cx, |git_store, cx| {
+                git_store.branch_diff_base_for_buffer(buffer_id, cx)
+            })
+            .expect("file changed on branch should have a branch diff base");
+        let branch_diff = git_store
+            .update(cx, |git_store, cx| {
+                git_store.open_diff_since(oid, buffer.clone(), repo, cx)
+            })
+            .await
+            .unwrap();
+        branch_diff.read_with(cx, |diff, cx| {
+            assert_eq!(diff.base_text_string(cx).as_deref(), Some("base\n"));
+        });
+
+        // ... and the file shows as changed for the panel, even though the
+        // working tree is clean.
+        git_store.read_with(cx, |git_store, cx| {
+            let status = git_store
+                .project_path_git_status(&(worktree_id, rel_path("committed.txt")).into(), cx)
+                .expect("branch change should surface as a status");
+            assert!(status.has_changes());
+
+            let snapshots = git_store.display_repo_snapshots(cx);
+            let has_entry = snapshots.values().any(|snapshot| {
+                snapshot
+                    .statuses_by_path
+                    .iter()
+                    .any(|entry| entry.repo_path == repo_path("committed.txt"))
+            });
+            assert!(has_entry, "merged statuses should include the branch change");
+        });
+
+        // Disable and confirm we're back to working-changes semantics.
+        git_store.update(cx, |git_store, cx| {
+            git_store.set_branch_diff_indicators_enabled(false, cx);
+        });
+        cx.run_until_parked();
+        git_store.read_with(cx, |git_store, cx| {
+            assert!(
+                git_store
+                    .branch_diff_base_for_buffer(buffer_id, cx)
+                    .is_none()
+            );
+            assert!(
+                git_store
+                    .project_path_git_status(&(worktree_id, rel_path("committed.txt")).into(), cx)
+                    .is_none()
             );
         });
     }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4339,11 +4339,7 @@ impl GitStore {
     }
 
     /// Turns branch-diff-indicators mode on or off, refreshing every repository.
-    pub fn set_branch_diff_indicators_enabled(
-        &mut self,
-        enabled: bool,
-        cx: &mut Context<Self>,
-    ) {
+    pub fn set_branch_diff_indicators_enabled(&mut self, enabled: bool, cx: &mut Context<Self>) {
         if enabled == self.branch_diff_indicators.is_some() {
             return;
         }
@@ -10410,7 +10406,10 @@ mod tests {
                     .iter()
                     .any(|entry| entry.repo_path == repo_path("committed.txt"))
             });
-            assert!(has_entry, "merged statuses should include the branch change");
+            assert!(
+                has_entry,
+                "merged statuses should include the branch change"
+            );
         });
 
         // Disable and confirm we're back to working-changes semantics.

--- a/crates/project/src/git_store/diff_buffer_list.rs
+++ b/crates/project/src/git_store/diff_buffer_list.rs
@@ -230,54 +230,7 @@ impl DiffBufferList {
         diff_from_head: Option<FileStatus>,
         diff_from_merge_base: Option<&TreeDiffStatus>,
     ) -> Option<FileStatus> {
-        match (diff_from_head, diff_from_merge_base) {
-            (None, None) => None,
-            (Some(diff_from_head), None) => Some(diff_from_head),
-            (Some(diff_from_head @ FileStatus::Unmerged(_)), _) => Some(diff_from_head),
-
-            // file does not exist in HEAD
-            // but *does* exist in work-tree
-            // and *does* exist in merge-base
-            (
-                Some(FileStatus::Untracked)
-                | Some(FileStatus::Tracked(TrackedStatus {
-                    index_status: StatusCode::Added,
-                    worktree_status: _,
-                })),
-                Some(_),
-            ) => Some(FileStatus::Tracked(TrackedStatus {
-                index_status: StatusCode::Modified,
-                worktree_status: StatusCode::Modified,
-            })),
-
-            // file exists in HEAD
-            // but *does not* exist in work-tree
-            (Some(diff_from_head), Some(diff_from_merge_base)) if diff_from_head.is_deleted() => {
-                match diff_from_merge_base {
-                    TreeDiffStatus::Added => None, // unchanged, didn't exist in merge base or worktree
-                    _ => Some(diff_from_head),
-                }
-            }
-
-            // file exists in HEAD
-            // and *does* exist in work-tree
-            (Some(FileStatus::Tracked(_)), Some(tree_status)) => {
-                Some(FileStatus::Tracked(TrackedStatus {
-                    index_status: match tree_status {
-                        TreeDiffStatus::Added { .. } => StatusCode::Added,
-                        _ => StatusCode::Modified,
-                    },
-                    worktree_status: match tree_status {
-                        TreeDiffStatus::Added => StatusCode::Added,
-                        _ => StatusCode::Modified,
-                    },
-                }))
-            }
-
-            (_, Some(diff_from_merge_base)) => {
-                Some(diff_status_to_file_status(diff_from_merge_base))
-            }
-        }
+        merge_statuses(diff_from_head, diff_from_merge_base)
     }
 
     fn spawn_reload_tree_diff(&mut self, cx: &mut Context<Self>) {
@@ -504,7 +457,61 @@ impl DiffBufferList {
     }
 }
 
-fn diff_status_to_file_status(branch_diff: &git::status::TreeDiffStatus) -> FileStatus {
+/// Combines a file's working-tree status with its merge-base tree-diff status
+/// into its effective status relative to the merge base (`None` if unchanged).
+pub(crate) fn merge_statuses(
+    diff_from_head: Option<FileStatus>,
+    diff_from_merge_base: Option<&TreeDiffStatus>,
+) -> Option<FileStatus> {
+    match (diff_from_head, diff_from_merge_base) {
+        (None, None) => None,
+        (Some(diff_from_head), None) => Some(diff_from_head),
+        (Some(diff_from_head @ FileStatus::Unmerged(_)), _) => Some(diff_from_head),
+
+        // file does not exist in HEAD
+        // but *does* exist in work-tree
+        // and *does* exist in merge-base
+        (
+            Some(FileStatus::Untracked)
+            | Some(FileStatus::Tracked(TrackedStatus {
+                index_status: StatusCode::Added,
+                worktree_status: _,
+            })),
+            Some(_),
+        ) => Some(FileStatus::Tracked(TrackedStatus {
+            index_status: StatusCode::Modified,
+            worktree_status: StatusCode::Modified,
+        })),
+
+        // file exists in HEAD
+        // but *does not* exist in work-tree
+        (Some(diff_from_head), Some(diff_from_merge_base)) if diff_from_head.is_deleted() => {
+            match diff_from_merge_base {
+                TreeDiffStatus::Added => None, // unchanged, didn't exist in merge base or worktree
+                _ => Some(diff_from_head),
+            }
+        }
+
+        // file exists in HEAD
+        // and *does* exist in work-tree
+        (Some(FileStatus::Tracked(_)), Some(tree_status)) => {
+            Some(FileStatus::Tracked(TrackedStatus {
+                index_status: match tree_status {
+                    TreeDiffStatus::Added { .. } => StatusCode::Added,
+                    _ => StatusCode::Modified,
+                },
+                worktree_status: match tree_status {
+                    TreeDiffStatus::Added => StatusCode::Added,
+                    _ => StatusCode::Modified,
+                },
+            }))
+        }
+
+        (_, Some(diff_from_merge_base)) => Some(diff_status_to_file_status(diff_from_merge_base)),
+    }
+}
+
+pub(crate) fn diff_status_to_file_status(branch_diff: &git::status::TreeDiffStatus) -> FileStatus {
     let file_status = match branch_diff {
         git::status::TreeDiffStatus::Added { .. } => FileStatus::Tracked(TrackedStatus {
             index_status: StatusCode::Added,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -670,7 +670,8 @@ impl ProjectPanel {
                 |this, _, event, window, cx| match event {
                     GitStoreEvent::RepositoryUpdated(_, RepositoryEvent::StatusesChanged, _)
                     | GitStoreEvent::RepositoryAdded
-                    | GitStoreEvent::RepositoryRemoved(_) => {
+                    | GitStoreEvent::RepositoryRemoved(_)
+                    | GitStoreEvent::BranchDiffIndicatorsChanged => {
                         this.update_visible_entries(None, false, false, window, cx);
                         cx.notify();
                     }
@@ -2780,7 +2781,7 @@ impl ProjectPanel {
         let parent_entry = worktree.entry_for_path(parent_path)?;
 
         // Remove all siblings that are being deleted except the last marked entry
-        let repo_snapshots = git_store.repo_snapshots(cx);
+        let repo_snapshots = git_store.display_repo_snapshots(cx);
         let worktree_snapshot = worktree.snapshot();
         let hide_gitignore = ProjectPanelSettings::get_global(cx).hide_gitignore;
         let mut siblings: Vec<_> =
@@ -4218,7 +4219,7 @@ impl ProjectPanel {
         let sort_mode = settings.sort_mode;
         let sort_order = settings.sort_order;
         let project = self.project.read(cx);
-        let repo_snapshots = project.git_store().read(cx).repo_snapshots(cx);
+        let repo_snapshots = project.git_store().read(cx).display_repo_snapshots(cx);
 
         let old_ancestors = self.state.ancestors.clone();
         let temporary_unfolded_pending_state = self.state.temporarily_unfolded_pending_state.take();
@@ -5217,7 +5218,7 @@ impl ProjectPanel {
             .read(cx)
             .git_store()
             .read(cx)
-            .repo_snapshots(cx);
+            .display_repo_snapshots(cx);
         let worktree = self.project.read(cx).worktree_for_id(worktree_id, cx)?;
         worktree.read_with(cx, |tree, _| {
             utils::ReversibleIterable::new(
@@ -5247,7 +5248,7 @@ impl ProjectPanel {
             .read(cx)
             .git_store()
             .read(cx)
-            .repo_snapshots(cx);
+            .display_repo_snapshots(cx);
 
         let mut last_found: Option<SelectedEntry> = None;
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -631,6 +631,8 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
         let git_blame_status = cx.new(|_| git_ui::GitBlameStatus::default());
         let merge_conflict_indicator =
             cx.new(|cx| git_ui::MergeConflictIndicator::new(workspace, cx));
+        let branch_diff_indicator =
+            cx.new(|cx| git_ui::BranchDiffIndicator::new(workspace, cx));
         workspace.status_bar().update(cx, |status_bar, cx| {
             status_bar.add_left_item(search_button, window, cx);
             status_bar.add_left_item(lsp_button, window, cx);
@@ -639,6 +641,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
             status_bar.add_left_item(git_blame_status, window, cx);
             status_bar.add_left_item(merge_conflict_indicator, window, cx);
             status_bar.add_left_item(activity_indicator, window, cx);
+            status_bar.add_right_item(branch_diff_indicator, window, cx);
             status_bar.add_right_item(edit_prediction_ui, window, cx);
             status_bar.add_right_item(active_buffer_encoding, window, cx);
             status_bar.add_right_item(active_buffer_language, window, cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -631,8 +631,7 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
         let git_blame_status = cx.new(|_| git_ui::GitBlameStatus::default());
         let merge_conflict_indicator =
             cx.new(|cx| git_ui::MergeConflictIndicator::new(workspace, cx));
-        let branch_diff_indicator =
-            cx.new(|cx| git_ui::BranchDiffIndicator::new(workspace, cx));
+        let branch_diff_indicator = cx.new(|cx| git_ui::BranchDiffIndicator::new(workspace, cx));
         workspace.status_bar().update(cx, |status_bar, cx| {
             status_bar.add_left_item(search_button, window, cx);
             status_bar.add_left_item(lsp_button, window, cx);


### PR DESCRIPTION
# Objective

As discussed on slack and at your booth at AIE WF last week, I've really wanted a way to see the branch diff, not just working changes while viewing code for some time.

This was implemented with claude. Happy to revise to make edits if you're willing to accept this. I've reviewed the code, but since I'm not familar with the the codebase, I don't pretend to have a good perspective on what needs to be addressed.

## Solution

Introduce a session-only mode, toggled via the git: Toggle Branch Diff Indicators command, that shows changes relative to each repository's merge base with its default branch instead of working changes. While active, the editor gutter (and all downstream hunk UI), the project/outline panel coloring, and editor tab colors reflect the whole branch diff, while the git panel keeps showing real working status.

The mode reuses the existing branch-diff machinery: GitStore lazily maintains a per-repository merge-base tree diff, resolved from default_branch and diff_tree and refreshed on HEAD/status changes. Editors route through open_diff_since against the merge-base blob, and the panels read display_repo_snapshots, which substitutes merged statuses without mutating the shared repository snapshots. A status bar indicator appears while the mode is active and turns it off when clicked.

## Testing

- Did you test these changes? If so, how? claude wrote tests, I built locally and tried it
- Are there any parts that need more testing? no
- How can other people (reviewers) test your changes? Is there anything specific they need to know? just check out a branch and use the command palette to switch mode
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? macos

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Added a "Toggle Branch Diff Indicators" command that shows the whole branch diff (vs. the default branch's merge base) in the editor gutter and project panel instead of only working changes.
