### PR TITLE
Add license symlinks to lint test fixture crates

### DIFF
--- a/tooling/lints/test_fixture/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/consumer/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/consumer/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/gpui/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/gpui/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/gpui_shared_string/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/gpui_shared_string/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE

--- a/tooling/lints/test_fixture/render_consumer/LICENSE-APACHE
+++ b/tooling/lints/test_fixture/render_consumer/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../../../LICENSE-APACHE


### PR DESCRIPTION
Stacked on #60502 and targets it — #60502 must land first (its orchestrator fix is what lets this `tooling/lints/`-touching PR go green rather than tripping the `rdeps(lints)` nextest filter). Re-creates the symlinks from #60504, which was accidentally merged into #60502's branch and reverted.

Follow-up to #60468, which added a `LICENSE-APACHE` symlink to the `tooling/lints` crate but not to the `test_fixture` sub-crates. Those five sub-crates each carry a `Cargo.toml`, so `script/check-licenses` requires a `LICENSE-GPL`/`LICENSE-APACHE` symlink in each, and `check_licenses` fails on any PR that changes `Cargo.lock`. This adds `LICENSE-APACHE` symlinks to the five fixture crates, matching #60468; `script/check-licenses` passes locally afterward.

Release Notes:

- N/A