### PR TITLE
settings_ui: Open ACP docs from Settings UI correctly

### DIFF
--- a/crates/settings_ui/src/pages/external_agents_page.rs
+++ b/crates/settings_ui/src/pages/external_agents_page.rs
@@ -18,7 +18,6 @@ use ui::{
 };
 use util::ResultExt as _;
 use workspace::{MultiWorkspace, Workspace, create_and_open_local_file};
-use zed_actions::OpenBrowser;
 
 use crate::SettingsWindow;
 
@@ -310,14 +309,7 @@ pub(crate) fn render_add_agent_popover(
                         .icon(IconName::ArrowUpRight)
                         .icon_color(Color::Muted)
                         .icon_position(IconPosition::End)
-                        .handler(move |window, cx| {
-                            window.dispatch_action(
-                                Box::new(OpenBrowser {
-                                    url: "https://agentclientprotocol.com/".into(),
-                                }),
-                                cx,
-                            );
-                        }),
+                        .handler(|_window, cx| cx.open_url("https://agentclientprotocol.com/")),
                 )
             }))
         });


### PR DESCRIPTION
## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Closes #60822.

---

Release Notes:

- Fixed broken handler for opening ACP documentation from the Settings UI
