### PR TITLE
acp: Support boolean ACP config options

### DIFF
--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -772,21 +772,20 @@ fn client_capabilities_for_agent(
             .write_text_file(true))
         .terminal(true)
         .auth(acp::AuthCapabilities::new().terminal(true))
+        .session(
+            acp::ClientSessionCapabilities::new().config_options(
+                acp::SessionConfigOptionsCapabilities::new()
+                    .boolean(acp::BooleanConfigOptionCapabilities::new()),
+            ),
+        )
         .meta(meta);
 
     if supports_beta_features {
-        capabilities = capabilities
-            .elicitation(
-                acp::ElicitationCapabilities::new()
-                    .form(acp::ElicitationFormCapabilities::new())
-                    .url(acp::ElicitationUrlCapabilities::new()),
-            )
-            .session(
-                acp::ClientSessionCapabilities::new().config_options(
-                    acp::SessionConfigOptionsCapabilities::new()
-                        .boolean(acp::BooleanConfigOptionCapabilities::new()),
-                ),
-            );
+        capabilities = capabilities.elicitation(
+            acp::ElicitationCapabilities::new()
+                .form(acp::ElicitationFormCapabilities::new())
+                .url(acp::ElicitationUrlCapabilities::new()),
+        );
     }
 
     capabilities
@@ -1300,7 +1299,6 @@ impl AcpConnection {
         cx: &mut AsyncApp,
     ) {
         let id = self.id.clone();
-        let apply_boolean_defaults = cx.update(|cx| cx.has_flag::<AcpBetaFeatureFlag>());
         let defaults_to_apply: Vec<_> = {
             let config_opts_ref = config_options.borrow();
             config_opts_ref
@@ -1332,9 +1330,6 @@ impl AcpConnection {
                                     }),
                                 _ => None,
                             }
-                        }
-                        acp::SessionConfigKind::Boolean(_) if !apply_boolean_defaults => {
-                            return None;
                         }
                         acp::SessionConfigKind::Boolean(_) => default_value
                             .as_bool()
@@ -3045,8 +3040,8 @@ mod tests {
     }
 
     #[test]
-    fn client_capabilities_include_boolean_config_options_when_supported() {
-        let capabilities = client_capabilities_for_agent(&AgentId::new("codex-acp"), true);
+    fn client_capabilities_include_boolean_config_options() {
+        let capabilities = client_capabilities_for_agent(&AgentId::new("codex-acp"), false);
 
         assert!(
             capabilities
@@ -3055,13 +3050,6 @@ mod tests {
                 .and_then(|config_options| config_options.boolean)
                 .is_some()
         );
-    }
-
-    #[test]
-    fn client_capabilities_omit_boolean_config_options_when_unsupported() {
-        let capabilities = client_capabilities_for_agent(&AgentId::new("codex-acp"), false);
-
-        assert!(capabilities.session.is_none());
     }
 
     #[test]
@@ -3549,69 +3537,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn default_config_options_skip_boolean_defaults_when_acp_beta_is_disabled(
-        cx: &mut gpui::TestAppContext,
-    ) {
-        cx.update(|cx| init_settings_with_acp_beta_override(false, cx));
-
-        let (connection, set_config_requests) = connect_config_defaults_test_agent(cx).await;
-        connection.defaults.set(
-            None,
-            HashMap::from_iter([
-                (
-                    "web_search".to_string(),
-                    AgentConfigOptionValue::Boolean(true),
-                ),
-                ("mode".to_string(), AgentConfigOptionValue::from("manual")),
-            ]),
-        );
-        let config_options = Rc::new(RefCell::new(vec![
-            acp::SessionConfigOption::boolean("web_search", "Web Search", false),
-            acp::SessionConfigOption::select(
-                "mode",
-                "Mode",
-                "auto",
-                vec![
-                    acp::SessionConfigSelectOption::new("auto", "Auto"),
-                    acp::SessionConfigSelectOption::new("manual", "Manual"),
-                ],
-            ),
-        ]));
-
-        let mut async_cx = cx.to_async();
-        connection.apply_default_config_options(
-            &acp::SessionId::new("session-config-defaults"),
-            &config_options,
-            &mut async_cx,
-        );
-        drop(async_cx);
-        cx.run_until_parked();
-
-        let requests = set_config_requests
-            .lock()
-            .expect("set config requests mutex poisoned");
-        assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].config_id, acp::SessionConfigId::new("mode"));
-        assert_eq!(
-            requests[0].value,
-            acp::SessionConfigOptionValue::value_id("manual")
-        );
-
-        let options = config_options.borrow();
-        assert!(
-            matches!(&options[0].kind, acp::SessionConfigKind::Boolean(boolean) if !boolean.current_value)
-        );
-        assert!(
-            matches!(&options[1].kind, acp::SessionConfigKind::Select(select) if select.current_value == acp::SessionConfigValueId::new("manual"))
-        );
-    }
-
-    #[gpui::test]
-    async fn default_config_options_apply_boolean_defaults_when_acp_beta_is_enabled(
-        cx: &mut gpui::TestAppContext,
-    ) {
-        cx.update(|cx| init_settings_with_acp_beta_override(true, cx));
-
+    async fn default_config_options_apply_boolean_defaults(cx: &mut gpui::TestAppContext) {
         let (connection, set_config_requests) = connect_config_defaults_test_agent(cx).await;
         connection.defaults.set(
             None,
@@ -3652,19 +3578,6 @@ mod tests {
         assert!(
             matches!(&options[0].kind, acp::SessionConfigKind::Boolean(boolean) if boolean.current_value)
         );
-    }
-
-    fn init_settings_with_acp_beta_override(enabled: bool, cx: &mut App) {
-        let mut store = settings::SettingsStore::test(cx);
-        store.register_setting::<feature_flags::FeatureFlagsSettings>();
-        store.update_user_settings(cx, |content| {
-            content.feature_flags.get_or_insert_default().insert(
-                AcpBetaFeatureFlag::NAME.to_string(),
-                if enabled { "on" } else { "off" }.to_string(),
-            );
-        });
-        cx.set_global(store);
-        cx.update_flags(false, Vec::new());
     }
 
     async fn connect_config_defaults_test_agent(

--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -5,7 +5,6 @@ use agent_client_protocol::schema::v1 as acp;
 use agent_servers::AgentServer;
 
 use collections::HashSet;
-use feature_flags::{AcpBetaFeatureFlag, FeatureFlagAppExt as _};
 use fs::Fs;
 use fuzzy::StringMatchCandidate;
 use gpui::{
@@ -99,9 +98,8 @@ impl ConfigOptionsView {
         favorites_only: bool,
         cx: &mut Context<Self>,
     ) -> bool {
-        let render_boolean_config_options = should_render_boolean_config_options(cx);
         let Some(config_id) = self.first_config_option_id_matching(category, |option| {
-            Self::can_cycle_config_option(option, favorites_only, render_boolean_config_options)
+            Self::can_cycle_config_option(option, favorites_only)
         }) else {
             return false;
         };
@@ -147,11 +145,10 @@ impl ConfigOptionsView {
     fn can_cycle_config_option(
         option: &acp::SessionConfigOption,
         favorites_only: bool,
-        render_boolean_config_options: bool,
     ) -> bool {
         match &option.kind {
             acp::SessionConfigKind::Select(_) => true,
-            acp::SessionConfigKind::Boolean(_) => !favorites_only && render_boolean_config_options,
+            acp::SessionConfigKind::Boolean(_) => !favorites_only,
             _ => false,
         }
     }
@@ -213,7 +210,7 @@ impl ConfigOptionsView {
                 ))
             }
             acp::SessionConfigKind::Boolean(boolean) => {
-                if favorites_only || !should_render_boolean_config_options(cx) {
+                if favorites_only {
                     None
                 } else {
                     Some(acp::SessionConfigOptionValue::boolean(
@@ -545,10 +542,6 @@ impl Render for ConfigOptionSelector {
                 .into_any_element()
             }
             acp::SessionConfigKind::Boolean(boolean) => {
-                if !should_render_boolean_config_options(cx) {
-                    return div().into_any_element();
-                }
-
                 let option_id = option.id.clone();
                 let option_name: SharedString = option.name.clone().into();
                 let option_description: Option<SharedString> =
@@ -991,10 +984,6 @@ fn setting_value_for_config_option_value(
     }
 }
 
-fn should_render_boolean_config_options(cx: &App) -> bool {
-    cx.has_flag::<AcpBetaFeatureFlag>()
-}
-
 fn options_to_picker_entries(
     options: &[ConfigOptionValue],
     favorites: &HashSet<acp::SessionConfigValueId>,
@@ -1110,9 +1099,8 @@ fn count_config_options(option: &acp::SessionConfigOption) -> usize {
 mod tests {
     use super::*;
     use acp_thread::AgentConnection;
-    use feature_flags::FeatureFlag as _;
     use fs::FakeFs;
-    use gpui::{TestAppContext, UpdateGlobal};
+    use gpui::TestAppContext;
     use parking_lot::Mutex;
     use project::{AgentId, Project};
     use std::{any::Any, cell::RefCell};
@@ -1178,9 +1166,6 @@ mod tests {
         let fs: Arc<dyn Fs> = FakeFs::new(cx.executor());
 
         cx.update(|cx| {
-            init_feature_flag_settings(cx);
-            set_feature_flag_override(AcpBetaFeatureFlag::NAME, "on", cx);
-
             let config_options: Rc<dyn AgentSessionConfigOptions> = config_options.clone();
             let agent_server: Rc<dyn AgentServer> = agent_server.clone();
             let fs = fs.clone();
@@ -1215,41 +1200,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn cycling_hidden_boolean_config_option_is_unhandled(cx: &mut TestAppContext) {
-        let agent_server = Rc::new(TestAgentServer::default());
-        let config_options = Rc::new(TestSessionConfigOptions::new(vec![
-            acp::SessionConfigOption::boolean("web_search", "Web Search", false)
-                .category(acp::SessionConfigOptionCategory::ModelConfig),
-        ]));
-        let fs: Arc<dyn Fs> = FakeFs::new(cx.executor());
-
-        cx.update(|cx| {
-            init_feature_flag_settings(cx);
-            set_feature_flag_override(AcpBetaFeatureFlag::NAME, "off", cx);
-
-            let config_options: Rc<dyn AgentSessionConfigOptions> = config_options.clone();
-            let agent_server: Rc<dyn AgentServer> = agent_server.clone();
-            let fs = fs.clone();
-            let view = cx.new(|_| ConfigOptionsView {
-                config_option_ids: ConfigOptionsView::config_option_ids(&config_options),
-                config_options,
-                selectors: Vec::new(),
-                agent_server,
-                fs,
-                _refresh_task: Task::ready(()),
-            });
-
-            assert!(!view.update(cx, |view, cx| {
-                view.cycle_category_option(acp::SessionConfigOptionCategory::ModelConfig, false, cx)
-            }));
-        });
-
-        assert!(agent_server.saved_defaults.lock().is_empty());
-        assert!(config_options.set_values.borrow().is_empty());
-    }
-
-    #[gpui::test]
-    fn cycling_category_skips_hidden_boolean_config_option(cx: &mut TestAppContext) {
+    fn cycling_category_cycles_boolean_config_option_first(cx: &mut TestAppContext) {
         let agent_server = Rc::new(TestAgentServer::default());
         let config_options = Rc::new(TestSessionConfigOptions::new(vec![
             acp::SessionConfigOption::boolean("web_search", "Web Search", false)
@@ -1268,9 +1219,6 @@ mod tests {
         let fs: Arc<dyn Fs> = FakeFs::new(cx.executor());
 
         cx.update(|cx| {
-            init_feature_flag_settings(cx);
-            set_feature_flag_override(AcpBetaFeatureFlag::NAME, "off", cx);
-
             let config_options: Rc<dyn AgentSessionConfigOptions> = config_options.clone();
             let agent_server: Rc<dyn AgentServer> = agent_server.clone();
             let fs = fs.clone();
@@ -1291,15 +1239,15 @@ mod tests {
         assert_eq!(
             agent_server.saved_defaults.lock().as_slice(),
             &[(
-                "model".to_string(),
-                Some(AgentConfigOptionValue::ValueId("large".to_string()))
+                "web_search".to_string(),
+                Some(AgentConfigOptionValue::Boolean(true))
             )]
         );
         assert_eq!(
             config_options.set_values.borrow().as_slice(),
             &[(
-                "model".to_string(),
-                acp::SessionConfigOptionValue::value_id("large")
+                "web_search".to_string(),
+                acp::SessionConfigOptionValue::boolean(true)
             )]
         );
     }
@@ -1330,43 +1278,9 @@ mod tests {
         assert!(!handled);
     }
 
-    #[gpui::test]
-    fn boolean_config_option_rendering_is_beta_gated(cx: &mut TestAppContext) {
-        cx.update(|cx| {
-            init_feature_flag_settings(cx);
-
-            cx.update_flags(false, Vec::new());
-            set_feature_flag_override(AcpBetaFeatureFlag::NAME, "off", cx);
-            assert!(!should_render_boolean_config_options(cx));
-
-            set_feature_flag_override(AcpBetaFeatureFlag::NAME, "on", cx);
-            assert!(should_render_boolean_config_options(cx));
-        });
-    }
-
     #[derive(Default)]
     struct TestAgentServer {
         saved_defaults: Arc<Mutex<Vec<(String, Option<AgentConfigOptionValue>)>>>,
-    }
-
-    fn init_feature_flag_settings(cx: &mut App) {
-        let store = SettingsStore::test(cx);
-        cx.set_global(store);
-        SettingsStore::update_global(cx, |store, _| {
-            store.register_setting::<feature_flags::FeatureFlagsSettings>();
-        });
-        cx.update_flags(false, Vec::new());
-    }
-
-    fn set_feature_flag_override(name: &str, value: &str, cx: &mut App) {
-        SettingsStore::update_global(cx, |store, cx| {
-            store.update_user_settings(cx, |content| {
-                content
-                    .feature_flags
-                    .get_or_insert_default()
-                    .insert(name.to_string(), value.to_string());
-            });
-        });
     }
 
     impl AgentServer for TestAgentServer {

--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -142,10 +142,7 @@ impl ConfigOptionsView {
             .map(|option| option.id)
     }
 
-    fn can_cycle_config_option(
-        option: &acp::SessionConfigOption,
-        favorites_only: bool,
-    ) -> bool {
+    fn can_cycle_config_option(option: &acp::SessionConfigOption, favorites_only: bool) -> bool {
         match &option.kind {
             acp::SessionConfigKind::Select(_) => true,
             acp::SessionConfigKind::Boolean(_) => !favorites_only,


### PR DESCRIPTION
Removing the feature flag now that the API is stable.

Release Notes:

- acp: Support boolean toggles for ACP session configuration in agents that use them.
