### PR TITLE
bedrock: Fix duplicated messages and colliding tool call ids from Bedrock Mantle

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -937,14 +937,14 @@ async fn test_tool_authorization(cx: &mut TestAppContext) {
         message.content,
         vec![
             language_model::MessageContent::ToolResult(LanguageModelToolResult {
-                tool_use_id: tool_call_auth_1.tool_call.tool_call_id.0.to_string().into(),
+                tool_use_id: "tool_id_1".into(),
                 tool_name: ToolRequiringPermission::NAME.into(),
                 is_error: false,
                 content: vec!["Allowed".into()],
                 output: Some("Allowed".into())
             }),
             language_model::MessageContent::ToolResult(LanguageModelToolResult {
-                tool_use_id: tool_call_auth_2.tool_call.tool_call_id.0.to_string().into(),
+                tool_use_id: "tool_id_2".into(),
                 tool_name: ToolRequiringPermission::NAME.into(),
                 is_error: true,
                 content: vec!["Permission to run tool denied by user".into()],
@@ -983,7 +983,7 @@ async fn test_tool_authorization(cx: &mut TestAppContext) {
         message.content,
         vec![language_model::MessageContent::ToolResult(
             LanguageModelToolResult {
-                tool_use_id: tool_call_auth_3.tool_call.tool_call_id.0.to_string().into(),
+                tool_use_id: "tool_id_3".into(),
                 tool_name: ToolRequiringPermission::NAME.into(),
                 is_error: false,
                 content: vec!["Allowed".into()],
@@ -1051,6 +1051,180 @@ async fn test_tool_hallucination(cx: &mut TestAppContext) {
     assert_eq!(update.fields.status, Some(acp::ToolCallStatus::Failed));
 }
 
+/// Regression test: some providers (confirmed on Bedrock Mantle/GPT-5.x)
+/// reset their raw `tool_use` id counter every request/response cycle, so
+/// the same id (e.g. `call_1`) can recur within one turn. Used verbatim as
+/// the ACP id, this let a later tool call overwrite an earlier, unrelated
+/// one in `AcpThread::upsert_tool_call`.
+#[gpui::test]
+async fn test_tool_call_id_scoped_per_completion_request(cx: &mut TestAppContext) {
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    thread.update(cx, |thread, _cx| {
+        thread.add_tool(EchoTool);
+    });
+
+    let mut events = thread
+        .update(cx, |thread, cx| {
+            thread.send(ClientUserMessageId::new(), ["Use the echo tool twice"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "call_1".into(),
+            name: EchoTool::NAME.into(),
+            raw_input: json!({"text": "first"}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(json!({"text": "first"})),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    let first_tool_call = next_tool_call(&mut events).await;
+    cx.run_until_parked();
+
+    // Same turn, second cycle: the id counter has reset, so "call_1" recurs
+    // for a different tool call.
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "call_1".into(),
+            name: EchoTool::NAME.into(),
+            raw_input: json!({"text": "second"}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(json!({"text": "second"})),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    let second_tool_call = next_tool_call(&mut events).await;
+    cx.run_until_parked();
+
+    fake_model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+
+    assert_ne!(
+        first_tool_call.tool_call_id, second_tool_call.tool_call_id,
+        "raw tool_use ids that recur across separate completion requests within the same turn \
+         must map to distinct ACP tool call ids, otherwise the second tool call would overwrite \
+         the first instead of appearing as a new entry"
+    );
+}
+
+/// Same bug as `test_tool_call_id_scoped_per_completion_request`, but
+/// exercised through persistence and `Thread::replay()` instead of live
+/// streaming.
+#[gpui::test]
+async fn test_replayed_tool_call_ids_scoped_across_messages(cx: &mut TestAppContext) {
+    let ThreadTest {
+        model,
+        thread,
+        project_context,
+        ..
+    } = setup(cx, TestModel::Fake).await;
+    let fake_model = model.as_fake();
+
+    thread.update(cx, |thread, _cx| {
+        thread.add_tool(EchoTool);
+    });
+
+    thread
+        .update(cx, |thread, cx| {
+            thread.send(ClientUserMessageId::new(), ["Use the echo tool"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "call_1".into(),
+            name: EchoTool::NAME.into(),
+            raw_input: json!({"text": "first"}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(json!({"text": "first"})),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+    fake_model.send_last_completion_stream_text_chunk("Done with first");
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    // Different turn: the id counter has reset, so "call_1" recurs in a
+    // different `AgentMessage`.
+    thread
+        .update(cx, |thread, cx| {
+            thread.send(ClientUserMessageId::new(), ["Use the echo tool again"], cx)
+        })
+        .unwrap();
+    cx.run_until_parked();
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "call_1".into(),
+            name: EchoTool::NAME.into(),
+            raw_input: json!({"text": "second"}).to_string(),
+            input: language_model::LanguageModelToolUseInput::Json(json!({"text": "second"})),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+    fake_model.send_last_completion_stream_text_chunk("Done with second");
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let db_thread = thread.read_with(cx, |thread, cx| thread.to_db(cx)).await;
+
+    cx.update(|cx| {
+        LanguageModelRegistry::test(cx);
+    });
+    let restored = cx.update(|cx| {
+        let thread = thread.read(cx);
+        let project = thread.project.clone();
+        let context_server_registry = thread.context_server_registry.clone();
+        let templates = thread.templates.clone();
+        cx.new(|cx| {
+            Thread::from_db(
+                acp::SessionId::new("restored"),
+                db_thread,
+                project,
+                project_context.clone(),
+                context_server_registry,
+                templates,
+                cx,
+            )
+        })
+    });
+    restored.update(cx, |thread, _cx| {
+        thread.add_tool(EchoTool);
+    });
+
+    let mut replay_events = restored.update(cx, |thread, cx| thread.replay(cx));
+    let mut tool_call_ids = Vec::new();
+    while let Some(event) = replay_events.next().await {
+        if let ThreadEvent::ToolCall(tool_call) = event.unwrap() {
+            tool_call_ids.push(tool_call.tool_call_id);
+        }
+    }
+
+    assert_eq!(
+        tool_call_ids.len(),
+        2,
+        "expected one replayed tool call per message"
+    );
+    assert_ne!(
+        tool_call_ids[0], tool_call_ids[1],
+        "raw tool_use ids that recur across separate AgentMessages must map to distinct ACP \
+         tool call ids when replayed from a persisted thread, otherwise the second tool call \
+         would overwrite the first instead of appearing as a new entry"
+    );
+}
+
 async fn expect_tool_call(events: &mut UnboundedReceiver<Result<ThreadEvent>>) -> acp::ToolCall {
     let event = events
         .next()
@@ -1061,6 +1235,21 @@ async fn expect_tool_call(events: &mut UnboundedReceiver<Result<ThreadEvent>>) -
         ThreadEvent::ToolCall(tool_call) => tool_call,
         event => {
             panic!("Unexpected event {event:?}");
+        }
+    }
+}
+
+/// Like [`expect_tool_call`], but skips other events until a `ToolCall`
+/// appears -- useful across multiple request/response cycles in one turn.
+async fn next_tool_call(events: &mut UnboundedReceiver<Result<ThreadEvent>>) -> acp::ToolCall {
+    loop {
+        let event = events
+            .next()
+            .await
+            .expect("no tool call event received")
+            .unwrap();
+        if let ThreadEvent::ToolCall(tool_call) = event {
+            return tool_call;
         }
     }
 }
@@ -2007,15 +2196,19 @@ async fn test_mcp_tool_result_displayed_when_server_disconnected(cx: &mut TestAp
 
     let mut found_tool_call = None;
     let mut found_tool_call_update_with_output = None;
+    // The ACP id is scoped by message index (see `scoped_tool_call_id`), so
+    // capture it instead of assuming it matches the raw provider id.
+    let mut tool_call_id = None;
 
     while let Some(event) = replay_events.next().await {
         let event = event.unwrap();
         match &event {
-            ThreadEvent::ToolCall(tc) if tc.tool_call_id.to_string() == "tool_1" => {
+            ThreadEvent::ToolCall(tc) => {
+                tool_call_id = Some(tc.tool_call_id.clone());
                 found_tool_call = Some(tc.clone());
             }
             ThreadEvent::ToolCallUpdate(acp_thread::ToolCallUpdate::UpdateFields(update))
-                if update.tool_call_id.to_string() == "tool_1" =>
+                if tool_call_id.as_ref() == Some(&update.tool_call_id) =>
             {
                 if update.fields.raw_output.is_some() {
                     found_tool_call_update_with_output = Some(update.clone());
@@ -4118,10 +4311,14 @@ async fn test_tool_updates_to_completion(cx: &mut TestAppContext) {
     fake_model.end_last_completion_stream();
     cx.run_until_parked();
 
+    // User message is index 0, so the tool call is scoped to index 1 (see
+    // `scoped_tool_call_id`).
+    let tool_call_id = scoped_tool_call_id(1, &"1".into());
+
     let tool_call = expect_tool_call(&mut events).await;
     assert_eq!(
         tool_call,
-        acp::ToolCall::new("1", "Echo")
+        acp::ToolCall::new(tool_call_id.clone(), "Echo")
             .raw_input(json!({}))
             .meta(acp::Meta::from_iter([("tool_name".into(), "echo".into())]))
     );
@@ -4129,7 +4326,7 @@ async fn test_tool_updates_to_completion(cx: &mut TestAppContext) {
     assert_eq!(
         update,
         acp::ToolCallUpdate::new(
-            "1",
+            tool_call_id.clone(),
             acp::ToolCallUpdateFields::new()
                 .title("Echo")
                 .kind(acp::ToolKind::Other)
@@ -4140,7 +4337,7 @@ async fn test_tool_updates_to_completion(cx: &mut TestAppContext) {
     assert_eq!(
         update,
         acp::ToolCallUpdate::new(
-            "1",
+            tool_call_id.clone(),
             acp::ToolCallUpdateFields::new().status(acp::ToolCallStatus::InProgress)
         )
     );
@@ -4148,7 +4345,7 @@ async fn test_tool_updates_to_completion(cx: &mut TestAppContext) {
     assert_eq!(
         update,
         acp::ToolCallUpdate::new(
-            "1",
+            tool_call_id,
             acp::ToolCallUpdateFields::new()
                 .status(acp::ToolCallStatus::Completed)
                 .raw_output("Hello!")
@@ -8107,9 +8304,11 @@ async fn test_queued_message_ends_turn_at_boundary(cx: &mut TestAppContext) {
             _ => None,
         })
         .collect();
+    // User message is index 0, so the tool call is scoped to index 1 (see
+    // `scoped_tool_call_id`).
     assert_eq!(
         tool_call_ids,
-        vec!["tool_1"],
+        vec![scoped_tool_call_id(1, &"tool_1".into()).to_string()],
         "Should have received a tool call event for our echo tool"
     );
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1503,6 +1503,7 @@ impl Thread {
                                 self.replay_tool_call(
                                     tool_use,
                                     assistant_message.tool_results.get(&tool_use.id),
+                                    message_ix,
                                     &stream,
                                     cx,
                                 );
@@ -1540,6 +1541,7 @@ impl Thread {
         &self,
         tool_use: &LanguageModelToolUse,
         tool_result: Option<&LanguageModelToolResult>,
+        owning_message_ix: usize,
         stream: &ThreadEventStream,
         cx: &mut Context<Self>,
     ) {
@@ -1550,6 +1552,7 @@ impl Thread {
             return;
         }
 
+        let tool_call_id = scoped_tool_call_id(owning_message_ix, &tool_use.id);
         let output = tool_result
             .as_ref()
             .and_then(|result| result.output.clone());
@@ -1591,7 +1594,7 @@ impl Thread {
             stream
                 .0
                 .unbounded_send(Ok(ThreadEvent::ToolCall(
-                    acp::ToolCall::new(tool_use.id.to_string(), tool_use.name.to_string())
+                    acp::ToolCall::new(tool_call_id.clone(), tool_use.name.to_string())
                         .status(status)
                         .raw_input(tool_use.input.to_display_json()),
                 )))
@@ -1602,7 +1605,7 @@ impl Thread {
             if let Some(content) = replay_content {
                 fields = fields.content(content);
             }
-            stream.update_tool_call_fields(&tool_use.id, fields, None);
+            stream.update_tool_call_fields(&tool_call_id, fields, None);
             return;
         };
 
@@ -1611,11 +1614,11 @@ impl Thread {
         };
         let title = tool.initial_title(input.clone(), cx);
         let kind = tool.kind();
-        stream.send_tool_call(&tool_use.id, &tool_use.name, title, kind, input.clone());
+        stream.send_tool_call(&tool_call_id, &tool_use.name, title, kind, input.clone());
 
         if let Some(content) = replay_content {
             stream.update_tool_call_fields(
-                &tool_use.id,
+                &tool_call_id,
                 acp::ToolCallUpdateFields::new().content(content),
                 None,
             );
@@ -1626,6 +1629,7 @@ impl Thread {
             let (_cancellation_tx, cancellation_rx) = watch::channel(false);
             let tool_event_stream = ToolCallEventStream::new(
                 tool_use.id.clone(),
+                tool_call_id.clone(),
                 stream.clone(),
                 Some(self.project.read(cx).fs().clone()),
                 cancellation_rx,
@@ -1636,7 +1640,7 @@ impl Thread {
         }
 
         stream.update_tool_call_fields(
-            &tool_use.id,
+            &tool_call_id,
             acp::ToolCallUpdateFields::new()
                 .status(status)
                 .raw_output(output),
@@ -2818,9 +2822,9 @@ impl Thread {
                 Ok(events) => (events.fuse(), None),
                 Err(err) => (stream::empty().boxed().fuse(), Some(err)),
             };
-            let mut tool_results: FuturesUnordered<Task<LanguageModelToolResult>> =
+            let mut tool_results: FuturesUnordered<Task<(usize, LanguageModelToolResult)>> =
                 FuturesUnordered::new();
-            let mut early_tool_results: Vec<LanguageModelToolResult> = Vec::new();
+            let mut early_tool_results: Vec<(usize, LanguageModelToolResult)> = Vec::new();
             let mut cancelled = false;
             let mut had_refusal = false;
             loop {
@@ -2828,6 +2832,7 @@ impl Thread {
                 let first_event = futures::select! {
                     event = events.next().fuse() => event,
                     tool_result = futures::StreamExt::select_next_some(&mut tool_results) => {
+                        let (owning_message_ix, tool_result) = tool_result;
                         let is_error = tool_result.is_error;
                         let is_still_streaming = this
                             .read_with(cx, |this, _cx| {
@@ -2838,7 +2843,7 @@ impl Thread {
                             })
                             .unwrap_or(false);
 
-                        early_tool_results.push(tool_result);
+                        early_tool_results.push((owning_message_ix, tool_result));
 
                         // Only break if the tool errored and we are still
                         // streaming the input of the tool. If the tool errored
@@ -2992,11 +2997,11 @@ impl Thread {
 
             let end_turn = tool_results.is_empty() && early_tool_results.is_empty();
 
-            for tool_result in early_tool_results {
-                Self::process_tool_result(this, event_stream, cx, tool_result)?;
+            for (owning_message_ix, tool_result) in early_tool_results {
+                Self::process_tool_result(this, event_stream, cx, owning_message_ix, tool_result)?;
             }
-            while let Some(tool_result) = tool_results.next().await {
-                Self::process_tool_result(this, event_stream, cx, tool_result)?;
+            while let Some((owning_message_ix, tool_result)) = tool_results.next().await {
+                Self::process_tool_result(this, event_stream, cx, owning_message_ix, tool_result)?;
             }
 
             this.update(cx, |this, cx| {
@@ -3225,12 +3230,13 @@ impl Thread {
         this: &WeakEntity<Thread>,
         event_stream: &ThreadEventStream,
         cx: &mut AsyncApp,
+        owning_message_ix: usize,
         tool_result: LanguageModelToolResult,
     ) -> Result<(), anyhow::Error> {
         log::debug!("Tool finished {:?}", tool_result);
 
         event_stream.update_tool_call_fields(
-            &tool_result.tool_use_id,
+            &scoped_tool_call_id(owning_message_ix, &tool_result.tool_use_id),
             acp::ToolCallUpdateFields::new()
                 .status(if tool_result.is_error {
                     acp::ToolCallStatus::Failed
@@ -3314,7 +3320,7 @@ impl Thread {
         event_stream: &ThreadEventStream,
         cancellation_rx: watch::Receiver<bool>,
         cx: &mut Context<Self>,
-    ) -> Result<Option<Task<LanguageModelToolResult>>> {
+    ) -> Result<Option<Task<(usize, LanguageModelToolResult)>>> {
         log::trace!("Handling streamed completion event: {:?}", event);
         use LanguageModelCompletionEvent::*;
 
@@ -3437,9 +3443,10 @@ impl Thread {
         event_stream: &ThreadEventStream,
         cancellation_rx: watch::Receiver<bool>,
         cx: &mut Context<Self>,
-    ) -> Option<Task<LanguageModelToolResult>> {
+    ) -> Option<Task<(usize, LanguageModelToolResult)>> {
         cx.notify();
 
+        let owning_message_ix = self.messages.len();
         let tool = self.tool(tool_use.name.as_ref());
         let mut title = SharedString::from(&tool_use.name);
         let mut kind = acp::ToolKind::Other;
@@ -3450,17 +3457,20 @@ impl Thread {
             kind = tool.kind();
         }
 
-        self.send_or_update_tool_use(&tool_use, title, kind, event_stream);
+        self.send_or_update_tool_use(&tool_use, title, kind, owning_message_ix, event_stream);
 
         let Some(tool) = tool else {
             let content = format!("No tool named {} exists", tool_use.name);
-            return Some(Task::ready(LanguageModelToolResult {
-                content: vec![LanguageModelToolResultContent::Text(Arc::from(content))],
-                tool_use_id: tool_use.id,
-                tool_name: tool_use.name,
-                is_error: true,
-                output: None,
-            }));
+            return Some(Task::ready((
+                owning_message_ix,
+                LanguageModelToolResult {
+                    content: vec![LanguageModelToolResultContent::Text(Arc::from(content))],
+                    tool_use_id: tool_use.id,
+                    tool_name: tool_use.name,
+                    is_error: true,
+                    output: None,
+                },
+            )));
         };
 
         // Agent tools are JSON-schema tools. Custom text-tool deltas are rejected
@@ -3468,15 +3478,18 @@ impl Thread {
         let input = match tool_use.input.clone().into_json() {
             Ok(input) => input,
             Err(error) => {
-                return Some(Task::ready(LanguageModelToolResult {
-                    content: vec![LanguageModelToolResultContent::Text(Arc::from(
-                        error.to_string(),
-                    ))],
-                    tool_use_id: tool_use.id,
-                    tool_name: tool_use.name,
-                    is_error: true,
-                    output: None,
-                }));
+                return Some(Task::ready((
+                    owning_message_ix,
+                    LanguageModelToolResult {
+                        content: vec![LanguageModelToolResultContent::Text(Arc::from(
+                            error.to_string(),
+                        ))],
+                        tool_use_id: tool_use.id,
+                        tool_name: tool_use.name,
+                        is_error: true,
+                        output: None,
+                    },
+                )));
             }
         };
 
@@ -3501,6 +3514,7 @@ impl Thread {
                     tool_input,
                     tool_use.id,
                     tool_use.name,
+                    owning_message_ix,
                     event_stream,
                     cancellation_rx,
                     cx,
@@ -3527,6 +3541,7 @@ impl Thread {
             tool_input,
             tool_use.id,
             tool_use.name,
+            owning_message_ix,
             event_stream,
             cancellation_rx,
             cx,
@@ -3539,10 +3554,11 @@ impl Thread {
         tool_input: ToolInput<serde_json::Value>,
         tool_use_id: LanguageModelToolUseId,
         tool_name: Arc<str>,
+        owning_message_ix: usize,
         event_stream: &ThreadEventStream,
         cancellation_rx: watch::Receiver<bool>,
         cx: &mut Context<Self>,
-    ) -> Task<LanguageModelToolResult> {
+    ) -> Task<(usize, LanguageModelToolResult)> {
         // A workspace can become restricted after a thread has already started.
         // Tools that aren't allowed in restricted workspaces must never run in
         // that state, even though they were exposed to the model earlier.
@@ -3552,20 +3568,25 @@ impl Thread {
                 cx,
             )
         {
-            return Task::ready(LanguageModelToolResult {
-                tool_use_id,
-                tool_name,
-                is_error: true,
-                content: vec![LanguageModelToolResultContent::Text(Arc::from(
-                    "workspace has become restricted",
-                ))],
-                output: None,
-            });
+            return Task::ready((
+                owning_message_ix,
+                LanguageModelToolResult {
+                    tool_use_id,
+                    tool_name,
+                    is_error: true,
+                    content: vec![LanguageModelToolResultContent::Text(Arc::from(
+                        "workspace has become restricted",
+                    ))],
+                    output: None,
+                },
+            ));
         }
 
         let fs = self.project.read(cx).fs().clone();
+        let tool_call_id = scoped_tool_call_id(owning_message_ix, &tool_use_id);
         let tool_event_stream = ToolCallEventStream::new(
             tool_use_id.clone(),
+            tool_call_id,
             event_stream.clone(),
             Some(fs),
             cancellation_rx,
@@ -3621,13 +3642,16 @@ impl Thread {
                 Err(output) => (true, output),
             };
 
-            LanguageModelToolResult {
-                tool_use_id,
-                tool_name,
-                is_error,
-                content: output.llm_output,
-                output: Some(output.raw_output),
-            }
+            (
+                owning_message_ix,
+                LanguageModelToolResult {
+                    tool_use_id,
+                    tool_name,
+                    is_error,
+                    content: output.llm_output,
+                    output: Some(output.raw_output),
+                },
+            )
         })
     }
 
@@ -3640,7 +3664,8 @@ impl Thread {
         event_stream: &ThreadEventStream,
         cancellation_rx: watch::Receiver<bool>,
         cx: &mut Context<Self>,
-    ) -> Option<Task<LanguageModelToolResult>> {
+    ) -> Option<Task<(usize, LanguageModelToolResult)>> {
+        let owning_message_ix = self.messages.len();
         let tool_use = LanguageModelToolUse {
             id: tool_use_id,
             name: tool_name,
@@ -3653,6 +3678,7 @@ impl Thread {
             &tool_use,
             SharedString::from(&tool_use.name),
             acp::ToolKind::Other,
+            owning_message_ix,
             event_stream,
         );
 
@@ -3660,13 +3686,16 @@ impl Thread {
 
         let Some(tool) = tool else {
             let content = format!("No tool named {} exists", tool_use.name);
-            return Some(Task::ready(LanguageModelToolResult {
-                content: vec![LanguageModelToolResultContent::Text(Arc::from(content))],
-                tool_use_id: tool_use.id,
-                tool_name: tool_use.name,
-                is_error: true,
-                output: None,
-            }));
+            return Some(Task::ready((
+                owning_message_ix,
+                LanguageModelToolResult {
+                    content: vec![LanguageModelToolResultContent::Text(Arc::from(content))],
+                    tool_use_id: tool_use.id,
+                    tool_name: tool_use.name,
+                    is_error: true,
+                    output: None,
+                },
+            )));
         };
 
         let error_message = format!("Error parsing input JSON: {json_parse_error}");
@@ -3689,6 +3718,7 @@ impl Thread {
             tool_input,
             tool_use.id,
             tool_use.name,
+            owning_message_ix,
             event_stream,
             cancellation_rx,
             cx,
@@ -3700,8 +3730,11 @@ impl Thread {
         tool_use: &LanguageModelToolUse,
         title: SharedString,
         kind: acp::ToolKind,
+        owning_message_ix: usize,
         event_stream: &ThreadEventStream,
     ) {
+        let tool_call_id = scoped_tool_call_id(owning_message_ix, &tool_use.id);
+
         // Ensure the last message ends in the current tool use
         let last_message = self.pending_message();
 
@@ -3717,7 +3750,7 @@ impl Thread {
 
         if !has_tool_use {
             event_stream.send_tool_call(
-                &tool_use.id,
+                &tool_call_id,
                 &tool_use.name,
                 title,
                 kind,
@@ -3728,7 +3761,7 @@ impl Thread {
                 .push(AgentMessageContent::ToolUse(tool_use.clone()));
         } else {
             event_stream.update_tool_call_fields(
-                &tool_use.id,
+                &tool_call_id,
                 acp::ToolCallUpdateFields::new()
                     .title(title.as_str())
                     .kind(kind)
@@ -5229,6 +5262,23 @@ where
     }
 }
 
+/// Builds the ACP-facing tool call id for a tool use in the message at
+/// `message_ix`.
+///
+/// Provider-issued `tool_use` ids aren't guaranteed unique across separate
+/// request/response cycles in the same turn -- some providers reset a
+/// per-request counter (e.g. `call_1`, `call_2`, ...), so the same raw id
+/// can recur. Scoping by message index keeps the id stable for one tool
+/// call's lifetime while preventing it from colliding with an unrelated one.
+pub(crate) fn scoped_tool_call_id(
+    message_ix: usize,
+    tool_use_id: &LanguageModelToolUseId,
+) -> acp::ToolCallId {
+    // `message_ix` is non-zero-padded decimal, so the `:` delimiter is always
+    // unambiguous -- this would break if the index were zero-padded.
+    acp::ToolCallId::new(format!("{message_ix}:{tool_use_id}"))
+}
+
 #[derive(Clone)]
 struct ThreadEventStream(mpsc::UnboundedSender<Result<ThreadEvent>>);
 
@@ -5253,7 +5303,7 @@ impl ThreadEventStream {
 
     fn send_tool_call(
         &self,
-        id: &LanguageModelToolUseId,
+        id: &acp::ToolCallId,
         tool_name: &str,
         title: SharedString,
         kind: acp::ToolKind,
@@ -5271,13 +5321,13 @@ impl ThreadEventStream {
     }
 
     fn initial_tool_call(
-        id: &LanguageModelToolUseId,
+        id: &acp::ToolCallId,
         tool_name: &str,
         title: String,
         kind: acp::ToolKind,
         input: serde_json::Value,
     ) -> acp::ToolCall {
-        acp::ToolCall::new(id.to_string(), title)
+        acp::ToolCall::new(id.clone(), title)
             .kind(kind)
             .raw_input(input)
             .meta(acp_thread::meta_with_tool_name(tool_name))
@@ -5285,13 +5335,13 @@ impl ThreadEventStream {
 
     fn update_tool_call_fields(
         &self,
-        tool_use_id: &LanguageModelToolUseId,
+        tool_call_id: &acp::ToolCallId,
         fields: acp::ToolCallUpdateFields,
         meta: Option<acp::Meta>,
     ) {
         self.0
             .unbounded_send(Ok(ThreadEvent::ToolCallUpdate(
-                acp::ToolCallUpdate::new(tool_use_id.to_string(), fields)
+                acp::ToolCallUpdate::new(tool_call_id.clone(), fields)
                     .meta(meta)
                     .into(),
             )))
@@ -5300,12 +5350,12 @@ impl ThreadEventStream {
 
     fn resolve_tool_call_authorization(
         &self,
-        tool_use_id: &LanguageModelToolUseId,
+        tool_call_id: &acp::ToolCallId,
         outcome: acp_thread::SelectedPermissionOutcome,
     ) {
         self.0
             .unbounded_send(Ok(ThreadEvent::ToolCallAuthorizationResolved {
-                tool_call_id: acp::ToolCallId::new(tool_use_id.to_string()),
+                tool_call_id: tool_call_id.clone(),
                 outcome,
             }))
             .ok();
@@ -5396,6 +5446,9 @@ pub(crate) enum SandboxFallbackDecision {
 #[derive(Clone)]
 pub struct ToolCallEventStream {
     tool_use_id: LanguageModelToolUseId,
+    /// The ACP-facing id for this tool call (see [`scoped_tool_call_id`]).
+    /// Distinct from `tool_use_id`, which is the raw, provider-issued id.
+    tool_call_id: acp::ToolCallId,
     stream: ThreadEventStream,
     fs: Option<Arc<dyn Fs>>,
     cancellation_rx: watch::Receiver<bool>,
@@ -5427,6 +5480,7 @@ impl ToolCallEventStream {
 
         let stream = ToolCallEventStream::new(
             "test_id".into(),
+            acp::ToolCallId::new("test_id"),
             ThreadEventStream(events_tx),
             None,
             cancellation_rx,
@@ -5444,6 +5498,7 @@ impl ToolCallEventStream {
 
         let stream = ToolCallEventStream::new(
             "test_id".into(),
+            acp::ToolCallId::new("test_id"),
             ThreadEventStream(events_tx),
             None,
             cancellation_rx,
@@ -5466,6 +5521,7 @@ impl ToolCallEventStream {
 
     fn new(
         tool_use_id: LanguageModelToolUseId,
+        tool_call_id: acp::ToolCallId,
         stream: ThreadEventStream,
         fs: Option<Arc<dyn Fs>>,
         cancellation_rx: watch::Receiver<bool>,
@@ -5474,6 +5530,7 @@ impl ToolCallEventStream {
     ) -> Self {
         Self {
             tool_use_id,
+            tool_call_id,
             stream,
             fs,
             cancellation_rx,
@@ -5531,7 +5588,7 @@ impl ToolCallEventStream {
 
     pub fn update_fields(&self, fields: acp::ToolCallUpdateFields) {
         self.stream
-            .update_tool_call_fields(&self.tool_use_id, fields, None);
+            .update_tool_call_fields(&self.tool_call_id, fields, None);
     }
 
     pub fn update_fields_with_meta(
@@ -5540,12 +5597,12 @@ impl ToolCallEventStream {
         meta: Option<acp::Meta>,
     ) {
         self.stream
-            .update_tool_call_fields(&self.tool_use_id, fields, meta);
+            .update_tool_call_fields(&self.tool_call_id, fields, meta);
     }
 
     pub fn resolve_authorization(&self, outcome: acp_thread::SelectedPermissionOutcome) {
         self.stream
-            .resolve_tool_call_authorization(&self.tool_use_id, outcome);
+            .resolve_tool_call_authorization(&self.tool_call_id, outcome);
     }
 
     pub fn update_diff(&self, diff: Entity<acp_thread::Diff>) {
@@ -5553,7 +5610,7 @@ impl ToolCallEventStream {
             .0
             .unbounded_send(Ok(ThreadEvent::ToolCallUpdate(
                 acp_thread::ToolCallUpdateDiff {
-                    id: acp::ToolCallId::new(self.tool_use_id.to_string()),
+                    id: self.tool_call_id.clone(),
                     diff,
                 }
                 .into(),
@@ -5748,7 +5805,7 @@ impl ToolCallEventStream {
 
         let fs = self.fs.clone();
         let stream = self.stream.clone();
-        let tool_use_id = self.tool_use_id.clone();
+        let tool_call_id = self.tool_call_id.clone();
         let sandbox_grants = self.sandbox_grants.clone();
         let thread = self.thread.clone();
         let auto_allow_outcome = match auto_resolve_permission_outcome(&options, true) {
@@ -5762,7 +5819,7 @@ impl ToolCallEventStream {
                 .unbounded_send(Ok(ThreadEvent::ToolCallAuthorization(
                     ToolCallAuthorization {
                         tool_call: acp::ToolCallUpdate::new(
-                            tool_use_id.to_string(),
+                            tool_call_id.clone(),
                             // Leave the title untouched so the card keeps
                             // showing the command (matching the fallback flow).
                             acp::ToolCallUpdateFields::new(),
@@ -5815,7 +5872,7 @@ impl ToolCallEventStream {
                         )) {
                             drop(response_rx);
                             stream.resolve_tool_call_authorization(
-                                &tool_use_id,
+                                &tool_call_id,
                                 auto_allow_outcome.clone(),
                             );
                             return Ok(());
@@ -6050,7 +6107,7 @@ impl ToolCallEventStream {
 
         let fs = self.fs.clone();
         let stream = self.stream.clone();
-        let tool_use_id = self.tool_use_id.clone();
+        let tool_call_id = self.tool_call_id.clone();
         let sandbox_grants = self.sandbox_grants.clone();
         let thread = self.thread.clone();
         cx.spawn(async move |cx| {
@@ -6065,7 +6122,7 @@ impl ToolCallEventStream {
                         // they're approving to run unsandboxed. The reason is
                         // surfaced separately by the fallback details / warning.
                         tool_call: acp::ToolCallUpdate::new(
-                            tool_use_id.to_string(),
+                            tool_call_id.clone(),
                             acp::ToolCallUpdateFields::new(),
                         )
                         .meta(
@@ -6156,7 +6213,7 @@ impl ToolCallEventStream {
     ) -> Task<Result<acp::PermissionOptionId>> {
         let options = acp_thread::PermissionOptions::Flat(options);
         let stream = self.stream.clone();
-        let tool_use_id = self.tool_use_id.clone();
+        let tool_call_id = self.tool_call_id.clone();
         cx.spawn(async move |_cx| {
             let mut fields = acp::ToolCallUpdateFields::new();
             if let Some(title) = title {
@@ -6171,7 +6228,7 @@ impl ToolCallEventStream {
                 .0
                 .unbounded_send(Ok(ThreadEvent::ToolCallAuthorization(
                     ToolCallAuthorization {
-                        tool_call: acp::ToolCallUpdate::new(tool_use_id.to_string(), fields),
+                        tool_call: acp::ToolCallUpdate::new(tool_call_id.clone(), fields),
                         options,
                         response: response_tx,
                         context: None,
@@ -6223,7 +6280,7 @@ impl ToolCallEventStream {
 
         let fs = self.fs.clone();
         let stream = self.stream.clone();
-        let tool_use_id = self.tool_use_id.clone();
+        let tool_call_id = self.tool_call_id.clone();
         let auto_resolution_outcomes = if check_settings.is_some() {
             match (
                 auto_resolve_permission_outcome(&options, true),
@@ -6242,7 +6299,7 @@ impl ToolCallEventStream {
                 .unbounded_send(Ok(ThreadEvent::ToolCallAuthorization(
                     ToolCallAuthorization {
                         tool_call: acp::ToolCallUpdate::new(
-                            tool_use_id.to_string(),
+                            tool_call_id.clone(),
                             acp::ToolCallUpdateFields::new().title(title),
                         ),
                         options,
@@ -6301,7 +6358,7 @@ impl ToolCallEventStream {
                             ToolPermissionDecision::Allow => {
                                 drop(response_rx);
                                 stream.resolve_tool_call_authorization(
-                                    &tool_use_id,
+                                    &tool_call_id,
                                     auto_allow_outcome.clone(),
                                 );
                                 return Ok(());
@@ -6309,7 +6366,7 @@ impl ToolCallEventStream {
                             ToolPermissionDecision::Deny(reason) => {
                                 drop(response_rx);
                                 stream.resolve_tool_call_authorization(
-                                    &tool_use_id,
+                                    &tool_call_id,
                                     auto_deny_outcome.clone(),
                                 );
                                 return Err(anyhow!(reason));
@@ -8045,8 +8102,16 @@ mod tests {
             }
         }
 
-        assert!(tool_use_ids_with_image_content.contains(&registered_tool_use_id.to_string()));
-        assert!(tool_use_ids_with_image_content.contains(&missing_tool_use_id.to_string()));
+        // Both tool uses live in the message pushed above, at index 0 (see
+        // `scoped_tool_call_id`).
+        assert!(
+            tool_use_ids_with_image_content
+                .contains(&scoped_tool_call_id(0, &registered_tool_use_id).to_string())
+        );
+        assert!(
+            tool_use_ids_with_image_content
+                .contains(&scoped_tool_call_id(0, &missing_tool_use_id).to_string())
+        );
     }
 
     #[gpui::test]
@@ -8243,7 +8308,7 @@ mod tests {
 
         let (_cancellation_tx, cancellation_rx) = watch::channel(false);
 
-        let result = cx
+        let (_owning_message_ix, result) = cx
             .update(|cx| {
                 thread.update(cx, |thread, cx| {
                     // Call the function under test

--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -49,6 +49,7 @@ use language_model::{
     SubPageProviderSettings, TokenUsage, env_var,
 };
 use open_ai::responses::Request as OpenAiResponseRequest;
+use open_ai::responses::{ResponseOutputItem, StreamEvent as OpenAiResponseStreamEvent};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -1278,6 +1279,437 @@ fn strip_unsupported_mantle_response_fields(request: &mut OpenAiResponseRequest)
     request.context_management = None;
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum MantleMessageSnapshotKind {
+    Undetermined,
+    Cumulative,
+    Independent,
+}
+
+struct MantleMessageSnapshot {
+    item_id: String,
+    text: String,
+    emitted_text_length: usize,
+    kind: MantleMessageSnapshotKind,
+    phase: Option<String>,
+    output_index: usize,
+    content_index: Option<usize>,
+}
+
+/// The most recently completed message item, used to detect Mantle's cumulative
+/// snapshot replays.
+#[derive(Clone)]
+struct MantlePreviousMessage {
+    text: String,
+    phase: Option<String>,
+}
+
+/// Adapts Mantle's cumulative Responses message snapshots to incremental events.
+///
+/// Mantle can emit a new message item containing all text produced so far, then
+/// replay the corresponding output deltas. The shared OpenAI mapper assumes each
+/// delta is new text, so forwarding those events directly duplicates the reply.
+///
+/// Only adjacent, same-phase, strict-prefix extensions are collapsed. Equal,
+/// shrinking, divergent, or different-phase messages stay visible. Any non-message
+/// output item (reasoning, tool call, etc.) is a hard boundary: it is forwarded
+/// unchanged and clears the snapshot used for collapsing, so a message after a
+/// tool call is never merged with the one before it.
+struct MantleResponseEventMapper {
+    open_ai_mapper: OpenAiResponseEventMapper,
+    current_message: Option<MantleMessageSnapshot>,
+    previous_message: Option<MantlePreviousMessage>,
+    pending_message_events: Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>>,
+}
+
+impl MantleResponseEventMapper {
+    fn new() -> Self {
+        Self {
+            open_ai_mapper: OpenAiResponseEventMapper::new(),
+            current_message: None,
+            previous_message: None,
+            pending_message_events: Vec::new(),
+        }
+    }
+
+    fn map_stream(
+        mut self,
+        events: BoxStream<'static, Result<OpenAiResponseStreamEvent>>,
+    ) -> BoxStream<'static, Result<LanguageModelCompletionEvent, LanguageModelCompletionError>>
+    {
+        events
+            .flat_map(move |event| {
+                futures::stream::iter(match event {
+                    Ok(event) => self.map_event(event),
+                    Err(error) => vec![Err(LanguageModelCompletionError::from(error))],
+                })
+            })
+            .boxed()
+    }
+
+    fn map_event(
+        &mut self,
+        event: OpenAiResponseStreamEvent,
+    ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
+        match event {
+            OpenAiResponseStreamEvent::OutputItemAdded {
+                output_index,
+                sequence_number,
+                item,
+            } => match &item {
+                ResponseOutputItem::Message(message) => {
+                    let mut events = self.finish_current_message();
+                    let item_id = message.id.clone();
+                    let phase = message.phase.clone();
+                    if let Some(item_id) = item_id {
+                        self.current_message = Some(MantleMessageSnapshot {
+                            item_id,
+                            text: String::new(),
+                            emitted_text_length: 0,
+                            kind: MantleMessageSnapshotKind::Undetermined,
+                            phase,
+                            output_index,
+                            content_index: None,
+                        });
+
+                        self.map_message_added(OpenAiResponseStreamEvent::OutputItemAdded {
+                            output_index,
+                            sequence_number,
+                            item,
+                        });
+                    } else {
+                        self.flush_pending_message(&mut events, false);
+                        events.extend(self.open_ai_mapper.map_event(
+                            OpenAiResponseStreamEvent::OutputItemAdded {
+                                output_index,
+                                sequence_number,
+                                item,
+                            },
+                        ));
+                    }
+                    events
+                }
+                _ => {
+                    let mut events = self.finish_current_message();
+                    self.previous_message = None;
+                    events.extend(self.open_ai_mapper.map_event(
+                        OpenAiResponseStreamEvent::OutputItemAdded {
+                            output_index,
+                            sequence_number,
+                            item,
+                        },
+                    ));
+                    events
+                }
+            },
+            OpenAiResponseStreamEvent::OutputTextDelta {
+                item_id,
+                output_index,
+                content_index,
+                delta,
+            } => self.map_text_delta(item_id, output_index, content_index, delta),
+            OpenAiResponseStreamEvent::OutputTextDone {
+                item_id,
+                output_index,
+                content_index,
+                text,
+            } => {
+                let suffix = self
+                    .current_message
+                    .as_ref()
+                    .filter(|message| message.item_id == item_id)
+                    .and_then(|message| text.strip_prefix(&message.text))
+                    .map(str::to_string);
+                if let Some(suffix) = suffix {
+                    if suffix.is_empty() {
+                        return Vec::new();
+                    }
+                    return self.map_text_delta(item_id, output_index, content_index, suffix);
+                }
+
+                let mut events = self.finish_current_message();
+                events.extend(self.open_ai_mapper.map_event(
+                    OpenAiResponseStreamEvent::OutputTextDone {
+                        item_id,
+                        output_index,
+                        content_index,
+                        text,
+                    },
+                ));
+                events
+            }
+            OpenAiResponseStreamEvent::ContentPartAdded { ref item_id, .. }
+            | OpenAiResponseStreamEvent::ContentPartDone { ref item_id, .. }
+            | OpenAiResponseStreamEvent::RefusalDelta { ref item_id, .. }
+            | OpenAiResponseStreamEvent::RefusalDone { ref item_id, .. }
+                if self
+                    .current_message
+                    .as_ref()
+                    .is_some_and(|message| &message.item_id == item_id) =>
+            {
+                self.open_ai_mapper.map_event(event)
+            }
+            OpenAiResponseStreamEvent::OutputItemDone {
+                output_index,
+                sequence_number,
+                item,
+            } => {
+                if let ResponseOutputItem::Message(message) = &item
+                    && let Some(item_id) = message.id.as_ref()
+                    && let Some(current_message) = self.current_message.as_mut()
+                    && &current_message.item_id == item_id
+                {
+                    current_message.phase = message.phase.clone();
+                }
+
+                let is_non_message = !matches!(item, ResponseOutputItem::Message(_));
+                let was_merged = matches!(
+                    self.current_message.as_ref(),
+                    Some(current_message)
+                        if current_message.kind == MantleMessageSnapshotKind::Cumulative
+                );
+                let mut events = self.finish_current_message();
+                if is_non_message {
+                    self.previous_message = None;
+                }
+                let done_events =
+                    self.open_ai_mapper
+                        .map_event(OpenAiResponseStreamEvent::OutputItemDone {
+                            output_index,
+                            sequence_number,
+                            item,
+                        });
+                if was_merged {
+                    // The message was merged into the previous one, so the phase/
+                    // reasoning metadata this `OutputItemDone` would otherwise emit
+                    // again is already reflected by the metadata emitted earlier.
+                    events.extend(done_events.into_iter().filter(|event| {
+                        !matches!(event, Ok(LanguageModelCompletionEvent::ReasoningDetails(_)))
+                    }));
+                } else {
+                    events.extend(done_events);
+                }
+                events
+            }
+            event => {
+                let mut events = self.finish_current_message();
+                events.extend(self.open_ai_mapper.map_event(event));
+                events
+            }
+        }
+    }
+
+    fn map_message_added(&mut self, event: OpenAiResponseStreamEvent) {
+        debug_assert!(
+            self.pending_message_events.is_empty(),
+            "pending message events must be flushed before a new message is added"
+        );
+        self.pending_message_events = self.open_ai_mapper.map_event(event);
+    }
+
+    fn map_text_delta(
+        &mut self,
+        item_id: String,
+        output_index: usize,
+        content_index: Option<usize>,
+        delta: String,
+    ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
+        if !self
+            .current_message
+            .as_ref()
+            .is_some_and(|current_message| current_message.item_id == item_id)
+        {
+            let mut events = self.finish_current_message();
+            events.extend(self.open_ai_mapper.map_event(
+                OpenAiResponseStreamEvent::OutputTextDelta {
+                    item_id,
+                    output_index,
+                    content_index,
+                    delta,
+                },
+            ));
+            return events;
+        }
+
+        let Some(current_message) = self.current_message.as_mut() else {
+            return Vec::new();
+        };
+        current_message.text.push_str(&delta);
+        current_message.output_index = output_index;
+        current_message.content_index = content_index;
+        let snapshot = current_message.text.clone();
+        let kind = current_message.kind;
+        let phase = current_message.phase.clone();
+        let previous = self.previous_message.clone();
+
+        match kind {
+            MantleMessageSnapshotKind::Undetermined => {
+                if let Some(previous) = previous
+                    && previous.phase == phase
+                {
+                    // Strict same-phase extension: previous text is a proper prefix of
+                    // the new snapshot. Collapse the replayed prefix and emit only the
+                    // suffix.
+                    if snapshot.starts_with(&previous.text) && snapshot.len() > previous.text.len()
+                    {
+                        if let Some(current_message) = self.current_message.as_mut() {
+                            current_message.kind = MantleMessageSnapshotKind::Cumulative;
+                            current_message.emitted_text_length = previous.text.len();
+                        }
+                        let mut events = Vec::new();
+                        self.flush_pending_message(&mut events, true);
+                        events.extend(self.map_snapshot_suffix(
+                            output_index,
+                            content_index,
+                            snapshot,
+                        ));
+                        return events;
+                    }
+
+                    // The snapshot is still a prefix of (or equal to) the previous
+                    // message. A genuine cumulative replay keeps growing past the
+                    // previous text, so defer the decision and withhold emission
+                    // until it either exceeds the previous text or diverges.
+                    if previous.text.starts_with(&snapshot) {
+                        return Vec::new();
+                    }
+                }
+
+                // Diverged from the previous message, had a different phase, or there
+                // was no previous message: this is an independent message.
+                if let Some(current_message) = self.current_message.as_mut() {
+                    current_message.kind = MantleMessageSnapshotKind::Independent;
+                }
+                let mut events = Vec::new();
+                self.flush_pending_message(&mut events, false);
+                events.extend(self.map_text_event(item_id, output_index, content_index, snapshot));
+                events
+            }
+            MantleMessageSnapshotKind::Cumulative => {
+                self.map_snapshot_suffix(output_index, content_index, snapshot)
+            }
+            MantleMessageSnapshotKind::Independent => {
+                self.map_text_event(item_id, output_index, content_index, delta)
+            }
+        }
+    }
+
+    fn map_snapshot_suffix(
+        &mut self,
+        output_index: usize,
+        content_index: Option<usize>,
+        snapshot: String,
+    ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
+        let (item_id, suffix) = {
+            let Some(current_message) = self.current_message.as_mut() else {
+                return Vec::new();
+            };
+
+            if snapshot.len() <= current_message.emitted_text_length {
+                return Vec::new();
+            }
+
+            let suffix = snapshot[current_message.emitted_text_length..].to_string();
+            current_message.emitted_text_length = snapshot.len();
+            (current_message.item_id.clone(), suffix)
+        };
+
+        self.map_text_event(item_id, output_index, content_index, suffix)
+    }
+
+    fn map_text_event(
+        &mut self,
+        item_id: String,
+        output_index: usize,
+        content_index: Option<usize>,
+        delta: String,
+    ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
+        if delta.is_empty() {
+            return Vec::new();
+        }
+
+        self.open_ai_mapper
+            .map_event(OpenAiResponseStreamEvent::OutputTextDelta {
+                item_id,
+                output_index,
+                content_index,
+                delta,
+            })
+    }
+
+    fn finish_current_message(
+        &mut self,
+    ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
+        let mut events = Vec::new();
+        self.finish_current_message_into(&mut events);
+        events
+    }
+
+    fn finish_current_message_into(
+        &mut self,
+        events: &mut Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>>,
+    ) {
+        let Some(current_message) = self.current_message.take() else {
+            self.flush_pending_message(events, false);
+            return;
+        };
+
+        match current_message.kind {
+            MantleMessageSnapshotKind::Cumulative => {
+                self.flush_pending_message(events, true);
+            }
+            MantleMessageSnapshotKind::Independent => {
+                self.flush_pending_message(events, false);
+            }
+            MantleMessageSnapshotKind::Undetermined => {
+                // The message never exceeded or diverged from the previous one, so
+                // it could not be confirmed as a cumulative replay. Treat it as an
+                // independent message: emit the withheld StartMessage and any text
+                // accumulated while deferring the decision.
+                self.flush_pending_message(events, false);
+                if !current_message.text.is_empty() {
+                    events.extend(self.map_text_event(
+                        current_message.item_id.clone(),
+                        current_message.output_index,
+                        current_message.content_index,
+                        current_message.text.clone(),
+                    ));
+                }
+            }
+        }
+
+        if !current_message.text.is_empty() {
+            self.previous_message = Some(MantlePreviousMessage {
+                text: current_message.text,
+                phase: current_message.phase,
+            });
+        }
+    }
+
+    fn flush_pending_message(
+        &mut self,
+        events: &mut Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>>,
+        suppress_start_message: bool,
+    ) {
+        for event in self.pending_message_events.drain(..) {
+            // When merging into the previous message, the phase/reasoning metadata
+            // can't have changed since it was last emitted (a merge only happens for
+            // adjacent, same-phase messages with no reasoning item in between), so
+            // suppress both the StartMessage and the now-redundant ReasoningDetails.
+            if suppress_start_message
+                && matches!(
+                    event,
+                    Ok(LanguageModelCompletionEvent::StartMessage { .. })
+                        | Ok(LanguageModelCompletionEvent::ReasoningDetails(_))
+                )
+            {
+                continue;
+            }
+            events.push(event);
+        }
+    }
+}
+
 struct BedrockMantleModel {
     id: LanguageModelId,
     model: MantleModel,
@@ -1477,7 +1909,7 @@ impl LanguageModel for BedrockMantleModel {
                 );
                 let completions = self.stream_response(request, cx);
                 async move {
-                    let mapper = OpenAiResponseEventMapper::new();
+                    let mapper = MantleResponseEventMapper::new();
                     Ok(mapper.map_stream(completions.await?).boxed())
                 }
                 .boxed()
@@ -2442,6 +2874,9 @@ impl ConfigurationView {
 mod tests {
     use super::*;
     use language_model::LanguageModelRequestMessage;
+    use open_ai::responses::{
+        ResponseFunctionToolCall, ResponseOutputMessage, ResponseReasoningItem,
+    };
 
     fn into_bedrock_request(messages: Vec<LanguageModelRequestMessage>) -> bedrock::Request {
         into_bedrock(
@@ -2602,6 +3037,528 @@ mod tests {
         assert!(MANTLE_SUPPORTED_REGIONS.contains(&"us-east-1"));
         assert!(MANTLE_SUPPORTED_REGIONS.contains(&"eu-west-1"));
         assert!(!MANTLE_SUPPORTED_REGIONS.contains(&"ap-southeast-1"));
+    }
+
+    fn mantle_message_item(id: &str) -> ResponseOutputItem {
+        mantle_message_item_with_phase(id, None)
+    }
+
+    fn mantle_message_item_with_phase(id: &str, phase: Option<&str>) -> ResponseOutputItem {
+        ResponseOutputItem::Message(ResponseOutputMessage {
+            id: Some(id.to_string()),
+            content: Vec::new(),
+            role: Some("assistant".to_string()),
+            status: Some("in_progress".to_string()),
+            phase: phase.map(str::to_string),
+        })
+    }
+
+    fn mantle_function_call_item(id: &str, name: &str, call_id: &str) -> ResponseOutputItem {
+        ResponseOutputItem::FunctionCall(ResponseFunctionToolCall {
+            id: Some(id.to_string()),
+            arguments: String::new(),
+            call_id: Some(call_id.to_string()),
+            name: Some(name.to_string()),
+            status: Some("in_progress".to_string()),
+        })
+    }
+
+    fn mantle_reasoning_item(id: &str) -> ResponseOutputItem {
+        ResponseOutputItem::Reasoning(ResponseReasoningItem {
+            id: Some(id.to_string()),
+            summary: Vec::new(),
+            content: Vec::new(),
+            encrypted_content: None,
+            status: Some("in_progress".to_string()),
+        })
+    }
+
+    fn text_delta(item_id: &str, output_index: usize, delta: &str) -> OpenAiResponseStreamEvent {
+        OpenAiResponseStreamEvent::OutputTextDelta {
+            item_id: item_id.to_string(),
+            output_index,
+            content_index: Some(0),
+            delta: delta.to_string(),
+        }
+    }
+
+    fn item_added(output_index: usize, item: ResponseOutputItem) -> OpenAiResponseStreamEvent {
+        OpenAiResponseStreamEvent::OutputItemAdded {
+            output_index,
+            sequence_number: None,
+            item,
+        }
+    }
+
+    fn item_done(output_index: usize, item: ResponseOutputItem) -> OpenAiResponseStreamEvent {
+        OpenAiResponseStreamEvent::OutputItemDone {
+            output_index,
+            sequence_number: None,
+            item,
+        }
+    }
+
+    fn map_mantle_response_events(
+        events: Vec<OpenAiResponseStreamEvent>,
+    ) -> Vec<LanguageModelCompletionEvent> {
+        let mut mapper = MantleResponseEventMapper::new();
+        events
+            .into_iter()
+            .flat_map(|event| mapper.map_event(event))
+            .map(|event| event.expect("Mantle response event should map successfully"))
+            .collect()
+    }
+
+    // Keeps only StartMessage and Text events so phase/reasoning tests can assert on
+    // message boundaries without depending on incidental ReasoningDetails metadata.
+    fn start_messages_and_texts(
+        events: Vec<LanguageModelCompletionEvent>,
+    ) -> Vec<LanguageModelCompletionEvent> {
+        events
+            .into_iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    LanguageModelCompletionEvent::StartMessage { .. }
+                        | LanguageModelCompletionEvent::Text(_)
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn mantle_response_mapper_coalesces_cumulative_message_snapshots() {
+        let first_message = mantle_message_item("msg_1");
+        let second_message = mantle_message_item("msg_2");
+        let events = map_mantle_response_events(vec![
+            OpenAiResponseStreamEvent::OutputItemAdded {
+                output_index: 0,
+                sequence_number: None,
+                item: first_message.clone(),
+            },
+            OpenAiResponseStreamEvent::OutputTextDelta {
+                item_id: "msg_1".to_string(),
+                output_index: 0,
+                content_index: Some(0),
+                delta: "Plan: rename".to_string(),
+            },
+            OpenAiResponseStreamEvent::OutputItemDone {
+                output_index: 0,
+                sequence_number: None,
+                item: first_message,
+            },
+            OpenAiResponseStreamEvent::OutputItemAdded {
+                output_index: 1,
+                sequence_number: None,
+                item: second_message.clone(),
+            },
+            OpenAiResponseStreamEvent::OutputTextDelta {
+                item_id: "msg_2".to_string(),
+                output_index: 1,
+                content_index: Some(0),
+                delta: "Plan: rename".to_string(),
+            },
+            OpenAiResponseStreamEvent::OutputTextDelta {
+                item_id: "msg_2".to_string(),
+                output_index: 1,
+                content_index: Some(0),
+                delta: " and regenerate".to_string(),
+            },
+            OpenAiResponseStreamEvent::OutputItemDone {
+                output_index: 1,
+                sequence_number: None,
+                item: second_message,
+            },
+            OpenAiResponseStreamEvent::Completed {
+                response: open_ai::responses::ResponseSummary::default(),
+            },
+        ]);
+
+        assert_eq!(
+            events,
+            vec![
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_1".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan: rename".to_string()),
+                LanguageModelCompletionEvent::Text(" and regenerate".to_string()),
+                LanguageModelCompletionEvent::Stop(language_model::StopReason::EndTurn),
+            ]
+        );
+    }
+
+    #[test]
+    fn mantle_response_mapper_preserves_independent_messages() {
+        let first_message = mantle_message_item("msg_1");
+        let second_message = mantle_message_item("msg_2");
+        let events = map_mantle_response_events(vec![
+            OpenAiResponseStreamEvent::OutputItemAdded {
+                output_index: 0,
+                sequence_number: None,
+                item: first_message.clone(),
+            },
+            OpenAiResponseStreamEvent::OutputTextDelta {
+                item_id: "msg_1".to_string(),
+                output_index: 0,
+                content_index: Some(0),
+                delta: "Plan".to_string(),
+            },
+            OpenAiResponseStreamEvent::OutputItemDone {
+                output_index: 0,
+                sequence_number: None,
+                item: first_message,
+            },
+            OpenAiResponseStreamEvent::OutputItemAdded {
+                output_index: 1,
+                sequence_number: None,
+                item: second_message.clone(),
+            },
+            OpenAiResponseStreamEvent::OutputTextDelta {
+                item_id: "msg_2".to_string(),
+                output_index: 1,
+                content_index: Some(0),
+                delta: "Final answer".to_string(),
+            },
+            OpenAiResponseStreamEvent::OutputItemDone {
+                output_index: 1,
+                sequence_number: None,
+                item: second_message,
+            },
+        ]);
+
+        assert_eq!(
+            events,
+            vec![
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_1".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan".to_string()),
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_2".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Final answer".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mantle_response_mapper_coalesces_multi_delta_cumulative_snapshots() {
+        // The first message is finalized, then a second item replays the full text
+        // across several growing deltas, each of which is a strict prefix extension.
+        let first_message = mantle_message_item("msg_1");
+        let second_message = mantle_message_item("msg_2");
+        let events = map_mantle_response_events(vec![
+            item_added(0, first_message.clone()),
+            text_delta("msg_1", 0, "Plan"),
+            item_done(0, first_message),
+            item_added(1, second_message.clone()),
+            text_delta("msg_2", 1, "Pl"),
+            text_delta("msg_2", 1, "an"),
+            text_delta("msg_2", 1, " and go"),
+            item_done(1, second_message),
+        ]);
+
+        assert_eq!(
+            events,
+            vec![
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_1".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan".to_string()),
+                LanguageModelCompletionEvent::Text(" and go".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mantle_response_mapper_keeps_message_state_across_content_events() {
+        let first_message = mantle_message_item("msg_1");
+        let second_message = mantle_message_item("msg_2");
+        let events = map_mantle_response_events(vec![
+            item_added(0, first_message.clone()),
+            text_delta("msg_1", 0, "Plan"),
+            item_done(0, first_message),
+            item_added(1, second_message.clone()),
+            OpenAiResponseStreamEvent::ContentPartAdded {
+                item_id: "msg_2".to_string(),
+                output_index: 1,
+                content_index: 0,
+                part: serde_json::json!({"type": "output_text", "text": ""}),
+            },
+            text_delta("msg_2", 1, "Plan"),
+            text_delta("msg_2", 1, " and continue"),
+            OpenAiResponseStreamEvent::OutputTextDone {
+                item_id: "msg_2".to_string(),
+                output_index: 1,
+                content_index: Some(0),
+                text: "Plan and continue".to_string(),
+            },
+            OpenAiResponseStreamEvent::ContentPartDone {
+                item_id: "msg_2".to_string(),
+                output_index: 1,
+                content_index: 0,
+                part: serde_json::json!({"type": "output_text", "text": "Plan and continue"}),
+            },
+            item_done(1, second_message),
+        ]);
+
+        assert_eq!(
+            events,
+            vec![
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_1".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan".to_string()),
+                LanguageModelCompletionEvent::Text(" and continue".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mantle_response_mapper_resets_on_non_message_item_done() {
+        let first_message = mantle_message_item("msg_1");
+        let second_message = mantle_message_item("msg_2");
+        let tool_call = mantle_function_call_item("call_1", "get_weather", "server_call_1");
+        let events = map_mantle_response_events(vec![
+            item_added(0, first_message.clone()),
+            text_delta("msg_1", 0, "Plan"),
+            item_done(0, first_message),
+            item_done(1, tool_call),
+            item_added(2, second_message.clone()),
+            text_delta("msg_2", 2, "Plan continued"),
+            item_done(2, second_message),
+        ]);
+
+        assert_eq!(
+            start_messages_and_texts(events),
+            vec![
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_1".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan".to_string()),
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_2".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan continued".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mantle_response_mapper_keeps_post_tool_message_separate_when_extending_prior_text() {
+        // A tool call sits between two messages. Even though the second message's
+        // text happens to extend the first message's text, the tool call is a hard
+        // boundary and the second message must remain a separate, visible message.
+        let first_message = mantle_message_item("msg_1");
+        let tool_call = mantle_function_call_item("call_1", "get_weather", "server_call_1");
+        let second_message = mantle_message_item("msg_2");
+        let events = map_mantle_response_events(vec![
+            item_added(0, first_message.clone()),
+            text_delta("msg_1", 0, "Plan"),
+            item_done(0, first_message),
+            item_added(1, tool_call.clone()),
+            OpenAiResponseStreamEvent::FunctionCallArgumentsDone {
+                item_id: "call_1".to_string(),
+                output_index: 1,
+                arguments: "{\"city\":\"Boston\"}".to_string(),
+                sequence_number: None,
+            },
+            item_done(1, tool_call),
+            item_added(2, second_message.clone()),
+            text_delta("msg_2", 2, "Plan continued"),
+            item_done(2, second_message),
+        ]);
+
+        assert_eq!(
+            events,
+            vec![
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_1".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan".to_string()),
+                LanguageModelCompletionEvent::ToolUse(LanguageModelToolUse {
+                    id: language_model::LanguageModelToolUseId::from("server_call_1"),
+                    name: Arc::<str>::from("get_weather"),
+                    is_input_complete: true,
+                    input: language_model::LanguageModelToolUseInput::Json(
+                        serde_json::json!({"city": "Boston"}),
+                    ),
+                    raw_input: "{\"city\":\"Boston\"}".to_string(),
+                    thought_signature: None,
+                }),
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_2".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan continued".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mantle_response_mapper_treats_reasoning_as_collapse_boundary() {
+        // A reasoning item between two messages breaks adjacency, so the second
+        // message is emitted independently even though it repeats the first's text.
+        let first_message = mantle_message_item("msg_1");
+        let reasoning = mantle_reasoning_item("rsn_1");
+        let second_message = mantle_message_item("msg_2");
+        let events = map_mantle_response_events(vec![
+            item_added(0, first_message.clone()),
+            text_delta("msg_1", 0, "Plan"),
+            item_done(0, first_message),
+            item_added(1, reasoning.clone()),
+            item_done(1, reasoning),
+            item_added(2, second_message.clone()),
+            text_delta("msg_2", 2, "Plan"),
+            item_done(2, second_message),
+        ]);
+
+        assert_eq!(
+            start_messages_and_texts(events),
+            vec![
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_1".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan".to_string()),
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_2".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mantle_response_mapper_preserves_equal_and_shrinking_messages() {
+        // Equal and strict-prefix (shrinking) adjacent messages must not be dropped:
+        // they are emitted as independent messages rather than collapsed away.
+        let first_message = mantle_message_item("msg_1");
+        let second_message = mantle_message_item("msg_2");
+        let third_message = mantle_message_item("msg_3");
+        let events = map_mantle_response_events(vec![
+            item_added(0, first_message.clone()),
+            text_delta("msg_1", 0, "Hello world"),
+            item_done(0, first_message),
+            // Equal to the previous message.
+            item_added(1, second_message.clone()),
+            text_delta("msg_2", 1, "Hello world"),
+            item_done(1, second_message),
+            // Strict prefix of (shorter than) the previous message.
+            item_added(2, third_message.clone()),
+            text_delta("msg_3", 2, "Hello"),
+            item_done(2, third_message),
+        ]);
+
+        assert_eq!(
+            events,
+            vec![
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_1".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Hello world".to_string()),
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_2".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Hello world".to_string()),
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_3".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Hello".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mantle_response_mapper_keeps_different_phase_messages_separate() {
+        // Two messages share a text prefix but have different phases; only same-phase
+        // strict extensions collapse, so the second message stays visible.
+        let first_message = mantle_message_item_with_phase("msg_1", Some("commentary"));
+        let second_message = mantle_message_item_with_phase("msg_2", Some("final_answer"));
+        let events = map_mantle_response_events(vec![
+            item_added(0, first_message.clone()),
+            text_delta("msg_1", 0, "Plan: rename"),
+            item_done(0, first_message),
+            item_added(1, second_message.clone()),
+            text_delta("msg_2", 1, "Plan: rename and regenerate"),
+            item_done(1, second_message),
+        ]);
+
+        assert_eq!(
+            start_messages_and_texts(events),
+            vec![
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_1".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan: rename".to_string()),
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_2".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan: rename and regenerate".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mantle_response_mapper_coalesces_same_phase_strict_extension() {
+        // Same phase, strict extension: the replayed prefix is collapsed and only the
+        // new suffix is emitted, so no second StartMessage appears.
+        let first_message = mantle_message_item_with_phase("msg_1", Some("final_answer"));
+        let second_message = mantle_message_item_with_phase("msg_2", Some("final_answer"));
+        let events = map_mantle_response_events(vec![
+            item_added(0, first_message.clone()),
+            text_delta("msg_1", 0, "Plan: rename"),
+            item_done(0, first_message),
+            item_added(1, second_message.clone()),
+            text_delta("msg_2", 1, "Plan: rename"),
+            text_delta("msg_2", 1, " and regenerate"),
+            item_done(1, second_message),
+        ]);
+
+        assert_eq!(
+            start_messages_and_texts(events),
+            vec![
+                LanguageModelCompletionEvent::StartMessage {
+                    message_id: "msg_1".to_string(),
+                },
+                LanguageModelCompletionEvent::Text("Plan: rename".to_string()),
+                LanguageModelCompletionEvent::Text(" and regenerate".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn mantle_response_mapper_does_not_duplicate_reasoning_details_on_merge() {
+        // Merging a second message into the first must not emit any additional
+        // phase/reasoning metadata events beyond what the first message alone would
+        // have produced, since the metadata can't have changed by merging.
+        fn reasoning_details_count(events: &[LanguageModelCompletionEvent]) -> usize {
+            events
+                .iter()
+                .filter(|event| matches!(event, LanguageModelCompletionEvent::ReasoningDetails(_)))
+                .count()
+        }
+
+        let first_message = mantle_message_item_with_phase("msg_1", Some("final_answer"));
+        let baseline_events = map_mantle_response_events(vec![
+            item_added(0, first_message.clone()),
+            text_delta("msg_1", 0, "Plan: rename"),
+            item_done(0, first_message.clone()),
+        ]);
+
+        let second_message = mantle_message_item_with_phase("msg_2", Some("final_answer"));
+        let merged_events = map_mantle_response_events(vec![
+            item_added(0, first_message.clone()),
+            text_delta("msg_1", 0, "Plan: rename"),
+            item_done(0, first_message),
+            item_added(1, second_message.clone()),
+            text_delta("msg_2", 1, "Plan: rename"),
+            text_delta("msg_2", 1, " and regenerate"),
+            item_done(1, second_message),
+        ]);
+
+        assert_eq!(
+            reasoning_details_count(&merged_events),
+            reasoning_details_count(&baseline_events),
+        );
     }
 
     #[test]

--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -1341,7 +1341,11 @@ impl MantleResponseEventMapper {
             .flat_map(move |event| {
                 futures::stream::iter(match event {
                     Ok(event) => self.map_event(event),
-                    Err(error) => vec![Err(LanguageModelCompletionError::from(error))],
+                    Err(error) => {
+                        let mut events = self.finish_current_message();
+                        events.push(Err(LanguageModelCompletionError::from(error)));
+                        events
+                    }
                 })
             })
             .boxed()
@@ -1537,13 +1541,14 @@ impl MantleResponseEventMapper {
         current_message.text.push_str(&delta);
         current_message.output_index = output_index;
         current_message.content_index = content_index;
-        let snapshot = current_message.text.clone();
         let kind = current_message.kind;
-        let phase = current_message.phase.clone();
-        let previous = self.previous_message.clone();
 
         match kind {
             MantleMessageSnapshotKind::Undetermined => {
+                let snapshot = current_message.text.clone();
+                let phase = current_message.phase.clone();
+                let previous = self.previous_message.clone();
+
                 if let Some(previous) = previous
                     && previous.phase == phase
                 {
@@ -1558,11 +1563,7 @@ impl MantleResponseEventMapper {
                         }
                         let mut events = Vec::new();
                         self.flush_pending_message(&mut events, true);
-                        events.extend(self.map_snapshot_suffix(
-                            output_index,
-                            content_index,
-                            snapshot,
-                        ));
+                        events.extend(self.map_snapshot_suffix(output_index, content_index));
                         return events;
                     }
 
@@ -1586,7 +1587,7 @@ impl MantleResponseEventMapper {
                 events
             }
             MantleMessageSnapshotKind::Cumulative => {
-                self.map_snapshot_suffix(output_index, content_index, snapshot)
+                self.map_snapshot_suffix(output_index, content_index)
             }
             MantleMessageSnapshotKind::Independent => {
                 self.map_text_event(item_id, output_index, content_index, delta)
@@ -1598,19 +1599,18 @@ impl MantleResponseEventMapper {
         &mut self,
         output_index: usize,
         content_index: Option<usize>,
-        snapshot: String,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let (item_id, suffix) = {
             let Some(current_message) = self.current_message.as_mut() else {
                 return Vec::new();
             };
 
-            if snapshot.len() <= current_message.emitted_text_length {
+            if current_message.text.len() <= current_message.emitted_text_length {
                 return Vec::new();
             }
 
-            let suffix = snapshot[current_message.emitted_text_length..].to_string();
-            current_message.emitted_text_length = snapshot.len();
+            let suffix = current_message.text[current_message.emitted_text_length..].to_string();
+            current_message.emitted_text_length = current_message.text.len();
             (current_message.item_id.clone(), suffix)
         };
 
@@ -3242,20 +3242,22 @@ mod tests {
     }
 
     #[test]
-    fn mantle_response_mapper_coalesces_multi_delta_cumulative_snapshots() {
-        // The first message is finalized, then a second item replays the full text
-        // across several growing deltas, each of which is a strict prefix extension.
+    fn mantle_response_mapper_coalesces_chained_cumulative_snapshots() {
+        // Each merge must thread `previous_message`/`emitted_text_length`
+        // through to the next.
         let first_message = mantle_message_item("msg_1");
         let second_message = mantle_message_item("msg_2");
+        let third_message = mantle_message_item("msg_3");
         let events = map_mantle_response_events(vec![
             item_added(0, first_message.clone()),
             text_delta("msg_1", 0, "Plan"),
             item_done(0, first_message),
             item_added(1, second_message.clone()),
-            text_delta("msg_2", 1, "Pl"),
-            text_delta("msg_2", 1, "an"),
-            text_delta("msg_2", 1, " and go"),
+            text_delta("msg_2", 1, "Plan and go"),
             item_done(1, second_message),
+            item_added(2, third_message.clone()),
+            text_delta("msg_3", 2, "Plan and go further"),
+            item_done(2, third_message),
         ]);
 
         assert_eq!(
@@ -3266,6 +3268,7 @@ mod tests {
                 },
                 LanguageModelCompletionEvent::Text("Plan".to_string()),
                 LanguageModelCompletionEvent::Text(" and go".to_string()),
+                LanguageModelCompletionEvent::Text(" further".to_string()),
             ]
         );
     }


### PR DESCRIPTION
## Problem

AWS Bedrock's Mantle endpoint (used for GPT-5.x models via the OpenAI-compatible Responses API) has two independent bugs that both cause visible duplication/corruption in the agent panel:

1. **Duplicated message text.** Mantle streams a reply as a series of new `message` output items, where each new item's text is a growing prefix-superset of the previous one, and the full `output_text.delta` sequence is replayed for each item. Forwarding these events through the shared `OpenAiResponseEventMapper` unmodified caused the assistant's reply (and its phase/reasoning metadata) to appear duplicated in the UI.
2. **Colliding tool call ids.** Mantle assigns raw `tool_use` ids as a simple per-request counter (`call_1`, `call_2`, ...) that resets to `call_1` on every request/response cycle to the model — including separate cycles within a single agent turn as it performs tool calls sequentially. Since `acp::ToolCallId` was built directly from that raw id, and `AcpThread::upsert_tool_call` matches tool calls by id across a thread's entire entry list, a later, unrelated tool call reusing a raw id would silently overwrite an earlier, already-completed one instead of appearing as a new entry — visible as "old tool calls getting replaced by new ones."

Both were confirmed against real raw Mantle SSE traces and a real persisted thread (`call_1` recurring across 10+ separate request cycles within a single turn).

## Fix

**For message duplication:** `MantleResponseEventMapper` wraps `OpenAiResponseEventMapper` and collapses adjacent, same-phase, strict-prefix message extensions into a single logical message, forwarding only the replayed suffix as ordinary incremental text.
- Only adjacent, same-phase, strict-prefix extensions are collapsed. Equal, shrinking, divergent, or different-phase messages are still shown as-is.
- Any non-message output item (reasoning, tool call) is a hard boundary: it's forwarded unchanged and clears the merge state, so a message after a tool call is never merged with the one before it.
- When a message is merged into the previous one, its `StartMessage` and `ReasoningDetails` metadata events are suppressed, since they'd otherwise duplicate what was already emitted for the first message.

**For tool call id collisions:** `scoped_tool_call_id(message_ix, tool_use_id)` combines the raw provider id with the index of the `AgentMessage` it belongs to in `Thread::messages`. That index is stable for the lifetime of one request/response cycle (`flush_pending_message` only runs on the next `StartMessage` event), so ids stay unique across the whole thread without needing the raw provider id itself to be globally unique. The index is threaded through explicitly from where each tool call is created (`handle_tool_use_event`/`run_tool`) to where it's later referenced (`process_tool_result`), rather than recomputed later by re-reading `Thread::messages.len()`.

We deliberately did not rewrite the raw `tool_use` id itself at the provider layer to make it globally unique, since that id round-trips back to Mantle verbatim as `call_id` in `function_call_output` items on the next request — rewriting it would require a fragile reverse-mapping on every code path that replays tool results.

## Testing

- `cargo test -p language_models --lib bedrock` — 23/23 pass (11 tests covering coalescing, independent messages, phase boundaries, tool/reasoning boundaries, chained cumulative extensions, and metadata deduplication).
- `cargo test -p agent --lib` — 699/699 pass (2 new regression tests for tool call id scoping: one via live streaming across two request cycles in one turn, one via persistence/`Thread::replay()` across two separate turns).
- `script/clippy -p language_models -p agent` — clean.

Release Notes:

- Fixed duplicated assistant replies and colliding tool calls when using GPT-5.x models on Amazon Bedrock's Mantle endpoint
