### PR TITLE
path: Fix unconditional use of `serde` in `path` crate

### DIFF
--- a/crates/path/src/rel_path.rs
+++ b/crates/path/src/rel_path.rs
@@ -597,6 +597,7 @@ impl<'a> DoubleEndedIterator for RelPathComponents<'a> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for RelPathBuf {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where


### PR DESCRIPTION

Release Notes:

- N/A or Added/Fixed/Improved ...
