### PR TITLE
Relax core-foundation pin from =0.10.0 to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -572,7 +572,7 @@ cocoa = "=0.26.0"
 cocoa-foundation = "=0.2.0"
 const_format = "0.2"
 convert_case = "0.11.0"
-core-foundation = "=0.10.0"
+core-foundation = "0.10"
 core-foundation-sys = "0.8.6"
 core-video = { version = "0.5.2", features = ["metal"] }
 cpal = "0.17"


### PR DESCRIPTION
This PR relaxes the workspace `core-foundation` pin from an exact `=0.10.0` to `0.10`.

I am not sure why this is pinned - digging a bit did not turn up any specific reason so I have to assume it was not on purpose. At the moment you cannot use gpui with nusb 0.2 (which is muuuuuch improved over 0.1, it's not a cosmetic update) for example because of this restriction.

I would much appreciate if this relaxation was in the realm of possibilities :)

Release Notes:

- N/A