### PR TITLE
Show runnable task results in gutter

### DIFF
--- a/crates/editor/src/code_actions.rs
+++ b/crates/editor/src/code_actions.rs
@@ -204,7 +204,7 @@ impl Editor {
             };
 
         let action_ix = action.item_ix.unwrap_or(actions_menu.selected_item);
-        let action = actions_menu.actions.get(action_ix)?.clone();
+        let action = actions_menu.actions.get(action_ix)?;
         let title = action.label();
         let runnable_task_key =
             self.runnable_task_key_for_source(&actions_menu.deployed_from, window, cx);

--- a/crates/editor/src/code_actions.rs
+++ b/crates/editor/src/code_actions.rs
@@ -204,21 +204,54 @@ impl Editor {
             };
 
         let action_ix = action.item_ix.unwrap_or(actions_menu.selected_item);
-        let action = actions_menu.actions.get(action_ix)?;
+        let action = actions_menu.actions.get(action_ix)?.clone();
         let title = action.label();
+        let runnable_task_key =
+            self.runnable_task_key_for_source(&actions_menu.deployed_from, window, cx);
         let buffer = actions_menu.buffer;
         let workspace = self.workspace()?;
 
         match action {
             CodeActionsItem::Task(task_source_kind, resolved_task) => {
-                workspace.update(cx, |workspace, cx| {
-                    workspace.schedule_resolved_task(
-                        task_source_kind,
-                        resolved_task,
-                        false,
-                        window,
+                if let Some((buffer_id, buffer_row)) = runnable_task_key {
+                    self.set_runnable_task_status(
+                        buffer_id,
+                        buffer_row,
+                        RunnableTaskStatus::Running,
                         cx,
                     );
+                }
+                let editor = cx.weak_entity();
+                workspace.update(cx, |workspace, cx| {
+                    if let Some((buffer_id, buffer_row)) = runnable_task_key {
+                        workspace.schedule_resolved_task_with_completion(
+                            task_source_kind,
+                            resolved_task,
+                            false,
+                            move |result, cx| {
+                                editor
+                                    .update(cx, |editor, cx| {
+                                        editor.set_runnable_task_status(
+                                            buffer_id,
+                                            buffer_row,
+                                            RunnableTaskStatus::from(result),
+                                            cx,
+                                        );
+                                    })
+                                    .ok();
+                            },
+                            window,
+                            cx,
+                        );
+                    } else {
+                        workspace.schedule_resolved_task(
+                            task_source_kind,
+                            resolved_task,
+                            false,
+                            window,
+                            cx,
+                        );
+                    }
 
                     Some(Task::ready(Ok(())))
                 })
@@ -260,6 +293,25 @@ impl Editor {
                 Some(Task::ready(Ok(())))
             }
         }
+    }
+
+    fn runnable_task_key_for_source(
+        &self,
+        source: &Option<CodeActionSource>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<(BufferId, BufferRow)> {
+        let display_row = match source {
+            Some(CodeActionSource::RunMenu(row)) => *row,
+            _ => return None,
+        };
+        let snapshot = self.snapshot(window, cx);
+        let multibuffer_row =
+            MultiBufferRow(DisplayPoint::new(display_row, 0).to_point(&snapshot).row);
+        let (buffer_snapshot, range) = snapshot
+            .buffer_snapshot()
+            .buffer_line_for_row(multibuffer_row)?;
+        Some((buffer_snapshot.remote_id(), range.start.row))
     }
 
     pub fn code_actions_enabled_for_toolbar(&self, cx: &App) -> bool {

--- a/crates/editor/src/code_lens.rs
+++ b/crates/editor/src/code_lens.rs
@@ -5,7 +5,7 @@ use futures::{StreamExt as _, future::join_all, stream::FuturesUnordered};
 use gpui::{MouseButton, SharedString, Task, TaskExt, WeakEntity};
 use itertools::Itertools;
 use language::{BufferId, ClientCommand};
-use multi_buffer::{Anchor, MultiBufferRow, MultiBufferSnapshot, ToPoint as _};
+use multi_buffer::{Anchor, BufferOffset, MultiBufferRow, MultiBufferSnapshot, ToPoint as _};
 use project::{CodeAction, TaskSourceKind, lsp_store::code_lens::CodeLensActions};
 use task::TaskContext;
 use text::ToOffset as _;
@@ -17,6 +17,7 @@ use crate::{
     actions::ToggleCodeLens,
     display_map::{BlockPlacement, BlockProperties, BlockStyle, CustomBlockId, RenderBlock},
     hover_links::HoverLink,
+    runnables::RunnableTaskStatus,
 };
 
 static EMPTY_LENS_FALLBACK_TITLE: SharedString = SharedString::new_static("0 references");
@@ -97,7 +98,7 @@ pub(super) fn try_handle_client_command(
 fn schedule_task(
     task_template: task::TaskTemplate,
     action: &CodeAction,
-    editor: &Editor,
+    editor: &mut Editor,
     workspace: &gpui::Entity<workspace::Workspace>,
     window: &mut Window,
     cx: &mut Context<Editor>,
@@ -127,15 +128,50 @@ fn schedule_task(
         },
     };
 
+    let Some(resolved_task) =
+        task_template.resolve_task(&task_source_kind.to_id_base(), &task_context)
+    else {
+        return true;
+    };
+    let runnable_task_key = editor
+        .buffer()
+        .read(cx)
+        .buffer(action.range.start.buffer_id)
+        .map(|buffer| {
+            let buffer_snapshot = buffer.read(cx).snapshot();
+            let buffer_id = buffer_snapshot.remote_id();
+            let offset = BufferOffset(action.range.start.to_offset(&buffer_snapshot));
+            editor.runnable_task_key_for_offset(buffer_id, offset)
+        })
+        .flatten();
+    if let Some((buffer_id, buffer_row)) = runnable_task_key {
+        editor.set_runnable_task_status(buffer_id, buffer_row, RunnableTaskStatus::Running, cx);
+    }
+    let editor_handle = cx.weak_entity();
     workspace.update(cx, |workspace, cx| {
-        workspace.schedule_task(
-            task_source_kind,
-            &task_template,
-            &task_context,
-            false,
-            window,
-            cx,
-        );
+        if let Some((buffer_id, buffer_row)) = runnable_task_key {
+            workspace.schedule_resolved_task_with_completion(
+                task_source_kind,
+                resolved_task,
+                false,
+                move |result, cx| {
+                    editor_handle
+                        .update(cx, |editor, cx| {
+                            editor.set_runnable_task_status(
+                                buffer_id,
+                                buffer_row,
+                                RunnableTaskStatus::from(result),
+                                cx,
+                            );
+                        })
+                        .ok();
+                },
+                window,
+                cx,
+            );
+        } else {
+            workspace.schedule_resolved_task(task_source_kind, resolved_task, false, window, cx);
+        }
     });
     true
 }

--- a/crates/editor/src/code_lens.rs
+++ b/crates/editor/src/code_lens.rs
@@ -137,13 +137,12 @@ fn schedule_task(
         .buffer()
         .read(cx)
         .buffer(action.range.start.buffer_id)
-        .map(|buffer| {
+        .and_then(|buffer| {
             let buffer_snapshot = buffer.read(cx).snapshot();
             let buffer_id = buffer_snapshot.remote_id();
             let offset = BufferOffset(action.range.start.to_offset(&buffer_snapshot));
             editor.runnable_task_key_for_offset(buffer_id, offset)
-        })
-        .flatten();
+        });
     if let Some((buffer_id, buffer_row)) = runnable_task_key {
         editor.set_runnable_task_status(buffer_id, buffer_row, RunnableTaskStatus::Running, cx);
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -282,7 +282,7 @@ use crate::{
         InlineValueCache,
         inlay_hints::{LspInlayHintData, inlay_hint_settings},
     },
-    runnables::{ResolvedTasks, RunnableData, RunnableTasks},
+    runnables::{ResolvedTasks, RunnableData, RunnableTaskStatus, RunnableTasks},
     scroll::{ScrollOffset, ScrollPixelOffset},
     selections_collection::resolve_selections_wrapping_blocks,
     semantic_tokens::SemanticTokenState,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2611,6 +2611,14 @@ impl EditorElement {
             run_indicators
                 .iter()
                 .filter_map(|display_row| {
+                    let task_status = gutter
+                        .row_infos
+                        .get((display_row.0.saturating_sub(gutter.range.start.0)) as usize)
+                        .and_then(|row_info| Some((row_info.buffer_id?, row_info.buffer_row?)))
+                        .and_then(|(buffer_id, buffer_row)| {
+                            editor.runnable_task_status(buffer_id, buffer_row)
+                        });
+
                     gutter.layout_item(
                         *display_row,
                         |cx, _| {
@@ -2619,6 +2627,7 @@ impl EditorElement {
                                     &self.style,
                                     Some(*display_row) == active_task_indicator_row,
                                     breakpoints.get(&display_row).map(|(anchor, _, _)| *anchor),
+                                    task_status,
                                     *display_row,
                                     cx,
                                 )

--- a/crates/editor/src/runnables.rs
+++ b/crates/editor/src/runnables.rs
@@ -24,6 +24,7 @@ use crate::{
 #[derive(Debug)]
 pub(super) struct RunnableData {
     runnables: HashMap<BufferId, (Global, BTreeMap<BufferRow, RunnableTasks>)>,
+    task_statuses: HashMap<(BufferId, BufferRow), RunnableTaskStatus>,
     invalidate_buffer_data: HashSet<BufferId>,
     runnables_update_task: Task<()>,
 }
@@ -32,6 +33,7 @@ impl RunnableData {
     pub fn new() -> Self {
         Self {
             runnables: HashMap::default(),
+            task_statuses: HashMap::default(),
             invalidate_buffer_data: HashSet::default(),
             runnables_update_task: Task::ready(()),
         }
@@ -48,6 +50,38 @@ impl RunnableData {
         self.runnables
             .values()
             .flat_map(|(_, tasks)| tasks.values())
+    }
+
+    pub fn task_status(
+        &self,
+        (buffer_id, buffer_row): (BufferId, BufferRow),
+    ) -> Option<RunnableTaskStatus> {
+        self.task_statuses.get(&(buffer_id, buffer_row)).copied()
+    }
+
+    pub fn set_task_status(
+        &mut self,
+        (buffer_id, buffer_row): (BufferId, BufferRow),
+        status: RunnableTaskStatus,
+    ) {
+        self.task_statuses.insert((buffer_id, buffer_row), status);
+    }
+
+    pub fn task_key_for_offset(
+        &self,
+        buffer_id: BufferId,
+        offset: BufferOffset,
+    ) -> Option<(BufferId, BufferRow)> {
+        let (_, tasks_by_row) = self.runnables.get(&buffer_id)?;
+        tasks_by_row
+            .iter()
+            .find(|(_, tasks)| tasks.context_range.contains(&offset))
+            .or_else(|| {
+                tasks_by_row
+                    .iter()
+                    .find(|(_, tasks)| tasks.context_range.start >= offset)
+            })
+            .map(|(row, _)| (buffer_id, *row))
     }
 
     pub fn has_cached(&self, buffer_id: BufferId, version: &Global) -> bool {
@@ -69,6 +103,24 @@ impl RunnableData {
             .or_insert_with(|| (version, BTreeMap::default()))
             .1
             .insert(buffer_row, tasks);
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RunnableTaskStatus {
+    Running,
+    Passed,
+    Failed,
+}
+
+impl From<workspace::tasks::ScheduledTaskResult> for RunnableTaskStatus {
+    fn from(result: workspace::tasks::ScheduledTaskResult) -> Self {
+        match result {
+            workspace::tasks::ScheduledTaskResult::Success => Self::Passed,
+            workspace::tasks::ScheduledTaskResult::Failure
+            | workspace::tasks::ScheduledTaskResult::SpawnFailed
+            | workspace::tasks::ScheduledTaskResult::Cancelled => Self::Failed,
+        }
     }
 }
 
@@ -307,6 +359,8 @@ impl Editor {
             return;
         };
 
+        let buffer_id = buffer.read(cx).remote_id();
+        let editor = cx.weak_entity();
         let reveal_strategy = action.reveal;
         let task_context = Self::build_tasks_context(&project, &buffer, buffer_row, &tasks, cx);
         cx.spawn_in(window, async move |_, cx| {
@@ -316,12 +370,34 @@ impl Editor {
             let resolved = &mut resolved_task.resolved;
             resolved.reveal = reveal_strategy;
 
+            editor
+                .update(cx, |editor, cx| {
+                    editor.set_runnable_task_status(
+                        buffer_id,
+                        buffer_row,
+                        RunnableTaskStatus::Running,
+                        cx,
+                    );
+                })
+                .ok();
             workspace
                 .update_in(cx, |workspace, window, cx| {
-                    workspace.schedule_resolved_task(
+                    workspace.schedule_resolved_task_with_completion(
                         task_source_kind,
                         resolved_task,
                         false,
+                        move |result, cx| {
+                            editor
+                                .update(cx, |editor, cx| {
+                                    editor.set_runnable_task_status(
+                                        buffer_id,
+                                        buffer_row,
+                                        RunnableTaskStatus::from(result),
+                                        cx,
+                                    );
+                                })
+                                .ok();
+                        },
                         window,
                         cx,
                     );
@@ -334,11 +410,43 @@ impl Editor {
     pub fn clear_runnables(&mut self, for_buffer: Option<BufferId>) {
         if let Some(buffer_id) = for_buffer {
             self.runnables.runnables.remove(&buffer_id);
+            self.runnables
+                .task_statuses
+                .retain(|(status_buffer_id, _), _| *status_buffer_id != buffer_id);
         } else {
             self.runnables.runnables.clear();
+            self.runnables.task_statuses.clear();
         }
         self.runnables.invalidate_buffer_data.clear();
         self.runnables.runnables_update_task = Task::ready(());
+    }
+
+    pub(crate) fn runnable_task_status(
+        &self,
+        buffer_id: BufferId,
+        buffer_row: BufferRow,
+    ) -> Option<RunnableTaskStatus> {
+        self.runnables.task_status((buffer_id, buffer_row))
+    }
+
+    pub(crate) fn set_runnable_task_status(
+        &mut self,
+        buffer_id: BufferId,
+        buffer_row: BufferRow,
+        status: RunnableTaskStatus,
+        cx: &mut Context<Self>,
+    ) {
+        self.runnables
+            .set_task_status((buffer_id, buffer_row), status);
+        cx.notify();
+    }
+
+    pub(crate) fn runnable_task_key_for_offset(
+        &self,
+        buffer_id: BufferId,
+        offset: BufferOffset,
+    ) -> Option<(BufferId, BufferRow)> {
+        self.runnables.task_key_for_offset(buffer_id, offset)
     }
 
     pub fn task_context(&self, window: &mut Window, cx: &mut App) -> Task<Option<TaskContext>> {
@@ -515,44 +623,53 @@ impl Editor {
         None
     }
 
-    pub fn render_run_indicator(
+    pub(crate) fn render_run_indicator(
         &self,
         _style: &EditorStyle,
         is_active: bool,
         active_breakpoint: Option<Anchor>,
+        task_status: Option<RunnableTaskStatus>,
         row: DisplayRow,
         cx: &mut Context<Self>,
     ) -> IconButton {
-        let color = Color::Muted;
+        let (icon, color) = match task_status {
+            Some(RunnableTaskStatus::Running) => (ui::IconName::PlayOutlined, Color::Accent),
+            Some(RunnableTaskStatus::Passed) => (ui::IconName::Check, Color::Success),
+            Some(RunnableTaskStatus::Failed) => (ui::IconName::XCircle, Color::Error),
+            None => (ui::IconName::PlayOutlined, Color::Muted),
+        };
 
-        IconButton::new(
-            ("run_indicator", row.0 as usize),
-            ui::IconName::PlayOutlined,
-        )
-        .shape(ui::IconButtonShape::Square)
-        .icon_size(IconSize::XSmall)
-        .icon_color(color)
-        .toggle_state(is_active)
-        .on_click(cx.listener(move |editor, e: &ClickEvent, window, cx| {
-            let quick_launch = match e {
-                ClickEvent::Keyboard(_) => true,
-                ClickEvent::Mouse(e) => e.down.button == MouseButton::Left,
-                ClickEvent::Touch(_) => true,
-            };
+        IconButton::new(("run_indicator", row.0 as usize), icon)
+            .shape(ui::IconButtonShape::Square)
+            .icon_size(IconSize::XSmall)
+            .icon_color(color)
+            .toggle_state(is_active)
+            .on_click(cx.listener(move |editor, e: &ClickEvent, window, cx| {
+                let quick_launch = match e {
+                    ClickEvent::Keyboard(_) => true,
+                    ClickEvent::Mouse(e) => e.down.button == MouseButton::Left,
+                    ClickEvent::Touch(_) => true,
+                };
 
-            window.focus(&editor.focus_handle(cx), cx);
-            editor.toggle_code_actions(
-                &ToggleCodeActions {
-                    deployed_from: Some(CodeActionSource::RunMenu(row)),
-                    quick_launch,
-                },
-                window,
-                cx,
-            );
-        }))
-        .on_right_click(cx.listener(move |editor, event: &ClickEvent, window, cx| {
-            editor.set_gutter_context_menu(row, active_breakpoint, event.position(), window, cx);
-        }))
+                window.focus(&editor.focus_handle(cx), cx);
+                editor.toggle_code_actions(
+                    &ToggleCodeActions {
+                        deployed_from: Some(CodeActionSource::RunMenu(row)),
+                        quick_launch,
+                    },
+                    window,
+                    cx,
+                );
+            }))
+            .on_right_click(cx.listener(move |editor, event: &ClickEvent, window, cx| {
+                editor.set_gutter_context_menu(
+                    row,
+                    active_breakpoint,
+                    event.position(),
+                    window,
+                    cx,
+                );
+            }))
     }
 
     fn insert_runnables(

--- a/crates/workspace/src/tasks.rs
+++ b/crates/workspace/src/tasks.rs
@@ -15,6 +15,16 @@ use util::TryFutureExt;
 
 use crate::{SaveIntent, Toast, Workspace, notifications::NotificationId};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScheduledTaskResult {
+    Success,
+    Failure,
+    SpawnFailed,
+    Cancelled,
+}
+
+type TaskCompletionHandler = Box<dyn FnOnce(ScheduledTaskResult, &mut AsyncWindowContext)>;
+
 impl Workspace {
     pub fn schedule_task(
         self: &mut Workspace,
@@ -59,6 +69,44 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
+        self.schedule_resolved_task_internal(
+            task_source_kind,
+            resolved_task,
+            omit_history,
+            None,
+            window,
+            cx,
+        );
+    }
+
+    pub fn schedule_resolved_task_with_completion(
+        self: &mut Workspace,
+        task_source_kind: TaskSourceKind,
+        resolved_task: ResolvedTask,
+        omit_history: bool,
+        on_complete: impl FnOnce(ScheduledTaskResult, &mut AsyncWindowContext) + 'static,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        self.schedule_resolved_task_internal(
+            task_source_kind,
+            resolved_task,
+            omit_history,
+            Some(Box::new(on_complete)),
+            window,
+            cx,
+        );
+    }
+
+    fn schedule_resolved_task_internal(
+        self: &mut Workspace,
+        task_source_kind: TaskSourceKind,
+        resolved_task: ResolvedTask,
+        omit_history: bool,
+        on_complete: Option<TaskCompletionHandler>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
         let spawn_in_terminal = resolved_task.resolved.clone();
         if !omit_history {
             if let Some(debugger_provider) = self.debugger_provider.as_ref() {
@@ -90,12 +138,14 @@ impl Workspace {
                 });
                 if let Some(spawn_task) = spawn_task.ok().flatten() {
                     let res = cx.background_spawn(spawn_task).await;
-                    match res {
+                    let result = match res {
                         Some(Ok(status)) => {
                             if status.success() {
                                 log::debug!("Task spawn succeeded");
+                                ScheduledTaskResult::Success
                             } else {
                                 log::debug!("Task spawn failed, code: {:?}", status.code());
+                                ScheduledTaskResult::Failure
                             }
                         }
                         Some(Err(e)) => {
@@ -103,10 +153,19 @@ impl Workspace {
                             _ = workspace.update(cx, |w, cx| {
                                 let id = NotificationId::unique::<ResolvedTask>();
                                 w.show_toast(Toast::new(id, format!("Task spawn failed: {e}")), cx);
-                            })
+                            });
+                            ScheduledTaskResult::SpawnFailed
                         }
-                        None => log::debug!("Task spawn got cancelled"),
+                        None => {
+                            log::debug!("Task spawn got cancelled");
+                            ScheduledTaskResult::Cancelled
+                        }
                     };
+                    if let Some(on_complete) = on_complete {
+                        on_complete(result, cx);
+                    }
+                } else if let Some(on_complete) = on_complete {
+                    on_complete(ScheduledTaskResult::Cancelled, cx);
                 }
             });
             self.scheduled_tasks.push(task);
@@ -358,6 +417,30 @@ mod tests {
 
         assert_eq!(*fixture.dirty_before_spawn.lock(), Some(true));
         assert!(cx.read(|cx| fixture.item.read(cx).is_dirty));
+    }
+
+    #[gpui::test]
+    async fn test_schedule_resolved_task_with_completion_reports_success(cx: &mut TestAppContext) {
+        let (fixture, cx) = create_fixture(cx, SaveStrategy::None).await;
+        let task_result = Arc::new(Mutex::new(None));
+        fixture.workspace.update_in(cx, |workspace, window, cx| {
+            workspace.schedule_resolved_task_with_completion(
+                TaskSourceKind::UserInput,
+                fixture.task,
+                false,
+                {
+                    let task_result = task_result.clone();
+                    move |result, _| {
+                        *task_result.lock() = Some(result);
+                    }
+                },
+                window,
+                cx,
+            );
+        });
+        cx.executor().run_until_parked();
+
+        assert_eq!(*task_result.lock(), Some(ScheduledTaskResult::Success));
     }
 
     async fn create_fixture(


### PR DESCRIPTION
# Objective

- Make runnable task results visible directly in the editor gutter after running a test or task.
- This makes it easier to see whether the last run passed or failed without looking at the terminal output.

## Solution

- Track the completion result for scheduled runnable tasks.
- Show the last runnable result in the gutter:
  - running task: accent play icon
  - successful task: success check icon
  - failed/cancelled task: error icon
- Apply the same status update path when running from the gutter play button and from inline code lens actions such as `Run Test`.

## Testing

- Ran `cargo check -p editor -p workspace`.
- Ran `cargo test -p workspace test_schedule_resolved_task_with_completion_reports_success`.
- Manually tested running a GPUI test from the gutter play button.
- Manually tested running a GPUI test from the inline `Run Test` code lens.
- Verified the gutter icon updates after completion in both cases.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon]
  (https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before:
<img width="1897" height="691" alt="before" src="https://github.com/user-attachments/assets/614c2811-ee0a-43c0-8619-d0301836aa62" />

After:
<img width="1897" height="691" alt="after" src="https://github.com/user-attachments/assets/a3db19f2-71e6-4c9b-824d-43a4f020a6b7" />

---

Release Notes:

- Improved runnable tasks by showing the last run result in the editor gutter.