### PR TITLE
Update pnpm setup action for Node 24

### DIFF
--- a/.github/workflows/autofix_pr.yml
+++ b/.github/workflows/autofix_pr.yml
@@ -48,7 +48,7 @@ jobs:
     - name: steps::download_wasi_sdk
       run: ./script/download-wasi-sdk
     - name: steps::setup_pnpm
-      uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
       with:
         version: '9'
     - name: autofix_pr::run_autofix::install_cargo_machete

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         clean: false
     - name: steps::setup_pnpm
-      uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
       with:
         version: '9'
     - name: steps::setup_node

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -157,7 +157,7 @@ jobs:
         cache: rust
         path: ~/.rustup
     - name: steps::setup_pnpm
-      uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
       with:
         version: '9'
     - name: steps::prettier

--- a/tooling/xtask/src/tasks/workflows/steps.rs
+++ b/tooling/xtask/src/tasks/workflows/steps.rs
@@ -164,7 +164,7 @@ pub fn setup_pnpm() -> Step<Use> {
     named::uses(
         "pnpm",
         "action-setup",
-        "fe02b34f77f8bc703788d5817da081398fad5dd2", // v4.0.0
+        "fc06bc1257f339d1d5d8b3a19a8cae5388b55320", // v4.4.0
     )
     .add_with(("version", "9"))
 }


### PR DESCRIPTION
## Summary

- Update `pnpm/action-setup` from v4.0.0 to v4.4.0
- Use the action release backed by Node 24 while continuing to install pnpm 9
- Regenerate the affected workflows

## Testing

- `cargo xtask workflows`
- `git diff --check`

Release Notes:

- N/A