### PR TITLE
agent: Fix cmd-f not working when buffer is open

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -299,13 +299,6 @@
     },
   },
   {
-    "context": "AgentTerminalThread",
-    "use_key_equivalents": true,
-    "bindings": {
-      "ctrl-f": "agent::ToggleSearch",
-    },
-  },
-  {
     "context": "AcpThreadSearchBar",
     "use_key_equivalents": true,
     "bindings": {
@@ -326,6 +319,7 @@
     "context": "AcpThread > Editor",
     "use_key_equivalents": true,
     "bindings": {
+      "ctrl-f": "agent::ToggleSearch",
       "ctrl-alt-pageup": "agent::ScrollOutputPageUp",
       "ctrl-alt-pagedown": "agent::ScrollOutputPageDown",
       "ctrl-alt-home": "agent::ScrollOutputToTop",
@@ -1270,7 +1264,9 @@
   },
   {
     "context": "AgentPanel > Terminal",
+    "use_key_equivalents": true,
     "bindings": {
+      "ctrl-f": "agent::ToggleSearch",
       "ctrl-n": "agent::NewThread",
     },
   },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -337,13 +337,6 @@
     },
   },
   {
-    "context": "AgentTerminalThread",
-    "use_key_equivalents": true,
-    "bindings": {
-      "cmd-f": "agent::ToggleSearch",
-    },
-  },
-  {
     "context": "AcpThreadSearchBar",
     "use_key_equivalents": true,
     "bindings": {
@@ -364,6 +357,7 @@
     "context": "AcpThread > Editor",
     "use_key_equivalents": true,
     "bindings": {
+      "cmd-f": "agent::ToggleSearch",
       "ctrl-pageup": "agent::ScrollOutputPageUp",
       "ctrl-pagedown": "agent::ScrollOutputPageDown",
       "ctrl-home": "agent::ScrollOutputToTop",
@@ -1341,6 +1335,7 @@
     "context": "AgentPanel > Terminal",
     "use_key_equivalents": true,
     "bindings": {
+      "cmd-f": "agent::ToggleSearch",
       "cmd-n": "agent::NewThread",
     },
   },

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -300,13 +300,6 @@
     },
   },
   {
-    "context": "AgentTerminalThread",
-    "use_key_equivalents": true,
-    "bindings": {
-      "ctrl-f": "agent::ToggleSearch",
-    },
-  },
-  {
     "context": "AcpThreadSearchBar",
     "use_key_equivalents": true,
     "bindings": {
@@ -327,6 +320,7 @@
     "context": "AcpThread > Editor",
     "use_key_equivalents": true,
     "bindings": {
+      "ctrl-f": "agent::ToggleSearch",
       "ctrl-alt-pageup": "agent::ScrollOutputPageUp",
       "ctrl-alt-pagedown": "agent::ScrollOutputPageDown",
       "ctrl-alt-home": "agent::ScrollOutputToTop",
@@ -1285,6 +1279,7 @@
     "context": "AgentPanel > Terminal",
     "use_key_equivalents": true,
     "bindings": {
+      "ctrl-f": "agent::ToggleSearch",
       "ctrl-n": "agent::NewThread",
     },
   },

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -12487,20 +12487,13 @@ mod tests {
         });
     }
     #[gpui::test]
-    async fn test_search_does_not_target_center_pane_from_agent_panel(cx: &mut TestAppContext) {
+    async fn test_vim_search_does_not_steal_focus_from_agent_panel(cx: &mut TestAppContext) {
         init_test(cx);
         cx.update(|cx| {
             agent::ThreadStore::init_global(cx);
             language_model::LanguageModelRegistry::test(cx);
             vim::init(cx);
             search::init(cx);
-
-            let default_key_bindings = settings::KeymapFile::load_asset_allow_partial_failure(
-                "keymaps/default-macos.json",
-                cx,
-            )
-            .expect("default macOS keymap should load");
-            cx.bind_keys(default_key_bindings);
 
             // Enable vim mode
             settings::SettingsStore::update_global(cx, |store, cx| {
@@ -12579,22 +12572,6 @@ mod tests {
             );
         });
 
-        cx.simulate_keystrokes("cmd-f");
-        cx.run_until_parked();
-
-        let thread_view = panel
-            .read_with(&cx, |panel, cx| {
-                panel
-                    .active_conversation_view()?
-                    .read(cx)
-                    .root_thread_view()
-            })
-            .expect("active conversation should have a root thread view");
-        assert!(thread_view.read_with(&cx, |view, _cx| view.thread_search_visible));
-
-        cx.simulate_keystrokes("escape");
-        cx.run_until_parked();
-
         // Press '/' — the vim search keybinding.
         cx.simulate_keystrokes("/");
 
@@ -12604,25 +12581,6 @@ mod tests {
                 panel.read(cx).focus_handle(cx).contains_focused(window, cx),
                 "Focus should remain on the agent panel after pressing '/'"
             );
-        });
-
-        panel
-            .update_in(&mut cx, |panel, window, cx| {
-                panel.insert_test_terminal("Dev Server", true, window, cx)
-            })
-            .expect("test terminal should be inserted");
-        cx.run_until_parked();
-
-        cx.simulate_keystrokes("cmd-f");
-        cx.run_until_parked();
-
-        panel.read_with(&cx, |panel, cx| {
-            let search_bar = panel
-                .active_terminal_id()
-                .and_then(|terminal_id| panel.terminals.get(&terminal_id))
-                .and_then(|terminal| terminal.search_bar.as_ref())
-                .expect("terminal search bar should be deployed");
-            assert!(!search_bar.read(cx).is_dismissed());
         });
     }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -6484,7 +6484,6 @@ impl Render for AgentPanel {
                         .and_then(|terminal_id| self.terminals.get(&terminal_id))
                         .and_then(|terminal| terminal.search_bar.clone());
                     let terminal_content = v_flex()
-                        .key_context("AgentTerminalThread")
                         .size_full()
                         .when_some(search_bar, |this, search_bar| {
                             this.when(!search_bar.read(cx).is_dismissed(), |this| {
@@ -12488,13 +12487,20 @@ mod tests {
         });
     }
     #[gpui::test]
-    async fn test_vim_search_does_not_steal_focus_from_agent_panel(cx: &mut TestAppContext) {
+    async fn test_search_does_not_target_center_pane_from_agent_panel(cx: &mut TestAppContext) {
         init_test(cx);
         cx.update(|cx| {
             agent::ThreadStore::init_global(cx);
             language_model::LanguageModelRegistry::test(cx);
             vim::init(cx);
             search::init(cx);
+
+            let default_key_bindings = settings::KeymapFile::load_asset_allow_partial_failure(
+                "keymaps/default-macos.json",
+                cx,
+            )
+            .expect("default macOS keymap should load");
+            cx.bind_keys(default_key_bindings);
 
             // Enable vim mode
             settings::SettingsStore::update_global(cx, |store, cx| {
@@ -12573,6 +12579,22 @@ mod tests {
             );
         });
 
+        cx.simulate_keystrokes("cmd-f");
+        cx.run_until_parked();
+
+        let thread_view = panel
+            .read_with(&cx, |panel, cx| {
+                panel
+                    .active_conversation_view()?
+                    .read(cx)
+                    .root_thread_view()
+            })
+            .expect("active conversation should have a root thread view");
+        assert!(thread_view.read_with(&cx, |view, _cx| view.thread_search_visible));
+
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
         // Press '/' — the vim search keybinding.
         cx.simulate_keystrokes("/");
 
@@ -12582,6 +12604,25 @@ mod tests {
                 panel.read(cx).focus_handle(cx).contains_focused(window, cx),
                 "Focus should remain on the agent panel after pressing '/'"
             );
+        });
+
+        panel
+            .update_in(&mut cx, |panel, window, cx| {
+                panel.insert_test_terminal("Dev Server", true, window, cx)
+            })
+            .expect("test terminal should be inserted");
+        cx.run_until_parked();
+
+        cx.simulate_keystrokes("cmd-f");
+        cx.run_until_parked();
+
+        panel.read_with(&cx, |panel, cx| {
+            let search_bar = panel
+                .active_terminal_id()
+                .and_then(|terminal_id| panel.terminals.get(&terminal_id))
+                .and_then(|terminal| terminal.search_bar.as_ref())
+                .expect("terminal search bar should be deployed");
+            assert!(!search_bar.read(cx).is_dismissed());
         });
     }
 


### PR DESCRIPTION
Turns out I only tested it with all tabs closed, the keybinding would only work when all tabs were closed and you focused the agent panel. If a file was opened in the center pane, cmd-f would open a search in that file instead of searching in the agent panel, even if the thread view as focused.

Closes #60686

Release Notes:

- agent: Fixed an issue where cmd-f would not work if file is open in center pane
