### PR TITLE
csv_preview: #7 Add single-line row displaying mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ crates/docs_preprocessor/actions.json
 
 # NixOS integration test state
 .nixos-test-history
+
+.local*

--- a/crates/csv_preview/src/csv_preview.rs
+++ b/crates/csv_preview/src/csv_preview.rs
@@ -25,6 +25,10 @@ mod types;
 
 actions!(csv, [OpenPreview, OpenPreviewToTheSide]);
 
+/// Bootstrap row height used only until the first render populates
+/// `CsvPreviewView::row_height` with the actual text line height.
+const INITIAL_ROW_HEIGHT: Pixels = px(24.);
+
 pub struct TabularDataPreviewFeatureFlag;
 
 impl FeatureFlag for TabularDataPreviewFeatureFlag {
@@ -49,8 +53,9 @@ pub struct CsvPreviewView {
     /// Performance metrics for debugging and monitoring CSV operations.
     pub(crate) performance_metrics: PerformanceMetrics,
     pub(crate) list_state: gpui::ListState,
-    /// Cached row height used as a scroll height hint for off-screen list items.
-    /// Updated each render frame from the actual text line height.
+    /// Cached row height, refreshed from the actual text line height on every render.
+    /// Used to size not-yet-rendered rows for the scrollbar without a full `.measure_all()`
+    /// pass, so it tracks the real row height instead of a hardcoded guess.
     pub(crate) row_height: Pixels,
     /// Time when the last parsing operation ended, used for smart debouncing
     pub(crate) last_parse_end_time: Option<std::time::Instant>,
@@ -176,7 +181,6 @@ impl CsvPreviewView {
                 },
             );
 
-            const INITIAL_ROW_HEIGHT: Pixels = px(24.);
             let mut view = CsvPreviewView {
                 focus_handle: cx.focus_handle(),
                 active_editor_state: EditorState {
@@ -244,8 +248,8 @@ impl CsvPreviewView {
             this.update(cx, |view, cx| {
                 view.engine.set_d2d_mapping(mapping);
                 let visible_rows = view.engine.d2d_mapping().visible_row_count();
-                // Approximation of single csv table row height. Will be re-measured on scrolling.
-                // This cheap solution allow to render scrollbar with fraction of a cost compared to `.measure_all()` call
+                // Uses the row height measured on the last render. Cheaper than a full
+                // `.measure_all()` pass; exact row heights are re-measured on scrolling.
                 view.list_state
                     .reset_with_uniform_height(visible_rows, view.row_height);
                 cx.notify();

--- a/crates/csv_preview/src/csv_preview.rs
+++ b/crates/csv_preview/src/csv_preview.rs
@@ -49,6 +49,9 @@ pub struct CsvPreviewView {
     /// Performance metrics for debugging and monitoring CSV operations.
     pub(crate) performance_metrics: PerformanceMetrics,
     pub(crate) list_state: gpui::ListState,
+    /// Cached row height used as a scroll height hint for off-screen list items.
+    /// Updated each render frame from the actual text line height.
+    pub(crate) row_height: Pixels,
     /// Time when the last parsing operation ended, used for smart debouncing
     pub(crate) last_parse_end_time: Option<std::time::Instant>,
 }
@@ -187,6 +190,7 @@ impl CsvPreviewView {
                 performance_metrics: PerformanceMetrics::default(),
                 list_state: gpui::ListState::new(contents.rows.len(), ListAlignment::Top, px(1.))
                     .with_uniform_item_height(px(24.)),
+                row_height: px(24.),
                 settings: CsvPreviewSettings::default(),
                 last_parse_end_time: None,
                 engine: TableDataEngine::default(),
@@ -241,9 +245,8 @@ impl CsvPreviewView {
                 let visible_rows = view.engine.d2d_mapping().visible_row_count();
                 // Approximation of single csv table row height. Will be re-measured on scrolling.
                 // This cheap solution allow to render scrollbar with fraction of a cost compared to `.measure_all()` call
-                let approximate_height = px(24.);
                 view.list_state
-                    .reset_with_uniform_height(visible_rows, approximate_height);
+                    .reset_with_uniform_height(visible_rows, view.row_height);
                 cx.notify();
             })
             .ok();

--- a/crates/csv_preview/src/csv_preview.rs
+++ b/crates/csv_preview/src/csv_preview.rs
@@ -98,7 +98,7 @@ impl CsvPreviewView {
                         .and_then(|item| item.act_as::<Editor>(cx))
                         .filter(|editor| Self::is_csv_file(editor, cx))
                     {
-                        let csv_preview = Self::new(&editor, cx);
+                        let csv_preview = Self::new(&editor, window, cx);
                         workspace.active_pane().update(cx, |pane, cx| {
                             let existing = pane
                                 .items_of_type::<CsvPreviewView>()
@@ -119,7 +119,7 @@ impl CsvPreviewView {
                             .and_then(|item| item.act_as::<Editor>(cx))
                             .filter(|editor| Self::is_csv_file(editor, cx))
                         {
-                            let csv_preview = Self::new(&editor, cx);
+                            let csv_preview = Self::new(&editor, window, cx);
                             let pane = workspace
                                 .find_pane_in_direction(SplitDirection::Right, cx)
                                 .unwrap_or_else(|| {
@@ -156,7 +156,7 @@ impl CsvPreviewView {
         });
     }
 
-    fn new(editor: &Entity<Editor>, cx: &mut Context<Workspace>) -> Entity<Self> {
+    fn new(editor: &Entity<Editor>, window: &Window, cx: &mut Context<Workspace>) -> Entity<Self> {
         let contents = TableLikeContent::default();
         let table_interaction_state = cx.new(|cx| {
             TableInteractionState::new(cx).with_custom_scrollbar(ui::Scrollbars::for_settings::<
@@ -177,10 +177,7 @@ impl CsvPreviewView {
                 },
             );
 
-            /// Bootstrap row height used only until the first render populates
-            /// `CsvPreviewView::row_height` with the actual text line height.
-            const INITIAL_ROW_HEIGHT: Pixels = px(24.);
-
+            let row_height = window.pixel_snap(window.line_height());
             let mut view = CsvPreviewView {
                 focus_handle: cx.focus_handle(),
                 active_editor_state: EditorState {
@@ -194,8 +191,8 @@ impl CsvPreviewView {
                 filter_sort_task: None,
                 performance_metrics: PerformanceMetrics::default(),
                 list_state: gpui::ListState::new(contents.rows.len(), ListAlignment::Top, px(1.))
-                    .with_uniform_item_height(INITIAL_ROW_HEIGHT),
-                row_height: INITIAL_ROW_HEIGHT,
+                    .with_uniform_item_height(row_height),
+                row_height,
                 settings: CsvPreviewSettings::default(),
                 last_parse_end_time: None,
                 engine: TableDataEngine::default(),

--- a/crates/csv_preview/src/csv_preview.rs
+++ b/crates/csv_preview/src/csv_preview.rs
@@ -25,10 +25,6 @@ mod types;
 
 actions!(csv, [OpenPreview, OpenPreviewToTheSide]);
 
-/// Bootstrap row height used only until the first render populates
-/// `CsvPreviewView::row_height` with the actual text line height.
-const INITIAL_ROW_HEIGHT: Pixels = px(24.);
-
 pub struct TabularDataPreviewFeatureFlag;
 
 impl FeatureFlag for TabularDataPreviewFeatureFlag {
@@ -180,6 +176,10 @@ impl CsvPreviewView {
                     };
                 },
             );
+
+            /// Bootstrap row height used only until the first render populates
+            /// `CsvPreviewView::row_height` with the actual text line height.
+            const INITIAL_ROW_HEIGHT: Pixels = px(24.);
 
             let mut view = CsvPreviewView {
                 focus_handle: cx.focus_handle(),

--- a/crates/csv_preview/src/csv_preview.rs
+++ b/crates/csv_preview/src/csv_preview.rs
@@ -176,6 +176,7 @@ impl CsvPreviewView {
                 },
             );
 
+            const INITIAL_ROW_HEIGHT: Pixels = px(24.);
             let mut view = CsvPreviewView {
                 focus_handle: cx.focus_handle(),
                 active_editor_state: EditorState {
@@ -189,8 +190,8 @@ impl CsvPreviewView {
                 filter_sort_task: None,
                 performance_metrics: PerformanceMetrics::default(),
                 list_state: gpui::ListState::new(contents.rows.len(), ListAlignment::Top, px(1.))
-                    .with_uniform_item_height(px(24.)),
-                row_height: px(24.),
+                    .with_uniform_item_height(INITIAL_ROW_HEIGHT),
+                row_height: INITIAL_ROW_HEIGHT,
                 settings: CsvPreviewSettings::default(),
                 last_parse_end_time: None,
                 engine: TableDataEngine::default(),

--- a/crates/csv_preview/src/renderer/preview_view.rs
+++ b/crates/csv_preview/src/renderer/preview_view.rs
@@ -7,6 +7,9 @@ use crate::CsvPreviewView;
 impl Render for CsvPreviewView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
+        self.row_height = window
+            .text_style()
+            .line_height_in_pixels(window.rem_size());
 
         let render_prep_start = Instant::now();
         let table_with_settings = v_flex()

--- a/crates/csv_preview/src/renderer/preview_view.rs
+++ b/crates/csv_preview/src/renderer/preview_view.rs
@@ -7,10 +7,15 @@ use crate::CsvPreviewView;
 impl Render for CsvPreviewView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
-        self.row_height = window
-            .text_style()
-            .line_height_in_pixels(window.rem_size());
-
+        let row_height = window.pixel_snap(window.line_height());
+        if row_height != self.row_height {
+            self.row_height = row_height;
+            // Font size (rem size, buffer font override, ...) changed since the list was last
+            // measured: existing rows and unmeasured-item height hints are now the wrong size.
+            // Unlike `reset_with_uniform_height`, this preserves scroll position and keeps each
+            // item's prior size as a hint rather than dropping straight to a fresh guess.
+            self.list_state.remeasure();
+        }
         let render_prep_start = Instant::now();
         let table_with_settings = v_flex()
             .size_full()

--- a/crates/csv_preview/src/renderer/render_table.rs
+++ b/crates/csv_preview/src/renderer/render_table.rs
@@ -69,6 +69,7 @@ impl CsvPreviewView {
                                     cols,
                                     display_row,
                                     row_identifier_text_color,
+                                    this.row_height,
                                     cx,
                                 )
                                 .unwrap_or_else(|| panic!("Expected to render a table row"))
@@ -83,6 +84,7 @@ impl CsvPreviewView {
                                     .rendered_indices
                                     .extend(range.clone());
 
+                                let row_height = this.row_height;
                                 range
                                     .filter_map(|display_index| {
                                         Self::render_single_table_row(
@@ -90,6 +92,7 @@ impl CsvPreviewView {
                                             cols,
                                             DisplayRow(display_index),
                                             row_identifier_text_color,
+                                            row_height,
                                             cx,
                                         )
                                     })
@@ -110,6 +113,7 @@ impl CsvPreviewView {
         cols: usize,
         display_row: DisplayRow,
         row_identifier_text_color: gpui::Hsla,
+        row_height: Pixels,
         cx: &Context<CsvPreviewView>,
     ) -> Option<UncheckedTableRow<AnyElement>> {
         // Get the actual row index from our sorted indices
@@ -130,12 +134,15 @@ impl CsvPreviewView {
 
             let cell = div()
                 .size_full()
-                .when(!this.settings.multiline_cells_enabled, |div| {
-                    div.whitespace_nowrap()
-                        .text_ellipsis()
-                        .h(this.row_height)
-                        .overflow_hidden()
-                })
+                .when(
+                    !this.settings.multiline_cells_effectively_enabled(),
+                    |div| {
+                        div.whitespace_nowrap()
+                            .text_ellipsis()
+                            .h(row_height)
+                            .overflow_hidden()
+                    },
+                )
                 .child(CsvPreviewView::create_selectable_cell(
                     display_cell_id,
                     cell_content,

--- a/crates/csv_preview/src/renderer/render_table.rs
+++ b/crates/csv_preview/src/renderer/render_table.rs
@@ -128,14 +128,20 @@ impl CsvPreviewView {
 
             let display_cell_id = DisplayCellId::new(display_row, col);
 
-            let cell = div().size_full().whitespace_nowrap().text_ellipsis().child(
-                CsvPreviewView::create_selectable_cell(
+            let cell = div()
+                .size_full()
+                .when(!this.settings.multiline_cells_enabled, |div| {
+                    div.whitespace_nowrap()
+                        .text_ellipsis()
+                        .h(this.row_height)
+                        .overflow_hidden()
+                })
+                .child(CsvPreviewView::create_selectable_cell(
                     display_cell_id,
                     cell_content,
                     this.settings.vertical_alignment,
                     cx,
-                ),
-            );
+                ));
 
             elements.push(
                 div()
@@ -154,7 +160,6 @@ impl CsvPreviewView {
                             },
                         ))
                     })
-                    .text_ui(cx)
                     .child(cell)
                     .into_any_element(),
             );

--- a/crates/csv_preview/src/renderer/row_identifiers.rs
+++ b/crates/csv_preview/src/renderer/row_identifiers.rs
@@ -1,12 +1,12 @@
 use ui::{
     ActiveTheme as _, AnyElement, Button, ButtonCommon as _, ButtonSize, ButtonStyle,
-    Clickable as _, Context, ElementId, FluentBuilder as _, IntoElement as _, ParentElement as _,
-    SharedString, Styled as _, StyledTypography as _, Tooltip, div,
+    Clickable as _, Context, ElementId, IntoElement as _, ParentElement as _, SharedString,
+    Styled as _, StyledTypography as _, Tooltip, div,
 };
 
 use crate::{
     CsvPreviewView,
-    settings::{RowIdentifiers, VerticalAlignment},
+    settings::RowIdentifiers,
     types::{DataRow, DisplayRow, LineNumber},
 };
 
@@ -77,11 +77,6 @@ impl CsvPreviewView {
         } else {
             (max_line_number as f32).log10().floor() as usize + 1
         };
-
-        // if !self.settings.multiline_cells_enabled {
-        //     // Uses horizontal line numbers layout like `123-456`. Needs twice the size
-        //     digit_count *= 2;
-        // }
 
         let char_width_px = 9.0; // TODO: get real width of the characters
         let base_width = (digit_count as f32) * char_width_px;
@@ -157,7 +152,7 @@ impl CsvPreviewView {
                 .contents
                 .line_numbers
                 .get(*data_row)?
-                .display_string(if self.settings.multiline_cells_enabled {
+                .display_string(if self.settings.multiline_cells_effectively_enabled() {
                     RowIdentDisplayMode::Vertical
                 } else {
                     RowIdentDisplayMode::Horizontal
@@ -172,14 +167,11 @@ impl CsvPreviewView {
             .border_color(cx.theme().colors().border_variant)
             .bg(cx.theme().colors().panel_background)
             .h_full()
-            .text_ui(cx)
             .text_color(cx.theme().colors().text_muted)
             .justify_center()
-            .map(|div| match self.settings.vertical_alignment {
-                VerticalAlignment::Top => div.items_start(),
-                VerticalAlignment::Center => div.items_center(),
-            })
+            .items_center()
             .font_buffer(cx)
+            .text_ui(cx)
             .child(row_identifier)
             .into_any_element();
         Some(value)

--- a/crates/csv_preview/src/renderer/row_identifiers.rs
+++ b/crates/csv_preview/src/renderer/row_identifiers.rs
@@ -34,7 +34,7 @@ impl LineNumber {
                     if start + 1 == end {
                         format!("{start}\n{end}")
                     } else {
-                        format!("{start}\n...\n{end}")
+                        format!("{start}\n-\n{end}")
                     }
                 }
                 RowIdentDisplayMode::Horizontal => {

--- a/crates/csv_preview/src/renderer/settings.rs
+++ b/crates/csv_preview/src/renderer/settings.rs
@@ -1,6 +1,7 @@
 use ui::{
-    ActiveTheme as _, AnyElement, ButtonSize, Context, ContextMenu, DropdownMenu, ElementId,
-    IntoElement as _, ParentElement as _, Styled as _, Tooltip, Window, div, h_flex,
+    ActiveTheme as _, AnyElement, ButtonSize, Checkbox, Context, ContextMenu, DropdownMenu,
+    ElementId, IntoElement as _, ParentElement as _, Styled as _, ToggleState, Tooltip, Window,
+    div, h_flex,
 };
 
 use crate::{
@@ -121,6 +122,30 @@ impl CsvPreviewView {
                     ),
             );
 
+        let multiline_enabled = self.settings.multiline_cells_enabled;
+        let panel = panel.child({
+            let view = view.clone();
+            Checkbox::new(
+                ElementId::Name("multiline-rows-checkbox".into()),
+                if multiline_enabled {
+                    ToggleState::Selected
+                } else {
+                    ToggleState::Unselected
+                },
+            )
+            .label("Display multiline rows")
+            .tooltip(Tooltip::text(
+                "When enabled, row height grows to show all content. \
+                 When disabled, only the first line is visible — hover a cell to see the rest.",
+            ))
+            .on_click(move |_state, _window, cx| {
+                view.update(cx, |this, cx| {
+                    this.settings.multiline_cells_enabled = !this.settings.multiline_cells_enabled;
+                    cx.notify();
+                });
+            })
+        });
+
         #[cfg(feature = "dev-tools")]
         let panel = panel.child(
             h_flex()
@@ -171,7 +196,6 @@ fn create_dev_only_popover_menu(
                                     view_entity.update(cx, |view, cx| {
                                         view.settings.rendering_with =
                                             RowRenderMechanism::VariableList;
-                                        view.settings.multiline_cells_enabled = true;
                                         cx.notify();
                                     })
                                 }
@@ -188,7 +212,6 @@ fn create_dev_only_popover_menu(
                                     view_entity.update(cx, |view, cx| {
                                         view.settings.rendering_with =
                                             RowRenderMechanism::UniformList;
-                                        view.settings.multiline_cells_enabled = false;
                                         cx.notify();
                                     })
                                 }

--- a/crates/csv_preview/src/renderer/table_header.rs
+++ b/crates/csv_preview/src/renderer/table_header.rs
@@ -44,6 +44,7 @@ impl CsvPreviewView {
             .w_full()
             .items_center()
             .font_buffer(cx)
+            .text_buffer(cx)
             .child(
                 div()
                     .flex_1()

--- a/crates/csv_preview/src/settings.rs
+++ b/crates/csv_preview/src/settings.rs
@@ -46,3 +46,12 @@ pub(crate) struct CsvPreviewSettings {
     pub(crate) show_perf_metrics_overlay: bool,
     pub(crate) multiline_cells_enabled: bool,
 }
+
+impl CsvPreviewSettings {
+    /// `multiline_cells_enabled` only makes sense with `VariableList`, which
+    /// supports per-row heights; `UniformList` requires every row to share one
+    /// height, so multiline is never honored there regardless of the setting.
+    pub(crate) fn multiline_cells_effectively_enabled(&self) -> bool {
+        self.multiline_cells_enabled && self.rendering_with == RowRenderMechanism::VariableList
+    }
+}


### PR DESCRIPTION
### Changes

Adds a checkbox to toggle between multiline cells (current behavior) and single-line rows that clip overflow, so wide CSVs stay compact when full cell content isn't needed at a glance.

#### Demo
| Before | After |
| --- | --- |
| No single line mode | <img width="662" height="316" alt="image" src="https://github.com/user-attachments/assets/3f2a9673-557c-4539-b755-9ff2633de2d7" /> |
| <img width="666" height="287" alt="image" src="https://github.com/user-attachments/assets/703f7214-a722-4fa5-9125-f043439e21b2" /> | <img width="660" height="317" alt="image" src="https://github.com/user-attachments/assets/be6ca912-e686-44da-90eb-58f09fab51f1" /> |

### Testing

- Toggle "Display multiline rows" off: cells clip to one line with ellipsis instead of wrapping
- Toggle it back on: cells wrap and grow to show full content
- Resize the window / change font size: single-line clip height tracks the actual text line height instead of a stale hardcoded value

Release Notes:

-  N/A

