### PR TITLE
Route integrated-terminal CLI invocations to their source window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,6 +3173,7 @@ dependencies = [
  "walkdir",
  "windows 0.61.3",
  "windows_resources",
+ "zed_env_vars",
 ]
 
 [[package]]
@@ -18398,6 +18399,7 @@ dependencies = [
  "util_macros",
  "vte",
  "windows 0.61.3",
+ "zed_env_vars",
 ]
 
 [[package]]

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -5320,6 +5320,7 @@ mod tests {
                     0,
                     false,
                     0,
+                    None,
                     Some(completion_tx),
                     cx,
                     vec![],

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -38,6 +38,7 @@ util.workspace = true
 tempfile.workspace = true
 rayon.workspace = true
 walkdir = "2.5"
+zed_env_vars.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -68,10 +68,18 @@ pub enum CliRequest {
         dev_container: bool,
         #[serde(default)]
         cwd: Option<PathBuf>,
+        #[serde(default)]
+        terminal_origin: Option<CliTerminalOrigin>,
     },
     SetOpenBehavior {
         behavior: CliBehaviorSetting,
     },
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct CliTerminalOrigin {
+    pub window_id: u64,
+    pub workspace_id: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -643,7 +643,7 @@ fn run() -> Result<()> {
         cli::OpenBehavior::Default
     };
 
-    let mut env = {
+    let mut env: Option<collections::HashMap<String, String>> = {
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         {
             use collections::HashMap;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -13,7 +13,7 @@ use crate::completions::Shell;
 
 use anyhow::{Context as _, Result};
 use clap::{CommandFactory, Parser};
-use cli::{CliRequest, CliResponse, IpcHandshake, ipc::IpcOneShotServer};
+use cli::{CliRequest, CliResponse, CliTerminalOrigin, IpcHandshake, ipc::IpcOneShotServer};
 use parking_lot::Mutex;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -28,6 +28,7 @@ use std::{
 use tempfile::{NamedTempFile, TempDir};
 use util::paths::PathWithPosition;
 use walkdir::WalkDir;
+use zed_env_vars::{ZED_CLI_ORIGIN_WINDOW_ID, ZED_CLI_ORIGIN_WORKSPACE_ID};
 
 use std::io::IsTerminal;
 
@@ -304,6 +305,7 @@ fn create_empty_stub(temp_dir: &mut TempDir, rel: &Path) -> anyhow::Result<PathB
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::collections::HashMap;
     use util::path;
     use util::paths::SanitizedPath;
     use util::test::TempTree;
@@ -420,6 +422,43 @@ mod tests {
         .unwrap();
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn test_terminal_origin_from_env_valid() {
+        let vars = HashMap::from([
+            (ZED_CLI_ORIGIN_WINDOW_ID.to_string(), "42".to_string()),
+            (ZED_CLI_ORIGIN_WORKSPACE_ID.to_string(), "24".to_string()),
+        ]);
+        let origin = terminal_origin_from_env(|key| vars.get(key).cloned()).unwrap();
+        assert_eq!(origin.window_id, 42);
+        assert_eq!(origin.workspace_id, 24);
+    }
+
+    #[test]
+    fn test_terminal_origin_from_env_missing() {
+        // Neither var present.
+        assert!(terminal_origin_from_env(|_| None).is_none());
+
+        // Only one of the two present is not enough.
+        let only_window = HashMap::from([(ZED_CLI_ORIGIN_WINDOW_ID.to_string(), "42".to_string())]);
+        assert!(terminal_origin_from_env(|key| only_window.get(key).cloned()).is_none());
+
+        let only_workspace =
+            HashMap::from([(ZED_CLI_ORIGIN_WORKSPACE_ID.to_string(), "24".to_string())]);
+        assert!(terminal_origin_from_env(|key| only_workspace.get(key).cloned()).is_none());
+    }
+
+    #[test]
+    fn test_terminal_origin_from_env_malformed() {
+        let vars = HashMap::from([
+            (
+                ZED_CLI_ORIGIN_WINDOW_ID.to_string(),
+                "not-a-number".to_string(),
+            ),
+            (ZED_CLI_ORIGIN_WORKSPACE_ID.to_string(), "24".to_string()),
+        ]);
+        assert!(terminal_origin_from_env(|key| vars.get(key).cloned()).is_none());
+    }
 }
 
 fn parse_path_in_wsl(source: &str, wsl: &str) -> Result<String> {
@@ -472,6 +511,18 @@ fn main() {
         eprintln!("error: {error:#}");
         std::process::exit(1);
     }
+}
+
+/// Reads the terminal origin from the environment. Both env vars must be present
+/// and parse as `u64`, otherwise there is no usable origin. `get_var` is injected
+/// so this can be exercised without touching the process environment.
+fn terminal_origin_from_env(get_var: impl Fn(&str) -> Option<String>) -> Option<CliTerminalOrigin> {
+    let window_id = get_var(ZED_CLI_ORIGIN_WINDOW_ID)?;
+    let workspace_id = get_var(ZED_CLI_ORIGIN_WORKSPACE_ID)?;
+    Some(CliTerminalOrigin {
+        window_id: window_id.parse().ok()?,
+        workspace_id: workspace_id.parse().ok()?,
+    })
 }
 
 fn run() -> Result<()> {
@@ -592,7 +643,7 @@ fn run() -> Result<()> {
         cli::OpenBehavior::Default
     };
 
-    let env = {
+    let mut env = {
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         {
             use collections::HashMap;
@@ -623,6 +674,17 @@ fn run() -> Result<()> {
             Some(std::env::vars().collect::<HashMap<_, _>>())
         }
     };
+
+    let terminal_origin = terminal_origin_from_env(|key| env::var(key).ok());
+
+    // The terminal origin is forwarded in its own `terminal_origin` field, so
+    // strip it from the environment we hand to Zed. Otherwise a project opened
+    // via `zed <path>` from an integrated terminal would inherit that terminal's
+    // origin as part of its project environment.
+    if let Some(env) = env.as_mut() {
+        env.remove(ZED_CLI_ORIGIN_WINDOW_ID);
+        env.remove(ZED_CLI_ORIGIN_WORKSPACE_ID);
+    }
 
     let exit_status = Arc::new(Mutex::new(None));
     let mut paths = vec![];
@@ -722,6 +784,7 @@ fn run() -> Result<()> {
                     user_data_dir: user_data_dir_for_thread,
                     dev_container: args.dev_container,
                     cwd: env::current_dir().ok(),
+                    terminal_origin,
                 };
 
                 tx.send(open_request)?;

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -15,7 +15,7 @@ use std::{
 };
 use task::{Shell, ShellBuilder, ShellKind, SpawnInTerminal};
 use terminal::{
-    TaskState, TaskStatus, Terminal, TerminalBuilder, insert_zed_terminal_env,
+    TaskState, TaskStatus, Terminal, TerminalBuilder, TerminalSource, insert_zed_terminal_env,
     terminal_settings::TerminalSettings,
 };
 use util::{
@@ -64,6 +64,15 @@ impl Project {
     pub fn create_terminal_task(
         &mut self,
         spawn_task: SpawnInTerminal,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<Terminal>>> {
+        self.create_terminal_task_with_origin(spawn_task, None, cx)
+    }
+
+    pub fn create_terminal_task_with_origin(
+        &mut self,
+        spawn_task: SpawnInTerminal,
+        terminal_source: Option<TerminalSource>,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
         let is_via_remote = self.remote_client.is_some();
@@ -254,6 +263,7 @@ impl Project {
                         settings.path_hyperlink_timeout_ms,
                         is_via_remote,
                         cx.entity_id().as_u64(),
+                        terminal_source,
                         Some(completion_tx),
                         cx,
                         activation_script,
@@ -292,7 +302,16 @@ impl Project {
         cwd: Option<PathBuf>,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
-        self.create_terminal_shell_internal(cwd, false, cx)
+        self.create_terminal_shell_with_origin(cwd, None, cx)
+    }
+
+    pub fn create_terminal_shell_with_origin(
+        &mut self,
+        cwd: Option<PathBuf>,
+        terminal_source: Option<TerminalSource>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<Terminal>>> {
+        self.create_terminal_shell_internal(cwd, false, terminal_source, cx)
     }
 
     /// Creates a local terminal even if the project is remote.
@@ -302,6 +321,14 @@ impl Project {
         &mut self,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
+        self.create_local_terminal_with_origin(None, cx)
+    }
+
+    pub fn create_local_terminal_with_origin(
+        &mut self,
+        terminal_source: Option<TerminalSource>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<Terminal>>> {
         let working_directory = if self.remote_client.is_some() {
             // Remote project: don't use remote paths, let shell use Zed's cwd
             None
@@ -309,7 +336,7 @@ impl Project {
             // Local project: use project directory like normal terminals
             self.active_project_directory(cx).map(|p| p.to_path_buf())
         };
-        self.create_terminal_shell_internal(working_directory, true, cx)
+        self.create_terminal_shell_internal(working_directory, true, terminal_source, cx)
     }
 
     /// Internal method for creating terminal shells.
@@ -319,6 +346,7 @@ impl Project {
         &mut self,
         cwd: Option<PathBuf>,
         force_local: bool,
+        terminal_source: Option<TerminalSource>,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Terminal>>> {
         let path = cwd.map(|p| Arc::from(&*p));
@@ -424,6 +452,7 @@ impl Project {
                         settings.path_hyperlink_timeout_ms,
                         is_via_remote,
                         cx.entity_id().as_u64(),
+                        terminal_source,
                         None,
                         cx,
                         activation_script,
@@ -463,10 +492,20 @@ impl Project {
         cx: &mut Context<'_, Project>,
         cwd: Option<PathBuf>,
     ) -> Task<Result<Entity<Terminal>>> {
+        self.clone_terminal_with_origin(terminal, cx, cwd, None)
+    }
+
+    pub fn clone_terminal_with_origin(
+        &mut self,
+        terminal: &Entity<Terminal>,
+        cx: &mut Context<'_, Project>,
+        cwd: Option<PathBuf>,
+        terminal_source: Option<TerminalSource>,
+    ) -> Task<Result<Entity<Terminal>>> {
         // We cannot clone the task's terminal, as it will effectively re-spawn the task, which might not be desirable.
         // For now, create a new shell instead.
         if terminal.read(cx).task().is_some() {
-            return self.create_terminal_shell(cwd, cx);
+            return self.create_terminal_shell_with_origin(cwd, terminal_source, cx);
         }
         let local_path = if self.is_via_remote_server() {
             None
@@ -474,7 +513,9 @@ impl Project {
             cwd
         };
 
-        let builder = terminal.read(cx).clone_builder(cx, local_path);
+        let builder = terminal
+            .read(cx)
+            .clone_builder(cx, local_path, terminal_source);
         cx.spawn(async |project, cx| {
             let terminal = builder.await?;
             project.update(cx, |project, cx| {
@@ -619,7 +660,7 @@ fn create_remote_shell(
     remote_client: Entity<RemoteClient>,
     cx: &mut App,
 ) -> Result<(Shell, HashMap<String, String>)> {
-    insert_zed_terminal_env(&mut env, &release_channel::AppVersion::global(cx));
+    insert_zed_terminal_env(&mut env, &release_channel::AppVersion::global(cx), None);
 
     let (program, args) = match spawn_command {
         Some((program, args)) => (Some(program.clone()), args),

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -44,6 +44,7 @@ url.workspace = true
 util.workspace = true
 urlencoding.workspace = true
 vte.workspace = true
+zed_env_vars.workspace = true
 parking_lot.workspace = true
 percent-encoding.workspace = true
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -32,6 +32,7 @@ use terminal_settings::{AlternateScroll, CursorShape as SettingsCursorShape, Ter
 use theme::{ActiveTheme, Theme};
 use urlencoding;
 use util::{ResultExt as _, paths::PathStyle, truncate_and_trailoff};
+use zed_env_vars::{ZED_CLI_ORIGIN_WINDOW_ID, ZED_CLI_ORIGIN_WORKSPACE_ID};
 
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt;
@@ -637,12 +638,29 @@ const DEBUG_LINE_HEIGHT: Pixels = px(5.);
 pub fn insert_zed_terminal_env(
     env: &mut HashMap<String, String>,
     version: &impl std::fmt::Display,
+    source: Option<TerminalSource>,
 ) {
     env.insert("ZED_TERM".to_string(), "true".to_string());
     env.insert("TERM_PROGRAM".to_string(), "zed".to_string());
     env.insert("TERM".to_string(), "xterm-256color".to_string());
     env.insert("COLORTERM".to_string(), "truecolor".to_string());
     env.insert("TERM_PROGRAM_VERSION".to_string(), version.to_string());
+    if let Some(source) = source {
+        env.insert(
+            ZED_CLI_ORIGIN_WINDOW_ID.to_string(),
+            source.window_id.to_string(),
+        );
+        env.insert(
+            ZED_CLI_ORIGIN_WORKSPACE_ID.to_string(),
+            source.workspace_id.to_string(),
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TerminalSource {
+    pub window_id: u64,
+    pub workspace_id: u64,
 }
 
 ///Upward flowing events, for changing the title and such
@@ -1024,6 +1042,7 @@ impl TerminalBuilder {
         path_hyperlink_timeout_ms: u64,
         is_remote_terminal: bool,
         window_id: u64,
+        terminal_source: Option<TerminalSource>,
         completion_tx: Option<Sender<Option<ExitStatus>>>,
         cx: &App,
         activation_script: Vec<String>,
@@ -1056,7 +1075,11 @@ impl TerminalBuilder {
                     .or_insert_with(|| "en_US.UTF-8".to_string());
             }
 
-            insert_zed_terminal_env(&mut env, &version);
+            insert_zed_terminal_env(
+                &mut env,
+                &version,
+                (!is_remote_terminal).then_some(terminal_source).flatten(),
+            );
 
             #[derive(Default)]
             struct ShellParams {
@@ -2876,7 +2899,12 @@ impl Terminal {
         self.vi_mode_enabled
     }
 
-    pub fn clone_builder(&self, cx: &App, cwd: Option<PathBuf>) -> Task<Result<TerminalBuilder>> {
+    pub fn clone_builder(
+        &self,
+        cx: &App,
+        cwd: Option<PathBuf>,
+        terminal_source: Option<TerminalSource>,
+    ) -> Task<Result<TerminalBuilder>> {
         let working_directory = self.working_directory().or_else(|| cwd);
         TerminalBuilder::new(
             working_directory,
@@ -2890,6 +2918,7 @@ impl Terminal {
             self.template.path_hyperlink_timeout_ms,
             self.is_remote_terminal,
             self.template.window_id,
+            terminal_source,
             None,
             cx,
             self.activation_script.clone(),
@@ -3288,6 +3317,26 @@ mod tests {
     use task::{Shell, ShellBuilder};
 
     #[test]
+    fn test_insert_zed_terminal_env_includes_cli_origin() {
+        let mut env = HashMap::default();
+
+        insert_zed_terminal_env(
+            &mut env,
+            &"1.0.0",
+            Some(TerminalSource {
+                window_id: 42,
+                workspace_id: 24,
+            }),
+        );
+
+        assert_eq!(env.get(ZED_CLI_ORIGIN_WINDOW_ID), Some(&"42".to_string()));
+        assert_eq!(
+            env.get(ZED_CLI_ORIGIN_WORKSPACE_ID),
+            Some(&"24".to_string())
+        );
+    }
+
+    #[test]
     fn test_init_command_startup_marker_commands_do_not_contain_marker() {
         let marker_id = 42;
         let marker = init_command_startup_marker(marker_id);
@@ -3441,6 +3490,7 @@ mod tests {
                     0,
                     false,
                     0,
+                    None,
                     Some(completion_tx),
                     cx,
                     vec![],
@@ -3492,6 +3542,7 @@ mod tests {
                     0,
                     false,
                     0,
+                    None,
                     Some(completion_tx),
                     cx,
                     vec![],
@@ -3774,6 +3825,7 @@ mod tests {
                     0,
                     false,
                     0,
+                    None,
                     Some(completion_tx),
                     cx,
                     Vec::new(),
@@ -3843,6 +3895,7 @@ mod tests {
                     false,
                     0,
                     None,
+                    None,
                     cx,
                     Vec::new(),
                     PathStyle::local(),
@@ -3908,6 +3961,7 @@ mod tests {
                     0,
                     false,
                     0,
+                    None,
                     Some(completion_tx),
                     cx,
                     Vec::new(),
@@ -4619,6 +4673,7 @@ mod tests {
                         test_path_hyperlink_timeout_ms,
                         false,
                         window.window_handle().window_id().as_u64(),
+                        None,
                         None,
                         cx,
                         vec![],

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -6,6 +6,7 @@ use gpui::{AppContext as _, AsyncWindowContext, Axis, Entity, Task, WeakEntity};
 use project::Project;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use terminal::TerminalSource;
 use ui::{App, Context, Window};
 use util::ResultExt as _;
 
@@ -244,9 +245,19 @@ async fn deserialize_pane_group(
                             .update(cx, |workspace, cx| default_working_directory(workspace, cx))
                             .ok()
                             .flatten();
+                        let terminal_source = pane
+                            .update_in(cx, |_, window, _| TerminalSource {
+                                window_id: window.window_handle().window_id().as_u64(),
+                                workspace_id: workspace.entity_id().as_u64(),
+                            })
+                            .ok();
                         let terminal = project
                             .update(cx, |project, cx| {
-                                project.create_terminal_shell(working_directory, cx)
+                                project.create_terminal_shell_with_origin(
+                                    working_directory,
+                                    terminal_source,
+                                    cx,
+                                )
                             })
                             .await
                             .log_err();

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -20,7 +20,7 @@ use project::{Fs, Project};
 
 use settings::{Settings, TerminalDockPosition};
 use task::{RevealStrategy, RevealTarget, Shell, ShellBuilder, SpawnInTerminal, TaskId};
-use terminal::{Terminal, terminal_settings::TerminalSettings};
+use terminal::{Terminal, TerminalSource, terminal_settings::TerminalSettings};
 use ui::{
     ButtonLike, Clickable, ContextMenu, FluentBuilder, PopoverMenu, SplitButton, Toggleable,
     Tooltip, prelude::*,
@@ -435,6 +435,7 @@ impl TerminalPanel {
         let Some(workspace) = self.workspace.upgrade() else {
             return Task::ready(None);
         };
+        let workspace_id = workspace.entity_id().as_u64();
         let workspace = workspace.read(cx);
         let database_id = workspace.database_id();
         let weak_workspace = self.workspace.clone();
@@ -468,15 +469,24 @@ impl TerminalPanel {
         } else {
             false
         };
+        let terminal_source = Some(TerminalSource {
+            window_id: window.window_handle().window_id().as_u64(),
+            workspace_id,
+        });
         cx.spawn_in(window, async move |panel, cx| {
             let terminal = project
                 .update(cx, |project, cx| match terminal_view {
-                    Some(view) => project.clone_terminal(
+                    Some(view) => project.clone_terminal_with_origin(
                         &view.read(cx).terminal.clone(),
                         cx,
                         working_directory,
+                        terminal_source,
                     ),
-                    None => project.create_terminal_shell(working_directory, cx),
+                    None => project.create_terminal_shell_with_origin(
+                        working_directory,
+                        terminal_source,
+                        cx,
+                    ),
                 })
                 .await
                 .log_err()?;
@@ -625,9 +635,18 @@ impl TerminalPanel {
             RevealTarget::Center => self
                 .workspace
                 .update(cx, |workspace, cx| {
-                    Self::add_center_terminal(workspace, window, cx, |project, cx| {
-                        project.create_terminal_task(spawn_task, cx)
-                    })
+                    Self::add_center_terminal(
+                        workspace,
+                        window,
+                        cx,
+                        |project, origin_window_id, cx| {
+                            project.create_terminal_task_with_origin(
+                                spawn_task,
+                                origin_window_id,
+                                cx,
+                            )
+                        },
+                    )
                 })
                 .unwrap_or_else(|e| Task::ready(Err(e))),
             RevealTarget::Dock => self.add_terminal_task(spawn_task, reveal, window, cx),
@@ -651,13 +670,22 @@ impl TerminalPanel {
         if center_pane_has_focus && active_center_item_is_terminal {
             let working_directory = default_working_directory(workspace, cx);
             let local = action.local;
-            Self::add_center_terminal(workspace, window, cx, move |project, cx| {
-                if local {
-                    project.create_local_terminal(cx)
-                } else {
-                    project.create_terminal_shell(working_directory, cx)
-                }
-            })
+            Self::add_center_terminal(
+                workspace,
+                window,
+                cx,
+                move |project, origin_window_id, cx| {
+                    if local {
+                        project.create_local_terminal_with_origin(origin_window_id, cx)
+                    } else {
+                        project.create_terminal_shell_with_origin(
+                            working_directory,
+                            origin_window_id,
+                            cx,
+                        )
+                    }
+                },
+            )
             .detach_and_log_err(cx);
             return;
         }
@@ -743,6 +771,7 @@ impl TerminalPanel {
         cx: &mut Context<Workspace>,
         create_terminal: impl FnOnce(
             &mut Project,
+            Option<TerminalSource>,
             &mut Context<Project>,
         ) -> Task<Result<Entity<Terminal>>>
         + 'static,
@@ -753,8 +782,16 @@ impl TerminalPanel {
             )));
         }
         let project = workspace.project().downgrade();
+        let terminal_source = Some(TerminalSource {
+            window_id: window.window_handle().window_id().as_u64(),
+            workspace_id: cx.entity_id().as_u64(),
+        });
         cx.spawn_in(window, async move |workspace, cx| {
-            let terminal = project.update(cx, create_terminal)?.await?;
+            let terminal = project
+                .update(cx, |project, cx| {
+                    create_terminal(project, terminal_source, cx)
+                })?
+                .await?;
 
             workspace.update_in(cx, |workspace, window, cx| {
                 let terminal_view = cx.new(|cx| {
@@ -781,6 +818,10 @@ impl TerminalPanel {
         cx: &mut Context<Self>,
     ) -> Task<Result<WeakEntity<Terminal>>> {
         let workspace = self.workspace.clone();
+        let terminal_source = Some(TerminalSource {
+            window_id: window.window_handle().window_id().as_u64(),
+            workspace_id: self.workspace.entity_id().as_u64(),
+        });
         cx.spawn_in(window, async move |terminal_panel, cx| {
             if workspace.update(cx, |workspace, cx| !is_enabled_in_workspace(workspace, cx))? {
                 anyhow::bail!("terminal not yet supported for remote projects");
@@ -791,7 +832,9 @@ impl TerminalPanel {
             })?;
             let project = workspace.read_with(cx, |workspace, _| workspace.project().clone())?;
             let terminal = project
-                .update(cx, |project, cx| project.create_terminal_task(task, cx))
+                .update(cx, |project, cx| {
+                    project.create_terminal_task_with_origin(task, terminal_source, cx)
+                })
                 .await?;
             let result = workspace.update_in(cx, |workspace, window, cx| {
                 let terminal_view = Box::new(cx.new(|cx| {
@@ -859,7 +902,10 @@ impl TerminalPanel {
         cx: &mut Context<Self>,
     ) -> Task<Result<WeakEntity<Terminal>>> {
         let workspace = self.workspace.clone();
-
+        let terminal_source = Some(TerminalSource {
+            window_id: window.window_handle().window_id().as_u64(),
+            workspace_id: self.workspace.entity_id().as_u64(),
+        });
         cx.spawn_in(window, async move |terminal_panel, cx| {
             if workspace.update(cx, |workspace, cx| !is_enabled_in_workspace(workspace, cx))? {
                 anyhow::bail!("terminal not yet supported for collaborative projects");
@@ -871,11 +917,15 @@ impl TerminalPanel {
             let project = workspace.read_with(cx, |workspace, _| workspace.project().clone())?;
             let terminal = if force_local {
                 project
-                    .update(cx, |project, cx| project.create_local_terminal(cx))
+                    .update(cx, |project, cx| {
+                        project.create_local_terminal_with_origin(terminal_source, cx)
+                    })
                     .await
             } else {
                 project
-                    .update(cx, |project, cx| project.create_terminal_shell(cwd, cx))
+                    .update(cx, |project, cx| {
+                        project.create_terminal_shell_with_origin(cwd, terminal_source, cx)
+                    })
                     .await
             };
 
@@ -986,6 +1036,10 @@ impl TerminalPanel {
     ) -> Task<Result<WeakEntity<Terminal>>> {
         let reveal = spawn_task.reveal;
         let task_workspace = self.workspace.clone();
+        let terminal_source = Some(TerminalSource {
+            window_id: window.window_handle().window_id().as_u64(),
+            workspace_id: self.workspace.entity_id().as_u64(),
+        });
         cx.spawn_in(window, async move |terminal_panel, cx| {
             let project = terminal_panel.update(cx, |this, cx| {
                 this.workspace
@@ -993,7 +1047,7 @@ impl TerminalPanel {
             })??;
             let new_terminal = project
                 .update(cx, |project, cx| {
-                    project.create_terminal_task(spawn_task, cx)
+                    project.create_terminal_task_with_origin(spawn_task, terminal_source, cx)
                 })
                 .await?;
             terminal_to_replace.update_in(cx, |terminal_to_replace, window, cx| {
@@ -2045,9 +2099,14 @@ mod tests {
         window_handle
             .update(cx, |multi_workspace, window, cx| {
                 multi_workspace.workspace().update(cx, |workspace, cx| {
-                    TerminalPanel::add_center_terminal(workspace, window, cx, |project, cx| {
-                        project.create_terminal_shell(None, cx)
-                    })
+                    TerminalPanel::add_center_terminal(
+                        workspace,
+                        window,
+                        cx,
+                        |project, origin_window_id, cx| {
+                            project.create_terminal_shell_with_origin(None, origin_window_id, cx)
+                        },
+                    )
                 })
             })
             .expect("Failed to update workspace")
@@ -2214,9 +2273,14 @@ mod tests {
         window_handle
             .update(cx, |multi_workspace, window, cx| {
                 multi_workspace.workspace().update(cx, |workspace, cx| {
-                    TerminalPanel::add_center_terminal(workspace, window, cx, |project, cx| {
-                        project.create_terminal_shell(None, cx)
-                    })
+                    TerminalPanel::add_center_terminal(
+                        workspace,
+                        window,
+                        cx,
+                        |project, origin_window_id, cx| {
+                            project.create_terminal_shell_with_origin(None, origin_window_id, cx)
+                        },
+                    )
                 })
             })
             .expect("Failed to update workspace")
@@ -2304,9 +2368,14 @@ mod tests {
         window_handle
             .update(cx, |multi_workspace, window, cx| {
                 multi_workspace.workspace().update(cx, |workspace, cx| {
-                    TerminalPanel::add_center_terminal(workspace, window, cx, |project, cx| {
-                        project.create_terminal_shell(None, cx)
-                    })
+                    TerminalPanel::add_center_terminal(
+                        workspace,
+                        window,
+                        cx,
+                        |project, origin_window_id, cx| {
+                            project.create_terminal_shell_with_origin(None, origin_window_id, cx)
+                        },
+                    )
                 })
             })
             .expect("Failed to update workspace")

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -35,7 +35,8 @@ use task::TaskId;
 use terminal::{
     Clear, Copy, Event, HoveredWord, MaybeNavigationTarget, Modes, Paste, PasteText, Point, Range,
     ScrollLineDown, ScrollLineUp, ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop,
-    Search, ShowCharacterPalette, TaskState, TaskStatus, Terminal, TerminalBounds, ToggleViMode,
+    Search, ShowCharacterPalette, TaskState, TaskStatus, Terminal, TerminalBounds, TerminalSource,
+    ToggleViMode,
     terminal_settings::{CursorShape, TerminalSettings},
 };
 use terminal_element::TerminalElement;
@@ -220,13 +221,22 @@ impl TerminalView {
     ) {
         let local = action.local;
         let working_directory = default_working_directory(workspace, cx);
-        TerminalPanel::add_center_terminal(workspace, window, cx, move |project, cx| {
-            if local {
-                project.create_local_terminal(cx)
-            } else {
-                project.create_terminal_shell(working_directory, cx)
-            }
-        })
+        TerminalPanel::add_center_terminal(
+            workspace,
+            window,
+            cx,
+            move |project, origin_window_id, cx| {
+                if local {
+                    project.create_local_terminal_with_origin(origin_window_id, cx)
+                } else {
+                    project.create_terminal_shell_with_origin(
+                        working_directory,
+                        origin_window_id,
+                        cx,
+                    )
+                }
+            },
+        )
         .detach_and_log_err(cx);
     }
 
@@ -1745,11 +1755,15 @@ impl Item for TerminalView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Option<Entity<Self>>> {
+        let terminal_source = Some(TerminalSource {
+            window_id: window.window_handle().window_id().as_u64(),
+            workspace_id: self.workspace.entity_id().as_u64(),
+        });
         let Ok(terminal) = self.project.update(cx, |project, cx| {
             let cwd = project
                 .active_project_directory(cx)
                 .map(|it| it.to_path_buf());
-            project.clone_terminal(self.terminal(), cx, cwd)
+            project.clone_terminal_with_origin(self.terminal(), cx, cwd, terminal_source)
         }) else {
             return Task::ready(None);
         };
@@ -1901,8 +1915,8 @@ impl SerializableItem for TerminalView {
         cx: &mut App,
     ) -> Task<anyhow::Result<Entity<Self>>> {
         window.spawn(cx, async move |cx| {
-            let (cwd, custom_title) = cx
-                .update(|_window, cx| {
+            let (cwd, custom_title, terminal_source) = cx
+                .update(|window, cx| {
                     let db = TerminalDb::global(cx);
                     let from_db = db
                         .get_working_directory(item_id, workspace_id)
@@ -1923,13 +1937,22 @@ impl SerializableItem for TerminalView {
                         .log_err()
                         .flatten()
                         .filter(|title| !title.trim().is_empty());
-                    (cwd, custom_title)
+                    (
+                        cwd,
+                        custom_title,
+                        Some(TerminalSource {
+                            window_id: window.window_handle().window_id().as_u64(),
+                            workspace_id: workspace.entity_id().as_u64(),
+                        }),
+                    )
                 })
                 .ok()
-                .unwrap_or((None, None));
+                .unwrap_or((None, None, None));
 
             let terminal = project
-                .update(cx, |project, cx| project.create_terminal_shell(cwd, cx))
+                .update(cx, |project, cx| {
+                    project.create_terminal_shell_with_origin(cwd, terminal_source, cx)
+                })
                 .await?;
             cx.update(|window, cx| {
                 cx.new(|cx| {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -9788,6 +9788,24 @@ pub async fn find_existing_workspace(
     let mut open_visible = OpenVisible::All;
     let mut best_match = None;
 
+    if open_options.workspace_matching == WorkspaceMatching::MatchSubdirectory {
+        if let Some(requesting_window) = open_options.requesting_window {
+            existing = cx.update(|cx| {
+                workspace_windows_for_location(location, cx)
+                    .contains(&requesting_window)
+                    .then(|| {
+                        requesting_window.read(cx).ok().map(|multi_workspace| {
+                            let workspace =
+                                requesting_workspace_in_window(open_options, multi_workspace)
+                                    .unwrap_or_else(|| multi_workspace.workspace().clone());
+                            (requesting_window, workspace)
+                        })
+                    })
+                    .flatten()
+            });
+        }
+    }
+
     if open_options.workspace_matching != WorkspaceMatching::None {
         cx.update(|cx| {
             for window in workspace_windows_for_location(location, cx) {
@@ -9809,7 +9827,8 @@ pub async fn find_existing_workspace(
                         if m > best_match {
                             existing = Some((window, workspace.clone()));
                             best_match = m;
-                        } else if best_match.is_none()
+                        } else if existing.is_none()
+                            && best_match.is_none()
                             && open_options.workspace_matching
                                 == WorkspaceMatching::MatchSubdirectory
                         {
@@ -9845,15 +9864,21 @@ pub async fn find_existing_workspace(
         if open_options.wait && existing.is_some() && all_paths_are_files {
             cx.update(|cx| {
                 let windows = workspace_windows_for_location(location, cx);
-                let window = cx
-                    .active_window()
-                    .and_then(|window| window.downcast::<MultiWorkspace>())
+                let window = open_options
+                    .requesting_window
                     .filter(|window| windows.contains(window))
-                    .or_else(|| windows.into_iter().next());
+                    .or_else(|| {
+                        cx.active_window()
+                            .and_then(|window| window.downcast::<MultiWorkspace>())
+                            .filter(|window| windows.contains(window))
+                            .or_else(|| windows.into_iter().next())
+                    });
                 if let Some(window) = window {
                     if let Ok(multi_workspace) = window.read(cx) {
-                        let active_workspace = multi_workspace.workspace().clone();
-                        existing = Some((window, active_workspace));
+                        let workspace =
+                            requesting_workspace_in_window(open_options, multi_workspace)
+                                .unwrap_or_else(|| multi_workspace.workspace().clone());
+                        existing = Some((window, workspace));
                         open_visible = OpenVisible::None;
                     }
                 }
@@ -9894,6 +9919,7 @@ pub struct OpenOptions {
     pub add_dirs_to_sidebar: bool,
     pub wait: bool,
     pub requesting_window: Option<WindowHandle<MultiWorkspace>>,
+    pub requesting_workspace: Option<WeakEntity<Workspace>>,
     pub open_mode: OpenMode,
     pub env: Option<HashMap<String, String>>,
     pub open_in_dev_container: bool,
@@ -9908,6 +9934,7 @@ impl Default for OpenOptions {
             add_dirs_to_sidebar: true,
             wait: false,
             requesting_window: None,
+            requesting_workspace: None,
             open_mode: OpenMode::default(),
             env: None,
             open_in_dev_container: false,
@@ -9922,6 +9949,17 @@ impl OpenOptions {
             WorkspaceMatching::None | WorkspaceMatching::MatchSubpaths
         ) && self.open_mode != OpenMode::NewWindow
     }
+}
+
+fn requesting_workspace_in_window(
+    open_options: &OpenOptions,
+    multi_workspace: &MultiWorkspace,
+) -> Option<Entity<Workspace>> {
+    let requesting_workspace = open_options.requesting_workspace.as_ref()?.upgrade()?;
+    multi_workspace
+        .workspaces()
+        .find(|workspace| **workspace == requesting_workspace)
+        .cloned()
 }
 
 /// The result of opening a workspace via [`open_paths`], [`Workspace::new_local`],
@@ -10084,15 +10122,22 @@ pub fn open_paths(
                         &SerializedWorkspaceLocation::Local,
                         cx,
                     );
-                    let window = cx
+                    let window = open_options
+                        .requesting_window
+                        .filter(|window| windows.contains(window))
+                        .or_else(|| cx
                         .active_window()
                         .and_then(|window| window.downcast::<MultiWorkspace>())
                         .filter(|window| windows.contains(window))
-                        .or_else(|| windows.into_iter().next());
+                        .or_else(|| windows.into_iter().next()));
                     if let Some(window) = window {
                         if let Ok(multi_workspace) = window.read(cx) {
-                            let active_workspace = multi_workspace.workspace().clone();
-                            existing = Some((window, active_workspace));
+                            let workspace = requesting_workspace_in_window(
+                                &open_options,
+                                multi_workspace,
+                            )
+                            .unwrap_or_else(|| multi_workspace.workspace().clone());
+                            existing = Some((window, workspace));
                             open_visible = OpenVisible::None;
                         }
                     }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -72,9 +72,10 @@ use workspace::{
     restore_multiworkspace,
 };
 use zed::{
-    OpenListener, OpenRequest, RawOpenRequest, app_menus, build_window_options,
-    derive_paths_with_position, edit_prediction_registry, handle_cli_connection,
-    handle_keymap_file_changes, initialize_workspace, open_paths_with_positions,
+    OpenListener, OpenRequest, RawOpenRequest, app_menus, apply_terminal_origin,
+    build_window_options, derive_paths_with_position, edit_prediction_registry,
+    handle_cli_connection, handle_keymap_file_changes, initialize_workspace,
+    open_paths_with_positions,
 };
 
 use crate::zed::{CrashHandler, OpenRequestKind, eager_load_active_theme_and_icon_theme};
@@ -981,6 +982,7 @@ fn main() {
 }
 
 fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut App) {
+    let terminal_origin = request.terminal_origin;
     if let Some(kind) = request.kind {
         match kind {
             OpenRequestKind::CliConnection(connection) => {
@@ -1183,11 +1185,12 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
                 });
             }
             OpenRequestKind::GitCommit { sha } => {
-                let base_open_options = zed::open_options_for_request(
+                let mut base_open_options = zed::open_options_for_request(
                     request.open_behavior,
                     &workspace::SerializedWorkspaceLocation::Local,
                     cx,
                 );
+                apply_terminal_origin(&mut base_open_options, terminal_origin, cx);
                 cx.spawn(async move |cx| {
                     let paths_with_position =
                         derive_paths_with_position(app_state.fs.as_ref(), request.open_paths).await;
@@ -1240,7 +1243,8 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
     if let Some(connection_options) = request.remote_connection {
         let open_behavior = request.open_behavior;
         let location = workspace::SerializedWorkspaceLocation::Remote(connection_options.clone());
-        let base_open_options = zed::open_options_for_request(open_behavior, &location, cx);
+        let mut base_open_options = zed::open_options_for_request(open_behavior, &location, cx);
+        apply_terminal_origin(&mut base_open_options, terminal_origin, cx);
         cx.spawn(async move |cx| {
             let paths: Vec<PathBuf> = request.open_paths.into_iter().map(PathBuf::from).collect();
             open_remote_project(connection_options, paths, app_state, base_open_options, cx).await
@@ -1253,11 +1257,12 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
     let dev_container = request.dev_container;
     if !request.open_paths.is_empty() || !request.diff_paths.is_empty() {
         let app_state = app_state.clone();
-        let base_open_options = zed::open_options_for_request(
+        let mut base_open_options = zed::open_options_for_request(
             request.open_behavior,
             &workspace::SerializedWorkspaceLocation::Local,
             cx,
         );
+        apply_terminal_origin(&mut base_open_options, terminal_origin, cx);
         task = Some(cx.spawn(async move |cx| {
             let paths_with_position =
                 derive_paths_with_position(app_state.fs.as_ref(), request.open_paths).await;

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -2,7 +2,7 @@ use crate::handle_open_request;
 use crate::restore_or_create_workspace;
 use agent_ui::ExternalSourcePrompt;
 use anyhow::{Context as _, Result, anyhow};
-use cli::{CliRequest, CliResponse, CliResponseSink};
+use cli::{CliRequest, CliResponse, CliResponseSink, CliTerminalOrigin};
 use cli::{IpcHandshake, ipc};
 use client::{ZedLink, parse_zed_link};
 use db::kvp::KeyValueStore;
@@ -14,7 +14,7 @@ use futures::future;
 
 use futures::{FutureExt, StreamExt};
 use git_ui::{file_diff_view::FileDiffView, multi_diff_view::MultiDiffView};
-use gpui::{App, AsyncApp, Global, TaskExt, WindowHandle};
+use gpui::{App, AsyncApp, Global, TaskExt, WeakEntity, WindowHandle, WindowId};
 use onboarding::FIRST_OPEN;
 use onboarding::show_onboarding_view;
 use recent_projects::{RemoteSettings, navigate_to_positions, open_remote_project};
@@ -43,6 +43,7 @@ pub struct OpenRequest {
     pub join_channel: Option<u64>,
     pub remote_connection: Option<RemoteConnectionOptions>,
     pub open_behavior: Option<cli::OpenBehavior>,
+    pub terminal_origin: Option<CliTerminalOrigin>,
 }
 
 pub enum OpenRequestKind {
@@ -138,6 +139,7 @@ impl OpenRequest {
         this.diff_all = request.diff_all;
         this.dev_container = request.dev_container;
         this.open_behavior = request.open_behavior;
+        this.terminal_origin = request.terminal_origin;
         if let Some(wsl) = request.wsl {
             let (user, distro_name) = if let Some((user, distro)) = wsl.split_once('@') {
                 if user.is_empty() {
@@ -387,6 +389,7 @@ pub struct RawOpenRequest {
     pub dev_container: bool,
     pub wsl: Option<String>,
     pub open_behavior: Option<cli::OpenBehavior>,
+    pub terminal_origin: Option<CliTerminalOrigin>,
 }
 
 impl Global for OpenListener {}
@@ -566,6 +569,7 @@ pub async fn handle_cli_connection(
                 user_data_dir: _,
                 dev_container,
                 cwd,
+                terminal_origin,
             } => {
                 if !urls.is_empty() {
                     cx.update(|cx| {
@@ -577,6 +581,7 @@ pub async fn handle_cli_connection(
                                 dev_container,
                                 wsl,
                                 open_behavior: Some(open_behavior),
+                                terminal_origin,
                             },
                             cx,
                         ) {
@@ -635,6 +640,7 @@ pub async fn handle_cli_connection(
                     app_state.clone(),
                     env,
                     cwd,
+                    terminal_origin,
                     cx,
                 )
                 .await;
@@ -803,6 +809,47 @@ fn open_behavior_for_default_setting(cx: &App) -> cli::OpenBehavior {
     }
 }
 
+fn terminal_origin_workspace(
+    terminal_origin: CliTerminalOrigin,
+    cx: &App,
+) -> Option<(
+    WindowHandle<MultiWorkspace>,
+    WeakEntity<workspace::Workspace>,
+)> {
+    let origin_window = WindowHandle::new(WindowId::from(terminal_origin.window_id));
+    let origin_window = cx
+        .windows()
+        .into_iter()
+        .filter_map(|window| window.downcast::<MultiWorkspace>())
+        .find(|window| *window == origin_window)?;
+    let origin_workspace = origin_window
+        .read(cx)
+        .ok()?
+        .workspaces()
+        .find(|workspace| workspace.entity_id().as_u64() == terminal_origin.workspace_id)?;
+    Some((origin_window, origin_workspace.downgrade()))
+}
+
+pub(crate) fn apply_terminal_origin(
+    open_options: &mut workspace::OpenOptions,
+    terminal_origin: Option<CliTerminalOrigin>,
+    cx: &App,
+) {
+    if open_options.workspace_matching == workspace::WorkspaceMatching::MatchSubpaths
+        || (open_options.workspace_matching == workspace::WorkspaceMatching::None
+            && open_options.requesting_window.is_none())
+    {
+        return;
+    }
+
+    if let Some((origin_window, origin_workspace)) =
+        terminal_origin.and_then(|origin| terminal_origin_workspace(origin, cx))
+    {
+        open_options.requesting_window = Some(origin_window);
+        open_options.requesting_workspace = Some(origin_workspace);
+    }
+}
+
 async fn open_workspaces(
     paths: Vec<String>,
     diff_paths: Vec<[String; 2]>,
@@ -814,6 +861,7 @@ async fn open_workspaces(
     app_state: Arc<AppState>,
     env: Option<collections::HashMap<String, String>>,
     cwd: Option<PathBuf>,
+    terminal_origin: Option<CliTerminalOrigin>,
     cx: &mut AsyncApp,
 ) -> Result<()> {
     if paths.is_empty()
@@ -861,8 +909,9 @@ async fn open_workspaces(
     let mut errored = false;
 
     for (location, workspace_paths) in grouped_locations {
-        let base_open_options =
+        let mut base_open_options =
             cx.update(|cx| open_options_for_behavior(open_behavior, &location, cx));
+        cx.update(|cx| apply_terminal_origin(&mut base_open_options, terminal_origin, cx));
         let open_options = workspace::OpenOptions {
             wait,
             env: env.clone(),
@@ -1106,6 +1155,7 @@ mod tests {
     use futures::poll;
     use gpui::{AppContext as _, TestAppContext, UpdateGlobal as _};
     use language::LineEnding;
+    use project::Project;
     use remote::SshConnectionOptions;
     use rope::Rope;
     use serde_json::json;
@@ -1326,6 +1376,31 @@ mod tests {
         });
 
         assert_eq!(request.open_behavior, Some(cli::OpenBehavior::AlwaysNew));
+    }
+
+    #[gpui::test]
+    fn test_parse_file_url_preserves_terminal_origin(cx: &mut TestAppContext) {
+        let _app_state = init_test(cx);
+
+        let request = cx.update(|cx| {
+            OpenRequest::parse(
+                RawOpenRequest {
+                    urls: vec!["file:///tmp/example.rs".into()],
+                    terminal_origin: Some(CliTerminalOrigin {
+                        window_id: 42,
+                        workspace_id: 24,
+                    }),
+                    ..Default::default()
+                },
+                cx,
+            )
+            .unwrap()
+        });
+
+        assert_eq!(request.open_paths, vec!["/tmp/example.rs"]);
+        let terminal_origin = request.terminal_origin.unwrap();
+        assert_eq!(terminal_origin.window_id, 42);
+        assert_eq!(terminal_origin.workspace_id, 24);
     }
 
     #[gpui::test]
@@ -1979,36 +2054,23 @@ mod tests {
             })
             .await;
 
-        // Now test the reuse functionality - should replace the existing workspace
-        let workspace_paths_reuse = vec![file1_path.to_string()];
-        let paths: Vec<PathBuf> = workspace_paths_reuse.iter().map(PathBuf::from).collect();
-        let window_to_replace = workspace::find_existing_workspace(
-            &paths,
-            &workspace::OpenOptions::default(),
-            &workspace::SerializedWorkspaceLocation::Local,
-            &mut cx.to_async(),
-        )
-        .await
-        .0
-        .unwrap()
-        .0;
-
-        let errored_reuse = cx
+        let reuse_result = cx
             .spawn({
                 let app_state = app_state.clone();
                 |mut cx| async move {
                     let response_sink = DiscardResponseSink;
-                    open_local_workspace(
-                        workspace_paths_reuse,
+                    open_workspaces(
+                        vec![file2_path.to_string()],
                         vec![],
                         false,
-                        workspace::OpenOptions {
-                            requesting_window: Some(window_to_replace),
-                            ..Default::default()
-                        },
-                        None,
+                        cli::OpenBehavior::Reuse,
                         &response_sink,
-                        &app_state,
+                        false,
+                        false,
+                        app_state,
+                        None,
+                        None,
+                        None,
                         &mut cx,
                     )
                     .await
@@ -2016,7 +2078,38 @@ mod tests {
             })
             .await;
 
-        assert!(!errored_reuse);
+        assert!(reuse_result.is_ok());
+        assert_eq!(cx.windows().len(), 1);
+
+        let stale_origin_result = cx
+            .spawn({
+                let app_state = app_state.clone();
+                |mut cx| async move {
+                    let response_sink = DiscardResponseSink;
+                    open_workspaces(
+                        vec![file1_path.to_string()],
+                        vec![],
+                        false,
+                        cli::OpenBehavior::Reuse,
+                        &response_sink,
+                        false,
+                        false,
+                        app_state,
+                        None,
+                        None,
+                        Some(CliTerminalOrigin {
+                            window_id: 999_999,
+                            workspace_id: 999_999,
+                        }),
+                        &mut cx,
+                    )
+                    .await
+                }
+            })
+            .await;
+
+        assert!(stale_origin_result.is_ok());
+        assert_eq!(cx.windows().len(), 1);
     }
 
     #[gpui::test]
@@ -2096,7 +2189,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_add_flag_prefers_focused_window(cx: &mut TestAppContext) {
+    async fn test_add_flag_prefers_terminal_origin_window(cx: &mut TestAppContext) {
         let app_state = init_test(cx);
 
         let root_dir = if cfg!(windows) { "C:\\root" } else { "/root" };
@@ -2194,8 +2287,14 @@ mod tests {
         assert_eq!(cx.windows().len(), 2);
         let multi_workspace_2 = cx.windows()[1].downcast::<MultiWorkspace>().unwrap();
 
-        // Focus window2
-        multi_workspace_2
+        let terminal_origin = multi_workspace_2
+            .update(cx, |multi_workspace, window, _| CliTerminalOrigin {
+                window_id: window.window_handle().window_id().as_u64(),
+                workspace_id: multi_workspace.workspace().entity_id().as_u64(),
+            })
+            .unwrap();
+
+        multi_workspace_1
             .update(cx, |_, window, _| {
                 window.activate_window();
             })
@@ -2215,33 +2314,35 @@ mod tests {
             .unwrap();
 
         let workspace_paths_add = vec![new_file_path.to_string()];
-        let _errored = cx
+        let result = cx
             .spawn({
                 let app_state = app_state.clone();
                 |mut cx| async move {
                     let response_sink = DiscardResponseSink;
-                    open_local_workspace(
+                    open_workspaces(
                         workspace_paths_add,
                         Vec::new(),
                         false,
-                        workspace::OpenOptions {
-                            workspace_matching: workspace::WorkspaceMatching::MatchSubdirectory, // --add flag
-                            ..Default::default()
-                        },
-                        None,
+                        cli::OpenBehavior::Add,
                         &response_sink,
-                        &app_state,
+                        false,
+                        false,
+                        app_state,
+                        None,
+                        None,
+                        Some(terminal_origin),
                         &mut cx,
                     )
                     .await
                 }
             })
             .await;
+        assert!(result.is_ok());
 
         // Should still have 2 windows (file added to existing focused window)
         assert_eq!(cx.windows().len(), 2);
 
-        // Verify the file was added to window2 (the focused one)
+        // Verify the file was added to window2, despite window1 being active.
         multi_workspace_2
             .update(cx, |workspace, _, cx| {
                 let items = workspace.workspace().read(cx).items(cx).collect::<Vec<_>>();
@@ -2257,6 +2358,221 @@ mod tests {
                 assert_eq!(items.len(), 1, "Other window should still have 1 item");
             })
             .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_unmatched_directory_prefers_terminal_origin_window(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+
+        let root_dir = if cfg!(windows) { "C:\\root" } else { "/root" };
+        let file1_path = if cfg!(windows) {
+            "C:\\root\\file1.txt"
+        } else {
+            "/root/file1.txt"
+        };
+        let file2_path = if cfg!(windows) {
+            "C:\\root\\file2.txt"
+        } else {
+            "/root/file2.txt"
+        };
+        let unmatched_dir = if cfg!(windows) {
+            "C:\\unmatched-dir"
+        } else {
+            "/unmatched-dir"
+        };
+
+        app_state.fs.create_dir(Path::new(root_dir)).await.unwrap();
+        app_state
+            .fs
+            .create_file(Path::new(file1_path), Default::default())
+            .await
+            .unwrap();
+        app_state
+            .fs
+            .create_file(Path::new(file2_path), Default::default())
+            .await
+            .unwrap();
+        app_state
+            .fs
+            .create_dir(Path::new(unmatched_dir))
+            .await
+            .unwrap();
+
+        open_workspace_file(
+            file1_path,
+            workspace::OpenOptions::default(),
+            app_state.clone(),
+            cx,
+        )
+        .await;
+        assert_eq!(cx.windows().len(), 1);
+        let multi_workspace_1 = cx.windows()[0].downcast::<MultiWorkspace>().unwrap();
+
+        open_workspace_file(
+            file2_path,
+            workspace::OpenOptions {
+                workspace_matching: workspace::WorkspaceMatching::None,
+                ..Default::default()
+            },
+            app_state.clone(),
+            cx,
+        )
+        .await;
+        assert_eq!(cx.windows().len(), 2);
+        let multi_workspace_2 = cx.windows()[1].downcast::<MultiWorkspace>().unwrap();
+
+        let terminal_origin = multi_workspace_2
+            .update(cx, |multi_workspace, window, _| CliTerminalOrigin {
+                window_id: window.window_handle().window_id().as_u64(),
+                workspace_id: multi_workspace.workspace().entity_id().as_u64(),
+            })
+            .unwrap();
+
+        // Focus window 1 so we can prove the directory routes to the origin
+        // window (2) rather than the active one.
+        multi_workspace_1
+            .update(cx, |_, window, _| window.activate_window())
+            .unwrap();
+
+        let result = cx
+            .spawn({
+                let app_state = app_state.clone();
+                |mut cx| async move {
+                    let response_sink = DiscardResponseSink;
+                    open_workspaces(
+                        vec![unmatched_dir.to_string()],
+                        Vec::new(),
+                        false,
+                        cli::OpenBehavior::ExistingWindow,
+                        &response_sink,
+                        false,
+                        false,
+                        app_state,
+                        None,
+                        None,
+                        Some(terminal_origin),
+                        &mut cx,
+                    )
+                    .await
+                }
+            })
+            .await;
+        assert!(result.is_ok());
+
+        // No new window should be opened for the unmatched directory.
+        assert_eq!(cx.windows().len(), 2);
+
+        // The directory should be added to the origin window's multi-workspace,
+        // not the active window's.
+        let workspaces_1 = multi_workspace_1
+            .read_with(cx, |multi_workspace, _| {
+                multi_workspace.workspaces().count()
+            })
+            .unwrap();
+        let workspaces_2 = multi_workspace_2
+            .read_with(cx, |multi_workspace, _| {
+                multi_workspace.workspaces().count()
+            })
+            .unwrap();
+        assert_eq!(workspaces_1, 1, "active window should be untouched");
+        assert_eq!(
+            workspaces_2, 2,
+            "origin window should host the unmatched directory"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_file_fallback_prefers_terminal_origin_workspace(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let root_dir = if cfg!(windows) { "C:\\root" } else { "/root" };
+        let source_file = if cfg!(windows) {
+            "C:\\root\\source.txt"
+        } else {
+            "/root/source.txt"
+        };
+        let unmatched_file = if cfg!(windows) {
+            "C:\\unmatched.txt"
+        } else {
+            "/unmatched.txt"
+        };
+
+        app_state.fs.create_dir(Path::new(root_dir)).await.unwrap();
+        app_state
+            .fs
+            .create_file(Path::new(source_file), Default::default())
+            .await
+            .unwrap();
+        app_state
+            .fs
+            .create_file(Path::new(unmatched_file), Default::default())
+            .await
+            .unwrap();
+
+        open_workspace_file(
+            source_file,
+            workspace::OpenOptions::default(),
+            app_state.clone(),
+            cx,
+        )
+        .await;
+
+        let multi_workspace = cx.windows()[0].downcast::<MultiWorkspace>().unwrap();
+        let source_workspace = multi_workspace
+            .read_with(cx, |multi_workspace, _| multi_workspace.workspace().clone())
+            .unwrap();
+        let active_project = Project::test(app_state.fs.clone(), [], cx).await;
+        let active_workspace = multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.test_add_workspace(active_project, window, cx)
+            })
+            .unwrap();
+        let terminal_origin = multi_workspace
+            .update(cx, |_, window, _| CliTerminalOrigin {
+                window_id: window.window_handle().window_id().as_u64(),
+                workspace_id: source_workspace.entity_id().as_u64(),
+            })
+            .unwrap();
+
+        assert_eq!(
+            multi_workspace
+                .read_with(cx, |multi_workspace, _| multi_workspace
+                    .workspace()
+                    .entity_id())
+                .unwrap(),
+            active_workspace.entity_id()
+        );
+
+        let result = cx
+            .spawn({
+                let app_state = app_state.clone();
+                |mut cx| async move {
+                    let response_sink = DiscardResponseSink;
+                    open_workspaces(
+                        vec![unmatched_file.to_string()],
+                        Vec::new(),
+                        false,
+                        cli::OpenBehavior::ExistingWindow,
+                        &response_sink,
+                        false,
+                        false,
+                        app_state,
+                        None,
+                        None,
+                        Some(terminal_origin),
+                        &mut cx,
+                    )
+                    .await
+                }
+            })
+            .await;
+
+        assert!(result.is_ok());
+        source_workspace.update(cx, |workspace, cx| {
+            assert_eq!(workspace.items(cx).count(), 2);
+        });
+        active_workspace.update(cx, |workspace, cx| {
+            assert_eq!(workspace.items(cx).count(), 0);
+        });
     }
 
     #[gpui::test]
@@ -2394,6 +2710,7 @@ mod tests {
             user_data_dir: None,
             dev_container: false,
             cwd: None,
+            terminal_origin: None,
         }
     }
 
@@ -2413,6 +2730,7 @@ mod tests {
             user_data_dir: None,
             dev_container: false,
             cwd: None,
+            terminal_origin: None,
         }
     }
 

--- a/crates/zed/src/zed/windows_only_instance.rs
+++ b/crates/zed/src/zed/windows_only_instance.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, thread::JoinHandle};
 
 use anyhow::Context;
-use cli::{CliRequest, CliResponse, IpcHandshake, ipc::IpcOneShotServer};
+use cli::{CliRequest, CliResponse, CliTerminalOrigin, IpcHandshake, ipc::IpcOneShotServer};
 use parking_lot::Mutex;
 use release_channel::app_identifier;
 use util::ResultExt;
@@ -22,6 +22,7 @@ use windows::{
     },
     core::HSTRING,
 };
+use zed_env_vars::{ZED_CLI_ORIGIN_WINDOW_ID, ZED_CLI_ORIGIN_WORKSPACE_ID};
 
 use crate::{Args, OpenListener, RawOpenRequest};
 
@@ -163,6 +164,15 @@ fn send_args_to_instance(args: &Args) -> anyhow::Result<()> {
             user_data_dir: args.user_data_dir.clone(),
             dev_container: args.dev_container,
             cwd: std::env::current_dir().ok(),
+            terminal_origin: std::env::var(ZED_CLI_ORIGIN_WINDOW_ID)
+                .ok()
+                .zip(std::env::var(ZED_CLI_ORIGIN_WORKSPACE_ID).ok())
+                .and_then(|(window_id, workspace_id)| {
+                    Some(CliTerminalOrigin {
+                        window_id: window_id.parse().ok()?,
+                        workspace_id: workspace_id.parse().ok()?,
+                    })
+                }),
         }
     };
 

--- a/crates/zed_env_vars/src/zed_env_vars.rs
+++ b/crates/zed_env_vars/src/zed_env_vars.rs
@@ -4,3 +4,6 @@ use std::sync::LazyLock;
 /// Whether Zed is running in stateless mode.
 /// When true, Zed will use in-memory databases instead of persistent storage.
 pub static ZED_STATELESS: LazyLock<bool> = bool_env_var!("ZED_STATELESS");
+
+pub const ZED_CLI_ORIGIN_WINDOW_ID: &str = "ZED_CLI_ORIGIN_WINDOW_ID";
+pub const ZED_CLI_ORIGIN_WORKSPACE_ID: &str = "ZED_CLI_ORIGIN_WORKSPACE_ID";


### PR DESCRIPTION
## Context

Running the `zed` CLI from Zed's own integrated terminal (for example `zed --add ../some-dir` or `zed ./file`) did not target the window the terminal belongs to. The CLI request carried no record of where it came from, so routing fell back to the active or first Zed window, and the command could land in the wrong window.

Closes #47914 .

The fix gives integrated-terminal CLI requests an explicit origin. When Zed spawns a local terminal, it injects the source window and workspace IDs into the environment (`ZED_CLI_ORIGIN_WINDOW_ID` and `ZED_CLI_ORIGIN_WORKSPACE_ID`). The CLI reads them back and forwards them in a dedicated `terminal_origin` field. On the receiving side the origin is applied only as a fallback: real exact and subpath workspace matches and explicit new-window behavior are left untouched, and the origin only replaces the arbitrary active-or-first-window fallback. Remote SSH terminals are excluded.

## How to Review

- `crates/zed_env_vars/src/zed_env_vars.rs`: Defines the two shared env-var name constants used by both the terminal (producer) and the CLI (consumer).
- `crates/cli/src/cli.rs`: Adds the serialized `CliTerminalOrigin { window_id, workspace_id }` type and an optional `terminal_origin` field on `CliRequest::Open` (`#[serde(default)]` for backward compatibility with older CLIs).
- `crates/cli/src/main.rs`: Reads the origin from the environment through a small testable helper (`terminal_origin_from_env`), strips the origin keys from the forwarded env payload so they can't leak into the opened project's environment, and sends the origin in the request. Includes parser tests for valid, missing, and malformed values.
- `crates/terminal/src/terminal.rs`: Adds `TerminalSource` and makes `insert_zed_terminal_env` inject the origin env vars. `TerminalBuilder` threads the source through and only injects it for local (non-remote) terminals. Includes a unit test.
- `crates/project/src/terminals.rs`: Adds source-aware terminal helpers (`create_terminal_shell_with_origin`, `create_local_terminal_with_origin`, `clone_terminal_with_origin`, `create_terminal_task_with_origin`), keeping the existing methods as `None` wrappers.
- `crates/terminal_view/src/terminal_panel.rs`, `terminal_view.rs`, `persistence.rs`: Compute the origin from the current `Window` and `Workspace` at every local terminal-creation site (panel shells, center terminals, cloned and split terminals, task terminals, and restored or deserialized terminals).
- `crates/workspace/src/workspace.rs`: Adds `OpenOptions::requesting_workspace` and updates fallback routing. Exact and subpath matches still win; `--add`/`MatchSubdirectory` with no real match falls back to the requesting window; the file fallback prefers the requesting workspace before the active or first window.
- `crates/zed/src/zed/open_listener.rs`: Plumbs `terminal_origin` through `OpenRequest`, resolves it to a live window and workspace (`terminal_origin_workspace`), and applies it to compatible behaviors only (`apply_terminal_origin`). New tests cover `--add`, the file fallback, the unmatched-directory case, parsing, and stale-origin fallback.
- `crates/zed/src/main.rs`, `windows_only_instance.rs`: Carry `terminal_origin` into `RawOpenRequest` and apply it on the local, remote, and Windows single-instance open paths.
- `crates/cli/Cargo.toml`, `crates/terminal/Cargo.toml`, `Cargo.lock`: Add the `zed_env_vars` dependency.

## How to Test

### Automated

```bash
cargo test -p cli terminal_origin
cargo test -p zed open_listener::tests::
cargo test -p terminal test_insert_zed_terminal_env
```

### Manual

> Important: dev builds skip the CLI single-instance listener, so a raw `target/debug/zed` launch never binds the socket the CLI attaches to. Every `zed` or `cli` call would then spawn a separate process, and because window and workspace IDs are process local they would collide. Set a non-dev channel with `ZED_RELEASE_CHANNEL` so both binaries run as one instance.

```bash
cargo build -p zed -p cli
mkdir -p /tmp/zed-cli-routing/{data,projectA,projectB,add-dir,add-dir-2}

# Window A (one instance, isolated data dir)
ZED_RELEASE_CHANNEL=nightly target/debug/zed \
  --user-data-dir /tmp/zed-cli-routing/data \
  /tmp/zed-cli-routing/projectA &

# Window B: a new window in the same instance
ZED_RELEASE_CHANNEL=nightly target/debug/cli \
  --user-data-dir /tmp/zed-cli-routing/data \
  --new /tmp/zed-cli-routing/projectB
```

1. Confirm the setup is one instance with two windows. Open the integrated terminal (`` Ctrl+` ``) in each window and run `env | grep ZED_CLI_ORIGIN`. The two windows must report different `ZED_CLI_ORIGIN_WINDOW_ID` values. A shared value means you launched two separate processes, so recheck the `ZED_RELEASE_CHANNEL` and `--user-data-dir` flags.

2. Route to the terminal's window rather than the active one. Click window A so it is focused. From window B's integrated terminal, run:

   ```bash
   ZED_RELEASE_CHANNEL=nightly /ABSOLUTE/PATH/TO/target/debug/cli \
     --user-data-dir /tmp/zed-cli-routing/data \
     --add /tmp/zed-cli-routing/add-dir
   ```

   Expected: `add-dir` is added to window B, window A is untouched, and no third window opens.

3. Check the other direction. Click window B so it is focused. From window A's integrated terminal, run the same command with `--add /tmp/zed-cli-routing/add-dir-2`. Expected: `add-dir-2` is added to window A, and window B is untouched.

4. Confirm existing behavior is preserved. From an external terminal (not a Zed one), `zed --add <dir>` and `zed <file>` route via the previous active-or-first-window fallback, and `zed -n <path>` still opens a new window.

Video of manual test below :

[Screencast from 2026-07-11 01-04-58.webm](https://github.com/user-attachments/assets/1217a8a9-f549-4f40-8b57-7757ca06d506)


## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed `zed` commands run from Zed's integrated terminal targeting the wrong window instead of the terminal's own window
