### PR TITLE
editor: Expose right-click context menu as ShowContextMenuAtMouse action

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -711,6 +711,9 @@ actions!(
         ViewBookmarks,
         /// Opens the context menu at cursor position.
         OpenContextMenu,
+        /// Opens the context menu at mouse position. Intended for right-click binding
+        /// so users can remap or layer actions on right-click via keybindings.
+        ShowContextMenuAtMouse,
         /// Opens excerpts from the current file.
         OpenExcerpts,
         /// Opens excerpts in a split pane.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10359,6 +10359,33 @@ impl Editor {
         mouse_context_menu::deploy_context_menu(self, None, position, window, cx);
     }
 
+    /// Shows the context menu at the current mouse position.
+    /// This is the action dispatched by right-click in the editor, so users can
+    /// remap or layer additional actions on right-click via keybindings
+    /// (e.g. `rightclick: ["editor::ShowContextMenuAtMouse", "workspace::Save"]`).
+    pub fn show_context_menu_at_mouse(
+        &mut self,
+        _: &ShowContextMenuAtMouse,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(position_map) = self.last_position_map.clone() else {
+            return;
+        };
+        let mouse_position = window.mouse_position();
+        if !position_map.text_hitbox.contains(&mouse_position) {
+            return;
+        }
+        let point_for_position = position_map.point_for_position(mouse_position);
+        mouse_context_menu::deploy_context_menu(
+            self,
+            Some(mouse_position),
+            point_for_position.nearest_valid,
+            window,
+            cx,
+        );
+    }
+
     pub fn is_focused(&self, window: &Window) -> bool {
         self.focus_handle.is_focused(window)
     }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -262,6 +262,7 @@ impl EditorElement {
         crate::clangd_ext::apply_related_actions(editor, window, cx);
 
         register_action(editor, window, Editor::open_context_menu);
+        register_action(editor, window, Editor::show_context_menu_at_mouse);
         register_action(editor, window, Editor::move_left);
         register_action(editor, window, Editor::move_right);
         register_action(editor, window, Editor::move_down);

--- a/crates/editor/src/element/mouse.rs
+++ b/crates/editor/src/element/mouse.rs
@@ -796,13 +796,9 @@ impl EditorElement {
         }
 
         let point_for_position = position_map.point_for_position(event.position);
-        mouse_context_menu::deploy_context_menu(
-            editor,
-            Some(event.position),
-            point_for_position.nearest_valid,
-            window,
-            cx,
-        );
+        // Dispatch as an action so keybindings (including mouse bindings from PR #55216)
+        // can intercept or layer on top of the default right-click context menu.
+        window.dispatch_action(Box::new(ShowContextMenuAtMouse), cx);
         cx.stop_propagation();
     }
 


### PR DESCRIPTION

## Summary

Exposes the editor right-click context menu as a proper `ShowContextMenuAtMouse` action, so users can remap or layer additional actions on right-click via keybindings (once mouse binding support lands in #55216).

## Changes (4 files, +34 / -7)

### `crates/editor/src/actions.rs`
Added `ShowContextMenuAtMouse` action variant alongside the existing keyboard-triggered `OpenContextMenu`.

### `crates/editor/src/element/mouse.rs`
`mouse_right_down` now dispatches `ShowContextMenuAtMouse` via `window.dispatch_action()` instead of calling `deploy_context_menu` directly.

### `crates/editor/src/element.rs`
Registered `Editor::show_context_menu_at_mouse` as an action handler.

### `crates/editor/src/editor.rs`
Added `show_context_menu_at_mouse` handler that resolves the context menu position from `window.mouse_position()` and the editor last `position_map`.

## Motivation

Currently the right-click context menu is hardcoded — `mouse_right_down` calls `deploy_context_menu` directly. With #55216 adding mouse button → keystroke dispatch, users need an action to bind to. This PR provides it.

After both PRs land, users can configure:

```json
// Rebind right-click to save only
{ "context": "Editor", "bindings": { "rightclick": "workspace::Save" } }

// Or layer both: show menu AND save
{ "context": "Editor", "bindings": {
    "rightclick": ["editor::ShowContextMenuAtMouse", "workspace::Save"]
} }
```

## Related

- #55216 — mouse button & scroll wheel keybinding infrastructure
- #43989 — the original fix that stopped context menu from triggering autosave on focus change
- Closes #10647 once combined with #55216
