### PR TITLE
Improve sccache cache reuse

### DIFF
--- a/script/setup-sccache
+++ b/script/setup-sccache
@@ -2,16 +2,32 @@
 
 set -euo pipefail
 
-SCCACHE_VERSION="v0.10.0"
+SCCACHE_VERSION="v0.16.0"
 # Use absolute path to avoid issues with working directory changes between steps
 SCCACHE_DIR="$(pwd)/target/sccache"
 
 install_sccache() {
     mkdir -p "$SCCACHE_DIR"
 
-    if [[ -x "${SCCACHE_DIR}/sccache" ]] && "${SCCACHE_DIR}/sccache" --version &>/dev/null; then
-        echo "sccache already cached: $("${SCCACHE_DIR}/sccache" --version)"
+    local expected_version="sccache ${SCCACHE_VERSION#v}"
+    local installed_version=""
+    if [[ -x "${SCCACHE_DIR}/sccache" ]]; then
+        if ! installed_version="$("${SCCACHE_DIR}/sccache" --version 2>/dev/null)"; then
+            echo "Cached sccache binary is invalid; reinstalling"
+            installed_version=""
+        fi
+    fi
+
+    if [[ "${installed_version}" == "${expected_version}" ]]; then
+        echo "sccache already cached: ${installed_version}"
     else
+        if [[ -n "${installed_version}" ]]; then
+            echo "Stopping cached ${installed_version} server before upgrading..."
+            if ! "${SCCACHE_DIR}/sccache" --stop-server &>/dev/null; then
+                echo "No running sccache server to stop"
+            fi
+        fi
+
         echo "Installing sccache ${SCCACHE_VERSION} from GitHub releases..."
 
         local os arch archive basename
@@ -78,7 +94,7 @@ configure_sccache() {
     export SCCACHE_BUCKET="${bucket}"
     export SCCACHE_REGION="auto"
     export SCCACHE_S3_KEY_PREFIX="${key_prefix}"
-    export SCCACHE_BASEDIR="${base_dir}"
+    export SCCACHE_BASEDIRS="${base_dir}"
     export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
     export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
     export RUSTC_WRAPPER="${sccache_bin}"
@@ -90,7 +106,7 @@ configure_sccache() {
             echo "SCCACHE_BUCKET=${SCCACHE_BUCKET}"
             echo "SCCACHE_REGION=${SCCACHE_REGION}"
             echo "SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX}"
-            echo "SCCACHE_BASEDIR=${SCCACHE_BASEDIR}"
+            echo "SCCACHE_BASEDIRS=${SCCACHE_BASEDIRS}"
             echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
             echo "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
             echo "RUSTC_WRAPPER=${RUSTC_WRAPPER}"
@@ -108,7 +124,7 @@ show_config() {
     echo "SCCACHE_ENDPOINT: ${SCCACHE_ENDPOINT:-<not set>}"
     echo "SCCACHE_REGION: ${SCCACHE_REGION:-<not set>}"
     echo "SCCACHE_S3_KEY_PREFIX: ${SCCACHE_S3_KEY_PREFIX:-<not set>}"
-    echo "SCCACHE_BASEDIR: ${SCCACHE_BASEDIR:-<not set>}"
+    echo "SCCACHE_BASEDIRS: ${SCCACHE_BASEDIRS:-<not set>}"
     if [[ -n "${AWS_ACCESS_KEY_ID:-}" ]]; then
         echo "AWS_ACCESS_KEY_ID: <set, length=${#AWS_ACCESS_KEY_ID}>"
     else

--- a/script/setup-sccache.ps1
+++ b/script/setup-sccache.ps1
@@ -1,18 +1,42 @@
 #Requires -Version 5.1
 $ErrorActionPreference = "Stop"
 
-$SCCACHE_VERSION = "v0.10.0"
+$SCCACHE_VERSION = "v0.16.0"
 $SCCACHE_DIR = "./target/sccache"
 
 function Install-Sccache {
     New-Item -ItemType Directory -Path $SCCACHE_DIR -Force | Out-Null
 
     $sccachePath = Join-Path $SCCACHE_DIR "sccache.exe"
-
+    $expectedVersion = "sccache $($SCCACHE_VERSION.Substring(1))"
+    $installedVersion = $null
     if (Test-Path $sccachePath) {
-        Write-Host "sccache already cached: $(& $sccachePath --version)"
+        try {
+            $installedVersion = & $sccachePath --version
+        }
+        catch {
+            Write-Host "Cached sccache binary is invalid; reinstalling"
+            $installedVersion = $null
+        }
+    }
+
+    if ($installedVersion -eq $expectedVersion) {
+        Write-Host "sccache already cached: $installedVersion"
     }
     else {
+        if ($installedVersion) {
+            Write-Host "Stopping cached $installedVersion server before upgrading..."
+            try {
+                & $sccachePath --stop-server *> $null
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Host "No running sccache server to stop"
+                }
+            }
+            catch {
+                Write-Host "No running sccache server to stop"
+            }
+        }
+
         Write-Host "Installing sccache ${SCCACHE_VERSION} from GitHub releases..."
 
         $arch = if ([Environment]::Is64BitOperatingSystem) { "x86_64" } else { "i686" }
@@ -90,7 +114,7 @@ function Configure-Sccache {
     $env:SCCACHE_BUCKET = $bucket
     $env:SCCACHE_REGION = "auto"
     $env:SCCACHE_S3_KEY_PREFIX = $keyPrefix
-    $env:SCCACHE_BASEDIR = $baseDir
+    $env:SCCACHE_BASEDIRS = $baseDir
     $env:AWS_ACCESS_KEY_ID = $env:R2_ACCESS_KEY_ID
     $env:AWS_SECRET_ACCESS_KEY = $env:R2_SECRET_ACCESS_KEY
     $env:RUSTC_WRAPPER = $sccacheBin
@@ -102,7 +126,7 @@ function Configure-Sccache {
             "SCCACHE_BUCKET=$($env:SCCACHE_BUCKET)"
             "SCCACHE_REGION=$($env:SCCACHE_REGION)"
             "SCCACHE_S3_KEY_PREFIX=$($env:SCCACHE_S3_KEY_PREFIX)"
-            "SCCACHE_BASEDIR=$($env:SCCACHE_BASEDIR)"
+            "SCCACHE_BASEDIRS=$($env:SCCACHE_BASEDIRS)"
             "AWS_ACCESS_KEY_ID=$($env:AWS_ACCESS_KEY_ID)"
             "AWS_SECRET_ACCESS_KEY=$($env:AWS_SECRET_ACCESS_KEY)"
             "RUSTC_WRAPPER=$($env:RUSTC_WRAPPER)"
@@ -121,7 +145,7 @@ function Show-Config {
     Write-Host "SCCACHE_ENDPOINT: $($env:SCCACHE_ENDPOINT ?? '<not set>')"
     Write-Host "SCCACHE_REGION: $($env:SCCACHE_REGION ?? '<not set>')"
     Write-Host "SCCACHE_S3_KEY_PREFIX: $($env:SCCACHE_S3_KEY_PREFIX ?? '<not set>')"
-    Write-Host "SCCACHE_BASEDIR: $($env:SCCACHE_BASEDIR ?? '<not set>')"
+    Write-Host "SCCACHE_BASEDIRS: $($env:SCCACHE_BASEDIRS ?? '<not set>')"
 
     if ($env:AWS_ACCESS_KEY_ID) {
         Write-Host "AWS_ACCESS_KEY_ID: <set>"


### PR DESCRIPTION
## Summary

- Upgrade sccache from 0.10.0 to 0.16.0 on macOS, Linux, and Windows CI runners.
- Normalize the GitHub workspace with `SCCACHE_BASEDIRS` so identical builds can reuse cache entries across checkout roots.
- Validate the cached binary version and stop an older server before replacing it, including on Windows where a running executable cannot be overwritten.

## Why

The setup scripts configured `SCCACHE_BASEDIR`, which sccache did not use for cache-key path normalization. Absolute checkout paths therefore remained part of cache keys and reduced reuse between CI workspaces. sccache 0.16.0 supports `SCCACHE_BASEDIRS` and includes the Windows path-normalization fix needed for the Windows runner.

## Validation

- `bash -n script/setup-sccache`
- `git diff --check`
- Upgraded a live local sccache 0.15.0 server to 0.16.0 through the setup script.
- Compiled identical C sources from two checkout roots and observed one cache miss followed by one cache hit.
- Confirmed that every release asset referenced by the setup scripts exists for the supported CI runner targets.

Release Notes:

- N/A