### PR TITLE
gpui: Show hovertext on nested tooltips

### DIFF
--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -454,7 +454,7 @@ impl BlameRenderer for GitBlameRenderer {
                                             .child(Divider::vertical())
                                             .child(
                                                 CopyButton::new("copy-blame-sha", sha.to_string())
-                                                    .tooltip_label("Copy SHA"),
+                                                    .tooltip_label("Copy Commit SHA"),
                                             ),
                                     ),
                             ),

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -390,7 +390,7 @@ impl Render for CommitTooltip {
                                         .child(Divider::vertical())
                                         .child(
                                             CopyButton::new("copy-commit-sha", full_sha)
-                                                .tooltip_label("Copy SHA"),
+                                                .tooltip_label("Copy Commit SHA"),
                                         ),
                                 ),
                         ),

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -2582,7 +2582,7 @@ impl GitGraph {
                     }),
                 )
                 .entry(
-                    "Copy SHA",
+                    "Copy Commit SHA",
                     Some(CopyCommitSha.boxed_clone()),
                     window.handler_for(&git_graph, move |this, _window, cx| {
                         this.copy_commit_sha(index, cx);

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -4364,6 +4364,107 @@ mod tests {
         assert!(active_tooltip.borrow().is_none());
     }
 
+    struct NestedTooltipOwner;
+
+    impl Render for NestedTooltipOwner {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().child(
+                div()
+                    .id("outer-target")
+                    .w(px(50.))
+                    .h(px(50.))
+                    .hoverable_tooltip(|_, cx| cx.new(|_| TooltipWithInnerTooltip).into()),
+            )
+        }
+    }
+
+    struct TooltipWithInnerTooltip;
+
+    impl Render for TooltipWithInnerTooltip {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div().w(px(100.)).h(px(100.)).child(
+                div()
+                    .id("inner-target")
+                    .size_full()
+                    .tooltip(|_, cx| cx.new(|_| TestTooltipView).into()),
+            )
+        }
+    }
+
+    #[test]
+    fn tooltip_inside_hoverable_tooltip_is_rendered() {
+        fn draw(test_app: &mut TestAppContext, any_window: AnyWindowHandle) {
+            test_app
+                .update_window(any_window, |_, window, cx| {
+                    window.draw(cx).clear();
+                })
+                .unwrap();
+        }
+
+        fn move_mouse(
+            test_app: &mut TestAppContext,
+            any_window: AnyWindowHandle,
+            position: Point<Pixels>,
+        ) {
+            test_app
+                .update_window(any_window, |_, window, cx| {
+                    window.dispatch_event(
+                        MouseMoveEvent {
+                            position,
+                            modifiers: Default::default(),
+                            pressed_button: None,
+                        }
+                        .to_platform_input(),
+                        cx,
+                    );
+                })
+                .unwrap();
+        }
+
+        fn rendered_tooltip_count(
+            test_app: &mut TestAppContext,
+            any_window: AnyWindowHandle,
+        ) -> usize {
+            test_app
+                .update_window(any_window, |_, window, _| window.tooltip_bounds.len())
+                .unwrap()
+        }
+
+        let mut test_app = TestAppContext::single();
+        let window = test_app.add_window(|_, _| NestedTooltipOwner);
+        let any_window: AnyWindowHandle = window.into();
+
+        draw(&mut test_app, any_window);
+
+        // Hover the element that has the hoverable tooltip.
+        move_mouse(&mut test_app, any_window, point(px(10.), px(10.)));
+        draw(&mut test_app, any_window);
+        test_app
+            .dispatcher
+            .advance_clock(DEFAULT_TOOLTIP_SHOW_DELAY);
+        test_app.run_until_parked();
+        draw(&mut test_app, any_window);
+
+        assert_eq!(rendered_tooltip_count(&mut test_app, any_window), 1);
+
+        // Move into the tooltip (outside the origin element), over the inner element that has its
+        // own tooltip. The tooltip is shown at the mouse position (10, 10) offset by (1, 1) and is
+        // 100x100, so (75, 75) is inside it while being outside the 50x50 origin element.
+        move_mouse(&mut test_app, any_window, point(px(75.), px(75.)));
+        draw(&mut test_app, any_window);
+        test_app
+            .dispatcher
+            .advance_clock(DEFAULT_TOOLTIP_SHOW_DELAY);
+        test_app.run_until_parked();
+        draw(&mut test_app, any_window);
+
+        assert_eq!(
+            rendered_tooltip_count(&mut test_app, any_window),
+            2,
+            "the tooltip of an element inside a hoverable tooltip should render on top of it"
+        );
+    }
+
     #[test]
     fn test_write_a11y_info_string_and_numeric_properties() {
         let mut interactivity = Interactivity::default();

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -785,13 +785,9 @@ pub struct TooltipId(usize);
 impl TooltipId {
     /// Checks if the tooltip is currently hovered.
     pub fn is_hovered(&self, window: &Window) -> bool {
-        window
-            .tooltip_bounds
-            .as_ref()
-            .is_some_and(|tooltip_bounds| {
-                tooltip_bounds.id == *self
-                    && tooltip_bounds.bounds.contains(&window.mouse_position())
-            })
+        window.tooltip_bounds.iter().any(|tooltip_bounds| {
+            tooltip_bounds.id == *self && tooltip_bounds.bounds.contains(&window.mouse_position())
+        })
     }
 }
 
@@ -1015,7 +1011,7 @@ pub struct Window {
     pub(crate) next_frame: Frame,
     next_hitbox_id: HitboxId,
     pub(crate) next_tooltip_id: TooltipId,
-    pub(crate) tooltip_bounds: Option<TooltipBounds>,
+    pub(crate) tooltip_bounds: Vec<TooltipBounds>,
     next_frame_callbacks: Rc<RefCell<Vec<FrameCallback>>>,
     pub(crate) dirty_views: FxHashSet<EntityId>,
     focus_listeners: SubscriberSet<(), AnyWindowFocusListener>,
@@ -1724,7 +1720,7 @@ impl Window {
             next_frame_callbacks,
             next_hitbox_id: HitboxId(0),
             next_tooltip_id: TooltipId::default(),
-            tooltip_bounds: None,
+            tooltip_bounds: Vec::new(),
             dirty_views: FxHashSet::default(),
             focus_listeners: SubscriberSet::new(),
             focus_lost_listeners: SubscriberSet::new(),
@@ -2798,7 +2794,7 @@ impl Window {
 
     fn draw_roots(&mut self, cx: &mut App) {
         self.invalidator.set_phase(DrawPhase::Prepaint);
-        self.tooltip_bounds.take();
+        self.tooltip_bounds.clear();
 
         self.a11y.sync_active_flag();
         if self.a11y.is_active() {
@@ -2834,7 +2830,7 @@ impl Window {
 
         let mut prompt_element = None;
         let mut active_drag_element = None;
-        let mut tooltip_element = None;
+        let mut tooltip_elements = Vec::new();
         if let Some(prompt) = self.prompt.take() {
             let mut element = prompt.view.any_view().into_any();
             element.prepaint_as_root(Point::default(), root_size.into(), self, cx);
@@ -2847,7 +2843,7 @@ impl Window {
             active_drag_element = Some(element);
             cx.active_drag = Some(active_drag);
         } else {
-            tooltip_element = self.prepaint_tooltip(cx);
+            tooltip_elements = self.prepaint_tooltip(cx);
         }
 
         self.mouse_hit_test = self.next_frame.hit_test(self.mouse_position);
@@ -2865,8 +2861,11 @@ impl Window {
             prompt_element.paint(self, cx);
         } else if let Some(mut drag_element) = active_drag_element {
             drag_element.paint(self, cx);
-        } else if let Some(mut tooltip_element) = tooltip_element {
-            tooltip_element.paint(self, cx);
+        } else {
+            // Prepaint order, so nested tooltips paint above their containing tooltip.
+            for mut tooltip_element in tooltip_elements {
+                tooltip_element.paint(self, cx);
+            }
         }
 
         #[cfg(any(feature = "inspector", debug_assertions))]
@@ -2893,73 +2892,97 @@ impl Window {
         }
     }
 
-    fn prepaint_tooltip(&mut self, cx: &mut App) -> Option<AnyElement> {
-        // Use indexing instead of iteration to avoid borrowing self for the duration of the loop.
-        for tooltip_request_index in (0..self.next_frame.tooltip_requests.len()).rev() {
-            let Some(Some(tooltip_request)) = self
-                .next_frame
-                .tooltip_requests
-                .get(tooltip_request_index)
-                .cloned()
+    fn prepaint_tooltip(&mut self, cx: &mut App) -> Vec<AnyElement> {
+        // Prepainting a tooltip may append tooltip requests for elements inside it. Each pass
+        // renders the topmost visible tooltip among the requests appended by the previous pass,
+        // so a nested tooltip paints above its containing hoverable tooltip.
+        let mut tooltip_elements = Vec::new();
+        let mut consider_from = 0;
+        loop {
+            let requests_len = self.next_frame.tooltip_requests.len();
+            // Use indexing instead of iteration to avoid borrowing self for the duration of the
+            // loop.
+            let Some(element) =
+                (consider_from..requests_len)
+                    .rev()
+                    .find_map(|tooltip_request_index| {
+                        self.prepaint_tooltip_request(tooltip_request_index, cx)
+                    })
             else {
-                log::error!("Unexpectedly absent TooltipRequest");
-                continue;
+                break;
             };
-            let mut element = tooltip_request.tooltip.view.clone().into_any();
-            let mouse_position = tooltip_request.tooltip.mouse_position;
-            let tooltip_size = element.layout_as_root(AvailableSpace::min_size(), self, cx);
-
-            let mut tooltip_bounds =
-                Bounds::new(mouse_position + point(px(1.), px(1.)), tooltip_size);
-            let window_bounds = Bounds {
-                origin: Point::default(),
-                size: self.viewport_size(),
-            };
-
-            if tooltip_bounds.right() > window_bounds.right() {
-                let new_x = mouse_position.x - tooltip_bounds.size.width - px(1.);
-                if new_x >= Pixels::ZERO {
-                    tooltip_bounds.origin.x = new_x;
-                } else {
-                    tooltip_bounds.origin.x = cmp::max(
-                        Pixels::ZERO,
-                        tooltip_bounds.origin.x - tooltip_bounds.right() - window_bounds.right(),
-                    );
-                }
-            }
-
-            if tooltip_bounds.bottom() > window_bounds.bottom() {
-                let new_y = mouse_position.y - tooltip_bounds.size.height - px(1.);
-                if new_y >= Pixels::ZERO {
-                    tooltip_bounds.origin.y = new_y;
-                } else {
-                    tooltip_bounds.origin.y = cmp::max(
-                        Pixels::ZERO,
-                        tooltip_bounds.origin.y - tooltip_bounds.bottom() - window_bounds.bottom(),
-                    );
-                }
-            }
-
-            // It's possible for an element to have an active tooltip while not being painted (e.g.
-            // via the `visible_on_hover` method). Since mouse listeners are not active in this
-            // case, instead update the tooltip's visibility here.
-            let is_visible =
-                (tooltip_request.tooltip.check_visible_and_update)(tooltip_bounds, self, cx);
-            if !is_visible {
-                continue;
-            }
-
-            self.with_absolute_element_offset(tooltip_bounds.origin, |window| {
-                element.prepaint(window, cx)
-            });
-
-            self.tooltip_bounds = Some(TooltipBounds {
-                id: tooltip_request.id,
-                bounds: tooltip_bounds,
-            });
-            return Some(element);
+            tooltip_elements.push(element);
+            consider_from = requests_len;
         }
-        None
+        tooltip_elements
+    }
+
+    fn prepaint_tooltip_request(
+        &mut self,
+        tooltip_request_index: usize,
+        cx: &mut App,
+    ) -> Option<AnyElement> {
+        let Some(Some(tooltip_request)) = self
+            .next_frame
+            .tooltip_requests
+            .get(tooltip_request_index)
+            .cloned()
+        else {
+            log::error!("Unexpectedly absent TooltipRequest");
+            return None;
+        };
+        let mut element = tooltip_request.tooltip.view.clone().into_any();
+        let mouse_position = tooltip_request.tooltip.mouse_position;
+        let tooltip_size = element.layout_as_root(AvailableSpace::min_size(), self, cx);
+
+        let mut tooltip_bounds = Bounds::new(mouse_position + point(px(1.), px(1.)), tooltip_size);
+        let window_bounds = Bounds {
+            origin: Point::default(),
+            size: self.viewport_size(),
+        };
+
+        if tooltip_bounds.right() > window_bounds.right() {
+            let new_x = mouse_position.x - tooltip_bounds.size.width - px(1.);
+            if new_x >= Pixels::ZERO {
+                tooltip_bounds.origin.x = new_x;
+            } else {
+                tooltip_bounds.origin.x = cmp::max(
+                    Pixels::ZERO,
+                    tooltip_bounds.origin.x - tooltip_bounds.right() - window_bounds.right(),
+                );
+            }
+        }
+
+        if tooltip_bounds.bottom() > window_bounds.bottom() {
+            let new_y = mouse_position.y - tooltip_bounds.size.height - px(1.);
+            if new_y >= Pixels::ZERO {
+                tooltip_bounds.origin.y = new_y;
+            } else {
+                tooltip_bounds.origin.y = cmp::max(
+                    Pixels::ZERO,
+                    tooltip_bounds.origin.y - tooltip_bounds.bottom() - window_bounds.bottom(),
+                );
+            }
+        }
+
+        // It's possible for an element to have an active tooltip while not being painted (e.g.
+        // via the `visible_on_hover` method). Since mouse listeners are not active in this
+        // case, instead update the tooltip's visibility here.
+        let is_visible =
+            (tooltip_request.tooltip.check_visible_and_update)(tooltip_bounds, self, cx);
+        if !is_visible {
+            return None;
+        }
+
+        self.with_absolute_element_offset(tooltip_bounds.origin, |window| {
+            element.prepaint(window, cx)
+        });
+
+        self.tooltip_bounds.push(TooltipBounds {
+            id: tooltip_request.id,
+            bounds: tooltip_bounds,
+        });
+        Some(element)
     }
 
     fn prepaint_deferred_draws(&mut self, cx: &mut App) {


### PR DESCRIPTION
This PR makes GPUI aware of nested tooltips. Previously it was assumed that there was only ever one tooltip, which led to nested tooltips not rendering.

<img width="1399" height="842" alt="image" src="https://github.com/user-attachments/assets/351e8cd5-5648-4344-b99d-3288eb05d1b9" />

---

Release Notes:

- Fixed a bug where nested tooltips were not being rendered
