### PR TITLE
project: Optimize remote project search result handling

### DIFF
--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -12,7 +12,7 @@ use gpui::{
     WeakEntity,
 };
 use language::{
-    Buffer, BufferEvent, Capability, DiskState, File as _, Language, LineEnding, Operation,
+    Anchor, Buffer, BufferEvent, Capability, DiskState, File as _, Language, LineEnding, Operation,
     language_settings::{AllLanguageSettings, LineEndingSetting},
     proto::{
         deserialize_line_ending, deserialize_version, serialize_line_ending, serialize_version,
@@ -25,7 +25,7 @@ use rpc::{
 };
 
 use settings::Settings;
-use std::{io, sync::Arc, time::Instant};
+use std::{io, ops::Range, sync::Arc, time::Instant};
 use text::{BufferId, ReplicaId};
 use util::{ResultExt as _, TryFutureExt, debug_panic, maybe, rel_path::RelPath};
 use worktree::{File, PathChange, ProjectEntryId, Worktree, WorktreeId, WorktreeSettings};
@@ -47,11 +47,19 @@ pub struct BufferStore {
 #[derive(Default)]
 struct RemoteProjectSearchState {
     // List of ongoing project search chunks from our remote host. Used by the side issuing a search RPC request.
-    chunks: HashMap<u64, async_channel::Sender<BufferId>>,
+    chunks: HashMap<u64, async_channel::Sender<ProjectSearchCandidate>>,
     // Monotonously-increasing handle to hand out to remote host in order to identify the project search result chunk.
     next_id: u64,
     // Used by the side running the actual search for match candidates to potentially cancel the search prematurely.
     searches_in_progress: HashMap<(PeerId, u64), Task<Result<()>>>,
+}
+
+pub(crate) enum ProjectSearchCandidate {
+    Buffer {
+        buffer_id: BufferId,
+        ranges: Vec<Range<Anchor>>,
+    },
+    LimitReached,
 }
 
 #[derive(Hash, Eq, PartialEq, Clone)]
@@ -1717,7 +1725,7 @@ impl BufferStore {
 
     pub(crate) fn register_project_search_result_handle(
         &mut self,
-    ) -> (u64, async_channel::Receiver<BufferId>) {
+    ) -> (u64, async_channel::Receiver<ProjectSearchCandidate>) {
         let (tx, rx) = async_channel::unbounded();
         let handle = util::post_inc(&mut self.project_search.next_id);
         let _old_entry = self.project_search.chunks.insert(handle, tx);
@@ -1757,17 +1765,47 @@ impl BufferStore {
         use proto::find_search_candidates_chunk::Variant;
         let handle = envelope.payload.handle;
 
-        let buffer_ids = match envelope
+        let candidates = match envelope
             .payload
             .variant
             .context("Expected non-null variant")?
         {
-            Variant::Matches(find_search_candidates_matches) => find_search_candidates_matches
-                .buffer_ids
-                .into_iter()
-                .filter_map(|buffer_id| BufferId::new(buffer_id).ok())
-                .collect::<Vec<_>>(),
-            Variant::Done(_) => {
+            Variant::Matches(find_search_candidates_matches) => {
+                let buffer_ids = find_search_candidates_matches.buffer_ids;
+                let ranges_for_buffer = find_search_candidates_matches.ranges_for_buffer;
+                if buffer_ids.len() != ranges_for_buffer.len() {
+                    log::error!(
+                        "remote project search returned {} buffer ids and {} range batches",
+                        buffer_ids.len(),
+                        ranges_for_buffer.len()
+                    );
+                }
+                buffer_ids
+                    .into_iter()
+                    .zip(ranges_for_buffer)
+                    .filter_map(|(buffer_id, ranges)| {
+                        let buffer_id = BufferId::new(buffer_id).log_err()?;
+                        let ranges = deserialize_project_search_candidate_ranges(ranges)?;
+                        Some(ProjectSearchCandidate::Buffer { buffer_id, ranges })
+                    })
+                    .collect::<Vec<_>>()
+            }
+            Variant::Done(done) => {
+                let sender = this.read_with(&mut cx, |this, _| {
+                    this.project_search.chunks.get(&handle).cloned()
+                });
+                if done.limit_reached
+                    && let Some(sender) = sender
+                    && sender
+                        .send(ProjectSearchCandidate::LimitReached)
+                        .await
+                        .is_err()
+                {
+                    this.update(&mut cx, |this, _| {
+                        this.project_search.chunks.remove(&handle)
+                    });
+                    return Ok(proto::Ack {});
+                }
                 this.update(&mut cx, |this, _| {
                     this.project_search.chunks.remove(&handle)
                 });
@@ -1780,8 +1818,8 @@ impl BufferStore {
             return Ok(proto::Ack {});
         };
 
-        for buffer_id in buffer_ids {
-            let Ok(_) = sender.send(buffer_id).await else {
+        for candidate in candidates {
+            let Ok(_) = sender.send(candidate).await else {
                 this.update(&mut cx, |this, _| {
                     this.project_search.chunks.remove(&handle)
                 });
@@ -1790,6 +1828,17 @@ impl BufferStore {
         }
         Ok(proto::Ack {})
     }
+}
+
+fn deserialize_project_search_candidate_ranges(
+    ranges: proto::FindSearchCandidateRanges,
+) -> Option<Vec<Range<Anchor>>> {
+    ranges
+        .ranges
+        .into_iter()
+        .map(language::proto::deserialize_anchor_range)
+        .collect::<Result<Vec<_>>>()
+        .log_err()
 }
 
 impl OpenBuffer {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5654,17 +5654,29 @@ impl Project {
         let buffer_store = this.read_with(&cx, |this, _| this.buffer_store().clone());
         let client = this.read_with(&cx, |this, _| this.client());
         let task = cx.spawn(async move |cx| {
-            let results = this.update(cx, |this, cx| {
-                this.search_impl(query, cx).matching_buffers(cx)
-            });
-            let (batcher, batches) = project_search::AdaptiveBatcher::new(cx.background_executor());
+            let results = this.update(cx, |this, cx| this.search_impl(query, cx).results(cx));
+            let (batcher, batches) =
+                project_search::AdaptiveBatcher::<(u64, Vec<Range<Anchor>>)>::new(
+                    cx.background_executor(),
+                );
             let mut new_matches = Box::pin(results.rx);
 
             let sender_task = cx.background_executor().spawn({
                 let client = client.clone();
                 async move {
                     let mut batches = std::pin::pin!(batches);
-                    while let Some(buffer_ids) = batches.next().await {
+                    while let Some(matches) = batches.next().await {
+                        let mut buffer_ids = Vec::with_capacity(matches.len());
+                        let mut ranges_for_buffer = Vec::with_capacity(matches.len());
+                        for (buffer_id, ranges) in matches {
+                            buffer_ids.push(buffer_id);
+                            ranges_for_buffer.push(proto::FindSearchCandidateRanges {
+                                ranges: ranges
+                                    .into_iter()
+                                    .map(language::proto::serialize_anchor_range)
+                                    .collect(),
+                            });
+                        }
                         client
                             .request(proto::FindSearchCandidatesChunk {
                                 handle,
@@ -5672,7 +5684,10 @@ impl Project {
                                 project_id,
                                 variant: Some(
                                     proto::find_search_candidates_chunk::Variant::Matches(
-                                        proto::FindSearchCandidatesMatches { buffer_ids },
+                                        proto::FindSearchCandidatesMatches {
+                                            buffer_ids,
+                                            ranges_for_buffer,
+                                        },
                                     ),
                                 ),
                             })
@@ -5682,11 +5697,20 @@ impl Project {
                 }
             });
 
-            while let Some((buffer, _)) = new_matches.next().await {
-                let buffer_id = this.update(cx, |this, cx| {
-                    this.create_buffer_for_peer(&buffer, peer_id, cx).to_proto()
-                });
-                batcher.push(buffer_id).await;
+            let mut limit_reached = false;
+            while let Some(result) = new_matches.next().await {
+                match result {
+                    SearchResult::Buffer { buffer, ranges } => {
+                        let buffer_id = this.update(cx, |this, cx| {
+                            this.create_buffer_for_peer(&buffer, peer_id, cx).to_proto()
+                        });
+                        batcher.push((buffer_id, ranges)).await;
+                    }
+                    SearchResult::LimitReached => {
+                        limit_reached = true;
+                    }
+                    SearchResult::WaitingForScan | SearchResult::Searching => {}
+                }
             }
             batcher.flush().await;
 
@@ -5698,7 +5722,7 @@ impl Project {
                     peer_id: Some(peer_id),
                     project_id,
                     variant: Some(proto::find_search_candidates_chunk::Variant::Done(
-                        proto::FindSearchCandidatesDone {},
+                        proto::FindSearchCandidatesDone { limit_reached },
                     )),
                 })
                 .await?;

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::LazyCell,
-    collections::BTreeSet,
+    collections::{BTreeSet, HashMap},
     io::{BufRead, BufReader},
     ops::Range,
     path::{Path, PathBuf},
@@ -16,17 +16,18 @@ use fs::Fs;
 use futures::FutureExt as _;
 use futures::{SinkExt, StreamExt, select_biased, stream::FuturesOrdered};
 use gpui::{App, AppContext, AsyncApp, BackgroundExecutor, Entity, Priority, Task};
-use language::{Buffer, BufferSnapshot, Point};
+use language::{Anchor, Buffer, BufferSnapshot, Point};
 use parking_lot::Mutex;
 use postage::oneshot;
 use rpc::{AnyProtoClient, proto};
+use text::BufferId;
 
 use util::{ResultExt, maybe, paths::compare_rel_paths, rel_path::RelPath};
 use worktree::{Entry, ProjectEntryId, Snapshot, Worktree, WorktreeSettings};
 
 use crate::{
     Project, ProjectItem, ProjectPath, RemotelyCreatedModels,
-    buffer_store::BufferStore,
+    buffer_store::{BufferStore, ProjectSearchCandidate},
     search::{LineHint, SearchQuery, SearchResult},
     worktree_store::WorktreeStore,
 };
@@ -182,6 +183,7 @@ impl Search {
         let (grab_buffer_snapshot_tx, grab_buffer_snapshot_rx) =
             unbounded::<(Entity<Buffer>, LineHint)>();
         let matching_buffers = grab_buffer_snapshot_rx.clone();
+        let remote_search_ranges = Arc::new(Mutex::new(HashMap::new()));
         let trigger_search = Box::new(move |cx: &mut App| {
             cx.spawn(async move |cx| {
                 for buffer in unnamed_buffers {
@@ -193,6 +195,7 @@ impl Search {
                 let (find_all_matches_tx, find_all_matches_rx) =
                     bounded(MAX_CONCURRENT_BUFFER_OPENS);
                 let query = Arc::new(query);
+                let search_results_tx = tx.clone();
                 let (candidate_searcher, tasks) = match self.kind {
                     SearchKind::OpenBuffersOnly => {
                         let open_buffers = cx.update(|cx| self.all_loaded_buffers(&query, cx));
@@ -259,6 +262,8 @@ impl Search {
                         remote_id,
                         models,
                     } => {
+                        let remote_search_ranges = remote_search_ranges.clone();
+                        let search_results_tx = search_results_tx.clone();
                         let (handle, rx) = self
                             .buffer_store
                             .update(cx, |this, _| this.register_project_search_result_handle());
@@ -297,7 +302,20 @@ impl Search {
                                     let (buffer_tx, buffer_rx) = bounded(24);
 
                                     let wait_for_remote_buffers = cx.spawn(async move |cx| {
-                                        while let Ok(buffer_id) = rx.recv().await {
+                                        while let Ok(candidate) = rx.recv().await {
+                                            let (buffer_id, ranges) = match candidate {
+                                                ProjectSearchCandidate::Buffer {
+                                                    buffer_id,
+                                                    ranges,
+                                                } => (buffer_id, ranges),
+                                                ProjectSearchCandidate::LimitReached => {
+                                                    search_results_tx
+                                                        .send(SearchResult::LimitReached)
+                                                        .await?;
+                                                    continue;
+                                                }
+                                            };
+                                            remote_search_ranges.lock().insert(buffer_id, ranges);
                                             let buffer =
                                                 buffer_store.update(cx, |buffer_store, cx| {
                                                     buffer_store
@@ -354,6 +372,7 @@ impl Search {
                                     query: query.clone(),
                                     open_buffers: open_buffers.clone(),
                                     candidates: candidate_searcher.clone(),
+                                    remote_search_ranges: remote_search_ranges.clone(),
                                     find_all_matches_rx: find_all_matches_rx.clone(),
                                 };
                                 scope.spawn(worker.run());
@@ -660,6 +679,7 @@ struct Worker {
     query: Arc<SearchQuery>,
     open_buffers: Arc<HashSet<ProjectEntryId>>,
     candidates: FindSearchCandidates,
+    remote_search_ranges: Arc<Mutex<HashMap<BufferId, Vec<Range<Anchor>>>>>,
     /// Ok, we're back in background: run full scan & find all matches in a given buffer snapshot.
     /// Then, when you're done, share them via the channel you were given.
     find_all_matches_rx: Receiver<FindAllMatchesRequest>,
@@ -699,6 +719,7 @@ impl Worker {
                 query: &self.query,
                 open_entries: &self.open_buffers,
                 fs: fs.as_deref(),
+                remote_search_ranges: &self.remote_search_ranges,
                 confirm_contents_will_match_tx: &confirm_contents_will_match_tx,
             };
             // Whenever we notice that some step of a pipeline is closed, we don't want to close subsequent
@@ -739,6 +760,7 @@ struct RequestHandler<'worker> {
     query: &'worker SearchQuery,
     fs: Option<&'worker dyn Fs>,
     open_entries: &'worker HashSet<ProjectEntryId>,
+    remote_search_ranges: &'worker Mutex<HashMap<BufferId, Vec<Range<Anchor>>>>,
     confirm_contents_will_match_tx: &'worker Sender<MatchingEntry>,
 }
 
@@ -750,22 +772,29 @@ impl RequestHandler<'_> {
             line_hint,
             mut report_matches,
         } = request;
-        let range_offset = if line_hint > 0 {
-            snapshot.point_to_offset(Point::new(line_hint, 0))
+        let ranges = if let Some(ranges) = self
+            .remote_search_ranges
+            .lock()
+            .remove(&snapshot.text.remote_id())
+        {
+            ranges
         } else {
-            0
+            let range_offset = if line_hint > 0 {
+                snapshot.point_to_offset(Point::new(line_hint, 0))
+            } else {
+                0
+            };
+            let subrange = (range_offset > 0).then(|| range_offset..snapshot.len());
+            self.query
+                .search(&snapshot, subrange)
+                .await
+                .iter()
+                .map(|range| {
+                    snapshot.anchor_before(range.start + range_offset)
+                        ..snapshot.anchor_after(range.end + range_offset)
+                })
+                .collect::<Vec<_>>()
         };
-        let subrange = (range_offset > 0).then(|| range_offset..snapshot.len());
-        let ranges = self
-            .query
-            .search(&snapshot, subrange)
-            .await
-            .iter()
-            .map(|range| {
-                snapshot.anchor_before(range.start + range_offset)
-                    ..snapshot.anchor_after(range.end + range_offset)
-            })
-            .collect::<Vec<_>>();
 
         _ = report_matches.send((buffer, ranges)).await;
     }

--- a/crates/proto/proto/buffer.proto
+++ b/crates/proto/proto/buffer.proto
@@ -316,10 +316,17 @@ message FindSearchCandidates {
   uint64 handle = 4;
 }
 
-message FindSearchCandidatesDone {}
+message FindSearchCandidatesDone {
+  bool limit_reached = 1;
+}
 
 message FindSearchCandidatesMatches {
   repeated uint64 buffer_ids = 1;
+  repeated FindSearchCandidateRanges ranges_for_buffer = 2;
+}
+
+message FindSearchCandidateRanges {
+  repeated AnchorRange ranges = 1;
 }
 
 message FindSearchCandidatesChunk {

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -24,7 +24,7 @@ use project::{
     image_store::ImageId,
     lsp_store::log_store::{self, GlobalLogStore, LanguageServerKind, LogKind},
     project_settings::SettingsObserver,
-    search::SearchQuery,
+    search::{SearchQuery, SearchResult},
     task_store::TaskStore,
     trusted_worktrees::{PathTrust, RemoteHostLocation, TrustedWorktrees},
     worktree_store::{WorktreeIdCounter, WorktreeStore},
@@ -1080,17 +1080,30 @@ impl HeadlessProject {
                     cx,
                 )
                 .into_handle(query, cx)
-                .matching_buffers(cx)
+                .results(cx)
             });
-            let (batcher, batches) =
-                project::project_search::AdaptiveBatcher::new(cx.background_executor());
+            let (batcher, batches) = project::project_search::AdaptiveBatcher::<(
+                u64,
+                Vec<std::ops::Range<language::Anchor>>,
+            )>::new(cx.background_executor());
             let mut new_matches = Box::pin(results.rx);
 
             let sender_task = cx.background_executor().spawn({
                 let client = client.clone();
                 async move {
                     let mut batches = std::pin::pin!(batches);
-                    while let Some(buffer_ids) = batches.next().await {
+                    while let Some(matches) = batches.next().await {
+                        let mut buffer_ids = Vec::with_capacity(matches.len());
+                        let mut ranges_for_buffer = Vec::with_capacity(matches.len());
+                        for (buffer_id, ranges) in matches {
+                            buffer_ids.push(buffer_id);
+                            ranges_for_buffer.push(proto::FindSearchCandidateRanges {
+                                ranges: ranges
+                                    .into_iter()
+                                    .map(language::proto::serialize_anchor_range)
+                                    .collect(),
+                            });
+                        }
                         client
                             .request(proto::FindSearchCandidatesChunk {
                                 handle,
@@ -1098,7 +1111,10 @@ impl HeadlessProject {
                                 project_id,
                                 variant: Some(
                                     proto::find_search_candidates_chunk::Variant::Matches(
-                                        proto::FindSearchCandidatesMatches { buffer_ids },
+                                        proto::FindSearchCandidatesMatches {
+                                            buffer_ids,
+                                            ranges_for_buffer,
+                                        },
                                     ),
                                 ),
                             })
@@ -1108,14 +1124,23 @@ impl HeadlessProject {
                 }
             });
 
-            while let Some((buffer, _)) = new_matches.next().await {
-                let _ = buffer_store
-                    .update(cx, |this, cx| {
-                        this.create_buffer_for_peer(&buffer, REMOTE_SERVER_PEER_ID, cx)
-                    })
-                    .await;
-                let buffer_id = buffer.read_with(cx, |this, _| this.remote_id().to_proto());
-                batcher.push(buffer_id).await;
+            let mut limit_reached = false;
+            while let Some(result) = new_matches.next().await {
+                match result {
+                    SearchResult::Buffer { buffer, ranges } => {
+                        buffer_store
+                            .update(cx, |this, cx| {
+                                this.create_buffer_for_peer(&buffer, REMOTE_SERVER_PEER_ID, cx)
+                            })
+                            .await?;
+                        let buffer_id = buffer.read_with(cx, |this, _| this.remote_id().to_proto());
+                        batcher.push((buffer_id, ranges)).await;
+                    }
+                    SearchResult::LimitReached => {
+                        limit_reached = true;
+                    }
+                    SearchResult::WaitingForScan | SearchResult::Searching => {}
+                }
             }
             batcher.flush().await;
 
@@ -1127,7 +1152,7 @@ impl HeadlessProject {
                     peer_id: Some(peer_id),
                     project_id,
                     variant: Some(proto::find_search_candidates_chunk::Variant::Done(
-                        proto::FindSearchCandidatesDone {},
+                        proto::FindSearchCandidatesDone { limit_reached },
                     )),
                 })
                 .await?;


### PR DESCRIPTION
# Objective

Improve remote project search responsiveness by avoiding duplicate match computation on the client after the remote server has already searched the project.

## Solution

Remote project search now sends each matching buffer together with the match ranges computed on the remote server. The client still receives results incrementally, but instead of reopening each remote buffer and running the same search again locally, it reuses those remote-computed ranges to populate the project search results.

The final search message also carries whether the remote search hit the result limit, so the UI can still show that results were truncated when appropriate.

Release Notes:

- Improved remote project search responsiveness.