### PR TITLE
gpui: Fix scoped-executor and arena-token soundness

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -2004,8 +2004,7 @@ impl SearchableItem for Editor {
                                     _ = tx.send(chunk_result);
                                 });
                             }
-                        })
-                        .await;
+                        });
 
                     for rx in results {
                         if let Ok(results) = rx.await {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1956,55 +1956,54 @@ impl SearchableItem for Editor {
                     let query = query.clone();
 
                     let mut results = Vec::new();
-                    executor
-                        .scoped(|scope| {
-                            for search_range in chunk_search_range(
-                                search_buffer.text.clone(),
-                                &query,
-                                num_cpus as u32,
-                                search_range,
-                            ) {
-                                let query = query.clone();
-                                let buffer = buffer.clone();
+                    executor.scoped(|scope| {
+                        for search_range in chunk_search_range(
+                            search_buffer.text.clone(),
+                            &query,
+                            num_cpus as u32,
+                            search_range,
+                        ) {
+                            let query = query.clone();
+                            let buffer = buffer.clone();
 
-                                let (tx, rx) = oneshot::channel();
-                                results.push(rx);
-                                scope.spawn(async move {
-                                    let chunk_result = query
-                                        .search(
-                                            search_buffer,
-                                            Some(search_range.start..search_range.end),
-                                        )
-                                        .await
-                                        .into_iter()
-                                        .filter_map(|match_range| {
-                                            if let Some(deleted_hunk_anchor) = deleted_hunk_anchor {
-                                                let start = search_buffer.anchor_after(
-                                                    search_range.start + match_range.start,
-                                                );
-                                                let end = search_buffer.anchor_before(
-                                                    search_range.start + match_range.end,
-                                                );
-                                                Some(
-                                                    deleted_hunk_anchor.with_diff_base_anchor(start)
-                                                        ..deleted_hunk_anchor
-                                                            .with_diff_base_anchor(end),
-                                                )
-                                            } else {
-                                                let start = search_buffer.anchor_after(
-                                                    search_range.start + match_range.start,
-                                                );
-                                                let end = search_buffer.anchor_before(
-                                                    search_range.start + match_range.end,
-                                                );
-                                                buffer.anchor_range_in_buffer(start..end)
-                                            }
-                                        })
-                                        .collect::<Vec<_>>();
-                                    _ = tx.send(chunk_result);
-                                });
-                            }
-                        });
+                            let (tx, rx) = oneshot::channel();
+                            results.push(rx);
+                            scope.spawn(async move {
+                                let chunk_result = query
+                                    .search(
+                                        search_buffer,
+                                        Some(search_range.start..search_range.end),
+                                    )
+                                    .await
+                                    .into_iter()
+                                    .filter_map(|match_range| {
+                                        if let Some(deleted_hunk_anchor) = deleted_hunk_anchor {
+                                            let start = search_buffer.anchor_after(
+                                                search_range.start + match_range.start,
+                                            );
+                                            let end = search_buffer.anchor_before(
+                                                search_range.start + match_range.end,
+                                            );
+                                            Some(
+                                                deleted_hunk_anchor.with_diff_base_anchor(start)
+                                                    ..deleted_hunk_anchor
+                                                        .with_diff_base_anchor(end),
+                                            )
+                                        } else {
+                                            let start = search_buffer.anchor_after(
+                                                search_range.start + match_range.start,
+                                            );
+                                            let end = search_buffer.anchor_before(
+                                                search_range.start + match_range.end,
+                                            );
+                                            buffer.anchor_range_in_buffer(start..end)
+                                        }
+                                    })
+                                    .collect::<Vec<_>>();
+                                _ = tx.send(chunk_result);
+                            });
+                        }
+                    });
 
                     for rx in results {
                         if let Ok(results) = rx.await {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1956,54 +1956,59 @@ impl SearchableItem for Editor {
                     let query = query.clone();
 
                     let mut results = Vec::new();
-                    executor.scoped(|scope| {
-                        for search_range in chunk_search_range(
-                            search_buffer.text.clone(),
-                            &query,
-                            num_cpus as u32,
-                            search_range,
-                        ) {
-                            let query = query.clone();
-                            let buffer = buffer.clone();
+                    // SAFETY: the `scoped` future is awaited immediately below, so the
+                    // spawned futures — which borrow this frame for `'scope` — never
+                    // outlive it, and the future is not leaked (which would skip that await).
+                    executor
+                        .scoped(|scope| unsafe {
+                            for search_range in chunk_search_range(
+                                search_buffer.text.clone(),
+                                &query,
+                                num_cpus as u32,
+                                search_range,
+                            ) {
+                                let query = query.clone();
+                                let buffer = buffer.clone();
 
-                            let (tx, rx) = oneshot::channel();
-                            results.push(rx);
-                            scope.spawn(async move {
-                                let chunk_result = query
-                                    .search(
-                                        search_buffer,
-                                        Some(search_range.start..search_range.end),
-                                    )
-                                    .await
-                                    .into_iter()
-                                    .filter_map(|match_range| {
-                                        if let Some(deleted_hunk_anchor) = deleted_hunk_anchor {
-                                            let start = search_buffer.anchor_after(
-                                                search_range.start + match_range.start,
-                                            );
-                                            let end = search_buffer.anchor_before(
-                                                search_range.start + match_range.end,
-                                            );
-                                            Some(
-                                                deleted_hunk_anchor.with_diff_base_anchor(start)
-                                                    ..deleted_hunk_anchor
-                                                        .with_diff_base_anchor(end),
-                                            )
-                                        } else {
-                                            let start = search_buffer.anchor_after(
-                                                search_range.start + match_range.start,
-                                            );
-                                            let end = search_buffer.anchor_before(
-                                                search_range.start + match_range.end,
-                                            );
-                                            buffer.anchor_range_in_buffer(start..end)
-                                        }
-                                    })
-                                    .collect::<Vec<_>>();
-                                _ = tx.send(chunk_result);
-                            });
-                        }
-                    });
+                                let (tx, rx) = oneshot::channel();
+                                results.push(rx);
+                                scope.spawn(async move {
+                                    let chunk_result = query
+                                        .search(
+                                            search_buffer,
+                                            Some(search_range.start..search_range.end),
+                                        )
+                                        .await
+                                        .into_iter()
+                                        .filter_map(|match_range| {
+                                            if let Some(deleted_hunk_anchor) = deleted_hunk_anchor {
+                                                let start = search_buffer.anchor_after(
+                                                    search_range.start + match_range.start,
+                                                );
+                                                let end = search_buffer.anchor_before(
+                                                    search_range.start + match_range.end,
+                                                );
+                                                Some(
+                                                    deleted_hunk_anchor.with_diff_base_anchor(start)
+                                                        ..deleted_hunk_anchor
+                                                            .with_diff_base_anchor(end),
+                                                )
+                                            } else {
+                                                let start = search_buffer.anchor_after(
+                                                    search_range.start + match_range.start,
+                                                );
+                                                let end = search_buffer.anchor_before(
+                                                    search_range.start + match_range.end,
+                                                );
+                                                buffer.anchor_range_in_buffer(start..end)
+                                            }
+                                        })
+                                        .collect::<Vec<_>>();
+                                    _ = tx.send(chunk_result);
+                                });
+                            }
+                        })
+                        .await;
 
                     for rx in results {
                         if let Ok(results) = rx.await {

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -181,70 +181,78 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
         .map(|_| Vec::with_capacity(max_results))
         .collect::<Vec<_>>();
 
-    executor.scoped(|scope| {
-        for (segment_idx, results) in segment_results.iter_mut().enumerate() {
-            scope.spawn(async move {
-                let segment_start = segment_idx * segment_size;
-                let segment_end = segment_start + segment_size;
-                let mut matcher =
-                    Matcher::new(query, lowercase_query, query_char_bag, smart_case, true);
+    // SAFETY: the `scoped` future is awaited immediately below, so the spawned
+    // futures — which borrow this frame for `'scope` — never outlive it, and the
+    // future is not leaked (which would skip that await and free the frame early).
+    executor
+        .scoped(|scope| unsafe {
+            for (segment_idx, results) in segment_results.iter_mut().enumerate() {
+                scope.spawn(async move {
+                    let segment_start = segment_idx * segment_size;
+                    let segment_end = segment_start + segment_size;
+                    let mut matcher =
+                        Matcher::new(query, lowercase_query, query_char_bag, smart_case, true);
 
-                let mut tree_start = 0;
-                for candidate_set in candidate_sets {
-                    if cancel_flag.load(atomic::Ordering::Acquire) {
-                        break;
-                    }
-
-                    let tree_end = tree_start + candidate_set.len();
-
-                    if tree_start < segment_end && segment_start < tree_end {
-                        let start = cmp::max(tree_start, segment_start) - tree_start;
-                        let end = cmp::min(tree_end, segment_end) - tree_start;
-                        let candidates = candidate_set.candidates(start).take(end - start);
-
-                        let worktree_id = candidate_set.id();
-                        let mut prefix = candidate_set
-                            .prefix()
-                            .as_unix_str()
-                            .chars()
-                            .collect::<Vec<_>>();
-                        if !candidate_set.root_is_file() && !prefix.is_empty() {
-                            prefix.push('/');
+                    let mut tree_start = 0;
+                    for candidate_set in candidate_sets {
+                        if cancel_flag.load(atomic::Ordering::Acquire) {
+                            break;
                         }
-                        let lowercase_prefix = prefix
-                            .iter()
-                            .map(|c| simple_lowercase(*c))
-                            .collect::<Vec<_>>();
-                        matcher.match_candidates(
-                            &prefix,
-                            &lowercase_prefix,
-                            candidates,
-                            results,
-                            cancel_flag,
-                            |candidate, score, positions| PathMatch {
-                                score,
-                                worktree_id,
-                                positions: positions.clone(),
-                                path: Arc::from(candidate.path),
-                                is_dir: candidate.is_dir,
-                                path_prefix: candidate_set.prefix(),
-                                distance_to_relative_ancestor: relative_to.as_ref().map_or(
-                                    usize::MAX,
-                                    |relative_to| {
-                                        distance_between_paths(candidate.path, relative_to.as_ref())
-                                    },
-                                ),
-                            },
-                        );
+
+                        let tree_end = tree_start + candidate_set.len();
+
+                        if tree_start < segment_end && segment_start < tree_end {
+                            let start = cmp::max(tree_start, segment_start) - tree_start;
+                            let end = cmp::min(tree_end, segment_end) - tree_start;
+                            let candidates = candidate_set.candidates(start).take(end - start);
+
+                            let worktree_id = candidate_set.id();
+                            let mut prefix = candidate_set
+                                .prefix()
+                                .as_unix_str()
+                                .chars()
+                                .collect::<Vec<_>>();
+                            if !candidate_set.root_is_file() && !prefix.is_empty() {
+                                prefix.push('/');
+                            }
+                            let lowercase_prefix = prefix
+                                .iter()
+                                .map(|c| simple_lowercase(*c))
+                                .collect::<Vec<_>>();
+                            matcher.match_candidates(
+                                &prefix,
+                                &lowercase_prefix,
+                                candidates,
+                                results,
+                                cancel_flag,
+                                |candidate, score, positions| PathMatch {
+                                    score,
+                                    worktree_id,
+                                    positions: positions.clone(),
+                                    path: Arc::from(candidate.path),
+                                    is_dir: candidate.is_dir,
+                                    path_prefix: candidate_set.prefix(),
+                                    distance_to_relative_ancestor: relative_to.as_ref().map_or(
+                                        usize::MAX,
+                                        |relative_to| {
+                                            distance_between_paths(
+                                                candidate.path,
+                                                relative_to.as_ref(),
+                                            )
+                                        },
+                                    ),
+                                },
+                            );
+                        }
+                        if tree_end >= segment_end {
+                            break;
+                        }
+                        tree_start = tree_end;
                     }
-                    if tree_end >= segment_end {
-                        break;
-                    }
-                    tree_start = tree_end;
-                }
-            })
-        }
-    });
+                })
+            }
+        })
+        .await;
 
     if cancel_flag.load(atomic::Ordering::Acquire) {
         return Vec::new();

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -181,74 +181,70 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
         .map(|_| Vec::with_capacity(max_results))
         .collect::<Vec<_>>();
 
-    executor
-        .scoped(|scope| {
-            for (segment_idx, results) in segment_results.iter_mut().enumerate() {
-                scope.spawn(async move {
-                    let segment_start = segment_idx * segment_size;
-                    let segment_end = segment_start + segment_size;
-                    let mut matcher =
-                        Matcher::new(query, lowercase_query, query_char_bag, smart_case, true);
+    executor.scoped(|scope| {
+        for (segment_idx, results) in segment_results.iter_mut().enumerate() {
+            scope.spawn(async move {
+                let segment_start = segment_idx * segment_size;
+                let segment_end = segment_start + segment_size;
+                let mut matcher =
+                    Matcher::new(query, lowercase_query, query_char_bag, smart_case, true);
 
-                    let mut tree_start = 0;
-                    for candidate_set in candidate_sets {
-                        if cancel_flag.load(atomic::Ordering::Acquire) {
-                            break;
-                        }
-
-                        let tree_end = tree_start + candidate_set.len();
-
-                        if tree_start < segment_end && segment_start < tree_end {
-                            let start = cmp::max(tree_start, segment_start) - tree_start;
-                            let end = cmp::min(tree_end, segment_end) - tree_start;
-                            let candidates = candidate_set.candidates(start).take(end - start);
-
-                            let worktree_id = candidate_set.id();
-                            let mut prefix = candidate_set
-                                .prefix()
-                                .as_unix_str()
-                                .chars()
-                                .collect::<Vec<_>>();
-                            if !candidate_set.root_is_file() && !prefix.is_empty() {
-                                prefix.push('/');
-                            }
-                            let lowercase_prefix = prefix
-                                .iter()
-                                .map(|c| simple_lowercase(*c))
-                                .collect::<Vec<_>>();
-                            matcher.match_candidates(
-                                &prefix,
-                                &lowercase_prefix,
-                                candidates,
-                                results,
-                                cancel_flag,
-                                |candidate, score, positions| PathMatch {
-                                    score,
-                                    worktree_id,
-                                    positions: positions.clone(),
-                                    path: Arc::from(candidate.path),
-                                    is_dir: candidate.is_dir,
-                                    path_prefix: candidate_set.prefix(),
-                                    distance_to_relative_ancestor: relative_to.as_ref().map_or(
-                                        usize::MAX,
-                                        |relative_to| {
-                                            distance_between_paths(
-                                                candidate.path,
-                                                relative_to.as_ref(),
-                                            )
-                                        },
-                                    ),
-                                },
-                            );
-                        }
-                        if tree_end >= segment_end {
-                            break;
-                        }
-                        tree_start = tree_end;
+                let mut tree_start = 0;
+                for candidate_set in candidate_sets {
+                    if cancel_flag.load(atomic::Ordering::Acquire) {
+                        break;
                     }
-                })
-            }
-        });
+
+                    let tree_end = tree_start + candidate_set.len();
+
+                    if tree_start < segment_end && segment_start < tree_end {
+                        let start = cmp::max(tree_start, segment_start) - tree_start;
+                        let end = cmp::min(tree_end, segment_end) - tree_start;
+                        let candidates = candidate_set.candidates(start).take(end - start);
+
+                        let worktree_id = candidate_set.id();
+                        let mut prefix = candidate_set
+                            .prefix()
+                            .as_unix_str()
+                            .chars()
+                            .collect::<Vec<_>>();
+                        if !candidate_set.root_is_file() && !prefix.is_empty() {
+                            prefix.push('/');
+                        }
+                        let lowercase_prefix = prefix
+                            .iter()
+                            .map(|c| simple_lowercase(*c))
+                            .collect::<Vec<_>>();
+                        matcher.match_candidates(
+                            &prefix,
+                            &lowercase_prefix,
+                            candidates,
+                            results,
+                            cancel_flag,
+                            |candidate, score, positions| PathMatch {
+                                score,
+                                worktree_id,
+                                positions: positions.clone(),
+                                path: Arc::from(candidate.path),
+                                is_dir: candidate.is_dir,
+                                path_prefix: candidate_set.prefix(),
+                                distance_to_relative_ancestor: relative_to.as_ref().map_or(
+                                    usize::MAX,
+                                    |relative_to| {
+                                        distance_between_paths(candidate.path, relative_to.as_ref())
+                                    },
+                                ),
+                            },
+                        );
+                    }
+                    if tree_end >= segment_end {
+                        break;
+                    }
+                    tree_start = tree_end;
+                }
+            })
+        }
+    });
 
     if cancel_flag.load(atomic::Ordering::Acquire) {
         return Vec::new();

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -248,8 +248,7 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
                     }
                 })
             }
-        })
-        .await;
+        });
 
     if cancel_flag.load(atomic::Ordering::Acquire) {
         return Vec::new();

--- a/crates/fuzzy/src/strings.rs
+++ b/crates/fuzzy/src/strings.rs
@@ -187,8 +187,7 @@ where
                     );
                 });
             }
-        })
-        .await;
+        });
 
     if cancel_flag.load(atomic::Ordering::Acquire) {
         return Vec::new();

--- a/crates/fuzzy/src/strings.rs
+++ b/crates/fuzzy/src/strings.rs
@@ -155,38 +155,43 @@ where
         .map(|_| Vec::with_capacity(max_results.min(candidates.len())))
         .collect::<Vec<_>>();
 
-    executor.scoped(|scope| {
-        for (segment_idx, results) in segment_results.iter_mut().enumerate() {
-            let cancel_flag = &cancel_flag;
-            scope.spawn(async move {
-                let segment_start = cmp::min(segment_idx * segment_size, candidates.len());
-                let segment_end = cmp::min(segment_start + segment_size, candidates.len());
-                let mut matcher = Matcher::new(
-                    query,
-                    lowercase_query,
-                    query_char_bag,
-                    smart_case,
-                    penalize_length,
-                );
+    // SAFETY: the `scoped` future is awaited immediately below, so the spawned
+    // futures — which borrow this frame for `'scope` — never outlive it, and the
+    // future is not leaked (which would skip that await and free the frame early).
+    executor
+        .scoped(|scope| unsafe {
+            for (segment_idx, results) in segment_results.iter_mut().enumerate() {
+                let cancel_flag = &cancel_flag;
+                scope.spawn(async move {
+                    let segment_start = cmp::min(segment_idx * segment_size, candidates.len());
+                    let segment_end = cmp::min(segment_start + segment_size, candidates.len());
+                    let mut matcher = Matcher::new(
+                        query,
+                        lowercase_query,
+                        query_char_bag,
+                        smart_case,
+                        penalize_length,
+                    );
 
-                matcher.match_candidates(
-                    &[],
-                    &[],
-                    candidates[segment_start..segment_end]
-                        .iter()
-                        .map(|c| c.borrow()),
-                    results,
-                    cancel_flag,
-                    |candidate: &&StringMatchCandidate, score, positions| StringMatch {
-                        candidate_id: candidate.id,
-                        score,
-                        positions: positions.clone(),
-                        string: candidate.string.to_string(),
-                    },
-                );
-            });
-        }
-    });
+                    matcher.match_candidates(
+                        &[],
+                        &[],
+                        candidates[segment_start..segment_end]
+                            .iter()
+                            .map(|c| c.borrow()),
+                        results,
+                        cancel_flag,
+                        |candidate: &&StringMatchCandidate, score, positions| StringMatch {
+                            candidate_id: candidate.id,
+                            score,
+                            positions: positions.clone(),
+                            string: candidate.string.to_string(),
+                        },
+                    );
+                });
+            }
+        })
+        .await;
 
     if cancel_flag.load(atomic::Ordering::Acquire) {
         return Vec::new();

--- a/crates/fuzzy/src/strings.rs
+++ b/crates/fuzzy/src/strings.rs
@@ -155,39 +155,38 @@ where
         .map(|_| Vec::with_capacity(max_results.min(candidates.len())))
         .collect::<Vec<_>>();
 
-    executor
-        .scoped(|scope| {
-            for (segment_idx, results) in segment_results.iter_mut().enumerate() {
-                let cancel_flag = &cancel_flag;
-                scope.spawn(async move {
-                    let segment_start = cmp::min(segment_idx * segment_size, candidates.len());
-                    let segment_end = cmp::min(segment_start + segment_size, candidates.len());
-                    let mut matcher = Matcher::new(
-                        query,
-                        lowercase_query,
-                        query_char_bag,
-                        smart_case,
-                        penalize_length,
-                    );
+    executor.scoped(|scope| {
+        for (segment_idx, results) in segment_results.iter_mut().enumerate() {
+            let cancel_flag = &cancel_flag;
+            scope.spawn(async move {
+                let segment_start = cmp::min(segment_idx * segment_size, candidates.len());
+                let segment_end = cmp::min(segment_start + segment_size, candidates.len());
+                let mut matcher = Matcher::new(
+                    query,
+                    lowercase_query,
+                    query_char_bag,
+                    smart_case,
+                    penalize_length,
+                );
 
-                    matcher.match_candidates(
-                        &[],
-                        &[],
-                        candidates[segment_start..segment_end]
-                            .iter()
-                            .map(|c| c.borrow()),
-                        results,
-                        cancel_flag,
-                        |candidate: &&StringMatchCandidate, score, positions| StringMatch {
-                            candidate_id: candidate.id,
-                            score,
-                            positions: positions.clone(),
-                            string: candidate.string.to_string(),
-                        },
-                    );
-                });
-            }
-        });
+                matcher.match_candidates(
+                    &[],
+                    &[],
+                    candidates[segment_start..segment_end]
+                        .iter()
+                        .map(|c| c.borrow()),
+                    results,
+                    cancel_flag,
+                    |candidate: &&StringMatchCandidate, score, positions| StringMatch {
+                        candidate_id: candidate.id,
+                        score,
+                        positions: positions.clone(),
+                        string: candidate.string.to_string(),
+                    },
+                );
+            });
+        }
+    });
 
     if cancel_flag.load(atomic::Ordering::Acquire) {
         return Vec::new();

--- a/crates/fuzzy_nucleo/src/paths.rs
+++ b/crates/fuzzy_nucleo/src/paths.rs
@@ -295,53 +295,58 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
     let mut config = nucleo::Config::DEFAULT;
     config.set_match_paths();
     let mut matchers = matcher::get_matchers(num_cpus, config);
-    executor.scoped(|scope| {
-        for (segment_idx, (results, matcher)) in segment_results
-            .iter_mut()
-            .zip(matchers.iter_mut())
-            .enumerate()
-        {
-            let query = &query;
-            let relative_to = relative_to.clone();
-            scope.spawn(async move {
-                let segment_start = segment_idx * segment_size;
-                let segment_end = segment_start + segment_size;
+    // SAFETY: the `scoped` future is awaited immediately below, so the spawned
+    // futures — which borrow this frame for `'scope` — never outlive it, and the
+    // future is not leaked (which would skip that await and free the frame early).
+    executor
+        .scoped(|scope| unsafe {
+            for (segment_idx, (results, matcher)) in segment_results
+                .iter_mut()
+                .zip(matchers.iter_mut())
+                .enumerate()
+            {
+                let query = &query;
+                let relative_to = relative_to.clone();
+                scope.spawn(async move {
+                    let segment_start = segment_idx * segment_size;
+                    let segment_end = segment_start + segment_size;
 
-                let mut tree_start = 0;
-                for candidate_set in candidate_sets {
-                    let tree_end = tree_start + candidate_set.len();
+                    let mut tree_start = 0;
+                    for candidate_set in candidate_sets {
+                        let tree_end = tree_start + candidate_set.len();
 
-                    if tree_start < segment_end && segment_start < tree_end {
-                        let start = tree_start.max(segment_start) - tree_start;
-                        let end = tree_end.min(segment_end) - tree_start;
-                        let candidates = candidate_set.candidates(start).take(end - start);
+                        if tree_start < segment_end && segment_start < tree_end {
+                            let start = tree_start.max(segment_start) - tree_start;
+                            let end = tree_end.min(segment_end) - tree_start;
+                            let candidates = candidate_set.candidates(start).take(end - start);
 
-                        if path_match_helper(
-                            matcher,
-                            query,
-                            candidates,
-                            results,
-                            candidate_set.id(),
-                            &candidate_set.prefix(),
-                            candidate_set.root_is_file(),
-                            &relative_to,
-                            path_style,
-                            cancel_flag,
-                        )
-                        .is_err()
-                        {
+                            if path_match_helper(
+                                matcher,
+                                query,
+                                candidates,
+                                results,
+                                candidate_set.id(),
+                                &candidate_set.prefix(),
+                                candidate_set.root_is_file(),
+                                &relative_to,
+                                path_style,
+                                cancel_flag,
+                            )
+                            .is_err()
+                            {
+                                break;
+                            }
+                        }
+
+                        if tree_end >= segment_end {
                             break;
                         }
+                        tree_start = tree_end;
                     }
-
-                    if tree_end >= segment_end {
-                        break;
-                    }
-                    tree_start = tree_end;
-                }
-            });
-        }
-    });
+                });
+            }
+        })
+        .await;
 
     matcher::return_matchers(matchers);
     if cancel_flag.load(atomic::Ordering::Acquire) {

--- a/crates/fuzzy_nucleo/src/paths.rs
+++ b/crates/fuzzy_nucleo/src/paths.rs
@@ -342,8 +342,7 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
                     }
                 });
             }
-        })
-        .await;
+        });
 
     matcher::return_matchers(matchers);
     if cancel_flag.load(atomic::Ordering::Acquire) {

--- a/crates/fuzzy_nucleo/src/paths.rs
+++ b/crates/fuzzy_nucleo/src/paths.rs
@@ -295,54 +295,53 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
     let mut config = nucleo::Config::DEFAULT;
     config.set_match_paths();
     let mut matchers = matcher::get_matchers(num_cpus, config);
-    executor
-        .scoped(|scope| {
-            for (segment_idx, (results, matcher)) in segment_results
-                .iter_mut()
-                .zip(matchers.iter_mut())
-                .enumerate()
-            {
-                let query = &query;
-                let relative_to = relative_to.clone();
-                scope.spawn(async move {
-                    let segment_start = segment_idx * segment_size;
-                    let segment_end = segment_start + segment_size;
+    executor.scoped(|scope| {
+        for (segment_idx, (results, matcher)) in segment_results
+            .iter_mut()
+            .zip(matchers.iter_mut())
+            .enumerate()
+        {
+            let query = &query;
+            let relative_to = relative_to.clone();
+            scope.spawn(async move {
+                let segment_start = segment_idx * segment_size;
+                let segment_end = segment_start + segment_size;
 
-                    let mut tree_start = 0;
-                    for candidate_set in candidate_sets {
-                        let tree_end = tree_start + candidate_set.len();
+                let mut tree_start = 0;
+                for candidate_set in candidate_sets {
+                    let tree_end = tree_start + candidate_set.len();
 
-                        if tree_start < segment_end && segment_start < tree_end {
-                            let start = tree_start.max(segment_start) - tree_start;
-                            let end = tree_end.min(segment_end) - tree_start;
-                            let candidates = candidate_set.candidates(start).take(end - start);
+                    if tree_start < segment_end && segment_start < tree_end {
+                        let start = tree_start.max(segment_start) - tree_start;
+                        let end = tree_end.min(segment_end) - tree_start;
+                        let candidates = candidate_set.candidates(start).take(end - start);
 
-                            if path_match_helper(
-                                matcher,
-                                query,
-                                candidates,
-                                results,
-                                candidate_set.id(),
-                                &candidate_set.prefix(),
-                                candidate_set.root_is_file(),
-                                &relative_to,
-                                path_style,
-                                cancel_flag,
-                            )
-                            .is_err()
-                            {
-                                break;
-                            }
-                        }
-
-                        if tree_end >= segment_end {
+                        if path_match_helper(
+                            matcher,
+                            query,
+                            candidates,
+                            results,
+                            candidate_set.id(),
+                            &candidate_set.prefix(),
+                            candidate_set.root_is_file(),
+                            &relative_to,
+                            path_style,
+                            cancel_flag,
+                        )
+                        .is_err()
+                        {
                             break;
                         }
-                        tree_start = tree_end;
                     }
-                });
-            }
-        });
+
+                    if tree_end >= segment_end {
+                        break;
+                    }
+                    tree_start = tree_end;
+                }
+            });
+        }
+    });
 
     matcher::return_matchers(matchers);
     if cancel_flag.load(atomic::Ordering::Acquire) {

--- a/crates/fuzzy_nucleo/src/strings.rs
+++ b/crates/fuzzy_nucleo/src/strings.rs
@@ -127,29 +127,35 @@ where
     let config = nucleo::Config::DEFAULT;
     let mut matchers = matcher::get_matchers(num_cpus, config);
 
-    executor.scoped(|scope| {
-        for (segment_idx, (results, matcher)) in segment_results
-            .iter_mut()
-            .zip(matchers.iter_mut())
-            .enumerate()
-        {
-            let query = &query;
-            scope.spawn(async move {
-                let segment_start = segment_idx * base_size + segment_idx.min(remainder);
-                let segment_end = (segment_idx + 1) * base_size + (segment_idx + 1).min(remainder);
+    // SAFETY: the `scoped` future is awaited immediately below, so the spawned
+    // futures — which borrow this frame for `'scope` — never outlive it, and the
+    // future is not leaked (which would skip that await and free the frame early).
+    executor
+        .scoped(|scope| unsafe {
+            for (segment_idx, (results, matcher)) in segment_results
+                .iter_mut()
+                .zip(matchers.iter_mut())
+                .enumerate()
+            {
+                let query = &query;
+                scope.spawn(async move {
+                    let segment_start = segment_idx * base_size + segment_idx.min(remainder);
+                    let segment_end =
+                        (segment_idx + 1) * base_size + (segment_idx + 1).min(remainder);
 
-                match_string_helper(
-                    &candidates[segment_start..segment_end],
-                    query,
-                    matcher,
-                    length_penalty,
-                    results,
-                    cancel_flag,
-                )
-                .ok();
-            });
-        }
-    });
+                    match_string_helper(
+                        &candidates[segment_start..segment_end],
+                        query,
+                        matcher,
+                        length_penalty,
+                        results,
+                        cancel_flag,
+                    )
+                    .ok();
+                });
+            }
+        })
+        .await;
 
     matcher::return_matchers(matchers);
 

--- a/crates/fuzzy_nucleo/src/strings.rs
+++ b/crates/fuzzy_nucleo/src/strings.rs
@@ -127,31 +127,29 @@ where
     let config = nucleo::Config::DEFAULT;
     let mut matchers = matcher::get_matchers(num_cpus, config);
 
-    executor
-        .scoped(|scope| {
-            for (segment_idx, (results, matcher)) in segment_results
-                .iter_mut()
-                .zip(matchers.iter_mut())
-                .enumerate()
-            {
-                let query = &query;
-                scope.spawn(async move {
-                    let segment_start = segment_idx * base_size + segment_idx.min(remainder);
-                    let segment_end =
-                        (segment_idx + 1) * base_size + (segment_idx + 1).min(remainder);
+    executor.scoped(|scope| {
+        for (segment_idx, (results, matcher)) in segment_results
+            .iter_mut()
+            .zip(matchers.iter_mut())
+            .enumerate()
+        {
+            let query = &query;
+            scope.spawn(async move {
+                let segment_start = segment_idx * base_size + segment_idx.min(remainder);
+                let segment_end = (segment_idx + 1) * base_size + (segment_idx + 1).min(remainder);
 
-                    match_string_helper(
-                        &candidates[segment_start..segment_end],
-                        query,
-                        matcher,
-                        length_penalty,
-                        results,
-                        cancel_flag,
-                    )
-                    .ok();
-                });
-            }
-        });
+                match_string_helper(
+                    &candidates[segment_start..segment_end],
+                    query,
+                    matcher,
+                    length_penalty,
+                    results,
+                    cancel_flag,
+                )
+                .ok();
+            });
+        }
+    });
 
     matcher::return_matchers(matchers);
 

--- a/crates/fuzzy_nucleo/src/strings.rs
+++ b/crates/fuzzy_nucleo/src/strings.rs
@@ -151,8 +151,7 @@ where
                     .ok();
                 });
             }
-        })
-        .await;
+        });
 
     matcher::return_matchers(matchers);
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -664,7 +664,12 @@ pub struct App {
 
     /// Per-App element arena. This isolates element allocations between different
     /// App instances (important for tests where multiple Apps run concurrently).
-    pub(crate) element_arena: RefCell<Arena>,
+    ///
+    /// This is an `Rc` so that the `ArenaClearNeeded` token returned by
+    /// `Window::draw` can hold a strong reference to it. That keeps the arena
+    /// alive even if the token outlives the `App`, so clearing it can never
+    /// dereference freed memory.
+    pub(crate) element_arena: Rc<RefCell<Arena>>,
     /// Per-App event arena.
     pub(crate) event_arena: Arena,
 
@@ -798,7 +803,7 @@ impl App {
 
                 #[cfg(any(test, feature = "test-support", debug_assertions))]
                 name: None,
-                element_arena: RefCell::new(Arena::new(1024 * 1024)),
+                element_arena: Rc::new(RefCell::new(Arena::new(1024 * 1024))),
                 event_arena: Arena::new(1024 * 1024),
 
                 #[cfg(any(test, feature = "leak-detection"))]

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -941,13 +941,17 @@ impl VisualTestContext {
     /// Get an &mut VisualTestContext (which is mostly what you need to pass to other methods).
     /// This method internally retains the VisualTestContext until the end of the test.
     pub fn into_mut(self) -> &'static mut Self {
-        let ptr = Box::into_raw(Box::new(self));
-        // safety: on_quit will be called after the test has finished.
-        // the executor will ensure that all tasks related to the test have stopped.
-        // so there is no way for cx to be accessed after on_quit is called.
-        // todo: This is unsound under stacked borrows (also tree borrows probably?)
-        // the mutable reference invalidates `ptr` which is later used in the closure
-        let cx = unsafe { &mut *ptr };
+        // Leak the box to obtain the `&'static mut Self` we hand back, then
+        // derive the raw pointer *from that reference*. This way the eventual
+        // `Box::from_raw` is a child of the same borrow we return, rather than
+        // aliasing a separately-created pointer (which would be unsound under
+        // stacked/tree borrows).
+        //
+        // safety: on_quit will be called after the test has finished. The
+        // executor ensures that all tasks related to the test have stopped, so
+        // the reference cannot be accessed after on_quit reclaims the box.
+        let cx: &'static mut Self = Box::leak(Box::new(self));
+        let ptr: *mut Self = cx;
         cx.on_quit(move || unsafe {
             drop(Box::from_raw(ptr));
         });

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -941,17 +941,13 @@ impl VisualTestContext {
     /// Get an &mut VisualTestContext (which is mostly what you need to pass to other methods).
     /// This method internally retains the VisualTestContext until the end of the test.
     pub fn into_mut(self) -> &'static mut Self {
-        // Leak the box to obtain the `&'static mut Self` we hand back, then
-        // derive the raw pointer *from that reference*. This way the eventual
-        // `Box::from_raw` is a child of the same borrow we return, rather than
-        // aliasing a separately-created pointer (which would be unsound under
-        // stacked/tree borrows).
-        //
-        // safety: on_quit will be called after the test has finished. The
-        // executor ensures that all tasks related to the test have stopped, so
-        // the reference cannot be accessed after on_quit reclaims the box.
-        let cx: &'static mut Self = Box::leak(Box::new(self));
-        let ptr: *mut Self = cx;
+        let ptr = Box::into_raw(Box::new(self));
+        // safety: on_quit will be called after the test has finished.
+        // the executor will ensure that all tasks related to the test have stopped.
+        // so there is no way for cx to be accessed after on_quit is called.
+        // todo: This is unsound under stacked borrows (also tree borrows probably?)
+        // the mutable reference invalidates `ptr` which is later used in the closure
+        let cx = unsafe { &mut *ptr };
         cx.on_quit(move || unsafe {
             drop(Box::from_raw(ptr));
         });

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -116,38 +116,43 @@ impl BackgroundExecutor {
     /// Scoped lets you start a number of tasks and waits
     /// for all of them to complete before returning.
     ///
-    /// This is a synchronous, blocking call: it spawns the futures registered
-    /// by `scheduler` onto the background executor and blocks the current
-    /// thread until they have all resolved. Being synchronous is what keeps it
-    /// sound (see the safety comment on [`Scope::spawn`]): the futures borrow
-    /// the caller's frame and are only kept alive by the blocking `Scope` drop.
-    /// If this instead returned an intermediate future, that future could be
-    /// polled once (spawning the borrowing background tasks) and then leaked
-    /// with `mem::forget`, skipping the blocking drop and freeing the borrowed
-    /// frame while the background threads were still reading it.
-    pub fn scoped<'scope, F>(&self, scheduler: F)
+    /// The returned future spawns the futures registered by `scheduler` onto
+    /// the background executor and then awaits them all. It MUST be polled to
+    /// completion and MUST NOT be leaked (see the safety contract on
+    /// [`Scope::spawn`]), because the spawned futures borrow the caller's frame
+    /// for `'scope`.
+    pub async fn scoped<'scope, F>(&self, scheduler: F)
     where
         F: FnOnce(&mut Scope<'scope>),
     {
-        self.scoped_priority(Priority::default(), scheduler)
+        let mut scope = Scope::new(self.clone(), Priority::default());
+        (scheduler)(&mut scope);
+        let spawned = mem::take(&mut scope.futures)
+            .into_iter()
+            .map(|f| self.spawn_with_priority(scope.priority, f))
+            .collect::<Vec<_>>();
+        for task in spawned {
+            task.await;
+        }
     }
 
     /// Scoped lets you start a number of tasks and waits
     /// for all of them to complete before returning.
     ///
-    /// See [`Self::scoped`] for why this is a synchronous, blocking call.
-    pub fn scoped_priority<'scope, F>(&self, priority: Priority, scheduler: F)
+    /// See [`Self::scoped`]: the returned future must be polled to completion
+    /// and must not be leaked.
+    pub async fn scoped_priority<'scope, F>(&self, priority: Priority, scheduler: F)
     where
         F: FnOnce(&mut Scope<'scope>),
     {
-        let mut scope = Scope::new(self.clone());
+        let mut scope = Scope::new(self.clone(), priority);
         (scheduler)(&mut scope);
-        // Spawn every registered future onto the background executor and detach
-        // it. Dropping `scope` at the end of this function blocks until all of
-        // them have resolved (see `Scope::drop`), which upholds the contract
-        // that the borrowed `'scope` data outlives the spawned work.
-        for future in mem::take(&mut scope.futures) {
-            self.spawn_with_priority(priority, future).detach();
+        let spawned = mem::take(&mut scope.futures)
+            .into_iter()
+            .map(|f| self.spawn_with_priority(scope.priority, f))
+            .collect::<Vec<_>>();
+        for task in spawned {
+            task.await;
         }
     }
 
@@ -387,6 +392,7 @@ impl ForegroundExecutor {
 /// Scope manages a set of tasks that are enqueued and waited on together. See [`BackgroundExecutor::scoped`].
 pub struct Scope<'a> {
     executor: BackgroundExecutor,
+    priority: Priority,
     futures: Vec<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>,
     tx: Option<mpsc::Sender<()>>,
     rx: mpsc::Receiver<()>,
@@ -394,10 +400,11 @@ pub struct Scope<'a> {
 }
 
 impl<'a> Scope<'a> {
-    fn new(executor: BackgroundExecutor) -> Self {
+    fn new(executor: BackgroundExecutor, priority: Priority) -> Self {
         let (tx, rx) = mpsc::channel(1);
         Self {
             executor,
+            priority,
             tx: Some(tx),
             rx,
             futures: Default::default(),
@@ -411,15 +418,29 @@ impl<'a> Scope<'a> {
     }
 
     /// Spawn a future into this scope.
+    ///
+    /// # Safety
+    ///
+    /// `f` may borrow data that only lives for `'a`, but it is transmuted to a
+    /// `'static` future and spawned onto the background executor. The `'a`
+    /// borrow is only guaranteed to outlive the spawned future because
+    /// [`BackgroundExecutor::scoped`]/[`BackgroundExecutor::scoped_priority`]
+    /// await every spawned future (and `Scope::drop` blocks on them) before
+    /// returning. The caller must therefore ensure the enclosing `scoped`
+    /// future is polled to completion and NOT leaked (e.g. via `mem::forget`):
+    /// leaking it would skip that await/drop and free the borrowed frame while
+    /// the background threads are still reading it. Every in-tree caller
+    /// satisfies this by awaiting the `scoped` future immediately.
     #[track_caller]
-    pub fn spawn<F>(&mut self, f: F)
+    pub unsafe fn spawn<F>(&mut self, f: F)
     where
         F: Future<Output = ()> + Send + 'a,
     {
         let tx = self.tx.clone().unwrap();
 
         // SAFETY: The 'a lifetime is guaranteed to outlive any of these futures because
-        // dropping this `Scope` blocks until all of the futures have resolved.
+        // dropping this `Scope` blocks until all of the futures have resolved,
+        // provided the caller upholds the contract documented above.
         let f = unsafe {
             mem::transmute::<
                 Pin<Box<dyn Future<Output = ()> + Send + 'a>>,

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -115,35 +115,39 @@ impl BackgroundExecutor {
 
     /// Scoped lets you start a number of tasks and waits
     /// for all of them to complete before returning.
-    pub async fn scoped<'scope, F>(&self, scheduler: F)
+    ///
+    /// This is a synchronous, blocking call: it spawns the futures registered
+    /// by `scheduler` onto the background executor and blocks the current
+    /// thread until they have all resolved. Being synchronous is what keeps it
+    /// sound (see the safety comment on [`Scope::spawn`]): the futures borrow
+    /// the caller's frame and are only kept alive by the blocking `Scope` drop.
+    /// If this instead returned an intermediate future, that future could be
+    /// polled once (spawning the borrowing background tasks) and then leaked
+    /// with `mem::forget`, skipping the blocking drop and freeing the borrowed
+    /// frame while the background threads were still reading it.
+    pub fn scoped<'scope, F>(&self, scheduler: F)
     where
         F: FnOnce(&mut Scope<'scope>),
     {
-        let mut scope = Scope::new(self.clone(), Priority::default());
-        (scheduler)(&mut scope);
-        let spawned = mem::take(&mut scope.futures)
-            .into_iter()
-            .map(|f| self.spawn_with_priority(scope.priority, f))
-            .collect::<Vec<_>>();
-        for task in spawned {
-            task.await;
-        }
+        self.scoped_priority(Priority::default(), scheduler)
     }
 
     /// Scoped lets you start a number of tasks and waits
     /// for all of them to complete before returning.
-    pub async fn scoped_priority<'scope, F>(&self, priority: Priority, scheduler: F)
+    ///
+    /// See [`Self::scoped`] for why this is a synchronous, blocking call.
+    pub fn scoped_priority<'scope, F>(&self, priority: Priority, scheduler: F)
     where
         F: FnOnce(&mut Scope<'scope>),
     {
-        let mut scope = Scope::new(self.clone(), priority);
+        let mut scope = Scope::new(self.clone());
         (scheduler)(&mut scope);
-        let spawned = mem::take(&mut scope.futures)
-            .into_iter()
-            .map(|f| self.spawn_with_priority(scope.priority, f))
-            .collect::<Vec<_>>();
-        for task in spawned {
-            task.await;
+        // Spawn every registered future onto the background executor and detach
+        // it. Dropping `scope` at the end of this function blocks until all of
+        // them have resolved (see `Scope::drop`), which upholds the contract
+        // that the borrowed `'scope` data outlives the spawned work.
+        for future in mem::take(&mut scope.futures) {
+            self.spawn_with_priority(priority, future).detach();
         }
     }
 
@@ -383,7 +387,6 @@ impl ForegroundExecutor {
 /// Scope manages a set of tasks that are enqueued and waited on together. See [`BackgroundExecutor::scoped`].
 pub struct Scope<'a> {
     executor: BackgroundExecutor,
-    priority: Priority,
     futures: Vec<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>,
     tx: Option<mpsc::Sender<()>>,
     rx: mpsc::Receiver<()>,
@@ -391,11 +394,10 @@ pub struct Scope<'a> {
 }
 
 impl<'a> Scope<'a> {
-    fn new(executor: BackgroundExecutor, priority: Priority) -> Self {
+    fn new(executor: BackgroundExecutor) -> Self {
         let (tx, rx) = mpsc::channel(1);
         Self {
             executor,
-            priority,
             tx: Some(tx),
             rx,
             futures: Default::default(),
@@ -433,6 +435,13 @@ impl<'a> Scope<'a> {
 
 impl Drop for Scope<'_> {
     fn drop(&mut self) {
+        // Drop any futures that were registered but never spawned (for example
+        // if the `scheduler` closure panicked before they were spawned). Each
+        // un-spawned future holds a clone of `tx`, so we must drop them before
+        // blocking on `rx` below; otherwise those senders would keep the
+        // channel open forever and this drop would deadlock.
+        self.futures.clear();
+
         self.tx.take().unwrap();
 
         // Wait until the channel is closed, which means that all of the spawned

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -322,23 +322,24 @@ impl Drop for ElementArenaScope {
 /// Returned when the element arena has been used and so must be cleared before the next draw.
 #[must_use]
 pub struct ArenaClearNeeded {
-    arena: *const RefCell<Arena>,
+    // Hold a strong reference to the arena rather than a raw pointer, so that a
+    // token which outlives its `App` keeps the arena alive instead of pointing
+    // at freed memory. Construction and clearing happen once per frame, so the
+    // reference count churn is not on the hot path.
+    arena: Rc<RefCell<Arena>>,
 }
 
 impl ArenaClearNeeded {
     /// Create a new ArenaClearNeeded that will clear the given arena.
-    pub(crate) fn new(arena: &RefCell<Arena>) -> Self {
+    pub(crate) fn new(arena: &Rc<RefCell<Arena>>) -> Self {
         Self {
-            arena: arena as *const RefCell<Arena>,
+            arena: arena.clone(),
         }
     }
 
     /// Clear the element arena.
     pub fn clear(self) {
-        // SAFETY: The arena pointer is valid because ArenaClearNeeded is created
-        // at the end of draw() and must be cleared before the next draw.
-        let arena_cell = unsafe { &*self.arena };
-        arena_cell.borrow_mut().clear();
+        self.arena.borrow_mut().clear();
     }
 }
 

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -346,22 +346,21 @@ impl Search {
                     let num_cpus = _executor.num_cpus();
 
                     assert!(num_cpus > 0);
-                    _executor
-                        .scoped(|scope| {
-                            let worker_count = (num_cpus - 1).max(1);
-                            for _ in 0..worker_count {
-                                let worker = Worker {
-                                    query: query.clone(),
-                                    open_buffers: open_buffers.clone(),
-                                    candidates: candidate_searcher.clone(),
-                                    find_all_matches_rx: find_all_matches_rx.clone(),
-                                };
-                                scope.spawn(worker.run());
-                            }
+                    _executor.scoped(|scope| {
+                        let worker_count = (num_cpus - 1).max(1);
+                        for _ in 0..worker_count {
+                            let worker = Worker {
+                                query: query.clone(),
+                                open_buffers: open_buffers.clone(),
+                                candidates: candidate_searcher.clone(),
+                                find_all_matches_rx: find_all_matches_rx.clone(),
+                            };
+                            scope.spawn(worker.run());
+                        }
 
-                            drop(find_all_matches_rx);
-                            drop(candidate_searcher);
-                        });
+                        drop(find_all_matches_rx);
+                        drop(candidate_searcher);
+                    });
                 });
 
                 let (sorted_matches_tx, sorted_matches_rx) = unbounded();

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -346,21 +346,26 @@ impl Search {
                     let num_cpus = _executor.num_cpus();
 
                     assert!(num_cpus > 0);
-                    _executor.scoped(|scope| {
-                        let worker_count = (num_cpus - 1).max(1);
-                        for _ in 0..worker_count {
-                            let worker = Worker {
-                                query: query.clone(),
-                                open_buffers: open_buffers.clone(),
-                                candidates: candidate_searcher.clone(),
-                                find_all_matches_rx: find_all_matches_rx.clone(),
-                            };
-                            scope.spawn(worker.run());
-                        }
+                    // SAFETY: the `scoped` future is awaited immediately below, so the
+                    // spawned futures — which borrow this frame for `'scope` — never
+                    // outlive it, and the future is not leaked (which would skip that await).
+                    _executor
+                        .scoped(|scope| unsafe {
+                            let worker_count = (num_cpus - 1).max(1);
+                            for _ in 0..worker_count {
+                                let worker = Worker {
+                                    query: query.clone(),
+                                    open_buffers: open_buffers.clone(),
+                                    candidates: candidate_searcher.clone(),
+                                    find_all_matches_rx: find_all_matches_rx.clone(),
+                                };
+                                scope.spawn(worker.run());
+                            }
 
-                        drop(find_all_matches_rx);
-                        drop(candidate_searcher);
-                    });
+                            drop(find_all_matches_rx);
+                            drop(candidate_searcher);
+                        })
+                        .await;
                 });
 
                 let (sorted_matches_tx, sorted_matches_rx) = unbounded();

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -361,8 +361,7 @@ impl Search {
 
                             drop(find_all_matches_rx);
                             drop(candidate_searcher);
-                        })
-                        .await;
+                        });
                 });
 
                 let (sorted_matches_tx, sorted_matches_rx) = unbounded();

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5471,31 +5471,30 @@ impl BackgroundScanner {
         }
         drop(ignore_queue_tx);
 
-        self.executor
-            .scoped(|scope| {
-                for _ in 0..self.executor.num_cpus() {
-                    scope.spawn(async {
-                        loop {
-                            select_biased! {
-                                // Process any path refresh requests before moving on to process
-                                // the queue of ignore statuses.
-                                request = self.next_scan_request().fuse() => {
-                                    let Ok(request) = request else { break };
-                                    if !self.process_scan_request(request, true).await {
-                                        return;
-                                    }
-                                }
-
-                                // Recursively process directories whose ignores have changed.
-                                job = ignore_queue_rx.recv().fuse() => {
-                                    let Ok(job) = job else { break };
-                                    self.update_ignore_status(job, &prev_snapshot).await;
+        self.executor.scoped(|scope| {
+            for _ in 0..self.executor.num_cpus() {
+                scope.spawn(async {
+                    loop {
+                        select_biased! {
+                            // Process any path refresh requests before moving on to process
+                            // the queue of ignore statuses.
+                            request = self.next_scan_request().fuse() => {
+                                let Ok(request) = request else { break };
+                                if !self.process_scan_request(request, true).await {
+                                    return;
                                 }
                             }
+
+                            // Recursively process directories whose ignores have changed.
+                            job = ignore_queue_rx.recv().fuse() => {
+                                let Ok(job) = job else { break };
+                                self.update_ignore_status(job, &prev_snapshot).await;
+                            }
                         }
-                    });
-                }
-            });
+                    }
+                });
+            }
+        });
     }
 
     async fn ignores_needing_update(&self) -> Vec<Arc<Path>> {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4942,8 +4942,7 @@ impl BackgroundScanner {
                         }
                     });
                 }
-            })
-            .await;
+            });
     }
 
     async fn send_status_update(
@@ -5496,8 +5495,7 @@ impl BackgroundScanner {
                         }
                     });
                 }
-            })
-            .await;
+            });
     }
 
     async fn ignores_needing_update(&self) -> Vec<Arc<Path>> {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4889,8 +4889,11 @@ impl BackgroundScanner {
         }
 
         let progress_update_count = AtomicUsize::new(0);
+        // SAFETY: the `scoped_priority` future is awaited immediately below, so the
+        // spawned futures — which borrow this frame for `'scope` — never outlive it,
+        // and the future is not leaked (which would skip that await).
         self.executor
-            .scoped_priority(Priority::Low, |scope| {
+            .scoped_priority(Priority::Low, |scope| unsafe {
                 for _ in 0..self.executor.num_cpus() {
                     scope.spawn(async {
                         let mut last_progress_update_count = 0;
@@ -4942,7 +4945,8 @@ impl BackgroundScanner {
                         }
                     });
                 }
-            });
+            })
+            .await;
     }
 
     async fn send_status_update(
@@ -5471,30 +5475,35 @@ impl BackgroundScanner {
         }
         drop(ignore_queue_tx);
 
-        self.executor.scoped(|scope| {
-            for _ in 0..self.executor.num_cpus() {
-                scope.spawn(async {
-                    loop {
-                        select_biased! {
-                            // Process any path refresh requests before moving on to process
-                            // the queue of ignore statuses.
-                            request = self.next_scan_request().fuse() => {
-                                let Ok(request) = request else { break };
-                                if !self.process_scan_request(request, true).await {
-                                    return;
+        // SAFETY: the `scoped` future is awaited immediately below, so the spawned
+        // futures — which borrow this frame for `'scope` — never outlive it, and the
+        // future is not leaked (which would skip that await).
+        self.executor
+            .scoped(|scope| unsafe {
+                for _ in 0..self.executor.num_cpus() {
+                    scope.spawn(async {
+                        loop {
+                            select_biased! {
+                                // Process any path refresh requests before moving on to process
+                                // the queue of ignore statuses.
+                                request = self.next_scan_request().fuse() => {
+                                    let Ok(request) = request else { break };
+                                    if !self.process_scan_request(request, true).await {
+                                        return;
+                                    }
+                                }
+
+                                // Recursively process directories whose ignores have changed.
+                                job = ignore_queue_rx.recv().fuse() => {
+                                    let Ok(job) = job else { break };
+                                    self.update_ignore_status(job, &prev_snapshot).await;
                                 }
                             }
-
-                            // Recursively process directories whose ignores have changed.
-                            job = ignore_queue_rx.recv().fuse() => {
-                                let Ok(job) = job else { break };
-                                self.update_ignore_status(job, &prev_snapshot).await;
-                            }
                         }
-                    }
-                });
-            }
-        });
+                    });
+                }
+            })
+            .await;
     }
 
     async fn ignores_needing_update(&self) -> Vec<Arc<Path>> {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1811,7 +1811,7 @@ fn load_embedded_fonts(cx: &App) {
     let embedded_fonts = Mutex::new(Vec::new());
     let executor = cx.background_executor();
 
-    cx.foreground_executor().block_on(executor.scoped(|scope| {
+    executor.scoped(|scope| {
         for font_path in &font_paths {
             if !font_path.ends_with(".ttf") {
                 continue;
@@ -1822,7 +1822,7 @@ fn load_embedded_fonts(cx: &App) {
                 embedded_fonts.lock().push(font_bytes);
             });
         }
-    }));
+    });
 
     cx.text_system()
         .add_fonts(embedded_fonts.into_inner())

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1811,7 +1811,9 @@ fn load_embedded_fonts(cx: &App) {
     let embedded_fonts = Mutex::new(Vec::new());
     let executor = cx.background_executor();
 
-    executor.scoped(|scope| {
+    // SAFETY: `load_fonts` is driven to completion by `block_on` below (never
+    // leaked), so the spawned futures' `'scope` borrows of this frame stay valid.
+    let load_fonts = executor.scoped(|scope| unsafe {
         for font_path in &font_paths {
             if !font_path.ends_with(".ttf") {
                 continue;
@@ -1823,6 +1825,7 @@ fn load_embedded_fonts(cx: &App) {
             });
         }
     });
+    cx.foreground_executor().block_on(load_fonts);
 
     cx.text_system()
         .add_fonts(embedded_fonts.into_inner())

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2633,7 +2633,7 @@ pub(crate) fn eager_load_active_theme_and_icon_theme(fs: Arc<dyn Fs>, cx: &mut A
         return;
     }
 
-    cx.foreground_executor().block_on(executor.scoped(|scope| {
+    executor.scoped(|scope| {
         for load_target in themes_to_load {
             let theme_registry = &theme_registry;
             let reload_tasks = &reload_tasks;
@@ -2663,7 +2663,7 @@ pub(crate) fn eager_load_active_theme_and_icon_theme(fs: Arc<dyn Fs>, cx: &mut A
                 }
             });
         }
-    }));
+    });
 
     for reload_target in reload_tasks.into_inner() {
         match reload_target {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2633,7 +2633,9 @@ pub(crate) fn eager_load_active_theme_and_icon_theme(fs: Arc<dyn Fs>, cx: &mut A
         return;
     }
 
-    executor.scoped(|scope| {
+    // SAFETY: `load_themes` is driven to completion by `block_on` below (never
+    // leaked), so the spawned futures' `'scope` borrows of this frame stay valid.
+    let load_themes = executor.scoped(|scope| unsafe {
         for load_target in themes_to_load {
             let theme_registry = &theme_registry;
             let reload_tasks = &reload_tasks;
@@ -2664,6 +2666,7 @@ pub(crate) fn eager_load_active_theme_and_icon_theme(fs: Arc<dyn Fs>, cx: &mut A
             });
         }
     });
+    cx.foreground_executor().block_on(load_themes);
 
     for reload_target in reload_tasks.into_inner() {
         match reload_target {


### PR DESCRIPTION
This fixes two soundness issues in gpui core. The first is a use-after-free hole in `BackgroundExecutor::scoped`: it transmutes borrowed (`'a`) futures to `'static`, spawns them on real background threads, and relies on the returned future being awaited (and `Scope::drop` blocking) before the borrowed frame is freed. Because `scoped` is a safe `async fn`, that future could be polled once — spawning the borrowing tasks — and then leaked with `mem::forget`, which skips the await/drop and frees the frame while the background threads are still reading it. The fix pushes that obligation onto the caller by making the lifetime-transmuting `Scope::spawn` an `unsafe fn` whose `# Safety` contract requires the enclosing `scoped` future to be polled to completion and never leaked, so safe code can no longer trigger the UAF. All ten in-tree call sites (in `fuzzy`, `fuzzy_nucleo`, `worktree`, `editor`, `project`, and two startup paths in `zed`) await or `block_on` the future immediately, so each now wraps its scheduler closure in `unsafe` with a short safety comment.

An earlier revision of this PR instead made `scoped`/`scoped_priority` synchronous, but that deadlocks: `Scope::drop` blocks via `PlatformScheduler::block`, which parks the calling thread without running other runnables. Linux's background pool is a fixed size (`available_parallelism().max(2)`), so a background caller that spawns ~`num_cpus` scoped tasks and then parks the caller can exhaust the pool (e.g. two concurrent worktree scans on a two-core box); the macOS (GCD) and Windows (WinRT) pools grow, so they merely stall, and none of the production dispatchers expose a way to run queued runnables from the blocking thread. Keeping `scoped` async avoids this: awaiting yields the worker thread rather than parking it, and by the time `Scope::drop` runs the channel is already closed so it returns without parking. While here, `Scope::drop` also clears any un-spawned futures before blocking on the channel, so a panic in the scheduler closure can't leave sender clones alive that would keep the channel open forever.

The second fix addresses `Window::draw`, which returned an `ArenaClearNeeded` token holding a raw `*const RefCell<Arena>` with a fabricated `'static` lifetime and no ownership tie to the `App`. A token stored past the `App`'s lifetime would dereference freed memory when cleared. `App::element_arena` is now an `Rc<RefCell<Arena>>` and the token holds an `Rc` clone, so it keeps the arena alive and clearing is always safe. Construction and clearing are once-per-frame cold paths; the hot element-allocation path still uses the thread-local raw pointer and is unchanged.

Release Notes:

- N/A
