### PR TITLE
workspace: Use ellipsis character in "New" tooltip

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4213,7 +4213,7 @@ fn default_render_tab_bar_buttons(
             PopoverMenu::new("pane-tab-bar-popover-menu")
                 .trigger_with_tooltip(
                     IconButton::new("plus", IconName::Plus).icon_size(IconSize::Small),
-                    Tooltip::text("New..."),
+                    Tooltip::text("New…"),
                 )
                 .anchor(Anchor::TopRight)
                 .with_handle(pane.new_item_context_menu_handle.clone())


### PR DESCRIPTION
Explanation by @danilo-leal at https://github.com/zed-industries/zed/pull/60181#issuecomment-4866118310

## Testing

Ran with `cargo run` and tooltip appears correctly.

## Release Notes:

- N/A