### PR TITLE
Add GPT-5.6 to openai_subscribed provider

### DIFF
--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -194,8 +194,6 @@ impl LanguageModelProvider for OpenAiSubscribedProvider {
     }
 
     fn default_fast_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
-        // No GPT-5.5 Mini exists yet; per the OpenAI Codex docs, gpt-5.4-mini
-        // is the recommended fast/cheap default alongside gpt-5.5.
         Some(self.create_language_model(ChatGptModel::Gpt56Luna))
     }
 

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -196,7 +196,7 @@ impl LanguageModelProvider for OpenAiSubscribedProvider {
     fn default_fast_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
         // No GPT-5.5 Mini exists yet; per the OpenAI Codex docs, gpt-5.4-mini
         // is the recommended fast/cheap default alongside gpt-5.5.
-        Some(self.create_language_model(ChatGptModel::Gpt54Mini))
+        Some(self.create_language_model(ChatGptModel::Gpt56Luna))
     }
 
     fn provided_models(&self, _cx: &App) -> Vec<Arc<dyn LanguageModel>> {

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -311,6 +311,9 @@ impl LanguageModelProvider for OpenAiSubscribedProvider {
 // approximation; the entries below mirror that file's picker-visible models.
 #[derive(Clone, Debug, PartialEq)]
 enum ChatGptModel {
+    Gpt56Sol,
+    Gpt56Terra,
+    Gpt56Luna,
     Gpt55,
     Gpt54,
     Gpt54Mini,
@@ -318,11 +321,14 @@ enum ChatGptModel {
 
 impl ChatGptModel {
     fn all() -> Vec<Self> {
-        vec![Self::Gpt55, Self::Gpt54, Self::Gpt54Mini]
+        vec![Self::Gpt56Sol, Self::Gpt56Terra, Self::Gpt56Luna, Self::Gpt55, Self::Gpt54, Self::Gpt54Mini]
     }
 
     fn id(&self) -> &str {
         match self {
+            Self::Gpt56Sol => "gpt-5.6-sol",
+            Self::Gpt56Terra => "gpt-5.6-terra",
+            Self::Gpt56Luna => "gpt-5.6-luna",
             Self::Gpt55 => "gpt-5.5",
             Self::Gpt54 => "gpt-5.4",
             Self::Gpt54Mini => "gpt-5.4-mini",
@@ -331,6 +337,9 @@ impl ChatGptModel {
 
     fn display_name(&self) -> &str {
         match self {
+            Self::Gpt56Sol => "GPT-5.6 Sol",
+            Self::Gpt56Terra => "gGPT-5.6 Terra",
+            Self::Gpt56Luna => "GPT-5.6 Luna",
             Self::Gpt55 => "GPT-5.5",
             Self::Gpt54 => "GPT-5.4",
             Self::Gpt54Mini => "GPT-5.4 Mini",
@@ -338,11 +347,10 @@ impl ChatGptModel {
     }
 
     fn max_token_count(&self) -> u64 {
-        // All Codex-supported models use a 272K context window in the Codex
-        // backend, even when the raw model exposes a larger context window via the
-        // public API (e.g. gpt-5.4 has max_context_window 1M, but Codex uses
-        // context_window 272K). Source: openai/codex models-manager/models.json.
-        272_000
+      match self {
+        Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna => 372_000,
+        Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => 272_000,
+      }
     }
 
     fn max_output_tokens(&self) -> Option<u64> {
@@ -356,18 +364,29 @@ impl ChatGptModel {
     }
 
     fn default_reasoning_effort(&self) -> Option<ReasoningEffort> {
-        // Codex bundled models all default to Medium reasoning effort.
-        Some(ReasoningEffort::Medium)
+        match self {
+            Self::Gpt56Sol  => Some(ReasoningEffort::Low),
+            Self::Gpt56Terra | Self::Gpt56Luna | Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => Some(ReasoningEffort::Medium),
+        }
     }
 
     fn supported_reasoning_efforts(&self) -> &'static [ReasoningEffort] {
-        // The Codex backend's supported_reasoning_levels for every model in this list is low/medium/high/xhigh
-        &[
-            ReasoningEffort::Low,
-            ReasoningEffort::Medium,
-            ReasoningEffort::High,
-            ReasoningEffort::XHigh,
-        ]
+      match self {
+          Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna  => &[
+              ReasoningEffort::Low,
+              ReasoningEffort::Medium,
+              ReasoningEffort::High,
+              ReasoningEffort::XHigh,
+              ReasoningEffort::Max,
+          ],
+          Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => &[
+              ReasoningEffort::Low,
+              ReasoningEffort::Medium,
+              ReasoningEffort::High,
+              ReasoningEffort::XHigh,
+          ],
+      }
+
     }
 
     fn supports_parallel_tool_calls(&self) -> bool {
@@ -380,7 +399,7 @@ impl ChatGptModel {
 
     fn supports_priority(&self) -> bool {
         match self {
-            Self::Gpt55 | Self::Gpt54 => true,
+            Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna | Self::Gpt55 | Self::Gpt54 => true,
             Self::Gpt54Mini => false,
         }
     }

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -190,7 +190,7 @@ impl LanguageModelProvider for OpenAiSubscribedProvider {
     }
 
     fn default_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
-        Some(self.create_language_model(ChatGptModel::Gpt55))
+        Some(self.create_language_model(ChatGptModel::Gpt56Sol))
     }
 
     fn default_fast_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
@@ -321,7 +321,14 @@ enum ChatGptModel {
 
 impl ChatGptModel {
     fn all() -> Vec<Self> {
-        vec![Self::Gpt56Sol, Self::Gpt56Terra, Self::Gpt56Luna, Self::Gpt55, Self::Gpt54, Self::Gpt54Mini]
+        vec![
+            Self::Gpt56Sol,
+            Self::Gpt56Terra,
+            Self::Gpt56Luna,
+            Self::Gpt55,
+            Self::Gpt54,
+            Self::Gpt54Mini,
+        ]
     }
 
     fn id(&self) -> &str {
@@ -338,7 +345,7 @@ impl ChatGptModel {
     fn display_name(&self) -> &str {
         match self {
             Self::Gpt56Sol => "GPT-5.6 Sol",
-            Self::Gpt56Terra => "gGPT-5.6 Terra",
+            Self::Gpt56Terra => "GPT-5.6 Terra",
             Self::Gpt56Luna => "GPT-5.6 Luna",
             Self::Gpt55 => "GPT-5.5",
             Self::Gpt54 => "GPT-5.4",
@@ -347,10 +354,10 @@ impl ChatGptModel {
     }
 
     fn max_token_count(&self) -> u64 {
-      match self {
-        Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna => 372_000,
-        Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => 272_000,
-      }
+        match self {
+            Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna => 372_000,
+            Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => 272_000,
+        }
     }
 
     fn max_output_tokens(&self) -> Option<u64> {
@@ -365,28 +372,29 @@ impl ChatGptModel {
 
     fn default_reasoning_effort(&self) -> Option<ReasoningEffort> {
         match self {
-            Self::Gpt56Sol  => Some(ReasoningEffort::Low),
-            Self::Gpt56Terra | Self::Gpt56Luna | Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => Some(ReasoningEffort::Medium),
+            Self::Gpt56Sol => Some(ReasoningEffort::Low),
+            Self::Gpt56Terra | Self::Gpt56Luna | Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => {
+                Some(ReasoningEffort::Medium)
+            }
         }
     }
 
     fn supported_reasoning_efforts(&self) -> &'static [ReasoningEffort] {
-      match self {
-          Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna  => &[
-              ReasoningEffort::Low,
-              ReasoningEffort::Medium,
-              ReasoningEffort::High,
-              ReasoningEffort::XHigh,
-              ReasoningEffort::Max,
-          ],
-          Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => &[
-              ReasoningEffort::Low,
-              ReasoningEffort::Medium,
-              ReasoningEffort::High,
-              ReasoningEffort::XHigh,
-          ],
-      }
-
+        match self {
+            Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna => &[
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::XHigh,
+                ReasoningEffort::Max,
+            ],
+            Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => &[
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::XHigh,
+            ],
+        }
     }
 
     fn supports_parallel_tool_calls(&self) -> bool {
@@ -468,7 +476,7 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
                     ReasoningEffort::Medium => ("Medium", "medium"),
                     ReasoningEffort::High => ("High", "high"),
                     ReasoningEffort::XHigh => ("Extra High", "xhigh"),
-                    ReasoningEffort::Max => return None, // Not supported by any OpenAI models
+                    ReasoningEffort::Max => ("Max", "max"),
                 };
 
                 Some(LanguageModelEffortLevel {

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -194,7 +194,7 @@ impl LanguageModelProvider for OpenAiSubscribedProvider {
     }
 
     fn default_fast_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
-        Some(self.create_language_model(ChatGptModel::Gpt56Luna))
+        Some(self.create_language_model(ChatGptModel::Gpt54Mini))
     }
 
     fn provided_models(&self, _cx: &App) -> Vec<Arc<dyn LanguageModel>> {


### PR DESCRIPTION
Adds GPT-5.6 to openai_subscribed, based on model info from https://github.com/openai/codex/blob/dc23c7bcc8fd543fe727c7b4447a3d785836932f/codex-rs/models-manager/models.json

Release Notes:

- agent: Added GPT 5.6 support for ChatGPT subscription (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`)