### PR TITLE
editor: Add recursive fold/unfold via Shift+Click on gutter fold indicators

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1383,6 +1383,142 @@ fn test_fold_action_without_language(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_toggle_fold_at_recursive(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple(
+            &"
+                impl Foo {
+                    fn a() {
+                        if x {
+                            1
+                        }
+                        if y {
+                            2
+                        }
+                    }
+                    fn b() {
+                        3
+                    }
+                }
+            "
+            .unindent(),
+            cx,
+        );
+        build_editor(buffer, window, cx)
+    });
+
+    _ = editor.update(cx, |editor, window, cx| {
+        editor.toggle_fold_at_recursive(MultiBufferRow(0), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                impl Foo {
+                    fn a() {⋯
+                    }
+                    fn b() {⋯
+                    }
+                }
+            "
+            .unindent(),
+        );
+
+        editor.toggle_fold_at_recursive(MultiBufferRow(0), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                impl Foo {⋯
+                }
+            "
+            .unindent(),
+        );
+
+        editor.toggle_fold_at_recursive(MultiBufferRow(0), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            editor.buffer.read(cx).read(cx).text()
+        );
+
+        editor.toggle_fold_at_recursive(MultiBufferRow(0), window, cx);
+        editor.toggle_fold_at_recursive(MultiBufferRow(1), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                impl Foo {
+                    fn a() {
+                        if x {
+                            1
+                        }
+                        if y {
+                            2
+                        }
+                    }
+                    fn b() {⋯
+                    }
+                }
+            "
+            .unindent(),
+        );
+    });
+}
+
+#[gpui::test]
+fn test_fold_at_preserves_nested_fold_state(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let editor = cx.add_window(|window, cx| {
+        let buffer = MultiBuffer::build_simple(
+            &"
+                impl Foo {
+                    fn a() {
+                        if x {
+                            1
+                        }
+                        if y {
+                            2
+                        }
+                    }
+                }
+            "
+            .unindent(),
+            cx,
+        );
+        build_editor(buffer, window, cx)
+    });
+
+    _ = editor.update(cx, |editor, window, cx| {
+        editor.fold_at(MultiBufferRow(2), window, cx);
+        editor.fold_at(MultiBufferRow(0), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                impl Foo {⋯
+                }
+            "
+            .unindent(),
+        );
+
+        editor.unfold_at(MultiBufferRow(0), window, cx);
+        assert_eq!(
+            editor.display_text(cx),
+            "
+                impl Foo {
+                    fn a() {
+                        if x {⋯
+                        }
+                        if y {
+                            2
+                        }
+                    }
+                }
+            "
+            .unindent(),
+        );
+    });
+}
+
+#[gpui::test]
 fn test_fold_action_whitespace_sensitive_language(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/fold.rs
+++ b/crates/editor/src/fold.rs
@@ -59,13 +59,18 @@ impl EditorSnapshot {
             Some(
                 Disclosure::new(("gutter_crease", buffer_row.0), !folded)
                     .toggle_state(folded)
-                    .on_click(window.listener_for(&editor, move |this, _e, window, cx| {
-                        if folded {
-                            this.unfold_at(buffer_row, window, cx);
-                        } else {
-                            this.fold_at(buffer_row, window, cx);
-                        }
-                    }))
+                    .on_click(window.listener_for(
+                        &editor,
+                        move |this, event: &ClickEvent, window, cx| {
+                            if event.modifiers().shift {
+                                this.toggle_fold_at_recursive(buffer_row, window, cx);
+                            } else if folded {
+                                this.unfold_at(buffer_row, window, cx);
+                            } else {
+                                this.fold_at(buffer_row, window, cx);
+                            }
+                        },
+                    ))
                     .into_any_element(),
             )
         } else {
@@ -437,6 +442,70 @@ impl Editor {
                 .any(|selection| crease.range().overlaps(&selection.range()));
 
             self.fold_creases(vec![crease], autoscroll, window, cx);
+        }
+    }
+
+    /// Recursively toggles the fold at the given row: folds all unfolded
+    /// descendants of an unfolded region (or the region itself if there are
+    /// none), and unfolds a folded region together with all folds inside it.
+    pub fn toggle_fold_at_recursive(
+        &mut self,
+        buffer_row: MultiBufferRow,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
+
+        if display_map.is_line_folded(buffer_row) {
+            let buffer_snapshot = display_map.buffer_snapshot();
+            let mut unfold_range = Point::new(buffer_row.0, 0)
+                ..Point::new(buffer_row.0, buffer_snapshot.line_len(buffer_row));
+            // Folds on this line start at its end, so query into the next row
+            // to include them.
+            let query_range = Point::new(buffer_row.0, 0)
+                ..buffer_snapshot.clip_point(Point::new(buffer_row.0 + 1, 0), Bias::Left);
+            for fold in display_map.folds_in_range(query_range) {
+                unfold_range.start = unfold_range
+                    .start
+                    .min(fold.range.start.to_point(buffer_snapshot));
+                unfold_range.end = unfold_range
+                    .end
+                    .max(fold.range.end.to_point(buffer_snapshot));
+            }
+
+            let autoscroll = self
+                .selections
+                .all::<Point>(&display_map)
+                .iter()
+                .any(|selection| unfold_range.overlaps(&selection.range()));
+
+            self.unfold_ranges(&[unfold_range], true, autoscroll, cx);
+        } else {
+            let Some(crease) = display_map.crease_for_buffer_row(buffer_row) else {
+                return;
+            };
+            let crease_range = crease.range().clone();
+
+            let mut to_fold = Vec::new();
+            for row in crease_range.start.row + 1..=crease_range.end.row {
+                let row = MultiBufferRow(row);
+                if !display_map.is_line_folded(row)
+                    && let Some(inner_crease) = display_map.crease_for_buffer_row(row)
+                {
+                    to_fold.push(inner_crease);
+                }
+            }
+            if to_fold.is_empty() {
+                to_fold.push(crease);
+            }
+
+            let autoscroll = self
+                .selections
+                .all::<Point>(&display_map)
+                .iter()
+                .any(|selection| crease_range.overlaps(&selection.range()));
+
+            self.fold_creases(to_fold, autoscroll, window, cx);
         }
     }
 


### PR DESCRIPTION
Implements the behavior requested in discussion #41160: Shift+Click on a gutter fold indicator recursively folds/unfolds the clicked region, matching VS Code's semantics exactly.

> **AI disclosure:** The implementation was written by an AI coding agent (Claude Code). I directed the work: I wrote the behavior spec by verifying VS Code's semantics in its source (`onEditorMouseUp` in `src/vs/editor/contrib/folding/browser/folding.ts`), even though i am not well versed in rust, I tried to review every line of the diff, and tested the built binary locally. Happy to answer questions about any part of it.

## Behavior

- **Plain click is unchanged**: it still toggles only the clicked fold, and nested folds keep their state.
- **Shift+Click**: is a state-aware recursive toggle (VS Code parity, not a plain "fold/unfold all"):

| Clicked region | Result |
|---|---|
| Expanded, has expanded descendants | Fold all descendants at every depth; the clicked region stays expanded |
| Expanded, no expanded descendants | Fold the clicked region itself |
| Folded | Unfold it and all folds inside it |

Starting fully expanded, repeated Shift+Clicks cycle: children-collapsed → parent-collapsed → fully-expanded.

## Reasoning
This is motivated by my strong need to see all the compacted children of certain parent on a screen without scrolling. Unfortunately, with just the simple expand/collapse toggle, that is not possible. Manual clicking on all the properties of the current object just to be able to see them on a single screen is super annoying when working with large JSONs, which is exactly what I do quite often. The inability to work that way in zed is the only reason i still need to juggle between working in zed and vs code.