### PR TITLE
gpui_windows: Harden DirectWrite and DirectX buffer/texture handling

### DIFF
--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -67,6 +67,12 @@ struct GPUState {
     blend_state: ID3D11BlendState,
     vertex_shader: ID3D11VertexShader,
     pixel_shader: ID3D11PixelShader,
+    // The thread that created this `GPUState`. The color-glyph rasterizer drives the *shared* D3D11
+    // immediate context (`Map`/`Unmap`/`Draw`/`CopyResource`) that `DirectXRenderer` and
+    // `DirectXAtlas` also use. An immediate `ID3D11DeviceContext` is not thread-safe, so all of that
+    // must happen on the single UI thread. We record the owning thread here to assert the invariant
+    // in debug builds.
+    owner_thread: std::thread::ThreadId,
 }
 
 struct DirectWriteState {
@@ -158,6 +164,7 @@ impl GPUState {
             blend_state,
             vertex_shader,
             pixel_shader,
+            owner_thread: std::thread::current().id(),
         })
     }
 }
@@ -881,6 +888,18 @@ impl DirectWriteState {
         params: &RenderGlyphParams,
         glyph_bounds: Bounds<DevicePixels>,
     ) -> Result<Vec<u8>> {
+        // INVARIANT: the code below drives the *shared* D3D11 immediate context
+        // (`Map`/`Unmap`/`Draw`/`CopyResource`), which `DirectXRenderer` and `DirectXAtlas` also
+        // touch. An immediate `ID3D11DeviceContext` is not thread-safe, so this must run on the
+        // single UI thread that created the `GPUState`. Giving the emoji rasterizer its own
+        // device/immediate context would lift this constraint (see the PR description); until then,
+        // assert we are on the owning thread in debug builds.
+        debug_assert_eq!(
+            std::thread::current().id(),
+            self.gpu_state.owner_thread,
+            "color glyph rasterization must run on the GPUState owner thread; \
+             the D3D11 immediate context is not thread-safe",
+        );
         let bitmap_size = glyph_bounds.size;
         let subpixel_shift = params
             .subpixel_variant

--- a/crates/gpui_windows/src/direct_write.rs
+++ b/crates/gpui_windows/src/direct_write.rs
@@ -1174,6 +1174,10 @@ impl DirectWriteState {
             };
         }
 
+        // Release the mapping now that the rows have been copied out; leaving `staging_texture`
+        // mapped would leak the mapping and keep the resource pinned for later reuse.
+        unsafe { device_context.Unmap(&staging_texture, 0) };
+
         // Convert from premultiplied to straight alpha
         for chunk in rasterized.chunks_exact_mut(4) {
             let b = chunk[0] as f32;

--- a/crates/gpui_windows/src/directx_atlas.rs
+++ b/crates/gpui_windows/src/directx_atlas.rs
@@ -282,6 +282,24 @@ impl DirectXAtlasTexture {
         bounds: Bounds<DevicePixels>,
         bytes: &[u8],
     ) {
+        // `UpdateSubresource` reads `row_pitch * height` bytes from `bytes` based on the
+        // `D3D11_BOX` below. If the caller hands us a slice shorter than that, the driver would
+        // over-read past the end of the source buffer (potentially by multiple megabytes), so bail
+        // out instead. This is a first-insert path rather than a per-frame one, so the check is
+        // effectively free.
+        let row_bytes = bounds.size.width.to_bytes(self.bytes_per_pixel as u8) as usize;
+        let expected = row_bytes * bounds.size.height.0.max(0) as usize;
+        if bytes.len() < expected {
+            log::error!(
+                "DirectXAtlasTexture::upload: source slice is {} bytes but the {}x{} region \
+                 requires {} bytes; skipping upload to avoid a driver over-read",
+                bytes.len(),
+                bounds.size.width.0,
+                bounds.size.height.0,
+                expected,
+            );
+            return;
+        }
         unsafe {
             device_context.UpdateSubresource(
                 &self.texture,

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -191,6 +191,8 @@ impl DirectXRenderer {
         update_buffer(
             device_context,
             self.globals.global_params_buffer.as_ref().unwrap(),
+            // `global_params_buffer` is allocated to hold exactly one `GlobalParams`.
+            1,
             &[GlobalParams {
                 gamma_ratios: self.font_info.gamma_ratios,
                 viewport_size: [resources.viewport.Width, resources.viewport.Height],
@@ -1031,7 +1033,7 @@ impl<T> PipelineState<T> {
             self.view = view;
             self.buffer_size = new_buffer_size;
         }
-        update_buffer(device_context, &self.buffer, data)
+        update_buffer(device_context, &self.buffer, self.buffer_size, data)
     }
 
     fn draw(
@@ -1535,8 +1537,20 @@ fn create_buffer_view_range(
 fn update_buffer<T>(
     device_context: &ID3D11DeviceContext,
     buffer: &ID3D11Buffer,
+    capacity: usize,
     data: &[T],
 ) -> Result<()> {
+    // `copy_nonoverlapping` below writes `data.len()` elements of `T` into the mapped buffer, which
+    // was allocated with room for `capacity` elements. Writing past that would corrupt GPU memory
+    // beyond the end of the buffer. Callers are responsible for the capacity invariant (dynamic
+    // pipeline buffers grow before reaching this point), so a debug assertion is enough to catch a
+    // regression without paying for a COM `GetDesc` query on this per-frame path.
+    debug_assert!(
+        data.len() <= capacity,
+        "update_buffer: {} elements exceed buffer capacity of {}",
+        data.len(),
+        capacity,
+    );
     unsafe {
         let mut dest = std::mem::zeroed();
         device_context.Map(buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, Some(&mut dest))?;


### PR DESCRIPTION
This tightens up a few memory-safety hazards in the Windows text-system and DirectX rendering path, all reached from safe APIs. `DirectXAtlasTexture::upload` handed `bytes.as_ptr()` and a `D3D11_BOX` to `UpdateSubresource` without ever comparing the source slice length against the region it describes, so a too-short slice (reachable through the safe `PlatformAtlas::get_or_insert_with` trait) could cause the driver to over-read by multiple megabytes; it now computes the expected `row_pitch * height` byte count and skips the upload with a logged error if the slice is shorter. This runs on the first-insert path rather than per frame, so the comparison is effectively free.

The per-frame `update_buffer<T>` helper mapped a dynamic buffer with `WRITE_DISCARD` and `copy_nonoverlapping`d `data.len()` elements without knowing the buffer's element capacity. It now takes the known capacity from the caller and `debug_assert!`s the write fits; no release-mode COM query is added, since this is hot. In the DirectWrite color-glyph path, `rasterize_color` mapped the staging texture with `D3D11_MAP_READ` and copied rows out but never called `Unmap`, leaking the mapping and pinning the resource; it now unmaps after the row copy, before the premultiply conversion.

Finally, the color-glyph rasterizer drives the shared D3D11 immediate context (`Map`/`Unmap`/`Draw`/`CopyResource`), which `DirectXRenderer` and `DirectXAtlas` also touch, and an immediate `ID3D11DeviceContext` is not thread-safe. Rather than the larger structural fix, this records the owning thread id in `GPUState` at creation and `debug_assert_eq!`s it at the top of the rasterization path to document and enforce the single-UI-thread invariant in debug builds. The more robust option, giving the emoji rasterizer its own device and immediate context created once in `GPUState::new`, is left as a follow-up.

This is a Windows-only crate and I could not compile it on the macOS host used to author the change (the cross build fails in a native C dependency before reaching `gpui_windows`: `cc-rs` cannot find MSVC `lib.exe`), so the changes were verified by careful manual review and Windows CI is the compile gate.

Release Notes:

- N/A