### PR TITLE
thread_view: Add a component for the terminal's tool call header

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -24,7 +24,10 @@ use sandbox::{SandboxFsPolicy, SandboxNetPolicy, SandboxPolicy};
 
 use crate::completion_provider::{AvailableSkill, PromptLocalCommand};
 use crate::message_editor::SharedSessionCapabilities;
-use crate::ui::{SandboxGroup, SandboxRow, SandboxSection, SandboxStatusTooltip};
+use crate::ui::{
+    SandboxGroup, SandboxRow, SandboxSection, SandboxStatusTooltip, TerminalSandboxWarning,
+    TerminalToolHeader,
+};
 use crate::unicode_confusables;
 
 use db::kvp::KeyValueStore;
@@ -7692,17 +7695,10 @@ impl ThreadView {
             started_at.elapsed()
         };
 
-        let header_id =
-            SharedString::from(format!("terminal-tool-header-{}", terminal.entity_id()));
         let header_group = SharedString::from(format!(
             "terminal-tool-header-group-{}",
             terminal.entity_id()
         ));
-        let header_bg = cx
-            .theme()
-            .colors()
-            .element_background
-            .blend(cx.theme().colors().editor_foreground.opacity(0.025));
         let border_color = cx.theme().colors().border.opacity(0.6);
 
         let working_dir = working_dir
@@ -7723,148 +7719,70 @@ impl ThreadView {
             .read(cx)
             .is_tool_call_expanded(&tool_call.id);
 
-        let header = h_flex()
-            .id(header_id)
-            .pt_1()
-            .pl_1p5()
-            .pr_1()
-            .flex_none()
-            .gap_1()
-            .justify_between()
-            .rounded_t_md()
-            .child(
-                div()
-                    .id(("command-target-path", terminal.entity_id()))
-                    .w_full()
-                    .max_w_full()
-                    .overflow_x_scroll()
-                    .child(
-                        Label::new(working_dir)
-                            .buffer_font(cx)
-                            .size(LabelSize::XSmall)
-                            .color(Color::Muted),
-                    ),
-            )
-            .child(
-                Disclosure::new(
-                    SharedString::from(format!(
-                        "terminal-tool-disclosure-{}",
-                        terminal.entity_id()
-                    )),
-                    is_expanded,
-                )
-                .opened_icon(IconName::ChevronUp)
-                .closed_icon(IconName::ChevronDown)
-                .visible_on_hover(&header_group)
-                .on_click(cx.listener({
-                    let id = tool_call.id.clone();
-                    move |this, _event, window, cx| {
-                        this.entry_view_state.update(cx, |state, _cx| {
-                            state.toggle_tool_call_expansion(&id);
-                        });
-                        this.refresh_thread_search(window, cx);
-                        cx.notify();
-                    }
-                })),
-            )
-            .when(time_elapsed > Duration::from_secs(10), |header| {
-                header.child(
-                    Label::new(format!("({})", duration_alt_display(time_elapsed)))
-                        .buffer_font(cx)
-                        .color(Color::Muted)
-                        .size(LabelSize::XSmall),
-                )
-            })
-            .when(!command_finished && !needs_confirmation, |header| {
-                header
-                    .gap_1p5()
-                    .child(
-                        Icon::new(IconName::ArrowCircle)
-                            .size(IconSize::XSmall)
-                            .color(Color::Muted)
-                            .with_rotate_animation(2)
+        let truncated_tooltip = truncated_output.then(|| {
+            if let Some(output) = output {
+                if output_line_count + 10 > terminal::MAX_SCROLL_HISTORY_LINES {
+                    format!(
+                        "Output exceeded terminal max lines and was \
+                         truncated, the model received the first {}.",
+                        format_file_size(output.content.len() as u64, true)
                     )
-                    .child(div().h(relative(0.6)).ml_1p5().child(Divider::vertical().color(DividerColor::Border)))
-                    .child(
-                        IconButton::new(
-                            SharedString::from(format!("stop-terminal-{}", terminal.entity_id())),
-                            IconName::Stop
-                        )
-                        .icon_size(IconSize::Small)
-                        .icon_color(Color::Error)
-                        .tooltip(move |_window, cx| {
-                            Tooltip::with_meta(
-                                "Stop This Command",
-                                None,
-                                "Also possible by placing your cursor inside the terminal and using regular terminal bindings.",
-                                cx,
-                            )
-                        })
-                        .on_click({
-                            let terminal = terminal.clone();
-                            cx.listener(move |this, _event, _window, cx| {
-                                terminal.update(cx, |terminal, cx| {
-                                    terminal.stop_by_user(cx);
-                                });
-                                if AgentSettings::get_global(cx).cancel_generation_on_terminal_stop {
-                                    this.cancel_generation(cx);
-                                }
-                            })
-                        }),
-                    )
-            })
-            .when(truncated_output, |header| {
-                let tooltip = if let Some(output) = output {
-                    if output_line_count + 10 > terminal::MAX_SCROLL_HISTORY_LINES {
-                       format!("Output exceeded terminal max lines and was \
-                            truncated, the model received the first {}.", format_file_size(output.content.len() as u64, true))
-                    } else {
-                        format!(
-                            "Output is {} long, and to avoid unexpected token usage, \
-                                only {} was sent back to the agent.",
-                            format_file_size(output.original_content_len as u64, true),
-                             format_file_size(output.content.len() as u64, true)
-                        )
-                    }
                 } else {
-                    "Output was truncated".to_string()
-                };
+                    format!(
+                        "Output is {} long, and to avoid unexpected token usage, \
+                         only {} was sent back to the agent.",
+                        format_file_size(output.original_content_len as u64, true),
+                        format_file_size(output.content.len() as u64, true)
+                    )
+                }
+            } else {
+                "Output was truncated".to_string()
+            }
+        });
 
-                header.child(
-                    h_flex()
-                        .id(("terminal-tool-truncated-label", terminal.entity_id()))
-                        .gap_1()
-                        .child(
-                            Icon::new(IconName::Info)
-                                .size(IconSize::XSmall)
-                                .color(Color::Ignored),
-                        )
-                        .child(
-                            Label::new("Truncated")
-                                .color(Color::Muted)
-                                .size(LabelSize::XSmall),
-                        )
-                        .tooltip(Tooltip::text(tooltip)),
-                )
+        let header = TerminalToolHeader::new(
+            terminal.entity_id().to_string(),
+            header_group.clone(),
+            working_dir,
+            is_expanded,
+        )
+        .elapsed(time_elapsed)
+        .running(!command_finished && !needs_confirmation)
+        .on_toggle_expand(cx.listener({
+            let id = tool_call.id.clone();
+            move |this, _event, window, cx| {
+                this.entry_view_state.update(cx, |state, _cx| {
+                    state.toggle_tool_call_expansion(&id);
+                });
+                this.refresh_thread_search(window, cx);
+                cx.notify();
+            }
+        }))
+        .on_stop({
+            let terminal = terminal.clone();
+            cx.listener(move |this, _event, _window, cx| {
+                terminal.update(cx, |terminal, cx| {
+                    terminal.stop_by_user(cx);
+                });
+                if AgentSettings::get_global(cx).cancel_generation_on_terminal_stop {
+                    this.cancel_generation(cx);
+                }
             })
-            .when(tool_failed || command_failed, |header| {
-                header.child(
-                    div()
-                        .id(("terminal-tool-error-code-indicator", terminal.entity_id()))
-                        .child(
-                            Icon::new(IconName::Close)
-                                .size(IconSize::Small)
-                                .color(Color::Error),
-                        )
-                        .when_some(output.and_then(|o| o.exit_status), |this, status| {
-                            this.tooltip(Tooltip::text(format!(
-                                "Exited with code {}",
-                                status.code().unwrap_or(-1),
-                            )))
-                        }),
-                )
-            })
-;
+        })
+        .when_some(truncated_tooltip, |header, tooltip| {
+            header.truncated(tooltip)
+        })
+        .when(tool_failed || command_failed, |header| {
+            header.failed(
+                output
+                    .and_then(|o| o.exit_status)
+                    .map(|status| status.code().unwrap_or(-1)),
+            )
+        })
+        .when_some(tool_call.sandbox_not_applied.as_ref(), |header, reason| {
+            header.sandbox_warning(self.sandbox_not_applied_warning(reason, cx))
+        })
+        .command_slot(command_element);
 
         let terminal_view = self
             .entry_view_state
@@ -7882,17 +7800,7 @@ impl ThreadView {
                     .rounded_md()
             })
             .overflow_hidden()
-            .child(
-                v_flex()
-                    .group(&header_group)
-                    .bg(header_bg)
-                    .text_xs()
-                    .child(header)
-                    .child(command_element),
-            )
-            .when_some(tool_call.sandbox_not_applied.as_ref(), |this, reason| {
-                this.child(self.render_sandbox_not_applied_warning(reason, cx))
-            })
+            .child(header)
             .when(is_expanded && terminal_view.is_some(), |this| {
                 this.child(
                     div()

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -7850,13 +7850,11 @@ impl ThreadView {
             .into_any()
     }
 
-    /// Render the "ran without sandbox" warning shown on a terminal tool card,
-    /// tailored to *why* the sandbox wasn't applied.
-    fn render_sandbox_not_applied_warning(
+    fn sandbox_not_applied_warning(
         &self,
         reason: &SandboxNotAppliedReason,
         cx: &Context<Self>,
-    ) -> AnyElement {
+    ) -> TerminalSandboxWarning {
         // (title, detail line, docs section slug)
         let (title, detail, docs_section): (SharedString, SharedString, Option<&'static str>) =
             match reason {
@@ -7885,17 +7883,11 @@ impl ThreadView {
                 }
             };
 
-        Callout::new()
-            .severity(Severity::Warning)
-            .icon(IconName::Warning)
-            .title(title)
-            .description(detail)
-            .actions_slot(self.render_sandbox_docs_link(
-                "sandbox-not-applied-docs-link",
-                docs_section,
-                cx,
-            ))
-            .into_any_element()
+        TerminalSandboxWarning {
+            title,
+            detail,
+            docs_url: zed_urls::sandboxing_docs(docs_section, cx).into(),
+        }
     }
 
     /// Find the first terminal tool call in the thread whose sandbox couldn't be

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -7742,7 +7742,7 @@ impl ThreadView {
 
         let header = TerminalToolHeader::new(
             terminal.entity_id().to_string(),
-            header_group.clone(),
+            header_group,
             working_dir,
             is_expanded,
         )

--- a/crates/agent_ui/src/ui.rs
+++ b/crates/agent_ui/src/ui.rs
@@ -3,6 +3,7 @@ mod end_trial_upsell;
 mod mention_crease;
 mod model_selector_components;
 mod sandbox_status_tooltip;
+mod terminal_tool_header;
 mod undo_reject_toast;
 
 pub use agent_notification::*;
@@ -10,6 +11,7 @@ pub use end_trial_upsell::*;
 pub use mention_crease::*;
 pub use model_selector_components::*;
 pub use sandbox_status_tooltip::*;
+pub use terminal_tool_header::*;
 pub use undo_reject_toast::*;
 
 /// Returns the appropriate [`DocumentationSide`] for documentation asides

--- a/crates/agent_ui/src/ui/terminal_tool_header.rs
+++ b/crates/agent_ui/src/ui/terminal_tool_header.rs
@@ -143,19 +143,13 @@ impl RenderOnce for TerminalToolHeader {
             .justify_between()
             .rounded_t_md()
             .child(
-                div()
-                    .id(child_id("working-dir"))
-                    .w_full()
-                    .max_w_full()
-                    .overflow_hidden()
-                    .child(
-                        Label::new(working_dir.clone())
-                            .size(LabelSize::XSmall)
-                            .color(Color::Muted)
-                            .buffer_font(cx)
-                            .truncate(),
-                    )
-                    .tooltip(Tooltip::text(working_dir)),
+                div().w_full().min_w_0().overflow_hidden().child(
+                    Label::new(working_dir)
+                        .buffer_font(cx)
+                        .size(LabelSize::XSmall)
+                        .color(Color::Muted)
+                        .truncate_start(),
+                ),
             )
             .child(
                 Disclosure::new(child_id("disclosure"), is_expanded)
@@ -364,6 +358,21 @@ impl Component for TerminalToolHeader {
                         )
                         .sandbox_warning(sandbox_warning()),
                     ),
+                ),
+                single_example(
+                    "Long path (truncated from the start)",
+                    div()
+                        .w_80()
+                        .child(card(
+                            "long-path",
+                            TerminalToolHeader::new(
+                                "long-path",
+                                "preview-terminal-header-group-long-path",
+                                "/Users/you/Documents/GitHub/worktrees/some-monorepo/working-tree-three/packages/deeply/nested/service/backend/src",
+                                false,
+                            ),
+                        ))
+                        .into_any_element(),
                 ),
                 single_example(
                     "Everything at once",

--- a/crates/agent_ui/src/ui/terminal_tool_header.rs
+++ b/crates/agent_ui/src/ui/terminal_tool_header.rs
@@ -1,0 +1,387 @@
+use std::time::Duration;
+
+use gpui::{AnyElement, ClickEvent, CursorStyle, Window};
+use ui::{CommonAnimationExt, Disclosure, Divider, DividerColor, Tooltip, prelude::*};
+use util::time::duration_alt_display;
+
+const ELAPSED_DISPLAY_THRESHOLD: Duration = Duration::from_secs(10);
+
+type ClickHandler = Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
+
+pub struct TerminalSandboxWarning {
+    pub title: SharedString,
+    pub detail: SharedString,
+    pub docs_url: SharedString,
+}
+
+#[derive(IntoElement, RegisterComponent)]
+pub struct TerminalToolHeader {
+    id: SharedString,
+    hover_group: SharedString,
+    working_dir: SharedString,
+    is_expanded: bool,
+    elapsed: Option<Duration>,
+    running: bool,
+    truncated_tooltip: Option<SharedString>,
+    failed: bool,
+    exit_code: Option<i32>,
+    sandbox_warning: Option<TerminalSandboxWarning>,
+    on_toggle_expand: Option<ClickHandler>,
+    on_stop: Option<ClickHandler>,
+    command_slot: Option<AnyElement>,
+}
+
+impl TerminalToolHeader {
+    pub fn new(
+        id: impl Into<SharedString>,
+        hover_group: impl Into<SharedString>,
+        working_dir: impl Into<SharedString>,
+        is_expanded: bool,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            hover_group: hover_group.into(),
+            working_dir: working_dir.into(),
+            is_expanded,
+            elapsed: None,
+            running: false,
+            truncated_tooltip: None,
+            failed: false,
+            exit_code: None,
+            sandbox_warning: None,
+            on_toggle_expand: None,
+            on_stop: None,
+            command_slot: None,
+        }
+    }
+
+    pub fn elapsed(mut self, elapsed: Duration) -> Self {
+        self.elapsed = Some(elapsed);
+        self
+    }
+
+    pub fn running(mut self, running: bool) -> Self {
+        self.running = running;
+        self
+    }
+
+    pub fn truncated(mut self, tooltip: impl Into<SharedString>) -> Self {
+        self.truncated_tooltip = Some(tooltip.into());
+        self
+    }
+
+    pub fn failed(mut self, exit_code: Option<i32>) -> Self {
+        self.failed = true;
+        self.exit_code = exit_code;
+        self
+    }
+
+    pub fn sandbox_warning(mut self, warning: TerminalSandboxWarning) -> Self {
+        self.sandbox_warning = Some(warning);
+        self
+    }
+
+    pub fn on_toggle_expand(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_toggle_expand = Some(Box::new(handler));
+        self
+    }
+
+    pub fn on_stop(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_stop = Some(Box::new(handler));
+        self
+    }
+
+    pub fn command_slot(mut self, element: impl IntoElement) -> Self {
+        self.command_slot = Some(element.into_any_element());
+        self
+    }
+}
+
+impl RenderOnce for TerminalToolHeader {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let show_elapsed = self
+            .elapsed
+            .is_some_and(|elapsed| elapsed > ELAPSED_DISPLAY_THRESHOLD);
+
+        let Self {
+            id,
+            hover_group,
+            working_dir,
+            is_expanded,
+            elapsed,
+            running,
+            truncated_tooltip,
+            failed,
+            exit_code,
+            sandbox_warning,
+            on_toggle_expand,
+            on_stop,
+            command_slot,
+        } = self;
+
+        let child_id = |name: &str| format!("terminal-tool-{name}-{id}");
+
+        let header_bg = cx
+            .theme()
+            .colors()
+            .element_background
+            .blend(cx.theme().colors().editor_foreground.opacity(0.025));
+
+        let header_row = h_flex()
+            .id(child_id("header"))
+            .pt_1()
+            .pl_1p5()
+            .pr_1()
+            .flex_none()
+            .gap_1()
+            .justify_between()
+            .rounded_t_md()
+            .child(
+                div()
+                    .id(child_id("working-dir"))
+                    .w_full()
+                    .max_w_full()
+                    .overflow_hidden()
+                    .child(
+                        Label::new(working_dir.clone())
+                            .size(LabelSize::XSmall)
+                            .color(Color::Muted)
+                            .buffer_font(cx)
+                            .truncate(),
+                    )
+                    .tooltip(Tooltip::text(working_dir)),
+            )
+            .child(
+                Disclosure::new(child_id("disclosure"), is_expanded)
+                    .opened_icon(IconName::ChevronUp)
+                    .closed_icon(IconName::ChevronDown)
+                    .visible_on_hover(&hover_group)
+                    .when_some(on_toggle_expand, |this, handler| this.on_click(handler)),
+            )
+            .when(show_elapsed, |header| {
+                let elapsed = elapsed.unwrap_or_default();
+                header.child(
+                    Label::new(format!("({})", duration_alt_display(elapsed)))
+                        .buffer_font(cx)
+                        .color(Color::Muted)
+                        .size(LabelSize::XSmall)
+                        .mr_0p5()
+                        .when(truncated_tooltip.is_some(), |s| s.mr_0()),
+                )
+            })
+            .when(running, |header| {
+                header
+                    .gap_1p5()
+                    .child(
+                        Icon::new(IconName::LoadCircle)
+                            .size(IconSize::Small)
+                            .color(Color::Muted)
+                            .with_rotate_animation(2),
+                    )
+                    .child(Divider::vertical().color(DividerColor::Border).ml_1())
+                    .child(
+                        IconButton::new(child_id("stop"), IconName::Stop)
+                            .icon_size(IconSize::Small)
+                            .icon_color(Color::Error)
+                            .tooltip(move |_window, cx| {
+                                Tooltip::with_meta(
+                                    "Stop This Command",
+                                    None,
+                                    "Also possible by placing your cursor inside the terminal \
+                                     and using regular terminal bindings.",
+                                    cx,
+                                )
+                            })
+                            .when_some(on_stop, |this, handler| this.on_click(handler)),
+                    )
+            })
+            .when_some(truncated_tooltip, |header, tooltip| {
+                header.child(
+                    IconButton::new(child_id("truncated"), IconName::Info)
+                        .cursor_style(CursorStyle::Arrow)
+                        .style(ButtonStyle::Transparent)
+                        .icon_size(IconSize::Small)
+                        .icon_color(Color::Muted)
+                        .tooltip(Tooltip::text(tooltip)),
+                )
+            })
+            .when(failed, |header| {
+                header.child(
+                    IconButton::new(child_id("failed"), IconName::Close)
+                        .cursor_style(CursorStyle::Arrow)
+                        .style(ButtonStyle::Transparent)
+                        .icon_size(IconSize::Small)
+                        .icon_color(Color::Error)
+                        .when_some(exit_code, |this, code| {
+                            this.tooltip(Tooltip::text(format!("Exited with code {code}")))
+                        }),
+                )
+            })
+            .when_some(sandbox_warning, |header, warning| {
+                let TerminalSandboxWarning {
+                    title,
+                    detail,
+                    docs_url,
+                } = warning;
+                header.child(
+                    IconButton::new(child_id("sandbox-not-applied"), IconName::LockOff)
+                        .icon_size(IconSize::Small)
+                        .tooltip(move |_window, cx| {
+                            Tooltip::with_meta(
+                                title.clone(),
+                                None,
+                                format!("{detail} Click to learn more about sandboxing."),
+                                cx,
+                            )
+                        })
+                        .on_click(move |_, _, cx| cx.open_url(&docs_url)),
+                )
+            });
+
+        v_flex()
+            .group(hover_group)
+            .text_xs()
+            .bg(header_bg)
+            .child(header_row)
+            .children(command_slot)
+    }
+}
+
+impl Component for TerminalToolHeader {
+    fn scope() -> ComponentScope {
+        ComponentScope::Agent
+    }
+
+    fn name() -> &'static str {
+        "Terminal Tool Header"
+    }
+
+    fn description() -> &'static str {
+        "The top of a terminal tool call card in the agent panel."
+    }
+
+    fn preview(_window: &mut Window, cx: &mut App) -> AnyElement {
+        let working_dir = "/Users/you/projects/zed";
+
+        let card = |_id: &'static str, header: TerminalToolHeader| {
+            v_flex()
+                .w_full()
+                .border_1()
+                .border_color(cx.theme().colors().border.opacity(0.6))
+                .rounded_md()
+                .overflow_hidden()
+                .child(
+                    header.command_slot(
+                        div().px_1p5().pb_1().child(
+                            Label::new("cargo build --release")
+                                .buffer_font(cx)
+                                .size(LabelSize::XSmall),
+                        ),
+                    ),
+                )
+                .into_any_element()
+        };
+
+        let sandbox_warning = || TerminalSandboxWarning {
+            title: "Ran without sandbox".into(),
+            detail: "Unsandboxed execution is allowed for the rest of this thread.".into(),
+            docs_url: "https://zed.dev/docs/ai/sandboxing".into(),
+        };
+
+        v_flex()
+            .gap_4()
+            .child(example_group(vec![
+                single_example(
+                    "Running",
+                    card(
+                        "running",
+                        TerminalToolHeader::new(
+                            "running",
+                            "preview-terminal-header-group-running",
+                            working_dir,
+                            false,
+                        )
+                        .running(true),
+                    ),
+                ),
+                single_example(
+                    "Finished (long-running)",
+                    card(
+                        "elapsed",
+                        TerminalToolHeader::new(
+                            "elapsed",
+                            "preview-terminal-header-group-elapsed",
+                            working_dir,
+                            false,
+                        )
+                        .elapsed(Duration::from_secs(83)),
+                    ),
+                ),
+                single_example(
+                    "Truncated output",
+                    card(
+                        "truncated",
+                        TerminalToolHeader::new(
+                            "truncated",
+                            "preview-terminal-header-group-truncated",
+                            working_dir,
+                            true,
+                        )
+                        .truncated(
+                            "Output is 2.5 MB long, and to avoid unexpected token \
+                                     usage, only 16 KB was sent back to the agent.",
+                        ),
+                    ),
+                ),
+                single_example(
+                    "Failed with exit code",
+                    card(
+                        "failed",
+                        TerminalToolHeader::new(
+                            "failed",
+                            "preview-terminal-header-group-failed",
+                            working_dir,
+                            false,
+                        )
+                        .failed(Some(101)),
+                    ),
+                ),
+                single_example(
+                    "Ran without sandbox",
+                    card(
+                        "sandbox",
+                        TerminalToolHeader::new(
+                            "sandbox",
+                            "preview-terminal-header-group-sandbox",
+                            working_dir,
+                            false,
+                        )
+                        .sandbox_warning(sandbox_warning()),
+                    ),
+                ),
+                single_example(
+                    "Everything at once",
+                    card(
+                        "kitchen-sink",
+                        TerminalToolHeader::new(
+                            "kitchen-sink",
+                            "preview-terminal-header-group-kitchen-sink",
+                            working_dir,
+                            true,
+                        )
+                        .elapsed(Duration::from_secs(3671))
+                        .truncated("Output was truncated")
+                        .failed(Some(1))
+                        .sandbox_warning(sandbox_warning()),
+                    ),
+                ),
+            ]))
+            .into_any_element()
+    }
+}


### PR DESCRIPTION
This PR introduces a component for the terminal tool call's header. It was growing already pretty big in the terminal tool call render function in the thread view and hard to visualize in all of its use cases. I got motivated to do this because I wanted to make the UI for the case when it runs outside of the sandbox simpler, but it wasn't easy to make that show up in a true agent thread, and with it being a component, I can just use the component preview.

Here's a quick screenshot of it, it shouldn't look too different, just a bit more polished:

<img width="600" alt="Screenshot 2026-07-13 at 6  43@2x" src="https://github.com/user-attachments/assets/fb222e50-2003-4cf7-9039-7b211db3c86e" />

Release Notes:

- N/A
