### PR TITLE
Add license symlinks to lint test fixture crates

### DIFF
--- a/tooling/lints/test_fixture/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/consumer/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/consumer/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/gpui/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/gpui/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/gpui_shared_string/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/gpui_shared_string/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/render_consumer/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/render_consumer/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE


### PR DESCRIPTION
Stacked on #60501 (the CI-orchestration fix) and targets it — #60501 must land first. #60501 is what lets this fixtures-only PR go green: without it, a `tooling/lints/`-only change trips the `rdeps(lints)` nextest filter and `run_tests` errors out.

Follow-up to #60468, which added a `LICENSE-APACHE` symlink to the `tooling/lints` crate but not to the `test_fixture` sub-crates beneath it. Those five sub-crates still lack the `LICENSE-GPL`/`LICENSE-APACHE` symlink that `script/check-licenses` requires of every first-party crate, so `check_licenses` continues to fail on any pull request that changes `Cargo.lock`. This adds `LICENSE-APACHE` symlinks to the five `tooling/lints/test_fixture` crates, matching #60468; `script/check-licenses` passes locally afterward.

Release Notes:

- N/A