### PR TITLE
acp: Set agent as default when installing it from registry

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -26,7 +26,7 @@ use zed_actions::{
     agent::{
         AddSelectionToThread, ConflictContent, LogoutAgent, OpenSettings, ReauthenticateAgent,
         ResetAgentZoom, ResetOnboarding, ResolveConflictedFilesWithAgent,
-        ResolveConflictsWithAgent, ReviewBranchDiff,
+        ResolveConflictsWithAgent, ReviewBranchDiff, SelectAgent,
     },
     assistant::{
         FocusAgent, ManageSkills, OpenGlobalAgentsMdRules, OpenProjectAgentsMdRules, Toggle,
@@ -420,6 +420,14 @@ pub fn init(cx: &mut App) {
                         workspace.focus_panel::<AgentPanel>(window, cx);
                         panel.update(cx, |panel, cx| {
                             panel.new_external_agent_thread(action, window, cx);
+                        });
+                    }
+                })
+                .register_action(|workspace, action: &SelectAgent, window, cx| {
+                    if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
+                        panel.update(cx, |panel, cx| {
+                            let agent = AgentId::new(action.agent.clone()).into();
+                            panel.select_agent(agent, window, cx);
                         });
                     }
                 })
@@ -1913,6 +1921,58 @@ impl AgentPanel {
         self.activate_new_thread(true, AgentThreadSource::AgentPanel, window, cx);
     }
 
+    fn set_selected_agent_and_persist(&mut self, agent: Agent, cx: &mut Context<Self>) {
+        if self.selected_agent != agent {
+            self.selected_agent = agent.clone();
+            self.serialize(cx);
+        }
+
+        cx.background_spawn({
+            let kvp = KeyValueStore::global(cx);
+            async move {
+                write_global_last_used_agent(kvp, agent).await;
+            }
+        })
+        .detach();
+    }
+
+    /// Sets the panel's selected agent without opening the panel or focusing
+    /// it, so the agent is launched the next time the panel is opened (or
+    /// right away, if the panel is already showing the empty new-thread
+    /// draft).
+    pub fn select_agent(&mut self, agent: Agent, window: &mut Window, cx: &mut Context<Self>) {
+        if self.project.read(cx).is_via_collab() && !agent.is_native() {
+            return;
+        }
+
+        self.set_selected_agent_and_persist(agent, cx);
+
+        if let Some(draft) = self.draft_thread.clone() {
+            let draft_is_base_view = matches!(
+                &self.base_view,
+                BaseView::AgentThread { conversation_view }
+                    if conversation_view.entity_id() == draft.entity_id()
+            );
+            if draft_is_base_view {
+                // The empty new-thread slot is what the panel shows; retarget
+                // it so the newly selected agent launches in its place.
+                self.activate_draft(false, AgentThreadSource::AgentPanel, window, cx);
+            } else if !self.draft_has_content(&draft, cx)
+                && *draft.read(cx).agent_key() != self.selected_agent
+            {
+                // Drop the stale empty draft so the next panel open creates
+                // one bound to the newly selected agent.
+                let old_draft_id = draft.read(cx).thread_id;
+                ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                    store.delete(old_draft_id, cx);
+                });
+                self.draft_thread = None;
+                self._draft_editor_observation = None;
+            }
+        }
+        cx.notify();
+    }
+
     pub fn new_terminal(
         &mut self,
         workspace: Option<&Workspace>,
@@ -3180,18 +3240,8 @@ impl AgentPanel {
             cx,
         );
         if let Some(original) = saved_selected_agent {
-            if self.selected_agent != original {
-                self.selected_agent = original.clone();
-                self.serialize(cx);
-                // Restore the last-used-agent in persistent storage as well.
-                cx.background_spawn({
-                    let kvp = KeyValueStore::global(cx);
-                    async move {
-                        write_global_last_used_agent(kvp, original).await;
-                    }
-                })
-                .detach();
-            }
+            // Restore the last-used-agent in persistent storage as well.
+            self.set_selected_agent_and_persist(original, cx);
         }
         let thread_id = thread.conversation_view.read(cx).thread_id;
         self.retained_threads
@@ -4501,19 +4551,7 @@ impl AgentPanel {
         let workspace = self.workspace.clone();
         let project = self.project.clone();
 
-        if self.selected_agent != agent {
-            self.selected_agent = agent.clone();
-            self.serialize(cx);
-        }
-
-        cx.background_spawn({
-            let kvp = KeyValueStore::global(cx);
-            let agent = agent.clone();
-            async move {
-                write_global_last_used_agent(kvp, agent).await;
-            }
-        })
-        .detach();
+        self.set_selected_agent_and_persist(agent.clone(), cx);
 
         let server = server_override
             .unwrap_or_else(|| agent.server(self.fs.clone(), self.thread_store.clone()));
@@ -11316,6 +11354,67 @@ mod tests {
                 "new workspace should inherit the global last-used agent"
             );
         });
+    }
+
+    #[gpui::test]
+    async fn test_select_agent_action_selects_without_opening_panel(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs.clone(), [], cx).await;
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        // Dispatched by the onboarding page after installing an external
+        // agent, so the agent launches when the panel is next opened.
+        cx.dispatch_action(SelectAgent {
+            agent: "my-configured-agent".to_string(),
+        });
+        cx.run_until_parked();
+
+        let expected_agent = Agent::Custom {
+            id: "my-configured-agent".into(),
+        };
+
+        panel.read_with(cx, |panel, _cx| {
+            assert_eq!(
+                panel.selected_agent, expected_agent,
+                "the action should update the panel's selected agent"
+            );
+            assert!(
+                panel.active_conversation_view().is_none(),
+                "selecting an agent should not create or open a thread"
+            );
+            assert!(
+                panel.draft_thread.is_none(),
+                "selecting an agent should not create a draft thread"
+            );
+        });
+
+        // The selection is persisted globally so panels loaded later (e.g. in
+        // a new workspace) launch the configured agent.
+        let kvp = cx.update(|_, cx| KeyValueStore::global(cx));
+        assert_eq!(
+            read_global_last_used_agent(&kvp),
+            Some(expected_agent),
+            "the selection should be persisted as the global last-used agent"
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -11371,10 +11371,6 @@ mod tests {
             panel.activate_draft(false, AgentThreadSource::AgentPanel, window, cx);
         });
 
-        let initial_draft_id = panel.read_with(cx, |panel, _cx| {
-            panel.draft_thread.as_ref().unwrap().entity_id()
-        });
-
         cx.dispatch_action(SelectAgent {
             agent: "my-configured-agent".to_string(),
         });
@@ -11386,20 +11382,8 @@ mod tests {
 
         panel.read_with(cx, |panel, cx| {
             let draft = panel.draft_thread.as_ref().expect("draft should exist");
-            assert_ne!(
-                draft.entity_id(),
-                initial_draft_id,
-                "changing agents should replace the visible draft"
-            );
-            assert_eq!(
-                panel.selected_agent, expected_agent,
-                "the action should update the panel's selected agent"
-            );
-            assert_eq!(
-                *draft.read(cx).agent_key(),
-                expected_agent,
-                "the visible draft should use the selected agent"
-            );
+            assert_eq!(panel.selected_agent, expected_agent);
+            assert_eq!(*draft.read(cx).agent_key(), expected_agent);
         });
 
         let kvp = cx.update(|_, cx| KeyValueStore::global(cx));
@@ -11407,65 +11391,6 @@ mod tests {
             read_global_last_used_agent(&kvp),
             Some(expected_agent),
             "the selection should be persisted as the global last-used agent"
-        );
-    }
-
-    #[gpui::test]
-    async fn test_select_agent_action_preserves_visible_thread_selection(cx: &mut TestAppContext) {
-        init_test(cx);
-        let fs = FakeFs::new(cx.executor());
-        cx.update(|cx| {
-            agent::ThreadStore::init_global(cx);
-            language_model::LanguageModelRegistry::test(cx);
-            <dyn fs::Fs>::set_global(fs.clone(), cx);
-        });
-
-        fs.insert_tree("/project", json!({ "file.txt": "" })).await;
-        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
-
-        let multi_workspace =
-            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
-        let workspace = multi_workspace
-            .read_with(cx, |multi_workspace, _cx| {
-                multi_workspace.workspace().clone()
-            })
-            .unwrap();
-        workspace.update(cx, |workspace, _cx| {
-            workspace.set_random_database_id();
-        });
-        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
-
-        let panel = workspace.update_in(cx, |workspace, window, cx| {
-            let panel = cx.new(|cx| AgentPanel::new(workspace, window, cx));
-            workspace.add_panel(panel.clone(), window, cx);
-            panel
-        });
-
-        // Show an existing thread in the panel.
-        open_thread_with_connection(&panel, StubAgentConnection::new(), cx);
-        let thread_agent = panel.read_with(cx, |panel, _cx| panel.selected_agent.clone());
-
-        // Installing an agent (e.g. from onboarding or the ACP registry page)
-        // must not retarget the visible thread or its toolbar icon.
-        cx.dispatch_action(SelectAgent {
-            agent: "newly-installed-agent".to_string(),
-        });
-        cx.run_until_parked();
-
-        panel.read_with(cx, |panel, _cx| {
-            assert_eq!(
-                panel.selected_agent, thread_agent,
-                "selection (and toolbar icon) should keep reflecting the visible thread"
-            );
-        });
-
-        let kvp = cx.update(|_, cx| KeyValueStore::global(cx));
-        assert_ne!(
-            read_global_last_used_agent(&kvp),
-            Some(Agent::Custom {
-                id: "newly-installed-agent".into()
-            }),
-            "the newly installed agent should not become the global last-used agent while an existing thread is visible"
         );
     }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3247,7 +3247,6 @@ impl AgentPanel {
             cx,
         );
         if let Some(original) = saved_selected_agent {
-            // Restore the last-used-agent in persistent storage as well.
             self.set_selected_agent_and_persist(original, cx);
         }
         let thread_id = thread.conversation_view.read(cx).thread_id;

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1945,30 +1945,37 @@ impl AgentPanel {
             return;
         }
 
+        let showing_new_draft = matches!(
+            (&self.base_view, &self.draft_thread),
+            (BaseView::AgentThread { conversation_view }, Some(draft))
+                if conversation_view.entity_id() == draft.entity_id()
+        );
+
+        if matches!(self.base_view, BaseView::AgentThread { .. }) && !showing_new_draft {
+            cx.background_spawn({
+                let kvp = KeyValueStore::global(cx);
+                async move {
+                    write_global_last_used_agent(kvp, agent).await;
+                }
+            })
+            .detach();
+            return;
+        }
+
         self.set_selected_agent_and_persist(agent, cx);
 
-        if let Some(draft) = self.draft_thread.clone() {
-            let draft_is_base_view = matches!(
-                &self.base_view,
-                BaseView::AgentThread { conversation_view }
-                    if conversation_view.entity_id() == draft.entity_id()
-            );
-            if draft_is_base_view {
-                // The empty new-thread slot is what the panel shows; retarget
-                // it so the newly selected agent launches in its place.
-                self.activate_draft(false, AgentThreadSource::AgentPanel, window, cx);
-            } else if !self.draft_has_content(&draft, cx)
-                && *draft.read(cx).agent_key() != self.selected_agent
-            {
-                // Drop the stale empty draft so the next panel open creates
-                // one bound to the newly selected agent.
-                let old_draft_id = draft.read(cx).thread_id;
-                ThreadMetadataStore::global(cx).update(cx, |store, cx| {
-                    store.delete(old_draft_id, cx);
-                });
-                self.draft_thread = None;
-                self._draft_editor_observation = None;
-            }
+        if showing_new_draft {
+            self.activate_draft(false, AgentThreadSource::AgentPanel, window, cx);
+        } else if let Some(draft) = self.draft_thread.clone()
+            && !self.draft_has_content(&draft, cx)
+            && *draft.read(cx).agent_key() != self.selected_agent
+        {
+            let old_draft_id = draft.read(cx).thread_id;
+            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
+                store.delete(old_draft_id, cx);
+            });
+            self.draft_thread = None;
+            self._draft_editor_observation = None;
         }
         cx.notify();
     }
@@ -11414,6 +11421,66 @@ mod tests {
             read_global_last_used_agent(&kvp),
             Some(expected_agent),
             "the selection should be persisted as the global last-used agent"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_select_agent_action_preserves_visible_thread_selection(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        cx.update(|cx| {
+            agent::ThreadStore::init_global(cx);
+            language_model::LanguageModelRegistry::test(cx);
+            <dyn fs::Fs>::set_global(fs.clone(), cx);
+        });
+
+        fs.insert_tree("/project", json!({ "file.txt": "" })).await;
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+
+        let multi_workspace =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _cx| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        workspace.update(cx, |workspace, _cx| {
+            workspace.set_random_database_id();
+        });
+        let cx = &mut VisualTestContext::from_window(multi_workspace.into(), cx);
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| AgentPanel::new(workspace, window, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        });
+
+        // Show an existing thread in the panel.
+        open_thread_with_connection(&panel, StubAgentConnection::new(), cx);
+        let thread_agent = panel.read_with(cx, |panel, _cx| panel.selected_agent.clone());
+
+        // Installing an agent (e.g. from onboarding or the ACP registry page)
+        // selects it globally, but must not retarget the visible thread or
+        // its toolbar icon.
+        cx.dispatch_action(SelectAgent {
+            agent: "newly-installed-agent".to_string(),
+        });
+        cx.run_until_parked();
+
+        panel.read_with(cx, |panel, _cx| {
+            assert_eq!(
+                panel.selected_agent, thread_agent,
+                "selection (and toolbar icon) should keep reflecting the visible thread"
+            );
+        });
+
+        let kvp = cx.update(|_, cx| KeyValueStore::global(cx));
+        assert_eq!(
+            read_global_last_used_agent(&kvp),
+            Some(Agent::Custom {
+                id: "newly-installed-agent".into()
+            }),
+            "the newly installed agent should still become the global last-used agent"
         );
     }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1951,33 +1951,11 @@ impl AgentPanel {
                 if conversation_view.entity_id() == draft.entity_id()
         );
 
-        if matches!(self.base_view, BaseView::AgentThread { .. }) && !showing_new_draft {
-            cx.background_spawn({
-                let kvp = KeyValueStore::global(cx);
-                async move {
-                    write_global_last_used_agent(kvp, agent).await;
-                }
-            })
-            .detach();
-            return;
-        }
-
-        self.set_selected_agent_and_persist(agent, cx);
-
-        if showing_new_draft {
+        if matches!(self.base_view, BaseView::AgentThread { .. }) && showing_new_draft {
+            self.set_selected_agent_and_persist(agent, cx);
             self.activate_draft(false, AgentThreadSource::AgentPanel, window, cx);
-        } else if let Some(draft) = self.draft_thread.clone()
-            && !self.draft_has_content(&draft, cx)
-            && *draft.read(cx).agent_key() != self.selected_agent
-        {
-            let old_draft_id = draft.read(cx).thread_id;
-            ThreadMetadataStore::global(cx).update(cx, |store, cx| {
-                store.delete(old_draft_id, cx);
-            });
-            self.draft_thread = None;
-            self._draft_editor_observation = None;
+            cx.notify();
         }
-        cx.notify();
     }
 
     pub fn new_terminal(
@@ -11363,15 +11341,17 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_select_agent_action_selects_without_opening_panel(cx: &mut TestAppContext) {
+    async fn test_select_agent_action_updates_visible_draft(cx: &mut TestAppContext) {
         init_test(cx);
+        let fs = FakeFs::new(cx.executor());
         cx.update(|cx| {
             agent::ThreadStore::init_global(cx);
             language_model::LanguageModelRegistry::test(cx);
+            <dyn fs::Fs>::set_global(fs.clone(), cx);
         });
 
-        let fs = FakeFs::new(cx.executor());
-        let project = Project::test(fs.clone(), [], cx).await;
+        fs.insert_tree("/project", json!({ "file.txt": "" })).await;
+        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
         let multi_workspace =
             cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
         let workspace = multi_workspace
@@ -11387,8 +11367,14 @@ mod tests {
             panel
         });
 
-        // Dispatched by the onboarding page after installing an external
-        // agent, so the agent launches when the panel is next opened.
+        panel.update_in(cx, |panel, window, cx| {
+            panel.activate_draft(false, AgentThreadSource::AgentPanel, window, cx);
+        });
+
+        let initial_draft_id = panel.read_with(cx, |panel, _cx| {
+            panel.draft_thread.as_ref().unwrap().entity_id()
+        });
+
         cx.dispatch_action(SelectAgent {
             agent: "my-configured-agent".to_string(),
         });
@@ -11398,23 +11384,24 @@ mod tests {
             id: "my-configured-agent".into(),
         };
 
-        panel.read_with(cx, |panel, _cx| {
+        panel.read_with(cx, |panel, cx| {
+            let draft = panel.draft_thread.as_ref().expect("draft should exist");
+            assert_ne!(
+                draft.entity_id(),
+                initial_draft_id,
+                "changing agents should replace the visible draft"
+            );
             assert_eq!(
                 panel.selected_agent, expected_agent,
                 "the action should update the panel's selected agent"
             );
-            assert!(
-                panel.active_conversation_view().is_none(),
-                "selecting an agent should not create or open a thread"
-            );
-            assert!(
-                panel.draft_thread.is_none(),
-                "selecting an agent should not create a draft thread"
+            assert_eq!(
+                *draft.read(cx).agent_key(),
+                expected_agent,
+                "the visible draft should use the selected agent"
             );
         });
 
-        // The selection is persisted globally so panels loaded later (e.g. in
-        // a new workspace) launch the configured agent.
         let kvp = cx.update(|_, cx| KeyValueStore::global(cx));
         assert_eq!(
             read_global_last_used_agent(&kvp),
@@ -11459,8 +11446,7 @@ mod tests {
         let thread_agent = panel.read_with(cx, |panel, _cx| panel.selected_agent.clone());
 
         // Installing an agent (e.g. from onboarding or the ACP registry page)
-        // selects it globally, but must not retarget the visible thread or
-        // its toolbar icon.
+        // must not retarget the visible thread or its toolbar icon.
         cx.dispatch_action(SelectAgent {
             agent: "newly-installed-agent".to_string(),
         });
@@ -11474,12 +11460,12 @@ mod tests {
         });
 
         let kvp = cx.update(|_, cx| KeyValueStore::global(cx));
-        assert_eq!(
+        assert_ne!(
             read_global_last_used_agent(&kvp),
             Some(Agent::Custom {
                 id: "newly-installed-agent".into()
             }),
-            "the newly installed agent should still become the global last-used agent"
+            "the newly installed agent should not become the global last-used agent while an existing thread is visible"
         );
     }
 

--- a/crates/agent_ui/src/agent_registry_ui.rs
+++ b/crates/agent_ui/src/agent_registry_ui.rs
@@ -514,19 +514,27 @@ impl AgentRegistryPage {
                             .size(IconSize::Small)
                             .color(Color::Muted),
                     )
-                    .on_click(move |_, _, cx| {
-                        let agent_id = agent_id.clone();
-                        update_settings_file(fs.clone(), cx, move |settings, _| {
-                            let agent_servers = settings.agent_servers.get_or_insert_default();
-                            agent_servers.entry(agent_id).or_insert_with(|| {
-                                settings::CustomAgentServerSettings::Registry {
-                                    default_mode: None,
-                                    env: Default::default(),
-                                    default_config_options: HashMap::default(),
-                                    favorite_config_option_values: HashMap::default(),
-                                }
-                            });
+                    .on_click(move |_, window, cx| {
+                        update_settings_file(fs.clone(), cx, {
+                            let agent_id = agent_id.clone();
+                            move |settings, _| {
+                                let agent_servers = settings.agent_servers.get_or_insert_default();
+                                agent_servers.entry(agent_id).or_insert_with(|| {
+                                    settings::CustomAgentServerSettings::Registry {
+                                        default_mode: None,
+                                        env: Default::default(),
+                                        default_config_options: HashMap::default(),
+                                        favorite_config_option_values: HashMap::default(),
+                                    }
+                                });
+                            }
                         });
+                        window.dispatch_action(
+                            Box::new(zed_actions::agent::SelectAgent {
+                                agent: agent_id.clone(),
+                            }),
+                            cx,
+                        );
                     })
             }
             RegistryInstallStatus::InstalledRegistry => {

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -565,20 +565,30 @@ fn render_registry_agent_button(
         .name(agent.name().clone())
         .state(state_element)
         .disabled(installed)
-        .on_click(move |_, _, cx| {
+        .on_click(move |_, window, cx| {
             telemetry::event!("Welcome Agent Install Clicked", agent = agent_id.as_str());
-            let agent_id = agent_id.clone();
-            update_settings_file(fs.clone(), cx, move |settings, _| {
-                let agent_servers = settings.agent_servers.get_or_insert_default();
-                agent_servers.entry(agent_id).or_insert_with(|| {
-                    CustomAgentServerSettings::Registry {
-                        env: Default::default(),
-                        default_mode: None,
-                        default_config_options: HashMap::default(),
-                        favorite_config_option_values: HashMap::default(),
-                    }
-                });
+            update_settings_file(fs.clone(), cx, {
+                let agent_id = agent_id.clone();
+                move |settings, _| {
+                    let agent_servers = settings.agent_servers.get_or_insert_default();
+                    agent_servers.entry(agent_id).or_insert_with(|| {
+                        CustomAgentServerSettings::Registry {
+                            env: Default::default(),
+                            default_mode: None,
+                            default_config_options: HashMap::default(),
+                            favorite_config_option_values: HashMap::default(),
+                        }
+                    });
+                }
             });
+            // Select the newly installed agent in the agent panel so it's
+            // the one that launches when the panel is opened.
+            window.dispatch_action(
+                Box::new(zed_actions::agent::SelectAgent {
+                    agent: agent_id.clone(),
+                }),
+                cx,
+            );
         })
 }
 

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -581,8 +581,6 @@ fn render_registry_agent_button(
                     });
                 }
             });
-            // Select the newly installed agent in the agent panel so it's
-            // the one that launches when the panel is opened.
             window.dispatch_action(
                 Box::new(zed_actions::agent::SelectAgent {
                     agent: agent_id.clone(),

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -567,6 +567,17 @@ pub mod agent {
         ]
     );
 
+    /// Selects the agent used for new threads in the agent panel, without
+    /// opening the panel. The selected agent is launched the next time the
+    /// panel is opened.
+    #[derive(Clone, PartialEq, Deserialize, JsonSchema, Action)]
+    #[action(namespace = agent)]
+    #[serde(deny_unknown_fields)]
+    pub struct SelectAgent {
+        /// The id of the agent to select.
+        pub agent: String,
+    }
+
     /// Opens a new agent thread with the provided branch diff for review.
     #[derive(Clone, PartialEq, Deserialize, JsonSchema, Action)]
     #[action(namespace = agent)]


### PR DESCRIPTION
This PR makes it so that when you install an agent from the registry we set it as the default agent. We apply the same behaviour when installing an ACP agent from the onboarding page, which should make it less confusing for new users (they won't see the Zed agent when they see a new thread, but instead see the agent they installed)


https://github.com/user-attachments/assets/81f4711f-4c9a-4606-882a-9f944c90dfa3



Release Notes:

- agent: Improved onboarding experience when installing ACP agents
