### PR TITLE
Guard OpenCode bell plugin in ACP mode

### DIFF
--- a/docs/src/ai/terminal-threads.md
+++ b/docs/src/ai/terminal-threads.md
@@ -116,6 +116,8 @@ Create `.opencode/plugins/zed-bell.js` in your project, or `~/.config/opencode/p
 export const ZedBell = async () => {
   return {
     event: async ({ event }) => {
+      if (process.env.OPENCODE_CLIENT === "acp") return;
+
       if (event.type === "session.idle" || event.type === "permission.asked") {
         process.stdout.write("\x07");
       }


### PR DESCRIPTION
## Summary

- Add an ACP-mode guard to the documented OpenCode bell plugin snippet
- Preserve terminal bell notifications for Terminal Threads while avoiding writes to stdout when OpenCode is used as an ACP External Agent

## Rationale

The OpenCode bell plugin writes BEL to stdout for Terminal Thread notifications. When the plugin is installed globally and OpenCode runs in ACP mode, stdout is the JSON-RPC transport. OpenCode sets `OPENCODE_CLIENT=acp` in this mode, so the guard prevents BEL bytes from corrupting ACP JSON-RPC messages, including usage updates and permission flows.

Release Notes:

- N/A