### PR TITLE
Add more parameter colors to the theme

### DIFF
--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -387,6 +387,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "variable.parameter": {
+            "color": "#d2a6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
           "variant": {
             "color": "#5ac1feff",
             "font_style": null,
@@ -789,6 +794,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "variable.parameter": {
+            "color": "#a37accff",
+            "font_style": null,
+            "font_weight": null
+          },
           "variant": {
             "color": "#3b9ee5ff",
             "font_style": null,
@@ -1188,6 +1198,11 @@
           },
           "variable": {
             "color": "#cccac2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#dfbfffff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -397,6 +397,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "variable.parameter": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "variable.special": {
             "color": "#83a598ff",
             "font_style": null,
@@ -811,6 +816,11 @@
           },
           "variable": {
             "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1231,6 +1241,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "variable.parameter": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "variable.special": {
             "color": "#83a598ff",
             "font_style": null,
@@ -1645,6 +1660,11 @@
           },
           "variable": {
             "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#076678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2065,6 +2085,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "variable.parameter": {
+            "color": "#076678ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "variable.special": {
             "color": "#066578ff",
             "font_style": null,
@@ -2479,6 +2504,11 @@
           },
           "variable": {
             "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#076678ff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -394,6 +394,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "variable.parameter": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "variable.special": {
             "color": "#bf956aff",
             "font_style": null,
@@ -803,6 +808,11 @@
           },
           "variable": {
             "color": "#242529ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.parameter": {
+            "color": "#d3604fff",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/60949 based on https://github.com/zed-industries/zed/pull/60949#issuecomment-4994719726


`basedpyright` sends the token we lack the theme element for

<img width="1141" height="599" alt="before" src="https://github.com/user-attachments/assets/47fd6375-507d-4419-810b-04e69251fe90" />

supports that in theme definitions:

<img width="385" height="244" alt="after" src="https://github.com/user-attachments/assets/edfe3866-4bdb-480d-9bbd-b76c1366d311" />


---

Release Notes:

- Added `variable.parameter` theme color
