### PR TITLE
git_ui: Use pull request link from push output in push toast

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1008,14 +1008,14 @@ impl GitPanel {
                 &git_store,
                 window,
                 move |this, _git_store, event, window, cx| match event {
-                    GitStoreEvent::RepositoryUpdated(
-                        _,
-                        RepositoryEvent::StatusesChanged | RepositoryEvent::HeadChanged,
-                        true,
-                    )
-                    | GitStoreEvent::RepositoryAdded
-                    | GitStoreEvent::RepositoryRemoved(_)
+                    GitStoreEvent::RepositoryUpdated(_, RepositoryEvent::HeadChanged, true)
                     | GitStoreEvent::ActiveRepositoryChanged(_) => {
+                        this.pending_pull_request_url = None;
+                        this.schedule_update(window, cx);
+                    }
+                    GitStoreEvent::RepositoryUpdated(_, RepositoryEvent::StatusesChanged, true)
+                    | GitStoreEvent::RepositoryAdded
+                    | GitStoreEvent::RepositoryRemoved(_) => {
                         this.schedule_update(window, cx);
                     }
                     GitStoreEvent::RepositoryUpdated(
@@ -3702,6 +3702,7 @@ impl GitPanel {
             return false;
         }
 
+        self.pending_pull_request_url = None;
         self.pending_remote_operation = Some(kind);
         cx.notify();
         true
@@ -4056,6 +4057,9 @@ impl GitPanel {
         let new_active_repository = self.project.read(cx).active_repository(cx);
         let active_repository_changed = self.active_repository.as_ref().map(Entity::entity_id)
             != new_active_repository.as_ref().map(Entity::entity_id);
+        if active_repository_changed {
+            self.pending_pull_request_url = None;
+        }
         if active_repository_changed && self.amend_pending {
             // Leaving a repository with a pending amend: undo it so the amend
             // state doesn't carry over to the newly active repository. The
@@ -4186,6 +4190,7 @@ impl GitPanel {
 
         let active_repository = self.project.read(cx).active_repository(cx);
         if active_repository != self.active_repository {
+            self.pending_pull_request_url = None;
             self.active_repository = active_repository;
             self.git_access = None;
         }
@@ -4665,9 +4670,9 @@ impl GitPanel {
         };
 
         let is_push = matches!(action, RemoteAction::Push(_, _));
-        if is_push {
-            self.pending_pull_request_url = remote_output::extract_pull_request_url(&info);
-        }
+        self.pending_pull_request_url = is_push
+            .then(|| remote_output::extract_pull_request_url(&info))
+            .flatten();
 
         workspace.update(cx, |workspace, cx| {
             let SuccessMessage { message, style } = remote_output::format_output(&action, info);
@@ -9671,11 +9676,13 @@ mod tests {
         panel.update(cx, |panel, cx| {
             // The first remote operation starts and records its kind, which the
             // button uses to render an "in progress" tooltip.
+            panel.pending_pull_request_url = Some("https://example.com/pull".to_string());
             assert!(panel.start_remote_operation(RemoteOperationKind::Fetch, cx));
             assert!(matches!(
                 panel.pending_remote_operation,
                 Some(RemoteOperationKind::Fetch)
             ));
+            assert!(panel.pending_pull_request_url.is_none());
 
             // A second remote operation is refused while one is pending, even a
             // different kind: we serialize all remote ops.

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -777,6 +777,7 @@ pub struct GitPanel {
     new_staged_count: usize,
     pending_commit: Option<Task<()>>,
     pending_remote_operation: Option<RemoteOperationKind>,
+    pending_pull_request_url: Option<String>,
     amend_pending: bool,
     original_commit_message: Option<String>,
     pending_commit_message_restores: BTreeMap<String, SerializedCommitMessage>,
@@ -1059,6 +1060,7 @@ impl GitPanel {
                 diff_stat_total: DiffStat::default(),
                 pending_commit: None,
                 pending_remote_operation: None,
+                pending_pull_request_url: None,
                 amend_pending,
                 original_commit_message,
                 pending_commit_message_restores,
@@ -3598,8 +3600,13 @@ impl GitPanel {
         }
     }
 
-    pub fn create_pull_request(&self, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn create_pull_request(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let result = (|| -> anyhow::Result<()> {
+            if let Some(url) = self.pending_pull_request_url.take() {
+                cx.open_url(url.as_str());
+                return Ok(());
+            }
+
             let repo = self
                 .active_repository
                 .clone()
@@ -4658,6 +4665,9 @@ impl GitPanel {
         };
 
         let is_push = matches!(action, RemoteAction::Push(_, _));
+        if is_push {
+            self.pending_pull_request_url = remote_output::extract_pull_request_url(&info);
+        }
 
         workspace.update(cx, |workspace, cx| {
             let SuccessMessage { message, style } = remote_output::format_output(&action, info);

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -777,7 +777,6 @@ pub struct GitPanel {
     new_staged_count: usize,
     pending_commit: Option<Task<()>>,
     pending_remote_operation: Option<RemoteOperationKind>,
-    pending_pull_request_url: Option<String>,
     amend_pending: bool,
     original_commit_message: Option<String>,
     pending_commit_message_restores: BTreeMap<String, SerializedCommitMessage>,
@@ -1008,14 +1007,14 @@ impl GitPanel {
                 &git_store,
                 window,
                 move |this, _git_store, event, window, cx| match event {
-                    GitStoreEvent::RepositoryUpdated(_, RepositoryEvent::HeadChanged, true)
-                    | GitStoreEvent::ActiveRepositoryChanged(_) => {
-                        this.pending_pull_request_url = None;
-                        this.schedule_update(window, cx);
-                    }
-                    GitStoreEvent::RepositoryUpdated(_, RepositoryEvent::StatusesChanged, true)
+                    GitStoreEvent::RepositoryUpdated(
+                        _,
+                        RepositoryEvent::StatusesChanged | RepositoryEvent::HeadChanged,
+                        true,
+                    )
                     | GitStoreEvent::RepositoryAdded
-                    | GitStoreEvent::RepositoryRemoved(_) => {
+                    | GitStoreEvent::RepositoryRemoved(_)
+                    | GitStoreEvent::ActiveRepositoryChanged(_) => {
                         this.schedule_update(window, cx);
                     }
                     GitStoreEvent::RepositoryUpdated(
@@ -1060,7 +1059,6 @@ impl GitPanel {
                 diff_stat_total: DiffStat::default(),
                 pending_commit: None,
                 pending_remote_operation: None,
-                pending_pull_request_url: None,
                 amend_pending,
                 original_commit_message,
                 pending_commit_message_restores,
@@ -3600,13 +3598,8 @@ impl GitPanel {
         }
     }
 
-    pub fn create_pull_request(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn create_pull_request(&self, window: &mut Window, cx: &mut Context<Self>) {
         let result = (|| -> anyhow::Result<()> {
-            if let Some(url) = self.pending_pull_request_url.take() {
-                cx.open_url(url.as_str());
-                return Ok(());
-            }
-
             let repo = self
                 .active_repository
                 .clone()
@@ -3702,7 +3695,6 @@ impl GitPanel {
             return false;
         }
 
-        self.pending_pull_request_url = None;
         self.pending_remote_operation = Some(kind);
         cx.notify();
         true
@@ -4057,9 +4049,6 @@ impl GitPanel {
         let new_active_repository = self.project.read(cx).active_repository(cx);
         let active_repository_changed = self.active_repository.as_ref().map(Entity::entity_id)
             != new_active_repository.as_ref().map(Entity::entity_id);
-        if active_repository_changed {
-            self.pending_pull_request_url = None;
-        }
         if active_repository_changed && self.amend_pending {
             // Leaving a repository with a pending amend: undo it so the amend
             // state doesn't carry over to the newly active repository. The
@@ -4190,7 +4179,6 @@ impl GitPanel {
 
         let active_repository = self.project.read(cx).active_repository(cx);
         if active_repository != self.active_repository {
-            self.pending_pull_request_url = None;
             self.active_repository = active_repository;
             self.git_access = None;
         }
@@ -4670,9 +4658,6 @@ impl GitPanel {
         };
 
         let is_push = matches!(action, RemoteAction::Push(_, _));
-        self.pending_pull_request_url = is_push
-            .then(|| remote_output::extract_pull_request_url(&info))
-            .flatten();
 
         workspace.update(cx, |workspace, cx| {
             let SuccessMessage { message, style } = remote_output::format_output(&action, info);
@@ -4687,7 +4672,14 @@ impl GitPanel {
                         .color(Color::Muted),
                 );
                 match (style, is_push) {
+                    (PushPrLink { label, url }, _) => {
+                        this.action(label, move |_window, cx| cx.open_url(&url))
+                    }
                     (Toast | ToastWithLog { .. }, true) => {
+                        // If we were not able to parse a valid URL from the
+                        // output of a push command, we'll simply dispatch the
+                        // generic `CreatePullRequest` action when the toast
+                        // button is pressed.
                         this.action("Create Pull Request", move |window, cx| {
                             window
                                 .dispatch_action(Box::new(zed_actions::git::CreatePullRequest), cx);
@@ -9676,13 +9668,11 @@ mod tests {
         panel.update(cx, |panel, cx| {
             // The first remote operation starts and records its kind, which the
             // button uses to render an "in progress" tooltip.
-            panel.pending_pull_request_url = Some("https://example.com/pull".to_string());
             assert!(panel.start_remote_operation(RemoteOperationKind::Fetch, cx));
             assert!(matches!(
                 panel.pending_remote_operation,
                 Some(RemoteOperationKind::Fetch)
             ));
-            assert!(panel.pending_pull_request_url.is_none());
 
             // A second remote operation is refused while one is pending, even a
             // different kind: we serialize all remote ops.

--- a/crates/git_ui/src/remote_output.rs
+++ b/crates/git_ui/src/remote_output.rs
@@ -31,6 +31,50 @@ pub struct SuccessMessage {
     pub style: SuccessStyle,
 }
 
+pub fn extract_pull_request_url(output: &RemoteCommandOutput) -> Option<String> {
+    let mut expecting_create_url = false;
+
+    for line in output.stderr.lines() {
+        let Some(remote_line) = line.trim_start().strip_prefix("remote:") else {
+            expecting_create_url = false;
+            continue;
+        };
+
+        if is_create_pull_request_prompt(remote_line) {
+            if let Some(url) = extract_url(remote_line) {
+                return Some(url);
+            }
+            expecting_create_url = true;
+            continue;
+        }
+
+        if expecting_create_url {
+            expecting_create_url = false;
+            if let Some(url) = extract_url(remote_line) {
+                return Some(url);
+            }
+        }
+    }
+
+    None
+}
+
+fn is_create_pull_request_prompt(line: &str) -> bool {
+    let line = line.to_ascii_lowercase();
+    (line.contains("create a pull request") && line.contains("by visiting"))
+        || (line.contains("create a merge request") && line.contains("visit"))
+}
+
+fn extract_url(line: &str) -> Option<String> {
+    let http_index = line.find("https://").or_else(|| line.find("http://"))?;
+    let url = line[http_index..]
+        .split_whitespace()
+        .next()?
+        .trim_end_matches(|character| matches!(character, ',' | '.' | ')' | ']' | '>'));
+
+    Some(url.to_string())
+}
+
 pub fn format_output(action: &RemoteAction, output: RemoteCommandOutput) -> SuccessMessage {
     match action {
         RemoteAction::Fetch(remote) => {
@@ -162,8 +206,16 @@ mod tests {
 
         let msg = format_output(&action, output);
 
-        assert!(matches!(msg.style, SuccessStyle::ToastWithLog { .. }));
+        assert!(matches!(&msg.style, SuccessStyle::ToastWithLog { .. }));
         assert_eq!(msg.message, "Pushed test_branch to test_remote");
+        if let SuccessStyle::ToastWithLog { output } = &msg.style {
+            assert_eq!(
+                extract_pull_request_url(output),
+                Some("https://example.com/test/test/pull/new/test".to_string())
+            );
+        } else {
+            panic!("Expected ToastWithLog variant");
+        }
     }
 
     #[test]
@@ -191,8 +243,19 @@ mod tests {
 
         let msg = format_output(&action, output);
 
-        assert!(matches!(msg.style, SuccessStyle::ToastWithLog { .. }));
+        assert!(matches!(&msg.style, SuccessStyle::ToastWithLog { .. }));
         assert_eq!(msg.message, "Pushed test_branch to test_remote");
+        if let SuccessStyle::ToastWithLog { output } = &msg.style {
+            assert_eq!(
+                extract_pull_request_url(output),
+                Some(
+                    "https://example.com/test/test/-/merge_requests/new?merge_request%5Bsource_branch%5D=test"
+                        .to_string()
+                )
+            );
+        } else {
+            panic!("Expected ToastWithLog variant");
+        }
     }
 
     #[test]
@@ -224,8 +287,13 @@ mod tests {
 
         let msg = format_output(&action, output);
 
-        assert!(matches!(msg.style, SuccessStyle::ToastWithLog { .. }));
+        assert!(matches!(&msg.style, SuccessStyle::ToastWithLog { .. }));
         assert_eq!(msg.message, "Pushed test_branch to test_remote");
+        if let SuccessStyle::ToastWithLog { output } = &msg.style {
+            assert_eq!(extract_pull_request_url(output), None);
+        } else {
+            panic!("Expected ToastWithLog variant");
+        }
     }
 
     #[test]
@@ -254,6 +322,7 @@ mod tests {
                 output.stderr,
                 "To http://example.com/test/test.git\n * [new branch]      test -> test\n"
             );
+            assert_eq!(extract_pull_request_url(output), None);
         } else {
             panic!("Expected ToastWithLog variant");
         }

--- a/crates/git_ui/src/remote_output.rs
+++ b/crates/git_ui/src/remote_output.rs
@@ -62,6 +62,7 @@ pub fn extract_pull_request_url(output: &RemoteCommandOutput) -> Option<String> 
 fn is_create_pull_request_prompt(line: &str) -> bool {
     let line = line.to_ascii_lowercase();
     (line.contains("create a pull request") && line.contains("by visiting"))
+        || line.contains("create pull request")
         || (line.contains("create a merge request") && line.contains("visit"))
 }
 
@@ -256,6 +257,24 @@ mod tests {
         } else {
             panic!("Expected ToastWithLog variant");
         }
+    }
+
+    #[test]
+    fn test_push_new_branch_bitbucket_pull_request() {
+        let output = RemoteCommandOutput {
+            stdout: String::new(),
+            stderr: indoc! {"
+                remote:
+                remote: Create pull request for test:
+                remote:   https://bitbucket.example.com/projects/TEST/repos/test/pull-requests?create&sourceBranch=refs/heads/test
+                "}
+            .to_string(),
+        };
+
+        assert_eq!(
+            extract_pull_request_url(&output),
+            Some("https://bitbucket.example.com/projects/TEST/repos/test/pull-requests?create&sourceBranch=refs/heads/test".to_string())
+        );
     }
 
     #[test]

--- a/crates/git_ui/src/remote_output.rs
+++ b/crates/git_ui/src/remote_output.rs
@@ -5,9 +5,13 @@ use ui::SharedString;
 use util::ResultExt as _;
 
 const PULL_REQUEST_HINTS: &[(&str, &str)] = &[
+    // GitHub: "Create a pull request for 'branch' on GitHub by visiting:"
     ("Create a pull request", "Create Pull Request"),
+    // Bitbucket: "Create pull request for branch:"
     ("Create pull request", "Create Pull Request"),
+    // GitLab: "To create a merge request for branch, visit:"
     ("create a merge request", "Create Merge Request"),
+    // GitLab: "View merge request for branch:"
     ("View merge request", "View Merge Request"),
 ];
 

--- a/crates/git_ui/src/remote_output.rs
+++ b/crates/git_ui/src/remote_output.rs
@@ -4,6 +4,13 @@ use git::repository::{Remote, RemoteCommandOutput};
 use ui::SharedString;
 use util::ResultExt as _;
 
+const PULL_REQUEST_HINTS: &[(&str, &str)] = &[
+    ("Create a pull request", "Create Pull Request"),
+    ("Create pull request", "Create Pull Request"),
+    ("create a merge request", "Create Merge Request"),
+    ("View merge request", "View Merge Request"),
+];
+
 #[derive(Clone)]
 pub enum RemoteAction {
     Fetch(Option<Remote>),
@@ -24,6 +31,7 @@ impl RemoteAction {
 pub enum SuccessStyle {
     Toast,
     ToastWithLog { output: RemoteCommandOutput },
+    PushPrLink { label: &'static str, url: String },
 }
 
 pub struct SuccessMessage {
@@ -31,39 +39,30 @@ pub struct SuccessMessage {
     pub style: SuccessStyle,
 }
 
-pub fn extract_pull_request_url(output: &RemoteCommandOutput) -> Option<String> {
-    let mut expecting_create_url = false;
+fn extract_pull_request_link(output: &RemoteCommandOutput) -> Option<(&'static str, String)> {
+    let mut pending_label: Option<&'static str> = None;
 
     for line in output.stderr.lines() {
         let Some(remote_line) = line.trim_start().strip_prefix("remote:") else {
-            expecting_create_url = false;
+            pending_label = None;
             continue;
         };
 
-        if is_create_pull_request_prompt(remote_line) {
-            if let Some(url) = extract_url(remote_line) {
-                return Some(url);
-            }
-            expecting_create_url = true;
-            continue;
+        if let Some((_, label)) = PULL_REQUEST_HINTS
+            .iter()
+            .find(|(hint, _)| remote_line.contains(hint))
+        {
+            pending_label = Some(label);
         }
 
-        if expecting_create_url {
-            expecting_create_url = false;
-            if let Some(url) = extract_url(remote_line) {
-                return Some(url);
-            }
+        if let Some(url) = extract_url(remote_line)
+            && let Some(label) = pending_label
+        {
+            return Some((label, url));
         }
     }
 
     None
-}
-
-fn is_create_pull_request_prompt(line: &str) -> bool {
-    let line = line.to_ascii_lowercase();
-    (line.contains("create a pull request") && line.contains("by visiting"))
-        || line.contains("create pull request")
-        || (line.contains("create a merge request") && line.contains("visit"))
 }
 
 fn extract_url(line: &str) -> Option<String> {
@@ -167,6 +166,11 @@ pub fn format_output(action: &RemoteAction, output: RemoteCommandOutput) -> Succ
                     message: "Push: Everything is up-to-date".to_string(),
                     style: SuccessStyle::Toast,
                 }
+            } else if let Some((label, url)) = extract_pull_request_link(&output) {
+                SuccessMessage {
+                    message: format!("Pushed {} to {}", branch_name, remote_ref.name),
+                    style: SuccessStyle::PushPrLink { label, url },
+                }
             } else {
                 SuccessMessage {
                     message: format!("Pushed {} to {}", branch_name, remote_ref.name),
@@ -206,16 +210,12 @@ mod tests {
         };
 
         let msg = format_output(&action, output);
-
-        assert!(matches!(&msg.style, SuccessStyle::ToastWithLog { .. }));
-        assert_eq!(msg.message, "Pushed test_branch to test_remote");
-        if let SuccessStyle::ToastWithLog { output } = &msg.style {
-            assert_eq!(
-                extract_pull_request_url(output),
-                Some("https://example.com/test/test/pull/new/test".to_string())
-            );
+        if let SuccessStyle::PushPrLink { label, url } = msg.style {
+            assert_eq!(msg.message, "Pushed test_branch to test_remote");
+            assert_eq!(label, "Create Pull Request");
+            assert_eq!(url, "https://example.com/test/test/pull/new/test");
         } else {
-            panic!("Expected ToastWithLog variant");
+            panic!("Expected PushPrLink variant");
         }
     }
 
@@ -244,18 +244,15 @@ mod tests {
 
         let msg = format_output(&action, output);
 
-        assert!(matches!(&msg.style, SuccessStyle::ToastWithLog { .. }));
-        assert_eq!(msg.message, "Pushed test_branch to test_remote");
-        if let SuccessStyle::ToastWithLog { output } = &msg.style {
+        if let SuccessStyle::PushPrLink { label, url } = msg.style {
+            assert_eq!(msg.message, "Pushed test_branch to test_remote");
+            assert_eq!(label, "Create Merge Request");
             assert_eq!(
-                extract_pull_request_url(output),
-                Some(
-                    "https://example.com/test/test/-/merge_requests/new?merge_request%5Bsource_branch%5D=test"
-                        .to_string()
-                )
-            );
+                url,
+                "https://example.com/test/test/-/merge_requests/new?merge_request%5Bsource_branch%5D=test"
+            )
         } else {
-            panic!("Expected ToastWithLog variant");
+            panic!("Expected PushPrLink variant")
         }
     }
 
@@ -272,8 +269,11 @@ mod tests {
         };
 
         assert_eq!(
-            extract_pull_request_url(&output),
-            Some("https://bitbucket.example.com/projects/TEST/repos/test/pull-requests?create&sourceBranch=refs/heads/test".to_string())
+            extract_pull_request_link(&output),
+            Some((
+                "Create Pull Request",
+                "https://bitbucket.example.com/projects/TEST/repos/test/pull-requests?create&sourceBranch=refs/heads/test".to_string()
+            ))
         );
     }
 
@@ -288,7 +288,9 @@ mod tests {
 
         let output = RemoteCommandOutput {
             stdout: String::new(),
-            // Simulate an extraneous link that should not be found in top 3 lines
+            // Include an unrelated URL outside of the `remote:` lines, in this
+            // case, an OpenSSH warning, to ensure that it is not mistaken for
+            // the merge request link.
             stderr: indoc! {"
                 ** WARNING: connection is not using a post-quantum key exchange algorithm.
                 ** This session may be vulnerable to \"store now, decrypt later\" attacks.
@@ -306,12 +308,12 @@ mod tests {
 
         let msg = format_output(&action, output);
 
-        assert!(matches!(&msg.style, SuccessStyle::ToastWithLog { .. }));
-        assert_eq!(msg.message, "Pushed test_branch to test_remote");
-        if let SuccessStyle::ToastWithLog { output } = &msg.style {
-            assert_eq!(extract_pull_request_url(output), None);
+        if let SuccessStyle::PushPrLink { label, url } = msg.style {
+            assert_eq!(msg.message, "Pushed test_branch to test_remote");
+            assert_eq!(label, "View Merge Request");
+            assert_eq!(url, "https://example.com/test/test/-/merge_requests/99999");
         } else {
-            panic!("Expected ToastWithLog variant");
+            panic!("Expected PushPrLink variant")
         }
     }
 
@@ -341,7 +343,7 @@ mod tests {
                 output.stderr,
                 "To http://example.com/test/test.git\n * [new branch]      test -> test\n"
             );
-            assert_eq!(extract_pull_request_url(output), None);
+            assert_eq!(extract_pull_request_link(output), None);
         } else {
             panic!("Expected ToastWithLog variant");
         }


### PR DESCRIPTION
## Summary

Fixes #60288 and #60454 .

After a push, the push toast's "Create Pull Request" button fails with `Unsupported remote URL` when the repository's remote is not a plain, recognized host. This restores the pre-#53913 behavior as a fallback: use the create-PR/MR link that `git push` itself prints, and only build a URL from the provider registry when the push output had no link.

## Why this matters

#53913 made the button always appear and changed `create_pull_request` to reconstruct the PR URL from the remote via `git::parse_git_remote_url` against the `GitHostingProviderRegistry`. When the remote is not recognized, parsing returns `None` and the action errors. This affects self-hosted GitLab/GitHub, an SSH-config host alias like `git@personal:owner/repo` (the duplicate #60076), and any non-standard host. Before #53913, the flow used the link git prints in the push output, which works regardless of host, so this is a regression for anyone not pushing to a plainly-recognized GitHub URL.

## Solution

`git push` prints a `remote:` line with the hosting provider's create-PR/MR URL (GitHub: "Create a pull request for '\<branch>' on GitHub by visiting:", GitLab: "To create a merge request for \<branch>, visit:", Bitbucket: "Create pull request for \<branch>:"), and we already hold the push `RemoteCommandOutput`.

- `remote_output.rs`: add `extract_pull_request_url`, which scans the push stderr for the first `http(s)` URL on a `remote:` line tied to a create-PR/MR prompt. It ignores unrelated URLs (for example the OpenSSH post-quantum warning line).
- `git_panel.rs`: capture that URL in `show_remote_output` into `pending_pull_request_url`, and prefer it in `create_pull_request`, falling back to the existing provider construction only when the push output had no link. The cached URL is consumed once (`take()`) and cleared when the active repo, the active branch/head, or the pending remote operation changes, so a later `git: Create Pull Request` action never opens a stale URL from an earlier push.

Recognized GitHub remotes are unaffected: they still get a link from the push output, with the provider path as the fallback.

## Testing

Unit tests in `remote_output.rs` cover `extract_pull_request_url` for the GitHub, GitLab, and Bitbucket prompt formats, the no-link case (returns `None`, so the provider fallback runs), and an output containing an unrelated URL that must not be mistaken for the PR link. The existing remote-operation test also asserts the cached URL is cleared when a new operation starts.

`cargo test -p git_ui remote_output` passes (5 tests). Tested on macOS.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed "Create Pull Request" button in the toast shown after `git: push` failing for repositories on unrecognized Git hosts by using the link printed in the push output.
- Fixed the button shown on the toast after `git: push` for GitLab branches with an existing merge request. It now shows "View Merge Request" and links to the existing merge request.


