### PR TITLE
Expose subagent model settings in UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16722,6 +16722,7 @@ dependencies = [
  "agent",
  "agent_settings",
  "agent_skills",
+ "agent_ui",
  "anyhow",
  "audio",
  "cloud_api_types",

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -81,6 +81,8 @@ pub use agent_diff::{AgentDiffPane, AgentDiffToolbar};
 pub use conversation_view::open_markdown_in_workspace;
 pub use conversation_view::{ConversationView, StateChange};
 pub use external_source_prompt::ExternalSourcePrompt;
+pub use favorite_models::toggle_in_settings as toggle_favorite_model;
+pub use language_model_selector::{LanguageModelSelector, language_model_selector};
 pub(crate) use mode_selector::ModeSelector;
 pub(crate) use model_selector::ModelSelector;
 pub(crate) use model_selector_popover::ModelSelectorPopover;

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -933,6 +933,8 @@ impl ThreadView {
                     |this: &mut Self, _thread, _event: &agent::ModelChanged, cx| {
                         if matches!(this.thread_error, Some(ThreadError::NoModelSelected)) {
                             this.clear_thread_error(cx);
+                        } else {
+                            cx.notify();
                         }
                     },
                 ));
@@ -10084,6 +10086,12 @@ impl ThreadView {
             .as_ref()
             .map(|thread| thread.read(cx).session_id().clone());
         let action_log = thread.as_ref().map(|thread| thread.read(cx).action_log());
+        let subagent_model = thread_view.and_then(|thread_view| {
+            let thread_view = thread_view.read(cx);
+            let thread = thread_view.as_native_thread(cx)?;
+            let model = thread.read(cx).model()?;
+            Some((model.provider_name(), model.name()))
+        });
         let changed_buffers = action_log
             .map(|log| log.read(cx).changed_buffers(cx).collect::<Vec<_>>())
             .unwrap_or_default();
@@ -10231,6 +10239,20 @@ impl ThreadView {
                                         Label::new(title.to_string())
                                             .size(LabelSize::Custom(self.tool_name_font_size()))
                                             .truncate(),
+                                    )
+                                    .when_some(
+                                        subagent_model,
+                                        |this, (provider_name, model_name)| {
+                                            this.child(
+                                                Label::new(format!(
+                                                    "Model: {} · {}",
+                                                    provider_name.0, model_name.0
+                                                ))
+                                                .size(LabelSize::Custom(self.tool_name_font_size()))
+                                                .color(Color::Muted)
+                                                .truncate(),
+                                            )
+                                        },
                                     )
                                     .when(files_changed > 0, |this| {
                                         this.child(

--- a/crates/settings_ui/Cargo.toml
+++ b/crates/settings_ui/Cargo.toml
@@ -19,6 +19,7 @@ test-support = []
 agent.workspace = true
 agent_settings.workspace = true
 agent_skills.workspace = true
+agent_ui.workspace = true
 anyhow.workspace = true
 audio.workspace = true
 cloud_api_types.workspace = true

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2,7 +2,7 @@ use gpui::{Action as _, App};
 use itertools::Itertools as _;
 use settings::{
     AudioInputDeviceName, AudioOutputDeviceName, EditPredictionDataCollectionChoice,
-    LanguageSettingsContent, SemanticTokens, SettingsContent,
+    LanguageModelSelection, LanguageSettingsContent, SemanticTokens, SettingsContent,
 };
 use std::sync::{Arc, OnceLock};
 use strum::{EnumMessage, IntoDiscriminant as _, VariantArray};
@@ -8076,7 +8076,31 @@ fn ai_page(cx: &App) -> SettingsPage {
     }
 
     fn agent_configuration_section(_cx: &App) -> Box<[SettingsPageItem]> {
-        let mut items = vec![SettingsPageItem::SectionHeader("Agent Configuration")];
+        let mut items = vec![
+            SettingsPageItem::SectionHeader("Agent Configuration"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Default Subagent Model",
+                description: "The model used by subagents. Reset to use the parent thread's model.",
+                field: Box::new(SettingField::<Option<LanguageModelSelection>> {
+                    organization_override: None,
+                    json_path: Some("agent.subagent_model"),
+                    pick: |settings_content| {
+                        settings_content
+                            .agent
+                            .as_ref()
+                            .map(|agent| &agent.subagent_model)
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .agent
+                            .get_or_insert_default()
+                            .subagent_model = value.flatten();
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+        ];
 
         items.extend([
             SettingsPageItem::SubPageLink(SubPageLink {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -44,9 +44,9 @@ use std::{
 };
 use theme_settings::ThemeSettings;
 use ui::{
-    Banner, ContextMenu, Divider, DropdownMenu, DropdownStyle, IconButtonShape, KeyBinding,
-    KeybindingHint, PopoverMenu, Scrollbars, Switch, Tooltip, TreeViewItem, WithScrollbar,
-    prelude::*,
+    Banner, ContextMenu, Divider, DropdownMenu, DropdownStyle, IconButtonShape, IconPosition,
+    KeyBinding, KeybindingHint, PopoverMenu, Scrollbars, Switch, Tooltip, TreeViewItem,
+    WithScrollbar, prelude::*,
 };
 
 use util::{ResultExt as _, paths::PathStyle, rel_path::RelPath};
@@ -5096,7 +5096,7 @@ fn render_subagent_model_picker(
     };
 
     let handle = ui::PopoverMenuHandle::<LanguageModelSelector>::default();
-    PopoverMenu::new("language-model-picker")
+    let model_picker = PopoverMenu::new("language-model-picker")
         .trigger(wire_picker_trigger_a11y(
             render_picker_trigger_button(
                 "language_model_picker_trigger".into(),
@@ -5147,6 +5147,81 @@ fn render_subagent_model_picker(
             y: px(2.0),
         })
         .with_handle(handle)
+        .into_any_element();
+
+    let Some(model) = current_model else {
+        return model_picker;
+    };
+    let effort_levels = model.model.supported_effort_levels();
+    if effort_levels.len() < 2 {
+        return model_picker;
+    }
+    let Some(selection) = current_selection else {
+        return model_picker;
+    };
+    let selected_effort = selection
+        .effort
+        .as_ref()
+        .and_then(|effort| {
+            effort_levels
+                .iter()
+                .find(|level| level.value.as_ref() == effort)
+        })
+        .cloned()
+        .or_else(|| model.model.default_effort_level());
+    let Some(selected_effort) = selected_effort else {
+        return model_picker;
+    };
+
+    let selected_effort_value = selected_effort.value.clone();
+    let effort_menu = ContextMenu::build(_window, cx, move |mut menu, _window, _cx| {
+        for effort_level in effort_levels {
+            let is_selected = effort_level.value == selected_effort_value;
+            let effort_value = effort_level.value.clone();
+            let selection = selection.clone();
+            let file = file.clone();
+            menu.push_item(
+                ui::ContextMenuEntry::new(effort_level.name)
+                    .toggleable(IconPosition::End, is_selected)
+                    .handler(move |window, cx| {
+                        let mut selection = selection.clone();
+                        selection.effort = Some(effort_value.to_string());
+                        update_settings_file(
+                            file.clone(),
+                            field.json_path,
+                            window,
+                            cx,
+                            move |settings, app| {
+                                (field.write)(settings, Some(Some(selection)), app);
+                            },
+                        )
+                        .log_err();
+                    }),
+            );
+        }
+        menu
+    });
+
+    v_flex()
+        .gap_1()
+        .items_end()
+        .child(model_picker)
+        .child(
+            h_flex()
+                .gap_2()
+                .items_center()
+                .child(Label::new("Reasoning effort").size(LabelSize::Small))
+                .child(
+                    DropdownMenu::new(
+                        "subagent-model-effort-picker",
+                        selected_effort.name,
+                        effort_menu,
+                    )
+                    .style(DropdownStyle::Outlined)
+                    .trigger_size(ButtonSize::Compact)
+                    .aria_label("Default subagent reasoning effort"),
+                ),
+        )
         .into_any_element()
 }
 

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -5092,7 +5092,7 @@ fn render_subagent_model_picker(
         (Some(selection), None) => {
             format!("Unavailable: {}/{}", selection.provider.0, selection.model).into()
         }
-        (None, None) => default_option_label.clone(),
+        (None, None) => default_option_label,
     };
 
     let handle = ui::PopoverMenuHandle::<LanguageModelSelector>::default();

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -2,7 +2,9 @@ mod components;
 mod page_data;
 pub mod pages;
 
+use agent_settings::{AgentSettings, language_model_to_selection};
 use agent_skills::SkillIndex;
+use agent_ui::{LanguageModelSelector, language_model_selector};
 use anyhow::{Context as _, Result};
 use cloud_api_types::OrganizationConfiguration;
 use editor::{Editor, EditorEvent};
@@ -18,6 +20,9 @@ use gpui::{
 use heck::ToTitleCase as _;
 
 use language::Buffer;
+use language_model::{
+    ConfiguredModel, LanguageModelId, LanguageModelProviderId, LanguageModelRegistry,
+};
 use platform_title_bar::PlatformTitleBar;
 use project::{Project, ProjectPath, Worktree, WorktreeId};
 use release_channel::ReleaseChannel;
@@ -608,6 +613,9 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::NotifyWhenAgentWaiting>(render_dropdown)
         .add_basic_renderer::<settings::PlaySoundWhenAgentDone>(render_dropdown)
         .add_basic_renderer::<settings::ThinkingBlockDisplay>(render_dropdown)
+        .add_basic_renderer::<Option<settings::LanguageModelSelection>>(
+            render_subagent_model_picker,
+        )
         .add_basic_renderer::<settings::ImageFileSizeUnit>(render_dropdown)
         .add_basic_renderer::<settings::StatusStyle>(render_dropdown)
         .add_basic_renderer::<settings::GitPanelClickBehavior>(render_dropdown)
@@ -5047,6 +5055,99 @@ fn wire_picker_trigger_a11y<M: gpui::ManagedView>(
         .on_a11y_action(gpui::accesskit::Action::Collapse, move |_, _window, cx| {
             hide_handle.hide(cx);
         })
+}
+
+fn resolve_language_model_selection(
+    selection: &settings::LanguageModelSelection,
+    cx: &App,
+) -> Option<ConfiguredModel> {
+    let provider_id = LanguageModelProviderId::from(selection.provider.0.clone());
+    let model_id = LanguageModelId::from(selection.model.clone());
+    let provider = LanguageModelRegistry::read_global(cx).provider(&provider_id)?;
+    let model = provider
+        .provided_models(cx)
+        .into_iter()
+        .find(|model| model.id() == model_id)?;
+    Some(ConfiguredModel { provider, model })
+}
+
+fn render_subagent_model_picker(
+    field: SettingField<Option<settings::LanguageModelSelection>>,
+    file: SettingsUiFile,
+    _metadata: Option<&SettingsFieldMetadata>,
+    _window: &mut Window,
+    cx: &mut App,
+) -> AnyElement {
+    let default_option_label = SharedString::from("Same as parent");
+    let current_selection = SettingsStore::global(cx)
+        .get_value_from_file(file.to_settings(), field.pick)
+        .1
+        .and_then(|selection| selection.as_ref())
+        .cloned();
+    let current_model = current_selection
+        .as_ref()
+        .and_then(|selection| resolve_language_model_selection(selection, cx));
+    let current_label = match (&current_selection, &current_model) {
+        (_, Some(model)) => model.model.name().0,
+        (Some(selection), None) => {
+            format!("Unavailable: {}/{}", selection.provider.0, selection.model).into()
+        }
+        (None, None) => default_option_label.clone(),
+    };
+
+    let handle = ui::PopoverMenuHandle::<LanguageModelSelector>::default();
+    PopoverMenu::new("language-model-picker")
+        .trigger(wire_picker_trigger_a11y(
+            render_picker_trigger_button(
+                "language_model_picker_trigger".into(),
+                current_label.clone(),
+            )
+            .when_some(a11y_label_for_json_path(field.json_path), |this, label| {
+                this.aria_label(format!("{}: {}", label, current_label))
+            }),
+            handle.clone(),
+        ))
+        .menu(move |window, cx| {
+            Some(cx.new(move |cx| {
+                language_model_selector(
+                    |cx| {
+                        AgentSettings::get_global(cx)
+                            .subagent_model
+                            .as_ref()
+                            .and_then(|selection| resolve_language_model_selection(selection, cx))
+                    },
+                    move |model, cx| {
+                        let current_selection = AgentSettings::get_global(cx)
+                            .subagent_model
+                            .as_ref()
+                            .filter(|selection| {
+                                selection.provider.0 == model.provider_id().0.as_ref()
+                                    && selection.model == model.id().0.as_ref()
+                            });
+                        let selection = language_model_to_selection(&model, current_selection);
+                        let fs = <dyn fs::Fs>::global(cx);
+                        settings::update_settings_file(fs, cx, move |settings, app| {
+                            (field.write)(settings, Some(Some(selection)), app);
+                        });
+                    },
+                    move |model, should_be_favorite, cx| {
+                        let fs = <dyn fs::Fs>::global(cx);
+                        agent_ui::toggle_favorite_model(model, should_be_favorite, fs, cx);
+                    },
+                    true,
+                    cx.focus_handle(),
+                    window,
+                    cx,
+                )
+            }))
+        })
+        .anchor(gpui::Anchor::TopLeft)
+        .offset(gpui::Point {
+            x: px(0.0),
+            y: px(2.0),
+        })
+        .with_handle(handle)
+        .into_any_element()
 }
 
 fn render_font_picker(

--- a/docs/src/ai/agent-settings.md
+++ b/docs/src/ai/agent-settings.md
@@ -33,7 +33,7 @@ For the model-access paths and provider-specific setup, see [LLM Providers](./ll
 
 ## Feature-Specific Settings {#feature-specific-settings}
 
-Some Zed AI features have their own model or prompt settings in `settings.json`, including:
+Some Zed AI features have their own model or prompt settings, including:
 
 - `agent.inline_assistant_model`
 - `agent.commit_message_model`
@@ -41,6 +41,8 @@ Some Zed AI features have their own model or prompt settings in `settings.json`,
 - `agent.subagent_model`
 - `agent.commit_message_instructions`
 - `agent.inline_alternatives`
+
+Most are configured in `settings.json`. The default subagent model is also available in the Settings Editor under **AI → Agent Configuration**; reset it to use the parent thread's model.
 
 Use `agent.commit_message_instructions` for instructions that apply only to generated Git commit messages:
 

--- a/docs/src/ai/agent-settings.md
+++ b/docs/src/ai/agent-settings.md
@@ -42,7 +42,7 @@ Some Zed AI features have their own model or prompt settings, including:
 - `agent.commit_message_instructions`
 - `agent.inline_alternatives`
 
-Most are configured in `settings.json`. The default subagent model is also available in the Settings Editor under **AI → Agent Configuration**; reset it to use the parent thread's model.
+Most are configured in `settings.json`. The default subagent model is also available in the Settings Editor under **AI → Agent Configuration**; models with multiple reasoning-effort levels show an effort picker there. Reset the model to use the parent thread's model.
 
 Use `agent.commit_message_instructions` for instructions that apply only to generated Git commit messages:
 


### PR DESCRIPTION
## Summary
- Expose the default subagent model in **AI → Agent Configuration** in the Settings Editor.
- Show a compact reasoning-effort selector only for configured models with multiple supported effort levels.
- Reuse the existing model picker and Settings Editor reset control to restore parent-model inheritance.
- Show the actual provider and model on native subagent cards, including inherited-model updates.

## Testing
- cargo fmt --all -- --check
- ./script/clippy
- cargo check -p settings_ui
- cargo check -p agent_ui
- cargo -q test -p agent test_set_model_propagates_to_subagents -- --nocapture

Release Notes:

- Added UI for configuring and viewing subagent models and reasoning effort.