### PR TITLE
agent_ui: Do not scroll the agent thread when arrowing in the message editor

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -6906,6 +6906,10 @@ impl ThreadView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.message_editor.focus_handle(cx).is_focused(window) {
+            return;
+        }
+
         self.list_state.scroll_by(-window.line_height() * 3.);
         cx.notify();
     }
@@ -6916,6 +6920,10 @@ impl ThreadView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.message_editor.focus_handle(cx).is_focused(window) {
+            return;
+        }
+
         self.list_state.scroll_by(window.line_height() * 3.);
         cx.notify();
     }
@@ -12341,9 +12349,131 @@ mod tests {
     use super::*;
     use project::{FakeFs, Project};
     use serde_json::json;
-    use std::path::Path;
+    use std::{path::Path, rc::Rc};
     use util::path;
     use workspace::MultiWorkspace;
+
+    async fn setup_thread_view(
+        cx: &mut gpui::TestAppContext,
+    ) -> (Entity<ThreadView>, &mut gpui::VisualTestContext) {
+        crate::test_support::init_test(cx);
+        cx.update(|cx| {
+            ThreadMetadataStore::init_global(cx);
+            prompt_store::init(cx);
+        });
+
+        let file_system = FakeFs::new(cx.executor());
+        let project = Project::test(file_system, [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = multi_workspace.read_with(cx, |workspace, _| workspace.workspace().clone());
+        let thread_store = cx.update(|_window, cx| cx.new(|cx| ThreadStore::new(cx)));
+        let connection_store =
+            cx.update(|_window, cx| cx.new(|cx| AgentConnectionStore::new(project.clone(), cx)));
+
+        let conversation_view = cx.update(|window, cx| {
+            cx.new(|cx| {
+                ConversationView::new(
+                    Rc::new(crate::test_support::StubAgentServer::default_response()),
+                    connection_store,
+                    Agent::Custom { id: "Test".into() },
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    workspace.downgrade(),
+                    project,
+                    Some(thread_store),
+                    AgentThreadSource::AgentPanel,
+                    window,
+                    cx,
+                )
+            })
+        });
+        cx.run_until_parked();
+
+        let thread_view = conversation_view.read_with(cx, |view, _| {
+            view.active_thread()
+                .expect("thread should be connected")
+                .clone()
+        });
+        (thread_view, cx)
+    }
+
+    fn test_list_state(scroll_top: ListOffset) -> ListState {
+        let list_state =
+            ListState::new(20, gpui::ListAlignment::Top, px(0.)).with_uniform_item_height(px(20.));
+        list_state.scroll_to(scroll_top);
+        list_state
+    }
+
+    fn assert_scroll_top_eq(actual: ListOffset, expected: ListOffset) {
+        assert_eq!(actual.item_ix, expected.item_ix);
+        assert_eq!(actual.offset_in_item, expected.offset_in_item);
+    }
+
+    #[gpui::test]
+    async fn test_scroll_output_lines_ignore_focused_message_editor(cx: &mut gpui::TestAppContext) {
+        let (thread_view, cx) = setup_thread_view(cx).await;
+        let message_editor = thread_view.read_with(cx, |view, _| view.message_editor.clone());
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("first\nsecond\nthird", window, cx);
+            editor.set_cursor_offset(0, window, cx);
+            editor.focus_handle(cx).focus(window, cx);
+        });
+        cx.update(|window, cx| {
+            assert!(message_editor.focus_handle(cx).is_focused(window));
+        });
+
+        let initial_scroll_top = ListOffset {
+            item_ix: 5,
+            offset_in_item: px(7.),
+        };
+        thread_view.update_in(cx, |view, window, cx| {
+            view.list_state = test_list_state(initial_scroll_top);
+            view.scroll_output_line_up(&ScrollOutputLineUp, window, cx);
+            assert_scroll_top_eq(view.list_state.logical_scroll_top(), initial_scroll_top);
+        });
+
+        message_editor.update_in(cx, |editor, window, cx| {
+            let cursor_offset = editor.text(cx).len();
+            editor.set_cursor_offset(cursor_offset, window, cx);
+        });
+        thread_view.update_in(cx, |view, window, cx| {
+            view.list_state = test_list_state(initial_scroll_top);
+            view.scroll_output_line_down(&ScrollOutputLineDown, window, cx);
+            assert_scroll_top_eq(view.list_state.logical_scroll_top(), initial_scroll_top);
+        });
+
+        let thread_focus = thread_view.read_with(cx, |view, _| view.focus_handle.clone());
+        cx.update(|window, cx| thread_focus.focus(window, cx));
+        cx.update(|window, cx| {
+            assert!(!message_editor.focus_handle(cx).is_focused(window));
+        });
+
+        thread_view.update_in(cx, |view, window, cx| {
+            let expected = test_list_state(initial_scroll_top);
+            expected.scroll_by(-window.line_height() * 3.);
+            view.list_state = test_list_state(initial_scroll_top);
+            view.scroll_output_line_up(&ScrollOutputLineUp, window, cx);
+            assert_scroll_top_eq(
+                view.list_state.logical_scroll_top(),
+                expected.logical_scroll_top(),
+            );
+        });
+
+        thread_view.update_in(cx, |view, window, cx| {
+            let expected = test_list_state(initial_scroll_top);
+            expected.scroll_by(window.line_height() * 3.);
+            view.list_state = test_list_state(initial_scroll_top);
+            view.scroll_output_line_down(&ScrollOutputLineDown, window, cx);
+            assert_scroll_top_eq(
+                view.list_state.logical_scroll_top(),
+                expected.logical_scroll_top(),
+            );
+        });
+    }
 
     fn native_command(name: &str) -> acp::AvailableCommand {
         acp::AvailableCommand::new(name, "").meta(acp_thread::meta_with_command_category(


### PR DESCRIPTION
## Summary

Fixes #60190. Pressing Up or Down in the agent message editor also scrolled the conversation view above it, so cursor navigation inside the input moved the transcript.

## Why

Arrow keys at the top or bottom edge of the composer bubbled to the thread's line-scroll handlers, which scrolled the conversation. From the user's point of view, moving the cursor with Up or Down in the message editor unexpectedly scrolled the messages above.

## Solution

Added focus guards to both line-scroll handlers in the agent thread view so they only scroll the conversation when the message editor does not have focus. When the composer is focused, Up and Down are left to the editor for cursor movement.

## Testing

Added GPUI regression coverage for the composer top and bottom boundaries and for the non-focused scrolling path. `cargo fmt --check` passes and `cargo check -p agent_ui` builds cleanly. Clippy and the full test binary need some crates I could not fetch locally, so I verified compilation with `cargo check -p agent_ui`.

AI was used for assistance.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed the agent panel scrolling the conversation when using Up or Down to move the cursor in the message editor.
