### PR TITLE
Add lsp alias for language server search

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -949,6 +949,59 @@ mod tests {
         });
     }
 
+    #[derive(Clone, PartialEq, Default, Debug, gpui::Action)]
+    #[action(namespace = test, keywords = "lsp")]
+    struct TestKeywordAction;
+
+    #[gpui::test]
+    async fn test_keyword_surfaces_action(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+
+        let editor = cx.new_window_entity(|window, cx| Editor::single_line(window, cx));
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(editor.clone()), None, true, window, cx);
+            editor.update(cx, |editor, cx| window.focus(&editor.focus_handle(cx), cx))
+        });
+
+        cx.update(|_window, cx| {
+            cx.on_action::<TestKeywordAction>(|_, _| {});
+        });
+
+        cx.simulate_keystrokes("cmd-shift-p");
+        let palette = workspace.update(cx, |workspace, cx| {
+            workspace
+                .active_modal::<CommandPalette>(cx)
+                .unwrap()
+                .read(cx)
+                .picker
+                .clone()
+        });
+
+        cx.simulate_input("lsp");
+        palette.read_with(cx, |palette, _| {
+            assert!(
+                palette
+                    .delegate
+                    .matches
+                    .iter()
+                    .any(|string_match| string_match
+                        .string
+                        .starts_with("test: test keyword action")),
+                "expected the \"lsp\" keyword to surface \"test: test keyword action\", got: {:?}",
+                palette
+                    .delegate
+                    .matches
+                    .iter()
+                    .map(|string_match| &string_match.string)
+                    .collect::<Vec<_>>(),
+            );
+        });
+    }
+
     #[gpui::test]
     async fn test_selected_command_none_when_no_matches(cx: &mut TestAppContext) {
         let app_state = init_test(cx);

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -101,6 +101,7 @@ impl CommandPalette {
         cx: &mut Context<Self>,
     ) -> Self {
         let filter = CommandPaletteFilter::try_global(cx);
+        let action_keywords = cx.action_keywords();
 
         let commands = window
             .available_actions(cx)
@@ -112,6 +113,12 @@ impl CommandPalette {
 
                 Some(Command {
                     name: humanize_action_name(action.name()),
+                    keywords: action_keywords
+                        .get(action.name())
+                        .map(|keywords| {
+                            keywords.iter().map(|keyword| keyword.to_string()).collect()
+                        })
+                        .unwrap_or_default(),
                     action,
                 })
             })
@@ -176,6 +183,7 @@ pub struct CommandPaletteDelegate {
 struct Command {
     name: String,
     action: Box<dyn Action>,
+    keywords: Vec<String>,
 }
 
 #[derive(Default)]
@@ -268,6 +276,7 @@ impl Clone for Command {
         Self {
             name: self.name.clone(),
             action: self.action.boxed_clone(),
+            keywords: self.keywords.clone(),
         }
     }
 }
@@ -321,6 +330,7 @@ impl CommandPaletteDelegate {
             commands.push(Command {
                 name: string.clone(),
                 action,
+                keywords: Vec::new(),
             });
             new_matches.push(StringMatch {
                 candidate_id: commands.len() - 1,
@@ -476,7 +486,14 @@ impl PickerDelegate for CommandPaletteDelegate {
                 let candidates = commands
                     .iter()
                     .enumerate()
-                    .map(|(ix, command)| StringMatchCandidate::new(ix, &command.name))
+                    .map(|(ix, command)| {
+                        let searchable = if command.keywords.is_empty() {
+                            command.name.clone()
+                        } else {
+                            format!("{} {}", command.name, command.keywords.join(" "))
+                        };
+                        StringMatchCandidate::new(ix, &searchable)
+                    })
                     .collect::<Vec<_>>();
 
                 let matches = fuzzy_nucleo::match_strings_async(
@@ -623,6 +640,13 @@ impl PickerDelegate for CommandPaletteDelegate {
         let matching_command = self.matches.get(ix)?;
         let command = self.commands.get(matching_command.candidate_id)?;
 
+        let name_positions = matching_command
+            .positions
+            .iter()
+            .copied()
+            .filter(|position| *position < command.name.len())
+            .collect();
+
         Some(
             ListItem::new(ix)
                 .inset(true)
@@ -633,10 +657,7 @@ impl PickerDelegate for CommandPaletteDelegate {
                         .w_full()
                         .py_px()
                         .justify_between()
-                        .child(HighlightedLabel::new(
-                            command.name.clone(),
-                            matching_command.positions.clone(),
-                        ))
+                        .child(HighlightedLabel::new(command.name.clone(), name_positions))
                         .child(KeyBinding::for_action_in(
                             &*command.action,
                             &self.previous_focus_handle,

--- a/crates/gpui/src/action.rs
+++ b/crates/gpui/src/action.rs
@@ -170,6 +170,15 @@ pub trait Action: Any + Send {
     {
         None
     }
+
+    /// Additional search keywords for this action. In Zed, these let the command palette
+    /// surface the action when the query matches a keyword rather than the action's name.
+    fn keywords() -> &'static [&'static str]
+    where
+        Self: Sized,
+    {
+        &[]
+    }
 }
 
 impl std::fmt::Debug for dyn Action {
@@ -237,6 +246,7 @@ pub(crate) struct ActionRegistry {
     deprecated_aliases: HashMap<&'static str, &'static str>, // deprecated name -> preferred name
     deprecation_messages: HashMap<&'static str, &'static str>, // action name -> deprecation message
     documentation: HashMap<&'static str, &'static str>, // action name -> documentation
+    keywords: HashMap<&'static str, &'static [&'static str]>, // action name -> search keywords
 }
 
 impl Default for ActionRegistry {
@@ -248,6 +258,7 @@ impl Default for ActionRegistry {
             all_names: Default::default(),
             deprecated_aliases: Default::default(),
             deprecation_messages: Default::default(),
+            keywords: Default::default(),
         };
 
         this.load_actions();
@@ -277,6 +288,7 @@ pub struct MacroActionData {
     pub deprecated_aliases: &'static [&'static str],
     pub deprecation_message: Option<&'static str>,
     pub documentation: Option<&'static str>,
+    pub keywords: &'static [&'static str],
 }
 
 inventory::collect!(MacroActionBuilder);
@@ -329,6 +341,9 @@ impl ActionRegistry {
         }
         if let Some(documentation) = action.documentation {
             self.documentation.insert(name, documentation);
+        }
+        if !action.keywords.is_empty() {
+            self.keywords.insert(name, action.keywords);
         }
     }
 
@@ -405,6 +420,10 @@ impl ActionRegistry {
 
     pub fn deprecation_messages(&self) -> &HashMap<&'static str, &'static str> {
         &self.deprecation_messages
+    }
+
+    pub fn keywords(&self) -> &HashMap<&'static str, &'static [&'static str]> {
+        &self.keywords
     }
 
     pub fn documentation(&self) -> &HashMap<&'static str, &'static str> {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2174,6 +2174,11 @@ impl App {
         self.actions.documentation()
     }
 
+    /// Get a map from an action name to the keywords.
+    pub fn action_keywords(&self) -> &HashMap<&'static str, &'static [&'static str]> {
+        self.actions.keywords()
+    }
+
     /// Register a callback to be invoked when the application is about to quit.
     /// It is not possible to cancel the quit event at this point.
     pub fn on_app_quit<Fut>(

--- a/crates/gpui_macros/src/derive_action.rs
+++ b/crates/gpui_macros/src/derive_action.rs
@@ -10,6 +10,7 @@ pub(crate) fn derive_action(input: TokenStream) -> TokenStream {
     let struct_name = &input.ident;
     let mut name_argument = None;
     let mut deprecated_aliases = Vec::new();
+    let mut keywords = Vec::new();
     let mut no_json = false;
     let mut no_register = false;
     let mut namespace = None;
@@ -72,10 +73,14 @@ pub(crate) fn derive_action(input: TokenStream) -> TokenStream {
                     meta.input.parse::<Token![=]>()?;
                     let lit: LitStr = meta.input.parse()?;
                     deprecated = Some(lit.value());
+                } else if meta.path.is_ident("keywords") {
+                    meta.input.parse::<Token![=]>()?;
+                    let lit: LitStr = meta.input.parse()?;
+                    keywords = lit.value().split_whitespace().map(|s| s.to_string()).collect();
                 } else {
                     return Err(meta.error(format!(
                         "'{:?}' argument not recognized, expected \
-                        'namespace', 'no_json', 'no_register, 'deprecated_aliases', or 'deprecated'",
+                        'namespace', 'no_json', 'no_register', 'deprecated_aliases', 'deprecated', or 'keywords'",
                         meta.path
                     )));
                 }
@@ -153,6 +158,13 @@ pub(crate) fn derive_action(input: TokenStream) -> TokenStream {
         quote! { None }
     };
 
+    let keywords_fn_body = if keywords.is_empty() {
+        quote! { &[] }
+    } else {
+        let keywords = keywords.iter();
+        quote! { &[#(#keywords),*] }
+    };
+
     let registration = if no_register {
         quote! {}
     } else {
@@ -201,6 +213,10 @@ pub(crate) fn derive_action(input: TokenStream) -> TokenStream {
 
             fn deprecation_message() -> Option<&'static str> {
                 #deprecation_fn_body
+            }
+
+            fn keywords() -> &'static [&'static str] {
+                #keywords_fn_body
             }
 
             fn documentation() -> Option<&'static str> {

--- a/crates/gpui_macros/src/register_action.rs
+++ b/crates/gpui_macros/src/register_action.rs
@@ -35,6 +35,7 @@ pub(crate) fn generate_register_action(type_name: &Ident) -> TokenStream2 {
                         deprecated_aliases: <#type_name as gpui::Action>::deprecated_aliases(),
                         deprecation_message: <#type_name as gpui::Action>::deprecation_message(),
                         documentation: <#type_name as gpui::Action>::documentation(),
+                        keywords: <#type_name as gpui::Action>::keywords(),
                     }
                 }
 

--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -109,6 +109,7 @@ actions!(
     dev,
     [
         /// Opens the language server protocol logs viewer.
+        #[action(keywords = "lsp")]
         OpenLanguageServerLogs
     ]
 );


### PR DESCRIPTION
# Objective

- Fixes https://github.com/zed-industries/zed/issues/60381
- Adds a search alias, typing "lsp" now surfaces the language server logs action in the command palette

## Solution

- Adds a keywords attribute to gpui actions `#[action(keywords = "lsp")]`
-  The command palette appends an action's keyword to the string so a query can match on a keyword. The keyword only affects matching, user-facing is unchanged
- Tags `OpenLanguageServerLogs` with `keywords = "lsp"`


## Testing

- Ran Zed locally, opened command palette, and typing "lsp": "Open Language Server Logs" now appears alongside the existing "lsp tool: toggle menu"
- Tested on Linux (WSL).

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="674" height="226" alt="image" src="https://github.com/user-attachments/assets/29a5856e-02ed-4239-ba50-049e0310e152" />

---

Release Notes:

- Improved command palette so typing "lsp" surfaces the language server logs