### PR TITLE
workspace: Highlight focused panels

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -89,6 +89,14 @@
     // Values are clamped to the [0.0, 1.0] range.
     "inactive_opacity": 1.0,
   },
+  // Styling settings applied to the focused dock panel.
+  "active_panel_modifiers": {
+    // Inset border size of the focused dock panel, in pixels.
+    "border_size": 0.0,
+    // Opacity of unfocused dock panels. 0 means transparent, 1 means opaque.
+    // Values are clamped to the [0.0, 1.0] range.
+    "inactive_opacity": 1.0,
+  },
   // Layout mode of the bottom dock. Defaults to "contained"
   //   choices: contained, full, left_aligned, right_aligned
   "bottom_dock_layout": "contained",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -95,6 +95,14 @@
     // Values are clamped to the [0.0, 1.0] range.
     "inactive_opacity": 1.0,
   },
+  // Styling settings applied to the focused dock panel.
+  "active_panel_modifiers": {
+    // Inset border size of the focused dock panel, in pixels.
+    "border_size": 0.0,
+    // Opacity of unfocused dock panels. 0 means transparent, 1 means opaque.
+    // Values are clamped to the [0.0, 1.0] range.
+    "inactive_opacity": 1.0,
+  },
   // Layout mode of the bottom dock. Defaults to "contained"
   //   choices: contained, full, left_aligned, right_aligned
   "bottom_dock_layout": "contained",

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -1004,14 +1004,17 @@ impl DebugPanel {
         direction: SplitDirection,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) {
-        if let Some(session) = self.active_session() {
-            session.update(cx, |session, cx| {
-                session.running_state().update(cx, |running, cx| {
-                    running.activate_pane_in_direction(direction, window, cx);
-                })
-            });
-        }
+    ) -> bool {
+        let Some(session) = self.active_session() else {
+            return false;
+        };
+
+        session.update(cx, |session, cx| {
+            session.running_state().update(cx, |running, cx| {
+                running.activate_pane_in_direction(direction, window, cx);
+            })
+        });
+        true
     }
 
     pub(crate) fn activate_item(
@@ -1580,37 +1583,57 @@ impl Render for DebugPanel {
             .on_action({
                 let this = this.clone();
                 move |_: &workspace::ActivatePaneLeft, window, cx| {
-                    this.update(cx, |this, cx| {
-                        this.activate_pane_in_direction(SplitDirection::Left, window, cx);
-                    })
-                    .ok();
+                    let handled = this
+                        .update(cx, |this, cx| {
+                            this.activate_pane_in_direction(SplitDirection::Left, window, cx)
+                        })
+                        .log_err()
+                        .unwrap_or(false);
+                    if !handled {
+                        cx.propagate();
+                    }
                 }
             })
             .on_action({
                 let this = this.clone();
                 move |_: &workspace::ActivatePaneRight, window, cx| {
-                    this.update(cx, |this, cx| {
-                        this.activate_pane_in_direction(SplitDirection::Right, window, cx);
-                    })
-                    .ok();
+                    let handled = this
+                        .update(cx, |this, cx| {
+                            this.activate_pane_in_direction(SplitDirection::Right, window, cx)
+                        })
+                        .log_err()
+                        .unwrap_or(false);
+                    if !handled {
+                        cx.propagate();
+                    }
                 }
             })
             .on_action({
                 let this = this.clone();
                 move |_: &workspace::ActivatePaneUp, window, cx| {
-                    this.update(cx, |this, cx| {
-                        this.activate_pane_in_direction(SplitDirection::Up, window, cx);
-                    })
-                    .ok();
+                    let handled = this
+                        .update(cx, |this, cx| {
+                            this.activate_pane_in_direction(SplitDirection::Up, window, cx)
+                        })
+                        .log_err()
+                        .unwrap_or(false);
+                    if !handled {
+                        cx.propagate();
+                    }
                 }
             })
             .on_action({
                 let this = this.clone();
                 move |_: &workspace::ActivatePaneDown, window, cx| {
-                    this.update(cx, |this, cx| {
-                        this.activate_pane_in_direction(SplitDirection::Down, window, cx);
-                    })
-                    .ok();
+                    let handled = this
+                        .update(cx, |this, cx| {
+                            this.activate_pane_in_direction(SplitDirection::Down, window, cx)
+                        })
+                        .log_err()
+                        .unwrap_or(false);
+                    if !handled {
+                        cx.propagate();
+                    }
                 }
             })
             .on_action({

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -1045,14 +1045,17 @@ impl DebugPanel {
         direction: SplitDirection,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) {
-        if let Some(session) = self.active_session() {
-            session.update(cx, |session, cx| {
-                session.running_state().update(cx, |running, cx| {
-                    running.activate_pane_in_direction(direction, window, cx);
-                })
-            });
-        }
+    ) -> bool {
+        let Some(session) = self.active_session() else {
+            return false;
+        };
+
+        session.update(cx, |session, cx| {
+            session.running_state().update(cx, |running, cx| {
+                running.activate_pane_in_direction(direction, window, cx);
+            })
+        });
+        true
     }
 
     pub(crate) fn activate_item(
@@ -1621,37 +1624,57 @@ impl Render for DebugPanel {
             .on_action({
                 let this = this.clone();
                 move |_: &workspace::ActivatePaneLeft, window, cx| {
-                    this.update(cx, |this, cx| {
-                        this.activate_pane_in_direction(SplitDirection::Left, window, cx);
-                    })
-                    .ok();
+                    let handled = this
+                        .update(cx, |this, cx| {
+                            this.activate_pane_in_direction(SplitDirection::Left, window, cx)
+                        })
+                        .log_err()
+                        .unwrap_or(false);
+                    if !handled {
+                        cx.propagate();
+                    }
                 }
             })
             .on_action({
                 let this = this.clone();
                 move |_: &workspace::ActivatePaneRight, window, cx| {
-                    this.update(cx, |this, cx| {
-                        this.activate_pane_in_direction(SplitDirection::Right, window, cx);
-                    })
-                    .ok();
+                    let handled = this
+                        .update(cx, |this, cx| {
+                            this.activate_pane_in_direction(SplitDirection::Right, window, cx)
+                        })
+                        .log_err()
+                        .unwrap_or(false);
+                    if !handled {
+                        cx.propagate();
+                    }
                 }
             })
             .on_action({
                 let this = this.clone();
                 move |_: &workspace::ActivatePaneUp, window, cx| {
-                    this.update(cx, |this, cx| {
-                        this.activate_pane_in_direction(SplitDirection::Up, window, cx);
-                    })
-                    .ok();
+                    let handled = this
+                        .update(cx, |this, cx| {
+                            this.activate_pane_in_direction(SplitDirection::Up, window, cx)
+                        })
+                        .log_err()
+                        .unwrap_or(false);
+                    if !handled {
+                        cx.propagate();
+                    }
                 }
             })
             .on_action({
                 let this = this.clone();
                 move |_: &workspace::ActivatePaneDown, window, cx| {
-                    this.update(cx, |this, cx| {
-                        this.activate_pane_in_direction(SplitDirection::Down, window, cx);
-                    })
-                    .ok();
+                    let handled = this
+                        .update(cx, |this, cx| {
+                            this.activate_pane_in_direction(SplitDirection::Down, window, cx)
+                        })
+                        .log_err()
+                        .unwrap_or(false);
+                    if !handled {
+                        cx.propagate();
+                    }
                 }
             })
             .on_action({

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1034,6 +1034,7 @@ impl VsCodeSettings {
         WorkspaceSettingsContent {
             active_pane_modifiers: self.active_pane_modifiers(),
             accessible_mode: None,
+            active_panel_modifiers: None,
             text_rendering_mode: None,
             autosave: self.read_enum("files.autoSave", |s| match s {
                 "off" => Some(AutosaveSetting::Off),

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1015,6 +1015,7 @@ impl VsCodeSettings {
         WorkspaceSettingsContent {
             active_pane_modifiers: self.active_pane_modifiers(),
             accessible_mode: None,
+            active_panel_modifiers: None,
             text_rendering_mode: None,
             autosave: self.read_enum("files.autoSave", |s| match s {
                 "off" => Some(AutosaveSetting::Off),

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -334,6 +334,7 @@ pub struct ActivePanelModifiers {
     #[schemars(range(min = 0.0, max = 1.0))]
     pub inactive_opacity: Option<InactiveOpacity>,
 }
+
 #[derive(
     Copy,
     Clone,

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -15,6 +15,8 @@ use crate::{
 pub struct WorkspaceSettingsContent {
     /// Active pane styling settings.
     pub active_pane_modifiers: Option<ActivePaneModifiers>,
+    /// Styling settings applied to the focused dock panel.
+    pub active_panel_modifiers: Option<ActivePanelModifiers>,
     /// The text rendering mode to use.
     ///
     /// Default: platform_default
@@ -312,6 +314,26 @@ pub struct ActivePaneModifiers {
     pub inactive_opacity: Option<InactiveOpacity>,
 }
 
+#[with_fallible_options]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[serde(rename_all = "snake_case")]
+pub struct ActivePanelModifiers {
+    /// Size of the border surrounding the focused dock panel.
+    /// When set to 0, the focused panel doesn't have any border.
+    /// The border is drawn inset.
+    ///
+    /// Default: `0.0`
+    #[serde(serialize_with = "crate::serialize_optional_f32_with_two_decimal_places")]
+    pub border_size: Option<f32>,
+    /// Opacity of dock panels that don't currently have focus.
+    /// When set to 1.0, unfocused panels have the same opacity as the focused one.
+    /// If set to 0, unfocused panel content will not be visible at all.
+    /// Values are clamped to the [0.0, 1.0] range.
+    ///
+    /// Default: `1.0`
+    #[schemars(range(min = 0.0, max = 1.0))]
+    pub inactive_opacity: Option<InactiveOpacity>,
+}
 #[derive(
     Copy,
     Clone,

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -15,6 +15,8 @@ use crate::{
 pub struct WorkspaceSettingsContent {
     /// Active pane styling settings.
     pub active_pane_modifiers: Option<ActivePaneModifiers>,
+    /// Styling settings applied to the focused dock panel.
+    pub active_panel_modifiers: Option<ActivePanelModifiers>,
     /// The text rendering mode to use.
     ///
     /// Default: platform_default
@@ -344,6 +346,27 @@ pub struct ActivePaneModifiers {
     pub inactive_opacity: Option<InactiveOpacity>,
 }
 
+#[with_fallible_options]
+#[derive(Copy, Clone, PartialEq, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[serde(rename_all = "snake_case")]
+pub struct ActivePanelModifiers {
+    /// Size of the border surrounding the focused dock panel.
+    /// When set to 0, the focused panel doesn't have any border.
+    /// The border is drawn inset.
+    ///
+    /// Default: `0.0`
+    #[serde(serialize_with = "crate::serialize_optional_f32_with_two_decimal_places")]
+    pub border_size: Option<f32>,
+    /// Opacity of dock panels that don't currently have focus.
+    /// When set to 1.0, unfocused panels have the same opacity as the focused one.
+    /// If set to 0, unfocused panel content will not be visible at all.
+    /// Values are clamped to the [0.0, 1.0] range.
+    ///
+    /// Default: `1.0`
+    #[schemars(range(min = 0.0, max = 1.0))]
+    pub inactive_opacity: Option<InactiveOpacity>,
+}
+
 #[derive(
     Copy,
     Clone,
@@ -610,6 +633,7 @@ pub enum EncodingDisplayOptions {
     #[default]
     NonUtf8,
 }
+
 impl EncodingDisplayOptions {
     pub fn should_show(&self, is_utf8: bool, has_bom: bool) -> bool {
         match self {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -20,13 +20,17 @@ use crate::{
 };
 
 const DEFAULT_STRING: String = String::new();
+
 /// A default empty string reference. Useful in `pick` functions for cases either in dynamic item fields, or when dealing with `settings::Maybe`
 /// to avoid the "NO DEFAULT" case.
 const DEFAULT_EMPTY_STRING: Option<&String> = Some(&DEFAULT_STRING);
 
 const DEFAULT_AUDIO_OUTPUT: AudioOutputDeviceName = AudioOutputDeviceName(None);
+
 const DEFAULT_EMPTY_AUDIO_OUTPUT: Option<&AudioOutputDeviceName> = Some(&DEFAULT_AUDIO_OUTPUT);
+
 const DEFAULT_AUDIO_INPUT: AudioInputDeviceName = AudioInputDeviceName(None);
+
 const DEFAULT_EMPTY_AUDIO_INPUT: Option<&AudioInputDeviceName> = Some(&DEFAULT_AUDIO_INPUT);
 
 macro_rules! concat_sections {
@@ -5243,6 +5247,62 @@ fn window_and_layout_page() -> SettingsPage {
         ]
     }
 
+    fn panel_modifiers_section() -> [SettingsPageItem; 3] {
+        [
+            SettingsPageItem::SectionHeader("Panel Modifiers"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Inactive Opacity",
+                description: "Opacity of unfocused dock panels (0.0 - 1.0).",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("active_panel_modifiers.inactive_opacity"),
+                    pick: |settings_content| {
+                        settings_content
+                            .workspace
+                            .active_panel_modifiers
+                            .as_ref()?
+                            .inactive_opacity
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .workspace
+                            .active_panel_modifiers
+                            .get_or_insert_default()
+                            .inactive_opacity = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Border Size",
+                description: "Size of the border surrounding the focused dock panel.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("active_panel_modifiers.border_size"),
+                    pick: |settings_content| {
+                        settings_content
+                            .workspace
+                            .active_panel_modifiers
+                            .as_ref()?
+                            .border_size
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .workspace
+                            .active_panel_modifiers
+                            .get_or_insert_default()
+                            .border_size = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+        ]
+    }
+
     fn pane_split_direction_section() -> [SettingsPageItem; 3] {
         [
             SettingsPageItem::SectionHeader("Pane Split Direction"),
@@ -5298,6 +5358,7 @@ fn window_and_layout_page() -> SettingsPage {
             layout_section(),
             window_section(),
             pane_modifiers_section(),
+            panel_modifiers_section(),
             pane_split_direction_section(),
         ],
     }

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4951,6 +4951,62 @@ fn window_and_layout_page() -> SettingsPage {
         ]
     }
 
+    fn panel_modifiers_section() -> [SettingsPageItem; 3] {
+        [
+            SettingsPageItem::SectionHeader("Panel Modifiers"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Inactive Opacity",
+                description: "Opacity of unfocused dock panels (0.0 - 1.0).",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("active_panel_modifiers.inactive_opacity"),
+                    pick: |settings_content| {
+                        settings_content
+                            .workspace
+                            .active_panel_modifiers
+                            .as_ref()?
+                            .inactive_opacity
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .workspace
+                            .active_panel_modifiers
+                            .get_or_insert_default()
+                            .inactive_opacity = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Border Size",
+                description: "Size of the border surrounding the focused dock panel.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("active_panel_modifiers.border_size"),
+                    pick: |settings_content| {
+                        settings_content
+                            .workspace
+                            .active_panel_modifiers
+                            .as_ref()?
+                            .border_size
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .workspace
+                            .active_panel_modifiers
+                            .get_or_insert_default()
+                            .border_size = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+        ]
+    }
+
     fn pane_split_direction_section() -> [SettingsPageItem; 3] {
         [
             SettingsPageItem::SectionHeader("Pane Split Direction"),
@@ -5006,6 +5062,7 @@ fn window_and_layout_page() -> SettingsPage {
             layout_section(),
             window_section(),
             pane_modifiers_section(),
+            panel_modifiers_section(),
             pane_split_direction_section(),
         ],
     }

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -435,10 +435,10 @@ impl Dock {
             let focus_subscription =
                 cx.on_focus(&focus_handle, window, |dock: &mut Dock, window, cx| {
                     if let Some(active_entry) = dock.active_panel_entry() {
-                        active_entry
-                            .panel
-                            .activation_focus_handle(cx)
-                            .focus(window, cx)
+                        let panel_focus_handle = active_entry.panel.panel_focus_handle(cx);
+                        if dock.focus_handle.contains(&panel_focus_handle, window) {
+                            panel_focus_handle.focus(window, cx);
+                        }
                     }
                 });
             let zoom_subscription = cx.subscribe(&workspace, |dock, workspace, e: &Event, cx| {
@@ -1615,6 +1615,7 @@ pub mod test {
         pub default_size: Pixels,
         pub flexible: bool,
         pub activation_priority: u32,
+        pub track_focus: bool,
     }
     actions!(test_only, [ToggleTestPanel]);
 
@@ -1631,6 +1632,18 @@ pub mod test {
                 default_size: px(300.),
                 flexible: false,
                 activation_priority,
+                track_focus: true,
+            }
+        }
+
+        pub fn new_without_tracked_focus(
+            position: DockPosition,
+            activation_priority: u32,
+            cx: &mut App,
+        ) -> Self {
+            Self {
+                track_focus: false,
+                ..Self::new(position, activation_priority, cx)
             }
         }
 
@@ -1661,7 +1674,9 @@ pub mod test {
         fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
             div()
                 .id("test")
-                .track_focus(&self.focus_handle(cx))
+                .when(self.track_focus, |this| {
+                    this.track_focus(&self.focus_handle(cx))
+                })
                 .children(self.activation_focus_handle.iter().map(|focus_handle| {
                     div().id("test-activation-child").track_focus(focus_handle)
                 }))

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -415,10 +415,10 @@ impl Dock {
             let focus_subscription =
                 cx.on_focus(&focus_handle, window, |dock: &mut Dock, window, cx| {
                     if let Some(active_entry) = dock.active_panel_entry() {
-                        active_entry
-                            .panel
-                            .activation_focus_handle(cx)
-                            .focus(window, cx)
+                        let activation_focus_handle = active_entry.panel.activation_focus_handle(cx);
+                        if dock.focus_handle.contains(&activation_focus_handle, window) {
+                            activation_focus_handle.focus(window, cx);
+                        }
                     }
                 });
             let zoom_subscription = cx.subscribe(&workspace, |dock, workspace, e: &Event, cx| {
@@ -1477,6 +1477,7 @@ pub mod test {
         pub default_size: Pixels,
         pub flexible: bool,
         pub activation_priority: u32,
+        pub track_focus: bool,
     }
     actions!(test_only, [ToggleTestPanel]);
 
@@ -1493,6 +1494,18 @@ pub mod test {
                 default_size: px(300.),
                 flexible: false,
                 activation_priority,
+                track_focus: true,
+            }
+        }
+
+        pub fn new_without_tracked_focus(
+            position: DockPosition,
+            activation_priority: u32,
+            cx: &mut App,
+        ) -> Self {
+            Self {
+                track_focus: false,
+                ..Self::new(position, activation_priority, cx)
             }
         }
 
@@ -1523,7 +1536,9 @@ pub mod test {
         fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
             div()
                 .id("test")
-                .track_focus(&self.focus_handle(cx))
+                .when(self.track_focus, |this| {
+                    this.track_focus(&self.focus_handle(cx))
+                })
                 .children(self.activation_focus_handle.iter().map(|focus_handle| {
                     div().id("test-activation-child").track_focus(focus_handle)
                 }))

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -28,9 +28,9 @@ const SIDEBAR_RESIZE_HANDLE_SIZE: Pixels = px(6.0);
 
 use crate::open_remote_project_with_existing_connection;
 use crate::{
-    CloseIntent, CloseWindow, DockPosition, Event as WorkspaceEvent, Item, ModalView, OpenMode,
-    Panel, Workspace, WorkspaceId, client_side_decorations,
-    persistence::model::MultiWorkspaceState,
+    CloseIntent, CloseWindow, DockPosition, Event as WorkspaceEvent, FocusedSurface, Item,
+    ModalView, OpenMode, Panel, Workspace, WorkspaceId, client_side_decorations,
+    panel_highlight_overlay, persistence::model::MultiWorkspaceState,
 };
 
 actions!(
@@ -2133,6 +2133,11 @@ impl Render for MultiWorkspace {
                 let weak = cx.weak_entity();
 
                 let sidebar_width = sidebar_handle.width(cx);
+                let sidebar_highlight = panel_highlight_overlay(
+                    self.workspace().read(cx).focused_surface(window, cx),
+                    FocusedSurface::Sidebar,
+                    cx,
+                );
                 let resize_handle = deferred(
                     div()
                         .id("sidebar-resize-handle")
@@ -2181,6 +2186,7 @@ impl Render for MultiWorkspace {
                     .w(sidebar_width)
                     .flex_shrink_0()
                     .child(sidebar_handle.to_any())
+                    .children(sidebar_highlight)
                     .child(resize_handle)
                     .into_any_element()
             })

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -27,9 +27,9 @@ const SIDEBAR_RESIZE_HANDLE_SIZE: Pixels = px(6.0);
 
 use crate::open_remote_project_with_existing_connection;
 use crate::{
-    CloseIntent, CloseWindow, DockPosition, Event as WorkspaceEvent, Item, ModalView, OpenMode,
-    Panel, Workspace, WorkspaceId, client_side_decorations,
-    persistence::model::MultiWorkspaceState,
+    CloseIntent, CloseWindow, DockPosition, Event as WorkspaceEvent, FocusedSurface, Item,
+    ModalView, OpenMode, Panel, Workspace, WorkspaceId, client_side_decorations,
+    panel_highlight_overlay, persistence::model::MultiWorkspaceState,
 };
 
 actions!(
@@ -2004,6 +2004,11 @@ impl Render for MultiWorkspace {
                 let weak = cx.weak_entity();
 
                 let sidebar_width = sidebar_handle.width(cx);
+                let sidebar_highlight = panel_highlight_overlay(
+                    self.workspace().read(cx).focused_surface(window, cx),
+                    FocusedSurface::Sidebar,
+                    cx,
+                );
                 let resize_handle = deferred(
                     div()
                         .id("sidebar-resize-handle")
@@ -2052,6 +2057,7 @@ impl Render for MultiWorkspace {
                     .w(sidebar_width)
                     .flex_shrink_0()
                     .child(sidebar_handle.to_any())
+                    .children(sidebar_highlight)
                     .child(resize_handle)
                     .into_any_element()
             })

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -501,6 +501,50 @@ pub(crate) fn pane_has_focus(pane: &Entity<Pane>, window: &Window, cx: &App) -> 
     pane.focus_handle(cx).contains_focused(window, cx)
 }
 
+fn active_pane_modifiers_overlay(
+    pane_focused: bool,
+    any_pane_focused: bool,
+    cx: &App,
+) -> Option<Div> {
+    let modifiers = WorkspaceSettings::get(None, cx).active_pane_modifiers;
+    let border = modifiers
+        .border_size
+        .and_then(|border_size| (border_size > 0.).then_some(border_size));
+
+    if pane_focused {
+        let border = border?;
+        return Some(
+            div()
+                .absolute()
+                .size_full()
+                .left_0()
+                .top_0()
+                .border(px(border))
+                .border_color(cx.theme().colors().border_selected),
+        );
+    }
+
+    if !any_pane_focused {
+        return None;
+    }
+
+    let opacity = modifiers
+        .inactive_opacity
+        .map(|opacity| opacity.0.clamp(0.0, 1.0))
+        .and_then(|opacity| (opacity < 1.).then_some(opacity))?;
+    let mut overlay_background = cx.theme().colors().editor_background;
+    overlay_background.fade_out(opacity);
+
+    Some(
+        div()
+            .absolute()
+            .size_full()
+            .left_0()
+            .top_0()
+            .bg(overlay_background),
+    )
+}
+
 impl Member {
     fn new_axis(old_pane: Entity<Pane>, new_pane: Entity<Pane>, direction: SplitDirection) -> Self {
         use Axis::*;
@@ -569,6 +613,9 @@ impl Member {
 
                 let decoration = render_cx.decorate(pane, cx);
                 let is_active = pane_has_focus(pane, window, cx);
+                let pane_modifiers_overlay = (basis == 0)
+                    .then(|| active_pane_modifiers_overlay(is_active, is_active, cx))
+                    .flatten();
 
                 let pane = div()
                     .relative()
@@ -595,7 +642,8 @@ impl Member {
                                 .border_color(color),
                         )
                     })
-                    .children(decoration.status_box);
+                    .children(decoration.status_box)
+                    .children(pane_modifiers_overlay);
 
                 PaneRenderResult {
                     element: div()

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -506,7 +506,7 @@ fn active_pane_modifiers_overlay(
     any_pane_focused: bool,
     cx: &App,
 ) -> Option<Div> {
-    let modifiers = WorkspaceSettings::get(None, cx).active_pane_modifiers;
+    let modifiers = WorkspaceSettings::get_global(cx).active_pane_modifiers;
     let border = modifiers
         .border_size
         .and_then(|border_size| (border_size > 0.).then_some(border_size));

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -8,8 +8,8 @@ use crate::{
 use anyhow::Result;
 use collections::HashMap;
 use gpui::{
-    Along, AnyView, AnyWeakView, Axis, Bounds, Entity, Hsla, IntoElement, MouseButton, Pixels,
-    Point, StyleRefinement, WeakEntity, Window, point, size,
+    Along, AnyView, AnyWeakView, Axis, Bounds, Entity, Focusable, Hsla, IntoElement, MouseButton,
+    Pixels, Point, StyleRefinement, WeakEntity, Window, point, size,
 };
 use parking_lot::Mutex;
 use project::Project;
@@ -497,6 +497,10 @@ impl PaneLeaderDecorator for PaneRenderContext<'_> {
     }
 }
 
+pub(crate) fn pane_has_focus(pane: &Entity<Pane>, window: &Window, cx: &App) -> bool {
+    pane.focus_handle(cx).contains_focused(window, cx)
+}
+
 impl Member {
     fn new_axis(old_pane: Entity<Pane>, new_pane: Entity<Pane>, direction: SplitDirection) -> Self {
         use Axis::*;
@@ -564,7 +568,7 @@ impl Member {
                 };
 
                 let decoration = render_cx.decorate(pane, cx);
-                let is_active = pane == render_cx.active_pane();
+                let is_active = pane_has_focus(pane, window, cx);
 
                 let pane = div()
                     .relative()
@@ -1004,8 +1008,8 @@ impl PaneAxis {
                 match member {
                     Member::Pane(pane) => {
                         is_leaf_pane[ix] = true;
-                        if pane == render_cx.active_pane() {
-                            active_pane_ix = pane.read(cx).has_focus(window, cx).then_some(ix);
+                        if pane_has_focus(pane, window, cx) {
+                            active_pane_ix = Some(ix);
                             contains_active_pane = true;
                         }
                     }
@@ -1032,6 +1036,7 @@ impl PaneAxis {
         .with_is_leaf_pane_mask(is_leaf_pane)
         .children(rendered_children)
         .with_active_pane(active_pane_ix)
+        .with_any_pane_focused(contains_active_pane)
         .into_any_element();
 
         PaneRenderResult {
@@ -1176,6 +1181,7 @@ mod element {
             active_pane_ix: None,
             workspace,
             is_leaf_pane_mask: Vec::new(),
+            any_pane_focused: false,
         }
     }
 
@@ -1191,6 +1197,7 @@ mod element {
         workspace: WeakEntity<Workspace>,
         // Track which children are leaf panes (Member::Pane) vs axes (Member::Axis)
         is_leaf_pane_mask: Vec<bool>,
+        any_pane_focused: bool,
     }
 
     pub struct PaneAxisLayout {
@@ -1218,6 +1225,11 @@ mod element {
 
         pub fn with_is_leaf_pane_mask(mut self, mask: Vec<bool>) -> Self {
             self.is_leaf_pane_mask = mask;
+            self
+        }
+
+        pub fn with_any_pane_focused(mut self, any_pane_focused: bool) -> Self {
+            self.any_pane_focused = any_pane_focused;
             self
         }
 
@@ -1491,7 +1503,8 @@ mod element {
                 .and_then(|val| (val >= 0.).then_some(val));
 
             for (ix, child) in &mut layout.children.iter_mut().enumerate() {
-                if overlay_opacity.is_some() || overlay_border.is_some() {
+                if self.any_pane_focused && (overlay_opacity.is_some() || overlay_border.is_some())
+                {
                     // the overlay has to be painted in origin+1px with size width-1px
                     // in order to accommodate the divider between panels
                     let overlay_bounds = Bounds {

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -8,8 +8,8 @@ use crate::{
 use anyhow::Result;
 use collections::HashMap;
 use gpui::{
-    Along, AnyView, AnyWeakView, Axis, Bounds, Entity, Hsla, IntoElement, MouseButton, Pixels,
-    Point, StyleRefinement, WeakEntity, Window, point, size,
+    Along, AnyView, AnyWeakView, Axis, Bounds, Entity, Focusable, Hsla, IntoElement, MouseButton,
+    Pixels, Point, StyleRefinement, WeakEntity, Window, point, size,
 };
 use parking_lot::Mutex;
 use project::Project;
@@ -564,7 +564,7 @@ impl Member {
                 };
 
                 let decoration = render_cx.decorate(pane, cx);
-                let is_active = pane == render_cx.active_pane();
+                let is_active = pane.focus_handle(cx).contains_focused(window, cx);
 
                 let pane = div()
                     .relative()
@@ -1004,8 +1004,8 @@ impl PaneAxis {
                 match member {
                     Member::Pane(pane) => {
                         is_leaf_pane[ix] = true;
-                        if pane == render_cx.active_pane() {
-                            active_pane_ix = pane.read(cx).has_focus(window, cx).then_some(ix);
+                        if pane.focus_handle(cx).contains_focused(window, cx) {
+                            active_pane_ix = Some(ix);
                             contains_active_pane = true;
                         }
                     }
@@ -1032,6 +1032,7 @@ impl PaneAxis {
         .with_is_leaf_pane_mask(is_leaf_pane)
         .children(rendered_children)
         .with_active_pane(active_pane_ix)
+        .with_any_pane_focused(contains_active_pane)
         .into_any_element();
 
         PaneRenderResult {
@@ -1176,6 +1177,7 @@ mod element {
             active_pane_ix: None,
             workspace,
             is_leaf_pane_mask: Vec::new(),
+            any_pane_focused: false,
         }
     }
 
@@ -1191,6 +1193,7 @@ mod element {
         workspace: WeakEntity<Workspace>,
         // Track which children are leaf panes (Member::Pane) vs axes (Member::Axis)
         is_leaf_pane_mask: Vec<bool>,
+        any_pane_focused: bool,
     }
 
     pub struct PaneAxisLayout {
@@ -1218,6 +1221,11 @@ mod element {
 
         pub fn with_is_leaf_pane_mask(mut self, mask: Vec<bool>) -> Self {
             self.is_leaf_pane_mask = mask;
+            self
+        }
+
+        pub fn with_any_pane_focused(mut self, any_pane_focused: bool) -> Self {
+            self.any_pane_focused = any_pane_focused;
             self
         }
 
@@ -1491,7 +1499,8 @@ mod element {
                 .and_then(|val| (val >= 0.).then_some(val));
 
             for (ix, child) in &mut layout.children.iter_mut().enumerate() {
-                if overlay_opacity.is_some() || overlay_border.is_some() {
+                if self.any_pane_focused && (overlay_opacity.is_some() || overlay_border.is_some())
+                {
                     // the overlay has to be painted in origin+1px with size width-1px
                     // in order to accommodate the divider between panels
                     let overlay_bounds = Bounds {

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -497,6 +497,27 @@ impl PaneLeaderDecorator for PaneRenderContext<'_> {
     }
 }
 
+fn active_pane_modifiers_overlay(pane_focused: bool, cx: &App) -> Option<Div> {
+    let modifiers = WorkspaceSettings::get_global(cx).active_pane_modifiers;
+
+    if pane_focused {
+        let border = modifiers
+            .border_size
+            .and_then(|border_size| (border_size > 0.).then_some(border_size))?;
+        return Some(
+            div()
+                .absolute()
+                .size_full()
+                .left_0()
+                .top_0()
+                .border(px(border))
+                .border_color(cx.theme().colors().border_selected),
+        );
+    }
+
+    None
+}
+
 impl Member {
     fn new_axis(old_pane: Entity<Pane>, new_pane: Entity<Pane>, direction: SplitDirection) -> Self {
         use Axis::*;
@@ -565,6 +586,8 @@ impl Member {
 
                 let decoration = render_cx.decorate(pane, cx);
                 let is_active = pane.focus_handle(cx).contains_focused(window, cx);
+                let pane_modifiers_overlay =
+                    (basis == 0).then(|| active_pane_modifiers_overlay(is_active, cx));
 
                 let pane = div()
                     .relative()
@@ -591,7 +614,8 @@ impl Member {
                                 .border_color(color),
                         )
                     })
-                    .children(decoration.status_box);
+                    .children(decoration.status_box)
+                    .children(pane_modifiers_overlay.flatten());
 
                 PaneRenderResult {
                     element: div()

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8095,7 +8095,7 @@ impl Workspace {
             .center
             .panes()
             .iter()
-            .any(|pane| pane.focus_handle(cx).contains_focused(window, cx))
+            .any(|pane| pane_group::pane_has_focus(pane, window, cx))
         {
             return Some(FocusedSurface::PaneGroup);
         }
@@ -14361,7 +14361,10 @@ mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             assert_eq!(workspace.active_pane(), &second_pane);
             let result = render_center_group(workspace, window, cx);
-            assert!(result.contains_active_pane);
+            assert!(
+                !result.contains_active_pane,
+                "a group with no truly-focused pane should not report one"
+            );
             assert_eq!(
                 result.decorated_pane_ix, None,
                 "an unfocused group should not decorate its active pane"
@@ -14998,6 +15001,55 @@ mod tests {
                 workspace.focused_surface(window, cx),
                 Some(FocusedSurface::Dock(DockPosition::Right)),
                 "The dock should still be considered the focused surface"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_panel_highlight_overlay(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        workspace.update_in(cx, |_workspace, _window, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.active_panel_modifiers =
+                        Some(settings::settings_content::ActivePanelModifiers {
+                            border_size: Some(2.0),
+                            inactive_opacity: Some(settings::settings_content::InactiveOpacity(
+                                0.5,
+                            )),
+                        });
+                });
+            });
+
+            assert!(
+                panel_highlight_overlay(
+                    Some(FocusedSurface::Dock(DockPosition::Left)),
+                    FocusedSurface::Dock(DockPosition::Left),
+                    cx,
+                )
+                .is_some(),
+                "the focused dock should get a border overlay"
+            );
+
+            assert!(
+                panel_highlight_overlay(
+                    Some(FocusedSurface::Dock(DockPosition::Right)),
+                    FocusedSurface::Dock(DockPosition::Left),
+                    cx,
+                )
+                .is_some(),
+                "an unfocused dock should get a dimming overlay when something else has focus"
+            );
+
+            assert!(
+                panel_highlight_overlay(None, FocusedSurface::Dock(DockPosition::Left), cx)
+                    .is_none(),
+                "no overlay should be drawn when nothing in the workspace has focus"
             );
         });
     }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1486,9 +1486,10 @@ pub enum OpenMode {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum FocusedSurface {
+pub(crate) enum FocusedSurface {
     PaneGroup,
     Dock(DockPosition),
+    Sidebar,
 }
 
 impl Workspace {
@@ -8083,7 +8084,15 @@ impl Workspace {
             )
     }
 
-    fn focused_surface(&self, window: &Window, cx: &App) -> Option<FocusedSurface> {
+    pub(crate) fn focused_surface(&self, window: &Window, cx: &App) -> Option<FocusedSurface> {
+        if self
+            .sidebar_focus_handle
+            .as_ref()
+            .is_some_and(|focus_handle| focus_handle.contains_focused(window, cx))
+        {
+            return Some(FocusedSurface::Sidebar);
+        }
+
         if self
             .center
             .panes()
@@ -8100,12 +8109,7 @@ impl Workspace {
         ]
         .into_iter()
         .find_map(|(dock, position)| {
-            dock.read(cx).visible_panel().and_then(|panel| {
-                panel
-                    .panel_focus_handle(cx)
-                    .contains_focused(window, cx)
-                    .then_some(FocusedSurface::Dock(position))
-            })
+            dock_has_focus(dock, window, cx).then_some(FocusedSurface::Dock(position))
         })
     }
 
@@ -8129,7 +8133,13 @@ impl Workspace {
         let panel_highlight = dock
             .read(cx)
             .is_open()
-            .then(|| panel_highlight_overlay(self.focused_surface(window, cx), position, cx))
+            .then(|| {
+                panel_highlight_overlay(
+                    self.focused_surface(window, cx),
+                    FocusedSurface::Dock(position),
+                    cx,
+                )
+            })
             .flatten();
 
         // Expose each open dock as a landmark region so assistive technology
@@ -8690,9 +8700,21 @@ pub enum ActiveCallEvent {
     RoomLeft,
 }
 
-fn panel_highlight_overlay(
+fn dock_has_focus(dock: &Entity<Dock>, window: &Window, cx: &App) -> bool {
+    let dock = dock.read(cx);
+    if !dock.is_open() {
+        return false;
+    }
+
+    dock.focus_handle(cx).contains_focused(window, cx)
+        || dock
+            .visible_panel()
+            .is_some_and(|panel| panel.panel_focus_handle(cx).contains_focused(window, cx))
+}
+
+pub(crate) fn panel_highlight_overlay(
     focused_surface: Option<FocusedSurface>,
-    position: DockPosition,
+    surface: FocusedSurface,
     cx: &App,
 ) -> Option<Div> {
     let modifiers = WorkspaceSettings::get_global(cx).active_panel_modifiers;
@@ -8705,7 +8727,7 @@ fn panel_highlight_overlay(
         .border_size
         .and_then(|value| (value > 0.).then_some(value));
 
-    if focused_surface == Some(FocusedSurface::Dock(position)) {
+    if focused_surface == Some(surface) {
         let border = overlay_border?;
         return Some(
             div()

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2292,9 +2292,7 @@ impl Workspace {
             (DockPosition::Bottom, &self.bottom_dock),
         ]
         .into_iter()
-        .find(|(_, dock)| {
-            dock.read(cx).is_open() && dock.focus_handle(cx).contains_focused(window, cx)
-        })
+        .find(|(_, dock)| dock_has_focus(dock, window, cx))
         .map(|(position, _)| position)
     }
 
@@ -3264,7 +3262,7 @@ impl Workspace {
         let docks = self.all_docks();
         let active_dock = docks
             .into_iter()
-            .find(|dock| dock.focus_handle(cx).contains_focused(window, cx));
+            .find(|dock| dock_has_focus(dock, window, cx));
 
         if let Some(dock) = active_dock {
             dock.update(cx, |dock, cx| {
@@ -4233,9 +4231,9 @@ impl Workspace {
     }
 
     fn active_dock(&self, window: &Window, cx: &Context<Self>) -> Option<&Entity<Dock>> {
-        self.all_docks().into_iter().find(|&dock| {
-            dock.read(cx).is_open() && dock.focus_handle(cx).contains_focused(window, cx)
-        })
+        self.all_docks()
+            .into_iter()
+            .find(|&dock| dock_has_focus(dock, window, cx))
     }
 
     fn close_active_dock(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
@@ -5242,7 +5240,7 @@ impl Workspace {
             ]
             .into_iter()
             .find_map(|(dock, origin)| {
-                if dock.focus_handle(cx).contains_focused(window, cx) && dock.read(cx).is_open() {
+                if dock_has_focus(dock, window, cx) {
                     Some(origin)
                 } else {
                     None
@@ -5401,8 +5399,8 @@ impl Workspace {
                 // Defer this to avoid a panic when the dock's active panel is already on the stack.
                 window.defer(cx, move |window, cx| {
                     let dock = dock.read(cx);
-                    if let Some(panel) = dock.active_panel() {
-                        panel.activation_focus_handle(cx).focus(window, cx);
+                    if dock.active_panel().is_some() {
+                        dock.focus_handle(cx).focus(window, cx);
                     } else {
                         log::error!("Could not find a focus target when in switching focus in {direction} direction for a {:?} dock", dock.position());
                     }
@@ -5503,7 +5501,7 @@ impl Workspace {
         let docks = self.all_docks();
         let active_dock = docks
             .into_iter()
-            .find(|dock| dock.focus_handle(cx).contains_focused(window, cx));
+            .find(|dock| dock_has_focus(dock, window, cx));
 
         if let Some(dock_entity) = active_dock {
             let dock = dock_entity.read(cx);
@@ -5886,7 +5884,7 @@ impl Workspace {
 
     pub fn focused_pane(&self, window: &Window, cx: &App) -> Entity<Pane> {
         for dock in self.all_docks() {
-            if dock.focus_handle(cx).contains_focused(window, cx)
+            if dock_has_focus(&dock, window, cx)
                 && let Some(pane) = dock
                     .read(cx)
                     .active_panel()
@@ -6716,7 +6714,7 @@ impl Workspace {
         let mut active_item = None;
         let mut panel_id = None;
         for dock in self.all_docks() {
-            if dock.focus_handle(cx).contains_focused(window, cx)
+            if dock_has_focus(&dock, window, cx)
                 && let Some(panel) = dock.read(cx).active_panel()
                 && let Some(pane) = panel.pane(cx)
                 && let Some(item) = pane.read(cx).active_item()
@@ -7701,7 +7699,7 @@ impl Workspace {
             .on_action(cx.listener(
                 |workspace: &mut Workspace, _: &ResetActiveDockSize, window, cx| {
                     for dock in workspace.all_docks() {
-                        if dock.focus_handle(cx).contains_focused(window, cx) {
+                        if dock_has_focus(&dock, window, cx) {
                             let panel = dock.read(cx).active_panel().cloned();
                             if let Some(panel) = panel {
                                 dock.update(cx, |dock, cx| {
@@ -9048,7 +9046,7 @@ fn adjust_active_dock_size_by_px(
     let Some(active_dock) = workspace
         .all_docks()
         .into_iter()
-        .find(|dock| dock.focus_handle(cx).contains_focused(window, cx))
+        .find(|dock| dock_has_focus(dock, window, cx))
     else {
         return;
     };
@@ -14898,6 +14896,108 @@ mod tests {
             assert_eq!(
                 right_width, expected_right,
                 "flexible right panel should share workspace width via flex ratios"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_focused_surface(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Right, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.toggle_dock(DockPosition::Right, window, cx);
+            panel
+        });
+
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            // Ensure center pane has focus before checking (toggle_dock focuses the panel)
+            window.focus(&pane.read(cx).focus_handle(cx), cx);
+
+            assert_eq!(
+                workspace.focused_surface(window, cx),
+                Some(FocusedSurface::PaneGroup),
+                "Center pane group should have focus after refocusing"
+            );
+
+            window.focus(&panel.read(cx).focus_handle(cx), cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert_eq!(
+                workspace.focused_surface(window, cx),
+                Some(FocusedSurface::Dock(DockPosition::Right)),
+                "Right dock should have focus after focusing its panel"
+            );
+
+            window.focus(&workspace.right_dock.focus_handle(cx), cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert_eq!(
+                workspace.focused_surface(window, cx),
+                Some(FocusedSurface::Dock(DockPosition::Right)),
+                "Right dock should have focus when the dock wrapper is focused"
+            );
+
+            let pane = workspace.active_pane().clone();
+            window.focus(&pane.read(cx).focus_handle(cx), cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert_eq!(
+                workspace.focused_surface(window, cx),
+                Some(FocusedSurface::PaneGroup),
+                "Center pane group should regain focus after refocusing the active pane"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_activate_pane_in_direction_focuses_dock_when_panel_focus_is_not_mounted(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel =
+                cx.new(|cx| TestPanel::new_without_tracked_focus(DockPosition::Right, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.toggle_dock(DockPosition::Right, window, cx);
+            panel
+        });
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            window.focus(&pane.read(cx).focus_handle(cx), cx);
+            workspace.activate_pane_in_direction(SplitDirection::Right, window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(
+                workspace.right_dock.focus_handle(cx).is_focused(window),
+                "Keyboard navigation into an empty panel should leave focus on the dock wrapper"
+            );
+            assert!(
+                !panel.read(cx).focus_handle(cx).contains_focused(window, cx),
+                "Panel focus handle is not mounted, so focus should not be moved to it"
+            );
+            assert_eq!(
+                workspace.focused_surface(window, cx),
+                Some(FocusedSurface::Dock(DockPosition::Right)),
+                "The dock should still be considered the focused surface"
             );
         });
     }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1485,6 +1485,12 @@ pub enum OpenMode {
     Activate,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum FocusedSurface {
+    PaneGroup,
+    Dock(DockPosition),
+}
+
 impl Workspace {
     pub fn new(
         workspace_id: Option<WorkspaceId>,
@@ -8077,6 +8083,32 @@ impl Workspace {
             )
     }
 
+    fn focused_surface(&self, window: &Window, cx: &App) -> Option<FocusedSurface> {
+        if self
+            .center
+            .panes()
+            .iter()
+            .any(|pane| pane.focus_handle(cx).contains_focused(window, cx))
+        {
+            return Some(FocusedSurface::PaneGroup);
+        }
+
+        [
+            (&self.left_dock, DockPosition::Left),
+            (&self.right_dock, DockPosition::Right),
+            (&self.bottom_dock, DockPosition::Bottom),
+        ]
+        .into_iter()
+        .find_map(|(dock, position)| {
+            dock.read(cx).visible_panel().and_then(|panel| {
+                panel
+                    .panel_focus_handle(cx)
+                    .contains_focused(window, cx)
+                    .then_some(FocusedSurface::Dock(position))
+            })
+        })
+    }
+
     fn render_dock(
         &self,
         position: DockPosition,
@@ -8093,6 +8125,12 @@ impl Workspace {
             let follower_states = &self.follower_states;
             leader_border_for_pane(follower_states, &pane, window, cx)
         });
+
+        let panel_highlight = dock
+            .read(cx)
+            .is_open()
+            .then(|| panel_highlight_overlay(self.focused_surface(window, cx), position, cx))
+            .flatten();
 
         // Expose each open dock as a landmark region so assistive technology
         // can navigate to it, and so region navigation announces it. While a
@@ -8122,7 +8160,8 @@ impl Workspace {
             .overflow_hidden()
             .flex_none()
             .child(dock.clone())
-            .children(leader_border);
+            .children(leader_border)
+            .children(panel_highlight);
 
         // Apply sizing only when the dock is open. When closed the dock is still
         // included in the element tree so its focus handle remains mounted — without
@@ -8649,6 +8688,51 @@ pub enum ActiveCallEvent {
     LocalScreenShareStarted,
     LocalScreenShareStopped,
     RoomLeft,
+}
+
+fn panel_highlight_overlay(
+    focused_surface: Option<FocusedSurface>,
+    position: DockPosition,
+    cx: &App,
+) -> Option<Div> {
+    let modifiers = WorkspaceSettings::get_global(cx).active_panel_modifiers;
+
+    let overlay_opacity = modifiers
+        .inactive_opacity
+        .map(|value| value.0.clamp(0.0, 1.0))
+        .and_then(|value| (value < 1.).then_some(value));
+    let overlay_border = modifiers
+        .border_size
+        .and_then(|value| (value > 0.).then_some(value));
+
+    if focused_surface == Some(FocusedSurface::Dock(position)) {
+        let border = overlay_border?;
+        return Some(
+            div()
+                .absolute()
+                .size_full()
+                .left_0()
+                .top_0()
+                .border(px(border))
+                .border_color(cx.theme().colors().border_selected),
+        );
+    }
+
+    if focused_surface.is_none() {
+        return None;
+    }
+
+    let opacity = overlay_opacity?;
+    let mut overlay_background = cx.theme().colors().panel_background;
+    overlay_background.fade_out(opacity);
+    Some(
+        div()
+            .absolute()
+            .size_full()
+            .left_0()
+            .top_0()
+            .bg(overlay_background),
+    )
 }
 
 fn leader_border_for_pane(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2595,9 +2595,7 @@ impl Workspace {
             (DockPosition::Bottom, &self.bottom_dock),
         ]
         .into_iter()
-        .find(|(_, dock)| {
-            dock.read(cx).is_open() && dock.focus_handle(cx).contains_focused(window, cx)
-        })
+        .find(|(_, dock)| dock_has_focus(dock, window, cx))
         .map(|(position, _)| position)
     }
 
@@ -3644,7 +3642,7 @@ impl Workspace {
         let docks = self.all_docks();
         let active_dock = docks
             .into_iter()
-            .find(|dock| dock.focus_handle(cx).contains_focused(window, cx));
+            .find(|dock| dock_has_focus(dock, window, cx));
 
         if let Some(dock) = active_dock {
             dock.update(cx, |dock, cx| {
@@ -4618,9 +4616,9 @@ impl Workspace {
     }
 
     fn active_dock(&self, window: &Window, cx: &Context<Self>) -> Option<&Entity<Dock>> {
-        self.all_docks().into_iter().find(|&dock| {
-            dock.read(cx).is_open() && dock.focus_handle(cx).contains_focused(window, cx)
-        })
+        self.all_docks()
+            .into_iter()
+            .find(|&dock| dock_has_focus(dock, window, cx))
     }
 
     fn close_active_dock(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
@@ -5733,7 +5731,7 @@ impl Workspace {
             ]
             .into_iter()
             .find_map(|(dock, origin)| {
-                if dock.focus_handle(cx).contains_focused(window, cx) && dock.read(cx).is_open() {
+                if dock_has_focus(dock, window, cx) {
                     Some(origin)
                 } else {
                     None
@@ -5892,8 +5890,8 @@ impl Workspace {
                 // Defer this to avoid a panic when the dock's active panel is already on the stack.
                 window.defer(cx, move |window, cx| {
                     let dock = dock.read(cx);
-                    if let Some(panel) = dock.active_panel() {
-                        panel.activation_focus_handle(cx).focus(window, cx);
+                    if dock.active_panel().is_some() {
+                        dock.focus_handle(cx).focus(window, cx);
                     } else {
                         log::error!("Could not find a focus target when in switching focus in {direction} direction for a {:?} dock", dock.position());
                     }
@@ -5994,7 +5992,7 @@ impl Workspace {
         let docks = self.all_docks();
         let active_dock = docks
             .into_iter()
-            .find(|dock| dock.focus_handle(cx).contains_focused(window, cx));
+            .find(|dock| dock_has_focus(dock, window, cx));
 
         if let Some(dock_entity) = active_dock {
             let dock = dock_entity.read(cx);
@@ -6378,7 +6376,7 @@ impl Workspace {
 
     pub fn focused_pane(&self, window: &Window, cx: &App) -> Entity<Pane> {
         for dock in self.all_docks() {
-            if dock.focus_handle(cx).contains_focused(window, cx)
+            if dock_has_focus(&dock, window, cx)
                 && let Some(pane) = dock
                     .read(cx)
                     .active_panel()
@@ -7311,7 +7309,7 @@ impl Workspace {
         let mut active_item = None;
         let mut panel_id = None;
         for dock in self.all_docks() {
-            if dock.focus_handle(cx).contains_focused(window, cx)
+            if dock_has_focus(&dock, window, cx)
                 && let Some(panel) = dock.read(cx).active_panel()
                 && let Some(pane) = panel.pane(cx)
                 && let Some(item) = pane.read(cx).active_item()
@@ -9642,7 +9640,7 @@ fn adjust_active_dock_size_by_px(
     let Some(active_dock) = workspace
         .all_docks()
         .into_iter()
-        .find(|dock| dock.focus_handle(cx).contains_focused(window, cx))
+        .find(|dock| dock_has_focus(dock, window, cx))
     else {
         return;
     };
@@ -15668,6 +15666,41 @@ mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             let result = render_center_group(workspace, window, cx);
             assert_eq!(result.decorated_pane_ix, Some(1));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_activate_pane_in_direction_keeps_focus_in_empty_dock_panel(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel =
+                cx.new(|cx| TestPanel::new_without_tracked_focus(DockPosition::Right, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.toggle_dock(DockPosition::Right, window, cx);
+            panel
+        });
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            window.focus(&pane.read(cx).focus_handle(cx), cx);
+            workspace.activate_pane_in_direction(SplitDirection::Right, window, cx);
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.right_dock.focus_handle(cx).is_focused(window));
+            assert!(!panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+            assert_eq!(
+                workspace.focused_surface(window, cx),
+                Some(FocusedSurface::Dock(DockPosition::Right)),
+            );
         });
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1730,9 +1730,10 @@ pub enum OpenMode {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum FocusedSurface {
+pub(crate) enum FocusedSurface {
     PaneGroup,
     Dock(DockPosition),
+    Sidebar,
 }
 
 impl Workspace {
@@ -8677,7 +8678,15 @@ impl Workspace {
             )
     }
 
-    fn focused_surface(&self, window: &Window, cx: &App) -> Option<FocusedSurface> {
+    pub(crate) fn focused_surface(&self, window: &Window, cx: &App) -> Option<FocusedSurface> {
+        if self
+            .sidebar_focus_handle
+            .as_ref()
+            .is_some_and(|focus_handle| focus_handle.contains_focused(window, cx))
+        {
+            return Some(FocusedSurface::Sidebar);
+        }
+
         if self
             .center
             .panes()
@@ -8694,12 +8703,7 @@ impl Workspace {
         ]
         .into_iter()
         .find_map(|(dock, position)| {
-            dock.read(cx).visible_panel().and_then(|panel| {
-                panel
-                    .panel_focus_handle(cx)
-                    .contains_focused(window, cx)
-                    .then_some(FocusedSurface::Dock(position))
-            })
+            dock_has_focus(dock, window, cx).then_some(FocusedSurface::Dock(position))
         })
     }
 
@@ -8723,7 +8727,13 @@ impl Workspace {
         let panel_highlight = dock
             .read(cx)
             .is_open()
-            .then(|| panel_highlight_overlay(self.focused_surface(window, cx), position, cx))
+            .then(|| {
+                panel_highlight_overlay(
+                    self.focused_surface(window, cx),
+                    FocusedSurface::Dock(position),
+                    cx,
+                )
+            })
             .flatten();
 
         // Expose each open dock as a landmark region so assistive technology
@@ -9284,9 +9294,21 @@ pub enum ActiveCallEvent {
     RoomLeft,
 }
 
-fn panel_highlight_overlay(
+fn dock_has_focus(dock: &Entity<Dock>, window: &Window, cx: &App) -> bool {
+    let dock = dock.read(cx);
+    if !dock.is_open() {
+        return false;
+    }
+
+    dock.focus_handle(cx).contains_focused(window, cx)
+        || dock
+            .visible_panel()
+            .is_some_and(|panel| panel.panel_focus_handle(cx).contains_focused(window, cx))
+}
+
+pub(crate) fn panel_highlight_overlay(
     focused_surface: Option<FocusedSurface>,
-    position: DockPosition,
+    surface: FocusedSurface,
     cx: &App,
 ) -> Option<Div> {
     let modifiers = WorkspaceSettings::get_global(cx).active_panel_modifiers;
@@ -9299,7 +9321,7 @@ fn panel_highlight_overlay(
         .border_size
         .and_then(|value| (value > 0.).then_some(value));
 
-    if focused_surface == Some(FocusedSurface::Dock(position)) {
+    if focused_surface == Some(surface) {
         let border = overlay_border?;
         return Some(
             div()
@@ -15627,7 +15649,10 @@ mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             assert_eq!(workspace.active_pane(), &second_pane);
             let result = render_center_group(workspace, window, cx);
-            assert!(!result.contains_active_pane);
+            assert!(
+                !result.contains_active_pane,
+                "a group with no truly-focused pane should not report one"
+            );
             assert_eq!(
                 result.decorated_pane_ix, None,
                 "an unfocused group should not decorate its active pane"
@@ -15643,6 +15668,55 @@ mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             let result = render_center_group(workspace, window, cx);
             assert_eq!(result.decorated_pane_ix, Some(1));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_panel_highlight_overlay(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        workspace.update_in(cx, |_workspace, _window, cx| {
+            SettingsStore::update_global(cx, |settings, cx| {
+                settings.update_user_settings(cx, |settings| {
+                    settings.workspace.active_panel_modifiers =
+                        Some(settings::settings_content::ActivePanelModifiers {
+                            border_size: Some(2.0),
+                            inactive_opacity: Some(settings::settings_content::InactiveOpacity(
+                                0.5,
+                            )),
+                        });
+                });
+            });
+
+            assert!(
+                panel_highlight_overlay(
+                    Some(FocusedSurface::Dock(DockPosition::Left)),
+                    FocusedSurface::Dock(DockPosition::Left),
+                    cx,
+                )
+                .is_some(),
+                "the focused dock should get a border overlay"
+            );
+
+            assert!(
+                panel_highlight_overlay(
+                    Some(FocusedSurface::Dock(DockPosition::Right)),
+                    FocusedSurface::Dock(DockPosition::Left),
+                    cx,
+                )
+                .is_some(),
+                "an unfocused dock should get a dimming overlay when something else has focus"
+            );
+
+            assert!(
+                panel_highlight_overlay(None, FocusedSurface::Dock(DockPosition::Left), cx)
+                    .is_none(),
+                "no overlay should be drawn when nothing in the workspace has focus"
+            );
         });
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1,32 +1,56 @@
 pub mod active_file_name;
+
 pub mod dock;
+
 pub mod history_manager;
+
 pub mod invalid_item_view;
+
 pub mod item;
+
 mod modal_layer;
+
 mod multi_workspace;
+
 #[cfg(test)]
 mod multi_workspace_tests;
+
 pub mod notifications;
+
 pub mod pane;
+
 pub mod pane_group;
+
 pub mod path_list {
     pub use util::path_list::{PathList, SerializedPathList};
 }
+
 pub mod path_link;
+
 mod persistence;
+
 pub mod searchable;
+
 pub mod security_modal;
+
 pub mod shared_screen;
 pub use shared_screen::SharedScreen;
 pub mod focus_follows_mouse;
+
 mod status_bar;
+
 pub mod tasks;
+
 mod theme_preview;
+
 mod toast_layer;
+
 mod toolbar;
+
 pub mod welcome;
+
 pub mod workspace_error;
+
 mod workspace_settings;
 
 pub use dock::Panel;
@@ -174,6 +198,7 @@ use crate::{
 };
 
 pub const SERIALIZATION_THROTTLE_TIME: Duration = Duration::from_millis(200);
+
 pub const MAX_RECENT_SELECTIONS: usize = 20;
 
 /// Which optional window-title variables are actually referenced by the active
@@ -868,11 +893,13 @@ impl WorkspaceId {
 }
 
 impl StaticColumnCount for WorkspaceId {}
+
 impl Bind for WorkspaceId {
     fn bind(&self, statement: &Statement, start_index: i32) -> Result<i32> {
         self.0.bind(statement, start_index)
     }
 }
+
 impl Column for WorkspaceId {
     fn column(statement: &mut Statement, start_index: i32) -> Result<(Self, i32)> {
         i64::column(statement, start_index)
@@ -880,6 +907,7 @@ impl Column for WorkspaceId {
             .with_context(|| format!("Failed to read WorkspaceId at index {start_index}"))
     }
 }
+
 impl From<WorkspaceId> for i64 {
     fn from(val: WorkspaceId) -> Self {
         val.0
@@ -1699,6 +1727,12 @@ pub enum OpenMode {
     /// Add to the window's multi workspace and activate it.
     #[default]
     Activate,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum FocusedSurface {
+    PaneGroup,
+    Dock(DockPosition),
 }
 
 impl Workspace {
@@ -8643,6 +8677,32 @@ impl Workspace {
             )
     }
 
+    fn focused_surface(&self, window: &Window, cx: &App) -> Option<FocusedSurface> {
+        if self
+            .center
+            .panes()
+            .iter()
+            .any(|pane| pane.focus_handle(cx).contains_focused(window, cx))
+        {
+            return Some(FocusedSurface::PaneGroup);
+        }
+
+        [
+            (&self.left_dock, DockPosition::Left),
+            (&self.right_dock, DockPosition::Right),
+            (&self.bottom_dock, DockPosition::Bottom),
+        ]
+        .into_iter()
+        .find_map(|(dock, position)| {
+            dock.read(cx).visible_panel().and_then(|panel| {
+                panel
+                    .panel_focus_handle(cx)
+                    .contains_focused(window, cx)
+                    .then_some(FocusedSurface::Dock(position))
+            })
+        })
+    }
+
     fn render_dock(
         &self,
         position: DockPosition,
@@ -8659,6 +8719,12 @@ impl Workspace {
             let follower_states = &self.follower_states;
             leader_border_for_pane(follower_states, &pane, window, cx)
         });
+
+        let panel_highlight = dock
+            .read(cx)
+            .is_open()
+            .then(|| panel_highlight_overlay(self.focused_surface(window, cx), position, cx))
+            .flatten();
 
         // Expose each open dock as a landmark region so assistive technology
         // can navigate to it, and so region navigation announces it. While a
@@ -8688,7 +8754,8 @@ impl Workspace {
             .overflow_hidden()
             .flex_none()
             .child(dock.clone())
-            .children(leader_border);
+            .children(leader_border)
+            .children(panel_highlight);
 
         // Apply sizing only when the dock is open. When closed the dock is still
         // included in the element tree so its focus handle remains mounted — without
@@ -9161,6 +9228,7 @@ pub trait AnyActiveCall {
 
 #[derive(Clone)]
 pub struct GlobalAnyActiveCall(pub Arc<dyn AnyActiveCall>);
+
 impl Global for GlobalAnyActiveCall {}
 
 impl GlobalAnyActiveCall {
@@ -9197,6 +9265,7 @@ impl ParticipantLocation {
         }
     }
 }
+
 /// Workspace-local view of a remote collaborator's state.
 /// This is the subset of `call::RemoteParticipant` that workspace needs.
 #[derive(Clone)]
@@ -9213,6 +9282,51 @@ pub enum ActiveCallEvent {
     LocalScreenShareStarted,
     LocalScreenShareStopped,
     RoomLeft,
+}
+
+fn panel_highlight_overlay(
+    focused_surface: Option<FocusedSurface>,
+    position: DockPosition,
+    cx: &App,
+) -> Option<Div> {
+    let modifiers = WorkspaceSettings::get_global(cx).active_panel_modifiers;
+
+    let overlay_opacity = modifiers
+        .inactive_opacity
+        .map(|value| value.0.clamp(0.0, 1.0))
+        .and_then(|value| (value < 1.).then_some(value));
+    let overlay_border = modifiers
+        .border_size
+        .and_then(|value| (value > 0.).then_some(value));
+
+    if focused_surface == Some(FocusedSurface::Dock(position)) {
+        let border = overlay_border?;
+        return Some(
+            div()
+                .absolute()
+                .size_full()
+                .left_0()
+                .top_0()
+                .border(px(border))
+                .border_color(cx.theme().colors().border_selected),
+        );
+    }
+
+    if focused_surface.is_none() {
+        return None;
+    }
+
+    let opacity = overlay_opacity?;
+    let mut overlay_background = cx.theme().colors().panel_background;
+    overlay_background.fade_out(opacity);
+    Some(
+        div()
+            .absolute()
+            .size_full()
+            .left_0()
+            .top_0()
+            .bg(overlay_background),
+    )
 }
 
 fn leader_border_for_pane(
@@ -15513,7 +15627,7 @@ mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             assert_eq!(workspace.active_pane(), &second_pane);
             let result = render_center_group(workspace, window, cx);
-            assert!(result.contains_active_pane);
+            assert!(!result.contains_active_pane);
             assert_eq!(
                 result.decorated_pane_ix, None,
                 "an unfocused group should not decorate its active pane"

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -13,7 +13,8 @@ use settings::{CommandAliasTarget, SettingsStore};
 
 #[derive(RegisterSetting)]
 pub struct WorkspaceSettings {
-    pub active_pane_modifiers: ActivePanelModifiers,
+    pub active_pane_modifiers: ActivePaneModifiers,
+    pub active_panel_modifiers: ActivePanelModifiers,
     pub bottom_dock_layout: settings::BottomDockLayout,
     pub pane_split_direction_horizontal: settings::PaneSplitDirectionHorizontal,
     pub pane_split_direction_vertical: settings::PaneSplitDirectionVertical,
@@ -50,7 +51,7 @@ pub struct FocusFollowsMouse {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
-pub struct ActivePanelModifiers {
+pub struct ActivePaneModifiers {
     /// Size of the border surrounding the active pane.
     /// When set to 0, the active pane doesn't have any border.
     /// The border is drawn inset.
@@ -61,6 +62,24 @@ pub struct ActivePanelModifiers {
     /// Opacity of inactive panels.
     /// When set to 1.0, the inactive panes have the same opacity as the active one.
     /// If set to 0, the inactive panes content will not be visible at all.
+    /// Values are clamped to the [0.0, 1.0] range.
+    ///
+    /// Default: `1.0`
+    // TODO: make this not an option, it is never None
+    pub inactive_opacity: Option<InactiveOpacity>,
+}
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+pub struct ActivePanelModifiers {
+    /// Size of the border surrounding the focused dock panel.
+    /// When set to 0, the focused panel doesn't have any border.
+    /// The border is drawn inset.
+    ///
+    /// Default: `0.0`
+    // TODO: make this not an option, it is never None
+    pub border_size: Option<f32>,
+    /// Opacity of dock panels that don't currently have focus.
+    /// When set to 1.0, unfocused panels have the same opacity as the focused one.
+    /// If set to 0, unfocused panel content will not be visible at all.
     /// Values are clamped to the [0.0, 1.0] range.
     ///
     /// Default: `1.0`
@@ -80,7 +99,7 @@ impl Settings for WorkspaceSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let workspace = &content.workspace;
         Self {
-            active_pane_modifiers: ActivePanelModifiers {
+            active_pane_modifiers: ActivePaneModifiers {
                 border_size: Some(
                     workspace
                         .active_pane_modifiers
@@ -91,6 +110,22 @@ impl Settings for WorkspaceSettings {
                 inactive_opacity: Some(
                     workspace
                         .active_pane_modifiers
+                        .unwrap()
+                        .inactive_opacity
+                        .unwrap(),
+                ),
+            },
+            active_panel_modifiers: ActivePanelModifiers {
+                border_size: Some(
+                    workspace
+                        .active_panel_modifiers
+                        .unwrap()
+                        .border_size
+                        .unwrap(),
+                ),
+                inactive_opacity: Some(
+                    workspace
+                        .active_panel_modifiers
                         .unwrap()
                         .inactive_opacity
                         .unwrap(),

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -68,6 +68,7 @@ pub struct ActivePaneModifiers {
     // TODO: make this not an option, it is never None
     pub inactive_opacity: Option<InactiveOpacity>,
 }
+
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
 pub struct ActivePanelModifiers {
     /// Size of the border surrounding the focused dock panel.

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -13,7 +13,8 @@ use settings::{CommandAliasTarget, SettingsStore};
 
 #[derive(RegisterSetting)]
 pub struct WorkspaceSettings {
-    pub active_pane_modifiers: ActivePanelModifiers,
+    pub active_pane_modifiers: ActivePaneModifiers,
+    pub active_panel_modifiers: ActivePanelModifiers,
     pub bottom_dock_layout: settings::BottomDockLayout,
     pub pane_split_direction_horizontal: settings::PaneSplitDirectionHorizontal,
     pub pane_split_direction_vertical: settings::PaneSplitDirectionVertical,
@@ -67,7 +68,7 @@ pub struct FocusFollowsMouse {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
-pub struct ActivePanelModifiers {
+pub struct ActivePaneModifiers {
     /// Size of the border surrounding the active pane.
     /// When set to 0, the active pane doesn't have any border.
     /// The border is drawn inset.
@@ -78,6 +79,25 @@ pub struct ActivePanelModifiers {
     /// Opacity of inactive panels.
     /// When set to 1.0, the inactive panes have the same opacity as the active one.
     /// If set to 0, the inactive panes content will not be visible at all.
+    /// Values are clamped to the [0.0, 1.0] range.
+    ///
+    /// Default: `1.0`
+    // TODO: make this not an option, it is never None
+    pub inactive_opacity: Option<InactiveOpacity>,
+}
+
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+pub struct ActivePanelModifiers {
+    /// Size of the border surrounding the focused dock panel.
+    /// When set to 0, the focused panel doesn't have any border.
+    /// The border is drawn inset.
+    ///
+    /// Default: `0.0`
+    // TODO: make this not an option, it is never None
+    pub border_size: Option<f32>,
+    /// Opacity of dock panels that don't currently have focus.
+    /// When set to 1.0, unfocused panels have the same opacity as the focused one.
+    /// If set to 0, unfocused panel content will not be visible at all.
     /// Values are clamped to the [0.0, 1.0] range.
     ///
     /// Default: `1.0`
@@ -97,7 +117,7 @@ impl Settings for WorkspaceSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let workspace = &content.workspace;
         Self {
-            active_pane_modifiers: ActivePanelModifiers {
+            active_pane_modifiers: ActivePaneModifiers {
                 border_size: Some(
                     *workspace
                         .active_pane_modifiers
@@ -108,6 +128,22 @@ impl Settings for WorkspaceSettings {
                 inactive_opacity: Some(
                     workspace
                         .active_pane_modifiers
+                        .unwrap()
+                        .inactive_opacity
+                        .unwrap(),
+                ),
+            },
+            active_panel_modifiers: ActivePanelModifiers {
+                border_size: Some(
+                    workspace
+                        .active_panel_modifiers
+                        .unwrap()
+                        .border_size
+                        .unwrap(),
+                ),
+                inactive_opacity: Some(
+                    workspace
+                        .active_panel_modifiers
                         .unwrap()
                         .inactive_opacity
                         .unwrap(),

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -48,6 +48,41 @@ Non-negative `float` values
 
 `float` values
 
+## Active Panel Modifiers
+
+- Description: Styling settings applied to the focused dock panel.
+- Setting: `active_panel_modifiers`
+- Default:
+
+```json [settings]
+{
+  "active_panel_modifiers": {
+    "border_size": 0.0,
+    "inactive_opacity": 1.0
+  }
+}
+```
+
+### Border size
+
+- Description: Size of the border surrounding the focused dock panel. When set to 0, the focused panel doesn't have any border. The border is drawn inset.
+- Setting: `border_size`
+- Default: `0.0`
+
+**Options**
+
+Non-negative `float` values
+
+### Inactive Opacity
+
+- Description: Opacity of dock panels that don't currently have focus. When set to 1.0, unfocused panels have the same opacity as the focused one. If set to 0, unfocused panel content is not visible. Values are clamped to the [0.0, 1.0] range.
+- Setting: `inactive_opacity`
+- Default: `1.0`
+
+**Options**
+
+`float` values
+
 ## Bottom Dock Layout
 
 - Description: Control the layout of the bottom dock, relative to the left and right docks.

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -164,6 +164,14 @@ To disable this behavior use:
     "inactive_opacity": 1.0
   },
 
+  // Styling settings applied to the focused dock panel.
+  "active_panel_modifiers": {
+    // Inset border size of the focused panel, in pixels.
+    "border_size": 0.0,
+    // Opacity of unfocused panels. 0 means transparent, 1 means opaque.
+    "inactive_opacity": 1.0
+  },
+
   // Layout mode of the bottom dock: contained, full, left_aligned, right_aligned
   "bottom_dock_layout": "contained",
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -166,6 +166,14 @@ To disable this behavior use:
     "inactive_opacity": 1.0
   },
 
+  // Styling settings applied to the focused dock panel.
+  "active_panel_modifiers": {
+    // Inset border size of the focused panel, in pixels.
+    "border_size": 0.0,
+    // Opacity of unfocused panels. 0 means transparent, 1 means opaque.
+    "inactive_opacity": 1.0
+  },
+
   // Layout mode of the bottom dock: contained, full, left_aligned, right_aligned
   "bottom_dock_layout": "contained",
 


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/discussions/51602

## Summary

- Add configurable focused-panel borders and inactive-panel dimming for docks, editor panes, and the agent threads sidebar.
- Preserve focus on dock wrappers when an empty panel has no mounted focus target, preventing focus flicker and allowing keyboard navigation to leave the panel.
- Let directional pane actions escape an empty Debug panel.

## Preview

https://github.com/user-attachments/assets/0cebdd7d-7d9c-4bb0-a822-b40b51754dde

## Testing

- `cargo fmt --all -- --check`
- `ZED_HEADLESS=1 cargo test -p workspace --lib --quiet`
- `ZED_HEADLESS=1 cargo test -p debugger_ui --lib -- --nocapture`

## Suggested .rules additions

- When keyboard navigation can focus a dock wrapper, test both mounted and unmounted panel focus handles; an unmounted panel must leave focus on the wrapper.

## Disclosure

- These changes were assisted with AI.

Release Notes:

- Improved focus highlighting and keyboard navigation for editor panes and dock panels.