### PR TITLE
Add GPT-5.6 to openai_subscribed provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9868,6 +9868,7 @@ dependencies = [
  "ui_input",
  "url",
  "util",
+ "uuid",
  "x_ai",
 ]
 

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -68,6 +68,7 @@ ui.workspace = true
 ui_input.workspace = true
 url.workspace = true
 util.workspace = true
+uuid.workspace = true
 x_ai = { workspace = true, features = ["schemars"] }
 
 [dev-dependencies]

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -194,8 +194,6 @@ impl LanguageModelProvider for OpenAiSubscribedProvider {
     }
 
     fn default_fast_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
-        // No GPT-5.5 Mini exists yet; per the OpenAI Codex docs, gpt-5.4-mini
-        // is the recommended fast/cheap default alongside gpt-5.5.
         Some(self.create_language_model(ChatGptModel::Gpt56Luna))
     }
 

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -196,7 +196,7 @@ impl LanguageModelProvider for OpenAiSubscribedProvider {
     fn default_fast_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
         // No GPT-5.5 Mini exists yet; per the OpenAI Codex docs, gpt-5.4-mini
         // is the recommended fast/cheap default alongside gpt-5.5.
-        Some(self.create_language_model(ChatGptModel::Gpt54Mini))
+        Some(self.create_language_model(ChatGptModel::Gpt56Luna))
     }
 
     fn provided_models(&self, _cx: &App) -> Vec<Arc<dyn LanguageModel>> {

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -311,6 +311,9 @@ impl LanguageModelProvider for OpenAiSubscribedProvider {
 // approximation; the entries below mirror that file's picker-visible models.
 #[derive(Clone, Debug, PartialEq)]
 enum ChatGptModel {
+    Gpt56Sol,
+    Gpt56Terra,
+    Gpt56Luna,
     Gpt55,
     Gpt54,
     Gpt54Mini,
@@ -318,11 +321,14 @@ enum ChatGptModel {
 
 impl ChatGptModel {
     fn all() -> Vec<Self> {
-        vec![Self::Gpt55, Self::Gpt54, Self::Gpt54Mini]
+        vec![Self::Gpt56Sol, Self::Gpt56Terra, Self::Gpt56Luna, Self::Gpt55, Self::Gpt54, Self::Gpt54Mini]
     }
 
     fn id(&self) -> &str {
         match self {
+            Self::Gpt56Sol => "gpt-5.6-sol",
+            Self::Gpt56Terra => "gpt-5.6-terra",
+            Self::Gpt56Luna => "gpt-5.6-luna",
             Self::Gpt55 => "gpt-5.5",
             Self::Gpt54 => "gpt-5.4",
             Self::Gpt54Mini => "gpt-5.4-mini",
@@ -331,6 +337,9 @@ impl ChatGptModel {
 
     fn display_name(&self) -> &str {
         match self {
+            Self::Gpt56Sol => "GPT-5.6 Sol",
+            Self::Gpt56Terra => "gGPT-5.6 Terra",
+            Self::Gpt56Luna => "GPT-5.6 Luna",
             Self::Gpt55 => "GPT-5.5",
             Self::Gpt54 => "GPT-5.4",
             Self::Gpt54Mini => "GPT-5.4 Mini",
@@ -338,11 +347,10 @@ impl ChatGptModel {
     }
 
     fn max_token_count(&self) -> u64 {
-        // All Codex-supported models use a 272K context window in the Codex
-        // backend, even when the raw model exposes a larger context window via the
-        // public API (e.g. gpt-5.4 has max_context_window 1M, but Codex uses
-        // context_window 272K). Source: openai/codex models-manager/models.json.
-        272_000
+      match self {
+        Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna => 372_000,
+        Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => 272_000,
+      }
     }
 
     fn max_output_tokens(&self) -> Option<u64> {
@@ -356,18 +364,29 @@ impl ChatGptModel {
     }
 
     fn default_reasoning_effort(&self) -> Option<ReasoningEffort> {
-        // Codex bundled models all default to Medium reasoning effort.
-        Some(ReasoningEffort::Medium)
+        match self {
+            Self::Gpt56Sol  => Some(ReasoningEffort::Low),
+            Self::Gpt56Terra | Self::Gpt56Luna | Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => Some(ReasoningEffort::Medium),
+        }
     }
 
     fn supported_reasoning_efforts(&self) -> &'static [ReasoningEffort] {
-        // The Codex backend's supported_reasoning_levels for every model in this list is low/medium/high/xhigh
-        &[
-            ReasoningEffort::Low,
-            ReasoningEffort::Medium,
-            ReasoningEffort::High,
-            ReasoningEffort::XHigh,
-        ]
+      match self {
+          Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna  => &[
+              ReasoningEffort::Low,
+              ReasoningEffort::Medium,
+              ReasoningEffort::High,
+              ReasoningEffort::XHigh,
+              ReasoningEffort::Max,
+          ],
+          Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => &[
+              ReasoningEffort::Low,
+              ReasoningEffort::Medium,
+              ReasoningEffort::High,
+              ReasoningEffort::XHigh,
+          ],
+      }
+
     }
 
     fn supports_parallel_tool_calls(&self) -> bool {
@@ -380,7 +399,7 @@ impl ChatGptModel {
 
     fn supports_priority(&self) -> bool {
         match self {
-            Self::Gpt55 | Self::Gpt54 => true,
+            Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna | Self::Gpt55 | Self::Gpt54 => true,
             Self::Gpt54Mini => false,
         }
     }

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -190,7 +190,7 @@ impl LanguageModelProvider for OpenAiSubscribedProvider {
     }
 
     fn default_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
-        Some(self.create_language_model(ChatGptModel::Gpt55))
+        Some(self.create_language_model(ChatGptModel::Gpt56Sol))
     }
 
     fn default_fast_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
@@ -321,7 +321,14 @@ enum ChatGptModel {
 
 impl ChatGptModel {
     fn all() -> Vec<Self> {
-        vec![Self::Gpt56Sol, Self::Gpt56Terra, Self::Gpt56Luna, Self::Gpt55, Self::Gpt54, Self::Gpt54Mini]
+        vec![
+            Self::Gpt56Sol,
+            Self::Gpt56Terra,
+            Self::Gpt56Luna,
+            Self::Gpt55,
+            Self::Gpt54,
+            Self::Gpt54Mini,
+        ]
     }
 
     fn id(&self) -> &str {
@@ -338,7 +345,7 @@ impl ChatGptModel {
     fn display_name(&self) -> &str {
         match self {
             Self::Gpt56Sol => "GPT-5.6 Sol",
-            Self::Gpt56Terra => "gGPT-5.6 Terra",
+            Self::Gpt56Terra => "GPT-5.6 Terra",
             Self::Gpt56Luna => "GPT-5.6 Luna",
             Self::Gpt55 => "GPT-5.5",
             Self::Gpt54 => "GPT-5.4",
@@ -347,10 +354,10 @@ impl ChatGptModel {
     }
 
     fn max_token_count(&self) -> u64 {
-      match self {
-        Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna => 372_000,
-        Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => 272_000,
-      }
+        match self {
+            Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna => 372_000,
+            Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => 272_000,
+        }
     }
 
     fn max_output_tokens(&self) -> Option<u64> {
@@ -365,28 +372,29 @@ impl ChatGptModel {
 
     fn default_reasoning_effort(&self) -> Option<ReasoningEffort> {
         match self {
-            Self::Gpt56Sol  => Some(ReasoningEffort::Low),
-            Self::Gpt56Terra | Self::Gpt56Luna | Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => Some(ReasoningEffort::Medium),
+            Self::Gpt56Sol => Some(ReasoningEffort::Low),
+            Self::Gpt56Terra | Self::Gpt56Luna | Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => {
+                Some(ReasoningEffort::Medium)
+            }
         }
     }
 
     fn supported_reasoning_efforts(&self) -> &'static [ReasoningEffort] {
-      match self {
-          Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna  => &[
-              ReasoningEffort::Low,
-              ReasoningEffort::Medium,
-              ReasoningEffort::High,
-              ReasoningEffort::XHigh,
-              ReasoningEffort::Max,
-          ],
-          Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => &[
-              ReasoningEffort::Low,
-              ReasoningEffort::Medium,
-              ReasoningEffort::High,
-              ReasoningEffort::XHigh,
-          ],
-      }
-
+        match self {
+            Self::Gpt56Sol | Self::Gpt56Terra | Self::Gpt56Luna => &[
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::XHigh,
+                ReasoningEffort::Max,
+            ],
+            Self::Gpt55 | Self::Gpt54 | Self::Gpt54Mini => &[
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::XHigh,
+            ],
+        }
     }
 
     fn supports_parallel_tool_calls(&self) -> bool {
@@ -468,7 +476,7 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
                     ReasoningEffort::Medium => ("Medium", "medium"),
                     ReasoningEffort::High => ("High", "high"),
                     ReasoningEffort::XHigh => ("Extra High", "xhigh"),
-                    ReasoningEffort::Max => return None, // Not supported by any OpenAI models
+                    ReasoningEffort::Max => ("Max", "max"),
                 };
 
                 Some(LanguageModelEffortLevel {

--- a/crates/language_models/src/provider/openai_subscribed.rs
+++ b/crates/language_models/src/provider/openai_subscribed.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context as _, Result, anyhow};
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use collections::HashMap;
 use credentials_provider::CredentialsProvider;
 use futures::{FutureExt, StreamExt, future::BoxFuture, future::Shared};
 use gpui::{App, AsyncApp, Context, Entity, SharedString, Task, Window};
@@ -24,6 +25,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use ui::{ConfiguredApiCard, prelude::*};
 use url::form_urlencoded;
 use util::ResultExt as _;
+use uuid::Uuid;
 
 use crate::provider::open_ai::{OpenAiResponseEventMapper, into_open_ai_response};
 
@@ -35,6 +37,7 @@ const SUBSCRIPTION_DESCRIPTION: &str =
     "Sign in with your ChatGPT Plus or Pro subscription to use OpenAI models in Zed's agent.";
 
 const CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+const CODEX_COMPATIBILITY_VERSION: &str = "0.144.0";
 const OPENAI_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
 const OPENAI_AUTHORIZE_URL: &str = "https://auth.openai.com/oauth/authorize";
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -63,6 +66,7 @@ pub struct State {
     sign_in_task: Option<Task<Result<()>>>,
     refresh_task: Option<Shared<Task<Result<CodexCredentials, Arc<anyhow::Error>>>>>,
     load_task: Option<Shared<Task<Result<(), Arc<anyhow::Error>>>>>,
+    codex_session_ids: HashMap<String, String>,
     credentials_provider: Arc<dyn CredentialsProvider>,
     auth_generation: u64,
     last_auth_error: Option<SharedString>,
@@ -113,6 +117,7 @@ impl OpenAiSubscribedProvider {
             sign_in_task: None,
             refresh_task: None,
             load_task: None,
+            codex_session_ids: HashMap::default(),
             credentials_provider,
             auth_generation: 0,
             last_auth_error: None,
@@ -516,6 +521,8 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
             request.speed = None;
         }
 
+        let thread_id = request.thread_id.clone();
+
         // The Codex backend rejects `max_output_tokens` (`Unsupported parameter`),
         // unlike the public OpenAI Responses API. Pass `None` so the field is
         // omitted from the serialized request body entirely.
@@ -556,6 +563,22 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
 
         let future = cx.spawn(async move |cx| {
             let creds = get_fresh_credentials(&state, &http_client, cx).await?;
+            let codex_session_id = if let Some(thread_id) = thread_id
+                .as_deref()
+                .filter(|thread_id| !thread_id.is_empty())
+            {
+                state
+                    .update(cx, |state, _| {
+                        state
+                            .codex_session_ids
+                            .entry(thread_id.to_string())
+                            .or_insert_with(|| Uuid::now_v7().to_string())
+                            .clone()
+                    })
+                    .map_err(LanguageModelCompletionError::Other)?
+            } else {
+                Uuid::now_v7().to_string()
+            };
 
             let mut header_pairs: Vec<(HeaderName, HeaderValue)> = vec![
                 (
@@ -566,7 +589,14 @@ impl LanguageModel for OpenAiSubscribedLanguageModel {
                     HeaderName::from_static("openai-beta"),
                     HeaderValue::from_static("responses=experimental"),
                 ),
+                (
+                    HeaderName::from_static("version"),
+                    HeaderValue::from_static(CODEX_COMPATIBILITY_VERSION),
+                ),
             ];
+            if let Ok(value) = HeaderValue::from_str(&codex_session_id) {
+                header_pairs.push((HeaderName::from_static("session-id"), value));
+            }
             if let Some(ref id) = creds.account_id {
                 if !id.is_empty() {
                     if let Ok(value) = HeaderValue::from_str(id) {
@@ -689,6 +719,7 @@ async fn get_fresh_credentials(
                     let _ = state_clone.update(cx, |s, cx| {
                         s.refresh_task = None;
                         s.credentials = None;
+                        s.codex_session_ids.clear();
                         s.last_auth_error =
                             Some("Your session has expired. Please sign in again.".into());
                         cx.notify();
@@ -1067,6 +1098,7 @@ fn do_sign_out(state: &gpui::WeakEntity<State>, cx: &mut App) -> Task<Result<()>
             s.credentials = None;
             s.sign_in_task = None;
             s.refresh_task = None;
+            s.codex_session_ids.clear();
             s.last_auth_error = None;
             cx.notify();
         })
@@ -1262,6 +1294,7 @@ mod tests {
             sign_in_task: None,
             refresh_task: None,
             load_task: None,
+            codex_session_ids: HashMap::default(),
             credentials_provider: Arc::new(FakeCredentialsProvider::new()),
             auth_generation: 0,
             last_auth_error: None,
@@ -1318,6 +1351,7 @@ mod tests {
             sign_in_task: None,
             refresh_task: None,
             load_task: None,
+            codex_session_ids: HashMap::default(),
             credentials_provider: Arc::new(FakeCredentialsProvider::new()),
             auth_generation: 0,
             last_auth_error: None,
@@ -1354,6 +1388,7 @@ mod tests {
             sign_in_task: None,
             refresh_task: None,
             load_task: None,
+            codex_session_ids: HashMap::default(),
             credentials_provider: Arc::new(FakeCredentialsProvider::new()),
             auth_generation: 0,
             last_auth_error: None,
@@ -1388,6 +1423,7 @@ mod tests {
             sign_in_task: None,
             refresh_task: None,
             load_task: None,
+            codex_session_ids: HashMap::default(),
             credentials_provider: creds_provider.clone(),
             auth_generation: 0,
             last_auth_error: None,
@@ -1431,6 +1467,7 @@ mod tests {
             sign_in_task: None,
             refresh_task: None,
             load_task: None,
+            codex_session_ids: HashMap::default(),
             credentials_provider: Arc::new(FakeCredentialsProvider::new()),
             auth_generation: 0,
             last_auth_error: None,
@@ -1488,6 +1525,7 @@ mod tests {
             sign_in_task: None,
             refresh_task: None,
             load_task: None,
+            codex_session_ids: HashMap::default(),
             credentials_provider: creds_provider.clone(),
             auth_generation: 0,
             last_auth_error: None,
@@ -1540,6 +1578,7 @@ mod tests {
             sign_in_task: None,
             refresh_task: None,
             load_task: None,
+            codex_session_ids: HashMap::default(),
             credentials_provider: creds_provider.clone(),
             auth_generation: 0,
             last_auth_error: None,


### PR DESCRIPTION
Adds GPT-5.6 to openai_subscribed, based on model info from https://github.com/openai/codex/blob/dc23c7bcc8fd543fe727c7b4447a3d785836932f/codex-rs/models-manager/models.json

Sol and Terra worked for me without needing any adaptions in api shape, however for Luna to work, it required the version (satisfying the codex minimum version requirement from models.json) and session-id to be sent as headers. These works with all the models in the catalog, so its applied across all of them, than specifically on Luna

Fixes #60726

Release Notes:

- agent: Added GPT 5.6 support for ChatGPT subscription (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`)