### PR TITLE
Show a single agent notification per event on Wayland

### DIFF
--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -102,6 +102,26 @@ use crate::{
     ToggleThinkingMode, UndoLastReject,
 };
 
+// #region agent log
+pub(crate) fn debug_log(location: &str, hypothesis: &str, message: &str, data: String) {
+    use std::io::Write as _;
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("/code/zed-wt-bugfix-dupe-notifications/.cursor/debug-80956d.log")
+    {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_millis())
+            .unwrap_or(0);
+        let _ = writeln!(
+            file,
+            "{{\"sessionId\":\"80956d\",\"timestamp\":{timestamp},\"location\":\"{location}\",\"hypothesisId\":\"{hypothesis}\",\"message\":\"{message}\",\"data\":{data}}}"
+        );
+    }
+}
+// #endregion
+
 const STOPWATCH_THRESHOLD: Duration = Duration::from_secs(30);
 const TOKEN_THRESHOLD: u64 = 250;
 
@@ -1578,6 +1598,30 @@ impl ConversationView {
             return;
         };
         let is_subagent = thread.read(cx).parent_session_id().is_some();
+        // #region agent log
+        {
+            let event_name = match event {
+                AcpThreadEvent::ToolAuthorizationRequested(_) => Some("ToolAuthorizationRequested"),
+                AcpThreadEvent::Stopped(_) => Some("Stopped"),
+                AcpThreadEvent::Refusal => Some("Refusal"),
+                AcpThreadEvent::Error => Some("Error"),
+                _ => None,
+            };
+            if let Some(event_name) = event_name {
+                debug_log(
+                    "conversation_view.rs:handle_thread_event",
+                    "B,D",
+                    "notification-relevant thread event",
+                    format!(
+                        "{{\"event\":\"{event_name}\",\"session_id\":\"{}\",\"is_subagent\":{is_subagent},\"view_entity_id\":\"{:?}\",\"thread_id\":\"{:?}\"}}",
+                        session_id.0,
+                        cx.entity_id(),
+                        self.thread_id
+                    ),
+                );
+            }
+        }
+        // #endregion
         if !is_subagent && affects_thread_metadata(event) {
             cx.emit(RootThreadUpdated);
         }
@@ -2834,6 +2878,29 @@ impl ConversationView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // #region agent log
+        {
+            let displays: Vec<String> = cx
+                .displays()
+                .iter()
+                .map(|display| format!("{:?}@{:?}", display.id(), display.bounds()))
+                .collect();
+            debug_log(
+                "conversation_view.rs:show_notification",
+                "A,B,C",
+                "show_notification entered",
+                format!(
+                    "{{\"view_entity_id\":\"{:?}\",\"thread_id\":\"{:?}\",\"existing_notifications\":{},\"display_count\":{},\"displays\":{:?},\"agent_status_visible\":{}}}",
+                    cx.entity_id(),
+                    self.thread_id,
+                    self.notifications.len(),
+                    displays.len(),
+                    displays,
+                    self.agent_status_visible(window, cx)
+                ),
+            );
+        }
+        // #endregion
         if !self.notifications.is_empty() {
             return;
         }
@@ -2908,6 +2975,9 @@ impl ConversationView {
         screen: Rc<dyn PlatformDisplay>,
         cx: &mut Context<Self>,
     ) {
+        // #region agent log
+        let screen_id_for_log = screen.id();
+        // #endregion
         let options = AgentNotification::window_options(screen, cx);
 
         let project_name = self.workspace.upgrade().and_then(|workspace| {
@@ -2929,6 +2999,20 @@ impl ConversationView {
             .log_err()
             && let Some(pop_up) = screen_window.entity(cx).log_err()
         {
+            // #region agent log
+            debug_log(
+                "conversation_view.rs:pop_up",
+                "A,B",
+                "notification window opened",
+                format!(
+                    "{{\"view_entity_id\":\"{:?}\",\"thread_id\":\"{:?}\",\"caption\":\"{}\",\"screen\":\"{screen_id_for_log:?}\",\"total_notifications_after\":{}}}",
+                    cx.entity_id(),
+                    self.thread_id,
+                    caption,
+                    self.notifications.len() + 1
+                ),
+            );
+            // #endregion
             self.notification_subscriptions
                 .entry(screen_window)
                 .or_insert_with(Vec::new)
@@ -3054,6 +3138,19 @@ impl ConversationView {
 
     pub(crate) fn dismiss_notifications(&mut self, cx: &mut Context<Self>) -> bool {
         let had_notifications = !self.notifications.is_empty();
+        // #region agent log
+        debug_log(
+            "conversation_view.rs:dismiss_notifications",
+            "C",
+            "dismissing notifications",
+            format!(
+                "{{\"view_entity_id\":\"{:?}\",\"thread_id\":\"{:?}\",\"count\":{}}}",
+                cx.entity_id(),
+                self.thread_id,
+                self.notifications.len()
+            ),
+        );
+        // #endregion
         for window in self.notifications.drain(..) {
             window
                 .update(cx, |_, window, _| {

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -2927,7 +2927,12 @@ impl ConversationView {
 
         match settings.notify_when_agent_waiting {
             NotifyWhenAgentWaiting::PrimaryScreen => {
-                if let Some(primary) = cx.primary_display() {
+                // There is no primary display on Wayland; fall back to any display so the
+                // default setting still produces a notification there.
+                if let Some(screen) = cx
+                    .primary_display()
+                    .or_else(|| cx.displays().into_iter().next())
+                {
                     self.pop_up(
                         icon,
                         caption.into(),
@@ -2936,14 +2941,22 @@ impl ConversationView {
                         root_work_dirs,
                         root_title,
                         window,
-                        primary,
+                        screen,
                         cx,
                     );
                 }
             }
             NotifyWhenAgentWaiting::AllScreens => {
                 let caption = caption.into();
-                for screen in cx.displays() {
+                // When the platform doesn't let us choose which display a window opens on
+                // (Wayland), per-screen popups would all land on the same screen and appear
+                // as duplicate notifications, so only open one.
+                let screens = if cx.can_position_windows() {
+                    cx.displays()
+                } else {
+                    cx.displays().into_iter().take(1).collect()
+                };
+                for screen in screens {
                     self.pop_up(
                         icon,
                         caption.clone(),

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -2885,19 +2885,72 @@ impl ConversationView {
                 .iter()
                 .map(|display| format!("{:?}@{:?}", display.id(), display.bounds()))
                 .collect();
+            let workspace_details = self.workspace.upgrade().map(|workspace| {
+                let workspace_entity_id = workspace.entity_id();
+                let workspace = workspace.read(cx);
+                let workspace_paths = workspace
+                    .project()
+                    .read(cx)
+                    .visible_worktrees(cx)
+                    .map(|worktree| worktree.read(cx).abs_path().display().to_string())
+                    .collect::<Vec<_>>();
+                serde_json::json!({
+                    "entity_id": format!("{workspace_entity_id:?}"),
+                    "database_id": workspace.database_id().map(|id| format!("{id:?}")),
+                    "session_id": workspace.session_id(),
+                    "paths": workspace_paths,
+                })
+            });
+            let multi_workspace_details =
+                window
+                    .root::<MultiWorkspace>()
+                    .flatten()
+                    .map(|multi_workspace| {
+                        let multi_workspace_entity_id = multi_workspace.entity_id();
+                        let multi_workspace = multi_workspace.read(cx);
+                        let active_workspace = multi_workspace.workspace();
+                        let active_workspace_entity_id = active_workspace.entity_id();
+                        let active_workspace_database_id =
+                            active_workspace.read(cx).database_id();
+                        let workspace_count = multi_workspace.workspaces().count();
+                        let workspace_details = multi_workspace
+                            .workspaces()
+                            .map(|workspace| {
+                                let workspace_entity_id = workspace.entity_id();
+                                let workspace = workspace.read(cx);
+                                serde_json::json!({
+                                    "entity_id": format!("{workspace_entity_id:?}"),
+                                    "database_id": workspace.database_id().map(|id| format!("{id:?}")),
+                                    "session_id": workspace.session_id(),
+                                })
+                            })
+                            .collect::<Vec<_>>();
+                        serde_json::json!({
+                            "entity_id": format!("{multi_workspace_entity_id:?}"),
+                            "active_workspace_entity_id": format!("{active_workspace_entity_id:?}"),
+                            "active_workspace_database_id": active_workspace_database_id.map(|id| format!("{id:?}")),
+                            "workspace_count": workspace_count,
+                            "sidebar_open": multi_workspace.sidebar_open(),
+                            "threads_list_active": multi_workspace.is_threads_list_view_active(cx),
+                            "workspaces": workspace_details,
+                        })
+                    });
             debug_log(
                 "conversation_view.rs:show_notification",
-                "A,B,C",
+                "A,B,C,E",
                 "show_notification entered",
-                format!(
-                    "{{\"view_entity_id\":\"{:?}\",\"thread_id\":\"{:?}\",\"existing_notifications\":{},\"display_count\":{},\"displays\":{:?},\"agent_status_visible\":{}}}",
-                    cx.entity_id(),
-                    self.thread_id,
-                    self.notifications.len(),
-                    displays.len(),
-                    displays,
-                    self.agent_status_visible(window, cx)
-                ),
+                serde_json::json!({
+                    "view_entity_id": format!("{:?}", cx.entity_id()),
+                    "thread_id": format!("{:?}", self.thread_id),
+                    "existing_notifications": self.notifications.len(),
+                    "display_count": displays.len(),
+                    "displays": displays,
+                    "agent_status_visible": self.agent_status_visible(window, cx),
+                    "can_position_windows": cx.can_position_windows(),
+                    "workspace": workspace_details,
+                    "multi_workspace": multi_workspace_details,
+                })
+                .to_string(),
             );
         }
         // #endregion
@@ -2956,6 +3009,24 @@ impl ConversationView {
                 } else {
                     cx.displays().into_iter().take(1).collect()
                 };
+                // #region agent log
+                debug_log(
+                    "conversation_view.rs:show_notification",
+                    "A,E",
+                    "all_screens target screens selected",
+                    serde_json::json!({
+                        "view_entity_id": format!("{:?}", cx.entity_id()),
+                        "thread_id": format!("{:?}", self.thread_id),
+                        "can_position_windows": cx.can_position_windows(),
+                        "target_screen_count": screens.len(),
+                        "target_screens": screens
+                            .iter()
+                            .map(|screen| format!("{:?}", screen.id()))
+                            .collect::<Vec<_>>(),
+                    })
+                    .to_string(),
+                );
+                // #endregion
                 for screen in screens {
                     self.pop_up(
                         icon,

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1262,6 +1262,13 @@ impl App {
         self.platform.primary_display()
     }
 
+    /// Returns whether windows can be programmatically placed on a chosen display.
+    /// On Wayland the compositor controls window placement, so windows opened for a
+    /// specific display may all end up on the same screen.
+    pub fn can_position_windows(&self) -> bool {
+        self.platform.can_position_windows()
+    }
+
     /// Returns whether `screen_capture_sources` may work.
     pub fn is_screen_capture_supported(&self) -> bool {
         self.platform.is_screen_capture_supported()

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -137,6 +137,13 @@ pub trait Platform: 'static {
 
     fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>>;
     fn primary_display(&self) -> Option<Rc<dyn PlatformDisplay>>;
+    /// Whether the platform honors `WindowOptions::display_id` and the requested window bounds,
+    /// allowing windows to be programmatically placed on a chosen display. On Wayland the
+    /// compositor controls placement of regular windows, so windows opened for a specific
+    /// display may all end up on the same screen.
+    fn can_position_windows(&self) -> bool {
+        true
+    }
     fn active_window(&self) -> Option<AnyWindowHandle>;
     fn window_stack(&self) -> Option<Vec<AnyWindowHandle>> {
         None

--- a/crates/gpui_linux/src/linux/platform.rs
+++ b/crates/gpui_linux/src/linux/platform.rs
@@ -54,6 +54,9 @@ pub(crate) trait LinuxClient {
     #[allow(unused)]
     fn display(&self, id: DisplayId) -> Option<Rc<dyn PlatformDisplay>>;
     fn primary_display(&self) -> Option<Rc<dyn PlatformDisplay>>;
+    fn can_position_windows(&self) -> bool {
+        true
+    }
 
     #[cfg(feature = "screen-capture")]
     fn is_screen_capture_supported(&self) -> bool {
@@ -349,6 +352,10 @@ impl<P: LinuxClient + 'static> Platform for LinuxPlatform<P> {
 
     fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>> {
         self.inner.displays()
+    }
+
+    fn can_position_windows(&self) -> bool {
+        self.inner.can_position_windows()
     }
 
     #[cfg(feature = "screen-capture")]

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -843,6 +843,10 @@ impl LinuxClient for WaylandClient {
         None
     }
 
+    fn can_position_windows(&self) -> bool {
+        false
+    }
+
     #[cfg(feature = "screen-capture")]
     fn screen_capture_sources(
         &self,

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -149,6 +149,26 @@ pub struct Globals {
     pub executor: ForegroundExecutor,
 }
 
+// #region agent log
+fn debug_log(location: &str, hypothesis: &str, message: &str, data: String) {
+    use std::io::Write as _;
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("/code/zed-wt-bugfix-dupe-notifications/.cursor/debug-80956d.log")
+    {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_millis())
+            .unwrap_or(0);
+        let _ = writeln!(
+            file,
+            "{{\"sessionId\":\"80956d\",\"timestamp\":{timestamp},\"location\":\"{location}\",\"hypothesisId\":\"{hypothesis}\",\"message\":\"{message}\",\"data\":{data}}}"
+        );
+    }
+}
+// #endregion
+
 impl Globals {
     fn new(
         globals: GlobalList,
@@ -1194,14 +1214,42 @@ impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for WaylandClientStat
                         (),
                     );
 
+                    // #region agent log
+                    let bound_object_id = output.id();
+                    // #endregion
                     state
                         .in_progress_outputs
                         .insert(output.id(), InProgressOutput::default());
                     state.wl_outputs.insert(output.id(), output);
+                    // #region agent log
+                    debug_log(
+                        "wayland/client.rs:registry_global_wl_output",
+                        "A",
+                        "wl_output global announced and bound",
+                        format!(
+                            "{{\"global_name\":{name},\"object_protocol_id\":{},\"wl_outputs_len\":{},\"outputs_len\":{}}}",
+                            bound_object_id.protocol_id(),
+                            state.wl_outputs.len(),
+                            state.outputs.len()
+                        ),
+                    );
+                    // #endregion
                 }
                 _ => {}
             },
-            wl_registry::Event::GlobalRemove { name: _ } => {
+            wl_registry::Event::GlobalRemove { name } => {
+                // #region agent log
+                debug_log(
+                    "wayland/client.rs:registry_global_remove",
+                    "A",
+                    "global removed (currently unhandled TODO)",
+                    format!(
+                        "{{\"global_name\":{name},\"wl_outputs_len\":{},\"outputs_len\":{}}}",
+                        state.wl_outputs.len(),
+                        state.outputs.len()
+                    ),
+                );
+                // #endregion
                 // TODO: handle global removal
             }
             _ => {}
@@ -1319,6 +1367,28 @@ impl Dispatch<wl_output::WlOutput, ()> for WaylandClientStatePtr {
                     state.outputs.insert(output.id(), complete);
                 }
                 state.in_progress_outputs.remove(&output.id());
+                // #region agent log
+                debug_log(
+                    "wayland/client.rs:wl_output_done",
+                    "A",
+                    "output configuration done",
+                    format!(
+                        "{{\"object_protocol_id\":{},\"outputs_len\":{},\"outputs\":{:?}}}",
+                        output.id().protocol_id(),
+                        state.outputs.len(),
+                        state
+                            .outputs
+                            .iter()
+                            .map(|(id, output)| format!(
+                                "{}:{}@{:?}",
+                                id.protocol_id(),
+                                output.name.clone().unwrap_or_default(),
+                                output.bounds
+                            ))
+                            .collect::<Vec<_>>()
+                    ),
+                );
+                // #endregion
             }
             _ => {}
         }


### PR DESCRIPTION
I had Cursor take a stab at this a while ago (Composer 2.5), and it did fix #53274 while I was using Zed daily. Hopefully the PR can point the maintainers in the right direction.

LLM's findings below.

### What happens

With `notify_when_agent_waiting = all_screens`, Zed opens one notification popup per display, each positioned via `WindowOptions::display_id`. On Wayland, only layer-shell surfaces can target a specific output; regular xdg-toplevels are placed by the compositor, so all per-screen popups land on the same screen and appear as duplicate notifications.

Separately, the default `primary_screen` setting showed **no** notification at all on Wayland, because `primary_display()` is `None` there.

### The fix

- Add `Platform::can_position_windows()` (false on Wayland) and open only one popup when display selection isn't honored.
- Under `primary_screen`, fall back to the first display when there is no primary display.

### Caveats — why this is a draft

Cursor diagnosed this with temporary debug instrumentation (first and last commits, marked to be dropped before merging) and wrote the fix, but I've since stopped using Zed regularly and can no longer runtime-verify it thoroughly on a multi-monitor Wayland setup. The last commit adds workspace-context logging, which suggests I was also investigating whether multiple workspaces contribute additional duplicate popups — that angle is unconfirmed. Compile-checked (`cargo check`/clippy on `gpui`, `gpui_linux`, `agent_ui`) and rebased onto current main. Submitting so the investigation isn't lost; happy for maintainers to take it from here.

Release Notes:

- Fixed duplicate agent notifications appearing on the same screen on Wayland with `notify_when_agent_waiting = all_screens`, and missing notifications with the default `primary_screen` setting.
