### PR TITLE
Restore last session for bare CLI launch

### DIFF
--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -816,13 +816,7 @@ async fn open_workspaces(
     cwd: Option<PathBuf>,
     cx: &mut AsyncApp,
 ) -> Result<()> {
-    if paths.is_empty()
-        && diff_paths.is_empty()
-        && !matches!(
-            open_behavior,
-            cli::OpenBehavior::AlwaysNew | cli::OpenBehavior::PreferNewWindow
-        )
-    {
+    if paths.is_empty() && diff_paths.is_empty() && open_behavior != cli::OpenBehavior::AlwaysNew {
         return restore_or_create_workspace(app_state, cx).await;
     }
 


### PR DESCRIPTION
Fixes #60325

# Objective

When `cli_default_open_behavior` is set to `new_window`, a bare `zed` invocation is mapped to `PreferNewWindow`. This caused the no-path CLI startup path to skip session restoration and fall through to opening an empty workspace.

## Solution

Only treat explicit `AlwaysNew` behavior as a request to bypass restore when no paths or diff paths are provided. This preserves `zed -n` behavior while allowing `zed` to restore the previous session regardless of the CLI default open behavior.

## Testing

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed an issue where launching from the command line with no arguments would not restore the session when `"cli_default_open_behavior": "new_window"` was set.