### PR TITLE
Clarify hosted model availability by plan

### DIFF
--- a/docs/src/account/plans-and-pricing.md
+++ b/docs/src/account/plans-and-pricing.md
@@ -13,7 +13,7 @@ Zed works without AI features or a subscription. No [authentication](../authenti
 
 |                                                | Free    | Pro       | Student   | Business  |
 | ---------------------------------------------- | ------- | --------- | --------- | --------- |
-| Zed-hosted AI models                           | —       | All       | Most      | All       |
+| Zed-hosted AI models                           | —       | ✓         | ✓         | ✓         |
 | [AI via own API keys](../ai/use-api-access.md) | ✓       | ✓         | ✓         | ✓         |
 | [External Agents](../ai/external-agents.md)    | ✓       | ✓         | ✓         | ✓         |
 | Edit Predictions                               | Limited | Unlimited | Unlimited | Unlimited |
@@ -23,7 +23,7 @@ Zed works without AI features or a subscription. No [authentication](../authenti
 
 ### Zed Free {#free}
 
-Zed is free to use. You can configure AI agents with your own API keys via [Use API Access](../ai/use-api-access.md). [Edit Predictions](../ai/edit-prediction.md) are available on a limited basis. Zed-hosted models are available through Pro, Student, and paid Business plans.
+Zed is free to use. You can configure AI agents with your own API keys via [Use API Access](../ai/use-api-access.md). [Edit Predictions](../ai/edit-prediction.md) are available on a limited basis. Zed's hosted models require a Pro subscription.
 
 ### Zed Pro {#pro}
 
@@ -39,7 +39,7 @@ For a full feature overview, see [Zed Business](../business/overview.md). For bi
 
 ### Student Plan {#student}
 
-The [Zed Student plan](https://zed.dev/education) includes unlimited [Edit Predictions](../ai/edit-prediction.md), most [hosted AI models](./zed-hosted-models.md), and $10/month in token credits. It excludes Claude Fable 5, Claude Opus models, GPT-5.5 pro, and GPT-5.4 pro. The plan is available free for one year to verified university students.
+The [Zed Student plan](https://zed.dev/education) includes all Zed Pro features: unlimited [Edit Predictions](../ai/edit-prediction.md), all [hosted AI models](./zed-hosted-models.md) except Claude Opus, and $10/month in token credits. Available free for one year to verified university students.
 
 ## Usage {#usage}
 
@@ -65,4 +65,4 @@ On Zed Business, administrators set a pre-tax org-wide spend limit from the Data
 
 ### Trials {#trials}
 
-Trials automatically convert to Zed Free when they end. Trials do not include Claude Fable 5, Claude Opus models, GPT-5.5 pro, or GPT-5.4 pro. No cancellation is needed to prevent conversion to Zed Pro.
+Trials automatically convert to Zed Free when they end. Trials do not include access to Anthropic's Opus models. No cancellation is needed to prevent conversion to Zed Pro.

--- a/docs/src/account/plans-and-pricing.md
+++ b/docs/src/account/plans-and-pricing.md
@@ -13,7 +13,7 @@ Zed works without AI features or a subscription. No [authentication](../authenti
 
 |                                                | Free    | Pro       | Student   | Business  |
 | ---------------------------------------------- | ------- | --------- | --------- | --------- |
-| Zed-hosted AI models                           | —       | ✓         | ✓         | ✓         |
+| Zed-hosted AI models                           | —       | All       | Most      | All       |
 | [AI via own API keys](../ai/use-api-access.md) | ✓       | ✓         | ✓         | ✓         |
 | [External Agents](../ai/external-agents.md)    | ✓       | ✓         | ✓         | ✓         |
 | Edit Predictions                               | Limited | Unlimited | Unlimited | Unlimited |
@@ -23,7 +23,7 @@ Zed works without AI features or a subscription. No [authentication](../authenti
 
 ### Zed Free {#free}
 
-Zed is free to use. You can configure AI agents with your own API keys via [Use API Access](../ai/use-api-access.md). [Edit Predictions](../ai/edit-prediction.md) are available on a limited basis. Zed's hosted models require a Pro subscription.
+Zed is free to use. You can configure AI agents with your own API keys via [Use API Access](../ai/use-api-access.md). [Edit Predictions](../ai/edit-prediction.md) are available on a limited basis. Zed-hosted models are available through Pro, Student, and paid Business plans.
 
 ### Zed Pro {#pro}
 
@@ -39,7 +39,7 @@ For a full feature overview, see [Zed Business](../business/overview.md). For bi
 
 ### Student Plan {#student}
 
-The [Zed Student plan](https://zed.dev/education) includes all Zed Pro features: unlimited [Edit Predictions](../ai/edit-prediction.md), all [hosted AI models](./zed-hosted-models.md) except Claude Opus, and $10/month in token credits. Available free for one year to verified university students.
+The [Zed Student plan](https://zed.dev/education) includes unlimited [Edit Predictions](../ai/edit-prediction.md), most [hosted AI models](./zed-hosted-models.md), and $10/month in token credits. It excludes Claude Fable 5, Claude Opus models, GPT-5.5 pro, and GPT-5.4 pro. The plan is available free for one year to verified university students.
 
 ## Usage {#usage}
 
@@ -65,4 +65,4 @@ On Zed Business, administrators set a pre-tax org-wide spend limit from the Data
 
 ### Trials {#trials}
 
-Trials automatically convert to Zed Free when they end. Trials do not include access to Anthropic's Opus models. No cancellation is needed to prevent conversion to Zed Pro.
+Trials automatically convert to Zed Free when they end. Trials do not include Claude Fable 5, Claude Opus models, GPT-5.5 pro, or GPT-5.4 pro. No cancellation is needed to prevent conversion to Zed Pro.

--- a/docs/src/account/zed-hosted-models.md
+++ b/docs/src/account/zed-hosted-models.md
@@ -1,13 +1,15 @@
 ---
 title: Zed-Hosted Models - Zed
-description: AI models available via Zed Pro including Claude Fable 5, Claude Sonnet 5, GPT-5.6, and Gemini 3. Pricing, context windows, and tool call support.
+description: AI models available through Zed plans, including pricing, context windows, and tool call support.
 ---
 
 # Zed-Hosted Models
 
 Zed's plans offer hosted versions of major LLMs with higher rate limits than direct API access. Model availability is updated regularly. To use your own API keys instead, see [LLM Providers](../ai/llm-providers.md). For general setup, see [AI Quick Start](../ai/quick-start.md).
 
-> **Note:** Claude Fable 5, Claude Opus models, GPT-5.5 pro, and GPT-5.4 pro are only available on Zed Pro and Zed Business.
+> **Note:** Pro trials and the Student plan do not include Claude Fable 5, Claude Opus models, GPT-5.5 pro, or GPT-5.4 pro. These models are available on paid Zed Pro and Business plans.
+
+## Pricing {#pricing}
 
 | Model             | Provider  | Token Type          | Provider Price per 1M tokens | Zed Price per 1M tokens |
 | ----------------- | --------- | ------------------- | ---------------------------- | ----------------------- |


### PR DESCRIPTION
## Summary

- Keep one hosted-model pricing table.
- List the models unavailable to Pro trial and Student users in the existing callout.
- Clarify that the page covers models available through Zed plans.

## Why

The hosted-model table matches the 24 models returned by `cloud` for paid Pro and Business users. Pro trial and Student users receive 17 of those models; they do not receive Claude Fable 5, the four Claude Opus models, GPT-5.5 pro, or GPT-5.4 pro. The callout now states that distinction directly.

## Validation

- Compared the table against `cloud`'s current `/models` implementation and plan-specific tests
- `npx prettier --check src/account/zed-hosted-models.md`
- `script/generate-action-metadata`
- `mdbook build docs -d book-codex-hosted-models-one-table`

Release Notes:

- N/A