### PR TITLE
picker: Automatically switch layout depending on window dimensions

### DIFF
--- a/crates/picker/src/footer.rs
+++ b/crates/picker/src/footer.rs
@@ -123,7 +123,7 @@ impl<D: PickerDelegate> Picker<D> {
 
     fn render_preview_controls(
         &self,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let focus_handle = self.focus_handle(cx);
@@ -131,6 +131,12 @@ impl<D: PickerDelegate> Picker<D> {
         let below_focus_handle = focus_handle.clone();
         let current = self.preview_layout().unwrap_or(preview::Layout::Hidden);
         let preview_visible = current != preview::Layout::Hidden;
+
+        let diff_split = if self.is_auto_vertical(window) {
+            IconName::DiffSplitAuto
+        } else {
+            IconName::DiffSplit
+        };
 
         h_flex()
             .child(
@@ -163,7 +169,7 @@ impl<D: PickerDelegate> Picker<D> {
                             })),
                     )
                     .child(
-                        IconButton::new("picker-preview-right", IconName::DiffSplit)
+                        IconButton::new("picker-preview-right", diff_split)
                             .icon_size(IconSize::Small)
                             .toggle_state(current == preview::Layout::Right)
                             .tooltip(move |_window, cx| {

--- a/crates/picker/src/footer.rs
+++ b/crates/picker/src/footer.rs
@@ -147,22 +147,6 @@ impl<D: PickerDelegate> Picker<D> {
             .when(preview_visible, |this| {
                 this.child(Divider::vertical().mx_1())
                     .child(
-                        IconButton::new("picker-preview-right", IconName::DiffSplit)
-                            .icon_size(IconSize::Small)
-                            .toggle_state(current == preview::Layout::Right)
-                            .tooltip(move |_window, cx| {
-                                Tooltip::for_action_in(
-                                    "Preview to the Right",
-                                    &SetPreviewRight,
-                                    &right_focus_handle,
-                                    cx,
-                                )
-                            })
-                            .on_click(cx.listener(|this, _, window, cx| {
-                                this.set_preview_layout(preview::Layout::Right, window, cx)
-                            })),
-                    )
-                    .child(
                         IconButton::new("picker-preview-below", IconName::DiffUnified)
                             .icon_size(IconSize::Small)
                             .toggle_state(current == preview::Layout::Below)
@@ -176,6 +160,22 @@ impl<D: PickerDelegate> Picker<D> {
                             })
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.set_preview_layout(preview::Layout::Below, window, cx)
+                            })),
+                    )
+                    .child(
+                        IconButton::new("picker-preview-right", IconName::DiffSplit)
+                            .icon_size(IconSize::Small)
+                            .toggle_state(current == preview::Layout::Right)
+                            .tooltip(move |_window, cx| {
+                                Tooltip::for_action_in(
+                                    "Preview to the Right",
+                                    &SetPreviewRight,
+                                    &right_focus_handle,
+                                    cx,
+                                )
+                            })
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.set_preview_layout(preview::Layout::Right, window, cx)
                             })),
                     )
             })

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -1280,10 +1280,34 @@ impl<D: PickerDelegate> Picker<D> {
     fn preview_layout(&self) -> Option<preview::Layout> {
         self.preview.as_ref().map(|p| p.layout)
     }
+    fn is_auto_vertical(&self, window: &Window) -> bool {
+        self.preview_layout() == Some(preview::Layout::Right)
+            && self
+                .size_bounds
+                .would_clamp_width_if_horizontal(&self.shape, window)
+    }
+    /// To check whether we're rendering vertically instead of
+    /// horizontally due to the auto override
+    fn preview_layout_rendered(&self, window: &Window) -> Option<preview::Layout> {
+        let would_clamp = matches!(
+            self.preview,
+            Some(Preview {
+                layout: preview::Layout::Right,
+                ..
+            })
+        ) && self.is_auto_vertical(window);
+        if would_clamp {
+            Some(preview::Layout::Below)
+        } else {
+            self.preview_layout()
+        }
+    }
 
     #[cfg(any(test, feature = "test-support"))]
     pub fn results_width(&self, window: &Window) -> gpui::Pixels {
-        let layout = self.preview_layout().unwrap_or(preview::Layout::Hidden);
+        let layout = self
+            .preview_layout_rendered(window)
+            .unwrap_or(preview::Layout::Hidden);
         let pos = self
             .shape
             .results_position_and_size(layout, &self.size_bounds, window);

--- a/crates/picker/src/render.rs
+++ b/crates/picker/src/render.rs
@@ -22,7 +22,9 @@ pub mod window_controls;
 impl<D: PickerDelegate> Render for Picker<D> {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         self.finish_any_completed_resize(window, cx);
-
+        // toggle between BelowForced and Right based on whether it'd clamp if
+        // horizontal
+        let rendered_layout = self.preview_layout_rendered(window);
         let content = match &self.preview {
             Some(
                 preview @ Preview {
@@ -30,6 +32,15 @@ impl<D: PickerDelegate> Render for Picker<D> {
                     ..
                 },
             ) => self
+                .render_with_preview_below(preview, window, cx)
+                .into_any_element(),
+            // render sideways based on bounds
+            Some(
+                preview @ Preview {
+                    layout: Layout::Right,
+                    ..
+                },
+            ) if rendered_layout == Some(Layout::Below) => self
                 .render_with_preview_below(preview, window, cx)
                 .into_any_element(),
             Some(
@@ -58,7 +69,9 @@ impl<D: PickerDelegate> Render for Picker<D> {
             .when(has_preview, |this| this.overflow_hidden())
             .child(content);
 
-        let layout = self.preview_layout().unwrap_or(Layout::Hidden);
+        let layout = self
+            .preview_layout_rendered(window)
+            .unwrap_or(Layout::Hidden);
 
         div()
             .relative()
@@ -101,7 +114,7 @@ impl<D: PickerDelegate> Picker<D> {
             .relative()
             .map(|this| {
                 self.shape.apply_results_size(
-                    self.preview_layout(),
+                    self.preview_layout_rendered(window),
                     &self.size_bounds,
                     self.fill_height(),
                     this,
@@ -309,7 +322,11 @@ impl<D: PickerDelegate> Picker<D> {
                     ),
             )
             .when(self.is_resizable(), |this| {
-                this.child(self.render_resize(window_controls::Middle(preview.layout), window, cx))
+                this.child(self.render_resize(
+                    window_controls::Middle(preview::Layout::Below),
+                    window,
+                    cx,
+                ))
             })
     }
 
@@ -365,7 +382,8 @@ impl<D: PickerDelegate> Picker<D> {
         if let Shape::Resizing(pos) = self.shape
             && !cx.has_active_drag()
         {
-            let centered = Shape::centered_and_relative(pos, self.preview_layout(), window);
+            let centered =
+                Shape::centered_and_relative(pos, self.preview_layout_rendered(window), window);
             persistence::store_shape_for_this_layout(
                 D::name(),
                 self.preview_layout(),

--- a/crates/picker/src/render/window_controls.rs
+++ b/crates/picker/src/render/window_controls.rs
@@ -438,7 +438,7 @@ impl<D: PickerDelegate> Picker<D> {
                 side.position(
                     this,
                     self.shape.clamped_position_and_size(
-                        self.preview_layout(),
+                        self.preview_layout_rendered(window),
                         &self.size_bounds,
                         window,
                     ),
@@ -451,7 +451,7 @@ impl<D: PickerDelegate> Picker<D> {
                 ResizeDrag::<S>::start_new(
                     self.shape,
                     &self.size_bounds,
-                    self.preview_layout(),
+                    self.preview_layout_rendered(window),
                     window,
                 ),
                 |_, _, _, cx| cx.new(|_| DragPreview),
@@ -464,7 +464,7 @@ impl<D: PickerDelegate> Picker<D> {
                     side.clamp(
                         &mut working,
                         &this.size_bounds,
-                        this.preview_layout(),
+                        this.preview_layout_rendered(window),
                         window,
                     );
                     this.shape = Shape::Resizing(working);
@@ -487,9 +487,11 @@ impl<D: PickerDelegate> Picker<D> {
             return;
         }
         side.revert_to_default_size(&mut self.shape, &self.default_shape, window);
-        let pos =
-            self.shape
-                .clamped_position_and_size(self.preview_layout(), &self.size_bounds, window);
+        let pos = self.shape.clamped_position_and_size(
+            self.preview_layout_rendered(window),
+            &self.size_bounds,
+            window,
+        );
         self.shape = Shape::Resizing(pos);
         cx.notify();
     }

--- a/crates/picker/src/shape.rs
+++ b/crates/picker/src/shape.rs
@@ -20,6 +20,12 @@ pub(crate) struct PositionAndShape {
     pub(crate) preview: Pixels,
 }
 
+impl PositionAndShape {
+    pub(crate) fn width(&self) -> Pixels {
+        self.right - self.left
+    }
+}
+
 macro_rules! relative_size {
     ($name:ident, $accessor:ident) => {
         /// Size type that is the sum of a relative size to the viewport and a
@@ -377,6 +383,16 @@ impl SizeBounds {
         };
         let max_preview = (total - min_results).max(min_preview);
         working.preview = working.preview.clamp(min_preview, max_preview);
+    }
+
+    pub(crate) fn would_clamp_width_if_horizontal(&self, shape: &Shape, window: &Window) -> bool {
+        let min_width = self.min_width(Some(Layout::Right), window);
+
+        let unbounded_width = shape
+            .picker_position_and_size(Some(Layout::Right), window)
+            .width();
+
+        unbounded_width <= min_width
     }
 
     /// Clamps a whole picker rect (results + preview) into bounds: the total size


### PR DESCRIPTION
# Objective

Fixes #59820. 

## Solution

At a high level, I approached this by conditionally rendering a `Below` preview layout only when the preview was at or below the min width of the `Right`  when the layout is `Right`. Since there's one breakpoint at `SizeBounds::min_width()` and hitting that breakpoint only changes rendering (and doesn't change the state), there's no need to persist to storage or memory that the view is forced to be Below. 

I toggled between the two rendering modes by defining `Picker::preview_layout_rendered()` that would return `Below` if the window was equal to or smaller than its min width. Then I replaced all calls of `preview_layout()` that used the response purely for rendering purposes with `preview_layout_rendered()`. I avoided replacing `preview_layout()` calls that were responsible for persisting the current layout and window dimensions to disk to ensure that changes to the window dimensions were properly synced to the correct layout. This way changes to the window while in the `BelowAuto` rendering mode edit the `Right` window dimensions on disk. 

## Testing

I tested these changes manually with the following actions on my local machine (an Apple Silicon Macbook Pro): 
- resizing the popover
- resizing the window
- adjusting the split
- making sure the popover size and split percent remains the same after:
  - closing and re-opening the popover
  - closing and re-opening the application and making sure the window size and split percent remains the same
  
Reviewers can test my changes by performing the same manual actions.

## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [X] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

## Showcase

### Before

https://github.com/user-attachments/assets/a4524065-d1a3-4595-bc9e-50c9715b4e66

### After

https://github.com/user-attachments/assets/fede7eb0-5d73-423c-8df0-8192caee8d26

---

Release Notes:

- fix(picker): Automatically switch from Right split to Down split when picker gets too narrow
