### PR TITLE
git_graph: Add create branch to the context menu

### DIFF
--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -1324,6 +1324,112 @@ struct GitGraphContextMenu {
     _subscription: Subscription,
 }
 
+struct CreateBranchModal {
+    editor: Entity<Editor>,
+    repository: Entity<Repository>,
+    workspace: WeakEntity<Workspace>,
+    git_graph: WeakEntity<GitGraph>,
+    base: SharedString,
+}
+
+impl EventEmitter<DismissEvent> for CreateBranchModal {}
+impl ModalView for CreateBranchModal {}
+impl Focusable for CreateBranchModal {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.editor.focus_handle(cx)
+    }
+}
+
+impl CreateBranchModal {
+    fn new(
+        repository: Entity<Repository>,
+        base: SharedString,
+        workspace: WeakEntity<Workspace>,
+        git_graph: WeakEntity<GitGraph>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            editor.set_placeholder_text("Branch name", window, cx);
+            editor
+        });
+        Self {
+            editor,
+            repository,
+            workspace,
+            git_graph,
+            base,
+        }
+    }
+
+    fn cancel(&mut self, _: &menu::Cancel, _window: &mut Window, cx: &mut Context<Self>) {
+        cx.emit(DismissEvent);
+    }
+
+    fn confirm(&mut self, _: &menu::Confirm, _window: &mut Window, cx: &mut Context<Self>) {
+        let name = self.editor.read(cx).text(cx).trim().to_string();
+        if name.is_empty() {
+            return;
+        }
+        let base = self.base.clone();
+        let workspace = self.workspace.clone();
+        let git_graph = self.git_graph.clone();
+        let receiver = self.repository.update(cx, |repository, _| {
+            repository.create_branch(name.clone(), Some(base.to_string()))
+        });
+        cx.spawn(async move |_, cx| match receiver.await {
+            Ok(Ok(())) => {
+                git_graph
+                    .update(cx, |git_graph, cx| git_graph.reload_graph(cx))
+                    .ok();
+            }
+            Ok(Err(error)) => {
+                if let Some(workspace) = workspace.upgrade() {
+                    cx.update(|cx| {
+                        show_error_toast(workspace, format!("switch -c {name} {base}"), error, cx)
+                    });
+                }
+            }
+            Err(_) => {}
+        })
+        .detach();
+        cx.emit(DismissEvent);
+    }
+}
+
+impl Render for CreateBranchModal {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .key_context("GitGraphCreateBranchModal")
+            .on_action(cx.listener(Self::cancel))
+            .on_action(cx.listener(Self::confirm))
+            .elevation_2(cx)
+            .w(rems(34.))
+            .child(
+                h_flex()
+                    .px_3()
+                    .pt_2()
+                    .pb_1()
+                    .gap_1p5()
+                    .child(Icon::new(IconName::GitBranch).size(IconSize::XSmall))
+                    .child(
+                        Label::new(format!("Create branch from {}", self.base))
+                            .size(LabelSize::Small),
+                    ),
+            )
+            .child(
+                div()
+                    .py_2()
+                    .px_3()
+                    .bg(cx.theme().colors().editor_background)
+                    .border_t_1()
+                    .border_color(cx.theme().colors().border_variant)
+                    .child(self.editor.clone()),
+            )
+    }
+}
+
 pub struct GitGraph {
     focus_handle: FocusHandle,
     search_state: SearchState,
@@ -1403,6 +1509,27 @@ impl GitGraph {
             repository.change_branch(ref_name.to_string())
         });
         self.detach_op_with_error_toast(format!("switch {ref_name}"), receiver, cx);
+    }
+
+    fn create_branch_from(
+        &mut self,
+        base: SharedString,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(repository) = self.get_repository(cx) else {
+            return;
+        };
+        let Some(workspace) = self.workspace.upgrade() else {
+            return;
+        };
+        let git_graph = cx.weak_entity();
+        workspace.update(cx, |workspace, cx| {
+            let workspace_handle = cx.weak_entity();
+            workspace.toggle_modal(window, cx, |window, cx| {
+                CreateBranchModal::new(repository, base, workspace_handle, git_graph, window, cx)
+            });
+        });
     }
 
     /// Computes the height of a single commit row in the git graph.
@@ -2622,18 +2749,41 @@ impl GitGraph {
                 })
                 .separator()
                 .map(|mut menu| {
-                    if let Some(branch_name) = ref_name.clone().filter(|_| !is_tag) {
-                        let checkout_branch = branch_name.clone();
-                        menu = menu.item(
-                            ContextMenuEntry::new("Check Out Branch")
-                                .disabled(is_checked_out)
-                                .handler(window.handler_for(
-                                    &git_graph,
-                                    move |this, _window, cx| {
-                                        this.checkout_ref(checkout_branch.clone(), cx);
-                                    },
-                                )),
-                        );
+                    match ref_name.clone().filter(|_| !is_tag) {
+                        Some(branch_name) => {
+                            let checkout_branch = branch_name.clone();
+                            menu = menu.item(
+                                ContextMenuEntry::new("Check Out Branch")
+                                    .disabled(is_checked_out)
+                                    .handler(window.handler_for(
+                                        &git_graph,
+                                        move |this, _window, cx| {
+                                            this.checkout_ref(checkout_branch.clone(), cx);
+                                        },
+                                    )),
+                            );
+
+                            let create_base = branch_name.clone();
+                            menu = menu.entry(
+                                "Create Branch from Here…",
+                                None,
+                                window.handler_for(&git_graph, move |this, window, cx| {
+                                    this.create_branch_from(create_base.clone(), window, cx);
+                                }),
+                            );
+                        }
+                        None => {
+                            let create_base = ref_name
+                                .clone()
+                                .unwrap_or_else(|| SharedString::from(sha.to_string()));
+                            menu = menu.entry(
+                                "Create Branch from Here…",
+                                None,
+                                window.handler_for(&git_graph, move |this, window, cx| {
+                                    this.create_branch_from(create_base.clone(), window, cx);
+                                }),
+                            );
+                        }
                     }
                     menu
                 })

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -1,11 +1,13 @@
 use crate::{
     commit_tooltip::{CommitAvatar, CommitDetails, CommitTooltip},
     commit_view::CommitView,
+    git_panel::show_error_toast,
     git_status_icon,
 };
 use collections::{BTreeMap, HashMap, IndexSet};
 use editor::Editor;
 use file_icons::FileIcons;
+use futures::channel::oneshot;
 use git::{
     BuildCommitPermalinkParams, GitHostingProviderRegistry, GitRemote, Oid, ParsedGitRemote,
     commit::ParsedCommitMessage,
@@ -1358,6 +1360,51 @@ impl GitGraph {
         cx.notify();
     }
 
+    /// Drops the repository's cached graph data and rebuilds the view. Unlike
+    /// `invalidate_state` alone, this forces `git log` to re-run, which is
+    /// required after operations (such as tag edits) that change refs without
+    /// emitting a repository event.
+    fn reload_graph(&mut self, cx: &mut Context<Self>) {
+        if let Some(repository) = self.get_repository(cx) {
+            repository.update(cx, |repository, _| repository.invalidate_graph_data());
+        }
+        self.invalidate_state(cx);
+    }
+
+    /// Detaches a repository operation, refreshing the graph on success and
+    /// surfacing any error as a toast labeled with the git subcommand that
+    /// failed.
+    fn detach_op_with_error_toast(
+        &self,
+        command_label: String,
+        receiver: oneshot::Receiver<Result<(), anyhow::Error>>,
+        cx: &mut Context<Self>,
+    ) {
+        let workspace = self.workspace.clone();
+        cx.spawn(async move |this, cx| match receiver.await {
+            Ok(Ok(())) => {
+                this.update(cx, |this, cx| this.reload_graph(cx)).ok();
+            }
+            Ok(Err(error)) => {
+                if let Some(workspace) = workspace.upgrade() {
+                    cx.update(|cx| show_error_toast(workspace, command_label, error, cx));
+                }
+            }
+            Err(_) => {}
+        })
+        .detach();
+    }
+
+    fn checkout_ref(&mut self, ref_name: SharedString, cx: &mut Context<Self>) {
+        let Some(repository) = self.get_repository(cx) else {
+            return;
+        };
+        let receiver = repository.update(cx, |repository, _| {
+            repository.change_branch(ref_name.to_string())
+        });
+        self.detach_op_with_error_toast(format!("switch {ref_name}"), receiver, cx);
+    }
+
     /// Computes the height of a single commit row in the git graph.
     ///
     /// The returned value is snapped to the nearest physical pixel. This is
@@ -2479,6 +2526,23 @@ impl GitGraph {
             .map(|task_context| self.git_context_menu_tasks(&task_context, cx))
             .unwrap_or_default();
 
+        let head_branch_name = self.get_repository(cx).and_then(|repository| {
+            repository
+                .read(cx)
+                .snapshot()
+                .branch
+                .as_ref()
+                .map(|branch| SharedString::from(branch.name().to_string()))
+        });
+        let is_tag = ref_name.as_ref().is_some_and(|ref_name| {
+            commit
+                .data
+                .tag_names()
+                .iter()
+                .any(|tag_name| *tag_name == ref_name.as_ref())
+        });
+        let is_checked_out = ref_name.is_some() && ref_name == head_branch_name;
+
         let header = match &ref_name {
             Some(ref_name) => format!("Ref {ref_name}"),
             None => format!("Commit {sha_short}"),
@@ -2555,6 +2619,23 @@ impl GitGraph {
                             }),
                         }
                     })
+                })
+                .separator()
+                .map(|mut menu| {
+                    if let Some(branch_name) = ref_name.clone().filter(|_| !is_tag) {
+                        let checkout_branch = branch_name.clone();
+                        menu = menu.item(
+                            ContextMenuEntry::new("Check Out Branch")
+                                .disabled(is_checked_out)
+                                .handler(window.handler_for(
+                                    &git_graph,
+                                    move |this, _window, cx| {
+                                        this.checkout_ref(checkout_branch.clone(), cx);
+                                    },
+                                )),
+                        );
+                    }
+                    menu
                 })
                 .map(|mut menu| {
                     menu = menu.separator().header("Custom Commands");

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -5749,6 +5749,13 @@ impl Repository {
         .detach();
     }
 
+    /// Drops the cached graph data so the next `graph_data` call re-runs
+    /// `git log`. Used to reflect ref changes (such as tag edits) that produce
+    /// no repository event of their own.
+    pub fn invalidate_graph_data(&mut self) {
+        self.initial_graph_data.clear();
+    }
+
     pub fn graph_data(
         &mut self,
         log_source: LogSource,

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -106,6 +106,10 @@ To view File History:
 - Right-click on an editor tab and select "View File History"
 - Use the Command Palette and search for "file history"
 
+## Git Graph
+
+The Git Graph ({#action git_graph::Open}) visualizes your repository's commit history across branches. Right-clicking a branch label opens a context menu with common Git operations, starting with **Check Out Branch**.
+
 ## Fetch, Push, and Pull
 
 Fetch, push, or pull from your Git repository in Zed via the buttons available on the Git Panel or via the Command Palette by looking at the respective actions: {#action git::Fetch}, {#action git::Push}, and {#action git::Pull}.

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -108,7 +108,12 @@ To view File History:
 
 ## Git Graph
 
-The Git Graph ({#action git_graph::Open}) visualizes your repository's commit history across branches. Right-clicking a branch label opens a context menu with common Git operations, starting with **Check Out Branch**.
+The Git Graph ({#action git_graph::Open}) visualizes your repository's commit history across branches. Right-clicking a branch label, tag label, or commit opens a context menu with common Git operations:
+
+- On a branch label: **Check Out Branch** or **Create Branch from Here…**.
+- On a commit or tag label: **Create Branch from Here…**.
+
+Creating a branch opens a small modal asking for the name.
 
 ## Fetch, Push, and Pull
 


### PR DESCRIPTION
Part 2 of the #60370 split (one feature per PR).

Adds **Create Branch from Here…** to the Git Graph context menu, available on branch, commit, and tag entries. It opens a small modal for the branch name and creates the branch from the clicked ref via the existing repository operation.

> **Stacked PR.** This builds on PR-1 (Check Out Branch), so the diff against `main` is cumulative. Review only this feature's change — the final commit — or the incremental diff: https://github.com/sergiooroman/zed/compare/git-graph-checkout-branch...git-graph-create-branch

## Testing

- `cargo check`/`clippy --deny warnings` clean; existing `git_ui` tests pass.
- Exercised manually on macOS against a local build.

Release Notes:

- Added a Create Branch action to the Git Graph commit context menu.
