### PR TITLE
vim: show a recording dot in the mode indicator while recording a macro

### DIFF
--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -145,8 +145,16 @@ impl Render for ModeIndicator {
             };
             (pending.into(), Some(mode))
         };
+
+        // A red recording dot in the status bar while a native macro (qa…q) records.
+        let is_recording = Vim::globals(cx).recording_register.is_some();
+        let recording_color = Color::Error.color(cx);
+
         h_flex()
             .gap_1()
+            .when(is_recording, |el| {
+                el.child(div().size_2().rounded_full().bg(recording_color))
+            })
             .when(!label.is_empty(), |el| {
                 el.child(
                     Label::new(label)


### PR DESCRIPTION
## What

Adds a small colored dot to the vim mode indicator in the status bar whenever a macro recording is active (`q{register}`).

## Why

The mode indicator already renders `recording @{register}` text while recording, but it's easy to overlook — you can be recording without noticing. A colored dot makes the recording state glanceable, the same way the editor already uses color elsewhere to signal status (e.g. diagnostics).

## Details

- Uses `Color::Error` (the theme's error color), so it adapts to the active theme.
- Shows only when `recording_register` is set; no other state touched.
- ~8 lines in `crates/vim/src/mode_indicator.rs`.

Happy to adjust the color, shape, or placement if you'd prefer something different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
