### PR TITLE
agent_ui: Remove duplicate MCP Servers menu item

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -5716,24 +5716,6 @@ impl AgentPanel {
 
                             menu = menu
                                 .separator()
-                                .header("MCP Servers")
-                                .action(
-                                    "Add Server…",
-                                    Box::new(zed_actions::OpenSettingsAt {
-                                        path: "context_servers".to_string(),
-                                        target: None,
-                                    }),
-                                )
-                                .action(
-                                    "Install New Servers…",
-                                    Box::new(zed_actions::Extensions {
-                                        category_filter: Some(
-                                            zed_actions::ExtensionCategoryFilter::ContextServers,
-                                        ),
-                                        id: None,
-                                    }),
-                                )
-                                .separator()
                                 .action("Profiles", Box::new(ManageProfiles::default()));
                         }
 


### PR DESCRIPTION
# Objective

Fixes https://github.com/zed-industries/zed/issues/60709 by removing the duplicate menu section for "MCP Servers".

## Solution

Update `agent_ui::agent_panel::AgentPanel::render_panel_options_menu` to ensure the "MCP Servers" section is only rendered once, if not using a Terminal Thread.

## Testing

Tested manually, comparing against the stable release, as this bug is present in Preview. Screenshot is shown in the "Showcase" section.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Before</summary>
  <img width="2736" height="1586" alt="CleanShot 2026-07-09 at 23 14 34@2x" src="https://github.com/user-attachments/assets/ce2014db-bd72-46fb-bfa1-247cd5471daf" />

</details>

<details>
  <summary>After</summary>
  <img width="2736" height="1586" alt="CleanShot 2026-07-09 at 23 15 13@2x" src="https://github.com/user-attachments/assets/bbba9965-3f6a-4137-94e5-17704efd2cce" />

</details>


---

Release Notes:

- N/A
