### PR TITLE
gpui_web: Tighten Send soundness under the multithreaded wasm feature

### DIFF
--- a/crates/gpui_web/src/display.rs
+++ b/crates/gpui_web/src/display.rs
@@ -8,10 +8,6 @@ pub struct WebDisplay {
     browser_window: web_sys::Window,
 }
 
-// Safety: WASM is single-threaded — there is no concurrent access to `web_sys::Window`.
-unsafe impl Send for WebDisplay {}
-unsafe impl Sync for WebDisplay {}
-
 impl WebDisplay {
     pub fn new(browser_window: web_sys::Window) -> Self {
         WebDisplay {

--- a/crates/gpui_web/src/http_client.rs
+++ b/crates/gpui_web/src/http_client.rs
@@ -17,6 +17,12 @@ pub struct FetchHttpClient {
     user_agent: Option<http_client::http::header::HeaderValue>,
 }
 
+// When the `multithreaded` feature is enabled, safe code must not be able to
+// obtain a `FetchHttpClient` without going through the `unsafe` constructors,
+// whose contract is what makes the `AssertSend` wrapper in `send` sound. A safe
+// `Default` impl would be a hole in that contract, so it is only provided in
+// single-threaded builds.
+#[cfg(not(feature = "multithreaded"))]
 impl Default for FetchHttpClient {
     fn default() -> Self {
         Self { user_agent: None }
@@ -29,7 +35,7 @@ impl FetchHttpClient {
     ///
     /// The caller must ensure that the created `FetchHttpClient` is only used in a single thread environment.
     pub unsafe fn new() -> Self {
-        Self::default()
+        Self { user_agent: None }
     }
 
     /// # Safety
@@ -61,12 +67,27 @@ impl FetchHttpClient {
 
 /// Wraps a `!Send` future to satisfy the `Send` bound on `BoxFuture`.
 ///
-/// Safety: only valid in WASM contexts where the `FetchHttpClient` is
-/// confined to a single thread (guaranteed by the caller via unsafe
-/// constructors when `multithreaded` is enabled, or by the absence of
-/// threads when it is not).
+/// The wrapped future dereferences `JsValue`s (`web_sys::Request`,
+/// `js_sys::Promise`, etc.), which are per-thread JS heap indices and are
+/// `!Send` for good reason: touching one from a different `wasm_thread` worker
+/// than the one that created it corrupts the JS heap at the boundary.
+///
+/// This wrapper is therefore only sound when the future is guaranteed never to
+/// migrate across workers, i.e. when the owning `FetchHttpClient` is confined
+/// to a single thread. Under the default `multithreaded` feature that
+/// guarantee can only be established by the caller through the `unsafe`
+/// constructors ([`FetchHttpClient::new`] / [`FetchHttpClient::with_user_agent`]),
+/// whose contract requires exactly this confinement; there is deliberately no
+/// safe `Default`/constructor in that configuration. Without the feature there
+/// are no worker threads, so the confinement holds unconditionally.
 struct AssertSend<F>(F);
 
+// SAFETY: `AssertSend` is only ever constructed inside `FetchHttpClient::send`.
+// A `FetchHttpClient` can only exist under the `multithreaded` feature via the
+// `unsafe` constructors, whose safety contract requires the client (and hence
+// every future it produces) to stay confined to a single thread. Given that
+// confinement the wrapped `JsValue`s are never touched from another worker, so
+// asserting `Send` cannot cause cross-worker access.
 unsafe impl<F> Send for AssertSend<F> {}
 
 impl<F: Future> Future for AssertSend<F> {


### PR DESCRIPTION
`gpui_web` targets wasm and enables a default `multithreaded` feature that runs work across several `wasm_thread` workers. `web_sys`/`js_sys` values are per-thread JS heap indices and are `!Send` for a reason: dereferencing one from a worker other than the one that created it corrupts the JS heap at the boundary. Two spots in the crate asserted `Send`/`Sync` in ways that are unsound once more than one worker exists, and this PR tightens both.

`WebDisplay` carried `unsafe impl Send`/`Sync` justified by "WASM is single-threaded", which is false under the default `multithreaded` feature. The impls are also unnecessary: `PlatformDisplay` only requires `Debug`, and every in-tree use is an `Rc<dyn PlatformDisplay>` living on the main thread. Both impls are removed outright.

`FetchHttpClient::send` wraps a `JsValue`-laden future in `AssertSend` (an unconditional `unsafe impl<F> Send`) so it satisfies the `Send` bound on `BoxFuture`, after which it is spawned on the multi-worker background executor. That is only sound if the client, and hence its futures, never migrate off the thread that created it. The crate already gates the constructors behind `unsafe fn` under `multithreaded` to force the caller to promise that confinement, but a safe, un-gated `impl Default` let safe code obtain a client without ever accepting that contract. This PR gates `impl Default` behind `#[cfg(not(feature = "multithreaded"))]` so the assertion is only reachable through the `unsafe` constructors, and expands the `// SAFETY:` documentation on `AssertSend` to state the single-thread-confinement requirement explicitly.

This does not make the multi-worker case fully sound: even a correctly-constructed client hands a `!Send` future to an executor that can resume it on a different worker. The robust fix is to proxy all JS work to the main thread and hand the executor a plain-data oneshot future instead; that is a larger refactor left as a follow-up. This PR closes the safe-`Default` hole and documents the boundary so the remaining unsoundness is confined and clearly labeled.

Release Notes:

- N/A