### PR TITLE
fs: Update trash crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19278,7 +19278,7 @@ dependencies = [
 [[package]]
 name = "trash"
 version = "5.2.5"
-source = "git+https://github.com/zed-industries/trash-rs?rev=3bf27effd4eb8699f2e484d3326b852fe3e53af7#3bf27effd4eb8699f2e484d3326b852fe3e53af7"
+source = "git+https://github.com/zed-industries/trash-rs?rev=47761739192828a66b11a94ba5420b82d63c03c5#47761739192828a66b11a94ba5420b82d63c03c5"
 dependencies = [
  "chrono",
  "libc",

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -44,8 +44,7 @@ time.workspace = true
 util.workspace = true
 is_executable = "1.0.5"
 notify = "9.0.0-rc.4"
-trash = { git = "https://github.com/zed-industries/trash-rs", rev = "3bf27effd4eb8699f2e484d3326b852fe3e53af7" }
-
+trash = { git = "https://github.com/zed-industries/trash-rs", rev = "47761739192828a66b11a94ba5420b82d63c03c5" }
 [target.'cfg(target_os = "windows")'.dependencies]
 windows.workspace = true
 dunce.workspace = true


### PR DESCRIPTION
# Objective

Fix errors in Windows when trashing files from the Git Panel. Closes #60716.

## Solution

The solution and discussion is available at https://github.com/zed-industries/trash-rs/pull/3 , seeing as the fix was fully done on the `trash` crate. Original discussion of this issue can be found at https://github.com/zed-industries/zed/pull/59595 .

## Testing

Testing was performed manually on a Windows machine by updating Zed's `fs` crate dependencies to point at the updated code and then building from source and testing out the same exact path, namely:

1. Create a new untracked file
2. Trash the file from the Git Panel's context menu
3. Confirm that, after confirming that you wish to trash the file, the file is trash and no error is shown

Since this whole trash-tracking logic was implemented in the context of the project panel's undo system, I also confirmed that the changes in the crate's code didn't affect trashing and restoring on Windows. 

## Self-Review Checklist:

N/A

## Showcase

<details>
  <summary>Before</summary>

  https://github.com/user-attachments/assets/120ab3ec-d631-4243-a21e-c510c27ed518
</details>

<details>
  <summary>After</summary>

  https://github.com/user-attachments/assets/7ff1e373-b56d-431f-aad5-d4c5bb301e02
</details>

---

Release Notes:

- Fixed issue when trashing untracked files in Git Panel on Windows