### PR TITLE
Add license symlinks to lint test fixture crates

### DIFF
--- a/tooling/lints/test_fixture/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/consumer/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/consumer/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/gpui/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/gpui/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/gpui_shared_string/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/gpui_shared_string/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/render_consumer/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/render_consumer/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE


### PR DESCRIPTION
Stacked on #60502 and targets it — #60502 must land first. #60502's orchestrator fix is what lets this PR (which touches `tooling/lints/**`) go green instead of tripping the `rdeps(lints)` nextest filter.

Follow-up to #60468, which added a `LICENSE-APACHE` symlink to the `tooling/lints` crate but not to the `test_fixture` sub-crates beneath it. Those five sub-crates each carry a `Cargo.toml`, so `script/check-licenses` requires a `LICENSE-GPL`/`LICENSE-APACHE` symlink in each, and `check_licenses` fails on any pull request that changes `Cargo.lock`. This adds `LICENSE-APACHE` symlinks to the five fixture crates, matching #60468; `script/check-licenses` passes locally afterward.

Release Notes:

- N/A