### PR TITLE
gpui: Clip content to rounded corners

### DIFF
--- a/crates/editor/src/edit_prediction.rs
+++ b/crates/editor/src/edit_prediction.rs
@@ -2125,6 +2125,7 @@ impl Editor {
         window.with_content_mask(
             Some(gpui::ContentMask {
                 bounds: *text_bounds,
+                ..Default::default()
             }),
             |window| {
                 window.defer_draw(element, origin, 1, Some(window.content_mask()));

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5496,6 +5496,7 @@ impl EditorElement {
         window.with_content_mask(
             Some(ContentMask {
                 bounds: layout.position_map.text_hitbox.bounds,
+                ..Default::default()
             }),
             |window| {
                 let editor = self.editor.read(cx);
@@ -6482,7 +6483,11 @@ impl EditorElement {
         for mut block in layout.spacer_blocks.drain(..) {
             let mut bounds = layout.hitbox.bounds;
             bounds.origin.x += layout.gutter_hitbox.bounds.size.width;
-            window.with_content_mask(Some(ContentMask { bounds }), |window| {
+            let content_mask = ContentMask {
+                bounds,
+                ..Default::default()
+            };
+            window.with_content_mask(Some(content_mask), |window| {
                 block.element.paint(window, cx);
             })
         }
@@ -6500,7 +6505,11 @@ impl EditorElement {
             } else {
                 let mut bounds = layout.hitbox.bounds;
                 bounds.origin.x += layout.gutter_hitbox.bounds.size.width;
-                window.with_content_mask(Some(ContentMask { bounds }), |window| {
+                let content_mask = ContentMask {
+                    bounds,
+                    ..Default::default()
+                };
+                window.with_content_mask(Some(content_mask), |window| {
                     block.element.paint(window, cx);
                 })
             }
@@ -7957,7 +7966,11 @@ impl Element for EditorElement {
         let rem_size = self.rem_size(cx);
         window.with_rem_size(rem_size, |window| {
             window.with_text_style(Some(text_style), |window| {
-                window.with_content_mask(Some(ContentMask { bounds }), |window| {
+                let content_mask = ContentMask {
+                    bounds,
+                    ..Default::default()
+                };
+                window.with_content_mask(Some(content_mask), |window| {
                     let (mut snapshot, is_read_only) = self.editor.update(cx, |editor, cx| {
                         (editor.snapshot(window, cx), editor.read_only(cx))
                     });
@@ -9440,7 +9453,11 @@ impl Element for EditorElement {
         let rem_size = self.rem_size(cx);
         window.with_rem_size(rem_size, |window| {
             window.with_text_style(Some(text_style), |window| {
-                window.with_content_mask(Some(ContentMask { bounds }), |window| {
+                let content_mask = ContentMask {
+                    bounds,
+                    ..Default::default()
+                };
+                window.with_content_mask(Some(content_mask), |window| {
                     self.paint_mouse_listeners(layout, window, cx);
 
                     // Mask the editor behind sticky scroll headers. Important
@@ -9463,6 +9480,7 @@ impl Element for EditorElement {
                                         .max(Pixels::ZERO),
                                 ),
                             },
+                            ..Default::default()
                         });
 
                     window.with_content_mask(below_sticky_headers_mask, |window| {
@@ -10732,7 +10750,14 @@ mod tests {
             bounds: zero_bounds,
             content_mask: ContentMask {
                 bounds: zero_bounds,
+                corner_radii: Corners {
+                    top_left: Pixels::ZERO,
+                    top_right: Pixels::ZERO,
+                    bottom_right: Pixels::ZERO,
+                    bottom_left: Pixels::ZERO,
+                },
             },
+            rounded_masks: Vec::new(),
             behavior: HitboxBehavior::Normal,
         }
     }
@@ -10770,7 +10795,9 @@ mod tests {
             row_info(5),
         ];
 
-        const HITBOX: Hitbox = placeholder_hitbox();
+        // `static` rather than `const`: `Hitbox` now contains a `Vec`, which prevents
+        // promotion of `&HITBOX` to a `'static` borrow of a constant.
+        static HITBOX: Hitbox = placeholder_hitbox();
         Gutter {
             line_height,
             range: DisplayRow(0)..DisplayRow(6),

--- a/crates/editor/src/element/header.rs
+++ b/crates/editor/src/element/header.rs
@@ -527,6 +527,7 @@ impl StickyHeaderLine {
                         + point(Pixels::ZERO, self.offset),
                     size(available_text_width, line_height),
                 ),
+                ..Default::default()
             }),
             |window| {
                 self.line.draw_with_custom_offset(

--- a/crates/editor/src/split_editor_view.rs
+++ b/crates/editor/src/split_editor_view.rs
@@ -351,6 +351,7 @@ impl Element for SplitBufferHeadersElement {
                 window.with_content_mask(
                     Some(ContentMask {
                         bounds: prepaint.content_bounds,
+                        ..Default::default()
                     }),
                     |window| {
                         for header_layout in &mut prepaint.non_sticky_headers {
@@ -688,7 +689,11 @@ impl SplitBufferHeadersElement {
         window: &mut Window,
         cx: &mut App,
     ) {
-        window.with_content_mask(Some(ContentMask { bounds }), |window| {
+        let content_mask = ContentMask {
+            bounds,
+            ..Default::default()
+        };
+        window.with_content_mask(Some(content_mask), |window| {
             header.prepaint_as_root(origin, available_size, window, cx);
         });
     }

--- a/crates/gpui/examples/rounded_clipping.rs
+++ b/crates/gpui/examples/rounded_clipping.rs
@@ -1,0 +1,96 @@
+//! Demonstrates rounded-corner clipping: children of a container with rounded
+//! corners and hidden overflow are clipped to the container's corner arcs, not
+//! just its rectangular bounds.
+#![cfg_attr(target_family = "wasm", no_main)]
+
+use gpui::{
+    App, Bounds, Context, Render, Window, WindowBounds, WindowOptions, div, prelude::*, px, rgb,
+    size,
+};
+use gpui_platform::application;
+
+struct RoundedClippingDemo;
+
+impl Render for RoundedClippingDemo {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .flex()
+            .flex_row()
+            .gap_8()
+            .items_center()
+            .justify_center()
+            .bg(rgb(0x1e1e2e))
+            .child(
+                // A rounded container whose child would poke out of the corners
+                // without rounded clipping.
+                div()
+                    .size(px(200.))
+                    .rounded(px(48.))
+                    .overflow_hidden()
+                    .bg(rgb(0x89b4fa))
+                    .child(div().size(px(200.)).bg(rgb(0xf38ba8)).rounded(px(0.))),
+            )
+            .child(
+                // A rounded scroll container: the scrolled content (text lines)
+                // stays inside the corner arcs while scrolling.
+                div()
+                    .id("scroller")
+                    .size(px(200.))
+                    .rounded(px(48.))
+                    .overflow_y_scroll()
+                    .bg(rgb(0xa6e3a1))
+                    .text_color(rgb(0x11111b))
+                    .children((0..50).map(|ix| div().px_2().child(format!("Line {ix}")))),
+            )
+            .child(
+                // Nested rounded clips: the inner clip's corners apply within
+                // the outer clip's corners.
+                div()
+                    .size(px(200.))
+                    .rounded(px(64.))
+                    .overflow_hidden()
+                    .bg(rgb(0xf9e2af))
+                    .child(
+                        div()
+                            .ml(px(-20.))
+                            .mt(px(-20.))
+                            .size(px(120.))
+                            .rounded(px(32.))
+                            .overflow_hidden()
+                            .bg(rgb(0xcba6f7))
+                            .child(div().size(px(120.)).bg(rgb(0x94e2d5))),
+                    ),
+            )
+    }
+}
+
+fn run_example() {
+    application().run(|cx: &mut App| {
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
+                    None,
+                    size(px(800.), px(400.)),
+                    cx,
+                ))),
+                ..Default::default()
+            },
+            |_, cx| cx.new(|_| RoundedClippingDemo),
+        )
+        .unwrap();
+        cx.activate(true);
+    });
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn main() {
+    run_example();
+}
+
+#[cfg(target_family = "wasm")]
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn start() {
+    gpui_platform::web_init();
+    run_example();
+}

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -4178,6 +4178,62 @@ mod tests {
         }
     }
 
+    struct RoundedClipView;
+
+    impl Render for RoundedClipView {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().child(
+                div()
+                    .size(px(100.))
+                    .rounded(px(24.))
+                    .overflow_hidden()
+                    .child(div().size_full().occlude().bg(crate::blue())),
+            )
+        }
+    }
+
+    #[test]
+    fn rounded_overflow_hidden_clips_hit_testing_and_scene_primitives() {
+        let mut test_app = TestAppContext::single();
+        let window = test_app.add_window(|_, _| RoundedClipView);
+        let any_window: AnyWindowHandle = window.into();
+        test_app
+            .update_window(any_window, |_, window, cx| {
+                window.draw(cx).clear();
+            })
+            .unwrap();
+
+        test_app
+            .update_window(any_window, |_, window, _| {
+                // The center of the rounded container hits the occluding child.
+                let center = window.rendered_frame.hit_test(point(px(50.), px(50.)));
+                assert!(!center.ids.is_empty());
+
+                // A corner point within the bounding rect but outside the corner arc
+                // is visually clipped away, so it doesn't hit. The point (3, 3) is
+                // ~29.7px from the arc center (24, 24), beyond the 24px radius.
+                let corner = window.rendered_frame.hit_test(point(px(3.), px(3.)));
+                assert!(corner.ids.is_empty());
+
+                // A point in the corner square but inside the arc still hits. The
+                // point (12, 12) is ~17px from the arc center, within the radius.
+                let inside_arc = window.rendered_frame.hit_test(point(px(12.), px(12.)));
+                assert!(!inside_arc.ids.is_empty());
+
+                // The child's background quad references a clip node whose rounded
+                // chain contains the container's rounded mask.
+                let scene = &window.rendered_frame.scene;
+                assert_eq!(scene.quads.len(), 1);
+                let quad = &scene.quads[0];
+                let node = scene.clips[quad.clip_id as usize];
+                assert_ne!(node.rounded_head, crate::ClipNode::NONE);
+                let head = scene.clips[node.rounded_head as usize];
+                assert!(head.corner_radii.top_left.0 > 0.);
+                assert_eq!(head.parent_rounded, crate::ClipNode::NONE);
+            })
+            .unwrap();
+    }
+
     #[test]
     fn scroll_handle_aligns_wide_children_to_left_edge() {
         let handle = ScrollHandle::new();

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -1268,8 +1268,12 @@ impl StateInner {
             if bounds.size.height > padding.top + padding.bottom {
                 let mut item_origin = bounds.origin + Point::new(px(0.), padding.top);
                 item_origin.y -= layout_response.scroll_top.offset_in_item;
+                let content_mask = ContentMask {
+                    bounds,
+                    ..Default::default()
+                };
                 for item in &mut layout_response.item_layouts {
-                    window.with_content_mask(Some(ContentMask { bounds }), |window| {
+                    window.with_content_mask(Some(content_mask), |window| {
                         item.element.prepaint_at(item_origin, window, cx);
                     });
 
@@ -1574,7 +1578,11 @@ impl Element for List {
         cx: &mut App,
     ) {
         let current_view = window.current_view();
-        window.with_content_mask(Some(ContentMask { bounds }), |window| {
+        let content_mask = ContentMask {
+            bounds,
+            ..Default::default()
+        };
+        window.with_content_mask(Some(content_mask), |window| {
             for item in &mut prepaint.layout.item_layouts {
                 item.element.paint(window, cx);
             }

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -489,7 +489,10 @@ impl Element for UniformList {
                         (self.render_items)(visible_range.clone(), window, cx)
                     };
 
-                    let content_mask = ContentMask { bounds };
+                    let content_mask = ContentMask {
+                        bounds,
+                        ..Default::default()
+                    };
                     window.with_content_mask(Some(content_mask), |window| {
                         for (mut item, ix) in items.into_iter().zip(visible_range.clone()) {
                             let item_origin = padded_bounds.origin

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -6,8 +6,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     AtlasTextureId, AtlasTile, Background, Bounds, ContentMask, Corners, Edges, Hsla, Pixels,
-    Point, Radians, ScaledPixels, Size, bounds_tree::BoundsTree, point,
+    Point, Radians, ScaledPixels, Size, bounds_tree::BoundsTree, point, size,
 };
+use collections::FxHashMap;
 use std::{
     fmt::Debug,
     iter::Peekable,
@@ -36,12 +37,44 @@ impl From<bool> for PaddedBool32 {
     }
 }
 
+/// A node in the scene's clip tree. Every primitive references one of these via its
+/// `clip_id`. Rectangular clips along a primitive's ancestor chain are folded eagerly
+/// into `folded_bounds`, so the common rect-only case costs a single bounds test.
+/// Rounded-rect clips can't be folded (the intersection of two rounded rects is not a
+/// rounded rect), so each one is retained as a node and linked through
+/// `parent_rounded`; shaders walk that chain evaluating one rounded-rect SDF per node.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct ClipNode {
+    /// Intersection of all rectangular clip bounds along the ancestor chain,
+    /// including the bounding rects of rounded clips.
+    pub folded_bounds: Bounds<ScaledPixels>,
+    /// The bounds this node's own corner radii apply to. Only meaningful when
+    /// `corner_radii` is nonzero.
+    pub rounded_bounds: Bounds<ScaledPixels>,
+    /// This node's own corner radii. All zeros for purely rectangular clips.
+    pub corner_radii: Corners<ScaledPixels>,
+    /// The nearest node in the ancestor chain (including this node itself) that
+    /// has nonzero corner radii, or [`ClipNode::NONE`]. This is where the
+    /// fragment shader starts its rounded-clip walk.
+    pub rounded_head: u32,
+    /// The nearest strict ancestor with nonzero corner radii, or
+    /// [`ClipNode::NONE`]. Links the rounded-clip chain.
+    pub parent_rounded: u32,
+}
+
+impl ClipNode {
+    /// Sentinel indicating the absence of a clip node reference.
+    pub const NONE: u32 = u32::MAX;
+}
+
 #[derive(Default)]
 #[expect(missing_docs)]
 pub struct Scene {
     pub(crate) paint_operations: Vec<PaintOperation>,
     primitive_bounds: BoundsTree<ScaledPixels>,
     layer_stack: Vec<DrawOrder>,
+    pub clips: Vec<ClipNode>,
     pub shadows: Vec<Shadow>,
     pub quads: Vec<Quad>,
     pub paths: Vec<Path<ScaledPixels>>,
@@ -58,6 +91,7 @@ impl Scene {
         self.paint_operations.clear();
         self.primitive_bounds.clear();
         self.layer_stack.clear();
+        self.clips.clear();
         self.paths.clear();
         self.shadows.clear();
         self.quads.clear();
@@ -84,11 +118,30 @@ impl Scene {
         self.paint_operations.push(PaintOperation::EndLayer);
     }
 
+    pub fn insert_clip(&mut self, node: ClipNode) -> u32 {
+        let id = self.clips.len() as u32;
+        self.clips.push(node);
+        id
+    }
+
+    pub fn clip_folded_bounds(&self, clip_id: u32) -> Bounds<ScaledPixels> {
+        debug_assert!((clip_id as usize) < self.clips.len(), "invalid clip id");
+        self.clips
+            .get(clip_id as usize)
+            .map(|node| node.folded_bounds)
+            // Fall back to an effectively unbounded rect (no clipping) rather than
+            // panicking on an invalid id.
+            .unwrap_or_else(|| Bounds {
+                origin: point(ScaledPixels(-1e15), ScaledPixels(-1e15)),
+                size: size(ScaledPixels(2e15), ScaledPixels(2e15)),
+            })
+    }
+
     pub fn insert_primitive(&mut self, primitive: impl Into<Primitive>) {
         let mut primitive = primitive.into();
         let clipped_bounds = primitive
             .bounds()
-            .intersect(&primitive.content_mask().bounds);
+            .intersect(&self.clip_folded_bounds(primitive.clip_id()));
 
         if clipped_bounds.is_empty() {
             return;
@@ -139,13 +192,54 @@ impl Scene {
     }
 
     pub fn replay(&mut self, range: Range<usize>, prev_scene: &Scene) {
+        // Clip ids in the previous scene's primitives point into `prev_scene.clips`,
+        // so the referenced nodes (and their rounded-clip chains) must be copied into
+        // this scene and the ids rewritten.
+        let mut clip_id_map = FxHashMap::default();
         for operation in &prev_scene.paint_operations[range] {
             match operation {
-                PaintOperation::Primitive(primitive) => self.insert_primitive(primitive.clone()),
+                PaintOperation::Primitive(primitive) => {
+                    let mut primitive = primitive.clone();
+                    let clip_id =
+                        self.import_clip(prev_scene, primitive.clip_id(), &mut clip_id_map);
+                    *primitive.clip_id_mut() = clip_id;
+                    self.insert_primitive(primitive);
+                }
                 PaintOperation::StartLayer(bounds) => self.push_layer(*bounds),
                 PaintOperation::EndLayer => self.pop_layer(),
             }
         }
+    }
+
+    /// Copy a clip node (and, transitively, its rounded-clip chain) from another scene
+    /// into this one, returning the node's id in this scene.
+    fn import_clip(
+        &mut self,
+        prev_scene: &Scene,
+        clip_id: u32,
+        clip_id_map: &mut FxHashMap<u32, u32>,
+    ) -> u32 {
+        if clip_id == ClipNode::NONE {
+            return ClipNode::NONE;
+        }
+        if let Some(&new_id) = clip_id_map.get(&clip_id) {
+            return new_id;
+        }
+        let Some(node) = prev_scene.clips.get(clip_id as usize).copied() else {
+            debug_assert!(false, "replayed primitive references invalid clip id");
+            return ClipNode::NONE;
+        };
+        // Insert the node before resolving its links so that a `rounded_head`
+        // pointing back at the node itself terminates via the map.
+        let new_id = self.insert_clip(node);
+        clip_id_map.insert(clip_id, new_id);
+        let rounded_head = self.import_clip(prev_scene, node.rounded_head, clip_id_map);
+        let parent_rounded = self.import_clip(prev_scene, node.parent_rounded, clip_id_map);
+        if let Some(node) = self.clips.get_mut(new_id as usize) {
+            node.rounded_head = rounded_head;
+            node.parent_rounded = parent_rounded;
+        }
+        new_id
     }
 
     pub fn finish(&mut self) {
@@ -245,16 +339,29 @@ impl Primitive {
         }
     }
 
-    pub fn content_mask(&self) -> &ContentMask<ScaledPixels> {
+    pub fn clip_id(&self) -> u32 {
         match self {
-            Primitive::Shadow(shadow) => &shadow.content_mask,
-            Primitive::Quad(quad) => &quad.content_mask,
-            Primitive::Path(path) => &path.content_mask,
-            Primitive::Underline(underline) => &underline.content_mask,
-            Primitive::MonochromeSprite(sprite) => &sprite.content_mask,
-            Primitive::SubpixelSprite(sprite) => &sprite.content_mask,
-            Primitive::PolychromeSprite(sprite) => &sprite.content_mask,
-            Primitive::Surface(surface) => &surface.content_mask,
+            Primitive::Shadow(shadow) => shadow.clip_id,
+            Primitive::Quad(quad) => quad.clip_id,
+            Primitive::Path(path) => path.clip_id,
+            Primitive::Underline(underline) => underline.clip_id,
+            Primitive::MonochromeSprite(sprite) => sprite.clip_id,
+            Primitive::SubpixelSprite(sprite) => sprite.clip_id,
+            Primitive::PolychromeSprite(sprite) => sprite.clip_id,
+            Primitive::Surface(surface) => surface.clip_id,
+        }
+    }
+
+    pub fn clip_id_mut(&mut self) -> &mut u32 {
+        match self {
+            Primitive::Shadow(shadow) => &mut shadow.clip_id,
+            Primitive::Quad(quad) => &mut quad.clip_id,
+            Primitive::Path(path) => &mut path.clip_id,
+            Primitive::Underline(underline) => &mut underline.clip_id,
+            Primitive::MonochromeSprite(sprite) => &mut sprite.clip_id,
+            Primitive::SubpixelSprite(sprite) => &mut sprite.clip_id,
+            Primitive::PolychromeSprite(sprite) => &mut sprite.clip_id,
+            Primitive::Surface(surface) => &mut surface.clip_id,
         }
     }
 }
@@ -502,7 +609,8 @@ pub struct Quad {
     pub order: DrawOrder,
     pub border_style: BorderStyle,
     pub bounds: Bounds<ScaledPixels>,
-    pub content_mask: ContentMask<ScaledPixels>,
+    pub clip_id: u32,
+    pub pad: u32, // keep size a multiple of 8 bytes for WGSL struct layout
     pub background: Background,
     pub border_color: Hsla,
     pub corner_radii: Corners<ScaledPixels>,
@@ -520,9 +628,8 @@ impl From<Quad> for Primitive {
 #[expect(missing_docs)]
 pub struct Underline {
     pub order: DrawOrder,
-    pub pad: u32, // align to 8 bytes
+    pub clip_id: u32,
     pub bounds: Bounds<ScaledPixels>,
-    pub content_mask: ContentMask<ScaledPixels>,
     pub color: Hsla,
     pub thickness: ScaledPixels,
     pub wavy: PaddedBool32,
@@ -542,13 +649,12 @@ pub struct Shadow {
     pub blur_radius: ScaledPixels,
     pub bounds: Bounds<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
-    pub content_mask: ContentMask<ScaledPixels>,
     pub color: Hsla,
     pub element_bounds: Bounds<ScaledPixels>,
     pub element_corner_radii: Corners<ScaledPixels>,
     /// 0 = drop shadow (rendered outside the element), 1 = inset shadow (rendered inside).
     pub inset: u32,
-    pub pad: u32, // align to 8 bytes
+    pub clip_id: u32,
 }
 
 impl From<Shadow> for Primitive {
@@ -676,9 +782,8 @@ impl Default for TransformationMatrix {
 #[expect(missing_docs)]
 pub struct MonochromeSprite {
     pub order: DrawOrder,
-    pub pad: u32,
+    pub clip_id: u32,
     pub bounds: Bounds<ScaledPixels>,
-    pub content_mask: ContentMask<ScaledPixels>,
     pub color: Hsla,
     pub tile: AtlasTile,
     pub transformation: TransformationMatrix,
@@ -695,9 +800,8 @@ impl From<MonochromeSprite> for Primitive {
 #[expect(missing_docs)]
 pub struct SubpixelSprite {
     pub order: DrawOrder,
-    pub pad: u32, // align to 8 bytes
+    pub clip_id: u32,
     pub bounds: Bounds<ScaledPixels>,
-    pub content_mask: ContentMask<ScaledPixels>,
     pub color: Hsla,
     pub tile: AtlasTile,
     pub transformation: TransformationMatrix,
@@ -714,11 +818,10 @@ impl From<SubpixelSprite> for Primitive {
 #[expect(missing_docs)]
 pub struct PolychromeSprite {
     pub order: DrawOrder,
-    pub pad: u32,
+    pub clip_id: u32,
     pub grayscale: PaddedBool32,
     pub opacity: f32,
     pub bounds: Bounds<ScaledPixels>,
-    pub content_mask: ContentMask<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
     pub tile: AtlasTile,
 }
@@ -734,7 +837,7 @@ impl From<PolychromeSprite> for Primitive {
 pub struct PaintSurface {
     pub order: DrawOrder,
     pub bounds: Bounds<ScaledPixels>,
-    pub content_mask: ContentMask<ScaledPixels>,
+    pub clip_id: u32,
     #[cfg(target_os = "macos")]
     pub image_buffer: core_video::pixel_buffer::CVPixelBuffer,
 }
@@ -756,7 +859,12 @@ pub struct Path<P: Clone + Debug + Default + PartialEq> {
     pub id: PathId,
     pub order: DrawOrder,
     pub bounds: Bounds<P>,
+    /// The folded rectangular clip that was active when the path was painted. Paths
+    /// aren't uploaded to the GPU as-is, so unlike other primitives they retain their
+    /// rectangular mask inline in addition to referencing a clip node via `clip_id`
+    /// (which carries the rounded-clip chain, if any).
     pub content_mask: ContentMask<P>,
+    pub clip_id: u32,
     pub vertices: Vec<PathVertex<P>>,
     pub color: Background,
     start: Point<P>,
@@ -778,6 +886,7 @@ impl Path<Pixels> {
                 size: Default::default(),
             },
             content_mask: Default::default(),
+            clip_id: 0,
             color: Default::default(),
             contour_count: 0,
         }
@@ -790,6 +899,7 @@ impl Path<Pixels> {
             order: self.order,
             bounds: self.bounds.scale(factor),
             content_mask: self.content_mask.scale(factor),
+            clip_id: self.clip_id,
             vertices: self
                 .vertices
                 .iter()
@@ -862,17 +972,14 @@ impl Path<Pixels> {
         self.vertices.push(PathVertex {
             xy_position: xy.0,
             st_position: st.0,
-            content_mask: Default::default(),
         });
         self.vertices.push(PathVertex {
             xy_position: xy.1,
             st_position: st.1,
-            content_mask: Default::default(),
         });
         self.vertices.push(PathVertex {
             xy_position: xy.2,
             st_position: st.2,
-            content_mask: Default::default(),
         });
     }
 }
@@ -900,7 +1007,6 @@ impl From<Path<ScaledPixels>> for Primitive {
 pub struct PathVertex<P: Clone + Debug + Default + PartialEq> {
     pub xy_position: Point<P>,
     pub st_position: Point<f32>,
-    pub content_mask: ContentMask<P>,
 }
 
 #[expect(missing_docs)]
@@ -909,7 +1015,84 @@ impl PathVertex<Pixels> {
         PathVertex {
             xy_position: self.xy_position.scale(factor),
             st_position: self.st_position,
-            content_mask: self.content_mask.scale(factor),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bounds(x: f32, y: f32, width: f32, height: f32) -> Bounds<ScaledPixels> {
+        Bounds {
+            origin: point(ScaledPixels(x), ScaledPixels(y)),
+            size: crate::size(ScaledPixels(width), ScaledPixels(height)),
+        }
+    }
+
+    fn quad(clip_id: u32, quad_bounds: Bounds<ScaledPixels>) -> Quad {
+        Quad {
+            order: 0,
+            border_style: Default::default(),
+            bounds: quad_bounds,
+            clip_id,
+            pad: 0,
+            background: Default::default(),
+            border_color: Default::default(),
+            corner_radii: Default::default(),
+            border_widths: Default::default(),
+        }
+    }
+
+    #[test]
+    fn replay_remaps_clip_chains() {
+        let mut prev_scene = Scene::default();
+        // A rectangular root and a rounded child clip, forming a chain.
+        let root = prev_scene.insert_clip(ClipNode {
+            folded_bounds: bounds(0., 0., 100., 100.),
+            rounded_bounds: Default::default(),
+            corner_radii: Default::default(),
+            rounded_head: ClipNode::NONE,
+            parent_rounded: ClipNode::NONE,
+        });
+        let rounded = prev_scene.insert_clip(ClipNode {
+            folded_bounds: bounds(10., 10., 50., 50.),
+            rounded_bounds: bounds(10., 10., 50., 50.),
+            corner_radii: Corners::all(ScaledPixels(8.)),
+            rounded_head: 1,
+            parent_rounded: ClipNode::NONE,
+        });
+        assert_eq!(rounded, 1);
+        prev_scene.insert_primitive(quad(root, bounds(0., 0., 100., 100.)));
+        prev_scene.insert_primitive(quad(rounded, bounds(10., 10., 50., 50.)));
+
+        // Replaying into a scene that already has clip nodes must rewrite the
+        // replayed primitives' clip ids.
+        let mut next_scene = Scene::default();
+        for _ in 0..3 {
+            next_scene.insert_clip(ClipNode {
+                folded_bounds: bounds(0., 0., 1., 1.),
+                rounded_bounds: Default::default(),
+                corner_radii: Default::default(),
+                rounded_head: ClipNode::NONE,
+                parent_rounded: ClipNode::NONE,
+            });
+        }
+        next_scene.replay(0..prev_scene.len(), &prev_scene);
+
+        assert_eq!(next_scene.quads.len(), 2);
+        let replayed_root_quad = &next_scene.quads[0];
+        let replayed_rounded_quad = &next_scene.quads[1];
+
+        let root_node = next_scene.clips[replayed_root_quad.clip_id as usize];
+        assert_eq!(root_node.folded_bounds, bounds(0., 0., 100., 100.));
+        assert_eq!(root_node.rounded_head, ClipNode::NONE);
+
+        let rounded_node = next_scene.clips[replayed_rounded_quad.clip_id as usize];
+        assert_eq!(rounded_node.folded_bounds, bounds(10., 10., 50., 50.));
+        assert_eq!(rounded_node.corner_radii, Corners::all(ScaledPixels(8.)));
+        // The self-referential rounded head must point at the node's new id.
+        assert_eq!(rounded_node.rounded_head, replayed_rounded_quad.clip_id);
+        assert_eq!(rounded_node.parent_rounded, ClipNode::NONE);
     }
 }

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -645,17 +645,19 @@ impl Style {
                 let mut min = bounds.origin;
                 let mut max = bounds.bottom_right();
 
+                let mut border_widths = Edges::<Pixels>::default();
                 if self
                     .border_color
                     .is_some_and(|color| !color.is_transparent())
                 {
-                    min.x += self.border_widths.left.to_pixels(rem_size);
-                    max.x -= self.border_widths.right.to_pixels(rem_size);
-                    min.y += self.border_widths.top.to_pixels(rem_size);
-                    max.y -= self.border_widths.bottom.to_pixels(rem_size);
+                    border_widths = self.border_widths.to_pixels(rem_size);
+                    min.x += border_widths.left;
+                    max.x -= border_widths.right;
+                    min.y += border_widths.top;
+                    max.y -= border_widths.bottom;
                 }
 
-                let bounds = match (
+                let mask_bounds = match (
                     self.overflow.x == Overflow::Visible,
                     self.overflow.y == Overflow::Visible,
                 ) {
@@ -675,7 +677,33 @@ impl Style {
                     (false, false) => Bounds::from_corners(min, max),
                 };
 
-                Some(ContentMask { bounds })
+                // Clip overflowing content to the element's rounded corners, matching
+                // the radii used to paint its background. When the mask is inset by a
+                // visible border, the corner radii shrink by the border width like the
+                // border's inner edge does (CSS's inner-radius rule), approximating the
+                // elliptical inner edge with a circular arc.
+                let corner_radii = self
+                    .corner_radii
+                    .to_pixels(rem_size)
+                    .clamp_radii_for_quad_size(bounds.size);
+                let corner_radii = Corners {
+                    top_left: (corner_radii.top_left - border_widths.left.max(border_widths.top))
+                        .max(Pixels::ZERO),
+                    top_right: (corner_radii.top_right
+                        - border_widths.right.max(border_widths.top))
+                    .max(Pixels::ZERO),
+                    bottom_right: (corner_radii.bottom_right
+                        - border_widths.right.max(border_widths.bottom))
+                    .max(Pixels::ZERO),
+                    bottom_left: (corner_radii.bottom_left
+                        - border_widths.left.max(border_widths.bottom))
+                    .max(Pixels::ZERO),
+                };
+
+                Some(ContentMask {
+                    bounds: mask_bounds,
+                    corner_radii,
+                })
             }
         }
     }
@@ -1326,11 +1354,69 @@ impl From<Position> for taffy::style::Position {
 
 #[cfg(test)]
 mod tests {
-    use crate::{blue, green, px, red, yellow};
+    use crate::{blue, green, point, px, red, size, yellow};
 
     use super::*;
 
     use util_macros::perf;
+
+    #[test]
+    fn overflow_mask_carries_corner_radii() {
+        let mut style = Style::default();
+        style.overflow.x = Overflow::Hidden;
+        style.overflow.y = Overflow::Hidden;
+        style.corner_radii = Corners {
+            top_left: px(10.).into(),
+            top_right: px(10.).into(),
+            bottom_right: px(10.).into(),
+            bottom_left: px(10.).into(),
+        };
+        let bounds = Bounds::new(point(px(0.), px(0.)), size(px(100.), px(50.)));
+
+        let mask = style.overflow_mask(bounds, px(16.)).unwrap();
+        assert_eq!(mask.bounds, bounds);
+        assert_eq!(mask.corner_radii, Corners::all(px(10.)));
+    }
+
+    #[test]
+    fn overflow_mask_radii_are_clamped_like_painted_quads() {
+        let mut style = Style::default();
+        style.overflow.x = Overflow::Hidden;
+        style.overflow.y = Overflow::Hidden;
+        style.corner_radii = Corners {
+            top_left: px(100.).into(),
+            top_right: px(100.).into(),
+            bottom_right: px(100.).into(),
+            bottom_left: px(100.).into(),
+        };
+        let bounds = Bounds::new(point(px(0.), px(0.)), size(px(100.), px(50.)));
+
+        let mask = style.overflow_mask(bounds, px(16.)).unwrap();
+        assert_eq!(mask.corner_radii, Corners::all(px(25.)));
+    }
+
+    #[test]
+    fn overflow_mask_insets_radii_by_visible_borders() {
+        let mut style = Style::default();
+        style.overflow.x = Overflow::Hidden;
+        style.overflow.y = Overflow::Hidden;
+        style.corner_radii = Corners {
+            top_left: px(10.).into(),
+            top_right: px(10.).into(),
+            bottom_right: px(10.).into(),
+            bottom_left: px(10.).into(),
+        };
+        style.border_widths = Edges::all(px(4.).into());
+        style.border_color = Some(crate::black());
+        let bounds = Bounds::new(point(px(0.), px(0.)), size(px(100.), px(50.)));
+
+        let mask = style.overflow_mask(bounds, px(16.)).unwrap();
+        assert_eq!(
+            mask.bounds,
+            Bounds::new(point(px(4.), px(4.)), size(px(92.), px(42.)))
+        );
+        assert_eq!(mask.corner_radii, Corners::all(px(6.)));
+    }
 
     #[perf]
     fn test_basic_highlight_style_combination() {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3,7 +3,7 @@ use crate::Inspector;
 use crate::{
     Action, AnyDrag, AnyElement, AnyImageCache, AnyTooltip, AnyView, App, AppContext, Arena, Asset,
     AsyncWindowContext, AvailableSpace, Background, BorderStyle, Bounds, BoxShadow, Capslock,
-    Context, Corners, CursorHideMode, CursorStyle, Decorations, DevicePixels,
+    ClipNode, Context, Corners, CursorHideMode, CursorStyle, Decorations, DevicePixels,
     DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity,
     EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs,
     Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke,
@@ -206,6 +206,10 @@ impl WindowInvalidator {
 
     pub fn not_drawing(&self) -> bool {
         self.inner.borrow().draw_phase == DrawPhase::None
+    }
+
+    pub fn is_paint(&self) -> bool {
+        self.inner.borrow().draw_phase == DrawPhase::Paint
     }
 
     #[track_caller]
@@ -681,8 +685,13 @@ pub struct Hitbox {
     /// The bounds of the hitbox.
     #[deref]
     pub bounds: Bounds<Pixels>,
-    /// The content mask when the hitbox was inserted.
+    /// The content mask when the hitbox was inserted. This is the folded rectangular
+    /// mask; any rounded masks that were active are retained in `rounded_masks`.
     pub content_mask: ContentMask<Pixels>,
+    /// The rounded content masks that were active when the hitbox was inserted,
+    /// outermost first. Hit testing honors their corner arcs, so points in visually
+    /// clipped corners don't hit. Empty unless a rounded mask was active.
+    pub rounded_masks: Vec<ContentMask<Pixels>>,
     /// Flags that specify hitbox behavior.
     pub behavior: HitboxBehavior,
 }
@@ -940,7 +949,12 @@ impl Frame {
         let mut hit_test = HitTest::default();
         for hitbox in self.hitboxes.iter().rev() {
             let bounds = hitbox.bounds.intersect(&hitbox.content_mask.bounds);
-            if bounds.contains(&position) {
+            if bounds.contains(&position)
+                && hitbox
+                    .rounded_masks
+                    .iter()
+                    .all(|mask| mask.contains(&position))
+            {
                 hit_test.ids.push(hitbox.id);
                 if !set_hover_hitbox_count
                     && hitbox.behavior == HitboxBehavior::BlockMouseExceptScroll
@@ -1008,7 +1022,10 @@ pub struct Window {
     pub(crate) rendered_entity_stack: Vec<EntityId>,
     pub(crate) element_offset_stack: Vec<Point<Pixels>>,
     pub(crate) element_opacity: f32,
-    pub(crate) content_mask_stack: Vec<ContentMask<Pixels>>,
+    pub(crate) content_mask_stack: Vec<ContentMaskEntry>,
+    /// The scene clip node covering the whole window for the frame currently being
+    /// drawn, created lazily and reset when the next frame is cleared.
+    root_clip_id: Option<u32>,
     pub(crate) requested_autoscroll: Option<Bounds<Pixels>>,
     pub(crate) image_cache_stack: Vec<AnyImageCache>,
     pub(crate) rendered_frame: Frame,
@@ -1717,6 +1734,7 @@ impl Window {
             rendered_entity_stack: Vec::new(),
             element_offset_stack: Vec::new(),
             content_mask_stack: Vec::new(),
+            root_clip_id: None,
             element_opacity: 1.0,
             requested_autoscroll: None,
             rendered_frame: Frame::new(DispatchTree::new(cx.keymap.clone(), cx.actions.clone())),
@@ -1783,13 +1801,16 @@ pub struct DispatchEventResult {
 }
 
 /// Indicates which region of the window is visible. Content falling outside of this mask will not be
-/// rendered. Currently, only rectangular content masks are supported, but we give the mask its own type
-/// to leave room to support more complex shapes in the future.
+/// rendered. A mask is a rectangle, optionally with rounded corners described by `corner_radii`
+/// (which apply to `bounds`).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct ContentMask<P: Clone + Debug + Default + PartialEq> {
     /// The bounds
     pub bounds: Bounds<P>,
+    /// Corner radii applied to `bounds`. When all zeros (the default), the mask is a
+    /// plain rectangle.
+    pub corner_radii: Corners<P>,
 }
 
 impl ContentMask<Pixels> {
@@ -1797,14 +1818,101 @@ impl ContentMask<Pixels> {
     pub fn scale(&self, factor: f32) -> ContentMask<ScaledPixels> {
         ContentMask {
             bounds: self.bounds.scale(factor),
+            corner_radii: self.corner_radii.scale(factor),
         }
     }
 
     /// Intersect the content mask with the given content mask.
+    ///
+    /// The intersection of two rounded rectangles is not representable as a rounded
+    /// rectangle, so the result is the rectangular intersection with no corner radii.
+    /// [`Window::with_content_mask`] retains each rounded mask individually instead of
+    /// using this method, so rounded clipping remains exact there.
     pub fn intersect(&self, other: &Self) -> Self {
         let bounds = self.bounds.intersect(&other.bounds);
-        ContentMask { bounds }
+        ContentMask {
+            bounds,
+            corner_radii: Corners::default(),
+        }
     }
+
+    /// Whether this mask has any nonzero corner radii.
+    pub fn is_rounded(&self) -> bool {
+        !self.corner_radii.is_zero()
+    }
+
+    /// Whether the given point falls inside this mask, honoring rounded corners.
+    pub fn contains(&self, position: &Point<Pixels>) -> bool {
+        if !self.bounds.contains(position) {
+            return false;
+        }
+        if !self.is_rounded() {
+            return true;
+        }
+        let corners = [
+            (
+                self.corner_radii.top_left,
+                self.bounds.origin + point(self.corner_radii.top_left, self.corner_radii.top_left),
+                point(Pixels(-1.), Pixels(-1.)),
+            ),
+            (
+                self.corner_radii.top_right,
+                point(
+                    self.bounds.right() - self.corner_radii.top_right,
+                    self.bounds.top() + self.corner_radii.top_right,
+                ),
+                point(Pixels(1.), Pixels(-1.)),
+            ),
+            (
+                self.corner_radii.bottom_right,
+                point(
+                    self.bounds.right() - self.corner_radii.bottom_right,
+                    self.bounds.bottom() - self.corner_radii.bottom_right,
+                ),
+                point(Pixels(1.), Pixels(1.)),
+            ),
+            (
+                self.corner_radii.bottom_left,
+                point(
+                    self.bounds.left() + self.corner_radii.bottom_left,
+                    self.bounds.bottom() - self.corner_radii.bottom_left,
+                ),
+                point(Pixels(-1.), Pixels(1.)),
+            ),
+        ];
+        for (radius, center, direction) in corners {
+            if radius <= Pixels::ZERO {
+                continue;
+            }
+            let offset = *position - center;
+            // The point is in this corner's square iff it lies beyond the arc's center
+            // in the corner's direction on both axes.
+            if offset.x.0 * direction.x.0 > 0. && offset.y.0 * direction.y.0 > 0. {
+                let distance_squared = offset.x.0 * offset.x.0 + offset.y.0 * offset.y.0;
+                if distance_squared > radius.0 * radius.0 {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+/// An entry in the window's content mask stack, combining the folded rectangular
+/// mask with the bookkeeping needed for rounded clips and scene clip nodes.
+pub(crate) struct ContentMaskEntry {
+    /// The running intersection of all rectangular mask bounds up to this entry.
+    /// Its corner radii are always zero; rounded masks are retained individually in
+    /// `rounded` instead, because rounded rects aren't closed under intersection.
+    mask: ContentMask<Pixels>,
+    /// This entry's own mask, if it has rounded corners.
+    rounded: Option<ContentMask<Pixels>>,
+    /// The scene clip node for this entry. Only valid during the paint phase;
+    /// [`ClipNode::NONE`] during prepaint.
+    clip_id: u32,
+    /// The nearest scene clip node at or above this entry with rounded corners, or
+    /// [`ClipNode::NONE`]. Only valid during the paint phase.
+    rounded_head: u32,
 }
 
 impl Window {
@@ -2552,13 +2660,6 @@ impl Window {
         )
     }
 
-    #[inline]
-    fn snapped_content_mask(&self) -> ContentMask<ScaledPixels> {
-        ContentMask {
-            bounds: self.cover_bounds(self.content_mask().bounds),
-        }
-    }
-
     /// Call to prevent the default action of an event. Currently only used to prevent
     /// parent elements from becoming focused on mouse down.
     pub fn prevent_default(&mut self) {
@@ -2698,6 +2799,7 @@ impl Window {
         let previous_window_active = self.rendered_frame.window_active;
         mem::swap(&mut self.rendered_frame, &mut self.next_frame);
         self.next_frame.clear();
+        self.root_clip_id = None;
         let current_focus_path = self.rendered_frame.focus_path();
         let current_window_active = self.rendered_frame.window_active;
 
@@ -3233,7 +3335,9 @@ impl Window {
     }
 
     /// Invoke the given function with the given content mask after intersecting it
-    /// with the current mask. This method should only be called during element drawing.
+    /// with the current mask. If the mask has corner radii, content drawn within is
+    /// also clipped to its rounded corners. This method should only be called during
+    /// element drawing.
     // This function is called in a highly recursive manner in editor
     // prepainting, make sure its inlined to reduce the stack burden
     #[inline]
@@ -3244,13 +3348,101 @@ impl Window {
     ) -> R {
         self.invalidator.debug_assert_paint_or_prepaint();
         if let Some(mask) = mask {
-            let mask = mask.intersect(&self.content_mask());
-            self.content_mask_stack.push(mask);
+            self.push_content_mask(mask);
             let result = f(self);
             self.content_mask_stack.pop();
             result
         } else {
             f(self)
+        }
+    }
+
+    fn push_content_mask(&mut self, mask: ContentMask<Pixels>) {
+        let parent_fold = self.content_mask();
+        let fold = ContentMask {
+            bounds: mask.bounds.intersect(&parent_fold.bounds),
+            corner_radii: Corners::default(),
+        };
+        let rounded = mask.is_rounded().then_some(mask);
+
+        // Scene clip nodes are only needed by painted primitives, so skip allocating
+        // them during prepaint. During paint, every entry on this stack was pushed
+        // during paint, so their node ids are always valid when read back.
+        let (clip_id, rounded_head) = if self.invalidator.is_paint() {
+            let parent = self
+                .content_mask_stack
+                .last()
+                .map(|entry| (entry.clip_id, entry.rounded_head));
+            let parent_head = parent.map_or(ClipNode::NONE, |(_, head)| head);
+            if rounded.is_none() && fold.bounds == parent_fold.bounds {
+                // This mask doesn't tighten the clip; reuse the parent's node.
+                let parent_id = match parent {
+                    Some((id, _)) => id,
+                    None => self.root_clip_id(),
+                };
+                (parent_id, parent_head)
+            } else {
+                let folded_bounds = self.cover_bounds(fold.bounds);
+                let node_id = self.next_frame.scene.clips.len() as u32;
+                let (rounded_bounds, corner_radii, rounded_head) = if let Some(mask) = &rounded {
+                    let scale_factor = self.scale_factor();
+                    (
+                        self.snap_bounds(mask.bounds),
+                        mask.corner_radii.scale(scale_factor),
+                        node_id,
+                    )
+                } else {
+                    (Default::default(), Default::default(), parent_head)
+                };
+                let clip_id = self.next_frame.scene.insert_clip(ClipNode {
+                    folded_bounds,
+                    rounded_bounds,
+                    corner_radii,
+                    rounded_head,
+                    parent_rounded: parent_head,
+                });
+                (clip_id, rounded_head)
+            }
+        } else {
+            (ClipNode::NONE, ClipNode::NONE)
+        };
+
+        self.content_mask_stack.push(ContentMaskEntry {
+            mask: fold,
+            rounded,
+            clip_id,
+            rounded_head,
+        });
+    }
+
+    /// The scene clip node covering the whole window, created lazily once per frame.
+    fn root_clip_id(&mut self) -> u32 {
+        if let Some(id) = self.root_clip_id {
+            return id;
+        }
+        let folded_bounds = self.cover_bounds(Bounds {
+            origin: Point::default(),
+            size: self.viewport_size,
+        });
+        let id = self.next_frame.scene.insert_clip(ClipNode {
+            folded_bounds,
+            rounded_bounds: Default::default(),
+            corner_radii: Default::default(),
+            rounded_head: ClipNode::NONE,
+            parent_rounded: ClipNode::NONE,
+        });
+        self.root_clip_id = Some(id);
+        id
+    }
+
+    /// The scene clip node for the current content mask. This method should only be
+    /// called during the paint phase of element drawing.
+    pub(crate) fn current_clip_id(&mut self) -> u32 {
+        self.invalidator.debug_assert_paint();
+        if let Some(entry) = self.content_mask_stack.last() {
+            entry.clip_id
+        } else {
+            self.root_clip_id()
         }
     }
 
@@ -3403,17 +3595,21 @@ impl Window {
         self.element_opacity
     }
 
-    /// Obtain the current content mask. This method should only be called during element drawing.
+    /// Obtain the current content mask. This returns the folded rectangular mask -- the
+    /// intersection of all mask bounds pushed so far -- and therefore always has zero
+    /// corner radii, even when rounded masks are active. This method should only be
+    /// called during element drawing.
     pub fn content_mask(&self) -> ContentMask<Pixels> {
         self.invalidator.debug_assert_paint_or_prepaint();
         self.content_mask_stack
             .last()
-            .cloned()
+            .map(|entry| entry.mask)
             .unwrap_or_else(|| ContentMask {
                 bounds: Bounds {
                     origin: Point::default(),
                     size: self.viewport_size,
                 },
+                corner_radii: Corners::default(),
             })
     }
 
@@ -3668,7 +3864,7 @@ impl Window {
         self.invalidator.debug_assert_paint();
 
         let scale_factor = self.scale_factor();
-        let content_mask = self.snapped_content_mask();
+        let clip_id = self.current_clip_id();
         let opacity = self.element_opacity();
         let element_bounds = self.cover_bounds(bounds);
         let element_corner_radii = corner_radii.scale(scale_factor);
@@ -3681,13 +3877,12 @@ impl Window {
                 order: 0,
                 blur_radius: shadow.blur_radius.scale(scale_factor),
                 bounds: self.cover_bounds(shadow_bounds),
-                content_mask,
                 corner_radii: corner_radii.scale(scale_factor),
                 color: shadow.color.opacity(opacity),
                 element_bounds,
                 element_corner_radii,
                 inset: 0,
-                pad: 0,
+                clip_id,
             });
         }
     }
@@ -3704,7 +3899,7 @@ impl Window {
         self.invalidator.debug_assert_paint();
 
         let scale_factor = self.scale_factor();
-        let content_mask = self.snapped_content_mask();
+        let clip_id = self.current_clip_id();
         let opacity = self.element_opacity();
         let element_bounds = self.cover_bounds(bounds);
         let element_corner_radii = corner_radii.scale(scale_factor);
@@ -3726,13 +3921,12 @@ impl Window {
                 order: 0,
                 blur_radius: shadow.blur_radius.scale(scale_factor),
                 bounds: self.cover_bounds(hole),
-                content_mask,
                 corner_radii: hole_corner_radii.scale(scale_factor),
                 color: shadow.color.opacity(opacity),
                 element_bounds,
                 element_corner_radii,
                 inset: 1,
-                pad: 0,
+                clip_id,
             });
         }
     }
@@ -3752,10 +3946,12 @@ impl Window {
         let opacity = self.element_opacity();
         let snapped_bounds = self.snap_bounds(quad.bounds);
         let snapped_border_widths = self.snap_border_widths(quad.border_widths);
+        let clip_id = self.current_clip_id();
         self.next_frame.scene.insert_primitive(Quad {
             order: 0,
             bounds: snapped_bounds,
-            content_mask: self.snapped_content_mask(),
+            clip_id,
+            pad: 0,
             background: quad.background.opacity(opacity),
             border_color: quad.border_color.opacity(opacity),
             corner_radii: quad.corner_radii.scale(self.scale_factor()),
@@ -3774,6 +3970,7 @@ impl Window {
         let content_mask = self.content_mask();
         let opacity = self.element_opacity();
         path.content_mask = content_mask;
+        path.clip_id = self.current_clip_id();
         let color: Background = color.into();
         path.color = color.opacity(opacity);
         self.next_frame
@@ -3805,11 +4002,11 @@ impl Window {
         };
         let element_opacity = self.element_opacity();
 
+        let clip_id = self.current_clip_id();
         self.next_frame.scene.insert_primitive(Underline {
             order: 0,
-            pad: 0,
+            clip_id,
             bounds,
-            content_mask: self.snapped_content_mask(),
             color: style.color.unwrap_or_default().opacity(element_opacity),
             thickness,
             wavy: style.wavy.into(),
@@ -3835,11 +4032,11 @@ impl Window {
         };
         let opacity = self.element_opacity();
 
+        let clip_id = self.current_clip_id();
         self.next_frame.scene.insert_primitive(Underline {
             order: 0,
-            pad: 0,
+            clip_id,
             bounds,
-            content_mask: self.snapped_content_mask(),
             thickness: self.snap_stroke(style.thickness),
             color: style.color.unwrap_or_default().opacity(opacity),
             wavy: false.into(),
@@ -3905,14 +4102,13 @@ impl Window {
                 origin: integer_origin + raster_bounds.origin.map(Into::into),
                 size: tile.bounds.size.map(Into::into),
             };
-            let content_mask = self.snapped_content_mask();
+            let clip_id = self.current_clip_id();
 
             if subpixel_rendering {
                 self.next_frame.scene.insert_primitive(SubpixelSprite {
                     order: 0,
-                    pad: 0,
+                    clip_id,
                     bounds,
-                    content_mask,
                     color: color.opacity(element_opacity),
                     tile,
                     transformation: TransformationMatrix::unit(),
@@ -3920,9 +4116,8 @@ impl Window {
             } else {
                 self.next_frame.scene.insert_primitive(MonochromeSprite {
                     order: 0,
-                    pad: 0,
+                    clip_id,
                     bounds,
-                    content_mask,
                     color: color.opacity(element_opacity),
                     tile,
                     transformation: TransformationMatrix::unit(),
@@ -3996,16 +4191,15 @@ impl Window {
                 origin: integer_origin + raster_bounds.origin.map(Into::into),
                 size: tile.bounds.size.map(Into::into),
             };
-            let content_mask = self.snapped_content_mask();
+            let clip_id = self.current_clip_id();
             let opacity = self.element_opacity();
 
             self.next_frame.scene.insert_primitive(PolychromeSprite {
                 order: 0,
-                pad: 0,
+                clip_id,
                 grayscale: false.into(),
                 bounds,
                 corner_radii: Default::default(),
-                content_mask,
                 tile,
                 opacity,
             });
@@ -4049,7 +4243,7 @@ impl Window {
         else {
             return Ok(());
         };
-        let content_mask = self.snapped_content_mask();
+        let clip_id = self.current_clip_id();
         let svg_bounds = Bounds {
             origin: bounds.center()
                 - Point::new(
@@ -4067,9 +4261,8 @@ impl Window {
 
         self.next_frame.scene.insert_primitive(MonochromeSprite {
             order: 0,
-            pad: 0,
+            clip_id,
             bounds: final_bounds,
-            content_mask,
             color: color.opacity(element_opacity),
             tile,
             transformation,
@@ -4110,16 +4303,15 @@ impl Window {
                 )))
             })?
             .expect("Callback above only returns Some");
-        let content_mask = self.snapped_content_mask();
+        let clip_id = self.current_clip_id();
         let corner_radii = corner_radii.scale(self.scale_factor());
         let opacity = self.element_opacity();
 
         self.next_frame.scene.insert_primitive(PolychromeSprite {
             order: 0,
-            pad: 0,
+            clip_id,
             grayscale: grayscale.into(),
             bounds,
-            content_mask,
             corner_radii,
             tile,
             opacity,
@@ -4137,11 +4329,11 @@ impl Window {
         self.invalidator.debug_assert_paint();
 
         let bounds = self.snap_bounds(bounds);
-        let content_mask = self.snapped_content_mask();
+        let clip_id = self.current_clip_id();
         self.next_frame.scene.insert_primitive(PaintSurface {
             order: 0,
             bounds,
-            content_mask,
+            clip_id,
             image_buffer,
         });
     }
@@ -4256,12 +4448,18 @@ impl Window {
         self.invalidator.debug_assert_prepaint();
 
         let content_mask = self.content_mask();
+        let rounded_masks = self
+            .content_mask_stack
+            .iter()
+            .filter_map(|entry| entry.rounded)
+            .collect();
         let mut id = self.next_hitbox_id;
         self.next_hitbox_id = self.next_hitbox_id.next();
         let hitbox = Hitbox {
             id,
             bounds,
             content_mask,
+            rounded_masks,
             behavior,
         };
         self.next_frame.hitboxes.push(hitbox.clone());
@@ -6310,5 +6508,54 @@ pub fn outline(
         border_widths: (1.).into(),
         border_color: border_color.into(),
         border_style,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_mask_contains_honors_rounded_corners() {
+        let mask = ContentMask {
+            bounds: Bounds::new(point(px(0.), px(0.)), size(px(100.), px(100.))),
+            corner_radii: Corners::all(px(20.)),
+        };
+
+        // Center and edge midpoints are inside.
+        assert!(mask.contains(&point(px(50.), px(50.))));
+        assert!(mask.contains(&point(px(0.), px(50.))));
+        assert!(mask.contains(&point(px(50.), px(99.))));
+
+        // Outside the rectangle entirely.
+        assert!(!mask.contains(&point(px(-1.), px(50.))));
+        assert!(!mask.contains(&point(px(50.), px(101.))));
+
+        // Points in each corner square but outside the arc are clipped away.
+        assert!(!mask.contains(&point(px(2.), px(2.))));
+        assert!(!mask.contains(&point(px(98.), px(2.))));
+        assert!(!mask.contains(&point(px(98.), px(98.))));
+        assert!(!mask.contains(&point(px(2.), px(98.))));
+
+        // Points in the corner square but inside the arc are retained. The point
+        // (10, 10) is ~14.1px from the arc center (20, 20), within the 20px radius.
+        assert!(mask.contains(&point(px(10.), px(10.))));
+        assert!(mask.contains(&point(px(90.), px(10.))));
+        assert!(mask.contains(&point(px(90.), px(90.))));
+        assert!(mask.contains(&point(px(10.), px(90.))));
+
+        // On the arc centers themselves.
+        assert!(mask.contains(&point(px(20.), px(20.))));
+    }
+
+    #[test]
+    fn content_mask_contains_without_radii_is_rectangular() {
+        let mask = ContentMask {
+            bounds: Bounds::new(point(px(0.), px(0.)), size(px(100.), px(100.))),
+            corner_radii: Corners::default(),
+        };
+        assert!(mask.contains(&point(px(0.), px(0.))));
+        assert!(mask.contains(&point(px(99.), px(99.))));
+        assert!(!mask.contains(&point(px(101.), px(50.))));
     }
 }

--- a/crates/gpui_macos/build.rs
+++ b/crates/gpui_macos/build.rs
@@ -43,6 +43,8 @@ mod macos_build {
             "PointF".into(),
             "Hsla".into(),
             "ContentMask".into(),
+            "ClipNode".into(),
+            "ClipsInputIndex".into(),
             "Uniforms".into(),
             "AtlasTile".into(),
             "PathRasterizationInputIndex".into(),

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -7,7 +7,7 @@ use cocoa::{
     quartzcore::AutoresizingMask,
 };
 use gpui::{
-    AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, MonochromeSprite, PaintSurface,
+    AtlasTextureId, Background, Bounds, ClipNode, DevicePixels, MonochromeSprite, PaintSurface,
     Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
     Surface, Underline, point, size,
 };
@@ -145,6 +145,9 @@ pub struct PathRasterizationVertex {
     pub st_position: Point<f32>,
     pub color: Background,
     pub bounds: Bounds<ScaledPixels>,
+    /// The nearest rounded clip node for this path, or [`ClipNode::NONE`].
+    pub rounded_head: u32,
+    pub pad: u32,
 }
 
 impl MetalRenderer {
@@ -837,6 +840,24 @@ impl MetalRenderer {
         let alpha = if self.opaque { 1. } else { 0. };
         let mut instance_offset = 0;
 
+        // Upload the scene's clip nodes once; they are bound on every command encoder
+        // so all pipelines can evaluate rounded clips.
+        let clips_bytes_len = mem::size_of_val(scene.clips.as_slice());
+        anyhow::ensure!(
+            clips_bytes_len <= instance_buffer.size,
+            "clip nodes exceed instance buffer size: {} clips",
+            scene.clips.len()
+        );
+        let clips_offset = instance_offset;
+        unsafe {
+            ptr::copy_nonoverlapping(
+                scene.clips.as_ptr() as *const u8,
+                (instance_buffer.metal_buffer.contents() as *mut u8).add(clips_offset),
+                clips_bytes_len,
+            );
+        }
+        instance_offset += clips_bytes_len;
+
         let mut command_encoder = new_command_encoder_for_texture(
             command_buffer,
             texture,
@@ -846,6 +867,7 @@ impl MetalRenderer {
                 color_attachment.set_clear_color(metal::MTLClearColor::new(0., 0., 0., alpha));
             },
         );
+        bind_clips(command_encoder, instance_buffer, clips_offset);
 
         for batch in scene.batches() {
             let ok = match batch {
@@ -869,8 +891,10 @@ impl MetalRenderer {
 
                     let did_draw = self.draw_paths_to_intermediate(
                         paths,
+                        &scene.clips,
                         instance_buffer,
                         &mut instance_offset,
+                        clips_offset,
                         viewport_size,
                         command_buffer,
                     );
@@ -883,6 +907,7 @@ impl MetalRenderer {
                             color_attachment.set_load_action(metal::MTLLoadAction::Load);
                         },
                     );
+                    bind_clips(command_encoder, instance_buffer, clips_offset);
 
                     if did_draw {
                         self.draw_paths_from_intermediate(
@@ -961,8 +986,10 @@ impl MetalRenderer {
     fn draw_paths_to_intermediate(
         &self,
         paths: &[Path<ScaledPixels>],
+        clips: &[ClipNode],
         instance_buffer: &mut InstanceBuffer,
         instance_offset: &mut usize,
+        clips_offset: usize,
         viewport_size: Size<DevicePixels>,
         command_buffer: &metal::CommandBufferRef,
     ) -> bool {
@@ -992,15 +1019,21 @@ impl MetalRenderer {
 
         let command_encoder = command_buffer.new_render_command_encoder(render_pass_descriptor);
         command_encoder.set_render_pipeline_state(&self.paths_rasterization_pipeline_state);
+        bind_clips(command_encoder, instance_buffer, clips_offset);
 
         align_offset(instance_offset);
         let mut vertices = Vec::new();
         for path in paths {
+            let rounded_head = clips
+                .get(path.clip_id as usize)
+                .map_or(ClipNode::NONE, |node| node.rounded_head);
             vertices.extend(path.vertices.iter().map(|v| PathRasterizationVertex {
                 xy_position: v.xy_position,
                 st_position: v.st_position,
                 color: path.color,
                 bounds: path.bounds.intersect(&path.content_mask.bounds),
+                rounded_head,
+                pad: 0,
             }));
         }
         let vertices_bytes_len = mem::size_of_val(vertices.as_slice());
@@ -1555,7 +1588,8 @@ impl MetalRenderer {
                     buffer_contents,
                     SurfaceBounds {
                         bounds: surface.bounds,
-                        content_mask: surface.content_mask,
+                        clip_id: surface.clip_id,
+                        pad: 0,
                     },
                 );
             }
@@ -1706,6 +1740,26 @@ fn align_offset(offset: &mut usize) {
     *offset = (*offset).div_ceil(256) * 256;
 }
 
+/// Bind the scene's clip nodes (uploaded at the start of the frame) to the given
+/// command encoder. Buffer bindings persist across pipeline changes within an
+/// encoder, so this only needs to happen once per encoder.
+fn bind_clips(
+    command_encoder: &metal::RenderCommandEncoderRef,
+    instance_buffer: &InstanceBuffer,
+    clips_offset: usize,
+) {
+    command_encoder.set_vertex_buffer(
+        ClipsInputIndex::Clips as u64,
+        Some(&instance_buffer.metal_buffer),
+        clips_offset as u64,
+    );
+    command_encoder.set_fragment_buffer(
+        ClipsInputIndex::Clips as u64,
+        Some(&instance_buffer.metal_buffer),
+        clips_offset as u64,
+    );
+}
+
 #[repr(C)]
 enum ShadowInputIndex {
     Vertices = 0,
@@ -1752,6 +1806,13 @@ enum PathRasterizationInputIndex {
     ViewportSize = 1,
 }
 
+/// The scene's clip nodes are bound once per command encoder at a fixed index that
+/// no pipeline uses for anything else, so every pipeline can read them.
+#[repr(C)]
+enum ClipsInputIndex {
+    Clips = 8,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[repr(C)]
 pub struct PathSprite {
@@ -1762,7 +1823,8 @@ pub struct PathSprite {
 #[repr(C)]
 pub struct SurfaceBounds {
     pub bounds: Bounds<ScaledPixels>,
-    pub content_mask: ContentMask<ScaledPixels>,
+    pub clip_id: u32,
+    pub pad: u32,
 }
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -20,6 +20,8 @@ float4 distance_from_clip_rect(float2 unit_vertex, Bounds_ScaledPixels bounds,
                                Bounds_ScaledPixels clip_bounds);
 float4 distance_from_clip_rect_transformed(float2 unit_vertex, Bounds_ScaledPixels bounds,
                                Bounds_ScaledPixels clip_bounds, TransformationMatrix transformation);
+float clip_chain_alpha(float2 position, uint rounded_head,
+                       constant ClipNode *clips);
 float corner_dash_velocity(float dv1, float dv2);
 float dash_alpha(float t, float period, float length, float dash_velocity,
                  float antialias_threshold);
@@ -51,6 +53,7 @@ struct QuadVertexOutput {
   float4 background_solid [[flat]];
   float4 background_color0 [[flat]];
   float4 background_color1 [[flat]];
+  uint rounded_head [[flat]];
   float clip_distance [[clip_distance]][4];
 };
 
@@ -61,6 +64,7 @@ struct QuadFragmentInput {
   float4 background_solid [[flat]];
   float4 background_color0 [[flat]];
   float4 background_color1 [[flat]];
+  uint rounded_head [[flat]];
 };
 
 vertex QuadVertexOutput quad_vertex(uint unit_vertex_id [[vertex_id]],
@@ -70,13 +74,16 @@ vertex QuadVertexOutput quad_vertex(uint unit_vertex_id [[vertex_id]],
                                     constant Quad *quads
                                     [[buffer(QuadInputIndex_Quads)]],
                                     constant Size_DevicePixels *viewport_size
-                                    [[buffer(QuadInputIndex_ViewportSize)]]) {
+                                    [[buffer(QuadInputIndex_ViewportSize)]],
+                                    constant ClipNode *clips
+                                    [[buffer(ClipsInputIndex_Clips)]]) {
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   Quad quad = quads[quad_id];
+  ClipNode clip = clips[quad.clip_id];
   float4 device_position =
       to_device_position(unit_vertex, quad.bounds, viewport_size);
   float4 clip_distance = distance_from_clip_rect(unit_vertex, quad.bounds,
-                                                 quad.content_mask.bounds);
+                                                 clip.folded_bounds);
   float4 border_color = hsla_to_rgba(quad.border_color);
 
   GradientColor gradient = prepare_fill_color(
@@ -94,13 +101,18 @@ vertex QuadVertexOutput quad_vertex(uint unit_vertex_id [[vertex_id]],
       gradient.solid,
       gradient.color0,
       gradient.color1,
+      clip.rounded_head,
       {clip_distance.x, clip_distance.y, clip_distance.z, clip_distance.w}};
 }
 
 fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
                               constant Quad *quads
-                              [[buffer(QuadInputIndex_Quads)]]) {
+                              [[buffer(QuadInputIndex_Quads)]],
+                              constant ClipNode *clips
+                              [[buffer(ClipsInputIndex_Clips)]]) {
   Quad quad = quads[input.quad_id];
+  float clip_alpha =
+      clip_chain_alpha(input.position.xy, input.rounded_head, clips);
   float4 background_color = fill_color(quad.background, input.position.xy, quad.bounds,
     input.background_solid, input.background_color0, input.background_color1);
 
@@ -115,7 +127,7 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
       quad.border_widths.right == 0.0 &&
       quad.border_widths.bottom == 0.0 &&
       unrounded) {
-    return background_color;
+    return background_color * float4(1.0, 1.0, 1.0, clip_alpha);
   }
 
   float2 size = float2(quad.bounds.size.width, quad.bounds.size.height);
@@ -175,7 +187,7 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
 
   // Fast path for points that must be part of the background
   if (is_within_inner_straight_border && !is_near_rounded_corner) {
-    return background_color;
+    return background_color * float4(1.0, 1.0, 1.0, clip_alpha);
   }
 
   // Signed distance of the point to the outside edge of the quad's border
@@ -393,7 +405,9 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
                 saturate(antialias_threshold - inner_sdf));
   }
 
-  return color * float4(1.0, 1.0, 1.0, saturate(antialias_threshold - outer_sdf));
+  return color *
+         float4(1.0, 1.0, 1.0,
+                saturate(antialias_threshold - outer_sdf) * clip_alpha);
 }
 
 // Returns the dash velocity of a corner given the dash velocity of the two
@@ -450,6 +464,7 @@ struct ShadowVertexOutput {
   float4 position [[position]];
   float4 color [[flat]];
   uint shadow_id [[flat]];
+  uint rounded_head [[flat]];
   float clip_distance [[clip_distance]][4];
 };
 
@@ -457,6 +472,7 @@ struct ShadowFragmentInput {
   float4 position [[position]];
   float4 color [[flat]];
   uint shadow_id [[flat]];
+  uint rounded_head [[flat]];
 };
 
 vertex ShadowVertexOutput shadow_vertex(
@@ -464,9 +480,11 @@ vertex ShadowVertexOutput shadow_vertex(
     constant float2 *unit_vertices [[buffer(ShadowInputIndex_Vertices)]],
     constant Shadow *shadows [[buffer(ShadowInputIndex_Shadows)]],
     constant Size_DevicePixels *viewport_size
-    [[buffer(ShadowInputIndex_ViewportSize)]]) {
+    [[buffer(ShadowInputIndex_ViewportSize)]],
+    constant ClipNode *clips [[buffer(ClipsInputIndex_Clips)]]) {
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   Shadow shadow = shadows[shadow_id];
+  ClipNode clip = clips[shadow.clip_id];
 
   Bounds_ScaledPixels bounds;
   if (shadow.inset != 0u) {
@@ -484,19 +502,22 @@ vertex ShadowVertexOutput shadow_vertex(
   float4 device_position =
       to_device_position(unit_vertex, bounds, viewport_size);
   float4 clip_distance =
-      distance_from_clip_rect(unit_vertex, bounds, shadow.content_mask.bounds);
+      distance_from_clip_rect(unit_vertex, bounds, clip.folded_bounds);
   float4 color = hsla_to_rgba(shadow.color);
 
   return ShadowVertexOutput{
       device_position,
       color,
       shadow_id,
+      clip.rounded_head,
       {clip_distance.x, clip_distance.y, clip_distance.z, clip_distance.w}};
 }
 
 fragment float4 shadow_fragment(ShadowFragmentInput input [[stage_in]],
                                 constant Shadow *shadows
-                                [[buffer(ShadowInputIndex_Shadows)]]) {
+                                [[buffer(ShadowInputIndex_Shadows)]],
+                                constant ClipNode *clips
+                                [[buffer(ClipsInputIndex_Clips)]]) {
   Shadow shadow = shadows[input.shadow_id];
 
   float2 origin = float2(shadow.bounds.origin.x, shadow.bounds.origin.y);
@@ -551,6 +572,8 @@ fragment float4 shadow_fragment(ShadowFragmentInput input [[stage_in]],
     alpha *= saturate(0.5 - element_distance);
   }
 
+  alpha *= clip_chain_alpha(input.position.xy, input.rounded_head, clips);
+
   return input.color * float4(1., 1., 1., alpha);
 }
 
@@ -558,6 +581,7 @@ struct UnderlineVertexOutput {
   float4 position [[position]];
   float4 color [[flat]];
   uint underline_id [[flat]];
+  uint rounded_head [[flat]];
   float clip_distance [[clip_distance]][4];
 };
 
@@ -565,6 +589,7 @@ struct UnderlineFragmentInput {
   float4 position [[position]];
   float4 color [[flat]];
   uint underline_id [[flat]];
+  uint rounded_head [[flat]];
 };
 
 vertex UnderlineVertexOutput underline_vertex(
@@ -572,28 +597,35 @@ vertex UnderlineVertexOutput underline_vertex(
     constant float2 *unit_vertices [[buffer(UnderlineInputIndex_Vertices)]],
     constant Underline *underlines [[buffer(UnderlineInputIndex_Underlines)]],
     constant Size_DevicePixels *viewport_size
-    [[buffer(ShadowInputIndex_ViewportSize)]]) {
+    [[buffer(ShadowInputIndex_ViewportSize)]],
+    constant ClipNode *clips [[buffer(ClipsInputIndex_Clips)]]) {
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   Underline underline = underlines[underline_id];
+  ClipNode clip = clips[underline.clip_id];
   float4 device_position =
       to_device_position(unit_vertex, underline.bounds, viewport_size);
   float4 clip_distance = distance_from_clip_rect(unit_vertex, underline.bounds,
-                                                 underline.content_mask.bounds);
+                                                 clip.folded_bounds);
   float4 color = hsla_to_rgba(underline.color);
   return UnderlineVertexOutput{
       device_position,
       color,
       underline_id,
+      clip.rounded_head,
       {clip_distance.x, clip_distance.y, clip_distance.z, clip_distance.w}};
 }
 
 fragment float4 underline_fragment(UnderlineFragmentInput input [[stage_in]],
                                    constant Underline *underlines
-                                   [[buffer(UnderlineInputIndex_Underlines)]]) {
+                                   [[buffer(UnderlineInputIndex_Underlines)]],
+                                   constant ClipNode *clips
+                                   [[buffer(ClipsInputIndex_Clips)]]) {
   const float WAVE_FREQUENCY = 2.0;
   const float WAVE_HEIGHT_RATIO = 0.8;
 
   Underline underline = underlines[input.underline_id];
+  float clip_alpha =
+      clip_chain_alpha(input.position.xy, input.rounded_head, clips);
   if (underline.wavy) {
     float half_thickness = underline.thickness * 0.5;
     float2 origin =
@@ -612,9 +644,9 @@ fragment float4 underline_fragment(UnderlineFragmentInput input [[stage_in]],
     float distance_from_bottom_border = distance_in_pixels + half_thickness;
     float alpha = saturate(
         0.5 - max(-distance_from_bottom_border, distance_from_top_border));
-    return input.color * float4(1., 1., 1., alpha);
+    return input.color * float4(1., 1., 1., alpha * clip_alpha);
   } else {
-    return input.color;
+    return input.color * float4(1., 1., 1., clip_alpha);
   }
 }
 
@@ -622,6 +654,7 @@ struct MonochromeSpriteVertexOutput {
   float4 position [[position]];
   float2 tile_position;
   float4 color [[flat]];
+  uint rounded_head [[flat]];
   float4 clip_distance;
 };
 
@@ -629,6 +662,7 @@ struct MonochromeSpriteFragmentInput {
   float4 position [[position]];
   float2 tile_position;
   float4 color [[flat]];
+  uint rounded_head [[flat]];
   float4 clip_distance;
 };
 
@@ -639,26 +673,30 @@ vertex MonochromeSpriteVertexOutput monochrome_sprite_vertex(
     constant Size_DevicePixels *viewport_size
     [[buffer(SpriteInputIndex_ViewportSize)]],
     constant Size_DevicePixels *atlas_size
-    [[buffer(SpriteInputIndex_AtlasTextureSize)]]) {
+    [[buffer(SpriteInputIndex_AtlasTextureSize)]],
+    constant ClipNode *clips [[buffer(ClipsInputIndex_Clips)]]) {
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   MonochromeSprite sprite = sprites[sprite_id];
+  ClipNode clip = clips[sprite.clip_id];
   float4 device_position =
       to_device_position_transformed(unit_vertex, sprite.bounds, sprite.transformation, viewport_size);
   float4 clip_distance = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds,
-                                                 sprite.content_mask.bounds, sprite.transformation);
+                                                 clip.folded_bounds, sprite.transformation);
   float2 tile_position = to_tile_position(unit_vertex, sprite.tile, atlas_size);
   float4 color = hsla_to_rgba(sprite.color);
   return MonochromeSpriteVertexOutput{
       device_position,
       tile_position,
       color,
+      clip.rounded_head,
       {clip_distance.x, clip_distance.y, clip_distance.z, clip_distance.w}};
 }
 
 fragment float4 monochrome_sprite_fragment(
     MonochromeSpriteFragmentInput input [[stage_in]],
     constant MonochromeSprite *sprites [[buffer(SpriteInputIndex_Sprites)]],
-    texture2d<float> atlas_texture [[texture(SpriteInputIndex_AtlasTexture)]]) {
+    texture2d<float> atlas_texture [[texture(SpriteInputIndex_AtlasTexture)]],
+    constant ClipNode *clips [[buffer(ClipsInputIndex_Clips)]]) {
   if (any(input.clip_distance < float4(0.0))) {
     return float4(0.0);
   }
@@ -668,7 +706,8 @@ fragment float4 monochrome_sprite_fragment(
   float4 sample =
       atlas_texture.sample(atlas_texture_sampler, input.tile_position);
   float4 color = input.color;
-  color.a *= sample.a;
+  color.a *= sample.a *
+             clip_chain_alpha(input.position.xy, input.rounded_head, clips);
   return color;
 }
 
@@ -676,6 +715,7 @@ struct PolychromeSpriteVertexOutput {
   float4 position [[position]];
   float2 tile_position;
   uint sprite_id [[flat]];
+  uint rounded_head [[flat]];
   float clip_distance [[clip_distance]][4];
 };
 
@@ -683,6 +723,7 @@ struct PolychromeSpriteFragmentInput {
   float4 position [[position]];
   float2 tile_position;
   uint sprite_id [[flat]];
+  uint rounded_head [[flat]];
 };
 
 vertex PolychromeSpriteVertexOutput polychrome_sprite_vertex(
@@ -692,26 +733,30 @@ vertex PolychromeSpriteVertexOutput polychrome_sprite_vertex(
     constant Size_DevicePixels *viewport_size
     [[buffer(SpriteInputIndex_ViewportSize)]],
     constant Size_DevicePixels *atlas_size
-    [[buffer(SpriteInputIndex_AtlasTextureSize)]]) {
+    [[buffer(SpriteInputIndex_AtlasTextureSize)]],
+    constant ClipNode *clips [[buffer(ClipsInputIndex_Clips)]]) {
 
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   PolychromeSprite sprite = sprites[sprite_id];
+  ClipNode clip = clips[sprite.clip_id];
   float4 device_position =
       to_device_position(unit_vertex, sprite.bounds, viewport_size);
   float4 clip_distance = distance_from_clip_rect(unit_vertex, sprite.bounds,
-                                                 sprite.content_mask.bounds);
+                                                 clip.folded_bounds);
   float2 tile_position = to_tile_position(unit_vertex, sprite.tile, atlas_size);
   return PolychromeSpriteVertexOutput{
       device_position,
       tile_position,
       sprite_id,
+      clip.rounded_head,
       {clip_distance.x, clip_distance.y, clip_distance.z, clip_distance.w}};
 }
 
 fragment float4 polychrome_sprite_fragment(
     PolychromeSpriteFragmentInput input [[stage_in]],
     constant PolychromeSprite *sprites [[buffer(SpriteInputIndex_Sprites)]],
-    texture2d<float> atlas_texture [[texture(SpriteInputIndex_AtlasTexture)]]) {
+    texture2d<float> atlas_texture [[texture(SpriteInputIndex_AtlasTexture)]],
+    constant ClipNode *clips [[buffer(ClipsInputIndex_Clips)]]) {
   PolychromeSprite sprite = sprites[input.sprite_id];
   constexpr sampler atlas_texture_sampler(mag_filter::linear,
                                           min_filter::linear);
@@ -727,7 +772,8 @@ fragment float4 polychrome_sprite_fragment(
     color.g = grayscale;
     color.b = grayscale;
   }
-  color.a *= sprite.opacity * saturate(0.5 - distance);
+  color.a *= sprite.opacity * saturate(0.5 - distance) *
+             clip_chain_alpha(input.position.xy, input.rounded_head, clips);
   return color;
 }
 
@@ -771,7 +817,8 @@ vertex PathRasterizationVertexOutput path_rasterization_vertex(
 
 fragment float4 path_rasterization_fragment(
   PathRasterizationFragmentInput input [[stage_in]],
-  constant PathRasterizationVertex *vertices [[buffer(PathRasterizationInputIndex_Vertices)]]
+  constant PathRasterizationVertex *vertices [[buffer(PathRasterizationInputIndex_Vertices)]],
+  constant ClipNode *clips [[buffer(ClipsInputIndex_Clips)]]
 ) {
   float2 dx = dfdx(input.st_position);
   float2 dy = dfdy(input.st_position);
@@ -791,6 +838,8 @@ fragment float4 path_rasterization_fragment(
     float distance = f / length(gradient);
     alpha = saturate(0.5 - distance);
   }
+
+  alpha *= clip_chain_alpha(input.position.xy, v.rounded_head, clips);
 
   GradientColor gradient_color = prepare_fill_color(
     background.tag,
@@ -850,12 +899,14 @@ fragment float4 path_sprite_fragment(
 struct SurfaceVertexOutput {
   float4 position [[position]];
   float2 texture_position;
+  uint rounded_head [[flat]];
   float clip_distance [[clip_distance]][4];
 };
 
 struct SurfaceFragmentInput {
   float4 position [[position]];
   float2 texture_position;
+  uint rounded_head [[flat]];
 };
 
 vertex SurfaceVertexOutput surface_vertex(
@@ -865,19 +916,22 @@ vertex SurfaceVertexOutput surface_vertex(
     constant Size_DevicePixels *viewport_size
     [[buffer(SurfaceInputIndex_ViewportSize)]],
     constant Size_DevicePixels *texture_size
-    [[buffer(SurfaceInputIndex_TextureSize)]]) {
+    [[buffer(SurfaceInputIndex_TextureSize)]],
+    constant ClipNode *clips [[buffer(ClipsInputIndex_Clips)]]) {
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   SurfaceBounds surface = surfaces[surface_id];
+  ClipNode clip = clips[surface.clip_id];
   float4 device_position =
       to_device_position(unit_vertex, surface.bounds, viewport_size);
   float4 clip_distance = distance_from_clip_rect(unit_vertex, surface.bounds,
-                                                 surface.content_mask.bounds);
+                                                 clip.folded_bounds);
   // We are going to copy the whole texture, so the texture position corresponds
   // to the current vertex of the unit triangle.
   float2 texture_position = unit_vertex;
   return SurfaceVertexOutput{
       device_position,
       texture_position,
+      clip.rounded_head,
       {clip_distance.x, clip_distance.y, clip_distance.z, clip_distance.w}};
 }
 
@@ -885,7 +939,9 @@ fragment float4 surface_fragment(SurfaceFragmentInput input [[stage_in]],
                                  texture2d<float> y_texture
                                  [[texture(SurfaceInputIndex_YTexture)]],
                                  texture2d<float> cb_cr_texture
-                                 [[texture(SurfaceInputIndex_CbCrTexture)]]) {
+                                 [[texture(SurfaceInputIndex_CbCrTexture)]],
+                                 constant ClipNode *clips
+                                 [[buffer(ClipsInputIndex_Clips)]]) {
   constexpr sampler texture_sampler(mag_filter::linear, min_filter::linear);
   const float4x4 ycbcrToRGBTransform =
       float4x4(float4(+1.0000f, +1.0000f, +1.0000f, +0.0000f),
@@ -896,7 +952,9 @@ fragment float4 surface_fragment(SurfaceFragmentInput input [[stage_in]],
       y_texture.sample(texture_sampler, input.texture_position).r,
       cb_cr_texture.sample(texture_sampler, input.texture_position).rg, 1.0);
 
-  return ycbcrToRGBTransform * ycbcr;
+  float4 color = ycbcrToRGBTransform * ycbcr;
+  color.a *= clip_chain_alpha(input.position.xy, input.rounded_head, clips);
+  return color;
 }
 
 float4 hsla_to_rgba(Hsla hsla) {
@@ -1087,6 +1145,26 @@ float quad_sdf_impl(float2 corner_center_to_point, float corner_radius) {
 
         return signed_distance_to_inset_quad - corner_radius;
     }
+}
+
+// Walks the rounded-clip chain starting at `rounded_head`, multiplying in one
+// antialiased rounded-rect coverage term per node. `rounded_head` is
+// `ClipNode_NONE` for purely rectangular clipping (the common case), making this a
+// zero-iteration loop; the chain only contains nodes with nonzero corner radii, so
+// its length is the number of rounded clips actually in effect (typically 0 or 1).
+// Rectangular clipping is handled separately via interpolated clip distances
+// computed in the vertex stage.
+float clip_chain_alpha(float2 position, uint rounded_head,
+                       constant ClipNode *clips) {
+  float alpha = 1.0;
+  uint clip_id = rounded_head;
+  while (clip_id != 0xFFFFFFFFu) {
+    ClipNode node = clips[clip_id];
+    float distance = quad_sdf(position, node.rounded_bounds, node.corner_radii);
+    alpha *= saturate(0.5 - distance);
+    clip_id = node.parent_rounded;
+  }
+  return alpha;
 }
 
 // A standard gaussian function, used for weighting samples

--- a/crates/gpui_platform/src/gpui_platform.rs
+++ b/crates/gpui_platform/src/gpui_platform.rs
@@ -75,6 +75,67 @@ pub fn current_headless_renderer() -> Option<Box<dyn gpui::PlatformHeadlessRende
     }
 }
 
+#[cfg(all(test, target_os = "macos", feature = "test-support"))]
+mod pixel_tests {
+    use super::*;
+    use gpui::{
+        AppContext, Context, HeadlessAppContext, IntoElement, ParentElement, Render, Styled,
+        Window, div, px, size,
+    };
+    use std::sync::Arc;
+
+    struct RoundedClipView;
+
+    impl Render for RoundedClipView {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().bg(gpui::black()).child(
+                div()
+                    .size(px(100.))
+                    .rounded(px(30.))
+                    .overflow_hidden()
+                    .child(div().size_full().bg(gpui::red())),
+            )
+        }
+    }
+
+    #[test]
+    fn rounded_overflow_hidden_clips_rendered_pixels() {
+        let text_system = Arc::new(gpui::NoopTextSystem);
+        let mut cx =
+            HeadlessAppContext::with_platform(text_system, Arc::new(()), current_headless_renderer);
+        let window = cx
+            .open_window(size(px(200.), px(200.)), |_, cx| {
+                cx.new(|_| RoundedClipView)
+            })
+            .unwrap();
+        cx.update_window(window.into(), |_, window, cx| {
+            window.draw(cx).clear();
+        })
+        .unwrap();
+        let image = cx.capture_screenshot(window.into()).unwrap();
+
+        let scale = image.width() as f32 / 200.;
+        let pixel = |x: f32, y: f32| image.get_pixel((x * scale) as u32, (y * scale) as u32).0;
+        let is_red = |p: [u8; 4]| p[0] > 200 && p[1] < 50 && p[2] < 50;
+
+        // Center of the rounded container is the child's red fill.
+        assert!(is_red(pixel(50., 50.)), "center: {:?}", pixel(50., 50.));
+        // Edge midpoints are inside the rounded rect.
+        assert!(is_red(pixel(50., 2.)), "top edge: {:?}", pixel(50., 2.));
+        // Corner pixels are outside the 30px arcs and must be clipped to the black
+        // background.
+        for (x, y) in [(2., 2.), (98., 2.), (98., 98.), (2., 98.)] {
+            let p = pixel(x, y);
+            assert!(!is_red(p), "corner ({x}, {y}) should be clipped: {p:?}");
+        }
+        // Points inside the arcs are red.
+        for (x, y) in [(12., 12.), (88., 12.), (88., 88.), (12., 88.)] {
+            let p = pixel(x, y);
+            assert!(is_red(p), "inside arc ({x}, {y}) should be red: {p:?}");
+        }
+    }
+}
+
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -167,6 +167,23 @@ struct TransformationMatrix {
     translation: vec2<f32>,
 }
 
+// A node in the scene's clip tree. Rectangular clipping uses `folded_bounds` (the
+// intersection of all rectangular clips along the ancestor chain), evaluated in the
+// vertex stage as interpolated clip distances. Rounded clips are retained
+// individually and linked through `parent_rounded`; fragments walk that chain via
+// `clip_chain_alpha`.
+struct ClipNode {
+    folded_bounds: Bounds,
+    rounded_bounds: Bounds,
+    corner_radii: Corners,
+    rounded_head: u32,
+    parent_rounded: u32,
+}
+
+const CLIP_NODE_NONE: u32 = 0xffffffffu;
+
+@group(0) @binding(2) var<storage, read> b_clips: array<ClipNode>;
+
 fn to_device_position_impl(position: vec2<f32>) -> vec4<f32> {
     let device_position = position / globals.viewport_size * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0);
     return vec4<f32>(device_position, 0.0, 1.0);
@@ -369,6 +386,23 @@ fn quad_sdf(point: vec2<f32>, bounds: Bounds, corner_radii: Corners) -> f32 {
     return quad_sdf_impl(corner_center_to_point, corner_radius);
 }
 
+// Walks the rounded-clip chain starting at `rounded_head`, multiplying in one
+// antialiased rounded-rect coverage term per node. `rounded_head` is
+// `CLIP_NODE_NONE` for purely rectangular clipping (the common case), making this
+// a zero-iteration loop; the chain only contains nodes with nonzero corner radii,
+// so its length is the number of rounded clips actually in effect (typically 0 or 1).
+fn clip_chain_alpha(position: vec2<f32>, rounded_head: u32) -> f32 {
+    var alpha = 1.0;
+    var clip_id = rounded_head;
+    while (clip_id != CLIP_NODE_NONE) {
+        let node = b_clips[clip_id];
+        let distance = quad_sdf(position, node.rounded_bounds, node.corner_radii);
+        alpha *= saturate(0.5 - distance);
+        clip_id = node.parent_rounded;
+    }
+    return alpha;
+}
+
 fn quad_sdf_impl(corner_center_to_point: vec2<f32>, corner_radius: f32) -> f32 {
     if (corner_radius == 0.0) {
         // Fast path for unrounded corners.
@@ -520,7 +554,8 @@ struct Quad {
     order: u32,
     border_style: u32,
     bounds: Bounds,
-    content_mask: Bounds,
+    clip_id: u32,
+    pad: u32,
     background: Background,
     border_color: Hsla,
     corner_radii: Corners,
@@ -537,6 +572,7 @@ struct QuadVarying {
     @location(3) @interpolate(flat) background_solid: vec4<f32>,
     @location(4) @interpolate(flat) background_color0: vec4<f32>,
     @location(5) @interpolate(flat) background_color1: vec4<f32>,
+    @location(6) @interpolate(flat) rounded_head: u32,
 }
 
 @vertex
@@ -558,7 +594,9 @@ fn vs_quad(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) insta
     out.background_color1 = gradient.color1;
     out.border_color = hsla_to_rgba(quad.border_color);
     out.quad_id = instance_id;
-    out.clip_distances = distance_from_clip_rect(unit_vertex, quad.bounds, quad.content_mask);
+    let clip = b_clips[quad.clip_id];
+    out.clip_distances = distance_from_clip_rect(unit_vertex, quad.bounds, clip.folded_bounds);
+    out.rounded_head = clip.rounded_head;
     return out;
 }
 
@@ -568,6 +606,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     if (any(input.clip_distances < vec4<f32>(0.0))) {
         return vec4<f32>(0.0);
     }
+    let clip_alpha = clip_chain_alpha(input.position.xy, input.rounded_head);
 
     let quad = b_quads[input.quad_id];
 
@@ -585,7 +624,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
             quad.border_widths.right == 0.0 &&
             quad.border_widths.bottom == 0.0 &&
             unrounded) {
-        return blend_color(background_color, 1.0);
+        return blend_color(background_color, clip_alpha);
     }
 
     let size = quad.bounds.size;
@@ -651,7 +690,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
     // However, that might negatively impact performance in the case of
     // reasonable sizes for rounded corners.
     if (is_within_inner_straight_border && !is_near_rounded_corner) {
-        return blend_color(background_color, 1.0);
+        return blend_color(background_color, clip_alpha);
     }
 
     // Signed distance of the point to the outside edge of the quad's border. It
@@ -890,7 +929,7 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
                     saturate(antialias_threshold - inner_sdf));
     }
 
-    return blend_color(color, saturate(antialias_threshold - outer_sdf));
+    return blend_color(color, saturate(antialias_threshold - outer_sdf) * clip_alpha);
 }
 
 // Returns the dash velocity of a corner given the dash velocity of the two
@@ -954,7 +993,6 @@ struct Shadow {
     // The shadow rect for drop shadows; the "hole" rect for inset shadows.
     bounds: Bounds,
     corner_radii: Corners,
-    content_mask: Bounds,
     color: Hsla,
     // Only consulted when `inset == 1u`: the element's own bounds, used as a rounded-rect
     // clip so the shadow never escapes the element.
@@ -962,7 +1000,7 @@ struct Shadow {
     element_corner_radii: Corners,
     // 0 = drop shadow, 1 = inset shadow.
     inset: u32,
-    pad: u32, // align to 8 bytes
+    clip_id: u32,
 }
 @group(1) @binding(0) var<storage, read> b_shadows: array<Shadow>;
 
@@ -970,6 +1008,7 @@ struct ShadowVarying {
     @builtin(position) position: vec4<f32>,
     @location(0) @interpolate(flat) color: vec4<f32>,
     @location(1) @interpolate(flat) shadow_id: u32,
+    @location(2) @interpolate(flat) rounded_head: u32,
     //TODO: use `clip_distance` once Naga supports it
     @location(3) clip_distances: vec4<f32>,
 }
@@ -994,7 +1033,9 @@ fn vs_shadow(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) ins
     out.position = to_device_position(unit_vertex, geometry);
     out.color = hsla_to_rgba(shadow.color);
     out.shadow_id = instance_id;
-    out.clip_distances = distance_from_clip_rect(unit_vertex, geometry, shadow.content_mask);
+    let clip = b_clips[shadow.clip_id];
+    out.clip_distances = distance_from_clip_rect(unit_vertex, geometry, clip.folded_bounds);
+    out.rounded_head = clip.rounded_head;
     return out;
 }
 
@@ -1044,6 +1085,8 @@ fn fs_shadow(input: ShadowVarying) -> @location(0) vec4<f32> {
         alpha *= saturate(0.5 - element_distance);
     }
 
+    alpha *= clip_chain_alpha(input.position.xy, input.rounded_head);
+
     return blend_color(input.color, alpha);
 }
 
@@ -1054,6 +1097,8 @@ struct PathRasterizationVertex {
     st_position: vec2<f32>,
     color: Background,
     bounds: Bounds,
+    rounded_head: u32,
+    pad: u32,
 }
 
 @group(1) @binding(0) var<storage, read> b_path_vertices: array<PathRasterizationVertex>;
@@ -1106,6 +1151,8 @@ fn fs_path_rasterization(input: PathRasterizationVarying) -> @location(0) vec4<f
         background.solid,
         background.colors,
     );
+    alpha *= clip_chain_alpha(input.position.xy, v.rounded_head);
+
     let color = gradient_color(background, input.position.xy, bounds,
         prepared_gradient.solid, prepared_gradient.color0, prepared_gradient.color1);
     return vec4<f32>(color.rgb * color.a * alpha, color.a * alpha);
@@ -1150,9 +1197,8 @@ fn fs_path(input: PathVarying) -> @location(0) vec4<f32> {
 
 struct Underline {
     order: u32,
-    pad: u32,
+    clip_id: u32,
     bounds: Bounds,
-    content_mask: Bounds,
     color: Hsla,
     thickness: f32,
     wavy: u32,
@@ -1163,6 +1209,7 @@ struct UnderlineVarying {
     @builtin(position) position: vec4<f32>,
     @location(0) @interpolate(flat) color: vec4<f32>,
     @location(1) @interpolate(flat) underline_id: u32,
+    @location(2) @interpolate(flat) rounded_head: u32,
     //TODO: use `clip_distance` once Naga supports it
     @location(3) clip_distances: vec4<f32>,
 }
@@ -1176,7 +1223,9 @@ fn vs_underline(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) 
     out.position = to_device_position(unit_vertex, underline.bounds);
     out.color = hsla_to_rgba(underline.color);
     out.underline_id = instance_id;
-    out.clip_distances = distance_from_clip_rect(unit_vertex, underline.bounds, underline.content_mask);
+    let clip = b_clips[underline.clip_id];
+    out.clip_distances = distance_from_clip_rect(unit_vertex, underline.bounds, clip.folded_bounds);
+    out.rounded_head = clip.rounded_head;
     return out;
 }
 
@@ -1190,10 +1239,11 @@ fn fs_underline(input: UnderlineVarying) -> @location(0) vec4<f32> {
         return vec4<f32>(0.0);
     }
 
+    let clip_alpha = clip_chain_alpha(input.position.xy, input.rounded_head);
     let underline = b_underlines[input.underline_id];
     if (underline.wavy == 0u)
     {
-        return blend_color(input.color, input.color.a);
+        return blend_color(input.color, input.color.a * clip_alpha);
     }
 
     let half_thickness = underline.thickness * 0.5;
@@ -1209,16 +1259,15 @@ fn fs_underline(input: UnderlineVarying) -> @location(0) vec4<f32> {
     let distance_from_top_border = distance_in_pixels - half_thickness;
     let distance_from_bottom_border = distance_in_pixels + half_thickness;
     let alpha = saturate(0.5 - max(-distance_from_bottom_border, distance_from_top_border));
-    return blend_color(input.color, alpha * input.color.a);
+    return blend_color(input.color, alpha * input.color.a * clip_alpha);
 }
 
 // --- monochrome sprites --- //
 
 struct MonochromeSprite {
     order: u32,
-    pad: u32,
+    clip_id: u32,
     bounds: Bounds,
-    content_mask: Bounds,
     color: Hsla,
     tile: AtlasTile,
     transformation: TransformationMatrix,
@@ -1229,6 +1278,7 @@ struct MonoSpriteVarying {
     @builtin(position) position: vec4<f32>,
     @location(0) tile_position: vec2<f32>,
     @location(1) @interpolate(flat) color: vec4<f32>,
+    @location(2) @interpolate(flat) rounded_head: u32,
     @location(3) clip_distances: vec4<f32>,
 }
 
@@ -1242,7 +1292,9 @@ fn vs_mono_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index
 
     out.tile_position = to_tile_position(unit_vertex, sprite.tile);
     out.color = hsla_to_rgba(sprite.color);
-    out.clip_distances = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, sprite.content_mask, sprite.transformation);
+    let clip = b_clips[sprite.clip_id];
+    out.clip_distances = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, clip.folded_bounds, sprite.transformation);
+    out.rounded_head = clip.rounded_head;
     return out;
 }
 
@@ -1255,19 +1307,19 @@ fn fs_mono_sprite(input: MonoSpriteVarying) -> @location(0) vec4<f32> {
     if (any(input.clip_distances < vec4<f32>(0.0))) {
         return vec4<f32>(0.0);
     }
+    let clip_alpha = clip_chain_alpha(input.position.xy, input.rounded_head);
 
-    return blend_color(input.color, alpha_corrected);
+    return blend_color(input.color, alpha_corrected * clip_alpha);
 }
 
 // --- polychrome sprites --- //
 
 struct PolychromeSprite {
     order: u32,
-    pad: u32,
+    clip_id: u32,
     grayscale: u32,
     opacity: f32,
     bounds: Bounds,
-    content_mask: Bounds,
     corner_radii: Corners,
     tile: AtlasTile,
 }
@@ -1277,6 +1329,7 @@ struct PolySpriteVarying {
     @builtin(position) position: vec4<f32>,
     @location(0) tile_position: vec2<f32>,
     @location(1) @interpolate(flat) sprite_id: u32,
+    @location(2) @interpolate(flat) rounded_head: u32,
     @location(3) clip_distances: vec4<f32>,
 }
 
@@ -1289,7 +1342,9 @@ fn vs_poly_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index
     out.position = to_device_position(unit_vertex, sprite.bounds);
     out.tile_position = to_tile_position(unit_vertex, sprite.tile);
     out.sprite_id = instance_id;
-    out.clip_distances = distance_from_clip_rect(unit_vertex, sprite.bounds, sprite.content_mask);
+    let clip = b_clips[sprite.clip_id];
+    out.clip_distances = distance_from_clip_rect(unit_vertex, sprite.bounds, clip.folded_bounds);
+    out.rounded_head = clip.rounded_head;
     return out;
 }
 
@@ -1309,7 +1364,8 @@ fn fs_poly_sprite(input: PolySpriteVarying) -> @location(0) vec4<f32> {
         let grayscale = dot(color.rgb, GRAYSCALE_FACTORS);
         color = vec4<f32>(vec3<f32>(grayscale), sample.a);
     }
-    return blend_color(color, sprite.opacity * saturate(0.5 - distance));
+    let clip_alpha = clip_chain_alpha(input.position.xy, input.rounded_head);
+    return blend_color(color, sprite.opacity * saturate(0.5 - distance) * clip_alpha);
 }
 
 // --- surfaces --- //

--- a/crates/gpui_wgpu/src/shaders_subpixel.wgsl
+++ b/crates/gpui_wgpu/src/shaders_subpixel.wgsl
@@ -2,9 +2,8 @@
 
 struct SubpixelSprite {
     order: u32,
-    pad: u32,
+    clip_id: u32,
     bounds: Bounds,
-    content_mask: Bounds,
     color: Hsla,
     tile: AtlasTile,
     transformation: TransformationMatrix,
@@ -15,6 +14,7 @@ struct SubpixelSpriteOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) tile_position: vec2<f32>,
     @location(1) @interpolate(flat) color: vec4<f32>,
+    @location(2) @interpolate(flat) rounded_head: u32,
     @location(3) clip_distances: vec4<f32>,
 }
 
@@ -32,7 +32,9 @@ fn vs_subpixel_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_i
     out.position = to_device_position_transformed(unit_vertex, sprite.bounds, sprite.transformation);
     out.tile_position = to_tile_position(unit_vertex, sprite.tile);
     out.color = hsla_to_rgba(sprite.color);
-    out.clip_distances = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, sprite.content_mask, sprite.transformation);
+    let clip = b_clips[sprite.clip_id];
+    out.clip_distances = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, clip.folded_bounds, sprite.transformation);
+    out.rounded_head = clip.rounded_head;
     return out;
 }
 
@@ -49,8 +51,10 @@ fn fs_subpixel_sprite(input: SubpixelSpriteOutput) -> SubpixelSpriteFragmentOutp
         return SubpixelSpriteFragmentOutput(vec4<f32>(0.0), vec4<f32>(0.0));
     }
 
+    let clip_alpha = clip_chain_alpha(input.position.xy, input.rounded_head);
+
     var out = SubpixelSpriteFragmentOutput();
     out.foreground = vec4<f32>(input.color.rgb, 1.0);
-    out.alpha = vec4<f32>(input.color.a * alpha_corrected, 1.0);
+    out.alpha = vec4<f32>(input.color.a * alpha_corrected * clip_alpha, 1.0);
     return out;
 }

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -1,9 +1,9 @@
 use crate::{CompositorGpuHint, WgpuAtlas, WgpuContext};
 use bytemuck::{Pod, Zeroable};
 use gpui::{
-    AtlasTextureId, Background, Bounds, DevicePixels, GpuSpecs, MonochromeSprite, Path, Point,
-    PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size, SubpixelSprite,
-    Underline, get_gamma_correction_ratios,
+    AtlasTextureId, Background, Bounds, ClipNode, DevicePixels, GpuSpecs, MonochromeSprite, Path,
+    Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
+    SubpixelSprite, Underline, get_gamma_correction_ratios,
 };
 use log::warn;
 #[cfg(not(target_family = "wasm"))]
@@ -67,6 +67,9 @@ struct PathRasterizationVertex {
     st_position: Point<f32>,
     color: Background,
     bounds: Bounds<ScaledPixels>,
+    /// The nearest rounded clip node for this path, or [`ClipNode::NONE`].
+    rounded_head: u32,
+    pad: u32,
 }
 
 pub struct WgpuSurfaceConfig {
@@ -104,6 +107,8 @@ struct WgpuBindGroupLayouts {
 /// Shared GPU context reference, used to coordinate device recovery across multiple windows.
 pub type GpuContext = Rc<RefCell<Option<WgpuContext>>>;
 
+const INITIAL_CLIPS_BUFFER_CAPACITY: u64 = 4096;
+
 /// GPU resources that must be dropped together during device recovery.
 struct WgpuResources {
     device: Arc<wgpu::Device>,
@@ -115,6 +120,7 @@ struct WgpuResources {
     globals_buffer: wgpu::Buffer,
     globals_bind_group: wgpu::BindGroup,
     path_globals_bind_group: wgpu::BindGroup,
+    clips_buffer: wgpu::Buffer,
     instance_buffer: wgpu::Buffer,
     path_intermediate_texture: Option<wgpu::Texture>,
     path_intermediate_view: Option<wgpu::TextureView>,
@@ -144,6 +150,7 @@ pub struct WgpuRenderer {
     path_globals_offset: u64,
     gamma_offset: u64,
     instance_buffer_capacity: u64,
+    clips_buffer_capacity: u64,
     max_buffer_size: u64,
     storage_buffer_alignment: u64,
     rendering_params: RenderingParameters,
@@ -391,51 +398,22 @@ impl WgpuRenderer {
             mapped_at_creation: false,
         });
 
-        let globals_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("globals_bind_group"),
-            layout: &bind_group_layouts.globals,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                        buffer: &globals_buffer,
-                        offset: 0,
-                        size: Some(NonZeroU64::new(globals_size).unwrap()),
-                    }),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                        buffer: &globals_buffer,
-                        offset: gamma_offset,
-                        size: Some(NonZeroU64::new(gamma_size).unwrap()),
-                    }),
-                },
-            ],
+        let clips_buffer_capacity = INITIAL_CLIPS_BUFFER_CAPACITY;
+        let clips_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("clips_buffer"),
+            size: clips_buffer_capacity,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
         });
 
-        let path_globals_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("path_globals_bind_group"),
-            layout: &bind_group_layouts.globals,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                        buffer: &globals_buffer,
-                        offset: path_globals_offset,
-                        size: Some(NonZeroU64::new(globals_size).unwrap()),
-                    }),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                        buffer: &globals_buffer,
-                        offset: gamma_offset,
-                        size: Some(NonZeroU64::new(gamma_size).unwrap()),
-                    }),
-                },
-            ],
-        });
+        let (globals_bind_group, path_globals_bind_group) = Self::create_globals_bind_groups(
+            &device,
+            &bind_group_layouts,
+            &globals_buffer,
+            path_globals_offset,
+            gamma_offset,
+            &clips_buffer,
+        );
 
         let adapter_info = context.adapter.get_info();
 
@@ -456,6 +434,7 @@ impl WgpuRenderer {
             globals_buffer,
             globals_bind_group,
             path_globals_bind_group,
+            clips_buffer,
             instance_buffer,
             // Defer intermediate texture creation to first draw call via ensure_intermediate_textures().
             // This avoids panics when the device/surface is in an invalid state during initialization.
@@ -474,6 +453,7 @@ impl WgpuRenderer {
             path_globals_offset,
             gamma_offset,
             instance_buffer_capacity: initial_instance_buffer_capacity,
+            clips_buffer_capacity,
             max_buffer_size,
             storage_buffer_alignment,
             rendering_params,
@@ -489,6 +469,50 @@ impl WgpuRenderer {
             surface_configured: true,
             needs_redraw: false,
         })
+    }
+
+    fn create_globals_bind_groups(
+        device: &wgpu::Device,
+        bind_group_layouts: &WgpuBindGroupLayouts,
+        globals_buffer: &wgpu::Buffer,
+        path_globals_offset: u64,
+        gamma_offset: u64,
+        clips_buffer: &wgpu::Buffer,
+    ) -> (wgpu::BindGroup, wgpu::BindGroup) {
+        let globals_size = std::mem::size_of::<GlobalParams>() as u64;
+        let gamma_size = std::mem::size_of::<GammaParams>() as u64;
+        let create = |label: &str, globals_offset: u64| {
+            device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some(label),
+                layout: &bind_group_layouts.globals,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                            buffer: globals_buffer,
+                            offset: globals_offset,
+                            size: Some(NonZeroU64::new(globals_size).unwrap()),
+                        }),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                            buffer: globals_buffer,
+                            offset: gamma_offset,
+                            size: Some(NonZeroU64::new(gamma_size).unwrap()),
+                        }),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: clips_buffer.as_entire_binding(),
+                    },
+                ],
+            })
+        };
+        (
+            create("globals_bind_group", 0),
+            create("path_globals_bind_group", path_globals_offset),
+        )
     }
 
     fn create_bind_group_layouts(device: &wgpu::Device) -> WgpuBindGroupLayouts {
@@ -517,6 +541,17 @@ impl WgpuRenderer {
                             min_binding_size: NonZeroU64::new(
                                 std::mem::size_of::<GammaParams>() as u64
                             ),
+                        },
+                        count: None,
+                    },
+                    // The scene's clip nodes, shared by all pipelines.
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
                         },
                         count: None,
                     },
@@ -1202,6 +1237,8 @@ impl WgpuRenderer {
             );
         }
 
+        self.upload_clips(&scene.clips);
+
         loop {
             let mut instance_offset: u64 = 0;
             let mut overflow = false;
@@ -1250,6 +1287,7 @@ impl WgpuRenderer {
                             let did_draw = self.draw_paths_to_intermediate(
                                 &mut encoder,
                                 paths,
+                                &scene.clips,
                                 &mut instance_offset,
                             );
 
@@ -1577,16 +1615,22 @@ impl WgpuRenderer {
         &self,
         encoder: &mut wgpu::CommandEncoder,
         paths: &[Path<ScaledPixels>],
+        clips: &[ClipNode],
         instance_offset: &mut u64,
     ) -> bool {
         let mut vertices = Vec::new();
         for path in paths {
             let bounds = path.clipped_bounds();
+            let rounded_head = clips
+                .get(path.clip_id as usize)
+                .map_or(ClipNode::NONE, |node| node.rounded_head);
             vertices.extend(path.vertices.iter().map(|v| PathRasterizationVertex {
                 xy_position: v.xy_position,
                 st_position: v.st_position,
                 color: path.color,
                 bounds,
+                rounded_head,
+                pad: 0,
             }));
         }
 
@@ -1646,6 +1690,45 @@ impl WgpuRenderer {
         }
 
         true
+    }
+
+    /// Write the scene's clip nodes into the clips buffer, growing it (and
+    /// recreating the bind groups that reference it) if needed.
+    fn upload_clips(&mut self, clips: &[ClipNode]) {
+        let clips_size = std::mem::size_of_val(clips) as u64;
+        if clips_size > self.clips_buffer_capacity {
+            let new_capacity = clips_size
+                .next_power_of_two()
+                .max(INITIAL_CLIPS_BUFFER_CAPACITY);
+            let path_globals_offset = self.path_globals_offset;
+            let gamma_offset = self.gamma_offset;
+            let resources = self.resources_mut();
+            resources.clips_buffer = resources.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("clips_buffer"),
+                size: new_capacity,
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            let (globals_bind_group, path_globals_bind_group) = Self::create_globals_bind_groups(
+                &resources.device,
+                &resources.bind_group_layouts,
+                &resources.globals_buffer,
+                path_globals_offset,
+                gamma_offset,
+                &resources.clips_buffer,
+            );
+            resources.globals_bind_group = globals_bind_group;
+            resources.path_globals_bind_group = path_globals_bind_group;
+            self.clips_buffer_capacity = new_capacity;
+        }
+        if !clips.is_empty() {
+            let resources = self.resources();
+            resources
+                .queue
+                .write_buffer(&resources.clips_buffer, 0, unsafe {
+                    Self::instance_bytes(clips)
+                });
+        }
     }
 
     fn grow_instance_buffer(&mut self) {

--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -90,6 +90,45 @@ struct DirectXRenderPipelines {
     mono_sprites: PipelineState<MonochromeSprite>,
     subpixel_sprites: PipelineState<SubpixelSprite>,
     poly_sprites: PipelineState<PolychromeSprite>,
+    clips: ClipsBuffer,
+}
+
+/// The scene's clip nodes, uploaded once per frame and bound at `t2` for all
+/// pipelines.
+struct ClipsBuffer {
+    buffer: ID3D11Buffer,
+    buffer_size: usize,
+    view: Option<ID3D11ShaderResourceView>,
+}
+
+impl ClipsBuffer {
+    fn new(device: &ID3D11Device) -> Result<Self> {
+        let buffer_size = 64;
+        let buffer = create_buffer(device, std::mem::size_of::<ClipNode>(), buffer_size)?;
+        let view = create_buffer_view(device, &buffer)?;
+        Ok(ClipsBuffer {
+            buffer,
+            buffer_size,
+            view,
+        })
+    }
+
+    fn update(
+        &mut self,
+        device: &ID3D11Device,
+        device_context: &ID3D11DeviceContext,
+        clips: &[ClipNode],
+    ) -> Result<()> {
+        if self.buffer_size < clips.len() {
+            let new_buffer_size = clips.len().next_power_of_two();
+            let buffer = create_buffer(device, std::mem::size_of::<ClipNode>(), new_buffer_size)?;
+            let view = create_buffer_view(device, &buffer)?;
+            self.buffer = buffer;
+            self.view = view;
+            self.buffer_size = new_buffer_size;
+        }
+        update_buffer(device_context, &self.buffer, clips)
+    }
 }
 
 struct DirectXGlobalElements {
@@ -324,7 +363,7 @@ impl DirectXRenderer {
                 PrimitiveBatch::Quads(range) => self.draw_quads(range.start, range.len()),
                 PrimitiveBatch::Paths(range) => {
                     let paths = &scene.paths[range];
-                    self.draw_paths_to_intermediate(paths)?;
+                    self.draw_paths_to_intermediate(paths, &scene.clips)?;
                     self.draw_paths_from_intermediate(paths)
                 }
                 PrimitiveBatch::Underlines(range) => self.draw_underlines(range.start, range.len()),
@@ -401,6 +440,22 @@ impl DirectXRenderer {
 
     fn upload_scene_buffers(&mut self, scene: &Scene) -> Result<()> {
         let devices = self.devices.as_ref().context("devices missing")?;
+
+        if !scene.clips.is_empty() {
+            self.pipelines
+                .clips
+                .update(&devices.device, &devices.device_context, &scene.clips)?;
+        }
+        // Bind the clip nodes once for the whole frame; slot t2 isn't touched by any
+        // per-draw state changes.
+        unsafe {
+            devices
+                .device_context
+                .VSSetShaderResources(2, Some(slice::from_ref(&self.pipelines.clips.view)));
+            devices
+                .device_context
+                .PSSetShaderResources(2, Some(slice::from_ref(&self.pipelines.clips.view)));
+        }
 
         if !scene.shadows.is_empty() {
             self.pipelines.shadow_pipeline.update_buffer(
@@ -497,7 +552,11 @@ impl DirectXRenderer {
         )
     }
 
-    fn draw_paths_to_intermediate(&mut self, paths: &[Path<ScaledPixels>]) -> Result<()> {
+    fn draw_paths_to_intermediate(
+        &mut self,
+        paths: &[Path<ScaledPixels>],
+        clips: &[ClipNode],
+    ) -> Result<()> {
         if paths.is_empty() {
             return Ok(());
         }
@@ -521,11 +580,16 @@ impl DirectXRenderer {
         let mut vertices = Vec::new();
 
         for path in paths {
+            let rounded_head = clips
+                .get(path.clip_id as usize)
+                .map_or(ClipNode::NONE, |node| node.rounded_head);
             vertices.extend(path.vertices.iter().map(|v| PathRasterizationSprite {
                 xy_position: v.xy_position,
                 st_position: v.st_position,
                 color: path.color,
                 bounds: path.clipped_bounds(),
+                rounded_head,
+                pad: 0,
             }));
         }
 
@@ -881,6 +945,7 @@ impl DirectXRenderPipelines {
             16,
             create_blend_state(device)?,
         )?;
+        let clips = ClipsBuffer::new(device)?;
 
         Ok(Self {
             shadow_pipeline,
@@ -891,6 +956,7 @@ impl DirectXRenderPipelines {
             mono_sprites,
             subpixel_sprites,
             poly_sprites,
+            clips,
         })
     }
 }
@@ -1154,6 +1220,9 @@ struct PathRasterizationSprite {
     st_position: Point<f32>,
     color: Background,
     bounds: Bounds<ScaledPixels>,
+    /// The nearest rounded clip node for this path, or [`ClipNode::NONE`].
+    rounded_head: u32,
+    pad: u32,
 }
 
 #[derive(Clone, Copy)]

--- a/crates/gpui_windows/src/shaders.hlsl
+++ b/crates/gpui_windows/src/shaders.hlsl
@@ -299,6 +299,23 @@ float quad_sdf_impl(float2 corner_center_to_point, float corner_radius) {
     }
 }
 
+// A node in the scene's clip tree. Rectangular clipping uses `folded_bounds` (the
+// intersection of all rectangular clips along the ancestor chain), evaluated in the
+// vertex stage as hardware clip distances. Rounded clips are retained individually
+// and linked through `parent_rounded`; fragments walk that chain via
+// `clip_chain_alpha`.
+struct ClipNode {
+    Bounds folded_bounds;
+    Bounds rounded_bounds;
+    Corners corner_radii;
+    uint rounded_head;
+    uint parent_rounded;
+};
+
+StructuredBuffer<ClipNode> clips: register(t2);
+
+static const uint CLIP_NODE_NONE = 0xffffffffu;
+
 float quad_sdf(float2 pt, Bounds bounds, Corners corner_radii) {
     float2 half_size = bounds.size / 2.;
     float2 center = bounds.origin + half_size;
@@ -307,6 +324,23 @@ float quad_sdf(float2 pt, Bounds bounds, Corners corner_radii) {
     float2 corner_to_point = abs(center_to_point) - half_size;
     float2 corner_center_to_point = corner_to_point + corner_radius;
     return quad_sdf_impl(corner_center_to_point, corner_radius);
+}
+
+// Walks the rounded-clip chain starting at `rounded_head`, multiplying in one
+// antialiased rounded-rect coverage term per node. `rounded_head` is
+// `CLIP_NODE_NONE` for purely rectangular clipping (the common case), making this
+// a zero-iteration loop; the chain only contains nodes with nonzero corner radii,
+// so its length is the number of rounded clips actually in effect (typically 0 or 1).
+float clip_chain_alpha(float2 pt, uint rounded_head) {
+    float alpha = 1.0;
+    uint clip_id = rounded_head;
+    while (clip_id != CLIP_NODE_NONE) {
+        ClipNode node = clips[clip_id];
+        float distance = quad_sdf(pt, node.rounded_bounds, node.corner_radii);
+        alpha *= saturate(0.5 - distance);
+        clip_id = node.parent_rounded;
+    }
+    return alpha;
 }
 
 GradientColor prepare_gradient_color(uint tag, uint color_space, Hsla solid, LinearColorStop colors[2]) {
@@ -497,7 +531,8 @@ struct Quad {
     uint order;
     uint border_style;
     Bounds bounds;
-    Bounds content_mask;
+    uint clip_id;
+    uint pad;
     Background background;
     Hsla border_color;
     Corners corner_radii;
@@ -506,6 +541,7 @@ struct Quad {
 
 struct QuadVertexOutput {
     nointerpolation uint quad_id: TEXCOORD0;
+    nointerpolation uint rounded_head: TEXCOORD1;
     float4 position: SV_Position;
     nointerpolation float4 border_color: COLOR0;
     nointerpolation float4 background_solid: COLOR1;
@@ -516,6 +552,7 @@ struct QuadVertexOutput {
 
 struct QuadFragmentInput {
     nointerpolation uint quad_id: TEXCOORD0;
+    nointerpolation uint rounded_head: TEXCOORD1;
     float4 position: SV_Position;
     nointerpolation float4 border_color: COLOR0;
     nointerpolation float4 background_solid: COLOR1;
@@ -536,13 +573,15 @@ QuadVertexOutput quad_vertex(uint vertex_id: SV_VertexID, uint quad_id: SV_Insta
         quad.background.solid,
         quad.background.colors
     );
-    float4 clip_distance = distance_from_clip_rect(unit_vertex, quad.bounds, quad.content_mask);
+    ClipNode clip = clips[quad.clip_id];
+    float4 clip_distance = distance_from_clip_rect(unit_vertex, quad.bounds, clip.folded_bounds);
     float4 border_color = hsla_to_rgba(quad.border_color);
 
     QuadVertexOutput output;
     output.position = device_position;
     output.border_color = border_color;
     output.quad_id = quad_id;
+    output.rounded_head = clip.rounded_head;
     output.background_solid = gradient.solid;
     output.background_color0 = gradient.color0;
     output.background_color1 = gradient.color1;
@@ -552,6 +591,7 @@ QuadVertexOutput quad_vertex(uint vertex_id: SV_VertexID, uint quad_id: SV_Insta
 
 float4 quad_fragment(QuadFragmentInput input): SV_Target {
     Quad quad = quads[input.quad_id];
+    float clip_alpha = clip_chain_alpha(input.position.xy, input.rounded_head);
     float4 background_color = gradient_color(quad.background, input.position.xy, quad.bounds,
     input.background_solid, input.background_color0, input.background_color1);
 
@@ -566,7 +606,7 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
         quad.border_widths.right == 0.0 &&
         quad.border_widths.bottom == 0.0 &&
         unrounded) {
-        return background_color;
+        return background_color * float4(1.0, 1.0, 1.0, clip_alpha);
     }
 
     float2 size = quad.bounds.size;
@@ -625,7 +665,7 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
 
     // Fast path for points that must be part of the background
     if (is_within_inner_straight_border && !is_near_rounded_corner) {
-        return background_color;
+        return background_color * float4(1.0, 1.0, 1.0, clip_alpha);
     }
 
     // Signed distance of the point to the outside edge of the quad's border
@@ -838,7 +878,7 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
                     saturate(antialias_threshold - inner_sdf));
     }
 
-    return color * float4(1.0, 1.0, 1.0, saturate(antialias_threshold - outer_sdf));
+    return color * float4(1.0, 1.0, 1.0, saturate(antialias_threshold - outer_sdf) * clip_alpha);
 }
 
 /*
@@ -852,16 +892,16 @@ struct Shadow {
     float blur_radius;
     Bounds bounds;
     Corners corner_radii;
-    Bounds content_mask;
     Hsla color;
     Bounds element_bounds;
     Corners element_corner_radii;
     uint inset;
-    uint pad; // align to 8 bytes
+    uint clip_id;
 };
 
 struct ShadowVertexOutput {
     nointerpolation uint shadow_id: TEXCOORD0;
+    nointerpolation uint rounded_head: TEXCOORD1;
     float4 position: SV_Position;
     nointerpolation float4 color: COLOR;
     float4 clip_distance: SV_ClipDistance;
@@ -869,6 +909,7 @@ struct ShadowVertexOutput {
 
 struct ShadowFragmentInput {
   nointerpolation uint shadow_id: TEXCOORD0;
+  nointerpolation uint rounded_head: TEXCOORD1;
   float4 position: SV_Position;
   nointerpolation float4 color: COLOR;
 };
@@ -891,13 +932,15 @@ ShadowVertexOutput shadow_vertex(uint vertex_id: SV_VertexID, uint shadow_id: SV
     }
 
     float4 device_position = to_device_position(unit_vertex, bounds);
-    float4 clip_distance = distance_from_clip_rect(unit_vertex, bounds, shadow.content_mask);
+    ClipNode clip = clips[shadow.clip_id];
+    float4 clip_distance = distance_from_clip_rect(unit_vertex, bounds, clip.folded_bounds);
     float4 color = hsla_to_rgba(shadow.color);
 
     ShadowVertexOutput output;
     output.position = device_position;
     output.color = color;
     output.shadow_id = shadow_id;
+    output.rounded_head = clip.rounded_head;
     output.clip_distance = clip_distance;
 
     return output;
@@ -943,6 +986,8 @@ float4 shadow_fragment(ShadowFragmentInput input): SV_TARGET {
         alpha *= saturate(0.5 - element_distance);
     }
 
+    alpha *= clip_chain_alpha(input.position.xy, input.rounded_head);
+
     return input.color * float4(1., 1., 1., alpha);
 }
 
@@ -957,6 +1002,8 @@ struct PathRasterizationSprite {
     float2 st_position;
     Background color;
     Bounds bounds;
+    uint rounded_head;
+    uint pad;
 };
 
 StructuredBuffer<PathRasterizationSprite> path_rasterization_sprites: register(t1);
@@ -1003,6 +1050,8 @@ float4 path_rasterization_fragment(PathFragmentInput input): SV_Target {
         float distance = f / length(gradient);
         alpha = saturate(0.5 - distance);
     }
+
+    alpha *= clip_chain_alpha(input.position.xy, sprite.rounded_head);
 
     GradientColor gradient = prepare_gradient_color(
         background.tag, background.color_space, background.solid, background.colors);
@@ -1057,9 +1106,8 @@ float4 path_sprite_fragment(PathSpriteVertexOutput input): SV_Target {
 
 struct Underline {
     uint order;
-    uint pad;
+    uint clip_id;
     Bounds bounds;
-    Bounds content_mask;
     Hsla color;
     float thickness;
     uint wavy;
@@ -1067,6 +1115,7 @@ struct Underline {
 
 struct UnderlineVertexOutput {
   nointerpolation uint underline_id: TEXCOORD0;
+  nointerpolation uint rounded_head: TEXCOORD1;
   float4 position: SV_Position;
   nointerpolation float4 color: COLOR;
   float4 clip_distance: SV_ClipDistance;
@@ -1074,6 +1123,7 @@ struct UnderlineVertexOutput {
 
 struct UnderlineFragmentInput {
   nointerpolation uint underline_id: TEXCOORD0;
+  nointerpolation uint rounded_head: TEXCOORD1;
   float4 position: SV_Position;
   nointerpolation float4 color: COLOR;
 };
@@ -1084,14 +1134,16 @@ UnderlineVertexOutput underline_vertex(uint vertex_id: SV_VertexID, uint underli
     float2 unit_vertex = float2(float(vertex_id & 1u), 0.5 * float(vertex_id & 2u));
     Underline underline = underlines[underline_id];
     float4 device_position = to_device_position(unit_vertex, underline.bounds);
+    ClipNode clip = clips[underline.clip_id];
     float4 clip_distance = distance_from_clip_rect(unit_vertex, underline.bounds,
-                                                    underline.content_mask);
+                                                    clip.folded_bounds);
     float4 color = hsla_to_rgba(underline.color);
 
     UnderlineVertexOutput output;
     output.position = device_position;
     output.color = color;
     output.underline_id = underline_id;
+    output.rounded_head = clip.rounded_head;
     output.clip_distance = clip_distance;
     return output;
 }
@@ -1101,6 +1153,7 @@ float4 underline_fragment(UnderlineFragmentInput input): SV_Target {
     const float WAVE_HEIGHT_RATIO = 0.8;
 
     Underline underline = underlines[input.underline_id];
+    float clip_alpha = clip_chain_alpha(input.position.xy, input.rounded_head);
     if (underline.wavy) {
         float half_thickness = underline.thickness * 0.5;
         float2 origin = underline.bounds.origin;
@@ -1117,9 +1170,9 @@ float4 underline_fragment(UnderlineFragmentInput input): SV_Target {
         float distance_from_bottom_border = distance_in_pixels + half_thickness;
         float alpha = saturate(
             0.5 - max(-distance_from_bottom_border, distance_from_top_border));
-        return input.color * float4(1., 1., 1., alpha);
+        return input.color * float4(1., 1., 1., alpha * clip_alpha);
     } else {
-        return input.color;
+        return input.color * float4(1., 1., 1., clip_alpha);
     }
 }
 
@@ -1131,9 +1184,8 @@ float4 underline_fragment(UnderlineFragmentInput input): SV_Target {
 
 struct MonochromeSprite {
     uint order;
-    uint pad;
+    uint clip_id;
     Bounds bounds;
-    Bounds content_mask;
     Hsla color;
     AtlasTile tile;
     TransformationMatrix transformation;
@@ -1143,6 +1195,7 @@ struct MonochromeSpriteVertexOutput {
     float4 position: SV_Position;
     float2 tile_position: POSITION;
     nointerpolation float4 color: COLOR;
+    nointerpolation uint rounded_head: TEXCOORD0;
     float4 clip_distance: SV_ClipDistance;
 };
 
@@ -1150,6 +1203,7 @@ struct MonochromeSpriteFragmentInput {
     float4 position: SV_Position;
     float2 tile_position: POSITION;
     nointerpolation float4 color: COLOR;
+    nointerpolation uint rounded_head: TEXCOORD0;
     float4 clip_distance: SV_ClipDistance;
 };
 
@@ -1160,7 +1214,8 @@ MonochromeSpriteVertexOutput monochrome_sprite_vertex(uint vertex_id: SV_VertexI
     MonochromeSprite sprite = mono_sprites[sprite_id];
     float4 device_position =
         to_device_position_transformed(unit_vertex, sprite.bounds, sprite.transformation);
-    float4 clip_distance = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, sprite.content_mask, sprite.transformation);
+    ClipNode clip = clips[sprite.clip_id];
+    float4 clip_distance = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, clip.folded_bounds, sprite.transformation);
     float2 tile_position = to_tile_position(unit_vertex, sprite.tile);
     float4 color = hsla_to_rgba(sprite.color);
 
@@ -1168,6 +1223,7 @@ MonochromeSpriteVertexOutput monochrome_sprite_vertex(uint vertex_id: SV_VertexI
     output.position = device_position;
     output.tile_position = tile_position;
     output.color = color;
+    output.rounded_head = clip.rounded_head;
     output.clip_distance = clip_distance;
     return output;
 }
@@ -1175,7 +1231,8 @@ MonochromeSpriteVertexOutput monochrome_sprite_vertex(uint vertex_id: SV_VertexI
 float4 monochrome_sprite_fragment(MonochromeSpriteFragmentInput input): SV_Target {
     float sample = t_sprite.Sample(s_sprite, input.tile_position).r;
     float alpha_corrected = apply_contrast_and_gamma_correction(sample, input.color.rgb, grayscale_enhanced_contrast, gamma_ratios);
-    return float4(input.color.rgb, input.color.a * alpha_corrected);
+    float clip_alpha = clip_chain_alpha(input.position.xy, input.rounded_head);
+    return float4(input.color.rgb, input.color.a * alpha_corrected * clip_alpha);
 }
 
 MonochromeSpriteVertexOutput subpixel_sprite_vertex(uint vertex_id: SV_VertexID, uint sprite_id: SV_InstanceID) {
@@ -1188,10 +1245,11 @@ SubpixelSpriteFragmentOutput subpixel_sprite_fragment(MonochromeSpriteFragmentIn
         sample = sample.bgr;
     }
     float3 alpha_corrected = apply_contrast_and_gamma_correction3(sample, input.color.rgb, subpixel_enhanced_contrast, gamma_ratios);
+    float clip_alpha = clip_chain_alpha(input.position.xy, input.rounded_head);
 
     SubpixelSpriteFragmentOutput output;
     output.foreground = float4(input.color.rgb, 1.0f);
-    output.alpha = float4(input.color.a * alpha_corrected, 1.0f);
+    output.alpha = float4(input.color.a * alpha_corrected * clip_alpha, 1.0f);
     return output;
 }
 
@@ -1203,17 +1261,17 @@ SubpixelSpriteFragmentOutput subpixel_sprite_fragment(MonochromeSpriteFragmentIn
 
 struct PolychromeSprite {
     uint order;
-    uint pad;
+    uint clip_id;
     uint grayscale;
     float opacity;
     Bounds bounds;
-    Bounds content_mask;
     Corners corner_radii;
     AtlasTile tile;
 };
 
 struct PolychromeSpriteVertexOutput {
     nointerpolation uint sprite_id: TEXCOORD0;
+    nointerpolation uint rounded_head: TEXCOORD1;
     float4 position: SV_Position;
     float2 tile_position: POSITION;
     float4 clip_distance: SV_ClipDistance;
@@ -1221,6 +1279,7 @@ struct PolychromeSpriteVertexOutput {
 
 struct PolychromeSpriteFragmentInput {
     nointerpolation uint sprite_id: TEXCOORD0;
+    nointerpolation uint rounded_head: TEXCOORD1;
     float4 position: SV_Position;
     float2 tile_position: POSITION;
 };
@@ -1231,14 +1290,16 @@ PolychromeSpriteVertexOutput polychrome_sprite_vertex(uint vertex_id: SV_VertexI
     float2 unit_vertex = float2(float(vertex_id & 1u), 0.5 * float(vertex_id & 2u));
     PolychromeSprite sprite = poly_sprites[sprite_id];
     float4 device_position = to_device_position(unit_vertex, sprite.bounds);
+    ClipNode clip = clips[sprite.clip_id];
     float4 clip_distance = distance_from_clip_rect(unit_vertex, sprite.bounds,
-                                                    sprite.content_mask);
+                                                    clip.folded_bounds);
     float2 tile_position = to_tile_position(unit_vertex, sprite.tile);
 
     PolychromeSpriteVertexOutput output;
     output.position = device_position;
     output.tile_position = tile_position;
     output.sprite_id = sprite_id;
+    output.rounded_head = clip.rounded_head;
     output.clip_distance = clip_distance;
     return output;
 }
@@ -1253,6 +1314,7 @@ float4 polychrome_sprite_fragment(PolychromeSpriteFragmentInput input): SV_Targe
         float3 grayscale = dot(color.rgb, GRAYSCALE_FACTORS);
         color = float4(grayscale, sample.a);
     }
-    color.a *= sprite.opacity * saturate(0.5 - distance);
+    float clip_alpha = clip_chain_alpha(input.position.xy, input.rounded_head);
+    color.a *= sprite.opacity * saturate(0.5 - distance) * clip_alpha;
     return color;
 }

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1332,7 +1332,11 @@ impl Element for TerminalElement {
         cx: &mut App,
     ) {
         let paint_start = Instant::now();
-        window.with_content_mask(Some(ContentMask { bounds }), |window| {
+        let content_mask = ContentMask {
+            bounds,
+            ..Default::default()
+        };
+        window.with_content_mask(Some(content_mask), |window| {
             let scroll_top = self.terminal_view.read(cx).scroll_top;
 
             window.paint_quad(fill(bounds, layout.background_color));

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -1309,7 +1309,11 @@ impl<T: ScrollableHandle> Element for ScrollbarElement<T> {
         };
 
         let bounds = Bounds::new(self.origin + origin, size);
-        window.with_content_mask(Some(ContentMask { bounds }), |window| {
+        let content_mask = ContentMask {
+            bounds,
+            ..Default::default()
+        };
+        window.with_content_mask(Some(content_mask), |window| {
             let colors = cx.theme().colors();
 
             let capture_phase;


### PR DESCRIPTION
Fixes the long-standing artifact where children of a `rounded_*().overflow_hidden()` (or rounded scroll) container leak into its corner arcs, by promoting clips from per-primitive inline data to first-class scene data — a minimal clip tree.

## Design

Clipping previously worked by eagerly folding all rectangular masks into one rect and copying that 16-byte rect into every primitive. That representation can't express rounded clips: rounded rects aren't closed under intersection, so there's nothing sensible to fold.

This PR keeps the eager rectangular fold (it's exact and cheap) but retains each *rounded* mask individually as a `ClipNode` in the scene:

- `Scene::clips: Vec<ClipNode>` where each node holds the **folded rectangular bounds** (the running intersection, exactly what primitives got before), the node's own **rounded rect + corner radii**, and links to the **nearest rounded ancestor** (`rounded_head` / `parent_rounded`).
- Primitives now store a `clip_id: u32` instead of an inline `ContentMask` (they *shrink* by 12 bytes; thousands of primitives under one mask share a node).
- **Fast path unchanged:** rectangular clipping still runs in the vertex stage as interpolated clip distances (hardware `SV_ClipDistance`/`[[clip_distance]]` where already used). A scene with no rounded clips does the same GPU work as before plus one coherent `rounded_head == NONE` check.
- **Rounded path:** fragment shaders walk the rounded-clip chain, multiplying in one antialiased rounded-rect SDF per node (the same `quad_sdf` used by rounded images today). The walk is a zero-iteration loop when no rounded clip is active, and its length is the number of rounded clips actually nested — so rounded-inside-rounded is exact, not approximated. Clip edges are antialiased, which the old hard rect clip wasn't.
- `Style::overflow_mask` emits the element's corner radii (clamped like the painted background quad, and inset by visible borders per CSS's inner-radius rule), so `div().rounded_lg().overflow_hidden()` and rounded scroll containers just work with no element API changes.
- **Hit testing** honors the same arcs: clicks in visually clipped corner pixels no longer hit (this was a real, if minor, bug before).
- `Scene::replay` remaps clip ids (memoized transitive copy of the rounded chain) so cached view reuse across frames stays correct.

All three backends are updated: Metal (struct mirrors come free via cbindgen), wgpu/WGSL (clips as a group-0 storage binding; validated with naga), and DirectX/HLSL (clips at `t2`). Paths, shadows, underlines, sprites, subpixel text, and video surfaces all respect rounded clips.

This is also groundwork: `ClipNode` is a clip-chain node in the single-coordinate-space case. Extending clipping to transforms later means adding a space id and a resolve step — not a redesign.

## Not in scope

Transform-aware clipping, arbitrary path/image masks, and capturing rounded chains across `defer_draw` boundaries (deferred elements keep today's rect-only behavior).

## Testing

- New unit tests: rounded `ContentMask::contains`, `Style::overflow_mask` radii (incl. clamping and border inset), `Scene::replay` clip-chain remapping.
- New integration test drawing a rounded overflow-hidden tree and asserting both hit-test behavior and the scene's clip-node structure.
- New **GPU pixel test** (`gpui_platform`, macOS + `test-support`) that renders through the real Metal headless renderer and asserts corner pixels are clipped while arc-interior pixels aren't. It runs off the main thread (unlike the `VisualTestAppContext` tests) and passes locally; reviewers may prefer to `#[ignore]` it if CI runners prove flaky.
- New example: `cargo run -p gpui --example rounded_clipping` (plain rounded clip, rounded scroll container, nested rounded clips).
- `cargo test -p gpui`, editor element tests, workspace `cargo check --all-targets`, and `./script/clippy` all pass. `gpui_windows` compiles on its target cfg but was not run on real hardware; HLSL changes mirror the validated WGSL/Metal ones.

Release Notes:

- N/A