### PR TITLE
editor: Place added cursors by tab-expanded column

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -136,7 +136,7 @@ use crate::{
 use block_map::{BlockPointCursor, BlockRow, BlockSnapshot};
 use fold_map::{FoldPointCursor, FoldSnapshot};
 use inlay_map::{BufferOffsetToInlayPointCursor, InlaySnapshot};
-use tab_map::{TabPointCursor, TabSnapshot};
+use tab_map::{TabPoint, TabPointCursor, TabSnapshot};
 use wrap_map::{WrapMap, WrapPatch, WrapPointCursor};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -1542,6 +1542,28 @@ impl DisplaySnapshot {
     }
     pub fn tab_snapshot(&self) -> &TabSnapshot {
         &self.block_snapshot.wrap_snapshot.tab_snapshot
+    }
+
+    /// The column `point` sits at once tabs are expanded, which is where it appears
+    /// on screen when the line isn't soft-wrapped. Unlike a display column this is
+    /// counted from the start of the buffer row rather than the wrapped segment.
+    pub fn tab_expanded_column(&self, point: Point) -> u32 {
+        self.tab_snapshot()
+            .point_to_tab_point(point, Bias::Left)
+            .0
+            .column
+    }
+
+    /// Inverse of [`Self::tab_expanded_column`], clamped to the end of the row.
+    pub fn point_for_tab_expanded_column(&self, row: u32, column: u32) -> Point {
+        let column = column.min(self.tab_snapshot().line_len(row));
+        self.tab_snapshot()
+            .tab_point_to_point(TabPoint(Point::new(row, column)), Bias::Left)
+    }
+
+    /// The length of `row` once tabs are expanded.
+    pub fn tab_expanded_line_len(&self, row: u32) -> u32 {
+        self.tab_snapshot().line_len(row)
     }
 
     pub fn fold_snapshot(&self) -> &FoldSnapshot {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10747,6 +10747,40 @@ async fn test_split_selection_into_lines_interacting_with_creases(cx: &mut TestA
 }
 
 #[gpui::test]
+/// A different number of tabs can align the same column on each row, so a cursor has to
+/// be placed by the column the tabs expand to. Counting a tab as a single column lands it
+/// wherever that many characters happen to reach on the next row.
+#[gpui::test]
+async fn test_add_selection_below_with_tab_aligned_columns(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.hard_tabs = Some(true);
+        settings.defaults.tab_size = Some(4.try_into().unwrap());
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    // Both `=` render at column 48: `current.rgb.r` ends at 37 and is padded by three
+    // tabs, `residuals[run].rgb.r` ends at 44 and is padded by one.
+    cx.set_state(
+        "\t\t\t\t\t\tcurrent.rgb.r\t\t\tˇ= p[0] >> 8;\n\t\t\t\t\t\tresiduals[run].rgb.r\t= p[0] & 0xff;\n",
+    );
+
+    cx.update_editor(|editor, window, cx| {
+        editor.add_selection_below(
+            &AddSelectionBelow {
+                skip_soft_wrap: true,
+            },
+            window,
+            cx,
+        );
+    });
+
+    cx.assert_editor_state(
+        "\t\t\t\t\t\tcurrent.rgb.r\t\t\tˇ= p[0] >> 8;\n\t\t\t\t\t\tresiduals[run].rgb.r\tˇ= p[0] & 0xff;\n",
+    );
+}
+
+#[gpui::test]
 async fn test_add_selection_above_below(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/selection.rs
+++ b/crates/editor/src/selection.rs
@@ -1937,10 +1937,11 @@ impl Editor {
             display_map.max_point().row()
         };
 
-        // When `skip_soft_wrap` is true, we use UTF-16 columns instead of pixel
-        // positions to place new selections, so we need to keep track of the
-        // column range of the oldest selection in each group, because
-        // intermediate selections may have been clamped to shorter lines.
+        // When `skip_soft_wrap` is true, we place new selections by column rather than
+        // pixel position, so we need to keep track of the column range of the oldest
+        // selection in each group, because intermediate selections may have been
+        // clamped to shorter lines. Columns are counted with tabs expanded so that
+        // tab-aligned code lines up the way it renders.
         let mut goal_columns_by_selection_id = if skip_soft_wrap {
             let mut map = HashMap::default();
             for group in state.groups.iter() {
@@ -1948,10 +1949,8 @@ impl Editor {
                     if let Some(oldest_selection) =
                         columnar_selections.iter().find(|s| s.id == *oldest_id)
                     {
-                        let snapshot = display_map.buffer_snapshot();
-                        let start_col =
-                            snapshot.point_to_point_utf16(oldest_selection.start).column;
-                        let end_col = snapshot.point_to_point_utf16(oldest_selection.end).column;
+                        let start_col = display_map.tab_expanded_column(oldest_selection.start);
+                        let end_col = display_map.tab_expanded_column(oldest_selection.end);
                         let goal_columns = start_col.min(end_col)..start_col.max(end_col);
                         for id in &group.stack {
                             map.insert(*id, goal_columns.clone());
@@ -1992,10 +1991,8 @@ impl Editor {
                         let goal_columns = goal_columns_by_selection_id
                             .remove(&selection.id)
                             .unwrap_or_else(|| {
-                                let snapshot = display_map.buffer_snapshot();
-                                let start_col =
-                                    snapshot.point_to_point_utf16(selection.start).column;
-                                let end_col = snapshot.point_to_point_utf16(selection.end).column;
+                                let start_col = display_map.tab_expanded_column(selection.start);
+                                let end_col = display_map.tab_expanded_column(selection.end);
                                 start_col.min(end_col)..start_col.max(end_col)
                             });
                         self.selections.find_next_columnar_selection_by_buffer_row(

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -6,7 +6,7 @@ use std::{
 
 use gpui::Pixels;
 use itertools::{Either, Itertools as _};
-use language::{Bias, Point, PointUtf16, Selection, SelectionGoal};
+use language::{Bias, Point, Selection, SelectionGoal};
 use multi_buffer::{MultiBufferDimension, MultiBufferOffset, ToPoint};
 use util::post_inc;
 
@@ -448,7 +448,7 @@ impl SelectionsCollection {
     /// Returns `None` if the range is not empty but it starts past the line's
     /// length, meaning that the line isn't long enough to be contained within
     /// part of the provided range.
-    fn build_columnar_selection_from_utf16_columns(
+    fn build_columnar_selection_from_tab_expanded_columns(
         &mut self,
         display_map: &DisplaySnapshot,
         buffer_row: u32,
@@ -456,22 +456,19 @@ impl SelectionsCollection {
         reversed: bool,
         text_layout_details: &TextLayoutDetails,
     ) -> Option<Selection<Point>> {
-        let snapshot = display_map.buffer_snapshot();
         let is_empty = positions.start == positions.end;
-        let line_len_utf16 = snapshot.line_len_utf16(multi_buffer::MultiBufferRow(buffer_row));
+        let line_len = display_map.tab_expanded_line_len(buffer_row);
 
         let (start, end) = if is_empty {
-            let column = std::cmp::min(positions.start, line_len_utf16);
-            let point = snapshot.point_utf16_to_point(PointUtf16::new(buffer_row, column));
+            let point = display_map.point_for_tab_expanded_column(buffer_row, positions.start);
             (point, point)
         } else {
-            if positions.start >= line_len_utf16 {
+            if positions.start >= line_len {
                 return None;
             }
 
-            let start = snapshot.point_utf16_to_point(PointUtf16::new(buffer_row, positions.start));
-            let end_column = std::cmp::min(positions.end, line_len_utf16);
-            let end = snapshot.point_utf16_to_point(PointUtf16::new(buffer_row, end_column));
+            let start = display_map.point_for_tab_expanded_column(buffer_row, positions.start);
+            let end = display_map.point_for_tab_expanded_column(buffer_row, positions.end);
             (start, end)
         };
 
@@ -545,7 +542,7 @@ impl SelectionsCollection {
             row = new_row.row();
             let buffer_row = new_row.to_point(display_map).row;
 
-            if let Some(selection) = self.build_columnar_selection_from_utf16_columns(
+            if let Some(selection) = self.build_columnar_selection_from_tab_expanded_columns(
                 display_map,
                 buffer_row,
                 goal_columns,


### PR DESCRIPTION
with `hard_tabs: true` and `tab_size: 4`, shift-alt-down off a tab-aligned column drops the cursor in the wrong spot:

```
      current.rgb.r         ˇ= p[0] >> 8;      <- cursor here
      residuals[run].rˇgb.r  = p[0] & 0xff;    <- lands here, not on the =
```

both `=` render at column 48 but sit at buffer columns 22 and 27, since a different number of tabs pads each row. shift-alt-down is `skip_soft_wrap: true`, which placed the cursor by utf16 column where a tab counts as one.

so count the column with tabs expanded instead. still a column and not a pixel position, so the buffer-column behaviour `test_add_selection_skip_soft_wrap_option` pins doesn't change (without tabs the expanded column *is* the buffer column). tried pixels first and it breaks that test, since x is measured inside a wrapped segment.

heads up that the existing tests here all pass `Default::default()`, which is `skip_soft_wrap: false` (the `default_true` only applies to deserializing), so nothing covered the branch the keybinding actually uses.

Closes #60752.

Release Notes:

- Fixed added cursors landing in the wrong column when using tabs to align code