### PR TITLE
open_ai: Add GPT 5.6 models

### DIFF
--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -464,6 +464,9 @@ impl LanguageModel for OpenAiLanguageModel {
             | Model::FivePointFourPro
             | Model::FivePointFive
             | Model::FivePointFivePro
+            | Model::FivePointSixSol
+            | Model::FivePointSixTerra
+            | Model::FivePointSixLuna
             | Model::O3 => true,
             Model::Four => false,
             Model::Custom {

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -511,48 +511,6 @@ mod tests {
             expected_efforts.as_slice()
         );
     }
-
-    #[test]
-    fn gpt_5_6_models_match_codex_metadata() {
-        let expected_efforts = [
-            ReasoningEffort::Low,
-            ReasoningEffort::Medium,
-            ReasoningEffort::High,
-            ReasoningEffort::XHigh,
-            ReasoningEffort::Max,
-        ];
-
-        assert_eq!(Model::default(), Model::FivePointSixSol);
-        assert_eq!(Model::default_fast(), Model::FivePointSixLuna);
-        assert_eq!(
-            Model::FivePointSixSol.reasoning_effort(),
-            Some(ReasoningEffort::Low)
-        );
-        assert_eq!(
-            Model::FivePointSixTerra.reasoning_effort(),
-            Some(ReasoningEffort::Medium)
-        );
-        assert_eq!(
-            Model::FivePointSixLuna.reasoning_effort(),
-            Some(ReasoningEffort::Medium)
-        );
-
-        for model in [
-            Model::FivePointSixSol,
-            Model::FivePointSixTerra,
-            Model::FivePointSixLuna,
-        ] {
-            assert_eq!(model.max_token_count(), 372_000);
-            assert_eq!(model.max_output_tokens(), Some(128_000));
-            assert_eq!(
-                model.supported_reasoning_efforts(),
-                expected_efforts.as_slice()
-            );
-            assert!(model.supports_parallel_tool_calls());
-            assert!(model.supports_compaction());
-            assert!(model.supports_priority());
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -68,7 +68,6 @@ pub enum Model {
     #[serde(rename = "gpt-5")]
     Five,
     #[serde(rename = "gpt-5-mini")]
-    #[default]
     FiveMini,
     #[serde(rename = "gpt-5-nano")]
     FiveNano,
@@ -90,6 +89,13 @@ pub enum Model {
     FivePointFive,
     #[serde(rename = "gpt-5.5-pro")]
     FivePointFivePro,
+    #[serde(rename = "gpt-5.6-sol")]
+    #[default]
+    FivePointSixSol,
+    #[serde(rename = "gpt-5.6-terra")]
+    FivePointSixTerra,
+    #[serde(rename = "gpt-5.6-luna")]
+    FivePointSixLuna,
     #[serde(rename = "custom")]
     Custom {
         name: String,
@@ -116,7 +122,7 @@ const fn default_supports_images() -> bool {
 
 impl Model {
     pub fn default_fast() -> Self {
-        Self::FiveMini
+        Self::FivePointSixLuna
     }
 
     pub fn from_id(id: &str) -> Result<Self> {
@@ -136,6 +142,9 @@ impl Model {
             "gpt-5.4-pro" => Ok(Self::FivePointFourPro),
             "gpt-5.5" => Ok(Self::FivePointFive),
             "gpt-5.5-pro" => Ok(Self::FivePointFivePro),
+            "gpt-5.6-sol" => Ok(Self::FivePointSixSol),
+            "gpt-5.6-terra" => Ok(Self::FivePointSixTerra),
+            "gpt-5.6-luna" => Ok(Self::FivePointSixLuna),
             invalid_id => anyhow::bail!("invalid model id '{invalid_id}'"),
         }
     }
@@ -157,6 +166,9 @@ impl Model {
             Self::FivePointFourPro => "gpt-5.4-pro",
             Self::FivePointFive => "gpt-5.5",
             Self::FivePointFivePro => "gpt-5.5-pro",
+            Self::FivePointSixSol => "gpt-5.6-sol",
+            Self::FivePointSixTerra => "gpt-5.6-terra",
+            Self::FivePointSixLuna => "gpt-5.6-luna",
             Self::Custom { name, .. } => name,
         }
     }
@@ -178,6 +190,9 @@ impl Model {
             Self::FivePointFourPro => "gpt-5.4-pro",
             Self::FivePointFive => "gpt-5.5",
             Self::FivePointFivePro => "gpt-5.5-pro",
+            Self::FivePointSixSol => "gpt-5.6-sol",
+            Self::FivePointSixTerra => "gpt-5.6-terra",
+            Self::FivePointSixLuna => "gpt-5.6-luna",
             Self::Custom { display_name, .. } => display_name.as_deref().unwrap_or(&self.id()),
         }
     }
@@ -199,6 +214,9 @@ impl Model {
             Self::FivePointFourPro => 1_050_000,
             Self::FivePointFive => 1_050_000,
             Self::FivePointFivePro => 1_050_000,
+            Self::FivePointSixSol => 1_050_000,
+            Self::FivePointSixTerra => 1_050_000,
+            Self::FivePointSixLuna => 1_050_000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
     }
@@ -223,6 +241,9 @@ impl Model {
             Self::FivePointFourPro => Some(128_000),
             Self::FivePointFive => Some(128_000),
             Self::FivePointFivePro => Some(128_000),
+            Self::FivePointSixSol => Some(128_000),
+            Self::FivePointSixTerra => Some(128_000),
+            Self::FivePointSixLuna => Some(128_000),
         }
     }
 
@@ -236,6 +257,7 @@ impl Model {
             | Self::FivePointFour
             | Self::FivePointFourMini
             | Self::FivePointFourNano => Some(ReasoningEffort::None),
+            Self::FivePointSixSol => Some(ReasoningEffort::Low),
             Self::O3
             | Self::Five
             | Self::FiveMini
@@ -243,7 +265,9 @@ impl Model {
             | Self::FivePointThreeCodex
             | Self::FivePointFourPro
             | Self::FivePointFive
-            | Self::FivePointFivePro => Some(ReasoningEffort::Medium),
+            | Self::FivePointFivePro
+            | Self::FivePointSixTerra
+            | Self::FivePointSixLuna => Some(ReasoningEffort::Medium),
             _ => None,
         }
     }
@@ -290,6 +314,13 @@ impl Model {
                 ReasoningEffort::High,
                 ReasoningEffort::XHigh,
             ],
+            Self::FivePointSixSol | Self::FivePointSixTerra | Self::FivePointSixLuna => &[
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::XHigh,
+                ReasoningEffort::Max,
+            ],
             Self::FivePointTwo
             | Self::FivePointFour
             | Self::FivePointFive
@@ -333,6 +364,9 @@ impl Model {
             | Self::FivePointFourPro
             | Self::FivePointFive
             | Self::FivePointFivePro
+            | Self::FivePointSixSol
+            | Self::FivePointSixTerra
+            | Self::FivePointSixLuna
             | Self::FiveNano => true,
             Self::O3 | Model::Custom { .. } => false,
         }
@@ -360,7 +394,10 @@ impl Model {
             | Self::FivePointFour
             | Self::FivePointFourPro
             | Self::FivePointFive
-            | Self::FivePointFivePro => true,
+            | Self::FivePointFivePro
+            | Self::FivePointSixSol
+            | Self::FivePointSixTerra
+            | Self::FivePointSixLuna => true,
             Self::Four
             | Self::FourOmniMini
             | Self::O3
@@ -387,7 +424,10 @@ impl Model {
             | Self::FivePointThreeCodex
             | Self::FivePointFourMini
             | Self::FivePointFour
-            | Self::FivePointFive => true,
+            | Self::FivePointFive
+            | Self::FivePointSixSol
+            | Self::FivePointSixTerra
+            | Self::FivePointSixLuna => true,
             Self::Four
             | Self::FiveNano
             | Self::FivePointFourNano
@@ -470,6 +510,48 @@ mod tests {
             Model::FivePointThreeCodex.supported_reasoning_efforts(),
             expected_efforts.as_slice()
         );
+    }
+
+    #[test]
+    fn gpt_5_6_models_match_codex_metadata() {
+        let expected_efforts = [
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::XHigh,
+            ReasoningEffort::Max,
+        ];
+
+        assert_eq!(Model::default(), Model::FivePointSixSol);
+        assert_eq!(Model::default_fast(), Model::FivePointSixLuna);
+        assert_eq!(
+            Model::FivePointSixSol.reasoning_effort(),
+            Some(ReasoningEffort::Low)
+        );
+        assert_eq!(
+            Model::FivePointSixTerra.reasoning_effort(),
+            Some(ReasoningEffort::Medium)
+        );
+        assert_eq!(
+            Model::FivePointSixLuna.reasoning_effort(),
+            Some(ReasoningEffort::Medium)
+        );
+
+        for model in [
+            Model::FivePointSixSol,
+            Model::FivePointSixTerra,
+            Model::FivePointSixLuna,
+        ] {
+            assert_eq!(model.max_token_count(), 372_000);
+            assert_eq!(model.max_output_tokens(), Some(128_000));
+            assert_eq!(
+                model.supported_reasoning_efforts(),
+                expected_efforts.as_slice()
+            );
+            assert!(model.supports_parallel_tool_calls());
+            assert!(model.supports_compaction());
+            assert!(model.supports_priority());
+        }
     }
 }
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -315,6 +315,7 @@ impl Model {
                 ReasoningEffort::XHigh,
             ],
             Self::FivePointSixSol | Self::FivePointSixTerra | Self::FivePointSixLuna => &[
+                ReasoningEffort::None,
                 ReasoningEffort::Low,
                 ReasoningEffort::Medium,
                 ReasoningEffort::High,


### PR DESCRIPTION
Co-authored-by: Christopher Biscardi <chris@christopherbiscardi.com>

Add new GPT 5.6 models

Release Notes:

- open_ai: Added support for GPT 5.6 Sol/Terra/Luna
