### PR TITLE
vtsls: Fix invalid tsserver install error in TypeScript 7 projects

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -637,6 +637,8 @@ impl TypeScriptLspAdapter {
             "node_modules/typescript/lib"
         };
 
+        // typescript-language-server doesn't support TypeScript 7+, which no longer
+        // ships `tsserver.js`.
         if self
             .fs
             .is_file(

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -57,9 +57,15 @@ impl VtslsLspAdapter {
             Self::TYPESCRIPT_TSDK_PATH
         };
 
+        // vtsls doesn't support TypeScript 7+, which no longer ships `tsserver.js`.
         if self
             .fs
-            .is_dir(&adapter.worktree_root_path().join(tsdk_path))
+            .is_file(
+                &adapter
+                    .worktree_root_path()
+                    .join(tsdk_path)
+                    .join("tsserver.js"),
+            )
             .await
         {
             Some(tsdk_path)


### PR DESCRIPTION
Closes #60761

Follow-up to #60970, which fixed this for `typescript-language-server`. `vtsls` had the same problem, we only checked that the workspace tsdk directory exists, but TypeScript 7 ships it without `tsserver.js`, causing vtsls to error on startup. 

Now we do the same `tsserver.js` check, so vtsls silently falls back to its bundled TypeScript (see #60951).

Release Notes:

- Fixed vtsls showing a "doesn't point to a valid tsserver install" error on startup in projects using TypeScript 7. For full TypeScript 7 support, install the `tsgo` extension to use TypeScript's native language server.
