### PR TITLE
agent_ui: Keep threads pinned to their git worktree group

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1527,12 +1527,20 @@ impl AgentPanel {
         let connection_store = cx.new(|cx| AgentConnectionStore::new(project.clone(), cx));
         let _project_subscription =
             cx.subscribe(&project, |this, _project, event, cx| match event {
+                // Only WorktreePathsChanged updates stored thread metadata:
+                // it carries the previous path set, and worktree
+                // additions/removals emit it too.
                 project::Event::WorktreeAdded(_)
                 | project::Event::WorktreeRemoved(_)
-                | project::Event::WorktreeOrderChanged
-                | project::Event::WorktreePathsChanged { .. } => {
+                | project::Event::WorktreeOrderChanged => {
                     this.ensure_native_agent_connection(cx);
-                    this.update_thread_work_dirs(cx);
+                    this.update_thread_work_dirs(None, cx);
+                    this.persist_all_terminal_metadata(cx);
+                    cx.notify();
+                }
+                project::Event::WorktreePathsChanged { old_worktree_paths } => {
+                    this.ensure_native_agent_connection(cx);
+                    this.update_thread_work_dirs(Some(old_worktree_paths), cx);
                     this.persist_all_terminal_metadata(cx);
                     cx.notify();
                 }
@@ -2376,9 +2384,14 @@ impl AgentPanel {
         let Some(store) = TerminalThreadMetadataStore::try_global(cx) else {
             return;
         };
-        let Some(metadata) = self.terminal_metadata(terminal_id, cx) else {
+        let Some(mut metadata) = self.terminal_metadata(terminal_id, cx) else {
             return;
         };
+        if let Some(existing) = store.read(cx).entry(terminal_id) {
+            metadata.worktree_paths = metadata
+                .worktree_paths
+                .preserving_resolved_main_paths(&existing.worktree_paths);
+        }
         store.update(cx, |store, cx| {
             store.save(metadata, cx);
         });
@@ -4112,7 +4125,11 @@ impl AgentPanel {
         false
     }
 
-    fn update_thread_work_dirs(&self, cx: &mut Context<Self>) {
+    fn update_thread_work_dirs(
+        &self,
+        old_worktree_paths: Option<&project::WorktreePaths>,
+        cx: &mut Context<Self>,
+    ) {
         let new_work_dirs = self.project.read(cx).default_path_list(cx);
         let new_worktree_paths = self.project.read(cx).worktree_paths(cx);
 
@@ -4136,13 +4153,21 @@ impl AgentPanel {
         // the project's current worktrees. Without this, threads saved
         // before a worktree was added would have stale paths and not
         // appear under the correct sidebar group.
+        let Some(old_worktree_paths) = old_worktree_paths else {
+            return;
+        };
         let mut thread_ids: Vec<ThreadId> = self.retained_threads.keys().copied().collect();
         if let Some(active_id) = self.active_thread_id(cx) {
             thread_ids.push(active_id);
         }
         if !thread_ids.is_empty() {
             ThreadMetadataStore::global(cx).update(cx, |store, cx| {
-                store.update_worktree_paths(&thread_ids, new_worktree_paths, cx);
+                store.update_worktree_paths(
+                    &thread_ids,
+                    old_worktree_paths.folder_path_list(),
+                    new_worktree_paths,
+                    cx,
+                );
             });
         }
     }

--- a/crates/agent_ui/src/thread_metadata_store.rs
+++ b/crates/agent_ui/src/thread_metadata_store.rs
@@ -812,6 +812,7 @@ impl ThreadMetadataStore {
     pub fn update_worktree_paths(
         &mut self,
         thread_ids: &[ThreadId],
+        old_folder_paths: &PathList,
         worktree_paths: WorktreePaths,
         cx: &mut Context<Self>,
     ) {
@@ -829,8 +830,19 @@ impl ThreadMetadataStore {
             if thread.archived {
                 continue;
             }
+            // A thread whose folder paths weren't tracking the project's
+            // previous path set is associated with a different worktree and
+            // must keep its association.
+            if thread.folder_paths() != old_folder_paths {
+                continue;
+            }
+            let worktree_paths =
+                worktree_paths.preserving_resolved_main_paths(&thread.worktree_paths);
+            if thread.worktree_paths == worktree_paths {
+                continue;
+            }
             self.save_internal(ThreadMetadata {
-                worktree_paths: worktree_paths.clone(),
+                worktree_paths,
                 ..thread.clone()
             });
             changed = true;
@@ -1316,7 +1328,11 @@ impl ThreadMetadataStore {
                 )
             } else {
                 let project = thread_ref.project().read(cx);
-                let worktree_paths = project.worktree_paths(cx);
+                let mut worktree_paths = project.worktree_paths(cx);
+                if let Some(existing) = existing_thread {
+                    worktree_paths =
+                        worktree_paths.preserving_resolved_main_paths(&existing.worktree_paths);
+                }
                 let remote_connection = project.remote_connection_options(cx);
 
                 (worktree_paths, remote_connection)
@@ -3968,6 +3984,82 @@ mod tests {
     }
 
     #[test]
+    fn test_thread_worktree_paths_add_replaces_main_for_same_folder() {
+        // A linked worktree's main path starts out equal to its folder path
+        // and is later resolved to the main repository. Adding the resolved
+        // pair must replace the stale one instead of duplicating the folder.
+        let mut paths = make_worktree_paths(&[(
+            "/projects/zed/.worktrees/feat-a",
+            "/projects/zed/.worktrees/feat-a",
+        )]);
+
+        paths.add_path(
+            Path::new("/projects/zed"),
+            Path::new("/projects/zed/.worktrees/feat-a"),
+        );
+
+        assert_eq!(paths.ordered_pairs().count(), 1);
+        assert_eq!(
+            paths.main_worktree_path_list(),
+            &PathList::new(&[Path::new("/projects/zed")])
+        );
+        assert_eq!(
+            paths.folder_path_list(),
+            &PathList::new(&[Path::new("/projects/zed/.worktrees/feat-a")])
+        );
+    }
+
+    #[test]
+    fn test_thread_worktree_paths_add_keeps_resolved_main_for_same_folder() {
+        // The reverse of the test above: while git state is unavailable, the
+        // computed main path falls back to the folder path. Adding that
+        // unresolved pair must not clobber the resolved association.
+        let mut paths =
+            make_worktree_paths(&[("/projects/zed", "/projects/zed/.worktrees/feat-a")]);
+
+        paths.add_path(
+            Path::new("/projects/zed/.worktrees/feat-a"),
+            Path::new("/projects/zed/.worktrees/feat-a"),
+        );
+
+        assert_eq!(paths.ordered_pairs().count(), 1);
+        assert_eq!(
+            paths.main_worktree_path_list(),
+            &PathList::new(&[Path::new("/projects/zed")])
+        );
+    }
+
+    #[test]
+    fn test_thread_worktree_paths_preserving_resolved_main_paths() {
+        let stored = make_worktree_paths(&[
+            ("/projects/zed", "/projects/zed/.worktrees/feat-a"),
+            ("/projects/cloud", "/projects/cloud"),
+        ]);
+        // Freshly computed while git state is unavailable: main paths fall
+        // back to the folder paths, and a new folder was added.
+        let fresh = make_worktree_paths(&[
+            (
+                "/projects/zed/.worktrees/feat-a",
+                "/projects/zed/.worktrees/feat-a",
+            ),
+            ("/projects/cloud", "/projects/cloud"),
+            ("/projects/new", "/projects/new"),
+        ]);
+
+        let merged = fresh.preserving_resolved_main_paths(&stored);
+
+        assert_eq!(
+            merged.main_worktree_path_list(),
+            &PathList::new(&[
+                Path::new("/projects/zed"),
+                Path::new("/projects/cloud"),
+                Path::new("/projects/new"),
+            ])
+        );
+        assert_eq!(merged.folder_path_list(), fresh.folder_path_list());
+    }
+
+    #[test]
     fn test_thread_worktree_paths_from_path_lists_preserves_association() {
         let folder = PathList::new(&[
             Path::new("/worktrees/selectric/zed"),
@@ -4267,6 +4359,173 @@ mod tests {
                 entry.folder_paths().paths(),
                 &[std::path::PathBuf::from("/project-a")],
                 "retained thread A's stored path must not be updated while the project is via collab"
+            );
+        });
+    }
+
+    // End-to-end setup for #60553: a thread created in a project rooted at a
+    // git worktree nested inside its repository must be stored with the main
+    // repository as its main worktree path once git state is resolved, and
+    // must keep that association across thread updates.
+    #[gpui::test]
+    async fn test_thread_in_nested_git_worktree_resolves_main_repo(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/repo",
+            serde_json::json!({
+                ".git": {},
+                "src": { "main.rs": "fn main() {}" }
+            }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/repo/.git"), Some("main"));
+        fs.insert_branches(Path::new("/repo/.git"), &["main", "feat-a"]);
+        fs.add_linked_worktree_for_repo(
+            Path::new("/repo/.git"),
+            true,
+            git::repository::Worktree {
+                path: PathBuf::from("/repo/.worktrees/feat-a"),
+                ref_name: Some("refs/heads/feat-a".into()),
+                sha: "abc123".into(),
+                is_main: false,
+                is_bare: false,
+            },
+        )
+        .await;
+
+        let project = Project::test(fs, [Path::new("/repo/.worktrees/feat-a")], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+
+        let (panel, mut vcx) = setup_panel_with_project(project.clone(), cx);
+
+        crate::test_support::open_thread_with_connection(
+            &panel,
+            StubAgentConnection::new(),
+            &mut vcx,
+        );
+        let thread_id = crate::test_support::active_thread_id(&panel, &vcx);
+        let thread = panel.read_with(&vcx, |panel, cx| panel.active_agent_thread(cx).unwrap());
+        thread.update_in(&mut vcx, |thread, _window, cx| {
+            thread.push_user_content_block(None, "hello".into(), cx);
+            thread.set_title("Thread".into(), cx).detach();
+        });
+        vcx.run_until_parked();
+
+        let assert_resolved = |cx: &mut TestAppContext, when: &str| {
+            cx.update(|cx| {
+                let store = ThreadMetadataStore::global(cx);
+                let entry = store.read(cx).entry(thread_id).unwrap().clone();
+                assert_eq!(
+                    entry.folder_paths().paths(),
+                    &[std::path::PathBuf::from("/repo/.worktrees/feat-a")],
+                    "folder path must be the worktree the thread runs in ({when})"
+                );
+                assert_eq!(
+                    entry.main_worktree_paths().paths(),
+                    &[std::path::PathBuf::from("/repo")],
+                    "main worktree path must be the main repository ({when})"
+                );
+            });
+        };
+        assert_resolved(cx, "after creation");
+
+        // Subsequent thread updates re-save the metadata; the association
+        // must remain stable.
+        thread.update_in(&mut vcx, |thread, _window, cx| {
+            thread.push_user_content_block(None, "more".into(), cx);
+        });
+        vcx.run_until_parked();
+        assert_resolved(cx, "after another update");
+    }
+
+    // Regression test for #60553: a thread's resolved main-worktree
+    // association (its folder is a linked git worktree of a main repository)
+    // must not regress to the folder-path fallback when the project's
+    // worktree set changes while git state is unresolved. Folder paths must
+    // still be kept in sync with the project's worktrees.
+    #[gpui::test]
+    async fn test_worktree_change_preserves_resolved_main_worktree_paths(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/project-a", serde_json::json!({})).await;
+        fs.insert_tree("/project-b", serde_json::json!({})).await;
+        let project = Project::test(fs, [Path::new("/project-a")], cx).await;
+
+        let (panel, mut vcx) = setup_panel_with_project(project.clone(), cx);
+
+        crate::test_support::open_thread_with_connection(
+            &panel,
+            StubAgentConnection::new(),
+            &mut vcx,
+        );
+        let thread_id = crate::test_support::active_thread_id(&panel, &vcx);
+        let thread = panel.read_with(&vcx, |panel, cx| panel.active_agent_thread(cx).unwrap());
+        thread.update_in(&mut vcx, |thread, _window, cx| {
+            thread.push_user_content_block(None, "hello".into(), cx);
+            thread.set_title("Thread".into(), cx).detach();
+        });
+        vcx.run_until_parked();
+
+        // Store the resolved association: /project-a is a linked git
+        // worktree of /main-repo. The project itself reports the unresolved
+        // fallback (main == folder) because FakeFs has no git state here,
+        // mirroring a worktree whose git scan hasn't completed.
+        let resolved_paths = WorktreePaths::from_path_lists(
+            PathList::new(&[Path::new("/main-repo")]),
+            PathList::new(&[Path::new("/project-a")]),
+        )
+        .unwrap();
+        cx.update(|cx| {
+            let store = ThreadMetadataStore::global(cx);
+            store.update(cx, |store, cx| {
+                let metadata = store.entry(thread_id).unwrap().clone();
+                store.save(
+                    ThreadMetadata {
+                        worktree_paths: resolved_paths.clone(),
+                        ..metadata
+                    },
+                    cx,
+                );
+            });
+        });
+
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_worktree(Path::new("/project-b"), true, cx)
+            })
+            .await
+            .unwrap();
+        vcx.run_until_parked();
+
+        cx.update(|cx| {
+            let store = ThreadMetadataStore::global(cx);
+            let entry = store
+                .read(cx)
+                .entry(thread_id)
+                .expect("thread must still exist in the store");
+            assert_eq!(
+                entry.folder_paths().paths(),
+                &[
+                    std::path::PathBuf::from("/project-a"),
+                    std::path::PathBuf::from("/project-b"),
+                ],
+                "folder paths must stay in sync with the project's worktrees"
+            );
+            assert_eq!(
+                entry.main_worktree_paths().paths(),
+                &[
+                    std::path::PathBuf::from("/main-repo"),
+                    std::path::PathBuf::from("/project-b"),
+                ],
+                "the resolved main worktree path for /project-a must not regress \
+                 to the folder-path fallback"
             );
         });
     }

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -106,8 +106,10 @@ impl WorktreePaths {
     }
 
     /// Add a new path pair. If the exact (main, folder) pair already exists,
-    /// this is a no-op. Rebuilds both internal `PathList`s to maintain
-    /// consistent ordering.
+    /// this is a no-op. A folder can only belong to one main worktree, so a
+    /// resolved pair (main != folder) replaces an unresolved one for the
+    /// same folder — but never the reverse, since the main path computation
+    /// falls back to the folder path while git state is unavailable.
     pub fn add_path(&mut self, main_path: &Path, folder_path: &Path) {
         let already_exists = self
             .ordered_pairs()
@@ -115,14 +117,52 @@ impl WorktreePaths {
         if already_exists {
             return;
         }
+        let folder_is_resolved = self
+            .ordered_pairs()
+            .any(|(m, f)| f.as_path() == folder_path && m != f);
+        if main_path == folder_path && folder_is_resolved {
+            return;
+        }
         let (mut mains, mut folders): (Vec<PathBuf>, Vec<PathBuf>) = self
             .ordered_pairs()
+            .filter(|(_, f)| f.as_path() != folder_path)
             .map(|(m, f)| (m.clone(), f.clone()))
             .unzip();
         mains.push(main_path.to_path_buf());
         folders.push(folder_path.to_path_buf());
         self.main_paths = PathList::new(&mains);
         self.paths = PathList::new(&folders);
+    }
+
+    /// Returns `self` with any unresolved pair (main == folder) replaced by
+    /// the resolved pair from `stored` for the same folder, if one exists.
+    ///
+    /// The main path computation falls back to the folder path while git
+    /// state is unavailable, so freshly-computed paths can transiently lose
+    /// a linked worktree's association with its main repository; the
+    /// previously-resolved main path must win, otherwise threads get
+    /// re-grouped under the wrong worktree.
+    pub fn preserving_resolved_main_paths(&self, stored: &WorktreePaths) -> WorktreePaths {
+        let (mains, folders): (Vec<PathBuf>, Vec<PathBuf>) = self
+            .ordered_pairs()
+            .map(|(main, folder)| {
+                if main == folder
+                    && let Some((stored_main, _)) = stored
+                        .ordered_pairs()
+                        .find(|(stored_main, stored_folder)| {
+                            *stored_folder == folder && *stored_main != folder
+                        })
+                {
+                    (stored_main.clone(), folder.clone())
+                } else {
+                    (main.clone(), folder.clone())
+                }
+            })
+            .unzip();
+        WorktreePaths {
+            paths: PathList::new(&folders),
+            main_paths: PathList::new(&mains),
+        }
     }
 
     /// Remove all pairs whose main worktree path matches the given path.


### PR DESCRIPTION
Closes #60553

With git worktrees nested inside the repository, a thread's worktree group in the Agent panel could change while navigating the file tree. Two causes:

- The computed main worktree path for a linked worktree falls back to the folder path whenever git state is unavailable (e.g. during scanning), and stored thread metadata was rewritten from that freshly-computed state on every worktree event and thread update, so a resolved association (`main-repo` / `worktree`) could regress and the thread jumped to another group.
- `WorktreePaths::add_path` accumulated a duplicate pair for the same folder when its main path was re-resolved, corrupting the group key.

Fix:

- `WorktreePaths::add_path` replaces a stale same-folder pair and never downgrades a resolved pair to the unresolved fallback.
- New `WorktreePaths::preserving_resolved_main_paths` keeps previously-resolved main paths when merging freshly-computed paths into stored thread/terminal metadata.
- `AgentPanel` only rewrites stored thread paths for threads that were tracking the project's previous path set, so threads associated with a different worktree keep their association.

Covered by a regression test (fails without the fix), an end-to-end test with the nested-worktree layout from the issue, and unit tests for the new `WorktreePaths` semantics.

Verified manually on a repo with `<repo>/.worktrees/<name>` worktrees — threads now stay pinned to their worktree while navigating:

![threads pinned to their worktrees](https://github.com/user-attachments/assets/ba10ee6a-6364-4283-bb83-76460f2c4e89)


Release Notes:

- Fixed agent threads being re-grouped under the wrong git worktree in the Agent panel when using worktrees nested inside the repository ([#60553](https://github.com/zed-industries/zed/issues/60553)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)