### PR TITLE
Fix gentoo cmake package name

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -263,7 +263,7 @@ if [[ -n $emerge ]]; then
     dev-libs/glib
     dev-libs/openssl
     dev-libs/wayland
-    dev-util/cmake
+    dev-build/cmake
     media-libs/alsa-lib
     media-libs/fontconfig
     media-libs/libva


### PR DESCRIPTION
script/linux tried to install dev-util/cmake, which is not the correct package name, so the script fails. Changing it to dev-build/cmake fixes this.

Release Notes:

- N/A