### PR TITLE
editor: Restart numbering when indenting markdown ordered list items

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -606,6 +606,16 @@
     },
   },
   {
+    "context": "Editor && (extension == md || extension == mdx || extension == mdwn || extension == mdc || extension == markdown)",
+    "use_key_equivalents": true,
+    "bindings": {
+      "tab": ["markdown::Indent", { "behavior": "tab" }],
+      "shift-tab": ["markdown::Outdent", { "behavior": "backtab" }],
+      "ctrl-]": "markdown::Indent",
+      "ctrl-[": "markdown::Outdent",
+    },
+  },
+  {
     "context": "Editor && extension == svg",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -648,6 +648,16 @@
     },
   },
   {
+    "context": "Editor && (extension == md || extension == mdx || extension == mdwn || extension == mdc || extension == markdown)",
+    "use_key_equivalents": true,
+    "bindings": {
+      "tab": ["markdown::Indent", { "behavior": "tab" }],
+      "shift-tab": ["markdown::Outdent", { "behavior": "backtab" }],
+      "cmd-]": "markdown::Indent",
+      "cmd-[": "markdown::Outdent"
+    },
+  },
+  {
     "context": "Editor && extension == svg",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -603,6 +603,16 @@
     },
   },
   {
+    "context": "Editor && (extension == md || extension == mdx || extension == mdwn || extension == mdc || extension == markdown)",
+    "use_key_equivalents": true,
+    "bindings": {
+      "tab": ["markdown::Indent", { "behavior": "tab" }],
+      "shift-tab": ["markdown::Outdent", { "behavior": "backtab" }],
+      "ctrl-]": "markdown::Indent",
+      "ctrl-[": "markdown::Outdent",
+    },
+  },
+  {
     "context": "Editor && extension == svg",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -181,7 +181,7 @@ use language::{
     BufferSnapshot, Capability, CharClassifier, CharKind, CharScopeContext, CodeLabel, CursorShape,
     DiagnosticEntryRef, DiffOptions, EditPredictionsMode, EditPreview, HighlightedText, IndentKind,
     IndentSize, Language, LanguageAwareStyling, LanguageName, LanguageRegistry, LanguageScope,
-    LocalFile, OffsetRangeExt, OutlineItem, Point, Selection, SelectionGoal, TextObject,
+    LocalFile, Node, OffsetRangeExt, OutlineItem, Point, Selection, SelectionGoal, TextObject,
     TransactionId, TreeSitterOptions, WordsQuery,
     language_settings::{
         self, AllLanguageSettings, LanguageSettings, LspInsertMode, RewrapBehavior,
@@ -272,6 +272,10 @@ use workspace::{
 };
 pub use zed_actions::editor::RevealInFileManager;
 use zed_actions::editor::{MoveDown, MoveUp};
+use zed_actions::markdown::{
+    Indent as MarkdownIndent, IndentBehavior as MarkdownIndentBehavior, Outdent as MarkdownOutdent,
+    OutdentBehavior as MarkdownOutdentBehavior,
+};
 
 use crate::{
     code_context_menus::CompletionsMenuSource,
@@ -5370,6 +5374,233 @@ impl Editor {
                 .all::<MultiBufferOffset>(&this.display_snapshot(cx));
             this.change_selections(Default::default(), window, cx, |s| s.select(selections));
         });
+    }
+
+    /// Indents in markdown buffers. Falls back to [`Editor::tab`]/[`Editor::indent`]
+    /// unless the selection touches an ordered list item, in which case the
+    /// indentation also renumbers the affected list markers (see
+    /// [`input::renumber_ordered_list_edits`]).
+    pub fn markdown_indent(
+        &mut self,
+        action: &MarkdownIndent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.mode.is_single_line() {
+            cx.propagate();
+            return;
+        }
+        if action.behavior == MarkdownIndentBehavior::Tab
+            && self.move_to_next_snippet_tabstop(window, cx)
+        {
+            return;
+        }
+        if self.read_only(cx) {
+            return;
+        }
+
+        // A preceding edit (e.g. the newline that inserted this item) may not
+        // have been reparsed yet, since parsing is asynchronous outside of
+        // tests. Ensure the tree is current before we read it to classify and
+        // renumber list items.
+        self.ensure_singleton_parsed_synchronously(cx);
+
+        let selections = self.selections.all::<Point>(&self.display_snapshot(cx));
+        let touches_ordered_list = self
+            .buffer
+            .read(cx)
+            .snapshot(cx)
+            .as_singleton()
+            .is_some_and(|singleton| input::selection_touches_ordered_list(&selections, singleton));
+
+        if !touches_ordered_list {
+            match action.behavior {
+                MarkdownIndentBehavior::Tab => self.tab(&Tab, window, cx),
+                MarkdownIndentBehavior::Indent => self.indent(&Indent, window, cx),
+            }
+            return;
+        }
+
+        self.apply_markdown_ordered_list_indent(window, cx);
+    }
+
+    fn ensure_singleton_parsed_synchronously(&mut self, cx: &mut Context<Self>) {
+        if let Some(buffer) = self.buffer.read(cx).as_singleton() {
+            buffer.update(cx, |buffer, cx| buffer.parse_synchronously(cx));
+        }
+    }
+
+    /// Outdents in markdown buffers. Falls back to [`Editor::outdent`] unless
+    /// the selection touches an ordered list item; see [`Editor::markdown_indent`].
+    pub fn markdown_outdent(
+        &mut self,
+        action: &MarkdownOutdent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.mode.is_single_line() {
+            cx.propagate();
+            return;
+        }
+        if action.behavior == MarkdownOutdentBehavior::Backtab
+            && self.move_to_prev_snippet_tabstop(window, cx)
+        {
+            return;
+        }
+        if self.read_only(cx) {
+            return;
+        }
+
+        // See the note in `markdown_indent`: parsing is asynchronous outside
+        // of tests, so make sure the tree is current before reading it.
+        self.ensure_singleton_parsed_synchronously(cx);
+
+        let selections = self.selections.all::<Point>(&self.display_snapshot(cx));
+        let touches_ordered_list = self
+            .buffer
+            .read(cx)
+            .snapshot(cx)
+            .as_singleton()
+            .is_some_and(|singleton| input::selection_touches_ordered_list(&selections, singleton));
+
+        if !touches_ordered_list {
+            self.outdent(&Outdent, window, cx);
+            return;
+        }
+
+        self.apply_markdown_ordered_list_outdent(window, cx);
+    }
+
+    fn apply_markdown_ordered_list_indent(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let mut selections = self.selections.all::<Point>(&self.display_snapshot(cx));
+        let mut prev_edited_row = 0;
+        let mut row_delta = 0;
+        let mut edits: Vec<(Range<Point>, String)> = Vec::new();
+        let mut row_indent_deltas: BTreeMap<u32, i64> = BTreeMap::default();
+        let buffer = self.buffer.read(cx);
+        let snapshot = buffer.snapshot(cx);
+        for selection in &mut selections {
+            if selection.start.row != prev_edited_row {
+                row_delta = 0;
+            }
+            prev_edited_row = selection.end.row;
+
+            let edits_start = edits.len();
+            row_delta =
+                Self::indent_selection(buffer, &snapshot, selection, &mut edits, row_delta, cx);
+            for (range, text) in &edits[edits_start..] {
+                *row_indent_deltas.entry(range.start.row).or_insert(0) +=
+                    text.chars().count() as i64;
+            }
+        }
+
+        if let Some(singleton) = snapshot.as_singleton() {
+            let renumber_edits = input::renumber_ordered_list_edits(singleton, &row_indent_deltas);
+            Self::apply_digit_width_deltas(&renumber_edits, &mut selections);
+            edits.extend(renumber_edits);
+        }
+
+        self.transact(window, cx, |this, window, cx| {
+            this.buffer.update(cx, |b, cx| b.edit(edits, None, cx));
+            this.change_selections(Default::default(), window, cx, |s| s.select(selections));
+        });
+    }
+
+    fn apply_markdown_ordered_list_outdent(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
+        let selections = self.selections.all::<Point>(&display_map);
+        let mut edits: Vec<(Range<Point>, String)> = Vec::new();
+        let mut row_indent_deltas: BTreeMap<u32, i64> = BTreeMap::default();
+        let mut last_outdent = None;
+        let buffer = self.buffer.read(cx);
+        let snapshot = buffer.snapshot(cx);
+        for selection in &selections {
+            let settings = buffer.language_settings_at(selection.start, cx);
+            let tab_size = settings.tab_size;
+            let mut rows = selection.spanned_rows(false, &display_map);
+
+            if let Some(last_row) = last_outdent
+                && last_row == rows.start
+            {
+                rows.start = rows.start.next_row();
+            }
+            let has_multiple_rows = rows.len() > 1;
+            for row in rows.iter_rows() {
+                let indent_size = snapshot.indent_size_for_line(row);
+                if indent_size.len > 0 {
+                    let deletion_len = indent_size.outdent_len(tab_size);
+                    let start = if has_multiple_rows
+                        || deletion_len > selection.start.column
+                        || indent_size.len < selection.start.column
+                    {
+                        0
+                    } else {
+                        selection.start.column - deletion_len
+                    };
+                    edits.push((
+                        Point::new(row.0, start)..Point::new(row.0, start + deletion_len),
+                        String::new(),
+                    ));
+                    *row_indent_deltas.entry(row.0).or_insert(0) -= deletion_len as i64;
+                    last_outdent = Some(row);
+                }
+            }
+        }
+
+        if let Some(singleton) = snapshot.as_singleton() {
+            edits.extend(input::renumber_ordered_list_edits(
+                singleton,
+                &row_indent_deltas,
+            ));
+        }
+
+        self.transact(window, cx, |this, window, cx| {
+            this.buffer.update(cx, |buffer, cx| {
+                buffer.edit(edits, None, cx);
+            });
+            let selections = this
+                .selections
+                .all::<MultiBufferOffset>(&this.display_snapshot(cx));
+            this.change_selections(Default::default(), window, cx, |s| s.select(selections));
+        });
+    }
+
+    /// Shifts `selections`' columns to account for digit-width changes in
+    /// `renumber_edits` (e.g. `9.` -> `10.`). Needed only where the caller
+    /// restores selections by explicitly recomputed columns (as
+    /// [`Editor::indent_selection`] does for the whitespace edit); callers
+    /// that instead read back live selections after the buffer edit already
+    /// get this for free from anchor tracking.
+    fn apply_digit_width_deltas(
+        renumber_edits: &[(Range<Point>, String)],
+        selections: &mut [Selection<Point>],
+    ) {
+        let mut deltas: BTreeMap<u32, Vec<(u32, i64)>> = BTreeMap::default();
+        for (range, text) in renumber_edits {
+            let old_len = range.end.column.saturating_sub(range.start.column) as i64;
+            let new_len = text.chars().count() as i64;
+            deltas
+                .entry(range.start.row)
+                .or_default()
+                .push((range.end.column, new_len - old_len));
+        }
+        if deltas.is_empty() {
+            return;
+        }
+
+        let shift = |column: &mut u32, row: u32| {
+            if let Some(row_deltas) = deltas.get(&row) {
+                for &(edit_end_column, delta) in row_deltas {
+                    if *column >= edit_end_column {
+                        *column = (*column as i64 + delta).max(0) as u32;
+                    }
+                }
+            }
+        };
+        for selection in selections.iter_mut() {
+            shift(&mut selection.start.column, selection.start.row);
+            shift(&mut selection.end.column, selection.end.row);
+        }
     }
 
     pub fn autoindent(&mut self, _: &AutoIndent, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -38366,6 +38366,40 @@ async fn test_newline_should_not_autoindent_ordered_list(cx: &mut TestAppContext
 }
 
 #[gpui::test]
+async fn test_newline_ordered_list_preserves_deep_indent(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = Some(2.try_into().unwrap());
+    });
+
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
+
+    // A doubly-indented (2-level, 4-space) item continued via Enter must
+    // keep its 4-space indent, not fall back to column 0 (#48244, #49017).
+    cx.set_state(indoc! {"
+        1. item
+        2. sub subˇ
+    "});
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. item
+            2. sub subˇ
+    "});
+
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. item
+            2. sub sub
+            3. ˇ
+    "});
+}
+
+#[gpui::test]
 async fn test_tab_list_indent(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.tab_size = Some(2.try_into().unwrap());
@@ -38474,6 +38508,454 @@ async fn test_tab_list_indent(cx: &mut TestAppContext) {
           ˇ- sub item
     "};
     cx.assert_editor_state(expected);
+}
+
+#[gpui::test]
+async fn test_markdown_ordered_list_indent_renumber(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = Some(2.try_into().unwrap());
+    });
+
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
+
+    // Case 1: issue #48244's exact repro. Indenting the second item of a
+    // flat list restarts its number at 1; outdenting restores it to 2.
+    cx.set_state(indoc! {"
+        1. a
+        2. ˇb
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. a
+          1. ˇb
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.markdown_outdent(
+            &MarkdownOutdent {
+                behavior: MarkdownOutdentBehavior::Backtab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. a
+        2. ˇb
+    "});
+
+    // Case 2: gap closing. Indenting the middle item of a 3-item list moves
+    // it into its own nested list and renumbers the trailing sibling to
+    // close the gap it left behind.
+    cx.set_state(indoc! {"
+        1. A
+        2. ˇB
+        3. C
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. A
+          1. ˇB
+        2. C
+    "});
+
+    // Case 3: dinocosta's #52677 counterexample. Indenting a selection that
+    // spans two different nesting levels must not let the deeper item share
+    // the shallower item's counter.
+    cx.set_state(indoc! {"
+        1. A
+        «2. B
+          1. Cˇ»
+          2. D
+        3. E
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. A
+          «1. B
+            1. Cˇ»
+          2. D
+        2. E
+    "});
+
+    // Case 4: smitbarmase's #49017 outdent repro. Outdenting `sub third`
+    // from the 4-space nested list makes it a sibling of `first` in the
+    // Markdown syntax tree, so it continues the parent sequence as `2`.
+    cx.set_state(indoc! {"
+        1. first
+            1. sub first
+            2. sub second
+            3. ˇsub third
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.markdown_outdent(
+            &MarkdownOutdent {
+                behavior: MarkdownOutdentBehavior::Backtab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. first
+            1. sub first
+            2. sub second
+          2. ˇsub third
+    "});
+
+    // Case 5: indenting onto a preceding nested run continues its
+    // numbering rather than restarting at 1 (the #51294 lesson).
+    cx.set_state(indoc! {"
+        1. A
+          1. suba
+          2. subb
+        2. ˇB
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. A
+          1. suba
+          2. subb
+          3. ˇB
+    "});
+
+    // Case 6: multiple cursors in two separate lists (split by a paragraph)
+    // renumber independently.
+    cx.set_state(indoc! {"
+        1. A
+        2. ˇB
+
+        Some paragraph.
+
+        1. X
+        2. ˇY
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. A
+          1. ˇB
+
+        Some paragraph.
+
+        1. X
+          1. ˇY
+    "});
+
+    // Case 7: digit-width changes (9 -> 10) still land the cursor correctly.
+    cx.set_state(indoc! {"
+        1. a
+        2. b
+        3. c
+        4. d
+        5. e
+        6. f
+        7. g
+        8. h
+        9. i
+        10. ˇj
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. a
+        2. b
+        3. c
+        4. d
+        5. e
+        6. f
+        7. g
+        8. h
+        9. i
+          1. ˇj
+    "});
+
+    // Case 8: a fenced code block containing ordered-list-looking text is
+    // left untouched, since the syntax tree never treats it as a list item.
+    cx.set_state(indoc! {"
+        ```
+        1. ˇfake
+        ```
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        ```
+          1. ˇfake
+        ```
+    "});
+
+    // Case 9: non-list content falls back to (and behaves identically to)
+    // stock Tab, which inserts a plain indent.
+    cx.set_state(indoc! {"
+        ˇSome plain paragraph.
+    "});
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(
+        indoc! {"
+        $$ˇSome plain paragraph.
+    "}
+        .replace("$", " ")
+        .as_str(),
+    );
+
+    // Case 10: an empty item at the end of the buffer with no trailing
+    // newline (what Enter's list continuation produces, and #48244's actual
+    // manual gesture). tree-sitter-md parses the bare trailing marker as an
+    // ERROR node outside the list, so renumbering must graft it back on.
+    cx.set_state("1. one\n2. ˇ");
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state("1. one\n  1. ˇ");
+}
+
+#[gpui::test]
+async fn test_markdown_ordered_list_renumber_uses_marker_language_scope(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = Some(2.try_into().unwrap());
+    });
+
+    let language_registry = Arc::new(language::LanguageRegistry::test(cx.executor()));
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
+    let python_language = languages::language("python", tree_sitter_python::LANGUAGE.into());
+    language_registry.add(markdown_language.clone());
+    language_registry.add(python_language);
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language_registry(language_registry);
+        buffer.set_language(Some(markdown_language), cx);
+    });
+    cx.set_state(indoc! {"
+        ```python
+        ˇpass
+        ```
+
+        1. A
+        2. ˇB
+    "});
+    cx.run_until_parked();
+
+    cx.update_editor(|editor, window, cx| {
+        editor.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        );
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        ```python
+          ˇpass
+        ```
+
+        1. A
+          1. ˇB
+    "});
+
+    cx.update_editor(|editor, window, cx| {
+        editor.markdown_outdent(
+            &MarkdownOutdent {
+                behavior: MarkdownOutdentBehavior::Backtab,
+            },
+            window,
+            cx,
+        );
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        ```python
+        ˇpass
+        ```
+
+        1. A
+        2. ˇB
+    "});
+}
+
+#[gpui::test]
+async fn test_markdown_ordered_list_renumbers_before_reparse(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = Some(2.try_into().unwrap());
+    });
+
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
+    // Reproduce production, where parsing is asynchronous: a fast user can
+    // insert a newline and press Tab before the background reparse lands, so
+    // the syntax tree is stale when the indent action fires. The handler must
+    // still renumber correctly by parsing synchronously first (#48244).
+    cx.update_buffer(|buffer, _| buffer.set_sync_parse_timeout(None));
+
+    cx.set_state(indoc! {"
+        1. aˇ
+    "});
+    cx.run_until_parked();
+
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    // Deliberately do NOT wait for the reparse before indenting.
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.run_until_parked();
+    cx.assert_editor_state(indoc! {"
+        1. a
+          1. ˇ
+    "});
+}
+
+#[gpui::test]
+async fn test_markdown_ordered_sublist_enter_preserves_indent(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = Some(2.try_into().unwrap());
+    });
+
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
+
+    // Full issue #48244 flow: type a list, indent (and renumber) the second
+    // item, then keep typing and continuing the resulting sublist. Every
+    // continuation must keep the sublist's indentation.
+    cx.set_state(indoc! {"
+        1. aˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. a
+          1. ˇ
+    "});
+
+    cx.update_editor(|e, window, cx| e.handle_input("b", window, cx));
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. a
+          1. b
+          2. ˇ
+    "});
+
+    // Indenting again (to a 4-space, tree-nested level) and continuing must
+    // also preserve indentation on Enter (OmChillure's #49017 diagnosis).
+    cx.update_editor(|e, window, cx| {
+        e.markdown_indent(
+            &MarkdownIndent {
+                behavior: MarkdownIndentBehavior::Tab,
+            },
+            window,
+            cx,
+        )
+    });
+    cx.wait_for_autoindent_applied().await;
+    cx.update_editor(|e, window, cx| e.handle_input("c", window, cx));
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. a
+          1. b
+            1. c
+            2. ˇ
+    "});
 }
 
 #[gpui::test]
@@ -41430,4 +41912,104 @@ async fn test_select_delimiters_expansion(cx: &mut TestAppContext) {
     cx.assert_editor_state("foo(x, «{ a: 1 }ˇ»);");
     cx.dispatch_action(SelectInsideDelimiters);
     cx.assert_editor_state("foo(«x, { a: 1 }ˇ»);");
+}
+
+#[gpui::test]
+async fn test_markdown_ordered_list_tab_through_default_keymap(cx: &mut TestAppContext) {
+    // End-to-end repro of #48244 through the real default keymap: a real
+    // `file.md` buffer, real markdown language config + grammar, and `tab`
+    // dispatched as a keystroke rather than a direct action call. Typing the
+    // list rather than using `set_state` matters: Enter's list continuation
+    // leaves an empty `2. ` marker at the end of the buffer, which
+    // tree-sitter-md parses as an ERROR node outside the list until content
+    // is typed after it.
+    let markdown_language = Arc::into_inner(languages::language(
+        "markdown",
+        tree_sitter_md::LANGUAGE.into(),
+    ))
+    .expect("markdown language should be uniquely owned");
+    let mut cx = EditorLspTestContext::new(markdown_language, Default::default(), cx).await;
+
+    cx.update(|_, cx| {
+        let mut bindings = settings::KeymapFile::load_asset_allow_partial_failure(
+            "keymaps/default-linux.json",
+            cx,
+        )
+        .unwrap();
+        for binding in &mut bindings {
+            binding.set_meta(settings::KeybindSource::Default.meta());
+        }
+        cx.bind_keys(bindings);
+    });
+
+    cx.set_state("ˇ");
+    cx.simulate_keystrokes("1 . space o n e enter");
+    cx.run_until_parked();
+    cx.assert_editor_state("1. one\n2. ˇ");
+
+    cx.simulate_keystrokes("tab");
+    cx.run_until_parked();
+    cx.assert_editor_state("1. one\n    1. ˇ");
+
+    cx.simulate_keystrokes("s u b enter");
+    cx.run_until_parked();
+    cx.assert_editor_state("1. one\n    1. sub\n    2. ˇ");
+
+    cx.simulate_keystrokes("shift-tab");
+    cx.run_until_parked();
+    cx.assert_editor_state("1. one\n    1. sub\n2. ˇ");
+}
+
+#[gpui::test]
+async fn test_markdown_indent_bindings_cover_markdown_extensions(cx: &mut TestAppContext) {
+    // The markdown indent/outdent bindings must cover every extension the
+    // Markdown language claims (crates/grammars/src/markdown/config.toml),
+    // not just `.md`; the editor lowercases the extension context key, so
+    // `MD` is covered by `md`.
+    init_test(cx, |_| {});
+    cx.update(|cx| {
+        for path in [
+            "keymaps/default-linux.json",
+            "keymaps/default-macos.json",
+            "keymaps/default-windows.json",
+        ] {
+            let bindings =
+                settings::KeymapFile::load_asset_allow_partial_failure(path, cx).unwrap();
+            let markdown_bindings: Vec<_> = bindings
+                .iter()
+                .filter(|b| matches!(b.action().name(), "markdown::Indent" | "markdown::Outdent"))
+                .collect();
+            assert_eq!(
+                markdown_bindings.len(),
+                4,
+                "{path}: expected 4 markdown indent/outdent bindings"
+            );
+            for ext in ["md", "mdx", "mdwn", "mdc", "markdown"] {
+                let mut key_context = gpui::KeyContext::default();
+                key_context.add("Editor");
+                key_context.set("extension", ext);
+                for binding in &markdown_bindings {
+                    let predicate = binding.predicate().expect("binding should have context");
+                    assert!(
+                        predicate.eval(std::slice::from_ref(&key_context)),
+                        "{path}: {} should match extension {ext}",
+                        binding.action().name()
+                    );
+                }
+            }
+            // A non-markdown extension must not match.
+            let mut key_context = gpui::KeyContext::default();
+            key_context.add("Editor");
+            key_context.set("extension", "rs");
+            for binding in &markdown_bindings {
+                let predicate = binding.predicate().expect("binding should have context");
+                assert!(
+                    !predicate.eval(std::slice::from_ref(&key_context)),
+                    "{path}: {} must not match extension rs",
+                    binding.action().name()
+                );
+            }
+            eprintln!("{path}: OK");
+        }
+    });
 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -580,6 +580,8 @@ impl EditorElement {
             register_action(editor, window, Editor::backtab);
             register_action(editor, window, Editor::indent);
             register_action(editor, window, Editor::outdent);
+            register_action(editor, window, Editor::markdown_indent);
+            register_action(editor, window, Editor::markdown_outdent);
             register_action(editor, window, Editor::autoindent);
             register_action(editor, window, Editor::delete_line);
             register_action(editor, window, Editor::join_lines);

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 const ORDERED_LIST_MAX_MARKER_LEN: usize = 16;
+const MARKDOWN_NESTED_LIST_MIN_INDENT: u32 = 4;
 
 impl Editor {
     pub fn set_input_enabled(&mut self, input_enabled: bool) {
@@ -2673,6 +2674,13 @@ fn list_delimiter_for_newline(
                 .any(|c| !c.is_whitespace());
 
             if has_content_after_marker && cursor_is_after_prefix {
+                if let NewlineConfig::Newline {
+                    prevent_auto_indent,
+                    ..
+                } = newline_config
+                {
+                    *prevent_auto_indent = true;
+                }
                 return Some((*continuation).into());
             }
 
@@ -2718,6 +2726,13 @@ fn list_delimiter_for_newline(
                 let continuation = ordered_config
                     .format
                     .replace("{1}", &(number + 1).to_string());
+                if let NewlineConfig::Newline {
+                    prevent_auto_indent,
+                    ..
+                } = newline_config
+                {
+                    *prevent_auto_indent = true;
+                }
                 return Some(continuation.into());
             }
 
@@ -2737,6 +2752,338 @@ fn list_delimiter_for_newline(
     }
 
     None
+}
+
+/// Returns true if any row spanned by `selections` begins an ordered list item,
+/// as determined by the markdown syntax tree (`list_item` nodes whose first
+/// child is a `list_marker_dot`/`list_marker_parenthesis` marker).
+pub(super) fn selection_touches_ordered_list(
+    selections: &[Selection<Point>],
+    snapshot: &BufferSnapshot,
+) -> bool {
+    for selection in selections {
+        let start_row = selection.start.row;
+        let mut end_row = selection.end.row + 1;
+        if selection.end.column == 0 && selection.end.row > selection.start.row {
+            end_row -= 1;
+        }
+        for row in start_row..end_row {
+            if ordered_list_marker_node_at_row(row, snapshot).is_some() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Locates the tree-sitter marker node for an ordered list item whose marker
+/// begins on `row`, if any. Used only to classify a single row; grouping and
+/// numbering are handled by [`renumber_ordered_list_edits`], which walks the
+/// enclosing `list` node instead of scanning the buffer.
+fn ordered_list_marker_node_at_row(row: u32, snapshot: &BufferSnapshot) -> Option<Node<'_>> {
+    let indent_len = snapshot.indent_size_for_line(row).len;
+    if indent_len >= snapshot.line_len(row) {
+        return None;
+    }
+    let anchor = Point::new(row, indent_len);
+    let mut current = snapshot.syntax_ancestor(anchor..Point::new(row, indent_len + 1));
+    while let Some(node) = current {
+        if matches!(node.kind(), "list_marker_dot" | "list_marker_parenthesis") {
+            return Some(node);
+        }
+        if node.kind() == "list_item" {
+            return None;
+        }
+        current = node.parent();
+    }
+    None
+}
+
+/// Finds the outermost tree-sitter `list` node enclosing `row`, if any.
+/// ERROR nodes count as list containers too: an empty item just inserted at
+/// the end of the buffer (e.g. by Enter's list continuation, before any
+/// content is typed after the marker) fails to parse as a `list_item`, and
+/// tree-sitter can wrap the marker, or the whole surrounding list, in an
+/// ERROR node instead.
+fn outermost_list_node_at_row(row: u32, snapshot: &BufferSnapshot) -> Option<Node<'_>> {
+    let indent_len = snapshot.indent_size_for_line(row).len;
+    let anchor = Point::new(row, indent_len);
+    let mut current = snapshot.syntax_ancestor(anchor..anchor);
+    let mut outermost = None;
+    while let Some(node) = current {
+        if matches!(node.kind(), "list" | "ERROR") {
+            outermost = Some(node);
+        }
+        current = node.parent();
+    }
+    outermost
+}
+
+struct ListItemEntry {
+    row: u32,
+    column: u32,
+    /// `Some((number, digit_byte_range))` for ordered items; `None` for
+    /// unordered/task items, which still occupy a nesting level but are
+    /// never renumbered.
+    ordered: Option<(u32, Range<usize>)>,
+}
+
+/// Recursively collects every `list_item` in `node` (a `list` or `ERROR`
+/// node, possibly containing nested `list` nodes) in document order. ERROR
+/// nodes are treated as transparent containers, and a bare list marker
+/// directly inside one (how an empty item at the end of the buffer parses,
+/// see [`outermost_list_node_at_row`]) counts as an item of its own.
+fn collect_list_items(
+    node: Node,
+    snapshot: &BufferSnapshot,
+    ordered_list_regexes: &mut HashMap<String, Option<Regex>>,
+    items: &mut Vec<ListItemEntry>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "list_item" => {
+                if let Some(marker) = child.child(0) {
+                    let ordered =
+                        if matches!(marker.kind(), "list_marker_dot" | "list_marker_parenthesis") {
+                            parse_ordered_marker(
+                                marker.byte_range(),
+                                snapshot,
+                                ordered_list_regexes,
+                            )
+                        } else {
+                            None
+                        };
+                    let row = snapshot.offset_to_point(child.start_byte()).row;
+                    // Read the column from the line's actual leading
+                    // whitespace rather than the marker node's own
+                    // start_position(): the markdown grammar's column
+                    // bookkeeping for continuation lines is not always
+                    // consistent with the visual indent for the first item
+                    // of a nested list.
+                    let column = snapshot.indent_size_for_line(row).len;
+                    items.push(ListItemEntry {
+                        row,
+                        column,
+                        ordered,
+                    });
+                }
+                collect_list_items(child, snapshot, ordered_list_regexes, items);
+            }
+            "list" | "ERROR" => {
+                collect_list_items(child, snapshot, ordered_list_regexes, items);
+            }
+            // A marker that is a direct child of an ERROR node (a `list_item`
+            // handles its own marker above) is an item the parser failed to
+            // reduce; still treat it as one.
+            "list_marker_dot" | "list_marker_parenthesis" if node.kind() == "ERROR" => {
+                let row = snapshot.offset_to_point(child.start_byte()).row;
+                items.push(ListItemEntry {
+                    row,
+                    column: snapshot.indent_size_for_line(row).len,
+                    ordered: parse_ordered_marker(
+                        child.byte_range(),
+                        snapshot,
+                        ordered_list_regexes,
+                    ),
+                });
+            }
+            "list_marker_minus" | "list_marker_plus" | "list_marker_star"
+                if node.kind() == "ERROR" =>
+            {
+                let row = snapshot.offset_to_point(child.start_byte()).row;
+                items.push(ListItemEntry {
+                    row,
+                    column: snapshot.indent_size_for_line(row).len,
+                    ordered: None,
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Reads the number out of an ordered marker's own text (e.g. `"12. "`),
+/// returning it along with the byte range of just the digits so callers can
+/// rewrite the number in place without touching the rest of the marker.
+fn parse_ordered_marker(
+    marker_byte_range: Range<usize>,
+    snapshot: &BufferSnapshot,
+    ordered_list_regexes: &mut HashMap<String, Option<Regex>>,
+) -> Option<(u32, Range<usize>)> {
+    let language = snapshot.language_scope_at(snapshot.offset_to_point(marker_byte_range.start))?;
+    let text: String = snapshot.text_for_range(marker_byte_range.clone()).collect();
+    for config in language.ordered_list() {
+        let Some(regex) = ordered_list_regexes
+            .entry(config.pattern.clone())
+            .or_insert_with(|| Regex::new(&config.pattern).ok())
+            .as_ref()
+        else {
+            continue;
+        };
+        let Some(captures) = regex.captures(&text) else {
+            continue;
+        };
+        let Some(digits) = captures.get(1) else {
+            continue;
+        };
+        let Ok(number) = digits.as_str().parse::<u32>() else {
+            continue;
+        };
+        let start = marker_byte_range.start + digits.start();
+        let end = marker_byte_range.start + digits.end();
+        return Some((number, start..end));
+    }
+    None
+}
+
+/// Tracks the numbering state for one open nesting level while walking a
+/// list's items in row order.
+struct RenumberFrame {
+    column: u32,
+    /// The number the next ordered item at this column should receive, if
+    /// this level is currently an uninterrupted ordered run.
+    next_number: Option<u32>,
+}
+
+fn renumber_list_group(
+    group: &[Node],
+    snapshot: &BufferSnapshot,
+    row_indent_deltas: &BTreeMap<u32, i64>,
+    ordered_list_regexes: &mut HashMap<String, Option<Regex>>,
+    edits: &mut Vec<(Range<Point>, String)>,
+) {
+    let mut items = Vec::new();
+    for node in group {
+        collect_list_items(*node, snapshot, ordered_list_regexes, &mut items);
+    }
+    items.sort_by_key(|item| item.row);
+
+    let mut stack: Vec<RenumberFrame> = Vec::new();
+    for item in &items {
+        let delta = row_indent_deltas.get(&item.row).copied().unwrap_or(0);
+        let moved = delta != 0;
+        let predicted_column = (item.column as i64 + delta).max(0) as u32;
+
+        while stack
+            .last()
+            .is_some_and(|frame| frame.column > predicted_column)
+        {
+            stack.pop();
+        }
+
+        // The Markdown scanner accepts up to three columns of indentation for
+        // a sibling list marker. When an outdent lands in that range, continue
+        // the nearest shallower counter instead of creating a visual level
+        // that does not exist in the syntax tree.
+        let numbering_column = if delta < 0 {
+            stack
+                .last()
+                .filter(|frame| {
+                    frame.column < predicted_column
+                        && predicted_column - frame.column < MARKDOWN_NESTED_LIST_MIN_INDENT
+                })
+                .map_or(predicted_column, |frame| frame.column)
+        } else {
+            predicted_column
+        };
+        if stack
+            .last()
+            .is_none_or(|frame| frame.column != numbering_column)
+        {
+            stack.push(RenumberFrame {
+                column: numbering_column,
+                next_number: None,
+            });
+        }
+
+        let Some((existing_number, digits_range)) = &item.ordered else {
+            // Unordered/task item: occupies the level but breaks any
+            // in-progress ordered run, so a later ordered item at the same
+            // column is treated as a fresh run rather than continuing it.
+            if let Some(frame) = stack.last_mut() {
+                frame.next_number = None;
+            }
+            continue;
+        };
+
+        // A frame for `predicted_column` exists at this point: either it was
+        // already on top, or the push above just put it there.
+        let Some(frame) = stack.last_mut() else {
+            continue;
+        };
+        let new_number = frame
+            .next_number
+            .unwrap_or(if moved { 1 } else { *existing_number });
+        frame.next_number = Some(new_number.saturating_add(1));
+
+        if new_number != *existing_number {
+            let start = snapshot.offset_to_point(digits_range.start);
+            let end = snapshot.offset_to_point(digits_range.end);
+            edits.push((start..end, new_number.to_string()));
+        }
+    }
+}
+
+/// Computes marker-renumbering edits for every ordered list touched by
+/// `row_indent_deltas` (rows about to be indented/outdented, mapped to their
+/// column delta). Grouping and nesting come entirely from the markdown
+/// syntax tree's `list`/`list_item` nodes so counters are never shared
+/// across separate lists or nesting levels; the numbers themselves are read
+/// from each marker's own text since tree-sitter list items carry no
+/// integer field.
+pub(super) fn renumber_ordered_list_edits(
+    snapshot: &BufferSnapshot,
+    row_indent_deltas: &BTreeMap<u32, i64>,
+) -> Vec<(Range<Point>, String)> {
+    let mut seen_ranges = HashSet::default();
+    let mut list_nodes = Vec::new();
+    for &row in row_indent_deltas.keys() {
+        let Some(list_node) = outermost_list_node_at_row(row, snapshot) else {
+            continue;
+        };
+        let range = list_node.byte_range();
+        if seen_ranges.insert((range.start, range.end)) {
+            list_nodes.push(list_node);
+        }
+    }
+    list_nodes.sort_by_key(|node| node.start_byte());
+
+    // A parse failure can split what is visually one list into a `list` node
+    // plus an adjacent ERROR node (e.g. a bare trailing marker at the end of
+    // the buffer). Renumber such row-adjacent groups as a single list so the
+    // ERROR part continues the counters of the intact part. Well-formed
+    // neighboring lists are never merged: tree-sitter only produces separate
+    // adjacent `list` nodes when something (marker style, other content)
+    // genuinely separates them.
+    let mut groups: Vec<Vec<Node>> = Vec::new();
+    for node in list_nodes {
+        if let Some(group) = groups.last_mut()
+            && let Some(last) = group.last()
+            && (last.kind() == "ERROR" || node.kind() == "ERROR")
+        {
+            let last_end_row = snapshot.offset_to_point(last.end_byte()).row;
+            let node_start_row = snapshot.offset_to_point(node.start_byte()).row;
+            if node_start_row <= last_end_row + 1 {
+                group.push(node);
+                continue;
+            }
+        }
+        groups.push(vec![node]);
+    }
+
+    let mut edits = Vec::new();
+    let mut ordered_list_regexes = HashMap::default();
+    for group in groups {
+        renumber_list_group(
+            &group,
+            snapshot,
+            row_indent_deltas,
+            &mut ordered_list_regexes,
+            &mut edits,
+        );
+    }
+    edits
 }
 
 impl EntityInputHandler for Editor {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1813,6 +1813,25 @@ impl Buffer {
         self.sync_parse_timeout = timeout;
     }
 
+    /// Ensures the syntax tree reflects the current buffer contents, parsing
+    /// synchronously if a reparse is currently pending. This is meant for the
+    /// rare synchronous operation that must read an up-to-date syntax tree
+    /// immediately after an edit rather than waiting for the background
+    /// reparse (for example, renumbering Markdown list markers on Tab). It is
+    /// a no-op when no parse is pending or the buffer has no language.
+    pub fn parse_synchronously(&mut self, cx: &mut Context<Self>) {
+        if self.language.is_none() || self.reparse.is_none() {
+            return;
+        }
+        // Drop the in-flight async parse so `reparse` does not early-return,
+        // then parse synchronously with a generous timeout.
+        self.reparse = None;
+        let previous_timeout = self.sync_parse_timeout;
+        self.sync_parse_timeout = Some(Duration::from_secs(1));
+        self.reparse(cx, true);
+        self.sync_parse_timeout = previous_timeout;
+    }
+
     fn invalidate_tree_sitter_data(
         tree_sitter_data: &mut Arc<TreeSitterData>,
         snapshot: &text::BufferSnapshot,

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -855,6 +855,46 @@ pub mod wsl_actions {
     }
 }
 
+pub mod markdown {
+    use gpui::Action;
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+
+    #[derive(PartialEq, Clone, Copy, Debug, Deserialize, JsonSchema, Default)]
+    #[serde(rename_all = "snake_case")]
+    pub enum IndentBehavior {
+        Tab,
+        #[default]
+        Indent,
+    }
+
+    /// Indents in markdown buffers, renumbering ordered list markers when indenting a list item.
+    #[derive(PartialEq, Clone, Deserialize, JsonSchema, Action)]
+    #[action(namespace = markdown)]
+    #[serde(deny_unknown_fields)]
+    pub struct Indent {
+        #[serde(default)]
+        pub behavior: IndentBehavior,
+    }
+
+    #[derive(PartialEq, Clone, Copy, Debug, Deserialize, JsonSchema, Default)]
+    #[serde(rename_all = "snake_case")]
+    pub enum OutdentBehavior {
+        Backtab,
+        #[default]
+        Outdent,
+    }
+
+    /// Outdents in markdown buffers, renumbering ordered list markers when outdenting a list item.
+    #[derive(PartialEq, Clone, Deserialize, JsonSchema, Action)]
+    #[action(namespace = markdown)]
+    #[serde(deny_unknown_fields)]
+    pub struct Outdent {
+        #[serde(default)]
+        pub behavior: OutdentBehavior,
+    }
+}
+
 pub mod preview {
     pub mod markdown {
         use gpui::actions;


### PR DESCRIPTION
## Context

Zed continued the parent list's numbering when indenting an ordered list item in markdown, instead of restarting the nested list at 1, and pressing Enter inside a sublist dropped the new item back to column 0 (see the VS Code vs Zed videos in the issue).

This PR adds `markdown::Indent` and `markdown::Outdent` actions, bound to `tab`/`shift-tab` and `ctrl-]`/`ctrl-[` (`cmd` on macOS) in markdown buffers (md, mdx, mdwn, mdc, markdown). When the selection touches an ordered list item, indenting/outdenting also renumbers the affected markers: nested lists restart at 1, trailing siblings close the gap, and outdented items continue the parent sequence. Outside ordered lists the actions fall back to the stock `tab`/`indent`/`outdent` behavior unchanged. Enter's list continuation now preserves the sublist's indentation.

Implementation notes:

- Renumbering derives list grouping and nesting from the markdown syntax tree (`list`/`list_item` nodes), so counters are never shared across separate lists or nesting levels.
- tree-sitter-md parses the empty item that list continuation inserts at the end of the buffer (`1. one\n2. `, no trailing newline) as an ERROR node rather than a `list_item`. This is exactly the state you are in when you press Tab right after Enter, so ERROR nodes are treated as transparent list containers: bare markers inside them count as items, and row-adjacent list/ERROR groups are renumbered as one list.
- Parsing is asynchronous outside of tests, so `Buffer::parse_synchronously` ensures the syntax tree reflects the buffer before it is read to classify and renumber items.

Video of the manual test below :

[Screencast from 2026-07-14 23-43-28.webm](https://github.com/user-attachments/assets/82dbafc2-ae0f-41ee-9b42-0839aeaf6502)


[Screencast from 2026-07-14 23-46-05.webm](https://github.com/user-attachments/assets/a29e39da-19fd-4bbc-9d9b-c1343283447f)


Closes #48244

## How to Review

9 files changed. Read in this order:

**crates/zed_actions/src/lib.rs** : Adds the `markdown` action namespace with `Indent`/`Outdent` actions. Each carries a `behavior` field (`tab`/`indent` and `backtab`/`outdent`) so one action can preserve the snippet-tabstop semantics of Tab while also backing the plain indent/outdent keybindings.

**assets/keymaps/default-linux.json**, **default-macos.json**, **default-windows.json** : Bind `tab`/`shift-tab` and `ctrl-]`/`ctrl-[` (`cmd` on macOS) to the new actions for every extension the Markdown language registers (md, mdx, mdwn, mdc, markdown), in a separate block from the `.md`-scoped preview bindings so those keep their existing scope. Later completion/snippet/edit-prediction bindings still take precedence over Tab.

**crates/editor/src/element.rs** : Registers the two new action handlers on the editor element.

**crates/editor/src/editor.rs** : `markdown_indent`/`markdown_outdent` mirror the stock `tab`/`backtab` ordering (single-line propagate, snippet tabstop, read-only), then fall back to the stock actions unless a selection touches an ordered list item. The apply paths reuse `indent_selection` (indent) or mirror `Editor::outdent` (outdent), collect per-row column deltas, and append the renumbering edits from `input.rs` into the same transaction so one undo reverts both. `apply_digit_width_deltas` keeps cursors in place when a marker changes digit width (`9.` to `10.`).

**crates/editor/src/input.rs** : The core logic. `renumber_ordered_list_edits` groups the edited rows by their outermost `list` node, collects every `list_item` in document order, and walks them with a column-keyed frame stack: moved items restart at 1 on a new level, continue an existing run otherwise, and trailing siblings close gaps. ERROR nodes are treated as transparent containers and bare markers inside them count as items; row-adjacent list/ERROR groups renumber as one list. Also sets `prevent_auto_indent` on list continuation so Enter keeps the sublist's indentation.

**crates/language/src/buffer.rs** : Adds `Buffer::parse_synchronously`, used before reading the tree since parsing is asynchronous outside of tests. It is a no-op when no reparse is pending and falls back to the background parser after 1s.

**crates/editor/src/editor_tests.rs** : `test_markdown_ordered_list_tab_through_default_keymap` types the issue's exact repro through the real default keymap into a real `file.md` buffer, which is the only way to reach the ERROR-node parse state (direct action calls with fixtures cannot). `test_markdown_ordered_list_indent_renumber` covers ten action-level cases including gap closing, mixed nesting selections, digit-width changes, code fences, and the bare trailing marker. `test_markdown_indent_bindings_cover_markdown_extensions` asserts the bindings and their extension coverage on all three platform keymaps. Further tests cover Enter continuation indentation and renumbering before a reparse completes.


## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed ordered list numbering in markdown: indenting with Tab now restarts nested lists at 1, outdenting renumbers correctly, and Enter preserves sublist indentation 