### PR TITLE
Fix double-click text selection and tab bar flicker in Markdown preview

### DIFF
--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -596,9 +596,10 @@ impl MarkdownPreviewView {
         });
     }
 
-    fn move_cursor_to_source_index(
+    fn change_selection_to_source_index(
         editor: &Entity<Editor>,
         source_index: usize,
+        move_focus: bool,
         window: &mut Window,
         cx: &mut App,
     ) {
@@ -610,7 +611,9 @@ impl MarkdownPreviewView {
                 cx,
                 |selections| selections.select_ranges(vec![selection]),
             );
-            window.focus(&editor.focus_handle(cx), cx);
+            if move_focus {
+                window.focus(&editor.focus_handle(cx), cx);
+            }
         });
     }
 
@@ -882,12 +885,16 @@ impl MarkdownPreviewView {
             let view_handle = cx.entity().downgrade();
             markdown_element = markdown_element
                 .on_source_click(move |source_index, click_count, window, cx| {
-                    if click_count == 2 {
-                        Self::move_cursor_to_source_index(&active_editor, source_index, window, cx);
-                        true
-                    } else {
-                        false
+                    if click_count == 1 {
+                        Self::change_selection_to_source_index(
+                            &active_editor,
+                            source_index,
+                            false,
+                            window,
+                            cx,
+                        );
                     }
+                    false
                 })
                 .on_checkbox_toggle(move |source_range, new_checked, window, cx| {
                     Self::apply_checkbox_toggle_to_editor(
@@ -976,9 +983,10 @@ fn handle_url_click(
 
                     if let Some(source_index) = source_index {
                         if let Some(editor) = active_editor {
-                            MarkdownPreviewView::move_cursor_to_source_index(
+                            MarkdownPreviewView::change_selection_to_source_index(
                                 &editor,
                                 source_index,
+                                true,
                                 window,
                                 cx,
                             );


### PR DESCRIPTION
# Objective

Fixes #60812

Previously, double-clicking in the preview updated the source editor selection/cursor position, moved focus to the source editor, and stopped the event from propagating. This prevented normal text selection in the preview. When the source editor was in the same pane but not the active tab, focus was then restored back to the preview, causing the tab/tab bar to flicker.
## Solution

Update the source editor selection/cursor position on single-click instead of double-click, while keeping focus in the Markdown preview. This leaves double-click behavior available for normal text selection in the preview.
- This approach keeps Markdown preview interactions consistent with common text behavior: double-clicking text should select the word/text under the cursor..
- The source editor selection/cursor position is still updated on single-click so the preview can continue to keep the source editor in sync with the location the user is inspecting.

## Testing

Manually tested the Markdown preview click behavior.

I also tried adding a regression test using `simulate_event` to simulate mouse events, but I could not find a reliable API for locating the rendered text position inside the Markdown preview. Because of that, this was validated manually.

Manual test steps:

1. Open a Markdown file.
2. Open the Markdown preview for that file.
3. Keep the source editor and Markdown preview as separate tabs in the same pane.
4. Activate the Markdown preview tab.
5. Single-click text in the Markdown preview.
   - Confirm the source editor selection/cursor position is updated.
   - Confirm focus remains in the Markdown preview.
   - Confirm the tab bar does not flicker.
6. Double-click text in the Markdown preview.
   - Confirm the text in the preview is selected.
   - Confirm focus remains in the Markdown preview.
   - Confirm the tab bar does not flicker.
## Self-Review Checklist:

- [X] I've reviewed my own diff for quality, security, and reliability
- [X] Unsafe blocks (if any) have justifying comments
- [X] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [X] Performance impact has been considered and is acceptable

## Showcase

after change:

[录屏 2026-07-11 23-44-16.webm](https://github.com/user-attachments/assets/616d1ed3-5802-402f-8499-4864b149c550)

---

Release Notes:

-  Fixed double-click text selection and tab bar flicker in Markdown preview.
