### PR TITLE
agent_ui: Match ACP boolean option label colors

### DIFF
--- a/crates/agent_ui/src/config_options.rs
+++ b/crates/agent_ui/src/config_options.rs
@@ -581,6 +581,7 @@ impl Render for ConfigOptionSelector {
                         .label(option_name)
                         .label_position(SwitchLabelPosition::Start)
                         .label_size(LabelSize::Small)
+                        .label_color(Color::Muted)
                         .disabled(self.setting_value)
                         .on_click(move |state, _window, cx| {
                             let next_value = matches!(state, ToggleState::Selected);

--- a/crates/ui/src/components/toggle.rs
+++ b/crates/ui/src/components/toggle.rs
@@ -343,6 +343,7 @@ pub struct Switch {
     label: Option<SharedString>,
     label_position: Option<SwitchLabelPosition>,
     label_size: LabelSize,
+    label_color: Color,
     full_width: bool,
     key_binding: Option<KeyBinding>,
     color: SwitchColor,
@@ -362,6 +363,7 @@ impl Switch {
             label: None,
             label_position: None,
             label_size: LabelSize::Small,
+            label_color: Color::Default,
             full_width: false,
             key_binding: None,
             color: SwitchColor::default(),
@@ -408,6 +410,11 @@ impl Switch {
 
     pub fn label_size(mut self, size: LabelSize) -> Self {
         self.label_size = size;
+        self
+    }
+
+    pub fn label_color(mut self, color: Color) -> Self {
+        self.label_color = color;
         self
     }
 
@@ -543,7 +550,11 @@ impl RenderOnce for Switch {
                 self.label_position == Some(SwitchLabelPosition::Start),
                 |this| {
                     this.when_some(label.clone(), |this, label| {
-                        this.child(Label::new(label).size(self.label_size))
+                        this.child(
+                            Label::new(label)
+                                .size(self.label_size)
+                                .color(self.label_color),
+                        )
                     })
                 },
             )
@@ -552,7 +563,11 @@ impl RenderOnce for Switch {
                 self.label_position == Some(SwitchLabelPosition::End),
                 |this| {
                     this.when_some(label, |this, label| {
-                        this.child(Label::new(label).size(self.label_size))
+                        this.child(
+                            Label::new(label)
+                                .size(self.label_size)
+                                .color(self.label_color),
+                        )
                     })
                 },
             )


### PR DESCRIPTION
# Objective

ACP boolean config option labels use the default text color, while select option labels use the muted text color. This makes boolean options such as Fast Mode look visually inconsistent with adjacent configuration controls.

## Solution

Add a label color override to `Switch` while retaining `Color::Default` for existing callers. Apply `Color::Muted` only when `agent_ui` renders ACP boolean config options, leaving all other switches unchanged.

## Testing

Manually verified on macOS in the light theme.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior (verified visually)
- [x] Performance impact has been considered and is acceptable

## Showcase

### Before

<img width="449" height="37" alt="image" src="https://github.com/user-attachments/assets/1abe3e39-b243-47b3-8a62-67a0b5a17b43" />

### After

<img width="445" height="39" alt="image" src="https://github.com/user-attachments/assets/e134378c-84cb-4c72-92d1-98eecc2137e4" />

---

Release Notes:

- Fixed ACP boolean option labels to match other agent configuration controls.
