### PR TITLE
git_ui: Respect the commit message template when generating commit messages

### DIFF
--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -85,6 +85,7 @@ fs = { workspace = true, features = ["test-support"] }
 git = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 indoc.workspace = true
+language_model = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true
 project = { workspace = true, features = ["test-support"] }
 rand.workspace = true

--- a/crates/git_ui/src/commit_message_prompt.txt
+++ b/crates/git_ui/src/commit_message_prompt.txt
@@ -15,3 +15,4 @@ Follow good Git style:
 - Use the imperative mood in the subject line
 - Wrap the body at 72 characters
 - Keep the body short and concise (omit it entirely if not useful)
+- Put Git trailers (such as Signed-off-by) at the very end of the message, after the body, separated by a blank line

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -191,10 +191,19 @@ impl CommitModal {
                 let mut editor =
                     commit_message_editor(buffer, None, project.clone(), false, window, cx);
                 editor.sync_selections(panel_editor, cx).detach();
+                editor.set_read_only(git_panel.is_generating_commit_message());
 
                 editor
             })
         });
+
+        cx.observe(&git_panel, |this, panel, cx| {
+            let generating = panel.read(cx).is_generating_commit_message();
+            this.commit_editor
+                .update(cx, |editor, _| editor.set_read_only(generating));
+            cx.notify();
+        })
+        .detach();
 
         let commit_message = commit_editor.read(cx).text(cx);
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3294,7 +3294,8 @@ impl GitPanel {
         user_agents_md: Option<&str>,
         rules_content: Option<&str>,
         instructions: Option<&str>,
-        subject: &str,
+        commit_template: Option<&str>,
+        current_message: &str,
         diff_text: &str,
     ) -> String {
         let user_agents_md_section = match user_agents_md {
@@ -3321,15 +3322,36 @@ impl GitPanel {
             _ => String::new(),
         };
 
-        let subject_section = if subject.trim().is_empty() {
+        let template_section = match commit_template {
+            Some(template) if !template.trim().is_empty() => format!(
+                "\n\nThe repository has a git commit message template configured. The commit message you write must follow its structure and include the boilerplate text it contains. Trailers (lines like Signed-off-by) always go at the very end of the message, after the body. Lines starting with a comment character (usually '#') are guidance only and must not appear in the commit message:\n\
+                <commit_template>\n{template}\n</commit_template>\n"
+            ),
+            _ => String::new(),
+        };
+
+        let current_message_section = if current_message.trim().is_empty() {
             String::new()
         } else {
-            format!("\nHere is the user's subject line:\n{subject}")
+            format!(
+                "\nHere is the current content of the commit message editor. Your response replaces it entirely. Respect what is already there: keep its intent, phrasing, and any structure or trailers it contains, only rewriting what is unclear, incomplete, or inconsistent with the rules above:\n<current_message>\n{current_message}\n</current_message>\n"
+            )
+        };
+
+        let closing_reminder = if template_section.is_empty() && current_message_section.is_empty()
+        {
+            ""
+        } else {
+            "\n\nRemember: respond with the complete commit message and nothing else. Never include the diff or any code in the message. Trailers (lines like Signed-off-by) go at the very end of the message."
         };
 
         format!(
-            "{prompt}{user_agents_md_section}{rules_section}{instructions_section}{subject_section}\nHere are the changes in this commit:\n{diff_text}"
+            "{prompt}{user_agents_md_section}{rules_section}{instructions_section}{template_section}{current_message_section}\nHere are the changes in this commit:\n{diff_text}{closing_reminder}"
         )
+    }
+
+    pub fn is_generating_commit_message(&self) -> bool {
+        self.generate_commit_message_task.is_some()
     }
 
     /// Generates a commit message using an LLM.
@@ -3366,13 +3388,27 @@ impl GitPanel {
         let instructions = AgentSettings::get_global(cx)
             .commit_message_instructions
             .clone();
+        let commit_template = self
+            .commit_template
+            .as_ref()
+            .map(|template| template.template.clone())
+            .filter(|template| !template.trim().is_empty());
         let project = self.project.clone();
         let repo_work_dir = repo.read(cx).work_directory_abs_path.clone();
 
+        // The streamed message is inserted at tracked positions, so user
+        // edits during generation would corrupt it.
+        self.commit_editor
+            .update(cx, |editor, _| editor.set_read_only(true));
+        cx.notify();
+
         self.generate_commit_message_task = Some(cx.spawn(async move |this, mut cx| {
             async move {
-                let _defer = cx.on_drop(&this, |this, _cx| {
+                let _defer = cx.on_drop(&this, |this, cx| {
                     this.generate_commit_message_task.take();
+                    this.commit_editor
+                        .update(cx, |editor, _| editor.set_read_only(false));
+                    cx.notify();
                 });
 
                 if let Some(task) = cx.update(|cx| {
@@ -3418,24 +3454,18 @@ impl GitPanel {
 
                 let prompt = include_str!("../src/commit_message_prompt.txt");
 
-                let subject = this.update(cx, |this, cx| {
-                    this.commit_editor
-                        .read(cx)
-                        .text(cx)
-                        .lines()
-                        .next()
-                        .map(ToOwned::to_owned)
-                        .unwrap_or_default()
-                })?;
-
-                let text_empty = subject.trim().is_empty();
+                let current_message = this
+                    .update(cx, |this, cx| this.commit_editor.read(cx).text(cx))?
+                    .trim()
+                    .to_owned();
 
                 let content = Self::build_commit_message_prompt(
                     &prompt,
                     user_agents_md.as_deref(),
                     rules_content.as_deref(),
                     instructions.as_deref(),
-                    &subject,
+                    commit_template.as_deref(),
+                    &current_message,
                     &diff_text,
                 );
 
@@ -3462,26 +3492,33 @@ impl GitPanel {
                 let stream = model.stream_completion_text(request, cx);
                 match stream.await {
                     Ok(mut messages) => {
-                        if !text_empty {
-                            this.update(cx, |this, cx| {
-                                this.commit_message_buffer(cx).update(cx, |buffer, cx| {
-                                    let insert_position = buffer.anchor_before(buffer.len());
-                                    buffer.edit(
-                                        [(insert_position..insert_position, "\n")],
-                                        None,
-                                        cx,
-                                    )
-                                });
-                            })?;
-                        }
+                        // Clearing is deferred until the stream is
+                        // established, so a failed request leaves the buffer
+                        // untouched.
+                        this.update(cx, |this, cx| {
+                            this.commit_message_buffer(cx).update(cx, |buffer, cx| {
+                                let end = buffer.len();
+                                buffer.edit([(0..end, "")], None, cx);
+                            });
+                        })?;
 
+                        let mut first_chunk = true;
                         while let Some(message) = messages.stream.next().await {
                             match message {
                                 Ok(text) => {
+                                    let text = if first_chunk {
+                                        let trimmed = text.trim_start().to_owned();
+                                        if trimmed.is_empty() {
+                                            continue;
+                                        }
+                                        first_chunk = false;
+                                        trimmed
+                                    } else {
+                                        text
+                                    };
                                     this.update(cx, |this, cx| {
                                         this.commit_message_buffer(cx).update(cx, |buffer, cx| {
-                                            let insert_position =
-                                                buffer.anchor_before(buffer.len());
+                                            let insert_position = buffer.len();
                                             buffer.edit(
                                                 [(insert_position..insert_position, text)],
                                                 None,
@@ -3495,6 +3532,46 @@ impl GitPanel {
                                     break;
                                 }
                             }
+                        }
+
+                        // Small models sometimes ignore the instructions and
+                        // echo the diff back or wrap the whole message in
+                        // quotes; both are stripped deterministically.
+                        if !first_chunk {
+                            this.update(cx, |this, cx| {
+                                this.commit_message_buffer(cx).update(cx, |buffer, cx| {
+                                    let text = buffer.text();
+                                    let echoed_diff_start = if text.starts_with("diff --git ") {
+                                        Some(0)
+                                    } else {
+                                        text.find("\ndiff --git ")
+                                    };
+                                    if let Some(echoed_diff_start) = echoed_diff_start {
+                                        let end = buffer.len();
+                                        buffer.edit(
+                                            [(echoed_diff_start..end, String::new())],
+                                            None,
+                                            cx,
+                                        );
+                                    }
+
+                                    let text = buffer.text();
+                                    let trimmed = text.trim_end();
+                                    if trimmed.len() >= 2
+                                        && (trimmed.starts_with('"') && trimmed.ends_with('"')
+                                            || trimmed.starts_with('`') && trimmed.ends_with('`'))
+                                    {
+                                        buffer.edit(
+                                            [
+                                                (0..1, String::new()),
+                                                (trimmed.len() - 1..trimmed.len(), String::new()),
+                                            ],
+                                            None,
+                                            cx,
+                                        );
+                                    }
+                                });
+                            })?;
                         }
                     }
                     Err(e) => {
@@ -11946,6 +12023,7 @@ mod tests {
             Some("Use terse commit messages."),
             Some("Use the git_ui prefix."),
             Some("Follow the configured commit message format."),
+            Some("Signed-off-by: Test User <test@example.com>"),
             "Update generated message",
             "diff --git a/file b/file",
         );
@@ -11959,8 +12037,10 @@ mod tests {
         let user_agents_md_index = prompt.find("<rules>").unwrap();
         let project_rules_index = prompt.find("<project_rules>").unwrap();
         let instructions_index = prompt.find("<commit_message_instructions>").unwrap();
+        let template_index = prompt.find("<commit_template>").unwrap();
         assert!(user_agents_md_index < project_rules_index);
         assert!(project_rules_index < instructions_index);
+        assert!(instructions_index < template_index);
     }
 
     #[test]
@@ -11970,11 +12050,56 @@ mod tests {
             None,
             None,
             Some("   \n  "),
+            None,
             "",
             "diff --git a/file b/file",
         );
 
         assert!(!prompt.contains("<commit_message_instructions>"));
+    }
+
+    #[test]
+    fn test_commit_message_prompt_omits_blank_commit_template() {
+        let prompt = GitPanel::build_commit_message_prompt(
+            "Write a commit message.",
+            None,
+            None,
+            None,
+            Some("   \n  "),
+            "",
+            "diff --git a/file b/file",
+        );
+
+        assert!(!prompt.contains("<commit_template>"));
+    }
+
+    #[test]
+    fn test_commit_message_prompt_includes_current_message() {
+        let prompt = GitPanel::build_commit_message_prompt(
+            "Write a commit message.",
+            None,
+            None,
+            None,
+            None,
+            "fix the thing\n\nSigned-off-by: Test User <test@example.com>",
+            "diff --git a/file b/file",
+        );
+
+        assert!(prompt.contains("<current_message>"));
+        assert!(prompt.contains("fix the thing"));
+        assert!(prompt.contains("Signed-off-by: Test User <test@example.com>"));
+
+        let prompt = GitPanel::build_commit_message_prompt(
+            "Write a commit message.",
+            None,
+            None,
+            None,
+            None,
+            "  \n ",
+            "diff --git a/file b/file",
+        );
+
+        assert!(!prompt.contains("<current_message>"));
     }
 
     #[gpui::test]

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3350,10 +3350,6 @@ impl GitPanel {
         )
     }
 
-    pub fn is_generating_commit_message(&self) -> bool {
-        self.generate_commit_message_task.is_some()
-    }
-
     /// Generates a commit message using an LLM.
     pub fn generate_commit_message(&mut self, cx: &mut Context<Self>) {
         if !self.can_commit() || !AgentSettings::get_global(cx).enabled(cx) {
@@ -12100,6 +12096,172 @@ mod tests {
         );
 
         assert!(!prompt.contains("<current_message>"));
+    }
+
+    async fn setup_commit_message_generation_test(
+        commit_template: Option<&str>,
+        cx: &mut TestAppContext,
+    ) -> (
+        VisualTestContext,
+        Entity<GitPanel>,
+        Arc<dyn language_model::LanguageModel>,
+    ) {
+        init_test(cx);
+
+        let model = cx.update(|cx| {
+            AgentSettings::register(cx);
+            LanguageModelRegistry::test(cx);
+            LanguageModelRegistry::read_global(cx)
+                .default_model()
+                .unwrap()
+                .model
+        });
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "tracked": "tracked\n",
+            }),
+        )
+        .await;
+        fs.set_head_and_index_for_repo(
+            path!("/project/.git").as_ref(),
+            &[("tracked", "old tracked\n".into())],
+        );
+        if let Some(template) = commit_template {
+            fs.with_git_state(path!("/project/.git").as_ref(), false, |state| {
+                state.commit_template = Some(GitCommitTemplate {
+                    template: template.to_string(),
+                });
+            })
+            .unwrap();
+        }
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let mut cx = VisualTestContext::from_window(window_handle.into(), cx);
+        register_git_commit_language(&project, &mut cx);
+        let panel = workspace.update_in(&mut cx, GitPanel::new);
+
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+        cx.run_until_parked();
+
+        (cx, panel, model)
+    }
+
+    #[gpui::test]
+    async fn test_generate_commit_message_replaces_message(cx: &mut TestAppContext) {
+        const TEMPLATE: &str = "\nSigned-off-by: Test User <test@example.com>\n";
+        let (mut cx, panel, model) = setup_commit_message_generation_test(Some(TEMPLATE), cx).await;
+        let cx = &mut cx;
+
+        let (initial_text, loaded_template) = panel.update(cx, |panel, cx| {
+            (
+                panel.commit_editor.read(cx).text(cx),
+                panel.commit_template.clone(),
+            )
+        });
+        assert_eq!(
+            loaded_template.map(|template| template.template),
+            Some(TEMPLATE.to_string()),
+            "commit template should be loaded from the repository"
+        );
+        assert_eq!(initial_text, TEMPLATE);
+
+        panel.update(cx, |panel, cx| panel.generate_commit_message(cx));
+        cx.run_until_parked();
+
+        let fake_model = model.as_fake();
+        let pending_completions = fake_model.pending_completions();
+        assert_eq!(pending_completions.len(), 1);
+        let prompt = pending_completions[0].messages[0].string_contents();
+        assert!(prompt.contains("<commit_template>"));
+        assert!(prompt.contains("Signed-off-by: Test User <test@example.com>"));
+        assert!(prompt.contains("<current_message>"));
+
+        assert!(panel.update(cx, |panel, cx| panel.commit_editor.read(cx).read_only(cx)));
+        assert!(panel.update(cx, |panel, _| panel.is_generating_commit_message()));
+
+        fake_model.send_last_completion_stream_text_chunk(concat!(
+            " \"Update tracked\n",
+            "\n",
+            "Signed-off-by: Test User <test@example.com>\"",
+        ));
+        fake_model.send_last_completion_stream_text_chunk("\ndiff --git a/tracked b/tracked");
+        fake_model.end_last_completion_stream();
+        cx.run_until_parked();
+
+        let text = panel.update(cx, |panel, cx| panel.commit_editor.read(cx).text(cx));
+        assert_eq!(
+            text, "Update tracked\n\nSigned-off-by: Test User <test@example.com>",
+            "the leading whitespace, wrapping quotes, and echoed diff should be stripped"
+        );
+        assert!(!panel.update(cx, |panel, cx| panel.commit_editor.read(cx).read_only(cx)));
+        assert!(!panel.update(cx, |panel, _| panel.is_generating_commit_message()));
+    }
+
+    #[gpui::test]
+    async fn test_generate_commit_message_error_unlocks_editor(cx: &mut TestAppContext) {
+        let (mut cx, panel, model) = setup_commit_message_generation_test(None, cx).await;
+        let cx = &mut cx;
+
+        panel.update(cx, |panel, cx| {
+            panel.commit_message_buffer(cx).update(cx, |buffer, cx| {
+                let end = buffer.len();
+                buffer.edit([(0..end, "my rough draft")], None, cx);
+            });
+        });
+
+        panel.update(cx, |panel, cx| panel.generate_commit_message(cx));
+        cx.run_until_parked();
+
+        let fake_model = model.as_fake();
+        let prompt = fake_model.pending_completions()[0].messages[0].string_contents();
+        assert!(prompt.contains("<current_message>"));
+        assert!(prompt.contains("my rough draft"));
+        assert!(!prompt.contains("<commit_template>"));
+
+        assert!(panel.update(cx, |panel, cx| panel.commit_editor.read(cx).read_only(cx)));
+
+        fake_model.send_last_completion_stream_error(
+            language_model::LanguageModelCompletionError::Other(anyhow::anyhow!(
+                "connection reset"
+            )),
+        );
+        fake_model.end_last_completion_stream();
+        cx.run_until_parked();
+
+        assert!(!panel.update(cx, |panel, cx| panel.commit_editor.read(cx).read_only(cx)));
+        assert!(!panel.update(cx, |panel, _| panel.is_generating_commit_message()));
+    }
+
+    #[gpui::test]
+    async fn test_cancel_generate_commit_message_unlocks_editor(cx: &mut TestAppContext) {
+        let (mut cx, panel, _model) = setup_commit_message_generation_test(None, cx).await;
+        let cx = &mut cx;
+
+        panel.update(cx, |panel, cx| panel.generate_commit_message(cx));
+        cx.run_until_parked();
+        assert!(panel.update(cx, |panel, cx| panel.commit_editor.read(cx).read_only(cx)));
+
+        panel.update(cx, |panel, cx| {
+            panel.generate_commit_message_task.take();
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        assert!(!panel.update(cx, |panel, cx| panel.commit_editor.read(cx).read_only(cx)));
+        assert!(!panel.update(cx, |panel, _| panel.is_generating_commit_message()));
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective

When a `commit.template` is configured in git, Zed pre-fills the commit message editor with it, but the AI commit message generation composes badly with that:

- The template's first line (for example a `Signed-off-by:` trailer) is sent to the model as "the user's subject line", which it is not.
- The generated message is appended after the existing content, so it ends up below the template's trailers instead of forming a complete message.
- Clicking generate again appends below the previous generation instead of rewriting it, stacking messages.

The objective is for generation to treat the whole editor content and the configured template as context, and produce the complete commit message that replaces what is in the editor.

## Solution

- Include the configured `commit.template` and the full current editor content in the generation prompt, so the model has the whole context and writes the complete message, including the template's boilerplate with trailers at the end.
- Replace the entire editor content with the model's response. The buffer is only cleared once the stream is established, so a failed request leaves the existing message untouched. This removes the previous behavior of keeping the first line as a user-authored subject and appending a body below it.
- Make the commit message editors (git panel and commit modal, which are separate editors over the same buffer) read-only while generation is streaming, since user edits would interleave with the streamed insertions.
- Deterministically clean up artifacts that small local models produce despite instructions: leading whitespace, a fully quote-wrapped message, and an echoed diff (everything from a `diff --git ` line onward is removed).

## Testing

- Unit tests cover the prompt assembly: template and current-message sections are included, blank sections are omitted, and section ordering is stable.
- Integration tests drive the full generation flow against `FakeLanguageModel`: the template pre-fills the editor from the repository, the outgoing prompt contains the template and the current message, the editor is read-only while streaming and unlocked on completion, mid-stream error, and cancellation, and a hostile response (leading whitespace, quote-wrapped message, echoed diff) is cleaned up to the expected commit message (`cargo test -p git_ui --lib commit_message`, 12 passing). This required teaching `FakeGitRepository` to serve a `commit_template` (it previously hard-coded `None`).
- Manually tested on macOS with a global `commit.template` containing a `Signed-off-by:` trailer, against local Ollama models (`mistral:7b`), covering: empty editor pre-filled with the template, a rough draft plus trailer, regenerating over a previous generation, cancelling mid-stream, and models echoing the diff or wrapping the message in quotes.
- To test as a reviewer: configure `git config --global commit.template <file>` with some boilerplate, set `agent.commit_message_model`, open the git panel with changes present, and use the generate button — with and without existing text in the message editor, and repeatedly.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

https://github.com/user-attachments/assets/db2d6ef8-f2f6-4b7c-bbaa-038a103ec7a2

<details>
  <summary>Click to view showcase</summary>

With `commit.template` containing:

```
Signed-off-by: Jane Doe <jane@example.com>
```

**Before** — generating with a draft in the editor:

```
my rough draft

Signed-off-by: Jane Doe <jane@example.com>

"Update commit message configuration"
```

**After** — the whole message is rewritten, using the draft as context:

```
Improve commit message generation

Signed-off-by: Jane Doe <jane@example.com>
```

</details>

---

Release Notes:

- Improved AI commit message generation to follow the configured git commit message template and rewrite the entire commit message, using any existing message as context
