### PR TITLE
editor: change language server actions names to lsp

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -428,7 +428,8 @@ actions!(
         /// Cancels the running flycheck operation.
         CancelFlycheck,
         /// Cancels pending language server work.
-        CancelLanguageServerWork,
+        #[action(deprecated_aliases = ["editor::CancelLanguageServerWork"])]
+        CancelLspWork,
         /// Clears flycheck results.
         ClearFlycheck,
         /// Confirms the rename operation.
@@ -747,7 +748,8 @@ actions!(
         /// Renames the symbol at cursor.
         Rename,
         /// Restarts the language server for the current file.
-        RestartLanguageServer,
+        #[action(deprecated_aliases = ["editor::RestartLanguageServer"])]
+        RestartLsp,
         /// Reverses the order of selected lines.
         ReverseLines,
         /// Reloads the file from disk.
@@ -847,7 +849,8 @@ actions!(
         /// Sorts selected lines case-sensitively.
         SortLinesCaseSensitive,
         /// Stops the language server for the current file.
-        StopLanguageServer,
+        #[action(deprecated_aliases = ["editor::StopLanguageServer"])]
+        StopLsp,
         /// Switches between source and header files.
         SwitchSourceHeader,
         /// Inserts a tab character or indents.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8210,12 +8210,7 @@ impl Editor {
         })
     }
 
-    fn restart_language_server(
-        &mut self,
-        _: &RestartLanguageServer,
-        _: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
+    fn restart_language_server(&mut self, _: &RestartLsp, _: &mut Window, cx: &mut Context<Self>) {
         if let Some(project) = self.project.clone() {
             self.buffer.update(cx, |multi_buffer, cx| {
                 project.update(cx, |project, cx| {
@@ -8230,12 +8225,7 @@ impl Editor {
         }
     }
 
-    fn stop_language_server(
-        &mut self,
-        _: &StopLanguageServer,
-        _: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
+    fn stop_language_server(&mut self, _: &StopLsp, _: &mut Window, cx: &mut Context<Self>) {
         if let Some(project) = self.project.clone() {
             self.buffer.update(cx, |multi_buffer, cx| {
                 project.update(cx, |project, cx| {
@@ -8251,7 +8241,7 @@ impl Editor {
 
     fn cancel_language_server_work(
         workspace: &mut Workspace,
-        _: &actions::CancelLanguageServerWork,
+        _: &actions::CancelLspWork,
         _: &mut Window,
         cx: &mut Context<Workspace>,
     ) {

--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -109,7 +109,8 @@ actions!(
     dev,
     [
         /// Opens the language server protocol logs viewer.
-        OpenLanguageServerLogs
+        #[action(deprecated_aliases = ["dev::OpenLanguageServerLogs"])]
+        OpenLspLogs
     ]
 );
 
@@ -122,7 +123,7 @@ pub fn init(on_headless_host: bool, cx: &mut App) {
         });
 
         let log_store = log_store.clone();
-        workspace.register_action(move |workspace, _: &OpenLanguageServerLogs, window, cx| {
+        workspace.register_action(move |workspace, _: &OpenLspLogs, window, cx| {
             let log_store = log_store.clone();
             let project = workspace.project().clone();
             get_or_create_tool(

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -438,10 +438,10 @@ Issues with Python in Zed typically involve virtual environments, language serve
 If a language server isn't responding or features like diagnostics or autocomplete aren't available:
 
 - Check your Zed log (using the {#action zed::OpenLog} action) for errors related to the language server you're trying to use. This is where you're likely to find useful information if the language server failed to start up at all.
-- Use the language server logs view to understand the lifecycle of the affected language server. You can access this view using the {#action dev::OpenLanguageServerLogs} action, or by clicking the lightning bolt icon in the status bar and selecting your language server. The most useful pieces of data in this view are:
+- Use the language server logs view to understand the lifecycle of the affected language server. You can access this view using the {#action dev::OpenLspLogs} action, or by clicking the lightning bolt icon in the status bar and selecting your language server. The most useful pieces of data in this view are:
   - "Server Logs", which shows any errors printed by the language server
   - "Server Info", which shows details about how the language server was started
 - Verify your `settings.json` or `pyrightconfig.json` is syntactically correct.
-- Restart Zed to reinitialize language server connections, or try restarting the language server using the {#action editor::RestartLanguageServer}
+- Restart Zed to reinitialize language server connections, or try restarting the language server using the {#action editor::RestartLsp}
 
 If the language server is failing to resolve imports, and you're using a virtual environment, make sure that the right environment is chosen in the selector. You can use "Server Info" view to confirm which virtual environment Zed is sending to the language server&mdash;look for the `* Configuration` section at the end.

--- a/docs/src/semantic-tokens.md
+++ b/docs/src/semantic-tokens.md
@@ -41,7 +41,7 @@ You can configure this globally or per-language:
 }
 ```
 
-> **Note:** Changing the `semantic_tokens` mode may require a language server restart to take effect. Use the {#action editor::RestartLanguageServer} command from the command palette if highlighting doesn't update immediately.
+> **Note:** Changing the `semantic_tokens` mode may require a language server restart to take effect. Use the {#action editor::RestartLsp} command from the command palette if highlighting doesn't update immediately.
 
 ## Customizing Token Colors
 
@@ -192,12 +192,12 @@ To see semantic tokens applied to your code in real-time, use the {#action dev::
 
 1. Ensure `semantic_tokens` is set to `"combined"` or `"full"` for the language
 2. Verify the language server supports semantic tokens (not all do)
-3. Try restarting the language server with {#action editor::RestartLanguageServer}
-4. Check the LSP logs ({#action dev::OpenLanguageServerLogs}) for errors
+3. Try restarting the language server with {#action editor::RestartLsp}
+4. Check the LSP logs ({#action dev::OpenLspLogs}) for errors
 
 ### Colors not updating after changing settings
 
-Changes to `semantic_tokens` mode may require a language server restart. Use {#action editor::RestartLanguageServer} from the command palette.
+Changes to `semantic_tokens` mode may require a language server restart. Use {#action editor::RestartLsp} from the command palette.
 
 ### Theme styles not being applied
 

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -86,7 +86,7 @@ If your issue persists after regenerating the database, please [file an issue](h
 
 ## Language Server Issues
 
-If you're experiencing language-server related issues, such as stale diagnostics or issues jumping to definitions, restarting the language server via {#action editor::RestartLanguageServer} from the command palette will often resolve the issue.
+If you're experiencing language-server related issues, such as stale diagnostics or issues jumping to definitions, restarting the language server via {#action editor::RestartLsp} from the command palette will often resolve the issue.
 
 ## Agent Error Messages
 

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -369,7 +369,7 @@ To configure command mnemonics, add the `command_aliases` key to your settings f
     "crp": "workspace::CopyRelativePath",
     "cpp": "workspace::CopyPath",
     "reveal": "editor::RevealInFileManager",
-    "clank": "editor::CancelLanguageServerWork"
+    "clank": "editor::CancelLspWork"
   }
 }
 ```


### PR DESCRIPTION
# Objective

- Fixes https://github.com/zed-industries/zed/issues/60381 
- The command palette used inconsistent terms: one action was under the lsp_tool namespace ("lsp tool: toggle menu") while the rest said "language server". So searching "lsp" didn't surface most language-server commands 

## Solution

- Renamed four actions from "language server" to "lsp":  editor::RestartLanguageServer → RestartLsp, editor::StopLanguageServer → StopLsp, editor::CancelLanguageServerWork → CancelLspWork, dev::OpenLanguageServerLogs → OpenLspLogs.
- Changed docs to reflect the change from old action names
- Added deprecated_aliases to each changed action to ensure user keybinds do not error

## Testing

- Ran Zed locally on Linux (WSL2), press `Ctrl+Shift+P` to open the actions tab, then look for one of the changed action names (e.g. `dev: open lsp logs`
- Other reviewers can test these changes the same way.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="608" height="490" alt="image" src="https://github.com/user-attachments/assets/8f8ddeda-439d-487b-823b-c291c8b991d8" /><details>

Release Notes:
Improved: changed actions containing "language server" to use "lsp" so they're discoverable in the command palette 