### PR TITLE
call_hierarchy: Add shared call hierarchy utilities and picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2703,6 +2703,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "call_hierarchy"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "editor",
+ "futures 0.3.32",
+ "fuzzy",
+ "gpui",
+ "language",
+ "lsp",
+ "picker",
+ "project",
+ "serde_json",
+ "settings",
+ "theme",
+ "theme_settings",
+ "tree-sitter-rust",
+ "ui",
+ "util",
+ "workspace",
+]
+
+[[package]]
 name = "calloop"
 version = "0.14.3"
 source = "git+https://github.com/zed-industries/calloop#eb6b4fd17b9af5ecc226546bdd04185391b3e265"
@@ -23028,6 +23051,7 @@ dependencies = [
  "auto_update_ui",
  "breadcrumbs",
  "call",
+ "call_hierarchy",
  "channel",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/breadcrumbs",
     "crates/buffer_diff",
     "crates/call",
+    "crates/call_hierarchy",
     "crates/channel",
     "crates/cli",
     "crates/client",
@@ -289,6 +290,7 @@ bedrock = { path = "crates/bedrock" }
 breadcrumbs = { path = "crates/breadcrumbs" }
 buffer_diff = { path = "crates/buffer_diff" }
 call = { path = "crates/call" }
+call_hierarchy = { path = "crates/call_hierarchy" }
 channel = { path = "crates/channel" }
 cli = { path = "crates/cli" }
 client = { path = "crates/client" }

--- a/crates/call_hierarchy/Cargo.toml
+++ b/crates/call_hierarchy/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "call_hierarchy"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/call_hierarchy.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+editor.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
+language.workspace = true
+picker.workspace = true
+project.workspace = true
+settings.workspace = true
+theme.workspace = true
+theme_settings.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
+
+[dev-dependencies]
+futures.workspace = true
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }
+serde_json.workspace = true
+tree-sitter-rust.workspace = true

--- a/crates/call_hierarchy/LICENSE-GPL
+++ b/crates/call_hierarchy/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/call_hierarchy/src/call_hierarchy.rs
+++ b/crates/call_hierarchy/src/call_hierarchy.rs
@@ -1,0 +1,1171 @@
+use std::{ops::Range, path::Path, sync::Arc};
+
+use editor::{Bias, Editor, SelectionEffects, scroll::Autoscroll, styled_runs_for_code_label};
+use fuzzy::{StringMatch, StringMatchCandidate};
+use gpui::{
+    App, AsyncWindowContext, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
+    HighlightStyle, ParentElement, Render, Styled, StyledText, Task, TextStyle, WeakEntity, Window,
+    actions, rems,
+};
+use language::{CodeLabel, PointUtf16, ToPointUtf16, Unclipped};
+use picker::{Picker, PickerDelegate};
+use project::{CallHierarchyItem, Project};
+use settings::Settings;
+use theme_settings::ThemeSettings;
+use ui::{ListItem, ListItemSpacing, Tooltip, prelude::*};
+use util::{ResultExt, paths::PathExt};
+use workspace::{ModalView, Workspace};
+
+actions!(call_hierarchy, [ShowIncomingCalls, ShowOutgoingCalls]);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum CallHierarchyMode {
+    #[default]
+    Incoming,
+    Outgoing,
+}
+
+#[derive(Debug, Clone)]
+pub struct Call {
+    pub item: CallHierarchyItem,
+    pub target: Unclipped<PointUtf16>,
+    pub label: Option<CodeLabel>,
+}
+
+pub async fn make_call(
+    item: CallHierarchyItem,
+    target: Unclipped<PointUtf16>,
+    project: &Entity<Project>,
+    cx: &mut AsyncWindowContext,
+) -> Call {
+    let label = label_for_call_hierarchy_item(&item, project, cx).await;
+    Call {
+        item,
+        target,
+        label,
+    }
+}
+
+pub async fn fetch_calls(
+    item: &CallHierarchyItem,
+    project: &Entity<Project>,
+    buffer: &Entity<language::Buffer>,
+    mode: CallHierarchyMode,
+    cx: &mut AsyncWindowContext,
+) -> Vec<Call> {
+    match mode {
+        CallHierarchyMode::Incoming => {
+            let task = project.update(cx, |project, cx| {
+                project.incoming_calls(buffer, item.clone(), cx)
+            });
+            let Some(calls) = task.await.log_err().flatten() else {
+                return Vec::new();
+            };
+            let mut labeled_calls = Vec::with_capacity(calls.len());
+            for call in calls {
+                let target = call
+                    .from_ranges
+                    .first()
+                    .map_or(call.from.selection_range.start, |r| r.start);
+                labeled_calls.push(make_call(call.from, target, project, cx).await);
+            }
+            labeled_calls
+        }
+        CallHierarchyMode::Outgoing => {
+            let task = project.update(cx, |project, cx| {
+                project.outgoing_calls(buffer, item.clone(), cx)
+            });
+            let Some(calls) = task.await.log_err().flatten() else {
+                return Vec::new();
+            };
+            let mut labeled_calls = Vec::with_capacity(calls.len());
+            for call in calls {
+                labeled_calls.push(
+                    make_call(call.to.clone(), call.to.selection_range.start, project, cx).await,
+                );
+            }
+            labeled_calls
+        }
+    }
+}
+
+async fn label_for_call_hierarchy_item(
+    item: &CallHierarchyItem,
+    project: &Entity<Project>,
+    cx: &mut AsyncWindowContext,
+) -> Option<CodeLabel> {
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    let file_path = item.uri.to_file_path().ok()?;
+    let file_name = file_path.file_name()?;
+    let language = language_registry
+        .load_language_for_file_path(Path::new(file_name))
+        .await
+        .ok()?;
+    let lsp_adapter = language_registry
+        .lsp_adapters(&language.name())
+        .first()
+        .cloned()?;
+
+    lsp_adapter
+        .labels_for_symbols(
+            &[language::Symbol {
+                name: item.name.clone(),
+                kind: item.kind,
+                container_name: None,
+            }],
+            &language,
+        )
+        .await
+        .log_err()?
+        .into_iter()
+        .next()
+        .flatten()
+}
+
+pub fn init(cx: &mut App) {
+    cx.observe_new(CallHierarchyView::register).detach();
+}
+
+fn toggle_call_hierarchy(
+    editor: Entity<Editor>,
+    mode: CallHierarchyMode,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    let Some(workspace) = window.root::<Workspace>().flatten() else {
+        return;
+    };
+
+    let project = workspace.read(cx).project().clone();
+    let workspace_weak = workspace.downgrade();
+
+    workspace.update(cx, |workspace, cx| {
+        workspace.toggle_modal(window, cx, |window, cx| {
+            CallHierarchyView::new(editor, project, workspace_weak, mode, window, cx)
+        });
+    });
+}
+
+pub struct CallHierarchyView {
+    picker: Entity<Picker<CallHierarchyDelegate>>,
+    mode: CallHierarchyMode,
+}
+
+impl CallHierarchyView {
+    fn register(editor: &mut Editor, _: Option<&mut Window>, cx: &mut Context<Editor>) {
+        if editor.mode().is_full() {
+            let handle = cx.entity().downgrade();
+            editor
+                .register_action({
+                    let handle = handle.clone();
+                    move |_: &ShowIncomingCalls, window, cx| {
+                        if let Some(editor) = handle.upgrade() {
+                            toggle_call_hierarchy(editor, CallHierarchyMode::Incoming, window, cx);
+                        }
+                    }
+                })
+                .detach();
+            editor
+                .register_action(move |_: &ShowOutgoingCalls, window, cx| {
+                    if let Some(editor) = handle.upgrade() {
+                        toggle_call_hierarchy(editor, CallHierarchyMode::Outgoing, window, cx);
+                    }
+                })
+                .detach();
+        }
+    }
+
+    fn new(
+        editor: Entity<Editor>,
+        project: Entity<Project>,
+        workspace: WeakEntity<Workspace>,
+        mode: CallHierarchyMode,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> CallHierarchyView {
+        let delegate =
+            CallHierarchyDelegate::new(cx.entity().downgrade(), editor, project, workspace, mode);
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(delegate, window, cx).max_height(Rems::from_pixels(
+                window.viewport_size().height * 0.75,
+                window,
+            ))
+        });
+
+        let picker_entity = picker.clone();
+        cx.spawn_in(window, async move |_view, cx| {
+            picker_entity
+                .update_in(cx, |picker, window, cx| {
+                    picker.delegate.fetch_calls(window, cx)
+                })?
+                .await;
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
+
+        CallHierarchyView { picker, mode }
+    }
+}
+
+impl Focusable for CallHierarchyView {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.picker.focus_handle(cx)
+    }
+}
+
+impl EventEmitter<DismissEvent> for CallHierarchyView {}
+
+impl ModalView for CallHierarchyView {}
+
+impl Render for CallHierarchyView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .w(rems(34.))
+            .when(self.mode == CallHierarchyMode::Incoming, |this| {
+                this.on_action(cx.listener(|_this, _: &ShowIncomingCalls, _window, cx| {
+                    cx.emit(DismissEvent);
+                }))
+            })
+            .when(self.mode == CallHierarchyMode::Outgoing, |this| {
+                this.on_action(cx.listener(|_this, _: &ShowOutgoingCalls, _window, cx| {
+                    cx.emit(DismissEvent);
+                }))
+            })
+            .child(self.picker.clone())
+    }
+}
+
+pub struct CallHierarchyDelegate {
+    view: WeakEntity<CallHierarchyView>,
+    workspace: WeakEntity<Workspace>,
+    project: Entity<Project>,
+    editor: Entity<Editor>,
+    mode: CallHierarchyMode,
+    root_item: Option<CallHierarchyItem>,
+    calls: Vec<Call>,
+    matches: Vec<StringMatch>,
+    selected_index: usize,
+}
+
+impl CallHierarchyDelegate {
+    fn new(
+        view: WeakEntity<CallHierarchyView>,
+        editor: Entity<Editor>,
+        project: Entity<Project>,
+        workspace: WeakEntity<Workspace>,
+        mode: CallHierarchyMode,
+    ) -> Self {
+        Self {
+            view,
+            workspace,
+            project,
+            editor,
+            mode,
+            root_item: None,
+            calls: Vec::new(),
+            matches: Vec::new(),
+            selected_index: 0,
+        }
+    }
+
+    fn fetch_calls(&mut self, window: &mut Window, cx: &mut Context<Picker<Self>>) -> Task<()> {
+        let buffer = self.editor.read(cx).buffer().read(cx).as_singleton();
+        let Some(buffer) = buffer else {
+            return Task::ready(());
+        };
+
+        let position = self.editor.update(cx, |editor, cx| {
+            let snapshot = editor.display_snapshot(cx);
+            editor
+                .selections
+                .newest::<language::Point>(&snapshot)
+                .head()
+        });
+        let position_utf16 = position.to_point_utf16(&buffer.read(cx).snapshot());
+
+        let prepare_task = self.project.update(cx, |project, cx| {
+            project.prepare_call_hierarchy(&buffer, position_utf16, cx)
+        });
+
+        let project = self.project.clone();
+        let buffer_clone = buffer.clone();
+        let mode = self.mode;
+
+        cx.spawn_in(window, async move |picker, mut cx| {
+            let items = prepare_task.await;
+            let Ok(Some(items)) = items else {
+                return;
+            };
+            let Some(root_item) = items.into_iter().next() else {
+                return;
+            };
+
+            let calls = fetch_calls(&root_item, &project, &buffer_clone, mode, &mut cx).await;
+
+            picker
+                .update_in(cx, |picker, _window, cx| {
+                    picker.delegate.root_item = Some(root_item);
+                    picker.delegate.calls = calls;
+                    picker.delegate.matches = picker
+                        .delegate
+                        .calls
+                        .iter()
+                        .enumerate()
+                        .map(|(index, _)| StringMatch {
+                            candidate_id: index,
+                            score: Default::default(),
+                            positions: Default::default(),
+                            string: Default::default(),
+                        })
+                        .collect();
+                    picker.delegate.selected_index = 0;
+                    cx.notify();
+                })
+                .log_err();
+        })
+    }
+}
+
+impl PickerDelegate for CallHierarchyDelegate {
+    type ListItem = ListItem;
+
+    fn name() -> &'static str {
+        "call hierarchy"
+    }
+
+    fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        match self.mode {
+            CallHierarchyMode::Incoming => "Search incoming calls...".into(),
+            CallHierarchyMode::Outgoing => "Search outgoing calls...".into(),
+        }
+    }
+
+    fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(
+        &mut self,
+        ix: usize,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) {
+        self.selected_index = ix;
+    }
+
+    fn update_matches(
+        &mut self,
+        query: String,
+        _window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> Task<()> {
+        let candidates: Vec<StringMatchCandidate> = self
+            .calls
+            .iter()
+            .enumerate()
+            .map(|(id, call)| StringMatchCandidate::new(id, &call.item.name))
+            .collect();
+
+        if query.is_empty() {
+            self.matches = self
+                .calls
+                .iter()
+                .enumerate()
+                .map(|(index, _)| StringMatch {
+                    candidate_id: index,
+                    score: Default::default(),
+                    positions: Default::default(),
+                    string: Default::default(),
+                })
+                .collect();
+            self.selected_index = 0;
+            return Task::ready(());
+        }
+
+        let executor = cx.background_executor().clone();
+        cx.spawn(async move |picker, cx| {
+            let matches = fuzzy::match_strings(
+                &candidates,
+                &query,
+                true,
+                true,
+                100,
+                &Default::default(),
+                executor,
+            )
+            .await;
+
+            picker
+                .update(cx, |picker, cx| {
+                    picker.delegate.matches = matches;
+                    picker.delegate.selected_index = 0;
+                    cx.notify();
+                })
+                .log_err();
+        })
+    }
+
+    fn confirm(&mut self, secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        let Some(mat) = self.matches.get(self.selected_index) else {
+            return;
+        };
+        let Some(call) = self.calls.get(mat.candidate_id) else {
+            return;
+        };
+
+        let uri = call.item.uri.clone();
+        let start_point = call.target;
+
+        let abs_path = match uri.to_file_path() {
+            Ok(path) => path,
+            Err(_) => return,
+        };
+
+        let buffer_task = self
+            .project
+            .update(cx, |project, cx| project.open_local_buffer(&abs_path, cx));
+        let workspace = self.workspace.clone();
+
+        cx.spawn_in(window, async move |_, cx| {
+            let buffer = buffer_task.await?;
+
+            workspace.update_in(cx, |workspace, window, cx| {
+                let position = buffer.read(cx).clip_point_utf16(start_point, Bias::Left);
+                let pane = if secondary {
+                    workspace.adjacent_pane(window, cx)
+                } else {
+                    workspace.active_pane().clone()
+                };
+
+                let editor = workspace
+                    .open_project_item::<Editor>(pane, buffer, true, true, true, true, window, cx);
+
+                editor.update(cx, |editor, cx| {
+                    editor.change_selections(
+                        SelectionEffects::scroll(Autoscroll::center()),
+                        window,
+                        cx,
+                        |s| s.select_ranges([position..position]),
+                    );
+                });
+            })?;
+
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
+
+        self.dismissed(window, cx);
+    }
+
+    fn dismissed(&mut self, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        self.view.update(cx, |_, cx| cx.emit(DismissEvent)).ok();
+    }
+
+    fn render_match(
+        &self,
+        ix: usize,
+        selected: bool,
+        _window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> Option<Self::ListItem> {
+        let mat = self.matches.get(ix)?;
+        let call = self.calls.get(mat.candidate_id)?;
+
+        let match_ranges = mat.positions.iter().map(|pos| *pos..*pos + 1);
+        let (name_styled, detail_styled, path_styled) = render_item(call, match_ranges, cx);
+
+        Some(
+            ListItem::new(ix)
+                .inset(true)
+                .spacing(ListItemSpacing::Sparse)
+                .toggle_state(selected)
+                .child(
+                    v_flex()
+                        .text_ui(cx)
+                        .child(name_styled)
+                        .when_some(detail_styled, |this, detail| this.child(detail)),
+                )
+                .when_some(path_styled, |this, path| {
+                    this.tooltip(Tooltip::element(move |_window, _cx| {
+                        div().max_w_72().child(path.clone()).into_any_element()
+                    }))
+                }),
+        )
+    }
+}
+
+/// Extracts display information from a `Call` for rendering in UI.
+fn extract_call_display_info(call: &Call) -> (String, Option<String>, Option<String>) {
+    let name = call.item.name.clone();
+    let line_number = call.target.0.row + 1;
+    let file_path = call.item.uri.to_file_path().ok();
+
+    let file_with_line = file_path
+        .as_ref()
+        .map(|p| format!("{}:{}", p.compact().to_string_lossy(), line_number));
+
+    let detail = extract_call_detail(call).or(file_with_line.clone());
+
+    (name, detail, file_with_line)
+}
+
+fn extract_call_detail(call: &Call) -> Option<String> {
+    if let Some(label) = call.label.as_ref()
+        && let Some(detail) = detail_from_label_suffix(label)
+    {
+        return Some(detail);
+    }
+
+    call.item
+        .detail
+        .as_deref()
+        .map(str::trim)
+        .filter(|detail| !detail.is_empty())
+        .map(|detail| detail.replace('\n', "↵"))
+        .and_then(|detail| trim_detail_after_symbol_name(&detail, &call.item.name).or(Some(detail)))
+}
+
+fn detail_from_label_suffix(label: &CodeLabel) -> Option<String> {
+    label
+        .text
+        .get(label.filter_range.end..)
+        .map(str::trim)
+        .filter(|suffix| !suffix.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn trim_detail_after_symbol_name(detail: &str, symbol_name: &str) -> Option<String> {
+    let suffix = detail
+        .find(symbol_name)
+        .and_then(|name_start| detail.get(name_start + symbol_name.len()..))?
+        .trim();
+    (!suffix.is_empty()).then(|| suffix.to_owned())
+}
+
+/// Renders call item name and detail as styled text, matching the outline panel's style.
+/// Returns a tuple of (name_styled, detail_styled) where:
+/// - name_styled: function-colored text with match highlight backgrounds
+/// - detail_styled: muted-colored text (if detail is provided)
+pub fn render_item(
+    call_item: &Call,
+    match_ranges: impl IntoIterator<Item = Range<usize>>,
+    cx: &App,
+) -> (StyledText, Option<StyledText>, Option<String>) {
+    let (name, detail, path) = extract_call_display_info(call_item);
+
+    let settings = ThemeSettings::get_global(cx);
+
+    let base_text_style = TextStyle {
+        font_family: settings.buffer_font.family.clone(),
+        font_features: settings.buffer_font.features.clone(),
+        font_fallbacks: settings.buffer_font.fallbacks.clone(),
+        font_size: settings.buffer_font_size(cx).into(),
+        font_weight: settings.buffer_font.weight,
+        line_height: relative(1.),
+        ..Default::default()
+    };
+
+    let highlight_style = HighlightStyle {
+        background_color: Some(cx.theme().colors().text_accent.alpha(0.3)),
+        ..Default::default()
+    };
+
+    let name_styled = if let Some(label) = call_item.label.as_ref() {
+        let theme = cx.theme();
+        let local_player = theme.players().local();
+        let syntax_runs = styled_runs_for_code_label(label, theme.syntax(), &local_player);
+        let custom_highlights = match_ranges.into_iter().map(|range| {
+            let start = label.filter_range.start + range.start;
+            let end = label.filter_range.start + range.end;
+            (start..end, highlight_style)
+        });
+
+        StyledText::new(label.text.clone()).with_default_highlights(
+            &base_text_style,
+            gpui::combine_highlights(custom_highlights, syntax_runs),
+        )
+    } else {
+        let mut name_style = base_text_style.clone();
+        name_style.color = cx.theme().colors().text;
+
+        StyledText::new(name).with_default_highlights(
+            &name_style,
+            match_ranges.into_iter().map(|r| (r, highlight_style)),
+        )
+    };
+
+    let detail_styled = detail.map(|d| {
+        let mut detail_style = base_text_style;
+        detail_style.color = cx.theme().colors().text_muted;
+        StyledText::new(d).with_default_highlights(&detail_style, std::iter::empty())
+    });
+
+    (name_styled, detail_styled, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt as _;
+    use gpui::TestAppContext;
+    use language::{FakeLspAdapter, Language, LanguageConfig, LanguageMatcher};
+    use project::{CallHierarchyItem, FakeFs};
+    use serde_json::json;
+    use std::sync::Arc;
+    use util::{path, rel_path::rel_path};
+    use workspace::AppState;
+
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let _state = AppState::test(cx);
+            init(cx);
+            editor::init(cx);
+        });
+    }
+
+    fn rust_lang() -> Arc<Language> {
+        Arc::new(Language::new(
+            LanguageConfig {
+                name: "Rust".into(),
+                matcher: LanguageMatcher {
+                    path_suffixes: vec!["rs".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            Some(tree_sitter_rust::LANGUAGE.into()),
+        ))
+    }
+
+    fn make_lsp_call_hierarchy_item(
+        name: &str,
+        uri: lsp::Uri,
+        line: u32,
+    ) -> lsp::CallHierarchyItem {
+        lsp::CallHierarchyItem {
+            name: name.to_string(),
+            kind: lsp::SymbolKind::FUNCTION,
+            tags: None,
+            detail: Some(format!("fn {name}()")),
+            uri,
+            range: lsp::Range {
+                start: lsp::Position { line, character: 0 },
+                end: lsp::Position {
+                    line,
+                    character: 10,
+                },
+            },
+            selection_range: lsp::Range {
+                start: lsp::Position { line, character: 3 },
+                end: lsp::Position {
+                    line,
+                    character: 3 + name.len() as u32,
+                },
+            },
+            data: None,
+        }
+    }
+
+    fn make_call(name: &str, uri: lsp::Uri, line: u32, detail: Option<String>) -> Call {
+        Call {
+            item: CallHierarchyItem {
+                name: name.to_string(),
+                kind: lsp::SymbolKind::FUNCTION,
+                detail,
+                uri,
+                range: Unclipped(PointUtf16::new(line, 0))..Unclipped(PointUtf16::new(line, 10)),
+                selection_range: Unclipped(PointUtf16::new(line, 3))
+                    ..Unclipped(PointUtf16::new(line, 3 + name.len() as u32)),
+                data: None,
+            },
+            target: Unclipped(PointUtf16::new(line, 3)),
+            label: None,
+        }
+    }
+
+    #[gpui::test]
+    async fn test_extract_call_display_info_basic(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/test"), json!({"src": {"main.rs": ""}}))
+            .await;
+
+        let test_uri = lsp::Uri::from_file_path(path!("/test/src/main.rs")).unwrap();
+
+        let call = make_call("my_function", test_uri, 10, None);
+        let (name, detail, file_with_line) = extract_call_display_info(&call);
+
+        #[cfg(not(windows))]
+        let expected_path = "/test/src/main.rs:11";
+        #[cfg(windows)]
+        let expected_path = "C:\\test\\src\\main.rs:11";
+
+        assert_eq!(name, "my_function");
+        assert_eq!(detail.as_deref(), Some(expected_path));
+        assert_eq!(file_with_line.as_deref(), Some(expected_path));
+    }
+
+    #[gpui::test]
+    async fn test_extract_call_display_info_home_path_compacted(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let home_dir = util::paths::home_dir();
+        let test_path = home_dir.join("projects/app/src/main.rs");
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            &home_dir,
+            json!({"projects": {"app": {"src": {"main.rs": ""}}}}),
+        )
+        .await;
+
+        let test_uri = lsp::Uri::from_file_path(&test_path).unwrap();
+
+        let call = make_call("my_function", test_uri, 10, None);
+        let (name, detail, file_with_line) = extract_call_display_info(&call);
+
+        #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
+        let expected_path = "~/projects/app/src/main.rs:11";
+        #[cfg(windows)]
+        let expected_path = format!("{}:11", test_path.to_string_lossy());
+
+        assert_eq!(name, "my_function");
+        assert_eq!(detail.as_deref(), Some(expected_path));
+        assert_eq!(file_with_line.as_deref(), Some(expected_path));
+    }
+
+    #[gpui::test]
+    async fn test_extract_call_display_info_with_detail(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/test"), json!({"src": {"lib.rs": ""}}))
+            .await;
+
+        let test_uri = lsp::Uri::from_file_path(path!("/test/src/lib.rs")).unwrap();
+
+        let call = make_call(
+            "helper",
+            test_uri,
+            5,
+            Some("fn helper() -> i32".to_string()),
+        );
+        let (name, detail, file_with_line) = extract_call_display_info(&call);
+
+        #[cfg(not(windows))]
+        let expected_path = "/test/src/lib.rs:6";
+        #[cfg(windows)]
+        let expected_path = "C:\\test\\src\\lib.rs:6";
+
+        assert_eq!(name, "helper");
+        assert_eq!(detail.as_deref(), Some("fn helper() -> i32"));
+        assert_eq!(file_with_line.as_deref(), Some(expected_path));
+    }
+
+    #[gpui::test]
+    async fn test_extract_call_display_info_prefers_label_suffix(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/test"), json!({"src": {"lib.rs": ""}}))
+            .await;
+
+        let test_uri = lsp::Uri::from_file_path(path!("/test/src/lib.rs")).unwrap();
+
+        let mut call = make_call(
+            "helper",
+            test_uri,
+            5,
+            Some("fn helper(&self) -> i32".to_string()),
+        );
+        call.label = Some(CodeLabel::new(
+            "fn helper(&self) -> i32".to_string(),
+            3..9,
+            Vec::new(),
+        ));
+
+        let (_, detail, _) = extract_call_display_info(&call);
+        assert_eq!(detail.as_deref(), Some("(&self) -> i32"));
+    }
+
+    #[gpui::test]
+    async fn test_extract_call_display_info_trims_raw_detail_after_symbol_name(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/test"), json!({"src": {"lib.rs": ""}}))
+            .await;
+
+        let test_uri = lsp::Uri::from_file_path(path!("/test/src/lib.rs")).unwrap();
+
+        let call = make_call(
+            "helper",
+            test_uri,
+            5,
+            Some("fn helper(&self, arg: i32) -> i32".to_string()),
+        );
+
+        let (_, detail, _) = extract_call_display_info(&call);
+        assert_eq!(detail.as_deref(), Some("(&self, arg: i32) -> i32"));
+    }
+
+    #[gpui::test]
+    async fn test_extract_call_display_info_multiline_detail(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/test"), json!({"main.rs": ""})).await;
+
+        let test_uri = lsp::Uri::from_file_path(path!("/test/main.rs")).unwrap();
+
+        let call = make_call("foo", test_uri, 0, Some("line1\nline2\nline3".to_string()));
+        let (name, detail, _) = extract_call_display_info(&call);
+
+        assert_eq!(name, "foo");
+        assert_eq!(detail.as_deref(), Some("line1↵line2↵line3"));
+    }
+
+    #[gpui::test]
+    async fn test_call_hierarchy_modal_basic(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/test"),
+            json!({
+                "src": {
+                    "main.rs": "fn main() { helper(); }\nfn helper() {}\n",
+                }
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [path!("/test").as_ref()], cx).await;
+        project.read_with(cx, |project, _| project.languages().add(rust_lang()));
+
+        let mut fake_servers = project.read_with(cx, |project, _| {
+            project.languages().register_fake_lsp(
+                "Rust",
+                FakeLspAdapter {
+                    capabilities: lsp::ServerCapabilities {
+                        call_hierarchy_provider: Some(lsp::CallHierarchyServerCapability::Simple(
+                            true,
+                        )),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+        });
+
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let _buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/test/src/main.rs"), cx)
+            })
+            .await
+            .unwrap();
+
+        let worktree_id = workspace.update(cx, |workspace, cx| {
+            workspace.project().update(cx, |project, cx| {
+                project.worktrees(cx).next().unwrap().read(cx).id()
+            })
+        });
+
+        let _editor = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_path(
+                    (worktree_id, rel_path("src/main.rs")),
+                    None,
+                    true,
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap()
+            .downcast::<Editor>()
+            .unwrap();
+
+        let fake_server = fake_servers.next().await.unwrap();
+        let test_uri = lsp::Uri::from_file_path(path!("/test/src/main.rs")).unwrap();
+
+        fake_server.set_request_handler::<lsp::request::CallHierarchyPrepare, _, _>({
+            let uri = test_uri.clone();
+            move |_, _| {
+                let uri = uri.clone();
+                async move { Ok(Some(vec![make_lsp_call_hierarchy_item("main", uri, 0)])) }
+            }
+        });
+
+        fake_server.set_request_handler::<lsp::request::CallHierarchyOutgoingCalls, _, _>({
+            move |_, _| {
+                let uri = test_uri.clone();
+                async move {
+                    Ok(Some(vec![lsp::CallHierarchyOutgoingCall {
+                        to: make_lsp_call_hierarchy_item("helper", uri, 1),
+                        from_ranges: vec![],
+                    }]))
+                }
+            }
+        });
+
+        cx.dispatch_action(ShowOutgoingCalls);
+        cx.executor().run_until_parked();
+
+        let has_modal = workspace.update(cx, |workspace, cx| {
+            workspace.active_modal::<CallHierarchyView>(cx).is_some()
+        });
+        assert!(has_modal, "Call hierarchy modal should be open");
+    }
+
+    #[gpui::test]
+    async fn test_call_hierarchy_modal_incoming_mode(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/test"),
+            json!({
+                "src": {
+                    "main.rs": "fn main() { helper(); }\nfn helper() {}\n",
+                }
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [path!("/test").as_ref()], cx).await;
+        project.read_with(cx, |project, _| project.languages().add(rust_lang()));
+
+        let mut fake_servers = project.read_with(cx, |project, _| {
+            project.languages().register_fake_lsp(
+                "Rust",
+                FakeLspAdapter {
+                    capabilities: lsp::ServerCapabilities {
+                        call_hierarchy_provider: Some(lsp::CallHierarchyServerCapability::Simple(
+                            true,
+                        )),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+        });
+
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let _buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/test/src/main.rs"), cx)
+            })
+            .await
+            .unwrap();
+
+        let worktree_id = workspace.update(cx, |workspace, cx| {
+            workspace.project().update(cx, |project, cx| {
+                project.worktrees(cx).next().unwrap().read(cx).id()
+            })
+        });
+
+        let _editor = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_path(
+                    (worktree_id, rel_path("src/main.rs")),
+                    None,
+                    true,
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap()
+            .downcast::<Editor>()
+            .unwrap();
+
+        let fake_server = fake_servers.next().await.unwrap();
+        let test_uri = lsp::Uri::from_file_path(path!("/test/src/main.rs")).unwrap();
+
+        fake_server.set_request_handler::<lsp::request::CallHierarchyPrepare, _, _>({
+            let uri = test_uri.clone();
+            move |_, _| {
+                let uri = uri.clone();
+                async move { Ok(Some(vec![make_lsp_call_hierarchy_item("helper", uri, 1)])) }
+            }
+        });
+
+        fake_server.set_request_handler::<lsp::request::CallHierarchyIncomingCalls, _, _>({
+            move |_, _| {
+                let uri = test_uri.clone();
+                async move {
+                    Ok(Some(vec![lsp::CallHierarchyIncomingCall {
+                        from: make_lsp_call_hierarchy_item("main", uri, 0),
+                        from_ranges: vec![lsp::Range {
+                            start: lsp::Position {
+                                line: 0,
+                                character: 12,
+                            },
+                            end: lsp::Position {
+                                line: 0,
+                                character: 18,
+                            },
+                        }],
+                    }]))
+                }
+            }
+        });
+
+        cx.dispatch_action(ShowIncomingCalls);
+        cx.executor().run_until_parked();
+
+        let has_modal = workspace.update(cx, |workspace, cx| {
+            workspace.active_modal::<CallHierarchyView>(cx).is_some()
+        });
+        assert!(
+            has_modal,
+            "Call hierarchy modal should be open in incoming mode"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_call_hierarchy_modal_filtering(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/test"),
+            json!({
+                "src": {
+                    "main.rs": "fn main() { foo(); bar(); baz(); }\nfn foo() {}\nfn bar() {}\nfn baz() {}\n",
+                }
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [path!("/test").as_ref()], cx).await;
+        project.read_with(cx, |project, _| project.languages().add(rust_lang()));
+
+        let mut fake_servers = project.read_with(cx, |project, _| {
+            project.languages().register_fake_lsp(
+                "Rust",
+                FakeLspAdapter {
+                    capabilities: lsp::ServerCapabilities {
+                        call_hierarchy_provider: Some(lsp::CallHierarchyServerCapability::Simple(
+                            true,
+                        )),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+        });
+
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let _buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/test/src/main.rs"), cx)
+            })
+            .await
+            .unwrap();
+
+        let worktree_id = workspace.update(cx, |workspace, cx| {
+            workspace.project().update(cx, |project, cx| {
+                project.worktrees(cx).next().unwrap().read(cx).id()
+            })
+        });
+
+        let _editor = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.open_path(
+                    (worktree_id, rel_path("src/main.rs")),
+                    None,
+                    true,
+                    window,
+                    cx,
+                )
+            })
+            .await
+            .unwrap()
+            .downcast::<Editor>()
+            .unwrap();
+
+        let fake_server = fake_servers.next().await.unwrap();
+        let test_uri = lsp::Uri::from_file_path(path!("/test/src/main.rs")).unwrap();
+
+        fake_server.set_request_handler::<lsp::request::CallHierarchyPrepare, _, _>({
+            let uri = test_uri.clone();
+            move |_, _| {
+                let uri = uri.clone();
+                async move { Ok(Some(vec![make_lsp_call_hierarchy_item("main", uri, 0)])) }
+            }
+        });
+
+        fake_server.set_request_handler::<lsp::request::CallHierarchyOutgoingCalls, _, _>({
+            let uri = test_uri.clone();
+            move |_, _| {
+                let uri = uri.clone();
+                async move {
+                    Ok(Some(vec![
+                        lsp::CallHierarchyOutgoingCall {
+                            to: make_lsp_call_hierarchy_item("foo", uri.clone(), 1),
+                            from_ranges: vec![],
+                        },
+                        lsp::CallHierarchyOutgoingCall {
+                            to: make_lsp_call_hierarchy_item("bar_1", uri.clone(), 2),
+                            from_ranges: vec![],
+                        },
+                        lsp::CallHierarchyOutgoingCall {
+                            to: make_lsp_call_hierarchy_item("bar_2", uri.clone(), 2),
+                            from_ranges: vec![],
+                        },
+                        lsp::CallHierarchyOutgoingCall {
+                            to: make_lsp_call_hierarchy_item("baz", uri, 3),
+                            from_ranges: vec![],
+                        },
+                    ]))
+                }
+            }
+        });
+
+        cx.dispatch_action(ShowOutgoingCalls);
+        cx.executor().run_until_parked();
+
+        let modal = workspace.update(cx, |workspace, cx| {
+            workspace.active_modal::<CallHierarchyView>(cx)
+        });
+        assert!(modal.is_some(), "Modal should be open");
+
+        let modal = modal.unwrap();
+        let match_count_before =
+            modal.read_with(cx, |view, cx| view.picker.read(cx).delegate.matches.len());
+        assert_eq!(match_count_before, 4, "Should have 4 matches initially");
+
+        let task = modal.update_in(cx, |view, window, cx| {
+            view.picker.update(cx, |picker, cx| {
+                picker
+                    .delegate
+                    .update_matches("bar".to_string(), window, cx)
+            })
+        });
+        task.await;
+        cx.executor().run_until_parked();
+
+        let match_count_after =
+            modal.read_with(cx, |view, cx| view.picker.read(cx).delegate.matches.len());
+        assert_eq!(
+            match_count_after, 2,
+            "Filter 'bar' should match 2 entries (bar, baz)"
+        );
+    }
+}

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -331,6 +331,467 @@ pub struct GetDocumentDiagnostics {
     pub previous_result_id: Option<SharedString>,
 }
 
+#[derive(Debug, Clone)]
+pub struct CallHierarchyItem {
+    pub name: String,
+    pub kind: lsp::SymbolKind,
+    pub detail: Option<String>,
+    pub uri: lsp::Uri,
+    pub range: Range<Unclipped<PointUtf16>>,
+    pub selection_range: Range<Unclipped<PointUtf16>>,
+    pub data: Option<serde_json::Value>,
+}
+
+impl From<lsp::CallHierarchyItem> for CallHierarchyItem {
+    fn from(item: lsp::CallHierarchyItem) -> Self {
+        Self {
+            name: item.name,
+            kind: item.kind,
+            detail: item.detail,
+            uri: item.uri,
+            range: range_from_lsp(item.range),
+            selection_range: range_from_lsp(item.selection_range),
+            data: item.data,
+        }
+    }
+}
+
+impl From<CallHierarchyItem> for lsp::CallHierarchyItem {
+    fn from(item: CallHierarchyItem) -> Self {
+        Self {
+            name: item.name,
+            kind: item.kind,
+            detail: item.detail,
+            uri: item.uri,
+            range: lsp::Range {
+                start: point_to_lsp(item.range.start.0),
+                end: point_to_lsp(item.range.end.0),
+            },
+            selection_range: lsp::Range {
+                start: point_to_lsp(item.selection_range.start.0),
+                end: point_to_lsp(item.selection_range.end.0),
+            },
+            data: item.data,
+            tags: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PrepareCallHierarchy {
+    pub position: PointUtf16,
+}
+
+fn lsp_range_to_proto(range: Range<Unclipped<PointUtf16>>) -> proto::LspRange {
+    proto::LspRange {
+        start_line: range.start.0.row,
+        start_column: range.start.0.column,
+        end_line: range.end.0.row,
+        end_column: range.end.0.column,
+    }
+}
+
+fn lsp_range_from_proto(range: proto::LspRange) -> Range<Unclipped<PointUtf16>> {
+    Unclipped(PointUtf16::new(range.start_line, range.start_column))
+        ..Unclipped(PointUtf16::new(range.end_line, range.end_column))
+}
+
+pub fn call_hierarchy_item_to_proto(item: CallHierarchyItem) -> proto::CallHierarchyItem {
+    proto::CallHierarchyItem {
+        name: item.name,
+        kind: unsafe { mem::transmute::<lsp::SymbolKind, i32>(item.kind) },
+        detail: item.detail,
+        uri: item.uri.to_string(),
+        range: Some(lsp_range_to_proto(item.range)),
+        selection_range: Some(lsp_range_to_proto(item.selection_range)),
+        data: item.data.map(|d| d.to_string().into_bytes()),
+    }
+}
+
+pub fn call_hierarchy_item_from_proto(item: proto::CallHierarchyItem) -> Result<CallHierarchyItem> {
+    Ok(CallHierarchyItem {
+        name: item.name,
+        kind: unsafe { mem::transmute::<i32, lsp::SymbolKind>(item.kind) },
+        detail: item.detail,
+        uri: lsp::Uri::from_str(&item.uri)?,
+        range: lsp_range_from_proto(item.range.context("missing range")?),
+        selection_range: lsp_range_from_proto(
+            item.selection_range.context("missing selection_range")?,
+        ),
+        data: item.data.map(|d| serde_json::from_slice(&d)).transpose()?,
+    })
+}
+
+#[async_trait(?Send)]
+impl LspCommand for PrepareCallHierarchy {
+    type Response = Vec<CallHierarchyItem>;
+    type LspRequest = lsp::request::CallHierarchyPrepare;
+    type ProtoRequest = proto::PrepareCallHierarchy;
+
+    fn display_name(&self) -> &str {
+        "Prepare call hierarchy"
+    }
+
+    fn check_capabilities(&self, capabilities: AdapterServerCapabilities) -> bool {
+        capabilities
+            .server_capabilities
+            .call_hierarchy_provider
+            .is_some()
+    }
+
+    fn to_lsp(
+        &self,
+        path: &Path,
+        _: &Buffer,
+        _: &Arc<LanguageServer>,
+        _: &App,
+    ) -> Result<lsp::CallHierarchyPrepareParams> {
+        Ok(lsp::CallHierarchyPrepareParams {
+            text_document_position_params: make_lsp_text_document_position(path, self.position)?,
+            work_done_progress_params: Default::default(),
+        })
+    }
+
+    async fn response_from_lsp(
+        self,
+        message: Option<Vec<lsp::CallHierarchyItem>>,
+        _lsp_store: Entity<LspStore>,
+        _buffer: Entity<Buffer>,
+        _server_id: LanguageServerId,
+        _cx: AsyncApp,
+    ) -> Result<Vec<CallHierarchyItem>> {
+        Ok(message
+            .unwrap_or_default()
+            .into_iter()
+            .map(CallHierarchyItem::from)
+            .collect())
+    }
+
+    fn to_proto(&self, project_id: u64, buffer: &Buffer) -> proto::PrepareCallHierarchy {
+        proto::PrepareCallHierarchy {
+            project_id,
+            buffer_id: buffer.remote_id().into(),
+            position: Some(serialize_anchor(&buffer.anchor_before(self.position))),
+            version: serialize_version(&buffer.version()),
+        }
+    }
+
+    async fn from_proto(
+        message: proto::PrepareCallHierarchy,
+        _: Entity<LspStore>,
+        buffer: Entity<Buffer>,
+        mut cx: AsyncApp,
+    ) -> Result<Self> {
+        let position = message
+            .position
+            .and_then(deserialize_anchor)
+            .context("invalid position")?;
+        buffer
+            .update(&mut cx, |buffer, _| {
+                buffer.wait_for_version(deserialize_version(&message.version))
+            })
+            .await?;
+        Ok(Self {
+            position: buffer.read_with(&cx, |buffer, _| position.to_point_utf16(buffer)),
+        })
+    }
+
+    fn response_to_proto(
+        response: Vec<CallHierarchyItem>,
+        _lsp_store: &mut LspStore,
+        _peer_id: PeerId,
+        _: &clock::Global,
+        _cx: &mut App,
+    ) -> proto::PrepareCallHierarchyResponse {
+        proto::PrepareCallHierarchyResponse {
+            items: response
+                .into_iter()
+                .map(call_hierarchy_item_to_proto)
+                .collect(),
+        }
+    }
+
+    async fn response_from_proto(
+        self,
+        message: proto::PrepareCallHierarchyResponse,
+        _lsp_store: Entity<LspStore>,
+        _: Entity<Buffer>,
+        _cx: AsyncApp,
+    ) -> Result<Vec<CallHierarchyItem>> {
+        message
+            .items
+            .into_iter()
+            .map(call_hierarchy_item_from_proto)
+            .collect::<Result<Vec<_>>>()
+    }
+
+    fn buffer_id_from_proto(message: &proto::PrepareCallHierarchy) -> Result<BufferId> {
+        BufferId::new(message.buffer_id)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IncomingCall {
+    pub from: CallHierarchyItem,
+    pub from_ranges: Vec<Range<Unclipped<PointUtf16>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct OutgoingCall {
+    pub to: CallHierarchyItem,
+    pub from_ranges: Vec<Range<Unclipped<PointUtf16>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GetIncomingCalls {
+    pub item: CallHierarchyItem,
+}
+
+pub fn incoming_call_to_proto(call: IncomingCall) -> proto::CallHierarchyIncomingCall {
+    proto::CallHierarchyIncomingCall {
+        from: Some(call_hierarchy_item_to_proto(call.from)),
+        from_ranges: call
+            .from_ranges
+            .into_iter()
+            .map(lsp_range_to_proto)
+            .collect(),
+    }
+}
+
+pub fn incoming_call_from_proto(call: proto::CallHierarchyIncomingCall) -> Result<IncomingCall> {
+    Ok(IncomingCall {
+        from: call_hierarchy_item_from_proto(call.from.context("missing from")?)?,
+        from_ranges: call
+            .from_ranges
+            .into_iter()
+            .map(lsp_range_from_proto)
+            .collect(),
+    })
+}
+
+#[async_trait(?Send)]
+impl LspCommand for GetIncomingCalls {
+    type Response = Vec<IncomingCall>;
+    type LspRequest = lsp::request::CallHierarchyIncomingCalls;
+    type ProtoRequest = proto::GetIncomingCalls;
+
+    fn display_name(&self) -> &str {
+        "Get incoming calls"
+    }
+
+    fn check_capabilities(&self, capabilities: AdapterServerCapabilities) -> bool {
+        capabilities
+            .server_capabilities
+            .call_hierarchy_provider
+            .is_some()
+    }
+
+    fn to_lsp(
+        &self,
+        _path: &Path,
+        _buffer: &Buffer,
+        _language_server: &Arc<LanguageServer>,
+        _cx: &App,
+    ) -> Result<lsp::CallHierarchyIncomingCallsParams> {
+        Ok(lsp::CallHierarchyIncomingCallsParams {
+            item: self.item.clone().into(),
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+    }
+
+    async fn response_from_lsp(
+        self,
+        message: Option<Vec<lsp::CallHierarchyIncomingCall>>,
+        _lsp_store: Entity<LspStore>,
+        _buffer: Entity<Buffer>,
+        _server_id: LanguageServerId,
+        _cx: AsyncApp,
+    ) -> Result<Vec<IncomingCall>> {
+        Ok(message
+            .unwrap_or_default()
+            .into_iter()
+            .map(|call| IncomingCall {
+                from: CallHierarchyItem::from(call.from),
+                from_ranges: call.from_ranges.into_iter().map(range_from_lsp).collect(),
+            })
+            .collect())
+    }
+
+    fn to_proto(&self, project_id: u64, _buffer: &Buffer) -> proto::GetIncomingCalls {
+        proto::GetIncomingCalls {
+            project_id,
+            item: Some(call_hierarchy_item_to_proto(self.item.clone())),
+        }
+    }
+
+    async fn from_proto(
+        message: proto::GetIncomingCalls,
+        _lsp_store: Entity<LspStore>,
+        _buffer: Entity<Buffer>,
+        _cx: AsyncApp,
+    ) -> Result<Self> {
+        Ok(Self {
+            item: call_hierarchy_item_from_proto(message.item.context("missing item")?)?,
+        })
+    }
+
+    fn response_to_proto(
+        response: Vec<IncomingCall>,
+        _lsp_store: &mut LspStore,
+        _peer_id: PeerId,
+        _buffer_version: &clock::Global,
+        _cx: &mut App,
+    ) -> proto::GetIncomingCallsResponse {
+        proto::GetIncomingCallsResponse {
+            calls: response.into_iter().map(incoming_call_to_proto).collect(),
+        }
+    }
+
+    async fn response_from_proto(
+        self,
+        message: proto::GetIncomingCallsResponse,
+        _lsp_store: Entity<LspStore>,
+        _buffer: Entity<Buffer>,
+        _cx: AsyncApp,
+    ) -> Result<Vec<IncomingCall>> {
+        message
+            .calls
+            .into_iter()
+            .map(incoming_call_from_proto)
+            .collect()
+    }
+
+    fn buffer_id_from_proto(_message: &proto::GetIncomingCalls) -> Result<BufferId> {
+        anyhow::bail!("GetIncomingCalls does not use buffer_id")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GetOutgoingCalls {
+    pub item: CallHierarchyItem,
+}
+
+pub fn outgoing_call_to_proto(call: OutgoingCall) -> proto::CallHierarchyOutgoingCall {
+    proto::CallHierarchyOutgoingCall {
+        to: Some(call_hierarchy_item_to_proto(call.to)),
+        from_ranges: call
+            .from_ranges
+            .into_iter()
+            .map(lsp_range_to_proto)
+            .collect(),
+    }
+}
+
+pub fn outgoing_call_from_proto(call: proto::CallHierarchyOutgoingCall) -> Result<OutgoingCall> {
+    Ok(OutgoingCall {
+        to: call_hierarchy_item_from_proto(call.to.context("missing to")?)?,
+        from_ranges: call
+            .from_ranges
+            .into_iter()
+            .map(lsp_range_from_proto)
+            .collect(),
+    })
+}
+
+#[async_trait(?Send)]
+impl LspCommand for GetOutgoingCalls {
+    type Response = Vec<OutgoingCall>;
+    type LspRequest = lsp::request::CallHierarchyOutgoingCalls;
+    type ProtoRequest = proto::GetOutgoingCalls;
+
+    fn display_name(&self) -> &str {
+        "Get outgoing calls"
+    }
+
+    fn check_capabilities(&self, capabilities: AdapterServerCapabilities) -> bool {
+        capabilities
+            .server_capabilities
+            .call_hierarchy_provider
+            .is_some()
+    }
+
+    fn to_lsp(
+        &self,
+        _path: &Path,
+        _buffer: &Buffer,
+        _language_server: &Arc<LanguageServer>,
+        _cx: &App,
+    ) -> Result<lsp::CallHierarchyOutgoingCallsParams> {
+        Ok(lsp::CallHierarchyOutgoingCallsParams {
+            item: self.item.clone().into(),
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        })
+    }
+
+    async fn response_from_lsp(
+        self,
+        message: Option<Vec<lsp::CallHierarchyOutgoingCall>>,
+        _lsp_store: Entity<LspStore>,
+        _buffer: Entity<Buffer>,
+        _server_id: LanguageServerId,
+        _cx: AsyncApp,
+    ) -> Result<Vec<OutgoingCall>> {
+        Ok(message
+            .unwrap_or_default()
+            .into_iter()
+            .map(|call| OutgoingCall {
+                to: CallHierarchyItem::from(call.to),
+                from_ranges: call.from_ranges.into_iter().map(range_from_lsp).collect(),
+            })
+            .collect())
+    }
+
+    fn to_proto(&self, project_id: u64, _buffer: &Buffer) -> proto::GetOutgoingCalls {
+        proto::GetOutgoingCalls {
+            project_id,
+            item: Some(call_hierarchy_item_to_proto(self.item.clone())),
+        }
+    }
+
+    async fn from_proto(
+        message: proto::GetOutgoingCalls,
+        _lsp_store: Entity<LspStore>,
+        _buffer: Entity<Buffer>,
+        _cx: AsyncApp,
+    ) -> Result<Self> {
+        Ok(Self {
+            item: call_hierarchy_item_from_proto(message.item.context("missing item")?)?,
+        })
+    }
+
+    fn response_to_proto(
+        response: Vec<OutgoingCall>,
+        _lsp_store: &mut LspStore,
+        _peer_id: PeerId,
+        _buffer_version: &clock::Global,
+        _cx: &mut App,
+    ) -> proto::GetOutgoingCallsResponse {
+        proto::GetOutgoingCallsResponse {
+            calls: response.into_iter().map(outgoing_call_to_proto).collect(),
+        }
+    }
+
+    async fn response_from_proto(
+        self,
+        message: proto::GetOutgoingCallsResponse,
+        _lsp_store: Entity<LspStore>,
+        _buffer: Entity<Buffer>,
+        _cx: AsyncApp,
+    ) -> Result<Vec<OutgoingCall>> {
+        message
+            .calls
+            .into_iter()
+            .map(outgoing_call_from_proto)
+            .collect()
+    }
+
+    fn buffer_id_from_proto(_message: &proto::GetOutgoingCalls) -> Result<BufferId> {
+        anyhow::bail!("GetOutgoingCalls does not use buffer_id")
+    }
+}
+
 #[async_trait(?Send)]
 impl LspCommand for PrepareRename {
     type Response = PrepareRenameResponse;

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -129,6 +129,7 @@ use std::{
     path::{self, Path, PathBuf},
     pin::pin,
     rc::Rc,
+    str::FromStr,
     sync::{
         Arc,
         atomic::{self, AtomicUsize},
@@ -6553,6 +6554,165 @@ impl LspStore {
         }
     }
 
+    pub fn prepare_call_hierarchy(
+        &mut self,
+        buffer: &Entity<Buffer>,
+        position: PointUtf16,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Option<Vec<CallHierarchyItem>>>> {
+        if let Some((upstream_client, project_id)) = self.upstream_client() {
+            let request = PrepareCallHierarchy { position };
+            if !self.is_capable_for_proto_request(buffer, &request, cx) {
+                return Task::ready(Ok(None));
+            }
+            let request_task = upstream_client.request_lsp(
+                project_id,
+                None,
+                DEFAULT_LSP_REQUEST_TIMEOUT,
+                cx.background_executor().clone(),
+                request.to_proto(project_id, buffer.read(cx)),
+            );
+            cx.background_spawn(async move {
+                let Some(responses) = request_task.await? else {
+                    return Ok(None);
+                };
+                let items = responses
+                    .payload
+                    .into_iter()
+                    .flat_map(|response| {
+                        response
+                            .response
+                            .items
+                            .into_iter()
+                            .filter_map(|item| call_hierarchy_item_from_proto(item).ok())
+                    })
+                    .collect();
+                Ok(Some(items))
+            })
+        } else {
+            let task = self.request_multiple_lsp_locally(
+                buffer,
+                Some(position),
+                PrepareCallHierarchy { position },
+                cx,
+            );
+            cx.background_spawn(async move {
+                Ok(Some(
+                    task.await
+                        .into_iter()
+                        .flat_map(|(_, items)| items)
+                        .collect(),
+                ))
+            })
+        }
+    }
+
+    pub fn incoming_calls(
+        &mut self,
+        buffer: &Entity<Buffer>,
+        item: CallHierarchyItem,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Option<Vec<IncomingCall>>>> {
+        if let Some((upstream_client, project_id)) = self.upstream_client() {
+            let request = GetIncomingCalls { item };
+            if !self.is_capable_for_proto_request(buffer, &request, cx) {
+                return Task::ready(Ok(None));
+            }
+            let request_task = upstream_client.request_lsp(
+                project_id,
+                None,
+                DEFAULT_LSP_REQUEST_TIMEOUT,
+                cx.background_executor().clone(),
+                request.to_proto(project_id, buffer.read(cx)),
+            );
+            cx.background_spawn(async move {
+                let Some(responses) = request_task.await? else {
+                    return Ok(None);
+                };
+                let calls = responses
+                    .payload
+                    .into_iter()
+                    .flat_map(|response| {
+                        response
+                            .response
+                            .calls
+                            .into_iter()
+                            .filter_map(|call| incoming_call_from_proto(call).ok())
+                    })
+                    .collect();
+                Ok(Some(calls))
+            })
+        } else {
+            let task = self.request_multiple_lsp_locally(
+                buffer,
+                None::<PointUtf16>,
+                GetIncomingCalls { item },
+                cx,
+            );
+            cx.background_spawn(async move {
+                Ok(Some(
+                    task.await
+                        .into_iter()
+                        .flat_map(|(_, calls)| calls)
+                        .collect(),
+                ))
+            })
+        }
+    }
+
+    pub fn outgoing_calls(
+        &mut self,
+        buffer: &Entity<Buffer>,
+        item: CallHierarchyItem,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Option<Vec<OutgoingCall>>>> {
+        if let Some((upstream_client, project_id)) = self.upstream_client() {
+            let request = GetOutgoingCalls { item };
+            if !self.is_capable_for_proto_request(buffer, &request, cx) {
+                return Task::ready(Ok(None));
+            }
+            let request_task = upstream_client.request_lsp(
+                project_id,
+                None,
+                DEFAULT_LSP_REQUEST_TIMEOUT,
+                cx.background_executor().clone(),
+                request.to_proto(project_id, buffer.read(cx)),
+            );
+            cx.background_spawn(async move {
+                let Some(responses) = request_task.await? else {
+                    return Ok(None);
+                };
+                let calls = responses
+                    .payload
+                    .into_iter()
+                    .flat_map(|response| {
+                        response
+                            .response
+                            .calls
+                            .into_iter()
+                            .filter_map(|call| outgoing_call_from_proto(call).ok())
+                    })
+                    .collect();
+                Ok(Some(calls))
+            })
+        } else {
+            let task = self.request_multiple_lsp_locally(
+                buffer,
+                None::<PointUtf16>,
+                GetOutgoingCalls { item },
+                cx,
+            );
+            cx.background_spawn(async move {
+                Ok(Some(
+                    task.await
+                        .into_iter()
+                        .flat_map(|(_, calls)| calls)
+                        .collect(),
+                ))
+            })
+        }
+    }
+
     pub fn code_actions(
         &mut self,
         buffer: &Entity<Buffer>,
@@ -9677,6 +9837,58 @@ impl LspStore {
                 )
                 .await
                 .context("querying for inlay hints")?
+            }
+            Request::PrepareCallHierarchy(prepare_call_hierarchy) => {
+                let position = prepare_call_hierarchy
+                    .position
+                    .clone()
+                    .and_then(deserialize_anchor);
+                Self::query_lsp_locally::<PrepareCallHierarchy>(
+                    lsp_store,
+                    server_id,
+                    sender_id,
+                    lsp_request_id,
+                    prepare_call_hierarchy,
+                    position,
+                    &mut cx,
+                )
+                .await?;
+            }
+            Request::GetIncomingCalls(get_incoming_calls) => {
+                let uri = get_incoming_calls
+                    .item
+                    .as_ref()
+                    .map(|item| lsp::Uri::from_str(&item.uri))
+                    .transpose()?
+                    .context("missing item uri")?;
+                Self::query_call_hierarchy_locally::<GetIncomingCalls>(
+                    lsp_store,
+                    server_id,
+                    sender_id,
+                    lsp_request_id,
+                    get_incoming_calls,
+                    uri,
+                    &mut cx,
+                )
+                .await?;
+            }
+            Request::GetOutgoingCalls(get_outgoing_calls) => {
+                let uri = get_outgoing_calls
+                    .item
+                    .as_ref()
+                    .map(|item| lsp::Uri::from_str(&item.uri))
+                    .transpose()?
+                    .context("missing item uri")?;
+                Self::query_call_hierarchy_locally::<GetOutgoingCalls>(
+                    lsp_store,
+                    server_id,
+                    sender_id,
+                    lsp_request_id,
+                    get_outgoing_calls,
+                    uri,
+                    &mut cx,
+                )
+                .await?;
             }
             //////////////////////////////
             // Below are LSP queries that need to fetch more data,
@@ -13898,6 +14110,98 @@ impl LspStore {
             .await?;
         let buffer_version = buffer.read_with(cx, |buffer, _| buffer.version());
         Ok((buffer_version, buffer))
+    }
+
+    async fn query_call_hierarchy_locally<T>(
+        lsp_store: Entity<Self>,
+        for_server_id: Option<LanguageServerId>,
+        sender_id: proto::PeerId,
+        lsp_request_id: LspRequestId,
+        proto_request: T::ProtoRequest,
+        uri: lsp::Uri,
+        cx: &mut AsyncApp,
+    ) -> Result<()>
+    where
+        T: LspCommand + Clone,
+        T::ProtoRequest: proto::LspRequestMessage,
+        <T::ProtoRequest as proto::RequestMessage>::Response:
+            Into<<T::ProtoRequest as proto::LspRequestMessage>::Response>,
+    {
+        let server_id = for_server_id.context("server_id required for call hierarchy queries")?;
+
+        let buffer = lsp_store
+            .update(cx, |lsp_store, cx| {
+                lsp_store.open_local_buffer_via_lsp(uri, server_id, cx)
+            })
+            .await?;
+
+        let buffer_version = buffer.read_with(cx, |buffer, _| buffer.version());
+        let request =
+            T::from_proto(proto_request, lsp_store.clone(), buffer.clone(), cx.clone()).await?;
+        let key = LspKey {
+            request_type: TypeId::of::<T>(),
+            server_queried: Some(server_id),
+        };
+
+        lsp_store.update(cx, |lsp_store, cx| {
+            let server_task = lsp_store.request_lsp(
+                buffer.clone(),
+                LanguageServerToQuery::Other(server_id),
+                request.clone(),
+                cx,
+            );
+            let request_task = cx.background_spawn(async move {
+                let mut responses = Vec::new();
+                match server_task.await {
+                    Ok(response) => responses.push((server_id, response)),
+                    Err(e) if format!("{e:#}").ends_with("content modified") => (),
+                    Err(e) => log::error!("Error handling response for request {request:?}: {e:#}"),
+                }
+                responses
+            });
+
+            let lsp_data = lsp_store.latest_lsp_data(&buffer, cx);
+            lsp_data.lsp_requests.entry(key).or_default().insert(
+                lsp_request_id,
+                cx.spawn(async move |lsp_store, cx| {
+                    let response = request_task.await;
+                    lsp_store
+                        .update(cx, |lsp_store, cx| {
+                            if let Some((client, project_id)) = lsp_store.downstream_client.clone()
+                            {
+                                let response = response
+                                    .into_iter()
+                                    .map(|(server_id, response)| {
+                                        (
+                                            server_id.to_proto(),
+                                            T::response_to_proto(
+                                                response,
+                                                lsp_store,
+                                                sender_id,
+                                                &buffer_version,
+                                                cx,
+                                            )
+                                            .into(),
+                                        )
+                                    })
+                                    .collect::<HashMap<_, _>>();
+                                match client.send_lsp_response::<T::ProtoRequest>(
+                                    project_id,
+                                    lsp_request_id,
+                                    response,
+                                ) {
+                                    Ok(()) => {}
+                                    Err(e) => {
+                                        log::error!("Failed to send LSP response: {e:#}",)
+                                    }
+                                }
+                            }
+                        })
+                        .ok();
+                }),
+            );
+        });
+        Ok(())
     }
 
     fn take_text_document_sync_options(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -162,6 +162,7 @@ pub use task_inventory::{
 };
 
 pub use buffer_store::ProjectTransaction;
+pub use lsp_command::{CallHierarchyItem, IncomingCall, OutgoingCall};
 pub use lsp_store::{
     DiagnosticSummary, InvalidationStrategy, LanguageServerLogType, LanguageServerProgress,
     LanguageServerPromptRequest, LanguageServerStatus, LanguageServerToQuery, LspStore,
@@ -4385,6 +4386,58 @@ impl Project {
         let guard = self.retain_remotely_created_models(cx);
         let task = self.lsp_store.update(cx, |lsp_store, cx| {
             lsp_store.references(buffer, position, cx)
+        });
+        cx.background_spawn(async move {
+            let result = task.await;
+            drop(guard);
+            result
+        })
+    }
+
+    pub fn prepare_call_hierarchy<T: ToPointUtf16>(
+        &mut self,
+        buffer: &Entity<Buffer>,
+        position: T,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Option<Vec<CallHierarchyItem>>>> {
+        let position = position.to_point_utf16(buffer.read(cx));
+        let guard = self.retain_remotely_created_models(cx);
+        let task = self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.prepare_call_hierarchy(buffer, position, cx)
+        });
+        cx.background_spawn(async move {
+            let result = task.await;
+            drop(guard);
+            result
+        })
+    }
+
+    pub fn incoming_calls(
+        &mut self,
+        buffer: &Entity<Buffer>,
+        item: CallHierarchyItem,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Option<Vec<IncomingCall>>>> {
+        let guard = self.retain_remotely_created_models(cx);
+        let task = self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.incoming_calls(buffer, item, cx)
+        });
+        cx.background_spawn(async move {
+            let result = task.await;
+            drop(guard);
+            result
+        })
+    }
+
+    pub fn outgoing_calls(
+        &mut self,
+        buffer: &Entity<Buffer>,
+        item: CallHierarchyItem,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Option<Vec<OutgoingCall>>>> {
+        let guard = self.retain_remotely_created_models(cx);
+        let task = self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.outgoing_calls(buffer, item, cx)
         });
         cx.background_spawn(async move {
             let result = task.await;

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -87,6 +87,62 @@ message DocumentHighlight {
   }
 }
 
+message LspRange {
+    uint32 start_line = 1;
+    uint32 start_column = 2;
+    uint32 end_line = 3;
+    uint32 end_column = 4;
+}
+
+message CallHierarchyItem {
+    string name = 1;
+    int32 kind = 2;
+    optional string detail = 3;
+    string uri = 4;
+    LspRange range = 5;
+    LspRange selection_range = 6;
+    optional bytes data = 7;
+}
+
+message CallHierarchyIncomingCall {
+    CallHierarchyItem from = 1;
+    repeated LspRange from_ranges = 2;
+}
+
+message CallHierarchyOutgoingCall {
+    CallHierarchyItem to = 1;
+    repeated LspRange from_ranges = 2;
+}
+
+message PrepareCallHierarchy {
+    uint64 project_id = 1;
+    uint64 buffer_id = 2;
+    Anchor position = 3;
+    repeated VectorClockEntry version = 4;
+}
+
+message PrepareCallHierarchyResponse {
+    repeated CallHierarchyItem items = 1;
+}
+
+message GetIncomingCalls {
+    uint64 project_id = 1;
+    CallHierarchyItem item = 2;
+}
+
+message GetIncomingCallsResponse {
+    repeated CallHierarchyIncomingCall calls = 1;
+}
+
+message GetOutgoingCalls {
+    uint64 project_id = 1;
+    CallHierarchyItem item = 2;
+}
+
+message GetOutgoingCallsResponse {
+    repeated CallHierarchyOutgoingCall calls = 1;
+}
+
 message GetProjectSymbols {
   uint64 project_id = 1;
   string query = 2;
@@ -897,6 +953,9 @@ message LspQuery {
     GetFoldingRanges get_folding_ranges = 17;
     GetDocumentSymbols get_document_symbols = 18;
     GetDocumentLinks get_document_links = 19;
+    PrepareCallHierarchy prepare_call_hierarchy = 20;
+    GetIncomingCalls get_incoming_calls = 21;
+    GetOutgoingCalls get_outgoing_calls = 22;
   }
 }
 
@@ -924,6 +983,9 @@ message LspResponse {
     GetFoldingRangesResponse get_folding_ranges_response = 15;
     GetDocumentSymbolsResponse get_document_symbols_response = 16;
     GetDocumentLinksResponse get_document_links_response = 17;
+    PrepareCallHierarchyResponse prepare_call_hierarchy_response = 18;
+    GetIncomingCallsResponse get_incoming_calls_response = 19;
+    GetOutgoingCallsResponse get_outgoing_calls_response = 20;
   }
   uint64 server_id = 7;
 }

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -489,7 +489,14 @@ message Envelope {
     GitWorktreeCreatedAtResponse git_worktree_created_at_response = 458;
     TelemetryEvent telemetry_event = 459;
     ResolveCodeAction resolve_code_action = 460;
-    ResolveCodeActionResponse resolve_code_action_response = 461; // current max
+    ResolveCodeActionResponse resolve_code_action_response = 461;
+
+    PrepareCallHierarchy prepare_call_hierarchy = 462;
+    PrepareCallHierarchyResponse prepare_call_hierarchy_response = 463;
+    GetIncomingCalls get_incoming_calls = 464;
+    GetIncomingCallsResponse get_incoming_calls_response = 465;
+    GetOutgoingCalls get_outgoing_calls = 466;
+    GetOutgoingCallsResponse get_outgoing_calls_response = 467; // current max
   }
 
   reserved 87 to 88;

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -120,6 +120,10 @@ messages!(
     (GetTypeDefinitionResponse, Background),
     (GetImplementation, Background),
     (GetImplementationResponse, Background),
+    (GetIncomingCalls, Background),
+    (GetIncomingCallsResponse, Background),
+    (GetOutgoingCalls, Background),
+    (GetOutgoingCallsResponse, Background),
     (OpenUnstagedDiff, Foreground),
     (OpenUnstagedDiffResponse, Foreground),
     (OpenUncommittedDiff, Foreground),
@@ -193,6 +197,8 @@ messages!(
     (PerformRename, Background),
     (PerformRenameResponse, Background),
     (Ping, Foreground),
+    (PrepareCallHierarchy, Background),
+    (PrepareCallHierarchyResponse, Background),
     (PrepareRename, Background),
     (PrepareRenameResponse, Background),
     (ProjectEntryResponse, Foreground),
@@ -454,6 +460,9 @@ request_messages!(
     (OpenNewBuffer, OpenBufferResponse),
     (PerformRename, PerformRenameResponse),
     (Ping, Ack),
+    (PrepareCallHierarchy, PrepareCallHierarchyResponse),
+    (GetIncomingCalls, GetIncomingCallsResponse),
+    (GetOutgoingCalls, GetOutgoingCallsResponse),
     (PrepareRename, PrepareRenameResponse),
     (RefreshInlayHints, Ack),
     (RefreshSemanticTokens, Ack),
@@ -614,8 +623,57 @@ lsp_messages!(
     (GetTypeDefinition, GetTypeDefinitionResponse, true),
     (GetImplementation, GetImplementationResponse, true),
     (InlayHints, InlayHintsResponse, false),
-    (SemanticTokens, SemanticTokensResponse, true)
+    (SemanticTokens, SemanticTokensResponse, true),
+    (PrepareCallHierarchy, PrepareCallHierarchyResponse, true),
 );
+
+impl LspRequestMessage for GetIncomingCalls {
+    type Response = GetIncomingCallsResponse;
+
+    fn to_proto_query(self) -> lsp_query::Request {
+        lsp_query::Request::GetIncomingCalls(self)
+    }
+
+    fn response_to_proto_query(response: Self::Response) -> lsp_response::Response {
+        lsp_response::Response::GetIncomingCallsResponse(response)
+    }
+
+    fn buffer_id(&self) -> u64 {
+        0
+    }
+
+    fn buffer_version(&self) -> &[VectorClockEntry] {
+        &[]
+    }
+
+    fn stop_previous_requests() -> bool {
+        true
+    }
+}
+
+impl LspRequestMessage for GetOutgoingCalls {
+    type Response = GetOutgoingCallsResponse;
+
+    fn to_proto_query(self) -> lsp_query::Request {
+        lsp_query::Request::GetOutgoingCalls(self)
+    }
+
+    fn response_to_proto_query(response: Self::Response) -> lsp_response::Response {
+        lsp_response::Response::GetOutgoingCallsResponse(response)
+    }
+
+    fn buffer_id(&self) -> u64 {
+        0
+    }
+
+    fn buffer_version(&self) -> &[VectorClockEntry] {
+        &[]
+    }
+
+    fn stop_previous_requests() -> bool {
+        true
+    }
+}
 
 entity_messages!(
     {project_id, ShareProject},
@@ -997,6 +1055,9 @@ impl LspQuery {
             Some(lsp_query::Request::GetDocumentLinks(_)) => ("GetDocumentLinks", false),
             Some(lsp_query::Request::InlayHints(_)) => ("InlayHints", false),
             Some(lsp_query::Request::SemanticTokens(_)) => ("SemanticTokens", false),
+            Some(lsp_query::Request::PrepareCallHierarchy(_)) => ("PrepareCallHierarchy", false),
+            Some(lsp_query::Request::GetIncomingCalls(_)) => ("GetIncomingCalls", false),
+            Some(lsp_query::Request::GetOutgoingCalls(_)) => ("GetOutgoingCalls", false),
             None => ("<unknown>", true),
         }
     }

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -888,6 +888,167 @@ async fn test_remote_lsp(cx: &mut TestAppContext, server_cx: &mut TestAppContext
 }
 
 #[gpui::test]
+async fn test_remote_call_hierarchy(cx: &mut TestAppContext, server_cx: &mut TestAppContext) {
+    let fs = FakeFs::new(server_cx.executor());
+    fs.insert_tree(
+        path!("/code"),
+        json!({
+            "project1": {
+                ".git": {},
+                "src": {
+                    "lib.rs": "fn main() { helper(); }\nfn helper() {}\n"
+                }
+            },
+        }),
+    )
+    .await;
+
+    let (project, headless) = init_test(&fs, cx, server_cx).await;
+
+    fs.insert_tree(
+        path!("/code/project1/.zed"),
+        json!({
+            "settings.json": r#"
+          {
+            "languages": {"Rust":{"language_servers":["rust-analyzer"]}},
+            "lsp": {
+              "rust-analyzer": {
+                "binary": {
+                  "path": "~/.cargo/bin/rust-analyzer"
+                }
+              }
+            }
+          }"#
+        }),
+    )
+    .await;
+
+    cx.update_entity(&project, |project, _| {
+        project.languages().register_test_language(LanguageConfig {
+            name: "Rust".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["rs".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        project.languages().register_fake_lsp_adapter(
+            "Rust",
+            FakeLspAdapter {
+                name: "rust-analyzer",
+                capabilities: lsp::ServerCapabilities {
+                    call_hierarchy_provider: Some(lsp::CallHierarchyServerCapability::Simple(true)),
+                    ..Default::default()
+                },
+                ..FakeLspAdapter::default()
+            },
+        )
+    });
+
+    let mut fake_lsp = server_cx.update(|cx| {
+        headless.read(cx).languages.register_fake_lsp_server(
+            LanguageServerName("rust-analyzer".into()),
+            lsp::ServerCapabilities {
+                call_hierarchy_provider: Some(lsp::CallHierarchyServerCapability::Simple(true)),
+                ..Default::default()
+            },
+            None,
+        )
+    });
+
+    cx.run_until_parked();
+
+    let worktree_id = project
+        .update(cx, |project, cx| {
+            project.languages().add(rust_lang());
+            project.find_or_create_worktree(path!("/code/project1"), true, cx)
+        })
+        .await
+        .unwrap()
+        .0
+        .read_with(cx, |worktree, _| worktree.id());
+
+    cx.run_until_parked();
+
+    let (buffer, _handle) = project
+        .update(cx, |project, cx| {
+            project.open_buffer_with_lsp((worktree_id, rel_path("src/lib.rs")), cx)
+        })
+        .await
+        .unwrap();
+
+    cx.run_until_parked();
+
+    let fake_lsp = fake_lsp.next().await.unwrap();
+    let test_uri = lsp::Uri::from_file_path(path!("/code/project1/src/lib.rs")).unwrap();
+
+    fake_lsp.set_request_handler::<lsp::request::CallHierarchyPrepare, _, _>({
+        let uri = test_uri.clone();
+        move |_, _| {
+            let uri = uri.clone();
+            async move {
+                Ok(Some(vec![lsp::CallHierarchyItem {
+                    name: "main".into(),
+                    kind: lsp::SymbolKind::FUNCTION,
+                    tags: None,
+                    detail: Some("fn main()".into()),
+                    uri,
+                    range: lsp::Range::new(lsp::Position::new(0, 0), lsp::Position::new(0, 21)),
+                    selection_range: lsp::Range::new(
+                        lsp::Position::new(0, 3),
+                        lsp::Position::new(0, 7),
+                    ),
+                    data: None,
+                }]))
+            }
+        }
+    });
+
+    fake_lsp.set_request_handler::<lsp::request::CallHierarchyOutgoingCalls, _, _>({
+        move |_, _| {
+            let uri = test_uri.clone();
+            async move {
+                Ok(Some(vec![lsp::CallHierarchyOutgoingCall {
+                    to: lsp::CallHierarchyItem {
+                        name: "helper".into(),
+                        kind: lsp::SymbolKind::FUNCTION,
+                        tags: None,
+                        detail: Some("fn helper()".into()),
+                        uri,
+                        range: lsp::Range::new(lsp::Position::new(1, 0), lsp::Position::new(1, 13)),
+                        selection_range: lsp::Range::new(
+                            lsp::Position::new(1, 3),
+                            lsp::Position::new(1, 9),
+                        ),
+                        data: None,
+                    },
+                    from_ranges: vec![],
+                }]))
+            }
+        }
+    });
+
+    let items = project
+        .update(cx, |project, cx| {
+            project.prepare_call_hierarchy(&buffer, PointUtf16::new(0, 3), cx)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].name, "main");
+
+    let outgoing_calls = project
+        .update(cx, |project, cx| {
+            project.outgoing_calls(&buffer, items[0].clone(), cx)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(outgoing_calls.len(), 1);
+    assert_eq!(outgoing_calls[0].to.name, "helper");
+}
+#[gpui::test]
 async fn test_remote_code_action_resolve(cx: &mut TestAppContext, server_cx: &mut TestAppContext) {
     cx.update(|cx| {
         let settings_store = SettingsStore::test(cx);
@@ -1345,7 +1506,6 @@ async fn test_remote_code_lens_resolve(cx: &mut TestAppContext, server_cx: &mut 
         assert_eq!(item.label(), "1 reference");
     });
 }
-
 #[gpui::test]
 async fn test_remote_cancel_language_server_work(
     cx: &mut TestAppContext,

--- a/crates/rpc/src/proto_client.rs
+++ b/crates/rpc/src/proto_client.rs
@@ -420,6 +420,15 @@ impl AnyProtoClient {
                             Response::GetDocumentLinksResponse(response) => {
                                 to_any_envelope(&envelope, response)
                             }
+                            Response::PrepareCallHierarchyResponse(response) => {
+                                to_any_envelope(&envelope, response)
+                            }
+                            Response::GetIncomingCallsResponse(response) => {
+                                to_any_envelope(&envelope, response)
+                            }
+                            Response::GetOutgoingCallsResponse(response) => {
+                                to_any_envelope(&envelope, response)
+                            }
                         };
                         Some(proto::ProtoLspResponse {
                             server_id,

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -78,6 +78,7 @@ auto_update.workspace = true
 auto_update_ui.workspace = true
 breadcrumbs.workspace = true
 call.workspace = true
+call_hierarchy.workspace = true
 chrono.workspace = true
 channel.workspace = true
 clap.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -741,6 +741,7 @@ fn main() {
         file_finder::init(cx);
         tab_switcher::init(cx);
         outline::init(cx);
+        call_hierarchy::init(cx);
         project_symbols::init(cx);
         project_panel::init(cx);
         outline_panel::init(cx);


### PR DESCRIPTION
# Objective

This is PR 2 of 5 breaking https://github.com/zed-industries/zed/pull/53239 into more digestible chunks, with the aim of closing https://github.com/zed-industries/zed/issues/14203.

This PR is stacked on top of https://github.com/zed-industries/zed/pull/60885 and https://github.com/swiftcoder/zed/pull/3

## Solution

Add the call_hierarchy crate with picker UI for incoming/outgoing calls and
shared helpers used by the panel.

## Testing

I conducted manual testing of the complete PR stack.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable
