### PR TITLE
agent_ui: Increase standalone tool call spacing

### DIFF
--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -8471,7 +8471,7 @@ impl ThreadView {
                         .bg(cx.theme().colors().editor_background)
                         .overflow_hidden()
                 } else {
-                    this.my_1()
+                    this.my_1p5()
                 }
             })
             .when(layout == ToolCallLayout::Standalone, |this| {


### PR DESCRIPTION
## Summary

- Align non-card standalone tool calls with card tool calls
- Increase vertical separation between consecutive agent activity entries

## Testing

- `cargo test -p agent_ui thread_view --lib`

Release Notes:

- Improved spacing between agent tool calls

### Screenshot

Pre-fix spacing consistency issue:

<img width="637" height="613" alt="image" src="https://github.com/user-attachments/assets/cfffa6ec-81c1-4968-a26e-bed4af162a8f" />