### PR TITLE
run_tests: Run dylint workspace tests and stop mislabeling non-workspace dirs as packages

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -76,11 +76,15 @@ jobs:
           FILE_CHANGED_PKGS=""
           for dir in $CHANGED_DIRS; do
             pkg=$(echo "$DIR_TO_PKG" | grep "^${dir}=" | cut -d= -f2 | head -1 || true)
+            # Only include directories that map to a real root-workspace package.
+            # Some directories (e.g. tooling/lints) are separate workspaces with no
+            # root-workspace package; fabricating a package name from the raw
+            # directory here would produce an invalid nextest filterset such as
+            # "rdeps(lints)" and fail the run with "operator didn't match any
+            # packages". Unmapped directories fall through to the "no package
+            # changes detected" path below, which runs the full suite.
             if [ -n "$pkg" ]; then
               FILE_CHANGED_PKGS=$(printf '%s\n%s' "$FILE_CHANGED_PKGS" "$pkg")
-            else
-              # Fall back to directory name if no mapping found
-              FILE_CHANGED_PKGS=$(printf '%s\n%s' "$FILE_CHANGED_PKGS" "$dir")
             fi
           done
           FILE_CHANGED_PKGS=$(echo "$FILE_CHANGED_PKGS" | grep -v '^$' | sort -u || true)
@@ -111,6 +115,7 @@ jobs:
         check_pattern "run_docs" '^(docs/|crates/.*\.rs)' -qP
         check_pattern "run_licenses" '^(Cargo.lock|script/.*licenses)' -qP
         check_pattern "run_tests" '^(docs/|script/update_top_ranking_issues/|\.github/(ISSUE_TEMPLATE|workflows/(?!run_tests))|extensions/)' -qvP
+        check_pattern "run_lint_tests" '^tooling/lints/' -qP
         # Detect changed extension directories (excluding extensions/workflows)
         CHANGED_EXTENSIONS=$(echo "$CHANGED_FILES" | grep -oP '^extensions/[^/]+(?=/)' | sort -u | grep -v '^extensions/workflows$' || true)
         # Filter out deleted extensions
@@ -133,6 +138,7 @@ jobs:
       run_docs: ${{ steps.filter.outputs.run_docs }}
       run_licenses: ${{ steps.filter.outputs.run_licenses }}
       run_tests: ${{ steps.filter.outputs.run_tests }}
+      run_lint_tests: ${{ steps.filter.outputs.run_lint_tests }}
       changed_extensions: ${{ steps.filter.outputs.changed_extensions }}
   check_style:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
@@ -549,6 +555,34 @@ jobs:
       run: |
         rm -rf ./../.cargo
     timeout-minutes: 60
+  lints_tests:
+    needs:
+    - orchestrate
+    if: needs.orchestrate.outputs.run_lint_tests == 'true' && github.event_name != 'merge_group'
+    runs-on: namespace-profile-16x32-ubuntu-2204
+    steps:
+    - name: steps::harden_runner
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411
+      with:
+        egress-policy: audit
+    - name: steps::checkout_repo
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      with:
+        clean: false
+    - name: steps::cache_rust_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@a90bb5d4b27522ce881c6e98eebd7d7e6d1653f9
+      with:
+        cache: rust
+        path: ~/.rustup
+    - name: run_tests::lints_tests::install_dylint
+      run: cargo install cargo-dylint dylint-link --version "^6.0"
+    - name: run_tests::lints_tests::install_lints_toolchain
+      run: rustup toolchain install
+      working-directory: tooling/lints
+    - name: run_tests::lints_tests::run_lints_tests
+      run: cargo test
+      working-directory: tooling/lints
+    timeout-minutes: 60
   check_workspace_binaries:
     needs:
     - orchestrate
@@ -892,6 +926,7 @@ jobs:
     - run_tests_mac
     - miri_scheduler
     - doctests
+    - lints_tests
     - check_workspace_binaries
     - build_visual_tests_binary
     - check_wasm
@@ -924,6 +959,7 @@ jobs:
         check_result "run_tests_mac" "$RESULT_RUN_TESTS_MAC"
         check_result "miri_scheduler" "$RESULT_MIRI_SCHEDULER"
         check_result "doctests" "$RESULT_DOCTESTS"
+        check_result "lints_tests" "$RESULT_LINTS_TESTS"
         check_result "check_workspace_binaries" "$RESULT_CHECK_WORKSPACE_BINARIES"
         check_result "build_visual_tests_binary" "$RESULT_BUILD_VISUAL_TESTS_BINARY"
         check_result "check_wasm" "$RESULT_CHECK_WASM"
@@ -946,6 +982,7 @@ jobs:
         RESULT_RUN_TESTS_MAC: ${{ needs.run_tests_mac.result }}
         RESULT_MIRI_SCHEDULER: ${{ needs.miri_scheduler.result }}
         RESULT_DOCTESTS: ${{ needs.doctests.result }}
+        RESULT_LINTS_TESTS: ${{ needs.lints_tests.result }}
         RESULT_CHECK_WORKSPACE_BINARIES: ${{ needs.check_workspace_binaries.result }}
         RESULT_BUILD_VISUAL_TESTS_BINARY: ${{ needs.build_visual_tests_binary.result }}
         RESULT_CHECK_WASM: ${{ needs.check_wasm.result }}

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -38,12 +38,17 @@ pub(crate) fn run_tests() -> Workflow {
     );
     let should_check_licences =
         PathCondition::new("run_licenses", r"^(Cargo.lock|script/.*licenses)");
+    // `tooling/lints` is a separate workspace (its own `[workspace]` and pinned
+    // nightly toolchain) that isn't part of the root workspace, so its dylint UI
+    // tests never run as part of the main suite. Run them when it changes.
+    let should_run_lint_tests = PathCondition::new("run_lint_tests", r"^tooling/lints/");
 
     let orchestrate = orchestrate(&[
         &should_check_scripts,
         &should_check_docs,
         &should_check_licences,
         &should_run_tests,
+        &should_run_lint_tests,
     ]);
 
     let mut jobs = vec![
@@ -76,6 +81,9 @@ pub(crate) fn run_tests() -> Workflow {
             .and_not_in_merge_queue()
             .then(miri_scheduler()),
         should_run_tests.and_not_in_merge_queue().then(doctests()),
+        should_run_lint_tests
+            .and_not_in_merge_queue()
+            .then(lints_tests()),
         should_run_tests
             .and_not_in_merge_queue()
             .then(check_workspace_binaries()),
@@ -222,11 +230,15 @@ fn orchestrate_impl(rules: &[&PathCondition], target: OrchestrateTarget) -> Name
           FILE_CHANGED_PKGS=""
           for dir in $CHANGED_DIRS; do
             pkg=$(echo "$DIR_TO_PKG" | grep "^${dir}=" | cut -d= -f2 | head -1 || true)
+            # Only include directories that map to a real root-workspace package.
+            # Some directories (e.g. tooling/lints) are separate workspaces with no
+            # root-workspace package; fabricating a package name from the raw
+            # directory here would produce an invalid nextest filterset such as
+            # "rdeps(lints)" and fail the run with "operator didn't match any
+            # packages". Unmapped directories fall through to the "no package
+            # changes detected" path below, which runs the full suite.
             if [ -n "$pkg" ]; then
               FILE_CHANGED_PKGS=$(printf '%s\n%s' "$FILE_CHANGED_PKGS" "$pkg")
-            else
-              # Fall back to directory name if no mapping found
-              FILE_CHANGED_PKGS=$(printf '%s\n%s' "$FILE_CHANGED_PKGS" "$dir")
             fi
           done
           FILE_CHANGED_PKGS=$(echo "$FILE_CHANGED_PKGS" | grep -v '^$' | sort -u || true)
@@ -764,6 +776,45 @@ fn doctests() -> NamedJob {
             .add_step(steps::show_sccache_stats(Platform::Linux))
             .add_step(steps::cleanup_cargo_config(Platform::Linux)),
     ))
+}
+
+/// Runs the dylint UI tests for the `tooling/lints` workspace. That workspace
+/// is intentionally kept out of the root workspace and pins its own nightly
+/// toolchain (see `tooling/lints/rust-toolchain.toml`), so its tests are never
+/// exercised by the main suite. They are plain `cargo test` invocations that
+/// build the lint library and run the UI fixtures via `dylint_testing`.
+fn lints_tests() -> NamedJob {
+    // Path to the separate dylint workspace, relative to the repo root.
+    const LINTS_DIR: &str = "tooling/lints";
+
+    fn install_dylint() -> Step<Run> {
+        // `dylint-link` is used as the linker for the lint library (see
+        // `tooling/lints/.cargo/config.toml`) and is required to build the
+        // tests; `cargo-dylint` is pinned to the same 6.x line as the
+        // `dylint_linting`/`dylint_testing` crates the library depends on.
+        named::bash(r#"cargo install cargo-dylint dylint-link --version "^6.0""#)
+    }
+
+    fn install_lints_toolchain() -> Step<Run> {
+        // With no toolchain argument, `rustup` installs the toolchain and
+        // components declared in `rust-toolchain.toml` of the current directory.
+        named::bash("rustup toolchain install").working_directory(LINTS_DIR)
+    }
+
+    fn run_lints_tests() -> Step<Run> {
+        named::bash("cargo test").working_directory(LINTS_DIR)
+    }
+
+    named::job(
+        release_job(&[])
+            .runs_on(runners::LINUX_DEFAULT)
+            .add_step(steps::harden_runner())
+            .add_step(steps::checkout_repo())
+            .add_step(steps::cache_rust_dependencies_namespace())
+            .add_step(install_dylint())
+            .add_step(install_lints_toolchain())
+            .add_step(run_lints_tests()),
+    )
 }
 
 fn check_licenses() -> NamedJob {


### PR DESCRIPTION
The `orchestrate` job that decides which tests to run built a directory-to-package map from `cargo metadata` on the root workspace and, when a changed directory had no mapping, fell back to using the raw directory name as if it were a package. Because `tooling/lints` is a separate workspace (its own `[workspace]` and pinned nightly toolchain) and not a root-workspace member, a change under `tooling/lints/**` extracted `dir=lints`, found no mapping, and injected `lints` into the generated nextest filterset as `rdeps(lints)`. That fails with `operator didn't match any packages` (exit 94), blocking any PR that only touches `tooling/lints/**`. This drops the fallback so unmapped directories fall through to the existing "no package changes detected" path, which safely runs the full suite instead of fabricating a bogus package filter.

It also adds a `lints_tests` job gated on `tooling/lints/**` changes so the dylint UI tests are actually exercised. That workspace pins its own nightly toolchain and is never touched by the main suite, so the job installs `cargo-dylint`/`dylint-link`, installs the pinned toolchain from `tooling/lints/rust-toolchain.toml`, and runs `cargo test` in that directory. The job is wired through the existing `PathCondition`/`orchestrate` mechanism like the other conditional jobs and is included in the `tests_pass` aggregation.

Both `run_tests.rs` and the regenerated `run_tests.yml` are committed; `cargo xtask workflows` is idempotent against them.

Release Notes:

- N/A