### PR TITLE
Fix buffer search in single-file git diff view

### DIFF
--- a/crates/git_ui/src/solo_diff_view.rs
+++ b/crates/git_ui/src/solo_diff_view.rs
@@ -430,14 +430,14 @@ impl Item for SoloDiffView {
         if type_id == TypeId::of::<Self>() {
             Some(self_handle.clone().into())
         } else if type_id == TypeId::of::<SplittableEditor>() {
-            None
+            Some(self.editor.clone().into())
         } else {
             self.editor.act_as_type(type_id, cx)
         }
     }
 
     fn as_searchable(&self, _: &Entity<Self>, _: &App) -> Option<Box<dyn SearchableItemHandle>> {
-        None
+        Some(Box::new(self.editor.clone()))
     }
 
     fn for_each_project_item(


### PR DESCRIPTION
Buffer search (Cmd+F) did nothing in the single-file git diff view (`SoloDiffView`) — the search bar never appeared. `SoloDiffView` returned `None` from `as_searchable` and from `act_as_type` for `SplittableEditor`, so the toolbar never picked up a searchable item. This was a regression from #59958. This forwards both methods to the underlying editor, matching every other diff view (`ProjectDiff`, `CommitView`, `FileDiffView`, `TextDiffView`).

Release Notes:

- Fixed buffer search (Cmd+F) not working in the single-file git diff view