### PR TITLE
language: Clip injection content ranges to parent layer's included ranges

### DIFF
--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -839,6 +839,14 @@ impl SyntaxSnapshot {
                                 text,
                             );
                         }
+                        let parent_included_ranges: Vec<Range<usize>> = tree
+                            .included_ranges()
+                            .into_iter()
+                            .map(|range| {
+                                (range.start_byte + step_start_byte)
+                                    ..(range.end_byte + step_start_byte)
+                            })
+                            .collect();
                         get_injections(
                             config,
                             text,
@@ -847,6 +855,7 @@ impl SyntaxSnapshot {
                                 step_start_byte,
                                 step_start_point.to_ts_point(),
                             ),
+                            &parent_included_ranges,
                             registry,
                             step.depth + 1,
                             &expanded_ranges,
@@ -1552,12 +1561,38 @@ fn parse_text(
     })
 }
 
+fn clip_range_to_parent(
+    range: tree_sitter::Range,
+    parent_included_ranges: &[Range<usize>],
+    text: &BufferSnapshot,
+    out: &mut Vec<tree_sitter::Range>,
+) {
+    for parent in parent_included_ranges {
+        let start = range.start_byte.max(parent.start);
+        let end = range.end_byte.min(parent.end);
+        if start >= end {
+            continue;
+        }
+        if start == range.start_byte && end == range.end_byte {
+            out.push(range);
+        } else {
+            out.push(tree_sitter::Range {
+                start_byte: start,
+                end_byte: end,
+                start_point: text.offset_to_point(start).to_ts_point(),
+                end_point: text.offset_to_point(end).to_ts_point(),
+            });
+        }
+    }
+}
+
 #[ztracing::instrument(skip_all)]
 fn get_injections(
     config: &InjectionConfig,
     text: &BufferSnapshot,
     outer_range: Range<Anchor>,
     node: Node,
+    parent_included_ranges: &[Range<usize>],
     language_registry: &Arc<LanguageRegistry>,
     depth: usize,
     changed_ranges: &[Range<usize>],
@@ -1585,10 +1620,15 @@ fn get_injections(
         query_cursor.set_byte_range(query_range.start.saturating_sub(1)..query_range.end + 1);
         let mut matches = query_cursor.matches(&config.query, node, TextProvider(text.as_rope()));
         while let Some(mat) = matches.next() {
-            let content_ranges = mat
-                .nodes_for_capture_index(config.content_capture_ix)
-                .map(|node| node.range())
-                .collect::<Vec<_>>();
+            let mut content_ranges = Vec::new();
+            for node in mat.nodes_for_capture_index(config.content_capture_ix) {
+                clip_range_to_parent(
+                    node.range(),
+                    parent_included_ranges,
+                    text,
+                    &mut content_ranges,
+                );
+            }
             if content_ranges.is_empty() {
                 continue;
             }

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -896,6 +896,92 @@ fn test_combined_injections_inside_injections(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_injection_content_clipped_to_parent_gaps(cx: &mut App) {
+    // ERB -> HTML -> Ruby: the ERB `<%= %>` directive is excluded from the combined HTML
+    // layer, so the injected Ruby layer must not re-introduce those excluded bytes.
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
+    registry.add(Arc::new(erb_lang()));
+    registry.add(Arc::new(ruby_lang()));
+    // A variant of HTML that injects Ruby into `<script>` bodies.
+    let html = Language::new(
+        LanguageConfig {
+            name: "HTML".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["html".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        Some(tree_sitter_html::LANGUAGE.into()),
+    )
+    .with_highlights_query("(tag_name) @tag")
+    .unwrap()
+    .with_injection_query(
+        r#"
+            (script_element
+              (raw_text) @injection.content
+              (#set! injection.language "ruby"))
+        "#,
+    )
+    .unwrap();
+    registry.add(Arc::new(html));
+
+    let buffer = Buffer::new(
+        ReplicaId::LOCAL,
+        BufferId::new(1).unwrap(),
+        r#"
+            <script>
+            a.first
+            <%= b.second %>
+            c.third
+            </script>
+        "#
+        .unindent(),
+    );
+
+    let erb = registry
+        .language_for_name("ERB")
+        .now_or_never()
+        .unwrap()
+        .unwrap();
+    let mut syntax_map = SyntaxMap::new(&buffer);
+    syntax_map.set_language_registry(registry);
+    syntax_map.reparse(erb, &buffer);
+
+    // Ruby should see only "a.first" and "c.third", not the excluded `<%= b.second %>` directive.
+    let ruby_layers: Vec<String> = syntax_map
+        .layers(&buffer.snapshot())
+        .into_iter()
+        .filter(|layer| layer.language.name().as_ref() == "Ruby")
+        .map(|layer| layer.node().to_sexp())
+        .collect();
+    assert!(
+        ruby_layers.iter().any(|sexp| sexp
+            == "(program (call receiver: (identifier) method: (identifier)) \
+                (call receiver: (identifier) method: (identifier)))"),
+        "expected a clean two-call Ruby layer for the script body, got: {ruby_layers:#?}"
+    );
+    assert!(
+        ruby_layers.iter().all(|sexp| !sexp.contains("ERROR")),
+        "injected Ruby layer should not span the excluded `<%= %>` directive, got: {ruby_layers:#?}"
+    );
+
+    // Highlighting still lands on each method call, including `third` after the gap.
+    assert_capture_ranges(
+        &syntax_map,
+        &buffer,
+        &["method"],
+        "
+            <script>
+            a.«first»
+            <%= b.«second» %>
+            c.«third»
+            </script>
+        ",
+    );
+}
+
+#[gpui::test]
 fn test_empty_combined_injections_inside_injections(cx: &mut App) {
     let (buffer, syntax_map) = test_edit_sequence(
         "Markdown",


### PR DESCRIPTION
# Objective

This PR fixes an issue with nested tree-sitter injections, specifically in embedded templating languages like ERB and EJS.

## Solution

It takes the parent's included content ranges (in this example the buffer minus the ERB directives) and intersects each injected content range with them, thereby preventing the injection from parsing the ERB directives.

## Testing

I tested it by compiling a release build via `cargo build --release`, installing Ruby support, and creating and editing an ERB file. I further implemented a test `test_injection_content_clipped_to_parent_gaps` to check if the template tags are parsed correctly (without ERROR nodes).

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Notice the syntax coloring inside the `<script>` is consistent with the rest of the Ruby/ERB code:

<img width="2518" height="1366" alt="example" src="https://github.com/user-attachments/assets/751042c1-8bc9-43dd-b0c0-1fa41fb82004" />