### PR TITLE
git_graph: Add check out branch to the context menu

### DIFF
--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -1,11 +1,13 @@
 use crate::{
     commit_tooltip::{CommitAvatar, CommitDetails, CommitTooltip},
     commit_view::CommitView,
+    git_panel::show_error_toast,
     git_status_icon,
 };
 use collections::{BTreeMap, HashMap, IndexSet};
 use editor::Editor;
 use file_icons::FileIcons;
+use futures::channel::oneshot;
 use git::{
     BuildCommitPermalinkParams, GitHostingProviderRegistry, GitRemote, Oid, ParsedGitRemote,
     commit::ParsedCommitMessage,
@@ -1358,6 +1360,51 @@ impl GitGraph {
         cx.notify();
     }
 
+    /// Drops the repository's cached graph data and rebuilds the view. Unlike
+    /// `invalidate_state` alone, this forces `git log` to re-run, which is
+    /// required after operations (such as tag edits) that change refs without
+    /// emitting a repository event.
+    fn reload_graph(&mut self, cx: &mut Context<Self>) {
+        if let Some(repository) = self.get_repository(cx) {
+            repository.update(cx, |repository, _| repository.invalidate_graph_data());
+        }
+        self.invalidate_state(cx);
+    }
+
+    /// Detaches a repository operation, refreshing the graph on success and
+    /// surfacing any error as a toast labeled with the git subcommand that
+    /// failed.
+    fn detach_op_with_error_toast(
+        &self,
+        command_label: String,
+        receiver: oneshot::Receiver<Result<(), anyhow::Error>>,
+        cx: &mut Context<Self>,
+    ) {
+        let workspace = self.workspace.clone();
+        cx.spawn(async move |this, cx| match receiver.await {
+            Ok(Ok(())) => {
+                this.update(cx, |this, cx| this.reload_graph(cx)).ok();
+            }
+            Ok(Err(error)) => {
+                if let Some(workspace) = workspace.upgrade() {
+                    cx.update(|cx| show_error_toast(workspace, command_label, error, cx));
+                }
+            }
+            Err(_) => {}
+        })
+        .detach();
+    }
+
+    fn checkout_ref(&mut self, ref_name: SharedString, cx: &mut Context<Self>) {
+        let Some(repository) = self.get_repository(cx) else {
+            return;
+        };
+        let receiver = repository.update(cx, |repository, _| {
+            repository.change_branch(ref_name.to_string())
+        });
+        self.detach_op_with_error_toast(format!("switch {ref_name}"), receiver, cx);
+    }
+
     /// Computes the height of a single commit row in the git graph.
     ///
     /// The returned value is snapped to the nearest physical pixel. This is
@@ -2479,6 +2526,23 @@ impl GitGraph {
             .map(|task_context| self.git_context_menu_tasks(&task_context, cx))
             .unwrap_or_default();
 
+        let head_branch_name = self.get_repository(cx).and_then(|repository| {
+            repository
+                .read(cx)
+                .snapshot()
+                .branch
+                .as_ref()
+                .map(|branch| SharedString::from(branch.name().to_string()))
+        });
+        let is_tag = ref_name.as_ref().is_some_and(|ref_name| {
+            commit
+                .data
+                .tag_names()
+                .iter()
+                .any(|tag_name| *tag_name == ref_name.as_ref())
+        });
+        let is_checked_out = ref_name.is_some() && ref_name == head_branch_name;
+
         let header = match &ref_name {
             Some(ref_name) => format!("Ref {ref_name}"),
             None => format!("Commit {sha_short}"),
@@ -2555,6 +2619,23 @@ impl GitGraph {
                             }),
                         }
                     })
+                })
+                .separator()
+                .map(|mut menu| {
+                    if let Some(branch_name) = ref_name.clone().filter(|_| !is_tag) {
+                        let checkout_branch = branch_name.clone();
+                        menu = menu.item(
+                            ContextMenuEntry::new("Check Out Branch")
+                                .disabled(is_checked_out)
+                                .handler(window.handler_for(
+                                    &git_graph,
+                                    move |this, _window, cx| {
+                                        this.checkout_ref(checkout_branch.clone(), cx);
+                                    },
+                                )),
+                        );
+                    }
+                    menu
                 })
                 .map(|mut menu| {
                     menu = menu.separator().header("Custom Commands");

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -5749,6 +5749,13 @@ impl Repository {
         .detach();
     }
 
+    /// Drops the cached graph data so the next `graph_data` call re-runs
+    /// `git log`. Used to reflect ref changes (such as tag edits) that produce
+    /// no repository event of their own.
+    pub fn invalidate_graph_data(&mut self) {
+        self.initial_graph_data.clear();
+    }
+
     pub fn graph_data(
         &mut self,
         log_source: LogSource,

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -106,6 +106,10 @@ To view File History:
 - Right-click on an editor tab and select "View File History"
 - Use the Command Palette and search for "file history"
 
+## Git Graph
+
+The Git Graph ({#action git_graph::Open}) visualizes your repository's commit history across branches. Right-clicking a branch label opens a context menu with common Git operations, starting with **Check Out Branch**.
+
 ## Fetch, Push, and Pull
 
 Fetch, push, or pull from your Git repository in Zed via the buttons available on the Git Panel or via the Command Palette by looking at the respective actions: {#action git::Fetch}, {#action git::Push}, and {#action git::Pull}.


### PR DESCRIPTION
Part 1 of a series that splits #60370 into one feature per PR, as requested.

Adds **Check Out Branch** to the Git Graph context menu: right-clicking a branch label switches to it via the existing repository operation. It also introduces the small shared infrastructure the later PRs build on — an error-toast helper and a graph reload that re-runs `git log` so ref changes are reflected immediately (some, like tag edits, emit no repository event).

## Testing

- `cargo check`/`clippy --deny warnings` clean on the touched crates; existing `git_ui` tests pass.
- Exercised manually on macOS against a local build.

Release Notes:

- Added a Check Out Branch action to the Git Graph commit context menu.
