### PR TITLE
project_panel: Add collapse-all button

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -6832,6 +6832,7 @@ impl Render for ProjectPanel {
         let has_worktree = !self.state.visible_entries.is_empty();
         let project = self.project.read(cx);
         let panel_settings = ProjectPanelSettings::get_global(cx);
+        let focus_handle = self.focus_handle(cx);
         let indent_size = panel_settings.indent_size;
         let show_indent_guides = panel_settings.indent_guides.show == ShowIndentGuides::Always;
         let horizontal_scroll = panel_settings.scrollbar.horizontal_scroll;
@@ -7012,6 +7013,31 @@ impl Render for ProjectPanel {
                 .track_focus(&self.focus_handle(cx))
                 .child(
                     v_flex()
+                        .child(
+                            h_flex()
+                                .h_8()
+                                .px_2()
+                                .justify_end()
+                                .border_b_1()
+                                .border_color(cx.theme().colors().border_variant)
+                                .bg(cx.theme().colors().toolbar_background)
+                                .child(
+                                    IconButton::new(
+                                        "collapse-all-project-entries",
+                                        IconName::ChevronDownUp,
+                                    )
+                                    .icon_size(IconSize::Small)
+                                    .disabled(!has_worktree)
+                                    .tooltip(Tooltip::for_action_title_in(
+                                        "Collapse All",
+                                        &CollapseAllEntries,
+                                        &focus_handle,
+                                    ))
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.collapse_all_entries(&CollapseAllEntries, window, cx);
+                                    })),
+                                ),
+                        )
                         .child(
                             uniform_list("entries", item_count, {
                                 cx.processor(|this, range: Range<usize>, window, cx| {


### PR DESCRIPTION
# Objective
- Add a quicker way to collapse expanded folders from the Project Panel UI.
- This PR does not fix a tracked issue.
## Solution
- Add a small collapse-all button at the top of the Project Panel.
- Reuse the existing `project_panel::CollapseAllEntries` action and `collapse_all_entries` behavior instead of introducing new collapse logic.
- Keep the change scoped to a minimal UI affordance in `project_panel` only.
## Testing
- Tested with:
  - `cargo test -p project_panel --lib test_collapse_all_entries`
  - `cargo check -p project_panel`
- The existing targeted tests cover the collapse-all behavior that the new button invokes.
- Additional manual testing is still useful for visual polish and narrow panel layouts.
- Reviewers can test by:
  - opening the Project Panel
  - expanding a few nested folders
  - clicking the new collapse button
  - verifying the panel returns to the same collapsed state as the existing `CollapseAllEntries` action
- Tested on:
  - macOS
- Not tested on:
  - Linux
  - Windows
## Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable
## Showcase
- Added a collapse-all button to the top-right area of the Project Panel for quicker access to the existing collapse-all behavior.
- A screenshot or short recording should be added before merge if reviewers want visual confirmation.

### Demo
Note that the recording software moves the mouse cursor away
<img width="1280" height="720" alt="zed_collapse_final" src="https://github.com/user-attachments/assets/64e4c3f4-64c8-4cce-8485-2c02f14b2ab4" />
