### PR TITLE
project: Fix include filters being ignored for non-ASCII search in multi-worktree projects

### DIFF
--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -118,7 +118,7 @@ impl SearchQuery {
                 include_ignored,
                 files_to_include,
                 files_to_exclude,
-                false,
+                match_full_paths,
                 buffers,
             );
         }


### PR DESCRIPTION
`SearchQuery::text()` drops the `match_full_paths` parameter when falling back to `escaped_regex` for non-ASCII queries, causing include filters to match against wrong path formats in multi-worktree projects.

search works correctly after the fix 
<img width="1465" height="329" alt="截屏2026-07-07 21 32 34" src="https://github.com/user-attachments/assets/039640e6-22ae-4eb5-a9da-909fd8498b77" />


Fixes #60513 

---

Release Notes:

- Fixed project search with non-ASCII queries incorrectly ignoring include filters in multi-worktree projects.
