### PR TITLE
settings_ui: Shrink constraint on minimum window width

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -870,10 +870,7 @@ fn open_settings_editor_with(
                 app_id: Some(app_id.to_owned()),
                 window_decorations: Some(window_decorations),
                 window_min_size: Some(gpui::Size {
-                    // Don't make the settings window thinner than this,
-                    // otherwise, it gets unusable. Users with smaller res monitors
-                    // can customize the height, but not the width.
-                    width: px(900.0),
+                    width: px(360.0),
                     height: px(240.0),
                 }),
                 window_bounds: Some(WindowBounds::centered(scaled_bounds, cx)),


### PR DESCRIPTION
# Objective

Right now the minimum width of the settings window is 900px, this makes it so that when I open it with my window manager (aerospace), it goes off the screen on the right side.

https://github.com/user-attachments/assets/e47c1f13-0b5c-49e1-9a1e-4d3b494eca8d

## Solution

There is a comment, that says:
```
// Don't make the settings window thinner than this,
// otherwise, it gets unusable. Users with smaller res monitors
// can customize the height, but not the width.
width: px(900.0),
height: px(240.0),
```
the comment and limit was added in #44505, which added the edit prediction provider ui. Now in the past, in #51878 I fixed a bug with the way that the edit prediction provider and some of the other sub menu type pages in the settings menu displayed. There isn't really any record of what specifically made the window unusable below 900px besides the issue that I fixed in #51878.

## Testing

I tested it by just sort of poking around the different settings pages, especially the ones I fixed in #51878, and every thing seems totally fine to me. That said I haven't exhaustively checked every page and if there was any more information on what that comment was referring to that would be awesome.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

How it looks after the change:

https://github.com/user-attachments/assets/9258f51f-5da5-4f4c-997d-7f09a3448e4b

---

Release Notes:

- settings_ui: Allowed window widths below 900px
