### PR TITLE
Fix file watching permanently stopping when macOS FSEvents exhausts its file descriptor budget

### DIFF
--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -845,8 +845,7 @@ impl GlobalWatcher {
             match self.watch(path.as_path(), mode) {
                 Ok(()) => {}
                 Err(error)
-                    if mode == WatcherMode::Native
-                        && is_native_watch_saturation_error(&error) =>
+                    if mode == WatcherMode::Native && is_native_watch_saturation_error(&error) =>
                 {
                     // On macOS all native paths share one FSEventStream, and a watch
                     // registration tears the stream down before rebuilding it with the
@@ -863,8 +862,7 @@ impl GlobalWatcher {
                         self.unwatch(path.as_path(), mode).log_err();
                         self.enqueue(
                             mode,
-                            Ok(Event::new(EventKind::Other)
-                                .set_flag(notify::event::Flag::Rescan)),
+                            Ok(Event::new(EventKind::Other).set_flag(notify::event::Flag::Rescan)),
                         );
                     }
                     self.start_native_watch_limit_cooldown(path.as_path());

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -844,7 +844,29 @@ impl GlobalWatcher {
             drop(state);
             match self.watch(path.as_path(), mode) {
                 Ok(()) => {}
-                Err(error) if mode == WatcherMode::Native && is_max_files_watch_error(&error) => {
+                Err(error)
+                    if mode == WatcherMode::Native
+                        && is_native_watch_saturation_error(&error) =>
+                {
+                    // On macOS all native paths share one FSEventStream, and a watch
+                    // registration tears the stream down before rebuilding it with the
+                    // new path appended. When that rebuild fails (fd budget exhausted:
+                    // each watched path costs ~11 descriptors), every previously
+                    // working watch is left dead and the failed path stays in notify's
+                    // path set, so any later registration would retry the same
+                    // oversized set and fail too. Unwatching the failed path rebuilds
+                    // the previous, known-good set, and the rescan tells the restored
+                    // registrations to resync whatever changed while the stream was
+                    // down (streams start at "now"; there is no event replay).
+                    #[cfg(target_os = "macos")]
+                    {
+                        self.unwatch(path.as_path(), mode).log_err();
+                        self.enqueue(
+                            mode,
+                            Ok(Event::new(EventKind::Other)
+                                .set_flag(notify::event::Flag::Rescan)),
+                        );
+                    }
                     self.start_native_watch_limit_cooldown(path.as_path());
                     return Ok(None);
                 }
@@ -1079,10 +1101,28 @@ impl GlobalWatcher {
     }
 }
 
-fn is_max_files_watch_error(error: &anyhow::Error) -> bool {
+/// Whether a native watch registration failed because the OS won't accept any
+/// more watches from this process right now.
+///
+/// On Linux this is inotify's `MaxFilesWatch` (`ENOSPC`/`EMFILE` on
+/// `inotify_add_watch`). On macOS there is no distinct error kind: all native
+/// paths share one `FSEventStream` costing ~11 file descriptors per watched
+/// path, and when a rebuild of that stream exceeds the process fd budget,
+/// `FSEventStreamStart` returns false and notify's FSEvents backend surfaces
+/// it as a generic "unable to start FSEvent stream" error. Both mean the same
+/// thing — the process has saturated the OS watcher capacity — so the caller
+/// should roll back and back off via the cooldown rather than treat the path
+/// as permanently unwatchable (which would silently stop delivering file
+/// events, leaving buffers, the project panel, and git status stale).
+fn is_native_watch_saturation_error(error: &anyhow::Error) -> bool {
     error
         .downcast_ref::<notify::Error>()
-        .is_some_and(|error| matches!(&error.kind, notify::ErrorKind::MaxFilesWatch))
+        .is_some_and(|error| match &error.kind {
+            notify::ErrorKind::MaxFilesWatch => true,
+            #[cfg(target_os = "macos")]
+            notify::ErrorKind::Generic(message) => message.contains("FSEvent"),
+            _ => false,
+        })
 }
 
 static POLL_INTERVAL: LazyLock<Duration> = LazyLock::new(|| {
@@ -1160,6 +1200,7 @@ mod tests {
         watch_calls: Vec<PathBuf>,
         unwatch_calls: Vec<PathBuf>,
         fail_with_watch_limit: bool,
+        fail_with_fsevent_start: bool,
     }
 
     struct SharedFakeWatchBackend(Arc<Mutex<FakeWatchBackend>>);
@@ -1171,6 +1212,11 @@ mod tests {
             backend.watch_calls.push(path.clone());
             if backend.fail_with_watch_limit {
                 return Err(notify::Error::new(notify::ErrorKind::MaxFilesWatch));
+            }
+            if backend.fail_with_fsevent_start {
+                // Mirrors notify's macOS FSEvents backend when `FSEventStreamStart`
+                // returns false because the process has too many live streams.
+                return Err(notify::Error::generic("unable to start FSEvent stream"));
             }
             backend.watched_paths.insert(path);
             Ok(())
@@ -1327,6 +1373,66 @@ mod tests {
 
         let native_backend = native_backend.lock();
         assert_eq!(native_backend.watch_calls, &[first_path.to_path_buf()]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn fsevent_stream_start_failure_rolls_back_rescans_and_cools_down() {
+        // macOS has no distinct "too many watches" error kind: once the process
+        // exhausts its fd budget (~11 descriptors per path in the shared
+        // FSEventStream), the stream rebuild fails with a generic "unable to
+        // start FSEvent stream" — and because the rebuild tore down the previous
+        // stream first, every existing watch is dead at that point. The failed
+        // path must be rolled back (restoring the previous set), all native
+        // registrations told to rescan, and further registrations skipped for
+        // the cooldown instead of retrying the oversized set forever.
+        let native_backend = Arc::new(Mutex::new(FakeWatchBackend {
+            fail_with_fsevent_start: true,
+            ..Default::default()
+        }));
+        let (event_tx, event_rx) = async_channel::unbounded();
+        let watcher = GlobalWatcher {
+            state: Mutex::new(WatcherState {
+                watchers: Default::default(),
+                native_path_registrations: Default::default(),
+                poll_path_registrations: Default::default(),
+                cooldown_until: None,
+                last_registration: Default::default(),
+            }),
+            native_watcher: Mutex::new(Some(Box::new(SharedFakeWatchBackend(
+                native_backend.clone(),
+            )))),
+            poll_watcher: Mutex::new(None),
+            event_tx,
+        };
+        let first_path = Arc::<Path>::from(Path::new("/repo/first"));
+        let second_path = Arc::<Path>::from(Path::new("/repo/second"));
+
+        let first_registration = watcher
+            .add(first_path.clone(), WatcherMode::Native, false, |_| {})
+            .expect("fsevent start failure is handled as saturation, not an error");
+        let second_registration = watcher
+            .add(second_path, WatcherMode::Native, false, |_| {})
+            .expect("subsequent registration is skipped during cooldown");
+
+        assert!(first_registration.is_none());
+        assert!(second_registration.is_none());
+
+        // The cooldown means only the first path ever reaches the OS backend; the
+        // second is skipped without a watch call. The failed path is unwatched to
+        // restore the previous stream.
+        {
+            let native_backend = native_backend.lock();
+            assert_eq!(native_backend.watch_calls, &[first_path.to_path_buf()]);
+            assert_eq!(native_backend.unwatch_calls, &[first_path.to_path_buf()]);
+        }
+
+        // All native registrations are told to rescan the window in which the
+        // stream was down.
+        let (mode, event) = event_rx.try_recv().expect("rescan event enqueued");
+        assert_eq!(mode, WatcherMode::Native);
+        assert!(event.expect("rescan event is not an error").need_rescan());
+        assert!(event_rx.is_empty(), "only one rescan per saturation");
     }
 
     fn modify_event(path: &str) -> notify::Event {

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -254,6 +254,55 @@ Error: Running Zed as root or via sudo is unsupported.
     }
 }
 
+/// Raises the soft limit on open file descriptors to the maximum the OS allows.
+///
+/// Processes launched from a GUI (Finder/launchd on macOS) inherit a soft limit
+/// of only 256 open files (Apple's frameworks bump it to 2560 on first use of
+/// some APIs), and Zed doesn't fit: language server pipes, sqlite, and sockets
+/// aside, the macOS FSEvents machinery consumes roughly 11 descriptors per
+/// watched path, so a language server registering a few hundred watched files
+/// exhausts the budget. Once that happens, `FSEventStreamStart` fails and file
+/// events silently stop, leaving buffers, git status, and the project panel
+/// stale. Chromium (8192), the JVM, and Go all raise this limit at startup for
+/// the same class of reasons.
+#[cfg(unix)]
+pub fn increase_open_file_limit() -> Result<()> {
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: `limit` is a valid rlimit struct for getrlimit to fill in.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) } != 0 {
+        return Err(anyhow::Error::from(std::io::Error::last_os_error())
+            .context("getrlimit(RLIMIT_NOFILE)"));
+    }
+
+    // macOS rejects rlim_cur values above OPEN_MAX even when rlim_max is
+    // RLIM_INFINITY (see setrlimit(2)). The libc crate doesn't expose OPEN_MAX,
+    // so use its value from <sys/syslimits.h>.
+    #[cfg(target_os = "macos")]
+    let new_soft_limit = {
+        const OPEN_MAX: libc::rlim_t = 10240;
+        limit.rlim_max.min(OPEN_MAX)
+    };
+    #[cfg(not(target_os = "macos"))]
+    let new_soft_limit = limit.rlim_max.min(65536);
+
+    if limit.rlim_cur >= new_soft_limit {
+        return Ok(());
+    }
+
+    limit.rlim_cur = new_soft_limit;
+    // SAFETY: `limit` holds the values just read back from getrlimit, with only
+    // the soft limit raised (never above the hard limit).
+    if unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limit) } != 0 {
+        return Err(anyhow::Error::from(std::io::Error::last_os_error())
+            .context("setrlimit(RLIMIT_NOFILE)"));
+    }
+    log::info!("raised open file soft limit to {new_soft_limit}");
+    Ok(())
+}
+
 #[cfg(unix)]
 fn load_shell_from_passwd() -> Result<()> {
     let buflen = match unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) } {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -303,6 +303,9 @@ fn main() {
     }
     ztracing::init();
 
+    #[cfg(unix)]
+    util::increase_open_file_limit().log_err();
+
     let version = option_env!("ZED_BUILD_ID");
     let app_commit_sha =
         option_env!("ZED_COMMIT_SHA").map(|commit_sha| AppCommitSha::new(commit_sha.to_string()));


### PR DESCRIPTION
# Objective

Addresses one root cause reported under #53901 (the macOS FSEvents fd-saturation case). #53901 is an umbrella "out of sync with external changes" report with more than one cause — see the Scope note below — so this intentionally does not use a closing keyword.

On macOS, Zed can permanently stop seeing all external file changes — open buffers don't reload, git status freezes, and the project panel stops updating — until the app is restarted. The log fills with `unable to start FSEvent stream` errors (3,392 from the worktree scanner and 778 from watcher retries in one session's log on my machine).

## Solution

Root cause, with each step verified empirically on an affected install (macOS 26.4.1, Zed 1.11.3, C#/Roslyn extension):

1. GUI-launched processes get a soft `RLIMIT_NOFILE` of 256 (hard: unlimited) from launchd. Apple's frameworks silently raise it to 2560 on first FSEvents use. Zed never raises it itself, and the `zed` CLI launches the app via `LSOpenFromURLSpec`, so launching from a terminal doesn't help.
2. All native watches share one `FSEventStream` (notify's design), and that stream costs ~11 file descriptors per watched path, so the effective budget is ~230 watched paths. Roslyn registering `didChangeWatchedFiles` for ~240 individual out-of-tree files (NuGet DLLs, dotnet SDK files) exceeds it. #47064 hit the same wall from the other side: 2,603 fds against the 2,560 limit.
3. The failure is not contained to the new path: notify's `watch()` rebuilds the stream (stop → append → recreate), so a failed rebuild kills every existing watch, and the failed path stays in notify's path set, so every later `watch()` retries the same oversized set and fails forever — observed live as continuous failures at only 146 open fds. `is_max_files_watch_error` only matches inotify's `MaxFilesWatch`, so on macOS this bypassed the #60662 cooldown and the blackout was permanent (consistent with the "fixed by restart" report in #53901).

Changes:

- `util`/`zed`: raise the soft fd limit to `min(hard, OPEN_MAX)` at startup on Unix — the formula documented in `setrlimit(2)` COMPATIBILITY. Chromium (8192 on Apple), the JVM, and Go do the same. 10240 fds ≈ 930 watched paths, ~4× the current implicit budget.
- `fs`: treat the FSEvents stream-start failure as watcher saturation and recover: unwatch the failed path (rebuilding the previous, known-good stream — verified against real notify that this resurrects all existing watches), broadcast a rescan to native registrations (streams start at `kFSEventStreamEventIdSinceNow`, so events during the dead window are not replayed), and start the existing native-watch-limit cooldown so a burst of doomed registrations can't thrash stream rebuilds. Skipped paths retry through the pending-registration machinery from #60662.

Scope: #53901 collects several distinct failures behind one symptom. This PR fixes the macOS-only case where all watches share one `FSEventStream` and `FSEventStreamStart` fails permanently once the fd budget is exhausted (log flooded with `unable to start FSEvent stream`). It does **not** address the separate delete-then-recreate race @Akizay reproduced on Linux (only the first ~9–10 of a burst appear, fixed by a sleep > `FS_WATCH_LATENCY`, no saturation errors in the log) — that's a worktree rescan/debounce issue around `FS_WATCH_LATENCY` and deserves its own fix. Both are real; they're just not the same bug.

Related: #53480, #58678, #47064. Overlaps #59571, which detects the same error string but only cools down; without the rollback, retries keep rebuilding the oversized path set and never succeed. Complementary: #57346 reduces watched-path demand by normalizing per-file registrations to parent directories; the two compose.

Disclosure per the AI policy: I investigated and developed this with assistance from an LLM agent (Claude Code/Fable 5), reviewing and directing each step; the measurements below are from real runs on my machine and I can defend them in review.

## Testing

- `cargo test -p fs`: 16/16, including a new test covering rollback + rescan broadcast + cooldown after an FSEvent stream-start failure.
- `./script/clippy -p fs -p util` clean; `cargo check -p zed` passes.
- Standalone binary against Zed's notify fork (`zed-industries/notify` rev `faecbc3`), run with `bash -c 'ulimit -n 256; ...'` to simulate GUI launch limits:
  - saturation reproduces at the 22nd watch; at failure all previously working watches are dead (fd count collapses 248 → 5) and retries fail forever with descriptors free;
  - after unwatching the failed path, the previously dead watches deliver events again (fd count returns to 249) — the rollback this PR adds;
  - with the startup rlimit raise (256 → 10240 under Launch-Services conditions, verified via a probe app launched with `open`), 400+ paths watch successfully.
- To reproduce the original failure end-to-end: on macOS, open a C# project with the Roslyn extension enabled in a Finder/Dock-launched Zed and watch the log for `unable to start FSEvent stream`; external edits, git changes, and new files stop appearing once it triggers.
- Performance: the rollback's stream rebuild measures 4ms/15ms/42ms at 50/200/500 watched paths (linear, background thread), bounded to once per cooldown window; ordinary `watch()` calls already pay the same rebuild cost. Hot paths are unchanged, and the rescan broadcast reuses the existing coalesced lost-sync rescan machinery from #60098.
- Not tested on Windows (change is `#[cfg(unix)]`-gated) or Linux beyond compilation; on Linux the new saturation arm only adds behavior already exercised by the `MaxFilesWatch` path.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed external file changes (open buffers, git status, and the project panel) no longer being detected on macOS after the file watcher exhausted its file descriptor budget, e.g. when language servers watch many files



