### PR TITLE
zeta_prompt: Restructure v4 editable context as chunks + retrievals

### DIFF
--- a/crates/cloud_api_types/src/cloud_api_types.rs
+++ b/crates/cloud_api_types/src/cloud_api_types.rs
@@ -159,7 +159,7 @@ pub struct SettledEditPredictionSampleData {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub buffer_diagnostics: Vec<zeta_prompt::ActiveBufferDiagnostic>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub editable_context: Vec<zeta_prompt::RelatedFile>,
+    pub editable_context: Vec<zeta_prompt::ContextFile>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub future_edit_history_events: Vec<Arc<zeta_prompt::Event>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/codestral/src/codestral.rs
+++ b/crates/codestral/src/codestral.rs
@@ -274,11 +274,21 @@ impl EditPredictionDelegate for CodestralEditPredictionDelegate {
                 cursor_offset,
                 &excerpt_offset_range,
             );
+            let excerpt_start_row = excerpt_point_range.start.row;
             let excerpt_text: String = snapshot.text_for_range(excerpt_point_range).collect();
+            let syntax_row_ranges = syntax_ranges
+                .iter()
+                .map(|range| {
+                    let row_range =
+                        zeta_prompt::offset_range_to_row_range(&excerpt_text, range.clone());
+                    excerpt_start_row + row_range.start..excerpt_start_row + row_range.end
+                })
+                .collect::<Vec<_>>();
             let (_, context_range) = zeta_prompt::compute_editable_and_context_ranges(
                 &excerpt_text,
                 cursor_offset_in_excerpt,
-                &syntax_ranges,
+                &syntax_row_ranges,
+                excerpt_start_row,
                 MAX_EDITABLE_TOKENS,
                 MAX_CONTEXT_TOKENS,
             );

--- a/crates/edit_prediction/src/cursor_excerpt.rs
+++ b/crates/edit_prediction/src/cursor_excerpt.rs
@@ -133,6 +133,33 @@ pub fn compute_syntax_ranges(
     ranges
 }
 
+pub fn compute_syntax_row_ranges(
+    snapshot: &BufferSnapshot,
+    cursor_offset: usize,
+) -> Vec<Range<u32>> {
+    let cursor_point = cursor_offset.to_point(snapshot);
+    let range = cursor_point..cursor_point;
+    let mut current = snapshot.syntax_ancestor(range);
+    let mut ranges = Vec::new();
+    let mut last_range: Option<(u32, u32)> = None;
+
+    while let Some(node) = current.take() {
+        let start = node.start_byte().to_point(snapshot).row;
+        let end = node.end_byte().to_point(snapshot).row;
+        let key = (start, end);
+
+        current = node.parent();
+
+        if last_range == Some(key) {
+            continue;
+        }
+        last_range = Some(key);
+        ranges.push(start..end);
+    }
+
+    ranges
+}
+
 /// Expands context by first trying to reach syntax boundaries,
 /// then expanding line-wise only if no syntax expansion occurred.
 pub fn expand_context_syntactically_then_linewise(
@@ -529,11 +556,23 @@ mod tests {
                     .collect();
                 let syntax_ranges =
                     compute_syntax_ranges(&snapshot, cursor_offset, &excerpt_offset_range);
+                let syntax_row_ranges = syntax_ranges
+                    .iter()
+                    .map(|range| {
+                        (excerpt_offset_range.start + range.start)
+                            .to_point(&snapshot)
+                            .row
+                            ..(excerpt_offset_range.start + range.end)
+                                .to_point(&snapshot)
+                                .row
+                    })
+                    .collect::<Vec<_>>();
 
                 let (actual_editable, actual_context) = compute_editable_and_context_ranges(
                     &excerpt_text,
                     cursor_offset_in_excerpt,
-                    &syntax_ranges,
+                    &syntax_row_ranges,
+                    excerpt_offset_range.start.to_point(&snapshot).row,
                     test_case.editable_token_limit,
                     test_case.context_token_limit,
                 );

--- a/crates/edit_prediction/src/data_collection.rs
+++ b/crates/edit_prediction/src/data_collection.rs
@@ -22,7 +22,7 @@ pub(crate) struct CapturedPredictionContext {
     pub(crate) revision: Option<String>,
     pub(crate) uncommitted_diff: Option<String>,
     pub(crate) buffer_diagnostics: Vec<zeta_prompt::ActiveBufferDiagnostic>,
-    pub(crate) editable_context: Vec<zeta_prompt::RelatedFile>,
+    pub(crate) editable_context: Vec<zeta_prompt::ContextFile>,
 }
 
 pub(crate) fn capture_prediction_context(
@@ -32,7 +32,7 @@ pub(crate) fn capture_prediction_context(
     stored_events: Vec<StoredEvent>,
     repository_url: Option<String>,
     revision: Option<String>,
-    editable_context_task: Task<Result<Vec<zeta_prompt::RelatedFile>>>,
+    editable_context_task: Task<Result<Vec<zeta_prompt::ContextFile>>>,
     cx: &mut Context<EditPredictionStore>,
 ) -> Option<Task<Result<CapturedPredictionContext>>> {
     let snapshot = buffer.read(cx).snapshot();
@@ -211,16 +211,14 @@ pub fn compute_cursor_excerpt(
     let cursor_offset = cursor_anchor.to_offset(snapshot);
     let (excerpt_point_range, excerpt_offset_range, cursor_offset_in_excerpt) =
         crate::cursor_excerpt::compute_cursor_excerpt(snapshot, cursor_offset);
-    let syntax_ranges = crate::cursor_excerpt::compute_syntax_ranges(
-        snapshot,
-        cursor_offset,
-        &excerpt_offset_range,
-    );
+    let excerpt_start_row = excerpt_point_range.start.row;
+    let syntax_ranges = crate::cursor_excerpt::compute_syntax_row_ranges(snapshot, cursor_offset);
     let excerpt_text: String = snapshot.text_for_range(excerpt_point_range).collect();
     let (_, context_range) = zeta_prompt::compute_editable_and_context_ranges(
         &excerpt_text,
         cursor_offset_in_excerpt,
         &syntax_ranges,
+        excerpt_start_row,
         100,
         50,
     );

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -24,7 +24,9 @@ use collections::{HashMap, HashSet};
 use copilot::{Copilot, Reinstall};
 use credentials_provider::CredentialsProvider;
 use db::kvp::{Dismissable, KeyValueStore};
-use edit_prediction_context::{RelatedExcerptStore, RelatedExcerptStoreEvent, RelatedFile};
+use edit_prediction_context::{
+    ContextFile, RelatedExcerptStore, RelatedExcerptStoreEvent, RelatedFile,
+};
 use edit_prediction_types::EditPredictionRequestTrigger;
 use feature_flags::{FeatureFlag, FeatureFlagAppExt as _, PresenceFlag, register_feature_flag};
 use futures::{
@@ -205,7 +207,7 @@ pub struct EditPredictionModelInput {
     events: Vec<Arc<zeta_prompt::Event>>,
     stored_events: Vec<StoredEvent>,
     related_files: Vec<RelatedFile>,
-    editable_context: Option<Task<anyhow::Result<Vec<RelatedFile>>>>,
+    editable_context: Option<Task<anyhow::Result<Vec<ContextFile>>>>,
     mode: PredictEditsMode,
     trigger: PredictEditsRequestTrigger,
     diagnostic_search_range: Range<Point>,
@@ -3121,7 +3123,7 @@ impl EditPredictionStore {
         oracle_targets: Vec<edit_prediction_context::OracleTarget>,
         context_sources: Vec<ContextSource>,
         cx: &mut Context<Self>,
-    ) -> Task<anyhow::Result<Vec<RelatedFile>>> {
+    ) -> Task<anyhow::Result<Vec<ContextFile>>> {
         use edit_prediction_context::{EditHistoryContextEntry, collect_editable_context};
 
         let buffers_by_id = project.read(cx).opened_buffers(cx).into_iter().fold(

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -3305,15 +3305,15 @@ async fn make_test_ep_store(
                             .find(|file| file.path == req.input.cursor_path)
                             .or_else(|| req.input.editable_context.first())
                             .expect("V4 requests should include editable context");
-                        let excerpt = file
-                            .excerpts
+                        let chunk = file
+                            .chunks
                             .first()
-                            .expect("V4 editable context should include an excerpt");
+                            .expect("V4 editable context should include a chunk");
                         let diff = unified_diff_with_offsets(
-                            &excerpt.text,
+                            &chunk.text,
                             &output,
-                            excerpt.row_range.start,
-                            excerpt.row_range.start,
+                            chunk.row_range.start,
+                            chunk.row_range.start,
                         );
                         let path = file.path.to_string_lossy();
                         let response = PredictEditsV4Response {
@@ -4019,16 +4019,20 @@ async fn test_edit_prediction_settled_sends_sample_data_after_quiescence(cx: &mu
                 snippet_buffer_row_range: 0..0,
                 diagnostic_range_in_snippet: 0..0,
             }],
-            editable_context: vec![zeta_prompt::RelatedFile {
+            editable_context: vec![zeta_prompt::ContextFile {
                 path: Path::new("foo.md").into(),
                 max_row: 60,
-                excerpts: vec![zeta_prompt::RelatedExcerpt {
+                chunks: vec![zeta_prompt::Chunk {
                     row_range: 0..2,
                     text: "line 0\nline 1\n".into(),
-                    order: 0,
-                    context_source: zeta_prompt::ContextSource::CurrentFile,
                 }],
-                in_open_source_repo: true,
+                retrievals: vec![zeta_prompt::Retrieval {
+                    source: zeta_prompt::ContextSource::CurrentFile,
+                    row_range: 0..2,
+                    rank: 0,
+                    score: None,
+                }],
+                syntax_ranges: Vec::new(),
             }],
         },
         Some(boundary),
@@ -4137,9 +4141,9 @@ async fn test_edit_prediction_settled_sends_sample_data_after_quiescence(cx: &mu
     assert_eq!(sample_data.editable_context.len(), 1);
     let editable_context = &sample_data.editable_context[0];
     assert_eq!(editable_context.path.as_ref(), Path::new("foo.md"));
-    assert_eq!(editable_context.excerpts.len(), 1);
+    assert_eq!(editable_context.chunks.len(), 1);
     assert_eq!(
-        editable_context.excerpts[0].context_source,
+        editable_context.retrievals[0].source,
         zeta_prompt::ContextSource::CurrentFile
     );
     assert_eq!(sample_data.future_edit_history_events.len(), 4);

--- a/crates/edit_prediction/src/fim.rs
+++ b/crates/edit_prediction/src/fim.rs
@@ -68,12 +68,12 @@ pub fn request_prediction(
             .text_for_range(excerpt_point_range.clone())
             .collect::<String>()
             .into();
-        let syntax_ranges =
-            cursor_excerpt::compute_syntax_ranges(&snapshot, cursor_offset, &excerpt_offset_range);
+        let syntax_ranges = cursor_excerpt::compute_syntax_row_ranges(&snapshot, cursor_offset);
         let (editable_range, _) = compute_editable_and_context_ranges(
             &cursor_excerpt,
             cursor_offset_in_excerpt,
             &syntax_ranges,
+            excerpt_point_range.start.row,
             FIM_CONTEXT_TOKENS,
             0,
         );

--- a/crates/edit_prediction/src/zeta.rs
+++ b/crates/edit_prediction/src/zeta.rs
@@ -3,7 +3,9 @@ use crate::{
     EditPredictionId, EditPredictionInputs, EditPredictionModelInput,
     EditPredictionStartedDebugEvent, EditPredictionStore, PromptHistoryBoundary,
     ZedUpdateRequiredError, buffer_path_with_id_fallback,
-    cursor_excerpt::{self, compute_cursor_excerpt, compute_syntax_ranges},
+    cursor_excerpt::{
+        self, compute_cursor_excerpt, compute_syntax_ranges, compute_syntax_row_ranges,
+    },
     data_collection::CapturedPredictionContext,
     prediction::EditPredictionResult,
     udiff::prediction_edits_for_single_file_diff,
@@ -149,7 +151,7 @@ pub(crate) fn request_prediction_with_zeta(
             let request_input =
                 if allow_jump && custom_server_settings.is_none() && raw_config.is_none() {
                     let cursor_point = snapshot.offset_to_point(cursor_offset);
-                    let editable_context = editable_context
+                    let mut editable_context = editable_context
                         .context("missing editable context task")?
                         .await?;
                     let active_buffer_diagnostics = active_buffer_diagnostics(
@@ -158,8 +160,13 @@ pub(crate) fn request_prediction_with_zeta(
                         cursor_point.row,
                         ACTIVE_BUFFER_DIAGNOSTIC_ADDITIONAL_CONTEXT_TOKEN_COUNT,
                     );
-                    let syntax_ranges =
-                        compute_syntax_ranges(&snapshot, cursor_offset, &(0..snapshot.len()));
+                    let syntax_ranges = compute_syntax_row_ranges(&snapshot, cursor_offset);
+                    if let Some(cursor_file) = editable_context
+                        .iter_mut()
+                        .find(|file| file.path == excerpt_path)
+                    {
+                        cursor_file.syntax_ranges = syntax_ranges;
+                    }
 
                     RequestInput::V4(Zeta3PromptInput {
                         cursor_path: excerpt_path,
@@ -169,7 +176,6 @@ pub(crate) fn request_prediction_with_zeta(
                         },
                         events,
                         editable_context,
-                        syntax_ranges,
                         active_buffer_diagnostics,
                         in_open_source_repo: is_open_source,
                         can_collect_data,

--- a/crates/edit_prediction_cli/src/retrieve_context.rs
+++ b/crates/edit_prediction_cli/src/retrieve_context.rs
@@ -189,7 +189,10 @@ pub async fn run_context_retrieval(
                 )
             })
             .await?;
-        merge_context_files(&mut context_files, editable_context);
+        merge_context_files(
+            &mut context_files,
+            zeta_prompt::context_files_to_related_files(&editable_context),
+        );
     }
 
     let excerpt_count: usize = context_files.iter().map(|f| f.excerpts.len()).sum();

--- a/crates/edit_prediction_cli/src/score.rs
+++ b/crates/edit_prediction_cli/src/score.rs
@@ -8,7 +8,6 @@ use crate::{
     progress::{ExampleProgress, Step},
 };
 use anyhow::Context as _;
-use edit_prediction_context::limit_retrieved_context_to_bytes;
 use edit_prediction_metrics::{
     ActualPredictionCursor, Excerpt, PredictionReversalContext, PredictionScoringInput,
 };
@@ -221,7 +220,7 @@ fn context_excerpts(
     if let Some(related_files) = &prompt_inputs.related_files {
         let related_files = filtered_related_files(related_files, context_source_filter);
         let related_files = if let Some(max_bytes) = retrieved_context_byte_limit {
-            limit_retrieved_context_to_bytes(&related_files, max_bytes)
+            limit_related_files_to_bytes(&related_files, max_bytes)
         } else {
             related_files
         };
@@ -286,7 +285,7 @@ fn retrieved_context_bytes(
     let related_files = example.prompt_inputs.as_ref()?.related_files.as_ref()?;
     let related_files = filtered_related_files(related_files, context_source_filter);
     let related_files = if let Some(max_bytes) = retrieved_context_byte_limit {
-        limit_retrieved_context_to_bytes(&related_files, max_bytes)
+        limit_related_files_to_bytes(&related_files, max_bytes)
     } else {
         related_files
     };
@@ -297,6 +296,58 @@ fn retrieved_context_bytes(
             .map(|excerpt| excerpt.text.len())
             .sum::<usize>(),
     )
+}
+
+fn limit_related_files_to_bytes(
+    related_files: &[RelatedFile],
+    max_bytes: usize,
+) -> Vec<RelatedFile> {
+    let mut candidates = related_files
+        .iter()
+        .enumerate()
+        .flat_map(|(file_index, file)| {
+            file.excerpts
+                .iter()
+                .enumerate()
+                .map(move |(excerpt_index, excerpt)| (excerpt.order, file_index, excerpt_index))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_unstable();
+
+    let mut selected = related_files
+        .iter()
+        .map(|file| vec![false; file.excerpts.len()])
+        .collect::<Vec<_>>();
+    let mut used_bytes = 0usize;
+    for (_, file_index, excerpt_index) in candidates {
+        let excerpt = &related_files[file_index].excerpts[excerpt_index];
+        if used_bytes.saturating_add(excerpt.text.len()) > max_bytes {
+            continue;
+        }
+        used_bytes += excerpt.text.len();
+        selected[file_index][excerpt_index] = true;
+    }
+
+    related_files
+        .iter()
+        .enumerate()
+        .filter_map(|(file_index, file)| {
+            let excerpts = file
+                .excerpts
+                .iter()
+                .enumerate()
+                .filter_map(|(excerpt_index, excerpt)| {
+                    selected[file_index][excerpt_index].then(|| excerpt.clone())
+                })
+                .collect::<Vec<_>>();
+            (!excerpts.is_empty()).then(|| RelatedFile {
+                path: file.path.clone(),
+                max_row: file.max_row,
+                excerpts,
+                in_open_source_repo: file.in_open_source_repo,
+            })
+        })
+        .collect()
 }
 
 pub fn print_report(

--- a/crates/edit_prediction_context/src/bm25_context.rs
+++ b/crates/edit_prediction_context/src/bm25_context.rs
@@ -27,7 +27,8 @@ const BM25_B: f64 = 0.75;
 pub(super) struct Bm25ContextCandidate {
     pub path: PathBuf,
     pub row_range: Range<u32>,
-    pub order: usize,
+    pub rank: usize,
+    pub score: Option<f32>,
 }
 
 pub async fn collect_bm25_context(
@@ -35,7 +36,6 @@ pub async fn collect_bm25_context(
     active_buffer: Entity<Buffer>,
     cursor_position: Anchor,
     edit_history: &[EditHistoryContextEntry],
-    next_order: usize,
     cx: &mut AsyncApp,
 ) -> Vec<Bm25ContextCandidate> {
     let Some(query) = build_query(&project, &active_buffer, cursor_position, edit_history, cx)
@@ -44,7 +44,7 @@ pub async fn collect_bm25_context(
     };
 
     let result = cx
-        .background_spawn(async move { collect_bm25_context_from_disk(query, next_order).await })
+        .background_spawn(async move { collect_bm25_context_from_disk(query).await })
         .await;
 
     match result {
@@ -135,7 +135,6 @@ fn expanded_anchor_range(
 
 async fn collect_bm25_context_from_disk(
     query: Bm25ContextQuery,
-    next_order: usize,
 ) -> Result<Vec<Bm25ContextCandidate>> {
     let query_terms = query_terms(&query);
     if query_terms.is_empty() {
@@ -154,7 +153,7 @@ async fn collect_bm25_context_from_disk(
         index.stats.term_count,
     );
 
-    let candidates = index.search(&query_terms, &query.worktree_root_name, next_order);
+    let candidates = index.search(&query_terms, &query.worktree_root_name);
     log::debug!("selected {} BM25 context chunks", candidates.len());
     Ok(candidates)
 }
@@ -259,7 +258,6 @@ impl Bm25Index {
         &self,
         query_terms: &HashMap<String, f64>,
         worktree_root_name: &str,
-        next_order: usize,
     ) -> Vec<Bm25ContextCandidate> {
         if self.documents.is_empty() || self.average_document_len == 0.0 {
             return Vec::new();
@@ -316,7 +314,8 @@ impl Bm25Index {
                 ))
                 .into(),
                 row_range: document.row_range.clone(),
-                order: next_order + selected_documents.len(),
+                rank: selected_documents.len(),
+                score: Some(scored_document.score as f32),
             });
 
             if selected_documents.len() >= BM25_CONTEXT_CHUNK_COUNT {
@@ -673,10 +672,11 @@ mod tests {
         let mut query = HashMap::new();
         add_query_terms(&mut query, "PrivateNetworkRequestPolicy", 1.0);
 
-        let candidates = index.search(&query, "repo", 0);
+        let candidates = index.search(&query, "repo");
 
         assert_eq!(candidates[0].path, Path::new("repo/src/network.rs"));
         assert_eq!(candidates[0].row_range, 0..1);
-        assert_eq!(candidates[0].order, 0);
+        assert_eq!(candidates[0].rank, 0);
+        assert!(candidates[0].score.is_some());
     }
 }

--- a/crates/edit_prediction_context/src/edit_prediction_context.rs
+++ b/crates/edit_prediction_context/src/edit_prediction_context.rs
@@ -33,7 +33,7 @@ pub use editable_context::{
     limit_retrieved_context_to_bytes,
 };
 
-pub use zeta_prompt::{ContextSource, RelatedExcerpt, RelatedFile};
+pub use zeta_prompt::{ContextFile, ContextSource, RelatedExcerpt, RelatedFile};
 
 const IDENTIFIER_LINE_COUNT: u32 = 3;
 const MAX_CONTEXT_IDENTIFIER_COUNT: usize = 32;

--- a/crates/edit_prediction_context/src/editable_context.rs
+++ b/crates/edit_prediction_context/src/editable_context.rs
@@ -9,7 +9,10 @@ use std::{
 };
 use text::Anchor;
 use util::{paths::PathStyle, rel_path::RelPath};
-use zeta_prompt::{ContextSource, RelatedExcerpt, RelatedFile, multi_region::is_good_block_start};
+use zeta_prompt::{
+    Chunk, ContextFile, ContextSource, Retrieval, default_retrieval_policy_key,
+    multi_region::is_good_block_start,
+};
 
 use crate::{
     bm25_context::{Bm25ContextCandidate, collect_bm25_context},
@@ -27,12 +30,7 @@ const ORACLE_SNIPPET_MAX_CONTEXT_LINE_COUNT: u32 = 40;
 /// How far excerpt boundaries may be nudged to land on a natural block
 /// boundary, mirroring `zeta_prompt::multi_region`'s marker placement.
 const BOUNDARY_SNAP_LINE_COUNT: u32 = 5;
-/// Maximum number of rows between two excerpts of the same buffer that get
-/// bridged into one contiguous excerpt instead of rendering an elision
-/// marker between them.
-const BRIDGED_GAP_LINE_COUNT: u32 = 3;
-
-type RangesByBuffer = HashMap<EntityId, (Entity<Buffer>, Vec<EditableContextRange>)>;
+type RangesByBuffer = HashMap<EntityId, (Entity<Buffer>, Vec<PendingRetrieval>)>;
 
 #[derive(Clone)]
 pub struct EditHistoryContextEntry {
@@ -50,16 +48,18 @@ pub struct OracleTarget {
     pub row_ranges: Vec<Range<u32>>,
 }
 
-struct EditableContextRange {
+struct PendingRetrieval {
     range: Range<Anchor>,
-    order: usize,
-    context_source: ContextSource,
+    rank: usize,
+    source: ContextSource,
+    score: Option<f32>,
 }
 
-struct ResolvedEditableContextRange {
+struct ResolvedPendingRetrieval {
     range: Range<Point>,
-    order: usize,
-    context_source: ContextSource,
+    rank: usize,
+    source: ContextSource,
+    score: Option<f32>,
 }
 
 pub async fn collect_editable_context(
@@ -70,7 +70,7 @@ pub async fn collect_editable_context(
     oracle_targets: Vec<OracleTarget>,
     context_sources: Vec<ContextSource>,
     cx: &mut AsyncApp,
-) -> anyhow::Result<Vec<RelatedFile>> {
+) -> anyhow::Result<Vec<ContextFile>> {
     let mut ranges_by_buffer = RangesByBuffer::default();
 
     if context_sources.contains(&ContextSource::CursorExcerpt) {
@@ -127,122 +127,122 @@ pub async fn collect_editable_context(
 
     Ok(cx.update(|cx| {
         let project = project.read(cx);
-        let mut related_files = ranges_by_buffer
+        let mut context_files = ranges_by_buffer
             .into_values()
-            .filter_map(|(buffer, ranges)| related_file_for_ranges(&project, &buffer, ranges, cx))
+            .filter_map(|(buffer, ranges)| context_file_for_ranges(&project, &buffer, ranges, cx))
             .collect::<Vec<_>>();
-        related_files.sort_by_key(|file| {
-            file.excerpts
+        context_files.sort_by_key(|file| {
+            file.retrievals
                 .iter()
-                .map(|excerpt| excerpt.order)
+                .enumerate()
+                .map(|(index, retrieval)| default_retrieval_policy_key(0, index, retrieval))
                 .min()
-                .unwrap_or(usize::MAX)
+                .unwrap_or((usize::MAX, usize::MAX, usize::MAX, usize::MAX))
         });
-        related_files
+        context_files
     }))
 }
 
 pub fn limit_retrieved_context_to_bytes(
-    related_files: &[RelatedFile],
+    context_files: &[ContextFile],
     max_bytes: usize,
-) -> Vec<RelatedFile> {
-    struct ExcerptCandidate {
+) -> Vec<ContextFile> {
+    struct RetrievalCandidate {
         file_index: usize,
-        excerpt_index: usize,
-        order: usize,
+        retrieval_index: usize,
     }
 
-    let mut candidates = related_files
+    let mut candidates = context_files
         .iter()
         .enumerate()
         .flat_map(|(file_index, file)| {
-            file.excerpts
+            file.retrievals
                 .iter()
                 .enumerate()
-                .map(move |(excerpt_index, excerpt)| ExcerptCandidate {
+                .map(move |(retrieval_index, _)| RetrievalCandidate {
                     file_index,
-                    excerpt_index,
-                    order: excerpt.order,
+                    retrieval_index,
                 })
         })
         .collect::<Vec<_>>();
     candidates.sort_by_key(|candidate| {
-        (
-            candidate.order,
-            candidate.file_index,
-            candidate.excerpt_index,
-        )
+        let retrieval = &context_files[candidate.file_index].retrievals[candidate.retrieval_index];
+        default_retrieval_policy_key(candidate.file_index, candidate.retrieval_index, retrieval)
     });
 
-    let mut selected_excerpts = related_files
-        .iter()
-        .map(|file| vec![false; file.excerpts.len()])
-        .collect::<Vec<_>>();
-    let mut covered_ranges_by_file = vec![Vec::<Range<u32>>::new(); related_files.len()];
+    let mut covered_ranges_by_file = vec![Vec::<Range<u32>>::new(); context_files.len()];
     let mut selected_bytes: usize = 0;
 
     for candidate in candidates {
-        let file = &related_files[candidate.file_index];
-        let excerpt = &file.excerpts[candidate.excerpt_index];
-        let added_bytes =
-            uncovered_excerpt_bytes(excerpt, &covered_ranges_by_file[candidate.file_index]);
+        let file = &context_files[candidate.file_index];
+        let retrieval = &file.retrievals[candidate.retrieval_index];
+        let added_bytes = uncovered_retrieval_bytes(
+            file,
+            retrieval,
+            &covered_ranges_by_file[candidate.file_index],
+        );
         if added_bytes == 0 || selected_bytes.saturating_add(added_bytes) > max_bytes {
             continue;
         }
 
         selected_bytes += added_bytes;
-        selected_excerpts[candidate.file_index][candidate.excerpt_index] = true;
-        push_covered_range(
+        push_merged_row_range(
             &mut covered_ranges_by_file[candidate.file_index],
-            excerpt.row_range.clone(),
+            retrieval.row_range.clone(),
         );
     }
 
-    related_files
+    context_files
         .iter()
         .enumerate()
         .filter_map(|(file_index, file)| {
-            let excerpts = file
-                .excerpts
-                .iter()
-                .enumerate()
-                .filter_map(|(excerpt_index, excerpt)| {
-                    selected_excerpts[file_index][excerpt_index].then(|| excerpt.clone())
-                })
-                .collect::<Vec<_>>();
-            if excerpts.is_empty() {
+            let chunks = chunks_for_row_ranges(file, &covered_ranges_by_file[file_index]);
+            if chunks.is_empty() {
                 return None;
             }
 
-            Some(RelatedFile {
+            Some(ContextFile {
                 path: file.path.clone(),
                 max_row: file.max_row,
-                excerpts,
-                in_open_source_repo: file.in_open_source_repo,
+                chunks,
+                retrievals: file.retrievals.clone(),
+                syntax_ranges: file.syntax_ranges.clone(),
             })
         })
         .collect()
 }
 
-fn uncovered_excerpt_bytes(excerpt: &RelatedExcerpt, covered_ranges: &[Range<u32>]) -> usize {
+fn uncovered_retrieval_bytes(
+    file: &ContextFile,
+    retrieval: &Retrieval,
+    covered_ranges: &[Range<u32>],
+) -> usize {
     let mut bytes = 0;
 
-    for (row, line) in (excerpt.row_range.start..).zip(excerpt.text.split_inclusive('\n')) {
-        if row >= excerpt.row_range.end {
-            break;
+    for chunk in &file.chunks {
+        let start = retrieval.row_range.start.max(chunk.row_range.start);
+        let end = retrieval.row_range.end.min(chunk.row_range.end);
+        if start >= end {
+            continue;
         }
-        if !covered_ranges
-            .iter()
-            .any(|covered_range| covered_range.contains(&row))
-        {
-            bytes += line.len();
+        for (row, line) in (chunk.row_range.start..).zip(chunk.text.split_inclusive('\n')) {
+            if row >= end {
+                break;
+            }
+            if row >= start
+                && !covered_ranges
+                    .iter()
+                    .any(|covered_range| covered_range.contains(&row))
+            {
+                bytes += line.len();
+            }
         }
     }
 
     bytes
 }
 
-fn push_covered_range(covered_ranges: &mut Vec<Range<u32>>, range: Range<u32>) {
+fn push_merged_row_range(covered_ranges: &mut Vec<Range<u32>>, range: Range<u32>) {
     covered_ranges.push(range);
     covered_ranges.sort_by_key(|range| (range.start, range.end));
 
@@ -282,6 +282,7 @@ fn collect_cursor_excerpt_context(
         cursor_range,
         0,
         ContextSource::CursorExcerpt,
+        None,
     );
 }
 
@@ -317,8 +318,9 @@ fn collect_edit_history_context(
             ranges_by_buffer,
             entry.buffer.clone(),
             edit_history_range,
-            index + 1,
+            index,
             ContextSource::EditHistory,
+            None,
         );
     }
 }
@@ -328,7 +330,6 @@ fn collect_edit_history_file_context(
     edit_history: &[EditHistoryContextEntry],
     cx: &mut AsyncApp,
 ) {
-    let next_order = next_context_order(ranges_by_buffer);
     let mut seen_buffers = HashSet::default();
     let mut index = 0;
 
@@ -340,7 +341,7 @@ fn collect_edit_history_file_context(
         collect_full_buffer_context(
             ranges_by_buffer,
             entry.buffer.clone(),
-            next_order + index,
+            index,
             ContextSource::EditHistoryFile,
             cx,
         );
@@ -356,13 +357,11 @@ async fn collect_bm25_context_ranges(
     edit_history: &[EditHistoryContextEntry],
     cx: &mut AsyncApp,
 ) {
-    let next_order = next_context_order(ranges_by_buffer);
     let candidates = collect_bm25_context(
         project.clone(),
         active_buffer,
         cursor_position,
         edit_history,
-        next_order,
         cx,
     )
     .await;
@@ -406,8 +405,9 @@ async fn collect_bm25_candidate_context(
         ranges_by_buffer,
         buffer,
         range,
-        candidate.order,
+        candidate.rank,
         ContextSource::Bm25,
+        candidate.score,
     );
 }
 
@@ -436,7 +436,6 @@ async fn collect_oracle_file_context(
     oracle_targets: &[OracleTarget],
     cx: &mut AsyncApp,
 ) {
-    let next_order = next_context_order(ranges_by_buffer);
     let mut seen_buffers = HashSet::default();
     let mut index = 0;
 
@@ -463,7 +462,7 @@ async fn collect_oracle_file_context(
         collect_full_buffer_context(
             ranges_by_buffer,
             buffer,
-            next_order + index,
+            index,
             ContextSource::OracleFile,
             cx,
         );
@@ -477,7 +476,6 @@ async fn collect_oracle_snippet_context(
     oracle_targets: &[OracleTarget],
     cx: &mut AsyncApp,
 ) {
-    let next_order = next_context_order(ranges_by_buffer);
     let mut index = 0;
 
     for target in oracle_targets {
@@ -530,8 +528,9 @@ async fn collect_oracle_snippet_context(
                 ranges_by_buffer,
                 buffer.clone(),
                 range,
-                next_order + index,
+                index,
                 ContextSource::OracleSnippet,
+                None,
             );
             index += 1;
         }
@@ -584,12 +583,12 @@ async fn open_buffer_for_path(
 fn collect_full_buffer_context(
     ranges_by_buffer: &mut RangesByBuffer,
     buffer: Entity<Buffer>,
-    order: usize,
-    context_source: ContextSource,
+    rank: usize,
+    source: ContextSource,
     cx: &mut AsyncApp,
 ) {
     let range = buffer.read_with(cx, |buffer, _cx| full_file_anchor_range(&buffer.snapshot()));
-    push_context_range(ranges_by_buffer, buffer, range, order, context_source);
+    push_context_range(ranges_by_buffer, buffer, range, rank, source, None);
 }
 
 fn full_file_anchor_range(snapshot: &BufferSnapshot) -> Range<Anchor> {
@@ -597,14 +596,6 @@ fn full_file_anchor_range(snapshot: &BufferSnapshot) -> Range<Anchor> {
     let max_point = snapshot.max_point();
     let end = snapshot.anchor_after(max_point);
     start..end
-}
-
-fn next_context_order(ranges_by_buffer: &RangesByBuffer) -> usize {
-    ranges_by_buffer
-        .values()
-        .flat_map(|(_, ranges)| ranges.iter().map(|range| range.order))
-        .max()
-        .map_or(0, |order| order + 1)
 }
 
 async fn collect_git_log_context(
@@ -645,8 +636,6 @@ async fn collect_git_log_context(
         }
     };
 
-    let next_order = next_context_order(ranges_by_buffer);
-
     for (index, related_path) in index
         .get_related(active_path.as_std_path(), GIT_LOG_CONTEXT_FILE_COUNT)
         .into_iter()
@@ -681,8 +670,9 @@ async fn collect_git_log_context(
             ranges_by_buffer,
             buffer,
             range,
-            next_order + index,
+            index,
             ContextSource::GitLog,
+            None,
         );
     }
 }
@@ -768,26 +758,28 @@ fn push_context_range(
     ranges_by_buffer: &mut RangesByBuffer,
     buffer: Entity<Buffer>,
     range: Range<Anchor>,
-    order: usize,
-    context_source: ContextSource,
+    rank: usize,
+    source: ContextSource,
+    score: Option<f32>,
 ) {
     ranges_by_buffer
         .entry(buffer.entity_id())
         .or_insert_with(|| (buffer.clone(), Vec::new()))
         .1
-        .push(EditableContextRange {
+        .push(PendingRetrieval {
             range,
-            order,
-            context_source,
+            rank,
+            source,
+            score,
         });
 }
 
-fn related_file_for_ranges(
+fn context_file_for_ranges(
     project: &Project,
     buffer: &Entity<Buffer>,
-    ranges: Vec<EditableContextRange>,
+    ranges: Vec<PendingRetrieval>,
     cx: &App,
-) -> Option<RelatedFile> {
+) -> Option<ContextFile> {
     let buffer = buffer.read(cx);
     let snapshot = buffer.snapshot();
     let file = snapshot.file()?;
@@ -799,34 +791,91 @@ fn related_file_for_ranges(
     ))
     .into();
 
-    let mut ranges = resolved_context_ranges(ranges, &snapshot);
-    split_overlapping_ranges(&mut ranges);
-
-    let excerpts = ranges
+    let retrievals = resolved_context_ranges(ranges, &snapshot)
         .into_iter()
-        .map(|range| RelatedExcerpt {
-            row_range: range.range.start.row..range.range.end.row,
-            text: snapshot
-                .text_for_range(range.range)
-                .collect::<String>()
-                .into(),
-            order: range.order,
-            context_source: range.context_source,
+        .filter_map(|range| {
+            let row_range = range.range.start.row..range.range.end.row;
+            (row_range.start < row_range.end).then(|| Retrieval {
+                source: range.source,
+                row_range,
+                rank: range.rank,
+                score: range.score,
+            })
         })
         .collect::<Vec<_>>();
+    if retrievals.is_empty() {
+        return None;
+    }
 
-    Some(RelatedFile {
+    let mut chunk_row_ranges = Vec::new();
+    for retrieval in &retrievals {
+        push_merged_row_range(&mut chunk_row_ranges, retrieval.row_range.clone());
+    }
+    let chunks = chunks_for_snapshot_ranges(&snapshot, &chunk_row_ranges);
+
+    Some(ContextFile {
         path,
         max_row: snapshot.max_point().row,
-        excerpts,
-        in_open_source_repo: false,
+        chunks,
+        retrievals,
+        syntax_ranges: Vec::new(),
     })
 }
 
+fn chunks_for_row_ranges(file: &ContextFile, row_ranges: &[Range<u32>]) -> Vec<Chunk> {
+    row_ranges
+        .iter()
+        .filter_map(|row_range| {
+            let mut text = String::new();
+            for chunk in &file.chunks {
+                let start = row_range.start.max(chunk.row_range.start);
+                let end = row_range.end.min(chunk.row_range.end);
+                if start >= end {
+                    continue;
+                }
+                for (row, line) in (chunk.row_range.start..).zip(chunk.text.split_inclusive('\n')) {
+                    if row >= end {
+                        break;
+                    }
+                    if row >= start {
+                        text.push_str(line);
+                    }
+                }
+            }
+            (!text.is_empty()).then(|| Chunk {
+                row_range: row_range.clone(),
+                text: text.into(),
+            })
+        })
+        .collect()
+}
+
+fn chunks_for_snapshot_ranges(snapshot: &BufferSnapshot, row_ranges: &[Range<u32>]) -> Vec<Chunk> {
+    row_ranges
+        .iter()
+        .filter_map(|row_range| {
+            if row_range.start >= row_range.end {
+                return None;
+            }
+            let start = Point::new(row_range.start, 0);
+            let end = if row_range.end > snapshot.max_point().row {
+                snapshot.max_point()
+            } else {
+                Point::new(row_range.end, 0)
+            };
+            let text = snapshot.text_for_range(start..end).collect::<String>();
+            (!text.is_empty()).then(|| Chunk {
+                row_range: row_range.clone(),
+                text: text.into(),
+            })
+        })
+        .collect()
+}
+
 fn resolved_context_ranges(
-    ranges: Vec<EditableContextRange>,
+    ranges: Vec<PendingRetrieval>,
     snapshot: &BufferSnapshot,
-) -> Vec<ResolvedEditableContextRange> {
+) -> Vec<ResolvedPendingRetrieval> {
     ranges
         .into_iter()
         .filter_map(|range| {
@@ -836,155 +885,14 @@ fn resolved_context_ranges(
                 return None;
             }
 
-            Some(ResolvedEditableContextRange {
+            Some(ResolvedPendingRetrieval {
                 range: start..end,
-                order: range.order,
-                context_source: range.context_source,
+                rank: range.rank,
+                source: range.source,
+                score: range.score,
             })
         })
         .collect()
-}
-
-/// Split overlapping ranges into disjoint segments instead of merging them
-/// into one range. Each segment keeps the minimum order and highest-priority
-/// source among the ranges covering it, and adjacent segments with equal
-/// order are coalesced. This preserves priority granularity: a small
-/// high-priority snippet inside a large low-priority range remains its own
-/// excerpt, so byte-budget selection can retain it even when the surrounding
-/// range doesn't fit. The resulting segments are disjoint and sorted by
-/// position.
-///
-/// Ranges separated by at most `BRIDGED_GAP_LINE_COUNT` rows are bridged:
-/// the small gap is attached to the preceding segment so the excerpts render
-/// as one contiguous block instead of being separated by an elision marker.
-fn split_overlapping_ranges(ranges: &mut Vec<ResolvedEditableContextRange>) {
-    ranges.sort_by_key(|range| (range.range.start, range.range.end));
-    let mut output: Vec<ResolvedEditableContextRange> = Vec::new();
-    let mut cluster: Vec<ResolvedEditableContextRange> = Vec::new();
-    let mut cluster_end = Point::zero();
-
-    for range in ranges.drain(..) {
-        let bridge_limit_row = row_aligned_end(cluster_end)
-            .row
-            .saturating_add(BRIDGED_GAP_LINE_COUNT);
-        if cluster.is_empty() || range.range.start.row <= bridge_limit_row {
-            cluster_end = cluster_end.max(range.range.end);
-            cluster.push(range);
-        } else {
-            split_cluster(std::mem::take(&mut cluster), cluster_end, &mut output);
-            cluster_end = range.range.end;
-            cluster.push(range);
-        }
-    }
-    if !cluster.is_empty() {
-        split_cluster(cluster, cluster_end, &mut output);
-    }
-
-    *ranges = output;
-}
-
-fn split_cluster(
-    cluster: Vec<ResolvedEditableContextRange>,
-    cluster_end: Point,
-    output: &mut Vec<ResolvedEditableContextRange>,
-) {
-    if cluster.len() == 1 {
-        output.extend(cluster);
-        return;
-    }
-
-    let cluster_start = cluster[0].range.start;
-    let mut boundaries = Vec::with_capacity(cluster.len() * 2 + 1);
-    boundaries.push(cluster_start);
-    for range in &cluster {
-        boundaries.push(range.range.start);
-        boundaries.push(row_aligned_end(range.range.end));
-    }
-    boundaries.retain(|boundary| *boundary >= cluster_start && *boundary < cluster_end);
-    boundaries.sort();
-    boundaries.dedup();
-    boundaries.push(cluster_end);
-
-    for window in boundaries.windows(2) {
-        let segment = window[0]..window[1];
-        // The segment is attributed to the lowest-order covering range
-        // (breaking ties by source priority), so that its source label is
-        // consistent with the order that drives budget selection.
-        let mut order_and_source: Option<(usize, ContextSource)> = None;
-        for range in &cluster {
-            if range.range.start <= segment.start && row_aligned_end(range.range.end) >= segment.end
-            {
-                let candidate = (range.order, range.context_source);
-                if order_and_source.is_none_or(|(order, context_source)| {
-                    (candidate.0, context_source_order(candidate.1))
-                        < (order, context_source_order(context_source))
-                }) {
-                    order_and_source = Some(candidate);
-                }
-            }
-        }
-        let Some((order, context_source)) = order_and_source else {
-            // A bridged gap between two nearby ranges: no range covers it, so
-            // attach it to the preceding segment to form contiguous output.
-            if let Some(last) = output.last_mut()
-                && last.range.end == segment.start
-            {
-                last.range.end = segment.end;
-            }
-            continue;
-        };
-
-        if let Some(last) = output.last_mut()
-            && last.range.end == segment.start
-            && last.order == order
-        {
-            last.range.end = segment.end;
-            if context_source_order(context_source) < context_source_order(last.context_source) {
-                last.context_source = context_source;
-            }
-            continue;
-        }
-
-        output.push(ResolvedEditableContextRange {
-            range: segment,
-            order,
-            context_source,
-        });
-    }
-}
-
-/// Context ranges always cover whole lines: their ends sit either at a line
-/// start (column 0) or at the end of a line's content. Cutting a segment at
-/// the end of a line's content would attribute the trailing newline to the
-/// next segment, so nudge such ends forward to the next line start.
-fn row_aligned_end(point: Point) -> Point {
-    if point.column > 0 {
-        Point::new(point.row + 1, 0)
-    } else {
-        point
-    }
-}
-
-#[allow(dead_code)]
-fn push_context_source(context_sources: &mut Vec<ContextSource>, context_source: ContextSource) {
-    if !context_sources.contains(&context_source) {
-        context_sources.push(context_source);
-        context_sources.sort_by_key(|context_source| context_source_order(*context_source));
-    }
-}
-
-fn context_source_order(context_source: ContextSource) -> usize {
-    match context_source {
-        ContextSource::Lsp => 0,
-        ContextSource::CursorExcerpt => 1,
-        ContextSource::CurrentFile => 2,
-        ContextSource::EditHistory => 3,
-        ContextSource::EditHistoryFile => 4,
-        ContextSource::GitLog => 5,
-        ContextSource::Bm25 => 6,
-        ContextSource::OracleSnippet => 7,
-        ContextSource::OracleFile => 8,
-    }
 }
 
 #[cfg(test)]
@@ -999,153 +907,6 @@ mod tests {
         )
         .snapshot()
         .clone()
-    }
-
-    fn resolved_range(
-        start_row: u32,
-        end_row: u32,
-        order: usize,
-        context_source: ContextSource,
-    ) -> ResolvedEditableContextRange {
-        ResolvedEditableContextRange {
-            range: Point::new(start_row, 0)..Point::new(end_row, 0),
-            order,
-            context_source,
-        }
-    }
-
-    #[test]
-    fn test_split_overlapping_ranges_coalesces_equal_orders() {
-        // A full-file current-file range plus edit-history windows inside it:
-        // every segment is covered by the order-0 full-file range, so they
-        // coalesce back into a single range with the highest-priority source.
-        let mut ranges = vec![
-            resolved_range(6, 46, 1, ContextSource::EditHistory),
-            resolved_range(0, 281, 0, ContextSource::CurrentFile),
-            resolved_range(17, 79, 2, ContextSource::EditHistory),
-            resolved_range(85, 125, 3, ContextSource::EditHistory),
-        ];
-        split_overlapping_ranges(&mut ranges);
-        assert_eq!(ranges.len(), 1);
-        assert_eq!(ranges[0].range, Point::new(0, 0)..Point::new(281, 0));
-        assert_eq!(ranges[0].order, 0);
-        assert_eq!(ranges[0].context_source, ContextSource::CurrentFile);
-    }
-
-    #[test]
-    fn test_split_overlapping_ranges_keeps_disjoint_ranges() {
-        let mut ranges = vec![
-            resolved_range(50, 60, 1, ContextSource::EditHistory),
-            resolved_range(0, 10, 0, ContextSource::CursorExcerpt),
-            resolved_range(5, 12, 2, ContextSource::EditHistory),
-        ];
-        split_overlapping_ranges(&mut ranges);
-        assert_eq!(ranges.len(), 3);
-        assert_eq!(ranges[0].range, Point::new(0, 0)..Point::new(10, 0));
-        assert_eq!(ranges[0].order, 0);
-        assert_eq!(ranges[0].context_source, ContextSource::CursorExcerpt);
-        assert_eq!(ranges[1].range, Point::new(10, 0)..Point::new(12, 0));
-        assert_eq!(ranges[1].order, 2);
-        assert_eq!(ranges[1].context_source, ContextSource::EditHistory);
-        assert_eq!(ranges[2].range, Point::new(50, 0)..Point::new(60, 0));
-        assert_eq!(ranges[2].order, 1);
-    }
-
-    #[test]
-    fn test_split_overlapping_ranges_keeps_adjacent_ranges_with_distinct_orders() {
-        let mut ranges = vec![
-            resolved_range(0, 10, 0, ContextSource::EditHistory),
-            resolved_range(10, 20, 1, ContextSource::EditHistory),
-        ];
-        split_overlapping_ranges(&mut ranges);
-        assert_eq!(ranges.len(), 2);
-        assert_eq!(ranges[0].range, Point::new(0, 0)..Point::new(10, 0));
-        assert_eq!(ranges[0].order, 0);
-        assert_eq!(ranges[1].range, Point::new(10, 0)..Point::new(20, 0));
-        assert_eq!(ranges[1].order, 1);
-    }
-
-    #[test]
-    fn test_split_overlapping_ranges_preserves_high_priority_snippet_inside_large_range() {
-        // A small high-priority snippet inside a large low-priority range
-        // stays its own segment, so byte-budget selection can keep it even
-        // when the surrounding range doesn't fit.
-        let mut ranges = vec![
-            resolved_range(0, 200, 8, ContextSource::GitLog),
-            resolved_range(50, 60, 2, ContextSource::OracleSnippet),
-        ];
-        split_overlapping_ranges(&mut ranges);
-        assert_eq!(ranges.len(), 3);
-        assert_eq!(ranges[0].range, Point::new(0, 0)..Point::new(50, 0));
-        assert_eq!(ranges[0].order, 8);
-        assert_eq!(ranges[0].context_source, ContextSource::GitLog);
-        assert_eq!(ranges[1].range, Point::new(50, 0)..Point::new(60, 0));
-        assert_eq!(ranges[1].order, 2);
-        assert_eq!(ranges[1].context_source, ContextSource::OracleSnippet);
-        assert_eq!(ranges[2].range, Point::new(60, 0)..Point::new(200, 0));
-        assert_eq!(ranges[2].order, 8);
-        assert_eq!(ranges[2].context_source, ContextSource::GitLog);
-    }
-
-    #[test]
-    fn test_split_overlapping_ranges_aligns_mid_line_ends_to_row_starts() {
-        // Ranges ending at a line's content end (column > 0) are treated as
-        // covering through that whole line, so equal-order overlapping ranges
-        // still coalesce into one segment.
-        let mut ranges = vec![
-            ResolvedEditableContextRange {
-                range: Point::new(0, 0)..Point::new(10, 5),
-                order: 1,
-                context_source: ContextSource::EditHistory,
-            },
-            resolved_range(5, 20, 1, ContextSource::EditHistory),
-        ];
-        split_overlapping_ranges(&mut ranges);
-        assert_eq!(ranges.len(), 1);
-        assert_eq!(ranges[0].range, Point::new(0, 0)..Point::new(20, 0));
-        assert_eq!(ranges[0].order, 1);
-    }
-
-    #[test]
-    fn test_split_overlapping_ranges_bridges_small_gaps() {
-        // Ranges separated by a few rows are bridged: the gap is attached to
-        // the preceding segment, producing contiguous excerpts.
-        let mut ranges = vec![
-            resolved_range(0, 10, 0, ContextSource::EditHistory),
-            resolved_range(13, 20, 1, ContextSource::Bm25),
-        ];
-        split_overlapping_ranges(&mut ranges);
-        assert_eq!(ranges.len(), 2);
-        assert_eq!(ranges[0].range, Point::new(0, 0)..Point::new(13, 0));
-        assert_eq!(ranges[0].order, 0);
-        assert_eq!(ranges[0].context_source, ContextSource::EditHistory);
-        assert_eq!(ranges[1].range, Point::new(13, 0)..Point::new(20, 0));
-        assert_eq!(ranges[1].order, 1);
-        assert_eq!(ranges[1].context_source, ContextSource::Bm25);
-    }
-
-    #[test]
-    fn test_split_overlapping_ranges_bridged_equal_orders_coalesce() {
-        let mut ranges = vec![
-            resolved_range(0, 10, 1, ContextSource::EditHistory),
-            resolved_range(12, 20, 1, ContextSource::EditHistory),
-        ];
-        split_overlapping_ranges(&mut ranges);
-        assert_eq!(ranges.len(), 1);
-        assert_eq!(ranges[0].range, Point::new(0, 0)..Point::new(20, 0));
-        assert_eq!(ranges[0].order, 1);
-    }
-
-    #[test]
-    fn test_split_overlapping_ranges_does_not_bridge_large_gaps() {
-        let mut ranges = vec![
-            resolved_range(0, 10, 0, ContextSource::EditHistory),
-            resolved_range(14, 20, 1, ContextSource::Bm25),
-        ];
-        split_overlapping_ranges(&mut ranges);
-        assert_eq!(ranges.len(), 2);
-        assert_eq!(ranges[0].range, Point::new(0, 0)..Point::new(10, 0));
-        assert_eq!(ranges[1].range, Point::new(14, 0)..Point::new(20, 0));
     }
 
     #[test]
@@ -1205,34 +966,62 @@ mod tests {
     #[test]
     fn test_limit_retrieved_context_keeps_high_priority_snippet_under_tight_budget() {
         let line = "0123456789\n";
-        let excerpt = |row_range: Range<u32>, order: usize, context_source: ContextSource| {
-            let text = line.repeat((row_range.end - row_range.start) as usize);
-            RelatedExcerpt {
-                row_range,
-                text: text.into(),
-                order,
-                context_source,
-            }
+        let chunk = |row_range: Range<u32>| Chunk {
+            text: line
+                .repeat((row_range.end - row_range.start) as usize)
+                .into(),
+            row_range,
         };
-        let related_files = vec![RelatedFile {
+        let retrieval = |row_range: Range<u32>, rank: usize, source: ContextSource| Retrieval {
+            source,
+            row_range,
+            rank,
+            score: None,
+        };
+        let context_files = vec![ContextFile {
             path: Path::new("root/file.rs").into(),
             max_row: 200,
-            excerpts: vec![
-                excerpt(0..50, 8, ContextSource::GitLog),
-                excerpt(50..60, 2, ContextSource::OracleSnippet),
-                excerpt(60..200, 8, ContextSource::GitLog),
+            chunks: vec![chunk(0..200)],
+            retrievals: vec![
+                retrieval(0..50, 8, ContextSource::GitLog),
+                retrieval(50..60, 2, ContextSource::OracleSnippet),
+                retrieval(60..200, 8, ContextSource::GitLog),
             ],
-            in_open_source_repo: false,
+            syntax_ranges: Vec::new(),
         }];
 
-        // Budget fits the snippet but not the surrounding segments.
-        let limited = limit_retrieved_context_to_bytes(&related_files, 20 * line.len());
-        assert_eq!(limited.len(), 1);
-        assert_eq!(limited[0].excerpts.len(), 1);
-        assert_eq!(limited[0].excerpts[0].row_range, 50..60);
+        let limited = limit_retrieved_context_to_bytes(&context_files, 20 * line.len());
         assert_eq!(
-            limited[0].excerpts[0].context_source,
-            ContextSource::OracleSnippet
+            limited,
+            vec![ContextFile {
+                path: Path::new("root/file.rs").into(),
+                max_row: 200,
+                chunks: vec![Chunk {
+                    row_range: 50..60,
+                    text: line.repeat(10).into(),
+                }],
+                retrievals: vec![
+                    Retrieval {
+                        source: ContextSource::GitLog,
+                        row_range: 0..50,
+                        rank: 8,
+                        score: None,
+                    },
+                    Retrieval {
+                        source: ContextSource::OracleSnippet,
+                        row_range: 50..60,
+                        rank: 2,
+                        score: None,
+                    },
+                    Retrieval {
+                        source: ContextSource::GitLog,
+                        row_range: 60..200,
+                        rank: 8,
+                        score: None,
+                    },
+                ],
+                syntax_ranges: Vec::new(),
+            }]
         );
     }
 }

--- a/crates/edit_prediction_metrics/src/main.rs
+++ b/crates/edit_prediction_metrics/src/main.rs
@@ -74,7 +74,15 @@ fn run() -> Result<(), String> {
 fn get_context_excerpts(example: &JsonExample) -> Vec<Excerpt> {
     let mut context = vec![get_cursor_excerpt(example)];
 
-    if let Some(related) = &example.prompt_inputs.related_files {
+    if let Some(related) = &example.prompt_inputs.editable_context {
+        context.extend(related.iter().flat_map(|file| {
+            file.chunks.iter().map(|chunk| Excerpt {
+                path: file.path.clone(),
+                row_range: chunk.row_range.clone(),
+                content: chunk.text.clone(),
+            })
+        }));
+    } else if let Some(related) = &example.prompt_inputs.related_files {
         context.extend(related.iter().flat_map(|file| {
             file.excerpts.iter().map(|excerpt| Excerpt {
                 path: file.path.clone(),
@@ -468,7 +476,23 @@ struct JsonExample {
 struct PromptInputs {
     cursor_excerpt: String,
     excerpt_start_row: u32,
+    #[serde(default)]
+    pub editable_context: Option<Vec<ContextFile>>,
+    #[serde(default)]
     pub related_files: Option<Vec<RelatedFile>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Hash, Deserialize)]
+pub struct ContextFile {
+    pub path: String,
+    pub max_row: u32,
+    pub chunks: Vec<Chunk>,
+}
+
+#[derive(Clone, Debug, PartialEq, Hash, Deserialize)]
+pub struct Chunk {
+    pub row_range: std::ops::Range<u32>,
+    pub text: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Hash, Deserialize)]

--- a/crates/edit_prediction_ui/src/rate_prediction_modal.rs
+++ b/crates/edit_prediction_ui/src/rate_prediction_modal.rs
@@ -27,7 +27,7 @@ use ui::{
     Tooltip, prelude::*,
 };
 use workspace::{ModalView, Workspace};
-use zeta_prompt::{ContextSource, FilePosition, RelatedExcerpt, RelatedFile, Zeta3PromptInput};
+use zeta_prompt::{Chunk, ContextFile, FilePosition, RelatedFile, Zeta3PromptInput};
 
 actions!(
     zeta,
@@ -429,7 +429,7 @@ impl RatePredictionsModal {
             }
             EditPredictionInputs::V3(inputs) => {
                 Self::write_events(formatted_inputs, &inputs.events);
-                Self::write_related_files(formatted_inputs, &inputs.editable_context);
+                Self::write_context_files(formatted_inputs, &inputs.editable_context);
                 Self::write_zeta3_cursor_excerpt(formatted_inputs, inputs);
             }
         }
@@ -463,28 +463,59 @@ impl RatePredictionsModal {
         }
     }
 
+    fn write_context_files(formatted_inputs: &mut String, included_files: &[ContextFile]) {
+        write!(formatted_inputs, "## Related files\n\n").unwrap();
+
+        for included_file in included_files {
+            write!(formatted_inputs, "### {}\n\n", included_file.path.display()).unwrap();
+
+            for chunk in included_file.chunks.iter() {
+                let sources = included_file
+                    .retrievals
+                    .iter()
+                    .filter(|retrieval| {
+                        retrieval.row_range.start < chunk.row_range.end
+                            && chunk.row_range.start < retrieval.row_range.end
+                    })
+                    .map(|retrieval| format!("{:?}#{}", retrieval.source, retrieval.rank))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                if !sources.is_empty() {
+                    writeln!(formatted_inputs, "`{sources}`").unwrap();
+                }
+                write!(
+                    formatted_inputs,
+                    "```{}\n{}\n```\n",
+                    included_file.path.display(),
+                    chunk.text
+                )
+                .unwrap();
+            }
+        }
+    }
+
     fn write_zeta3_cursor_excerpt(formatted_inputs: &mut String, inputs: &Zeta3PromptInput) {
-        let current_excerpt = inputs
+        let current_chunk = inputs
             .editable_context
             .iter()
-            .filter(|file| file.path == inputs.cursor_path)
-            .flat_map(|file| file.excerpts.iter())
-            .find_map(|excerpt| {
-                if excerpt.context_source != ContextSource::CurrentFile {
-                    return None;
-                }
-
-                Some((
-                    excerpt,
-                    Self::offset_for_position_in_excerpt(excerpt, inputs.cursor_position)?,
-                ))
+            .find(|file| file.path == inputs.cursor_path)
+            .and_then(|file| {
+                file.chunks
+                    .iter()
+                    .find(|chunk| chunk.row_range.contains(&inputs.cursor_position.row))
+                    .map(|chunk| {
+                        (
+                            chunk,
+                            Self::offset_for_position_in_chunk(chunk, inputs.cursor_position),
+                        )
+                    })
             });
 
-        if let Some((excerpt, cursor_offset)) = current_excerpt {
+        if let Some((chunk, Some(cursor_offset))) = current_chunk {
             Self::write_cursor_excerpt(
                 formatted_inputs,
                 inputs.cursor_path.as_ref(),
-                excerpt.text.as_ref(),
+                chunk.text.as_ref(),
                 cursor_offset,
             );
         } else {
@@ -498,6 +529,32 @@ impl RatePredictionsModal {
             )
             .unwrap();
         }
+    }
+
+    fn offset_for_position_in_chunk(chunk: &Chunk, position: FilePosition) -> Option<usize> {
+        if position.row < chunk.row_range.start {
+            return None;
+        }
+
+        let relative_row = (position.row - chunk.row_range.start) as usize;
+        let text = chunk.text.as_ref();
+        let mut row_start = 0;
+
+        for row in 0..=relative_row {
+            if row == relative_row {
+                let row_end = text[row_start..]
+                    .find('\n')
+                    .map_or(text.len(), |offset| row_start + offset);
+                let row_text = &text[row_start..row_end];
+                let column =
+                    row_text.floor_char_boundary((position.column as usize).min(row_text.len()));
+                return Some(row_start + column);
+            }
+
+            row_start += text[row_start..].find('\n')? + 1;
+        }
+
+        None
     }
 
     fn write_cursor_excerpt(
@@ -520,35 +577,6 @@ impl RatePredictionsModal {
             &cursor_excerpt[cursor_offset..],
         )
         .unwrap();
-    }
-
-    fn offset_for_position_in_excerpt(
-        excerpt: &RelatedExcerpt,
-        position: FilePosition,
-    ) -> Option<usize> {
-        if position.row < excerpt.row_range.start {
-            return None;
-        }
-
-        let relative_row = (position.row - excerpt.row_range.start) as usize;
-        let text = excerpt.text.as_ref();
-        let mut row_start = 0;
-
-        for row in 0..=relative_row {
-            if row == relative_row {
-                let row_end = text[row_start..]
-                    .find('\n')
-                    .map_or(text.len(), |offset| row_start + offset);
-                let row_text = &text[row_start..row_end];
-                let column =
-                    row_text.floor_char_boundary((position.column as usize).min(row_text.len()));
-                return Some(row_start + column);
-            }
-
-            row_start += text[row_start..].find('\n')? + 1;
-        }
-
-        None
     }
 
     pub fn select_completion(

--- a/crates/zeta_prompt/src/excerpt_ranges.rs
+++ b/crates/zeta_prompt/src/excerpt_ranges.rs
@@ -37,11 +37,19 @@ pub fn compute_legacy_excerpt_ranges(
     cursor_offset: usize,
     syntax_ranges: &[Range<usize>],
 ) -> ExcerptRanges {
+    let line_starts = compute_line_starts(cursor_excerpt);
+    let syntax_row_ranges = syntax_ranges
+        .iter()
+        .map(|range| {
+            offset_to_row(&line_starts, range.start)..offset_to_row(&line_starts, range.end)
+        })
+        .collect::<Vec<_>>();
     let compute = |editable_tokens, context_tokens| {
         compute_editable_and_context_ranges(
             cursor_excerpt,
             cursor_offset,
-            syntax_ranges,
+            &syntax_row_ranges,
+            0,
             editable_tokens,
             context_tokens,
         )
@@ -81,7 +89,8 @@ pub fn compute_legacy_excerpt_ranges(
 pub fn compute_editable_and_context_ranges(
     cursor_excerpt: &str,
     cursor_offset: usize,
-    syntax_ranges: &[Range<usize>],
+    syntax_ranges: &[Range<u32>],
+    row_offset: u32,
     editable_token_limit: usize,
     context_token_limit: usize,
 ) -> (Range<usize>, Range<usize>) {
@@ -95,6 +104,7 @@ pub fn compute_editable_and_context_ranges(
         cursor_row,
         max_row,
         syntax_ranges,
+        row_offset,
         editable_token_limit,
     );
 
@@ -104,6 +114,7 @@ pub fn compute_editable_and_context_ranges(
         max_row,
         &editable_range,
         syntax_ranges,
+        row_offset,
         context_token_limit,
     );
 
@@ -175,8 +186,8 @@ fn line_token_count_from_text(text: &str, line_starts: &[usize], row: u32) -> us
 /// Returns syntax boundaries (as row ranges) that contain the given row range
 /// and extend beyond it, ordered from smallest to largest.
 fn containing_syntax_boundaries_from_ranges(
-    line_starts: &[usize],
-    syntax_ranges: &[Range<usize>],
+    syntax_ranges: &[Range<u32>],
+    row_offset: u32,
     start_row: u32,
     end_row: u32,
 ) -> Vec<(u32, u32)> {
@@ -185,8 +196,8 @@ fn containing_syntax_boundaries_from_ranges(
 
     // syntax_ranges is innermost to outermost, so iterate in order.
     for range in syntax_ranges {
-        let node_start_row = offset_to_row(line_starts, range.start);
-        let node_end_row = offset_to_row(line_starts, range.end);
+        let node_start_row = range.start.saturating_sub(row_offset);
+        let node_end_row = range.end.saturating_sub(row_offset);
 
         // Skip nodes that don't extend beyond the current range.
         if node_start_row >= start_row && node_end_row <= end_row {
@@ -210,7 +221,8 @@ fn compute_editable_range_from_text(
     line_starts: &[usize],
     cursor_row: u32,
     max_row: u32,
-    syntax_ranges: &[Range<usize>],
+    syntax_ranges: &[Range<u32>],
+    row_offset: u32,
     token_limit: usize,
 ) -> Range<usize> {
     // Phase 1: Expand symmetrically from cursor using 75% of budget.
@@ -225,7 +237,7 @@ fn compute_editable_range_from_text(
 
     // Phase 2: Expand to syntax boundaries that fit within budget.
     let boundaries =
-        containing_syntax_boundaries_from_ranges(line_starts, syntax_ranges, start_row, end_row);
+        containing_syntax_boundaries_from_ranges(syntax_ranges, row_offset, start_row, end_row);
     for (boundary_start, boundary_end) in &boundaries {
         let tokens_for_start = if *boundary_start < start_row {
             estimate_tokens_for_row_range(text, line_starts, *boundary_start, start_row)
@@ -275,7 +287,8 @@ fn expand_context_from_text(
     line_starts: &[usize],
     max_row: u32,
     editable_range: &Range<usize>,
-    syntax_ranges: &[Range<usize>],
+    syntax_ranges: &[Range<u32>],
+    row_offset: u32,
     context_token_limit: usize,
 ) -> Range<usize> {
     let mut start_row = offset_to_row(line_starts, editable_range.start);
@@ -284,7 +297,7 @@ fn expand_context_from_text(
     let mut did_syntax_expand = false;
 
     let boundaries =
-        containing_syntax_boundaries_from_ranges(line_starts, syntax_ranges, start_row, end_row);
+        containing_syntax_boundaries_from_ranges(syntax_ranges, row_offset, start_row, end_row);
     for (boundary_start, boundary_end) in &boundaries {
         let tokens_for_start = if *boundary_start < start_row {
             estimate_tokens_for_row_range(text, line_starts, *boundary_start, start_row)

--- a/crates/zeta_prompt/src/zeta_prompt.rs
+++ b/crates/zeta_prompt/src/zeta_prompt.rs
@@ -7496,8 +7496,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_zeta3_prompt_tight_budget_accounts_for_diagnostics_in_related_files_selection()
-     {
+    fn test_format_zeta3_prompt_tight_budget_accounts_for_diagnostics_in_related_files_selection() {
         // Same fixture as
         // `test_format_zeta3_prompt_tight_budget_keeps_high_priority_drops_low_priority_tail`,
         // except the input now carries a diagnostic. Retrieval selection

--- a/crates/zeta_prompt/src/zeta_prompt.rs
+++ b/crates/zeta_prompt/src/zeta_prompt.rs
@@ -6,6 +6,7 @@ pub mod udiff;
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 use std::fmt::Write;
+use std::hash::{Hash, Hasher};
 use std::ops::Range;
 use std::path::Path;
 use std::sync::Arc;
@@ -89,9 +90,7 @@ pub struct Zeta3PromptInput {
     pub cursor_path: Arc<Path>,
     pub cursor_position: FilePosition,
     pub events: Vec<Arc<Event>>,
-    pub editable_context: Vec<RelatedFile>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub syntax_ranges: Vec<Range<usize>>,
+    pub editable_context: Vec<ContextFile>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub active_buffer_diagnostics: Vec<ActiveBufferDiagnostic>,
     #[serde(default)]
@@ -284,6 +283,39 @@ pub struct RelatedExcerpt {
     pub context_source: ContextSource,
 }
 
+#[derive(Clone, Debug, PartialEq, Hash, Serialize, Deserialize)]
+pub struct ContextFile {
+    pub path: Arc<Path>,
+    pub max_row: u32,
+    pub chunks: Vec<Chunk>,
+    pub retrievals: Vec<Retrieval>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub syntax_ranges: Vec<Range<u32>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Hash, Serialize, Deserialize)]
+pub struct Chunk {
+    pub row_range: Range<u32>,
+    pub text: Arc<str>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Retrieval {
+    pub source: ContextSource,
+    pub row_range: Range<u32>,
+    pub rank: usize,
+    pub score: Option<f32>,
+}
+
+impl Hash for Retrieval {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.source.hash(state);
+        self.row_range.hash(state);
+        self.rank.hash(state);
+        self.score.map(f32::to_bits).hash(state);
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ContextSource {
@@ -297,6 +329,33 @@ pub enum ContextSource {
     Bm25,
     OracleFile,
     OracleSnippet,
+}
+
+pub fn context_source_priority(context_source: ContextSource) -> usize {
+    match context_source {
+        ContextSource::Lsp => 0,
+        ContextSource::CursorExcerpt => 1,
+        ContextSource::CurrentFile => 2,
+        ContextSource::EditHistory => 3,
+        ContextSource::EditHistoryFile => 4,
+        ContextSource::GitLog => 5,
+        ContextSource::Bm25 => 6,
+        ContextSource::OracleSnippet => 7,
+        ContextSource::OracleFile => 8,
+    }
+}
+
+pub fn default_retrieval_policy_key(
+    file_index: usize,
+    retrieval_index: usize,
+    retrieval: &Retrieval,
+) -> (usize, usize, usize, usize) {
+    (
+        context_source_priority(retrieval.source),
+        retrieval.rank,
+        file_index,
+        retrieval_index,
+    )
 }
 
 pub fn prompt_input_contains_special_tokens(input: &Zeta2PromptInput, format: ZetaFormat) -> bool {
@@ -319,21 +378,42 @@ pub fn format_zeta3_prompt(input: &Zeta3PromptInput, format: ZetaFormat) -> Opti
         _ => return None,
     }
 
-    let (current_excerpt, cursor_offset_in_excerpt) = zeta3_current_file_excerpt(input)?;
+    let (cursor_file, cursor_chunk, cursor_offset_in_chunk) = zeta3_cursor_chunk(input)?;
     let (context, editable_range, context_range, cursor_offset) = resolve_zeta3_cursor_region(
-        current_excerpt.text.as_ref(),
-        cursor_offset_in_excerpt,
-        &input.syntax_ranges,
+        cursor_chunk.text.as_ref(),
+        cursor_offset_in_chunk,
+        &cursor_file.syntax_ranges,
+        cursor_chunk.row_range.start,
         format,
     );
-    let relative_row_range =
-        offset_range_to_row_range(current_excerpt.text.as_ref(), context_range);
-    let cursor_row_range = current_excerpt.row_range.start + relative_row_range.start
-        ..current_excerpt.row_range.start + relative_row_range.end;
-    let related_files = filter_redundant_excerpts(
-        zeta3_related_files(input, current_excerpt),
+    let relative_row_range = offset_range_to_row_range(cursor_chunk.text.as_ref(), context_range);
+    let cursor_row_range = cursor_chunk.row_range.start + relative_row_range.start
+        ..cursor_chunk.row_range.start + relative_row_range.end;
+    let max_tokens = max_prompt_tokens_for_format(format);
+    let mut cursor_section = String::new();
+    write_cursor_excerpt_section_for_format(
+        format,
+        &mut cursor_section,
+        input.cursor_path.as_ref(),
+        context,
+        &editable_range,
+        cursor_offset,
+    );
+    let related_files_token_budget = seed_coder::budget_before_related_files(
+        context,
+        &editable_range,
+        &cursor_section,
+        &input.events,
+        &input.active_buffer_diagnostics,
+        Some(input.cursor_position.row),
+        apply_prompt_budget_margin(max_tokens),
+    )
+    .budget_after_diagnostics;
+    let related_files = zeta3_related_files(
+        input,
         input.cursor_path.as_ref(),
         cursor_row_range,
+        related_files_token_budget,
     );
 
     format_resolved_prompt_with_budget(
@@ -346,7 +426,7 @@ pub fn format_zeta3_prompt(input: &Zeta3PromptInput, format: ZetaFormat) -> Opti
         &related_files,
         &input.active_buffer_diagnostics,
         Some(input.cursor_position.row),
-        max_prompt_tokens_for_format(format),
+        max_tokens,
     )
 }
 
@@ -374,33 +454,26 @@ fn max_prompt_tokens_for_format(format: ZetaFormat) -> usize {
     }
 }
 
-fn zeta3_current_file_excerpt(input: &Zeta3PromptInput) -> Option<(&RelatedExcerpt, usize)> {
-    input
+fn zeta3_cursor_chunk(input: &Zeta3PromptInput) -> Option<(&ContextFile, &Chunk, usize)> {
+    let file = input
         .editable_context
         .iter()
-        .filter(|file| file.path == input.cursor_path)
-        .flat_map(|file| file.excerpts.iter())
-        .find_map(|excerpt| {
-            if excerpt.context_source != ContextSource::CurrentFile {
-                return None;
-            }
-            Some((
-                excerpt,
-                offset_for_position_in_excerpt(excerpt, input.cursor_position)?,
-            ))
-        })
+        .find(|file| file.path == input.cursor_path)?;
+    let chunk = file
+        .chunks
+        .iter()
+        .find(|chunk| chunk.row_range.contains(&input.cursor_position.row))?;
+    let offset = offset_for_position_in_chunk(chunk, input.cursor_position)?;
+    Some((file, chunk, offset))
 }
 
-fn offset_for_position_in_excerpt(
-    excerpt: &RelatedExcerpt,
-    position: FilePosition,
-) -> Option<usize> {
-    if position.row < excerpt.row_range.start {
+fn offset_for_position_in_chunk(chunk: &Chunk, position: FilePosition) -> Option<usize> {
+    if position.row < chunk.row_range.start {
         return None;
     }
 
-    let relative_row = (position.row - excerpt.row_range.start) as usize;
-    let text = excerpt.text.as_ref();
+    let relative_row = (position.row - chunk.row_range.start) as usize;
+    let text = chunk.text.as_ref();
     let mut row_start = 0;
 
     for row in 0..=relative_row {
@@ -422,25 +495,22 @@ fn offset_for_position_in_excerpt(
 
 fn zeta3_related_files(
     input: &Zeta3PromptInput,
-    current_excerpt: &RelatedExcerpt,
+    cursor_path: &Path,
+    cursor_row_range: Range<u32>,
+    related_files_token_budget: usize,
 ) -> Vec<RelatedFile> {
-    input
-        .editable_context
-        .iter()
-        .filter_map(|file| {
-            let mut file = file.clone();
-            if file.path == input.cursor_path {
-                file.excerpts.retain(|excerpt| excerpt != current_excerpt);
-            }
-            (!file.excerpts.is_empty()).then_some(file)
-        })
-        .collect()
+    context_files_to_related_files_excluding_within_budget(
+        &input.editable_context,
+        Some((cursor_path, cursor_row_range)),
+        related_files_token_budget,
+    )
 }
 
 fn resolve_zeta3_cursor_region<'a>(
     cursor_excerpt: &'a str,
     cursor_offset: usize,
-    syntax_ranges: &[Range<usize>],
+    syntax_ranges: &[Range<u32>],
+    row_offset: u32,
     format: ZetaFormat,
 ) -> (&'a str, Range<usize>, Range<usize>, usize) {
     let (editable_tokens, context_tokens) = token_limits_for_format(format);
@@ -448,11 +518,457 @@ fn resolve_zeta3_cursor_region<'a>(
         cursor_excerpt,
         cursor_offset,
         syntax_ranges,
+        row_offset,
         editable_tokens,
         context_tokens,
     );
 
     adjust_cursor_region(cursor_excerpt, cursor_offset, editable_range, context_range)
+}
+
+pub fn context_files_to_related_files(context_files: &[ContextFile]) -> Vec<RelatedFile> {
+    context_files_to_related_files_excluding(context_files, None)
+}
+
+fn context_files_to_related_files_excluding(
+    context_files: &[ContextFile],
+    cursor_rows_to_subtract: Option<(&Path, Range<u32>)>,
+) -> Vec<RelatedFile> {
+    let mut candidates = context_files
+        .iter()
+        .enumerate()
+        .flat_map(|(file_index, file)| {
+            file.retrievals
+                .iter()
+                .enumerate()
+                .map(move |(retrieval_index, retrieval)| {
+                    (
+                        default_retrieval_policy_key(file_index, retrieval_index, retrieval),
+                        file_index,
+                        retrieval_index,
+                    )
+                })
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|candidate| candidate.0);
+
+    let mut selected_rows_by_file = vec![Vec::<Range<u32>>::new(); context_files.len()];
+    let mut retrieval_orders_by_file = context_files
+        .iter()
+        .map(|file| vec![usize::MAX; file.retrievals.len()])
+        .collect::<Vec<_>>();
+    for (order, (_, file_index, retrieval_index)) in candidates.into_iter().enumerate() {
+        if let Some(retrieval_orders) = retrieval_orders_by_file.get_mut(file_index)
+            && let Some(retrieval_order) = retrieval_orders.get_mut(retrieval_index)
+        {
+            *retrieval_order = order;
+        }
+        let file = &context_files[file_index];
+        let retrieval = &file.retrievals[retrieval_index];
+        let mut row_ranges = vec![retrieval.row_range.clone()];
+        if let Some((cursor_path, cursor_row_range)) = &cursor_rows_to_subtract
+            && file.path.as_ref() == *cursor_path
+        {
+            row_ranges = subtract_row_range(&retrieval.row_range, cursor_row_range);
+        }
+        for row_range in row_ranges {
+            push_merged_row_range(&mut selected_rows_by_file[file_index], row_range);
+        }
+    }
+
+    context_files
+        .iter()
+        .zip(selected_rows_by_file)
+        .zip(retrieval_orders_by_file)
+        .filter_map(|((file, selected_ranges), retrieval_orders)| {
+            let mut excerpts = Vec::new();
+            for selected_range in selected_ranges {
+                for chunk in &file.chunks {
+                    let start = selected_range.start.max(chunk.row_range.start);
+                    let end = selected_range.end.min(chunk.row_range.end);
+                    if start >= end {
+                        continue;
+                    }
+                    excerpts.push(RelatedExcerpt {
+                        row_range: start..end,
+                        text: text_for_chunk_rows(chunk, start..end).into(),
+                        order: best_retrieval_for_range(file, &retrieval_orders, start..end)
+                            .map_or(usize::MAX, |(order, _)| order),
+                        context_source: best_retrieval_source_for_range(file, start..end),
+                    });
+                }
+            }
+            excerpts.sort_by_key(|excerpt| (excerpt.row_range.start, excerpt.row_range.end));
+            (!excerpts.is_empty()).then(|| RelatedFile {
+                path: file.path.clone(),
+                max_row: file.max_row,
+                excerpts,
+                in_open_source_repo: false,
+            })
+        })
+        .collect()
+}
+
+/// Like [`context_files_to_related_files_excluding`], but performs token-budget
+/// selection in retrieval space, before rows from different retrievals are
+/// unioned into shared blocks.
+///
+/// Retrievals are walked in default policy order, and each is charged only for
+/// the rows it covers that no higher-priority (earlier) retrieval already
+/// covers. This ensures a low-priority retrieval whose row range happens to
+/// overlap a high-priority retrieval's rows can never cause the high-priority
+/// rows to be dropped: only rows that survive selection are unioned and handed
+/// to the renderer.
+fn context_files_to_related_files_excluding_within_budget(
+    context_files: &[ContextFile],
+    cursor_rows_to_subtract: Option<(&Path, Range<u32>)>,
+    max_tokens: usize,
+) -> Vec<RelatedFile> {
+    let mut candidates = context_files
+        .iter()
+        .enumerate()
+        .flat_map(|(file_index, file)| {
+            file.retrievals
+                .iter()
+                .enumerate()
+                .map(move |(retrieval_index, retrieval)| {
+                    (
+                        default_retrieval_policy_key(file_index, retrieval_index, retrieval),
+                        file_index,
+                        retrieval_index,
+                    )
+                })
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|candidate| candidate.0);
+
+    let mut selected_rows_by_file = vec![Vec::<Range<u32>>::new(); context_files.len()];
+    let mut retrieval_orders_by_file = context_files
+        .iter()
+        .map(|file| vec![usize::MAX; file.retrievals.len()])
+        .collect::<Vec<_>>();
+    let mut file_header_charged = vec![false; context_files.len()];
+    let mut remaining_budget = max_tokens;
+
+    for (order, (_, file_index, retrieval_index)) in candidates.into_iter().enumerate() {
+        let file = &context_files[file_index];
+        let retrieval = &file.retrievals[retrieval_index];
+
+        let mut row_ranges = vec![retrieval.row_range.clone()];
+        if let Some((cursor_path, cursor_row_range)) = &cursor_rows_to_subtract
+            && file.path.as_ref() == *cursor_path
+        {
+            row_ranges = row_ranges
+                .into_iter()
+                .flat_map(|row_range| subtract_row_range(&row_range, cursor_row_range))
+                .collect();
+        }
+
+        retrieval_orders_by_file[file_index][retrieval_index] = order;
+
+        let uncovered_ranges =
+            subtract_covered_row_ranges(&row_ranges, &selected_rows_by_file[file_index]);
+        if uncovered_ranges.is_empty() {
+            continue;
+        }
+
+        let header_cost = if file_header_charged[file_index] {
+            0
+        } else {
+            estimate_tokens(
+                format!(
+                    "{}{}\n",
+                    seed_coder::FILE_MARKER,
+                    file.path.to_string_lossy()
+                )
+                .len(),
+            )
+        };
+
+        let rows = uncovered_rows_with_tokens(file, &uncovered_ranges);
+        let uncovered_cost = batched_rows_cost(file, &rows);
+
+        if header_cost + uncovered_cost <= remaining_budget {
+            remaining_budget -= header_cost + uncovered_cost;
+            file_header_charged[file_index] = true;
+            for row_range in uncovered_ranges {
+                push_merged_row_range(&mut selected_rows_by_file[file_index], row_range);
+            }
+        } else {
+            if remaining_budget >= header_cost {
+                let budget_for_rows = remaining_budget - header_cost;
+                let clipped_ranges = clip_rows_to_budget_top_down(file, &rows, budget_for_rows);
+                if !clipped_ranges.is_empty() {
+                    file_header_charged[file_index] = true;
+                    for row_range in clipped_ranges {
+                        push_merged_row_range(&mut selected_rows_by_file[file_index], row_range);
+                    }
+                }
+            }
+            break;
+        }
+    }
+
+    context_files
+        .iter()
+        .zip(selected_rows_by_file)
+        .zip(retrieval_orders_by_file)
+        .filter_map(|((file, selected_ranges), retrieval_orders)| {
+            let mut excerpts = Vec::new();
+            for selected_range in selected_ranges {
+                for chunk in &file.chunks {
+                    let start = selected_range.start.max(chunk.row_range.start);
+                    let end = selected_range.end.min(chunk.row_range.end);
+                    if start >= end {
+                        continue;
+                    }
+                    excerpts.push(RelatedExcerpt {
+                        row_range: start..end,
+                        text: text_for_chunk_rows(chunk, start..end).into(),
+                        order: best_retrieval_for_range(file, &retrieval_orders, start..end)
+                            .map_or(usize::MAX, |(order, _)| order),
+                        context_source: best_retrieval_source_for_range(file, start..end),
+                    });
+                }
+            }
+            excerpts.sort_by_key(|excerpt| (excerpt.row_range.start, excerpt.row_range.end));
+            (!excerpts.is_empty()).then(|| RelatedFile {
+                path: file.path.clone(),
+                max_row: file.max_row,
+                excerpts,
+                in_open_source_repo: false,
+            })
+        })
+        .collect()
+}
+
+/// Subtracts already-`covered` (merged, non-overlapping) row ranges from
+/// `ranges`, returning the remaining uncovered pieces in ascending row order.
+fn subtract_covered_row_ranges(ranges: &[Range<u32>], covered: &[Range<u32>]) -> Vec<Range<u32>> {
+    let mut result = Vec::new();
+    for range in ranges {
+        let mut pieces = vec![range.clone()];
+        for covered_range in covered {
+            pieces = pieces
+                .into_iter()
+                .flat_map(|piece| subtract_row_range(&piece, covered_range))
+                .collect();
+        }
+        result.extend(pieces);
+    }
+    result.retain(|range| range.start < range.end);
+    result.sort_by_key(|range| (range.start, range.end));
+    result
+}
+
+/// Returns, in ascending row order, each row covered by `ranges` together
+/// with its raw line byte length and whether that line's text ends with a
+/// newline (false only for the very last line of a chunk that lacks a
+/// trailing newline). This is the raw material needed to charge the same
+/// *batched* cost the renderer's [`excerpt_rendered_tokens`] will charge for
+/// the eventual [`RelatedExcerpt`] — i.e. `estimate_tokens` of the summed
+/// bytes of a contiguous run plus newline/ellipsis overhead — rather than
+/// summing per-line `estimate_tokens` floors, which under-charges relative
+/// to the renderer (see [`batched_rows_cost`] and [`clip_rows_to_budget_top_down`]).
+fn uncovered_rows_with_tokens(
+    file: &ContextFile,
+    ranges: &[Range<u32>],
+) -> Vec<(u32, usize, bool)> {
+    let mut result = Vec::new();
+    for range in ranges {
+        for chunk in &file.chunks {
+            let start = range.start.max(chunk.row_range.start);
+            let end = range.end.min(chunk.row_range.end);
+            if start >= end {
+                continue;
+            }
+            for (row, line) in (chunk.row_range.start..).zip(chunk.text.split_inclusive('\n')) {
+                if row >= end {
+                    break;
+                }
+                if row >= start {
+                    result.push((row, line.len(), line.ends_with('\n')));
+                }
+            }
+        }
+    }
+    result.sort_by_key(|(row, _, _)| *row);
+    result
+}
+
+/// Charges the same units the renderer's `excerpt_rendered_tokens` will
+/// charge for a rendered excerpt spanning rows `first_row..=last_row`:
+/// `estimate_tokens` of the *summed* line bytes (floor-of-sum, not
+/// sum-of-per-line-floors) plus the trailing-newline / ellipsis overhead a
+/// `RelatedExcerpt` built from those rows would need.
+fn run_excerpt_tokens(
+    file: &ContextFile,
+    byte_sum: usize,
+    last_row: u32,
+    ends_with_newline: bool,
+) -> usize {
+    let needs_ellipsis = last_row + 1 < file.max_row;
+    let len = byte_sum
+        + if ends_with_newline { 0 } else { "\n".len() }
+        + if needs_ellipsis { "...\n".len() } else { 0 };
+    estimate_tokens(len)
+}
+
+/// Sums [`run_excerpt_tokens`] over each maximal contiguous run of rows in
+/// `rows` (rows already in ascending order, as returned by
+/// [`uncovered_rows_with_tokens`]), matching the granularity at which the
+/// renderer will actually slice these rows into separate `RelatedExcerpt`s.
+fn batched_rows_cost(file: &ContextFile, rows: &[(u32, usize, bool)]) -> usize {
+    let mut total = 0usize;
+    let mut run: Option<(u32, u32, usize, bool)> = None; // (start, last, byte_sum, last_ends_with_newline)
+    for &(row, len, ends_with_newline) in rows {
+        match &mut run {
+            Some((_, last, byte_sum, run_ends)) if *last + 1 == row => {
+                *last = row;
+                *byte_sum += len;
+                *run_ends = ends_with_newline;
+            }
+            _ => {
+                if let Some((_, last, byte_sum, run_ends)) = run.take() {
+                    total += run_excerpt_tokens(file, byte_sum, last, run_ends);
+                }
+                run = Some((row, row, len, ends_with_newline));
+            }
+        }
+    }
+    if let Some((_, last, byte_sum, run_ends)) = run {
+        total += run_excerpt_tokens(file, byte_sum, last, run_ends);
+    }
+    total
+}
+
+/// Selects a top-down (ascending row order) prefix of `rows` that fits within
+/// `budget`, merging consecutive selected rows into ranges. Charges the same
+/// batched, per-run cost as [`batched_rows_cost`] (rather than per-line
+/// floors) so that a range this function returns never costs more to render
+/// than `budget` once the renderer builds the corresponding excerpt(s).
+fn clip_rows_to_budget_top_down(
+    file: &ContextFile,
+    rows: &[(u32, usize, bool)],
+    budget: usize,
+) -> Vec<Range<u32>> {
+    let mut result = Vec::new();
+    let mut finalized_cost = 0usize;
+    let mut run: Option<(Range<u32>, usize, bool)> = None; // (row_range, byte_sum, last_ends_with_newline)
+
+    for &(row, len, ends_with_newline) in rows {
+        let contiguous = run.as_ref().is_some_and(|(range, _, _)| range.end == row);
+        let (candidate_range, candidate_byte_sum) = if contiguous {
+            let (range, byte_sum, _) = run.as_ref().expect("checked above");
+            (range.start..row + 1, byte_sum + len)
+        } else {
+            (row..row + 1, len)
+        };
+        let candidate_run_cost =
+            run_excerpt_tokens(file, candidate_byte_sum, row, ends_with_newline);
+        let other_finalized_cost = if contiguous {
+            finalized_cost
+        } else if let Some((range, byte_sum, run_ends)) = &run {
+            finalized_cost + run_excerpt_tokens(file, *byte_sum, range.end - 1, *run_ends)
+        } else {
+            finalized_cost
+        };
+
+        if other_finalized_cost + candidate_run_cost > budget {
+            break;
+        }
+
+        if !contiguous && let Some((range, byte_sum, run_ends)) = run.take() {
+            finalized_cost += run_excerpt_tokens(file, byte_sum, range.end - 1, run_ends);
+            result.push(range);
+        }
+        run = Some((candidate_range, candidate_byte_sum, ends_with_newline));
+    }
+
+    if let Some((range, _, _)) = run {
+        result.push(range);
+    }
+
+    result
+}
+
+fn subtract_row_range(row_range: &Range<u32>, subtract: &Range<u32>) -> Vec<Range<u32>> {
+    if row_range.end <= subtract.start || row_range.start >= subtract.end {
+        return vec![row_range.clone()];
+    }
+    let mut ranges = Vec::new();
+    if row_range.start < subtract.start {
+        ranges.push(row_range.start..subtract.start);
+    }
+    if subtract.end < row_range.end {
+        ranges.push(subtract.end..row_range.end);
+    }
+    ranges
+}
+
+fn push_merged_row_range(row_ranges: &mut Vec<Range<u32>>, row_range: Range<u32>) {
+    if row_range.start >= row_range.end {
+        return;
+    }
+    row_ranges.push(row_range);
+    row_ranges.sort_by_key(|range| (range.start, range.end));
+    let mut merged = Vec::<Range<u32>>::new();
+    for row_range in row_ranges.drain(..) {
+        if let Some(last) = merged.last_mut()
+            && row_range.start <= last.end
+        {
+            last.end = last.end.max(row_range.end);
+            continue;
+        }
+        merged.push(row_range);
+    }
+    *row_ranges = merged;
+}
+
+fn text_for_chunk_rows(chunk: &Chunk, row_range: Range<u32>) -> String {
+    let mut text = String::new();
+    for (row, line) in (chunk.row_range.start..).zip(chunk.text.split_inclusive('\n')) {
+        if row >= row_range.end {
+            break;
+        }
+        if row >= row_range.start {
+            text.push_str(line);
+        }
+    }
+    text
+}
+
+fn best_retrieval_for_range<'a>(
+    file: &'a ContextFile,
+    retrieval_orders: &[usize],
+    row_range: Range<u32>,
+) -> Option<(usize, &'a Retrieval)> {
+    file.retrievals
+        .iter()
+        .enumerate()
+        .filter(|(_, retrieval)| ranges_intersect(&retrieval.row_range, &row_range))
+        .min_by_key(|(index, _)| retrieval_orders.get(*index).copied().unwrap_or(usize::MAX))
+        .map(|(index, retrieval)| {
+            (
+                retrieval_orders.get(index).copied().unwrap_or(usize::MAX),
+                retrieval,
+            )
+        })
+}
+
+fn best_retrieval_source_for_range(file: &ContextFile, row_range: Range<u32>) -> ContextSource {
+    file.retrievals
+        .iter()
+        .enumerate()
+        .filter(|(_, retrieval)| ranges_intersect(&retrieval.row_range, &row_range))
+        .min_by_key(|(index, retrieval)| default_retrieval_policy_key(0, *index, retrieval))
+        .map_or(ContextSource::CurrentFile, |(_, retrieval)| {
+            retrieval.source
+        })
+}
+
+fn ranges_intersect<T: Ord>(left: &Range<T>, right: &Range<T>) -> bool {
+    left.start < right.end && right.start < left.end
 }
 
 pub fn special_tokens_for_format(format: ZetaFormat) -> &'static [&'static str] {
@@ -988,7 +1504,7 @@ fn build_v0317_cursor_prefix(
     section
 }
 
-fn offset_range_to_row_range(text: &str, range: Range<usize>) -> Range<u32> {
+pub fn offset_range_to_row_range(text: &str, range: Range<usize>) -> Range<u32> {
     let start_row = text[0..range.start].matches('\n').count() as u32;
     let mut end_row = start_row + text[range.clone()].matches('\n').count() as u32;
     if !text[..range.end].ends_with('\n') {
@@ -1931,12 +2447,13 @@ pub fn parse_zeta3_model_output_as_patch(
         Some(marker) => output.strip_suffix(marker).unwrap_or(output),
         None => output,
     };
-    let (current_excerpt, cursor_offset_in_excerpt) = zeta3_current_file_excerpt(input)
+    let (cursor_file, cursor_chunk, cursor_offset_in_chunk) = zeta3_cursor_chunk(input)
         .ok_or_else(|| anyhow!("Zeta3 input is missing current-file editable context at cursor"))?;
     let (context, editable_range_in_context, context_range, _) = resolve_zeta3_cursor_region(
-        current_excerpt.text.as_ref(),
-        cursor_offset_in_excerpt,
-        &input.syntax_ranges,
+        cursor_chunk.text.as_ref(),
+        cursor_offset_in_chunk,
+        &cursor_file.syntax_ranges,
+        cursor_chunk.row_range.start,
         format,
     );
     let old_editable_region = &context[editable_range_in_context.clone()];
@@ -1949,8 +2466,8 @@ pub fn parse_zeta3_model_output_as_patch(
 
     parsed_output_to_patch_for_excerpt(
         input.cursor_path.as_ref(),
-        current_excerpt.text.as_ref(),
-        current_excerpt.row_range.start,
+        cursor_chunk.text.as_ref(),
+        cursor_chunk.row_range.start,
         parsed,
     )
 }
@@ -2066,10 +2583,15 @@ pub fn resolve_cursor_region(
         (editable_range, context_range)
     } else if let Some(syntax_ranges) = &input.syntax_ranges {
         let (editable_tokens, context_tokens) = token_limits_for_format(format);
+        let syntax_row_ranges = syntax_ranges
+            .iter()
+            .map(|range| offset_range_to_row_range(&input.cursor_excerpt, range.clone()))
+            .collect::<Vec<_>>();
         compute_editable_and_context_ranges(
             &input.cursor_excerpt,
             input.cursor_offset_in_excerpt,
-            syntax_ranges,
+            &syntax_row_ranges,
+            0,
             editable_tokens,
             context_tokens,
         )
@@ -4206,21 +4728,35 @@ pub mod seed_coder {
         )
     }
 
-    pub fn assemble_fim_prompt(
+    /// The sections and remaining token budget computed prior to selecting or
+    /// rendering related files. Shared between [`assemble_fim_prompt`] (which
+    /// needs the section strings to render the final prompt) and
+    /// `format_zeta3_prompt` (which only needs `budget_after_diagnostics`, to
+    /// select related-file rows up front, before rendering) so the two stay
+    /// in bit-identical agreement by construction rather than by hand-copied
+    /// duplication.
+    pub(crate) struct BudgetBeforeRelatedFiles {
+        pub suffix_section: String,
+        pub edit_history_section: String,
+        pub diagnostics_section: String,
+        pub budget_after_diagnostics: usize,
+    }
+
+    pub(crate) fn budget_before_related_files(
         context: &str,
         editable_range: &Range<usize>,
         cursor_prefix_section: &str,
         events: &[Arc<Event>],
-        related_files: &[RelatedFile],
         diagnostics: &[ActiveBufferDiagnostic],
         cursor_buffer_row: Option<u32>,
-        max_tokens: usize,
-    ) -> String {
+        budget_with_margin: usize,
+    ) -> BudgetBeforeRelatedFiles {
         let suffix_section = build_suffix_section(context, editable_range);
 
         let suffix_tokens = estimate_tokens(suffix_section.len() + FIM_PREFIX.len());
         let cursor_prefix_tokens = estimate_tokens(cursor_prefix_section.len() + FIM_MIDDLE.len());
-        let budget_after_cursor = max_tokens.saturating_sub(suffix_tokens + cursor_prefix_tokens);
+        let budget_after_cursor =
+            budget_with_margin.saturating_sub(suffix_tokens + cursor_prefix_tokens);
 
         let edit_history_section = super::format_edit_history_within_budget(
             events,
@@ -4239,6 +4775,39 @@ pub mod seed_coder {
         );
         let diagnostics_tokens = estimate_tokens(diagnostics_section.len() + "\n".len());
         let budget_after_diagnostics = budget_after_edit_history.saturating_sub(diagnostics_tokens);
+
+        BudgetBeforeRelatedFiles {
+            suffix_section,
+            edit_history_section,
+            diagnostics_section,
+            budget_after_diagnostics,
+        }
+    }
+
+    pub fn assemble_fim_prompt(
+        context: &str,
+        editable_range: &Range<usize>,
+        cursor_prefix_section: &str,
+        events: &[Arc<Event>],
+        related_files: &[RelatedFile],
+        diagnostics: &[ActiveBufferDiagnostic],
+        cursor_buffer_row: Option<u32>,
+        max_tokens: usize,
+    ) -> String {
+        let BudgetBeforeRelatedFiles {
+            suffix_section,
+            edit_history_section,
+            diagnostics_section,
+            budget_after_diagnostics,
+        } = budget_before_related_files(
+            context,
+            editable_range,
+            cursor_prefix_section,
+            events,
+            diagnostics,
+            cursor_buffer_row,
+            max_tokens,
+        );
 
         let related_files_section = super::format_related_files_within_budget(
             related_files,
@@ -6487,23 +7056,226 @@ mod tests {
     }
 
     #[test]
+    fn test_related_files_budget_selection_high_priority_not_displaced() {
+        let path: Arc<Path> = Path::new("test.rs").into();
+        let line = "xx\n";
+        let chunk_text: String = line.repeat(60); // rows 90..150
+        let context_files = vec![ContextFile {
+            path: path.clone(),
+            max_row: 150,
+            chunks: vec![Chunk {
+                row_range: 90..150,
+                text: chunk_text.into(),
+            }],
+            retrievals: vec![
+                Retrieval {
+                    source: ContextSource::GitLog,
+                    row_range: 90..150,
+                    rank: 0,
+                    score: None,
+                },
+                Retrieval {
+                    source: ContextSource::EditHistory,
+                    row_range: 100..110,
+                    rank: 0,
+                    score: None,
+                },
+            ],
+            syntax_ranges: Vec::new(),
+        }];
+
+        // Header ("<filename>test.rs\n" = 18 bytes -> 6 tokens) plus the 10
+        // EditHistory rows charged as a single batched excerpt (30 bytes +
+        // "...\n" ellipsis overhead since more of the file follows = 34 bytes
+        // -> 11 tokens) totals 17 tokens, leaving nothing for any of GitLog's
+        // remaining rows.
+        let related_files =
+            context_files_to_related_files_excluding_within_budget(&context_files, None, 17);
+
+        assert_eq!(
+            related_files,
+            vec![RelatedFile {
+                path,
+                max_row: 150,
+                excerpts: vec![RelatedExcerpt {
+                    row_range: 100..110,
+                    text: line.repeat(10).into(),
+                    order: 0,
+                    context_source: ContextSource::EditHistory,
+                }],
+                in_open_source_repo: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_related_files_budget_selection_partial_fill_uses_leftover_budget() {
+        let path: Arc<Path> = Path::new("test.rs").into();
+        let line = "xx\n";
+        let chunk_text: String = line.repeat(60); // rows 90..150
+        let context_files = vec![ContextFile {
+            path: path.clone(),
+            max_row: 150,
+            chunks: vec![Chunk {
+                row_range: 90..150,
+                text: chunk_text.into(),
+            }],
+            retrievals: vec![
+                Retrieval {
+                    source: ContextSource::GitLog,
+                    row_range: 90..150,
+                    rank: 0,
+                    score: None,
+                },
+                Retrieval {
+                    source: ContextSource::EditHistory,
+                    row_range: 100..110,
+                    rank: 0,
+                    score: None,
+                },
+            ],
+            syntax_ranges: Vec::new(),
+        }];
+
+        // 17 tokens for EditHistory (as above) plus 6 leftover tokens, which
+        // fits exactly 5 of GitLog's uncovered rows (90..95) charged as one
+        // batched excerpt (15 bytes + "...\n" overhead = 19 bytes -> 6
+        // tokens), taken top-down; a 6th row would push the batched cost to
+        // 7 tokens and be rejected.
+        let related_files =
+            context_files_to_related_files_excluding_within_budget(&context_files, None, 23);
+
+        assert_eq!(
+            related_files,
+            vec![RelatedFile {
+                path,
+                max_row: 150,
+                excerpts: vec![
+                    RelatedExcerpt {
+                        row_range: 90..95,
+                        text: line.repeat(5).into(),
+                        order: 1,
+                        context_source: ContextSource::GitLog,
+                    },
+                    RelatedExcerpt {
+                        row_range: 100..110,
+                        text: line.repeat(10).into(),
+                        order: 0,
+                        context_source: ContextSource::EditHistory,
+                    },
+                ],
+                in_open_source_repo: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_related_files_budget_selection_zero_charge_for_fully_covered_retrieval() {
+        let path: Arc<Path> = Path::new("test.rs").into();
+        let line = "xx\n";
+        let chunk_text: String = line.repeat(20); // rows 0..20
+        let base_retrieval = Retrieval {
+            source: ContextSource::CurrentFile,
+            row_range: 0..20,
+            rank: 0,
+            score: None,
+        };
+        let overlapping_retrieval = Retrieval {
+            source: ContextSource::EditHistory,
+            row_range: 5..10,
+            rank: 0,
+            score: None,
+        };
+
+        let context_files_without_overlap = vec![ContextFile {
+            path: path.clone(),
+            max_row: 20,
+            chunks: vec![Chunk {
+                row_range: 0..20,
+                text: chunk_text.clone().into(),
+            }],
+            retrievals: vec![base_retrieval.clone()],
+            syntax_ranges: Vec::new(),
+        }];
+        let context_files_with_overlap = vec![ContextFile {
+            retrievals: vec![base_retrieval, overlapping_retrieval],
+            ..context_files_without_overlap[0].clone()
+        }];
+
+        // Header ("<filename>test.rs\n" = 18 bytes -> 6 tokens) plus 20 rows
+        // (1 token each) totals exactly 26 tokens; if the fully-covered
+        // retrieval added any cost, this tight budget would be exceeded and
+        // the output would change.
+        let budget = 26;
+        let without_overlap = context_files_to_related_files_excluding_within_budget(
+            &context_files_without_overlap,
+            None,
+            budget,
+        );
+        let with_overlap = context_files_to_related_files_excluding_within_budget(
+            &context_files_with_overlap,
+            None,
+            budget,
+        );
+
+        assert_eq!(with_overlap, without_overlap);
+        assert_eq!(
+            with_overlap,
+            vec![RelatedFile {
+                path,
+                max_row: 20,
+                excerpts: vec![RelatedExcerpt {
+                    row_range: 0..20,
+                    text: chunk_text.into(),
+                    order: 0,
+                    context_source: ContextSource::CurrentFile,
+                }],
+                in_open_source_repo: false,
+            }]
+        );
+    }
+
+    #[test]
     fn test_zeta3_prompt_matches_zeta2_seed_multi_region_prompt() {
         let excerpt = "fn main() {\n    helper();\n}\n";
         let cursor_offset = excerpt.find("helper").expect("cursor text exists") + "help".len();
         let cursor_row_start = excerpt.find("    helper").expect("cursor row exists");
         let syntax_ranges = vec![0..excerpt.len()];
         let related_file = make_related_file("related.rs", "fn helper() {}\n");
+        let related_context_file = ContextFile {
+            path: related_file.path.clone(),
+            max_row: related_file.max_row,
+            chunks: related_file
+                .excerpts
+                .iter()
+                .map(|excerpt| Chunk {
+                    row_range: excerpt.row_range.clone(),
+                    text: excerpt.text.clone(),
+                })
+                .collect(),
+            retrievals: related_file
+                .excerpts
+                .iter()
+                .map(|excerpt| Retrieval {
+                    source: excerpt.context_source,
+                    row_range: excerpt.row_range.clone(),
+                    rank: excerpt.order,
+                    score: None,
+                })
+                .collect(),
+            syntax_ranges: Vec::new(),
+        };
         let mut zeta2_input = make_input(
             excerpt,
             0..excerpt.len(),
             cursor_offset,
             vec![make_event("test.rs", "-old\n+new\n")],
-            vec![related_file.clone()],
+            vec![related_file],
         );
         zeta2_input.excerpt_start_row = Some(10);
         zeta2_input.excerpt_ranges =
             compute_legacy_excerpt_ranges(excerpt, cursor_offset, &syntax_ranges);
-        zeta2_input.syntax_ranges = Some(syntax_ranges.clone());
+        zeta2_input.syntax_ranges = Some(syntax_ranges);
 
         let zeta3_input = Zeta3PromptInput {
             cursor_path: Path::new("test.rs").into(),
@@ -6513,20 +7285,23 @@ mod tests {
             },
             events: vec![Arc::new(make_event("test.rs", "-old\n+new\n"))],
             editable_context: vec![
-                RelatedFile {
+                ContextFile {
                     path: Path::new("test.rs").into(),
                     max_row: 12,
-                    excerpts: vec![RelatedExcerpt {
+                    chunks: vec![Chunk {
                         row_range: 10..12,
                         text: excerpt.into(),
-                        order: 0,
-                        context_source: ContextSource::CurrentFile,
                     }],
-                    in_open_source_repo: false,
+                    retrievals: vec![Retrieval {
+                        source: ContextSource::CurrentFile,
+                        row_range: 10..12,
+                        rank: 0,
+                        score: None,
+                    }],
+                    syntax_ranges: vec![10..12],
                 },
-                related_file,
+                related_context_file,
             ],
-            syntax_ranges,
             active_buffer_diagnostics: vec![],
             in_open_source_repo: false,
             can_collect_data: false,
@@ -6537,6 +7312,310 @@ mod tests {
             format_zeta3_prompt(&zeta3_input, ZetaFormat::V0318SeedMultiRegions),
             format_zeta_prompt(&zeta2_input, ZetaFormat::V0318SeedMultiRegions),
         );
+    }
+
+    #[test]
+    fn test_related_files_budget_selection_matches_renderer_no_op() {
+        // Realistic, non-3-byte-multiple line lengths: per-line-floor
+        // accounting (the pre-fix behavior) under-charges relative to the
+        // renderer's batched excerpt accounting whenever line lengths aren't
+        // all multiples of 3, which this line deliberately is not.
+        let line = "    let value = compute(a, b);\n";
+        assert_ne!(line.len() % 3, 0, "line length must not be a multiple of 3");
+        let chunk_text: String = line.repeat(60); // rows 0..60
+        let context_files = vec![ContextFile {
+            path: Path::new("test.rs").into(),
+            max_row: 60,
+            chunks: vec![Chunk {
+                row_range: 0..60,
+                text: chunk_text.into(),
+            }],
+            retrievals: vec![
+                Retrieval {
+                    source: ContextSource::GitLog,
+                    row_range: 0..60,
+                    rank: 0,
+                    score: None,
+                },
+                Retrieval {
+                    source: ContextSource::EditHistory,
+                    row_range: 0..20,
+                    rank: 0,
+                    score: None,
+                },
+            ],
+            syntax_ranges: Vec::new(),
+        }];
+
+        // Binds partway through GitLog's uncovered tail (which is adjacent to
+        // EditHistory's range, so the two get unioned into a single merged
+        // block/excerpt) at a budget not aligned to any row boundary.
+        let budget = 270;
+        let related_files =
+            context_files_to_related_files_excluding_within_budget(&context_files, None, budget);
+
+        // A sanity check that this budget actually binds (selection didn't
+        // just include everything, which would make the no-op check trivial).
+        let total_selected_rows: u32 = related_files
+            .iter()
+            .flat_map(|file| &file.excerpts)
+            .map(|excerpt| excerpt.row_range.end - excerpt.row_range.start)
+            .sum();
+        assert!(
+            total_selected_rows < 60,
+            "budget did not bind: {total_selected_rows} rows selected"
+        );
+        assert!(
+            total_selected_rows > 20,
+            "budget selected nothing beyond EditHistory"
+        );
+
+        // The core invariant this fix restores: rendering the selected
+        // excerpts at the very budget selection used (or a much larger one)
+        // must yield the identical string. If selection under-charged
+        // relative to the renderer, the tight-budget render would trim
+        // further than the generous-budget render.
+        let rendered_with_selection_budget =
+            format_related_files_within_budget(&related_files, "<filename>", "", budget);
+        let rendered_with_generous_budget =
+            format_related_files_within_budget(&related_files, "<filename>", "", usize::MAX / 2);
+
+        assert_eq!(
+            rendered_with_selection_budget,
+            rendered_with_generous_budget
+        );
+        assert!(!rendered_with_selection_budget.is_empty());
+    }
+
+    #[test]
+    fn test_format_zeta3_prompt_tight_budget_keeps_high_priority_drops_low_priority_tail() {
+        // Realistic (non-3-byte-multiple) line length, per the F1 review
+        // finding: 3-byte lines make per-line and per-excerpt token
+        // accounting coincide and hide the under-charge bug this guards
+        // against.
+        let related_line = "    let value_0000 = compute(a, b, c, dd);\n";
+        assert_ne!(related_line.len() % 3, 0);
+
+        // EditHistory (higher priority than GitLog, see
+        // `context_source_priority`) covers rows 0..253, which is sized (via
+        // the real `estimate_tokens`/margin arithmetic, not a hand-tuned
+        // guess) to consume nearly all of the related-files budget available
+        // under the format's fixed 4096-token cap, leaving less budget than a
+        // single additional row costs. GitLog then overlaps that entire
+        // range and extends it by 27 more rows (253..280) that must be
+        // dropped entirely: not clipped to a partial tail, absent.
+        let high_priority_row_count = 253u32;
+        let total_row_count = 280u32;
+        let related_text: String = (0..total_row_count)
+            .map(|_| related_line.to_string())
+            .collect();
+        let related_context_file = ContextFile {
+            path: Path::new("related.rs").into(),
+            max_row: total_row_count,
+            chunks: vec![Chunk {
+                row_range: 0..total_row_count,
+                text: related_text.into(),
+            }],
+            retrievals: vec![
+                Retrieval {
+                    source: ContextSource::GitLog,
+                    row_range: 0..total_row_count,
+                    rank: 0,
+                    score: None,
+                },
+                Retrieval {
+                    source: ContextSource::EditHistory,
+                    row_range: 0..high_priority_row_count,
+                    rank: 0,
+                    score: None,
+                },
+            ],
+            syntax_ranges: Vec::new(),
+        };
+
+        let cursor_excerpt = "fn main() {\n    helper();\n}\n";
+        let cursor_offset =
+            cursor_excerpt.find("helper").expect("cursor text exists") + "help".len();
+        let cursor_row_start = cursor_excerpt
+            .find("    helper")
+            .expect("cursor row exists");
+
+        let zeta3_input = Zeta3PromptInput {
+            cursor_path: Path::new("test.rs").into(),
+            cursor_position: FilePosition {
+                row: 1,
+                column: (cursor_offset - cursor_row_start) as u32,
+            },
+            events: vec![],
+            editable_context: vec![
+                ContextFile {
+                    path: Path::new("test.rs").into(),
+                    max_row: 3,
+                    chunks: vec![Chunk {
+                        row_range: 0..3,
+                        text: cursor_excerpt.into(),
+                    }],
+                    retrievals: vec![Retrieval {
+                        source: ContextSource::CurrentFile,
+                        row_range: 0..3,
+                        rank: 0,
+                        score: None,
+                    }],
+                    syntax_ranges: vec![0..cursor_excerpt.len() as u32],
+                },
+                related_context_file,
+            ],
+            active_buffer_diagnostics: vec![],
+            in_open_source_repo: false,
+            can_collect_data: false,
+            repo_url: None,
+        };
+
+        let prompt = format_zeta3_prompt(&zeta3_input, ZetaFormat::V0318SeedMultiRegions)
+            .expect("prompt renders");
+
+        let expected_related_files_section = format!(
+            "<filename>related.rs\n{}...\n",
+            related_line.repeat(high_priority_row_count as usize)
+        );
+        assert!(
+            prompt.contains(&expected_related_files_section),
+            "expected exactly {high_priority_row_count} high-priority rows followed by an \
+             ellipsis; prompt:\n{prompt}"
+        );
+
+        // None of GitLog's low-priority-only tail rows survive: the renderer
+        // must emit exactly the row set selection chose, not a superset.
+        let dropped_row_line = related_line.to_string();
+        let occurrences = prompt.matches(&dropped_row_line).count();
+        assert_eq!(
+            occurrences, high_priority_row_count as usize,
+            "expected exactly the high-priority rows to appear and none of GitLog's \
+             low-priority-only tail; prompt:\n{prompt}"
+        );
+    }
+
+    #[test]
+    fn test_format_zeta3_prompt_tight_budget_accounts_for_diagnostics_in_related_files_selection()
+     {
+        // Same fixture as
+        // `test_format_zeta3_prompt_tight_budget_keeps_high_priority_drops_low_priority_tail`,
+        // except the input now carries a diagnostic. Retrieval selection
+        // (`budget_before_related_files`, called from `format_zeta3_prompt`)
+        // must charge the diagnostics section against the related-files
+        // budget the same way the final assembly does, or selection admits
+        // more high-priority rows than actually fit once the rest of the
+        // prompt is assembled.
+        let related_line = "    let value_0000 = compute(a, b, c, dd);\n";
+        assert_ne!(related_line.len() % 3, 0);
+
+        // high_priority_row_count is derived (not hand-tuned) from the real
+        // `estimate_tokens`/margin arithmetic `budget_before_related_files`
+        // and the renderer both use:
+        //   header_cost = estimate_tokens(len("<filename>related.rs\n")) = 7
+        //   row_cost(n) = header_cost
+        //       + estimate_tokens(n * related_line.len() + "...\n".len())
+        // With this one diagnostic present, `budget_before_related_files`
+        // (computed the same way `format_zeta3_prompt` computes it) yields a
+        // related-files budget of exactly 3376 tokens; row_cost(235) == 3376
+        // exactly (0 tokens left over) while row_cost(236) == 3391 (exceeds
+        // the budget). Without the diagnostic the budget is 3644 tokens,
+        // which fits 253 rows (see the sibling test) -- so accounting for
+        // diagnostics strictly tightens the selected row count from 253 to
+        // 235, and this test pins that exact, smaller boundary.
+        let high_priority_row_count = 235u32;
+        let total_row_count = 280u32;
+        let related_text: String = (0..total_row_count)
+            .map(|_| related_line.to_string())
+            .collect();
+        let related_context_file = ContextFile {
+            path: Path::new("related.rs").into(),
+            max_row: total_row_count,
+            chunks: vec![Chunk {
+                row_range: 0..total_row_count,
+                text: related_text.into(),
+            }],
+            retrievals: vec![
+                Retrieval {
+                    source: ContextSource::GitLog,
+                    row_range: 0..total_row_count,
+                    rank: 0,
+                    score: None,
+                },
+                Retrieval {
+                    source: ContextSource::EditHistory,
+                    row_range: 0..high_priority_row_count,
+                    rank: 0,
+                    score: None,
+                },
+            ],
+            syntax_ranges: Vec::new(),
+        };
+
+        let cursor_excerpt = "fn main() {\n    helper();\n}\n";
+        let cursor_offset =
+            cursor_excerpt.find("helper").expect("cursor text exists") + "help".len();
+        let cursor_row_start = cursor_excerpt
+            .find("    helper")
+            .expect("cursor row exists");
+
+        // A realistic diagnostic snippet/message: large enough (the snippet
+        // is clamped to 256 tokens by `format_active_buffer_diagnostics_with_budget`)
+        // that its rendered section consumes a meaningful, non-trivial chunk
+        // of the related-files budget above.
+        let active_buffer_diagnostics = vec![ActiveBufferDiagnostic {
+            severity: Some(1),
+            message: "cannot find value `dd` in this scope".to_string(),
+            snippet: related_line.repeat(50),
+            snippet_buffer_row_range: 0..50,
+            diagnostic_range_in_snippet: 0..10,
+        }];
+
+        let zeta3_input = Zeta3PromptInput {
+            cursor_path: Path::new("test.rs").into(),
+            cursor_position: FilePosition {
+                row: 1,
+                column: (cursor_offset - cursor_row_start) as u32,
+            },
+            events: vec![],
+            editable_context: vec![
+                ContextFile {
+                    path: Path::new("test.rs").into(),
+                    max_row: 3,
+                    chunks: vec![Chunk {
+                        row_range: 0..3,
+                        text: cursor_excerpt.into(),
+                    }],
+                    retrievals: vec![Retrieval {
+                        source: ContextSource::CurrentFile,
+                        row_range: 0..3,
+                        rank: 0,
+                        score: None,
+                    }],
+                    syntax_ranges: vec![0..cursor_excerpt.len() as u32],
+                },
+                related_context_file,
+            ],
+            active_buffer_diagnostics,
+            in_open_source_repo: false,
+            can_collect_data: false,
+            repo_url: None,
+        };
+
+        let prompt = format_zeta3_prompt(&zeta3_input, ZetaFormat::V0318SeedMultiRegions)
+            .expect("prompt renders");
+
+        // The related-files section must end exactly at the row boundary
+        // selection chose (235, not the diagnostics-blind 253): the full
+        // rendered prompt is asserted so that any extra or missing row --
+        // whether from selection ignoring the diagnostics budget again, or
+        // the renderer re-trimming a merged block to a different boundary --
+        // shows up as a mismatch.
+        let expected = format!(
+            "<[fim-suffix]>\n<[fim-prefix]><filename>related.rs\n{}...\n\n<filename>test.rs\n<|marker_1|>fn main() {{\n    help<|user_cursor|>er();\n}}\n<|marker_2|>\n<[fim-middle]>",
+            related_line.repeat(high_priority_row_count as usize)
+        );
+        assert_eq!(prompt, expected);
     }
 
     #[test]
@@ -6551,18 +7630,21 @@ mod tests {
             cursor_path: Path::new("test.rs").into(),
             cursor_position: FilePosition { row: 21, column: 8 },
             events: vec![],
-            editable_context: vec![RelatedFile {
+            editable_context: vec![ContextFile {
                 path: Path::new("test.rs").into(),
                 max_row: 24,
-                excerpts: vec![RelatedExcerpt {
+                chunks: vec![Chunk {
                     row_range: 20..24,
                     text: excerpt.into(),
-                    order: 0,
-                    context_source: ContextSource::CurrentFile,
                 }],
-                in_open_source_repo: false,
+                retrievals: vec![Retrieval {
+                    source: ContextSource::CurrentFile,
+                    row_range: 20..24,
+                    rank: 0,
+                    score: None,
+                }],
+                syntax_ranges: vec![20..24],
             }],
-            syntax_ranges: vec![0..excerpt.len()],
             active_buffer_diagnostics: vec![],
             in_open_source_repo: false,
             can_collect_data: false,


### PR DESCRIPTION
Closes EP-206

Replaces the merged-excerpt shape of `Zeta3PromptInput.editable_context` with a policy-free one, so prompt formatting has full retrieval information when deciding what to include in the prompt:

```rust
ContextFile {
    path: Arc<Path>,
    max_row: u32,
    chunks: Vec<Chunk>,          // disjoint text, stored once per file
    retrievals: Vec<Retrieval>,  // per-source provenance; may overlap, never merged
    syntax_ranges: Vec<Range<u32>>, // buffer rows, innermost→outermost, cursor file only
}
Chunk { row_range: Range<u32>, text: Arc<str> }
Retrieval { source: ContextSource, row_range: Range<u32>, rank: usize, score: Option<f32> }
```

Previously, overlapping context ranges were merged at collection time into flat `RelatedExcerpt`s, each keeping a single `context_source` and a single global `order` — discarding which sources found a region and their per-source ranking. Selection/prioritization now happens at prompt-format time instead:

- Collection emits per-source ranked retrievals and disjoint text chunks (row-range union replaces the old `split_overlapping_ranges` cluster machinery). All row ranges are 0-based half-open buffer rows.
- `format_zeta3_prompt` walks retrievals in default policy order (source priority, then per-source rank) and applies the related-files token budget in retrieval space, before rows are unioned: each retrieval is charged only for rows not already covered, so low-priority rows overlapping a high-priority retrieval can never displace the high-priority rows. Selection and rendering agree on one budget via a shared `seed_coder::budget_before_related_files`.
- Syntax ranges move from the top level of `Zeta3PromptInput` onto the cursor `ContextFile`, as row ranges (their consumer only ever used rows; byte offsets were converted and discarded).

This intentionally breaks the v4 wire format (staff-only) — no back-compat serde. v2/v3 (`Zeta2PromptInput`, `RelatedFile`, `RelatedExcerpt`) and their prompt formats are unchanged.

Release Notes:

- N/A
