### PR TITLE
git: Normalize clone URLs without a protocol

### DIFF
--- a/crates/git/src/remote.rs
+++ b/crates/git/src/remote.rs
@@ -30,6 +30,41 @@ impl FromStr for RemoteUrl {
     }
 }
 
+/// Normalize a user-entered Git remote URL. Recognizable bare `host/path` URLs
+/// are prefixed with `https://`, while URLs with a scheme, SCP-like remotes, and
+/// local paths are returned unchanged.
+pub fn normalize_remote_url(input: &str) -> String {
+    let trimmed = input.trim();
+    if trimmed.parse::<RemoteUrl>().is_ok() {
+        return trimmed.to_string();
+    }
+
+    if let Some((host, path)) = trimmed.split_once(':')
+        && !host.is_empty()
+        && !path.is_empty()
+        && !host.contains('/')
+        && !host.contains('\\')
+    {
+        return trimmed.to_string();
+    }
+
+    let Some((host, path)) = trimmed.split_once('/') else {
+        return trimmed.to_string();
+    };
+    let is_host = host.eq_ignore_ascii_case("localhost")
+        || host.contains('.') && host.split('.').all(|label| !label.is_empty());
+    if path.is_empty() || !is_host {
+        return trimmed.to_string();
+    }
+
+    let normalized = format!("https://{trimmed}");
+    if normalized.parse::<RemoteUrl>().is_ok() {
+        normalized
+    } else {
+        trimmed.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
@@ -109,6 +144,55 @@ mod tests {
                 url.parse::<RemoteUrl>().is_err(),
                 "expected \"{url}\" to not parse as a Git remote URL",
             );
+        }
+    }
+
+    #[test]
+    fn test_normalize_remote_url() {
+        // Bare `host/path` URLs get `https://` prepended.
+        assert_eq!(
+            normalize_remote_url("github.com/octocat/zed"),
+            "https://github.com/octocat/zed",
+        );
+        assert_eq!(
+            normalize_remote_url("github.com/octocat/zed.git"),
+            "https://github.com/octocat/zed.git",
+        );
+
+        // Surrounding whitespace is trimmed before prefixing.
+        assert_eq!(
+            normalize_remote_url("  github.com/octocat/zed  "),
+            "https://github.com/octocat/zed",
+        );
+
+        // URLs that already have a scheme are left unchanged (modulo trim).
+        for url in [
+            "https://github.com/octocat/zed.git",
+            "http://github.com/octocat/zed.git",
+            "ssh://git@github.com/octocat/zed.git",
+            "file:///path/to/local/zed",
+        ] {
+            assert_eq!(normalize_remote_url(url), url);
+        }
+
+        // SCP-like remotes are left unchanged, with or without a username.
+        for url in [
+            "git@github.com:octocat/zed.git",
+            "github.com:octocat/zed.git",
+        ] {
+            assert_eq!(normalize_remote_url(url), url);
+        }
+
+        // Local clone sources are left unchanged.
+        for path in [
+            "/path/to/local/zed",
+            "./path/to/local/zed",
+            "../path/to/local/zed",
+            "path/to/local/zed",
+            r"C:\path\to\local\zed",
+            r"\\server\share\zed",
+        ] {
+            assert_eq!(normalize_remote_url(path), path);
         }
     }
 }

--- a/crates/git_ui/src/clone.rs
+++ b/crates/git_ui/src/clone.rs
@@ -14,6 +14,8 @@ pub fn clone_and_open(
         dyn Fn(&mut Workspace, &mut Window, &mut Context<Workspace>) + Send + Sync + 'static,
     >,
 ) {
+    let repo_url = SharedString::from(git::normalize_remote_url(&repo_url));
+
     let destination_prompt = cx.prompt_for_paths(gpui::PathPromptOptions {
         files: false,
         directories: true,


### PR DESCRIPTION
## Context

Entering a repository URL without a protocol, such as `github.com/zed-industries/zed`, passed the value directly to `git clone`. Git then treated it as a local path and reported that the repository did not exist.

This change normalizes recognizable bare host URLs by prefixing them with `https://`. URLs that already include a scheme, SCP-style remotes, and local paths remain unchanged. Regression tests cover supported URL and path formats.

Closes #60863

Manual test after the fix :

[Screencast from 2026-07-15 23-06-42.webm](https://github.com/user-attachments/assets/85ed4360-7101-4bf7-9df5-7a86d8158632)

## How to Review

`crates/git/src/remote.rs`: Adds repository URL normalization and tests covering bare host URLs, existing HTTP, HTTPS, SSH, and file URLs, SCP-style remotes, and local paths across Unix and Windows formats.

`crates/git_ui/src/clone.rs`: Normalizes the user-entered repository URL before deriving the repository name and starting the clone operation.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed cloning repositories from URLs entered without a protocol.