### PR TITLE
project: Load shell environment before starting stdio MCP servers

### DIFF
--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -985,6 +985,36 @@ impl ContextServerStore {
                 None
             };
 
+        let is_local_stdio = !is_remote_project
+            && matches!(
+                configuration.as_ref(),
+                ContextServerConfiguration::Custom { .. }
+                    | ContextServerConfiguration::Extension { .. }
+            );
+
+        let shell_environment = if is_local_stdio {
+            let project = this.update(cx, |this, _| {
+                this.project.as_ref().and_then(|project| project.upgrade())
+            })?;
+
+            match project {
+                Some(project) => {
+                    let environment_task = project.update(cx, |project, cx| {
+                        project.environment().update(cx, |environment, cx| {
+                            match root_path.clone() {
+                                Some(path) => environment.directory_environment(path, cx),
+                                None => environment.default_environment(cx),
+                            }
+                        })
+                    });
+                    environment_task.await
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
+
         let server: Arc<ContextServer> = this.update(cx, |this, cx| {
             let global_timeout = this.timeout_for_server(&id, cx);
 
@@ -1021,6 +1051,12 @@ impl ContextServerStore {
                             .unwrap_or(global_timeout)
                             .min(MAX_TIMEOUT_SECS),
                     );
+
+                    if let Some(shell_environment) = shell_environment {
+                        let mut env = shell_environment;
+                        env.extend(command.env.take().unwrap_or_default());
+                        command.env = Some(env);
+                    }
 
                     // Don't pass remote paths as working directory for locally-spawned processes
                     let working_directory = if is_remote_project { None } else { root_path };


### PR DESCRIPTION
Fixes #60800.

## Summary

Custom stdio MCP servers that depend on PATH (e.g. `#!/usr/bin/env node` scripts or `npx`) can fail to auto-start when Zed is launched from Finder/Dock on macOS, showing `Context server request timeout`. The same configuration works when Zed is launched from a terminal.

## Root cause

MCP stdio servers were spawned with only the env vars from `context_servers.*.env`, without waiting for or merging the login shell / worktree environment. LSP servers already do this via `delegate.shell_env().await` before spawning.

On GUI launch, Zed loads the login shell environment asynchronously, but `ContextServerStore` starts MCP servers immediately on init — before PATH is fully populated.

## Fix

Before spawning a local stdio MCP server, load the project shell environment via `ProjectEnvironment::directory_environment` (or `default_environment`), merge it with the user-configured env (user values win), then spawn.

## Test plan

- [x] `cargo check -p project`
- [x] `cargo test -p project context_server_store` — all existing tests pass, no regressions
- [x] Reproduced the failure conditions locally on macOS and confirmed a PATH-dependent stdio MCP server (`#!/usr/bin/env node`, with `node` in a non-standard path) now auto-starts without timeout — see verification comment below
- [x] Terminal launch still works
- [x] User-configured env vars still applied (user values take precedence over shell env)

## Related

- UI issue (toggle showing disabled on failed start): #60552

---

Release Notes:

- Fixed custom stdio MCP servers failing to auto-start on macOS when Zed is launched from Finder/Dock.