### PR TITLE
Better "Restart to Update" button dismissals

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -180,6 +180,7 @@ pub struct AutoUpdater {
     pending_poll: Option<Task<Option<()>>>,
     quit_subscription: Option<gpui::Subscription>,
     update_check_type: UpdateCheckType,
+    dismissed_status: Option<AutoUpdateStatus>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -426,6 +427,7 @@ impl AutoUpdater {
             pending_poll: None,
             quit_subscription,
             update_check_type: UpdateCheckType::Automatic,
+            dismissed_status: None,
         }
     }
 
@@ -458,6 +460,9 @@ impl AutoUpdater {
     }
 
     pub fn poll(&mut self, check_type: UpdateCheckType, cx: &mut Context<Self>) {
+        if check_type.is_manual() {
+            self.dismissed_status = None;
+        }
         if self.pending_poll.is_some() {
             if self.update_check_type == UpdateCheckType::Automatic {
                 self.update_check_type = check_type;
@@ -509,6 +514,15 @@ impl AutoUpdater {
 
     pub fn status(&self) -> AutoUpdateStatus {
         self.status.clone()
+    }
+
+    pub fn dismissed_status(&self) -> Option<AutoUpdateStatus> {
+        self.dismissed_status.clone()
+    }
+
+    pub fn dismiss_status(&mut self, status: AutoUpdateStatus, cx: &mut Context<Self>) {
+        self.dismissed_status = Some(status);
+        cx.notify();
     }
 
     pub fn dismiss(&mut self, cx: &mut Context<Self>) -> bool {

--- a/crates/title_bar/src/update_version.rs
+++ b/crates/title_bar/src/update_version.rs
@@ -9,31 +9,30 @@ use ui::{UpdateButton, prelude::*};
 pub struct UpdateVersion {
     status: AutoUpdateStatus,
     update_check_type: UpdateCheckType,
-    dismissed: bool,
+    dismissed_status: Option<AutoUpdateStatus>,
 }
 
 impl UpdateVersion {
     pub fn new(cx: &mut Context<Self>) -> Self {
         if let Some(auto_updater) = AutoUpdater::get(cx) {
             cx.observe(&auto_updater, |this, auto_update, cx| {
-                this.status = auto_update.read(cx).status();
-                this.update_check_type = auto_update.read(cx).update_check_type();
-                if this.status.is_updated() {
-                    this.dismissed = false;
-                }
+                let auto_update = auto_update.read(cx);
+                this.status = auto_update.status();
+                this.update_check_type = auto_update.update_check_type();
+                this.dismissed_status = auto_update.dismissed_status();
                 cx.notify();
             })
             .detach();
             Self {
                 status: auto_updater.read(cx).status(),
                 update_check_type: UpdateCheckType::Automatic,
-                dismissed: false,
+                dismissed_status: auto_updater.read(cx).dismissed_status(),
             }
         } else {
             Self {
                 status: AutoUpdateStatus::Idle,
                 update_check_type: UpdateCheckType::Automatic,
-                dismissed: false,
+                dismissed_status: None,
             }
         }
     }
@@ -59,12 +58,27 @@ impl UpdateVersion {
 
         self.status = next_state;
         self.update_check_type = UpdateCheckType::Manual;
-        self.dismissed = false;
+        self.dismissed_status = None;
         cx.notify()
     }
 
     pub fn show_update_in_menu_bar(&self) -> bool {
-        self.dismissed && self.status.is_updated()
+        self.is_dismissed() && self.status.is_updated()
+    }
+
+    fn is_dismissed(&self) -> bool {
+        self.dismissed_status.as_ref() == Some(&self.status)
+    }
+
+    fn dismiss(&mut self, cx: &mut Context<Self>) {
+        self.dismissed_status = Some(self.status.clone());
+        if let Some(auto_updater) = AutoUpdater::get(cx) {
+            let status = self.status.clone();
+            auto_updater.update(cx, |auto_updater, cx| {
+                auto_updater.dismiss_status(status, cx)
+            });
+        }
+        cx.notify()
     }
 
     fn version_tooltip_message(version: &Version) -> String {
@@ -74,7 +88,7 @@ impl UpdateVersion {
 
 impl Render for UpdateVersion {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        if self.dismissed {
+        if self.is_dismissed() {
             return Empty.into_any_element();
         }
         match &self.status {
@@ -95,10 +109,7 @@ impl Render for UpdateVersion {
                     .on_click(|_, _, cx| {
                         workspace::reload(cx);
                     })
-                    .on_dismiss(cx.listener(|this, _, _window, cx| {
-                        this.dismissed = true;
-                        cx.notify()
-                    }))
+                    .on_dismiss(cx.listener(|this, _, _window, cx| this.dismiss(cx)))
                     .into_any_element()
             }
             AutoUpdateStatus::Errored { error } => {
@@ -107,10 +118,7 @@ impl Render for UpdateVersion {
                     .on_click(|_, window, cx| {
                         window.dispatch_action(Box::new(workspace::OpenLog), cx);
                     })
-                    .on_dismiss(cx.listener(|this, _, _window, cx| {
-                        this.dismissed = true;
-                        cx.notify()
-                    }))
+                    .on_dismiss(cx.listener(|this, _, _window, cx| this.dismiss(cx)))
                     .into_any_element()
             }
             AutoUpdateStatus::Idle | AutoUpdateStatus::Checking { .. } => Empty.into_any_element(),


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/59994 deals with 

<img width="173" height="39" alt="restart to update" src="https://github.com/user-attachments/assets/5209e15b-cbf9-4530-b0da-7326c8131448" />

button overly appearing.

The PR mentioned fixed the redownload issue, but the title bar code re-surfaced the button on every update check as `is_updated` in this semantics means a new Nightly update is ready to be installed: https://github.com/zed-industries/zed/blob/159246f0083787124160620118ac35df5f0f3754/crates/auto_update/src/auto_update.rs#L171-L173 and the old code used this as "can show the button again" reason after each recheck.

Instead, track dismissed update state better both in the title bar and the global auto updater, so no new version checks can trigger this and no new Zed windows get this button again (as it is now).

Release Notes:

- Improved "Restart to Update" button dismissals
