### PR TITLE
Improve file context auto @mention UX in agent panel

### DIFF
--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -836,13 +836,11 @@ fn single_query_param(url: &Url, name: &'static str) -> Result<Option<String>> {
 }
 
 pub fn selection_name(path: Option<&Path>, line_range: &RangeInclusive<u32>) -> String {
-    format!(
-        "{} ({}:{})",
+    format!("{}{}",
         path.and_then(|path| path.file_name())
             .unwrap_or("Untitled".as_ref())
             .display(),
-        *line_range.start() + 1,
-        *line_range.end() + 1
+        line_range_suffix(line_range)
     )
 }
 

--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -404,28 +404,12 @@ impl MentionUri {
                 abs_path,
                 line_range,
                 ..
-            } => Some(
-                format!(
-                    "{}:{}-{}",
-                    abs_path.display(),
-                    line_range.start(),
-                    line_range.end()
-                )
-                .into(),
-            ),
-            MentionUri::Selection {
-                abs_path: Some(path),
+            }
+            | MentionUri::Selection {
+                abs_path: Some(abs_path),
                 line_range,
                 ..
-            } => Some(
-                format!(
-                    "{}:{}-{}",
-                    path.display(),
-                    line_range.start(),
-                    line_range.end()
-                )
-                .into(),
-            ),
+            } => Some(format!("{}{}", abs_path.display(), line_range_suffix(line_range)).into()),
             MentionUri::Skill {
                 skill_file_path, ..
             } => Some(skill_file_path.to_string_lossy().into_owned().into()),

--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -820,7 +820,8 @@ fn single_query_param(url: &Url, name: &'static str) -> Result<Option<String>> {
 }
 
 pub fn selection_name(path: Option<&Path>, line_range: &RangeInclusive<u32>) -> String {
-    format!("{}{}",
+    format!(
+        "{}{}",
         path.and_then(|path| path.file_name())
             .unwrap_or("Untitled".as_ref())
             .display(),

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -1080,8 +1080,7 @@ impl MessageEditor {
         // Insert creases for pasted clipboard selections that:
         // 1. Contain exactly one selection
         // 2. Have an associated file path
-        // 3. Span multiple lines (not single-line selections)
-        // 4. Belong to a file that exists in the current project
+        // 3. Belong to a file that exists in the current project
         let should_insert_creases = util::maybe!({
             let selections = editor_clipboard_selections.as_ref()?;
             if selections.len() > 1 {
@@ -1089,11 +1088,6 @@ impl MessageEditor {
             }
             let selection = selections.first()?;
             let file_path = selection.file_path.as_ref()?;
-            let line_range = selection.line_range.as_ref()?;
-
-            if line_range.start() == line_range.end() {
-                return Some(false);
-            }
 
             Some(
                 workspace

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -133,7 +133,7 @@ The agent can search your codebase to find relevant context, but providing it ex
 Add context by typing `@` in the message editor.
 You can mention files, directories, symbols, previous threads, skills, diagnostics, branch diffs, and URLs to fetch.
 
-When you paste multi-line code selections copied from a buffer, Zed automatically formats them as @-mentions with the file context.
+When you paste selections copied from a buffer, Zed automatically formats them as @-mentions with the file context.
 To paste content without this automatic formatting, use {#kb agent::PasteRaw} to paste raw text directly.
 
 ### Selection as Context


### PR DESCRIPTION
# Objective

- Partially revert #45254 and make single line selections auto add context when pasting into the agent panel.
- Make line number formatting consistent across path tooltips and file name (see showcase).

I feel that single line selections should insert contexts as to not visually pollute prompts when typing. The `Paste as Plain Text` action is there for users who want to so - I understand this is subjective. :)

## Solution

- Remove check for single line selection pastes.
- De-dupe some logic used for line numbers formatting.
- Adjust a line of documentation to reflect auto @mention inserts are no longer specific to multi-line pastes.

## Showcase

Both screenshots show the result of pasting a single line selection, then a multi-line selection. Also notice the tooltip's line numbers now being 1-based.

<details>
  <summary>Click to view</summary>

Before:
![Before](https://github.com/user-attachments/assets/010b6939-ffbe-462a-95c9-342309c1407d)
After:
![After](https://github.com/user-attachments/assets/28a4e7c2-6c42-4376-bf99-4a63389a88e6)

</details>

Symbols also now use consistent tooltips (single line ref).

<details>
  <summary>Click to view</summary>

Before:
![Before](https://github.com/user-attachments/assets/6dba74e7-f698-477e-95c8-6576c2626025)
After:
![After](https://github.com/user-attachments/assets/6d5bd149-1696-4742-ba2e-315303208384)

</details>

## Testing

All intended changed behaviour (seems to) work without breaking other types of `@` calls in the agent panel.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fix pasting single line selections into agent panel not inserting file context in the agent panel.
