### PR TITLE
Revert "settings_ui: Shrink constraint on minimum window width (#60786)"

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -73,6 +73,9 @@ const HEADER_GROUP_TAB_INDEX: isize = 3;
 const CONTENT_CONTAINER_TAB_INDEX: isize = 4;
 const CONTENT_GROUP_TAB_INDEX: isize = 5;
 
+const SIDEBAR_WIDTH: Pixels = px(226.);
+const CONTENT_MIN_WIDTH: Pixels = px(400.);
+
 actions!(
     settings_editor,
     [
@@ -870,10 +873,11 @@ fn open_settings_editor_with(
                 app_id: Some(app_id.to_owned()),
                 window_decorations: Some(window_decorations),
                 window_min_size: Some(gpui::Size {
-                    // Don't make the settings window thinner than this,
-                    // otherwise, it gets unusable. Users with smaller res monitors
-                    // can customize the height, but not the width.
-                    width: px(900.0),
+                    // Do not make the settings window thinner than this,
+                    // otherwise, the space used to display the actual content
+                    // gets so small that certain sections grow too tall due
+                    // to intense text wrapping.
+                    width: SIDEBAR_WIDTH + CONTENT_MIN_WIDTH,
                     height: px(240.0),
                 }),
                 window_bounds: Some(WindowBounds::centered(scaled_bounds, cx)),
@@ -3134,7 +3138,7 @@ impl SettingsWindow {
                     cx,
                 );
             }))
-            .w_56()
+            .w(SIDEBAR_WIDTH)
             .h_full()
             .p_2p5()
             .when(cfg!(target_os = "macos"), |this| this.pt_10())

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -870,7 +870,10 @@ fn open_settings_editor_with(
                 app_id: Some(app_id.to_owned()),
                 window_decorations: Some(window_decorations),
                 window_min_size: Some(gpui::Size {
-                    width: px(360.0),
+                    // Don't make the settings window thinner than this,
+                    // otherwise, it gets unusable. Users with smaller res monitors
+                    // can customize the height, but not the width.
+                    width: px(900.0),
                     height: px(240.0),
                 }),
                 window_bounds: Some(WindowBounds::centered(scaled_bounds, cx)),


### PR DESCRIPTION
Allowing the settings UI to shrink smaller than that size can easily cause UI states where the whole window becomes unusable. The previously defined 900px size was defined so that those states did not happen. I appreciate how having such minimum size can be a bit of a hassle when the settings window is used with window managers, but given it's such a transient window (i.e., one which you won't always have open all the time) I think it's better to stay on the trade-off side of safety here.

As a quick example, it doesn't make sense to me to allow the UI to reach this state:

<img width="300" alt="Screenshot 2026-07-13 at 9  26@2x" src="https://github.com/user-attachments/assets/f2aebe21-293b-468f-b03e-37cd7305a9c5" />

---

Release Notes:

- N/A
