### PR TITLE
git_ui: Sanitize file names before rendering

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6799,7 +6799,7 @@ impl GitPanel {
     }
 
     fn entry_label(&self, label: impl Into<SharedString>, color: Color) -> Label {
-        Label::new(label.into()).color(color)
+        Label::new(label.into()).single_line().color(color)
     }
 
     fn list_item_height(&self) -> Rems {


### PR DESCRIPTION
# Objective

`GitPanel::entry_label` builds file-name labels directly from `git status` output without calling `.single_line()`. A raw newline in a file name splits its row across multiple visual lines in the Changes panel.

## Solution

- Add the missing `.single_line()` call in `entry_label`, matching the behavior in `project_panel.rs`.

## Testing

- Created a git repo with an untracked file whose name contains a literal newline byte and confirmed the Changes panel now renders it on one line, collapsing the newline to `⏎` like the project panel already does.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

# Showcase

Before:
<img width="441" height="216" alt="image" src="https://github.com/user-attachments/assets/921e5aad-01f9-49fd-89b1-f7270e2d203c" />

After:
<img width="447" height="206" alt="image" src="https://github.com/user-attachments/assets/1c09af36-ccf1-434a-be20-0ea2c5d232d5" />

Release Notes:

- Fixed file names containing newlines rendering across multiple
  lines in the Git Panel.