### PR TITLE
debugger: Don't eagerly fetch variables for expensive DAP scopes

### DIFF
--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -298,16 +298,10 @@ impl VariableList {
                     contains_local_scope = true;
                 }
 
-                if scope.expensive {
-                    // Don't fetch variables for expensive scopes just to check whether
-                    // they're empty: always keep them in the tree, collapsed, and let
-                    // the user opt in to resolving them by expanding.
-                    return true;
-                }
-
-                self.session.update(cx, |session, cx| {
-                    !session.variables(scope.variables_reference, cx).is_empty()
-                })
+                scope.expensive
+                    || self.session.update(cx, |session, cx| {
+                        !session.variables(scope.variables_reference, cx).is_empty()
+                    })
             })
             .map(|scope| {
                 (

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -298,6 +298,13 @@ impl VariableList {
                     contains_local_scope = true;
                 }
 
+                if scope.expensive {
+                    // Don't fetch variables for expensive scopes just to check whether
+                    // they're empty: always keep them in the tree, collapsed, and let
+                    // the user opt in to resolving them by expanding.
+                    return true;
+                }
+
                 self.session.update(cx, |session, cx| {
                     !session.variables(scope.variables_reference, cx).is_empty()
                 })
@@ -347,12 +354,13 @@ impl VariableList {
                 .or_insert(EntryState {
                     depth: path.indices.len(),
                     is_expanded: dap_kind.as_scope().is_some_and(|scope| {
-                        (scopes_count == 1 && !contains_local_scope)
-                            || scope
-                                .presentation_hint
-                                .as_ref()
-                                .map(|hint| *hint == ScopePresentationHint::Locals)
-                                .unwrap_or(scope.name.to_lowercase().starts_with("local"))
+                        !scope.expensive
+                            && ((scopes_count == 1 && !contains_local_scope)
+                                || scope
+                                    .presentation_hint
+                                    .as_ref()
+                                    .map(|hint| *hint == ScopePresentationHint::Locals)
+                                    .unwrap_or(scope.name.to_lowercase().starts_with("local")))
                     }),
                     parent_reference: container_reference,
                     has_children: variables_reference != 0,

--- a/crates/debugger_ui/src/tests/variable_list.rs
+++ b/crates/debugger_ui/src/tests/variable_list.rs
@@ -478,6 +478,257 @@ async fn test_fetch_variables_for_multiple_scopes(
     });
 }
 
+/// A scope marked `expensive: true` by the DAP adapter (e.g. a JavaScript "Global"
+/// scope) must not have its variables fetched automatically, since resolving it can
+/// hang indefinitely. It should render collapsed, and only be resolved once the user
+/// explicitly expands it.
+#[gpui::test]
+async fn test_expensive_scope_is_not_eagerly_fetched(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+
+    let test_file_content = r#"
+        const local = 1;
+    "#
+    .unindent();
+
+    fs.insert_tree(
+        path!("/project"),
+        json!({
+           "src": {
+               "test.js": test_file_content,
+           }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    workspace
+        .update(cx, |workspace, window, cx| {
+            workspace.focus_panel::<DebugPanel>(window, cx);
+        })
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let session = start_debug_session(&workspace, cx, |_| {}).unwrap();
+    let client = session.update(cx, |session, _| session.adapter_client().unwrap());
+
+    client.on_request::<dap::requests::Threads, _>(move |_, _| {
+        Ok(dap::ThreadsResponse {
+            threads: vec![dap::Thread {
+                id: 1,
+                name: "Thread 1".into(),
+            }],
+        })
+    });
+
+    client.on_request::<Initialize, _>(move |_, _| {
+        Ok(dap::Capabilities {
+            supports_step_back: Some(false),
+            ..Default::default()
+        })
+    });
+
+    client.on_request::<Launch, _>(move |_, _| Ok(()));
+
+    let stack_frames = vec![StackFrame {
+        id: 1,
+        name: "Stack Frame 1".into(),
+        source: Some(dap::Source {
+            name: Some("test.js".into()),
+            path: Some(path!("/project/src/test.js").into()),
+            source_reference: None,
+            presentation_hint: None,
+            origin: None,
+            sources: None,
+            adapter_data: None,
+            checksums: None,
+        }),
+        line: 1,
+        column: 1,
+        end_line: None,
+        end_column: None,
+        can_restart: None,
+        instruction_pointer_reference: None,
+        module_id: None,
+        presentation_hint: None,
+    }];
+
+    client.on_request::<StackTrace, _>({
+        let stack_frames = Arc::new(stack_frames.clone());
+        move |_, args| {
+            assert_eq!(1, args.thread_id);
+
+            Ok(dap::StackTraceResponse {
+                stack_frames: (*stack_frames).clone(),
+                total_frames: None,
+            })
+        }
+    });
+
+    let scopes = vec![
+        Scope {
+            name: "Local".into(),
+            presentation_hint: Some(dap::ScopePresentationHint::Locals),
+            variables_reference: 2,
+            named_variables: None,
+            indexed_variables: None,
+            expensive: false,
+            source: None,
+            line: None,
+            column: None,
+            end_line: None,
+            end_column: None,
+        },
+        Scope {
+            name: "Global".into(),
+            presentation_hint: None,
+            variables_reference: 3,
+            named_variables: None,
+            indexed_variables: None,
+            expensive: true,
+            source: None,
+            line: None,
+            column: None,
+            end_line: None,
+            end_column: None,
+        },
+    ];
+
+    client.on_request::<Scopes, _>({
+        let scopes = Arc::new(scopes.clone());
+        move |_, args| {
+            assert_eq!(1, args.frame_id);
+
+            Ok(dap::ScopesResponse {
+                scopes: (*scopes).clone(),
+            })
+        }
+    });
+
+    let fetched_expensive_scope = Arc::new(AtomicBool::new(false));
+
+    client.on_request::<Variables, _>({
+        let fetched_expensive_scope = fetched_expensive_scope.clone();
+        move |_, args| match args.variables_reference {
+            2 => Ok(dap::VariablesResponse {
+                variables: vec![Variable {
+                    name: "localVar".into(),
+                    value: "1".into(),
+                    type_: None,
+                    presentation_hint: None,
+                    evaluate_name: None,
+                    variables_reference: 0,
+                    named_variables: None,
+                    indexed_variables: None,
+                    memory_reference: None,
+                    declaration_location_reference: None,
+                    value_location_reference: None,
+                }],
+            }),
+            3 => {
+                fetched_expensive_scope.store(true, Ordering::SeqCst);
+                Ok(dap::VariablesResponse {
+                    variables: vec![Variable {
+                        name: "globalVar".into(),
+                        value: "expensive".into(),
+                        type_: None,
+                        presentation_hint: None,
+                        evaluate_name: None,
+                        variables_reference: 0,
+                        named_variables: None,
+                        indexed_variables: None,
+                        memory_reference: None,
+                        declaration_location_reference: None,
+                        value_location_reference: None,
+                    }],
+                })
+            }
+            id => unreachable!("unexpected variables reference {id}"),
+        }
+    });
+
+    client
+        .fake_event(dap::messages::Events::Stopped(dap::StoppedEvent {
+            reason: dap::StoppedEventReason::Pause,
+            description: None,
+            thread_id: Some(1),
+            preserve_focus_hint: None,
+            text: None,
+            all_threads_stopped: None,
+            hit_breakpoint_ids: None,
+        }))
+        .await;
+
+    cx.run_until_parked();
+
+    let running_state =
+        active_debug_session_panel(workspace, cx).update_in(cx, |item, window, cx| {
+            cx.focus_self(window);
+            let running = item.running_state().clone();
+
+            let variable_list = running.update(cx, |state, cx| {
+                // have to do this because the variable list pane should be shown/active
+                // for testing keyboard navigation
+                state.activate_item(DebuggerPaneItem::Variables, window, cx);
+
+                state.variable_list().clone()
+            });
+            variable_list.update(cx, |_, cx| cx.focus_self(window));
+            running
+        });
+    cx.run_until_parked();
+
+    running_state.update(cx, |running_state, cx| {
+        running_state
+            .variable_list()
+            .update(cx, |variable_list, _| {
+                // The expensive "Global" scope is visible but collapsed; its variables
+                // must not have been fetched yet.
+                variable_list.assert_visual_entries(vec!["v Local", "    > localVar", "> Global"]);
+            });
+    });
+
+    assert!(
+        !fetched_expensive_scope.load(Ordering::SeqCst),
+        "Zed must not eagerly fetch variables for a scope marked `expensive: true`"
+    );
+
+    // Select and expand the Global scope: only now should its variables be resolved.
+    cx.dispatch_action(SelectFirst);
+    cx.dispatch_action(SelectFirst);
+    cx.run_until_parked();
+    cx.dispatch_action(SelectNext);
+    cx.run_until_parked();
+    cx.dispatch_action(SelectNext);
+    cx.run_until_parked();
+    cx.dispatch_action(ExpandSelectedEntry);
+    cx.run_until_parked();
+
+    running_state.update(cx, |running_state, cx| {
+        running_state
+            .variable_list()
+            .update(cx, |variable_list, _| {
+                variable_list.assert_visual_entries(vec![
+                    "v Local",
+                    "    > localVar",
+                    "v Global <=== selected",
+                    "    > globalVar",
+                ]);
+            });
+    });
+
+    assert!(
+        fetched_expensive_scope.load(Ordering::SeqCst),
+        "Expanding the Global scope should fetch its variables"
+    );
+}
+
 // tests that toggling a variable will fetch its children and shows it
 #[gpui::test]
 async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestAppContext) {

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -2535,7 +2535,12 @@ impl Session {
                     };
 
                     for scope in scopes.iter() {
-                        this.variables(scope.variables_reference, cx);
+                        // `expensive` scopes (e.g. a JavaScript "Global" scope) can be
+                        // arbitrarily slow or hang entirely, so defer fetching their
+                        // variables until the user explicitly expands them.
+                        if !scope.expensive {
+                            this.variables(scope.variables_reference, cx);
+                        }
                     }
 
                     let entry = this

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -2534,13 +2534,8 @@ impl Session {
                         return
                     };
 
-                    for scope in scopes.iter() {
-                        // `expensive` scopes (e.g. a JavaScript "Global" scope) can be
-                        // arbitrarily slow or hang entirely, so defer fetching their
-                        // variables until the user explicitly expands them.
-                        if !scope.expensive {
+                    for scope in scopes.iter().filter(|scope| !scope.expensive) {
                             this.variables(scope.variables_reference, cx);
-                        }
                     }
 
                     let entry = this


### PR DESCRIPTION
# Objective

Zed eagerly fetches variables for every scope returned by a DAP `scopes` response, including scopes the adapter marked `expensive: true`.

Per the [DAP spec](https://microsoft.github.io/debug-adapter-protocol/specification#Types_Scope), `expensive` means "the number of variables in this scope is large or expensive to retrieve... recommended for UIs to not automatically expand and evaluate the scope. Some debug adapters (e.g. `vscode-js-debug`, used for JavaScript/Chrome debugging) mark scopes like "Global" as expensive because resolving them can hang forever. VS Code honors this and leaves the scope collapsed until the user opts in by expanding it; Zed did not, so any session with a hanging expensive scope would freeze the entire debug session (including Resume) with no user action at all.

Fixes #61105

## Solution

- `Session::scopes()` in `crates/project/src/debugger/session.rs` [unconditionally called `this.variables(...)`](https://github.com/zed-industries/zed/blob/058f01fa93503491a735bfded53e77bfaa276148/crates/project/src/debugger/session.rs#L2538) for every scope in the `scopes` response.
 - `VariableList::build_entries()` in `crates/debugger_ui/src/session/running/variable_list.rs` also called `session.variables(...)` [on every scope](https://github.com/zed-industries/zed/blob/058f01fa93503491a735bfded53e77bfaa276148/crates/debugger_ui/src/session/running/variable_list.rs#L291-L304), as a side effect of checking whether it was empty (used to decide whether to hide it from the tree). Fixing only the first call site wasn't enough, since this one would still trigger the fetch on the very next render.
  
Both now skip the fetch for `expensive` scopes. Expensive scopes still show up in the variable list, collapsed, so the user can expand them manually (which fetches lazily via the existing on-toggle path). Also hardened the auto-expand heuristic (e.g. "expand the only scope if it's not Locals") to never auto-expand an expensive scope, even in adapters where it happens to be the sole or "Locals"-named scope.

## Testing

  - Added `test_expensive_scope_is_not_eagerly_fetched` in `crates/debugger_ui/src/tests/variable_list.rs`, asserting the DAP `variables` request is never sent for an
  `expensive: true` scope until the user expands it, and that expanding it does trigger the fetch. Verified this test fails on the old code and passes with the fix.
  - Ran the full `debugger_ui` test suite, all pass, no regressions.
  - Manually reproduced and verified the fix using the minimal repro at https://github.com/jasonwilliams/zed-dap-repro

## Self-Review Checklist:

  - [x] I've reviewed my own diff for quality, security, and reliability
  - [x] Unsafe blocks (if any) have justifying comments
  - [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and
  [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
  - [x] Tests cover the new/changed behavior
  - [x] Performance impact has been considered and is acceptable

## Showcase

Before:
https://github.com/user-attachments/assets/7a3ead7e-aece-4726-883d-d60d49c83b7c
Here you can see that once the break has happened Zed has crashed, resuming doesn't help, i effectively need to kill the whole debug session.

After:
https://github.com/user-attachments/assets/7a36cbb0-f22b-4782-9326-9ccab9297fc7
Here you can see the Global scope is closed and clicking resume carries on without any crashes

Release Notes:

- Fixed debugger eagerly fetching expensive variable scopes
