### PR TITLE
gpui: Add CSS auto grid tracks for table-like column sizing

### DIFF
--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -1582,6 +1582,56 @@ mod content_sizing_tests {
     }
 
     #[gpui::test]
+    fn grid_auto_columns_size_like_a_table(cx: &mut TestAppContext) {
+        let cx = harness(cx);
+
+        // A two-column auto grid behaves like `table-layout: auto`: the
+        // short column hugs its content instead of taking an equal share,
+        // and the long column absorbs the remaining space and wraps.
+        draw_fixture(
+            cx,
+            div()
+                .grid()
+                .grid_cols_auto(2)
+                .w(px(300.))
+                .child(div().debug_selector(|| "LABEL".into()).child("label:"))
+                .child(div().debug_selector(|| "PROSE".into()).child(LONG_TEXT))
+                .into_any_element(),
+        );
+
+        let label_bounds = cx.debug_bounds("LABEL").unwrap();
+        let prose_bounds = cx.debug_bounds("PROSE").unwrap();
+
+        assert!(
+            label_bounds.size.width < px(100.),
+            "the short column should hug its content rather than split the \
+             grid evenly (got {:?})",
+            label_bounds.size.width
+        );
+        assert!(
+            label_bounds.size.width > px(10.),
+            "the short column should still fit its content (got {:?})",
+            label_bounds.size.width
+        );
+        assert!(
+            label_bounds.size.width + prose_bounds.size.width <= px(300.5),
+            "auto columns should not overflow the grid \
+             (label {:?} + prose {:?})",
+            label_bounds.size.width,
+            prose_bounds.size.width
+        );
+        assert!(
+            prose_bounds.size.height >= LINE_HEIGHT * 2.,
+            "the long column should wrap its text (got {:?})",
+            prose_bounds.size.height
+        );
+        assert!(
+            label_bounds.size.height <= prose_bounds.size.height,
+            "the label's row participation should not exceed the prose cell"
+        );
+    }
+
+    #[gpui::test]
     fn truncated_text_stays_on_a_single_line(cx: &mut TestAppContext) {
         let cx = harness(cx);
 

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -150,6 +150,11 @@ pub enum TemplateColumnMinSize {
     MinContent,
     /// The column size can be determined by the max content
     MaxContent,
+    /// The track sizes to its content: at least its min-content size, at
+    /// most its max-content size (CSS `auto`). Columns hug their content
+    /// when space allows and shrink no further than their widest unbreakable
+    /// word when it doesn't — the sizing behavior of `table-layout: auto`.
+    Auto,
 }
 
 /// A simplified representation of the grid-template-* value

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -776,11 +776,34 @@ pub trait Styled: Sized {
         self
     }
 
+    /// Sets the grid columns to CSS `auto` tracks, which size to their
+    /// content: each column is at least as wide as its widest unbreakable
+    /// word and at most as wide as its unwrapped content, with free space
+    /// distributed among columns that can still grow. This is the column
+    /// sizing behavior of `table-layout: auto`.
+    fn grid_cols_auto(mut self, cols: u16) -> Self {
+        self.style().grid_cols = Some(GridTemplate {
+            repeat: cols,
+            min_size: TemplateColumnMinSize::Auto,
+        });
+        self
+    }
+
     /// Sets the grid rows of this element.
     fn grid_rows(mut self, rows: u16) -> Self {
         self.style().grid_rows = Some(GridTemplate {
             repeat: rows,
             min_size: TemplateColumnMinSize::Zero,
+        });
+        self
+    }
+
+    /// Sets the grid rows to CSS `auto` tracks, which size to their content.
+    /// See [`Styled::grid_cols_auto`].
+    fn grid_rows_auto(mut self, rows: u16) -> Self {
+        self.style().grid_rows = Some(GridTemplate {
+            repeat: rows,
+            min_size: TemplateColumnMinSize::Auto,
         });
         self
     }

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -480,6 +480,10 @@ impl ToTaffy<taffy::style::Style> for Style {
                             vec![minmax(length(0.0_f32), max_content())],
                         )]
                     }
+                    // grid-template-*: repeat(<number>, auto)
+                    crate::TemplateColumnMinSize::Auto => {
+                        vec![repeat(template.repeat, vec![taffy::style_helpers::auto()])]
+                    }
                 }
             })
             .unwrap_or_default()


### PR DESCRIPTION
Adds `grid_cols_auto`/`grid_rows_auto`, mapping to `grid-template-*: repeat(n, auto)`. With text elements now reporting honest min-content sizes (#60722), auto tracks reproduce the column sizing of `table-layout: auto`: each column is at least as wide as its widest unbreakable word, at most as wide as its unwrapped content, and free space goes to columns that can still grow. Short columns hug their content instead of taking an equal `fr` share, and long columns wrap without overflowing the grid.

This is the building block for automatically sized tables — e.g. markdown tables, currently rendered with equal-width `1fr` columns, can switch to `grid_cols_auto` as a follow-up.

Stacked on #60722 (which is stacked on #60721).

Release Notes:

- N/A