### PR TITLE
project: Show clear error when moving a file that already exists at the destination

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2865,7 +2865,10 @@ impl Fs for FakeFs {
                     if options.overwrite {
                         *e.get_mut() = moved_entry;
                     } else if !options.ignore_if_exists {
-                        anyhow::bail!("path already exists: {new_path:?}");
+                        return Err(anyhow!(io::Error::new(
+                            io::ErrorKind::AlreadyExists,
+                            format!("path already exists: {new_path:?}")
+                        )));
                     }
                 }
                 btree_map::Entry::Vacant(e) => {

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -620,6 +620,13 @@ impl WorktreeStore {
                                     .await;
                                 }
                             }
+                            if let Some(err) = e.downcast_ref::<std::io::Error>()
+                                && err.kind() == std::io::ErrorKind::AlreadyExists
+                            {
+                                let file_name = abs_new_path.file_name().unwrap_or(abs_new_path.as_os_str()).to_string_lossy();
+                                anyhow::bail!("A file named '{file_name}' already exists in the destination folder")
+                            }
+
                             return Err(e);
                         }
                         Ok(())

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -5466,6 +5466,53 @@ async fn test_apply_code_actions_with_commands(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_rename_file_onto_existing_file(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.as_fake()
+        .insert_tree(
+            "/root",
+            json!({
+                "test.txt": "original",
+                "dir": {
+                    "test.txt": "existing"
+                }
+            }),
+        )
+        .await;
+
+    let project = Project::test(fs, [path!("/root").as_ref()], cx).await;
+
+    let (worktree, entry_id) = project.read_with(cx, |project, cx| {
+        let worktree = project.worktrees(cx).next().unwrap();
+        let entry_id = worktree
+            .read(cx)
+            .entry_for_path(rel_path("test.txt"))
+            .unwrap()
+            .id;
+        (worktree, entry_id)
+    });
+    let worktree_id = worktree.read_with(cx, |worktree, _| worktree.id());
+
+    // Moving `test.txt` into `dir/`, which already contains a file with the same
+    // name, should fail with a clear "already exists" error rather than a
+    // generic rename failure.
+    let result = project
+        .update(cx, |project, cx| {
+            project.rename_entry(entry_id, (worktree_id, rel_path("dir/test.txt")).into(), cx)
+        })
+        .await;
+
+    let Err(error) = result else {
+        panic!("moving a file onto an existing file should have failed");
+    };
+    assert!(
+        error.to_string().contains("already exists"),
+        "expected an 'already exists' error, got: {error}"
+    );
+}
+
+#[gpui::test]
 async fn test_rename_file_to_new_directory(cx: &mut gpui::TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.background_executor.clone());


### PR DESCRIPTION
# Objective

- Fixes https://github.com/zed-industries/zed/issues/60317
- Initially, if you drag a file from your directory to a subdir with a file that has an identical name, you will receive an unclear error message

## Solution

- Provides a clearer error message for when you drag a file into a subdir with an identical file name inside. 

## Testing

- Tested manually in a WSL2 (Linux) environment that the new error message surfaces when dragging file into subdir
- Added test case (test_rename_file_onto_existing_file) in `project/tests/integration/project_tests.rs` to perform the move and assert the error message
- Reviewers can test by dragging (or renaming) a file into a folder that already has the same name
- Also changed  `FakeFs::rename` to return `io::ErrorKind::AlreadyExists`, this is consistent with how we handle `NotFound`

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before: 
<img width="462" height="139" alt="image" src="https://github.com/user-attachments/assets/80c6eb60-e0fa-459a-938a-e2813badecba" />

After:
<img width="449" height="104" alt="image" src="https://github.com/user-attachments/assets/e997dd97-fe7b-4fdf-a4ec-618888fabd3b" />


---

Release Notes:

- Improved: fixed Clearer error message when moving or renaming a file onto a file with the same name