### PR TITLE
proto: Add call hierarchy RPC definitions

### DIFF
--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -87,6 +87,62 @@ message DocumentHighlight {
   }
 }
 
+message LspRange {
+    uint32 start_line = 1;
+    uint32 start_column = 2;
+    uint32 end_line = 3;
+    uint32 end_column = 4;
+}
+
+message CallHierarchyItem {
+    string name = 1;
+    int32 kind = 2;
+    optional string detail = 3;
+    string uri = 4;
+    LspRange range = 5;
+    LspRange selection_range = 6;
+    optional bytes data = 7;
+}
+
+message CallHierarchyIncomingCall {
+    CallHierarchyItem from = 1;
+    repeated LspRange from_ranges = 2;
+}
+
+message CallHierarchyOutgoingCall {
+    CallHierarchyItem to = 1;
+    repeated LspRange from_ranges = 2;
+}
+
+message PrepareCallHierarchy {
+    uint64 project_id = 1;
+    uint64 buffer_id = 2;
+    Anchor position = 3;
+    repeated VectorClockEntry version = 4;
+}
+
+message PrepareCallHierarchyResponse {
+    repeated CallHierarchyItem items = 1;
+}
+
+message GetIncomingCalls {
+    uint64 project_id = 1;
+    CallHierarchyItem item = 2;
+}
+
+message GetIncomingCallsResponse {
+    repeated CallHierarchyIncomingCall calls = 1;
+}
+
+message GetOutgoingCalls {
+    uint64 project_id = 1;
+    CallHierarchyItem item = 2;
+}
+
+message GetOutgoingCallsResponse {
+    repeated CallHierarchyOutgoingCall calls = 1;
+}
+
 message GetProjectSymbols {
   uint64 project_id = 1;
   string query = 2;
@@ -897,6 +953,9 @@ message LspQuery {
     GetFoldingRanges get_folding_ranges = 17;
     GetDocumentSymbols get_document_symbols = 18;
     GetDocumentLinks get_document_links = 19;
+    PrepareCallHierarchy prepare_call_hierarchy = 20;
+    GetIncomingCalls get_incoming_calls = 21;
+    GetOutgoingCalls get_outgoing_calls = 22;
   }
 }
 
@@ -924,6 +983,9 @@ message LspResponse {
     GetFoldingRangesResponse get_folding_ranges_response = 15;
     GetDocumentSymbolsResponse get_document_symbols_response = 16;
     GetDocumentLinksResponse get_document_links_response = 17;
+    PrepareCallHierarchyResponse prepare_call_hierarchy_response = 18;
+    GetIncomingCallsResponse get_incoming_calls_response = 19;
+    GetOutgoingCallsResponse get_outgoing_calls_response = 20;
   }
   uint64 server_id = 7;
 }

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -489,7 +489,14 @@ message Envelope {
     GitWorktreeCreatedAtResponse git_worktree_created_at_response = 458;
     TelemetryEvent telemetry_event = 459;
     ResolveCodeAction resolve_code_action = 460;
-    ResolveCodeActionResponse resolve_code_action_response = 461; // current max
+    ResolveCodeActionResponse resolve_code_action_response = 461;
+
+    PrepareCallHierarchy prepare_call_hierarchy = 462;
+    PrepareCallHierarchyResponse prepare_call_hierarchy_response = 463;
+    GetIncomingCalls get_incoming_calls = 464;
+    GetIncomingCallsResponse get_incoming_calls_response = 465;
+    GetOutgoingCalls get_outgoing_calls = 466;
+    GetOutgoingCallsResponse get_outgoing_calls_response = 467; // current max
   }
 
   reserved 87 to 88;

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -120,6 +120,10 @@ messages!(
     (GetTypeDefinitionResponse, Background),
     (GetImplementation, Background),
     (GetImplementationResponse, Background),
+    (GetIncomingCalls, Background),
+    (GetIncomingCallsResponse, Background),
+    (GetOutgoingCalls, Background),
+    (GetOutgoingCallsResponse, Background),
     (OpenUnstagedDiff, Foreground),
     (OpenUnstagedDiffResponse, Foreground),
     (OpenUncommittedDiff, Foreground),
@@ -193,6 +197,8 @@ messages!(
     (PerformRename, Background),
     (PerformRenameResponse, Background),
     (Ping, Foreground),
+    (PrepareCallHierarchy, Background),
+    (PrepareCallHierarchyResponse, Background),
     (PrepareRename, Background),
     (PrepareRenameResponse, Background),
     (ProjectEntryResponse, Foreground),
@@ -454,6 +460,9 @@ request_messages!(
     (OpenNewBuffer, OpenBufferResponse),
     (PerformRename, PerformRenameResponse),
     (Ping, Ack),
+    (PrepareCallHierarchy, PrepareCallHierarchyResponse),
+    (GetIncomingCalls, GetIncomingCallsResponse),
+    (GetOutgoingCalls, GetOutgoingCallsResponse),
     (PrepareRename, PrepareRenameResponse),
     (RefreshInlayHints, Ack),
     (RefreshSemanticTokens, Ack),
@@ -614,8 +623,57 @@ lsp_messages!(
     (GetTypeDefinition, GetTypeDefinitionResponse, true),
     (GetImplementation, GetImplementationResponse, true),
     (InlayHints, InlayHintsResponse, false),
-    (SemanticTokens, SemanticTokensResponse, true)
+    (SemanticTokens, SemanticTokensResponse, true),
+    (PrepareCallHierarchy, PrepareCallHierarchyResponse, true),
 );
+
+impl LspRequestMessage for GetIncomingCalls {
+    type Response = GetIncomingCallsResponse;
+
+    fn to_proto_query(self) -> lsp_query::Request {
+        lsp_query::Request::GetIncomingCalls(self)
+    }
+
+    fn response_to_proto_query(response: Self::Response) -> lsp_response::Response {
+        lsp_response::Response::GetIncomingCallsResponse(response)
+    }
+
+    fn buffer_id(&self) -> u64 {
+        0
+    }
+
+    fn buffer_version(&self) -> &[VectorClockEntry] {
+        &[]
+    }
+
+    fn stop_previous_requests() -> bool {
+        true
+    }
+}
+
+impl LspRequestMessage for GetOutgoingCalls {
+    type Response = GetOutgoingCallsResponse;
+
+    fn to_proto_query(self) -> lsp_query::Request {
+        lsp_query::Request::GetOutgoingCalls(self)
+    }
+
+    fn response_to_proto_query(response: Self::Response) -> lsp_response::Response {
+        lsp_response::Response::GetOutgoingCallsResponse(response)
+    }
+
+    fn buffer_id(&self) -> u64 {
+        0
+    }
+
+    fn buffer_version(&self) -> &[VectorClockEntry] {
+        &[]
+    }
+
+    fn stop_previous_requests() -> bool {
+        true
+    }
+}
 
 entity_messages!(
     {project_id, ShareProject},
@@ -997,6 +1055,9 @@ impl LspQuery {
             Some(lsp_query::Request::GetDocumentLinks(_)) => ("GetDocumentLinks", false),
             Some(lsp_query::Request::InlayHints(_)) => ("InlayHints", false),
             Some(lsp_query::Request::SemanticTokens(_)) => ("SemanticTokens", false),
+            Some(lsp_query::Request::PrepareCallHierarchy(_)) => ("PrepareCallHierarchy", false),
+            Some(lsp_query::Request::GetIncomingCalls(_)) => ("GetIncomingCalls", false),
+            Some(lsp_query::Request::GetOutgoingCalls(_)) => ("GetOutgoingCalls", false),
             None => ("<unknown>", true),
         }
     }

--- a/crates/rpc/src/proto_client.rs
+++ b/crates/rpc/src/proto_client.rs
@@ -420,6 +420,15 @@ impl AnyProtoClient {
                             Response::GetDocumentLinksResponse(response) => {
                                 to_any_envelope(&envelope, response)
                             }
+                            Response::PrepareCallHierarchyResponse(response) => {
+                                to_any_envelope(&envelope, response)
+                            }
+                            Response::GetIncomingCallsResponse(response) => {
+                                to_any_envelope(&envelope, response)
+                            }
+                            Response::GetOutgoingCallsResponse(response) => {
+                                to_any_envelope(&envelope, response)
+                            }
                         };
                         Some(proto::ProtoLspResponse {
                             server_id,


### PR DESCRIPTION
# Objective

This is PR 1 of 5 breaking https://github.com/zed-industries/zed/pull/53239 into more digestible chunks, with the aim of closing https://github.com/zed-industries/zed/issues/14203.

## Solution

Add LSP and host RPC message types for prepare/incoming/outgoing call hierarchy requests used by remote editing. The implementation of these calls is in the subsequent PR.

## Testing

I conducted manual testing of the complete PR stack.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable
