### PR TITLE
git_ui: Add native GitHub pull request reviews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7409,7 +7409,9 @@ dependencies = [
  "fuzzy",
  "fuzzy_nucleo",
  "git",
+ "github_pull_requests",
  "gpui",
+ "http_client",
  "indoc",
  "itertools 0.14.0",
  "language",
@@ -7453,9 +7455,25 @@ dependencies = [
  "windows 0.61.3",
  "workspace",
  "zed_actions",
+ "zed_credentials_provider",
  "zeroize",
  "zlog",
  "ztracing",
+]
+
+[[package]]
+name = "github_pull_requests"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "credentials_provider",
+ "futures 0.3.32",
+ "gpui",
+ "http_client",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ members = [
     "crates/fuzzy_nucleo",
     "crates/git",
     "crates/git_hosting_providers",
+    "crates/github_pull_requests",
     "crates/git_ui",
     "crates/go_to_line",
     "crates/google_ai",
@@ -342,6 +343,7 @@ fuzzy = { path = "crates/fuzzy" }
 fuzzy_nucleo = { path = "crates/fuzzy_nucleo" }
 git = { path = "crates/git" }
 git_hosting_providers = { path = "crates/git_hosting_providers" }
+github_pull_requests = { path = "crates/github_pull_requests" }
 git_ui = { path = "crates/git_ui" }
 go_to_line = { path = "crates/go_to_line" }
 google_ai = { path = "crates/google_ai" }

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -641,20 +641,44 @@ pub enum ResetMode {
 pub enum FetchOptions {
     All,
     Remote(Remote),
+    Refspec {
+        remote: Remote,
+        source: SharedString,
+        destination: SharedString,
+    },
 }
 
 impl FetchOptions {
-    pub fn to_proto(&self) -> Option<String> {
+    pub fn to_proto(&self) -> (Option<String>, Option<String>, Option<String>) {
         match self {
-            FetchOptions::All => None,
-            FetchOptions::Remote(remote) => Some(remote.clone().name.into()),
+            FetchOptions::All => (None, None, None),
+            FetchOptions::Remote(remote) => (Some(remote.clone().name.into()), None, None),
+            FetchOptions::Refspec {
+                remote,
+                source,
+                destination,
+            } => (
+                Some(remote.clone().name.into()),
+                Some(source.to_string()),
+                Some(destination.to_string()),
+            ),
         }
     }
 
-    pub fn from_proto(remote_name: Option<String>) -> Self {
-        match remote_name {
-            Some(name) => FetchOptions::Remote(Remote { name: name.into() }),
-            None => FetchOptions::All,
+    pub fn from_proto(
+        remote_name: Option<String>,
+        source: Option<String>,
+        destination: Option<String>,
+    ) -> Result<Self> {
+        match (remote_name, source, destination) {
+            (None, None, None) => Ok(FetchOptions::All),
+            (Some(name), None, None) => Ok(FetchOptions::Remote(Remote { name: name.into() })),
+            (Some(name), Some(source), Some(destination)) => Ok(FetchOptions::Refspec {
+                remote: Remote { name: name.into() },
+                source: source.into(),
+                destination: destination.into(),
+            }),
+            _ => bail!("invalid fetch options"),
         }
     }
 
@@ -662,6 +686,7 @@ impl FetchOptions {
         match self {
             Self::All => "Fetch all remotes".into(),
             Self::Remote(remote) => remote.name.clone(),
+            Self::Refspec { remote, .. } => remote.name.clone(),
         }
     }
 }
@@ -671,6 +696,11 @@ impl std::fmt::Display for FetchOptions {
         match self {
             FetchOptions::All => write!(f, "--all"),
             FetchOptions::Remote(remote) => write!(f, "{}", remote.name),
+            FetchOptions::Refspec {
+                remote,
+                source,
+                destination,
+            } => write!(f, "{} {source}:{destination}", remote.name),
         }
     }
 }
@@ -2674,7 +2704,6 @@ impl GitRepository for RealGitRepository {
     ) -> BoxFuture<'_, Result<RemoteCommandOutput>> {
         let working_directory = self.command_directory();
         let git_directory = self.path();
-        let remote_name = format!("{}", fetch_options);
         let git_binary_path = self.system_git_binary_path.clone();
         let executor = cx.background_executor().clone();
         let is_trusted = self.is_trusted();
@@ -2689,7 +2718,24 @@ impl GitRepository for RealGitRepository {
                 executor.clone(),
                 is_trusted,
             );
-            let mut command = git.build_command(&["fetch", &remote_name]);
+            let mut command = git.build_command(&["fetch"]);
+            match fetch_options {
+                FetchOptions::All => {
+                    command.arg("--all");
+                }
+                FetchOptions::Remote(remote) => {
+                    command.arg(remote.name.as_ref());
+                }
+                FetchOptions::Refspec {
+                    remote,
+                    source,
+                    destination,
+                } => {
+                    command
+                        .arg(remote.name.as_ref())
+                        .arg(format!("+{source}:{destination}"));
+                }
+            }
             command
                 .envs(env.iter())
                 .stdout(Stdio::piped())
@@ -3970,6 +4016,34 @@ mod tests {
 
     use super::*;
     use gpui::TestAppContext;
+
+    #[test]
+    fn fetch_refspec_round_trips_through_protocol_fields() {
+        let options = FetchOptions::Refspec {
+            remote: Remote {
+                name: "upstream".into(),
+            },
+            source: "refs/pull/42/head".into(),
+            destination: "refs/zed/pull-requests/owner/repository/42/head".into(),
+        };
+        let (remote, source, destination) = options.to_proto();
+        assert_eq!(
+            FetchOptions::from_proto(remote, source, destination).expect("valid refspec"),
+            options
+        );
+    }
+
+    #[test]
+    fn fetch_refspec_rejects_partial_protocol_fields() {
+        assert!(
+            FetchOptions::from_proto(
+                Some("origin".to_string()),
+                Some("refs/pull/42/head".to_string()),
+                None,
+            )
+            .is_err()
+        );
+    }
 
     fn disable_git_global_config() {
         unsafe {

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -35,7 +35,9 @@ futures.workspace = true
 fuzzy.workspace = true
 fuzzy_nucleo.workspace = true
 git.workspace = true
+github_pull_requests.workspace = true
 gpui.workspace = true
+http_client.workspace = true
 itertools.workspace = true
 language.workspace = true
 language_model.workspace = true
@@ -75,6 +77,7 @@ util.workspace = true
 watch.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
+zed_credentials_provider.workspace = true
 zeroize.workspace = true
 ztracing.workspace = true
 

--- a/crates/git_ui/src/branch_diff.rs
+++ b/crates/git_ui/src/branch_diff.rs
@@ -48,6 +48,7 @@ pub struct BranchDiff {
     diff: Entity<DiffMultibuffer>,
     project: Entity<Project>,
     workspace: WeakEntity<Workspace>,
+    custom_title: Option<SharedString>,
     _diff_event_subscription: Subscription,
 }
 
@@ -108,6 +109,7 @@ impl BranchDiff {
                         project,
                         intended_repo,
                         base_ref,
+                        None,
                         window,
                         cx,
                     );
@@ -154,6 +156,7 @@ impl BranchDiff {
                             project.clone(),
                             repository.clone(),
                             base_ref,
+                            None,
                             window,
                             cx,
                         );
@@ -174,11 +177,12 @@ impl BranchDiff {
         });
     }
 
-    fn deploy_branch_diff_with_base_ref(
+    pub(crate) fn deploy_branch_diff_with_base_ref(
         workspace: &mut Workspace,
         project: Entity<Project>,
         intended_repo: Entity<Repository>,
         base_ref: SharedString,
+        custom_title: Option<SharedString>,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
@@ -190,6 +194,10 @@ impl BranchDiff {
             )
         });
         if let Some(existing) = existing {
+            existing.update(cx, |existing, cx| {
+                existing.custom_title = custom_title;
+                cx.notify();
+            });
             workspace.activate_item(&existing, true, true, window, cx);
 
             let needs_switch = existing.read(cx).repo(cx).map_or(true, |current| {
@@ -221,6 +229,10 @@ impl BranchDiff {
                         )
                     })?
                     .await?;
+                this.update(cx, |this, cx| {
+                    this.custom_title = custom_title;
+                    cx.notify();
+                });
                 workspace
                     .update_in(cx, |workspace, window, cx| {
                         workspace.add_item_to_active_pane(Box::new(this), None, true, window, cx);
@@ -328,6 +340,7 @@ impl BranchDiff {
             diff,
             project,
             workspace: workspace.downgrade(),
+            custom_title: None,
             _diff_event_subscription: diff_event_subscription,
         }
     }
@@ -450,6 +463,9 @@ impl Item for BranchDiff {
     }
 
     fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
+        if let Some(custom_title) = &self.custom_title {
+            return custom_title.clone();
+        }
         match self.diff_base(cx) {
             DiffBase::Merge { base_ref } => format!("Changes since {}", base_ref).into(),
             DiffBase::Head | DiffBase::Index | DiffBase::Staged => "Changes".into(),

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3480,6 +3480,7 @@ impl GitPanel {
                     let action = match fetch_options {
                         FetchOptions::All => RemoteAction::Fetch(None),
                         FetchOptions::Remote(remote) => RemoteAction::Fetch(Some(remote)),
+                        FetchOptions::Refspec { remote, .. } => RemoteAction::Fetch(Some(remote)),
                     };
                     match remote_message {
                         Ok(remote_message) => this.show_remote_output(action, remote_message, cx),

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -51,8 +51,10 @@ mod git_runtime_diagnostics;
 pub mod multi_diff_view;
 pub mod picker_prompt;
 pub mod project_diff;
+pub mod pull_requests_panel;
 pub(crate) mod remote_output;
 pub mod repository_selector;
+mod review_comment_modal;
 pub mod solo_diff_view;
 pub mod staged_diff;
 pub mod stash_picker;
@@ -96,6 +98,7 @@ pub fn init(cx: &mut App) {
         branch_diff::BranchDiff::register(workspace, cx);
         CommitModal::register(workspace);
         git_panel::register(workspace);
+        pull_requests_panel::register(workspace);
         repository_selector::register(workspace);
         git_picker::register(workspace);
 

--- a/crates/git_ui/src/pull_requests_panel.rs
+++ b/crates/git_ui/src/pull_requests_panel.rs
@@ -1,0 +1,945 @@
+use crate::{
+    askpass_modal::AskPassModal, branch_diff::BranchDiff, review_comment_modal::ReviewCommentModal,
+};
+use anyhow::{Context as _, Result, anyhow};
+use askpass::AskPassDelegate;
+use git::{
+    GitHostingProviderRegistry, parse_git_remote_url,
+    repository::{FetchOptions, Remote},
+};
+use github_pull_requests::{
+    DeviceAuthorization, DeviceFlowPoll, GitHubAuthentication, GitHubClient, PullRequestDetails,
+    PullRequestList, PullRequestSummary, ReviewEvent, ReviewThread,
+};
+use gpui::{
+    Action, App, AppContext as _, AsyncWindowContext, Context, Entity, EventEmitter, FocusHandle,
+    Focusable, InteractiveElement, PromptLevel, Render, SharedString, Task, WeakEntity, Window,
+    actions, px,
+};
+use http_client::HttpClient;
+use project::Project;
+use std::{sync::Arc, time::Instant};
+use ui::{Button, ButtonStyle, IconButton, IconName, Label, prelude::*};
+use workspace::{
+    Workspace,
+    dock::{DockPosition, Panel, PanelEvent},
+};
+
+actions!(
+    pull_requests_panel,
+    [
+        /// Focuses the Pull Requests panel.
+        ToggleFocus,
+        /// Refreshes pull requests for the active repository.
+        Refresh,
+        /// Signs in to GitHub.
+        SignIn,
+        /// Signs out of GitHub.
+        SignOut,
+    ]
+);
+
+const PANEL_KEY: &str = "PullRequestsPanel";
+
+pub fn register(workspace: &mut Workspace) {
+    workspace.register_action(|workspace, _: &ToggleFocus, window, cx| {
+        workspace.toggle_panel_focus::<PullRequestsPanel>(window, cx);
+    });
+}
+
+enum PanelState {
+    LoadingCredentials,
+    SignedOut,
+    Authorizing(DeviceAuthorization),
+    Loading,
+    Ready(PullRequestList),
+    Review(PullRequestDetails),
+    Error(SharedString),
+}
+
+pub struct PullRequestsPanel {
+    workspace: WeakEntity<Workspace>,
+    project: Entity<Project>,
+    focus_handle: FocusHandle,
+    authentication: Option<Arc<GitHubAuthentication>>,
+    http_client: Arc<dyn HttpClient>,
+    client: Option<Arc<GitHubClient>>,
+    state: PanelState,
+    position: DockPosition,
+    active_task: Option<Task<Result<()>>>,
+}
+
+impl PullRequestsPanel {
+    pub async fn load(
+        workspace: WeakEntity<Workspace>,
+        mut cx: AsyncWindowContext,
+    ) -> Result<Entity<Self>> {
+        workspace.update_in(&mut cx, |workspace, _window, cx| {
+            let project = workspace.project().clone();
+            let http_client = cx.http_client();
+            let authentication = GitHubAuthentication::new(
+                http_client.clone(),
+                zed_credentials_provider::global(cx),
+            )
+            .map(Arc::new);
+            cx.new(|cx| {
+                let mut panel = Self {
+                    workspace: workspace.weak_handle(),
+                    project,
+                    focus_handle: cx.focus_handle(),
+                    authentication: authentication.as_ref().ok().cloned(),
+                    http_client,
+                    client: None,
+                    state: PanelState::LoadingCredentials,
+                    position: DockPosition::Left,
+                    active_task: None,
+                };
+                match authentication {
+                    Ok(_) => panel.load_credentials(cx),
+                    Err(error) => panel.state = PanelState::Error(error.to_string().into()),
+                }
+                panel
+            })
+        })
+    }
+
+    fn load_credentials(&mut self, cx: &mut Context<Self>) {
+        let Some(authentication) = self.authentication.clone() else {
+            self.state = PanelState::SignedOut;
+            return;
+        };
+        let http_client = self.http_client.clone();
+        let task = cx.spawn(async move |this, cx| {
+            match authentication.load_valid(&*cx).await {
+                Ok(Some(credentials)) => {
+                    let client = Arc::new(GitHubClient::new(http_client, credentials.access_token));
+                    this.update(cx, |this, cx| {
+                        this.client = Some(client);
+                        this.refresh(cx);
+                    })?;
+                }
+                Ok(None) => {
+                    this.update(cx, |this, cx| {
+                        this.state = PanelState::SignedOut;
+                        cx.notify();
+                    })?;
+                }
+                Err(error) => {
+                    this.update(cx, |this, cx| {
+                        this.state = PanelState::Error(error.to_string().into());
+                        cx.notify();
+                    })?;
+                }
+            }
+            anyhow::Ok(())
+        });
+        self.active_task = Some(task);
+    }
+
+    fn repository_coordinates(&self, cx: &App) -> Result<(Arc<str>, Arc<str>)> {
+        let repository = self
+            .project
+            .read(cx)
+            .active_repository(cx)
+            .context("No active Git repository")?;
+        let remote_url = repository
+            .read(cx)
+            .default_remote_url()
+            .context("The active repository has no GitHub remote")?;
+        let (provider, remote) =
+            parse_git_remote_url(GitHostingProviderRegistry::global(cx), &remote_url)
+                .context("The active repository is not hosted on GitHub")?;
+        if provider.name() != "GitHub" {
+            return Err(anyhow!(
+                "GitHub.com is the only supported pull request host"
+            ));
+        }
+        Ok((remote.owner, remote.repo))
+    }
+
+    fn refresh(&mut self, cx: &mut Context<Self>) {
+        let Some(client) = self.client.clone() else {
+            self.state = PanelState::SignedOut;
+            cx.notify();
+            return;
+        };
+        let coordinates = self.repository_coordinates(cx);
+        self.state = PanelState::Loading;
+        cx.notify();
+        let task = cx.spawn(async move |this, cx| {
+            let result = match coordinates {
+                Ok((owner, repository)) => client.list_pull_requests(&owner, &repository).await,
+                Err(error) => Err(error),
+            };
+            this.update(cx, |this, cx| {
+                this.state = match result {
+                    Ok(pull_requests) => PanelState::Ready(pull_requests),
+                    Err(error) => PanelState::Error(error.to_string().into()),
+                };
+                this.active_task = None;
+                cx.notify();
+            })?;
+            anyhow::Ok(())
+        });
+        self.active_task = Some(task);
+    }
+
+    fn sign_in(&mut self, cx: &mut Context<Self>) {
+        let Some(authentication) = self.authentication.clone() else {
+            self.state = PanelState::Error("GitHub sign-in is not configured in this build".into());
+            cx.notify();
+            return;
+        };
+        let http_client = self.http_client.clone();
+        self.state = PanelState::Loading;
+        let task = cx.spawn(async move |this, cx| {
+            let authorization = authentication.request_device_authorization().await?;
+            cx.update(|cx| cx.open_url(&authorization.verification_uri));
+            this.update(cx, |this, cx| {
+                this.state = PanelState::Authorizing(authorization.clone());
+                cx.notify();
+            })?;
+            let expires_at = Instant::now() + authorization.expires_in;
+            let mut interval = authorization.interval;
+            loop {
+                cx.background_executor().timer(interval).await;
+                if Instant::now() >= expires_at {
+                    return Err(anyhow!("GitHub device authorization expired"));
+                }
+                match authentication
+                    .poll_device_authorization(&authorization.device_code)
+                    .await?
+                {
+                    DeviceFlowPoll::Pending => {}
+                    DeviceFlowPoll::SlowDown(additional_delay) => {
+                        interval += additional_delay;
+                    }
+                    DeviceFlowPoll::Complete(credentials) => {
+                        authentication.store(&credentials, &*cx).await?;
+                        let client =
+                            Arc::new(GitHubClient::new(http_client, credentials.access_token));
+                        this.update(cx, |this, cx| {
+                            this.client = Some(client);
+                            this.refresh(cx);
+                        })?;
+                        return Ok(());
+                    }
+                    DeviceFlowPoll::AccessDenied => {
+                        return Err(anyhow!("GitHub authorization was denied"));
+                    }
+                    DeviceFlowPoll::Expired => {
+                        return Err(anyhow!("GitHub device authorization expired"));
+                    }
+                }
+            }
+        });
+        self.active_task = Some(cx.spawn(async move |this, cx| {
+            if let Err(error) = task.await {
+                this.update(cx, |this, cx| {
+                    this.active_task = None;
+                    this.state = PanelState::Error(error.to_string().into());
+                    cx.notify();
+                })?;
+            }
+            anyhow::Ok(())
+        }));
+    }
+
+    fn sign_out(&mut self, cx: &mut Context<Self>) {
+        let Some(authentication) = self.authentication.clone() else {
+            return;
+        };
+        let task = cx.spawn(async move |this, cx| {
+            authentication.clear(&*cx).await?;
+            this.update(cx, |this, cx| {
+                this.client = None;
+                this.state = PanelState::SignedOut;
+                this.active_task = None;
+                cx.notify();
+            })?;
+            anyhow::Ok(())
+        });
+        self.active_task = Some(cx.spawn(async move |this, cx| {
+            if let Err(error) = task.await {
+                this.update(cx, |this, cx| {
+                    this.active_task = None;
+                    this.state = PanelState::Error(error.to_string().into());
+                    cx.notify();
+                })?;
+            }
+            anyhow::Ok(())
+        }));
+    }
+
+    fn askpass_delegate(
+        &self,
+        operation: impl Into<SharedString>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> AskPassDelegate {
+        let workspace = self.workspace.clone();
+        let operation = operation.into();
+        let window = window.window_handle();
+        AskPassDelegate::new(&mut cx.to_async(), move |prompt, tx, cx| {
+            window
+                .update(cx, |_, window, cx| {
+                    workspace.update(cx, |workspace, cx| {
+                        workspace.toggle_modal(window, cx, |window, cx| {
+                            AskPassModal::new(operation.clone(), prompt.into(), tx, window, cx)
+                        });
+                    })
+                })
+                .ok();
+        })
+    }
+
+    fn open_pull_request(
+        &mut self,
+        pull_request: PullRequestSummary,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(client) = self.client.clone() else {
+            self.state = PanelState::SignedOut;
+            cx.notify();
+            return;
+        };
+        let Some(repository) = self.project.read(cx).active_repository(cx) else {
+            self.state = PanelState::Error("No active Git repository".into());
+            cx.notify();
+            return;
+        };
+        let has_git_changes = repository.read(cx).status_summary().count > 0;
+        let has_unsaved_edits = self
+            .project
+            .read(cx)
+            .opened_buffers(cx)
+            .into_iter()
+            .any(|buffer| buffer.read(cx).has_unsaved_edits());
+        if has_git_changes || has_unsaved_edits {
+            self.state = PanelState::Error(
+                "Save and commit or stash local changes before checking out a pull request".into(),
+            );
+            cx.notify();
+            return;
+        }
+
+        let Some(remote) = repository.read(cx).default_remote() else {
+            self.state = PanelState::Error("The active repository has no Git remote".into());
+            cx.notify();
+            return;
+        };
+        let askpass = self.askpass_delegate("fetch pull request", window, cx);
+        let base_askpass = self.askpass_delegate("fetch pull request base", window, cx);
+        let project = self.project.clone();
+        let workspace = self.workspace.clone();
+        self.state = PanelState::Loading;
+        cx.notify();
+        let task = cx.spawn_in(window, async move |this, cx| {
+            let namespace = format!(
+                "refs/zed/pull-requests/{}/{}/{}",
+                pull_request.id.owner, pull_request.id.repository, pull_request.id.number
+            );
+            let head_ref = format!("{namespace}/head");
+            let base_ref = format!("{namespace}/base");
+            repository
+                .update(cx, |repository, cx| {
+                    repository.fetch(
+                        FetchOptions::Refspec {
+                            remote: Remote {
+                                name: remote.name.clone(),
+                            },
+                            source: format!("refs/pull/{}/head", pull_request.id.number).into(),
+                            destination: head_ref.clone().into(),
+                        },
+                        askpass,
+                        cx,
+                    )
+                })
+                .await??;
+
+            repository
+                .update(cx, |repository, cx| {
+                    repository.fetch(
+                        FetchOptions::Refspec {
+                            remote,
+                            source: format!("refs/heads/{}", pull_request.base_ref).into(),
+                            destination: base_ref.clone().into(),
+                        },
+                        base_askpass,
+                        cx,
+                    )
+                })
+                .await??;
+
+            let short_sha = pull_request.head_sha.get(..12).unwrap_or(&pull_request.head_sha);
+            let branch_name = format!("zed-pr/{}-{}", pull_request.id.number, short_sha);
+            let branches = repository
+                .update(cx, |repository, _| repository.branches())
+                .await??;
+            if let Some(existing) = branches
+                .branches
+                .iter()
+                .find(|branch| !branch.is_remote() && branch.name() == branch_name)
+            {
+                let existing_sha = existing
+                    .most_recent_commit
+                    .as_ref()
+                    .map(|commit| commit.sha.as_ref());
+                if existing_sha != Some(pull_request.head_sha.as_ref()) {
+                    return Err(anyhow!(
+                        "Local branch {branch_name} points to a different commit; rename or delete it before retrying"
+                    ));
+                }
+                repository
+                    .update(cx, |repository, _| repository.change_branch(branch_name))
+                    .await??;
+            } else {
+                repository
+                    .update(cx, |repository, _| {
+                        repository.create_branch(branch_name, Some(head_ref))
+                    })
+                    .await??;
+            }
+
+            workspace.update_in(cx, |workspace, window, cx| {
+                BranchDiff::deploy_branch_diff_with_base_ref(
+                    workspace,
+                    project,
+                    repository,
+                    base_ref.into(),
+                    Some(format!("PR #{}: {}", pull_request.id.number, pull_request.title).into()),
+                    window,
+                    cx,
+                );
+            })?;
+            let details = client.pull_request_details(&pull_request.id).await?;
+            this.update(cx, |this, cx| {
+                this.active_task = None;
+                this.state = PanelState::Review(details);
+                cx.notify();
+            })?;
+            anyhow::Ok(())
+        });
+        self.active_task = Some(cx.spawn_in(window, async move |this, cx| {
+            if let Err(error) = task.await {
+                this.update(cx, |this, cx| {
+                    this.active_task = None;
+                    this.state = PanelState::Error(error.to_string().into());
+                    cx.notify();
+                })?;
+            }
+            anyhow::Ok(())
+        }));
+    }
+
+    fn approve(
+        &mut self,
+        details: PullRequestDetails,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(client) = self.client.clone() else {
+            return;
+        };
+        let answer = window.prompt(
+            PromptLevel::Info,
+            &format!("Approve pull request #{}?", details.summary.id.number),
+            Some(&details.summary.title),
+            &["Approve", "Cancel"],
+            cx,
+        );
+        let task = cx.spawn(async move |this, cx| {
+            if answer.await != Ok(0) {
+                this.update(cx, |this, _| this.active_task = None)?;
+                return Ok(());
+            }
+            let review_id = match &details.pending_review {
+                Some(review) => review.id.clone(),
+                None => {
+                    client
+                        .create_pending_review(&details.summary.id, &details.summary.head_sha)
+                        .await?
+                }
+            };
+            client
+                .submit_review(&details.summary.id, &review_id, ReviewEvent::Approve, "")
+                .await?;
+            let details = client.pull_request_details(&details.summary.id).await?;
+            this.update(cx, |this, cx| {
+                this.active_task = None;
+                this.state = PanelState::Review(details);
+                cx.notify();
+            })?;
+            anyhow::Ok(())
+        });
+        self.active_task = Some(cx.spawn(async move |this, cx| {
+            if let Err(error) = task.await {
+                this.update(cx, |this, cx| {
+                    this.active_task = None;
+                    this.state = PanelState::Error(error.to_string().into());
+                    cx.notify();
+                })?;
+            }
+            anyhow::Ok(())
+        }));
+    }
+
+    fn set_thread_resolved(
+        &mut self,
+        details: PullRequestDetails,
+        thread: ReviewThread,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(client) = self.client.clone() else {
+            return;
+        };
+        self.state = PanelState::Loading;
+        cx.notify();
+        let task = cx.spawn(async move |this, cx| {
+            client
+                .set_thread_resolved(&thread.id, !thread.is_resolved)
+                .await?;
+            let details = client.pull_request_details(&details.summary.id).await?;
+            this.update(cx, |this, cx| {
+                this.active_task = None;
+                this.state = PanelState::Review(details);
+                cx.notify();
+            })?;
+            anyhow::Ok(())
+        });
+        self.active_task = Some(cx.spawn(async move |this, cx| {
+            if let Err(error) = task.await {
+                this.update(cx, |this, cx| {
+                    this.active_task = None;
+                    this.state = PanelState::Error(error.to_string().into());
+                    cx.notify();
+                })?;
+            }
+            anyhow::Ok(())
+        }));
+    }
+
+    fn review_body_prompt(
+        &self,
+        title: SharedString,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> futures::channel::oneshot::Receiver<String> {
+        let (sender, receiver) = futures::channel::oneshot::channel();
+        let workspace = self.workspace.clone();
+        workspace
+            .update(cx, |workspace, cx| {
+                workspace.toggle_modal(window, cx, |window, cx| {
+                    ReviewCommentModal::new(title, sender, window, cx)
+                });
+            })
+            .ok();
+        receiver
+    }
+
+    fn request_changes(
+        &mut self,
+        details: PullRequestDetails,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(client) = self.client.clone() else {
+            return;
+        };
+        let body = self.review_body_prompt("Request changes".into(), window, cx);
+        let task = cx.spawn(async move |this, cx| {
+            let Ok(body) = body.await else {
+                return Ok(());
+            };
+            let review_id = match &details.pending_review {
+                Some(review) => review.id.clone(),
+                None => {
+                    client
+                        .create_pending_review(&details.summary.id, &details.summary.head_sha)
+                        .await?
+                }
+            };
+            client
+                .submit_review(
+                    &details.summary.id,
+                    &review_id,
+                    ReviewEvent::RequestChanges,
+                    &body,
+                )
+                .await?;
+            let details = client.pull_request_details(&details.summary.id).await?;
+            this.update(cx, |this, cx| {
+                this.active_task = None;
+                this.state = PanelState::Review(details);
+                cx.notify();
+            })?;
+            anyhow::Ok(())
+        });
+        self.active_task = Some(cx.spawn(async move |this, cx| {
+            if let Err(error) = task.await {
+                this.update(cx, |this, cx| {
+                    this.active_task = None;
+                    this.state = PanelState::Error(error.to_string().into());
+                    cx.notify();
+                })?;
+            }
+            anyhow::Ok(())
+        }));
+    }
+
+    fn reply_to_thread(
+        &mut self,
+        details: PullRequestDetails,
+        thread: ReviewThread,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(client) = self.client.clone() else {
+            return;
+        };
+        let Some(comment_id) = thread.comments.last().map(|comment| comment.id.clone()) else {
+            return;
+        };
+        let body = self.review_body_prompt("Reply to review thread".into(), window, cx);
+        let task = cx.spawn(async move |this, cx| {
+            let Ok(body) = body.await else {
+                return Ok(());
+            };
+            client
+                .reply_to_comment(&details.summary.id, comment_id, &body)
+                .await?;
+            let details = client.pull_request_details(&details.summary.id).await?;
+            this.update(cx, |this, cx| {
+                this.active_task = None;
+                this.state = PanelState::Review(details);
+                cx.notify();
+            })?;
+            anyhow::Ok(())
+        });
+        self.active_task = Some(cx.spawn(async move |this, cx| {
+            if let Err(error) = task.await {
+                this.update(cx, |this, cx| {
+                    this.active_task = None;
+                    this.state = PanelState::Error(error.to_string().into());
+                    cx.notify();
+                })?;
+            }
+            anyhow::Ok(())
+        }));
+    }
+
+    fn render_review(&self, details: &PullRequestDetails, cx: &mut Context<Self>) -> AnyElement {
+        let mut content = v_flex()
+            .p_3()
+            .gap_2()
+            .child(Label::new(details.summary.title.clone()).size(LabelSize::Large))
+            .child(
+                Label::new(format!(
+                    "#{} · {} → {} · +{} −{} · {} files",
+                    details.summary.id.number,
+                    details.summary.head_ref,
+                    details.summary.base_ref,
+                    details.additions,
+                    details.deletions,
+                    details.changed_files,
+                ))
+                .size(LabelSize::Small)
+                .color(Color::Muted),
+            )
+            .when(!details.body.is_empty(), |this| {
+                this.child(Label::new(details.body.clone()).size(LabelSize::Small))
+            })
+            .child(
+                h_flex()
+                    .gap_1()
+                    .child(
+                        Button::new("approve-pull-request", "Approve")
+                            .style(ButtonStyle::Filled)
+                            .on_click({
+                                let details = details.clone();
+                                cx.listener(move |this, _, window, cx| {
+                                    this.approve(details.clone(), window, cx)
+                                })
+                            }),
+                    )
+                    .child(
+                        Button::new("request-pull-request-changes", "Request Changes").on_click({
+                            let details = details.clone();
+                            cx.listener(move |this, _, window, cx| {
+                                this.request_changes(details.clone(), window, cx)
+                            })
+                        }),
+                    )
+                    .child(
+                        Button::new("open-pull-request-on-github", "Open on GitHub").on_click({
+                            let url = details.summary.html_url.clone();
+                            move |_, _, cx| cx.open_url(&url)
+                        }),
+                    ),
+            )
+            .child(Label::new(format!("Checks ({})", details.checks.len())))
+            .children(details.checks.iter().map(|check| {
+                Label::new(format!(
+                    "{} · {:?}",
+                    check.name,
+                    check.conclusion.unwrap_or_else(|| match check.state {
+                        github_pull_requests::CheckState::Queued
+                        | github_pull_requests::CheckState::InProgress => {
+                            github_pull_requests::CheckConclusion::Unknown
+                        }
+                        github_pull_requests::CheckState::Completed => {
+                            github_pull_requests::CheckConclusion::Unknown
+                        }
+                    })
+                ))
+                .size(LabelSize::Small)
+            }))
+            .child(Label::new(format!(
+                "Review threads ({})",
+                details.threads.len()
+            )));
+        for (thread_index, thread) in details.threads.iter().enumerate() {
+            let thread_for_click = thread.clone();
+            let details_for_click = details.clone();
+            let label = if thread.is_resolved {
+                "Reopen"
+            } else {
+                "Resolve"
+            };
+            let mut thread_content = v_flex().p_2().gap_1().border_1().rounded_sm();
+            for comment in &thread.comments {
+                thread_content = thread_content.child(
+                    v_flex()
+                        .child(Label::new(comment.author.login.clone()).size(LabelSize::XSmall))
+                        .child(Label::new(comment.body.clone()).size(LabelSize::Small)),
+                );
+            }
+            if thread.viewer_can_resolve {
+                thread_content = thread_content.child(
+                    Button::new(("resolve-review-thread", thread_index), label).on_click(
+                        cx.listener(move |this, _, _, cx| {
+                            this.set_thread_resolved(
+                                details_for_click.clone(),
+                                thread_for_click.clone(),
+                                cx,
+                            )
+                        }),
+                    ),
+                );
+            }
+            if thread.viewer_can_reply && !thread.comments.is_empty() {
+                let thread_for_click = thread.clone();
+                let details_for_click = details.clone();
+                thread_content = thread_content.child(
+                    Button::new(("reply-review-thread", thread_index), "Reply").on_click(
+                        cx.listener(move |this, _, window, cx| {
+                            this.reply_to_thread(
+                                details_for_click.clone(),
+                                thread_for_click.clone(),
+                                window,
+                                cx,
+                            )
+                        }),
+                    ),
+                );
+            }
+            content = content.child(thread_content);
+        }
+        content.into_any_element()
+    }
+
+    fn render_pull_request(
+        &self,
+        pull_request: &PullRequestSummary,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let title = pull_request.title.clone();
+        let subtitle: SharedString = format!(
+            "#{} · {}",
+            pull_request.id.number, pull_request.author.login
+        )
+        .into();
+        let pull_request = pull_request.clone();
+        v_flex()
+            .id(("pull-request", pull_request.id.number as usize))
+            .px_2()
+            .py_1()
+            .gap_0p5()
+            .hover(|style| style.bg(cx.theme().colors().element_hover))
+            .cursor_pointer()
+            .child(Label::new(title).size(LabelSize::Small))
+            .child(
+                Label::new(subtitle)
+                    .size(LabelSize::XSmall)
+                    .color(Color::Muted),
+            )
+            .on_click(cx.listener(move |this, _, window, cx| {
+                this.open_pull_request(pull_request.clone(), window, cx)
+            }))
+    }
+
+    fn render_list(&self, pull_requests: &PullRequestList, cx: &mut Context<Self>) -> AnyElement {
+        let mut content = v_flex().gap_1();
+        content = content.child(
+            h_flex()
+                .px_2()
+                .child(Label::new("Waiting for My Review").size(LabelSize::Small)),
+        );
+        if pull_requests.waiting_for_review.is_empty() {
+            content = content.child(
+                Label::new("No pull requests are waiting for you")
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+            );
+        } else {
+            for pull_request in &pull_requests.waiting_for_review {
+                content = content.child(self.render_pull_request(pull_request, cx));
+            }
+        }
+        content = content.child(
+            h_flex()
+                .mt_2()
+                .px_2()
+                .child(Label::new("Created by Me").size(LabelSize::Small)),
+        );
+        for pull_request in &pull_requests.authored_by_viewer {
+            content = content.child(self.render_pull_request(pull_request, cx));
+        }
+        content.into_any_element()
+    }
+}
+
+impl EventEmitter<PanelEvent> for PullRequestsPanel {}
+
+impl Focusable for PullRequestsPanel {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for PullRequestsPanel {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let header = h_flex()
+            .h_8()
+            .px_2()
+            .justify_between()
+            .border_b_1()
+            .border_color(cx.theme().colors().border_variant)
+            .child(Label::new("Pull Requests"))
+            .child(
+                h_flex()
+                    .child(
+                        IconButton::new("refresh-pull-requests", IconName::ArrowCircle)
+                            .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
+                    )
+                    .when(self.client.is_some(), |this| {
+                        this.child(
+                            IconButton::new("sign-out-github", IconName::Exit)
+                                .on_click(cx.listener(|this, _, _, cx| this.sign_out(cx))),
+                        )
+                    }),
+            );
+        let body = match &self.state {
+            PanelState::LoadingCredentials | PanelState::Loading => v_flex()
+                .p_3()
+                .child(Label::new("Loading pull requests…").color(Color::Muted))
+                .into_any_element(),
+            PanelState::SignedOut => v_flex()
+                .p_3()
+                .gap_2()
+                .child(Label::new(
+                    "Sign in to review GitHub pull requests from Zed.",
+                ))
+                .child(
+                    Button::new("sign-in-github", "Sign in to GitHub")
+                        .style(ButtonStyle::Filled)
+                        .on_click(cx.listener(|this, _, _, cx| this.sign_in(cx))),
+                )
+                .into_any_element(),
+            PanelState::Authorizing(authorization) => v_flex()
+                .p_3()
+                .gap_2()
+                .child(Label::new("Enter this code on GitHub:"))
+                .child(Label::new(authorization.user_code.clone()).size(LabelSize::Large))
+                .child(Label::new(authorization.verification_uri.clone()).color(Color::Muted))
+                .into_any_element(),
+            PanelState::Ready(pull_requests) => self.render_list(pull_requests, cx),
+            PanelState::Review(details) => self.render_review(details, cx),
+            PanelState::Error(error) => v_flex()
+                .p_3()
+                .gap_2()
+                .child(Label::new(error.clone()).color(Color::Error))
+                .child(
+                    Button::new("retry-pull-requests", "Retry").on_click(cx.listener(
+                        |this, _, _, cx| {
+                            if this.client.is_some() {
+                                this.refresh(cx);
+                            } else {
+                                this.sign_in(cx);
+                            }
+                        },
+                    )),
+                )
+                .into_any_element(),
+        };
+        v_flex()
+            .id("pull-requests-panel")
+            .size_full()
+            .track_focus(&self.focus_handle)
+            .child(header)
+            .child(
+                div()
+                    .id("pull-requests-scroll")
+                    .flex_1()
+                    .overflow_y_scroll()
+                    .child(body),
+            )
+    }
+}
+
+impl Panel for PullRequestsPanel {
+    fn persistent_name() -> &'static str {
+        PANEL_KEY
+    }
+
+    fn panel_key() -> &'static str {
+        PANEL_KEY
+    }
+
+    fn position(&self, _: &Window, _: &App) -> DockPosition {
+        self.position
+    }
+
+    fn position_is_valid(&self, position: DockPosition) -> bool {
+        matches!(position, DockPosition::Left | DockPosition::Right)
+    }
+
+    fn set_position(&mut self, position: DockPosition, _: &mut Window, _: &mut Context<Self>) {
+        self.position = position;
+    }
+
+    fn default_size(&self, _: &Window, _: &App) -> gpui::Pixels {
+        px(320.)
+    }
+
+    fn icon(&self, _: &Window, _: &App) -> Option<IconName> {
+        Some(IconName::Github)
+    }
+
+    fn icon_tooltip(&self, _: &Window, _: &App) -> Option<&'static str> {
+        Some("Pull Requests")
+    }
+
+    fn toggle_action(&self) -> Box<dyn Action> {
+        Box::new(ToggleFocus)
+    }
+
+    fn starts_open(&self, _: &Window, _: &App) -> bool {
+        false
+    }
+
+    fn activation_priority(&self) -> u32 {
+        4
+    }
+}

--- a/crates/git_ui/src/review_comment_modal.rs
+++ b/crates/git_ui/src/review_comment_modal.rs
@@ -1,0 +1,83 @@
+use editor::Editor;
+use futures::channel::oneshot;
+use gpui::{DismissEvent, Entity, EventEmitter, FocusHandle, Focusable};
+use menu::{Cancel, Confirm};
+use ui::{
+    App, Context, Headline, HeadlineSize, IntoElement, ParentElement, Render, SharedString, Styled,
+    Window, prelude::*,
+};
+use workspace::ModalView;
+
+pub(crate) struct ReviewCommentModal {
+    title: SharedString,
+    editor: Entity<Editor>,
+    sender: Option<oneshot::Sender<String>>,
+}
+
+impl ReviewCommentModal {
+    pub fn new(
+        title: SharedString,
+        sender: oneshot::Sender<String>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let editor = cx.new(|cx| Editor::auto_height(3, 8, window, cx));
+        Self {
+            title,
+            editor,
+            sender: Some(sender),
+        }
+    }
+
+    fn cancel(&mut self, _: &Cancel, _: &mut Window, cx: &mut Context<Self>) {
+        cx.emit(DismissEvent);
+    }
+
+    fn confirm(&mut self, _: &Confirm, _: &mut Window, cx: &mut Context<Self>) {
+        let body = self.editor.read(cx).text(cx).trim().to_string();
+        if body.is_empty() {
+            return;
+        }
+        if let Some(sender) = self.sender.take() {
+            sender.send(body).ok();
+        }
+        cx.emit(DismissEvent);
+    }
+}
+
+impl EventEmitter<DismissEvent> for ReviewCommentModal {}
+impl ModalView for ReviewCommentModal {}
+
+impl Focusable for ReviewCommentModal {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.editor.focus_handle(cx)
+    }
+}
+
+impl Render for ReviewCommentModal {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .key_context("ReviewCommentModal")
+            .track_focus(&self.focus_handle(cx))
+            .on_action(cx.listener(Self::cancel))
+            .on_action(cx.listener(Self::confirm))
+            .w(rems(34.))
+            .p_4()
+            .gap_3()
+            .elevation_3(cx)
+            .child(Headline::new(self.title.clone()).size(HeadlineSize::Small))
+            .child(
+                div()
+                    .p_2()
+                    .border_1()
+                    .border_color(cx.theme().colors().border)
+                    .rounded_md()
+                    .child(self.editor.clone()),
+            )
+            .child(
+                Label::new("Enter to submit · Escape to cancel")
+                    .size(LabelSize::XSmall)
+                    .color(Color::Muted),
+            )
+    }
+}

--- a/crates/github_pull_requests/Cargo.toml
+++ b/crates/github_pull_requests/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "github_pull_requests"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/github_pull_requests.rs"
+
+[dependencies]
+anyhow.workspace = true
+credentials_provider.workspace = true
+futures.workspace = true
+gpui.workspace = true
+http_client.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+url.workspace = true
+
+[dev-dependencies]
+gpui = { workspace = true, features = ["test-support"] }
+http_client = { workspace = true, features = ["test-support"] }
+pretty_assertions.workspace = true

--- a/crates/github_pull_requests/src/authentication.rs
+++ b/crates/github_pull_requests/src/authentication.rs
@@ -1,0 +1,228 @@
+use crate::{GITHUB_API_VERSION, GITHUB_APP_CLIENT_ID};
+use anyhow::{Context as _, Result, anyhow, bail};
+use credentials_provider::CredentialsProvider;
+use futures::AsyncReadExt as _;
+use gpui::AsyncApp;
+use http_client::{AsyncBody, HttpClient, Method, Request};
+use serde::{Deserialize, Serialize};
+use std::{sync::Arc, time::Duration};
+use url::form_urlencoded;
+
+const DEVICE_CODE_URL: &str = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
+const CREDENTIALS_KEY: &str = "https://github.com/zed-pull-requests";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GitHubCredentials {
+    pub access_token: String,
+    pub refresh_token: Option<String>,
+    pub expires_at_unix_seconds: Option<u64>,
+    pub refresh_token_expires_at_unix_seconds: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeviceAuthorization {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub expires_in: Duration,
+    pub interval: Duration,
+}
+
+#[derive(Debug)]
+pub enum DeviceFlowPoll {
+    Pending,
+    SlowDown(Duration),
+    Complete(GitHubCredentials),
+    AccessDenied,
+    Expired,
+}
+
+pub struct GitHubAuthentication {
+    http_client: Arc<dyn HttpClient>,
+    credentials_provider: Arc<dyn CredentialsProvider>,
+    client_id: Arc<str>,
+}
+
+impl GitHubAuthentication {
+    pub fn new(
+        http_client: Arc<dyn HttpClient>,
+        credentials_provider: Arc<dyn CredentialsProvider>,
+    ) -> Result<Self> {
+        let client_id = GITHUB_APP_CLIENT_ID
+            .filter(|client_id| !client_id.is_empty())
+            .ok_or_else(|| {
+                anyhow!(
+                    "GitHub pull request sign-in is not configured; set ZED_GITHUB_APP_CLIENT_ID when building Zed"
+                )
+            })?;
+        Ok(Self::with_client_id(
+            http_client,
+            credentials_provider,
+            client_id,
+        ))
+    }
+
+    pub fn with_client_id(
+        http_client: Arc<dyn HttpClient>,
+        credentials_provider: Arc<dyn CredentialsProvider>,
+        client_id: impl Into<Arc<str>>,
+    ) -> Self {
+        Self {
+            http_client,
+            credentials_provider,
+            client_id: client_id.into(),
+        }
+    }
+
+    pub async fn request_device_authorization(&self) -> Result<DeviceAuthorization> {
+        let body = form_urlencoded::Serializer::new(String::new())
+            .append_pair("client_id", &self.client_id)
+            .finish();
+        let response: DeviceCodeResponse = self.post_form(DEVICE_CODE_URL, body).await?;
+        Ok(DeviceAuthorization {
+            device_code: response.device_code,
+            user_code: response.user_code,
+            verification_uri: response.verification_uri,
+            expires_in: Duration::from_secs(response.expires_in),
+            interval: Duration::from_secs(response.interval),
+        })
+    }
+
+    pub async fn poll_device_authorization(&self, device_code: &str) -> Result<DeviceFlowPoll> {
+        let body = form_urlencoded::Serializer::new(String::new())
+            .append_pair("client_id", &self.client_id)
+            .append_pair("device_code", device_code)
+            .append_pair("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+            .finish();
+        let response: TokenResponse = self.post_form(ACCESS_TOKEN_URL, body).await?;
+        match response.error.as_deref() {
+            Some("authorization_pending") => Ok(DeviceFlowPoll::Pending),
+            Some("slow_down") => Ok(DeviceFlowPoll::SlowDown(Duration::from_secs(5))),
+            Some("access_denied") => Ok(DeviceFlowPoll::AccessDenied),
+            Some("expired_token") => Ok(DeviceFlowPoll::Expired),
+            Some(error) => bail!("GitHub device authorization failed: {error}"),
+            None => Ok(DeviceFlowPoll::Complete(response.into_credentials()?)),
+        }
+    }
+
+    pub async fn refresh(&self, refresh_token: &str) -> Result<GitHubCredentials> {
+        let body = form_urlencoded::Serializer::new(String::new())
+            .append_pair("client_id", &self.client_id)
+            .append_pair("grant_type", "refresh_token")
+            .append_pair("refresh_token", refresh_token)
+            .finish();
+        let response: TokenResponse = self.post_form(ACCESS_TOKEN_URL, body).await?;
+        if let Some(error) = response.error {
+            bail!("GitHub token refresh failed: {error}");
+        }
+        response.into_credentials()
+    }
+
+    pub async fn load(&self, cx: &AsyncApp) -> Result<Option<GitHubCredentials>> {
+        let Some((_, bytes)) = self
+            .credentials_provider
+            .read_credentials(CREDENTIALS_KEY, cx)
+            .await?
+        else {
+            return Ok(None);
+        };
+        serde_json::from_slice(&bytes).context("failed to read stored GitHub credentials")
+    }
+
+    pub async fn load_valid(&self, cx: &AsyncApp) -> Result<Option<GitHubCredentials>> {
+        let Some(credentials) = self.load(cx).await? else {
+            return Ok(None);
+        };
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_secs();
+        let needs_refresh = credentials
+            .expires_at_unix_seconds
+            .is_some_and(|expires_at| expires_at <= now.saturating_add(60));
+        if !needs_refresh {
+            return Ok(Some(credentials));
+        }
+        let refresh_token = credentials
+            .refresh_token
+            .as_deref()
+            .context("GitHub credentials expired and cannot be refreshed; sign in again")?;
+        if credentials
+            .refresh_token_expires_at_unix_seconds
+            .is_some_and(|expires_at| expires_at <= now)
+        {
+            bail!("GitHub credentials expired; sign in again");
+        }
+        let refreshed = self.refresh(refresh_token).await?;
+        self.store(&refreshed, cx).await?;
+        Ok(Some(refreshed))
+    }
+
+    pub async fn store(&self, credentials: &GitHubCredentials, cx: &AsyncApp) -> Result<()> {
+        let bytes = serde_json::to_vec(credentials)?;
+        self.credentials_provider
+            .write_credentials(CREDENTIALS_KEY, "Bearer", &bytes, cx)
+            .await
+    }
+
+    pub async fn clear(&self, cx: &AsyncApp) -> Result<()> {
+        self.credentials_provider
+            .delete_credentials(CREDENTIALS_KEY, cx)
+            .await
+    }
+
+    async fn post_form<T: for<'de> Deserialize<'de>>(&self, url: &str, body: String) -> Result<T> {
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri(url)
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+            .body(AsyncBody::from(body))?;
+        let mut response = self.http_client.send(request).await?;
+        let status = response.status();
+        let mut body = Vec::new();
+        response.body_mut().read_to_end(&mut body).await?;
+        if !status.is_success() {
+            bail!("GitHub authentication request failed with HTTP {status}");
+        }
+        serde_json::from_slice(&body).context("failed to parse GitHub authentication response")
+    }
+}
+
+#[derive(Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    expires_in: u64,
+    interval: u64,
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    expires_in: Option<u64>,
+    refresh_token_expires_in: Option<u64>,
+    error: Option<String>,
+}
+
+impl TokenResponse {
+    fn into_credentials(self) -> Result<GitHubCredentials> {
+        let access_token = self
+            .access_token
+            .context("GitHub token response did not include an access token")?;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_secs();
+        Ok(GitHubCredentials {
+            access_token,
+            refresh_token: self.refresh_token,
+            expires_at_unix_seconds: self.expires_in.map(|seconds| now + seconds),
+            refresh_token_expires_at_unix_seconds: self
+                .refresh_token_expires_in
+                .map(|seconds| now + seconds),
+        })
+    }
+}

--- a/crates/github_pull_requests/src/client.rs
+++ b/crates/github_pull_requests/src/client.rs
@@ -1,0 +1,795 @@
+use crate::{
+    ChangedFile, CheckConclusion, CheckState, CheckSummary, CommentId, DiffSide,
+    GITHUB_API_VERSION, Mergeability, PullRequestDetails, PullRequestId, PullRequestList,
+    PullRequestReview, PullRequestState, PullRequestSummary, ReviewAnchor, ReviewComment,
+    ReviewDecision, ReviewEvent, ReviewId, ReviewThread, ThreadId, User,
+};
+use anyhow::{Context as _, Result};
+use futures::AsyncReadExt as _;
+use http_client::{AsyncBody, HttpClient, Method, Request, StatusCode};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use std::{fmt, sync::Arc};
+
+const API_BASE_URL: &str = "https://api.github.com";
+
+#[derive(Debug)]
+pub struct GitHubApiError {
+    pub status: StatusCode,
+    pub message: String,
+    pub retry_after_seconds: Option<u64>,
+}
+
+impl fmt::Display for GitHubApiError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "GitHub API request failed with HTTP {}: {}",
+            self.status, self.message
+        )
+    }
+}
+
+impl std::error::Error for GitHubApiError {}
+
+pub struct GitHubClient {
+    http_client: Arc<dyn HttpClient>,
+    access_token: Arc<str>,
+}
+
+impl GitHubClient {
+    pub fn new(http_client: Arc<dyn HttpClient>, access_token: impl Into<Arc<str>>) -> Self {
+        Self {
+            http_client,
+            access_token: access_token.into(),
+        }
+    }
+
+    pub async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        self.send_json::<T, ()>(Method::GET, path, None).await
+    }
+
+    pub async fn viewer(&self) -> Result<User> {
+        let viewer: ApiUser = self.get("/user").await?;
+        Ok(viewer.into())
+    }
+
+    pub async fn list_pull_requests(
+        &self,
+        owner: &str,
+        repository: &str,
+    ) -> Result<PullRequestList> {
+        let viewer = self.viewer().await?;
+        let mut pulls = Vec::new();
+        for page in 1.. {
+            let page_items: Vec<ApiPullRequest> = self
+                .get(&format!(
+                    "/repos/{owner}/{repository}/pulls?state=open&sort=updated&direction=desc&per_page=100&page={page}"
+                ))
+                .await?;
+            let is_last_page = page_items.len() < 100;
+            pulls.extend(page_items);
+            if is_last_page {
+                break;
+            }
+        }
+        let mut waiting_for_review = Vec::new();
+        let mut authored_by_viewer = Vec::new();
+        for pull in pulls {
+            let summary = pull.into_summary(owner, repository)?;
+            if summary.author.login == viewer.login {
+                authored_by_viewer.push(summary.clone());
+            }
+            if summary
+                .requested_reviewers
+                .iter()
+                .any(|reviewer| reviewer.login == viewer.login)
+            {
+                waiting_for_review.push(summary);
+            }
+        }
+        Ok(PullRequestList {
+            waiting_for_review,
+            authored_by_viewer,
+        })
+    }
+
+    pub async fn pull_request_details(
+        &self,
+        pull_request: &PullRequestId,
+    ) -> Result<PullRequestDetails> {
+        let path = format!(
+            "/repos/{}/{}/pulls/{}",
+            pull_request.owner, pull_request.repository, pull_request.number
+        );
+        let details: ApiPullRequestDetails = self.get(&path).await?;
+        let summary = details
+            .pull
+            .into_summary(&pull_request.owner, &pull_request.repository)?;
+        let files = self.pull_request_files(pull_request).await?;
+        let checks = self.checks(pull_request, &summary.head_sha).await?;
+        let review_data = self.review_data(pull_request).await?;
+        Ok(PullRequestDetails {
+            summary,
+            body: details.body.unwrap_or_default().into(),
+            additions: details.additions,
+            deletions: details.deletions,
+            changed_files: details.changed_files,
+            mergeability: match details.mergeable {
+                Some(true) => Mergeability::Mergeable,
+                Some(false) => Mergeability::Conflicting,
+                None => Mergeability::Unknown,
+            },
+            review_decision: review_data.review_decision,
+            files,
+            threads: review_data.threads,
+            checks,
+            pending_review: review_data.pending_review,
+        })
+    }
+
+    async fn pull_request_files(&self, pull_request: &PullRequestId) -> Result<Vec<ChangedFile>> {
+        let mut files = Vec::new();
+        for page in 1.. {
+            let page_items: Vec<ApiChangedFile> = self
+                .get(&format!(
+                    "/repos/{}/{}/pulls/{}/files?per_page=100&page={page}",
+                    pull_request.owner, pull_request.repository, pull_request.number
+                ))
+                .await?;
+            let is_last_page = page_items.len() < 100;
+            files.extend(page_items.into_iter().map(Into::into));
+            if is_last_page {
+                break;
+            }
+        }
+        Ok(files)
+    }
+
+    async fn checks(
+        &self,
+        pull_request: &PullRequestId,
+        head_sha: &str,
+    ) -> Result<Vec<CheckSummary>> {
+        let response: ApiCheckRuns = self
+            .get(&format!(
+                "/repos/{}/{}/commits/{head_sha}/check-runs?per_page=100",
+                pull_request.owner, pull_request.repository
+            ))
+            .await?;
+        Ok(response.check_runs.into_iter().map(Into::into).collect())
+    }
+
+    async fn review_data(&self, pull_request: &PullRequestId) -> Result<ReviewData> {
+        const QUERY: &str = r#"
+            query PullRequestReviewData($owner: String!, $repository: String!, $number: Int!) {
+              repository(owner: $owner, name: $repository) {
+                pullRequest(number: $number) {
+                  reviewDecision
+                  reviews(last: 20, states: PENDING) {
+                    nodes { id body commit { oid } author { login avatarUrl url } }
+                  }
+                  reviewThreads(first: 100) {
+                    nodes {
+                      id isResolved isOutdated viewerCanResolve viewerCanReply
+                      comments(first: 100) {
+                        nodes {
+                          databaseId body createdAt url path line originalLine startLine
+                          diffSide originalCommit { oid }
+                          author { login avatarUrl url }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        "#;
+        let response: ReviewDataResponse = self
+            .graphql(
+                QUERY,
+                serde_json::json!({
+                    "owner": pull_request.owner.as_ref(),
+                    "repository": pull_request.repository.as_ref(),
+                    "number": pull_request.number,
+                }),
+            )
+            .await?;
+        response
+            .repository
+            .and_then(|repository| repository.pull_request)
+            .map(Into::into)
+            .context("GitHub pull request review data was missing")
+    }
+
+    pub async fn post<T: DeserializeOwned, B: Serialize>(&self, path: &str, body: &B) -> Result<T> {
+        self.send_json(Method::POST, path, Some(body)).await
+    }
+
+    pub async fn delete(&self, path: &str) -> Result<()> {
+        let _: Option<serde_json::Value> = self
+            .send_json::<Option<serde_json::Value>, ()>(Method::DELETE, path, None)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn create_pending_review(
+        &self,
+        pull_request: &PullRequestId,
+        commit_sha: &str,
+    ) -> Result<ReviewId> {
+        #[derive(Serialize)]
+        struct Body<'a> {
+            commit_id: &'a str,
+        }
+        #[derive(Deserialize)]
+        struct Response {
+            id: u64,
+        }
+        let response: Response = self
+            .post(
+                &format!(
+                    "/repos/{}/{}/pulls/{}/reviews",
+                    pull_request.owner, pull_request.repository, pull_request.number
+                ),
+                &Body {
+                    commit_id: commit_sha,
+                },
+            )
+            .await?;
+        Ok(ReviewId(response.id.to_string().into()))
+    }
+
+    pub async fn add_pending_comment(
+        &self,
+        pull_request: &PullRequestId,
+        review_id: &ReviewId,
+        anchor: &ReviewAnchor,
+        body: &str,
+    ) -> Result<CommentId> {
+        #[derive(Serialize)]
+        struct Body<'a> {
+            body: &'a str,
+            path: &'a str,
+            line: u32,
+            side: &'static str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            start_line: Option<u32>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            start_side: Option<&'static str>,
+        }
+        #[derive(Deserialize)]
+        struct Response {
+            id: u64,
+        }
+        let response: Response = self
+            .post(
+                &format!(
+                    "/repos/{}/{}/pulls/{}/reviews/{}/comments",
+                    pull_request.owner, pull_request.repository, pull_request.number, review_id.0
+                ),
+                &Body {
+                    body,
+                    path: &anchor.path,
+                    line: anchor.line,
+                    side: anchor.side.as_github_str(),
+                    start_line: anchor.start_line,
+                    start_side: anchor.start_line.map(|_| anchor.side.as_github_str()),
+                },
+            )
+            .await?;
+        Ok(CommentId(response.id))
+    }
+
+    pub async fn submit_review(
+        &self,
+        pull_request: &PullRequestId,
+        review_id: &ReviewId,
+        event: ReviewEvent,
+        body: &str,
+    ) -> Result<()> {
+        #[derive(Serialize)]
+        struct Body<'a> {
+            event: &'static str,
+            body: &'a str,
+        }
+        let _: serde_json::Value = self
+            .post(
+                &format!(
+                    "/repos/{}/{}/pulls/{}/reviews/{}/events",
+                    pull_request.owner, pull_request.repository, pull_request.number, review_id.0
+                ),
+                &Body {
+                    event: event.as_github_str(),
+                    body,
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn discard_review(
+        &self,
+        pull_request: &PullRequestId,
+        review_id: &ReviewId,
+    ) -> Result<()> {
+        self.delete(&format!(
+            "/repos/{}/{}/pulls/{}/reviews/{}",
+            pull_request.owner, pull_request.repository, pull_request.number, review_id.0
+        ))
+        .await
+    }
+
+    pub async fn reply_to_comment(
+        &self,
+        pull_request: &PullRequestId,
+        comment_id: CommentId,
+        body: &str,
+    ) -> Result<CommentId> {
+        #[derive(Serialize)]
+        struct Body<'a> {
+            body: &'a str,
+            in_reply_to: u64,
+        }
+        #[derive(Deserialize)]
+        struct Response {
+            id: u64,
+        }
+        let response: Response = self
+            .post(
+                &format!(
+                    "/repos/{}/{}/pulls/{}/comments",
+                    pull_request.owner, pull_request.repository, pull_request.number
+                ),
+                &Body {
+                    body,
+                    in_reply_to: comment_id.0,
+                },
+            )
+            .await?;
+        Ok(CommentId(response.id))
+    }
+
+    pub async fn set_thread_resolved(&self, thread_id: &ThreadId, resolved: bool) -> Result<()> {
+        let mutation = if resolved {
+            "mutation($threadId: ID!) { resolveReviewThread(input: {threadId: $threadId}) { thread { id } } }"
+        } else {
+            "mutation($threadId: ID!) { unresolveReviewThread(input: {threadId: $threadId}) { thread { id } } }"
+        };
+        let _: serde_json::Value = self
+            .graphql(
+                mutation,
+                serde_json::json!({ "threadId": thread_id.0.as_ref() }),
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn graphql<T: DeserializeOwned, V: Serialize>(
+        &self,
+        query: &str,
+        variables: V,
+    ) -> Result<T> {
+        #[derive(Serialize)]
+        struct GraphQlRequest<'a, V> {
+            query: &'a str,
+            variables: V,
+        }
+        let response: GraphQlResponse<T> = self
+            .post("/graphql", &GraphQlRequest { query, variables })
+            .await?;
+        if let Some(errors) = response.errors
+            && let Some(error) = errors.into_iter().next()
+        {
+            anyhow::bail!("GitHub GraphQL request failed: {}", error.message);
+        }
+        response.data.context("GitHub GraphQL response had no data")
+    }
+
+    async fn send_json<T: DeserializeOwned, B: Serialize>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&B>,
+    ) -> Result<T> {
+        let url = format!("{API_BASE_URL}{path}");
+        let body = match body {
+            Some(body) => AsyncBody::from(serde_json::to_vec(body)?),
+            None => AsyncBody::default(),
+        };
+        let request = Request::builder()
+            .method(method)
+            .uri(url)
+            .header("Accept", "application/vnd.github+json")
+            .header("Authorization", format!("Bearer {}", self.access_token))
+            .header("Content-Type", "application/json")
+            .header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+            .body(body)?;
+        let mut response = self.http_client.send(request).await?;
+        let status = response.status();
+        let retry_after_seconds = response
+            .headers()
+            .get("retry-after")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse().ok());
+        let mut bytes = Vec::new();
+        response.body_mut().read_to_end(&mut bytes).await?;
+        if !status.is_success() {
+            let message = serde_json::from_slice::<ApiErrorBody>(&bytes)
+                .map(|body| body.message)
+                .unwrap_or_else(|_| status.canonical_reason().unwrap_or("unknown error").into());
+            return Err(GitHubApiError {
+                status,
+                message,
+                retry_after_seconds,
+            }
+            .into());
+        }
+        if bytes.is_empty() {
+            return serde_json::from_slice(b"null")
+                .context("failed to decode empty GitHub API response");
+        }
+        serde_json::from_slice(&bytes).context("failed to decode GitHub API response")
+    }
+}
+
+#[derive(Deserialize)]
+struct ApiUser {
+    login: String,
+    avatar_url: Option<String>,
+    html_url: Option<String>,
+}
+
+impl From<ApiUser> for User {
+    fn from(user: ApiUser) -> Self {
+        Self {
+            login: user.login.into(),
+            avatar_url: user.avatar_url.map(Into::into),
+            html_url: user.html_url.map(Into::into),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ApiPullRequest {
+    number: u32,
+    title: String,
+    user: ApiUser,
+    state: PullRequestState,
+    draft: bool,
+    head: ApiBranch,
+    base: ApiBranch,
+    updated_at: String,
+    html_url: String,
+    #[serde(default)]
+    requested_reviewers: Vec<ApiUser>,
+}
+
+impl ApiPullRequest {
+    fn into_summary(self, owner: &str, repository: &str) -> Result<PullRequestSummary> {
+        if self.head.sha.is_empty() {
+            anyhow::bail!("GitHub pull request #{} had an empty head SHA", self.number);
+        }
+        Ok(PullRequestSummary {
+            id: PullRequestId::new(owner, repository, self.number),
+            title: self.title.into(),
+            author: self.user.into(),
+            state: self.state,
+            is_draft: self.draft,
+            head_ref: self.head.reference.into(),
+            head_sha: self.head.sha.into(),
+            base_ref: self.base.reference.into(),
+            updated_at: self.updated_at.into(),
+            html_url: self.html_url.into(),
+            requested_reviewers: self
+                .requested_reviewers
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct ApiBranch {
+    #[serde(rename = "ref")]
+    reference: String,
+    sha: String,
+}
+
+#[derive(Deserialize)]
+struct ApiPullRequestDetails {
+    #[serde(flatten)]
+    pull: ApiPullRequest,
+    body: Option<String>,
+    additions: u32,
+    deletions: u32,
+    changed_files: u32,
+    mergeable: Option<bool>,
+}
+
+#[derive(Deserialize)]
+struct ApiChangedFile {
+    filename: String,
+    previous_filename: Option<String>,
+    additions: u32,
+    deletions: u32,
+    status: String,
+    patch: Option<String>,
+}
+
+impl From<ApiChangedFile> for ChangedFile {
+    fn from(file: ApiChangedFile) -> Self {
+        Self {
+            path: file.filename.into(),
+            previous_path: file.previous_filename.map(Into::into),
+            additions: file.additions,
+            deletions: file.deletions,
+            status: file.status.into(),
+            patch: file.patch.map(Into::into),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct ApiCheckRuns {
+    check_runs: Vec<ApiCheckRun>,
+}
+
+#[derive(Deserialize)]
+struct ApiCheckRun {
+    name: String,
+    status: String,
+    conclusion: Option<String>,
+    details_url: Option<String>,
+}
+
+impl From<ApiCheckRun> for CheckSummary {
+    fn from(check: ApiCheckRun) -> Self {
+        let state = match check.status.as_str() {
+            "queued" => CheckState::Queued,
+            "in_progress" => CheckState::InProgress,
+            _ => CheckState::Completed,
+        };
+        let conclusion = check
+            .conclusion
+            .as_deref()
+            .map(|conclusion| match conclusion {
+                "success" => CheckConclusion::Success,
+                "failure" => CheckConclusion::Failure,
+                "cancelled" => CheckConclusion::Cancelled,
+                "neutral" => CheckConclusion::Neutral,
+                "skipped" => CheckConclusion::Skipped,
+                "timed_out" => CheckConclusion::TimedOut,
+                "action_required" => CheckConclusion::ActionRequired,
+                "stale" => CheckConclusion::Stale,
+                _ => CheckConclusion::Unknown,
+            });
+        Self {
+            name: check.name.into(),
+            state,
+            conclusion,
+            details_url: check.details_url.map(Into::into),
+        }
+    }
+}
+
+struct ReviewData {
+    review_decision: ReviewDecision,
+    threads: Vec<ReviewThread>,
+    pending_review: Option<PullRequestReview>,
+}
+
+#[derive(Deserialize)]
+struct ReviewDataResponse {
+    repository: Option<ReviewRepository>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReviewRepository {
+    pull_request: Option<GraphQlPullRequest>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphQlPullRequest {
+    review_decision: Option<String>,
+    reviews: GraphQlConnection<GraphQlPendingReview>,
+    review_threads: GraphQlConnection<GraphQlThread>,
+}
+
+#[derive(Deserialize)]
+struct GraphQlConnection<T> {
+    nodes: Vec<T>,
+}
+
+#[derive(Deserialize)]
+struct GraphQlUser {
+    login: String,
+    #[serde(rename = "avatarUrl")]
+    avatar_url: Option<String>,
+    url: Option<String>,
+}
+
+impl From<GraphQlUser> for User {
+    fn from(user: GraphQlUser) -> Self {
+        Self {
+            login: user.login.into(),
+            avatar_url: user.avatar_url.map(Into::into),
+            html_url: user.url.map(Into::into),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct GraphQlCommit {
+    oid: String,
+}
+
+#[derive(Deserialize)]
+struct GraphQlPendingReview {
+    id: String,
+    body: String,
+    commit: GraphQlCommit,
+    author: Option<GraphQlUser>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphQlThread {
+    id: String,
+    is_resolved: bool,
+    is_outdated: bool,
+    viewer_can_resolve: bool,
+    viewer_can_reply: bool,
+    comments: GraphQlConnection<GraphQlComment>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GraphQlComment {
+    database_id: Option<u64>,
+    body: String,
+    created_at: String,
+    url: String,
+    path: String,
+    line: Option<u32>,
+    original_line: Option<u32>,
+    start_line: Option<u32>,
+    diff_side: Option<String>,
+    original_commit: Option<GraphQlCommit>,
+    author: Option<GraphQlUser>,
+}
+
+impl From<GraphQlPullRequest> for ReviewData {
+    fn from(pull_request: GraphQlPullRequest) -> Self {
+        let review_decision = match pull_request.review_decision.as_deref() {
+            Some("APPROVED") => ReviewDecision::Approved,
+            Some("CHANGES_REQUESTED") => ReviewDecision::ChangesRequested,
+            Some("REVIEW_REQUIRED") => ReviewDecision::ReviewRequired,
+            _ => ReviewDecision::Unknown,
+        };
+        let pending_review =
+            pull_request
+                .reviews
+                .nodes
+                .into_iter()
+                .next()
+                .map(|review| PullRequestReview {
+                    id: ReviewId(review.id.into()),
+                    commit_sha: review.commit.oid.into(),
+                    author: review.author.map(Into::into).unwrap_or_else(unknown_user),
+                    body: review.body.into(),
+                });
+        let threads = pull_request
+            .review_threads
+            .nodes
+            .into_iter()
+            .map(|thread| {
+                let anchor = thread.comments.nodes.first().and_then(|comment| {
+                    let line = comment.line.or(comment.original_line)?;
+                    let commit_sha = comment.original_commit.as_ref()?.oid.clone();
+                    Some(ReviewAnchor {
+                        path: comment.path.clone().into(),
+                        commit_sha: commit_sha.into(),
+                        side: match comment.diff_side.as_deref() {
+                            Some("LEFT") => DiffSide::Left,
+                            _ => DiffSide::Right,
+                        },
+                        start_line: comment.start_line,
+                        line,
+                    })
+                });
+                ReviewThread {
+                    id: ThreadId(thread.id.into()),
+                    anchor,
+                    is_resolved: thread.is_resolved,
+                    is_outdated: thread.is_outdated,
+                    viewer_can_reply: thread.viewer_can_reply,
+                    viewer_can_resolve: thread.viewer_can_resolve,
+                    comments: thread
+                        .comments
+                        .nodes
+                        .into_iter()
+                        .filter_map(|comment| {
+                            Some(ReviewComment {
+                                id: CommentId(comment.database_id?),
+                                author: comment.author.map(Into::into).unwrap_or_else(unknown_user),
+                                body: comment.body.into(),
+                                created_at: comment.created_at.into(),
+                                html_url: comment.url.into(),
+                            })
+                        })
+                        .collect(),
+                }
+            })
+            .collect();
+        Self {
+            review_decision,
+            threads,
+            pending_review,
+        }
+    }
+}
+
+fn unknown_user() -> User {
+    User {
+        login: "ghost".into(),
+        avatar_url: None,
+        html_url: None,
+    }
+}
+
+#[derive(Deserialize)]
+struct ApiErrorBody {
+    message: String,
+}
+
+#[derive(Deserialize)]
+struct GraphQlResponse<T> {
+    data: Option<T>,
+    errors: Option<Vec<GraphQlError>>,
+}
+
+#[derive(Deserialize)]
+struct GraphQlError {
+    message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DiffSide;
+    use http_client::{FakeHttpClient, Response};
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn serializes_review_anchor_with_current_line_api() {
+        let anchor = ReviewAnchor {
+            path: "src/main.rs".into(),
+            commit_sha: "abc".into(),
+            side: DiffSide::Right,
+            start_line: Some(10),
+            line: 12,
+        };
+        assert_eq!(anchor.side.as_github_str(), "RIGHT");
+    }
+
+    #[gpui::test]
+    async fn reports_api_error_without_echoing_response(cx: &mut gpui::TestAppContext) {
+        let client = FakeHttpClient::create(|request| async move {
+            assert_eq!(request.headers()["authorization"], "Bearer test-token");
+            Ok(Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .body(AsyncBody::from(r#"{"message":"Resource not accessible"}"#))?)
+        });
+        let client = GitHubClient::new(client, "test-token");
+        let error = client
+            .get::<serde_json::Value>("/user")
+            .await
+            .expect_err("request should fail");
+        assert!(error.to_string().contains("Resource not accessible"));
+        assert!(!error.to_string().contains("test-token"));
+        cx.run_until_parked();
+    }
+}

--- a/crates/github_pull_requests/src/github_pull_requests.rs
+++ b/crates/github_pull_requests/src/github_pull_requests.rs
@@ -1,0 +1,17 @@
+mod authentication;
+mod client;
+mod models;
+
+pub use authentication::{
+    DeviceAuthorization, DeviceFlowPoll, GitHubAuthentication, GitHubCredentials,
+};
+pub use client::{GitHubApiError, GitHubClient};
+pub use models::{
+    ChangedFile, CheckConclusion, CheckState, CheckSummary, CommentId, DiffSide, Mergeability,
+    PullRequestDetails, PullRequestId, PullRequestList, PullRequestReview, PullRequestState,
+    PullRequestSummary, ReviewAnchor, ReviewComment, ReviewDecision, ReviewEvent, ReviewId,
+    ReviewThread, ThreadId, User,
+};
+
+pub const GITHUB_API_VERSION: &str = "2026-03-10";
+pub const GITHUB_APP_CLIENT_ID: Option<&str> = option_env!("ZED_GITHUB_APP_CLIENT_ID");

--- a/crates/github_pull_requests/src/models.rs
+++ b/crates/github_pull_requests/src/models.rs
@@ -1,0 +1,200 @@
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PullRequestId {
+    pub owner: Arc<str>,
+    pub repository: Arc<str>,
+    pub number: u32,
+}
+
+impl PullRequestId {
+    pub fn new(owner: impl Into<Arc<str>>, repository: impl Into<Arc<str>>, number: u32) -> Self {
+        Self {
+            owner: owner.into(),
+            repository: repository.into(),
+            number,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct User {
+    pub login: Arc<str>,
+    pub avatar_url: Option<Arc<str>>,
+    pub html_url: Option<Arc<str>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PullRequestState {
+    Open,
+    Closed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReviewDecision {
+    Approved,
+    ChangesRequested,
+    ReviewRequired,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Mergeability {
+    Mergeable,
+    Conflicting,
+    Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestSummary {
+    pub id: PullRequestId,
+    pub title: Arc<str>,
+    pub author: User,
+    pub state: PullRequestState,
+    pub is_draft: bool,
+    pub head_ref: Arc<str>,
+    pub head_sha: Arc<str>,
+    pub base_ref: Arc<str>,
+    pub updated_at: Arc<str>,
+    pub html_url: Arc<str>,
+    pub requested_reviewers: Vec<User>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestList {
+    pub waiting_for_review: Vec<PullRequestSummary>,
+    pub authored_by_viewer: Vec<PullRequestSummary>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestDetails {
+    pub summary: PullRequestSummary,
+    pub body: Arc<str>,
+    pub additions: u32,
+    pub deletions: u32,
+    pub changed_files: u32,
+    pub mergeability: Mergeability,
+    pub review_decision: ReviewDecision,
+    pub files: Vec<ChangedFile>,
+    pub threads: Vec<ReviewThread>,
+    pub checks: Vec<CheckSummary>,
+    pub pending_review: Option<PullRequestReview>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangedFile {
+    pub path: Arc<str>,
+    pub previous_path: Option<Arc<str>>,
+    pub additions: u32,
+    pub deletions: u32,
+    pub status: Arc<str>,
+    pub patch: Option<Arc<str>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DiffSide {
+    Left,
+    Right,
+}
+
+impl DiffSide {
+    pub fn as_github_str(self) -> &'static str {
+        match self {
+            Self::Left => "LEFT",
+            Self::Right => "RIGHT",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewAnchor {
+    pub path: Arc<str>,
+    pub commit_sha: Arc<str>,
+    pub side: DiffSide,
+    pub start_line: Option<u32>,
+    pub line: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ReviewId(pub Arc<str>);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ThreadId(pub Arc<str>);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CommentId(pub u64);
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewComment {
+    pub id: CommentId,
+    pub author: User,
+    pub body: Arc<str>,
+    pub created_at: Arc<str>,
+    pub html_url: Arc<str>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewThread {
+    pub id: ThreadId,
+    pub anchor: Option<ReviewAnchor>,
+    pub is_resolved: bool,
+    pub is_outdated: bool,
+    pub viewer_can_reply: bool,
+    pub viewer_can_resolve: bool,
+    pub comments: Vec<ReviewComment>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReviewEvent {
+    Comment,
+    Approve,
+    RequestChanges,
+}
+
+impl ReviewEvent {
+    pub fn as_github_str(self) -> &'static str {
+        match self {
+            Self::Comment => "COMMENT",
+            Self::Approve => "APPROVE",
+            Self::RequestChanges => "REQUEST_CHANGES",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestReview {
+    pub id: ReviewId,
+    pub commit_sha: Arc<str>,
+    pub author: User,
+    pub body: Arc<str>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CheckState {
+    Queued,
+    InProgress,
+    Completed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CheckConclusion {
+    Success,
+    Failure,
+    Cancelled,
+    Neutral,
+    Skipped,
+    TimedOut,
+    ActionRequired,
+    Stale,
+    Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckSummary {
+    pub name: Arc<str>,
+    pub state: CheckState,
+    pub conclusion: Option<CheckConclusion>,
+    pub details_url: Option<Arc<str>>,
+}

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2805,7 +2805,11 @@ impl GitStore {
     ) -> Result<proto::RemoteMessageResponse> {
         let repository_id = RepositoryId::from_proto(envelope.payload.repository_id);
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
-        let fetch_options = FetchOptions::from_proto(envelope.payload.remote);
+        let fetch_options = FetchOptions::from_proto(
+            envelope.payload.remote,
+            envelope.payload.source_ref,
+            envelope.payload.destination_ref,
+        )?;
         let askpass_id = envelope.payload.askpass_id;
 
         let askpass = make_remote_delegate(
@@ -7478,12 +7482,15 @@ impl Repository {
                             debug_assert!(askpass_delegate.is_some());
                         });
 
+                        let (remote, source_ref, destination_ref) = fetch_options.to_proto();
                         let response = client
                             .request(proto::Fetch {
                                 project_id: project_id.0,
                                 repository_id: id.to_proto(),
                                 askpass_id,
-                                remote: fetch_options.to_proto(),
+                                remote,
+                                source_ref,
+                                destination_ref,
                             })
                             .await?;
 
@@ -9316,6 +9323,20 @@ impl Repository {
         self.remote_upstream_url
             .clone()
             .or(self.remote_origin_url.clone())
+    }
+
+    pub fn default_remote(&self) -> Option<Remote> {
+        if self.remote_upstream_url.is_some() {
+            Some(Remote {
+                name: "upstream".into(),
+            })
+        } else if self.remote_origin_url.is_some() {
+            Some(Remote {
+                name: "origin".into(),
+            })
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -424,6 +424,8 @@ message Fetch {
   uint64 repository_id = 3;
   uint64 askpass_id = 4;
   optional string remote = 5;
+  optional string source_ref = 6;
+  optional string destination_ref = 7;
 }
 
 message GetRemotes {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -35,6 +35,7 @@ use git_ui::branch_diff::BranchDiffToolbar;
 use git_ui::commit_view::CommitViewToolbar;
 use git_ui::git_panel::GitPanel;
 use git_ui::project_diff::ProjectDiffToolbar;
+use git_ui::pull_requests_panel::PullRequestsPanel;
 use git_ui::solo_diff_view::{SoloDiffGitToolbar, SoloDiffStyleToolbar};
 use git_ui::staged_diff::StagedDiffToolbar;
 use git_ui::unstaged_diff::UnstagedDiffToolbar;
@@ -778,6 +779,8 @@ fn initialize_panels(window: &mut Window, cx: &mut Context<Workspace>) -> Task<a
         let outline_panel = OutlinePanel::load(workspace_handle.clone(), cx.clone());
         let terminal_panel = TerminalPanel::load(workspace_handle.clone(), cx.clone());
         let git_panel = GitPanel::load(workspace_handle.clone(), cx.clone());
+        let pull_requests_panel =
+            PullRequestsPanel::load(workspace_handle.clone(), cx.clone());
         let channels_panel =
             collab_ui::collab_panel::CollabPanel::load(workspace_handle.clone(), cx.clone());
         let debug_panel = DebugPanel::load(workspace_handle.clone(), cx);
@@ -802,6 +805,11 @@ fn initialize_panels(window: &mut Window, cx: &mut Context<Workspace>) -> Task<a
             add_panel_when_ready(outline_panel, workspace_handle.clone(), cx.clone()),
             add_panel_when_ready(terminal_panel, workspace_handle.clone(), cx.clone()),
             add_panel_when_ready(git_panel, workspace_handle.clone(), cx.clone()),
+            add_panel_when_ready(
+                pull_requests_panel,
+                workspace_handle.clone(),
+                cx.clone()
+            ),
             add_panel_when_ready(channels_panel, workspace_handle.clone(), cx.clone()),
             add_panel_when_ready(debug_panel, workspace_handle.clone(), cx.clone()),
             initialize_agent_panel(workspace_handle, cx.clone()).map(|r| r.log_err()),


### PR DESCRIPTION
## Summary

- add a native Pull Requests panel for GitHub repositories with device-flow authentication, secure credential storage, grouped review queues, checks, and review metadata
- fetch pull request heads and bases into isolated refspecs, guard checkout when local work is dirty, detect divergent review branches, and support remote projects
- open pull requests in Zed branch diffs with PR-specific titles and support approvals, request-changes reviews, thread replies, and resolve/reopen actions

GitHub authentication requires a GitHub App with Device Flow enabled and `ZED_GITHUB_APP_CLIENT_ID` set when building Zed.

## Verification

- `cargo test -p github_pull_requests`
- `cargo test -p git fetch_refspec`
- `cargo check -p git_ui`
- `./script/clippy -p github_pull_requests`
- `./script/clippy -p git`
- `./script/clippy -p git_ui`
- `cargo fmt --all -- --check`
- `git diff --check`

The full `cargo check -p zed` reached the existing macOS shader build but could not complete because the local developer tools do not provide the Apple `metal` utility.

Release Notes:

- Added native GitHub pull request browsing, checkout, and review workflows.