### PR TITLE
docs: Update community Debian mirror domain to deb.griffo.io

### DIFF
--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -66,7 +66,7 @@ The packages in this section provide binary installs for Zed but are not officia
 
 #### Debian and Ubuntu
 
-Zed is available in [this community-maintained repository](https://debian.griffo.io/).
+Zed is available in [this community-maintained repository](https://deb.griffo.io/).
 
 Instructions for each version are available in the README of the repository where packages are built.
 Build, packaging and instructions for each version are available in the README of the [repository](https://github.com/dariogriffo/zed-debian)


### PR DESCRIPTION
The community-maintained Debian repository linked in the Linux install docs moved from `debian.griffo.io` to `deb.griffo.io` to comply with the [Debian trademark policy](https://www.debian.org/trademark) (Debian trademarks may not be used in domain names). Same repository, packages, and signing key; the old domain serves permanent redirects, so existing links keep working — this just points the docs at the canonical URL.

I maintain the repository in question.

Release Notes:

- N/A