### PR TITLE
vtsls: Remove redundant TypeScript installation

### DIFF
--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -39,7 +39,6 @@ impl VtslsLspAdapter {
     const PACKAGE_NAME: &'static str = "@vtsls/language-server";
     const SERVER_PATH: &'static str = "node_modules/@vtsls/language-server/bin/vtsls.js";
 
-    const TYPESCRIPT_PACKAGE_NAME: &'static str = "typescript";
     const TYPESCRIPT_TSDK_PATH: &'static str = "node_modules/typescript/lib";
     const TYPESCRIPT_YARN_TSDK_PATH: &'static str = ".yarn/sdks/typescript/lib";
 
@@ -84,15 +83,10 @@ impl VtslsLspAdapter {
     }
 }
 
-pub struct TypeScriptVersions {
-    typescript_version: Version,
-    server_version: Version,
-}
-
 const SERVER_NAME: LanguageServerName = LanguageServerName::new_static("vtsls");
 
 impl LspInstaller for VtslsLspAdapter {
-    type BinaryVersion = TypeScriptVersions;
+    type BinaryVersion = Version;
 
     async fn fetch_latest_server_version(
         &self,
@@ -100,13 +94,9 @@ impl LspInstaller for VtslsLspAdapter {
         _: bool,
         _: &mut AsyncApp,
     ) -> Result<Self::BinaryVersion> {
-        Ok(TypeScriptVersions {
-            typescript_version: self.node.npm_package_latest_version("typescript").await?,
-            server_version: self
-                .node
-                .npm_package_latest_version("@vtsls/language-server")
-                .await?,
-        })
+        self.node
+            .npm_package_latest_version(Self::PACKAGE_NAME)
+            .await
     }
 
     async fn check_if_user_installed(
@@ -135,11 +125,8 @@ impl LspInstaller for VtslsLspAdapter {
         async move {
             let server_path = container_dir.join(Self::SERVER_PATH);
 
-            node.npm_install_latest_packages(
-                &container_dir,
-                &[Self::PACKAGE_NAME, Self::TYPESCRIPT_PACKAGE_NAME],
-            )
-            .await?;
+            node.npm_install_latest_packages(&container_dir, &[Self::PACKAGE_NAME])
+                .await?;
 
             Ok(LanguageServerBinary {
                 path: node.binary_path().await?,
@@ -156,8 +143,7 @@ impl LspInstaller for VtslsLspAdapter {
         _: &Arc<dyn LspAdapterDelegate>,
     ) -> impl Send + Future<Output = Option<LanguageServerBinary>> + use<> {
         let node = self.node.clone();
-        let typescript_version = version.typescript_version.clone();
-        let server_version = version.server_version.clone();
+        let server_version = version.clone();
         let container_dir = container_dir.clone();
 
         async move {
@@ -169,18 +155,6 @@ impl LspInstaller for VtslsLspAdapter {
                     &server_path,
                     &container_dir,
                     VersionStrategy::Latest(&server_version),
-                )
-                .await
-            {
-                return None;
-            }
-
-            if node
-                .should_install_npm_package(
-                    Self::TYPESCRIPT_PACKAGE_NAME,
-                    &container_dir.join(Self::TYPESCRIPT_TSDK_PATH),
-                    &container_dir,
-                    VersionStrategy::Latest(&typescript_version),
                 )
                 .await
             {


### PR DESCRIPTION
Context:

While looking at #60618, I found out the TypeScript 7 upgrade only breaks the `typescript-language-server` adapter, not the default vtsls adapter.

After digging in, it turns out the initial vtsls implementation in #12606 followed the same two-package installation pattern as the `typescript-language-server` adapter: it installed both `@vtsls/language-server` and the latest `typescript`. However, vtsls already bundles a compatible TypeScript version via `@vtsls/language-service` and uses it whenever a workspace SDK is unavailable.

I also cross-checked an intermediate vtsls upgrade issue, #18349, where we used the installed TypeScript version to decide whether both packages needed updating, so a new vtsls release could go uninstalled when TypeScript hadn't changed. #20197 fixed that by checking both packages independently, but kept the unnecessary standalone TypeScript installation.

Changes: 

This PR removes that redundant installation and version tracking from the vtsls adapter. Zed now tracks only `@vtsls/language-server` and relies on its declared TypeScript dependency. Workspace TypeScript and Yarn SDK detection remain unchanged, so vtsls still uses a workspace SDK when one is available and otherwise falls back to its bundled version.

As for the consequence of this change:
1. New users are not affected since npm installs vtsls's own pinned TypeScript dependency anyway.
2. For existing users, the previously installed standalone `typescript` was never resolvable by vtsls (its pinned version gets installed nested when the versions conflict), so leaving it there is harmless.

To verify the standalone copy was really unused, I nuked the vtsls dir and ran main (without this fix), which installed both the top-level `typescript@7.0.2` and vtsls's own pinned `typescript@5.9.3` nested under `@vtsls/language-service`. Node's module resolution shows vtsls can only ever see the nested copy as well as the LSP logs from the running server shows, all lib definition locations point at the nested copy:

```
"uri": "file:///.../vtsls/node_modules/@vtsls/language-service/node_modules/typescript/lib/lib.es5.d.ts"
```

I also tested this branch with a fresh install TypeScript files work the same as before.

Release Notes:

- N/A