### PR TITLE
acp: Enable ACP elicitations

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -430,16 +430,7 @@ impl ElicitationStore {
         &self.elicitations
     }
 
-    fn validate_request(
-        request: &acp::CreateElicitationRequest,
-        cx: &App,
-    ) -> Result<(), acp::Error> {
-        if !cx.has_flag::<AcpBetaFeatureFlag>() {
-            return Err(
-                acp::Error::invalid_params().data("elicitation support requires the ACP beta flag")
-            );
-        }
-
+    fn validate_request(request: &acp::CreateElicitationRequest) -> Result<(), acp::Error> {
         if let acp::ElicitationMode::Url(mode) = &request.mode {
             url::Url::parse(&mode.url)
                 .map_err(|_| acp::Error::invalid_params().data("invalid elicitation URL"))?;
@@ -590,7 +581,7 @@ impl ElicitationStore {
         request: acp::CreateElicitationRequest,
         cx: &mut Context<Self>,
     ) -> Result<(ElicitationEntryId, Task<acp::CreateElicitationResponse>), acp::Error> {
-        Self::validate_request(&request, cx)?;
+        Self::validate_request(&request)?;
         let (id, response_rx) = self.insert_pending_elicitation(request);
         cx.emit(ElicitationStoreEvent::ElicitationRequested(id.clone()));
         cx.notify();
@@ -3485,7 +3476,7 @@ impl AcpThread {
         request: acp::CreateElicitationRequest,
         cx: &mut Context<Self>,
     ) -> Result<(ElicitationEntryId, Task<acp::CreateElicitationResponse>), acp::Error> {
-        ElicitationStore::validate_request(&request, cx)?;
+        ElicitationStore::validate_request(&request)?;
 
         let (id, response_rx) = self.elicitations.insert_pending_elicitation(request);
         self.push_entry(AgentThreadEntry::Elicitation(id.clone()), cx);
@@ -7416,7 +7407,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_elicitation_requires_acp_beta_flag(cx: &mut TestAppContext) {
+    async fn test_elicitation_is_available_without_acp_beta_flag(cx: &mut TestAppContext) {
         init_test(cx);
         cx.update(|cx| {
             cx.update_flags(false, vec![]);
@@ -7438,8 +7429,13 @@ mod tests {
             )
         });
 
-        assert!(result.is_err());
-        thread.read_with(cx, |thread, _| assert!(thread.entries().is_empty()));
+        assert!(result.is_ok());
+        thread.read_with(cx, |thread, _| {
+            assert!(matches!(
+                thread.entries(),
+                [AgentThreadEntry::Elicitation(_)]
+            ));
+        });
     }
 
     #[gpui::test]

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -753,10 +753,7 @@ fn connect_client_future(
         )
 }
 
-fn client_capabilities_for_agent(
-    agent_id: &AgentId,
-    supports_beta_features: bool,
-) -> acp::ClientCapabilities {
+fn client_capabilities_for_agent(agent_id: &AgentId) -> acp::ClientCapabilities {
     let mut meta = acp::Meta::from_iter([
         ("terminal_output".into(), true.into()),
         ("terminal-auth".into(), true.into()),
@@ -766,7 +763,7 @@ fn client_capabilities_for_agent(
         meta.insert(PARAMETERIZED_MODEL_PICKER_META_KEY.into(), true.into());
     }
 
-    let mut capabilities = acp::ClientCapabilities::new()
+    acp::ClientCapabilities::new()
         .fs(acp::FileSystemCapabilities::new()
             .read_text_file(true)
             .write_text_file(true))
@@ -778,17 +775,12 @@ fn client_capabilities_for_agent(
                     .boolean(acp::BooleanConfigOptionCapabilities::new()),
             ),
         )
-        .meta(meta);
-
-    if supports_beta_features {
-        capabilities = capabilities.elicitation(
+        .elicitation(
             acp::ElicitationCapabilities::new()
                 .form(acp::ElicitationFormCapabilities::new())
                 .url(acp::ElicitationUrlCapabilities::new()),
-        );
-    }
-
-    capabilities
+        )
+        .meta(meta)
 }
 
 impl AcpConnection {
@@ -980,10 +972,7 @@ impl AcpConnection {
         let initialize_response = connection
             .send_request(
                 acp::InitializeRequest::new(ProtocolVersion::V1)
-                    .client_capabilities(client_capabilities_for_agent(
-                        &agent_id,
-                        cx.update(|cx| cx.has_flag::<AcpBetaFeatureFlag>()),
-                    ))
+                    .client_capabilities(client_capabilities_for_agent(&agent_id))
                     .client_info(
                         acp::Implementation::new("zed", version)
                             .title(release_channel.map(ToOwned::to_owned)),
@@ -2698,7 +2687,6 @@ mod tests {
 
     use super::*;
     use feature_flags::FeatureFlag as _;
-    use gpui::UpdateGlobal as _;
     use settings::Settings as _;
 
     fn init_feature_flags_test(cx: &mut gpui::TestAppContext) {
@@ -2710,50 +2698,15 @@ mod tests {
         });
     }
 
-    fn set_acp_beta_override(value: &str, cx: &mut gpui::TestAppContext) {
-        cx.update(|cx| {
-            SettingsStore::update_global(cx, |store, cx| {
-                store.update_user_settings(cx, |content| {
-                    content
-                        .feature_flags
-                        .get_or_insert_default()
-                        .insert(AcpBetaFeatureFlag::NAME.to_string(), value.to_string());
-                });
-            });
-        });
-    }
-
     #[gpui::test]
-    async fn client_capabilities_omit_elicitation_without_acp_beta(cx: &mut gpui::TestAppContext) {
+    async fn client_capabilities_include_elicitation_without_acp_beta(
+        cx: &mut gpui::TestAppContext,
+    ) {
         init_feature_flags_test(cx);
-        set_acp_beta_override("off", cx);
-
-        let capabilities = cx.update(|cx| {
-            client_capabilities_for_agent(
-                &AgentId::new("codex-acp"),
-                cx.has_flag::<AcpBetaFeatureFlag>(),
-            )
-        });
-
-        assert!(capabilities.elicitation.is_none());
-    }
-
-    #[gpui::test]
-    async fn client_capabilities_include_elicitation_with_acp_beta(cx: &mut gpui::TestAppContext) {
-        init_feature_flags_test(cx);
-        cx.update(|cx| {
-            cx.update_flags(false, vec![AcpBetaFeatureFlag::NAME.to_string()]);
-        });
-
-        let capabilities = cx.update(|cx| {
-            client_capabilities_for_agent(
-                &AgentId::new("codex-acp"),
-                cx.has_flag::<AcpBetaFeatureFlag>(),
-            )
-        });
+        let capabilities = client_capabilities_for_agent(&AgentId::new("codex-acp"));
         let elicitation = capabilities
             .elicitation
-            .expect("elicitation should be advertised when acp-beta is enabled");
+            .expect("elicitation should always be advertised");
 
         assert!(elicitation.form.is_some());
         assert!(elicitation.url.is_some());
@@ -3016,7 +2969,7 @@ mod tests {
 
     #[test]
     fn cursor_client_capabilities_include_parameterized_model_picker_meta() {
-        let capabilities = client_capabilities_for_agent(&AgentId::new(CURSOR_ID), false);
+        let capabilities = client_capabilities_for_agent(&AgentId::new(CURSOR_ID));
         let meta = capabilities
             .meta
             .expect("expected client capabilities meta");
@@ -3031,7 +2984,7 @@ mod tests {
 
     #[test]
     fn non_cursor_client_capabilities_do_not_include_parameterized_model_picker_meta() {
-        let capabilities = client_capabilities_for_agent(&AgentId::new("codex-acp"), false);
+        let capabilities = client_capabilities_for_agent(&AgentId::new("codex-acp"));
         let meta = capabilities
             .meta
             .expect("expected client capabilities meta");
@@ -3041,7 +2994,7 @@ mod tests {
 
     #[test]
     fn client_capabilities_include_boolean_config_options() {
-        let capabilities = client_capabilities_for_agent(&AgentId::new("codex-acp"), false);
+        let capabilities = client_capabilities_for_agent(&AgentId::new("codex-acp"));
 
         assert!(
             capabilities
@@ -4566,13 +4519,6 @@ fn handle_create_elicitation(
     cx: &mut AsyncApp,
     ctx: &ClientContext,
 ) {
-    if !cx.update(|cx| cx.has_flag::<AcpBetaFeatureFlag>()) {
-        return respond_err(
-            responder,
-            acp::Error::invalid_params().data("elicitation support requires the ACP beta flag"),
-        );
-    }
-
     match args.scope() {
         acp::ElicitationScope::Session(scope) => {
             let thread = match session_thread(ctx, &scope.session_id) {
@@ -4661,10 +4607,6 @@ fn handle_complete_elicitation(
     cx: &mut AsyncApp,
     ctx: &ClientContext,
 ) {
-    if !cx.update(|cx| cx.has_flag::<AcpBetaFeatureFlag>()) {
-        return;
-    }
-
     let threads = ctx
         .sessions
         .borrow()

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -23,7 +23,6 @@ use editor::scroll::Autoscroll;
 use editor::{
     Editor, EditorEvent, EditorMode, MultiBuffer, PathKey, SelectionEffects, SizingBehavior,
 };
-use feature_flags::{AcpBetaFeatureFlag, FeatureFlagAppExt as _};
 use file_icons::FileIcons;
 use fs::Fs;
 use futures::FutureExt as _;
@@ -277,7 +276,7 @@ impl Conversation {
         let session_id = thread.read(cx).session_id().clone();
         let subscription = cx.subscribe(&thread, {
             let session_id = session_id.clone();
-            move |this, _thread, event, cx| {
+            move |this, _thread, event, _cx| {
                 this.updated_at = Some(Instant::now());
                 match event {
                     AcpThreadEvent::ToolAuthorizationRequested(id) => {
@@ -294,15 +293,12 @@ impl Conversation {
                             }
                         }
                     }
-                    AcpThreadEvent::ElicitationRequested(id)
-                        if cx.has_flag::<AcpBetaFeatureFlag>() =>
-                    {
+                    AcpThreadEvent::ElicitationRequested(id) => {
                         this.elicitation_requests
                             .entry(session_id.clone())
                             .or_default()
                             .push(id.clone());
                     }
-                    AcpThreadEvent::ElicitationRequested(_) => {}
                     AcpThreadEvent::ElicitationResponded(id) => {
                         if let Some(elicitations) = this.elicitation_requests.get_mut(&session_id) {
                             elicitations.retain(|elicitation_id| elicitation_id != id);
@@ -422,10 +418,6 @@ impl Conversation {
         response: acp::CreateElicitationResponse,
         cx: &mut Context<Self>,
     ) -> Option<()> {
-        if !cx.has_flag::<AcpBetaFeatureFlag>() {
-            return None;
-        }
-
         let thread = self.threads.get(&session_id)?.clone();
         thread.update(cx, |thread, cx| {
             thread.respond_to_elicitation(&elicitation_id, response, cx);
@@ -1652,10 +1644,9 @@ impl ConversationView {
                 self.notify_with_sound("Waiting for tool confirmation", IconName::Info, window, cx);
             }
             AcpThreadEvent::ToolAuthorizationReceived(_) => {}
-            AcpThreadEvent::ElicitationRequested(_) if cx.has_flag::<AcpBetaFeatureFlag>() => {
+            AcpThreadEvent::ElicitationRequested(_) => {
                 self.notify_with_sound("Waiting for input", IconName::Info, window, cx);
             }
-            AcpThreadEvent::ElicitationRequested(_) => {}
             AcpThreadEvent::ElicitationResponded(_) => {}
             AcpThreadEvent::Retry(retry) => {
                 if let Some(active) = self.thread_view(&session_id) {
@@ -2347,11 +2338,6 @@ impl ConversationView {
     }
 
     fn sync_request_elicitation_states(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !cx.has_flag::<AcpBetaFeatureFlag>() {
-            self.request_elicitation_form_states.clear();
-            return;
-        }
-
         let Some(store) = self.request_elicitation_store() else {
             self.request_elicitation_form_states.clear();
             return;
@@ -2397,10 +2383,6 @@ impl ConversationView {
         view: WeakEntity<Self>,
         cx: &App,
     ) -> Vec<AnyElement> {
-        if !cx.has_flag::<AcpBetaFeatureFlag>() {
-            return Vec::new();
-        }
-
         let Some(store) = connection.request_elicitations() else {
             return Vec::new();
         };
@@ -2529,10 +2511,6 @@ impl ConversationView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !cx.has_flag::<AcpBetaFeatureFlag>() {
-            return;
-        }
-
         let Some(store) = self.request_elicitation_store() else {
             return;
         };
@@ -2581,10 +2559,6 @@ impl ConversationView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !cx.has_flag::<AcpBetaFeatureFlag>() {
-            return;
-        }
-
         self.respond_to_request_elicitation(
             elicitation_id,
             acp::CreateElicitationResponse::new(acp::ElicitationAction::Decline),
@@ -2598,10 +2572,6 @@ impl ConversationView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !cx.has_flag::<AcpBetaFeatureFlag>() {
-            return;
-        }
-
         self.respond_to_request_elicitation(
             elicitation_id,
             acp::CreateElicitationResponse::new(acp::ElicitationAction::Cancel),
@@ -3634,7 +3604,7 @@ pub(crate) mod tests {
     use agent_servers::FakeAcpAgentServer;
     use editor::MultiBufferOffset;
     use editor::actions::Paste;
-    use feature_flags::{FeatureFlag as _, FeatureFlagAppExt as _};
+    use feature_flags::{AcpBetaFeatureFlag, FeatureFlag as _, FeatureFlagAppExt as _};
     use fs::FakeFs;
     use gpui::{ClipboardItem, EventEmitter, TestAppContext, VisualTestContext, point, size};
     use parking_lot::Mutex;

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -20,7 +20,6 @@ use agent_settings::UserAgentsMd;
 use agent_skills::MAX_SKILL_DESCRIPTION_LEN;
 use cloud_api_types::{SubmitAgentThreadFeedbackBody, SubmitAgentThreadFeedbackCommentsBody};
 use editor::actions::OpenExcerpts;
-use feature_flags::{AcpBetaFeatureFlag, FeatureFlagAppExt as _};
 use sandbox::{SandboxFsPolicy, SandboxNetPolicy, SandboxPolicy};
 
 use crate::completion_provider::{AvailableSkill, PromptLocalCommand};
@@ -2526,16 +2525,13 @@ impl ThreadView {
                     ToolCallStatus::WaitingForConfirmation { .. }
                 )
             }
-            AgentThreadEntry::Elicitation(elicitation_id) => {
-                cx.has_flag::<AcpBetaFeatureFlag>()
-                    && self
-                        .thread
-                        .read(cx)
-                        .elicitation(elicitation_id)
-                        .is_some_and(|(_, elicitation)| {
-                            matches!(elicitation.status, ElicitationStatus::Pending { .. })
-                        })
-            }
+            AgentThreadEntry::Elicitation(elicitation_id) => self
+                .thread
+                .read(cx)
+                .elicitation(elicitation_id)
+                .is_some_and(|(_, elicitation)| {
+                    matches!(elicitation.status, ElicitationStatus::Pending { .. })
+                }),
             _ => false,
         }
     }
@@ -2554,11 +2550,6 @@ impl ThreadView {
             };
             elicitation_id.clone()
         };
-
-        if !cx.has_flag::<AcpBetaFeatureFlag>() {
-            self.elicitation_form_states.remove(&elicitation_id);
-            return;
-        }
 
         let thread = self.thread.read(cx);
         let entry = thread.elicitation(&elicitation_id).map(|(_, elicitation)| {
@@ -2605,10 +2596,6 @@ impl ThreadView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !cx.has_flag::<AcpBetaFeatureFlag>() {
-            return;
-        }
-
         let mode = self
             .thread
             .read(cx)
@@ -2654,10 +2641,6 @@ impl ThreadView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !cx.has_flag::<AcpBetaFeatureFlag>() {
-            return;
-        }
-
         self.respond_to_elicitation(
             elicitation_id,
             acp::CreateElicitationResponse::new(acp::ElicitationAction::Decline),
@@ -2671,10 +2654,6 @@ impl ThreadView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !cx.has_flag::<AcpBetaFeatureFlag>() {
-            return;
-        }
-
         self.respond_to_elicitation(
             elicitation_id,
             acp::CreateElicitationResponse::new(acp::ElicitationAction::Cancel),
@@ -6333,8 +6312,7 @@ impl ThreadView {
             }
             AgentThreadEntry::Elicitation(elicitation_id) => {
                 let thread = self.thread.read(cx);
-                if cx.has_flag::<AcpBetaFeatureFlag>()
-                    && let Some((_, elicitation)) = thread.elicitation(elicitation_id)
+                if let Some((_, elicitation)) = thread.elicitation(elicitation_id)
                     && should_render_elicitation(elicitation)
                 {
                     let elicitation = self.render_elicitation(entry_ix, elicitation, window, cx);

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2517,25 +2517,6 @@ impl ThreadView {
         Some(())
     }
 
-    fn is_waiting_for_confirmation(&self, entry: &AgentThreadEntry, cx: &Context<Self>) -> bool {
-        match entry {
-            AgentThreadEntry::ToolCall(tool_call) => {
-                matches!(
-                    tool_call.status,
-                    ToolCallStatus::WaitingForConfirmation { .. }
-                )
-            }
-            AgentThreadEntry::Elicitation(elicitation_id) => self
-                .thread
-                .read(cx)
-                .elicitation(elicitation_id)
-                .is_some_and(|(_, elicitation)| {
-                    matches!(elicitation.status, ElicitationStatus::Pending { .. })
-                }),
-            _ => false,
-        }
-    }
-
     fn has_pending_request_elicitation(&self, cx: &App) -> bool {
         self.server_view
             .read_with(cx, |server_view, cx| {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -6003,9 +6003,7 @@ impl ThreadView {
                     let rendered = this.render_entry(index, entries.len(), entry, window, cx);
                     centered_container(rendered.into_any_element()).into_any_element()
                 } else if this.generating_indicator_in_list {
-                    let confirmation = entries
-                        .last()
-                        .is_some_and(|entry| this.is_waiting_for_confirmation(entry, cx))
+                    let confirmation = this.thread.read(cx).is_waiting_for_confirmation()
                         || this.has_pending_request_elicitation(cx);
                     let rendered = this.render_generating(confirmation, cx);
                     centered_container(rendered.into_any_element()).into_any_element()
@@ -6419,8 +6417,8 @@ impl ThreadView {
             primary
         };
 
-        let needs_confirmation =
-            self.is_waiting_for_confirmation(entry, cx) || self.has_pending_request_elicitation(cx);
+        let needs_confirmation = thread.read(cx).is_waiting_for_confirmation()
+            || self.has_pending_request_elicitation(cx);
 
         let comments_editor = self.thread_feedback.comments_editor.clone();
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -2536,6 +2536,20 @@ impl ThreadView {
         }
     }
 
+    fn has_pending_request_elicitation(&self, cx: &App) -> bool {
+        self.server_view
+            .read_with(cx, |server_view, cx| {
+                server_view
+                    .request_elicitation_store()
+                    .is_some_and(|store| {
+                        store.read(cx).elicitations().iter().any(|elicitation| {
+                            matches!(elicitation.status, ElicitationStatus::Pending { .. })
+                        })
+                    })
+            })
+            .unwrap_or(false)
+    }
+
     pub fn sync_elicitation_state_for_entry(
         &mut self,
         index: usize,
@@ -5991,7 +6005,8 @@ impl ThreadView {
                 } else if this.generating_indicator_in_list {
                     let confirmation = entries
                         .last()
-                        .is_some_and(|entry| this.is_waiting_for_confirmation(entry, cx));
+                        .is_some_and(|entry| this.is_waiting_for_confirmation(entry, cx))
+                        || this.has_pending_request_elicitation(cx);
                     let rendered = this.render_generating(confirmation, cx);
                     centered_container(rendered.into_any_element()).into_any_element()
                 } else {
@@ -6404,7 +6419,8 @@ impl ThreadView {
             primary
         };
 
-        let needs_confirmation = self.is_waiting_for_confirmation(entry, cx);
+        let needs_confirmation =
+            self.is_waiting_for_confirmation(entry, cx) || self.has_pending_request_elicitation(cx);
 
         let comments_editor = self.thread_feedback.comments_editor.clone();
 

--- a/crates/agent_ui/src/entry_view_state.rs
+++ b/crates/agent_ui/src/entry_view_state.rs
@@ -713,7 +713,6 @@ mod tests {
     use agent_client_protocol::schema::v1 as acp;
     use buffer_diff::{DiffHunkStatus, DiffHunkStatusKind};
     use editor::RowInfo;
-    use feature_flags::{AcpBetaFeatureFlag, FeatureFlag as _, FeatureFlagAppExt as _};
     use fs::FakeFs;
     use gpui::{AppContext as _, TestAppContext};
     use parking_lot::RwLock;
@@ -851,11 +850,8 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_hidden_elicitation_preserves_entry_index(cx: &mut TestAppContext) {
+    async fn test_elicitation_preserves_entry_index(cx: &mut TestAppContext) {
         init_test(cx);
-        cx.update(|cx| {
-            cx.update_flags(false, vec![AcpBetaFeatureFlag::NAME.to_string()]);
-        });
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree("/project", json!({})).await;
@@ -900,7 +896,6 @@ mod tests {
                 )),
                 cx,
             );
-            cx.update_flags(false, vec![]);
         });
 
         let view_state = cx.new(|_cx| {


### PR DESCRIPTION
Removes the feature flag. The RFD is in Preview and I am confident it
will be stable without major changes by the time this hits Zed Stable.

Release Notes:

- acp: Allow ACP agents to use Elicitation capturing structure user input.
