### PR TITLE
crashes: Make the crash handler signal-safe and drop the panic-hook setenv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4344,6 +4344,7 @@ version = "0.1.0"
 dependencies = [
  "async-process",
  "crash-handler",
+ "libc",
  "log",
  "mach2 0.5.0",
  "minidumper",

--- a/crates/crashes/Cargo.toml
+++ b/crates/crashes/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later"
 [dependencies]
 async-process.workspace = true
 crash-handler.workspace = true
+libc.workspace = true
 log.workspace = true
 minidumper.workspace = true
 parking_lot.workspace = true

--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -27,10 +27,15 @@ const CRASH_HANDLER_PING_TIMEOUT: Duration = Duration::from_secs(60);
 const CRASH_HANDLER_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Force a backtrace to be printed on panic.
+///
+/// This only installs the panic hook. It intentionally does not touch
+/// `RUST_BACKTRACE`: a panic hook runs on a live, multithreaded process
+/// (including for caught panics), and mutating the environment there races other
+/// threads' `getenv`, which is a use-after-free in glibc. Callers that want a
+/// backtrace must set `RUST_BACKTRACE` themselves at single-threaded startup.
 pub fn force_backtrace() {
     let old_hook = panic::take_hook();
     panic::set_hook(Box::new(move |info| {
-        unsafe { env::set_var("RUST_BACKTRACE", "1") };
         old_hook(info);
         // prevent the macOS crash dialog from popping up
         if cfg!(target_os = "macos") {

--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -120,8 +120,14 @@ where
                 // minidump request.
                 client.ping().ok();
                 let r = client.request_dump(crash_context);
-                if let Err(e) = &r {
-                    eprintln!("failed to request dump: {:?}", e);
+                if r.is_err() {
+                    // On Linux this closure runs in an async-signal context on the
+                    // faulting thread. A heap-corruption crash may have faulted inside
+                    // malloc, so `eprintln!` (which allocates and takes the stderr lock)
+                    // could reenter the allocator or deadlock. Emit a fixed message with
+                    // a single `write` syscall, which is async-signal-safe.
+                    const MESSAGE: &[u8] = b"failed to request dump\n";
+                    libc::write(2, MESSAGE.as_ptr() as *const _, MESSAGE.len() as _);
                 }
                 #[cfg(target_os = "macos")]
                 macos::resume_all_other_threads();

--- a/crates/remote_server/src/server.rs
+++ b/crates/remote_server/src/server.rs
@@ -567,6 +567,16 @@ pub fn execute_run(
 ) -> Result<()> {
     init_paths()?;
 
+    // Enable Rust backtraces so the panic hook installed by `crashes::force_backtrace`
+    // (used when the crash handler is not installed) prints a backtrace. This has to
+    // happen while we are still single-threaded, before the gpui app and rayon pool
+    // below spawn threads: mutating the environment after other threads exist races with
+    // concurrent `getenv` calls. The `crashes` crate deliberately never touches the
+    // environment itself for this reason.
+    // SAFETY: this is the earliest point in the server's startup and no threads have
+    // been spawned yet.
+    unsafe { env::set_var("RUST_BACKTRACE", "1") };
+
     let startup_time = Instant::now();
     let app = gpui_platform::headless();
     let pid = std::process::id();

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -339,6 +339,15 @@ fn main() {
         gpui::set_startup_activation_token(startup_activation_token);
     }
 
+    // Enable Rust backtraces so the panic hook installed by `crashes::force_backtrace`
+    // (used when the crash handler is not installed) prints a backtrace. This has to
+    // happen here while we are still single-threaded, before the rayon pool below and
+    // any other threads exist: mutating the environment after other threads exist races
+    // with concurrent `getenv` calls. The `crashes` crate deliberately never touches the
+    // environment itself for this reason.
+    // SAFETY: `main` is still single-threaded here.
+    unsafe { env::set_var("RUST_BACKTRACE", "1") };
+
     rayon::ThreadPoolBuilder::new()
         .num_threads(std::thread::available_parallelism().map_or(1, |n| n.get().div_ceil(2)))
         .stack_size(10 * 1024 * 1024)


### PR DESCRIPTION
This is stacked on #60492 and must not land before it: this PR sets `RUST_BACKTRACE` in the single-threaded startup section that #60492 establishes (next to the `XDG_ACTIVATION_TOKEN` handling, before the rayon thread pool is built), so #60492 needs to merge first.

This fixes two undefined-behavior hazards in the crash-handling code. First, the crash-handler closure installed by `CrashHandler::attach` runs, on Linux, in an async-signal context on the faulting thread. When the dump request failed there (a crash-server ping timeout, or a race with the keepalive thread's ack) the failure branch called `eprintln!`, which allocates and takes the stderr lock. If the crash is a heap corruption that faulted inside malloc, that reenters the allocator or deadlocks, which is undefined behavior in a signal handler. It now emits a fixed byte string through a single `write(2)` syscall, which is async-signal-safe and needs no allocation or locking.

Second, `force_backtrace` installed a panic hook that called `set_var("RUST_BACKTRACE", "1")` at panic time. Panic hooks run on a live, multithreaded process (including for caught panics), so that `setenv` races other threads' `getenv`, which is a use-after-free in glibc. The hook only set the variable so the default panic printer would emit a backtrace, so the `crashes` crate no longer touches the environment at all: `force_backtrace` just installs the hook. Each binary instead sets `RUST_BACKTRACE=1` once at single-threaded startup, before any threads exist, where the mutation is provably sound. In `zed` this sits in the single-threaded startup section next to the `XDG_ACTIVATION_TOKEN` handling (before the rayon pool is built); in `remote_server` it is the first thing `execute_run` does, before the gpui app and rayon pool spawn threads. (The `Backtrace::force_capture` alternative was avoided because it would change the printed output; the hook never used a backtrace value directly, it only relied on the default printer.)

Release Notes:

- N/A