### PR TITLE
Fix “Open file in project" option in the right-click menu not working

### DIFF
--- a/crates/editor/src/element/header.rs
+++ b/crates/editor/src/element/header.rs
@@ -976,7 +976,7 @@ pub(crate) fn render_buffer_header(
     let editor = editor.clone();
     let buffer_snapshot = buffer.clone();
 
-    right_click_menu("buffer-header-context-menu")
+    right_click_menu(("buffer-header-context-menu", buffer_id.to_proto()))
         .trigger(move |_, _, _| header)
         .menu(move |window, cx| {
             let menu_context = focus_handle.clone();


### PR DESCRIPTION
# Objective

Fix file header context menu actions in multi-file Git history diffs. Previously, `Open File in Project` worked for the first file but did nothing for subsequent files.

Fixes #60790

## Solution

Include the buffer ID in each file header context menu's GPUI element ID. This prevents multiple file headers in split diff views from sharing the same menu state.

## Testing

- Ran `cargo check -p editor --lib`.
- Ran `cargo fmt --package editor -- --check`.
- Reviewers can test by opening a multi-file commit from Git Panel → History in split diff mode, then using `Open File in Project` on the second and subsequent file headers.

https://github.com/user-attachments/assets/46fa4e15-60ac-4ae3-9a73-a89c7f107cb0

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed opening project files from context menus in multi-file Git history diffs.
