### PR TITLE
sqlez: Guard SQLite FFI against null handles

### DIFF
--- a/crates/sqlez/src/connection.rs
+++ b/crates/sqlez/src/connection.rs
@@ -87,6 +87,13 @@ impl Connection {
                 self.sqlite3,
                 CString::new("main")?.as_ptr(),
             );
+            // `sqlite3_backup_init` returns null on error (e.g. the same connection is used as
+            // both source and destination). The null check inside `sqlite3_backup_step` only
+            // exists under a SQLite build flag, so guard against the null handle ourselves.
+            if backup.is_null() {
+                destination.last_error()?;
+                anyhow::bail!("sqlite3_backup_init failed");
+            }
             sqlite3_backup_step(backup, -1);
             sqlite3_backup_finish(backup);
             destination.last_error()

--- a/crates/sqlez/src/connection.rs
+++ b/crates/sqlez/src/connection.rs
@@ -192,6 +192,13 @@ impl Connection {
 
                 return Some((err_msg, offset as usize + sub_statement_correction));
             }
+            // Several `sqlite3_prepare_v2` failure paths (OOM, shared-cache schema lock, TOOBIG)
+            // return a code other than the plain syntax-error code while leaving `*pzTail` unset
+            // (still null). The syntax-error branch above won't fire in those cases, so guard
+            // against calling `CStr::from_ptr` on a null pointer here.
+            if remaining_sql_ptr.is_null() {
+                return None;
+            }
             remaining_sql = unsafe { CStr::from_ptr(remaining_sql_ptr) };
             alter_table = None;
         }

--- a/crates/sqlez/src/connection.rs
+++ b/crates/sqlez/src/connection.rs
@@ -27,12 +27,18 @@ impl Connection {
         };
 
         unsafe {
-            sqlite3_open_v2(
+            let result = sqlite3_open_v2(
                 CString::new(uri)?.as_ptr(),
                 &mut connection.sqlite3,
                 flags,
                 ptr::null(),
             );
+
+            // On allocation failure `sqlite3_open_v2` leaves the handle null. Every call below
+            // dereferences it, so bail out before touching the handle.
+            if connection.sqlite3.is_null() {
+                anyhow::bail!("sqlite3_open_v2 failed to allocate a connection (code {result})");
+            }
 
             // Turn on extended error codes
             sqlite3_extended_result_codes(connection.sqlite3, 1);

--- a/crates/sqlez/src/thread_safe_connection.rs
+++ b/crates/sqlez/src/thread_safe_connection.rs
@@ -38,9 +38,6 @@ pub struct ThreadSafeConnection {
     connections: Arc<ThreadLocal<Connection>>,
 }
 
-unsafe impl Send for ThreadSafeConnection {}
-unsafe impl Sync for ThreadSafeConnection {}
-
 pub struct ThreadSafeConnectionBuilder<M: Migrator + 'static = ()> {
     db_initialize_query: Option<&'static str>,
     write_queue_constructor: Option<WriteQueueConstructor>,


### PR DESCRIPTION
This hardens sqlez's SQLite FFI against several paths where a null handle could be dereferenced. In each case the code passed a raw pointer straight into a follow-up call whose only null guard lives behind a SQLite build flag rather than in our own code, so the safety was incidental rather than guaranteed.

`sql_has_syntax_error` prepares a multi-statement string in a loop and, after checking for a plain syntax error, calls `CStr::from_ptr` on the tail pointer written by `sqlite3_prepare_v2`. Several failure paths (out of memory, a shared-cache schema lock, or an over-large statement) return a code other than the plain syntax-error code while leaving `*pzTail` still null, so the existing early return does not fire and `CStr::from_ptr(null)` runs `strlen` on address zero. It now bails out when the tail is null. `backup_main` unconditionally called `sqlite3_backup_step` on the handle from `sqlite3_backup_init`, which returns null on error (for example when the same connection is used as both source and destination); it now checks for null and surfaces the error first. `open_with_flags` called `sqlite3_extended_result_codes` on the connection handle immediately after `sqlite3_open_v2` while ignoring its return code, but allocation failure leaves that handle null; it now checks the handle before any further call on it.

It also removes the manual `unsafe impl Send`/`Sync for ThreadSafeConnection`. All of its fields are already `Send + Sync`, so the auto traits apply, and dropping the manual impls restores auto-trait checking so a future non-thread-safe field would be caught at compile time instead of silently becoming unsound.

Release Notes:

- N/A