### PR TITLE
Respect `lsp_results_location` for declaration and type definition

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -578,8 +578,6 @@ actions!(
         /// edits outside the selected ranges are discarded. External command formatters do not
         /// support range formatting and are skipped.
         FormatSelections,
-        /// Goes to the declaration of the symbol at cursor.
-        GoToDeclaration,
         /// Goes to declaration in a split pane.
         GoToDeclarationSplit,
         /// Goes to definition in a split pane.
@@ -608,8 +606,6 @@ actions!(
         GoToNextReference,
         /// Goes to the previous reference to the symbol under the cursor.
         GoToPreviousReference,
-        /// Goes to the type definition of the symbol at cursor.
-        GoToTypeDefinition,
         /// Goes to type definition in a split pane.
         GoToTypeDefinitionSplit,
         /// Goes to the next document highlight.
@@ -958,12 +954,34 @@ pub struct GoToDefinition {
     pub open_results_in: Option<OpenResultsIn>,
 }
 
+/// Goes to the declaration of the symbol at cursor.
+#[derive(PartialEq, Clone, Default, Deserialize, JsonSchema, Action)]
+#[action(namespace = editor)]
+#[serde(deny_unknown_fields)]
+pub struct GoToDeclaration {
+    /// Where to show the declarations. Falls back to the `lsp_results_location`
+    /// setting when omitted. A single result is always opened directly.
+    #[serde(default)]
+    pub open_results_in: Option<OpenResultsIn>,
+}
+
 /// Goes to the implementation of the symbol at cursor.
 #[derive(PartialEq, Clone, Default, Deserialize, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
 pub struct GoToImplementation {
     /// Where to show the implementations. Falls back to the `lsp_results_location`
+    /// setting when omitted. A single result is always opened directly.
+    #[serde(default)]
+    pub open_results_in: Option<OpenResultsIn>,
+}
+
+/// Goes to the type definition of the symbol at cursor.
+#[derive(PartialEq, Clone, Default, Deserialize, JsonSchema, Action)]
+#[action(namespace = editor)]
+#[serde(deny_unknown_fields)]
+pub struct GoToTypeDefinition {
+    /// Where to show the definitions. Falls back to the `lsp_results_location`
     /// setting when omitted. A single result is always opened directly.
     #[serde(default)]
     pub open_results_in: Option<OpenResultsIn>,

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -578,8 +578,6 @@ actions!(
         /// edits outside the selected ranges are discarded. External command formatters do not
         /// support range formatting and are skipped.
         FormatSelections,
-        /// Goes to the declaration of the symbol at cursor.
-        GoToDeclaration,
         /// Goes to declaration in a split pane.
         GoToDeclarationSplit,
         /// Goes to definition in a split pane.
@@ -608,8 +606,6 @@ actions!(
         GoToNextReference,
         /// Goes to the previous reference to the symbol under the cursor.
         GoToPreviousReference,
-        /// Goes to the type definition of the symbol at cursor.
-        GoToTypeDefinition,
         /// Goes to type definition in a split pane.
         GoToTypeDefinitionSplit,
         /// Goes to the next document highlight.
@@ -962,12 +958,34 @@ pub struct GoToDefinition {
     pub open_results_in: Option<OpenResultsIn>,
 }
 
+/// Goes to the declaration of the symbol at cursor.
+#[derive(PartialEq, Clone, Default, Deserialize, JsonSchema, Action)]
+#[action(namespace = editor)]
+#[serde(deny_unknown_fields)]
+pub struct GoToDeclaration {
+    /// Where to show the declarations. Falls back to the `lsp_results_location`
+    /// setting when omitted. A single result is always opened directly.
+    #[serde(default)]
+    pub open_results_in: Option<OpenResultsIn>,
+}
+
 /// Goes to the implementation of the symbol at cursor.
 #[derive(PartialEq, Clone, Default, Deserialize, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
 pub struct GoToImplementation {
     /// Where to show the implementations. Falls back to the `lsp_results_location`
+    /// setting when omitted. A single result is always opened directly.
+    #[serde(default)]
+    pub open_results_in: Option<OpenResultsIn>,
+}
+
+/// Goes to the type definition of the symbol at cursor.
+#[derive(PartialEq, Clone, Default, Deserialize, JsonSchema, Action)]
+#[action(namespace = editor)]
+#[serde(deny_unknown_fields)]
+pub struct GoToTypeDefinition {
+    /// Where to show the definitions. Falls back to the `lsp_results_location`
     /// setting when omitted. A single result is always opened directly.
     #[serde(default)]
     pub open_results_in: Option<OpenResultsIn>,

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -333,7 +333,9 @@ impl Editor {
                 (true, true) => {
                     self.go_to_type_definition_split(&GoToTypeDefinitionSplit, window, cx)
                 }
-                (true, false) => self.go_to_type_definition(&GoToTypeDefinition, window, cx),
+                (true, false) => {
+                    self.go_to_type_definition(&GoToTypeDefinition::default(), window, cx)
+                }
                 (false, true) => self.go_to_definition_split(&GoToDefinitionSplit, window, cx),
                 (false, false) => self.go_to_definition(&GoToDefinition::default(), window, cx),
             }

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -321,7 +321,9 @@ impl Editor {
                 (true, true) => {
                     self.go_to_type_definition_split(&GoToTypeDefinitionSplit, window, cx)
                 }
-                (true, false) => self.go_to_type_definition(&GoToTypeDefinition, window, cx),
+                (true, false) => {
+                    self.go_to_type_definition(&GoToTypeDefinition::default(), window, cx)
+                }
                 (false, true) => self.go_to_definition_split(&GoToDefinitionSplit, window, cx),
                 (false, false) => {
                     self.go_to_definition_of_kind(GotoDefinitionKind::Symbol, false, window, cx)

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -257,8 +257,11 @@ pub fn deploy_context_menu(
                     |builder| builder.separator(),
                 )
                 .action("Go to Definition", Box::new(GoToDefinition::default()))
-                .action("Go to Declaration", Box::new(GoToDeclaration))
-                .action("Go to Type Definition", Box::new(GoToTypeDefinition))
+                .action("Go to Declaration", Box::new(GoToDeclaration::default()))
+                .action(
+                    "Go to Type Definition",
+                    Box::new(GoToTypeDefinition::default()),
+                )
                 .action(
                     "Go to Implementation",
                     Box::new(GoToImplementation::default()),

--- a/crates/editor/src/navigation.rs
+++ b/crates/editor/src/navigation.rs
@@ -1068,7 +1068,7 @@ impl Editor {
 
     pub fn go_to_declaration_split(
         &mut self,
-        _: &GoToDeclaration,
+        _: &GoToDeclarationSplit,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<Navigated>> {

--- a/crates/lsp_locations/src/lsp_locations.rs
+++ b/crates/lsp_locations/src/lsp_locations.rs
@@ -2,7 +2,9 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use collections::HashMap;
-use editor::actions::{FindAllReferences, GoToDefinition, GoToImplementation};
+use editor::actions::{
+    FindAllReferences, GoToDeclaration, GoToDefinition, GoToImplementation, GoToTypeDefinition,
+};
 use editor::{Editor, EditorSettings, GotoDefinitionKind, OpenResultsIn};
 use file_icons::FileIcons;
 use fuzzy::StringMatchCandidate;
@@ -54,10 +56,38 @@ fn register(editor: &mut Editor, _window: Option<&mut Window>, cx: &mut Context<
     editor
         .register_action({
             let handle = handle.clone();
+            move |action: &GoToDeclaration, window, cx| {
+                handle_nav_action(
+                    action.open_results_in,
+                    LspPickerKind::Declaration,
+                    &handle,
+                    window,
+                    cx,
+                );
+            }
+        })
+        .detach();
+    editor
+        .register_action({
+            let handle = handle.clone();
             move |action: &GoToImplementation, window, cx| {
                 handle_nav_action(
                     action.open_results_in,
                     LspPickerKind::Implementation,
+                    &handle,
+                    window,
+                    cx,
+                );
+            }
+        })
+        .detach();
+    editor
+        .register_action({
+            let handle = handle.clone();
+            move |action: &GoToTypeDefinition, window, cx| {
+                handle_nav_action(
+                    action.open_results_in,
+                    LspPickerKind::TypeDefinition,
                     &handle,
                     window,
                     cx,
@@ -162,7 +192,9 @@ fn show_no_results_toast(
 pub enum LspPickerKind {
     References,
     Definition,
+    Declaration,
     Implementation,
+    TypeDefinition,
 }
 
 impl LspPickerKind {
@@ -170,7 +202,9 @@ impl LspPickerKind {
         match self {
             LspPickerKind::References => "Filter references…",
             LspPickerKind::Definition => "Filter definitions…",
+            LspPickerKind::Declaration => "Filter declarations…",
             LspPickerKind::Implementation => "Filter implementations…",
+            LspPickerKind::TypeDefinition => "Filter type definitions…",
         }
     }
 
@@ -180,7 +214,9 @@ impl LspPickerKind {
         match self {
             LspPickerKind::References => "No references found",
             LspPickerKind::Definition => "No definitions found",
+            LspPickerKind::Declaration => "No declarations found",
             LspPickerKind::Implementation => "No implementations found",
+            LspPickerKind::TypeDefinition => "No type definitions found",
         }
     }
 
@@ -197,8 +233,14 @@ impl LspPickerKind {
             LspPickerKind::Definition => {
                 editor.definition_locations_of_kind(GotoDefinitionKind::Symbol, cx)
             }
+            LspPickerKind::Declaration => {
+                editor.definition_locations_of_kind(GotoDefinitionKind::Declaration, cx)
+            }
             LspPickerKind::Implementation => {
                 editor.definition_locations_of_kind(GotoDefinitionKind::Implementation, cx)
+            }
+            LspPickerKind::TypeDefinition => {
+                editor.definition_locations_of_kind(GotoDefinitionKind::Type, cx)
             }
         }
     }

--- a/crates/lsp_locations/src/lsp_locations.rs
+++ b/crates/lsp_locations/src/lsp_locations.rs
@@ -2,7 +2,9 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use collections::HashMap;
-use editor::actions::{FindAllReferences, GoToDefinition, GoToImplementation};
+use editor::actions::{
+    FindAllReferences, GoToDeclaration, GoToDefinition, GoToImplementation, GoToTypeDefinition,
+};
 use editor::{Editor, EditorSettings, GotoDefinitionKind, OpenResultsIn};
 use file_icons::FileIcons;
 use fuzzy::StringMatchCandidate;
@@ -54,10 +56,38 @@ fn register(editor: &mut Editor, _window: Option<&mut Window>, cx: &mut Context<
     editor
         .register_action({
             let handle = handle.clone();
+            move |action: &GoToDeclaration, window, cx| {
+                handle_nav_action(
+                    action.open_results_in,
+                    LspPickerKind::Declaration,
+                    &handle,
+                    window,
+                    cx,
+                );
+            }
+        })
+        .detach();
+    editor
+        .register_action({
+            let handle = handle.clone();
             move |action: &GoToImplementation, window, cx| {
                 handle_nav_action(
                     action.open_results_in,
                     LspPickerKind::Implementation,
+                    &handle,
+                    window,
+                    cx,
+                );
+            }
+        })
+        .detach();
+    editor
+        .register_action({
+            let handle = handle.clone();
+            move |action: &GoToTypeDefinition, window, cx| {
+                handle_nav_action(
+                    action.open_results_in,
+                    LspPickerKind::TypeDefinition,
                     &handle,
                     window,
                     cx,
@@ -162,7 +192,9 @@ fn show_no_results_toast(
 pub enum LspPickerKind {
     References,
     Definition,
+    Declaration,
     Implementation,
+    TypeDefinition,
 }
 
 impl LspPickerKind {
@@ -170,7 +202,9 @@ impl LspPickerKind {
         match self {
             LspPickerKind::References => "Filter references…",
             LspPickerKind::Definition => "Filter definitions…",
+            LspPickerKind::Declaration => "Filter declarations…",
             LspPickerKind::Implementation => "Filter implementations…",
+            LspPickerKind::TypeDefinition => "Filter type definitions…",
         }
     }
 
@@ -180,7 +214,9 @@ impl LspPickerKind {
         match self {
             LspPickerKind::References => "No references found",
             LspPickerKind::Definition => "No definitions found",
+            LspPickerKind::Declaration => "No declarations found",
             LspPickerKind::Implementation => "No implementations found",
+            LspPickerKind::TypeDefinition => "No type definitions found",
         }
     }
 
@@ -197,8 +233,14 @@ impl LspPickerKind {
             LspPickerKind::Definition => {
                 editor.definition_locations_of_kind(GotoDefinitionKind::Symbol, cx)
             }
+            LspPickerKind::Declaration => {
+                editor.definition_locations_of_kind(GotoDefinitionKind::Declaration, cx)
+            }
             LspPickerKind::Implementation => {
                 editor.definition_locations_of_kind(GotoDefinitionKind::Implementation, cx)
+            }
+            LspPickerKind::TypeDefinition => {
+                editor.definition_locations_of_kind(GotoDefinitionKind::Type, cx)
             }
         }
     }
@@ -1010,6 +1052,92 @@ mod tests {
         assert!(
             active_picker(&mut cx).is_some(),
             "the cmd-click go-to-definition fallback should open the references picker when lsp_results_location is picker"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_type_definition_honors_lsp_results_location(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let mut cx = rust_cx(
+            lsp::ServerCapabilities {
+                type_definition_provider: Some(lsp::TypeDefinitionProviderCapability::Simple(true)),
+                ..Default::default()
+            },
+            cx,
+        )
+        .await;
+        cx.update(|_window, cx| {
+            cx.update_global::<settings::SettingsStore, _>(|settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.editor.lsp_results_location = Some(OpenResultsIn::Picker);
+                });
+            });
+        });
+        cx.set_state(indoc! {r#"
+            fn main() {
+                struct Foo<T>(T);
+                struct Bar;
+                let fˇoo: Foo<Bar>;
+            }
+        "#});
+        cx.lsp
+            .set_request_handler::<lsp::request::GotoTypeDefinition, _, _>(
+                async move |params, _| {
+                    let uri = params.text_document_position_params.text_document.uri;
+                    Ok(Some(lsp::GotoDefinitionResponse::Array(references(
+                        uri,
+                        &[(1, 11, 14), (2, 11, 14)],
+                    ))))
+                },
+            );
+
+        cx.dispatch_action(GoToTypeDefinition::default());
+
+        assert!(
+            active_picker(&mut cx).is_some(),
+            "type definition should open the picker when lsp_results_location is picker"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_declaration_honors_lsp_results_location(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let mut cx = rust_cx(
+            lsp::ServerCapabilities {
+                declaration_provider: Some(lsp::DeclarationCapability::Simple(true)),
+                ..Default::default()
+            },
+            cx,
+        )
+        .await;
+        cx.update(|_window, cx| {
+            cx.update_global::<settings::SettingsStore, _>(|settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.editor.lsp_results_location = Some(OpenResultsIn::Picker);
+                });
+            });
+        });
+        cx.set_state(indoc! {r#"
+            fn main() {
+                let foo = ();
+                let foo = ();
+                let bar = fˇoo;
+            }
+        "#});
+        cx.lsp
+            .set_request_handler::<lsp::request::GotoDeclaration, _, _>(async move |params, _| {
+                let uri = params.text_document_position_params.text_document.uri;
+                Ok(Some(lsp::GotoDefinitionResponse::Array(references(
+                    uri,
+                    &[(1, 8, 11), (2, 8, 11)],
+                ))))
+            });
+
+        cx.dispatch_action(GoToDeclaration::default());
+
+        assert!(
+            active_picker(&mut cx).is_some(),
+            "declaration should open the picker when lsp_results_location is picker"
         );
     }
 }

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -236,8 +236,14 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
                     "Go to Definition",
                     editor::actions::GoToDefinition::default(),
                 ),
-                MenuItem::action("Go to Declaration", editor::actions::GoToDeclaration),
-                MenuItem::action("Go to Type Definition", editor::actions::GoToTypeDefinition),
+                MenuItem::action(
+                    "Go to Declaration",
+                    editor::actions::GoToDeclaration::default(),
+                ),
+                MenuItem::action(
+                    "Go to Type Definition",
+                    editor::actions::GoToTypeDefinition::default(),
+                ),
                 MenuItem::action(
                     "Find All References",
                     editor::actions::FindAllReferences::default(),


### PR DESCRIPTION
# Objective
use pickers for all kinds of lsp definitions

## Solution

add handlers for `GoToDeclaration` and `GoToTypeDefinition` in `lsp_locations.rs`

## Testing

- Did you test these changes? If so, how?
- Are there any parts that need more testing?
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

this rust code can be used to test for multiple type definitions on `a`
```rs
macro_rules! foo {
    ($e:ident) => {
        let $e: Vec<()>;
        let $e: String;
    };
}
fn main() {
    foo!(a);
}
```
<img width="735" height="288" alt="image" src="https://github.com/user-attachments/assets/578e6dc2-b201-4194-bd8b-e8d17b4d3d50" />

---

Release Notes:

- Respect `"lsp_results_location": "picker"` for go to declaration and type definition
