### PR TITLE
project_panel: Avoid recording record excluded files changes

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1980,18 +1980,6 @@ impl ProjectPanel {
             let new_entry = edit_task.await;
             project_panel.update(cx, |project_panel, cx| {
                 project_panel.state.edit_state = None;
-
-                // Record the operation if the edit was applied
-                if new_entry.is_ok() {
-                    let operation = if let Some(old_entry) = edited_entry {
-                        Change::Renamed((worktree_id, old_entry.path).into(), new_project_path)
-                    } else {
-                        Change::Created(new_project_path)
-                    };
-
-                    project_panel.undo_manager.record([operation]).log_err();
-                }
-
                 cx.notify();
             })?;
 
@@ -2007,6 +1995,23 @@ impl ProjectPanel {
                 }
                 Ok(CreatedEntry::Included(new_entry)) => {
                     project_panel.update_in(cx, |project_panel, window, cx| {
+                        // Only recording changes in included files as otherwise
+                        // undoing some operations would fail, as
+                        // `Worktree::entry_for_path` would return `None` for
+                        // excluded paths.
+                        // In the future we can look into adding support for recording
+                        // changes in excluded paths, but that would mean updating
+                        // methods that rely on `EntryId` to now rely on the actual
+                        // paths.
+                        let operation = match edited_entry {
+                            Some(old_entry) => {
+                                let project_path = (worktree_id, old_entry.path).into();
+                                Change::Renamed(project_path, new_project_path)
+                            }
+                            None => Change::Created(new_project_path),
+                        };
+                        project_panel.undo_manager.record([operation]).log_err();
+
                         if let Some(selection) = &mut project_panel.selection
                             && selection.entry_id == edited_entry_id
                         {

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -11193,12 +11193,12 @@ fn ensure_no_open_items_and_panes(workspace: &Entity<Workspace>, cx: &mut Visual
     });
 }
 
-struct TestProjectItemView {
+pub(crate) struct TestProjectItemView {
     focus_handle: FocusHandle,
     path: ProjectPath,
 }
 
-struct TestProjectItem {
+pub(crate) struct TestProjectItem {
     path: ProjectPath,
 }
 

--- a/crates/project_panel/src/tests/undo.rs
+++ b/crates/project_panel/src/tests/undo.rs
@@ -2,14 +2,15 @@
 
 use collections::HashSet;
 use fs::{FakeFs, Fs};
-use gpui::{Entity, VisualTestContext};
+use gpui::{App, BorrowAppContext, Entity, VisualTestContext};
 use project::Project;
 use serde_json::{Value, json};
+use settings::SettingsStore;
 use std::path::Path;
 use std::sync::Arc;
-use workspace::MultiWorkspace;
+use workspace::{MultiWorkspace, register_project_item};
 
-use crate::project_panel_tests::{self, find_project_entry, select_path};
+use crate::project_panel_tests::{self, TestProjectItemView, find_project_entry, select_path};
 use crate::{NewDirectory, NewFile, ProjectPanel, Redo, Rename, Trash, Undo};
 
 struct TestContext {
@@ -244,6 +245,10 @@ impl TestContext {
 
         TestContext { panel, fs, cx }
     }
+
+    fn update_app<R>(&mut self, update: impl FnOnce(&mut App) -> R) -> R {
+        self.cx.cx.update(update)
+    }
 }
 
 #[gpui::test]
@@ -457,4 +462,43 @@ async fn record_via_collab(cx: &mut gpui::TestAppContext) {
 
     cx.redo().await;
     cx.assert_fs_state_is(&["b.txt", "renamed.txt"]);
+}
+
+#[gpui::test]
+async fn excluded_create_is_not_recorded(cx: &mut gpui::TestAppContext) {
+    let mut cx = TestContext::new_with_tree(
+        cx,
+        json!({
+            "a.txt": "",
+            "b.txt": ""
+        }),
+    )
+    .await;
+
+    cx.update_app(|cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.worktree.file_scan_exclusions = Some(vec![
+                    "**/token.secret".to_string(),
+                    "**/banana.secret".to_string(),
+                ]);
+            });
+        });
+
+        register_project_item::<TestProjectItemView>(cx);
+    });
+
+    cx.rename("a.txt", "renamed.txt").await;
+    cx.create_file("token.secret").await;
+    cx.assert_fs_state_is(&["b.txt", "renamed.txt", "token.secret"]);
+
+    cx.undo().await;
+    cx.assert_fs_state_is(&["b.txt", "a.txt", "token.secret"]);
+
+    cx.rename("a.txt", "renamed.txt").await;
+    cx.rename("b.txt", "banana.secret").await;
+    cx.assert_fs_state_is(&["renamed.txt", "token.secret", "banana.secret"]);
+
+    cx.undo().await;
+    cx.assert_fs_state_is(&["a.txt", "token.secret", "banana.secret"]);
 }


### PR DESCRIPTION
# Objective

Fix error shown when attempting to undo/redo operations on excluded files, for example, undoing a creation of a file in an excluded path.

## Solution

Since `worktree::Snapshot::entry_for_path` always returns `None` for excluded files, these changes will simply avoid calling `UndoManager::record` in `ProjectPanel::confirm_edit` if the created entry is excluded. This can be confusing if the user is renaming a file to another path that is excluded, as that will not be recorded and can't be undone but we accept it as a limitation for now and will document that.

In the future we can potentially support undoing of operations for excluded file paths but that would mean not only introducing new methods that operate directly on the absolute path instead of the entry id, as well as changes to the proto messages, in order to ensure it's also fixed in remote and collab.

## Testing

Tested manually, as shown in the "Showcase" section below and also introduced a test for this – `project_panel::tests::undo::excluded_create_is_not_recorded` .

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase

<details>
  <summary>Before</summary>

  https://github.com/user-attachments/assets/7f8fca3e-2716-40bb-95db-c7119bb39b83

</details>

<details>
  <summary>After</summary>
  
  https://github.com/user-attachments/assets/47b0322e-a323-4648-8a56-6e96266888d3

</details>

---

Release Notes:

- N/A
