### PR TITLE
Match thread archive search highlights against the rendered title

### DIFF
--- a/crates/agent_ui/src/threads_archive_view.rs
+++ b/crates/agent_ui/src/threads_archive_view.rs
@@ -7,7 +7,7 @@ use crate::agent_connection_store::AgentConnectionStore;
 use crate::thread_metadata_store::{
     ThreadId, ThreadMetadata, ThreadMetadataStore, worktree_info_from_thread_paths,
 };
-use crate::{Agent, ArchiveSelectedThread, DEFAULT_THREAD_TITLE, RemoveSelectedThread};
+use crate::{Agent, ArchiveSelectedThread, RemoveSelectedThread};
 
 use agent::ThreadStore;
 use agent_client_protocol::schema::v1 as acp;
@@ -300,12 +300,12 @@ impl ThreadsArchiveView {
 
         for session in sessions {
             let highlight_positions = if !query.is_empty() {
-                let title = session
-                    .title
-                    .as_ref()
-                    .map(|t| t.as_ref())
-                    .unwrap_or(DEFAULT_THREAD_TITLE);
-                if let Some(positions) = fuzzy_match_positions(&query, title) {
+                // Match against the same string that gets rendered
+                // (`display_title` prefers `title_override`); positions
+                // computed on a different string can land inside a multi-byte
+                // character and panic in `HighlightedLabel`.
+                let title = session.display_title();
+                if let Some(positions) = fuzzy_match_positions(&query, title.as_ref()) {
                     positions
                 } else {
                     // If title didn't match, also try matching the project name
@@ -1293,11 +1293,7 @@ impl PickerDelegate for ProjectPickerDelegate {
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
         format!(
             "Associate the \"{}\" thread with...",
-            self.thread
-                .title
-                .as_ref()
-                .map(|t| t.as_ref())
-                .unwrap_or(DEFAULT_THREAD_TITLE)
+            self.thread.display_title()
         )
         .into()
     }


### PR DESCRIPTION
# Objective

The thread archive's search ("Search all threads…") computes fuzzy-match
highlight positions against the raw `title` field, but renders
`display_title()`, which prefers `title_override`. For a renamed thread the
positions belong to a different string than the one rendered, so an index can
land inside a multi-byte character (or past the end) and hit the UTF-8
boundary panic in `HighlightedLabel::new`.

Fixes #60159.

## Solution

Match against `session.display_title()` — the same string that gets rendered —
mirroring what the sidebar already does. Also use `display_title()` in the
project picker's placeholder, which showed the stale pre-rename title for the
same reason.

This also means searching now matches the title the user actually sees, rather
than the old auto-generated one.

## Testing

Reproduced the panic condition deterministically with the copied
`fuzzy_match_positions`: matching "lead" against a raw title
"FAQs for National Lead onboarding" yields positions [18, 19, 20, 21]; applied
to a shorter renamed title, index 21 fails `is_char_boundary` — the exact
index from the crash report. With the fix, positions are always derived from
the rendered string, so every index is a boundary of it by construction.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed a crash when searching threads in the agent panel's archive view after a thread with multi-byte characters in its title had been renamed.
