### PR TITLE
project: Search unopened non-UTF-8 files

### DIFF
--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::LazyCell,
     collections::BTreeSet,
-    io::{BufRead, BufReader},
+    io::{BufRead, BufReader, Cursor},
     ops::Range,
     path::{Path, PathBuf},
     pin::pin,
@@ -16,7 +16,9 @@ use fs::Fs;
 use futures::FutureExt as _;
 use futures::{SinkExt, StreamExt, select_biased, stream::FuturesOrdered};
 use gpui::{App, AppContext, AsyncApp, BackgroundExecutor, Entity, Priority, Task};
-use language::{Buffer, BufferSnapshot, Point};
+use language::{
+    Buffer, BufferSnapshot, ByteContent, FILE_ANALYSIS_BYTES, Point, analyze_byte_content,
+};
 use parking_lot::Mutex;
 use postage::oneshot;
 use rpc::{AnyProtoClient, proto};
@@ -789,23 +791,35 @@ impl RequestHandler<'_> {
             if let Err(Some(starting_position)) =
                 std::str::from_utf8(file_start).map_err(|e| e.error_len())
             {
-                // Before attempting to match the file content, throw away files that have invalid UTF-8 sequences early on;
-                // That way we can still match files in a streaming fashion without having look at "obviously binary" files.
+                if analyze_byte_content(&file_start[..file_start.len().min(FILE_ANALYSIS_BYTES)])
+                    == ByteContent::Binary
+                {
+                    return Ok(());
+                }
                 log::debug!(
                     "Invalid UTF-8 sequence in file {abs_path:?} \
                     at byte position {starting_position}"
                 );
-                return Ok(());
+                let (text, _, _) = worktree::decode_file_text(
+                    self.fs.context(
+                        "Trying to decode a file without access to the local filesystem",
+                    )?,
+                    &abs_path,
+                )
+                .await?;
+                // ponytail: non-UTF-8 matches read the file again when opening the buffer;
+                // pass decoded contents through the search pipeline if this becomes a bottleneck.
+                file = BufReader::new(Box::new(Cursor::new(text)));
             }
 
-            if let Some(line_hint) = self.query.detect(file).await.ok().flatten() {
+            if let Some(line_hint) = self.query.detect(file).await? {
                 // Yes, we should scan the whole file.
                 entry.should_scan_tx.send((entry.path, line_hint)).await?;
             }
             Ok(())
         }
         .await
-        .ok();
+        .log_err();
     }
 
     async fn handle_scan_path(&self, req: InputPath) {

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -8068,6 +8068,48 @@ async fn test_search(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_search_unopened_gbk_file(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(path!("/dir"), json!({})).await;
+
+    let text = "这是一个使用 GBK 编码的测试文件。\n需要搜索的中文关键词：编码搜索命中。\n再添加一些中文内容帮助检测编码。";
+    let query = "编码搜索命中";
+    let (bytes, _, had_errors) = encoding_rs::GBK.encode(text);
+    assert!(!had_errors);
+    fs.insert_file(path!("/dir/gbk.txt"), bytes.into_owned())
+        .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let match_start = text.find(query).expect("query should be present");
+
+    assert_eq!(
+        search(
+            &project,
+            SearchQuery::text(
+                query,
+                false,
+                true,
+                false,
+                Default::default(),
+                Default::default(),
+                false,
+                None,
+            )
+            .unwrap(),
+            cx,
+        )
+        .await
+        .unwrap(),
+        HashMap::from_iter([(
+            path!("dir/gbk.txt").to_string(),
+            vec![match_start..match_start + query.len()],
+        )])
+    );
+}
+
+#[gpui::test]
 async fn test_search_multiline_crlf(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -6865,7 +6865,7 @@ impl fs::Watcher for NullWatcher {
     }
 }
 
-async fn decode_file_text(
+pub async fn decode_file_text(
     fs: &dyn Fs,
     abs_path: &Path,
 ) -> Result<(String, &'static Encoding, bool)> {


### PR DESCRIPTION
## Summary

- keep the existing streaming fast path for UTF-8 project search candidates
- reuse worktree encoding detection and decoding for unopened non-UTF-8 files
- continue rejecting files classified as binary before decoding
- add a regression test for an unopened GBK-encoded file

## Testing

- `rustfmt --edition 2024 crates/project/src/project_search.rs crates/worktree/src/worktree.rs crates/project/tests/integration/project_tests.rs`
- `git diff --check`
- verified the regression fixture with `chardetng 0.1.17` and `encoding_rs 0.8.35`; it is detected as GBK and decodes without errors
- `cargo test -p project --features test-support test_search_unopened_gbk_file -- --nocapture`

Release Notes:

- Fixed project search failing to find matches in unopened non-UTF-8 files.
