### PR TITLE
gpui_web: Only cancel the native context menu when the app claims the right-click

### DIFF
--- a/crates/gpui_web/src/events.rs
+++ b/crates/gpui_web/src/events.rs
@@ -150,13 +150,21 @@ impl WebWindowInner {
                 current_state.modifiers = modifiers;
             }
 
-            this.dispatch_input(PlatformInput::MouseDown(MouseDownEvent {
+            let result = this.dispatch_input(PlatformInput::MouseDown(MouseDownEvent {
                 button,
                 position,
                 modifiers,
                 click_count,
                 first_mouse: false,
             }));
+
+            // The browser fires `contextmenu` after this event; remember whether
+            // the app claimed the right-click (e.g. opened its own menu) so the
+            // contextmenu listener cancels the native menu only in that case.
+            if button == MouseButton::Right {
+                let claimed = result.is_some_and(|result| !result.propagate);
+                this.app_claimed_right_click.set(claimed);
+            }
         })
     }
 
@@ -270,9 +278,12 @@ impl WebWindowInner {
     }
 
     fn register_context_menu(self: &Rc<Self>) -> Closure<dyn FnMut(JsValue)> {
+        let this = Rc::clone(self);
         self.listen("contextmenu", move |event: JsValue| {
             let event: web_sys::Event = event.unchecked_into();
-            event.prevent_default();
+            if this.app_claimed_right_click.replace(false) {
+                event.prevent_default();
+            }
         })
     }
 

--- a/crates/gpui_web/src/window.rs
+++ b/crates/gpui_web/src/window.rs
@@ -55,6 +55,7 @@ pub(crate) struct WebWindowInner {
     pub(crate) last_physical_size: Cell<(u32, u32)>,
     pub(crate) notify_scale: Cell<bool>,
     pub(crate) is_composing: Cell<bool>,
+    pub(crate) app_claimed_right_click: Cell<bool>,
     mql_handle: RefCell<Option<MqlHandle>>,
     pending_physical_size: Cell<Option<(u32, u32)>>,
 }
@@ -182,6 +183,7 @@ impl WebWindow {
             last_physical_size: Cell::new((0, 0)),
             notify_scale: Cell::new(false),
             is_composing: Cell::new(false),
+            app_claimed_right_click: Cell::new(false),
             mql_handle: RefCell::new(None),
             pending_physical_size: Cell::new(None),
         });


### PR DESCRIPTION
# Objective

The contextmenu listener cancelled the browser's native menu unconditionally, so pages hosting a gpui app lost right-click entirely wherever the app showed no menu of its own, and apps that do show one had no native menu to suppress selectively.

## Solution

Record whether the right-button MouseDown dispatch was consumed (a handler called stop_propagation, e.g. to open a custom menu) and cancel the native menu only in that case: app menus win where they exist, the browser menu everywhere else. Apps opening custom context menus should mark the triggering mousedown consumed to opt in.

## Testing

Tested locally

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="816" height="288" alt="context menu" src="https://github.com/user-attachments/assets/c79cd2ef-d465-4431-8461-7a9feb922576" />


Release Notes:

- N/A
