### PR TITLE
Recognize deno.lock as JSON

### DIFF
--- a/crates/grammars/src/json/config.toml
+++ b/crates/grammars/src/json/config.toml
@@ -1,6 +1,6 @@
 name = "JSON"
 grammar = "json"
-path_suffixes = ["json", "flake.lock", "geojson", "topojson", "prettierrc", "json.dist"]
+path_suffixes = ["json", "flake.lock", "geojson", "topojson", "prettierrc", "json.dist", "deno.lock"]
 line_comments = ["// "]
 autoclose_before = ",]}"
 brackets = [


### PR DESCRIPTION
Reasons: Deno officially states that the deno.lock file is of JSON type.
https://github.com/denoland/vscode_deno/blob/main/schemas/lockfile.schema.json

Release Notes:

- Added JSON language support for `deno.lock` files.