### PR TITLE
worktree: Add read-only file exclusions

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1646,6 +1646,9 @@
   // Globs to match files that will be opened as read-only. You can still view these files,
   // but cannot edit them. This is useful for generated files or external dependencies.
   "read_only_files": [],
+  // Globs to exclude from `read_only_files`. These exclusions take precedence over matches in
+  // `read_only_files`.
+  "read_only_files_exclusions": [],
   // Git gutter behavior configuration.
   "git": {
     // Global switch to enable or disable all git integration features.

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -15625,6 +15625,8 @@ async fn test_read_only_files_setting(cx: &mut gpui::TestAppContext) {
                     "**/generated/**".to_string(),
                     "**/*.gen.rs".to_string(),
                 ]);
+                settings.project.worktree.read_only_files_exclusions =
+                    Some(vec!["**/generated/editable/**".to_string()]);
             });
         });
     });
@@ -15639,6 +15641,9 @@ async fn test_read_only_files_setting(cx: &mut gpui::TestAppContext) {
             },
             "generated": {
                 "schema.rs": "// Auto-generated schema",
+                "editable": {
+                    "config.rs": "// Hand-maintained configuration",
+                },
             }
         }),
     )
@@ -15685,6 +15690,20 @@ async fn test_read_only_files_setting(cx: &mut gpui::TestAppContext) {
         assert!(
             buffer.read_only(),
             "File in generated directory should be read-only"
+        );
+    });
+
+    let excluded_buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/root/generated/editable/config.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    excluded_buffer.read_with(cx, |buffer, _| {
+        assert!(
+            !buffer.read_only(),
+            "File matching a read-only exclusion should be read-write"
         );
     });
 }
@@ -15753,6 +15772,14 @@ async fn test_read_only_files_empty_setting(cx: &mut gpui::TestAppContext) {
 async fn test_os_read_only_files_open_as_read_only(cx: &mut gpui::TestAppContext) {
     init_test(cx);
     cx.executor().allow_parking();
+    cx.update(|cx| {
+        cx.update_global::<SettingsStore, _>(|store, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.project.worktree.read_only_files_exclusions =
+                    Some(vec!["**/test.txt".to_string()]);
+            });
+        });
+    });
 
     let root = TempTree::new(json!({
         "project": {
@@ -15781,7 +15808,7 @@ async fn test_os_read_only_files_open_as_read_only(cx: &mut gpui::TestAppContext
     buffer.read_with(cx, |buffer, _| {
         assert!(
             buffer.read_only(),
-            "OS read-only files should open as read-only"
+            "Settings exclusions should not override OS read-only files"
         );
     });
 }

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -2605,6 +2605,37 @@ mod tests {
             .unindent(),
             cx,
         );
+
+        check_vscode_import(
+            &mut store,
+            "{}".to_owned(),
+            r#"{
+              "files.readonlyInclude": {
+                "**/generated/**": true,
+                "**/ignored/**": false
+              },
+              "files.readonlyExclude": {
+                "**/generated/editable/**": true,
+                "**/still-read-only/**": false
+              }
+            }"#
+            .to_owned(),
+            r#"{
+              "base_keymap": "VSCode",
+              "minimap": {
+                "show": "always"
+              },
+              "read_only_files_exclusions": [
+                "**/generated/editable/**"
+              ],
+              "read_only_files": [
+                "**/generated/**"
+              ]
+            }
+            "#
+            .unindent(),
+            cx,
+        );
     }
 
     #[track_caller]

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -1106,7 +1106,7 @@ impl VsCodeSettings {
             private_files: None,
             hidden_files: None,
             read_only_files: self
-                .read_value("files.readonlyExclude")
+                .read_value("files.readonlyInclude")
                 .and_then(|v| v.as_object())
                 .map(|v| {
                     v.iter()
@@ -1120,6 +1120,17 @@ impl VsCodeSettings {
                         .collect::<Vec<_>>()
                 })
                 .filter(|r| !r.is_empty()),
+            read_only_files_exclusions: self
+                .read_value("files.readonlyExclude")
+                .and_then(|v| v.as_object())
+                .map(|v| {
+                    v.iter()
+                        .filter_map(|(pattern, enabled)| {
+                            enabled.as_bool().unwrap_or(false).then(|| pattern.to_owned())
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .filter(|patterns| !patterns.is_empty()),
         }
     }
 }

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -162,6 +162,10 @@ pub struct WorktreeSettingsContent {
     /// external dependencies that should not be modified directly.
     /// Default: []
     pub read_only_files: Option<Vec<String>>,
+
+    /// Exclude files matching these globs from `read_only_files`.
+    /// Default: []
+    pub read_only_files_exclusions: Option<Vec<String>>,
 }
 
 #[with_fallible_options]

--- a/crates/worktree/src/worktree_settings.rs
+++ b/crates/worktree/src/worktree_settings.rs
@@ -21,6 +21,7 @@ pub struct WorktreeSettings {
     pub private_files: PathMatcher,
     pub hidden_files: PathMatcher,
     pub read_only_files: PathMatcher,
+    pub read_only_files_exclusions: PathMatcher,
 }
 
 impl WorktreeSettings {
@@ -48,11 +49,12 @@ impl WorktreeSettings {
     }
 
     pub fn is_path_read_only(&self, path: &RelPath) -> bool {
-        self.read_only_files.is_match(path)
+        self.read_only_files.is_match(path) && !self.read_only_files_exclusions.is_match(path)
     }
 
     pub fn is_std_path_read_only(&self, path: &Path) -> bool {
         self.read_only_files.is_match_std_path(path)
+            && !self.read_only_files_exclusions.is_match_std_path(path)
     }
 }
 
@@ -64,6 +66,7 @@ impl Settings for WorktreeSettings {
         let private_files = worktree.private_files.unwrap().0;
         let hidden_files = worktree.hidden_files.unwrap();
         let read_only_files = worktree.read_only_files.unwrap_or_default();
+        let read_only_files_exclusions = worktree.read_only_files_exclusions.unwrap_or_default();
         let scan_symlinks = worktree.scan_symlinks.unwrap();
         let parsed_file_scan_inclusions: Vec<String> = file_scan_inclusions
             .iter()
@@ -97,6 +100,12 @@ impl Settings for WorktreeSettings {
             read_only_files: path_matchers(read_only_files, "read_only_files")
                 .log_err()
                 .unwrap_or_default(),
+            read_only_files_exclusions: path_matchers(
+                read_only_files_exclusions,
+                "read_only_files_exclusions",
+            )
+            .log_err()
+            .unwrap_or_default(),
             scan_symlinks,
         }
     }

--- a/crates/worktree/tests/integration/worktree_settings_tests.rs
+++ b/crates/worktree/tests/integration/worktree_settings_tests.rs
@@ -5,7 +5,7 @@ use util::{
 };
 use worktree::*;
 
-fn make_settings_with_read_only(patterns: &[&str]) -> WorktreeSettings {
+fn make_settings_with_read_only(patterns: &[&str], exclusions: &[&str]) -> WorktreeSettings {
     WorktreeSettings {
         prevent_sharing_in_public_channels: false,
         file_scan_exclusions: PathMatcher::default(),
@@ -18,13 +18,18 @@ fn make_settings_with_read_only(patterns: &[&str]) -> WorktreeSettings {
             PathStyle::local(),
         )
         .unwrap(),
+        read_only_files_exclusions: PathMatcher::new(
+            exclusions.iter().map(|pattern| pattern.to_string()),
+            PathStyle::local(),
+        )
+        .unwrap(),
         scan_symlinks: Default::default(),
     }
 }
 
 #[test]
 fn test_is_path_read_only_with_glob_patterns() {
-    let settings = make_settings_with_read_only(&["**/generated/**", "**/*.gen.rs"]);
+    let settings = make_settings_with_read_only(&["**/generated/**", "**/*.gen.rs"], &[]);
 
     let generated_file =
         RelPath::new(Path::new("src/generated/schema.rs"), PathStyle::local()).unwrap();
@@ -54,7 +59,7 @@ fn test_is_path_read_only_with_glob_patterns() {
 
 #[test]
 fn test_is_path_read_only_with_specific_paths() {
-    let settings = make_settings_with_read_only(&["vendor/**", "node_modules/**"]);
+    let settings = make_settings_with_read_only(&["vendor/**", "node_modules/**"], &[]);
 
     let vendor_file = RelPath::new(Path::new("vendor/lib/package.js"), PathStyle::local()).unwrap();
     assert!(
@@ -81,7 +86,7 @@ fn test_is_path_read_only_with_specific_paths() {
 
 #[test]
 fn test_is_path_read_only_empty_patterns() {
-    let settings = make_settings_with_read_only(&[]);
+    let settings = make_settings_with_read_only(&[], &[]);
 
     let any_file = RelPath::new(Path::new("src/main.rs"), PathStyle::local()).unwrap();
     assert!(
@@ -92,7 +97,7 @@ fn test_is_path_read_only_empty_patterns() {
 
 #[test]
 fn test_is_path_read_only_with_extension_pattern() {
-    let settings = make_settings_with_read_only(&["**/*.lock", "**/*.min.js"]);
+    let settings = make_settings_with_read_only(&["**/*.lock", "**/*.min.js"], &[]);
 
     let lock_file = RelPath::new(Path::new("Cargo.lock"), PathStyle::local()).unwrap();
     assert!(
@@ -118,4 +123,26 @@ fn test_is_path_read_only_with_extension_pattern() {
         !settings.is_path_read_only(&regular_js),
         "Regular JS files should not be read-only"
     );
+}
+
+#[test]
+fn test_read_only_exclusions_take_precedence() {
+    let settings = make_settings_with_read_only(
+        &["**/generated/**"],
+        &["**/generated/editable/**"],
+    );
+
+    let generated_file =
+        RelPath::new(Path::new("generated/schema.rs"), PathStyle::local()).unwrap();
+    assert!(settings.is_path_read_only(&generated_file));
+
+    let excluded_file = RelPath::new(
+        Path::new("generated/editable/config.rs"),
+        PathStyle::local(),
+    )
+    .unwrap();
+    assert!(!settings.is_path_read_only(&excluded_file));
+
+    let settings = make_settings_with_read_only(&[], &["**/generated/**"]);
+    assert!(!settings.is_path_read_only(&generated_file));
 }

--- a/docs/src/migrate/vs-code.md
+++ b/docs/src/migrate/vs-code.md
@@ -89,6 +89,8 @@ The following VS Code settings are automatically imported when you use **Import 
 | `files.associations`        | `file_types`                   |
 | `files.watcherExclude`      | `file_scan_exclusions`         |
 | `files.watcherInclude`      | `file_scan_inclusions`         |
+| `files.readonlyInclude`     | `read_only_files`              |
+| `files.readonlyExclude`     | `read_only_files_exclusions`   |
 | `files.simpleDialog.enable` | `use_system_path_prompts`      |
 | `search.smartCase`          | `use_smartcase_search`         |
 | `search.useIgnoreFiles`     | `search.include_ignored`       |

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3506,6 +3506,41 @@ List of `string` glob patterns
 
 `boolean` values
 
+## Read Only File Exclusions
+
+- Description: Globs to exclude from `read_only_files`. Exclusions take precedence over read-only matches.
+- Setting: `read_only_files_exclusions`
+- Default: `[]`
+
+**Options**
+
+List of `string` glob patterns
+
+For example, this makes generated files read-only except for files in `generated/editable`:
+
+```json [settings]
+{
+  "read_only_files": ["**/generated/**"],
+  "read_only_files_exclusions": ["**/generated/editable/**"]
+}
+```
+
+## Read Only Files
+
+- Description: Globs to match files that Zed should open as read-only. Matching files display a lock icon and cannot be edited unless you unlock them with {#action workspace::ToggleReadOnlyFile}. See [Globs](../globs.md) for supported pattern syntax.
+- Setting: `read_only_files`
+- Default: `[]`
+
+**Options**
+
+List of `string` glob patterns
+
+```json [settings]
+{
+  "read_only_files": ["**/generated/**", "**/*.lock"]
+}
+```
+
 ## Read SSH Config
 
 - Description: Whether to read SSH configuration files


### PR DESCRIPTION
# Objective

Follow-up to PR #44376 .

Read-only protection for important code files (for example, library files and header files) is an important editor behavior. It can prevent irreversible damage caused by accidental user actions.

This PR aims to further improve Zed's read-only file protection feature.

- On the basis of the existing specified `read_only_files` option, allow users to exclude specific files.
- It is useful when a broad glob marks a directory as read-only, but a subset of files inside that directory still needs to be editable.
- Correct the VS Code settings import, which currently maps `files.readonlyExclude` to `read_only_files` instead of importing the include and exclude settings separately.
- Supplement the documentation to guide users on how to use this feature.

## Solution

- Added a `read_only_files_exclusions` setting containing glob patterns.
- A file is opened as read-only only when it matches `read_only_files` and does not match `read_only_files_exclusions`.
- Exclusions only override read-only status introduced by `read_only_files`; they do not override filesystem permissions or intrinsically read-only buffers.
- Updated VS Code settings import to map:
- `files.readonlyInclude` to `read_only_files`
- `files.readonlyExclude` to `read_only_files_exclusions`
- Documented both settings in the settings reference and VS Code migration guide.

Example:

```json
{
  "read_only_files": ["**/generated/**"],
  "read_only_files_exclusions": ["**/generated/editable/**"]
}
```

## Testing

Tested on macOS with:

- cargo test -p worktree --test integration --features test-support worktree_settings_tests
- cargo test -p project --test integration --features test-support test_read_only_files
- cargo test -p project --test integration --features test-support test_os_read_only_files_open_as_read_only
- cargo test -p settings test_vscode_import
- cargo fmt --all -- --check

The tests cover:

- Read-only glob matching
- Exclusions taking precedence over read-only matches
- Exclusions without matching include rules
- Opening excluded files as editable
- Preserving read-only status imposed by filesystem permissions
- Importing VS Code include and exclude settings
- Ignoring disabled VS Code glob entries

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

> This PR does not include a visual change. But it's helpful to offer a showcase to demonstrate its result.

<details>
  <summary>Click to view showcase</summary>
<img width="1205" height="465" alt="image" src="https://github.com/user-attachments/assets/30060214-279a-4b66-aff3-b0843409b1e7" />
</details>

---

Release Notes:

- Added the `read_only_files_exclusions` setting for keeping selected files editable when they match `read_only_files`.
