### PR TITLE
settings_ui: Move deleted skills to trash instead of permanently deleting

### DIFF
--- a/crates/settings_ui/src/pages/skills_setup.rs
+++ b/crates/settings_ui/src/pages/skills_setup.rs
@@ -227,8 +227,8 @@ fn render_skill_row(
                             let app_state = workspace::AppState::global(cx);
                             let fs = app_state.fs.clone();
                             cx.spawn(async move |settings_window, cx| {
-                                let remove_result = fs
-                                    .remove_dir(
+                                let trash_result = fs
+                                    .trash(
                                         &directory_path,
                                         RemoveOptions {
                                             recursive: true,
@@ -236,9 +236,9 @@ fn render_skill_row(
                                         },
                                     )
                                     .await;
-                                if let Err(error) = remove_result {
+                                if let Err(error) = trash_result {
                                     log::error!(
-                                        "failed to delete skill directory {}: {error:#}",
+                                        "failed to move skill directory {} to trash: {error:#}",
                                         directory_path.display()
                                     );
                                     settings_window


### PR DESCRIPTION
Deleting a skill from the settings UI permanently removed its directory from `~/.agents/skills`, which is shared with other tools that read the same unified skills directory. Now we move it to the system trash instead so it's recoverable.

Release Notes:

- Deleting a skill now moves it to the system trash instead of permanently deleting it.