### PR TITLE
collab: Use new fuzzy search endpoint

### DIFF
--- a/crates/cloud_api_types/src/internal_api.rs
+++ b/crates/cloud_api_types/src/internal_api.rs
@@ -44,14 +44,14 @@ pub struct FuzzySearchUsersResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct FuzzySearchChannelMembersByGithubLoginBody {
+pub struct FuzzySearchChannelMembersBody {
     pub channel_id: i32,
     pub query: String,
     pub limit: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct FuzzySearchChannelMembersByGithubLoginResponse {
+pub struct FuzzySearchChannelMembersResponse {
     pub channel_members: Vec<ChannelMember>,
     pub users: Vec<User>,
 }

--- a/crates/collab/src/services/user_service.rs
+++ b/crates/collab/src/services/user_service.rs
@@ -1,10 +1,9 @@
 use anyhow::{Context as _, anyhow};
 use async_trait::async_trait;
 use cloud_api_types::internal_api::{
-    self, FuzzySearchChannelMembersByGithubLoginBody,
-    FuzzySearchChannelMembersByGithubLoginResponse, FuzzySearchUsersBody, FuzzySearchUsersResponse,
-    LookUpUserByGithubLoginBody, LookUpUserByGithubLoginResponse, LookUpUsersByLegacyIdBody,
-    LookUpUsersByLegacyIdResponse,
+    self, FuzzySearchChannelMembersBody, FuzzySearchChannelMembersResponse, FuzzySearchUsersBody,
+    FuzzySearchUsersResponse, LookUpUserByGithubLoginBody, LookUpUserByGithubLoginResponse,
+    LookUpUsersByLegacyIdBody, LookUpUsersByLegacyIdResponse,
 };
 use reqwest::RequestBuilder;
 use rpc::proto;
@@ -157,14 +156,14 @@ impl UserService for CloudUserService {
         query: &str,
         limit: u32,
     ) -> Result<(Vec<proto::ChannelMember>, Vec<User>)> {
-        let response_body: FuzzySearchChannelMembersByGithubLoginResponse = self
+        let response_body: FuzzySearchChannelMembersResponse = self
             .send_request(
                 self.http_client
                     .post(format!(
-                        "{}/internal/channel_members/fuzzy_search_by_github_login",
+                        "{}/internal/channel_members/fuzzy_search",
                         &self.zed_cloud_url
                     ))
-                    .json(&FuzzySearchChannelMembersByGithubLoginBody {
+                    .json(&FuzzySearchChannelMembersBody {
                         channel_id: channel.root_id().0,
                         query: query.to_string(),
                         limit,


### PR DESCRIPTION
Updates Collab to use the new `/internal/channel_members/fuzzy_search` endpoint that searches users by username (instead of GitHub login). Request and response shapes are the same.

Release Notes:

- N/A