### PR TITLE
pickers: Remove `picker::ToMultiBuffer` action we did not land

### DIFF
--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -76,8 +76,6 @@ actions!(
         SetPreviewHidden,
         /// Opens the footer's actions menu.
         ToggleActionsMenu,
-        /// Take the picker's content and open it in a multibuffer
-        ToMultiBuffer,
         /// Toggles multi-select mode, in which clicking items adds them to
         /// the selection instead of opening them
         ToggleMultiSelect,

--- a/crates/picker_preview/src/picker_preview.rs
+++ b/crates/picker_preview/src/picker_preview.rs
@@ -3,13 +3,11 @@
 use std::sync::Arc;
 
 use gpui::{
-    Action, AnyElement, App, AppContext as _, Context, Entity, IntoElement, Pixels, StyledText,
-    Task, Window, px,
+    AnyElement, App, AppContext as _, Context, Entity, IntoElement, Pixels, StyledText, Task,
+    Window, px,
 };
 use language::{Bias, Buffer, HighlightedText, HighlightedTextBuilder, ToPoint};
-use picker::{
-    MatchLocation, PreviewBackend, PreviewLayout, PreviewSource, PreviewUpdate, ToMultiBuffer,
-};
+use picker::{MatchLocation, PreviewBackend, PreviewLayout, PreviewSource, PreviewUpdate};
 use project::{Project, Symbol};
 use rope::Point;
 use settings::Settings;
@@ -335,7 +333,7 @@ impl EditorPreview {
             div()
                 .flex_1()
                 .overflow_hidden()
-                .child(self.editor_as_giant_button())
+                .child(self.occluded_editor())
                 .into_any_element()
         }
     }
@@ -357,7 +355,7 @@ impl EditorPreview {
             .child(content)
     }
 
-    fn editor_as_giant_button(&self) -> impl IntoElement {
+    fn occluded_editor(&self) -> impl IntoElement {
         div()
             .relative()
             .size_full()
@@ -367,10 +365,7 @@ impl EditorPreview {
                     .id("picker-preview-editor")
                     .absolute()
                     .inset_0()
-                    .occlude()
-                    .on_click(|_, window, cx| {
-                        window.dispatch_action(ToMultiBuffer.boxed_clone(), cx);
-                    }),
+                    .occlude(),
             )
     }
 }


### PR DESCRIPTION
Missed this when shipping the pickers. The feature is still planned and tracked in the tracking issue.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A
