### PR TITLE
language: Scope the BufferChunks Send assertion and document the QueryCursor invariants

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -508,8 +508,24 @@ struct IndentSuggestion {
     within_error: bool,
 }
 
+/// Wrapper that asserts `Send` for the tree-sitter captures iterator, which is
+/// the only part of [`BufferChunkHighlights`] (and thus [`BufferChunks`]) that
+/// isn't automatically `Send`.
+///
+/// `SyntaxMapCaptures` isn't auto-`Send` because it transitively holds a
+/// `tree_sitter::QueryCaptures`, which retains a raw `*mut TSQueryCursor`.
+struct SendableCaptures<'a>(SyntaxMapCaptures<'a>);
+
+// SAFETY: The raw `*mut TSQueryCursor` inside the captures iterator points at a
+// pooled `QueryCursor` that lives inside the same `SyntaxMapCaptures` value (in
+// its `_query_cursor` handle). Because the cursor travels together with the
+// iterator that borrows it, exclusive access to the cursor is preserved across
+// a move to another thread. tree-sitter itself asserts `unsafe impl Send for
+// QueryCursor` for exactly this pointer, so sending the pair is sound.
+unsafe impl Send for SendableCaptures<'_> {}
+
 struct BufferChunkHighlights<'a> {
-    captures: SyntaxMapCaptures<'a>,
+    captures: SendableCaptures<'a>,
     next_capture: Option<SyntaxMapCapture<'a>>,
     stack: Vec<(usize, HighlightId)>,
     highlight_maps: Vec<HighlightMap>,
@@ -5623,8 +5639,6 @@ impl Deref for BufferSnapshot {
     }
 }
 
-unsafe impl Send for BufferChunks<'_> {}
-
 impl<'a> BufferChunks<'a> {
     pub(crate) fn new(
         text: &'a Rope,
@@ -5636,7 +5650,7 @@ impl<'a> BufferChunks<'a> {
         let mut highlights = None;
         if let Some((captures, highlight_maps)) = syntax {
             highlights = Some(BufferChunkHighlights {
-                captures,
+                captures: SendableCaptures(captures),
                 next_capture: None,
                 stack: Default::default(),
                 highlight_maps,
@@ -5688,7 +5702,7 @@ impl<'a> BufferChunks<'a> {
             } else if let Some(snapshot) = self.buffer_snapshot {
                 let (captures, highlight_maps) = snapshot.get_highlights(self.range.clone());
                 *highlights = BufferChunkHighlights {
-                    captures,
+                    captures: SendableCaptures(captures),
                     next_capture: None,
                     stack: Default::default(),
                     highlight_maps,
@@ -5702,7 +5716,7 @@ impl<'a> BufferChunks<'a> {
                 );
             }
 
-            highlights.captures.set_byte_range(self.range.clone());
+            highlights.captures.0.set_byte_range(self.range.clone());
             self.initialize_diagnostic_endpoints();
         }
     }
@@ -5806,7 +5820,7 @@ impl<'a> Iterator for BufferChunks<'a> {
             }
 
             if highlights.next_capture.is_none() {
-                highlights.next_capture = highlights.captures.next();
+                highlights.next_capture = highlights.captures.0.next();
             }
 
             while let Some(capture) = highlights.next_capture.as_ref() {
@@ -5821,7 +5835,7 @@ impl<'a> Iterator for BufferChunks<'a> {
                             .stack
                             .push((capture.node.end_byte(), highlight_id));
                     }
-                    highlights.next_capture = highlights.captures.next();
+                    highlights.next_capture = highlights.captures.0.next();
                 }
             }
         }

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -101,6 +101,9 @@ pub struct SyntaxMapMatch<'a> {
 
 struct SyntaxMapCapturesLayer<'a> {
     depth: usize,
+    // Field order is load-bearing: `captures` borrows `_query_cursor` (see the
+    // SAFETY note at the `transmute` in `SyntaxMapCaptures::new`) and must be
+    // dropped first, so it has to be declared before `_query_cursor`.
     captures: QueryCaptures<'a, 'a, TextProvider<'a>, &'a [u8]>,
     next_capture: Option<QueryCapture<'a>>,
     grammar_index: usize,
@@ -113,6 +116,9 @@ struct SyntaxMapMatchesLayer<'a> {
     next_pattern_index: usize,
     next_captures: Vec<QueryCapture<'a>>,
     has_next: bool,
+    // Field order is load-bearing: `matches` borrows `_query_cursor` (see the
+    // SAFETY note at the `transmute` in `SyntaxMapMatches::new`) and must be
+    // dropped first, so it has to be declared before `_query_cursor`.
     matches: QueryMatches<'a, 'a, TextProvider<'a>, &'a [u8]>,
     query: &'a Query,
     grammar_index: usize,
@@ -1118,6 +1124,24 @@ impl<'a> SyntaxMapCaptures<'a> {
             let mut query_cursor = QueryCursorHandle::new();
 
             // TODO - add a Tree-sitter API to remove the need for this.
+            //
+            // SAFETY: We fabricate a `'static` mutable borrow of the cursor so
+            // that the resulting `QueryCaptures` can be stored alongside the
+            // cursor in the same struct. This relies on two invariants:
+            //
+            //  1. `QueryCaptures` does not actually retain this transmuted
+            //     reference: it stores a raw `*mut ffi::TSQueryCursor` copied
+            //     out of it (heap-stable, independent of where the handle
+            //     lives), so the fake `'static` lifetime never escapes.
+            //  2. In `SyntaxMapCapturesLayer` the `captures` field is declared
+            //     before `_query_cursor`, so the iterator is dropped before the
+            //     cursor is recycled into the pool by `QueryCursorHandle::drop`.
+            //     If that order flipped, the cursor would be reset and reused
+            //     while `captures` still pointed at it.
+            //
+            // Invariant (1) is not part of tree-sitter's public contract, so it
+            // must be re-verified whenever the `tree-sitter` dependency is
+            // bumped.
             let cursor = unsafe {
                 std::mem::transmute::<&mut tree_sitter::QueryCursor, &'static mut QueryCursor>(
                     query_cursor.deref_mut(),
@@ -1253,6 +1277,24 @@ impl<'a> SyntaxMapMatches<'a> {
             let mut query_cursor = QueryCursorHandle::new();
 
             // TODO - add a Tree-sitter API to remove the need for this.
+            //
+            // SAFETY: We fabricate a `'static` mutable borrow of the cursor so
+            // that the resulting `QueryMatches` can be stored alongside the
+            // cursor in the same struct. This relies on two invariants:
+            //
+            //  1. `QueryMatches` does not actually retain this transmuted
+            //     reference: it stores a raw `*mut ffi::TSQueryCursor` copied
+            //     out of it (heap-stable, independent of where the handle
+            //     lives), so the fake `'static` lifetime never escapes.
+            //  2. In `SyntaxMapMatchesLayer` the `matches` field is declared
+            //     before `_query_cursor`, so the iterator is dropped before the
+            //     cursor is recycled into the pool by `QueryCursorHandle::drop`.
+            //     If that order flipped, the cursor would be reset and reused
+            //     while `matches` still pointed at it.
+            //
+            // Invariant (1) is not part of tree-sitter's public contract, so it
+            // must be re-verified whenever the `tree-sitter` dependency is
+            // bumped.
             let cursor = unsafe {
                 std::mem::transmute::<&mut tree_sitter::QueryCursor, &'static mut QueryCursor>(
                     query_cursor.deref_mut(),


### PR DESCRIPTION
`BufferChunks` carried a blanket `unsafe impl Send for BufferChunks<'_> {}`, but the only field that actually isn't auto-`Send` is the tree-sitter captures iterator (`SyntaxMapCaptures`, which transitively holds a `QueryCaptures` retaining a raw `*mut TSQueryCursor`). A blanket assertion silences auto-trait checking for every current and future field, so if a genuinely non-`Send` field were added later the compiler would stay silent. This narrows the assertion to a `SendableCaptures` newtype wrapping just that one field with a `// SAFETY:` comment citing tree-sitter's own `unsafe impl Send for QueryCursor` (the pooled cursor travels inside the same struct as the iterator that borrows it, preserving exclusive access), and deletes the blanket impl so the rest of the struct auto-derives `Send`. Behavior is identical; a temporary static assertion confirmed `BufferChunks` still implements `Send`.

It also documents the `&mut QueryCursor` → `&'static mut` transmutes in `syntax_map.rs`, whose soundness rests on two facts that were previously undocumented: `QueryCaptures`/`QueryMatches` retain a heap-stable `*mut ffi::TSQueryCursor` rather than the transmuted reference, and the `captures`/`matches` field is declared before `_query_cursor` in the layer structs so the iterator drops before the cursor is recycled. The existing `// TODO` comments are expanded into `// SAFETY:` comments naming both invariants (and noting the retention fact must be re-verified on any `tree-sitter` bump), and the layer struct fields gain a short note that their order is load-bearing so a reorder gets flagged in review. No runtime change.

Release Notes:

- N/A