### PR TITLE
editor: Skip multi-cursor selection broadcast when unshared

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11161,8 +11161,7 @@ pub trait CollaborationHub {
     /// audience (e.g. an unshared local project) override this so the editor can
     /// skip the per-keystroke `set_active_selections` work, which is
     /// `O(selections)` and pure overhead when nobody is observing.
-    fn should_broadcast_selections(&self, cx: &App) -> bool {
-        let _ = cx;
+    fn should_broadcast_selections(&self, _: &App) -> bool {
         true
     }
 }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11147,11 +11147,29 @@ pub trait CollaborationHub {
     fn collaborators<'a>(&self, cx: &'a App) -> &'a HashMap<PeerId, Collaborator>;
     fn user_participant_indices<'a>(&self, cx: &'a App) -> &'a HashMap<u64, ParticipantIndex>;
     fn user_names(&self, cx: &App) -> HashMap<u64, SharedString>;
+
+    /// Whether local selection changes need to be broadcast to other
+    /// participants. Defaults to `true`; hubs that can be certain there is no
+    /// audience (e.g. an unshared local project) override this so the editor can
+    /// skip the per-keystroke `set_active_selections` work, which is
+    /// `O(selections)` and pure overhead when nobody is observing.
+    fn should_broadcast_selections(&self, cx: &App) -> bool {
+        let _ = cx;
+        true
+    }
 }
 
 impl CollaborationHub for Entity<Project> {
     fn collaborators<'a>(&self, cx: &'a App) -> &'a HashMap<PeerId, Collaborator> {
         self.read(cx).collaborators()
+    }
+
+    fn should_broadcast_selections(&self, cx: &App) -> bool {
+        // `is_shared()` is true for a host that has shared the project and for a
+        // collab guest, and stays correct even before peer-join notifications
+        // have propagated locally (unlike a live collaborator count). A purely
+        // local project has no audience, so selections need not be broadcast.
+        self.read(cx).is_shared()
     }
 
     fn user_participant_indices<'a>(&self, cx: &'a App) -> &'a HashMap<u64, ParticipantIndex> {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2001,6 +2001,14 @@ impl Editor {
                 project,
                 window,
                 |editor, _, event, window, cx| match event {
+                    project::Event::RemoteIdChanged(Some(_))
+                    | project::Event::Reshared
+                    | project::Event::HostReshared => {
+                        // The per-change selection broadcast is skipped while the
+                        // project is unshared, so re-publish current selections
+                        // once it becomes (re)shared.
+                        editor.republish_active_selections(window, cx);
+                    }
                     project::Event::RefreshCodeLens => {
                         editor.refresh_code_lenses(None, window, cx);
                     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2038,6 +2038,14 @@ impl Editor {
                 project,
                 window,
                 |editor, _, event, window, cx| match event {
+                    project::Event::RemoteIdChanged(Some(_))
+                    | project::Event::Reshared
+                    | project::Event::HostReshared => {
+                        // The per-change selection broadcast is skipped while the
+                        // project is unshared, so re-publish current selections
+                        // once it becomes (re)shared.
+                        editor.republish_active_selections(window, cx);
+                    }
                     project::Event::RefreshCodeLens { .. } => {
                         editor.refresh_code_lenses(None, window, cx);
                     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11553,11 +11553,29 @@ pub trait CollaborationHub {
     fn collaborators<'a>(&self, cx: &'a App) -> &'a HashMap<PeerId, Collaborator>;
     fn user_participant_indices<'a>(&self, cx: &'a App) -> &'a HashMap<u64, ParticipantIndex>;
     fn user_names(&self, cx: &App) -> HashMap<u64, SharedString>;
+
+    /// Whether local selection changes need to be broadcast to other
+    /// participants. Defaults to `true`; hubs that can be certain there is no
+    /// audience (e.g. an unshared local project) override this so the editor can
+    /// skip the per-keystroke `set_active_selections` work, which is
+    /// `O(selections)` and pure overhead when nobody is observing.
+    fn should_broadcast_selections(&self, cx: &App) -> bool {
+        let _ = cx;
+        true
+    }
 }
 
 impl CollaborationHub for Entity<Project> {
     fn collaborators<'a>(&self, cx: &'a App) -> &'a HashMap<PeerId, Collaborator> {
         self.read(cx).collaborators()
+    }
+
+    fn should_broadcast_selections(&self, cx: &App) -> bool {
+        // `is_shared()` is true for a host that has shared the project and for a
+        // collab guest, and stays correct even before peer-join notifications
+        // have propagated locally (unlike a live collaborator count). A purely
+        // local project has no audience, so selections need not be broadcast.
+        self.read(cx).is_shared()
     }
 
     fn user_participant_indices<'a>(&self, cx: &'a App) -> &'a HashMap<u64, ParticipantIndex> {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11567,8 +11567,7 @@ pub trait CollaborationHub {
     /// audience (e.g. an unshared local project) override this so the editor can
     /// skip the per-keystroke `set_active_selections` work, which is
     /// `O(selections)` and pure overhead when nobody is observing.
-    fn should_broadcast_selections(&self, cx: &App) -> bool {
-        let _ = cx;
+    fn should_broadcast_selections(&self, _: &App) -> bool {
         true
     }
 }

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -503,11 +503,12 @@ impl Editor {
                 this.show_edit_predictions_in_menu() || !had_active_edit_prediction;
             if this.hard_wrap.is_some() {
                 let latest: Range<Point> = this.selections.newest(&map).range();
+                // Reuse the post-edit snapshot captured in `map` above; the buffer
+                // is not mutated between there and here (only selections move), so a
+                // fresh `buffer().snapshot(cx)` would be redundant.
                 if latest.is_empty()
-                    && this
-                        .buffer()
-                        .read(cx)
-                        .snapshot(cx)
+                    && map
+                        .buffer_snapshot()
                         .line_len(MultiBufferRow(latest.start.row))
                         == latest.start.column
                 {

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -500,11 +500,12 @@ impl Editor {
                 this.show_edit_predictions_in_menu() || !had_active_edit_prediction;
             if this.hard_wrap.is_some() {
                 let latest: Range<Point> = this.selections.newest(&map).range();
+                // Reuse the post-edit snapshot captured in `map` above; the buffer
+                // is not mutated between there and here (only selections move), so a
+                // fresh `buffer().snapshot(cx)` would be redundant.
                 if latest.is_empty()
-                    && this
-                        .buffer()
-                        .read(cx)
-                        .snapshot(cx)
+                    && map
+                        .buffer_snapshot()
                         .line_len(MultiBufferRow(latest.start.row))
                         == latest.start.column
                 {

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -1552,7 +1552,13 @@ impl Editor {
 
         let selection_anchors = self.selections.disjoint_anchors_arc();
 
-        if self.focus_handle.is_focused(window) && self.leader_id.is_none() {
+        let should_broadcast_selections = self
+            .collaboration_hub()
+            .is_some_and(|hub| hub.should_broadcast_selections(cx));
+        if should_broadcast_selections
+            && self.focus_handle.is_focused(window)
+            && self.leader_id.is_none()
+        {
             self.buffer.update(cx, |buffer, cx| {
                 buffer.set_active_selections(
                     &selection_anchors,

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -1514,6 +1514,34 @@ impl Editor {
         }
     }
 
+    /// Re-publishes the current selections to collaborators immediately. The
+    /// per-change broadcast in `selections_did_change` is skipped while the
+    /// project is unshared, so when a project becomes shared this is called to
+    /// re-establish this editor's cursor for peers, who would otherwise not see
+    /// it until the next selection change.
+    pub(crate) fn republish_active_selections(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let should_broadcast_selections = self
+            .collaboration_hub()
+            .is_some_and(|hub| hub.should_broadcast_selections(cx));
+        if should_broadcast_selections
+            && self.focus_handle.is_focused(window)
+            && self.leader_id.is_none()
+        {
+            self.buffer.update(cx, |buffer, cx| {
+                buffer.set_active_selections(
+                    &self.selections.disjoint_anchors_arc(),
+                    self.selections.line_mode(),
+                    self.cursor_shape,
+                    cx,
+                )
+            });
+        }
+    }
+
     fn selections_did_change(
         &mut self,
         local: bool,

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -1539,6 +1539,34 @@ impl Editor {
         }
     }
 
+    /// Re-publishes the current selections to collaborators immediately. The
+    /// per-change broadcast in `selections_did_change` is skipped while the
+    /// project is unshared, so when a project becomes shared this is called to
+    /// re-establish this editor's cursor for peers, who would otherwise not see
+    /// it until the next selection change.
+    pub(crate) fn republish_active_selections(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let should_broadcast_selections = self
+            .collaboration_hub()
+            .is_some_and(|hub| hub.should_broadcast_selections(cx));
+        if should_broadcast_selections
+            && self.focus_handle.is_focused(window)
+            && self.leader_id.is_none()
+        {
+            self.buffer.update(cx, |buffer, cx| {
+                buffer.set_active_selections(
+                    &self.selections.disjoint_anchors_arc(),
+                    self.selections.line_mode(),
+                    self.cursor_shape,
+                    cx,
+                )
+            });
+        }
+    }
+
     fn selections_did_change(
         &mut self,
         local: bool,

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -1577,7 +1577,13 @@ impl Editor {
 
         let selection_anchors = self.selections.disjoint_anchors_arc();
 
-        if self.focus_handle.is_focused(window) && self.leader_id.is_none() {
+        let should_broadcast_selections = self
+            .collaboration_hub()
+            .is_some_and(|hub| hub.should_broadcast_selections(cx));
+        if should_broadcast_selections
+            && self.focus_handle.is_focused(window)
+            && self.leader_id.is_none()
+        {
             self.buffer.update(cx, |buffer, cx| {
                 buffer.set_active_selections(
                     &selection_anchors,


### PR DESCRIPTION
Resubmit of #59731, which got auto-closed when I accidentally deleted its branch. It wasn't rejected, it had already been reviewed. This is rebased onto latest `main`, and osiewicz's review feedback (using `_` for the unused param in the trait default) is already in.

Follow-up to #58510. Profiling multi-cursor typing on current main showed the per-keystroke `set_active_selections` broadcast does an O(selections) multi-buffer anchor remap and runs even with zero collaborators (about 0.9ms/call at 1k cursors, 8.4ms at 10k, fired ~3x per edited iteration).

This skips the broadcast when the buffer has no audience, and re-publishes on share so there's no regression:

- Add `CollaborationHub::should_broadcast_selections`, defaulting to `true`. `Entity<Project>` overrides it to `Project::is_shared()`, which is true for a host that shared the project and for a collab guest, and stays correct before peer-join notifications have propagated locally (unlike a live collaborator count). A purely local project has no audience.
- Gate `set_active_selections` in `selections_did_change` on it. Follow-mode is unaffected since it uses the separate UpdateFollowers/UpdateView channel, and the focused user's own cursors render from `editor.selections`, not `remote_selections`.
- When the project becomes (re)shared (`RemoteIdChanged(Some)`, `Reshared`, `HostReshared`), the focused editor re-publishes its current selections, so a peer joining after a share still sees the host's cursor without waiting for the next selection change.
- Reuse the post-edit display snapshot in the `hard_wrap` branch instead of taking a redundant fresh buffer snapshot.

Multi-cursor type+delete benchmark: about 5% faster at both 1k and 10k cursors (615 to 583 ms at 10k, significant). All 773 editor tests pass locally. Collab and channel-buffer integration tests need the test DB, so they run on CI.

Discussion and profiling: https://github.com/zed-industries/zed/issues/32051

Release Notes:

- Improved multi cursor editing performance
