### PR TITLE
Add idle timeout for Git commands

### DIFF
--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -179,6 +179,59 @@ impl AskPassSession {
         }
     }
 
+    /// Like [`AskPassSession::run`], but with an *idle* connection timeout that is
+    /// reset every time a value is received on `activity`.
+    ///
+    /// Git remote commands (push/fetch/pull) run their hooks — notably `pre-push` —
+    /// *inside* the git process, before it ever contacts the remote. A fixed
+    /// wall-clock timeout therefore mistakes a slow-but-healthy hook for a stalled
+    /// connection and kills it. Callers feed `activity` from the git process's output,
+    /// so the timeout only elapses after genuine silence for `connection_timeout`.
+    /// When the `activity` sender is dropped (git's streams closed as it exits), this
+    /// parks so the caller's own output future resolves instead.
+    pub async fn run_with_activity(
+        &mut self,
+        connection_timeout: Duration,
+        activity: smol::channel::Receiver<()>,
+    ) -> AskPassResult {
+        let askpass_opened_rx = self.askpass_opened_rx.take().expect("Only call run once");
+        let askpass_kill_master_rx = self
+            .askpass_kill_master_rx
+            .take()
+            .expect("Only call run once");
+        let executor = self.executor.clone();
+
+        let idle_timeout = async {
+            loop {
+                select_biased! {
+                    activity = activity.recv().fuse() => {
+                        if activity.is_err() {
+                            // Sender dropped: git's pipes closed, so it is exiting.
+                            // Stop arming the timeout; let the caller's output win.
+                            std::future::pending::<()>().await;
+                        }
+                        // Otherwise git produced output — restart the countdown.
+                    }
+                    _ = executor.timer(connection_timeout).fuse() => {
+                        break;
+                    }
+                }
+            }
+        };
+
+        select_biased! {
+            _ = askpass_opened_rx.fuse() => {
+                // Note: this await can only resolve after we are dropped.
+                askpass_kill_master_rx.await.ok();
+                AskPassResult::CancelledByUser
+            }
+
+            _ = idle_timeout.fuse() => {
+                AskPassResult::Timedout
+            }
+        }
+    }
+
     /// This will return the password that was last set by the askpass script.
     #[cfg(target_os = "windows")]
     pub fn get_password(&self) -> Option<EncryptedPassword> {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -3764,10 +3764,66 @@ async fn run_git_command(
 
 async fn run_askpass_command(
     mut ask_pass: AskPassSession,
-    git_process: util::command::Child,
+    mut git_process: util::command::Child,
 ) -> anyhow::Result<RemoteCommandOutput> {
+    // The connection timeout is *idle*-based rather than a fixed wall-clock cap: git
+    // runs the `pre-push` hook inside this process before it ever contacts the remote,
+    // so a fixed timeout would kill hooks (full test suites, builds) that take longer
+    // than it. We reset the timeout every time git emits output, so it only trips when
+    // the connection is genuinely stalled (no output at all for this long).
+    let connection_timeout = std::time::Duration::from_secs(120);
+    let (activity_tx, activity_rx) = smol::channel::unbounded::<()>();
+
+    let mut stdout = git_process.stdout.take();
+    let mut stderr = git_process.stderr.take();
+    let status = git_process.status();
+
+    let stdout_activity_tx = activity_tx.clone();
+    let stdout_future = async move {
+        let mut data = Vec::new();
+        if let Some(stdout) = stdout.as_mut() {
+            let mut buf = [0u8; 8192];
+            loop {
+                let n = stdout.read(&mut buf).await?;
+                if n == 0 {
+                    break;
+                }
+                data.extend_from_slice(&buf[..n]);
+                let _ = stdout_activity_tx.try_send(());
+            }
+        }
+        std::io::Result::Ok(data)
+    };
+
+    let stderr_activity_tx = activity_tx.clone();
+    let stderr_future = async move {
+        let mut data = Vec::new();
+        if let Some(stderr) = stderr.as_mut() {
+            let mut buf = [0u8; 8192];
+            loop {
+                let n = stderr.read(&mut buf).await?;
+                if n == 0 {
+                    break;
+                }
+                data.extend_from_slice(&buf[..n]);
+                let _ = stderr_activity_tx.try_send(());
+            }
+        }
+        std::io::Result::Ok(data)
+    };
+
+    // Drop our own sender so `activity` closes once both readers reach EOF.
+    drop(activity_tx);
+
+    let output_future = async move {
+        let (stdout_data, stderr_data) =
+            futures::future::try_join(stdout_future, stderr_future).await?;
+        let status = status.await?;
+        std::io::Result::Ok((status, stdout_data, stderr_data))
+    };
+
     select_biased! {
-        result = ask_pass.run().fuse() => {
+        result = ask_pass.run_with_activity(connection_timeout, activity_rx).fuse() => {
             match result {
                 AskPassResult::CancelledByUser => {
                     Err(anyhow!(REMOTE_CANCELLED_BY_USER))?
@@ -3777,16 +3833,16 @@ async fn run_askpass_command(
                 }
             }
         }
-        output = git_process.output().fuse() => {
-            let output = output?;
+        output = output_future.fuse() => {
+            let (status, stdout, stderr) = output?;
             anyhow::ensure!(
-                output.status.success(),
+                status.success(),
                 "{}",
-                String::from_utf8_lossy(&output.stderr)
+                String::from_utf8_lossy(&stderr)
             );
             Ok(RemoteCommandOutput {
-                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                stdout: String::from_utf8_lossy(&stdout).to_string(),
+                stderr: String::from_utf8_lossy(&stderr).to_string(),
             })
         }
     }


### PR DESCRIPTION
Previously Git connection checks used a fixed time limit, which caused failures when Git's internal scripts (e.g. pre-push hooks) ran longer than the limit even though the connection itself was healthy.

This changes the timeout to track activity instead: the timer is reset on every response from Git, and the connection is only dropped after 120 seconds of silence. This lets long-running operations (large pushes, slow hooks) finish successfully while still guarding against genuinely hung connections.

Changes are in `crates/askpass/src/askpass.rs` and `crates/git/src/repository.rs`.

Release Notes:

- Fixed Git operations timing out when internal hooks or scripts ran longer than the fixed connection limit