### PR TITLE
Windows: Harden window-procedure message and pointer handling

### DIFF
--- a/crates/auto_update_helper/src/dialog.rs
+++ b/crates/auto_update_helper/src/dialog.rs
@@ -237,12 +237,10 @@ where
     // procedure can re-enter (for instance through the modal loop that `show_error` runs), and
     // re-`Box::from_raw`-ing the same pointer would create a second owner aliasing a live
     // allocation. The pointer is null before `WM_NCCREATE` stores it and after `WM_NCDESTROY`
-    // clears it, so guard against dereferencing null.
+    // clears it; `as_ref` turns that null case into `None` instead of dereferencing it.
     let raw = unsafe { GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *const RefCell<DialogInfo> };
-    if raw.is_null() {
-        return None;
-    }
-    Some(f(unsafe { &*raw }))
+    let data = unsafe { raw.as_ref() };
+    data.map(f)
 }
 
 fn get_system_ui_font_name() -> String {

--- a/crates/auto_update_helper/src/dialog.rs
+++ b/crates/auto_update_helper/src/dialog.rs
@@ -214,7 +214,10 @@ unsafe extern "system" fn wnd_proc(
         }
         WM_NCDESTROY => unsafe {
             // The window is going away and no further messages will reference the state, so
-            // reclaim and drop the boxed `DialogInfo` exactly once.
+            // reclaim and drop the boxed `DialogInfo` here. This frees it at most once, and only
+            // if `WM_NCDESTROY` actually runs: the normal exit path uses `PostQuitMessage` (which
+            // unwinds the message loop without destroying the window) and simply leaks the box to
+            // process exit, as before.
             let raw = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut RefCell<DialogInfo>;
             if !raw.is_null() {
                 SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);

--- a/crates/auto_update_helper/src/dialog.rs
+++ b/crates/auto_update_helper/src/dialog.rs
@@ -18,8 +18,8 @@ use windows::{
                 IMAGE_ICON, LR_DEFAULTSIZE, LR_SHARED, LoadImageW, PostQuitMessage, RegisterClassW,
                 SPI_GETICONTITLELOGFONT, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SendMessageW,
                 SetWindowLongPtrW, SystemParametersInfoW, WINDOW_EX_STYLE, WM_CLOSE, WM_CREATE,
-                WM_DESTROY, WM_NCCREATE, WM_PAINT, WNDCLASSW, WS_CAPTION, WS_CHILD, WS_EX_TOPMOST,
-                WS_POPUP, WS_VISIBLE,
+                WM_DESTROY, WM_NCCREATE, WM_NCDESTROY, WM_PAINT, WNDCLASSW, WS_CAPTION, WS_CHILD,
+                WS_EX_TOPMOST, WS_POPUP, WS_VISIBLE,
             },
         },
     },
@@ -113,10 +113,20 @@ unsafe extern "system" fn wnd_proc(
 ) -> LRESULT {
     match msg {
         WM_NCCREATE => unsafe {
-            let create_struct = lparam.0 as *const CREATESTRUCTW;
-            let info = (*create_struct).lpCreateParams as *mut RefCell<DialogInfo>;
-            let info = Box::from_raw(info);
-            SetWindowLongPtrW(hwnd, GWLP_USERDATA, Box::into_raw(info) as _);
+            // Adopt the boxed `DialogInfo` that `CreateWindowExW` passed via `lpCreateParams`,
+            // but only once: refuse to overwrite an already-stored pointer (a duplicate or
+            // forged `WM_NCCREATE` must not clobber live state), and validate both the creation
+            // struct and its payload before storing the pointer we later reclaim in
+            // `WM_NCDESTROY`.
+            if GetWindowLongPtrW(hwnd, GWLP_USERDATA) == 0 {
+                let create_struct = (lparam.0 as *const CREATESTRUCTW).as_ref();
+                if let Some(create_struct) = create_struct {
+                    let info = create_struct.lpCreateParams as *mut RefCell<DialogInfo>;
+                    if !info.is_null() {
+                        SetWindowLongPtrW(hwnd, GWLP_USERDATA, info as _);
+                    }
+                }
+            }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         },
         WM_CREATE => unsafe {
@@ -183,16 +193,17 @@ unsafe extern "system" fn wnd_proc(
         WM_JOB_UPDATED => with_dialog_data(hwnd, |data| {
             let progress_bar = data.borrow().progress_bar;
             unsafe { SendMessageW(HWND(progress_bar as _), PBM_STEPIT, None, None) }
-        }),
+        })
+        .unwrap_or_else(|| unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) }),
         WM_TERMINATE => {
-            with_dialog_data(hwnd, |data| {
-                if let Ok(result) = data.borrow_mut().rx.recv()
-                    && let Err(e) = result
-                {
-                    log::error!("Failed to update Zed: {:?}", e);
-                    show_error(format!("Error: {:?}", e));
-                }
-            });
+            // Receive the update result while only briefly borrowing the state, then release
+            // the borrow before calling `show_error`: its modal message loop can re-enter this
+            // window procedure, which must not find the state already borrowed.
+            let update_result = with_dialog_data(hwnd, |data| data.borrow_mut().rx.recv());
+            if let Some(Ok(Err(e))) = update_result {
+                log::error!("Failed to update Zed: {:?}", e);
+                show_error(format!("Error: {:?}", e));
+            }
             unsafe { PostQuitMessage(0) };
             LRESULT(0)
         }
@@ -201,19 +212,34 @@ unsafe extern "system" fn wnd_proc(
             unsafe { PostQuitMessage(0) };
             LRESULT(0)
         }
+        WM_NCDESTROY => unsafe {
+            // The window is going away and no further messages will reference the state, so
+            // reclaim and drop the boxed `DialogInfo` exactly once.
+            let raw = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut RefCell<DialogInfo>;
+            if !raw.is_null() {
+                SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
+                drop(Box::from_raw(raw));
+            }
+            DefWindowProcW(hwnd, msg, wparam, lparam)
+        },
         _ => unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) },
     }
 }
 
-fn with_dialog_data<F, T>(hwnd: HWND, f: F) -> T
+fn with_dialog_data<F, T>(hwnd: HWND, f: F) -> Option<T>
 where
     F: FnOnce(&RefCell<DialogInfo>) -> T,
 {
-    let raw = unsafe { GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *mut RefCell<DialogInfo> };
-    let data = unsafe { Box::from_raw(raw) };
-    let result = f(data.as_ref());
-    unsafe { SetWindowLongPtrW(hwnd, GWLP_USERDATA, Box::into_raw(data) as _) };
-    result
+    // Borrow the state stored in `GWLP_USERDATA` rather than taking ownership of it. The window
+    // procedure can re-enter (for instance through the modal loop that `show_error` runs), and
+    // re-`Box::from_raw`-ing the same pointer would create a second owner aliasing a live
+    // allocation. The pointer is null before `WM_NCCREATE` stores it and after `WM_NCDESTROY`
+    // clears it, so guard against dereferencing null.
+    let raw = unsafe { GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *const RefCell<DialogInfo> };
+    if raw.is_null() {
+        return None;
+    }
+    Some(f(unsafe { &*raw }))
 }
 
 fn get_system_ui_font_name() -> String {

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -1591,18 +1591,20 @@ fn parse_ime_composition_string(ctx: HIMC, comp_type: IME_COMPOSITION_STRING) ->
     unsafe {
         let string_len = ImmGetCompositionStringW(ctx, comp_type, None, 0);
         if string_len >= 0 {
-            let mut buffer = vec![0u8; string_len as usize + 2];
+            let string_len = string_len as usize;
+            // `ImmGetCompositionStringW` writes UTF-16 code units but measures lengths in bytes.
+            // Read straight into a `Vec<u16>` (rather than reinterpreting a byte buffer, which is
+            // only 1-byte aligned) so the resulting `[u16]` has the 2-byte alignment it requires.
+            // `string_len / 2 + 1` code units always covers `string_len` bytes.
+            let mut buffer = vec![0u16; string_len / 2 + 1];
             ImmGetCompositionStringW(
                 ctx,
                 comp_type,
                 Some(buffer.as_mut_ptr() as _),
                 string_len as _,
             );
-            let wstring = std::slice::from_raw_parts::<u16>(
-                buffer.as_mut_ptr().cast::<u16>(),
-                string_len as usize / 2,
-            );
-            Some(wstring.to_vec())
+            buffer.truncate(string_len / 2);
+            Some(buffer)
         } else {
             None
         }

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -110,7 +110,7 @@ impl WindowsWindowInner {
             WM_SHOWWINDOW => self.handle_window_visibility_changed(handle, wparam),
             WM_GPUI_CURSOR_STYLE_CHANGED => self.handle_cursor_changed(lparam),
             WM_GPUI_FORCE_UPDATE_WINDOW => self.draw_window(handle, true),
-            WM_GPUI_GPU_DEVICE_LOST => self.handle_device_lost(lparam),
+            WM_GPUI_GPU_DEVICE_LOST => self.handle_device_lost(wparam, lparam),
             DM_POINTERHITTEST => self.handle_dm_pointer_hit_test(wparam),
             WM_GETOBJECT => self.handle_wm_getobject(wparam, lparam),
             _ => None,
@@ -1189,7 +1189,16 @@ impl WindowsWindowInner {
         None
     }
 
-    fn handle_device_lost(&self, lparam: LPARAM) -> Option<isize> {
+    fn handle_device_lost(&self, wparam: WPARAM, lparam: LPARAM) -> Option<isize> {
+        // The `lparam` is a raw pointer into another thread's `DirectXDevices`, which we
+        // dereference and walk COM vtables through below. Only the platform's device-loss
+        // recovery posts this message, and it always tags it with our validation number.
+        // Reject anything else so a stray or hostile `WM_USER + 7` can't hand us an
+        // arbitrary pointer to dereference. This mirrors the check in `handle_gpui_events`.
+        if wparam.0 != self.validation_number {
+            log::error!("Wrong validation number while processing device lost message");
+            return None;
+        }
         let devices = lparam.0 as *const DirectXDevices;
         let devices = unsafe { &*devices };
         if let Err(err) = self

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -2,17 +2,15 @@ use std::{rc::Rc, sync::atomic::Ordering};
 
 use anyhow::Context as _;
 use gpui_util::ResultExt;
-use windows::{
-    Win32::{
-        Foundation::*,
-        Graphics::Gdi::*,
-        System::SystemServices::*,
-        UI::{
-            Controls::*,
-            HiDpi::*,
-            Input::{Ime::*, KeyboardAndMouse::*},
-            WindowsAndMessaging::*,
-        },
+use windows::Win32::{
+    Foundation::*,
+    Graphics::Gdi::*,
+    System::SystemServices::*,
+    UI::{
+        Controls::*,
+        HiDpi::*,
+        Input::{Ime::*, KeyboardAndMouse::*},
+        WindowsAndMessaging::*,
     },
 };
 

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -1153,9 +1153,13 @@ impl WindowsWindowInner {
         const MAX_UNITS: usize = 64;
         let mut units = Vec::with_capacity(MAX_UNITS);
         for offset in 0..MAX_UNITS {
-            // SAFETY: `pointer` is non-null and we advance one unit at a time only while the
-            // preceding unit was a non-NUL part of the string, stopping at the terminator, so we
-            // never read past the end of a well-formed NUL-terminated buffer.
+            // SAFETY: `pointer` is non-null. For a well-formed NUL-terminated buffer we stop at
+            // the terminator and never read past the end. For a malformed, non-NUL-terminated
+            // buffer (e.g. a hostile message) `pointer.add(offset)` can still walk past the real
+            // allocation, so this is technically an over-read; the `MAX_UNITS` cap only *mitigates*
+            // that rather than eliminating it. It is nonetheless a strict improvement over the
+            // prior unbounded scan, and the cap cannot cause us to miss the only value we compare
+            // against ("ImmersiveColorSet", 17 units), which fits well within the limit.
             let unit = unsafe { pointer.add(offset).read() };
             if unit == 0 {
                 break;

--- a/crates/gpui_windows/src/events.rs
+++ b/crates/gpui_windows/src/events.rs
@@ -14,7 +14,6 @@ use windows::{
             WindowsAndMessaging::*,
         },
     },
-    core::PCWSTR,
 };
 
 use crate::*;
@@ -1144,14 +1143,31 @@ impl WindowsWindowInner {
     }
 
     fn handle_system_theme_changed(&self, handle: HWND, lparam: LPARAM) -> Option<isize> {
-        // lParam is a pointer to a string that indicates the area containing the system parameter
-        // that was changed.
-        let parameter = PCWSTR::from_raw(lparam.0 as _);
-        if unsafe { !parameter.is_null() && !parameter.is_empty() }
-            && let Some(parameter_string) = unsafe { parameter.to_string() }.log_err()
-        {
+        // lParam is a pointer to a NUL-terminated wide string naming the area containing the
+        // system parameter that was changed. It comes straight off the message queue, so bound
+        // how far we walk it: the value is only ever compared against "ImmersiveColorSet", and
+        // scanning for the terminator without a limit would let a malformed message walk us off
+        // the end of the buffer.
+        let pointer = lparam.0 as *const u16;
+        if pointer.is_null() {
+            return Some(0);
+        }
+        const MAX_UNITS: usize = 64;
+        let mut units = Vec::with_capacity(MAX_UNITS);
+        for offset in 0..MAX_UNITS {
+            // SAFETY: `pointer` is non-null and we advance one unit at a time only while the
+            // preceding unit was a non-NUL part of the string, stopping at the terminator, so we
+            // never read past the end of a well-formed NUL-terminated buffer.
+            let unit = unsafe { pointer.add(offset).read() };
+            if unit == 0 {
+                break;
+            }
+            units.push(unit);
+        }
+        if !units.is_empty() {
+            let parameter_string = String::from_utf16_lossy(&units);
             log::info!("System settings changed: {}", parameter_string);
-            if parameter_string.as_str() == "ImmersiveColorSet" {
+            if parameter_string == "ImmersiveColorSet" {
                 let new_appearance = system_appearance()
                     .context("unable to get system appearance when handling ImmersiveColorSet")
                     .log_err()?;


### PR DESCRIPTION
This hardens the Windows window procedures against malformed or hostile window messages, all of which currently trust attacker-controllable payloads. In `gpui_windows`, the per-window `WndProc` routed `WM_GPUI_GPU_DEVICE_LOST` straight into `handle_device_lost`, dereferencing the `lparam` as a `*const DirectXDevices` and walking its COM vtables with no validation, even though the platform-side handler already gates the same message on the window's validation number; any local process could post `WM_USER + 7` with an arbitrary `lparam` and get an arbitrary-pointer dereference. The handler now rejects the message unless `wparam` matches the window's validation number, mirroring `handle_gpui_events`. Alongside that, the `WM_SETTINGCHANGE` handler scanned the `lParam` wide string for a NUL terminator with no bound, so it now reads at most a small fixed number of UTF-16 code units (the value is only ever compared against `\"ImmersiveColorSet\"`), and `parse_ime_composition_string` now reads the IME composition directly into a `Vec<u16>` rather than reinterpreting a 1-byte-aligned `Vec<u8>` as `&[u16]`, which violated the alignment `slice::from_raw_parts` requires.

In `auto_update_helper`, `with_dialog_data` took ownership of the `GWLP_USERDATA` pointer via `Box::from_raw` on every message and reboxed it afterward, with no null check. Under the modal message loop that `MessageBoxW` runs in the error path, the procedure re-enters and creates a second `Box` aliasing the same live allocation, and `Box::from_raw(null)` would be undefined if a message arrived before `WM_NCCREATE`. It now borrows the state through a null-checked `&*` instead of re-owning it, returning `Option` so callers fall through to `DefWindowProcW`, and the single owning `Box::from_raw` moves into a new `WM_NCDESTROY` handler. `WM_NCCREATE` now stores the creation payload only when no pointer is already set and null-checks both the `CREATESTRUCTW` and its `lpCreateParams` first, and the terminate path releases its borrow before invoking the modal error dialog.

These crates are Windows-only and don't build on the author's macOS host (`auto_update_helper` cross-checks cleanly against `x86_64-pc-windows-msvc`, but `gpui_windows` can't reach its own code because a native C dependency needs the MSVC `lib.exe`), so Windows CI is the compile gate for this change.

Release Notes:

- N/A