### PR TITLE
Add TrimTrailingWhitespace editor action

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -944,6 +944,8 @@ actions!(
         WrapSelectionsInTag,
         /// Aligns selections from different rows into the same column
         AlignSelections,
+        /// Trims trailing whitespace from each line in the buffer.
+        TrimTrailingWhitespace,
         /// Saves the current location to navigation history.
         SaveLocation,
         /// Toggles breadcrumbs display.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8731,6 +8731,46 @@ impl Editor {
         });
     }
 
+    pub fn trim_trailing_whitespace(
+        &mut self,
+        _: &TrimTrailingWhitespace,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.read_only(cx) {
+            return;
+        }
+
+        let buffers: Vec<_> = self.buffer.read(cx).all_buffers_iter().collect();
+        let diff_tasks: Vec<_> = buffers
+            .iter()
+            .map(|buffer| {
+                buffer.read_with(cx, |buffer, cx| buffer.remove_trailing_whitespace(None, cx))
+            })
+            .collect();
+
+        cx.spawn_in(window, async move |editor, cx| {
+            let mut diffs = Vec::with_capacity(buffers.len());
+            for (buffer, diff_task) in buffers.iter().zip(diff_tasks.into_iter()) {
+                let diff = diff_task.await;
+                diffs.push((buffer.clone(), diff));
+            }
+
+            editor
+                .update_in(cx, |editor, window, cx| {
+                    editor.transact(window, cx, |_, _, cx| {
+                        for (buffer, diff) in &diffs {
+                            buffer.update(cx, |buffer, cx| {
+                                buffer.apply_diff(diff.clone(), cx);
+                            });
+                        }
+                    });
+                })
+                .ok();
+        })
+        .detach();
+    }
+
     pub fn open_selections_in_multibuffer(
         &mut self,
         _: &OpenSelectionsInMultibuffer,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -40715,3 +40715,45 @@ async fn test_select_delimiters_expansion(cx: &mut TestAppContext) {
     cx.dispatch_action(SelectInsideDelimiters);
     cx.assert_editor_state("foo(«x, { a: 1 }ˇ»);");
 }
+
+#[gpui::test]
+async fn test_trim_trailing_whitespace(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("hello   ˇ\nworld  \n  foo \nbar");
+    cx.update_editor(|e, window, cx| {
+        e.trim_trailing_whitespace(&TrimTrailingWhitespace, window, cx)
+    });
+    cx.run_until_parked();
+    assert_eq!(cx.buffer_text(), "hello\nworld\n  foo\nbar");
+}
+
+#[gpui::test]
+async fn test_trim_trailing_whitespace_noop(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    let text = "hello\nworld\n  foo\nbar";
+    cx.set_state("helloˇ\nworld\n  foo\nbar");
+    cx.update_editor(|e, window, cx| {
+        e.trim_trailing_whitespace(&TrimTrailingWhitespace, window, cx)
+    });
+    cx.run_until_parked();
+    assert_eq!(cx.buffer_text(), text);
+}
+
+#[gpui::test]
+async fn test_trim_trailing_whitespace_read_only(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    let text = "hello   \nworld  \n";
+    cx.set_state("hello   ˇ\nworld  \n");
+    cx.update_editor(|e, _window, cx| e.set_read_only(true));
+    cx.update_editor(|e, window, cx| {
+        e.trim_trailing_whitespace(&TrimTrailingWhitespace, window, cx)
+    });
+    cx.run_until_parked();
+    assert_eq!(cx.buffer_text(), text);
+}

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -627,6 +627,7 @@ impl EditorElement {
             register_action(editor, window, Editor::insert_uuid_v4);
             register_action(editor, window, Editor::insert_uuid_v7);
             register_action(editor, window, Editor::align_selections);
+            register_action(editor, window, Editor::trim_trailing_whitespace);
             if editor.read(cx).enable_wrap_selections_in_tag(cx) {
                 register_action(editor, window, Editor::wrap_selections_in_tag);
             }


### PR DESCRIPTION
## Summary

- Adds a new `editor::TrimTrailingWhitespace` action that trims trailing whitespace from every line in the active buffer
- Accessible via the command palette (`Ctrl+Shift+P` → "trim trailing whitespace") and bindable to a custom keybinding
- Reuses the existing `Buffer::remove_trailing_whitespace` + `Buffer::apply_diff` pipeline, so the core logic and three-way merge for concurrent edits are shared with the `remove_trailing_whitespace_on_save` setting
- A `read_only` guard ensures the action is a no-op in non-editable contexts (diff views, merge editors, read-only files, remote collaboration buffers)

## Background

Zed already had the setting `remove_trailing_whitespace_on_save` that automatically trims trailing whitespace on save, but there was no manually triggerable action. Users coming from VS Code (`editor.action.trimTrailingWhitespace`), Sublime Text (`trim_trailing_white_space`), and Vim (`:%s/\s\+$//e`) have repeatedly requested this feature, as they prefer on-demand trimming over automatic save-time trimming.

## Test plan

- [x] `test_trim_trailing_whitespace` — verifies trailing whitespace is removed from all lines while leading indentation is preserved
- [x] `test_trim_trailing_whitespace_noop` — verifies the action is a no-op when there is no trailing whitespace
- [x] `test_trim_trailing_whitespace_read_only` — verifies the action does nothing when the editor is read-only
- [x] Manual: open the command palette, search "trim trailing whitespace", and confirm the action appears and works
- [x] Manual: bind the action to a keybinding and confirm it works via the shortcut
- [x] Manual: open a diff/merge editor and confirm the action does not modify content

Closes #4528
Relates to #44188

Release Notes:

- Added `editor::TrimTrailingWhitespace` action, manually trims trailing whitespace from all lines in the buffer via the command palette or a custom keybinding.


<img width="1369" height="619" alt="image" src="https://github.com/user-attachments/assets/6dad4474-e517-4a21-bf32-bfc84ee952d4" />
