### PR TITLE
git_ui: Load worktree switcher list off the serial git job queue

### DIFF
--- a/crates/git_ui_core/src/worktree_picker.rs
+++ b/crates/git_ui_core/src/worktree_picker.rs
@@ -96,9 +96,9 @@ impl WorktreePicker {
                 .map(|branch| branch.name().to_string())
         });
 
-        let all_worktrees_request = repository
-            .clone()
-            .map(|repository| repository.update(cx, |repository, _| repository.worktrees()));
+        let all_worktrees_request = repository.clone().map(|repository| {
+            repository.update(cx, |repository, cx| repository.worktrees_unqueued(cx))
+        });
 
         let default_branch_request = repository.clone().map(|repository| {
             repository.update(cx, |repository, _| repository.default_branch(true))
@@ -139,36 +139,50 @@ impl WorktreePicker {
 
         let mut subscriptions = Vec::new();
 
-        {
+        // Populate the worktree list as soon as `git worktree list` returns,
+        // without waiting for the default branch lookup. Gating the whole list
+        // on `default_branch` would keep it empty until that second request
+        // also completes.
+        if let Some(all_worktrees_request) = all_worktrees_request {
             let picker_handle = picker.downgrade();
             cx.spawn_in(window, async move |_this, cx| {
-                let all_worktrees: Vec<_> = match all_worktrees_request {
-                    Some(req) => match req.await {
-                        Ok(Ok(worktrees)) => {
-                            worktrees.into_iter().filter(|wt| !wt.is_bare).collect()
-                        }
-                        Ok(Err(err)) => {
-                            log::warn!("WorktreePicker: git worktree list failed: {err}");
-                            return anyhow::Ok(());
-                        }
-                        Err(_) => {
-                            log::warn!("WorktreePicker: worktree request was cancelled");
-                            return anyhow::Ok(());
-                        }
-                    },
-                    None => Vec::new(),
-                };
-
-                let default_branch = match default_branch_request {
-                    Some(req) => req.await.ok().and_then(Result::ok).flatten(),
-                    None => None,
+                let all_worktrees: Vec<_> = match all_worktrees_request.await {
+                    Ok(Ok(worktrees)) => worktrees.into_iter().filter(|wt| !wt.is_bare).collect(),
+                    Ok(Err(err)) => {
+                        log::warn!("WorktreePicker: git worktree list failed: {err}");
+                        return anyhow::Ok(());
+                    }
+                    Err(_) => {
+                        log::warn!("WorktreePicker: worktree request was cancelled");
+                        return anyhow::Ok(());
+                    }
                 };
 
                 picker_handle.update_in(cx, |picker, window, cx| {
                     picker.delegate.all_worktrees = all_worktrees;
-                    picker.delegate.default_branch =
-                        default_branch.and_then(|branch| RemoteBranchName::parse(&branch));
                     picker.delegate.refresh_project_worktree_paths(window, cx);
+                    picker.refresh(window, cx);
+                })?;
+
+                anyhow::Ok(())
+            })
+            .detach_and_log_err(cx);
+        }
+
+        // Fill in the "create from default branch" option independently, once
+        // the default branch lookup resolves.
+        if let Some(default_branch_request) = default_branch_request {
+            let picker_handle = picker.downgrade();
+            cx.spawn_in(window, async move |_this, cx| {
+                let default_branch = default_branch_request
+                    .await
+                    .ok()
+                    .and_then(Result::ok)
+                    .flatten()
+                    .and_then(|branch| RemoteBranchName::parse(&branch));
+
+                picker_handle.update_in(cx, |picker, window, cx| {
+                    picker.delegate.default_branch = default_branch;
                     picker.refresh(window, cx);
                 })?;
 
@@ -184,7 +198,8 @@ impl WorktreePicker {
                 window,
                 move |_this, repo, event: &RepositoryEvent, window, cx| {
                     if matches!(event, RepositoryEvent::GitWorktreeListChanged) {
-                        let worktrees_request = repo.update(cx, |repo, _| repo.worktrees());
+                        let worktrees_request =
+                            repo.update(cx, |repo, cx| repo.worktrees_unqueued(cx));
                         let picker = picker_entity.clone();
                         cx.spawn_in(window, async move |_, cx| {
                             let all_worktrees: Vec<_> = worktrees_request

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -8379,6 +8379,52 @@ impl Repository {
         })
     }
 
+    /// Lists git worktrees without going through the serial per-repository git
+    /// job queue. `git worktree list` is read-only and independent of the
+    /// status snapshot, so it must not wait behind long-running scans (status /
+    /// diff refreshes) in a large monorepo, where queuing it makes the worktree
+    /// switcher take minutes to populate. Runs directly against the backend,
+    /// mirroring the off-queue pattern used by [`Self::search_commits`] and the
+    /// git graph data readers. The queued [`Self::worktrees`] is still used by
+    /// `compute_snapshot`, where ordering keeps the snapshot internally
+    /// consistent.
+    pub fn worktrees_unqueued(
+        &self,
+        cx: &mut Context<Self>,
+    ) -> oneshot::Receiver<Result<Vec<GitWorktree>>> {
+        let (tx, rx) = oneshot::channel();
+        let repository_state = self.repository_state.clone();
+        let id = self.id;
+        cx.background_spawn(async move {
+            let result = match repository_state.await {
+                Ok(RepositoryState::Local(LocalRepositoryState { backend, .. })) => {
+                    backend.worktrees().await
+                }
+                Ok(RepositoryState::Remote(RemoteRepositoryState { project_id, client })) => {
+                    async move {
+                        let response = client
+                            .request(proto::GitGetWorktrees {
+                                project_id: project_id.0,
+                                repository_id: id.to_proto(),
+                            })
+                            .await?;
+                        let worktrees = response
+                            .worktrees
+                            .into_iter()
+                            .map(|worktree| proto_to_worktree(&worktree))
+                            .collect();
+                        Ok(worktrees)
+                    }
+                    .await
+                }
+                Err(error) => Err(anyhow!(error)),
+            };
+            tx.send(result).ok();
+        })
+        .detach();
+        rx
+    }
+
     pub fn create_worktree(
         &mut self,
         target: CreateWorktreeTarget,


### PR DESCRIPTION
## Objective

- In a large monorepo the Git Worktrees switcher in the title bar took tens
  of seconds to populate: opening the dropdown showed only the current
  worktree while the full list loaded very slowly.
- The cost was not `git worktree list` itself (it is cheap), but that the
  picker requested it through the single serial per-repository git job
  queue, where it was stuck behind the expensive full-repo status/diff
  scans (`ReloadGitState` / `RefreshStatuses`). Until those long-running
  scans finished, the list could not start.
  
  > There are actually other issues related to git job locks in large repositories,
  but this particular one is the most annoying and blocking for me personally.

## Solution

- Add `Repository::worktrees_unqueued`, which runs `git worktree list`
  directly against the backend and bypasses the serial job queue, mirroring
  the off-queue pattern already used by `search_commits` and the git graph
  data readers.
- The queued `Repository::worktrees` is intentionally kept for
  `compute_snapshot`, the remote-server proto handler, and worktree-creation
  collision checks, where ordering relative to other git jobs matters.
- Point the worktree picker at the unqueued variant, and stop gating the
  list on the default-branch lookup: the worktrees now render as soon as
  `git worktree list` returns, while the "create from default branch" option
  fills in independently once that request resolves.

## Testing

- `cargo test -p git_ui worktree_picker` — all tests pass.
- `cargo check -p project -p git_ui` and `cargo clippy -p project -p git_ui`
  are clean.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed the Git Worktrees switcher taking a long time to populate in large repositories.
