### PR TITLE
gpui_macos: Fix use-after-free on the CVDisplayLink thread during teardown

### DIFF
--- a/crates/gpui_macos/src/display_link.rs
+++ b/crates/gpui_macos/src/display_link.rs
@@ -8,7 +8,7 @@ use std::ffi::c_void;
 
 pub struct DisplayLink {
     display_link: Option<sys::DisplayLink>,
-    frame_requests: DispatchRetained<DispatchSource>,
+    frame_requests: Option<DispatchRetained<DispatchSource>>,
 }
 
 impl DisplayLink {
@@ -51,7 +51,7 @@ impl DisplayLink {
 
             Ok(Self {
                 display_link: Some(display_link),
-                frame_requests,
+                frame_requests: Some(frame_requests),
             })
         }
     }
@@ -82,7 +82,17 @@ impl Drop for DisplayLink {
         //
         // We might also want to upgrade to CADisplayLink, but that requires dropping old macOS support.
         std::mem::forget(self.display_link.take());
-        self.frame_requests.cancel();
+
+        // The CVDisplayLink output callback holds a raw pointer to `frame_requests` and can still
+        // fire on the CVDisplayLink background thread after `stop`. Cancelling the source prevents
+        // its event handler from running and makes any further `merge_data` calls harmless, but
+        // releasing the source would free the callback's context and cause a cross-thread
+        // use-after-free. So, like the link above, we leak the source to keep that context valid
+        // for the now-detached background thread.
+        if let Some(frame_requests) = self.frame_requests.take() {
+            frame_requests.cancel();
+            std::mem::forget(frame_requests);
+        }
     }
 }
 


### PR DESCRIPTION
Tearing down a `DisplayLink` stops the `CVDisplayLink` and `mem::forget`s the link object to work around segfaults caused by the background timer thread still accessing it after release, but it previously released the GCD `DispatchSource` backing `frame_requests`. The `CVDisplayLink` output callback holds a raw pointer to that source and can still fire on the `CVDisplayLink` background thread after `stop`, so releasing the source freed the callback's context and produced a cross-thread use-after-free. Because display links are torn down constantly (window close, occlusion, screen change), this surfaced as occasional crashes on the display-link thread. This makes `frame_requests` an `Option` so `Drop` can take it, and after cancelling the source it also `mem::forget`s it. Cancelling stops the source's event handler from ever running and makes any further `merge_data` calls harmless, and leaking the source (one small GCD object per teardown, a cold path already consistent with the leaked link) keeps the callback's captured context valid for the now-detached background thread.

Release Notes:

- Fixed an occasional crash on the display-link thread when closing windows or changing displays