### PR TITLE
worktree: Refresh Git state on ORIG_HEAD changes

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -23,9 +23,8 @@ use futures::{
 use fuzzy::CharBag;
 use git::{
     BISECT_LOG, COMMIT_MESSAGE, DOT_GIT, FETCH_HEAD, FSMONITOR_DAEMON, GC_PID, GITIGNORE,
-    HOOKS_DIR, INFO_DIR, LFS_DIR, LOGS_DIR, LOGS_REF_STASH, OBJECTS_DIR, ORIG_HEAD,
-    REBASE_APPLY_DIR, REBASE_MERGE_DIR, REFS_DIR, REFTABLE_DIR, REPO_EXCLUDE, SEQUENCER_DIR,
-    status::GitSummary,
+    HOOKS_DIR, INFO_DIR, LFS_DIR, LOGS_DIR, LOGS_REF_STASH, OBJECTS_DIR, REBASE_APPLY_DIR,
+    REBASE_MERGE_DIR, REFS_DIR, REFTABLE_DIR, REPO_EXCLUDE, SEQUENCER_DIR, status::GitSummary,
 };
 use gpui::{
     App, AppContext as _, AsyncApp, BackgroundExecutor, Context, Entity, EventEmitter, Priority,
@@ -4634,8 +4633,7 @@ impl BackgroundScanner {
         //
         // Certain directories may have FS changes, but do not lead to git data changes that Zed cares about.
         // Ignore these, to avoid Zed unnecessarily rescanning git metadata.
-        let skipped_file_names_in_dot_git =
-            [COMMIT_MESSAGE, FETCH_HEAD, ORIG_HEAD, BISECT_LOG, GC_PID];
+        let skipped_file_names_in_dot_git = [COMMIT_MESSAGE, FETCH_HEAD, BISECT_LOG, GC_PID];
         let skipped_dirs_in_dot_git = [
             FSMONITOR_DAEMON,
             LFS_DIR,

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -4288,7 +4288,9 @@ async fn test_noisy_dot_git_events_do_not_emit_git_repo_update(
     // reflogs of HEAD/branches/remote-tracking branches carry no git state
     // changes that Zed cares about beyond what the accompanying ref or index
     // events already convey, so they must not trigger a git metadata rescan.
-    // The stash reflog and ref updates themselves must still trigger one.
+    // The stash reflog, ref updates themselves, and ORIG_HEAD must still trigger one.
+    // ORIG_HEAD is written by reset operations, and on some platforms it can be
+    // the only reliable event for `git reset --soft`, which does not update the index.
     //
     init_test(cx);
 
@@ -4371,7 +4373,6 @@ async fn test_noisy_dot_git_events_do_not_emit_git_repo_update(
         path!("/main_repo/.git/index.new"),
         path!("/main_repo/.git/index-abc123.tmp"),
         path!("/main_repo/.git/FETCH_HEAD"),
-        path!("/main_repo/.git/ORIG_HEAD"),
         path!("/main_repo/.git/BISECT_LOG"),
         path!("/main_repo/.git/info/refs"),
         path!("/main_repo/.git/info/refs_lzOf51"),
@@ -4393,6 +4394,7 @@ async fn test_noisy_dot_git_events_do_not_emit_git_repo_update(
         // Standard common git dir rescan paths
         path!("/main_repo/.git/logs/refs/stash"),
         path!("/main_repo/.git/refs/heads/main"),
+        path!("/main_repo/.git/ORIG_HEAD"),
         path!("/main_repo/.git/info/exclude"),
         path!("/main_repo/.git/refs/heads/branch.new"),
         path!("/main_repo/.git/refs/heads/branch.tmp"),


### PR DESCRIPTION
`git reset --soft` does not update the index, so Zed cannot rely on `.git/index` events to refresh repository state. Allow `.git/ORIG_HEAD` events through the worktree Git metadata filter so reset operations trigger a repository rescan.

Update the worktree integration test to assert that ORIG_HEAD changes emit UpdatedGitRepositories.

# Objective

- Fix Git status not reliably refreshing after `git reset --soft HEAD^`.
- Fixes #61027 

## Solution

- Stop filtering `.git/ORIG_HEAD` as noisy Git metadata.
- Keep filtering noisy paths such as lock files, temporary files, object database writes, normal reflog updates, and unrelated metadata.
- Add coverage to the worktree integration test so `.git/ORIG_HEAD` changes emit `UpdatedGitRepositories`.

## Testing

- Ran `cargo fmt --all`.
- Ran `cargo test -p worktree test_noisy_dot_git_events_do_not_emit_git_repo_update -- --nocapture`.
- Ran `git diff --check -- crates/worktree/src/worktree.rs crates/worktree/tests/integration/worktree_tests.rs`.

Tested on Linux in the development environment. The reported issue reproduces on Windows 11.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed Git status sometimes not refreshing after soft reset operations.
