### PR TITLE
buffer_diff: Compute word diffs for unequal hunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,7 @@ dependencies = [
  "rand 0.9.4",
  "rope",
  "settings",
+ "strsim 0.11.1",
  "sum_tree",
  "text",
  "tracing",

--- a/crates/buffer_diff/Cargo.toml
+++ b/crates/buffer_diff/Cargo.toml
@@ -23,6 +23,7 @@ log.workspace = true
 pretty_assertions.workspace = true
 rope.workspace = true
 settings = { workspace = true, optional = true }
+strsim.workspace = true
 sum_tree.workspace = true
 text.workspace = true
 tracing.workspace = true

--- a/crates/buffer_diff/src/buffer_diff.rs
+++ b/crates/buffer_diff/src/buffer_diff.rs
@@ -19,6 +19,10 @@ use util::{ResultExt, debug_panic};
 
 pub const MAX_WORD_DIFF_LINE_COUNT: usize = 5;
 
+// Unequal hunks can mix modified lines with unrelated additions and deletions. A conservative
+// similarity threshold prevents those unmatched lines from receiving misleading word highlights.
+const MIN_MODIFIED_LINE_SIMILARITY: f64 = 0.5;
+
 pub struct BufferDiff {
     pub buffer_id: BufferId,
     base_text_buffer: Entity<language::Buffer>,
@@ -1284,14 +1288,19 @@ impl Sink for HunkSink<'_> {
                 .collect();
             let buffer_text: String = self.buffer.text_for_range(buffer_range.clone()).collect();
 
-            let (base_word_diffs, buffer_word_diffs_relative) = word_diff_ranges(
-                &base_text,
-                &buffer_text,
-                DiffOptions {
-                    language_scope: diff_options.language_scope.clone(),
-                    ..*diff_options
-                },
-            );
+            let (base_word_diffs, buffer_word_diffs_relative) =
+                if base_line_count == buffer_line_count {
+                    word_diff_ranges(
+                        &base_text,
+                        &buffer_text,
+                        DiffOptions {
+                            language_scope: diff_options.language_scope.clone(),
+                            ..*diff_options
+                        },
+                    )
+                } else {
+                    word_diff_ranges_for_unequal_lines(&base_text, &buffer_text, diff_options)
+                };
 
             let buffer_start_offset = buffer_range.start.to_offset(self.buffer);
             let buffer_word_diffs = buffer_word_diffs_relative
@@ -1325,6 +1334,117 @@ impl Sink for HunkSink<'_> {
     fn finish(self) -> Self::Out {
         self.hunks
     }
+}
+
+#[derive(Clone, Copy)]
+enum LineAlignmentStep {
+    SkipBase,
+    SkipBuffer,
+    Pair,
+}
+
+#[derive(Clone, Copy)]
+struct HunkLine<'a> {
+    offset: usize,
+    text: &'a str,
+}
+
+fn lines_with_offsets(text: &str) -> Vec<HunkLine<'_>> {
+    text.split_inclusive('\n')
+        .scan(0, |offset, text| {
+            let line = HunkLine {
+                offset: *offset,
+                text,
+            };
+            *offset += text.len();
+            Some(line)
+        })
+        .collect()
+}
+
+fn paired_lines(base_lines: &[HunkLine<'_>], buffer_lines: &[HunkLine<'_>]) -> Vec<(usize, usize)> {
+    let mut scores = vec![vec![0.; buffer_lines.len() + 1]; base_lines.len() + 1];
+    let mut steps = vec![vec![LineAlignmentStep::SkipBase; buffer_lines.len()]; base_lines.len()];
+
+    for base_ix in (0..base_lines.len()).rev() {
+        for buffer_ix in (0..buffer_lines.len()).rev() {
+            let skip_base_score = scores[base_ix + 1][buffer_ix];
+            let skip_buffer_score = scores[base_ix][buffer_ix + 1];
+            let (mut best_score, mut best_step) = if skip_base_score >= skip_buffer_score {
+                (skip_base_score, LineAlignmentStep::SkipBase)
+            } else {
+                (skip_buffer_score, LineAlignmentStep::SkipBuffer)
+            };
+
+            let similarity = strsim::normalized_levenshtein(
+                base_lines[base_ix].text.trim(),
+                buffer_lines[buffer_ix].text.trim(),
+            );
+            if similarity >= MIN_MODIFIED_LINE_SIMILARITY {
+                let pair_score = similarity + scores[base_ix + 1][buffer_ix + 1];
+                if pair_score > best_score {
+                    best_score = pair_score;
+                    best_step = LineAlignmentStep::Pair;
+                }
+            }
+
+            scores[base_ix][buffer_ix] = best_score;
+            steps[base_ix][buffer_ix] = best_step;
+        }
+    }
+
+    let mut pairs = Vec::new();
+    let mut base_ix = 0;
+    let mut buffer_ix = 0;
+    while base_ix < base_lines.len() && buffer_ix < buffer_lines.len() {
+        match steps[base_ix][buffer_ix] {
+            LineAlignmentStep::SkipBase => base_ix += 1,
+            LineAlignmentStep::SkipBuffer => buffer_ix += 1,
+            LineAlignmentStep::Pair => {
+                pairs.push((base_ix, buffer_ix));
+                base_ix += 1;
+                buffer_ix += 1;
+            }
+        }
+    }
+    pairs
+}
+
+fn word_diff_ranges_for_unequal_lines(
+    base_text: &str,
+    buffer_text: &str,
+    diff_options: &DiffOptions,
+) -> (Vec<Range<usize>>, Vec<Range<usize>>) {
+    let base_lines = lines_with_offsets(base_text);
+    let buffer_lines = lines_with_offsets(buffer_text);
+
+    let mut base_word_diffs = Vec::new();
+    let mut buffer_word_diffs = Vec::new();
+    for (base_ix, buffer_ix) in paired_lines(&base_lines, &buffer_lines) {
+        let base_line = base_lines[base_ix];
+        let buffer_line = buffer_lines[buffer_ix];
+        let (base_line_word_diffs, buffer_line_word_diffs) = word_diff_ranges(
+            base_line.text,
+            buffer_line.text,
+            DiffOptions {
+                language_scope: diff_options.language_scope.clone(),
+                ..*diff_options
+            },
+        );
+
+        base_word_diffs.extend(
+            base_line_word_diffs
+                .into_iter()
+                .map(|range| base_line.offset + range.start..base_line.offset + range.end),
+        );
+        buffer_word_diffs.extend(
+            buffer_line_word_diffs
+                .into_iter()
+                .map(|range| buffer_line.offset + range.start..buffer_line.offset + range.end),
+        );
+    }
+
+    (base_word_diffs, buffer_word_diffs)
 }
 
 fn compare_hunks(

--- a/crates/buffer_diff/src/buffer_diff.rs
+++ b/crates/buffer_diff/src/buffer_diff.rs
@@ -1273,9 +1273,10 @@ impl Sink for HunkSink<'_> {
         let buffer_line_count = new_end - new_start;
 
         let (base_word_diffs, buffer_word_diffs) = if let Some(diff_options) = self.diff_options
-            && !buffer_row_range.is_empty()
-            && base_line_count == buffer_line_count
-            && diff_options.max_word_diff_line_count >= base_line_count
+            && base_line_count > 0
+            && buffer_line_count > 0
+            && base_line_count <= diff_options.max_word_diff_line_count
+            && buffer_line_count <= diff_options.max_word_diff_line_count
         {
             let base_text: String = self
                 .diff_base_rope

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -5636,6 +5636,19 @@ async fn test_word_diff_consecutive_modified_lines(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_word_diff_modified_line_shifted_by_blank_lines(cx: &mut TestAppContext) {
+    let settings_store = cx.update(|cx| SettingsStore::test(cx));
+    cx.set_global(settings_store);
+
+    let base_text = "const message = \"hello world from zed\";\n";
+    let modified_text = "\n\n\nconst message = \"hello brave new world from zed\";\n";
+
+    let word_diffs = collect_word_diffs(base_text, modified_text, cx);
+
+    assert_eq!(word_diffs, vec!["\n\n\n", " brave new"]);
+}
+
+#[gpui::test]
 async fn test_word_diff_modified_lines_with_deletion_between(cx: &mut TestAppContext) {
     let settings_store = cx.update(|cx| SettingsStore::test(cx));
     cx.set_global(settings_store);
@@ -5647,9 +5660,61 @@ async fn test_word_diff_modified_lines_with_deletion_between(cx: &mut TestAppCon
 
     assert_eq!(
         word_diffs,
-        Vec::<String>::new(),
-        "modified lines with a deleted line between should not produce word diffs"
+        vec!["bbb\ndeleted line", "ddd", "BBB", "DDD"],
+        "modified lines with a deleted line between should produce word diffs"
     );
+}
+
+#[gpui::test]
+async fn test_word_diff_skips_pure_addition(cx: &mut TestAppContext) {
+    let settings_store = cx.update(|cx| SettingsStore::test(cx));
+    cx.set_global(settings_store);
+
+    let base_text = "unchanged\n";
+    let modified_text = "unchanged\nadded line\n";
+
+    let word_diffs = collect_word_diffs(base_text, modified_text, cx);
+
+    assert_eq!(word_diffs, Vec::<String>::new());
+}
+
+#[gpui::test]
+async fn test_word_diff_skips_pure_deletion(cx: &mut TestAppContext) {
+    let settings_store = cx.update(|cx| SettingsStore::test(cx));
+    cx.set_global(settings_store);
+
+    let base_text = "unchanged\ndeleted line\n";
+    let modified_text = "unchanged\n";
+
+    let word_diffs = collect_word_diffs(base_text, modified_text, cx);
+
+    assert_eq!(word_diffs, Vec::<String>::new());
+}
+
+#[gpui::test]
+async fn test_word_diff_skips_hunk_when_base_exceeds_line_limit(cx: &mut TestAppContext) {
+    let settings_store = cx.update(|cx| SettingsStore::test(cx));
+    cx.set_global(settings_store);
+
+    let base_text = "\n\n\n\n\nhello world\n";
+    let modified_text = "hello WORLD\n";
+
+    let word_diffs = collect_word_diffs(base_text, modified_text, cx);
+
+    assert_eq!(word_diffs, Vec::<String>::new());
+}
+
+#[gpui::test]
+async fn test_word_diff_skips_hunk_when_buffer_exceeds_line_limit(cx: &mut TestAppContext) {
+    let settings_store = cx.update(|cx| SettingsStore::test(cx));
+    cx.set_global(settings_store);
+
+    let base_text = "hello world\n";
+    let modified_text = "\n\n\n\n\nhello WORLD\n";
+
+    let word_diffs = collect_word_diffs(base_text, modified_text, cx);
+
+    assert_eq!(word_diffs, Vec::<String>::new());
 }
 
 #[gpui::test]

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -5645,7 +5645,20 @@ async fn test_word_diff_modified_line_shifted_by_blank_lines(cx: &mut TestAppCon
 
     let word_diffs = collect_word_diffs(base_text, modified_text, cx);
 
-    assert_eq!(word_diffs, vec!["\n\n\n", " brave new"]);
+    assert_eq!(word_diffs, vec!["brave new "]);
+}
+
+#[gpui::test]
+async fn test_word_diff_skips_unmatched_lines_in_mixed_hunk(cx: &mut TestAppContext) {
+    let settings_store = cx.update(|cx| SettingsStore::test(cx));
+    cx.set_global(settings_store);
+
+    let base_text = "}\n// {}\n";
+    let modified_text = "}\n\nfn main() {\n    something;\n}\nfn thing() {}\n";
+
+    let word_diffs = collect_word_diffs(base_text, modified_text, cx);
+
+    assert_eq!(word_diffs, Vec::<String>::new());
 }
 
 #[gpui::test]
@@ -5660,8 +5673,25 @@ async fn test_word_diff_modified_lines_with_deletion_between(cx: &mut TestAppCon
 
     assert_eq!(
         word_diffs,
-        vec!["bbb\ndeleted line", "ddd", "BBB", "DDD"],
+        vec!["bbb", "ddd", "BBB", "DDD"],
         "modified lines with a deleted line between should produce word diffs"
+    );
+}
+
+#[gpui::test]
+async fn test_word_diff_modified_lines_with_addition_between(cx: &mut TestAppContext) {
+    let settings_store = cx.update(|cx| SettingsStore::test(cx));
+    cx.set_global(settings_store);
+
+    let base_text = "aaa bbb\nccc ddd\n";
+    let modified_text = "aaa BBB\nadded line\nccc DDD\n";
+
+    let word_diffs = collect_word_diffs(base_text, modified_text, cx);
+
+    assert_eq!(
+        word_diffs,
+        vec!["bbb", "ddd", "BBB", "DDD"],
+        "modified lines with an added line between should produce word diffs"
     );
 }
 


### PR DESCRIPTION
# Objective

Fix word-level diff highlighting when an edited line moves because lines were added or removed nearby.

Previously, word-level highlighting was only computed when a diff hunk contained the same number of base and buffer lines. For example:

```diff
-const message = "hello world from zed";
+
+
+
+const message = "hello brave new world from zed";
```

This produces a mixed hunk containing one base line and four buffer lines. Because the line counts differed, `BufferDiff` returned no word-diff ranges, leaving the renderer with only whole-line deletion and addition highlighting.

This was independent of the selected theme, diff-view style, and `word_diff_enabled` setting because the word ranges were never generated.

Fixes #60859

## Solution

Allow word diffs to be computed for mixed hunks whose base and buffer line counts differ.

The previous equality requirement is replaced with explicit conditions that require:

- At least one base line.
- At least one buffer line.
- The base side to remain within `max_word_diff_line_count`.
- The buffer side to remain within `max_word_diff_line_count`.

This preserves the existing behavior for pure additions and pure deletions, since those do not have text on both sides to compare. It also independently enforces the existing line-count limit on both sides, preventing an unequal hunk from bypassing the bound simply because one side is small.

The existing `word_diff_ranges` implementation performs the token-level comparison. This change does not modify the diff renderer, display-map conversion, caching behavior, settings, or theme colors.

## Testing

Added coverage for:

- A modified line shifted by three inserted blank lines, matching the reported reproduction.
- Modified lines with a deleted line between them.
- Pure-addition hunks, which continue to skip word-diff computation.
- Pure-deletion hunks, which continue to skip word-diff computation.
- Unequal hunks whose base side exceeds the word-diff line limit.
- Unequal hunks whose buffer side exceeds the word-diff line limit.
- Existing equal-line, whitespace-only, disabled-setting, and consecutive-line behavior.

Automated verification:

```sh
cargo test -j 4 -p buffer_diff -p multi_buffer --lib
```

Result: 78 tests passed—15 in `buffer_diff` and 63 in `multi_buffer`.

```sh
CARGO_BUILD_JOBS=4 ./script/clippy -p buffer_diff -p multi_buffer
cargo fmt --all -- --check
git diff --check
cargo build -j 4 -p zed
```

All commands completed successfully.

Manual verification was performed on Fedora Linux using a locally built Zed binary. The reported shifted-line reproduction now highlights `brave new` more strongly than the surrounding added line. Only Linux was tested manually; the implementation is in the platform-independent buffer-diff path.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

### Before

<img width="2560" height="1365" alt="image" src="https://github.com/user-attachments/assets/32144c96-8969-4fc4-9ecf-751fc85c22cb" />

Word-level ranges were absent when the edited line moved, so both sides received only whole-line highlighting.

### After

<img width="2560" height="1399" alt="image" src="https://github.com/user-attachments/assets/553e1885-05b9-4199-a5b3-74ff0eb9b8bb" />

The moved line retains its whole-line diff background while `brave new` receives the stronger word-level highlight.

---

Release Notes:

- Fixed word-level diff highlighting for modified lines that move because nearby lines were added or removed.