### PR TITLE
agent: Show errors when provider is not authenticated but model is configured

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -374,7 +374,10 @@ impl LanguageModels {
                 }
             }
 
-            cx.update(language_models::update_environment_fallback_model);
+            cx.update(|cx| {
+                LanguageModelRegistry::global(cx)
+                    .update(cx, |registry, cx| registry.refresh_fallback_model(cx))
+            });
         })
     }
 }

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1181,7 +1181,7 @@ enum CompletionError {
     Other(#[from] anyhow::Error),
 }
 
-pub(crate) enum ThreadModel {
+pub enum ThreadModel {
     Ready(Arc<dyn LanguageModel>),
     Unresolved(SelectedModel),
     Unset,
@@ -1944,6 +1944,10 @@ impl Thread {
 
     pub fn model(&self) -> Option<&Arc<dyn LanguageModel>> {
         self.model.as_model()
+    }
+
+    pub fn thread_model(&self) -> &ThreadModel {
+        &&self.model
     }
 
     pub(crate) fn ensure_model(

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1986,6 +1986,7 @@ impl Thread {
             cx.emit(TokenUsageUpdated(new_usage));
         }
         self.prompt_capabilities_tx.send(new_caps).log_err();
+        cx.emit(ModelChanged);
 
         for subagent in &self.running_subagents {
             subagent
@@ -4789,6 +4790,10 @@ impl EventEmitter<TokenUsageUpdated> for Thread {}
 pub struct TitleUpdated;
 
 impl EventEmitter<TitleUpdated> for Thread {}
+
+pub struct ModelChanged;
+
+impl EventEmitter<ModelChanged> for Thread {}
 
 /// A channel-based wrapper that delivers tool input to a running tool.
 ///

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1947,7 +1947,7 @@ impl Thread {
     }
 
     pub fn thread_model(&self) -> &ThreadModel {
-        &&self.model
+        &self.model
     }
 
     pub(crate) fn ensure_model(

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -35,7 +35,8 @@ use futures::{
 };
 use futures::{StreamExt, stream};
 use gpui::{
-    App, AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Task, WeakEntity,
+    App, AppContext, AsyncApp, Context, Entity, EventEmitter, ReadGlobal as _, SharedString, Task,
+    WeakEntity,
 };
 use heck::ToSnakeCase as _;
 use language_model::{
@@ -1357,7 +1358,11 @@ impl Thread {
             .and_then(|model| model.speed);
         let (prompt_capabilities_tx, prompt_capabilities_rx) =
             watch::channel(Self::prompt_capabilities(model.as_deref()));
-        let model = model.map_or(ThreadModel::Unset, ThreadModel::Ready);
+        let model = match model {
+            Some(model) => ThreadModel::Ready(model),
+            None => Self::user_configured_model_selection(cx)
+                .map_or(ThreadModel::Unset, ThreadModel::Unresolved),
+        };
         Self {
             id: acp::SessionId::new(uuid::Uuid::new_v4().to_string()),
             prompt_id: PromptId::new(),
@@ -2397,6 +2402,20 @@ impl Thread {
             .default_model
             .clone()?;
         Self::resolve_model_from_selection(&selection, cx)
+    }
+
+    fn user_configured_model_selection(cx: &App) -> Option<SelectedModel> {
+        let selection = SettingsStore::global(cx)
+            .raw_user_settings()?
+            .content
+            .agent
+            .as_ref()?
+            .default_model
+            .as_ref()?;
+        Some(SelectedModel {
+            provider: LanguageModelProviderId::from(selection.provider.0.clone()),
+            model: LanguageModelId::from(selection.model.clone()),
+        })
     }
 
     /// Translate a stored model selection into the configured model from the registry.

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -47,8 +47,8 @@ use editor::{Editor, SelectionEffects, scroll::Autoscroll};
 use feature_flags::FeatureFlagAppExt as _;
 use fs::Fs;
 use gpui::{
-    Action, App, Context, Entity, ImageSource, Resource, SharedString, SharedUri, TaskExt, Window,
-    actions,
+    Action, App, Context, Entity, ImageSource, ReadGlobal as _, Resource, SharedString, SharedUri,
+    TaskExt, Window, actions,
 };
 use language::{
     LanguageRegistry,
@@ -880,6 +880,12 @@ fn update_active_language_model_from_settings(cx: &mut App) {
         }
     }
 
+    let should_use_fallback = SettingsStore::global(cx)
+        .raw_user_settings()
+        .and_then(|user| user.content.agent.as_ref())
+        .and_then(|agent| agent.default_model.as_ref())
+        .is_none();
+
     let default = settings.default_model.as_ref().map(to_selected_model);
     let inline_assistant = settings
         .inline_assistant_model
@@ -905,6 +911,7 @@ fn update_active_language_model_from_settings(cx: &mut App) {
         registry.select_commit_message_model(commit_message.as_ref(), cx);
         registry.select_thread_summary_model(thread_summary.as_ref(), cx);
         registry.select_inline_alternative_models(inline_alternatives, cx);
+        registry.set_should_use_fallback(should_use_fallback);
     });
 }
 

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -857,11 +857,12 @@ fn init_language_model_settings(cx: &mut App) {
         .detach();
     cx.subscribe(
         &LanguageModelRegistry::global(cx),
-        |_, event: &language_model::Event, cx| match event {
+        |registry, event: &language_model::Event, cx| match event {
             language_model::Event::ProviderStateChanged(_)
             | language_model::Event::AddedProvider(_)
             | language_model::Event::RemovedProvider(_)
             | language_model::Event::ProvidersChanged => {
+                registry.update(cx, |registry, cx| registry.refresh_fallback_model(cx));
                 update_active_language_model_from_settings(cx);
             }
             _ => {}

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -10671,13 +10671,17 @@ impl ThreadView {
                 false,
                 cx,
             ),
-            ThreadError::NoModelSelected => self.render_error_callout(
-                "No Model Selected",
-                "Select a model from the model picker below to get started.".into(),
-                false,
-                false,
-                cx,
-            ),
+            ThreadError::NoModelSelected => self
+                .render_model_not_available_error(cx)
+                .unwrap_or_else(|| {
+                    self.render_error_callout(
+                        "No Model Selected",
+                        "Select a model from the model picker below to get started.".into(),
+                        false,
+                        false,
+                        cx,
+                    )
+                }),
             ThreadError::ApiError { provider } => self.render_error_callout(
                 "API Error",
                 format!(
@@ -10776,6 +10780,74 @@ impl ThreadView {
                 )
             })
             .dismiss_action(self.dismiss_error_button(cx))
+    }
+
+    fn render_model_not_available_error(&self, cx: &mut Context<Self>) -> Option<Callout> {
+        let thread = self.as_native_thread(cx)?;
+
+        let (title, description): (SharedString, SharedString) =
+            match thread.read(cx).thread_model() {
+                agent::ThreadModel::Ready(_) => { dbg!("MODEL Ready"); return None },
+                agent::ThreadModel::Unresolved(selected_model) => {
+                    if let Some(provider) = LanguageModelRegistry::global(cx)
+                        .read(cx)
+                        .provider(&&selected_model.provider)
+                    {
+                        if !provider.is_authenticated(cx) {
+                            (
+                                format!("Failed to authenticate with {} provider", provider.name())
+                                    .into(),
+                                "Open the settings to configure the selected provider".into(),
+                            )
+                        } else {
+                            (
+                                format!("Model {} was not found", selected_model.model.0).into(),
+                                "You may need to reconfigure authentication for this provider"
+                                    .into(),
+                            )
+                        }
+                    } else {
+                        (
+                            format!("Provider {} was not found", selected_model.provider).into(),
+                            "Open the settings to configure providers".into(),
+                        )
+                    }
+                }
+                agent::ThreadModel::Unset => (
+                    "No model selected".into(),
+                    "Select a model from the model picker below to get started.".into(),
+                ),
+            };
+
+        let callout = Callout::new()
+            .severity(Severity::Error)
+            .icon(IconName::XCircle)
+            .title(title)
+            .description(description)
+            .actions_slot(
+                h_flex()
+                    .gap_0p5()
+                    .child(self.open_llm_providers_settings_button(cx)),
+            )
+            .dismiss_action(self.dismiss_error_button(cx));
+
+        Some(callout)
+    }
+
+    fn open_llm_providers_settings_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        Button::new("configure-llm-provider", "Configure")
+            .label_size(LabelSize::Small)
+            .style(ButtonStyle::Filled)
+            .on_click(cx.listener(|this, _, window, cx| {
+                this.clear_thread_error(cx);
+                window.dispatch_action(
+                    Box::new(zed_actions::OpenSettingsAt {
+                        path: "llm_providers".to_string(),
+                        target: None,
+                    }),
+                    cx,
+                );
+            }))
     }
 
     fn render_prompt_too_large_error(&self, cx: &mut Context<Self>) -> Callout {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -10785,6 +10785,9 @@ impl ThreadView {
     fn render_model_not_available_error(&self, cx: &mut Context<Self>) -> Option<Callout> {
         let thread = self.as_native_thread(cx)?;
 
+        let has_authenticated_provider =
+            LanguageModelRegistry::read_global(cx).has_authenticated_provider(cx);
+
         let (title, description): (SharedString, SharedString) =
             match thread.read(cx).thread_model() {
                 agent::ThreadModel::Ready(_) => return None,
@@ -10813,10 +10816,20 @@ impl ThreadView {
                         )
                     }
                 }
-                agent::ThreadModel::Unset => (
-                    "No model selected".into(),
-                    "Select a model from the model picker below to get started.".into(),
-                ),
+                agent::ThreadModel::Unset => {
+                    if has_authenticated_provider {
+                        (
+                            "No model selected".into(),
+                            "Choose a different model or configure other providers to get started"
+                                .into(),
+                        )
+                    } else {
+                        (
+                            "No model selected".into(),
+                            "Configure a provider to get started".into(),
+                        )
+                    }
+                }
             };
 
         let callout = Callout::new()
@@ -10827,7 +10840,10 @@ impl ThreadView {
             .actions_slot(
                 h_flex()
                     .gap_0p5()
-                    .child(self.open_llm_providers_settings_button(cx)),
+                    .child(self.open_llm_providers_settings_button(cx))
+                    .when(has_authenticated_provider, |this| {
+                        this.child(self.open_model_selector_button(cx))
+                    }),
             )
             .dismiss_action(self.dismiss_error_button(cx));
 
@@ -10835,7 +10851,7 @@ impl ThreadView {
     }
 
     fn open_llm_providers_settings_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        Button::new("configure-llm-provider", "Configure")
+        Button::new("configure-llm-provider", "Configure Provider")
             .label_size(LabelSize::Small)
             .style(ButtonStyle::Filled)
             .on_click(cx.listener(|this, _, window, cx| {
@@ -10847,6 +10863,16 @@ impl ThreadView {
                     }),
                     cx,
                 );
+            }))
+    }
+
+    fn open_model_selector_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        Button::new("open-model-selector", "Select Model")
+            .label_size(LabelSize::Small)
+            .style(ButtonStyle::Filled)
+            .on_click(cx.listener(|this, _, window, cx| {
+                this.clear_thread_error(cx);
+                window.dispatch_action(ToggleModelSelector.boxed_clone(), cx);
             }))
     }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -10787,7 +10787,7 @@ impl ThreadView {
 
         let (title, description): (SharedString, SharedString) =
             match thread.read(cx).thread_model() {
-                agent::ThreadModel::Ready(_) => { dbg!("MODEL Ready"); return None },
+                agent::ThreadModel::Ready(_) => return None,
                 agent::ThreadModel::Unresolved(selected_model) => {
                     if let Some(provider) = LanguageModelRegistry::global(cx)
                         .read(cx)

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -924,6 +924,20 @@ impl ThreadView {
                     cx.notify();
                 },
             ));
+
+            // A "no model selected" error is stale as soon as the thread has a
+            // usable model
+            if let Some(native_thread) = native_connection.thread(thread.read(cx).session_id(), cx)
+            {
+                subscriptions.push(cx.subscribe(
+                    &native_thread,
+                    |this: &mut Self, _thread, _event: &agent::ModelChanged, cx| {
+                        if matches!(this.thread_error, Some(ThreadError::NoModelSelected)) {
+                            this.clear_thread_error(cx);
+                        }
+                    },
+                ));
+            }
         }
 
         subscriptions.push(cx.observe(&message_editor, |this, editor, cx| {
@@ -10585,17 +10599,6 @@ impl ThreadView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Div> {
-        // A "no model selected" error is stale once the thread has a usable
-        // model
-        if matches!(self.thread_error, Some(ThreadError::NoModelSelected))
-            && self.as_native_thread(cx).is_some_and(|thread| {
-                matches!(thread.read(cx).thread_model(), agent::ThreadModel::Ready(_))
-            })
-        {
-            self.clear_thread_error(cx);
-            return None;
-        }
-
         let callout = match self.thread_error.as_ref()? {
             ThreadError::Other { message, .. } => {
                 self.render_any_thread_error(message.clone(), window, cx)

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -10585,6 +10585,17 @@ impl ThreadView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Div> {
+        // A "no model selected" error is stale once the thread has a usable
+        // model
+        if matches!(self.thread_error, Some(ThreadError::NoModelSelected))
+            && self.as_native_thread(cx).is_some_and(|thread| {
+                matches!(thread.read(cx).thread_model(), agent::ThreadModel::Ready(_))
+            })
+        {
+            self.clear_thread_error(cx);
+            return None;
+        }
+
         let callout = match self.thread_error.as_ref()? {
             ThreadError::Other { message, .. } => {
                 self.render_any_thread_error(message.clone(), window, cx)

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -10853,7 +10853,7 @@ impl ThreadView {
             .description(description)
             .actions_slot(
                 h_flex()
-                    .gap_0p5()
+                    .gap_1()
                     .child(self.open_llm_providers_settings_button(cx))
                     .when(has_authenticated_provider, |this| {
                         this.child(self.open_model_selector_button(cx))
@@ -10884,6 +10884,7 @@ impl ThreadView {
         Button::new("open-model-selector", "Select Model")
             .label_size(LabelSize::Small)
             .style(ButtonStyle::Filled)
+            .key_binding(KeyBinding::for_action(&ToggleModelSelector, cx))
             .on_click(cx.listener(|this, _, window, cx| {
                 this.clear_thread_error(cx);
                 window.dispatch_action(ToggleModelSelector.boxed_clone(), cx);

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -363,11 +363,30 @@ impl LanguageModelRegistry {
         self.default_model = model;
     }
 
-    pub fn set_environment_fallback_model(
-        &mut self,
-        model: Option<ConfiguredModel>,
-        cx: &mut Context<Self>,
-    ) {
+    pub fn refresh_fallback_model(&mut self, cx: &mut Context<Self>) {
+        // If the fallback model was already set or we don't want to use it, do nothing
+        if !self.should_use_fallback || self.available_fallback_model.is_some() {
+            return;
+        }
+
+        let fallback_model = self
+            .providers()
+            .iter()
+            .filter(|provider| provider.is_authenticated(cx))
+            .find_map(|provider| {
+                let model = provider
+                    .default_model(cx)
+                    .or_else(|| provider.recommended_models(cx).first().cloned())?;
+                Some(ConfiguredModel {
+                    provider: provider.clone(),
+                    model,
+                })
+            });
+
+        self.set_fallback_model(fallback_model, cx);
+    }
+
+    fn set_fallback_model(&mut self, model: Option<ConfiguredModel>, cx: &mut Context<Self>) {
         if self.default_model.is_none() {
             match (self.available_fallback_model.as_ref(), model.as_ref()) {
                 (Some(old), Some(new)) if old.is_same_as(new) => {}
@@ -627,7 +646,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_configure_environment_fallback_model(cx: &mut gpui::TestAppContext) {
+    async fn test_configure_fallback_model(cx: &mut gpui::TestAppContext) {
         let registry = cx.new(|_| LanguageModelRegistry::default());
 
         let provider = Arc::new(FakeLanguageModelProvider::default());
@@ -641,7 +660,7 @@ mod tests {
             let provider = registry.provider(&provider.id()).unwrap();
             let model = provider.default_model(cx).unwrap();
 
-            registry.set_environment_fallback_model(
+            registry.set_fallback_model(
                 Some(ConfiguredModel {
                     provider: provider.clone(),
                     model: model.clone(),

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -668,6 +668,10 @@ mod tests {
                 cx,
             );
 
+            assert!(registry.default_model().is_none());
+
+            registry.set_should_use_fallback(true);
+
             let default_model = registry.default_model().unwrap();
             assert_eq!(default_model.model.id(), model.id());
             assert_eq!(default_model.provider.id(), provider.id());

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -44,6 +44,8 @@ impl std::fmt::Debug for ConfigurationError {
 
 #[derive(Default)]
 pub struct LanguageModelRegistry {
+    /// True if the user has *NO* default model configured in settings
+    should_use_fallback: bool,
     default_model: Option<ConfiguredModel>,
     /// This model is automatically configured by a user's environment after
     /// authenticating all providers. It's only used when `default_model` is not set.
@@ -149,6 +151,10 @@ impl LanguageModelRegistry {
     #[cfg(any(test, feature = "test-support"))]
     pub fn fake_model(&self) -> Arc<dyn LanguageModel> {
         self.default_model.as_ref().unwrap().model.clone()
+    }
+
+    pub fn set_should_use_fallback(&mut self, value: bool) {
+        self.should_use_fallback = value;
     }
 
     pub fn register_provider<T: LanguageModelProvider + LanguageModelProviderState>(
@@ -417,9 +423,13 @@ impl LanguageModelRegistry {
             return None;
         }
 
-        self.default_model
-            .clone()
-            .or_else(|| self.available_fallback_model.clone())
+        self.default_model.clone().or_else(|| {
+            if self.should_use_fallback {
+                self.available_fallback_model.clone()
+            } else {
+                None
+            }
+        })
     }
 
     pub fn default_fast_model(&self, cx: &App) -> Option<ConfiguredModel> {

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -169,6 +169,8 @@ pub fn update_environment_fallback_model(cx: &mut App) {
                 .iter()
                 .filter(|provider| provider.is_authenticated(cx))
                 .find_map(|provider| {
+                    dbg!(provider.id());
+                    dbg!(provider.recommended_models(cx).len());
                     let model = provider
                         .default_model(cx)
                         .or_else(|| provider.recommended_models(cx).first().cloned())?;
@@ -179,6 +181,8 @@ pub fn update_environment_fallback_model(cx: &mut App) {
                 })
         }
     };
+
+    dbg!(&fallback_model.as_ref().map(|s| (s.model.id(), s.provider.id())));
     registry.update(cx, |registry, cx| {
         registry.set_environment_fallback_model(fallback_model, cx);
     });

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -5,9 +5,7 @@ use client::{Client, UserStore};
 use collections::{HashMap, HashSet};
 use credentials_provider::CredentialsProvider;
 use gpui::{App, Context, Entity};
-use language_model::{
-    ConfiguredModel, LanguageModelProviderId, LanguageModelRegistry, ZED_CLOUD_PROVIDER_ID,
-};
+use language_model::{LanguageModelProviderId, LanguageModelRegistry};
 use provider::deepseek::DeepSeekLanguageModelProvider;
 
 pub mod extension;
@@ -138,54 +136,6 @@ pub fn init(user_store: Entity<UserStore>, client: Arc<Client>, cx: &mut App) {
         }
     })
     .detach();
-}
-
-/// Recomputes and sets the [`LanguageModelRegistry`]'s environment fallback
-/// model based on currently authenticated providers.
-///
-/// Prefers the Zed cloud provider so that, once the user is signed in, we
-/// always pick a Zed-hosted model over models from other authenticated
-/// providers in the environment. If the Zed cloud provider is authenticated
-/// but hasn't finished loading its models yet, we don't fall back to another
-/// provider to avoid flickering between providers during sign in.
-pub fn update_environment_fallback_model(cx: &mut App) {
-    let registry = LanguageModelRegistry::global(cx);
-    let fallback_model = {
-        let registry = registry.read(cx);
-        let cloud_provider = registry.provider(&ZED_CLOUD_PROVIDER_ID);
-        if cloud_provider
-            .as_ref()
-            .is_some_and(|provider| provider.is_authenticated(cx))
-        {
-            cloud_provider.and_then(|provider| {
-                let model = provider
-                    .default_model(cx)
-                    .or_else(|| provider.recommended_models(cx).first().cloned())?;
-                Some(ConfiguredModel { provider, model })
-            })
-        } else {
-            registry
-                .providers()
-                .iter()
-                .filter(|provider| provider.is_authenticated(cx))
-                .find_map(|provider| {
-                    dbg!(provider.id());
-                    dbg!(provider.recommended_models(cx).len());
-                    let model = provider
-                        .default_model(cx)
-                        .or_else(|| provider.recommended_models(cx).first().cloned())?;
-                    Some(ConfiguredModel {
-                        provider: provider.clone(),
-                        model,
-                    })
-                })
-        }
-    };
-
-    dbg!(&fallback_model.as_ref().map(|s| (s.model.id(), s.provider.id())));
-    registry.update(cx, |registry, cx| {
-        registry.set_environment_fallback_model(fallback_model, cx);
-    });
 }
 
 #[derive(Default, PartialEq, Eq)]


### PR DESCRIPTION
This PR improves the onboarding experience when using the agent panel.
Previously we would pick a fallback model in case the provider failed to authenticate/was slow to resolve models. However, this code had a race condition (for providers that resolve models dynamically like Anthropic/GitHub Copilot), since we pick a fallback immediately after all providers have been authenticated. However, at that point the configured provider might not have resolved its models, so we would fall back to a different provider. At some point we added a workaround for the zed.dev provider.
We landed on a much simpler approach that eliminates the race condition: We only pick a fallback model in case the user actually has no model configured in his settings. In case the user has a model configured, we won't fallback and show an actionable error message:

1. Model is not set and no fallback available

<img width="862" height="78" alt="image" src="https://github.com/user-attachments/assets/e8e7472a-1c05-4cd2-8efc-49e6d921b0a4" />

2. Model is set, but provider is not authenticated

<img width="865" height="65" alt="image" src="https://github.com/user-attachments/assets/3c8cbf1d-7dd5-4b2e-809a-61e6662721a3" />

3. Model is set, provider is authenticated, but model is not in model list

<img width="863" height="63" alt="image" src="https://github.com/user-attachments/assets/b97defa2-3fb4-4ec0-b3c6-26878d1c815c" />

4. Model is set, but provider is not recognised

<img width="865" height="67" alt="image" src="https://github.com/user-attachments/assets/ecff1e3f-4f6b-47eb-a25d-125a104baafc" />



This plays well with the reason why we have the fallback model in the first place: We only want to pick a fallback for users that open Zed for a first time and e.g. have an Anthropic API key present in their environment. As soon as the user manually changes his provider/model we won't apply the fallback anymore.



Release Notes:

- agent: Improved error messaging when provider is not configured
- agent: Improve fallback model selection
