### PR TITLE
multi_workspace: Allow closing of currently selected project

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -1444,37 +1444,35 @@ impl PickerDelegate for RecentProjectsDelegate {
                                 }),
                         )
                     })
-                    .when(!is_active, |this| {
-                        this.child(
-                            IconButton::new("remove_open_project", IconName::Close)
-                                .icon_size(IconSize::Small)
-                                .tooltip({
-                                    let focus_handle = self.focus_handle.clone();
-                                    move |_, cx| {
-                                        Tooltip::for_action_in(
-                                            "Remove Project from Window",
-                                            &RemoveSelected,
-                                            &focus_handle,
-                                            cx,
-                                        )
-                                    }
+                    .child(
+                        IconButton::new("remove_open_project", IconName::Close)
+                            .icon_size(IconSize::Small)
+                            .tooltip({
+                                let focus_handle = self.focus_handle.clone();
+                                move |_, cx| {
+                                    Tooltip::for_action_in(
+                                        "Remove Project from Window",
+                                        &RemoveSelected,
+                                        &focus_handle,
+                                        cx,
+                                    )
+                                }
+                            })
+                            .on_click({
+                                let project_group_key = project_group_key.clone();
+                                cx.listener(move |picker, _, window, cx| {
+                                    cx.stop_propagation();
+                                    window.prevent_default();
+                                    picker.delegate.remove_project_group(
+                                        project_group_key.clone(),
+                                        window,
+                                        cx,
+                                    );
+                                    let query = picker.query(cx);
+                                    picker.update_matches(query, window, cx);
                                 })
-                                .on_click({
-                                    let project_group_key = project_group_key.clone();
-                                    cx.listener(move |picker, _, window, cx| {
-                                        cx.stop_propagation();
-                                        window.prevent_default();
-                                        picker.delegate.remove_project_group(
-                                            project_group_key.clone(),
-                                            window,
-                                            cx,
-                                        );
-                                        let query = picker.query(cx);
-                                        picker.update_matches(query, window, cx);
-                                    })
-                                }),
-                        )
-                    })
+                            }),
+                    )
                     .into_any_element();
 
                 Some(

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -795,9 +795,6 @@ impl RecentProjects {
                         .get(hit.candidate_id)
                         .cloned()
                     {
-                        if picker.delegate.is_active_project_group(&key, cx) {
-                            return;
-                        }
                         picker.delegate.remove_project_group(key, window, cx);
                         let query = picker.query(cx);
                         picker.update_matches(query, window, cx);
@@ -1459,7 +1456,6 @@ impl PickerDelegate for RecentProjectsDelegate {
                                 }
                             })
                             .on_click({
-                                let project_group_key = project_group_key.clone();
                                 cx.listener(move |picker, _, window, cx| {
                                     cx.stop_propagation();
                                     window.prevent_default();

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -1054,6 +1054,18 @@ impl MultiWorkspace {
         self.remove(
             workspaces,
             move |this, window, cx| {
+                if let Some(neighbor_key) = neighbor_key.as_ref()
+                    && let Some(workspace) = this
+                        .last_active_workspace_for_group(neighbor_key, cx)
+                        .or_else(|| {
+                            this.workspaces_for_project_group(neighbor_key, cx)
+                                .unwrap_or_default()
+                                .into_iter()
+                                .find(|candidate| !excluded_workspaces.contains(candidate))
+                        })
+                {
+                    return Task::ready(Ok(workspace));
+                }
                 if let Some(neighbor_key) = neighbor_key
                     && neighbor_key.host().is_none()
                 {

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -944,80 +944,16 @@ impl MultiWorkspace {
                     return Task::ready(Ok(workspace));
                 }
 
-                let current_group_index = this
+                let group_index = this
                     .project_groups
                     .iter()
                     .position(|group| group.key == group_key);
-
-                if let Some(current_group_index) = current_group_index {
-                    for distance in 1..this.project_groups.len() {
-                        for neighboring_index in [
-                            current_group_index.checked_add(distance),
-                            current_group_index.checked_sub(distance),
-                        ]
-                        .into_iter()
-                        .flatten()
-                        {
-                            let Some(neighboring_group) =
-                                this.project_groups.get(neighboring_index)
-                            else {
-                                continue;
-                            };
-
-                            if let Some(workspace) = this
-                                .last_active_workspace_for_group(&neighboring_group.key, cx)
-                                .or_else(|| {
-                                    this.workspaces_for_project_group(&neighboring_group.key, cx)
-                                        .unwrap_or_default()
-                                        .into_iter()
-                                        .find(|candidate| candidate != &excluded_workspace)
-                                })
-                            {
-                                return Task::ready(Ok(workspace));
-                            }
-                        }
-                    }
-                }
-
-                let neighboring_group_key = current_group_index.and_then(|index| {
-                    this.project_groups
-                        .get(index + 1)
-                        .or_else(|| {
-                            index
-                                .checked_sub(1)
-                                .and_then(|previous| this.project_groups.get(previous))
-                        })
-                        .map(|group| group.key.clone())
-                });
-
-                if let Some(neighboring_group_key) = neighboring_group_key
-                    && neighboring_group_key.host().is_none()
-                {
-                    return this.find_or_create_local_workspace(
-                        neighboring_group_key.path_list().clone(),
-                        Some(neighboring_group_key),
-                        std::slice::from_ref(&excluded_workspace),
-                        None,
-                        OpenMode::Activate,
-                        window,
-                        cx,
-                    );
-                }
-
-                let app_state = this.workspace().read(cx).app_state().clone();
-                let project = Project::local(
-                    app_state.client.clone(),
-                    app_state.node_runtime.clone(),
-                    app_state.user_store.clone(),
-                    app_state.languages.clone(),
-                    app_state.fs.clone(),
-                    None,
-                    project::LocalProjectFlags::default(),
+                this.fallback_workspace(
+                    group_index,
+                    std::slice::from_ref(&excluded_workspace),
+                    window,
                     cx,
-                );
-                let new_workspace =
-                    cx.new(|cx| Workspace::new(None, project, app_state, window, cx));
-                Task::ready(Ok(new_workspace))
+                )
             },
             window,
             cx,
@@ -1030,75 +966,147 @@ impl MultiWorkspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<bool>> {
-        let pos = self
+        let group_index = self
             .project_groups
             .iter()
             .position(|group| group.key == *group_key);
+
+        // The active workspace can remain provisional while the sidebar is
+        // closed. Retain it before removal so switching to the fallback does
+        // not recreate the project group that is being removed.
+        let active_workspace = self.workspace().clone();
+        if active_workspace.read(cx).project_group_key(cx) == *group_key
+            && !self.is_workspace_retained(&active_workspace)
+        {
+            self.retain_workspace(active_workspace, group_key.clone(), cx);
+        }
+
         let workspaces = self
             .workspaces_for_project_group(group_key, cx)
             .unwrap_or_default();
-
-        // Compute the neighbor while the group is still in the list.
-        let neighbor_key = pos.and_then(|pos| {
-            self.project_groups
-                .get(pos + 1)
-                .or_else(|| pos.checked_sub(1).and_then(|i| self.project_groups.get(i)))
-                .map(|group| group.key.clone())
-        });
-
-        // Now remove the group.
-        self.project_groups.retain(|group| group.key != *group_key);
-        cx.emit(MultiWorkspaceEvent::ProjectGroupsChanged);
-
         let excluded_workspaces = workspaces.clone();
-        self.remove(
+        let removal_task = self.remove(
             workspaces,
             move |this, window, cx| {
-                if let Some(neighbor_key) = neighbor_key.as_ref()
-                    && let Some(workspace) = this
-                        .last_active_workspace_for_group(neighbor_key, cx)
-                        .or_else(|| {
-                            this.workspaces_for_project_group(neighbor_key, cx)
-                                .unwrap_or_default()
-                                .into_iter()
-                                .find(|candidate| !excluded_workspaces.contains(candidate))
-                        })
-                {
-                    return Task::ready(Ok(workspace));
-                }
-                if let Some(neighbor_key) = neighbor_key
-                    && neighbor_key.host().is_none()
-                {
-                    return this.find_or_create_local_workspace(
-                        neighbor_key.path_list().clone(),
-                        Some(neighbor_key.clone()),
-                        &excluded_workspaces,
-                        None,
-                        OpenMode::Activate,
-                        window,
-                        cx,
-                    );
-                }
-
-                // No other project groups remain — create an empty workspace.
-                let app_state = this.workspace().read(cx).app_state().clone();
-                let project = Project::local(
-                    app_state.client.clone(),
-                    app_state.node_runtime.clone(),
-                    app_state.user_store.clone(),
-                    app_state.languages.clone(),
-                    app_state.fs.clone(),
-                    None,
-                    project::LocalProjectFlags::default(),
-                    cx,
-                );
-                let new_workspace =
-                    cx.new(|cx| Workspace::new(None, project, app_state, window, cx));
-                Task::ready(Ok(new_workspace))
+                this.fallback_workspace(group_index, &excluded_workspaces, window, cx)
             },
             window,
             cx,
-        )
+        );
+
+        self.project_groups.retain(|group| group.key != *group_key);
+        cx.emit(MultiWorkspaceEvent::ProjectGroupsChanged);
+
+        removal_task
+    }
+
+    /// Finds a fallback workspace outside the project group at `group_index`.
+    ///
+    /// Prefers the nearest retained workspace in another group. If none exists,
+    /// opens the immediately neighboring group when it is local, and otherwise
+    /// creates an empty workspace.
+    fn fallback_workspace(
+        &mut self,
+        group_index: Option<usize>,
+        excluded_workspaces: &[Entity<Workspace>],
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<Workspace>>> {
+        if let Some(group_index) = group_index {
+            if let Some(workspace) =
+                self.nearest_retained_workspace(group_index, excluded_workspaces, cx)
+            {
+                return Task::ready(Ok(workspace));
+            }
+
+            let neighboring_group_key = self
+                .project_groups
+                .get(group_index + 1)
+                .or_else(|| {
+                    group_index
+                        .checked_sub(1)
+                        .and_then(|previous| self.project_groups.get(previous))
+                })
+                .map(|group| group.key.clone());
+
+            if let Some(key) = neighboring_group_key
+                && key.host().is_none()
+            {
+                return self.find_or_create_local_workspace(
+                    key.path_list().clone(),
+                    Some(key),
+                    excluded_workspaces,
+                    None,
+                    OpenMode::Activate,
+                    window,
+                    cx,
+                );
+            }
+        }
+
+        let app_state = self.workspace().read(cx).app_state().clone();
+        let project = Project::local(
+            app_state.client.clone(),
+            app_state.node_runtime.clone(),
+            app_state.user_store.clone(),
+            app_state.languages.clone(),
+            app_state.fs.clone(),
+            None,
+            project::LocalProjectFlags::default(),
+            cx,
+        );
+        let new_workspace = cx.new(|cx| Workspace::new(None, project, app_state, window, cx));
+        Task::ready(Ok(new_workspace))
+    }
+
+    /// Returns the nearest retained workspace outside the project group at
+    /// `group_index`.
+    ///
+    /// Searches project groups by increasing distance, preferring the following
+    /// group over the preceding group at equal distances. Within each group,
+    /// prefers its last active workspace before falling back to any retained
+    /// workspace. Workspaces in `excluded_workspaces` are ignored by both
+    /// lookups.
+    ///
+    /// The `group_index` must identify a project group that is still present in
+    /// [`Self::project_groups`].
+    pub(super) fn nearest_retained_workspace(
+        &self,
+        group_index: usize,
+        excluded_workspaces: &[Entity<Workspace>],
+        cx: &App,
+    ) -> Option<Entity<Workspace>> {
+        for distance in 1..self.project_groups.len() {
+            for index in [
+                group_index.checked_add(distance),
+                group_index.checked_sub(distance),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                if let Some(group) = self.project_groups.get(index) {
+                    let workspace_is_available = |workspace: &Entity<Workspace>| {
+                        !excluded_workspaces.contains(workspace)
+                            && !workspace.read(cx).project().read(cx).is_disconnected(cx)
+                    };
+                    let workspace = self
+                        .last_active_workspace_for_group(&group.key, cx)
+                        .filter(&workspace_is_available)
+                        .or_else(|| {
+                            self.workspaces_for_project_group(&group.key, cx)
+                                .unwrap_or_default()
+                                .into_iter()
+                                .find(workspace_is_available)
+                        });
+
+                    if workspace.is_some() {
+                        return workspace;
+                    }
+                }
+            }
+        }
+
+        None
     }
 
     /// Goes through sqlite: serialize -> close -> open new window

--- a/crates/workspace/src/multi_workspace_tests.rs
+++ b/crates/workspace/src/multi_workspace_tests.rs
@@ -20,6 +20,32 @@ fn init_test(cx: &mut TestAppContext) {
     });
 }
 
+fn setup_multi_workspace<'a>(
+    projects: &[Entity<Project>],
+    cx: &'a mut TestAppContext,
+) -> (Entity<MultiWorkspace>, &'a mut VisualTestContext) {
+    let mut iterator = projects.iter();
+    let project = iterator
+        .next()
+        .expect("At least one project should be provided")
+        .clone();
+
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+
+    for project in iterator {
+        multi_workspace.update_in(cx, |multi_workspace, window, cx| {
+            multi_workspace.test_add_workspace(project.clone(), window, cx);
+        })
+    }
+
+    // Opening the sidebar retains the workspaces and establishes their project groups.
+    multi_workspace.update(cx, |multi_workspace, cx| multi_workspace.open_sidebar(cx));
+    cx.run_until_parked();
+
+    (multi_workspace, cx)
+}
+
 #[gpui::test]
 async fn test_sidebar_disabled_when_disable_ai_is_enabled(cx: &mut TestAppContext) {
     init_test(cx);
@@ -717,6 +743,227 @@ async fn test_close_workspace_prefers_already_loaded_neighboring_workspace(
 }
 
 #[gpui::test]
+async fn test_close_workspace_prefers_workspace_in_same_project_group(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/project-a", json!({})).await;
+    fs.insert_tree("/project-b", json!({})).await;
+
+    let project_a_1 = Project::test(fs.clone(), ["/project-a".as_ref()], cx).await;
+    let project_a_2 = Project::test(fs.clone(), ["/project-a".as_ref()], cx).await;
+    let project_b = Project::test(fs, ["/project-b".as_ref()], cx).await;
+    let key_a = project_a_1.read_with(cx, |project, cx| project.project_group_key(cx));
+    let (multi_workspace, cx) = setup_multi_workspace(&[project_a_1, project_a_2, project_b], cx);
+
+    let (workspace_a_1, workspace_a_2) = multi_workspace.read_with(cx, |multi_workspace, cx| {
+        let mut workspaces = multi_workspace
+            .workspaces_for_project_group(&key_a, cx)
+            .expect("project group A should have retained workspaces")
+            .into_iter();
+        let first = workspaces
+            .next()
+            .expect("project group A should have a first workspace");
+        let second = workspaces
+            .next()
+            .expect("project group A should have a second workspace");
+
+        assert!(
+            workspaces.next().is_none(),
+            "project group A should have exactly two workspaces"
+        );
+
+        (first, second)
+    });
+
+    multi_workspace.update_in(cx, |multi_workspace, window, cx| {
+        multi_workspace.activate(workspace_a_1.clone(), None, window, cx);
+    });
+
+    let closed = multi_workspace
+        .update_in(cx, |multi_workspace, window, cx| {
+            multi_workspace.close_workspace(&workspace_a_1, window, cx)
+        })
+        .await
+        .expect("closing the active workspace should succeed");
+
+    assert!(closed, "close_workspace should remove the active workspace");
+    multi_workspace.read_with(cx, |multi_workspace, cx| {
+        assert_eq!(
+            multi_workspace.workspace(),
+            &workspace_a_2,
+            "the second workspace for project group a should be preferred"
+        );
+
+        assert_eq!(
+            multi_workspace
+                .workspaces_for_project_group(&key_a, cx)
+                .expect("project group A should remain"),
+            vec![workspace_a_2],
+            "only the fallback workspace should remain in project group A"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_close_workspace_opens_unloaded_local_neighbor(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/project-a", json!({})).await;
+    fs.insert_tree("/project-b", json!({})).await;
+    cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+
+    let project_a = Project::test(fs.clone(), ["/project-a".as_ref()], cx).await;
+    let project_b = Project::test(fs, ["/project-b".as_ref()], cx).await;
+    let key_b = project_b.read_with(cx, |project, cx| project.project_group_key(cx));
+    let (multi_workspace, cx) = setup_multi_workspace(&[project_a], cx);
+    let workspace_a = multi_workspace.read_with(cx, |multi_workspace, _cx| {
+        multi_workspace.workspace().clone()
+    });
+
+    multi_workspace.update(cx, |multi_workspace, _cx| {
+        multi_workspace.test_add_project_group(ProjectGroup {
+            key: key_b.clone(),
+            workspaces: Vec::new(),
+            expanded: true,
+        });
+    });
+
+    let closed = multi_workspace
+        .update_in(cx, |multi_workspace, window, cx| {
+            multi_workspace.close_workspace(&workspace_a, window, cx)
+        })
+        .await
+        .expect("closing the active workspace should succeed");
+
+    assert!(closed, "close_workspace should remove the active workspace");
+    multi_workspace.read_with(cx, |multi_workspace, cx| {
+        assert_eq!(
+            multi_workspace.workspace().read(cx).project_group_key(cx),
+            key_b,
+            "the unloaded local neighboring group should be opened"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_remove_project_group_opens_unloaded_local_neighbor(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/project-a", json!({})).await;
+    fs.insert_tree("/project-b", json!({})).await;
+    cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+
+    let project_a = Project::test(fs.clone(), ["/project-a".as_ref()], cx).await;
+    let project_b = Project::test(fs, ["/project-b".as_ref()], cx).await;
+    let key_a = project_a.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_b = project_b.read_with(cx, |project, cx| project.project_group_key(cx));
+    let (multi_workspace, cx) = setup_multi_workspace(&[project_a], cx);
+
+    multi_workspace.update(cx, |multi_workspace, _cx| {
+        multi_workspace.test_add_project_group(ProjectGroup {
+            key: key_b.clone(),
+            workspaces: Vec::new(),
+            expanded: true,
+        });
+    });
+
+    let removed = multi_workspace
+        .update_in(cx, |multi_workspace, window, cx| {
+            multi_workspace.remove_project_group(&key_a, window, cx)
+        })
+        .await
+        .expect("removing the active project group should succeed");
+
+    assert!(
+        removed,
+        "remove_project_group should remove the active group"
+    );
+
+    multi_workspace.read_with(cx, |multi_workspace, cx| {
+        assert_eq!(
+            multi_workspace.workspace().read(cx).project_group_key(cx),
+            key_b,
+            "the unloaded local neighboring group should be opened"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_remove_project_group_replaces_unretained_active_workspace(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/project-a", json!({})).await;
+
+    let project_a = Project::test(fs, ["/project-a".as_ref()], cx).await;
+    let key_a = project_a.read_with(cx, |project, cx| project.project_group_key(cx));
+    let remote_key = ProjectGroupKey::new(
+        Some(RemoteConnectionOptions::Mock(
+            remote::MockConnectionOptions { id: 1 },
+        )),
+        PathList::new(&[PathBuf::from("/remote/project")]),
+    );
+    let (multi_workspace, cx) =
+        cx.add_window_view(|window, cx| MultiWorkspace::test_new(project_a, window, cx));
+    let workspace_a = multi_workspace.read_with(cx, |multi_workspace, _cx| {
+        multi_workspace.workspace().clone()
+    });
+
+    multi_workspace.update(cx, |multi_workspace, cx| {
+        multi_workspace.restore_project_groups(
+            vec![
+                SerializedProjectGroupState {
+                    key: key_a.clone(),
+                    expanded: true,
+                },
+                SerializedProjectGroupState {
+                    key: remote_key.clone(),
+                    expanded: true,
+                },
+            ],
+            cx,
+        );
+
+        assert!(
+            !multi_workspace.active_workspace_is_retained(),
+            "the active workspace should remain provisional"
+        );
+        assert_eq!(
+            multi_workspace.project_group_keys(),
+            vec![key_a.clone(), remote_key.clone()],
+            "the remote project group should immediately follow the active local group"
+        );
+    });
+
+    multi_workspace
+        .update_in(cx, |multi_workspace, window, cx| {
+            multi_workspace.remove_project_group(&key_a, window, cx)
+        })
+        .await
+        .expect("removing the active project group should succeed");
+
+    multi_workspace.read_with(cx, |multi_workspace, cx| {
+        assert_ne!(
+            multi_workspace.workspace(),
+            &workspace_a,
+            "removing the active project group should replace its provisional workspace"
+        );
+        assert!(
+            multi_workspace
+                .workspace()
+                .read(cx)
+                .root_paths(cx)
+                .is_empty(),
+            "an unloaded remote neighbor should fall back to an empty workspace"
+        );
+        assert_eq!(
+            multi_workspace.project_group_keys(),
+            vec![remote_key],
+            "only the remote project group should remain"
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_switching_projects_with_sidebar_closed_retains_old_active_workspace(
     cx: &mut TestAppContext,
 ) {
@@ -1127,5 +1374,175 @@ async fn test_remove_project_group_with_remote_neighbor_does_not_create_local_wo
                 "remote neighbor should not have created a local workspace after remove_project_group"
             );
         }
+    });
+}
+
+#[gpui::test]
+async fn test_nearest_retained_workspace(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/project-a", json!({})).await;
+    fs.insert_tree("/project-b", json!({})).await;
+    fs.insert_tree("/project-c", json!({})).await;
+    fs.insert_tree("/project-d", json!({})).await;
+
+    // These two projects create separate workspaces in the same project group. The second
+    // workspace is activated after the first, making it the group's last active workspace.
+    let project_a_1 = Project::test(fs.clone(), ["/project-a".as_ref()], cx).await;
+    let project_a_2 = Project::test(fs.clone(), ["/project-a".as_ref()], cx).await;
+    let project_b = Project::test(fs.clone(), ["/project-b".as_ref()], cx).await;
+    let project_c = Project::test(fs.clone(), ["/project-c".as_ref()], cx).await;
+    let project_d = Project::test(fs, ["/project-d".as_ref()], cx).await;
+    let key_a = project_a_1.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_b = project_b.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_c = project_c.read_with(cx, |project, cx| project.project_group_key(cx));
+    let key_d = project_d.read_with(cx, |project, cx| project.project_group_key(cx));
+
+    let (multi_workspace, cx) = setup_multi_workspace(
+        &[project_a_1, project_a_2, project_b, project_c, project_d],
+        cx,
+    );
+
+    multi_workspace.update(cx, |multi_workspace, cx| {
+        assert_eq!(
+            multi_workspace.project_group_keys(),
+            vec![key_d.clone(), key_c.clone(), key_b.clone(), key_a.clone()],
+            "new project groups should be inserted before existing groups"
+        );
+
+        let group_c_index = multi_workspace
+            .project_groups(cx)
+            .iter()
+            .position(|project_group| project_group.key == key_c)
+            .expect("project group for project-c should exist");
+        let workspace_b = multi_workspace
+            .workspaces_for_project_group(&key_b, cx)
+            .and_then(|workspaces| workspaces.into_iter().next())
+            .expect("workspace for project-b should exist");
+        let workspace_d = multi_workspace
+            .workspaces_for_project_group(&key_d, cx)
+            .and_then(|workspaces| workspaces.into_iter().next())
+            .expect("workspace for project-d should exist");
+        let retained_workspaces_a = multi_workspace
+            .workspaces_for_project_group(&key_a, cx)
+            .expect("project group A should have retained workspaces");
+        assert_eq!(
+            retained_workspaces_a.len(),
+            2,
+            "project group A should retain both workspaces"
+        );
+        let workspace_a_1 = retained_workspaces_a
+            .first()
+            .expect("project group A should have a retained workspace")
+            .clone();
+        let workspace_a_2 = multi_workspace
+            .last_active_workspace_for_group(&key_a, cx)
+            .expect("project group A should have a last active workspace");
+        assert_ne!(
+            workspace_a_1, workspace_a_2,
+            "project group A's last active workspace should differ from its first retained workspace"
+        );
+
+        // Since Project Group B is the one after C, it is preferred over
+        // Project Group D, even if they're at the same distance.
+        assert_eq!(
+            multi_workspace.nearest_retained_workspace(group_c_index, &[], cx),
+            Some(workspace_b.clone()),
+            "the following project group should be preferred at equal distance"
+        );
+
+        // With Project Group B being excluded, Project Group D is picked as it
+        // is the one with the smallest distance.
+        assert_eq!(
+            multi_workspace.nearest_retained_workspace(
+                group_c_index,
+                std::slice::from_ref(&workspace_b),
+                cx,
+            ),
+            Some(workspace_d.clone()),
+            "the preceding project group should be used when the following workspace is excluded"
+        );
+
+        // With both adjacent Project Groups excluded, the search expands and
+        // reaches Project A at distance 2 and prefers its last active workspace (A2)
+        // over its first retained workspace (A1).
+        assert_eq!(
+            multi_workspace.nearest_retained_workspace(
+                group_c_index,
+                &[workspace_b.clone(), workspace_d.clone()],
+                cx
+            ),
+            Some(workspace_a_2.clone()),
+            "the farther group's last active workspace should be preferred"
+        );
+
+        // We'll now clear the project group's last active workspace.
+        // In that state, the search falls back to the group's first retained
+        // workspace.
+        multi_workspace
+            .group_state_by_key_mut(&key_a)
+            .expect("project group A should exist")
+            .last_active_workspace
+            .take();
+
+        assert_eq!(
+            multi_workspace.nearest_retained_workspace(
+                group_c_index,
+                &[workspace_b.clone(), workspace_d.clone()],
+                cx
+            ),
+            Some(workspace_a_1.clone()),
+            "the first retained workspace should be used without a last active workspace"
+        );
+
+        // Excluding every neighboring workspace exhausts the search.
+        assert_eq!(
+            multi_workspace.nearest_retained_workspace(
+                group_c_index,
+                &[
+                    workspace_b,
+                    workspace_d,
+                    workspace_a_1,
+                    workspace_a_2,
+                ],
+                cx
+            ),
+            None,
+            "no workspace should be returned when every candidate is excluded"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_nearest_retained_workspace_skips_disconnected_workspace(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree("/project-a", json!({})).await;
+    fs.insert_tree("/project-b", json!({})).await;
+
+    let project_a = Project::test(fs.clone(), ["/project-a".as_ref()], cx).await;
+    let project_b = Project::test(fs, ["/project-b".as_ref()], cx).await;
+    let key_a = project_a.read_with(cx, |project, cx| project.project_group_key(cx));
+    let (multi_workspace, cx) = setup_multi_workspace(&[project_a.clone(), project_b.clone()], cx);
+
+    project_b.update(cx, |project, cx| {
+        project.mark_as_collab_for_testing();
+        project.disconnected_from_host(cx);
+    });
+    cx.run_until_parked();
+
+    multi_workspace.update(cx, |multi_workspace, cx| {
+        let group_a_index = multi_workspace
+            .project_groups(cx)
+            .iter()
+            .position(|group| group.key == key_a)
+            .expect("project group A should exist");
+
+        assert_eq!(
+            multi_workspace.nearest_retained_workspace(group_a_index, &[], cx),
+            None,
+            "a disconnected workspace should not be selected as a fallback"
+        );
     });
 }


### PR DESCRIPTION
# Objective

When working across multiple projects open in the same window, closing the **currently selected** project requried a two-step flow: switch to another project first then close the one that you initially wanted to. 
The project's close button was hidden on the active project, so the only way to remove the project was to navigate away first. 

## Solution

Always render the close button in the project picker, including for the active project. Closing the active project now removes it and switches to a neighboring project automatically. 
This worked well for local projects but broke for remote ones. For any remote neighbor it actually fell through to an empty workspace. 

There are 3 cases now: 
1. Activate the neighbor's already open workspace when one exists (now either if its local or remote)
2. Load the neighbor through the host-aware **find_or_create_workspace** which connects and opens a remote neighbor when it isn't already open
3. Fallback to an empty workspace only when no neighbor remains

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

https://github.com/user-attachments/assets/6e1d1968-702a-4f13-9442-5e90fe7ae9f9

</details>

---

Release Notes:

- Improved the project switcher to allow closing the currently selected project, switching to a neighboring project (local or remote) automatically. 
