### PR TITLE
cloud_api_types: Add new ID fields to `AuthenticatedUser`

### DIFF
--- a/crates/client/src/test.rs
+++ b/crates/client/src/test.rs
@@ -240,7 +240,8 @@ pub fn make_get_authenticated_user_response(
 ) -> GetAuthenticatedUserResponse {
     GetAuthenticatedUserResponse {
         user: AuthenticatedUser {
-            id: user_id,
+            id_v2: format!("user_{user_id}"),
+            legacy_user_id: user_id,
             metrics_id: format!("metrics-id-{user_id}"),
             username: username.clone(),
             avatar_url: "".to_string(),

--- a/crates/cloud_api_types/src/cloud_api_types.rs
+++ b/crates/cloud_api_types/src/cloud_api_types.rs
@@ -36,7 +36,8 @@ pub struct GetAuthenticatedUserResponse {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct AuthenticatedUser {
-    pub id: i32,
+    pub id_v2: String,
+    pub legacy_user_id: i32,
     pub metrics_id: String,
     pub username: String,
     pub avatar_url: String,

--- a/crates/collab/src/auth.rs
+++ b/crates/collab/src/auth.rs
@@ -67,7 +67,7 @@ pub async fn validate_header<B>(mut req: Request<B>, next: Next<B>) -> impl Into
             .context("failed to parse response body")?;
 
         let user = User {
-            id: UserId(response_body.user.id),
+            id: UserId(response_body.user.legacy_user_id),
             username: response_body.user.username,
             github_login: response_body.user.github_login,
             avatar_url: response_body.user.avatar_url,


### PR DESCRIPTION
This PR adds the new `id_v2` and `legacy_user_id` fields to the `AuthenticatedUser` type and starts using them in place of the `id` field.

Release Notes:

- N/A
