### PR TITLE
editor: Preserve preview tabs for references multibuffers

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -29513,16 +29513,14 @@ async fn test_find_all_references_editor_reuse(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_find_all_references_preview_survives_uncommitted_diff_load(cx: &mut TestAppContext) {
+async fn test_find_all_references_preserves_preview_tab(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     cx.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |settings: &mut SettingsContent| {
                 let preview_tabs = settings.preview_tabs.get_or_insert_default();
                 preview_tabs.enabled = Some(true);
-                preview_tabs.enable_keep_preview_on_code_navigation = Some(true);
                 preview_tabs.enable_preview_multibuffer_from_code_navigation = Some(true);
-                preview_tabs.enable_preview_from_multibuffer = Some(false);
             });
         });
     });
@@ -29536,6 +29534,12 @@ async fn test_find_all_references_preview_survives_uncommitted_diff_load(cx: &mu
     )
     .await;
 
+    // Calling `set_state` here will make it such that the underlying buffer
+    // will now report edits since its `preview_version` field, which is set
+    // when the buffer is first created. That is one of the conditions that
+    // determines whether a pane's item should remain as the preview item, or
+    // not, as such, if that field is not updated accordingly, we'd end up not
+    // having a preview item at the end of the test.
     cx.set_state(
         &r#"
         fn one() {
@@ -29546,6 +29550,7 @@ async fn test_find_all_references_preview_survives_uncommitted_diff_load(cx: &mu
             .unindent(),
     );
     cx.executor().run_until_parked();
+
     cx.lsp
         .set_request_handler::<lsp::request::References, _, _>(move |params, _| async move {
             Ok(Some(vec![
@@ -29560,56 +29565,33 @@ async fn test_find_all_references_preview_survives_uncommitted_diff_load(cx: &mu
             ]))
         });
 
-    let navigated = cx
-        .update_editor(|editor, window, cx| {
+    // Using the `editor: find all references` action adds excerpts to the
+    // multibuffer, which emits `ItemEvent::Edit`. When the pane handles that
+    // event it decides whether to keep its preview item and, if the buffer
+    // reports any edits since its `preview_version`, the item is unpreviewed.
+    // We also need to run until the executor is parked because the
+    // `ItemEvent::Edit` is delivered later, after the item has been registered
+    // with the pane.
+    assert_eq!(
+        cx.update_editor(|editor, window, cx| {
             editor.find_all_references(&FindAllReferences::default(), window, cx)
         })
-        .unwrap()
+        .expect("Editor::find_all_references should return a task")
         .await
-        .expect("Failed to navigate to references");
-    assert_eq!(navigated, Navigated::Yes);
-
-    let references_editor = cx.update_workspace(|workspace, _, cx| {
-        workspace
-            .active_pane()
-            .read(cx)
-            .active_item()
-            .unwrap()
-            .downcast::<Editor>()
-            .unwrap()
-    });
-    let (preview_item_id, active_item_id) = cx.update_workspace(|workspace, _, cx| {
-        let active_pane = workspace.active_pane().read(cx);
-        (
-            active_pane.preview_item_id(),
-            active_pane.active_item().unwrap().item_id(),
-        )
-    });
-    assert_eq!(preview_item_id, Some(active_item_id));
-
+        .expect("Should be able to find all references"),
+        Navigated::Yes
+    );
     cx.executor().run_until_parked();
 
-    let has_diff = cx.update_workspace(|_, _, cx| {
-        let multi_buffer = references_editor.read(cx).buffer().clone();
-        let multi_buffer = multi_buffer.read(cx);
-        multi_buffer.all_buffers_iter().any(|buffer| {
-            let buffer_id = buffer.read(cx).remote_id();
-            multi_buffer.diff_for(buffer_id).is_some()
-        })
-    });
-    assert!(
-        has_diff,
-        "references multibuffer should load uncommitted diffs"
-    );
-
-    let (preview_item_id, active_item_id) = cx.update_workspace(|workspace, _, cx| {
+    cx.update_workspace(|workspace, _window, cx| {
         let active_pane = workspace.active_pane().read(cx);
-        (
+
+        assert_eq!(
             active_pane.preview_item_id(),
-            active_pane.active_item().unwrap().item_id(),
-        )
+            Some(active_pane.active_item().unwrap().item_id()),
+            "The preview item id should be the same as the id of the multibuffer"
+        );
     });
-    assert_eq!(preview_item_id, Some(active_item_id));
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -29511,6 +29511,107 @@ async fn test_find_all_references_editor_reuse(cx: &mut TestAppContext) {
         );
     });
 }
+
+#[gpui::test]
+async fn test_find_all_references_preview_survives_uncommitted_diff_load(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    cx.update(|cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_user_settings(cx, |settings: &mut SettingsContent| {
+                let preview_tabs = settings.preview_tabs.get_or_insert_default();
+                preview_tabs.enabled = Some(true);
+                preview_tabs.enable_keep_preview_on_code_navigation = Some(true);
+                preview_tabs.enable_preview_multibuffer_from_code_navigation = Some(true);
+                preview_tabs.enable_preview_from_multibuffer = Some(false);
+            });
+        });
+    });
+
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            references_provider: Some(lsp::OneOf::Left(true)),
+            ..lsp::ServerCapabilities::default()
+        },
+        cx,
+    )
+    .await;
+
+    cx.set_state(
+        &r#"
+        fn one() {
+            let mut a = two();
+        }
+
+        fn ˇtwo() {}"#
+            .unindent(),
+    );
+    cx.executor().run_until_parked();
+    cx.lsp
+        .set_request_handler::<lsp::request::References, _, _>(move |params, _| async move {
+            Ok(Some(vec![
+                lsp::Location {
+                    uri: params.text_document_position.text_document.uri.clone(),
+                    range: lsp::Range::new(lsp::Position::new(0, 16), lsp::Position::new(0, 19)),
+                },
+                lsp::Location {
+                    uri: params.text_document_position.text_document.uri,
+                    range: lsp::Range::new(lsp::Position::new(4, 4), lsp::Position::new(4, 7)),
+                },
+            ]))
+        });
+
+    let navigated = cx
+        .update_editor(|editor, window, cx| {
+            editor.find_all_references(&FindAllReferences::default(), window, cx)
+        })
+        .unwrap()
+        .await
+        .expect("Failed to navigate to references");
+    assert_eq!(navigated, Navigated::Yes);
+
+    let references_editor = cx.update_workspace(|workspace, _, cx| {
+        workspace
+            .active_pane()
+            .read(cx)
+            .active_item()
+            .unwrap()
+            .downcast::<Editor>()
+            .unwrap()
+    });
+    let (preview_item_id, active_item_id) = cx.update_workspace(|workspace, _, cx| {
+        let active_pane = workspace.active_pane().read(cx);
+        (
+            active_pane.preview_item_id(),
+            active_pane.active_item().unwrap().item_id(),
+        )
+    });
+    assert_eq!(preview_item_id, Some(active_item_id));
+
+    cx.executor().run_until_parked();
+
+    let has_diff = cx.update_workspace(|_, _, cx| {
+        let multi_buffer = references_editor.read(cx).buffer().clone();
+        let multi_buffer = multi_buffer.read(cx);
+        multi_buffer.all_buffers_iter().any(|buffer| {
+            let buffer_id = buffer.read(cx).remote_id();
+            multi_buffer.diff_for(buffer_id).is_some()
+        })
+    });
+    assert!(
+        has_diff,
+        "references multibuffer should load uncommitted diffs"
+    );
+
+    let (preview_item_id, active_item_id) = cx.update_workspace(|workspace, _, cx| {
+        let active_pane = workspace.active_pane().read(cx);
+        (
+            active_pane.preview_item_id(),
+            active_pane.active_item().unwrap().item_id(),
+        )
+    });
+    assert_eq!(preview_item_id, Some(active_item_id));
+}
+
 #[gpui::test]
 async fn test_find_enclosing_node_with_task(cx: &mut TestAppContext) {
     init_test(cx, |_| {});

--- a/crates/editor/src/navigation.rs
+++ b/crates/editor/src/navigation.rs
@@ -2206,11 +2206,6 @@ impl Editor {
             }
         });
 
-        if allow_preview && !was_existing && PreviewTabsSettings::get_global(cx).enabled {
-            let multibuffer = editor.read(cx).buffer().clone();
-            multibuffer.update(cx, |multibuffer, cx| multibuffer.refresh_preview(cx));
-        }
-
         let item = Box::new(editor.clone());
 
         let pane = if split {
@@ -2224,6 +2219,11 @@ impl Editor {
         pane.update(cx, |pane, cx| {
             if allow_preview && !was_existing {
                 destination_index = pane.replace_preview_item_id(item.item_id(), window, cx);
+                editor.update(cx, |editor, cx| {
+                    editor
+                        .buffer
+                        .update(cx, |buffer, cx| buffer.refresh_preview(cx))
+                });
             }
             if was_existing && !allow_preview {
                 pane.unpreview_item_if_preview(item.item_id());

--- a/crates/editor/src/navigation.rs
+++ b/crates/editor/src/navigation.rs
@@ -2206,6 +2206,11 @@ impl Editor {
             }
         });
 
+        if allow_preview && !was_existing && PreviewTabsSettings::get_global(cx).enabled {
+            let multibuffer = editor.read(cx).buffer().clone();
+            multibuffer.update(cx, |multibuffer, cx| multibuffer.refresh_preview(cx));
+        }
+
         let item = Box::new(editor.clone());
 
         let pane = if split {


### PR DESCRIPTION
When `preview_tabs.enabled` and `preview_tabs.enable_preview_multibuffer_from_code_navigation` are enabled, Find All References opens its multibuffer as a preview tab.

A references multibuffer is assembled from existing buffers, which may already contain edits when the preview is created. When creating the multibuffer to display the references, it ends up emitting edit events as excerpts are added, this will later cause `Pane::handle_item_edit` to run, which would see these buffer edits since `Buffer::preview_version` and unpreview the tab, as the `Buffer::preview_version` value was not being updated after edits.

Refresh the multibuffer’s preview baseline before opening a newly created code-navigation multibuffer as a preview. Background diff updates then preserve the preview, while subsequent user edits still make it permanent. This leaves the existing editor event and search invalidation behavior unchanged.

Release Notes:

- Fixed `editor: find all references` preview tabs becoming permanent tabs if any of the buffers had been edited before