### PR TITLE
Distinguish parameters from normal variables in semantic token highlighting

### DIFF
--- a/assets/settings/default_semantic_token_rules.json
+++ b/assets/settings/default_semantic_token_rules.json
@@ -121,18 +121,8 @@
   // References
   {
     "token_type": "parameter",
-    "token_modifiers": ["declaration"],
-    "style": ["variable.parameter"]
-  },
-  {
-    "token_type": "parameter",
-    "token_modifiers": ["definition"],
-    "style": ["variable.parameter"]
-  },
-  {
-    "token_type": "parameter",
     "token_modifiers": [],
-    "style": ["variable"],
+    "style": ["variable.parameter"],
   },
   {
     "token_type": "variable",


### PR DESCRIPTION
# Objective

Closes #60928

Currently, only the declaration of parameters in a function header is highlighted as `variable.parameter`. Inside the function body, parameters are highlighted as normal variables, making them indistinguishable from local variables. 

This PR ensures consistent highlighting for parameters throughout their entire scope, helping developers distinguish between function inputs and locally defined variables.

## Solution

- Updated the `default_semantic_token_rules.json`: when the token type is `parameter`, no matter what token modifiers are, it is now mapped to `variable.parameter` highlight style.

## Testing

Tested locally with Rust. The improvement in visual hierarchy is demonstrated in the comparison below.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

| Before | After |
| :---: | :---: |
| <img width="1178" height="400" alt="before" src="https://github.com/user-attachments/assets/90a01543-2dcc-41e0-a2a3-f8020c6d77ee" /> | <img width="1194" height="387" alt="after" src="https://github.com/user-attachments/assets/c81ba273-2ea7-4d38-b7df-a6069c09c28a" />|

---

Release Notes:

- Improved semantic token highlighting to distinguish function parameters from local variables.