### PR TITLE
git_ui: Hide pull request action after default branch push

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3477,7 +3477,9 @@ impl GitPanel {
                         FetchOptions::Remote(remote) => RemoteAction::Fetch(Some(remote)),
                     };
                     match remote_message {
-                        Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
+                        Ok(remote_message) => {
+                            this.show_remote_output(action, remote_message, false, cx)
+                        }
                         Err(e) => {
                             log::error!("Error while fetching {:?}", e);
                             this.show_error_toast(action.name(), e, cx)
@@ -3637,7 +3639,7 @@ impl GitPanel {
 
             let action = RemoteAction::Pull(remote);
             this.update(cx, |this, cx| match remote_message {
-                Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
+                Ok(remote_message) => this.show_remote_output(action, remote_message, false, cx),
                 Err(e) => {
                     log::error!("Error while pulling {:?}", e);
                     this.show_error_toast(action.name(), e, cx)
@@ -3716,17 +3718,18 @@ impl GitPanel {
                 this.askpass_delegate(format!("git push {}", remote.name), window, cx)
             })?;
 
+            let remote_branch_name: SharedString = branch
+                .upstream
+                .as_ref()
+                .filter(|upstream| matches!(upstream.tracking, UpstreamTracking::Tracked(_)))
+                .and_then(|upstream| upstream.branch_name())
+                .unwrap_or_else(|| branch.name())
+                .to_owned()
+                .into();
             let push = repo.update(cx, |repo, cx| {
                 repo.push(
                     branch.name().to_owned().into(),
-                    branch
-                        .upstream
-                        .as_ref()
-                        .filter(|u| matches!(u.tracking, UpstreamTracking::Tracked(_)))
-                        .and_then(|u| u.branch_name())
-                        .unwrap_or_else(|| branch.name())
-                        .to_owned()
-                        .into(),
+                    remote_branch_name.clone(),
                     remote.name.clone(),
                     options,
                     askpass_delegate,
@@ -3735,10 +3738,25 @@ impl GitPanel {
             });
 
             let remote_output = push.await?;
+            let default_branch = repo.update(cx, |repo, _| repo.default_branch(true));
+            let pushed_to_default = default_branch
+                .await
+                .ok()
+                .and_then(Result::ok)
+                .flatten()
+                .is_some_and(|default_branch| {
+                    is_pushed_to_default_branch(
+                        &default_branch,
+                        &remote.name,
+                        &remote_branch_name,
+                    )
+                });
 
             let action = RemoteAction::Push(branch.name().to_owned().into(), remote);
             this.update(cx, |this, cx| match remote_output {
-                Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
+                Ok(remote_message) => {
+                    this.show_remote_output(action, remote_message, pushed_to_default, cx)
+                }
                 Err(e) => {
                     log::error!("Error while pushing {:?}", e);
                     this.show_error_toast(action.name(), e, cx)
@@ -4953,6 +4971,7 @@ impl GitPanel {
         &mut self,
         action: RemoteAction,
         info: RemoteCommandOutput,
+        pushed_to_default: bool,
         cx: &mut Context<Self>,
     ) {
         let Some(workspace) = self.workspace.upgrade() else {
@@ -4973,7 +4992,7 @@ impl GitPanel {
                         .size(IconSize::Small)
                         .color(Color::Muted),
                 );
-                match (style, is_push) {
+                match (style, is_push && !pushed_to_default) {
                     (PushPrLink { label, url }, _) => {
                         this.action(label, move |_window, cx| cx.open_url(&url))
                     }
@@ -8564,6 +8583,14 @@ pub(crate) fn commit_title_exceeds_limit(title: &str, max_length: usize) -> bool
     max_length > 0 && title.chars().count() > max_length
 }
 
+fn is_pushed_to_default_branch(
+    default_branch: &str,
+    remote_name: &str,
+    remote_branch_name: &str,
+) -> bool {
+    default_branch == format!("{remote_name}/{remote_branch_name}")
+}
+
 #[cfg(test)]
 mod tests {
     use git::{
@@ -8648,6 +8675,17 @@ mod tests {
         assert!(matches!(
             new_entries.first(),
             Some((GitListEntry::Directory(entry), _)) if entry.expanded
+        ));
+    }
+
+    #[test]
+    fn test_is_pushed_to_default_branch() {
+        assert!(is_pushed_to_default_branch("origin/main", "origin", "main"));
+        assert!(!is_pushed_to_default_branch("main", "origin", "main"));
+        assert!(!is_pushed_to_default_branch(
+            "origin/main",
+            "origin",
+            "feature"
         ));
     }
 


### PR DESCRIPTION
# Objective

- Fixes #60851.
- Prevent the push success toast from offering to create a pull request after pushing directly to the repository's default branch, which would open a comparison with no diff.

## Solution

- After a successful push, compare the pushed destination with the remote-qualified default branch.
- Suppress the fallback **Create Pull Request** action only when they match exactly.
- Preserve the existing fallback when the default branch cannot be determined reliably.
- Continue trusting and displaying pull request links explicitly provided by the remote.

## Testing

- `cargo test -p git_ui`
- Added a unit test covering a remote-qualified default branch match, a bare fallback branch name, and a different pushed branch.
- Built the macOS debug application with `cargo build`.
- Manual verification:
  - Push to a confirmed default branch and verify that the success toast does not show **Create Pull Request**.
  - Push a new non-default branch without a remote-provided pull request URL and verify that the fallback action is still shown.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

The video demonstrates how the push success toast changes based on the pushed branch.

<details>
  <summary> On the default branch (`main`), the toast does not show **Create Pull Request**.</summary>

https://github.com/user-attachments/assets/82006b24-76ea-4187-9f57-5e0245b02549

</details>

<details>
  <summary> On a non-default branch, the fallback **Create Pull Request** action remains available.</summary>

https://github.com/user-attachments/assets/ffe486a0-0fdd-486a-9955-40157100908f
</details>

---

Release Notes:

- Fixed the Git push success toast showing a pull request action after pushing to the default branch.
