### PR TITLE
search: Add opt-in search-as-you-type for project search

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -729,6 +729,9 @@
     "regex": false,
     // Whether to center the cursor on each search match when navigating.
     "center_on_match": false,
+    // Whether project-wide search should run automatically (debounced) as you
+    // type the query, instead of waiting for the enter key.
+    "search_on_type": false,
   },
   // When to populate a new search's query based on the text under the cursor.
   // This setting can take the following three values:

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -184,6 +184,9 @@ pub struct SearchSettings {
     pub regex: bool,
     /// Whether to center the cursor on each search match when navigating.
     pub center_on_match: bool,
+    /// Whether project-wide search should run automatically (debounced) as you
+    /// type the query, instead of waiting for the enter key.
+    pub search_on_type: bool,
 }
 
 impl EditorSettings {
@@ -284,6 +287,7 @@ impl Settings for EditorSettings {
                 include_ignored: search.include_ignored.unwrap(),
                 regex: search.regex.unwrap(),
                 center_on_match: search.center_on_match.unwrap(),
+                search_on_type: search.search_on_type.unwrap(),
             },
             auto_signature_help: editor.auto_signature_help.unwrap(),
             show_signature_help_after_edits: editor.show_signature_help_after_edits.unwrap(),

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -3670,6 +3670,7 @@ mod tests {
                 include_ignored: false,
                 regex: false,
                 center_on_match: false,
+                search_on_type: false,
             },
             cx,
         );
@@ -3733,6 +3734,7 @@ mod tests {
                 include_ignored: false,
                 regex: false,
                 center_on_match: false,
+                search_on_type: false,
             },
             cx,
         );
@@ -3771,6 +3773,7 @@ mod tests {
                 include_ignored: false,
                 regex: false,
                 center_on_match: false,
+                search_on_type: false,
             },
             cx,
         );
@@ -3955,6 +3958,7 @@ mod tests {
                         include_ignored: Some(search_settings.include_ignored),
                         regex: Some(search_settings.regex),
                         center_on_match: Some(search_settings.center_on_match),
+                        search_on_type: Some(search_settings.search_on_type),
                     });
                 });
             });

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -308,6 +308,7 @@ pub struct ProjectSearchView {
     pending_replace_all: bool,
     included_opened_only: bool,
     regex_language: Option<Arc<Language>>,
+    debounced_search_task: Option<Task<()>>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -1068,15 +1069,18 @@ impl ProjectSearchView {
         // Subscribe to query_editor in order to reraise editor events for workspace item activation purposes
         subscriptions.push(
             cx.subscribe(&query_editor, |this, _, event: &EditorEvent, cx| {
-                if let EditorEvent::Edited { .. } = event
-                    && EditorSettings::get_global(cx).use_smartcase_search
-                {
-                    let query = this.search_query_text(cx);
-                    if !query.is_empty()
-                        && this.search_options.contains(SearchOptions::CASE_SENSITIVE)
-                            != contains_uppercase(&query)
-                    {
-                        this.toggle_search_option(SearchOptions::CASE_SENSITIVE, cx);
+                if let EditorEvent::Edited { .. } = event {
+                    if EditorSettings::get_global(cx).use_smartcase_search {
+                        let query = this.search_query_text(cx);
+                        if !query.is_empty()
+                            && this.search_options.contains(SearchOptions::CASE_SENSITIVE)
+                                != contains_uppercase(&query)
+                        {
+                            this.toggle_search_option(SearchOptions::CASE_SENSITIVE, cx);
+                        }
+                    }
+                    if EditorSettings::get_global(cx).search.search_on_type {
+                        this.schedule_search_on_type(cx);
                     }
                 }
                 cx.emit(ViewEvent::EditorEvent(event.clone()))
@@ -1186,6 +1190,7 @@ impl ProjectSearchView {
             pending_replace_all: false,
             included_opened_only: false,
             regex_language: None,
+            debounced_search_task: None,
             _subscriptions: subscriptions,
         };
 
@@ -1446,6 +1451,7 @@ impl ProjectSearchView {
     }
 
     fn search(&mut self, cx: &mut Context<Self>) {
+        self.debounced_search_task.take();
         let open_buffers = if self.included_opened_only {
             self.workspace
                 .update(cx, |workspace, cx| self.open_buffers(cx, workspace))
@@ -1456,6 +1462,25 @@ impl ProjectSearchView {
         if let Some(query) = self.build_search_query(cx, open_buffers) {
             self.entity.update(cx, |model, cx| model.search(query, cx));
         }
+    }
+
+    /// Schedules a debounced search to run shortly after the user stops
+    /// typing. Any previously scheduled (not yet started) search is
+    /// cancelled by dropping its task, so at most one search is pending.
+    fn schedule_search_on_type(&mut self, cx: &mut Context<Self>) {
+        const SEARCH_ON_TYPE_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(300);
+
+        self.debounced_search_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(SEARCH_ON_TYPE_DEBOUNCE)
+                .await;
+            this.update(cx, |this, cx| {
+                if !this.search_query_text(cx).is_empty() {
+                    this.search(cx);
+                }
+            })
+            .ok();
+        }));
     }
 
     pub fn search_query_text(&self, cx: &App) -> String {

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -941,6 +941,11 @@ pub struct SearchSettingsContent {
     pub regex: Option<bool>,
     /// Whether to center the cursor on each search match when navigating.
     pub center_on_match: Option<bool>,
+    /// Whether project-wide search should run automatically (debounced) as you
+    /// type the query, instead of waiting for the enter key.
+    ///
+    /// Default: false
+    pub search_on_type: Option<bool>,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
Adds a new editor.search.search_on_type setting (default: false). When enabled, project-wide search runs automatically ~300ms after the user stops typing, instead of waiting for Enter. Stale pending searches are cancelled when a new character arrives or when a search is triggered explicitly.

Closes #9318, closes #22303

# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, use "Fixes #X" for each issue as [described in the GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Solution

- Describe the solution used to achieve the objective above.

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

## Self-Review Checklist:

- [ ] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---

Release Notes:

- N/A or Added/Fixed/Improved ...
