### PR TITLE
emacs: Stop ctrl-n and ctrl-p falling back to the default bindings

### DIFF
--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -17,8 +17,11 @@
     "bindings": {
       "ctrl-g": null, // currently activates `go_to_line::Toggle` when there is nothing to cancel
       "ctrl-x": null, // currently activates `editor::Cut` if no following key is pressed for 1 second
-      "ctrl-p": null, // currently activates `file_finder::Toggle` when the cursor is on the first character of the buffer
-      "ctrl-n": null, // currently activates `workspace::NewFile` when the cursor is on the last character of the buffer
+      // `null` only stops binding resolution in a user keymap, so these use a targeted unbind:
+      // `editor::MoveUp`/`MoveDown` propagate when the cursor doesn't move, which at the ends of
+      // the buffer would otherwise fall through to these.
+      "ctrl-p": ["zed::Unbind", "file_finder::Toggle"],
+      "ctrl-n": ["zed::Unbind", "workspace::NewFile"],
     },
   },
   {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -5133,6 +5133,94 @@ mod tests {
 
     actions!(test_only, [ActionA, ActionB]);
 
+    /// The actions the emacs keymap resolves for `keystroke` in `context`.
+    fn emacs_bindings_for(keystroke: &str, context: &str, cx: &mut TestAppContext) -> Vec<String> {
+        cx.update(|cx| {
+            let mut bindings = settings::KeymapFile::load_asset_allow_partial_failure(
+                "keymaps/default-linux.json",
+                cx,
+            )
+            .unwrap();
+            for binding in &mut bindings {
+                binding.set_meta(settings::KeybindSource::Default.meta());
+            }
+            let mut emacs_bindings = settings::KeymapFile::load_asset_allow_partial_failure(
+                "keymaps/linux/emacs.json",
+                cx,
+            )
+            .unwrap();
+            for binding in &mut emacs_bindings {
+                binding.set_meta(settings::KeybindSource::Base.meta());
+            }
+            bindings.extend(emacs_bindings);
+
+            gpui::Keymap::new(bindings)
+                .bindings_for_input(
+                    &[gpui::Keystroke::parse(keystroke).unwrap()],
+                    &[gpui::KeyContext::parse(context).unwrap()],
+                )
+                .0
+                .iter()
+                .map(|binding| binding.action().name().to_string())
+                .collect()
+        })
+    }
+
+    /// `editor::MoveDown` and `editor::MoveUp` propagate when the cursor doesn't move, which at the
+    /// ends of a buffer let `ctrl-n` and `ctrl-p` fall through to the default bindings and open a
+    /// new file / the file finder.
+    #[gpui::test]
+    fn test_emacs_cursor_keys_do_not_fall_back_to_default_bindings(cx: &mut TestAppContext) {
+        init_keymap_test(cx);
+
+        let ctrl_n = emacs_bindings_for("ctrl-n", "Workspace Editor", cx);
+        assert!(
+            ctrl_n.contains(&"editor::MoveDown".to_string()),
+            "ctrl-n should still move down, got {ctrl_n:?}"
+        );
+        assert!(
+            !ctrl_n.contains(&"workspace::NewFile".to_string()),
+            "ctrl-n should not fall through to workspace::NewFile, got {ctrl_n:?}"
+        );
+
+        let ctrl_p = emacs_bindings_for("ctrl-p", "Workspace Editor", cx);
+        assert!(
+            ctrl_p.contains(&"editor::MoveUp".to_string()),
+            "ctrl-p should still move up, got {ctrl_p:?}"
+        );
+        assert!(
+            !ctrl_p.contains(&"file_finder::Toggle".to_string()),
+            "ctrl-p should not fall through to file_finder::Toggle, got {ctrl_p:?}"
+        );
+    }
+
+    /// The unbind above only targets `workspace::NewFile` / `file_finder::Toggle`, so the narrower
+    /// `ctrl-n` and `ctrl-p` bindings still win where they apply.
+    #[gpui::test]
+    fn test_emacs_cursor_keys_keep_narrower_bindings(cx: &mut TestAppContext) {
+        init_keymap_test(cx);
+
+        let completions = "Workspace Editor showing_completions";
+        assert_eq!(
+            emacs_bindings_for("ctrl-n", completions, cx).first(),
+            Some(&"editor::ContextMenuNext".to_string())
+        );
+        assert_eq!(
+            emacs_bindings_for("ctrl-p", completions, cx).first(),
+            Some(&"editor::ContextMenuPrevious".to_string())
+        );
+
+        let selection_mode = "Workspace Editor selection_mode";
+        assert_eq!(
+            emacs_bindings_for("ctrl-n", selection_mode, cx).first(),
+            Some(&"editor::SelectDown".to_string())
+        );
+        assert_eq!(
+            emacs_bindings_for("ctrl-p", selection_mode, cx).first(),
+            Some(&"editor::SelectUp".to_string())
+        );
+    }
+
     #[gpui::test]
     async fn test_base_keymap(cx: &mut gpui::TestAppContext) {
         let executor = cx.executor();


### PR DESCRIPTION
on linux with the emacs keymap, holding `ctrl-n` at the end of the buffer opens a new file every press. `ctrl-p` at the top opens the file finder.

the keymap already tries `"ctrl-n": null`, but `null` only breaks resolution in a *user* keymap, so from a base keymap `workspace::NewFile` still resolves. a targeted unbind works regardless of source:

```json
"ctrl-p": ["zed::Unbind", "file_finder::Toggle"],
"ctrl-n": ["zed::Unbind", "workspace::NewFile"],
```

left the MoveDown/MoveUp propagation alone, it's load bearing (agent panel uses it for up-to-edit-last-message). tests cover the fix plus the narrower ctrl-n/ctrl-p bindings still winning, since the unbind only targets the one action.

ctrl-g/ctrl-x in that block are still null and probably just as broken, but ctrl-x is a prefix key so i left them.

Closes #45010.

Release Notes:

- Fixed `ctrl-n` opening a new file and `ctrl-p` opening the file finder at the ends of a buffer when using the Emacs keymap on Linux