### PR TITLE
gpui_linux: Fix Chinese IME failing after long runtime on Linux X11

### DIFF
--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -82,6 +82,10 @@ const GPUI_X11_SCALE_FACTOR_ENV: &str = "GPUI_X11_SCALE_FACTOR";
 /// Prevents a tight reconnect loop when the input method server keeps returning bad replies.
 const MAX_XIM_PROTOCOL_ERROR_RECONNECTS: u8 = 3;
 
+/// Maximum events to process after a protocol-error reconnect before retrying if handshake
+/// hasn't completed. Approximately 1-2 seconds of typical event flow.
+const MAX_XIM_RECONNECT_EVENTS: u16 = 100;
+
 pub(crate) struct WindowRef {
     window: X11WindowStatePtr,
     refresh_state: Option<RefreshState>,
@@ -217,6 +221,9 @@ pub struct X11ClientState {
     /// Protocol-error reconnect attempts in the current focus session. Reset on FocusOut and
     /// after a successful reconnect.
     xim_protocol_error_reconnect_count: u8,
+    /// Events processed since the last protocol-error reconnect while handshake is still pending.
+    /// When this exceeds MAX_XIM_RECONNECT_EVENTS, trigger another reconnect attempt.
+    xim_protocol_error_reconnect_event_count: u16,
     pub(crate) pre_key_char_down: Option<Keystroke>,
     pub(crate) cursor_handle: cursor::Handle,
     pub(crate) cursor_styles: HashMap<xproto::Window, CursorStyle>,
@@ -557,6 +564,7 @@ impl X11Client {
             composing: false,
             xim_reconnect_attempted_for_focus: false,
             xim_protocol_error_reconnect_count: 0,
+            xim_protocol_error_reconnect_event_count: 0,
 
             cursor_handle,
             cursor_styles: HashMap::default(),
@@ -709,6 +717,30 @@ impl X11Client {
 
                 let mut state = self.0.borrow_mut();
                 state.restore_xim(ximc, xim_handler);
+
+                if state.xim_protocol_error_reconnect_count > 0 {
+                    if let Some(handler) = state.xim_handler.as_ref() {
+                        if !handler.connected {
+                            state.xim_protocol_error_reconnect_event_count += 1;
+                            if state.xim_protocol_error_reconnect_event_count
+                                >= MAX_XIM_RECONNECT_EVENTS
+                            {
+                                drop(state);
+                                log::warn!(
+                                    "XIM handshake did not complete after {MAX_XIM_RECONNECT_EVENTS} events, retrying reconnect"
+                                );
+                                if !self.reconnect_xim_after_protocol_error() {
+                                    log::warn!(
+                                        "IME input unavailable: XIM handshake retry failed; refocus the window or restart Zed to retry"
+                                    );
+                                }
+                                continue;
+                            }
+                        } else {
+                            state.xim_protocol_error_reconnect_event_count = 0;
+                        }
+                    }
+                }
                 drop(state);
 
                 if let Some(event) = xim_callback_event {
@@ -773,8 +805,9 @@ impl X11Client {
             return false;
         }
 
-        log::warn!("XIM connection re-established");
+        log::warn!("XIM reconnect initiated, async handshake pending");
         state.xim_protocol_error_reconnect_count = 0;
+        state.xim_protocol_error_reconnect_event_count = 0;
         true
     }
 
@@ -813,6 +846,8 @@ impl X11Client {
         let Some((mut ximc, xim_handler)) = state.take_xim() else {
             return;
         };
+        let keyboard_focused_window = state.keyboard_focused_window;
+        drop(state);
         log::trace!(
             "enable_ime: im_id={}, ic_id={}, connected={}, handler_window={}",
             xim_handler.im_id,
@@ -822,11 +857,18 @@ impl X11Client {
         );
 
         if !xim_handler.connected {
-            // The async XIM handshake (handle_connect → handle_open → handle_create_ic)
-            // hasn't completed yet. The handler will automatically create the IC with the
-            // correct im_id once the handshake finishes. Creating an IC now would use an
-            // uninitialized im_id and leave orphan ICs on the XIM server.
-            state.restore_xim(ximc, xim_handler);
+            // The async handshake hasn't completed. If the XIM server never
+            // responded (e.g. fcitx restarted), this connection is dead and
+            // will never become connected. Discard it so the next FocusIn can
+            // attempt a fresh reconnect, rather than staying stuck forever.
+            drop(ximc);
+            drop(xim_handler);
+            let mut state = self.0.borrow_mut();
+            state.discard_xim();
+            drop(state);
+
+            log::warn!("enable_ime: XIM handshake incomplete, discarding and retrying");
+            self.ensure_xim_connection_on_focus();
             return;
         }
 
@@ -835,9 +877,7 @@ impl X11Client {
             .push(AttributeName::ClientWindow, xim_handler.window)
             .push(AttributeName::FocusWindow, xim_handler.window);
 
-        let window_id = state.keyboard_focused_window;
-        drop(state);
-        if let Some(window_id) = window_id {
+        if let Some(window_id) = keyboard_focused_window {
             let Some(window) = self.get_window(window_id) else {
                 log::error!("Failed to get window for IME positioning");
                 let mut state = self.0.borrow_mut();
@@ -1078,9 +1118,16 @@ impl X11Client {
                 if let Some(handler) = state.xim_handler.as_mut() {
                     handler.window = event.event;
                 }
-                let xim_state = state.xim_handler.as_ref().map(|h| {
-                    format!("im_id={}, ic_id={}, connected={}", h.im_id, h.ic_id, h.connected)
-                }).unwrap_or_else(|| "no handler".to_string());
+                let xim_state = state
+                    .xim_handler
+                    .as_ref()
+                    .map(|h| {
+                        format!(
+                            "im_id={}, ic_id={}, connected={}",
+                            h.im_id, h.ic_id, h.connected
+                        )
+                    })
+                    .unwrap_or_else(|| "no handler".to_string());
                 log::info!("FocusIn: window={}, XIM state: [{xim_state}]", event.event);
                 drop(state);
                 self.enable_ime();
@@ -1093,7 +1140,10 @@ impl X11Client {
                 reset_all_pointer_device_scroll_positions(&mut state.pointer_device_states);
                 state.keyboard_focused_window = None;
                 state.reset_xim_reconnect_state();
-                log::info!("FocusOut: window={}, XIM reconnect state reset", event.event);
+                log::info!(
+                    "FocusOut: window={}, XIM reconnect state reset",
+                    event.event
+                );
                 if let Some(compose_state) = state.compose_state.as_mut() {
                     compose_state.reset();
                 }
@@ -1986,14 +2036,19 @@ impl X11ClientState {
 
     /// Drops the current XIM client. Used when the connection is broken and must be replaced.
     fn discard_xim(&mut self) {
+        let had_xim = self.ximc.is_some();
         self.ximc.take();
         self.xim_handler.take();
         self.composing = false;
+        if had_xim {
+            log::trace!("discard_xim: XIM connection discarded");
+        }
     }
 
     fn reset_xim_reconnect_state(&mut self) {
         self.xim_reconnect_attempted_for_focus = false;
         self.xim_protocol_error_reconnect_count = 0;
+        self.xim_protocol_error_reconnect_event_count = 0;
     }
 
     /// Opens a new XIM connection to the input method server (e.g. Fcitx).

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -36,7 +36,7 @@ use x11rb::{
     wrapper::ConnectionExt as _,
     xcb_ffi::XCBConnection,
 };
-use xim::{AttributeName, Client, InputStyle, x11rb::X11rbClient};
+use xim::{AttributeName, Client, x11rb::X11rbClient};
 use xkbc::x11::ffi::{XKB_X11_MIN_MAJOR_XKB_VERSION, XKB_X11_MIN_MINOR_XKB_VERSION};
 use xkbcommon::xkb::{self as xkbc, STATE_LAYOUT_EFFECTIVE};
 
@@ -688,10 +688,24 @@ impl X11Client {
                     continue;
                 };
                 let xim_connected = xim_handler.connected;
+                log::trace!(
+                    "XIM event: connected={xim_connected}, im_id={}, ic_id={}, window={}",
+                    xim_handler.im_id,
+                    xim_handler.ic_id,
+                    xim_handler.window
+                );
                 drop(state);
 
                 let xim_filtered = ximc.filter_event(&event, &mut xim_handler);
                 let xim_callback_event = xim_handler.last_callback_event.take();
+                let xim_connected_after = xim_handler.connected;
+                if xim_connected_after != xim_connected {
+                    log::info!(
+                        "XIM event: connected changed {xim_connected} -> {xim_connected_after}, im_id={}, ic_id={}",
+                        xim_handler.im_id,
+                        xim_handler.ic_id
+                    );
+                }
 
                 let mut state = self.0.borrow_mut();
                 state.restore_xim(ximc, xim_handler);
@@ -709,15 +723,21 @@ impl X11Client {
                         if xim_connected {
                             self.xim_handle_event(event);
                         } else {
+                            log::trace!(
+                                "XIM not connected, routing event directly (bypassing IME)"
+                            );
                             self.handle_event(event);
                         }
                     }
                     Err(err) => {
                         // The XIM server (e.g. Fcitx) can return a bad reply after a crash or restart.
+                        // Reconnect opens a fresh XIM client; the async handshake
+                        // (handle_connect → handle_open → handle_create_ic) runs
+                        // on subsequent filter_event() calls and automatically
+                        // creates the input context, so we must NOT call enable_ime()
+                        // here — the handler's im_id is not yet set.
                         log::warn!("XIMClientError: {err}");
-                        if self.reconnect_xim_after_protocol_error() {
-                            self.enable_ime();
-                        } else {
+                        if !self.reconnect_xim_after_protocol_error() {
                             log::warn!(
                                 "IME input unavailable after XIM protocol error; refocus the window or restart Zed to retry"
                             );
@@ -793,9 +813,25 @@ impl X11Client {
         let Some((mut ximc, xim_handler)) = state.take_xim() else {
             return;
         };
+        log::trace!(
+            "enable_ime: im_id={}, ic_id={}, connected={}, handler_window={}",
+            xim_handler.im_id,
+            xim_handler.ic_id,
+            xim_handler.connected,
+            xim_handler.window
+        );
+
+        if !xim_handler.connected {
+            // The async XIM handshake (handle_connect → handle_open → handle_create_ic)
+            // hasn't completed yet. The handler will automatically create the IC with the
+            // correct im_id once the handshake finishes. Creating an IC now would use an
+            // uninitialized im_id and leave orphan ICs on the XIM server.
+            state.restore_xim(ximc, xim_handler);
+            return;
+        }
+
         let mut ic_attributes = ximc
             .build_ic_attributes()
-            .push(AttributeName::InputStyle, InputStyle::PREEDIT_CALLBACKS)
             .push(AttributeName::ClientWindow, xim_handler.window)
             .push(AttributeName::FocusWindow, xim_handler.window);
 
@@ -822,8 +858,18 @@ impl X11Client {
                     });
             }
         }
-        ximc.create_ic(xim_handler.im_id, ic_attributes.build())
-            .ok();
+        match ximc.set_ic_values(xim_handler.im_id, xim_handler.ic_id, ic_attributes.build()) {
+            Ok(_) => log::trace!(
+                "enable_ime: set_ic_values succeeded for im_id={}, ic_id={}",
+                xim_handler.im_id,
+                xim_handler.ic_id
+            ),
+            Err(err) => log::warn!(
+                "enable_ime: set_ic_values failed for im_id={}, ic_id={}: {err}",
+                xim_handler.im_id,
+                xim_handler.ic_id
+            ),
+        }
         let mut state = self.0.borrow_mut();
         state.restore_xim(ximc, xim_handler);
     }
@@ -1032,6 +1078,10 @@ impl X11Client {
                 if let Some(handler) = state.xim_handler.as_mut() {
                     handler.window = event.event;
                 }
+                let xim_state = state.xim_handler.as_ref().map(|h| {
+                    format!("im_id={}, ic_id={}, connected={}", h.im_id, h.ic_id, h.connected)
+                }).unwrap_or_else(|| "no handler".to_string());
+                log::info!("FocusIn: window={}, XIM state: [{xim_state}]", event.event);
                 drop(state);
                 self.enable_ime();
             }
@@ -1043,6 +1093,7 @@ impl X11Client {
                 reset_all_pointer_device_scroll_positions(&mut state.pointer_device_states);
                 state.keyboard_focused_window = None;
                 state.reset_xim_reconnect_state();
+                log::info!("FocusOut: window={}, XIM reconnect state reset", event.event);
                 if let Some(compose_state) = state.compose_state.as_mut() {
                     compose_state.reset();
                 }
@@ -1952,6 +2003,7 @@ impl X11ClientState {
         let Some(ximc) =
             X11rbClient::init(Rc::clone(&self.xcb_connection), self.x_root_index, None).ok()
         else {
+            log::warn!("open_xim_connection: X11rbClient::init failed");
             return false;
         };
 
@@ -1959,6 +2011,10 @@ impl X11ClientState {
         if let Some(window) = self.keyboard_focused_window {
             xim_handler.window = window;
         }
+        log::info!(
+            "open_xim_connection: X11rbClient created, handler window={}, connected=false (async handshake pending)",
+            xim_handler.window
+        );
 
         self.ximc = Some(ximc);
         self.xim_handler = Some(xim_handler);

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -78,6 +78,10 @@ pub(crate) const XINPUT_ALL_DEVICE_GROUPS: xinput::DeviceId = 1;
 
 const GPUI_X11_SCALE_FACTOR_ENV: &str = "GPUI_X11_SCALE_FACTOR";
 
+/// Maximum XIM reconnect attempts triggered by protocol errors within a single focus session.
+/// Prevents a tight reconnect loop when the input method server keeps returning bad replies.
+const MAX_XIM_PROTOCOL_ERROR_RECONNECTS: u8 = 3;
+
 pub(crate) struct WindowRef {
     window: X11WindowStatePtr,
     refresh_state: Option<RefreshState>,
@@ -207,6 +211,12 @@ pub struct X11ClientState {
     pub(crate) compose_state: Option<xkbc::compose::State>,
     pub(crate) pre_edit_text: Option<String>,
     pub(crate) composing: bool,
+    /// Whether we already tried to reconnect XIM during the current keyboard focus session.
+    /// Reset on FocusOut so each refocus gets a single reconnect attempt.
+    xim_reconnect_attempted_for_focus: bool,
+    /// Protocol-error reconnect attempts in the current focus session. Reset on FocusOut and
+    /// after a successful reconnect.
+    xim_protocol_error_reconnect_count: u8,
     pub(crate) pre_key_char_down: Option<Keystroke>,
     pub(crate) cursor_handle: cursor::Handle,
     pub(crate) cursor_styles: HashMap<xproto::Window, CursorStyle>,
@@ -545,6 +555,8 @@ impl X11Client {
             pre_edit_text: None,
             pre_key_char_down: None,
             composing: false,
+            xim_reconnect_attempted_for_focus: false,
+            xim_protocol_error_reconnect_count: 0,
 
             cursor_handle,
             cursor_styles: HashMap::default(),
@@ -701,14 +713,15 @@ impl X11Client {
                         }
                     }
                     Err(err) => {
-                        // this might happen when xim server crashes on one of the events
-                        // we do lose 1-2 keys when crash happens since there is no reliable way to get that info
-                        // luckily, x11 sends us window not found error when xim server crashes upon further key press
-                        // hence we fall back to handle_event
-                        log::error!("XIMClientError: {}", err);
-                        let mut state = self.0.borrow_mut();
-                        state.take_xim();
-                        drop(state);
+                        // The XIM server (e.g. Fcitx) can return a bad reply after a crash or restart.
+                        log::warn!("XIMClientError: {err}");
+                        if self.reconnect_xim_after_protocol_error() {
+                            self.enable_ime();
+                        } else {
+                            log::warn!(
+                                "IME input unavailable after XIM protocol error; refocus the window or restart Zed to retry"
+                            );
+                        }
                         self.handle_event(event);
                     }
                 }
@@ -717,12 +730,66 @@ impl X11Client {
         Ok(())
     }
 
-    pub fn enable_ime(&self) {
+    /// Reconnects to the XIM server after a protocol error and re-creates the input context.
+    /// Returns false when the per-focus-session attempt limit is reached.
+    fn reconnect_xim_after_protocol_error(&self) -> bool {
         let mut state = self.0.borrow_mut();
-        if !state.has_xim() {
+        if state.xim_protocol_error_reconnect_count >= MAX_XIM_PROTOCOL_ERROR_RECONNECTS {
+            log::warn!(
+                "Giving up on XIM reconnect after {MAX_XIM_PROTOCOL_ERROR_RECONNECTS} protocol errors this focus session; refocus the window to retry"
+            );
+            state.discard_xim();
+            return false;
+        }
+
+        state.xim_protocol_error_reconnect_count += 1;
+        let attempt = state.xim_protocol_error_reconnect_count;
+        log::warn!(
+            "Attempting XIM reconnect after protocol error ({attempt}/{MAX_XIM_PROTOCOL_ERROR_RECONNECTS})"
+        );
+
+        if !state.open_xim_connection() {
+            log::warn!("XIM reconnect failed: could not open a new XIM connection");
+            return false;
+        }
+
+        log::warn!("XIM connection re-established");
+        state.xim_protocol_error_reconnect_count = 0;
+        true
+    }
+
+    /// Ensures an XIM connection exists when a window gains keyboard focus.
+    /// At most one reconnect is attempted per focus session (until FocusOut).
+    fn ensure_xim_connection_on_focus(&self) -> bool {
+        let mut state = self.0.borrow_mut();
+        if state.has_xim() {
+            return true;
+        }
+        if state.xim_reconnect_attempted_for_focus {
+            log::warn!(
+                "IME unavailable: XIM not connected and reconnect already attempted for this focus session"
+            );
+            return false;
+        }
+
+        state.xim_reconnect_attempted_for_focus = true;
+        log::warn!("Attempting XIM reconnect on window focus");
+
+        if !state.open_xim_connection() {
+            log::warn!("XIM reconnect failed: could not open a new XIM connection");
+            return false;
+        }
+
+        log::warn!("XIM connection re-established");
+        true
+    }
+
+    pub fn enable_ime(&self) {
+        if !self.ensure_xim_connection_on_focus() {
             return;
         }
 
+        let mut state = self.0.borrow_mut();
         let Some((mut ximc, xim_handler)) = state.take_xim() else {
             return;
         };
@@ -975,6 +1042,7 @@ impl X11Client {
                 // Set last scroll values to `None` so that a large delta isn't created if scrolling is done outside the window (the valuator is global)
                 reset_all_pointer_device_scroll_positions(&mut state.pointer_device_states);
                 state.keyboard_focused_window = None;
+                state.reset_xim_reconnect_state();
                 if let Some(compose_state) = state.compose_state.as_mut() {
                     compose_state.reset();
                 }
@@ -1863,6 +1931,38 @@ impl LinuxClient for X11Client {
 impl X11ClientState {
     fn has_xim(&self) -> bool {
         self.ximc.is_some() && self.xim_handler.is_some()
+    }
+
+    /// Drops the current XIM client. Used when the connection is broken and must be replaced.
+    fn discard_xim(&mut self) {
+        self.ximc.take();
+        self.xim_handler.take();
+        self.composing = false;
+    }
+
+    fn reset_xim_reconnect_state(&mut self) {
+        self.xim_reconnect_attempted_for_focus = false;
+        self.xim_protocol_error_reconnect_count = 0;
+    }
+
+    /// Opens a new XIM connection to the input method server (e.g. Fcitx).
+    fn open_xim_connection(&mut self) -> bool {
+        self.discard_xim();
+
+        let Some(ximc) =
+            X11rbClient::init(Rc::clone(&self.xcb_connection), self.x_root_index, None).ok()
+        else {
+            return false;
+        };
+
+        let mut xim_handler = XimHandler::new();
+        if let Some(window) = self.keyboard_focused_window {
+            xim_handler.window = window;
+        }
+
+        self.ximc = Some(ximc);
+        self.xim_handler = Some(xim_handler);
+        true
     }
 
     fn take_xim(&mut self) -> Option<(X11rbClient<Rc<XCBConnection>>, XimHandler)> {

--- a/crates/gpui_linux/src/linux/x11/xim_handler.rs
+++ b/crates/gpui_linux/src/linux/x11/xim_handler.rs
@@ -31,11 +31,13 @@ impl XimHandler {
 
 impl<C: Client<XEvent = xproto::KeyPressEvent>> ClientHandler<C> for XimHandler {
     fn handle_connect(&mut self, client: &mut C) -> Result<(), ClientError> {
+        log::trace!("XIM handle_connect: opening input method with locale \"C\"");
         client.open("C")
     }
 
     fn handle_open(&mut self, client: &mut C, input_method_id: u16) -> Result<(), ClientError> {
         self.im_id = input_method_id;
+        log::trace!("XIM handle_open: im_id={input_method_id}, querying input styles");
 
         client.get_im_values(input_method_id, &[AttributeName::QueryInputStyle])
     }
@@ -46,6 +48,10 @@ impl<C: Client<XEvent = xproto::KeyPressEvent>> ClientHandler<C> for XimHandler 
         input_method_id: u16,
         _attributes: AHashMap<AttributeName, Vec<u8>>,
     ) -> Result<(), ClientError> {
+        log::trace!(
+            "XIM handle_get_im_values: im_id={input_method_id}, window={}, creating IC with PREEDIT_CALLBACKS",
+            self.window
+        );
         let ic_attributes = client
             .build_ic_attributes()
             .push(AttributeName::InputStyle, InputStyle::PREEDIT_CALLBACKS)
@@ -58,11 +64,15 @@ impl<C: Client<XEvent = xproto::KeyPressEvent>> ClientHandler<C> for XimHandler 
     fn handle_create_ic(
         &mut self,
         _client: &mut C,
-        _input_method_id: u16,
+        input_method_id: u16,
         input_context_id: u16,
     ) -> Result<(), ClientError> {
         self.connected = true;
         self.ic_id = input_context_id;
+        log::info!(
+            "XIM handle_create_ic: im_id={input_method_id}, ic_id={input_context_id}, window={}, connected=true",
+            self.window
+        );
         Ok(())
     }
 
@@ -73,6 +83,7 @@ impl<C: Client<XEvent = xproto::KeyPressEvent>> ClientHandler<C> for XimHandler 
         _input_context_id: u16,
         text: &str,
     ) -> Result<(), ClientError> {
+        log::trace!("XIM handle_commit: text={text:?}, window={}", self.window);
         self.last_callback_event = Some(XimCallbackEvent::XimCommitEvent(
             self.window,
             String::from(text),
@@ -90,9 +101,17 @@ impl<C: Client<XEvent = xproto::KeyPressEvent>> ClientHandler<C> for XimHandler 
     ) -> Result<(), ClientError> {
         match xev.response_type {
             x11rb::protocol::xproto::KEY_PRESS_EVENT => {
+                log::trace!(
+                    "XIM handle_forward_event: KEY_PRESS keycode={}, ic_id={_input_context_id}",
+                    xev.detail
+                );
                 self.last_callback_event = Some(XimCallbackEvent::XimXEvent(Event::KeyPress(xev)));
             }
             x11rb::protocol::xproto::KEY_RELEASE_EVENT => {
+                log::trace!(
+                    "XIM handle_forward_event: KEY_RELEASE keycode={}, ic_id={_input_context_id}",
+                    xev.detail
+                );
                 self.last_callback_event =
                     Some(XimCallbackEvent::XimXEvent(Event::KeyRelease(xev)));
             }
@@ -102,6 +121,8 @@ impl<C: Client<XEvent = xproto::KeyPressEvent>> ClientHandler<C> for XimHandler 
     }
 
     fn handle_close(&mut self, client: &mut C, _input_method_id: u16) -> Result<(), ClientError> {
+        log::info!("XIM handle_close: im_id={_input_method_id}, disconnecting");
+        self.connected = false;
         client.disconnect()
     }
 
@@ -117,6 +138,10 @@ impl<C: Client<XEvent = xproto::KeyPressEvent>> ClientHandler<C> for XimHandler 
         preedit_string: &str,
         _feedbacks: Vec<xim::Feedback>,
     ) -> Result<(), ClientError> {
+        log::trace!(
+            "XIM handle_preedit_draw: preedit={preedit_string:?}, ic_id={_input_context_id}, window={}",
+            self.window
+        );
         // XIMReverse: 1, XIMPrimary: 8, XIMTertiary: 32: selected text
         // XIMUnderline: 2, XIMSecondary: 16: underlined text
         // XIMHighlight: 4: normal text

--- a/crates/gpui_linux/src/linux/x11/xim_handler.rs
+++ b/crates/gpui_linux/src/linux/x11/xim_handler.rs
@@ -126,6 +126,32 @@ impl<C: Client<XEvent = xproto::KeyPressEvent>> ClientHandler<C> for XimHandler 
         client.disconnect()
     }
 
+    fn handle_destroy_ic(
+        &mut self,
+        _client: &mut C,
+        input_method_id: u16,
+        input_context_id: u16,
+    ) -> Result<(), ClientError> {
+        log::trace!(
+            "XIM handle_destroy_ic: im_id={input_method_id}, ic_id={input_context_id}, current_ic_id={}",
+            self.ic_id
+        );
+        if input_context_id == self.ic_id {
+            self.connected = false;
+        }
+        Ok(())
+    }
+
+    fn handle_disconnect(&mut self) {
+        log::trace!(
+            "XIM handle_disconnect: im_id={}, ic_id={}, connected={}",
+            self.im_id,
+            self.ic_id,
+            self.connected
+        );
+        self.connected = false;
+    }
+
     fn handle_preedit_draw(
         &mut self,
         _client: &mut C,


### PR DESCRIPTION
## Summary

Fixes an intermittent but user-visible IME failure on **Linux with X11** (e.g. Ubuntu + Fcitx + Sogou Pinyin): after Zed has been running for a while, **Chinese input can no longer be switched on or used** inside the editor. Ctrl+Space / Shift and other IME hotkeys stop working for the Zed window, while other applications continue to type Chinese normally. The only reliable workaround was restarting Zed.

### Root Cause

A transient `XIMClientError` (such as `Invalid reply from server` from Fcitx) caused Zed to **permanently discard** its XIM client for the rest of the process. After that, Zed no longer talks to Fcitx/Sogou over XIM and keystrokes are handled as raw ASCII. The problem appeared "after long runtime" because the XIM error is intermittent, not because of a slow leak.

The original reconnect logic had additional bugs that prevented recovery:

1. **Premature `enable_ime()` after reconnect**: called immediately after `open_xim_connection()`, but the XIM handshake is asynchronous — `im_id` is still 0 when `enable_ime()` runs, creating bogus input contexts with uninitialized IDs and corrupting the handler state.
2. **FocusIn race condition**: `enable_ime()` could fire before the async handshake completes (`connected=false`, `im_id=0`), again creating orphan ICs on the XIM server.
3. **Orphan IC accumulation**: `enable_ime()` called `create_ic` on every FocusIn, creating a new IC each time and overwriting `ic_id` without destroying the old IC on the server.
4. **Stuck handshake with no recovery**: when `enable_ime()` found `connected=false`, it restored the XIM connection and waited indefinitely for the async handshake to complete — but if the XIM server never responded (e.g. fcitx restarted mid-handshake), the connection was dead and Zed stayed stuck forever.
5. **Missing disconnect/destroy callbacks**: `handle_destroy_ic` and `handle_disconnect` were not implemented, so the handler's `connected` flag was never cleared when the XIM server destroyed our IC or dropped the connection.

### Changes

**`client.rs`:**
- On `XIMClientError`: reconnect via `open_xim_connection()` only — do **not** call `enable_ime()` afterward; the async handshake completes on subsequent `filter_event()` calls automatically. Limit to 3 reconnect attempts per focus session.
- `enable_ime()`: when the handshake hasn't completed (`connected=false`), **discard** the stale XIM connection instead of restoring it, and trigger a fresh reconnect via `ensure_xim_connection_on_focus()`. This prevents getting stuck forever when the XIM server never responds.
- `enable_ime()`: replaced `create_ic` with `set_ic_values` to update the existing IC instead of creating orphan ICs on every FocusIn.
- Added event-counted reconnect retry: if the XIM handshake doesn't complete within `MAX_XIM_RECONNECT_EVENTS` (100) events after a protocol-error reconnect, trigger another reconnect attempt. This handles the case where the first reconnect's handshake stalls.
- Moved `keyboard_focused_window` read before `drop(state)` in `enable_ime()` to minimize borrow duration.
- Diagnostic logging at key state transitions (`info` for lifecycle events, `trace` for high-frequency events).

**`xim_handler.rs`:**
- `handle_close`: set `connected = false` to properly track disconnect state.
- Added `handle_destroy_ic` callback: set `connected = false` when the XIM server destroys our input context.
- Added `handle_disconnect` callback: set `connected = false` when the XIM connection is dropped.
- Diagnostic logging at `trace` level for handshake steps and input events.

**Scope:** Linux **X11** only. Wayland uses `text-input-v3` and is unchanged.

Related: https://github.com/zed-industries/zed/issues/60578

## Test plan

- [x] Build and run Zed on **Linux X11** with Fcitx (Sogou Pinyin) for extended sessions
- [x] Confirm Chinese input works normally on fresh launch
- [x] Trigger `XIMClientError` (e.g. by restarting Fcitx), verify automatic reconnect recovers Chinese input without restarting Zed
- [x] Verify `ic_id` stays constant across multiple FocusIn events (no orphan IC accumulation)
- [x] Verify post-reconnect commits continue working (42+ Chinese text commits observed across sessions)
- [x] Verify that a stuck handshake (fcitx restart mid-handshake) is recovered by the event-counted reconnect retry

Release Notes:

- Fixed Chinese and other IME input permanently breaking on Linux X11 after a transient XIM error, including cases where IME could not be switched back on until Zed was restarted