### PR TITLE
Move startup environment mutations before threads are spawned

### DIFF
--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -48,7 +48,6 @@ fn main() -> Result<()> {
         .block_on(async_main())
 }
 
-#[expect(clippy::result_large_err)]
 async fn async_main() -> Result<()> {
     let mut args = args().skip(1);
     match args.next().as_deref() {

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -29,8 +29,11 @@ use tracing_subscriber::{
 use util::ResultExt as _;
 
 #[expect(clippy::result_large_err)]
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    // Load environment variables before starting the tokio runtime. `set_var`
+    // mutates the process environment, which races with concurrent `getenv`
+    // calls on other threads, so it must happen while we are still
+    // single-threaded (i.e. before the runtime spawns its worker threads).
     if let Err(error) = env::load_dotenv() {
         eprintln!(
             "error loading .env.toml (this is expected in production): {}",
@@ -38,6 +41,15 @@ async fn main() -> Result<()> {
         );
     }
 
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| anyhow!(error))?
+        .block_on(async_main())
+}
+
+#[expect(clippy::result_large_err)]
+async fn async_main() -> Result<()> {
     let mut args = args().skip(1);
     match args.next().as_deref() {
         Some("version") => {

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -159,6 +159,26 @@ pub use window::*;
 
 pub use pollster::block_on;
 
+static STARTUP_ACTIVATION_TOKEN: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+
+/// Stores the XDG desktop startup activation token that was read from the
+/// environment during single-threaded process startup.
+///
+/// The token has to be read (and removed from the environment) before any
+/// threads are spawned: mutating the process environment after other threads
+/// exist races with concurrent `getenv` calls. Platform code reads the stashed
+/// value later via [`startup_activation_token`] instead of touching the
+/// environment itself. See `crates/zed/src/main.rs`.
+pub fn set_startup_activation_token(token: Option<String>) {
+    STARTUP_ACTIVATION_TOKEN.set(token).ok();
+}
+
+/// Returns the XDG desktop startup activation token that was captured from the
+/// environment at process startup, if one was present.
+pub fn startup_activation_token() -> Option<String> {
+    STARTUP_ACTIVATION_TOKEN.get().cloned().flatten()
+}
+
 /// The context trait, allows the different contexts in GPUI to be used
 /// interchangeably for certain operations.
 pub trait AppContext {

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -108,19 +108,6 @@ use wayland_protocols::wp::linux_dmabuf::zv1::client::{
 const MIN_KEYCODE: u32 = 8;
 
 const UNKNOWN_KEYBOARD_LAYOUT_NAME: SharedString = SharedString::new_static("unknown");
-const XDG_ACTIVATION_TOKEN_ENV_VAR: &str = "XDG_ACTIVATION_TOKEN";
-
-fn take_startup_activation_token_from_environment() -> Option<String> {
-    let startup_activation_token = std::env::var(XDG_ACTIVATION_TOKEN_ENV_VAR)
-        .ok()
-        .filter(|token| !token.is_empty());
-    // The token must be removed from the environment so it isn't inherited by child
-    // processes we spawn, per the xdg-activation spec: https://wayland.app/protocols/xdg-activation-v1
-    // SAFETY: This runs during Wayland platform initialization before GPUI starts
-    // concurrent environment access or spawning child processes.
-    unsafe { std::env::remove_var(XDG_ACTIVATION_TOKEN_ENV_VAR) };
-    startup_activation_token
-}
 
 #[derive(Clone)]
 pub struct Globals {
@@ -563,7 +550,10 @@ fn wl_output_version(version: u32) -> u32 {
 
 impl WaylandClient {
     pub(crate) fn new() -> Self {
-        let startup_activation_token = take_startup_activation_token_from_environment();
+        // The XDG desktop startup activation token was read from the environment
+        // (and removed from it) during single-threaded process startup; see
+        // `gpui::startup_activation_token` and `crates/zed/src/main.rs`.
+        let startup_activation_token = gpui::startup_activation_token();
         let conn = Connection::connect_to_env().unwrap();
 
         let (globals, event_queue) = registry_queue_init::<WaylandClientStatePtr>(&conn).unwrap();

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -320,6 +320,25 @@ fn main() {
         return;
     }
 
+    // Capture the XDG desktop startup activation token before spawning any
+    // threads. It has to be read and removed from the environment while we are
+    // still single-threaded: mutating the process environment after other
+    // threads exist races with concurrent `getenv` calls. The token must still
+    // be removed globally so it isn't inherited by child processes we spawn (per
+    // the xdg-activation spec: https://wayland.app/protocols/xdg-activation-v1).
+    // The Wayland platform reads the stashed value later via
+    // `gpui::startup_activation_token()` instead of touching the environment.
+    {
+        const XDG_ACTIVATION_TOKEN_ENV_VAR: &str = "XDG_ACTIVATION_TOKEN";
+        let startup_activation_token = env::var(XDG_ACTIVATION_TOKEN_ENV_VAR)
+            .ok()
+            .filter(|token| !token.is_empty());
+        // SAFETY: `main` is still single-threaded here; this runs before the
+        // rayon thread pool is built and before any other threads are spawned.
+        unsafe { env::remove_var(XDG_ACTIVATION_TOKEN_ENV_VAR) };
+        gpui::set_startup_activation_token(startup_activation_token);
+    }
+
     rayon::ThreadPoolBuilder::new()
         .num_threads(std::thread::available_parallelism().map_or(1, |n| n.get().div_ceil(2)))
         .stack_size(10 * 1024 * 1024)


### PR DESCRIPTION
Mutating the process environment with `setenv`/`unsetenv` after other threads exist is a data race against concurrent `getenv` calls, which is undefined behavior. This moves two such mutations so they happen while the process is still single-threaded.

In `collab`, `env::load_dotenv` calls `set_var` in a loop, and it was invoked as the first statement of a `#[tokio::main] async fn main` — by which point the multi-threaded runtime's worker threads are already running. `main` is now a plain `fn` that loads the dotenv file first and then builds the tokio runtime explicitly, running the former async body inside `block_on`.

For Wayland startup activation, `WaylandClient::new` used to remove `XDG_ACTIVATION_TOKEN` from the environment, but it runs (via `build_application`) after the rayon thread pool is built, so parked rayon workers already existed during the `unsetenv`. The token is now read and removed at the top of Zed's `main`, before the rayon pool and any other thread spawns, and stashed in a process-global accessor in `gpui`; the Wayland client reads the stashed value instead of touching the environment. The removal still happens globally so the token isn't inherited by child processes we spawn. The `collab` change and the `gpui`/`zed` `main.rs` change build on macOS; the Wayland client is Linux-only and is verified by CI.

Release Notes:

- N/A