### PR TITLE
gpui_macos: Harden window and event FFI boundaries

### DIFF
--- a/crates/gpui_macos/src/events.rs
+++ b/crates/gpui_macos/src/events.rs
@@ -12,6 +12,7 @@ use crate::{
 use cocoa::{
     appkit::{NSEvent, NSEventModifierFlags, NSEventPhase, NSEventType},
     base::{YES, id},
+    foundation::NSUInteger,
 };
 use core_foundation::data::{CFDataGetBytePtr, CFDataRef};
 use core_graphics::event::CGKeyCode;
@@ -106,16 +107,19 @@ pub(crate) unsafe fn platform_input_from_native(
     window_height: Option<Pixels>,
 ) -> Option<PlatformInput> {
     unsafe {
-        let event_type = native_event.eventType();
-
-        // Filter out event types that aren't in the NSEventType enum.
+        // AppKit can deliver raw event types that fall outside the `NSEventType`
+        // enum (e.g. SmartMagnify=32, QuickLook=33, DirectTouch=37, ChangeMode=38,
+        // and values added in future macOS releases). Materializing an out-of-range
+        // value as the Rust enum is undefined behavior, so read the raw integer
+        // first and only convert to `NSEventType` once it matches a known-valid
+        // discriminant.
         // See https://github.com/servo/cocoa-rs/issues/155#issuecomment-323482792 for details.
-        match event_type as u64 {
-            0 | 21 | 32 | 33 | 35 | 36 | 37 => {
-                return None;
-            }
-            _ => {}
+        let raw_event_type: NSUInteger = msg_send![native_event, r#type];
+        if !matches!(raw_event_type, 1..=20 | 22..=27 | 29..=31 | 34) {
+            return None;
         }
+
+        let event_type = native_event.eventType();
 
         match event_type {
             NSEventType::NSFlagsChanged => {

--- a/crates/gpui_macos/src/keyboard.rs
+++ b/crates/gpui_macos/src/keyboard.rs
@@ -51,23 +51,52 @@ impl PlatformKeyboardMapper for MacKeyboardMapper {
 }
 
 impl MacKeyboardLayout {
+    fn unknown() -> Self {
+        Self {
+            id: "unknown".to_string(),
+            name: "Unknown".to_string(),
+        }
+    }
+
     pub(crate) fn new() -> Self {
         unsafe {
             let current_keyboard = TISCopyCurrentKeyboardLayoutInputSource();
+            // TIS can return null when there is no current input source (e.g. at the
+            // login window, over some remote sessions, or mid layout-switch).
+            if current_keyboard.is_null() {
+                return Self::unknown();
+            }
 
-            let id: *mut Object = TISGetInputSourceProperty(
+            let id_source: *mut Object = TISGetInputSourceProperty(
                 current_keyboard,
                 kTISPropertyInputSourceID as *const c_void,
             );
-            let id: *const std::os::raw::c_char = msg_send![id, UTF8String];
-            let id = CStr::from_ptr(id).to_str().unwrap().to_string();
-
-            let name: *mut Object = TISGetInputSourceProperty(
+            let name_source: *mut Object = TISGetInputSourceProperty(
                 current_keyboard,
                 kTISPropertyLocalizedName as *const c_void,
             );
-            let name: *const std::os::raw::c_char = msg_send![name, UTF8String];
-            let name = CStr::from_ptr(name).to_str().unwrap().to_string();
+            // TISGetInputSourceProperty may return null for a property, in which case
+            // there is nothing to dereference.
+            if id_source.is_null() || name_source.is_null() {
+                let _: () = msg_send![current_keyboard, release];
+                return Self::unknown();
+            }
+
+            let id_ptr: *const std::os::raw::c_char = msg_send![id_source, UTF8String];
+            let name_ptr: *const std::os::raw::c_char = msg_send![name_source, UTF8String];
+            if id_ptr.is_null() || name_ptr.is_null() {
+                let _: () = msg_send![current_keyboard, release];
+                return Self::unknown();
+            }
+
+            let id = CStr::from_ptr(id_ptr)
+                .to_str()
+                .unwrap_or("unknown")
+                .to_string();
+            let name = CStr::from_ptr(name_ptr)
+                .to_str()
+                .unwrap_or("Unknown")
+                .to_string();
 
             let _: () = msg_send![current_keyboard, release];
 

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -2811,6 +2811,10 @@ extern "C" fn attributed_substring_for_proposed_range(
         unsafe {
             let string: id = msg_send![class!(NSAttributedString), alloc];
             let string: id = msg_send![string, initWithString: ns_string(&selected_text)];
+            // Cocoa expects a +0 (autoreleased) return value here; `alloc` +
+            // `initWithString:` yields +1, so autorelease to avoid leaking one
+            // attributed string per IME/dictation query.
+            let string: id = msg_send![string, autorelease];
             Some(string)
         }
     })

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -60,7 +60,7 @@ use raw_window_handle as rwh;
 use smallvec::SmallVec;
 use std::{
     cell::Cell,
-    ffi::{CStr, c_void},
+    ffi::c_void,
     mem,
     ops::Range,
     path::PathBuf,
@@ -1132,13 +1132,17 @@ impl MacWindow {
                 nil
             };
 
-            let value_str = if !value.is_null() {
-                CStr::from_ptr(NSString::UTF8String(value)).to_string_lossy()
+            // `objectForKey:` may hand back a non-string value (e.g. an `NSNumber`
+            // or `__NSCFBoolean`); sending `UTF8String` to those would be undefined.
+            // Guard on the class and otherwise fall back to the default preference.
+            let is_string: BOOL = if value.is_null() {
+                NO
             } else {
-                "".into()
+                msg_send![value, isKindOfClass: class!(NSString)]
             };
+            let value_str = if is_string == YES { value.to_str() } else { "" };
 
-            match value_str.as_ref() {
+            match value_str {
                 "manual" => Some(UserTabbingPreference::Never),
                 "always" => Some(UserTabbingPreference::Always),
                 _ => Some(UserTabbingPreference::InFullScreen),
@@ -1775,13 +1779,18 @@ impl PlatformWindow for MacWindow {
                             nil
                         };
 
-                        let action_str = if !action.is_null() {
-                            CStr::from_ptr(NSString::UTF8String(action)).to_string_lossy()
+                        // `objectForKey:` may hand back a non-string value (e.g. an
+                        // `NSNumber` or `__NSCFBoolean`); sending `UTF8String` to those
+                        // would be undefined. Guard on the class and otherwise fall back
+                        // to the default (zoom) action.
+                        let is_string: BOOL = if action.is_null() {
+                            NO
                         } else {
-                            "".into()
+                            msg_send![action, isKindOfClass: class!(NSString)]
                         };
+                        let action_str = if is_string == YES { action.to_str() } else { "" };
 
-                        match action_str.as_ref() {
+                        match action_str {
                             "None" => {
                                 // "Do Nothing" selected, so do no action
                             }

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1020,6 +1020,11 @@ impl MacWindow {
                         };
                         let _: () =
                             msg_send![parent, beginSheet: native_window completionHandler: nil];
+                        // Retain the parent so it outlives this sheet: `Drop` sends
+                        // `endSheet:` to it later, and without this retain the parent
+                        // window could be closed and freed first, turning that message
+                        // into a use-after-free. Balanced by a `release` in `Drop`.
+                        let _: () = msg_send![parent, retain];
                         sheet_parent = Some(parent);
                     }
                 }
@@ -1158,6 +1163,8 @@ impl Drop for MacWindow {
                 unsafe {
                     if let Some(parent) = sheet_parent {
                         let _: () = msg_send![parent, endSheet: window];
+                        // Balance the `retain` performed when the sheet parent was stored.
+                        let _: () = msg_send![parent, release];
                     }
                     window.close();
                     window.autorelease();

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -731,8 +731,6 @@ impl MacWindowState {
     }
 }
 
-unsafe impl Send for MacWindowState {}
-
 pub(crate) struct MacWindow(Arc<Mutex<MacWindowState>>);
 
 impl MacWindow {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -22,7 +22,6 @@ use cocoa::{
         NSUserDefaults,
     },
 };
-use dispatch2::DispatchQueue;
 use gpui::{
     AnyWindowHandle, BackgroundExecutor, Bounds, Capslock, CursorStyle, ExternalPaths,
     FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke, Modifiers, ModifiersChangedEvent,
@@ -1221,34 +1220,33 @@ impl PlatformWindow for MacWindow {
     }
 
     fn merge_all_windows(&self) {
-        let native_window = self.0.lock().native_window;
-        extern "C" fn merge_windows_async(context: *mut std::ffi::c_void) {
-            unsafe {
-                let native_window = context as id;
-                let _: () = msg_send![native_window, mergeAllWindows:nil];
-            }
-        }
-
-        unsafe {
-            DispatchQueue::main()
-                .exec_async_f(native_window as *mut std::ffi::c_void, merge_windows_async);
-        }
+        let this = self.0.lock();
+        let window = this.native_window;
+        let closed = this.closed.clone();
+        // Route through the foreground executor and skip if the window has been
+        // closed, matching `resize`/`zoom`: messaging a freed `native_window` from a
+        // deferred main-queue block would hard fault.
+        this.foreground_executor
+            .spawn(async move {
+                if_window_not_closed(closed, || unsafe {
+                    let _: () = msg_send![window, mergeAllWindows: nil];
+                })
+            })
+            .detach();
     }
 
     fn move_tab_to_new_window(&self) {
-        let native_window = self.0.lock().native_window;
-        extern "C" fn move_tab_async(context: *mut std::ffi::c_void) {
-            unsafe {
-                let native_window = context as id;
-                let _: () = msg_send![native_window, moveTabToNewWindow:nil];
-                let _: () = msg_send![native_window, makeKeyAndOrderFront: nil];
-            }
-        }
-
-        unsafe {
-            DispatchQueue::main()
-                .exec_async_f(native_window as *mut std::ffi::c_void, move_tab_async);
-        }
+        let this = self.0.lock();
+        let window = this.native_window;
+        let closed = this.closed.clone();
+        this.foreground_executor
+            .spawn(async move {
+                if_window_not_closed(closed, || unsafe {
+                    let _: () = msg_send![window, moveTabToNewWindow: nil];
+                    let _: () = msg_send![window, makeKeyAndOrderFront: nil];
+                })
+            })
+            .detach();
     }
 
     fn toggle_window_tab_overview(&self) {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1787,7 +1787,11 @@ impl PlatformWindow for MacWindow {
                         } else {
                             msg_send![action, isKindOfClass: class!(NSString)]
                         };
-                        let action_str = if is_string == YES { action.to_str() } else { "" };
+                        let action_str = if is_string == YES {
+                            action.to_str()
+                        } else {
+                            ""
+                        };
 
                         match action_str {
                             "None" => {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -1159,6 +1159,9 @@ impl Drop for MacWindow {
             this.native_window.setDelegate_(nil);
         }
         this.input_handler.take();
+        // Drop the AccessKit adapter too: it subclasses the window and retains GPU-backed
+        // resources, so leaving it in place forms a retain cycle that leaks per window.
+        this.accesskit_adapter.take();
         this.foreground_executor
             .spawn(async move {
                 unsafe {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -2916,11 +2916,20 @@ fn external_paths_from_event(dragging_info: *mut Object) -> Option<ExternalPaths
     if filenames == nil {
         return None;
     }
+    // A hostile drag source controls the property-list value returned here. Blindly
+    // messaging it as an `NSArray` of `NSString`s (count/iterate/UTF8String) could
+    // raise an Objective-C exception that unwinds through this `extern "C"` frame,
+    // so validate the class of the plist and of every element before use.
+    let is_array: BOOL = unsafe { msg_send![filenames, isKindOfClass: class!(NSArray)] };
+    if is_array != YES {
+        return None;
+    }
     for file in unsafe { filenames.iter() } {
-        let path = unsafe {
-            let f = NSString::UTF8String(file);
-            CStr::from_ptr(f).to_string_lossy().into_owned()
-        };
+        let is_string: BOOL = unsafe { msg_send![file, isKindOfClass: class!(NSString)] };
+        if is_string != YES {
+            continue;
+        }
+        let path = unsafe { file.to_str().to_owned() };
         paths.push(PathBuf::from(path))
     }
     Some(ExternalPaths(paths))


### PR DESCRIPTION
This hardens several unsafe FFI boundaries in the macOS window and input code where malformed or unexpected data coming from AppKit could cause undefined behavior, crashes, or leaks. The changes fall into a few classes. First, raw-enum validation: `platform_input_from_native` used to materialize an `NSEventType` before filtering it, but AppKit delivers raw event types outside the enum's discriminants (SmartMagnify, QuickLook, DirectTouch, ChangeMode, and future additions), and holding an out-of-range discriminant is UB; it now reads the raw integer, allowlists the known-valid discriminants, and only then converts. Second, null and type guards on system data: null checks around the TIS keyboard-layout calls (falling back to an "unknown" layout), `isKindOfClass:` validation of the drag pasteboard plist and its elements before treating them as an `NSArray` of `NSString` (a hostile drag source could otherwise raise an ObjC exception that unwinds through an `extern \"C\"` frame), and `isKindOfClass:` guards before reading user-defaults values that may be `NSNumber`/`__NSCFBoolean` rather than strings.

Third, lifetime and closed-window safety: the `Dialog` sheet parent is now retained while stored and released after `endSheet:` to avoid a use-after-free if the parent closes first; `merge_all_windows` and `move_tab_to_new_window` now route through the foreground executor with an `if_window_not_closed` guard like `resize`/`zoom` instead of messaging a possibly-freed window from a deferred main-queue block; the AccessKit `SubclassingAdapter` is now taken in `Drop` to break a retain cycle that leaked GPU resources per window; and `attributedSubstringForProposedRange:` now autoreleases its `+1` result, which Cocoa expects at `+0`, fixing a leak per IME/dictation query. Finally, the unsound `unsafe impl Send for MacWindowState` (it holds thread-affine AppKit pointers, the Metal renderer, and `Rc`-capturing callbacks) was removed; nothing required the bound and the crate still checks.

Note that the correctness of the ObjC `msg_send!` selectors and retain/release balancing here is not something `cargo check` can verify, so those changes were made by inspection against AppKit's memory-management conventions.

One lower-priority, latent item was deferred: the `super` trampolines message `super(this, class!(NSWindow))` for both the window and panel classes, which skips any `NSPanel` override for panel instances. A correct fix needs per-class superclass registration/stashing across roughly a dozen trampolines, and is complicated by AccessKit dynamically subclassing the window at runtime (a naive runtime-superclass lookup could recurse infinitely). It is left for a focused follow-up.

Release Notes:

- Fixed several potential crashes in window handling, drag-and-drop, and keyboard-layout detection on macOS