### PR TITLE
Validate and unify git repository detection

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -9321,7 +9321,9 @@ mod tests {
         .await
         .unwrap();
         cx.run_until_parked();
-        fs.create_dir(Path::new(path!("/test/.git"))).await.unwrap();
+        fs.git_init(Path::new(path!("/test")), "main".to_string())
+            .await
+            .unwrap();
         cx.run_until_parked();
 
         complete_tx.send(()).unwrap();

--- a/crates/agent_ui/src/test_support.rs
+++ b/crates/agent_ui/src/test_support.rs
@@ -123,7 +123,7 @@ pub fn init_test(cx: &mut TestAppContext) {
 /// the FakeFs directory mtime as a stand-in for the creation time).
 pub async fn fake_worktree_created_at(fs: &dyn fs::Fs, worktree_path: &Path) -> SystemTime {
     let git_file = fs.load(&worktree_path.join(".git")).await.unwrap();
-    let git_dir = worktree_path.join(git_file.strip_prefix("gitdir:").unwrap().trim());
+    let git_dir = worktree_path.join(git::parse_gitfile(git_file.as_bytes()).unwrap());
     let (seconds, nanos) = fs
         .metadata(&git_dir)
         .await

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -612,11 +612,7 @@ impl GitRepository for FakeGitRepository {
                 .load(&dot_git_path)
                 .await
                 .with_context(|| format!("failed to read {}", dot_git_path.display()))?;
-            let git_dir = git_file
-                .strip_prefix("gitdir:")
-                .context("worktree .git file missing gitdir pointer")?
-                .trim();
-            let git_dir = worktree_path.join(git_dir);
+            let git_dir = worktree_path.join(git::parse_gitfile(git_file.as_bytes())?);
             let metadata = fs
                 .metadata(&git_dir)
                 .await?
@@ -793,11 +789,7 @@ impl GitRepository for FakeGitRepository {
             // mirroring real git's behavior with `--force`.
             let dot_git_file = path.join(".git");
             let worktree_entry_dir = if let Ok(content) = fs.load(&dot_git_file).await {
-                let gitdir = content
-                    .strip_prefix("gitdir:")
-                    .context("invalid .git file in worktree")?
-                    .trim();
-                PathBuf::from(gitdir)
+                git::parse_gitfile(content.as_bytes())?
             } else {
                 self.find_worktree_entry_dir_by_path(&path)
                     .await
@@ -849,11 +841,7 @@ impl GitRepository for FakeGitRepository {
                 .load(&dot_git_file)
                 .await
                 .with_context(|| format!("no worktree found at path: {}", old_path.display()))?;
-            let gitdir = content
-                .strip_prefix("gitdir:")
-                .context("invalid .git file in worktree")?
-                .trim();
-            let worktree_entry_dir = PathBuf::from(gitdir);
+            let worktree_entry_dir = git::parse_gitfile(content.as_bytes())?;
 
             // Move the worktree checkout directory.
             fs.rename(

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -341,14 +341,6 @@ impl GitRepository for FakeGitRepository {
         unimplemented!()
     }
 
-    fn path(&self) -> PathBuf {
-        self.repository_dir_path.clone()
-    }
-
-    fn main_repository_path(&self) -> PathBuf {
-        self.common_dir_path.clone()
-    }
-
     fn merge_message(&self) -> BoxFuture<'_, Option<String>> {
         async move { None }.boxed()
     }

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -41,7 +41,7 @@ use smol::io::AsyncWriteExt;
 #[cfg(feature = "test-support")]
 use std::path::Component;
 use std::{
-    io::{self, Write},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
@@ -49,6 +49,7 @@ use std::{
 };
 use tempfile::TempDir;
 use text::LineEnding;
+use util::ResultExt as _;
 
 #[cfg(feature = "test-support")]
 mod fake_git_repo;
@@ -92,6 +93,174 @@ impl From<PathEvent> for PathBuf {
     fn from(event: PathEvent) -> Self {
         event.path
     }
+}
+
+/// Resolves a `.git` entry — a directory, or a gitfile pointing elsewhere — to its
+/// validated `(repository_dir, common_dir)`, mirroring git's discovery. Worktree
+/// discovery and identity resolution share it (the sync git backend shares only the
+/// grammar helpers), so they agree on what a repository is and where its dirs are.
+/// The two dirs differ only for a linked worktree, whose `HEAD` is per-worktree while
+/// the object/ref stores live in the shared common dir.
+///
+/// * `Ok(Some(_))` — fully resolved and structurally valid.
+/// * `Ok(None)` — confirmed *not* a repository (absent, malformed/empty gitfile,
+///   broken gitfile/`commondir` target, or a leftover/empty `.git`).
+/// * `Err(_)` — the answer is indeterminate because an I/O operation failed (a
+///   permission or other read error); a caller holding a registration must preserve it
+///   rather than remove it. This "confirmed gone" vs "couldn't read it" distinction is
+///   why the return type is `Result<Option<_>>`.
+pub async fn resolve_git_repository(
+    dot_git_path: &Path,
+    fs: &dyn Fs,
+) -> Result<Option<(PathBuf, PathBuf)>> {
+    let Some(metadata) = fs.metadata(dot_git_path).await? else {
+        return Ok(None);
+    };
+
+    let repository_dir = if metadata.is_dir {
+        // A plain `.git` or bare directory keeps its own identity; git does not
+        // canonicalize it during discovery.
+        dot_git_path.to_path_buf()
+    } else {
+        // A gitfile: the `.git` of a linked worktree or a separate-git-dir checkout.
+        // Confirmed-absent content (dangling symlink, TOCTOU delete) is non-repo,
+        // not a transient failure — same tri-state as `canonicalize_existing`.
+        let Some(contents) = load_bytes_existing(fs, dot_git_path).await? else {
+            return Ok(None);
+        };
+        let Some(target) = git::parse_gitfile(&contents).log_err() else {
+            return Ok(None);
+        };
+        // `Path::join` replaces the base for an absolute gitdir pointer.
+        let target = dot_git_path.parent().unwrap_or(Path::new("")).join(target);
+        // A gitfile pointing at a nonexistent directory is a broken worktree link;
+        // a transient error propagates so an existing registration is preserved.
+        let Some(resolved) = canonicalize_existing(fs, &target).await? else {
+            return Ok(None);
+        };
+        resolved
+    };
+
+    let Some(common_dir) = resolve_common_dir(&repository_dir, fs).await? else {
+        return Ok(None);
+    };
+
+    Ok(fs
+        .is_git_repository(&repository_dir, &common_dir)
+        .await?
+        .then_some((repository_dir, common_dir)))
+}
+
+/// Canonicalizes a path, distinguishing a confirmed-missing target (`Ok(None)`, a
+/// broken link) from a transient permission/I/O failure (`Err`) that a caller holding
+/// a registration must not treat as a deletion.
+async fn canonicalize_existing(fs: &dyn Fs, path: &Path) -> Result<Option<PathBuf>> {
+    match fs.canonicalize(path).await {
+        Ok(path) => Ok(Some(path)),
+        Err(error) if io_error_is_absence(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Loads file bytes, mapping confirmed absence to `Ok(None)` the same way
+/// [`canonicalize_existing`] does, so a missing gitfile/commondir is not treated as a
+/// transient I/O failure that would preserve a stale registration.
+async fn load_bytes_existing(fs: &dyn Fs, path: &Path) -> Result<Option<Vec<u8>>> {
+    match fs.load_bytes(path).await {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if io_error_is_absence(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Whether `error` is confirmed path absence (`NotFound` / `NotADirectory`) rather
+/// than an indeterminate I/O failure. This is the absence half of the resolver's
+/// tri-state contract; shared so callers cannot drift from each other.
+pub fn io_error_is_absence(error: &anyhow::Error) -> bool {
+    error.downcast_ref::<io::Error>().is_some_and(|error| {
+        matches!(
+            error.kind(),
+            io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+        )
+    })
+}
+
+/// Resolves the common directory for `repository_dir`, following a `commondir` file
+/// when present (git's `get_common_dir_noenv`). Returns `Ok(None)` when a `commondir`
+/// is present but broken (a directory, or a target that is missing or not a directory);
+/// git does not silently fall back to `repository_dir` in that case.
+async fn resolve_common_dir(repository_dir: &Path, fs: &dyn Fs) -> Result<Option<PathBuf>> {
+    let commondir_path = repository_dir.join(git::COMMONDIR);
+    let Some(metadata) = fs.metadata(&commondir_path).await? else {
+        // No `commondir`: the repository is its own common dir (normal or bare repo).
+        return Ok(Some(repository_dir.to_path_buf()));
+    };
+    if metadata.is_dir {
+        return Ok(None);
+    }
+    let Some(contents) = load_bytes_existing(fs, &commondir_path).await? else {
+        return Ok(None);
+    };
+    let Some(target) = git::parse_commondir(&contents).log_err() else {
+        return Ok(None);
+    };
+    let target = repository_dir.join(target);
+    let Some(resolved) = canonicalize_existing(fs, &target).await? else {
+        return Ok(None);
+    };
+    Ok(dir_exists(fs, &resolved).await?.then_some(resolved))
+}
+
+/// Whether `path` is an existing directory, distinguishing confirmed absence
+/// (`Ok(false)`) from a transient I/O error (`Err`). `Fs::metadata` already maps
+/// `NotFound`/`NotADirectory` to `Ok(None)`.
+async fn dir_exists<F: Fs + ?Sized>(fs: &F, path: &Path) -> Result<bool> {
+    Ok(fs
+        .metadata(path)
+        .await?
+        .is_some_and(|metadata| metadata.is_dir))
+}
+
+/// Whether the common dir holds git's object and ref stores (`objects` and `refs`).
+/// git's `is_git_directory` requires both; reftable repos still create `refs/`, so
+/// there is no "reftable instead of refs" branch. A missing store is `Ok(false)`; a
+/// transient I/O error propagates as `Err` so a valid repository is not spuriously
+/// unregistered.
+async fn common_dir_has_stores<F: Fs + ?Sized>(fs: &F, common_dir: &Path) -> Result<bool> {
+    Ok(dir_exists(fs, &common_dir.join(git::OBJECTS_DIR)).await?
+        && dir_exists(fs, &common_dir.join(git::REFS_DIR)).await?)
+}
+
+/// Path-aware `HEAD` validation, faithful to git's `validate_headref`: a symlink
+/// `HEAD` is validated by its link text without being followed (an unborn or
+/// packed-only target is legal), while a regular `HEAD` is validated from its
+/// first bytes. Returns `Err` only for transient I/O failures.
+async fn git_head_is_valid<F: Fs + ?Sized>(fs: &F, head_path: &Path) -> Result<bool> {
+    let Some(metadata) = fs.metadata(head_path).await? else {
+        return Ok(false);
+    };
+    // Symlink first: a symlink-to-directory is validated by link text, not rejected
+    // as a directory HEAD. Directory HEAD is confirmed-invalid (git rejects it).
+    if metadata.is_symlink {
+        return match fs.read_link(head_path).await {
+            Ok(target) => Ok(git::head_symlink_target_is_valid(target.as_os_str())),
+            Err(error) if io_error_is_absence(&error) => Ok(false),
+            Err(error) => Err(error),
+        };
+    }
+    if metadata.is_dir {
+        return Ok(false);
+    }
+    // git reads a fixed 255-byte buffer; HEAD is tiny, and the bound keeps a
+    // pathological large file from forcing a full read.
+    let reader = match fs.open_sync(head_path).await {
+        Ok(reader) => reader,
+        Err(error) if io_error_is_absence(&error) => return Ok(false),
+        Err(error) => return Err(error),
+    };
+    let mut contents = Vec::new();
+    reader.take(255).read_to_end(&mut contents)?;
+    Ok(git::regular_head_contents_are_valid(&contents))
 }
 
 #[async_trait::async_trait]
@@ -164,6 +333,27 @@ pub trait Fs: Send + Sync {
     -> Result<()>;
     async fn git_clone(&self, abs_work_directory: &Path, repo_url: &str) -> Result<()>;
     async fn git_config(&self, abs_work_directory: &Path, args: Vec<String>) -> Result<String>;
+
+    /// Whether the resolved `(repository_dir, common_dir)` is a valid git repository.
+    /// A leftover/empty `.git` directory isn't one: git walks up to the parent, and so
+    /// must discovery, or the phantom shadows the real parent. A gitfile pointing at a
+    /// non-repository is a fatal discovery error in git; discovery here deliberately
+    /// walks up instead so the phantom cannot shadow the real parent. Returns `Err`
+    /// for a transient I/O failure so callers can preserve an existing registration
+    /// rather than remove it. Most callers should use [`resolve_git_repository`], which
+    /// also resolves the dirs; this hook exists so `FakeFs` can consult its in-memory
+    /// model.
+    async fn is_git_repository(&self, repository_dir: &Path, common_dir: &Path) -> Result<bool> {
+        // The structural shape git's `is_git_directory` looks for: a valid `HEAD` in the
+        // repository dir plus `objects` and `refs` stores in the common dir (which
+        // differs from the repository dir only for a linked worktree). Existence is
+        // checked by type, not git's `X_OK` access check.
+        Ok(
+            git_head_is_valid(self, &repository_dir.join(git::HEAD)).await?
+                && common_dir_has_stores(self, common_dir).await?,
+        )
+    }
+
     fn is_fake(&self) -> bool;
     async fn is_case_sensitive(&self) -> bool;
     fn subscribe_to_jobs(&self) -> JobEventReceiver;
@@ -1083,7 +1273,7 @@ impl Fs for RealFs {
         Pin<Box<dyn Send + Stream<Item = Vec<PathEvent>>>>,
         Arc<dyn Watcher>,
     ) {
-        use util::{ResultExt as _, paths::SanitizedPath};
+        use util::paths::SanitizedPath;
         let executor = self.executor.clone();
 
         let (tx, rx) = async_channel::unbounded();
@@ -1902,6 +2092,7 @@ impl FakeFs {
             tree: serde_json::Value,
         ) -> futures::future::BoxFuture<'a, ()> {
             async move {
+                let is_dir = matches!(tree, Object(_) | Null);
                 match tree {
                     Object(map) => {
                         this.create_dir(&path).await.unwrap();
@@ -1920,6 +2111,15 @@ impl FakeFs {
                     _ => {
                         panic!("JSON object must contain only objects, strings, or null");
                     }
+                }
+                // A directory named `.git` models a git repository, so mark it as an
+                // initialized repository (in-memory state, no files) — repository
+                // discovery recognizes it via `is_git_repository`. A `.git` created
+                // directly via `create_dir` deliberately stays uninitialized, so tests
+                // can model an invalid/phantom `.git`.
+                if is_dir && path.file_name() == Some(*FS_DOT_GIT) {
+                    this.with_git_state(&path, false, |_| {})
+                        .expect("just-created .git dir should accept git state");
                 }
             }
             .boxed()
@@ -1991,11 +2191,7 @@ impl FakeFs {
             let path = match git_dir_path {
                 Some(path) => path,
                 None => {
-                    let path = std::str::from_utf8(content)
-                        .ok()
-                        .and_then(|content| content.strip_prefix("gitdir:"))
-                        .context("not a valid gitfile")?
-                        .trim();
+                    let path = git::parse_gitfile(content)?;
                     git_dir_path.insert(normalize_path(&dot_git.parent().unwrap().join(path)))
                 }
             }
@@ -2012,14 +2208,11 @@ impl FakeFs {
                 anyhow::bail!("gitfile points to a non-directory")
             };
             let common_dir = if let Some(child) = entries.get("commondir") {
-                let raw = std::str::from_utf8(child.file_content("commondir".as_ref())?)
-                    .context("commondir content")?
-                    .trim();
-                let raw_path = Path::new(raw);
+                let raw_path = git::parse_commondir(child.file_content("commondir".as_ref())?)?;
                 if raw_path.is_relative() {
-                    normalize_path(&canonical_path.join(raw_path))
+                    normalize_path(&canonical_path.join(&raw_path))
                 } else {
-                    raw_path.to_owned()
+                    raw_path
                 }
             } else {
                 canonical_path.clone()
@@ -3069,10 +3262,14 @@ impl Fs for FakeFs {
         let path = normalize_path(path);
         self.simulate_random_delay().await;
         let state = self.state.lock();
-        let canonical_path = state
-            .canonicalize(&path, true)
-            .with_context(|| format!("path does not exist: {path:?}"))?;
-        Ok(canonical_path)
+        // Real `io::Error` so `io_error_is_absence` downcasts like RealFs (an
+        // `Option` + `.with_context` does not put `io::Error` in the chain).
+        state.canonicalize(&path, true).ok_or_else(|| {
+            anyhow!(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("path does not exist: {path:?}")
+            ))
+        })
     }
 
     async fn is_file(&self, path: &Path) -> bool {
@@ -3143,9 +3340,12 @@ impl Fs for FakeFs {
         self.simulate_random_delay().await;
         let path = normalize_path(path);
         let mut state = self.state.lock();
-        let (entry, _) = state
-            .try_entry(&path, false)
-            .with_context(|| format!("path does not exist: {path:?}"))?;
+        let Some((entry, _)) = state.try_entry(&path, false) else {
+            return Err(anyhow!(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("path does not exist: {path:?}")
+            )));
+        };
         if let FakeFsEntry::Symlink { target } = entry {
             Ok(target.clone())
         } else {
@@ -3237,7 +3437,10 @@ impl Fs for FakeFs {
         abs_work_directory_path: &Path,
         _fallback_branch_name: String,
     ) -> Result<()> {
-        self.create_dir(&abs_work_directory_path.join(".git")).await
+        let dot_git = abs_work_directory_path.join(".git");
+        self.create_dir(&dot_git).await?;
+        self.with_git_state(&dot_git, false, |_| {})?;
+        Ok(())
     }
 
     async fn git_clone(&self, _abs_work_directory: &Path, _repo_url: &str) -> Result<()> {
@@ -3246,6 +3449,31 @@ impl Fs for FakeFs {
 
     async fn git_config(&self, _abs_work_directory: &Path, _args: Vec<String>) -> Result<String> {
         anyhow::bail!("Git config is not supported in fake Fs")
+    }
+
+    async fn is_git_repository(&self, repository_dir: &Path, common_dir: &Path) -> Result<bool> {
+        // A fake repository is modeled either in memory (git state attached to the
+        // common dir — `insert_tree` on a `.git` dir, `git_init`, and the
+        // `set_*_for_repo` helpers all initialize it) or by literal files in the fixture
+        // (e.g. bare-backed linked worktrees, which write `HEAD`/`objects`/`refs`). A
+        // bare `create_dir` does neither, so tests can model an empty/leftover `.git`.
+        let has_git_state = matches!(
+            self.state.lock().try_entry(common_dir, false),
+            Some((
+                FakeFsEntry::Dir {
+                    git_repo_state: Some(_),
+                    ..
+                },
+                _
+            ))
+        );
+        // In-memory state lives on the common dir. It vouches for the whole repository
+        // only when the dirs coincide; for a split layout (linked worktree) the
+        // per-worktree `HEAD` is still validated from files so an invalidated gitfile is
+        // not masked, and the state can vouch only for the shared object/ref stores.
+        let head_is_valid = (repository_dir == common_dir && has_git_state)
+            || git_head_is_valid(self, &repository_dir.join(git::HEAD)).await?;
+        Ok(head_is_valid && (has_git_state || common_dir_has_stores(self, common_dir).await?))
     }
 
     fn is_fake(&self) -> bool {

--- a/crates/fs/tests/integration/fake_git_repo_tests.rs
+++ b/crates/fs/tests/integration/fake_git_repo_tests.rs
@@ -194,3 +194,32 @@ async fn test_checkpoints(executor: BackgroundExecutor) {
     assert!(diff.contains("b"), "diff should mention changed file 'b'");
     assert!(diff.contains("c"), "diff should mention added file 'c'");
 }
+
+#[gpui::test]
+async fn test_is_git_repository(cx: &mut TestAppContext) {
+    let fs = FakeFs::new(cx.executor());
+
+    // A `.git` via `insert_tree` and one via `git_init` are both initialized
+    // repositories; a `.git` created directly with `create_dir` models an
+    // empty/leftover `.git` (the phantom-repository bug case) and is not one.
+    fs.insert_tree("/repo", json!({".git": {}, "file.txt": "content"}))
+        .await;
+    fs.create_dir(Path::new("/repo2")).await.unwrap();
+    fs.git_init(Path::new("/repo2"), "main".to_string())
+        .await
+        .unwrap();
+    fs.create_dir(Path::new("/phantom/.git")).await.unwrap();
+
+    for (git_dir, expected) in [
+        ("/repo/.git", true),
+        ("/repo2/.git", true),
+        ("/phantom/.git", false),
+    ] {
+        let git_dir = Path::new(git_dir);
+        assert_eq!(
+            fs.is_git_repository(git_dir, git_dir).await.unwrap(),
+            expected,
+            "is_git_repository({git_dir:?})"
+        );
+    }
+}

--- a/crates/fs/tests/integration/fs_tests.rs
+++ b/crates/fs/tests/integration/fs_tests.rs
@@ -431,6 +431,248 @@ async fn test_copy_recursive_with_ignoring(executor: BackgroundExecutor) {
 }
 
 #[gpui::test]
+async fn test_realfs_is_git_repository(executor: BackgroundExecutor) {
+    // Exercises the production `Fs::is_git_repository` default impl against real
+    // on-disk `.git` layouts (FakeFs overrides it with an in-memory bit, so this is
+    // the only coverage of the actual HEAD/objects/refs parsing).
+    let fs = RealFs::new(None, executor);
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    const VALID_HEAD: &str = "ref: refs/heads/main\n";
+    const DETACHED_HEAD: &str = "0123456789abcdef0123456789abcdef01234567\n";
+
+    let git_dir = |name: &str, head: Option<&str>, stores: &[&str]| {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        if let Some(head) = head {
+            std::fs::write(dir.join("HEAD"), head).unwrap();
+        }
+        for store in stores {
+            std::fs::create_dir_all(dir.join(store)).unwrap();
+        }
+        dir
+    };
+
+    let cases: &[(&str, Option<&str>, &[&str], bool)] = &[
+        ("valid", Some(VALID_HEAD), &["objects", "refs"], true),
+        ("detached", Some(DETACHED_HEAD), &["objects", "refs"], true),
+        // What `git init --ref-format=reftable` creates: reftable *and* refs.
+        (
+            "reftable_with_refs",
+            Some(VALID_HEAD),
+            &["objects", "refs", "reftable"],
+            true,
+        ),
+        // Phantom shape git rejects (no refs); must not register as a repository.
+        (
+            "reftable_without_refs",
+            Some(VALID_HEAD),
+            &["objects", "reftable"],
+            false,
+        ),
+        ("empty", None, &[], false), // the phantom-repository bug
+        ("no_objects", Some(VALID_HEAD), &["refs"], false),
+        ("no_refs", Some(VALID_HEAD), &["objects"], false),
+        ("bad_head", Some("garbage\n"), &["objects", "refs"], false),
+    ];
+    for (name, head, stores, expected) in cases {
+        let dir = git_dir(name, *head, stores);
+        assert_eq!(
+            fs.is_git_repository(&dir, &dir).await.unwrap(),
+            *expected,
+            "is_git_repository({name})"
+        );
+    }
+
+    // Linked-worktree shape: HEAD is checked in the repository (per-worktree) dir, while
+    // objects/refs are checked in the shared common dir — exactly as git does.
+    let common_dir = git_dir("wt_common", None, &["objects", "refs"]);
+    let worktree_git_dir = git_dir("wt_repo", Some(VALID_HEAD), &[]);
+    assert!(
+        fs.is_git_repository(&worktree_git_dir, &common_dir)
+            .await
+            .unwrap()
+    );
+    // A leftover worktree admin dir whose own HEAD is gone is not a repository.
+    let worktree_without_head = git_dir("wt_repo_no_head", None, &[]);
+    assert!(
+        !fs.is_git_repository(&worktree_without_head, &common_dir)
+            .await
+            .unwrap()
+    );
+
+    // A symlink HEAD is validated by its link text without being followed (git's
+    // legacy symref form): `refs/…` is accepted even if the target is unborn, while a
+    // link to a non-`refs/` path is rejected regardless of what it points at.
+    #[cfg(unix)]
+    {
+        let symref = git_dir("symref", None, &["objects", "refs"]);
+        std::os::unix::fs::symlink("refs/heads/unborn", symref.join("HEAD")).unwrap();
+        assert!(fs.is_git_repository(&symref, &symref).await.unwrap());
+
+        let bad_symref = git_dir("bad_symref", None, &["objects", "refs"]);
+        std::fs::write(bad_symref.join("ORIG_HEAD"), DETACHED_HEAD).unwrap();
+        std::os::unix::fs::symlink("ORIG_HEAD", bad_symref.join("HEAD")).unwrap();
+        assert!(
+            !fs.is_git_repository(&bad_symref, &bad_symref)
+                .await
+                .unwrap()
+        );
+    }
+}
+
+#[gpui::test]
+async fn test_realfs_resolve_git_repository(executor: BackgroundExecutor) {
+    // The canonical resolver: turns a `.git` entry (directory or gitfile) into its
+    // validated `(repository_dir, common_dir)`, or `Ok(None)` when it is not a repo.
+    let fs = RealFs::new(None, executor);
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    const VALID_HEAD: &str = "ref: refs/heads/main\n";
+
+    // A normal repository directory resolves to itself.
+    let repo = root.join("repo/.git");
+    std::fs::create_dir_all(repo.join("objects")).unwrap();
+    std::fs::create_dir_all(repo.join("refs")).unwrap();
+    std::fs::write(repo.join("HEAD"), VALID_HEAD).unwrap();
+    // A plain `.git` directory keeps its own (un-canonicalized) identity.
+    let resolved = resolve_git_repository(&repo, &fs).await.unwrap();
+    assert_eq!(resolved, Some((repo.clone(), repo.clone())));
+    let repo_canonical = std::fs::canonicalize(&repo).unwrap();
+
+    // A linked worktree: `.git` is a gitfile pointing at the per-worktree admin dir,
+    // whose `commondir` points back at the shared repository.
+    let worktree_admin = repo.join("worktrees/wt");
+    std::fs::create_dir_all(&worktree_admin).unwrap();
+    std::fs::write(worktree_admin.join("HEAD"), VALID_HEAD).unwrap();
+    std::fs::write(worktree_admin.join("commondir"), "../..\n").unwrap();
+    let worktree = root.join("wt");
+    std::fs::create_dir_all(&worktree).unwrap();
+    std::fs::write(
+        worktree.join(".git"),
+        format!("gitdir: {}\n", worktree_admin.display()),
+    )
+    .unwrap();
+    let (repository_dir, common_dir) = resolve_git_repository(&worktree.join(".git"), &fs)
+        .await
+        .unwrap()
+        .expect("linked worktree resolves");
+    assert_eq!(
+        repository_dir,
+        std::fs::canonicalize(&worktree_admin).unwrap()
+    );
+    assert_eq!(common_dir, repo_canonical);
+
+    // A gitfile without the literal `gitdir: ` (git rejects a missing space), a gitfile
+    // pointing nowhere, a `commondir` pointing nowhere, and a leftover empty `.git` are
+    // all confirmed non-repositories (`Ok(None)`), not errors.
+    let none_cases: &[(&str, &str)] = &[
+        ("no_space", "gitdir:/nowhere\n"),
+        ("bad_target", "gitdir: /does/not/exist\n"),
+        ("garbage", "not a gitfile\n"),
+    ];
+    for (name, contents) in none_cases {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(".git"), contents).unwrap();
+        assert_eq!(
+            resolve_git_repository(&dir.join(".git"), &fs)
+                .await
+                .unwrap(),
+            None,
+            "resolve({name})"
+        );
+    }
+    let empty = root.join("empty/.git");
+    std::fs::create_dir_all(&empty).unwrap();
+    assert_eq!(resolve_git_repository(&empty, &fs).await.unwrap(), None);
+
+    // A present-but-broken `commondir` (target missing) rejects the whole repository
+    // rather than silently falling back to the repository dir.
+    let broken = root.join("broken/.git");
+    std::fs::create_dir_all(broken.join("objects")).unwrap();
+    std::fs::create_dir_all(broken.join("refs")).unwrap();
+    std::fs::write(broken.join("HEAD"), VALID_HEAD).unwrap();
+    std::fs::write(broken.join("commondir"), "/does/not/exist\n").unwrap();
+    assert_eq!(resolve_git_repository(&broken, &fs).await.unwrap(), None);
+
+    // An absent `.git` is `Ok(None)`.
+    assert_eq!(
+        resolve_git_repository(&root.join("missing/.git"), &fs)
+            .await
+            .unwrap(),
+        None
+    );
+
+    // A dangling-symlink `.git` is confirmed non-repo (`Ok(None)`), not a transient
+    // read error: RealFs reports the symlink's own metadata when the target is gone,
+    // so the path is treated as a gitfile whose content load then hits absence.
+    #[cfg(unix)]
+    {
+        let dangling = root.join("dangling");
+        std::fs::create_dir_all(&dangling).unwrap();
+        std::os::unix::fs::symlink("/does/not/exist", dangling.join(".git")).unwrap();
+        assert_eq!(
+            resolve_git_repository(&dangling.join(".git"), &fs)
+                .await
+                .unwrap(),
+            None,
+            "dangling-symlink .git must resolve to Ok(None), not Err"
+        );
+    }
+
+    // A directory `HEAD` is confirmed-invalid (`Ok(None)`). A symlink HEAD to
+    // `refs/…` remains valid, guarding the is_symlink-before-is_dir branch order.
+    let dir_head = root.join("dir_head/.git");
+    std::fs::create_dir_all(dir_head.join("objects")).unwrap();
+    std::fs::create_dir_all(dir_head.join("refs")).unwrap();
+    std::fs::create_dir_all(dir_head.join("HEAD")).unwrap();
+    assert_eq!(
+        resolve_git_repository(&dir_head, &fs).await.unwrap(),
+        None,
+        "directory HEAD must resolve to Ok(None)"
+    );
+
+    #[cfg(unix)]
+    {
+        let symlink_head = root.join("symlink_head/.git");
+        std::fs::create_dir_all(symlink_head.join("objects")).unwrap();
+        std::fs::create_dir_all(symlink_head.join("refs")).unwrap();
+        // Target is a directory so metadata is both symlink and dir; validating by
+        // link text (not rejecting as directory HEAD) requires is_symlink before is_dir.
+        std::fs::create_dir_all(symlink_head.join("refs/heads/main")).unwrap();
+        std::os::unix::fs::symlink("refs/heads/main", symlink_head.join("HEAD")).unwrap();
+        let resolved = resolve_git_repository(&symlink_head, &fs)
+            .await
+            .unwrap()
+            .expect("symlink HEAD to refs/… remains valid");
+        assert_eq!(resolved, (symlink_head.clone(), symlink_head));
+    }
+}
+
+#[gpui::test]
+async fn test_fakefs_resolve_missing_gitfile_target_is_ok_none(executor: BackgroundExecutor) {
+    // FakeFs must classify absence with a real io::Error so it downcasts like RealFs.
+    let fake_fs = FakeFs::new(executor);
+    fake_fs
+        .insert_tree(
+            path!("/linked"),
+            json!({
+                ".git": "gitdir: /does/not/exist\n",
+                "file.txt": "content",
+            }),
+        )
+        .await;
+    let fake_result = resolve_git_repository(Path::new(path!("/linked/.git")), fake_fs.as_ref())
+        .await
+        .expect("FakeFs: missing gitfile target must not be Err");
+    assert_eq!(
+        fake_result, None,
+        "FakeFs: missing gitfile target must be Ok(None)"
+    );
+}
+
+#[gpui::test]
 async fn test_realfs_atomic_write(executor: BackgroundExecutor) {
     // With the file handle still open, the file should be replaced
     // https://github.com/zed-industries/zed/issues/30054

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -8,18 +8,21 @@ pub mod status;
 
 pub use crate::hosting_provider::*;
 pub use crate::remote::*;
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use gpui::{Action, actions};
 pub use repository::RemoteCommandOutput;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
 use std::fmt::{self, Write as _};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 pub const DOT_GIT: &str = ".git";
 pub const GITIGNORE: &str = ".gitignore";
 pub const FSMONITOR_DAEMON: &str = "fsmonitor--daemon";
 pub const LFS_DIR: &str = "lfs";
+pub const HEAD: &str = "HEAD";
 pub const OBJECTS_DIR: &str = "objects";
 pub const REFS_DIR: &str = "refs";
 pub const REFTABLE_DIR: &str = "reftable";
@@ -36,6 +39,7 @@ pub const BISECT_LOG: &str = "BISECT_LOG";
 pub const GC_PID: &str = "gc.pid";
 pub const INFO_DIR: &str = "info";
 pub const REPO_EXCLUDE: &str = "info/exclude";
+pub const COMMONDIR: &str = "commondir";
 
 actions!(
     git,
@@ -160,6 +164,87 @@ const SHA256_BYTE_LENGTH: usize = 32;
 const SHA1_HEX_LENGTH: usize = SHA1_BYTE_LENGTH * 2;
 const SHA256_HEX_LENGTH: usize = SHA256_BYTE_LENGTH * 2;
 const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+
+/// Whether the raw contents of a regular `.git/HEAD` file denote a valid git head,
+/// mirroring git's `validate_headref` (setup.c) for the non-symlink case:
+///
+/// * a symbolic ref `ref:` (at byte zero, no leading whitespace) whose target —
+///   after skipping only space, tab, LF, CR (git's `sane isspace`) — begins with
+///   `refs/`. git does not validate the refname further, so neither do we; and
+/// * otherwise a detached object id, accepted when the contents begin with at
+///   least 40 ASCII hex digits. git parses "any supported algorithm, longest
+///   first" and never checks the trailing byte, so 40 hex (SHA-1), 64 hex
+///   (SHA-256), and any longer/junk-suffixed hex prefix all pass; this keeps
+///   git's forward compatibility with future, longer hashes. Fewer than 40 hex
+///   is rejected. `Oid::from_str` is deliberately not used here — it accepts
+///   abbreviated (<40) ids, which git's HEAD check does not.
+///
+/// An empty or leftover `.git` has no valid `HEAD`, so this returns `false`.
+/// Operates on bytes so a non-UTF-8 suffix after an otherwise-valid prefix (which
+/// git accepts) is not spuriously rejected.
+pub fn regular_head_contents_are_valid(contents: &[u8]) -> bool {
+    if let Some(mut target) = contents.strip_prefix(b"ref:") {
+        while let [first, rest @ ..] = target
+            && matches!(*first, b' ' | b'\t' | b'\n' | b'\r')
+        {
+            target = rest;
+        }
+        return target.starts_with(b"refs/");
+    }
+    contents
+        .get(..SHA1_HEX_LENGTH)
+        .is_some_and(|prefix| prefix.iter().all(u8::is_ascii_hexdigit))
+}
+
+/// Whether a symlink `HEAD`'s raw link text denotes a valid git head. git's
+/// `validate_headref` inspects the symlink target *without following it* and
+/// accepts it iff the link text begins with `refs/` (an unborn or packed-only
+/// target is legal). Pass the raw `readlink` result; it is never resolved.
+pub fn head_symlink_target_is_valid(target: &OsStr) -> bool {
+    target.as_encoded_bytes().starts_with(b"refs/")
+}
+
+/// Parses a `.git` *gitfile* (the `.git` of a linked worktree or a separate
+/// git-dir checkout), returning the referenced git directory path. Mirrors git's
+/// `read_gitfile_gently`: the contents must begin with the literal `gitdir: `
+/// (including the single space); only trailing CR/LF is stripped, so any further
+/// spaces or tabs are part of the path. The returned path may be relative — the
+/// caller resolves it against the gitfile's parent. Non-UTF-8 paths are preserved
+/// on Unix.
+pub fn parse_gitfile(contents: &[u8]) -> Result<PathBuf> {
+    let path = contents
+        .strip_prefix(b"gitdir: ")
+        .context("gitfile must begin with `gitdir: `")?;
+    let path = strip_trailing_crlf(path);
+    anyhow::ensure!(!path.is_empty(), "gitfile has an empty gitdir path");
+    Ok(bytes_to_path(path))
+}
+
+/// Parses a git `commondir` file, returning the referenced common directory path.
+/// Mirrors git's `get_common_dir_noenv`: a zero-byte file is invalid, but after
+/// stripping trailing CR/LF the remainder may be empty — git treats that as an empty
+/// relative path, which the caller resolves back to the repository directory. The
+/// returned path may be relative.
+pub fn parse_commondir(contents: &[u8]) -> Result<PathBuf> {
+    anyhow::ensure!(!contents.is_empty(), "commondir file is empty");
+    Ok(bytes_to_path(strip_trailing_crlf(contents)))
+}
+
+fn strip_trailing_crlf(mut bytes: &[u8]) -> &[u8] {
+    while let [rest @ .., last] = bytes
+        && matches!(*last, b'\n' | b'\r')
+    {
+        bytes = rest;
+    }
+    bytes
+}
+
+fn bytes_to_path(bytes: &[u8]) -> PathBuf {
+    // Unix: raw bytes; Windows: WTF-8. Lossy conversion is only reachable for
+    // genuinely malformed metadata, which resolution then rejects downstream.
+    <PathBuf as util::paths::PathExt>::try_from_bytes(bytes)
+        .unwrap_or_else(|_| PathBuf::from(String::from_utf8_lossy(bytes).into_owned()))
+}
 
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct Oid {
@@ -356,6 +441,99 @@ impl From<Oid> for usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validates_head_contents() {
+        let valid = |head: &str| regular_head_contents_are_valid(head.as_bytes());
+
+        // Symbolic refs must point under `refs/`, mirroring git's `validate_headref`.
+        assert!(valid("ref: refs/heads/main\n"));
+        assert!(valid("ref: refs/heads/main")); // no trailing newline
+        assert!(valid("ref: refs/heads/feature/x\r\n")); // CRLF
+        assert!(valid("ref:refs/heads/main")); // no space after `ref:`
+        assert!(valid("ref:\trefs/heads/main")); // tab after `ref:`
+        assert!(valid("ref: refs/heads/.invalid")); // reftable stub HEAD (git creates this)
+        assert!(!valid("ref: HEAD")); // not under `refs/`
+        assert!(!valid("ref: ../evil")); // not under `refs/`
+        assert!(!valid("ref: ")); // empty target
+        assert!(!valid("ref:")); // empty target
+        // git skips only ASCII space/tab/LF/CR after `ref:`, not other whitespace.
+        assert!(!valid("ref:\x0brefs/heads/main")); // vertical tab
+        assert!(!valid("ref:\x0crefs/heads/main")); // form feed
+        assert!(!valid("ref:\u{a0}refs/heads/main")); // NBSP
+
+        // Detached HEADs are accepted when the contents begin with >= 40 hex.
+        let sha1 = "0123456789abcdef0123456789abcdef01234567";
+        let sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        assert_eq!(sha1.len(), SHA1_HEX_LENGTH);
+        assert_eq!(sha256.len(), SHA256_HEX_LENGTH);
+        assert!(valid(sha1));
+        assert!(valid(&format!("{sha1}\n")));
+        assert!(valid(sha256));
+        // git parses a >= 40-hex prefix and ignores the suffix (forward-hash rule).
+        assert!(valid(&format!("{sha1}garbage"))); // 40 hex + junk
+        assert!(valid(&"a".repeat(50))); // 41..63 hex
+        assert!(valid(&"a".repeat(65))); // > 64 hex
+        // A non-UTF-8 suffix after a valid 40-hex prefix is still accepted.
+        let mut bytes = sha1.as_bytes().to_vec();
+        bytes.push(0xff);
+        assert!(regular_head_contents_are_valid(&bytes));
+
+        // Junk / empty / truncated / non-hex is not a valid HEAD.
+        assert!(!valid(""));
+        assert!(!valid("   "));
+        assert!(!valid("garbage"));
+        assert!(!valid("0123456789abcdef")); // too short for any oid
+        assert!(!valid(&"a".repeat(39))); // 39 hex, one short of SHA-1
+        assert!(!valid(&"z".repeat(SHA1_HEX_LENGTH))); // right length, non-hex
+        assert!(!valid(&format!(" {sha1}"))); // leading whitespace
+    }
+
+    #[test]
+    fn validates_head_symlink_target() {
+        assert!(head_symlink_target_is_valid(OsStr::new("refs/heads/main")));
+        assert!(head_symlink_target_is_valid(OsStr::new(
+            "refs/heads/unborn"
+        ))); // target need not exist
+        assert!(!head_symlink_target_is_valid(OsStr::new("ORIG_HEAD")));
+        assert!(!head_symlink_target_is_valid(OsStr::new("HEAD.saved")));
+        assert!(!head_symlink_target_is_valid(OsStr::new(
+            "../refs/heads/main"
+        )));
+    }
+
+    #[test]
+    fn parses_gitfile_and_commondir() {
+        // Requires the literal `gitdir: ` prefix (with the space), like git.
+        assert_eq!(
+            parse_gitfile(b"gitdir: /repo/.git/worktrees/wt\n").unwrap(),
+            PathBuf::from("/repo/.git/worktrees/wt"),
+        );
+        assert_eq!(
+            parse_gitfile(b"gitdir: ../relative\r\n").unwrap(),
+            PathBuf::from("../relative"),
+        );
+        // Spaces beyond the required one are part of the path (git strips only CR/LF).
+        assert_eq!(
+            parse_gitfile(b"gitdir: /has spaces/x\n").unwrap(),
+            PathBuf::from("/has spaces/x"),
+        );
+        assert!(parse_gitfile(b"gitdir:/no-space").is_err()); // git rejects a missing space
+        assert!(parse_gitfile(b"gitdir: \n").is_err()); // empty path
+        assert!(parse_gitfile(b"not a gitfile").is_err());
+
+        assert_eq!(
+            parse_commondir(b"/repo/.git\n").unwrap(),
+            PathBuf::from("/repo/.git"),
+        );
+        assert_eq!(
+            parse_commondir(b"../..\r\n").unwrap(),
+            PathBuf::from("../..")
+        );
+        assert!(parse_commondir(b"").is_err()); // a zero-byte file is invalid
+        // git accepts newline-only content as an empty relative path (→ repository dir).
+        assert_eq!(parse_commondir(b"\n").unwrap(), PathBuf::new());
+    }
 
     #[test]
     fn parses_short_sha1_oid_by_padding_trailing_nibbles() {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -987,12 +987,6 @@ pub trait GitRepository: Send + Sync {
         line_ending: LineEnding,
     ) -> BoxFuture<'_, Result<crate::blame::Blame>>;
 
-    /// Returns the absolute path to the repository. For worktrees, this will be the path to the
-    /// worktree's gitdir within the main repository (typically `.git/worktrees/<name>`).
-    fn path(&self) -> PathBuf;
-
-    fn main_repository_path(&self) -> PathBuf;
-
     /// Updates the index to match the worktree at the given paths.
     ///
     /// If any of the paths have been deleted from the worktree, they will be removed from the index if found there.
@@ -1300,7 +1294,7 @@ impl RealGitRepository {
         Ok(GitBinary::new(
             self.any_git_binary_path.clone(),
             self.working_directory()?,
-            self.path(),
+            self.git_dir.clone(),
             self.executor.clone(),
             self.is_trusted(),
         ))
@@ -1310,7 +1304,7 @@ impl RealGitRepository {
         GitBinary::new(
             self.any_git_binary_path.clone(),
             self.command_directory(),
-            self.path(),
+            self.git_dir.clone(),
             self.executor.clone(),
             self.is_trusted(),
         )
@@ -1402,14 +1396,6 @@ pub async fn get_git_committer(cx: &AsyncApp) -> GitCommitter {
 }
 
 impl GitRepository for RealGitRepository {
-    fn path(&self) -> PathBuf {
-        self.git_dir.clone()
-    }
-
-    fn main_repository_path(&self) -> PathBuf {
-        self.common_dir.clone()
-    }
-
     fn show(&self, commit: String) -> BoxFuture<'_, Result<CommitDetails>> {
         let git = self.git_binary();
         self.executor
@@ -1848,7 +1834,7 @@ impl GitRepository for RealGitRepository {
     }
 
     fn merge_message(&self) -> BoxFuture<'_, Option<String>> {
-        let path = self.path().join("MERGE_MSG");
+        let path = self.git_dir.join("MERGE_MSG");
         self.executor
             .spawn(async move { std::fs::read_to_string(&path).ok() })
             .boxed()
@@ -2139,7 +2125,7 @@ impl GitRepository for RealGitRepository {
         let git_binary = GitBinary::new(
             self.any_git_binary_path.clone(),
             worktree_path,
-            self.path(),
+            self.git_dir.clone(),
             self.executor.clone(),
             self.is_trusted(),
         );
@@ -2570,7 +2556,7 @@ impl GitRepository for RealGitRepository {
         cx: AsyncApp,
     ) -> BoxFuture<'_, Result<RemoteCommandOutput>> {
         let working_directory = self.command_directory();
-        let git_directory = self.path();
+        let git_directory = self.git_dir.clone();
         let executor = cx.background_executor().clone();
         let git_binary_path = self.system_git_binary_path.clone();
         let is_trusted = self.is_trusted();
@@ -2613,7 +2599,7 @@ impl GitRepository for RealGitRepository {
         cx: AsyncApp,
     ) -> BoxFuture<'_, Result<RemoteCommandOutput>> {
         let working_directory = self.command_directory();
-        let git_directory = self.path();
+        let git_directory = self.git_dir.clone();
         let executor = cx.background_executor().clone();
         let git_binary_path = self.system_git_binary_path.clone();
         let is_trusted = self.is_trusted();
@@ -2654,7 +2640,7 @@ impl GitRepository for RealGitRepository {
         cx: AsyncApp,
     ) -> BoxFuture<'_, Result<RemoteCommandOutput>> {
         let working_directory = self.command_directory();
-        let git_directory = self.path();
+        let git_directory = self.git_dir.clone();
         let remote_name = format!("{}", fetch_options);
         let git_binary_path = self.system_git_binary_path.clone();
         let executor = cx.background_executor().clone();
@@ -4357,7 +4343,6 @@ mod tests {
         assert_same_path(&repository.git_dir, &repo_dir);
         assert_same_path(&repository.common_dir, &repo_dir);
         assert_eq!(repository.working_directory, None);
-        assert_same_path(repository.main_repository_path(), &repo_dir);
         assert_eq!(
             repository
                 .git_binary()
@@ -5899,7 +5884,7 @@ mod tests {
         /// Force a Git garbage collection on the repository.
         fn gc(&self) -> BoxFuture<'_, Result<()>> {
             let working_directory = self.command_directory();
-            let git_directory = self.path();
+            let git_directory = self.git_dir.clone();
             let git_binary_path = self.any_git_binary_path.clone();
             let executor = self.executor.clone();
             self.executor

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -79,12 +79,9 @@ pub fn original_repo_path_from_common_dir(common_dir: &Path) -> Option<PathBuf> 
 
 fn linked_worktree_git_dir(worktree_path: &Path) -> Result<PathBuf> {
     let dot_git_path = worktree_path.join(".git");
-    let git_file = std::fs::read_to_string(&dot_git_path)
+    let git_file = std::fs::read(&dot_git_path)
         .with_context(|| format!("failed to read {}", dot_git_path.display()))?;
-    let git_dir = git_file
-        .strip_prefix("gitdir:")
-        .context("worktree .git file missing gitdir pointer")?
-        .trim();
+    let git_dir = crate::parse_gitfile(&git_file)?;
     Ok(worktree_path.join(git_dir))
 }
 
@@ -1255,37 +1252,21 @@ impl RealGitRepository {
             None
         };
 
+        // Gitfile/commondir grammar is shared with discovery via `git::parse_gitfile`/
+        // `git::parse_commondir`. `Path::join` already replaces the base for an absolute
+        // pointer, so it handles both absolute and relative targets.
         let git_dir = if dotgit_path.is_file() {
-            let content =
-                std::fs::read_to_string(dotgit_path).context("reading .git worktree file")?;
-            let path_str = content
-                .strip_prefix("gitdir: ")
-                .context("expected .git file to start with 'gitdir: '")?
-                .trim();
-            let resolved = PathBuf::from(path_str);
-            let resolved = if resolved.is_absolute() {
-                resolved
-            } else {
-                dotgit_parent.join(resolved)
-            };
-            normalize_git_metadata_path(resolved)?
+            let content = std::fs::read(dotgit_path).context("reading .git worktree file")?;
+            normalize_git_metadata_path(dotgit_parent.join(crate::parse_gitfile(&content)?))?
         } else {
             normalize_git_metadata_path(dotgit_path.to_path_buf())?
         };
 
         let common_dir = {
-            let commondir_file = git_dir.join("commondir");
+            let commondir_file = git_dir.join(crate::COMMONDIR);
             if commondir_file.is_file() {
-                let content =
-                    std::fs::read_to_string(&commondir_file).context("reading commondir file")?;
-                let path_str = content.trim();
-                let resolved = PathBuf::from(path_str);
-                let resolved = if resolved.is_absolute() {
-                    resolved
-                } else {
-                    git_dir.join(resolved)
-                };
-                normalize_git_metadata_path(resolved)?
+                let content = std::fs::read(&commondir_file).context("reading commondir file")?;
+                normalize_git_metadata_path(git_dir.join(crate::parse_commondir(&content)?))?
             } else {
                 git_dir.clone()
             }
@@ -3635,9 +3616,25 @@ impl GitBinary {
     }
 
     pub async fn with_exclude_overrides(&self) -> Result<GitExcludeOverride> {
-        let path = self.git_directory.join("info").join("exclude");
-
-        GitExcludeOverride::new(path).await
+        // `info/exclude` lives in the common dir, which differs from this per-worktree
+        // git dir for a linked worktree; follow its `commondir` pointer when present,
+        // using the shared grammar so this agrees with repository discovery.
+        let common_dir = match smol::fs::read(self.git_directory.join(crate::COMMONDIR)).await {
+            // `Path::join` replaces the base for an absolute `commondir` pointer.
+            Ok(contents) => self.git_directory.join(crate::parse_commondir(&contents)?),
+            // Only a missing `commondir` means "this dir is the common dir"; a transient
+            // read error must not silently route excludes to the wrong location.
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+                ) =>
+            {
+                self.git_directory.clone()
+            }
+            Err(error) => return Err(error).context("reading commondir"),
+        };
+        GitExcludeOverride::new(common_dir.join(crate::REPO_EXCLUDE)).await
     }
 
     fn path_for_index_id(&self, id: Uuid) -> PathBuf {
@@ -4573,9 +4570,7 @@ mod tests {
         };
 
         assert!(
-            error
-                .to_string()
-                .contains("expected .git file to start with 'gitdir: '"),
+            error.to_string().contains("gitfile must begin with"),
             "unexpected error: {error:#}"
         );
     }

--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -5439,45 +5439,82 @@ mod tests {
         let commits = generate_random_commit_dag(&mut rng, 10, false);
         fs.set_graph_commits(Path::new("/project/.git"), commits.clone());
 
-        let project = Project::test(fs.clone(), [Path::new("/project")], cx).await;
+        // Build the project WITHOUT a worktree so no repository exists yet, then
+        // install the git-store subscription BEFORE the initial scan. With the
+        // in-memory `is_git_repository` fast path the whole initial scan can otherwise
+        // complete inside `Project::test`, so a subscription installed afterwards would
+        // miss the initial `RepositoryAdded`/`HeadChanged`.
+        let project = Project::test(fs.clone(), [] as [&Path; 0], cx).await;
+
         let observed_repository_events = Arc::new(Mutex::new(Vec::new()));
         project.update(cx, |project, cx| {
             let observed_repository_events = observed_repository_events.clone();
-            cx.subscribe(project.git_store(), move |_, _, event, _| {
-                if let GitStoreEvent::RepositoryUpdated(_, repository_event, true) = event {
-                    observed_repository_events
-                        .lock()
-                        .expect("repository event mutex should be available")
-                        .push(repository_event.clone());
-                }
-            })
+            cx.subscribe(
+                project.git_store(),
+                move |_, git_store, event, cx| match event {
+                    // `RepositoryAdded` is emitted synchronously the moment the repository
+                    // is first registered, at `scan_id == 0`, BEFORE the git worker runs
+                    // `compute_snapshot`. Kicking off the graph-data load here is the only
+                    // deterministic way to guarantee the initial graph data exists before
+                    // the initial scan's `HeadChanged` (which fires at `scan_id == 1`),
+                    // independent of how fast the repository-validity check is.
+                    GitStoreEvent::RepositoryAdded => {
+                        if let Some(repo) =
+                            git_store.read(cx).repositories().values().next().cloned()
+                        {
+                            repo.update(cx, |repo, cx| {
+                                repo.graph_data(
+                                    LogSource::default(),
+                                    LogOrder::default(),
+                                    0..usize::MAX,
+                                    cx,
+                                );
+                            });
+                        }
+                    }
+                    GitStoreEvent::RepositoryUpdated(_, repository_event, true) => {
+                        observed_repository_events
+                            .lock()
+                            .expect("repository event mutex should be available")
+                            .push(repository_event.clone());
+                    }
+                    _ => {}
+                },
+            )
             .detach();
         });
+
+        // Registering the worktree triggers the initial repository scan.
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_worktree(Path::new("/project"), true, cx)
+            })
+            .await
+            .unwrap();
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        cx.run_until_parked();
+
+        // The initial scan must actually have emitted `HeadChanged` (scan_id -> 1);
+        // otherwise the guard this test protects was never exercised.
+        {
+            let observed_repository_events = observed_repository_events
+                .lock()
+                .expect("repository event mutex should be available");
+            assert!(
+                observed_repository_events
+                    .iter()
+                    .any(|event| matches!(event, RepositoryEvent::HeadChanged)),
+                "initial repository scan should emit HeadChanged"
+            );
+        }
 
         let repository = project.read_with(cx, |project, cx| {
             project
                 .active_repository(cx)
                 .expect("should have a repository")
         });
-
-        repository.update(cx, |repo, cx| {
-            repo.graph_data(LogSource::default(), LogOrder::default(), 0..usize::MAX, cx);
-        });
-
-        project
-            .update(cx, |project, cx| project.git_scans_complete(cx))
-            .await;
-        cx.run_until_parked();
-
-        let observed_repository_events = observed_repository_events
-            .lock()
-            .expect("repository event mutex should be available");
-        assert!(
-            observed_repository_events
-                .iter()
-                .any(|event| matches!(event, RepositoryEvent::HeadChanged)),
-            "initial repository scan should emit HeadChanged"
-        );
         let commit_count_after = repository.read_with(cx, |repo, _| {
             repo.get_graph_data(LogSource::default(), LogOrder::default())
                 .map(|data| data.commit_data.len())

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -488,8 +488,7 @@ impl ContextServerStore {
             subscriptions.push(cx.subscribe(&worktree_store, |this, _store, event, cx| {
                 if matches!(
                     event,
-                    WorktreeStoreEvent::WorktreeAdded(_)
-                        | WorktreeStoreEvent::WorktreeRemoved(_, _)
+                    WorktreeStoreEvent::WorktreeAdded(_) | WorktreeStoreEvent::WorktreeRemoved(_)
                 ) && !DisableAiSettings::get_global(cx).disable_ai
                 {
                     this.available_context_servers_changed(cx);

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -90,17 +90,29 @@ use util::{
     rel_path::RelPath,
 };
 use worktree::{
-    File, PathChange, PathKey, PathProgress, PathSummary, PathTarget, ProjectEntryId,
-    UpdatedGitRepositoriesSet, UpdatedGitRepository, Worktree,
+    File, GitRepositoryChange, GitRepositoryChanges, GitRepositoryIdentity, PathChange, PathKey,
+    PathProgress, PathSummary, PathTarget, ProjectEntryId, Worktree,
 };
 use zeroize::Zeroize;
+
+/// Stable local association from a worktree registration to a GitStore repository.
+///
+/// Many `(WorktreeId, ProjectEntryId)` pairs may map to one `RepositoryId`
+/// (multi-worktree coalescing on work-dir path).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+struct WorktreeRepositoryKey {
+    worktree_id: WorktreeId,
+    work_directory_id: ProjectEntryId,
+}
 
 pub struct GitStore {
     state: GitStoreState,
     buffer_store: Entity<BufferStore>,
     worktree_store: Entity<WorktreeStore>,
     repositories: HashMap<RepositoryId, Entity<Repository>>,
-    worktree_ids: HashMap<RepositoryId, HashSet<WorktreeId>>,
+    /// Forward map from worktree registration → host-minted repository id.
+    /// Reverse membership (worktrees for a repo) is derived from this map.
+    repository_ids_by_worktree_repository: HashMap<WorktreeRepositoryKey, RepositoryId>,
     active_repo_id: Option<RepositoryId>,
     #[allow(clippy::type_complexity)]
     loading_diffs:
@@ -738,7 +750,7 @@ impl GitStore {
             buffer_store,
             worktree_store,
             repositories: HashMap::default(),
-            worktree_ids: HashMap::default(),
+            repository_ids_by_worktree_repository: HashMap::default(),
             active_repo_id: None,
             _subscriptions,
             loading_diffs: HashMap::default(),
@@ -2034,18 +2046,11 @@ impl GitStore {
 
     fn on_worktree_store_event(
         &mut self,
-        worktree_store: Entity<WorktreeStore>,
+        _worktree_store: Entity<WorktreeStore>,
         event: &WorktreeStoreEvent,
         cx: &mut Context<Self>,
     ) {
-        let GitStoreState::Local {
-            project_environment,
-            downstream,
-            next_repository_id,
-            fs,
-            ..
-        } = &self.state
-        else {
+        let GitStoreState::Local { downstream, .. } = &self.state else {
             return;
         };
 
@@ -2073,51 +2078,45 @@ impl GitStore {
                 }
             }
             WorktreeStoreEvent::WorktreeUpdatedGitRepositories(worktree_id, changed_repos) => {
-                let Some(worktree) = worktree_store.read(cx).worktree_for_id(*worktree_id, cx)
-                else {
-                    return;
-                };
                 log::debug!("received worktree update for repositories: {changed_repos:?}");
                 self.update_repositories_from_worktree(
                     *worktree_id,
-                    project_environment.clone(),
-                    next_repository_id.clone(),
                     downstream
                         .as_ref()
                         .map(|downstream| downstream.updates_tx.clone()),
                     changed_repos.clone(),
-                    fs.clone(),
                     cx,
                 );
-                self.local_worktree_git_repos_changed(worktree, changed_repos, cx);
             }
             WorktreeStoreEvent::WorktreeRemoved(_entity_id, worktree_id) => {
-                let repos_without_worktree: Vec<RepositoryId> = self
-                    .worktree_ids
-                    .iter_mut()
-                    .filter_map(|(repo_id, worktree_ids)| {
-                        worktree_ids.remove(worktree_id);
-                        if worktree_ids.is_empty() {
-                            Some(*repo_id)
-                        } else {
-                            None
-                        }
+                let associations_for_worktree: Vec<(WorktreeRepositoryKey, RepositoryId)> = self
+                    .repository_ids_by_worktree_repository
+                    .iter()
+                    .filter(|(key, _)| key.worktree_id == *worktree_id)
+                    .map(|(key, repo_id)| (*key, *repo_id))
+                    .collect();
+                for (key, _) in &associations_for_worktree {
+                    self.repository_ids_by_worktree_repository.remove(key);
+                }
+                let repos_without_worktree: Vec<RepositoryId> = associations_for_worktree
+                    .into_iter()
+                    .map(|(_, repo_id)| repo_id)
+                    .filter(|repo_id| {
+                        !self
+                            .repository_ids_by_worktree_repository
+                            .values()
+                            .any(|id| id == repo_id)
                     })
                     .collect();
                 let is_active_repo_removed = repos_without_worktree
                     .iter()
                     .any(|repo_id| self.active_repo_id == Some(*repo_id));
 
+                let updates_tx = downstream
+                    .as_ref()
+                    .map(|downstream| downstream.updates_tx.clone());
                 for repo_id in repos_without_worktree {
-                    self.repositories.remove(&repo_id);
-                    self.worktree_ids.remove(&repo_id);
-                    if let Some(updates_tx) =
-                        downstream.as_ref().map(|downstream| &downstream.updates_tx)
-                    {
-                        updates_tx
-                            .unbounded_send(DownstreamUpdate::RemoveRepository(repo_id))
-                            .ok();
-                    }
+                    self.remove_repository_if_unreferenced(repo_id, updates_tx.as_ref());
                 }
 
                 if is_active_repo_removed {
@@ -2178,33 +2177,76 @@ impl GitStore {
     }
 
     fn repository_is_trusted(&self, repository_id: RepositoryId, cx: &mut Context<Self>) -> bool {
-        let Some(worktree_ids) = self.worktree_ids.get(&repository_id) else {
-            return false;
-        };
         let Some(trusted_worktrees) = TrustedWorktrees::try_get_global(cx) else {
             return false;
         };
 
-        worktree_ids.iter().any(|worktree_id| {
-            trusted_worktrees.update(cx, |trusted_worktrees, cx| {
-                trusted_worktrees.can_trust(&self.worktree_store, *worktree_id, cx)
+        self.repository_ids_by_worktree_repository
+            .iter()
+            .filter(|(_, id)| **id == repository_id)
+            .any(|(key, _)| {
+                trusted_worktrees.update(cx, |trusted_worktrees, cx| {
+                    trusted_worktrees.can_trust(&self.worktree_store, key.worktree_id, cx)
+                })
             })
-        })
     }
 
-    /// Update our list of repositories and schedule git scans in response to a notification from a worktree,
+    fn repository_has_associations(&self, repository_id: RepositoryId) -> bool {
+        self.repository_ids_by_worktree_repository
+            .values()
+            .any(|id| *id == repository_id)
+    }
+
+    /// Last-reference check + `repositories.remove` + optional downstream
+    /// `RemoveRepository`. Association-key removal and active-repository policy
+    /// stay at callers (worktree removal elects a survivor; registration removal
+    /// clears to None).
+    fn remove_repository_if_unreferenced(
+        &mut self,
+        id: RepositoryId,
+        updates_tx: Option<&mpsc::UnboundedSender<DownstreamUpdate>>,
+    ) -> bool {
+        if self.repository_has_associations(id) {
+            return false;
+        }
+        self.repositories.remove(&id);
+        if let Some(updates_tx) = updates_tx {
+            updates_tx
+                .unbounded_send(DownstreamUpdate::RemoveRepository(id))
+                .ok();
+        }
+        true
+    }
+
+    /// Associations are keyed by `(WorktreeId, ProjectEntryId)`. Path equality is used only
+    /// once, on first sight of a registration, to coalesce many worktrees onto one repo.
+    ///
+    /// `updates_tx` stays injectable so same-batch tests can observe the absence of a
+    /// downstream removal. `project_environment` / `next_repository_id` / `fs` are taken
+    /// from `GitStoreState::Local`.
     fn update_repositories_from_worktree(
         &mut self,
         worktree_id: WorktreeId,
-        project_environment: Entity<ProjectEnvironment>,
-        next_repository_id: Arc<AtomicU64>,
         updates_tx: Option<mpsc::UnboundedSender<DownstreamUpdate>>,
-        updated_git_repositories: UpdatedGitRepositoriesSet,
-        fs: Arc<dyn Fs>,
+        changed_repos: GitRepositoryChanges,
         cx: &mut Context<Self>,
     ) {
-        let mut removed_ids = Vec::new();
+        let (project_environment, next_repository_id, fs) = match &self.state {
+            GitStoreState::Local {
+                project_environment,
+                next_repository_id,
+                fs,
+                ..
+            } => (
+                project_environment.clone(),
+                next_repository_id.clone(),
+                fs.clone(),
+            ),
+            GitStoreState::Remote { .. } => return,
+        };
 
+        let mut removed_ids = Vec::new();
+        let mut affected_repo_ids: HashSet<RepositoryId> = HashSet::default();
         let is_trusted = TrustedWorktrees::try_get_global(cx)
             .map(|trusted_worktrees| {
                 trusted_worktrees.update(cx, |trusted_worktrees, cx| {
@@ -2213,130 +2255,144 @@ impl GitStore {
             })
             .unwrap_or(false);
 
-        for update in updated_git_repositories.iter() {
-            if let Some((id, existing)) = self.repositories.iter().find(|(_, repo)| {
-                let existing_work_directory_abs_path = &repo.read(cx).work_directory_abs_path;
-                Some(existing_work_directory_abs_path)
-                    == update.old_work_directory_abs_path.as_ref()
-                    || Some(existing_work_directory_abs_path)
-                        == update.new_work_directory_abs_path.as_ref()
-            }) {
-                let repo_id = *id;
-                if let Some(new_work_directory_abs_path) =
-                    update.new_work_directory_abs_path.clone()
-                {
-                    self.worktree_ids
-                        .entry(repo_id)
-                        .or_insert_with(HashSet::new)
-                        .insert(worktree_id);
-                    // Reinitialize the backend when the repository's identity changes —
-                    // not only its work-directory path but also its resolved `.git`,
-                    // repository, or common dir. The latter happens when a gitfile is
-                    // retargeted to a different repository while the checkout stays put;
-                    // without this the backend would keep pointing at the old repository.
-                    let identity_changed = {
-                        let snapshot = &existing.read(cx).snapshot;
-                        let changed = |new: &Option<Arc<Path>>, current: &Arc<Path>| {
-                            new.as_ref().is_some_and(|new| new != current)
-                        };
-                        update.old_work_directory_abs_path.as_ref()
-                            != update.new_work_directory_abs_path.as_ref()
-                            || changed(
-                                &update.repository_dir_abs_path,
-                                &snapshot.repository_dir_abs_path,
-                            )
-                            || changed(&update.common_dir_abs_path, &snapshot.common_dir_abs_path)
-                            || changed(&update.dot_git_abs_path, &snapshot.dot_git_abs_path)
+        for change in changed_repos.iter() {
+            match change {
+                GitRepositoryChange::Removed { repository } => {
+                    let key = WorktreeRepositoryKey {
+                        worktree_id,
+                        work_directory_id: repository.work_directory_id,
                     };
-                    if identity_changed
-                        && let Some(dot_git_abs_path) = update.dot_git_abs_path.clone()
-                        && let Some(repository_dir_abs_path) =
-                            update.repository_dir_abs_path.clone()
-                        && let Some(common_dir_abs_path) = update.common_dir_abs_path.clone()
+                    if let Some(repo_id) = self.repository_ids_by_worktree_repository.remove(&key) {
+                        if self.repository_has_associations(repo_id) {
+                            affected_repo_ids.insert(repo_id);
+                        } else {
+                            removed_ids.push(repo_id);
+                        }
+                    }
+                }
+                GitRepositoryChange::AddedOrUpdated {
+                    repository,
+                    identity_changed,
+                } => {
+                    let key = WorktreeRepositoryKey {
+                        worktree_id,
+                        work_directory_id: repository.work_directory_id,
+                    };
+                    let identity = &repository.identity;
+                    let identity_changed = *identity_changed;
+
+                    // Select (RepositoryId, Entity) together. Live association only when
+                    // the entity still exists; dangling keys are overwritten by coalesce
+                    // or mint below (both re-insert the association key).
+                    let (repo_id, existing) = if let Some(pair) = self
+                        .repository_ids_by_worktree_repository
+                        .get(&key)
+                        .copied()
+                        .and_then(|id| {
+                            self.repositories
+                                .get(&id)
+                                .cloned()
+                                .map(|entity| (id, entity))
+                        }) {
+                        pair
+                    } else if let Some((&id, entity)) =
+                        self.repositories.iter().find(|(_, repo)| {
+                            repo.read(cx).work_directory_abs_path
+                                == identity.work_directory_abs_path
+                        })
                     {
-                        existing.update(cx, |existing, cx| {
+                        self.repository_ids_by_worktree_repository.insert(key, id);
+                        (id, entity.clone())
+                    } else {
+                        let id = RepositoryId(
+                            next_repository_id.fetch_add(1, atomic::Ordering::Release),
+                        );
+                        let git_store = cx.weak_entity();
+                        let repo = cx.new(|cx| {
+                            let mut repo = Repository::local(
+                                id,
+                                identity,
+                                project_environment.downgrade(),
+                                fs.clone(),
+                                is_trusted,
+                                git_store,
+                                cx,
+                            );
+                            if let Some(updates_tx) = updates_tx.as_ref() {
+                                updates_tx
+                                    .unbounded_send(DownstreamUpdate::UpdateRepository(
+                                        repo.snapshot(),
+                                    ))
+                                    .ok();
+                            }
+                            repo.schedule_scan(updates_tx.clone(), cx);
+                            repo
+                        });
+                        self._subscriptions
+                            .push(cx.subscribe(&repo, Self::on_repository_event));
+                        self._subscriptions
+                            .push(cx.subscribe(&repo, Self::on_jobs_updated));
+                        self.repositories.insert(id, repo);
+                        self.repository_ids_by_worktree_repository.insert(key, id);
+                        cx.emit(GitStoreEvent::RepositoryAdded);
+                        self.active_repo_id.get_or_insert_with(|| {
+                            cx.emit(GitStoreEvent::ActiveRepositoryChanged(Some(id)));
+                            id
+                        });
+                        affected_repo_ids.insert(id);
+                        continue;
+                    };
+
+                    self.repository_ids_by_worktree_repository
+                        .insert(key, repo_id);
+
+                    // Reinit when identity_changed OR received identity differs from the
+                    // canonical snapshot (preserves coalesced-registration behavior).
+                    let needs_reinit = {
+                        let snapshot = &existing.read(cx).snapshot;
+                        identity_changed
+                            || identity.repository_dir_abs_path != snapshot.repository_dir_abs_path
+                            || identity.common_dir_abs_path != snapshot.common_dir_abs_path
+                            || identity.dot_git_abs_path != snapshot.dot_git_abs_path
+                            || identity.work_directory_abs_path != snapshot.work_directory_abs_path
+                    };
+                    existing.update(cx, |existing, cx| {
+                        if needs_reinit {
                             existing.reinitialize_local_backend(
-                                new_work_directory_abs_path,
-                                dot_git_abs_path,
-                                repository_dir_abs_path,
-                                common_dir_abs_path,
+                                identity,
                                 project_environment.downgrade(),
                                 fs.clone(),
                                 is_trusted,
                                 cx,
                             );
-                            existing.schedule_scan(updates_tx.clone(), cx);
-                        });
-                    } else {
-                        existing.update(cx, |existing, cx| {
-                            existing.snapshot.work_directory_abs_path = new_work_directory_abs_path;
-                            existing.schedule_scan(updates_tx.clone(), cx);
-                        });
-                    }
-                } else {
-                    if let Some(worktree_ids) = self.worktree_ids.get_mut(&repo_id) {
-                        worktree_ids.remove(&worktree_id);
-                        if worktree_ids.is_empty() {
-                            removed_ids.push(repo_id);
                         }
-                    }
+                        existing.schedule_scan(updates_tx.clone(), cx);
+                    });
+                    affected_repo_ids.insert(repo_id);
                 }
-            } else if let UpdatedGitRepository {
-                new_work_directory_abs_path: Some(work_directory_abs_path),
-                dot_git_abs_path: Some(dot_git_abs_path),
-                repository_dir_abs_path: Some(repository_dir_abs_path),
-                common_dir_abs_path: Some(common_dir_abs_path),
-                ..
-            } = update
-            {
-                let id = RepositoryId(next_repository_id.fetch_add(1, atomic::Ordering::Release));
-                let git_store = cx.weak_entity();
-                let repo = cx.new(|cx| {
-                    let mut repo = Repository::local(
-                        id,
-                        work_directory_abs_path.clone(),
-                        repository_dir_abs_path.clone(),
-                        common_dir_abs_path.clone(),
-                        dot_git_abs_path.clone(),
-                        project_environment.downgrade(),
-                        fs.clone(),
-                        is_trusted,
-                        git_store,
-                        cx,
-                    );
-                    if let Some(updates_tx) = updates_tx.as_ref() {
-                        // trigger an empty `UpdateRepository` to ensure remote active_repo_id is set correctly
-                        updates_tx
-                            .unbounded_send(DownstreamUpdate::UpdateRepository(repo.snapshot()))
-                            .ok();
-                    }
-                    repo.schedule_scan(updates_tx.clone(), cx);
-                    repo
-                });
-                self._subscriptions
-                    .push(cx.subscribe(&repo, Self::on_repository_event));
-                self._subscriptions
-                    .push(cx.subscribe(&repo, Self::on_jobs_updated));
-                self.repositories.insert(id, repo);
-                self.worktree_ids.insert(id, HashSet::from([worktree_id]));
-                cx.emit(GitStoreEvent::RepositoryAdded);
-                self.active_repo_id.get_or_insert_with(|| {
-                    cx.emit(GitStoreEvent::ActiveRepositoryChanged(Some(id)));
-                    id
-                });
             }
         }
 
         for id in removed_ids {
+            // Same-batch Added may re-associate this id after it was queued for
+            // removal (inode swap → Removed{old} then Added{new}, same work dir).
+            // Active-repo policy stays at the caller: clear to None on registration removal.
+            if self.repository_has_associations(id) {
+                continue;
+            }
             if self.active_repo_id == Some(id) {
                 self.active_repo_id = None;
                 cx.emit(GitStoreEvent::ActiveRepositoryChanged(None));
             }
-            self.repositories.remove(&id);
-            if let Some(updates_tx) = updates_tx.as_ref() {
-                updates_tx
-                    .unbounded_send(DownstreamUpdate::RemoveRepository(id))
-                    .ok();
+            self.remove_repository_if_unreferenced(id, updates_tx.as_ref());
+        }
+
+        for repo_id in affected_repo_ids {
+            if let Some(repository) = self.repositories.get(&repo_id) {
+                repository.update(cx, |repository, cx| {
+                    repository.reload_buffer_diff_bases(cx);
+                    cx.emit(RepositoryEvent::GitDirectoryChanged);
+                });
             }
         }
     }
@@ -2356,20 +2412,22 @@ impl GitStore {
             TrustedWorktreesEvent::Restricted(_, restricted_paths) => (false, restricted_paths),
         };
 
-        for (repo_id, worktree_ids) in &self.worktree_ids {
-            if worktree_ids
-                .iter()
-                .any(|worktree_id| event_paths.contains(&PathTrust::Worktree(*worktree_id)))
-            {
-                if let Some(repo) = self.repositories.get(repo_id) {
-                    let repository_state = repo.read(cx).repository_state.clone();
-                    cx.background_spawn(async move {
-                        if let Ok(RepositoryState::Local(state)) = repository_state.await {
-                            state.backend.set_trusted(is_trusted);
-                        }
-                    })
-                    .detach();
-                }
+        let mut notified_repo_ids: HashSet<RepositoryId> = HashSet::default();
+        for (key, repo_id) in &self.repository_ids_by_worktree_repository {
+            if !event_paths.contains(&PathTrust::Worktree(key.worktree_id)) {
+                continue;
+            }
+            if !notified_repo_ids.insert(*repo_id) {
+                continue;
+            }
+            if let Some(repo) = self.repositories.get(repo_id) {
+                let repository_state = repo.read(cx).repository_state.clone();
+                cx.background_spawn(async move {
+                    if let Ok(RepositoryState::Local(state)) = repository_state.await {
+                        state.backend.set_trusted(is_trusted);
+                    }
+                })
+                .detach();
             }
         }
     }
@@ -2520,29 +2578,6 @@ impl GitStore {
         .detach();
     }
 
-    fn local_worktree_git_repos_changed(
-        &mut self,
-        worktree: Entity<Worktree>,
-        changed_repos: &UpdatedGitRepositoriesSet,
-        cx: &mut Context<Self>,
-    ) {
-        log::debug!("local worktree repos changed");
-        debug_assert!(worktree.read(cx).is_local());
-
-        for repository in self.repositories.values() {
-            repository.update(cx, |repository, cx| {
-                let repo_abs_path = &repository.work_directory_abs_path;
-                if changed_repos.iter().any(|update| {
-                    update.old_work_directory_abs_path.as_ref() == Some(repo_abs_path)
-                        || update.new_work_directory_abs_path.as_ref() == Some(repo_abs_path)
-                }) {
-                    repository.reload_buffer_diff_bases(cx);
-                    cx.emit(RepositoryEvent::GitDirectoryChanged);
-                }
-            });
-        }
-    }
-
     pub fn repositories(&self) -> &HashMap<RepositoryId, Entity<Repository>> {
         &self.repositories
     }
@@ -2556,15 +2591,20 @@ impl GitStore {
         worktree_id: WorktreeId,
         cx: &App,
     ) -> Option<Arc<Path>> {
+        let associated = |repo_id: RepositoryId| {
+            self.repository_ids_by_worktree_repository
+                .iter()
+                .any(|(key, id)| key.worktree_id == worktree_id && *id == repo_id)
+        };
         self.active_repo_id
-            .iter()
-            .chain(self.worktree_ids.keys())
-            .find(|repo_id| {
-                self.worktree_ids
-                    .get(repo_id)
-                    .is_some_and(|ids| ids.contains(&worktree_id))
+            .filter(|id| associated(*id))
+            .or_else(|| {
+                self.repository_ids_by_worktree_repository
+                    .iter()
+                    .find(|(key, _)| key.worktree_id == worktree_id)
+                    .map(|(_, id)| *id)
             })
-            .and_then(|repo_id| self.repositories.get(repo_id))
+            .and_then(|repo_id| self.repositories.get(&repo_id))
             .and_then(|repo| {
                 repo.read(cx)
                     .snapshot()
@@ -5493,28 +5533,22 @@ impl Repository {
 
     fn reinitialize_local_backend(
         &mut self,
-        work_directory_abs_path: Arc<Path>,
-        dot_git_abs_path: Arc<Path>,
-        repository_dir_abs_path: Arc<Path>,
-        common_dir_abs_path: Arc<Path>,
+        identity: &GitRepositoryIdentity,
         project_environment: WeakEntity<ProjectEnvironment>,
         fs: Arc<dyn Fs>,
         is_trusted: bool,
         cx: &mut Context<Self>,
     ) {
-        self.snapshot.work_directory_abs_path = work_directory_abs_path;
-        self.snapshot.dot_git_abs_path = dot_git_abs_path;
-        self.snapshot.repository_dir_abs_path = repository_dir_abs_path;
-        self.snapshot.common_dir_abs_path = common_dir_abs_path;
+        self.snapshot.work_directory_abs_path = identity.work_directory_abs_path.clone();
+        self.snapshot.dot_git_abs_path = identity.dot_git_abs_path.clone();
+        self.snapshot.repository_dir_abs_path = identity.repository_dir_abs_path.clone();
+        self.snapshot.common_dir_abs_path = identity.common_dir_abs_path.clone();
         self.respawn_local_worker(project_environment, fs, is_trusted, cx);
     }
 
     fn local(
         id: RepositoryId,
-        work_directory_abs_path: Arc<Path>,
-        repository_dir_abs_path: Arc<Path>,
-        common_dir_abs_path: Arc<Path>,
-        dot_git_abs_path: Arc<Path>,
+        identity: &GitRepositoryIdentity,
         project_environment: WeakEntity<ProjectEnvironment>,
         fs: Arc<dyn Fs>,
         is_trusted: bool,
@@ -5523,10 +5557,10 @@ impl Repository {
     ) -> Self {
         let snapshot = RepositorySnapshot::empty(
             id,
-            work_directory_abs_path,
-            Some(repository_dir_abs_path),
-            Some(dot_git_abs_path),
-            Some(common_dir_abs_path),
+            identity.work_directory_abs_path.clone(),
+            Some(identity.repository_dir_abs_path.clone()),
+            Some(identity.dot_git_abs_path.clone()),
+            Some(identity.common_dir_abs_path.clone()),
             PathStyle::local(),
         );
 
@@ -10055,6 +10089,287 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(fs.load(&path).await.unwrap(), "build/\ntarget/\n");
+    }
+
+    /// Host/downstream: same host-minted id across add/retarget/remove; proto
+    /// round-trip preserves fields; absent optional paths leave last-good defaults.
+    #[gpui::test]
+    async fn test_host_downstream_repository_id_stability(cx: &mut TestAppContext) {
+        use git::repository::Worktree as GitWorktree;
+        use util::path;
+
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(path!("/repo_a"), json!({ ".git": {}, "file.txt": "a" }))
+            .await;
+        fs.insert_tree(path!("/repo_b"), json!({ ".git": {}, "file.txt": "b" }))
+            .await;
+        fs.add_linked_worktree_for_repo(
+            Path::new(path!("/repo_a/.git")),
+            false,
+            GitWorktree {
+                path: PathBuf::from(path!("/linked")),
+                ref_name: Some("refs/heads/feature".into()),
+                sha: "aaa111".into(),
+                is_main: false,
+                is_bare: false,
+            },
+        )
+        .await;
+        fs.write(path!("/linked/file.txt").as_ref(), b"content")
+            .await
+            .unwrap();
+
+        let admin_b = PathBuf::from(path!("/repo_b/.git/worktrees/feature"));
+        fs.create_dir(&admin_b).await.unwrap();
+        fs.write(&admin_b.join("HEAD"), b"ref: refs/heads/feature\n")
+            .await
+            .unwrap();
+        fs.write(&admin_b.join("commondir"), path!("/repo_b/.git").as_bytes())
+            .await
+            .unwrap();
+        fs.write(&admin_b.join("gitdir"), path!("/linked/.git").as_bytes())
+            .await
+            .unwrap();
+
+        let project = Project::test(fs.clone(), [path!("/linked").as_ref()], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        cx.executor().run_until_parked();
+
+        let (repository_id, snapshot_before) = project.read_with(cx, |project, cx| {
+            let repositories = project.repositories(cx);
+            assert_eq!(repositories.len(), 1, "add → one repository");
+            let (id, entity) = repositories.iter().next().unwrap();
+            (*id, entity.read(cx).snapshot())
+        });
+
+        let encoded = snapshot_before.initial_update(1);
+        assert_eq!(RepositoryId::from_proto(encoded.id), repository_id);
+        assert_eq!(
+            encoded.abs_path.as_str(),
+            snapshot_before.work_directory_abs_path.to_string_lossy()
+        );
+        assert_eq!(
+            encoded.repository_dir_abs_path.as_deref(),
+            Some(
+                snapshot_before
+                    .repository_dir_abs_path
+                    .to_string_lossy()
+                    .as_ref()
+            )
+        );
+        assert_eq!(
+            encoded.common_dir_abs_path.as_deref(),
+            Some(
+                snapshot_before
+                    .common_dir_abs_path
+                    .to_string_lossy()
+                    .as_ref()
+            )
+        );
+
+        fs.pause_events();
+        fs.remove_file(path!("/linked/.git").as_ref(), Default::default())
+            .await
+            .unwrap();
+        fs.write(
+            path!("/linked/.git").as_ref(),
+            format!("gitdir: {}\n", admin_b.display()).as_bytes(),
+        )
+        .await
+        .unwrap();
+        fs.unpause_events_and_flush();
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        cx.executor().run_until_parked();
+
+        let after = project.read_with(cx, |project, cx| {
+            let repositories = project.repositories(cx);
+            assert_eq!(repositories.len(), 1, "retarget is not remove+add");
+            let (id, entity) = repositories.iter().next().unwrap();
+            assert_eq!(*id, repository_id, "same RepositoryId after retarget");
+            entity.read(cx).snapshot()
+        });
+        assert_eq!(
+            after.common_dir_abs_path.as_ref(),
+            Path::new(path!("/repo_b/.git"))
+        );
+
+        let relayed = after.initial_update(1);
+        assert_eq!(RepositoryId::from_proto(relayed.id), repository_id);
+        assert_eq!(
+            relayed.repository_dir_abs_path.as_deref(),
+            Some(after.repository_dir_abs_path.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            relayed.common_dir_abs_path.as_deref(),
+            Some(after.common_dir_abs_path.to_string_lossy().as_ref())
+        );
+
+        // apply_remote_update only overwrites optional paths when present.
+        let mut sparse = after.initial_update(1);
+        sparse.repository_dir_abs_path = None;
+        sparse.common_dir_abs_path = None;
+        assert!(sparse.repository_dir_abs_path.is_none() && sparse.common_dir_abs_path.is_none());
+        // Guest keeps last-good when optionals are absent (mirrors apply_remote_update).
+        assert_eq!(
+            sparse
+                .repository_dir_abs_path
+                .as_deref()
+                .map(Path::new)
+                .unwrap_or(after.repository_dir_abs_path.as_ref()),
+            after.repository_dir_abs_path.as_ref()
+        );
+        assert_eq!(
+            sparse
+                .common_dir_abs_path
+                .as_deref()
+                .map(Path::new)
+                .unwrap_or(after.common_dir_abs_path.as_ref()),
+            after.common_dir_abs_path.as_ref()
+        );
+
+        let worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+        project.update(cx, |project, cx| {
+            project.remove_worktree(worktree_id, cx);
+        });
+        cx.executor().run_until_parked();
+        project.read_with(cx, |project, cx| {
+            assert!(
+                !project.repositories(cx).contains_key(&repository_id),
+                "last association removal drops the same RepositoryId"
+            );
+        });
+    }
+
+    /// Same-batch Removed{old entry id} + Added{new entry id} with identical work-dir
+    /// identity must coalesce onto the surviving RepositoryId and must not emit
+    /// RemoveRepository (inode swap within one debounce window).
+    #[gpui::test]
+    async fn test_same_batch_removed_added_coalesces_repository(cx: &mut TestAppContext) {
+        use util::path;
+        use worktree::{GitRepositoryChange, GitRepositoryIdentity, GitRepositoryRegistration};
+
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(path!("/project"), json!({ ".git": {}, "file.txt": "a" }))
+            .await;
+
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        project
+            .update(cx, |project, cx| project.git_scans_complete(cx))
+            .await;
+        cx.executor().run_until_parked();
+
+        let (worktree_id, old_entry_id, identity, repository_id) =
+            project.read_with(cx, |project, cx| {
+                let worktree = project.worktrees(cx).next().unwrap();
+                let worktree_id = worktree.read(cx).id();
+                let git_store = project.git_store().read(cx);
+                assert_eq!(git_store.repositories.len(), 1, "one repository after scan");
+                let (&repository_id, entity) = git_store.repositories.iter().next().unwrap();
+                let snapshot = entity.read(cx).snapshot();
+                let identity = GitRepositoryIdentity {
+                    work_directory_abs_path: snapshot.work_directory_abs_path,
+                    dot_git_abs_path: snapshot.dot_git_abs_path,
+                    repository_dir_abs_path: snapshot.repository_dir_abs_path,
+                    common_dir_abs_path: snapshot.common_dir_abs_path,
+                };
+                let old_entry_id = git_store
+                    .repository_ids_by_worktree_repository
+                    .iter()
+                    .find(|(key, id)| key.worktree_id == worktree_id && **id == repository_id)
+                    .map(|(key, _)| key.work_directory_id)
+                    .expect("association for scanned repository");
+                (worktree_id, old_entry_id, identity, repository_id)
+            });
+
+        // Fresh larger ProjectEntryId as after an inode-minting work-dir replace.
+        let new_entry_id = ProjectEntryId::from_proto(old_entry_id.to_proto().saturating_add(1000));
+        assert_ne!(old_entry_id, new_entry_id);
+
+        let (updates_tx, mut updates_rx) = mpsc::unbounded();
+        let removed = GitRepositoryRegistration {
+            work_directory_id: old_entry_id,
+            identity: identity.clone(),
+        };
+        let added = GitRepositoryRegistration {
+            work_directory_id: new_entry_id,
+            identity,
+        };
+        let batch: GitRepositoryChanges = Arc::from([
+            GitRepositoryChange::Removed {
+                repository: removed,
+            },
+            GitRepositoryChange::AddedOrUpdated {
+                repository: added,
+                identity_changed: false,
+            },
+        ]);
+
+        project.update(cx, |project, cx| {
+            project.git_store().update(cx, |git_store, cx| {
+                git_store.update_repositories_from_worktree(
+                    worktree_id,
+                    Some(updates_tx),
+                    batch,
+                    cx,
+                );
+            });
+        });
+        cx.executor().run_until_parked();
+
+        let mut saw_remove = false;
+        while let Ok(update) = updates_rx.try_recv() {
+            if matches!(update, DownstreamUpdate::RemoveRepository(_)) {
+                saw_remove = true;
+            }
+        }
+        assert!(
+            !saw_remove,
+            "same-batch Removed+Added must not emit RemoveRepository"
+        );
+
+        project.read_with(cx, |project, cx| {
+            let git_store = project.git_store().read(cx);
+            assert!(
+                git_store.repositories.contains_key(&repository_id),
+                "repository must survive same-batch inode swap"
+            );
+            assert_eq!(
+                git_store.repositories.len(),
+                1,
+                "must not mint a second repository"
+            );
+            let associated =
+                git_store
+                    .repository_ids_by_worktree_repository
+                    .get(&WorktreeRepositoryKey {
+                        worktree_id,
+                        work_directory_id: new_entry_id,
+                    });
+            assert_eq!(
+                associated.copied(),
+                Some(repository_id),
+                "new entry id must associate to the coalesced RepositoryId"
+            );
+            assert!(
+                !git_store
+                    .repository_ids_by_worktree_repository
+                    .contains_key(&WorktreeRepositoryKey {
+                        worktree_id,
+                        work_directory_id: old_entry_id,
+                    }),
+                "old entry association must be dropped"
+            );
+        });
     }
 
     #[gpui::test]

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2088,7 +2088,7 @@ impl GitStore {
                     cx,
                 );
             }
-            WorktreeStoreEvent::WorktreeRemoved(_entity_id, worktree_id) => {
+            WorktreeStoreEvent::WorktreeRemoved(worktree_id) => {
                 let associations_for_worktree: Vec<(WorktreeRepositoryKey, RepositoryId)> = self
                     .repository_ids_by_worktree_repository
                     .iter()

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2229,9 +2229,26 @@ impl GitStore {
                         .entry(repo_id)
                         .or_insert_with(HashSet::new)
                         .insert(worktree_id);
-                    let path_changed = update.old_work_directory_abs_path.as_ref()
-                        != update.new_work_directory_abs_path.as_ref();
-                    if path_changed
+                    // Reinitialize the backend when the repository's identity changes —
+                    // not only its work-directory path but also its resolved `.git`,
+                    // repository, or common dir. The latter happens when a gitfile is
+                    // retargeted to a different repository while the checkout stays put;
+                    // without this the backend would keep pointing at the old repository.
+                    let identity_changed = {
+                        let snapshot = &existing.read(cx).snapshot;
+                        let changed = |new: &Option<Arc<Path>>, current: &Arc<Path>| {
+                            new.as_ref().is_some_and(|new| new != current)
+                        };
+                        update.old_work_directory_abs_path.as_ref()
+                            != update.new_work_directory_abs_path.as_ref()
+                            || changed(
+                                &update.repository_dir_abs_path,
+                                &snapshot.repository_dir_abs_path,
+                            )
+                            || changed(&update.common_dir_abs_path, &snapshot.common_dir_abs_path)
+                            || changed(&update.dot_git_abs_path, &snapshot.dot_git_abs_path)
+                    };
+                    if identity_changed
                         && let Some(dot_git_abs_path) = update.dot_git_abs_path.clone()
                         && let Some(repository_dir_abs_path) =
                             update.repository_dir_abs_path.clone()
@@ -7282,7 +7299,9 @@ impl Repository {
         repo_path: &RepoPath,
         is_dir: bool,
     ) -> oneshot::Receiver<Result<()>> {
-        let repository_dir = self.snapshot.repository_dir_abs_path.clone();
+        // `info/exclude` lives in the common dir, which is shared across a repository's
+        // linked worktrees — not in the per-worktree repository dir.
+        let common_dir = self.snapshot.common_dir_abs_path.clone();
         let path_display = repo_path.as_ref().display(PathStyle::Unix);
         let file_path_str = if is_dir {
             format!("{}/", path_display)
@@ -7298,7 +7317,7 @@ impl Repository {
                     RepositoryState::Local(LocalRepositoryState { fs, .. }) => {
                         append_pattern_to_ignore_file(
                             fs,
-                            repository_dir.join(git::REPO_EXCLUDE),
+                            common_dir.join(git::REPO_EXCLUDE),
                             file_path_str,
                         )
                         .await
@@ -9348,28 +9367,15 @@ fn format_job_key(key: &GitJobKey) -> SharedString {
 /// repository root. Returns `None` if `path` is a normal repository, not a git
 /// repo, or if resolution fails.
 ///
-/// Resolution works by:
-/// 1. Reading the `.git` file to get the `gitdir:` pointer
-/// 2. Following that to the worktree-specific git directory
-/// 3. Reading the `commondir` file to find the shared `.git` directory
-/// 4. Deriving the main repo's identity path from the common dir
+/// Resolution goes through the shared [`fs::resolve_git_repository`], so it agrees
+/// with worktree discovery and only treats *validated* repositories as worktrees; a
+/// linked worktree is distinguished by its repository dir differing from the shared
+/// common dir, from which the main repo's identity path is derived.
 pub async fn resolve_git_worktree_to_main_repo(fs: &dyn Fs, path: &Path) -> Option<PathBuf> {
-    let dot_git = path.join(".git");
-    let metadata = fs.metadata(&dot_git).await.ok()??;
-    if metadata.is_dir {
-        return None; // Normal repo, not a linked worktree
-    }
-    // It's a .git file — parse the gitdir: pointer
-    let content = fs.load(&dot_git).await.ok()?;
-    let gitdir_rel = content.strip_prefix("gitdir:")?.trim();
-    let gitdir_abs = fs.canonicalize(&path.join(gitdir_rel)).await.ok()?;
-    // Read commondir to find the main .git directory
-    let commondir_content = fs.load(&gitdir_abs.join("commondir")).await.ok()?;
-    let common_dir = fs
-        .canonicalize(&gitdir_abs.join(commondir_content.trim()))
+    let (repository_dir, common_dir) = fs::resolve_git_repository(&path.join(git::DOT_GIT), fs)
         .await
-        .ok()?;
-    Some(repo_identity_path(&common_dir).to_path_buf())
+        .ok()??;
+    (repository_dir != common_dir).then(|| repo_identity_path(&common_dir).to_path_buf())
 }
 
 /// Validates that the resolved worktree directory is acceptable:

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -166,7 +166,7 @@ pub use semantic_tokens::{
 
 pub use worktree::{
     Entry, EntryKind, FS_WATCH_LATENCY, File, LocalWorktree, PathChange, ProjectEntryId,
-    UpdatedEntriesSet, UpdatedGitRepositoriesSet, Worktree, WorktreeId, WorktreeSettings,
+    UpdatedEntriesSet, Worktree, WorktreeId, WorktreeSettings,
 };
 
 const SERVER_LAUNCHING_BEFORE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4606,14 +4606,14 @@ impl LspStore {
                 })
                 .detach()
             }
-            WorktreeStoreEvent::WorktreeRemoved(_, id) => self.remove_worktree(*id, cx),
+            WorktreeStoreEvent::WorktreeRemoved(id) => self.remove_worktree(*id, cx),
             WorktreeStoreEvent::WorktreeUpdateSent(worktree) => {
                 worktree.update(cx, |worktree, _cx| self.send_diagnostic_summaries(worktree));
             }
             WorktreeStoreEvent::WorktreeUpdatedEntries(worktree_id, changes) => {
                 self.invalidate_diagnostic_summaries_for_removed_entries(*worktree_id, changes, cx);
             }
-            WorktreeStoreEvent::WorktreeReleased(..)
+            WorktreeStoreEvent::WorktreeReleased(_)
             | WorktreeStoreEvent::WorktreeOrderChanged
             | WorktreeStoreEvent::WorktreeUpdatedGitRepositories(..)
             | WorktreeStoreEvent::WorktreeDeletedEntry(..)

--- a/crates/project/src/manifest_tree.rs
+++ b/crates/project/src/manifest_tree.rs
@@ -196,7 +196,7 @@ impl ManifestTree {
         evt: &WorktreeStoreEvent,
         _: &mut Context<Self>,
     ) {
-        if let WorktreeStoreEvent::WorktreeRemoved(_, worktree_id) = evt {
+        if let WorktreeStoreEvent::WorktreeRemoved(worktree_id) = evt {
             self.root_points.remove(worktree_id);
         }
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -146,8 +146,7 @@ use util::{
 use worktree::{CreatedEntry, Snapshot, Traversal};
 pub use worktree::{
     Entry, EntryKind, FS_WATCH_LATENCY, File, LocalWorktree, PathChange, ProjectEntryId,
-    UpdatedEntriesSet, UpdatedGitRepositoriesSet, Worktree, WorktreeId, WorktreeSettings,
-    discover_root_repo_common_dir,
+    UpdatedEntriesSet, Worktree, WorktreeId, WorktreeSettings, discover_root_repo_common_dir,
 };
 use worktree_store::{WorktreeStore, WorktreeStoreEvent};
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3874,11 +3874,11 @@ impl Project {
                 cx.emit(Event::WorktreeAdded(worktree.read(cx).id()));
                 self.emit_group_key_changed_if_needed(cx);
             }
-            WorktreeStoreEvent::WorktreeRemoved(_, id) => {
+            WorktreeStoreEvent::WorktreeRemoved(id) => {
                 cx.emit(Event::WorktreeRemoved(*id));
                 self.emit_group_key_changed_if_needed(cx);
             }
-            WorktreeStoreEvent::WorktreeReleased(_, id) => {
+            WorktreeStoreEvent::WorktreeReleased(id) => {
                 self.on_worktree_released(*id, cx);
             }
             WorktreeStoreEvent::WorktreeOrderChanged => cx.emit(Event::WorktreeOrderChanged),

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -1130,7 +1130,7 @@ impl SettingsObserver {
                     }
                 })
                 .detach(),
-            WorktreeStoreEvent::WorktreeRemoved(_, worktree_id) => {
+            WorktreeStoreEvent::WorktreeRemoved(worktree_id) => {
                 cx.update_global::<SettingsStore, _>(|store, cx| {
                     store.clear_local_settings(*worktree_id, cx).log_err();
                 });

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -29,7 +29,7 @@ use util::{
     rel_path::RelPath,
 };
 use worktree::{
-    CreatedEntry, Entry, ProjectEntryId, UpdatedEntriesSet, UpdatedGitRepositoriesSet, Worktree,
+    CreatedEntry, Entry, GitRepositoryChanges, ProjectEntryId, UpdatedEntriesSet, Worktree,
     WorktreeId,
 };
 
@@ -204,7 +204,7 @@ pub enum WorktreeStoreEvent {
     WorktreeOrderChanged,
     WorktreeUpdateSent(Entity<Worktree>),
     WorktreeUpdatedEntries(WorktreeId, UpdatedEntriesSet),
-    WorktreeUpdatedGitRepositories(WorktreeId, UpdatedGitRepositoriesSet),
+    WorktreeUpdatedGitRepositories(WorktreeId, GitRepositoryChanges),
     WorktreeDeletedEntry(WorktreeId, ProjectEntryId),
     WorktreeUpdatedRootRepoCommonDir(WorktreeId),
 }

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -12,7 +12,7 @@ use collections::HashMap;
 use fs::{Fs, copy_recursive};
 use futures::{FutureExt, future::Shared};
 use gpui::{
-    App, AppContext as _, AsyncApp, Context, Entity, EntityId, EventEmitter, Global, Task, TaskExt,
+    App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Global, Task, TaskExt,
     WeakEntity,
 };
 use itertools::Either;
@@ -199,8 +199,8 @@ pub struct WorktreeStore {
 #[derive(Debug)]
 pub enum WorktreeStoreEvent {
     WorktreeAdded(Entity<Worktree>),
-    WorktreeRemoved(EntityId, WorktreeId),
-    WorktreeReleased(EntityId, WorktreeId),
+    WorktreeRemoved(WorktreeId),
+    WorktreeReleased(WorktreeId),
     WorktreeOrderChanged,
     WorktreeUpdateSent(Entity<Worktree>),
     WorktreeUpdatedEntries(WorktreeId, UpdatedEntriesSet),
@@ -896,7 +896,6 @@ impl WorktreeStore {
         cx.emit(WorktreeStoreEvent::WorktreeAdded(worktree.clone()));
         self.send_project_updates(cx);
 
-        let handle_id = worktree.entity_id();
         cx.subscribe(worktree, |_, worktree, event, cx| {
             let worktree_id = worktree.read(cx).id();
             match event {
@@ -928,14 +927,8 @@ impl WorktreeStore {
         })
         .detach();
         cx.observe_release(worktree, move |this, worktree, cx| {
-            cx.emit(WorktreeStoreEvent::WorktreeReleased(
-                handle_id,
-                worktree.id(),
-            ));
-            cx.emit(WorktreeStoreEvent::WorktreeRemoved(
-                handle_id,
-                worktree.id(),
-            ));
+            cx.emit(WorktreeStoreEvent::WorktreeReleased(worktree.id()));
+            cx.emit(WorktreeStoreEvent::WorktreeRemoved(worktree.id()));
             this.send_project_updates(cx);
         })
         .detach();
@@ -945,10 +938,7 @@ impl WorktreeStore {
         self.worktrees.retain(|worktree| {
             if let Some(worktree) = worktree.upgrade() {
                 if worktree.read(cx).id() == id_to_remove {
-                    cx.emit(WorktreeStoreEvent::WorktreeRemoved(
-                        worktree.entity_id(),
-                        id_to_remove,
-                    ));
+                    cx.emit(WorktreeStoreEvent::WorktreeRemoved(id_to_remove));
                     false
                 } else {
                     true

--- a/crates/project/tests/integration/git_store.rs
+++ b/crates/project/tests/integration/git_store.rs
@@ -1634,6 +1634,200 @@ mod trust_tests {
     }
 }
 
+mod gitfile_retarget {
+    use fs::{FakeFs, Fs};
+    use git::repository::Worktree as GitWorktree;
+    use gpui::TestAppContext;
+    use project::Project;
+    use serde_json::json;
+    use settings::SettingsStore;
+    use std::path::{Path, PathBuf};
+    use util::path;
+
+    fn init_test(cx: &mut TestAppContext) {
+        zlog::init_test();
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+    }
+
+    /// Rewriting a linked worktree's gitfile from admin dir A to admin dir B (same
+    /// work-directory path) must reinitialize GitStore's local backend so identity
+    /// paths and B-derived backend state both switch to B — not only Worktree's
+    /// published path fields.
+    #[gpui::test]
+    async fn test_gitfile_retarget_reinitializes_git_store_backend(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/repo_a"),
+            json!({
+                ".git": {},
+                "file.txt": "a",
+            }),
+        )
+        .await;
+        fs.insert_tree(
+            path!("/repo_b"),
+            json!({
+                ".git": {},
+                "file.txt": "b",
+            }),
+        )
+        .await;
+
+        fs.add_linked_worktree_for_repo(
+            Path::new(path!("/repo_a/.git")),
+            false,
+            GitWorktree {
+                path: PathBuf::from(path!("/linked")),
+                ref_name: Some("refs/heads/feature".into()),
+                sha: "aaa111".into(),
+                is_main: false,
+                is_bare: false,
+            },
+        )
+        .await;
+        fs.write(path!("/linked/file.txt").as_ref(), b"content")
+            .await
+            .unwrap();
+
+        // FakeGitRepository follows the gitfile to the admin dir for state, so attach
+        // A- and B-specific origins there (not only on the common dirs).
+        let admin_a = PathBuf::from(path!("/repo_a/.git/worktrees/feature"));
+        fs.with_git_state(&admin_a, false, |state| {
+            state
+                .remotes
+                .insert("origin".into(), "https://example.com/repo-a.git".into());
+        })
+        .unwrap();
+
+        let admin_b = PathBuf::from(path!("/repo_b/.git/worktrees/feature"));
+        fs.create_dir(&admin_b).await.unwrap();
+        fs.write(&admin_b.join("HEAD"), b"ref: refs/heads/feature\n")
+            .await
+            .unwrap();
+        fs.write(&admin_b.join("commondir"), path!("/repo_b/.git").as_bytes())
+            .await
+            .unwrap();
+        fs.write(&admin_b.join("gitdir"), path!("/linked/.git").as_bytes())
+            .await
+            .unwrap();
+        fs.with_git_state(&admin_b, false, |state| {
+            state
+                .remotes
+                .insert("origin".into(), "https://example.com/repo-b.git".into());
+        })
+        .unwrap();
+
+        let project = Project::test(fs.clone(), [path!("/linked").as_ref()], cx).await;
+        cx.executor().run_until_parked();
+
+        let (repository_id, snapshot_before) = project.read_with(cx, |project, cx| {
+            let repositories = project.repositories(cx);
+            assert_eq!(
+                repositories.len(),
+                1,
+                "linked worktree should register one GitStore repository"
+            );
+            let (id, entity) = repositories.iter().next().unwrap();
+            (*id, entity.read(cx).snapshot())
+        });
+        assert_eq!(
+            snapshot_before.common_dir_abs_path.as_ref(),
+            Path::new(path!("/repo_a/.git")),
+            "initially bound to repository A"
+        );
+        assert!(
+            snapshot_before
+                .repository_dir_abs_path
+                .as_ref()
+                .starts_with(path!("/repo_a/.git")),
+            "admin dir under A: {:?}",
+            snapshot_before.repository_dir_abs_path
+        );
+        assert_eq!(
+            snapshot_before.remote_origin_url.as_deref(),
+            Some("https://example.com/repo-a.git"),
+            "backend should report A's origin before retarget"
+        );
+        // FakeGitRepository::worktrees builds the main path from its *cached*
+        // common_dir_path (set only at open_repo / reinitialize). Snapshot path
+        // fields alone do not prove the backend was reopened.
+        let main_worktree_path_before = snapshot_before
+            .linked_worktrees
+            .iter()
+            .find(|worktree| worktree.is_main)
+            .map(|worktree| worktree.path.clone());
+        assert_eq!(
+            main_worktree_path_before.as_deref(),
+            Some(Path::new(path!("/repo_a"))),
+            "cached backend common_dir parent (main worktree path) starts at A"
+        );
+
+        // Pause events so a remove+write of the gitfile is observed as a single
+        // retarget: FakeFs caches a resolved `git_dir_path` on the file entry, and
+        // a plain content overwrite would leave the backend stuck on admin A.
+        // remove+write rebuilds the entry with a fresh parse; pause avoids a
+        // transient Ok(None) unregister between the two steps.
+        fs.pause_events();
+        fs.remove_file(path!("/linked/.git").as_ref(), Default::default())
+            .await
+            .unwrap();
+        fs.write(
+            path!("/linked/.git").as_ref(),
+            format!("gitdir: {}\n", admin_b.display()).as_bytes(),
+        )
+        .await
+        .unwrap();
+        fs.unpause_events_and_flush();
+        cx.executor().run_until_parked();
+
+        let snapshot_after = project.read_with(cx, |project, cx| {
+            let repositories = project.repositories(cx);
+            assert_eq!(
+                repositories.len(),
+                1,
+                "retarget must not remove/re-add under a new RepositoryId"
+            );
+            let (id, entity) = repositories.iter().next().unwrap();
+            assert_eq!(
+                *id, repository_id,
+                "RepositoryId must be preserved across gitfile retarget"
+            );
+            entity.read(cx).snapshot()
+        });
+
+        assert_eq!(
+            snapshot_after.common_dir_abs_path.as_ref(),
+            Path::new(path!("/repo_b/.git")),
+            "GitStore common_dir must switch to B (identity gate / reinitialize_local_backend)"
+        );
+        assert_eq!(
+            snapshot_after.repository_dir_abs_path.as_ref(),
+            admin_b.as_path(),
+            "GitStore repository_dir must switch to B's admin dir"
+        );
+        assert_eq!(
+            snapshot_after.remote_origin_url.as_deref(),
+            Some("https://example.com/repo-b.git"),
+            "backend must re-open against B and report B's origin, not A's"
+        );
+        let main_worktree_path_after = snapshot_after
+            .linked_worktrees
+            .iter()
+            .find(|worktree| worktree.is_main)
+            .map(|worktree| worktree.path.clone());
+        assert_eq!(
+            main_worktree_path_after.as_deref(),
+            Some(Path::new(path!("/repo_b"))),
+            "cached backend common_dir parent must flip to B only after reinitialize_local_backend"
+        );
+    }
+}
+
 mod resolve_worktree_tests {
     use fs::FakeFs;
     use gpui::TestAppContext;
@@ -1700,6 +1894,11 @@ mod resolve_worktree_tests {
         fs.insert_tree(
             "/monty/.bare",
             json!({
+                // A real bare repo has its own HEAD and object/ref stores in the
+                // common dir; resolution now validates the repository.
+                "HEAD": "ref: refs/heads/main",
+                "objects": {},
+                "refs": {},
                 "worktrees": {
                     "feature-a": {
                         "commondir": "../../",

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -13204,16 +13204,21 @@ async fn test_project_group_keys_match_for_bare_repo_linked_worktrees(
                 ".git": "gitdir: ./.bare\n",
                 ".bare": {
                     "HEAD": "ref: refs/heads/main\n",
+                    "objects": {},
+                    "refs": {},
                     "worktrees": {
                         "main": {
+                            "HEAD": "ref: refs/heads/main\n",
                             "commondir": "../..",
                             "gitdir": "/root/monty/main/.git",
                         },
                         "feature-a": {
+                            "HEAD": "ref: refs/heads/feature-a\n",
                             "commondir": "../..",
                             "gitdir": "/root/monty/feature-a/.git",
                         },
                         "feature-b": {
+                            "HEAD": "ref: refs/heads/feature-b\n",
                             "commondir": "../..",
                             "gitdir": "/root/monty/feature-b/.git",
                         },
@@ -14399,16 +14404,20 @@ async fn test_git_worktrees_and_submodules(cx: &mut gpui::TestAppContext) {
                 "worktrees": {
                     "some-worktree": {
                         "commondir": "../..\n",
-                        // For is_git_dir
-                        "HEAD": "",
+                        // A linked worktree's object/ref stores live in the common dir
+                        // (this `.git`); only HEAD is per-worktree.
+                        "HEAD": "ref: refs/heads/some-worktree\n",
                         "config": ""
                     }
                 },
                 "modules": {
                     "subdir": {
+                        // A submodule's git dir is a full repository: valid HEAD plus its
+                        // own object/ref stores.
                         "some-submodule": {
-                            // For is_git_dir
-                            "HEAD": "",
+                            "HEAD": "ref: refs/heads/main\n",
+                            "objects": {},
+                            "refs": {},
                             "config": "",
                         }
                     }

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -13623,8 +13623,9 @@ async fn test_rename_work_directory(cx: &mut gpui::TestAppContext) {
         .await;
     cx.executor().run_until_parked();
 
-    let repository = project.read_with(cx, |project, cx| {
-        project.repositories(cx).values().next().unwrap().clone()
+    let (repository_id, repository) = project.read_with(cx, |project, cx| {
+        let (id, entity) = project.repositories(cx).iter().next().unwrap();
+        (*id, entity.clone())
     });
 
     repository.read_with(cx, |repository, _| {
@@ -13656,6 +13657,20 @@ async fn test_rename_work_directory(cx: &mut gpui::TestAppContext) {
         .update(cx, |project, cx| project.git_scans_complete(cx))
         .await;
     cx.executor().run_until_parked();
+
+    // Id and entity must be stable across work-directory rename (association map,
+    // not path-keyed re-mint).
+    project.read_with(cx, |project, cx| {
+        let repositories = project.repositories(cx);
+        assert_eq!(repositories.len(), 1);
+        let (id, entity) = repositories.iter().next().unwrap();
+        assert_eq!(*id, repository_id, "RepositoryId stable across rename");
+        assert_eq!(
+            entity.entity_id(),
+            repository.entity_id(),
+            "Entity stable across rename"
+        );
+    });
 
     repository.read_with(cx, |repository, _| {
         assert_eq!(
@@ -14605,14 +14620,26 @@ async fn test_repository_deduplication(cx: &mut gpui::TestAppContext) {
         .await;
     cx.executor().run_until_parked();
 
-    let repos = project.read_with(cx, |project, cx| {
-        project
-            .repositories(cx)
-            .values()
-            .map(|repo| repo.read(cx).work_directory_abs_path.clone())
-            .collect::<Vec<_>>()
+    let (repo_id, repo_entity, repos) = project.read_with(cx, |project, cx| {
+        let repositories = project.repositories(cx);
+        assert_eq!(
+            repositories.len(),
+            1,
+            "two worktrees must coalesce to one repo"
+        );
+        let (id, entity) = repositories.iter().next().unwrap();
+        (
+            *id,
+            entity.entity_id(),
+            repositories
+                .values()
+                .map(|repo| repo.read(cx).work_directory_abs_path.clone())
+                .collect::<Vec<_>>(),
+        )
     });
     pretty_assertions::assert_eq!(repos, [Path::new(path!("/root/project")).into()]);
+    // Membership comes from the association map (two worktree registrations → one id).
+    let _ = (repo_id, repo_entity);
 }
 
 #[gpui::test]
@@ -15418,11 +15445,23 @@ async fn test_git_worktree_remove(cx: &mut gpui::TestAppContext) {
     let repos = project.update(cx, |p, cx| p.git_store().read(cx).repositories().clone());
     assert_eq!(repos.len(), 2);
 
+    // Capture id+entity for `/root/b` (coalesced across worktree b + b/script).
+    let (repo_b_id, repo_b_entity) = project.read_with(cx, |p, cx| {
+        p.repositories(cx)
+            .iter()
+            .find(|(_, repo)| {
+                repo.read(cx).work_directory_abs_path.as_ref() == Path::new(path!("/root/b"))
+            })
+            .map(|(id, entity)| (*id, entity.entity_id()))
+            .expect("repo b")
+    });
+
     project.update(cx, |project, cx| {
         project.remove_worktree(*worktree_id, cx);
     });
     cx.run_until_parked();
 
+    // Partial removal: drop b/script worktree; repo b survives with same id+entity.
     let mut repo_paths = project
         .update(cx, |p, cx| p.git_store().read(cx).repositories().clone())
         .values()
@@ -15437,6 +15476,21 @@ async fn test_git_worktree_remove(cx: &mut gpui::TestAppContext) {
             Path::new(path!("/root/b")).into(),
         ]
     );
+    project.read_with(cx, |p, cx| {
+        let (id, entity) = p
+            .repositories(cx)
+            .iter()
+            .find(|(_, repo)| {
+                repo.read(cx).work_directory_abs_path.as_ref() == Path::new(path!("/root/b"))
+            })
+            .expect("repo b survives partial worktree removal");
+        assert_eq!(*id, repo_b_id, "RepositoryId survives partial removal");
+        assert_eq!(
+            entity.entity_id(),
+            repo_b_entity,
+            "Entity survives partial removal"
+        );
+    });
 
     let active_repo_path = project
         .read_with(cx, |p, cx| {
@@ -15462,6 +15516,7 @@ async fn test_git_worktree_remove(cx: &mut gpui::TestAppContext) {
         .unwrap();
     assert_eq!(active_repo_path.as_ref(), Path::new(path!("/root/b")));
 
+    // Last association for repo b dies with the last worktree.
     let worktree_id = worktree_id_by_abs_path
         .get(Path::new(path!("/root/b")))
         .unwrap();

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -14620,26 +14620,19 @@ async fn test_repository_deduplication(cx: &mut gpui::TestAppContext) {
         .await;
     cx.executor().run_until_parked();
 
-    let (repo_id, repo_entity, repos) = project.read_with(cx, |project, cx| {
+    let repos = project.read_with(cx, |project, cx| {
         let repositories = project.repositories(cx);
         assert_eq!(
             repositories.len(),
             1,
             "two worktrees must coalesce to one repo"
         );
-        let (id, entity) = repositories.iter().next().unwrap();
-        (
-            *id,
-            entity.entity_id(),
-            repositories
-                .values()
-                .map(|repo| repo.read(cx).work_directory_abs_path.clone())
-                .collect::<Vec<_>>(),
-        )
+        repositories
+            .values()
+            .map(|repo| repo.read(cx).work_directory_abs_path.clone())
+            .collect::<Vec<_>>()
     });
     pretty_assertions::assert_eq!(repos, [Path::new(path!("/root/project")).into()]);
-    // Membership comes from the association map (two worktree registrations → one id).
-    let _ = (repo_id, repo_entity);
 }
 
 #[gpui::test]

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -2699,8 +2699,7 @@ async fn resolve_local_workspace_identity(fs: &dyn Fs, paths: &PathList) -> Opti
                 .unwrap_or_else(|| original.clone())
         })
         .collect();
-    let resolved_path_refs: Vec<&Path> = resolved_paths.iter().map(PathBuf::as_path).collect();
-    Some(PathList::new(&resolved_path_refs))
+    Some(PathList::new(&resolved_paths))
 }
 
 fn dedupe_recent_workspaces(

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -5255,6 +5255,9 @@ mod tests {
         fs.insert_tree(
             "/foo/.bare",
             json!({
+                "HEAD": "ref: refs/heads/main",
+                "objects": {},
+                "refs": {},
                 "worktrees": {
                     "my-feature": {
                         "commondir": "../../",
@@ -5290,17 +5293,15 @@ mod tests {
         assert_eq!(result.identity_paths.paths(), &[PathBuf::from("/foo")]);
     }
 
-    #[gpui::test]
-    async fn test_recent_workspace_identity_deduplicates_main_and_linked_worktree(
-        cx: &mut gpui::TestAppContext,
-    ) {
-        let fs = fs::FakeFs::new(cx.executor());
-
+    async fn insert_linked_worktree_project(fs: &fs::FakeFs) {
         fs.insert_tree(
             "/the-project",
             json!({
                 ".git": "gitdir: ./.bare\n",
                 ".bare": {
+                    "HEAD": "ref: refs/heads/main",
+                    "objects": {},
+                    "refs": {},
                     "worktrees": {
                         "feature-a": {
                             "commondir": "../../",
@@ -5312,7 +5313,6 @@ mod tests {
             }),
         )
         .await;
-
         fs.insert_tree(
             "/the-project/feature-a",
             json!({
@@ -5321,6 +5321,14 @@ mod tests {
             }),
         )
         .await;
+    }
+
+    #[gpui::test]
+    async fn test_recent_workspace_identity_deduplicates_main_and_linked_worktree(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let fs = fs::FakeFs::new(cx.executor());
+        insert_linked_worktree_project(&fs).await;
 
         let t0 = Utc::now() - chrono::Duration::hours(1);
         let t1 = Utc::now();
@@ -5358,31 +5366,7 @@ mod tests {
         let db =
             WorkspaceDb::open_test_db("test_recent_project_workspaces_preserve_reopen_paths").await;
 
-        fs.insert_tree(
-            "/the-project",
-            json!({
-                ".git": "gitdir: ./.bare\n",
-                ".bare": {
-                    "worktrees": {
-                        "feature-a": {
-                            "commondir": "../../",
-                            "HEAD": "ref: refs/heads/feature-a"
-                        }
-                    }
-                },
-                "src": { "main.rs": "" }
-            }),
-        )
-        .await;
-
-        fs.insert_tree(
-            "/the-project/feature-a",
-            json!({
-                ".git": "gitdir: ../.bare/worktrees/feature-a\n",
-                "src": { "lib.rs": "" }
-            }),
-        )
-        .await;
+        insert_linked_worktree_project(&fs).await;
 
         db.save_workspace(workspace_with(
             1,
@@ -5457,6 +5441,9 @@ mod tests {
             json!({
                 ".git": "gitdir: ./.bare\n",
                 ".bare": {
+                    "HEAD": "ref: refs/heads/main",
+                    "objects": {},
+                    "refs": {},
                     "worktrees": {
                         "feature-a": {
                             "commondir": "../../",
@@ -5535,6 +5522,9 @@ mod tests {
             json!({
                 ".git": "gitdir: ./.bare\n",
                 ".bare": {
+                    "HEAD": "ref: refs/heads/main",
+                    "objects": {},
+                    "refs": {},
                     "worktrees": {
                         "feature-a": {
                             "commondir": "../../",

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -9,7 +9,7 @@ use collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use encoding_rs::Encoding;
 use fs::{
     Fs, MTime, PathEvent, PathEventKind, RemoveOptions, TrashId, Watcher, copy_recursive,
-    read_dir_items,
+    io_error_is_absence, read_dir_items,
 };
 use futures::{
     FutureExt as _, Stream, StreamExt,
@@ -1485,10 +1485,7 @@ impl LocalWorktree {
                             new_repos.next();
                         }
                         Ordering::Equal => {
-                            if new_repo.git_dir_scan_id != old_repo.git_dir_scan_id
-                                || new_repo.work_directory_abs_path
-                                    != old_repo.work_directory_abs_path
-                            {
+                            if repository_identity_or_scan_changed(&old_repo, &new_repo) {
                                 changes.push(UpdatedGitRepository {
                                     work_directory_id: new_entry_id,
                                     old_work_directory_abs_path: Some(
@@ -2244,6 +2241,29 @@ impl LocalWorktree {
             .values()
             .map(|entry| entry.work_directory_abs_path.clone())
             .collect::<Vec<_>>()
+    }
+
+    /// `(repository_dir, common_dir)` for each registered repository.
+    #[cfg(feature = "test-support")]
+    pub fn repository_identities(&self) -> Vec<(Arc<Path>, Arc<Path>)> {
+        self.git_repositories
+            .values()
+            .map(|entry| {
+                (
+                    entry.repository_dir_abs_path.clone(),
+                    entry.common_dir_abs_path.clone(),
+                )
+            })
+            .collect()
+    }
+
+    /// Whether the cached `info/exclude` for `work_dir_abs_path` still needs a re-read.
+    #[cfg(feature = "test-support")]
+    pub fn repo_exclude_needs_update(&self, work_dir_abs_path: &Path) -> Option<bool> {
+        self.snapshot
+            .repo_exclude_by_work_dir_abs_path
+            .get(work_dir_abs_path)
+            .map(|(_, needs_update)| *needs_update)
     }
 }
 
@@ -3056,6 +3076,16 @@ impl LocalSnapshot {
     ) -> IgnoreStack {
         let mut new_ignores = Vec::new();
         let mut repo_root = None;
+        // Deepest registered work dir covering this path — already validated at
+        // registration, so `reload_entries_for_paths` can skip a full resolve on the
+        // hot path (thousands of event paths per checkout). Invalid `.git` never
+        // enters `git_repositories`, so a phantom cannot win as a registered root.
+        let covering_registered = self
+            .git_repositories
+            .values()
+            .filter(|repo| abs_path.starts_with(repo.work_directory_abs_path.as_ref()))
+            .max_by_key(|repo| repo.work_directory_abs_path.as_os_str().len())
+            .map(|repo| repo.work_directory_abs_path.clone());
         for (index, ancestor) in abs_path.ancestors().enumerate() {
             if index > 0 {
                 if let Some((ignore, _)) = self.ignores_by_parent_abs_path.get(ancestor) {
@@ -3065,11 +3095,29 @@ impl LocalSnapshot {
                 }
             }
 
-            if repo_root.is_none() {
-                let metadata = fs.metadata(&ancestor.join(DOT_GIT)).await.ok().flatten();
-                if metadata.is_some() {
-                    repo_root = Some(Arc::from(ancestor));
-                }
+            // Anchor the ignore root at a *validated* repository, so an invalid nested
+            // `.git` cannot shadow the real parent's excludes/ignore rooting.
+            if repo_root.is_some() {
+                continue;
+            }
+
+            // Covering registered root: free, no filesystem.
+            if covering_registered
+                .as_ref()
+                .is_some_and(|root| root.as_ref() == ancestor)
+            {
+                repo_root = covering_registered.clone();
+                continue;
+            }
+
+            // Deeper than the covering registration, or nothing registered yet: resolve.
+            // `reload_entries_for_paths` runs before `update_git_repositories`, so a
+            // newly-appeared nested repo may not be registered yet and must still win.
+            if discover_valid_git_repository(&ancestor.join(DOT_GIT), fs)
+                .await
+                .is_some()
+            {
+                repo_root = Some(Arc::from(ancestor));
             }
         }
 
@@ -3531,13 +3579,15 @@ impl BackgroundScannerState {
         .log_err();
     }
 
+    /// Registers a validated git repository for `work_directory`, returning whether a
+    /// repository was inserted (`Ok(false)` when the `.git` entry is not a repository).
     async fn insert_git_repository_for_path(
         &mut self,
         work_directory: WorkDirectory,
         dot_git_abs_path: Arc<Path>,
         fs: &dyn Fs,
         watcher: &dyn Watcher,
-    ) -> Result<LocalRepositoryEntry> {
+    ) -> Result<bool> {
         let work_dir_entry = self
             .snapshot
             .entry_for_path(&work_directory.path_key().0)
@@ -3552,8 +3602,13 @@ impl BackgroundScannerState {
             })?;
         let work_directory_abs_path = self.snapshot.work_directory_abs_path(&work_directory);
 
-        let (repository_dir_abs_path, common_dir_abs_path) =
-            discover_git_paths(&dot_git_abs_path, fs).await;
+        // Bail before setting up any watches if the `.git` entry isn't a real repository.
+        let Some((repository_dir_abs_path, common_dir_abs_path)) =
+            discover_valid_git_repository(&dot_git_abs_path, fs).await
+        else {
+            return Ok(false);
+        };
+
         watcher
             .add(&common_dir_abs_path)
             .context("failed to add common directory to watcher")
@@ -3570,22 +3625,46 @@ impl BackgroundScannerState {
 
         let work_directory_id = work_dir_entry.id;
 
-        let local_repository = LocalRepositoryEntry {
-            work_directory_id,
-            work_directory,
-            work_directory_abs_path: work_directory_abs_path.as_path().into(),
-            git_dir_scan_id: 0,
-            dot_git_abs_path,
-            common_dir_abs_path,
-            repository_dir_abs_path,
-        };
-
+        let work_directory_abs_path: Arc<Path> = work_directory_abs_path.as_path().into();
+        // Registration owns exclude state: load a present info/exclude now so
+        // ignore updates that run after insert (affected_repo_roots) see it.
+        // Always insert an entry so a later info/exclude create can mark it
+        // dirty. Present, confirmed-absent, and unparsable are clean;
+        // indeterminate I/O inserts empty but stays dirty so the reload path
+        // retries instead of treating a transient failure as known-gone.
+        let exclude_abs_path = common_dir_abs_path.join(REPO_EXCLUDE);
+        let (exclude, needs_update) =
+            match load_gitignore_existing(&exclude_abs_path, &work_directory_abs_path, fs).await {
+                GitignoreLoad::Present(ignore) => (Arc::new(ignore), false),
+                GitignoreLoad::Absent => (Arc::new(Gitignore::empty()), false),
+                GitignoreLoad::Unparsable(error) => {
+                    Err::<(), _>(error).log_err();
+                    (Arc::new(Gitignore::empty()), false)
+                }
+                GitignoreLoad::Indeterminate(error) => {
+                    Err::<(), _>(error).log_err();
+                    (Arc::new(Gitignore::empty()), true)
+                }
+            };
         self.snapshot
-            .git_repositories
-            .insert(work_directory_id, local_repository.clone());
+            .repo_exclude_by_work_dir_abs_path
+            .insert(work_directory_abs_path.clone(), (exclude, needs_update));
+
+        self.snapshot.git_repositories.insert(
+            work_directory_id,
+            LocalRepositoryEntry {
+                work_directory_id,
+                work_directory,
+                work_directory_abs_path,
+                git_dir_scan_id: 0,
+                dot_git_abs_path,
+                common_dir_abs_path,
+                repository_dir_abs_path,
+            },
+        );
 
         log::trace!("inserting new local git repository");
-        Ok(local_repository)
+        Ok(true)
     }
 }
 
@@ -3638,22 +3717,55 @@ async fn watch_dir_tree(root_abs_path: PathBuf, fs: &dyn Fs, watcher: &dyn Watch
     }
 }
 
-async fn is_dot_git(path: &Path, fs: &dyn Fs) -> bool {
-    if let Some(file_name) = path.file_name()
-        && file_name == DOT_GIT
-    {
-        return true;
-    }
+/// Whether a registered repository should publish an update between snapshots.
+/// Identity paths are first-class: a gitfile retarget changes repository_dir/
+/// common_dir without moving the work directory. Emitting only on scan_id or
+/// work-dir would miss that unless a scan token happens to bump — not an invariant.
+fn repository_identity_or_scan_changed(
+    old_repo: &LocalRepositoryEntry,
+    new_repo: &LocalRepositoryEntry,
+) -> bool {
+    new_repo.git_dir_scan_id != old_repo.git_dir_scan_id
+        || new_repo.work_directory_abs_path != old_repo.work_directory_abs_path
+        || new_repo.dot_git_abs_path != old_repo.dot_git_abs_path
+        || new_repo.repository_dir_abs_path != old_repo.repository_dir_abs_path
+        || new_repo.common_dir_abs_path != old_repo.common_dir_abs_path
+}
 
-    // If we're in a bare repository, we are not inside a `.git` folder. In a
-    // bare repository, the root folder contains what would normally be in the
-    // `.git` folder.
-    let head_metadata = fs.metadata(&path.join("HEAD")).await;
-    if !matches!(head_metadata, Ok(Some(_))) {
-        return false;
-    }
-    let config_metadata = fs.metadata(&path.join("config")).await;
-    matches!(config_metadata, Ok(Some(_)))
+/// Classifies an fs event against git metadata directories, returning the matched
+/// git-dir root and the event's path within it, or `None` when it is not git metadata.
+/// Registered repositories are matched by their resolved `.git`/repository/common dirs,
+/// so linked worktrees and bare repositories are recognized by identity rather than by
+/// a name or the old `HEAD`+`config` heuristic (which missed config-less bare repos).
+fn match_git_metadata_event(
+    snapshot: &LocalSnapshot,
+    abs_path: &Path,
+) -> Option<(PathBuf, PathBuf)> {
+    let root = snapshot
+        .git_repositories
+        .values()
+        .flat_map(|repo| {
+            [
+                repo.dot_git_abs_path.as_ref(),
+                repo.repository_dir_abs_path.as_ref(),
+                repo.common_dir_abs_path.as_ref(),
+            ]
+        })
+        .filter(|root| abs_path.starts_with(root))
+        // The deepest matching root wins, so an event in a nested repository is
+        // attributed to it rather than an ancestor (a deeper root is necessarily longer).
+        .max_by_key(|root| root.as_os_str().len())
+        // Only a literally-named `.git` ancestor may seed a new (unregistered)
+        // repository, so a nested bare `cache.git` never claims a spurious worktree.
+        .or_else(|| {
+            abs_path
+                .ancestors()
+                .find(|ancestor| ancestor.file_name() == Some(OsStr::new(DOT_GIT)))
+        })?;
+    Some((
+        root.to_owned(),
+        abs_path.strip_prefix(root).ok()?.to_owned(),
+    ))
 }
 
 async fn build_gitignore(abs_path: &Path, fs: &dyn Fs) -> Result<Gitignore> {
@@ -3666,6 +3778,50 @@ async fn build_gitignore_with_root(abs_path: &Path, root: &Path, fs: &dyn Fs) ->
         .load(abs_path)
         .await
         .with_context(|| format!("failed to load gitignore file at {}", abs_path.display()))?;
+    parse_gitignore_contents(abs_path, root, &contents)
+}
+
+/// Outcome of loading an exclude/gitignore file that may be absent or bad.
+///
+/// Classified at the error-production site so callers never need to downcast
+/// `anyhow` chains. Unparsable content fails identically forever (clear dirty);
+/// transient I/O is Indeterminate (leave dirty and retry).
+enum GitignoreLoad {
+    Present(Gitignore),
+    Absent,
+    Unparsable(anyhow::Error),
+    Indeterminate(anyhow::Error),
+}
+
+/// Loads a gitignore file, distinguishing present / confirmed-absent /
+/// unparsable content / indeterminate I/O.
+async fn load_gitignore_existing(abs_path: &Path, root: &Path, fs: &dyn Fs) -> GitignoreLoad {
+    let bytes = match fs.load_bytes(abs_path).await {
+        Ok(bytes) => bytes,
+        Err(error) if io_error_is_absence(&error) => return GitignoreLoad::Absent,
+        Err(error) => {
+            return GitignoreLoad::Indeterminate(error.context(format!(
+                "failed to load gitignore file at {}",
+                abs_path.display()
+            )));
+        }
+    };
+    let contents = match String::from_utf8(bytes) {
+        Ok(contents) => contents,
+        Err(error) => {
+            return GitignoreLoad::Unparsable(anyhow::Error::new(error).context(format!(
+                "gitignore file at {} is not valid UTF-8",
+                abs_path.display()
+            )));
+        }
+    };
+    match parse_gitignore_contents(abs_path, root, &contents) {
+        Ok(gitignore) => GitignoreLoad::Present(gitignore),
+        Err(error) => GitignoreLoad::Unparsable(error),
+    }
+}
+
+fn parse_gitignore_contents(abs_path: &Path, root: &Path, contents: &str) -> Result<Gitignore> {
     let mut builder = GitignoreBuilder::new(root);
     for line in contents.lines() {
         builder.add_line(Some(abs_path.into()), line)?;
@@ -4335,7 +4491,8 @@ impl BackgroundScanner {
             && self.track_git_repositories
         {
             maybe!(async {
-                self.state
+                let inserted = self
+                    .state
                     .lock()
                     .await
                     .insert_git_repository_for_path(
@@ -4345,8 +4502,10 @@ impl BackgroundScanner {
                         self.watcher.as_ref(),
                     )
                     .await
+                    // Bail on both an error and an invalid `.git` (`Ok(false)`), so a
+                    // non-repository is never reported as the containing repo.
                     .log_err()?;
-                Some(ancestor_dot_git)
+                inserted.then_some(ancestor_dot_git)
             })
             .await
         } else {
@@ -4722,10 +4881,12 @@ impl BackgroundScanner {
         // Ignore these, to avoid Zed unnecessarily rescanning git metadata.
         let skipped_file_names_in_dot_git =
             [COMMIT_MESSAGE, FETCH_HEAD, ORIG_HEAD, BISECT_LOG, GC_PID];
+        // `objects` is intentionally absent: it is a repository-validity input
+        // (`common_dir_has_stores`), so the bare `objects` path must revalidate. Only
+        // descendants (loose-object writes) are skipped, via the carve-out below.
         let skipped_dirs_in_dot_git = [
             FSMONITOR_DAEMON,
             LFS_DIR,
-            OBJECTS_DIR,
             HOOKS_DIR,
             REBASE_MERGE_DIR,
             REBASE_APPLY_DIR,
@@ -4743,20 +4904,11 @@ impl BackgroundScanner {
             for (ix, event) in events.iter().enumerate() {
                 let abs_path = SanitizedPath::new(&event.path);
 
-                let mut dot_git_paths = None;
-
-                if self.track_git_repositories {
-                    for ancestor in abs_path.as_path().ancestors() {
-                        if is_dot_git(ancestor, self.fs.as_ref()).await {
-                            let path_in_git_dir = abs_path
-                                .as_path()
-                                .strip_prefix(ancestor)
-                                .expect("stripping off the ancestor");
-                            dot_git_paths = Some((ancestor.to_owned(), path_in_git_dir.to_owned()));
-                            break;
-                        }
-                    }
-                }
+                let dot_git_paths = if self.track_git_repositories {
+                    match_git_metadata_event(snapshot, abs_path.as_path())
+                } else {
+                    None
+                };
 
                 if let Some((dot_git_abs_path, path_in_git_dir)) = dot_git_paths {
                     let is_ignored = skipped_file_names_in_dot_git.iter().any(|skipped| {
@@ -4767,6 +4919,8 @@ impl BackgroundScanner {
                         && path_in_git_dir != Path::new(LOGS_REF_STASH))
                         || (path_in_git_dir.starts_with(INFO_DIR)
                             && path_in_git_dir != Path::new(REPO_EXCLUDE))
+                        || (path_in_git_dir.starts_with(OBJECTS_DIR)
+                            && path_in_git_dir != Path::new(OBJECTS_DIR))
                         || skipped_dirs_in_dot_git.iter().any(|skipped_git_subdir| {
                             path_in_git_dir.starts_with(skipped_git_subdir)
                         })
@@ -4820,12 +4974,13 @@ impl BackgroundScanner {
                     }
                 }
 
-                if self.track_git_repositories
-                    && abs_path
-                        .as_path()
-                        .ends_with(Path::new(DOT_GIT).join(REPO_EXCLUDE))
-                {
-                    if let Some(repository) = snapshot.git_repositories.values().find(|repo| {
+                // Route `info/exclude` changes by the resolved common dir, not by a
+                // literal `.git/info/exclude` suffix, so a linked worktree or bare repo
+                // whose common dir is named `foo.git`/`.bare` still refreshes its cache.
+                // A main checkout and linked worktree can share one common dir while
+                // keeping separate cache entries keyed by work dir — dirty every match.
+                if self.track_git_repositories && abs_path.as_path().ends_with(REPO_EXCLUDE) {
+                    for repository in snapshot.git_repositories.values().filter(|repo| {
                         repo.common_dir_abs_path.join(REPO_EXCLUDE) == abs_path.as_path()
                     }) {
                         work_dirs_needing_exclude_update
@@ -5229,6 +5384,9 @@ impl BackgroundScanner {
 
         if let Some(path) = child_paths.first()
             && path.ends_with(DOT_GIT)
+            && discover_valid_git_repository(path, self.fs.as_ref())
+                .await
+                .is_some()
         {
             ignore_stack.repo_root = Some(job.abs_path.clone());
         }
@@ -5247,6 +5405,19 @@ impl BackgroundScanner {
             if self.track_git_repositories {
                 if child_name == DOT_GIT {
                     let mut state = self.state.lock().await;
+                    // On the initial scan a nested repo is not yet in
+                    // `repo_exclude_by_work_dir_abs_path` when the job's stack
+                    // was built (child jobs inherit the parent's stack), so
+                    // siblings would miss info/exclude. Append after a *new*
+                    // registration only — rescans already have the exclude on
+                    // the stack from `ignore_stack_for_abs_path` (cache hit).
+                    // `Ok(true)` from insert means "valid repo inserted",
+                    // including re-insert, so newness is the pre-insert cache
+                    // miss, not the bool return.
+                    let exclude_already_loaded = state
+                        .snapshot
+                        .repo_exclude_by_work_dir_abs_path
+                        .contains_key(&job.abs_path);
                     state
                         .insert_git_repository(
                             child_path.clone(),
@@ -5254,6 +5425,15 @@ impl BackgroundScanner {
                             self.watcher.as_ref(),
                         )
                         .await;
+                    if !exclude_already_loaded
+                        && let Some((exclude, _)) = state
+                            .snapshot
+                            .repo_exclude_by_work_dir_abs_path
+                            .get(&job.abs_path)
+                    {
+                        ignore_stack =
+                            ignore_stack.append(IgnoreKind::RepoExclude, exclude.clone());
+                    }
                 } else if child_name == GITIGNORE {
                     match build_gitignore(&child_abs_path, self.fs.as_ref()).await {
                         Ok(ignore) => {
@@ -5714,6 +5894,9 @@ impl BackgroundScanner {
         let mut excludes_to_load: Vec<(Arc<Path>, PathBuf)> = Vec::new();
 
         // First pass: collect updates and drop stale entries without awaiting.
+        // Do not clear exclude dirty flags here — only after Present, Absent, or
+        // Unparsable. Indeterminate I/O must leave dirty set so the next scan
+        // retries instead of stranding a never-loaded exclude.
         {
             let snapshot = &mut self.state.lock().await.snapshot;
             let abs_path = snapshot.abs_path.clone();
@@ -5727,18 +5910,9 @@ impl BackgroundScanner {
                     .iter()
                     .find(|(_, repo)| &repo.work_directory_abs_path == work_dir_abs_path);
 
-                if *needs_update {
-                    *needs_update = false;
-                    if work_dir_abs_path.starts_with(abs_path.as_path()) {
-                        ignores_to_update.push(work_dir_abs_path.clone());
-                    } else {
-                        ignores_to_update.push(abs_path.as_path().into());
-                    }
-
-                    if let Some((_, repository)) = repository {
-                        let exclude_abs_path = repository.common_dir_abs_path.join(REPO_EXCLUDE);
-                        excludes_to_load.push((work_dir_abs_path.clone(), exclude_abs_path));
-                    }
+                if *needs_update && let Some((_, repository)) = repository {
+                    let exclude_abs_path = repository.common_dir_abs_path.join(REPO_EXCLUDE);
+                    excludes_to_load.push((work_dir_abs_path.clone(), exclude_abs_path));
                 }
 
                 if repository.is_none() {
@@ -5774,27 +5948,62 @@ impl BackgroundScanner {
                 });
         }
 
-        // Load gitignores asynchronously (outside the lock)
+        // Load excludes asynchronously (outside the lock).
+        // Present/Absent: install matcher, clear dirty, schedule ignore recompute.
+        // Unparsable: keep last-good matcher, clear dirty (no re-read loop), no
+        // recompute — installed rules did not change.
+        // Indeterminate: leave dirty for retry.
         let mut loaded_excludes: Vec<(Arc<Path>, Arc<Gitignore>)> = Vec::new();
+        let mut unparsable_excludes: Vec<Arc<Path>> = Vec::new();
         for (work_dir_abs_path, exclude_abs_path) in excludes_to_load {
-            if let Ok(current_exclude) =
-                build_gitignore_with_root(&exclude_abs_path, &work_dir_abs_path, self.fs.as_ref())
-                    .await
+            match load_gitignore_existing(&exclude_abs_path, &work_dir_abs_path, self.fs.as_ref())
+                .await
             {
-                loaded_excludes.push((work_dir_abs_path, Arc::new(current_exclude)));
+                GitignoreLoad::Present(current_exclude) => {
+                    loaded_excludes.push((work_dir_abs_path, Arc::new(current_exclude)));
+                }
+                GitignoreLoad::Absent => {
+                    loaded_excludes.push((work_dir_abs_path, Arc::new(Gitignore::empty())));
+                }
+                GitignoreLoad::Unparsable(error) => {
+                    Err::<(), _>(error).log_err();
+                    unparsable_excludes.push(work_dir_abs_path);
+                }
+                GitignoreLoad::Indeterminate(error) => {
+                    Err::<(), _>(error).log_err();
+                }
             }
         }
 
-        // Second pass: apply updates.
+        // Second pass: install definitive loads and clear dirty.
         if !loaded_excludes.is_empty() {
             let snapshot = &mut self.state.lock().await.snapshot;
+            let abs_path = snapshot.abs_path.clone();
 
             for (work_dir_abs_path, exclude) in loaded_excludes {
-                if let Some((existing_exclude, _)) = snapshot
+                if let Some((existing_exclude, needs_update)) = snapshot
                     .repo_exclude_by_work_dir_abs_path
                     .get_mut(&work_dir_abs_path)
                 {
                     *existing_exclude = exclude;
+                    *needs_update = false;
+                    if work_dir_abs_path.starts_with(abs_path.as_path()) {
+                        ignores_to_update.push(work_dir_abs_path);
+                    } else {
+                        ignores_to_update.push(abs_path.as_path().into());
+                    }
+                }
+            }
+        }
+
+        if !unparsable_excludes.is_empty() {
+            let snapshot = &mut self.state.lock().await.snapshot;
+            for work_dir_abs_path in unparsable_excludes {
+                if let Some((_, needs_update)) = snapshot
+                    .repo_exclude_by_work_dir_abs_path
+                    .get_mut(&work_dir_abs_path)
+                {
+                    *needs_update = false;
                 }
             }
         }
@@ -5855,8 +6064,11 @@ impl BackgroundScanner {
             return;
         };
 
-        if let Ok(Some(metadata)) = self.fs.metadata(&job.abs_path.join(DOT_GIT)).await
-            && metadata.is_dir
+        // Anchor the ignore root at a *validated* repository (a `.git` directory or a
+        // linked-worktree gitfile), so an invalid/leftover `.git` doesn't shadow it.
+        if discover_valid_git_repository(&job.abs_path.join(DOT_GIT), self.fs.as_ref())
+            .await
+            .is_some()
         {
             ignore_stack.repo_root = Some(job.abs_path.clone());
         }
@@ -5983,49 +6195,87 @@ impl BackgroundScanner {
             }
         }
 
-        // Remove any git repositories whose .git entry no longer exists.
-        let snapshot = &mut state.snapshot;
-        let mut ids_to_preserve = HashSet::default();
-        for (&work_directory_id, entry) in snapshot.git_repositories.iter() {
-            let exists_in_snapshot =
-                snapshot
-                    .entry_for_id(work_directory_id)
-                    .is_some_and(|entry| {
-                        snapshot
-                            .entry_for_path(
-                                &entry.path.join(RelPath::from_unix_str(DOT_GIT).unwrap()),
-                            )
-                            .is_some()
+        // Revalidate every registered repository against the filesystem, relying on the
+        // resolver's tri-state: `Ok(None)` is a confirmed non-repository and removes the
+        // registration, `Err(_)` is a transient failure that must *preserve* the entry —
+        // otherwise the repository flaps out of and back into the snapshot, churning its
+        // `RepositoryId` — and a valid-but-different result retargets the entry in place
+        // (same identity).
+        let registered = state
+            .snapshot
+            .git_repositories
+            .iter()
+            .map(|(&id, repo)| {
+                (
+                    id,
+                    repo.dot_git_abs_path.clone(),
+                    repo.repository_dir_abs_path.clone(),
+                    repo.common_dir_abs_path.clone(),
+                    repo.work_directory_abs_path.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+        for (id, dot_git_abs_path, repository_dir, common_dir, work_directory_abs_path) in
+            registered
+        {
+            match fs::resolve_git_repository(&dot_git_abs_path, self.fs.as_ref()).await {
+                Ok(Some((new_repository_dir, new_common_dir)))
+                    if new_repository_dir.as_path() != repository_dir.as_ref()
+                        || new_common_dir.as_path() != common_dir.as_ref() =>
+                {
+                    let new_repository_dir = Arc::<Path>::from(new_repository_dir);
+                    let new_common_dir = Arc::<Path>::from(new_common_dir);
+                    // Add watches for the new metadata dirs before publishing the retarget
+                    // so no events under them are missed. Old watches are left in place: a
+                    // watch that may be shared with another linked worktree is unsafe to
+                    // remove, and a stale watch only produces events that no longer match a
+                    // registered repository and are ignored.
+                    self.watcher.add(&new_common_dir).log_err();
+                    self.watcher.add(&new_repository_dir).log_err();
+                    watch_git_dir_subdirectories(
+                        &new_common_dir,
+                        self.fs.as_ref(),
+                        self.watcher.as_ref(),
+                    )
+                    .await;
+                    if new_repository_dir != new_common_dir {
+                        watch_git_dir_subdirectories(
+                            &new_repository_dir,
+                            self.fs.as_ref(),
+                            self.watcher.as_ref(),
+                        )
+                        .await;
+                    }
+                    state.snapshot.git_repositories.update(&id, |entry| {
+                        entry.repository_dir_abs_path = new_repository_dir;
+                        entry.common_dir_abs_path = new_common_dir;
+                        entry.git_dir_scan_id = scan_id;
                     });
-
-            // Only drop a repository when we can positively confirm that its git
-            // directory is gone. `metadata` returns `Ok(None)` for a confirmed
-            // absence, but `Err(_)` for a transient failure (which can happen
-            // under heavy filesystem churn). Treating an error as a deletion
-            // makes the repository flap out of and back into the snapshot,
-            // causing the GitStore to repeatedly tear it down and re-create it
-            // with a fresh `RepositoryId`. So preserve the repository unless the
-            // `.git` entry is confirmed absent.
-            let dot_git_present =
-                !matches!(self.fs.metadata(&entry.dot_git_abs_path).await, Ok(None));
-
-            if exists_in_snapshot || dot_git_present {
-                ids_to_preserve.insert(work_directory_id);
+                    // Retarget changes which common dir's info/exclude applies; dirty so
+                    // B's rules reload instead of retaining A's.
+                    state
+                        .snapshot
+                        .repo_exclude_by_work_dir_abs_path
+                        .entry(work_directory_abs_path.clone())
+                        .or_insert_with(|| (Arc::new(Gitignore::empty()), true))
+                        .1 = true;
+                    affected_repo_roots.push(work_directory_abs_path);
+                }
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    if let Some(entry) = state.snapshot.git_repositories.remove(&id) {
+                        state
+                            .snapshot
+                            .repo_exclude_by_work_dir_abs_path
+                            .remove(&entry.work_directory_abs_path);
+                        affected_repo_roots.push(entry.work_directory_abs_path);
+                    }
+                }
+                Err(error) => log::debug!(
+                    "preserving repository at {dot_git_abs_path:?} after transient resolve error: {error:#}"
+                ),
             }
         }
-
-        snapshot
-            .git_repositories
-            .retain(|work_directory_id, entry| {
-                let preserve = ids_to_preserve.contains(work_directory_id);
-                if !preserve {
-                    affected_repo_roots.push(entry.dot_git_abs_path.parent().unwrap().into());
-                    snapshot
-                        .repo_exclude_by_work_dir_abs_path
-                        .remove(&entry.work_directory_abs_path);
-                }
-                preserve
-            });
 
         affected_repo_roots
     }
@@ -6119,7 +6369,13 @@ async fn discover_ancestor_git_repo(
                 ancestor_dot_git.clone()
             };
             let dot_git_abs_path: Arc<Path> = dot_git_abs_path.as_path().into();
-            let (_, common_dir_abs_path) = discover_git_paths(&dot_git_abs_path, fs.as_ref()).await;
+
+            // Keep walking up past an invalid `.git`.
+            let Some((_, common_dir_abs_path)) =
+                discover_valid_git_repository(&dot_git_abs_path, fs.as_ref()).await
+            else {
+                continue;
+            };
 
             let repo_exclude_abs_path = common_dir_abs_path.join(REPO_EXCLUDE);
             if let Ok(repo_exclude) =
@@ -6852,33 +7108,6 @@ impl CreatedEntry {
     }
 }
 
-fn parse_gitfile(content: &str) -> anyhow::Result<&Path> {
-    let path = content
-        .strip_prefix("gitdir:")
-        .with_context(|| format!("parsing gitfile content {content:?}"))?;
-    Ok(Path::new(path.trim()))
-}
-
-fn resolve_gitfile_path(dot_git_abs_path: &Path, gitfile_path: &Path) -> PathBuf {
-    if gitfile_path.is_absolute() {
-        gitfile_path.into()
-    } else {
-        dot_git_abs_path
-            .parent()
-            .unwrap_or_else(|| Path::new(""))
-            .join(gitfile_path)
-    }
-}
-
-fn resolve_commondir_path(repository_dir_abs_path: &Path, commondir_path: &str) -> PathBuf {
-    let commondir_path = Path::new(commondir_path.trim());
-    if commondir_path.is_absolute() {
-        commondir_path.into()
-    } else {
-        repository_dir_abs_path.join(commondir_path)
-    }
-}
-
 pub async fn discover_root_repo_common_dir(root_abs_path: &Path, fs: &dyn Fs) -> Option<Arc<Path>> {
     discover_root_repo_metadata(root_abs_path, fs)
         .await
@@ -6889,43 +7118,28 @@ async fn discover_root_repo_metadata(
     root_abs_path: &Path,
     fs: &dyn Fs,
 ) -> Option<(Arc<Path>, bool)> {
-    let root_dot_git = root_abs_path.join(DOT_GIT);
-    if !fs.metadata(&root_dot_git).await.is_ok_and(|m| m.is_some()) {
-        return None;
-    }
-    let dot_git_path: Arc<Path> = root_dot_git.into();
-    let (repository_dir, common_dir) = discover_git_paths(&dot_git_path, fs).await;
+    let (repository_dir, common_dir) =
+        discover_valid_git_repository(&root_abs_path.join(DOT_GIT), fs).await?;
     let is_linked_worktree = repository_dir != common_dir;
     Some((common_dir, is_linked_worktree))
 }
 
-async fn discover_git_paths(dot_git_abs_path: &Arc<Path>, fs: &dyn Fs) -> (Arc<Path>, Arc<Path>) {
-    let mut repository_dir_abs_path = dot_git_abs_path.clone();
-    let mut common_dir_abs_path = dot_git_abs_path.clone();
-
-    if let Some(path) = fs
-        .load(dot_git_abs_path)
-        .await
-        .ok()
-        .as_ref()
-        .and_then(|contents| parse_gitfile(contents).log_err())
-    {
-        let path = resolve_gitfile_path(dot_git_abs_path, path);
-        if let Some(path) = fs.canonicalize(&path).await.log_err() {
-            repository_dir_abs_path = Path::new(&path).into();
-            common_dir_abs_path = repository_dir_abs_path.clone();
-
-            if let Some(commondir_contents) = fs.load(&path.join("commondir")).await.ok()
-                && let Some(commondir_path) = fs
-                    .canonicalize(&resolve_commondir_path(&path, &commondir_contents))
-                    .await
-                    .log_err()
-            {
-                common_dir_abs_path = commondir_path.as_path().into();
-            }
+/// Adapts [`fs::resolve_git_repository`] to the `Arc<Path>` identities discovery stores.
+/// A transient I/O error is collapsed to `None` here (a later rescan retries) — unlike
+/// event revalidation, which must tell a transient failure apart from a confirmed
+/// removal and so calls the resolver directly.
+async fn discover_valid_git_repository(
+    dot_git_abs_path: &Path,
+    fs: &dyn Fs,
+) -> Option<(Arc<Path>, Arc<Path>)> {
+    match fs::resolve_git_repository(dot_git_abs_path, fs).await {
+        Ok(Some((repository_dir, common_dir))) => Some((repository_dir.into(), common_dir.into())),
+        Ok(None) => None,
+        Err(error) => {
+            log::debug!("failed to resolve git repository at {dot_git_abs_path:?}: {error:#}");
+            None
         }
-    };
-    (repository_dir_abs_path, common_dir_abs_path)
+    }
 }
 
 struct NullWatcher;
@@ -7129,6 +7343,51 @@ mod tests {
             result,
             ByteContent::Binary,
             "LE 16-bit binary with control characters should be detected as Binary"
+        );
+    }
+
+    fn sample_repo_entry(
+        work_directory_id: ProjectEntryId,
+        repository_dir: &str,
+        common_dir: &str,
+        git_dir_scan_id: usize,
+    ) -> LocalRepositoryEntry {
+        let work_dir: Arc<Path> = Path::new("/linked").into();
+        LocalRepositoryEntry {
+            work_directory_id,
+            work_directory: WorkDirectory::InProject {
+                relative_path: RelPath::empty_arc(),
+            },
+            work_directory_abs_path: work_dir,
+            git_dir_scan_id,
+            dot_git_abs_path: Path::new("/linked/.git").into(),
+            repository_dir_abs_path: Path::new(repository_dir).into(),
+            common_dir_abs_path: Path::new(common_dir).into(),
+        }
+    }
+
+    #[test]
+    fn test_repository_identity_change_emits_without_scan_id_bump() {
+        let work_directory_id = ProjectEntryId::from_proto(1);
+        let old_repo = sample_repo_entry(
+            work_directory_id,
+            "/repo_a/.git/worktrees/feature",
+            "/repo_a/.git",
+            0,
+        );
+        let new_repo = sample_repo_entry(
+            work_directory_id,
+            "/repo_b/.git/worktrees/feature",
+            "/repo_b/.git",
+            0, // same scan token as old — identity-only change
+        );
+        assert!(
+            repository_identity_or_scan_changed(&old_repo, &new_repo),
+            "retarget of repository_dir/common_dir must emit even when git_dir_scan_id is unchanged"
+        );
+        assert!(
+            !repository_identity_or_scan_changed(&old_repo, &old_repo),
+            "identical registration must not look changed"
         );
     }
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -68,7 +68,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use sum_tree::{Bias, Dimensions, Edit, KeyedItem, SeekTarget, SumTree, Summary, TreeMap, TreeSet};
+use sum_tree::{Bias, Dimensions, Edit, SeekTarget, SumTree, Summary, TreeMap, TreeSet};
 use text::{LineEnding, Rope};
 use util::{
     ResultExt, maybe,
@@ -245,13 +245,21 @@ impl Default for WorkDirectory {
     }
 }
 
+/// Absolute identity of a registered git repository.
+///
+/// Paths are local-only and never enter the worktree proto envelope.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitRepositoryIdentity {
+    pub work_directory_abs_path: Arc<Path>,
+    pub dot_git_abs_path: Arc<Path>,
+    pub repository_dir_abs_path: Arc<Path>,
+    pub common_dir_abs_path: Arc<Path>,
+}
+
 #[derive(Clone)]
 pub struct LocalSnapshot {
     snapshot: Snapshot,
     global_gitignore: Option<Arc<Gitignore>>,
-    /// Exclude files for all git repositories in the worktree, indexed by their absolute path.
-    /// The boolean indicates whether the gitignore needs to be updated.
-    repo_exclude_by_work_dir_abs_path: HashMap<Arc<Path>, (Arc<Gitignore>, bool)>,
     /// All of the gitignore files in the worktree, indexed by their absolute path.
     /// The boolean indicates whether the gitignore needs to be updated.
     ignores_by_parent_abs_path: HashMap<Arc<Path>, (Arc<Gitignore>, bool)>,
@@ -339,58 +347,22 @@ struct EventRoot {
     was_rescanned: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 struct LocalRepositoryEntry {
-    work_directory_id: ProjectEntryId,
-    work_directory: WorkDirectory,
-    work_directory_abs_path: Arc<Path>,
+    identity: GitRepositoryIdentity,
     git_dir_scan_id: usize,
-    /// Absolute path to the original .git entry that caused us to create this repository.
-    ///
-    /// This is normally a directory, but may be a "gitfile" that points to a directory elsewhere
-    /// (whose path we then store in `repository_dir_abs_path`).
-    dot_git_abs_path: Arc<Path>,
-    /// Absolute path to the "commondir" for this repository.
-    ///
-    /// This is always a directory. For a normal repository, this is the same as
-    /// `dot_git_abs_path`. For a linked worktree, this is the main repo's `.git`
-    /// directory (resolved from the worktree's `commondir` file). For a submodule,
-    /// this equals `repository_dir_abs_path` (submodules don't have a `commondir`
-    /// file).
-    common_dir_abs_path: Arc<Path>,
-    /// Absolute path to the directory holding the repository's state.
-    ///
-    /// For a normal repository, this is a directory and coincides with `dot_git_abs_path` and
-    /// `common_dir_abs_path`. For a submodule or worktree, this is some subdirectory of the
-    /// commondir like `/project/.git/modules/foo`.
-    repository_dir_abs_path: Arc<Path>,
+    /// Cached `info/exclude` for this repository (owned by the registration).
+    info_exclude: Arc<Gitignore>,
+    /// When true, re-read `info/exclude` from disk on the next batch.
+    /// Opposite of `ignores_by_parent_abs_path`'s dirty bit (which means recompute
+    /// statuses without re-reading).
+    info_exclude_needs_update: bool,
 }
 
-impl sum_tree::Item for LocalRepositoryEntry {
-    type Summary = PathSummary<sum_tree::NoSummary>;
-
-    fn summary(&self, _: <Self::Summary as Summary>::Context<'_>) -> Self::Summary {
-        PathSummary {
-            max_path: self.work_directory.path_key().0,
-            item_summary: sum_tree::NoSummary,
-        }
-    }
-}
-
-impl KeyedItem for LocalRepositoryEntry {
-    type Key = PathKey;
-
-    fn key(&self) -> Self::Key {
-        self.work_directory.path_key()
-    }
-}
-
-impl Deref for LocalRepositoryEntry {
-    type Target = WorkDirectory;
-
-    fn deref(&self) -> &Self::Target {
-        &self.work_directory
-    }
+/// Outcome of inserting a validated repository into the local snapshot.
+struct RegistrationOutcome {
+    work_directory_id: ProjectEntryId,
+    was_added: bool,
 }
 
 impl Deref for LocalSnapshot {
@@ -430,7 +402,7 @@ struct UpdateObservationState {
 #[derive(Debug, Clone)]
 pub enum Event {
     UpdatedEntries(UpdatedEntriesSet),
-    UpdatedGitRepositories(UpdatedGitRepositoriesSet),
+    UpdatedGitRepositories(GitRepositoryChanges),
     UpdatedRootRepoCommonDir {
         old: Option<Arc<SanitizedPath>>,
     },
@@ -490,7 +462,6 @@ impl Worktree {
             let mut snapshot = LocalSnapshot {
                 ignores_by_parent_abs_path: Default::default(),
                 global_gitignore: Default::default(),
-                repo_exclude_by_work_dir_abs_path: Default::default(),
                 git_repositories: Default::default(),
                 external_canonical_to_relative: Default::default(),
                 snapshot: Snapshot::new(
@@ -1402,14 +1373,16 @@ impl LocalWorktree {
         entry_changes: UpdatedEntriesSet,
         cx: &mut Context<Worktree>,
     ) {
-        let repo_changes = self.changed_repos(&self.snapshot, &mut new_snapshot);
+        // Diff repos before root-metadata derivation so ordering of set_snapshot
+        // (and WorktreeMetadata / project grouping consumers) stays unchanged.
+        let repo_changes = changed_git_repositories(&self.snapshot, &new_snapshot);
 
         if let Some((common_dir, is_linked_worktree)) = new_snapshot
             .local_repo_for_work_directory_path(RelPath::empty())
             .map(|repo| {
                 (
-                    SanitizedPath::from_arc(repo.common_dir_abs_path.clone()),
-                    repo.repository_dir_abs_path != repo.common_dir_abs_path,
+                    SanitizedPath::from_arc(repo.identity.common_dir_abs_path.clone()),
+                    repo.identity.repository_dir_abs_path != repo.identity.common_dir_abs_path,
                 )
             })
         {
@@ -1453,103 +1426,6 @@ impl LocalWorktree {
                 break;
             }
         }
-    }
-
-    fn changed_repos(
-        &self,
-        old_snapshot: &LocalSnapshot,
-        new_snapshot: &mut LocalSnapshot,
-    ) -> UpdatedGitRepositoriesSet {
-        let mut changes = Vec::new();
-        let mut old_repos = old_snapshot.git_repositories.iter().peekable();
-        let new_repos = new_snapshot.git_repositories.clone();
-        let mut new_repos = new_repos.iter().peekable();
-
-        loop {
-            match (new_repos.peek().map(clone), old_repos.peek().map(clone)) {
-                (Some((new_entry_id, new_repo)), Some((old_entry_id, old_repo))) => {
-                    match Ord::cmp(&new_entry_id, &old_entry_id) {
-                        Ordering::Less => {
-                            changes.push(UpdatedGitRepository {
-                                work_directory_id: new_entry_id,
-                                old_work_directory_abs_path: None,
-                                new_work_directory_abs_path: Some(
-                                    new_repo.work_directory_abs_path.clone(),
-                                ),
-                                dot_git_abs_path: Some(new_repo.dot_git_abs_path.clone()),
-                                repository_dir_abs_path: Some(
-                                    new_repo.repository_dir_abs_path.clone(),
-                                ),
-                                common_dir_abs_path: Some(new_repo.common_dir_abs_path.clone()),
-                            });
-                            new_repos.next();
-                        }
-                        Ordering::Equal => {
-                            if repository_identity_or_scan_changed(&old_repo, &new_repo) {
-                                changes.push(UpdatedGitRepository {
-                                    work_directory_id: new_entry_id,
-                                    old_work_directory_abs_path: Some(
-                                        old_repo.work_directory_abs_path.clone(),
-                                    ),
-                                    new_work_directory_abs_path: Some(
-                                        new_repo.work_directory_abs_path.clone(),
-                                    ),
-                                    dot_git_abs_path: Some(new_repo.dot_git_abs_path.clone()),
-                                    repository_dir_abs_path: Some(
-                                        new_repo.repository_dir_abs_path.clone(),
-                                    ),
-                                    common_dir_abs_path: Some(new_repo.common_dir_abs_path.clone()),
-                                });
-                            }
-                            new_repos.next();
-                            old_repos.next();
-                        }
-                        Ordering::Greater => {
-                            changes.push(UpdatedGitRepository {
-                                work_directory_id: old_entry_id,
-                                old_work_directory_abs_path: Some(
-                                    old_repo.work_directory_abs_path.clone(),
-                                ),
-                                new_work_directory_abs_path: None,
-                                dot_git_abs_path: None,
-                                repository_dir_abs_path: None,
-                                common_dir_abs_path: None,
-                            });
-                            old_repos.next();
-                        }
-                    }
-                }
-                (Some((entry_id, repo)), None) => {
-                    changes.push(UpdatedGitRepository {
-                        work_directory_id: entry_id,
-                        old_work_directory_abs_path: None,
-                        new_work_directory_abs_path: Some(repo.work_directory_abs_path.clone()),
-                        dot_git_abs_path: Some(repo.dot_git_abs_path.clone()),
-                        repository_dir_abs_path: Some(repo.repository_dir_abs_path.clone()),
-                        common_dir_abs_path: Some(repo.common_dir_abs_path.clone()),
-                    });
-                    new_repos.next();
-                }
-                (None, Some((entry_id, repo))) => {
-                    changes.push(UpdatedGitRepository {
-                        work_directory_id: entry_id,
-                        old_work_directory_abs_path: Some(repo.work_directory_abs_path.clone()),
-                        new_work_directory_abs_path: None,
-                        dot_git_abs_path: Some(repo.dot_git_abs_path.clone()),
-                        repository_dir_abs_path: Some(repo.repository_dir_abs_path.clone()),
-                        common_dir_abs_path: Some(repo.common_dir_abs_path.clone()),
-                    });
-                    old_repos.next();
-                }
-                (None, None) => break,
-            }
-        }
-
-        fn clone<T: Clone, U: Clone>(value: &(&T, &U)) -> (T, U) {
-            (value.0.clone(), value.1.clone())
-        }
-
-        changes.into()
     }
 
     pub fn scan_complete(&self) -> impl Future<Output = ()> + use<> {
@@ -2239,7 +2115,7 @@ impl LocalWorktree {
     pub fn repositories(&self) -> Vec<Arc<Path>> {
         self.git_repositories
             .values()
-            .map(|entry| entry.work_directory_abs_path.clone())
+            .map(|entry| entry.identity.work_directory_abs_path.clone())
             .collect::<Vec<_>>()
     }
 
@@ -2250,20 +2126,11 @@ impl LocalWorktree {
             .values()
             .map(|entry| {
                 (
-                    entry.repository_dir_abs_path.clone(),
-                    entry.common_dir_abs_path.clone(),
+                    entry.identity.repository_dir_abs_path.clone(),
+                    entry.identity.common_dir_abs_path.clone(),
                 )
             })
             .collect()
-    }
-
-    /// Whether the cached `info/exclude` for `work_dir_abs_path` still needs a re-read.
-    #[cfg(feature = "test-support")]
-    pub fn repo_exclude_needs_update(&self, work_dir_abs_path: &Path) -> Option<bool> {
-        self.snapshot
-            .repo_exclude_by_work_dir_abs_path
-            .get(work_dir_abs_path)
-            .map(|(_, needs_update)| *needs_update)
     }
 }
 
@@ -2964,11 +2831,45 @@ impl Snapshot {
 }
 
 impl LocalSnapshot {
+    /// Whether `path` is under this registration's work directory, using the
+    /// already-translated logical relative event path (not a raw absolute path)
+    /// so external-symlink routing stays correct.
+    fn repository_directory_contains(&self, entry: &LocalRepositoryEntry, path: &RelPath) -> bool {
+        match entry
+            .identity
+            .work_directory_abs_path
+            .strip_prefix(self.abs_path.as_path())
+        {
+            // AboveProject: work dir is outside the project root and covers all paths.
+            Err(_) => true,
+            Ok(relative) => RelPath::new(relative, self.path_style)
+                .map(|work_rel| path.starts_with(work_rel.as_ref()))
+                .unwrap_or(false),
+        }
+    }
+
+    /// PathKey formerly stored on `WorkDirectory`: empty for root InProject and
+    /// AboveProject; otherwise the relative path of the work dir within the project.
+    fn work_directory_path_key(&self, entry: &LocalRepositoryEntry) -> PathKey {
+        match entry
+            .identity
+            .work_directory_abs_path
+            .strip_prefix(self.abs_path.as_path())
+        {
+            Ok(relative) if !relative.as_os_str().is_empty() => {
+                match RelPath::new(relative, self.path_style) {
+                    Ok(work_rel) => PathKey(work_rel.into_owned().into()),
+                    Err(_) => PathKey(RelPath::empty_arc()),
+                }
+            }
+            _ => PathKey(RelPath::empty_arc()),
+        }
+    }
+
     fn local_repo_for_work_directory_path(&self, path: &RelPath) -> Option<&LocalRepositoryEntry> {
         self.git_repositories
-            .iter()
-            .map(|(_, entry)| entry)
-            .find(|entry| entry.work_directory.path_key() == PathKey(path.into()))
+            .values()
+            .find(|entry| self.work_directory_path_key(entry).0.as_ref() == path)
     }
 
     fn build_update(
@@ -3080,12 +2981,15 @@ impl LocalSnapshot {
         // registration, so `reload_entries_for_paths` can skip a full resolve on the
         // hot path (thousands of event paths per checkout). Invalid `.git` never
         // enters `git_repositories`, so a phantom cannot win as a registered root.
+        // Prefer the covering entry's owned `info_exclude` over a path-keyed lookup.
         let covering_registered = self
             .git_repositories
             .values()
-            .filter(|repo| abs_path.starts_with(repo.work_directory_abs_path.as_ref()))
-            .max_by_key(|repo| repo.work_directory_abs_path.as_os_str().len())
-            .map(|repo| repo.work_directory_abs_path.clone());
+            .filter(|repo| abs_path.starts_with(repo.identity.work_directory_abs_path.as_ref()))
+            .max_by_key(|repo| repo.identity.work_directory_abs_path.as_os_str().len());
+        let covering_work_dir =
+            covering_registered.map(|repo| repo.identity.work_directory_abs_path.clone());
+        let covering_exclude = covering_registered.map(|repo| repo.info_exclude.clone());
         for (index, ancestor) in abs_path.ancestors().enumerate() {
             if index > 0 {
                 if let Some((ignore, _)) = self.ignores_by_parent_abs_path.get(ancestor) {
@@ -3102,17 +3006,19 @@ impl LocalSnapshot {
             }
 
             // Covering registered root: free, no filesystem.
-            if covering_registered
+            if covering_work_dir
                 .as_ref()
                 .is_some_and(|root| root.as_ref() == ancestor)
             {
-                repo_root = covering_registered.clone();
+                repo_root = covering_work_dir.clone();
                 continue;
             }
 
             // Deeper than the covering registration, or nothing registered yet: resolve.
             // `reload_entries_for_paths` runs before `update_git_repositories`, so a
             // newly-appeared nested repo may not be registered yet and must still win.
+            // Unregistered deeper repos intentionally miss the registered exclude —
+            // preserved by construction (no parallel exclude map).
             if discover_valid_git_repository(&ancestor.join(DOT_GIT), fs)
                 .await
                 .is_some()
@@ -3127,11 +3033,12 @@ impl LocalSnapshot {
             IgnoreStack::none()
         };
 
-        if let Some((repo_exclude, _)) = repo_root
-            .as_ref()
-            .and_then(|abs_path| self.repo_exclude_by_work_dir_abs_path.get(abs_path))
+        // Only the covering *registered* root contributes its exclude. An unregistered
+        // deeper discovery sets `repo_root` without an exclude entry — same miss as before.
+        if covering_work_dir.as_ref() == repo_root.as_ref()
+            && let Some(repo_exclude) = covering_exclude
         {
-            ignore_stack = ignore_stack.append(IgnoreKind::RepoExclude, repo_exclude.clone());
+            ignore_stack = ignore_stack.append(IgnoreKind::RepoExclude, repo_exclude);
         }
         ignore_stack.repo_root = repo_root;
         let mut ancestor_ignore_stack = ignore_stack.clone();
@@ -3436,8 +3343,10 @@ impl BackgroundScannerState {
         let mut repository_watches_to_preserve = HashSet::<Arc<Path>>::default();
         if preserve_repository_watches {
             for repository in self.snapshot.git_repositories.values() {
-                repository_watches_to_preserve.insert(repository.common_dir_abs_path.clone());
-                repository_watches_to_preserve.insert(repository.repository_dir_abs_path.clone());
+                repository_watches_to_preserve
+                    .insert(repository.identity.common_dir_abs_path.clone());
+                repository_watches_to_preserve
+                    .insert(repository.identity.repository_dir_abs_path.clone());
             }
         }
 
@@ -3539,7 +3448,7 @@ impl BackgroundScannerState {
         dot_git_path: Arc<RelPath>,
         fs: &dyn Fs,
         watcher: &dyn Watcher,
-    ) {
+    ) -> Option<RegistrationOutcome> {
         let work_dir_path: Arc<RelPath> = match dot_git_path.parent() {
             Some(parent_dir) => {
                 // Guard against repositories inside the repository metadata
@@ -3550,7 +3459,7 @@ impl BackgroundScannerState {
                     log::debug!(
                         "not building git repository for nested `.git` directory, `.git` path in the worktree: {dot_git_path:?}"
                     );
-                    return;
+                    return None;
                 };
 
                 parent_dir.into()
@@ -3561,7 +3470,7 @@ impl BackgroundScannerState {
                 log::debug!(
                     "not building git repository for the worktree itself, `.git` path in the worktree: {dot_git_path:?}"
                 );
-                return;
+                return None;
             }
         };
 
@@ -3576,18 +3485,21 @@ impl BackgroundScannerState {
             watcher,
         )
         .await
-        .log_err();
+        .log_err()
+        .flatten()
     }
 
-    /// Registers a validated git repository for `work_directory`, returning whether a
-    /// repository was inserted (`Ok(false)` when the `.git` entry is not a repository).
+    /// Registers a validated git repository for `work_directory`.
+    ///
+    /// Returns `Ok(None)` when the `.git` entry is not a repository, otherwise the
+    /// registration outcome (`was_added` is false on re-insert of the same key).
     async fn insert_git_repository_for_path(
         &mut self,
         work_directory: WorkDirectory,
         dot_git_abs_path: Arc<Path>,
         fs: &dyn Fs,
         watcher: &dyn Watcher,
-    ) -> Result<bool> {
+    ) -> Result<Option<RegistrationOutcome>> {
         let work_dir_entry = self
             .snapshot
             .entry_for_path(&work_directory.path_key().0)
@@ -3606,7 +3518,7 @@ impl BackgroundScannerState {
         let Some((repository_dir_abs_path, common_dir_abs_path)) =
             discover_valid_git_repository(&dot_git_abs_path, fs).await
         else {
-            return Ok(false);
+            return Ok(None);
         };
 
         watcher
@@ -3624,47 +3536,41 @@ impl BackgroundScannerState {
         }
 
         let work_directory_id = work_dir_entry.id;
+        // Clone last-good before rebuild; KeepLastGood* leave the seed in place.
+        let previous_info_exclude = self
+            .snapshot
+            .git_repositories
+            .get(&work_directory_id)
+            .map(|previous| previous.info_exclude.clone());
+        let was_added = previous_info_exclude.is_none();
 
         let work_directory_abs_path: Arc<Path> = work_directory_abs_path.as_path().into();
         // Registration owns exclude state: load a present info/exclude now so
         // ignore updates that run after insert (affected_repo_roots) see it.
-        // Always insert an entry so a later info/exclude create can mark it
-        // dirty. Present, confirmed-absent, and unparsable are clean;
-        // indeterminate I/O inserts empty but stays dirty so the reload path
-        // retries instead of treating a transient failure as known-gone.
+        // Present/Absent/Unparsable start clean; Indeterminate starts dirty so
+        // the reload path retries.
         let exclude_abs_path = common_dir_abs_path.join(REPO_EXCLUDE);
-        let (exclude, needs_update) =
-            match load_gitignore_existing(&exclude_abs_path, &work_directory_abs_path, fs).await {
-                GitignoreLoad::Present(ignore) => (Arc::new(ignore), false),
-                GitignoreLoad::Absent => (Arc::new(Gitignore::empty()), false),
-                GitignoreLoad::Unparsable(error) => {
-                    Err::<(), _>(error).log_err();
-                    (Arc::new(Gitignore::empty()), false)
-                }
-                GitignoreLoad::Indeterminate(error) => {
-                    Err::<(), _>(error).log_err();
-                    (Arc::new(Gitignore::empty()), true)
-                }
-            };
-        self.snapshot
-            .repo_exclude_by_work_dir_abs_path
-            .insert(work_directory_abs_path.clone(), (exclude, needs_update));
-
-        self.snapshot.git_repositories.insert(
-            work_directory_id,
-            LocalRepositoryEntry {
-                work_directory_id,
-                work_directory,
+        let apply = load_gitignore_existing(&exclude_abs_path, &work_directory_abs_path, fs).await;
+        let entry = local_repository_entry_for_registration(
+            GitRepositoryIdentity {
                 work_directory_abs_path,
-                git_dir_scan_id: 0,
                 dot_git_abs_path,
                 common_dir_abs_path,
                 repository_dir_abs_path,
             },
+            previous_info_exclude,
+            apply,
         );
 
+        self.snapshot
+            .git_repositories
+            .insert(work_directory_id, entry);
+
         log::trace!("inserting new local git repository");
-        Ok(true)
+        Ok(Some(RegistrationOutcome {
+            work_directory_id,
+            was_added,
+        }))
     }
 }
 
@@ -3717,19 +3623,76 @@ async fn watch_dir_tree(root_abs_path: PathBuf, fs: &dyn Fs, watcher: &dyn Watch
     }
 }
 
-/// Whether a registered repository should publish an update between snapshots.
-/// Identity paths are first-class: a gitfile retarget changes repository_dir/
-/// common_dir without moving the work directory. Emitting only on scan_id or
-/// work-dir would miss that unless a scan token happens to bump — not an invariant.
-fn repository_identity_or_scan_changed(
-    old_repo: &LocalRepositoryEntry,
-    new_repo: &LocalRepositoryEntry,
-) -> bool {
-    new_repo.git_dir_scan_id != old_repo.git_dir_scan_id
-        || new_repo.work_directory_abs_path != old_repo.work_directory_abs_path
-        || new_repo.dot_git_abs_path != old_repo.dot_git_abs_path
-        || new_repo.repository_dir_abs_path != old_repo.repository_dir_abs_path
-        || new_repo.common_dir_abs_path != old_repo.common_dir_abs_path
+/// Diffs local repository registrations between two snapshots.
+///
+/// Emits: new-only → AddedOrUpdated{identity_changed:false}; same key + scan-token
+/// change → AddedOrUpdated{false}; same key + identity change → AddedOrUpdated{true};
+/// old-only (both merge branches) → identical Removed carrying the complete old
+/// registration.
+fn changed_git_repositories(
+    old_snapshot: &LocalSnapshot,
+    new_snapshot: &LocalSnapshot,
+) -> GitRepositoryChanges {
+    fn registration(id: ProjectEntryId, entry: &LocalRepositoryEntry) -> GitRepositoryRegistration {
+        GitRepositoryRegistration {
+            work_directory_id: id,
+            identity: entry.identity.clone(),
+        }
+    }
+
+    let mut changes = Vec::new();
+    let mut old_repos = old_snapshot.git_repositories.iter().peekable();
+    let mut new_repos = new_snapshot.git_repositories.iter().peekable();
+
+    loop {
+        match (new_repos.peek().copied(), old_repos.peek().copied()) {
+            (Some((&new_entry_id, new_repo)), Some((&old_entry_id, old_repo))) => {
+                match Ord::cmp(&new_entry_id, &old_entry_id) {
+                    Ordering::Less => {
+                        changes.push(GitRepositoryChange::AddedOrUpdated {
+                            repository: registration(new_entry_id, new_repo),
+                            identity_changed: false,
+                        });
+                        new_repos.next();
+                    }
+                    Ordering::Equal => {
+                        let identity_changed = new_repo.identity != old_repo.identity;
+                        let scan_changed = new_repo.git_dir_scan_id != old_repo.git_dir_scan_id;
+                        if identity_changed || scan_changed {
+                            changes.push(GitRepositoryChange::AddedOrUpdated {
+                                repository: registration(new_entry_id, new_repo),
+                                identity_changed,
+                            });
+                        }
+                        new_repos.next();
+                        old_repos.next();
+                    }
+                    Ordering::Greater => {
+                        changes.push(GitRepositoryChange::Removed {
+                            repository: registration(old_entry_id, old_repo),
+                        });
+                        old_repos.next();
+                    }
+                }
+            }
+            (Some((&entry_id, repo)), None) => {
+                changes.push(GitRepositoryChange::AddedOrUpdated {
+                    repository: registration(entry_id, repo),
+                    identity_changed: false,
+                });
+                new_repos.next();
+            }
+            (None, Some((&entry_id, repo))) => {
+                changes.push(GitRepositoryChange::Removed {
+                    repository: registration(entry_id, repo),
+                });
+                old_repos.next();
+            }
+            (None, None) => break,
+        }
+    }
+
+    changes.into()
 }
 
 /// Classifies an fs event against git metadata directories, returning the matched
@@ -3746,9 +3709,9 @@ fn match_git_metadata_event(
         .values()
         .flat_map(|repo| {
             [
-                repo.dot_git_abs_path.as_ref(),
-                repo.repository_dir_abs_path.as_ref(),
-                repo.common_dir_abs_path.as_ref(),
+                repo.identity.dot_git_abs_path.as_ref(),
+                repo.identity.repository_dir_abs_path.as_ref(),
+                repo.identity.common_dir_abs_path.as_ref(),
             ]
         })
         .filter(|root| abs_path.starts_with(root))
@@ -3783,41 +3746,106 @@ async fn build_gitignore_with_root(abs_path: &Path, root: &Path, fs: &dyn Fs) ->
 
 /// Outcome of loading an exclude/gitignore file that may be absent or bad.
 ///
-/// Classified at the error-production site so callers never need to downcast
-/// `anyhow` chains. Unparsable content fails identically forever (clear dirty);
-/// transient I/O is Indeterminate (leave dirty and retry).
-enum GitignoreLoad {
-    Present(Gitignore),
-    Absent,
-    Unparsable(anyhow::Error),
-    Indeterminate(anyhow::Error),
+/// Action-ready outcome of loading a repository's `info/exclude`.
+///
+/// Four states map 1:1 onto apply transitions. Error logging, empty-matcher
+/// creation, and Arc construction happen in the loader (before the snapshot lock).
+/// Unit tests pin Unparsable→clear dirty (keep last-good) vs Indeterminate→stay
+/// pending without a filesystem.
+#[derive(Debug, Clone)]
+enum RepositoryExcludeApply {
+    /// Install matcher and clear dirty.
+    Present(Arc<Gitignore>),
+    /// Install empty matcher and clear dirty.
+    Absent(Arc<Gitignore>),
+    /// Keep last-good matcher, clear dirty (no re-read loop). Error already logged.
+    Unparsable,
+    /// Keep last-good matcher, leave dirty for a later retry. Error already logged.
+    Indeterminate,
 }
 
-/// Loads a gitignore file, distinguishing present / confirmed-absent /
-/// unparsable content / indeterminate I/O.
-async fn load_gitignore_existing(abs_path: &Path, root: &Path, fs: &dyn Fs) -> GitignoreLoad {
+/// Applies an exclude-load decision to a repository entry.
+///
+/// Returns whether ignore statuses under this work directory should recompute
+/// (only when the installed matcher actually changed — Present/Absent).
+fn apply_repository_exclude_to_entry(
+    entry: &mut LocalRepositoryEntry,
+    apply: RepositoryExcludeApply,
+) -> bool {
+    match apply {
+        RepositoryExcludeApply::Present(exclude) | RepositoryExcludeApply::Absent(exclude) => {
+            entry.info_exclude = exclude;
+            entry.info_exclude_needs_update = false;
+            true
+        }
+        RepositoryExcludeApply::Unparsable => {
+            entry.info_exclude_needs_update = false;
+            false
+        }
+        RepositoryExcludeApply::Indeterminate => false,
+    }
+}
+
+/// Builds a registration entry after loading `info/exclude`.
+///
+/// First insert seeds an empty matcher; re-insert carries the previous matcher
+/// so Unparsable/Indeterminate preserve real last-good rather than an empty rebuild seed.
+fn local_repository_entry_for_registration(
+    identity: GitRepositoryIdentity,
+    previous_info_exclude: Option<Arc<Gitignore>>,
+    apply: RepositoryExcludeApply,
+) -> LocalRepositoryEntry {
+    let mut entry = LocalRepositoryEntry {
+        identity,
+        git_dir_scan_id: 0,
+        info_exclude: previous_info_exclude.unwrap_or_else(|| Arc::new(Gitignore::empty())),
+        info_exclude_needs_update: true,
+    };
+    apply_repository_exclude_to_entry(&mut entry, apply);
+    entry
+}
+
+/// Loads `info/exclude` into an action-ready four-state outcome.
+///
+/// Arc construction and error logging complete before the caller takes the
+/// snapshot lock. Unparsable content fails identically forever (clear dirty);
+/// transient I/O is Indeterminate (leave dirty and retry).
+async fn load_gitignore_existing(
+    abs_path: &Path,
+    root: &Path,
+    fs: &dyn Fs,
+) -> RepositoryExcludeApply {
     let bytes = match fs.load_bytes(abs_path).await {
         Ok(bytes) => bytes,
-        Err(error) if io_error_is_absence(&error) => return GitignoreLoad::Absent,
+        Err(error) if io_error_is_absence(&error) => {
+            return RepositoryExcludeApply::Absent(Arc::new(Gitignore::empty()));
+        }
         Err(error) => {
-            return GitignoreLoad::Indeterminate(error.context(format!(
+            Err::<(), _>(error.context(format!(
                 "failed to load gitignore file at {}",
                 abs_path.display()
-            )));
+            )))
+            .log_err();
+            return RepositoryExcludeApply::Indeterminate;
         }
     };
     let contents = match String::from_utf8(bytes) {
         Ok(contents) => contents,
         Err(error) => {
-            return GitignoreLoad::Unparsable(anyhow::Error::new(error).context(format!(
+            Err::<(), _>(anyhow::Error::new(error).context(format!(
                 "gitignore file at {} is not valid UTF-8",
                 abs_path.display()
-            )));
+            )))
+            .log_err();
+            return RepositoryExcludeApply::Unparsable;
         }
     };
     match parse_gitignore_contents(abs_path, root, &contents) {
-        Ok(gitignore) => GitignoreLoad::Present(gitignore),
-        Err(error) => GitignoreLoad::Unparsable(error),
+        Ok(gitignore) => RepositoryExcludeApply::Present(Arc::new(gitignore)),
+        Err(error) => {
+            Err::<(), _>(error).log_err();
+            RepositoryExcludeApply::Unparsable
+        }
     }
 }
 
@@ -4114,24 +4142,34 @@ pub enum PathChange {
     Loaded,
 }
 
+/// A worktree-local registration of a git repository (entry id + absolute identity).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct UpdatedGitRepository {
-    /// ID of the repository's working directory.
-    ///
-    /// For a repo that's above the worktree root, this is the ID of the worktree root, and hence not unique.
-    /// It's included here to aid the GitStore in detecting when a repository's working directory is renamed.
+pub struct GitRepositoryRegistration {
     pub work_directory_id: ProjectEntryId,
-    pub old_work_directory_abs_path: Option<Arc<Path>>,
-    pub new_work_directory_abs_path: Option<Arc<Path>>,
-    /// For a normal git repository checkout, the absolute path to the .git directory.
-    /// For a worktree, the absolute path to the worktree's subdirectory inside the .git directory.
-    pub dot_git_abs_path: Option<Arc<Path>>,
-    pub repository_dir_abs_path: Option<Arc<Path>>,
-    pub common_dir_abs_path: Option<Arc<Path>>,
+    pub identity: GitRepositoryIdentity,
+}
+
+/// Typed snapshot-diff for local repository bookkeeping.
+///
+/// `Removed` always carries the complete *old* registration. Both merge-removal
+/// branches of the sorted key walk emit identical `Removed` payloads.
+///
+/// `identity_changed` is load-bearing at the consumer (reinit = job cancellation +
+/// failed-open retry + trust re-install for coalesced siblings) and must not be
+/// derived from canonical comparison alone.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GitRepositoryChange {
+    AddedOrUpdated {
+        repository: GitRepositoryRegistration,
+        identity_changed: bool,
+    },
+    Removed {
+        repository: GitRepositoryRegistration,
+    },
 }
 
 pub type UpdatedEntriesSet = Arc<[(Arc<RelPath>, ProjectEntryId, PathChange)]>;
-pub type UpdatedGitRepositoriesSet = Arc<[UpdatedGitRepository]>;
+pub type GitRepositoryChanges = Arc<[GitRepositoryChange]>;
 
 #[derive(Clone, Debug)]
 pub struct PathProgress<'a> {
@@ -4459,28 +4497,11 @@ impl BackgroundScanner {
 
         // If the worktree root does not contain a git repository, then find
         // the git repository in an ancestor directory. Find any gitignore files
-        // in ancestor directories.
+        // in ancestor directories. Exclude is loaded at registration time.
         let repo = if scanning_enabled && self.track_git_repositories {
-            let (ignores, exclude, repo) =
-                discover_ancestor_git_repo(self.fs.clone(), &root_abs_path).await;
+            let (ignores, repo) = discover_ancestor_git_repo(self.fs.clone(), &root_abs_path).await;
             let mut state = self.state.lock().await;
             state.snapshot.ignores_by_parent_abs_path.extend(ignores);
-            if let Some(exclude) = exclude {
-                let work_directory_abs_path: Arc<Path> = repo
-                    .as_ref()
-                    .map(|(_, work_directory)| {
-                        state
-                            .snapshot
-                            .work_directory_abs_path(work_directory)
-                            .into()
-                    })
-                    .unwrap_or_else(|| root_abs_path.as_path().into());
-                state
-                    .snapshot
-                    .repo_exclude_by_work_dir_abs_path
-                    .insert(work_directory_abs_path, (exclude, false));
-            }
-
             repo
         } else {
             None
@@ -4491,7 +4512,7 @@ impl BackgroundScanner {
             && self.track_git_repositories
         {
             maybe!(async {
-                let inserted = self
+                let outcome = self
                     .state
                     .lock()
                     .await
@@ -4502,10 +4523,10 @@ impl BackgroundScanner {
                         self.watcher.as_ref(),
                     )
                     .await
-                    // Bail on both an error and an invalid `.git` (`Ok(false)`), so a
+                    // Bail on both an error and an invalid `.git` (`Ok(None)`), so a
                     // non-repository is never reported as the containing repo.
                     .log_err()?;
-                inserted.then_some(ancestor_dot_git)
+                outcome.map(|_| ancestor_dot_git)
             })
             .await
         } else {
@@ -4598,16 +4619,22 @@ impl BackgroundScanner {
             }
             for repo in state.snapshot.git_repositories.values() {
                 if !repo
+                    .identity
                     .common_dir_abs_path
                     .starts_with(root_abs_path.as_path())
                 {
-                    self.watcher.add(&repo.common_dir_abs_path).log_err();
+                    self.watcher
+                        .add(&repo.identity.common_dir_abs_path)
+                        .log_err();
                 }
                 if !repo
+                    .identity
                     .repository_dir_abs_path
                     .starts_with(root_abs_path.as_path())
                 {
-                    self.watcher.add(&repo.repository_dir_abs_path).log_err();
+                    self.watcher
+                        .add(&repo.identity.repository_dir_abs_path)
+                        .log_err();
                 }
             }
             drop(state);
@@ -4894,7 +4921,7 @@ impl BackgroundScanner {
         ];
 
         let mut dot_git_abs_paths = Vec::new();
-        let mut work_dirs_needing_exclude_update = Vec::new();
+        let mut repo_ids_needing_exclude_update = Vec::new();
 
         {
             let snapshot = &self.state.lock().await.snapshot;
@@ -4978,13 +5005,12 @@ impl BackgroundScanner {
                 // literal `.git/info/exclude` suffix, so a linked worktree or bare repo
                 // whose common dir is named `foo.git`/`.bare` still refreshes its cache.
                 // A main checkout and linked worktree can share one common dir while
-                // keeping separate cache entries keyed by work dir — dirty every match.
+                // each holding its own entry — dirty every match.
                 if self.track_git_repositories && abs_path.as_path().ends_with(REPO_EXCLUDE) {
-                    for repository in snapshot.git_repositories.values().filter(|repo| {
-                        repo.common_dir_abs_path.join(REPO_EXCLUDE) == abs_path.as_path()
+                    for (id, _) in snapshot.git_repositories.iter().filter(|(_, repo)| {
+                        repo.identity.common_dir_abs_path.join(REPO_EXCLUDE) == abs_path.as_path()
                     }) {
-                        work_dirs_needing_exclude_update
-                            .push(repository.work_directory_abs_path.clone());
+                        repo_ids_needing_exclude_update.push(*id);
                     }
                 }
             }
@@ -5059,15 +5085,15 @@ impl BackgroundScanner {
                 if self.track_git_repositories
                     && abs_path.file_name() == Some(OsStr::new(GITIGNORE))
                 {
-                    for (_, repo) in snapshot
-                        .git_repositories
-                        .iter()
-                        .filter(|(_, repo)| repo.directory_contains(&relative_path))
-                    {
+                    for (_, repo) in snapshot.git_repositories.iter().filter(|(_, repo)| {
+                        // Logical relative event path — not the raw absolute path —
+                        // preserves external-symlink routing.
+                        snapshot.repository_directory_contains(repo, &relative_path)
+                    }) {
                         if !dot_git_abs_paths.iter().any(|dot_git_abs_path| {
-                            dot_git_abs_path == repo.common_dir_abs_path.as_ref()
+                            dot_git_abs_path == repo.identity.common_dir_abs_path.as_ref()
                         }) {
-                            dot_git_abs_paths.push(repo.common_dir_abs_path.to_path_buf());
+                            dot_git_abs_paths.push(repo.identity.common_dir_abs_path.to_path_buf());
                         }
                     }
                 }
@@ -5103,16 +5129,15 @@ impl BackgroundScanner {
             return;
         }
 
-        if !work_dirs_needing_exclude_update.is_empty() {
+        if !repo_ids_needing_exclude_update.is_empty() {
             let mut state = self.state.lock().await;
-            for work_dir_abs_path in work_dirs_needing_exclude_update {
-                if let Some((_, needs_update)) = state
+            for work_directory_id in repo_ids_needing_exclude_update {
+                state
                     .snapshot
-                    .repo_exclude_by_work_dir_abs_path
-                    .get_mut(&work_dir_abs_path)
-                {
-                    *needs_update = true;
-                }
+                    .git_repositories
+                    .update(&work_directory_id, |entry| {
+                        entry.info_exclude_needs_update = true;
+                    });
             }
         }
 
@@ -5151,6 +5176,7 @@ impl BackgroundScanner {
 
         {
             let mut ignores_to_update = self.ignores_needing_update().await;
+            ignores_to_update.extend(self.reload_repository_excludes().await);
             ignores_to_update.extend(affected_repo_roots);
             let ignores_to_update = self.order_ignores(ignores_to_update).await;
             let snapshot = self.state.lock().await.snapshot.clone();
@@ -5405,34 +5431,27 @@ impl BackgroundScanner {
             if self.track_git_repositories {
                 if child_name == DOT_GIT {
                     let mut state = self.state.lock().await;
-                    // On the initial scan a nested repo is not yet in
-                    // `repo_exclude_by_work_dir_abs_path` when the job's stack
-                    // was built (child jobs inherit the parent's stack), so
-                    // siblings would miss info/exclude. Append after a *new*
-                    // registration only — rescans already have the exclude on
-                    // the stack from `ignore_stack_for_abs_path` (cache hit).
-                    // `Ok(true)` from insert means "valid repo inserted",
-                    // including re-insert, so newness is the pre-insert cache
-                    // miss, not the bool return.
-                    let exclude_already_loaded = state
-                        .snapshot
-                        .repo_exclude_by_work_dir_abs_path
-                        .contains_key(&job.abs_path);
-                    state
+                    // On the initial scan a nested repo is not yet registered when
+                    // the job's stack was built (child jobs inherit the parent's
+                    // stack), so siblings would miss info/exclude. Append after a
+                    // *new* registration only — rescans already have the exclude
+                    // on the stack from `ignore_stack_for_abs_path`.
+                    let outcome = state
                         .insert_git_repository(
                             child_path.clone(),
                             self.fs.as_ref(),
                             self.watcher.as_ref(),
                         )
                         .await;
-                    if !exclude_already_loaded
-                        && let Some((exclude, _)) = state
+                    if let Some(outcome) = outcome
+                        && outcome.was_added
+                        && let Some(entry) = state
                             .snapshot
-                            .repo_exclude_by_work_dir_abs_path
-                            .get(&job.abs_path)
+                            .git_repositories
+                            .get(&outcome.work_directory_id)
                     {
-                        ignore_stack =
-                            ignore_stack.append(IgnoreKind::RepoExclude, exclude.clone());
+                        ignore_stack = ignore_stack
+                            .append(IgnoreKind::RepoExclude, entry.info_exclude.clone());
                     }
                 } else if child_name == GITIGNORE {
                     match build_gitignore(&child_abs_path, self.fs.as_ref()).await {
@@ -5772,20 +5791,11 @@ impl BackgroundScanner {
                         .await;
 
                     if path.is_empty()
-                        && let Some((ignores, exclude, repo)) = new_ancestor_repo.take()
+                        && let Some((ignores, repo)) = new_ancestor_repo.take()
                     {
                         log::trace!("updating ancestor git repository");
                         state.snapshot.ignores_by_parent_abs_path.extend(ignores);
                         if let Some((ancestor_dot_git, work_directory)) = repo {
-                            if let Some(exclude) = exclude {
-                                let work_directory_abs_path =
-                                    state.snapshot.work_directory_abs_path(&work_directory);
-
-                                state
-                                    .snapshot
-                                    .repo_exclude_by_work_dir_abs_path
-                                    .insert(work_directory_abs_path.into(), (exclude, false));
-                            }
                             state
                                 .insert_git_repository_for_path(
                                     work_directory,
@@ -5799,7 +5809,8 @@ impl BackgroundScanner {
                     }
                 }
                 Ok(None) => {
-                    self.remove_repo_path(path.clone(), &mut state.snapshot);
+                    // Path+registration pruning already done by
+                    // `remove_path_from_snapshot` with repository pruning enabled.
                     state.unwatch_path(
                         self.watcher.as_ref(),
                         path,
@@ -5825,19 +5836,6 @@ impl BackgroundScanner {
             usize::MAX,
             Ord::cmp,
         );
-    }
-
-    fn remove_repo_path(&self, path: Arc<RelPath>, snapshot: &mut LocalSnapshot) -> Option<()> {
-        if !path.components().any(|component| component == DOT_GIT)
-            && let Some(local_repo) = snapshot.local_repo_for_work_directory_path(&path)
-        {
-            let id = local_repo.work_directory_id;
-            log::debug!("remove repo path: {:?}", path);
-            snapshot.git_repositories.remove(&id);
-            return Some(());
-        }
-
-        Some(())
     }
 
     async fn update_ignore_statuses_for_paths(
@@ -5889,40 +5887,13 @@ impl BackgroundScanner {
             .await;
     }
 
+    /// Collects `.gitignore` parents whose dirty bit is set. Repository
+    /// `info/exclude` reloads live in `reload_repository_excludes`.
     async fn ignores_needing_update(&self) -> Vec<Arc<Path>> {
         let mut ignores_to_update = Vec::new();
-        let mut excludes_to_load: Vec<(Arc<Path>, PathBuf)> = Vec::new();
-
-        // First pass: collect updates and drop stale entries without awaiting.
-        // Do not clear exclude dirty flags here — only after Present, Absent, or
-        // Unparsable. Indeterminate I/O must leave dirty set so the next scan
-        // retries instead of stranding a never-loaded exclude.
         {
             let snapshot = &mut self.state.lock().await.snapshot;
             let abs_path = snapshot.abs_path.clone();
-            let mut repo_exclude_keys_to_remove: Vec<Arc<Path>> = Vec::new();
-
-            for (work_dir_abs_path, (_, needs_update)) in
-                snapshot.repo_exclude_by_work_dir_abs_path.iter_mut()
-            {
-                let repository = snapshot
-                    .git_repositories
-                    .iter()
-                    .find(|(_, repo)| &repo.work_directory_abs_path == work_dir_abs_path);
-
-                if *needs_update && let Some((_, repository)) = repository {
-                    let exclude_abs_path = repository.common_dir_abs_path.join(REPO_EXCLUDE);
-                    excludes_to_load.push((work_dir_abs_path.clone(), exclude_abs_path));
-                }
-
-                if repository.is_none() {
-                    repo_exclude_keys_to_remove.push(work_dir_abs_path.clone());
-                }
-            }
-
-            for key in repo_exclude_keys_to_remove {
-                snapshot.repo_exclude_by_work_dir_abs_path.remove(&key);
-            }
 
             snapshot
                 .ignores_by_parent_abs_path
@@ -5947,67 +5918,75 @@ impl BackgroundScanner {
                     true
                 });
         }
+        ignores_to_update
+    }
 
-        // Load excludes asynchronously (outside the lock).
-        // Present/Absent: install matcher, clear dirty, schedule ignore recompute.
-        // Unparsable: keep last-good matcher, clear dirty (no re-read loop), no
-        // recompute — installed rules did not change.
-        // Indeterminate: leave dirty for retry.
-        let mut loaded_excludes: Vec<(Arc<Path>, Arc<Gitignore>)> = Vec::new();
-        let mut unparsable_excludes: Vec<Arc<Path>> = Vec::new();
-        for (work_dir_abs_path, exclude_abs_path) in excludes_to_load {
-            match load_gitignore_existing(&exclude_abs_path, &work_dir_abs_path, self.fs.as_ref())
-                .await
-            {
-                GitignoreLoad::Present(current_exclude) => {
-                    loaded_excludes.push((work_dir_abs_path, Arc::new(current_exclude)));
-                }
-                GitignoreLoad::Absent => {
-                    loaded_excludes.push((work_dir_abs_path, Arc::new(Gitignore::empty())));
-                }
-                GitignoreLoad::Unparsable(error) => {
-                    Err::<(), _>(error).log_err();
-                    unparsable_excludes.push(work_dir_abs_path);
-                }
-                GitignoreLoad::Indeterminate(error) => {
-                    Err::<(), _>(error).log_err();
-                }
-            }
+    /// Reloads pending `info/exclude` files for registered repositories.
+    ///
+    /// Snapshots `(ProjectEntryId, common_dir, work_dir)` under the lock, loads
+    /// outside it, then reapplies only when the entry's common dir still matches
+    /// (closes the load-after-retarget race). Four-outcome semantics:
+    /// Present=install+clear; Absent=empty+clear; Unparsable=keep last-good+clear+log;
+    /// Indeterminate=keep+stay-pending+log.
+    async fn reload_repository_excludes(&self) -> Vec<Arc<Path>> {
+        let pending: Vec<(ProjectEntryId, Arc<Path>, Arc<Path>)> = {
+            let snapshot = &self.state.lock().await.snapshot;
+            snapshot
+                .git_repositories
+                .iter()
+                .filter(|(_, entry)| entry.info_exclude_needs_update)
+                .map(|(&id, entry)| {
+                    (
+                        id,
+                        entry.identity.common_dir_abs_path.clone(),
+                        entry.identity.work_directory_abs_path.clone(),
+                    )
+                })
+                .collect()
+        };
+
+        if pending.is_empty() {
+            return Vec::new();
         }
 
-        // Second pass: install definitive loads and clear dirty.
-        if !loaded_excludes.is_empty() {
+        // Load (and Arc/empty-matcher/log) before taking the snapshot lock.
+        let mut loaded: Vec<(ProjectEntryId, Arc<Path>, Arc<Path>, RepositoryExcludeApply)> =
+            Vec::new();
+        for (id, common_dir, work_dir) in pending {
+            let exclude_abs_path = common_dir.join(REPO_EXCLUDE);
+            let apply =
+                load_gitignore_existing(&exclude_abs_path, &work_dir, self.fs.as_ref()).await;
+            loaded.push((id, common_dir, work_dir, apply));
+        }
+
+        let mut ignores_to_update = Vec::new();
+        {
             let snapshot = &mut self.state.lock().await.snapshot;
             let abs_path = snapshot.abs_path.clone();
-
-            for (work_dir_abs_path, exclude) in loaded_excludes {
-                if let Some((existing_exclude, needs_update)) = snapshot
-                    .repo_exclude_by_work_dir_abs_path
-                    .get_mut(&work_dir_abs_path)
+            for (id, expected_common_dir, expected_work_dir, apply) in loaded {
+                let Some(entry) = snapshot.git_repositories.get(&id) else {
+                    continue;
+                };
+                // Drop loads whose identity moved underfoot (retarget / concurrent scan).
+                if entry.identity.common_dir_abs_path != expected_common_dir
+                    || entry.identity.work_directory_abs_path != expected_work_dir
                 {
-                    *existing_exclude = exclude;
-                    *needs_update = false;
-                    if work_dir_abs_path.starts_with(abs_path.as_path()) {
-                        ignores_to_update.push(work_dir_abs_path);
+                    continue;
+                }
+                let work_dir = entry.identity.work_directory_abs_path.clone();
+                let recompute = snapshot
+                    .git_repositories
+                    .update(&id, |entry| apply_repository_exclude_to_entry(entry, apply))
+                    .unwrap_or(false);
+                if recompute {
+                    if work_dir.starts_with(abs_path.as_path()) {
+                        ignores_to_update.push(work_dir);
                     } else {
                         ignores_to_update.push(abs_path.as_path().into());
                     }
                 }
             }
         }
-
-        if !unparsable_excludes.is_empty() {
-            let snapshot = &mut self.state.lock().await.snapshot;
-            for work_dir_abs_path in unparsable_excludes {
-                if let Some((_, needs_update)) = snapshot
-                    .repo_exclude_by_work_dir_abs_path
-                    .get_mut(&work_dir_abs_path)
-                {
-                    *needs_update = false;
-                }
-            }
-        }
-
         ignores_to_update
     }
 
@@ -6151,9 +6130,11 @@ impl BackgroundScanner {
                 .iter()
                 .filter_map(|(&work_directory_id, repo)| {
                     let dot_git_dir = SanitizedPath::new(&dot_git_dir);
-                    if SanitizedPath::new(repo.common_dir_abs_path.as_ref()) == dot_git_dir
-                        || SanitizedPath::new(repo.repository_dir_abs_path.as_ref()) == dot_git_dir
-                        || SanitizedPath::new(repo.dot_git_abs_path.as_ref()) == dot_git_dir
+                    if SanitizedPath::new(repo.identity.common_dir_abs_path.as_ref()) == dot_git_dir
+                        || SanitizedPath::new(repo.identity.repository_dir_abs_path.as_ref())
+                            == dot_git_dir
+                        || SanitizedPath::new(repo.identity.dot_git_abs_path.as_ref())
+                            == dot_git_dir
                     {
                         Some(work_directory_id)
                     } else {
@@ -6208,10 +6189,10 @@ impl BackgroundScanner {
             .map(|(&id, repo)| {
                 (
                     id,
-                    repo.dot_git_abs_path.clone(),
-                    repo.repository_dir_abs_path.clone(),
-                    repo.common_dir_abs_path.clone(),
-                    repo.work_directory_abs_path.clone(),
+                    repo.identity.dot_git_abs_path.clone(),
+                    repo.identity.repository_dir_abs_path.clone(),
+                    repo.identity.common_dir_abs_path.clone(),
+                    repo.identity.work_directory_abs_path.clone(),
                 )
             })
             .collect::<Vec<_>>();
@@ -6246,29 +6227,19 @@ impl BackgroundScanner {
                         )
                         .await;
                     }
+                    // Retarget updates identity + dirties exclude in the same `.update()`.
                     state.snapshot.git_repositories.update(&id, |entry| {
-                        entry.repository_dir_abs_path = new_repository_dir;
-                        entry.common_dir_abs_path = new_common_dir;
+                        entry.identity.repository_dir_abs_path = new_repository_dir;
+                        entry.identity.common_dir_abs_path = new_common_dir;
                         entry.git_dir_scan_id = scan_id;
+                        entry.info_exclude_needs_update = true;
                     });
-                    // Retarget changes which common dir's info/exclude applies; dirty so
-                    // B's rules reload instead of retaining A's.
-                    state
-                        .snapshot
-                        .repo_exclude_by_work_dir_abs_path
-                        .entry(work_directory_abs_path.clone())
-                        .or_insert_with(|| (Arc::new(Gitignore::empty()), true))
-                        .1 = true;
                     affected_repo_roots.push(work_directory_abs_path);
                 }
                 Ok(Some(_)) => {}
                 Ok(None) => {
                     if let Some(entry) = state.snapshot.git_repositories.remove(&id) {
-                        state
-                            .snapshot
-                            .repo_exclude_by_work_dir_abs_path
-                            .remove(&entry.work_directory_abs_path);
-                        affected_repo_roots.push(entry.work_directory_abs_path);
+                        affected_repo_roots.push(entry.identity.work_directory_abs_path);
                     }
                 }
                 Err(error) => log::debug!(
@@ -6333,10 +6304,8 @@ async fn discover_ancestor_git_repo(
     root_abs_path: &SanitizedPath,
 ) -> (
     HashMap<Arc<Path>, (Arc<Gitignore>, bool)>,
-    Option<Arc<Gitignore>>,
     Option<(PathBuf, WorkDirectory)>,
 ) {
-    let mut exclude = None;
     let mut ignores = HashMap::default();
     for (index, ancestor) in root_abs_path.as_path().ancestors().enumerate() {
         if index != 0 {
@@ -6370,18 +6339,12 @@ async fn discover_ancestor_git_repo(
             };
             let dot_git_abs_path: Arc<Path> = dot_git_abs_path.as_path().into();
 
-            // Keep walking up past an invalid `.git`.
-            let Some((_, common_dir_abs_path)) =
-                discover_valid_git_repository(&dot_git_abs_path, fs.as_ref()).await
-            else {
-                continue;
-            };
-
-            let repo_exclude_abs_path = common_dir_abs_path.join(REPO_EXCLUDE);
-            if let Ok(repo_exclude) =
-                build_gitignore_with_root(&repo_exclude_abs_path, ancestor, fs.as_ref()).await
+            // Keep walking up past an invalid `.git`. Exclude is loaded at registration.
+            if discover_valid_git_repository(&dot_git_abs_path, fs.as_ref())
+                .await
+                .is_none()
             {
-                exclude = Some(Arc::new(repo_exclude));
+                continue;
             }
 
             if index != 0 {
@@ -6395,7 +6358,6 @@ async fn discover_ancestor_git_repo(
                 // also mark where in the git repo the root folder is located.
                 return (
                     ignores,
-                    exclude,
                     Some((
                         dot_git_abs_path.as_ref().into(),
                         WorkDirectory::AboveProject {
@@ -6410,7 +6372,7 @@ async fn discover_ancestor_git_repo(
         }
     }
 
-    (ignores, exclude, None)
+    (ignores, None)
 }
 
 fn merge_event_roots(changed_paths: &[Arc<RelPath>], event_roots: &[EventRoot]) -> Vec<EventRoot> {
@@ -6688,11 +6650,13 @@ impl WorktreeModelHandle for Entity<Worktree> {
             let local_repo_entry = tree
                 .git_repositories
                 .values()
-                .min_by_key(|local_repo_entry| local_repo_entry.work_directory.clone())
+                .min_by_key(|local_repo_entry| {
+                    local_repo_entry.identity.work_directory_abs_path.clone()
+                })
                 .unwrap();
             (
                 tree.fs.clone(),
-                local_repo_entry.common_dir_abs_path.clone(),
+                local_repo_entry.identity.common_dir_abs_path.clone(),
                 local_repo_entry.git_dir_scan_id,
             )
         });
@@ -6703,7 +6667,9 @@ impl WorktreeModelHandle for Entity<Worktree> {
             let local_repo_entry = tree
                 .git_repositories
                 .values()
-                .min_by_key(|local_repo_entry| local_repo_entry.work_directory.clone())
+                .min_by_key(|local_repo_entry| {
+                    local_repo_entry.identity.work_directory_abs_path.clone()
+                })
                 .unwrap();
 
             if local_repo_entry.git_dir_scan_id > *git_dir_scan_id {
@@ -7346,49 +7312,352 @@ mod tests {
         );
     }
 
+    fn sample_local_snapshot(entries: Vec<(u64, LocalRepositoryEntry)>) -> LocalSnapshot {
+        let mut snapshot = LocalSnapshot {
+            snapshot: Snapshot::new(
+                WorktreeId::from_proto(0),
+                RelPath::empty_arc(),
+                Path::new("/project").into(),
+                PathStyle::local(),
+            ),
+            global_gitignore: None,
+            ignores_by_parent_abs_path: Default::default(),
+            git_repositories: Default::default(),
+            root_file_handle: None,
+            external_canonical_to_relative: Default::default(),
+        };
+        for (id, entry) in entries {
+            snapshot
+                .git_repositories
+                .insert(ProjectEntryId::from_proto(id), entry);
+        }
+        snapshot
+    }
+
     fn sample_repo_entry(
-        work_directory_id: ProjectEntryId,
+        work_dir: &str,
+        dot_git: &str,
         repository_dir: &str,
         common_dir: &str,
         git_dir_scan_id: usize,
     ) -> LocalRepositoryEntry {
-        let work_dir: Arc<Path> = Path::new("/linked").into();
         LocalRepositoryEntry {
-            work_directory_id,
-            work_directory: WorkDirectory::InProject {
-                relative_path: RelPath::empty_arc(),
+            identity: GitRepositoryIdentity {
+                work_directory_abs_path: Path::new(work_dir).into(),
+                dot_git_abs_path: Path::new(dot_git).into(),
+                repository_dir_abs_path: Path::new(repository_dir).into(),
+                common_dir_abs_path: Path::new(common_dir).into(),
             },
-            work_directory_abs_path: work_dir,
             git_dir_scan_id,
-            dot_git_abs_path: Path::new("/linked/.git").into(),
-            repository_dir_abs_path: Path::new(repository_dir).into(),
-            common_dir_abs_path: Path::new(common_dir).into(),
+            info_exclude: Arc::new(Gitignore::empty()),
+            info_exclude_needs_update: false,
+        }
+    }
+
+    /// Unit transition table for info/exclude apply: Unparsable clears dirty and
+    /// keeps last-good; Indeterminate keeps last-good and stays pending for retry.
+    /// Present/Absent install and clear. Drives the real production helpers.
+    #[test]
+    fn test_repository_exclude_apply_transition_table() {
+        let last_good = Arc::new(Gitignore::empty());
+        // Distinct Arc so keep-last-good paths can be checked by pointer identity.
+        let last_good_ptr = Arc::as_ptr(&last_good) as usize;
+
+        // Present → install + clear dirty + recompute
+        {
+            let mut entry = sample_repo_entry("/p", "/p/.git", "/p/.git", "/p/.git", 0);
+            entry.info_exclude = last_good.clone();
+            entry.info_exclude_needs_update = true;
+            let apply = RepositoryExcludeApply::Present(Arc::new(Gitignore::empty()));
+            assert!(matches!(apply, RepositoryExcludeApply::Present(_)));
+            let recompute = apply_repository_exclude_to_entry(&mut entry, apply);
+            assert!(recompute, "Present must recompute ignore statuses");
+            assert!(!entry.info_exclude_needs_update, "Present must clear dirty");
+        }
+
+        // Absent → install empty + clear dirty + recompute
+        {
+            let mut entry = sample_repo_entry("/p", "/p/.git", "/p/.git", "/p/.git", 0);
+            entry.info_exclude = last_good.clone();
+            entry.info_exclude_needs_update = true;
+            let apply = RepositoryExcludeApply::Absent(Arc::new(Gitignore::empty()));
+            assert!(matches!(apply, RepositoryExcludeApply::Absent(_)));
+            let recompute = apply_repository_exclude_to_entry(&mut entry, apply);
+            assert!(recompute, "Absent must recompute ignore statuses");
+            assert!(!entry.info_exclude_needs_update, "Absent must clear dirty");
+        }
+
+        // Unparsable → keep last-good, clear dirty, no recompute
+        {
+            let mut entry = sample_repo_entry("/p", "/p/.git", "/p/.git", "/p/.git", 0);
+            entry.info_exclude = last_good.clone();
+            entry.info_exclude_needs_update = true;
+            let apply = RepositoryExcludeApply::Unparsable;
+            assert!(
+                matches!(apply, RepositoryExcludeApply::Unparsable),
+                "Unparsable must stay Unparsable, got {apply:?}"
+            );
+            let recompute = apply_repository_exclude_to_entry(&mut entry, apply);
+            assert!(
+                !recompute,
+                "Unparsable must not recompute (matcher unchanged)"
+            );
+            assert!(
+                !entry.info_exclude_needs_update,
+                "Unparsable must clear dirty so later batches do not re-read forever"
+            );
+            assert_eq!(
+                Arc::as_ptr(&entry.info_exclude) as usize,
+                last_good_ptr,
+                "Unparsable must keep last-good matcher"
+            );
+        }
+
+        // Indeterminate → keep last-good, stay pending, no recompute
+        {
+            let mut entry = sample_repo_entry("/p", "/p/.git", "/p/.git", "/p/.git", 0);
+            entry.info_exclude = last_good;
+            entry.info_exclude_needs_update = true;
+            let apply = RepositoryExcludeApply::Indeterminate;
+            assert!(
+                matches!(apply, RepositoryExcludeApply::Indeterminate),
+                "Indeterminate must stay Indeterminate, got {apply:?}"
+            );
+            let recompute = apply_repository_exclude_to_entry(&mut entry, apply);
+            assert!(
+                !recompute,
+                "Indeterminate must not recompute (matcher unchanged)"
+            );
+            assert!(
+                entry.info_exclude_needs_update,
+                "Indeterminate must leave dirty so a later batch retries"
+            );
+            assert_eq!(
+                Arc::as_ptr(&entry.info_exclude) as usize,
+                last_good_ptr,
+                "Indeterminate must keep last-good matcher"
+            );
+        }
+    }
+
+    /// Re-registration must seed info_exclude from the previous entry so
+    /// Unparsable/Indeterminate preserve a non-empty installed matcher (not an empty seed).
+    #[test]
+    fn test_reregistration_seeds_info_exclude_from_previous() {
+        let root = Path::new("/p");
+        let exclude_path = root.join(".git/info/exclude");
+        let installed = Arc::new(
+            parse_gitignore_contents(&exclude_path, root, "*.secret\n")
+                .expect("sample exclude patterns must parse"),
+        );
+        assert!(
+            installed
+                .matched(root.join("foo.secret"), false)
+                .is_ignore(),
+            "fixture matcher must match *.secret"
+        );
+        let installed_ptr = Arc::as_ptr(&installed) as usize;
+        let previous = {
+            let mut entry = sample_repo_entry("/p", "/p/.git", "/p/.git", "/p/.git", 0);
+            entry.info_exclude = installed;
+            entry.info_exclude_needs_update = false;
+            entry
+        };
+
+        // Unparsable re-registration: keep last-good, clear dirty.
+        {
+            let apply = RepositoryExcludeApply::Unparsable;
+            let entry = local_repository_entry_for_registration(
+                previous.identity.clone(),
+                Some(previous.info_exclude.clone()),
+                apply,
+            );
+            assert!(
+                !entry.info_exclude_needs_update,
+                "Unparsable re-registration must clear dirty"
+            );
+            assert_eq!(
+                Arc::as_ptr(&entry.info_exclude) as usize,
+                installed_ptr,
+                "Unparsable re-registration must keep previous non-empty matcher"
+            );
+            assert!(
+                entry
+                    .info_exclude
+                    .matched(root.join("foo.secret"), false)
+                    .is_ignore(),
+                "previous matcher must still match after Unparsable re-registration"
+            );
+        }
+
+        // Indeterminate re-registration: keep last-good, stay pending.
+        {
+            let apply = RepositoryExcludeApply::Indeterminate;
+            let entry = local_repository_entry_for_registration(
+                previous.identity,
+                Some(previous.info_exclude),
+                apply,
+            );
+            assert!(
+                entry.info_exclude_needs_update,
+                "Indeterminate re-registration must leave dirty pending"
+            );
+            assert_eq!(
+                Arc::as_ptr(&entry.info_exclude) as usize,
+                installed_ptr,
+                "Indeterminate re-registration must keep previous non-empty matcher"
+            );
+            assert!(
+                entry
+                    .info_exclude
+                    .matched(root.join("foo.secret"), false)
+                    .is_ignore(),
+                "previous matcher must still match after Indeterminate re-registration"
+            );
         }
     }
 
     #[test]
-    fn test_repository_identity_change_emits_without_scan_id_bump() {
-        let work_directory_id = ProjectEntryId::from_proto(1);
-        let old_repo = sample_repo_entry(
-            work_directory_id,
+    fn test_changed_git_repositories_snapshot_diff_table() {
+        let base = sample_repo_entry(
+            "/linked",
+            "/linked/.git",
             "/repo_a/.git/worktrees/feature",
             "/repo_a/.git",
             0,
         );
-        let new_repo = sample_repo_entry(
-            work_directory_id,
-            "/repo_b/.git/worktrees/feature",
-            "/repo_b/.git",
-            0, // same scan token as old — identity-only change
-        );
-        assert!(
-            repository_identity_or_scan_changed(&old_repo, &new_repo),
-            "retarget of repository_dir/common_dir must emit even when git_dir_scan_id is unchanged"
-        );
-        assert!(
-            !repository_identity_or_scan_changed(&old_repo, &old_repo),
-            "identical registration must not look changed"
-        );
+
+        // empty → AddedOrUpdated{identity_changed:false}
+        {
+            let old = sample_local_snapshot(vec![]);
+            let new = sample_local_snapshot(vec![(1, base.clone())]);
+            let changes = changed_git_repositories(&old, &new);
+            assert_eq!(changes.len(), 1);
+            match &changes[0] {
+                GitRepositoryChange::AddedOrUpdated {
+                    repository,
+                    identity_changed: false,
+                } => {
+                    assert_eq!(repository.work_directory_id, ProjectEntryId::from_proto(1));
+                    assert_eq!(repository.identity, base.identity);
+                }
+                other => panic!("expected AddedOrUpdated{{false}}, got {other:?}"),
+            }
+        }
+
+        // scan-token-only → AddedOrUpdated{identity_changed:false}
+        {
+            let mut updated = base.clone();
+            updated.git_dir_scan_id = 7;
+            let old = sample_local_snapshot(vec![(1, base.clone())]);
+            let new = sample_local_snapshot(vec![(1, updated)]);
+            let changes = changed_git_repositories(&old, &new);
+            assert_eq!(changes.len(), 1);
+            match &changes[0] {
+                GitRepositoryChange::AddedOrUpdated {
+                    identity_changed: false,
+                    repository,
+                } => {
+                    assert_eq!(repository.identity, base.identity);
+                }
+                other => panic!("expected AddedOrUpdated{{false}}, got {other:?}"),
+            }
+        }
+
+        // each of the 4 identity paths individually → AddedOrUpdated{true}
+        for (field, altered) in [
+            ("work_directory_abs_path", {
+                let mut e = base.clone();
+                e.identity.work_directory_abs_path = Path::new("/other").into();
+                e
+            }),
+            ("dot_git_abs_path", {
+                let mut e = base.clone();
+                e.identity.dot_git_abs_path = Path::new("/other/.git").into();
+                e
+            }),
+            ("repository_dir_abs_path", {
+                let mut e = base.clone();
+                e.identity.repository_dir_abs_path =
+                    Path::new("/repo_b/.git/worktrees/feature").into();
+                e
+            }),
+            ("common_dir_abs_path", {
+                let mut e = base.clone();
+                e.identity.common_dir_abs_path = Path::new("/repo_b/.git").into();
+                e
+            }),
+        ] {
+            let old = sample_local_snapshot(vec![(1, base.clone())]);
+            let new = sample_local_snapshot(vec![(1, altered.clone())]);
+            let changes = changed_git_repositories(&old, &new);
+            assert_eq!(changes.len(), 1, "field {field}");
+            match &changes[0] {
+                GitRepositoryChange::AddedOrUpdated {
+                    identity_changed: true,
+                    repository,
+                } => {
+                    assert_eq!(repository.identity, altered.identity, "field {field}");
+                }
+                other => panic!("field {field}: expected AddedOrUpdated{{true}}, got {other:?}"),
+            }
+        }
+
+        // unchanged → no event
+        {
+            let old = sample_local_snapshot(vec![(1, base.clone())]);
+            let new = sample_local_snapshot(vec![(1, base.clone())]);
+            let changes = changed_git_repositories(&old, &new);
+            assert!(changes.is_empty());
+        }
+
+        // removal carries complete old identity
+        {
+            let old = sample_local_snapshot(vec![(1, base.clone())]);
+            let new = sample_local_snapshot(vec![]);
+            let changes = changed_git_repositories(&old, &new);
+            assert_eq!(changes.len(), 1);
+            match &changes[0] {
+                GitRepositoryChange::Removed { repository } => {
+                    assert_eq!(repository.identity, base.identity);
+                    assert_eq!(repository.work_directory_id, ProjectEntryId::from_proto(1));
+                }
+                other => panic!("expected Removed, got {other:?}"),
+            }
+        }
+
+        // keys [1,3,5] → [3] forces BOTH removal branches — identical Removed payloads
+        {
+            let entry1 = sample_repo_entry("/a", "/a/.git", "/a/.git", "/a/.git", 0);
+            let entry3 = sample_repo_entry("/b", "/b/.git", "/b/.git", "/b/.git", 0);
+            let entry5 = sample_repo_entry("/c", "/c/.git", "/c/.git", "/c/.git", 0);
+            let old = sample_local_snapshot(vec![
+                (1, entry1.clone()),
+                (3, entry3.clone()),
+                (5, entry5.clone()),
+            ]);
+            let new = sample_local_snapshot(vec![(3, entry3)]);
+            let changes = changed_git_repositories(&old, &new);
+            // Both merge-removal arms (Greater mid-walk + old-only tail) emit
+            // identical Removed payloads carrying the complete old identity.
+            assert_eq!(
+                changes.as_ref(),
+                &[
+                    GitRepositoryChange::Removed {
+                        repository: GitRepositoryRegistration {
+                            work_directory_id: ProjectEntryId::from_proto(1),
+                            identity: entry1.identity,
+                        },
+                    },
+                    GitRepositoryChange::Removed {
+                        repository: GitRepositoryRegistration {
+                            work_directory_id: ProjectEntryId::from_proto(5),
+                            identity: entry5.identity,
+                        },
+                    },
+                ]
+            );
+        }
     }
 
     #[test]

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -71,7 +71,7 @@ use std::{
 use sum_tree::{Bias, Dimensions, Edit, SeekTarget, SumTree, Summary, TreeMap, TreeSet};
 use text::{LineEnding, Rope};
 use util::{
-    ResultExt, maybe,
+    ResultExt,
     paths::{PathMatcher, PathStyle, SanitizedPath, home_dir},
     rel_path::RelPath,
 };
@@ -206,13 +206,8 @@ pub struct Snapshot {
 /// project root and the .git folder is located in a parent directory.
 #[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub enum WorkDirectory {
-    InProject {
-        relative_path: Arc<RelPath>,
-    },
-    AboveProject {
-        absolute_path: Arc<Path>,
-        location_in_repo: Arc<Path>,
-    },
+    InProject { relative_path: Arc<RelPath> },
+    AboveProject { absolute_path: Arc<Path> },
 }
 
 impl WorkDirectory {
@@ -2479,7 +2474,7 @@ impl Snapshot {
     pub fn work_directory_abs_path(&self, work_directory: &WorkDirectory) -> PathBuf {
         match work_directory {
             WorkDirectory::InProject { relative_path } => self.absolutize(relative_path),
-            WorkDirectory::AboveProject { absolute_path, .. } => absolute_path.as_ref().to_owned(),
+            WorkDirectory::AboveProject { absolute_path } => absolute_path.as_ref().to_owned(),
         }
     }
 
@@ -3485,40 +3480,38 @@ impl BackgroundScannerState {
             watcher,
         )
         .await
-        .log_err()
-        .flatten()
     }
 
     /// Registers a validated git repository for `work_directory`.
     ///
-    /// Returns `Ok(None)` when the `.git` entry is not a repository, otherwise the
-    /// registration outcome (`was_added` is false on re-insert of the same key).
+    /// Returns `None` when the work directory is not indexed or the `.git` entry is not a
+    /// repository; otherwise the registration outcome (`was_added` is false on re-insert
+    /// of the same key).
     async fn insert_git_repository_for_path(
         &mut self,
         work_directory: WorkDirectory,
         dot_git_abs_path: Arc<Path>,
         fs: &dyn Fs,
         watcher: &dyn Watcher,
-    ) -> Result<Option<RegistrationOutcome>> {
-        let work_dir_entry = self
-            .snapshot
-            .entry_for_path(&work_directory.path_key().0)
-            .with_context(|| {
-                format!(
-                    "working directory `{}` not indexed",
-                    work_directory
-                        .path_key()
-                        .0
-                        .display(self.snapshot.path_style)
-                )
-            })?;
+    ) -> Option<RegistrationOutcome> {
+        let Some(work_dir_entry) = self.snapshot.entry_for_path(&work_directory.path_key().0)
+        else {
+            log::error!(
+                "working directory `{}` not indexed",
+                work_directory
+                    .path_key()
+                    .0
+                    .display(self.snapshot.path_style)
+            );
+            return None;
+        };
         let work_directory_abs_path = self.snapshot.work_directory_abs_path(&work_directory);
 
         // Bail before setting up any watches if the `.git` entry isn't a real repository.
         let Some((repository_dir_abs_path, common_dir_abs_path)) =
             discover_valid_git_repository(&dot_git_abs_path, fs).await
         else {
-            return Ok(None);
+            return None;
         };
 
         watcher
@@ -3567,10 +3560,10 @@ impl BackgroundScannerState {
             .insert(work_directory_id, entry);
 
         log::trace!("inserting new local git repository");
-        Ok(Some(RegistrationOutcome {
+        Some(RegistrationOutcome {
             work_directory_id,
             was_added,
-        }))
+        })
     }
 }
 
@@ -3732,11 +3725,7 @@ fn match_git_metadata_event(
 }
 
 async fn build_gitignore(abs_path: &Path, fs: &dyn Fs) -> Result<Gitignore> {
-    let parent = abs_path.parent().unwrap_or_else(|| Path::new("/"));
-    build_gitignore_with_root(abs_path, parent, fs).await
-}
-
-async fn build_gitignore_with_root(abs_path: &Path, root: &Path, fs: &dyn Fs) -> Result<Gitignore> {
+    let root = abs_path.parent().unwrap_or_else(|| Path::new("/"));
     let contents = fs
         .load(abs_path)
         .await
@@ -4507,28 +4496,22 @@ impl BackgroundScanner {
             None
         };
 
-        let containing_git_repository = if let Some((ancestor_dot_git, work_directory)) = repo
-            && scanning_enabled
-            && self.track_git_repositories
-        {
-            maybe!(async {
-                let outcome = self
-                    .state
-                    .lock()
-                    .await
-                    .insert_git_repository_for_path(
-                        work_directory,
-                        ancestor_dot_git.clone().into(),
-                        self.fs.as_ref(),
-                        self.watcher.as_ref(),
-                    )
-                    .await
-                    // Bail on both an error and an invalid `.git` (`Ok(None)`), so a
-                    // non-repository is never reported as the containing repo.
-                    .log_err()?;
-                outcome.map(|_| ancestor_dot_git)
-            })
-            .await
+        // `repo` is only `Some` when scanning and git tracking are enabled above.
+        let containing_git_repository = if let Some((ancestor_dot_git, work_directory)) = repo {
+            let outcome = self
+                .state
+                .lock()
+                .await
+                .insert_git_repository_for_path(
+                    work_directory,
+                    ancestor_dot_git.clone().into(),
+                    self.fs.as_ref(),
+                    self.watcher.as_ref(),
+                )
+                .await;
+            // Bail on an invalid `.git` (`None`), so a non-repository is never reported
+            // as the containing repo.
+            outcome.map(|_| ancestor_dot_git)
         } else {
             None
         };
@@ -5803,8 +5786,7 @@ impl BackgroundScanner {
                                     self.fs.as_ref(),
                                     self.watcher.as_ref(),
                                 )
-                                .await
-                                .log_err();
+                                .await;
                         }
                     }
                 }
@@ -6348,21 +6330,14 @@ async fn discover_ancestor_git_repo(
             }
 
             if index != 0 {
-                let location_in_repo = root_abs_path
-                    .as_path()
-                    .strip_prefix(ancestor)
-                    .unwrap()
-                    .into();
-                log::info!("inserting parent git repo for this worktree: {location_in_repo:?}");
-                // We associate the external git repo with our root folder and
-                // also mark where in the git repo the root folder is located.
+                log::info!("inserting parent git repo for this worktree: {ancestor:?}");
+                // We associate the external git repo with our root folder.
                 return (
                     ignores,
                     Some((
                         dot_git_abs_path.as_ref().into(),
                         WorkDirectory::AboveProject {
                             absolute_path: ancestor.into(),
-                            location_in_repo,
                         },
                     )),
                 );

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -3875,12 +3875,14 @@ async fn test_info_exclude_unparsable_preserves_last_good_and_clears_dirty(
 
     let fs = FakeFs::new(executor);
     let project_dir = Path::new(path!("/project"));
+    // Pattern matches any `*.env` so a second matching file can prove last-good
+    // rules remain installed after an unparsable rewrite (not only the original path).
     fs.insert_tree(
         project_dir,
         json!({
             ".git": {
                 "info": {
-                    "exclude": "secret.env\n"
+                    "exclude": "*.env\n"
                 }
             },
             "secret.env": "x=1",
@@ -3916,14 +3918,6 @@ async fn test_info_exclude_unparsable_preserves_last_good_and_clears_dirty(
                 ..Default::default()
             },
         );
-        assert_eq!(
-            worktree
-                .as_local()
-                .unwrap()
-                .repo_exclude_needs_update(project_dir),
-            Some(false),
-            "valid exclude should be clean after registration"
-        );
     });
 
     // `[z-a]` is rejected by globset (reversed character range). Unclosed `[` is
@@ -3947,13 +3941,32 @@ async fn test_info_exclude_unparsable_preserves_last_good_and_clears_dirty(
                 ..Default::default()
             },
         );
-        assert_eq!(
-            worktree
-                .as_local()
-                .unwrap()
-                .repo_exclude_needs_update(project_dir),
-            Some(false),
-            "unparsable exclude must clear dirty so later batches do not re-read forever"
+    });
+
+    // Observable last-good: a second matching file created after unparsable write
+    // must still be excluded by the preserved rules. One unrelated real event
+    // (touch tracked.txt) forces a batch so ignore status recomputes if needed.
+    fs.write(&project_dir.join("secret2.env"), b"y=2")
+        .await
+        .unwrap();
+    fs.write(&project_dir.join("tracked.txt"), b"ok2")
+        .await
+        .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    worktree.update(cx, |worktree, _cx| {
+        check_worktree_entries(
+            worktree,
+            WorktreeExpectations {
+                ignored_paths: &["secret.env", "secret2.env"],
+                tracked_paths: &["tracked.txt"],
+                ..Default::default()
+            },
         );
     });
 
@@ -3969,17 +3982,10 @@ async fn test_info_exclude_unparsable_preserves_last_good_and_clears_dirty(
         check_worktree_entries(
             worktree,
             WorktreeExpectations {
-                ignored_paths: &["secret.env"],
+                ignored_paths: &["secret.env", "secret2.env"],
                 tracked_paths: &["tracked.txt"],
                 ..Default::default()
             },
-        );
-        assert_eq!(
-            worktree
-                .as_local()
-                .unwrap()
-                .repo_exclude_needs_update(project_dir),
-            Some(false),
         );
     });
 }
@@ -5160,11 +5166,12 @@ async fn test_shared_common_dir_event_updates_all_repositories(
     let mut updated_work_dirs = Vec::new();
     while let Ok(event) = events.try_recv() {
         if let Event::UpdatedGitRepositories(updates) = event {
-            updated_work_dirs.extend(
-                updates
-                    .iter()
-                    .filter_map(|update| update.new_work_directory_abs_path.clone()),
-            );
+            updated_work_dirs.extend(updates.iter().filter_map(|update| match update {
+                worktree::GitRepositoryChange::AddedOrUpdated { repository, .. } => {
+                    Some(repository.identity.work_directory_abs_path.clone())
+                }
+                worktree::GitRepositoryChange::Removed { .. } => None,
+            }));
         }
     }
     updated_work_dirs.sort();

--- a/crates/worktree/tests/integration/worktree_tests.rs
+++ b/crates/worktree/tests/integration/worktree_tests.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use encoding_rs;
 use fs::{FakeFs, Fs, PathEventKind, RealFs, RemoveOptions};
 use git::{DOT_GIT, GITIGNORE, REPO_EXCLUDE};
-use gpui::{AppContext as _, BackgroundExecutor, BorrowAppContext, Context, Task, TestAppContext};
+use gpui::{
+    AppContext as _, BackgroundExecutor, BorrowAppContext, Context, Entity, Task, TestAppContext,
+};
 use parking_lot::Mutex;
 use postage::stream::Stream;
 use pretty_assertions::assert_eq;
@@ -1693,17 +1695,15 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
     let path = PathBuf::from("/root/one/node_modules/c/lib");
 
     // No work happens when files and directories change within an unloaded directory.
+    // Git-metadata classification of the resulting event is purely in-memory (matched
+    // against registered repositories), so it makes no per-ancestor fs.metadata calls.
     let prev_fs_call_count = fs.read_dir_call_count() + fs.metadata_call_count();
-    // When we open a directory, we check each ancestor whether it's a git
-    // repository. That means we have an fs.metadata call per ancestor that we
-    // need to subtract here.
-    let ancestors = path.ancestors().count();
 
     fs.create_dir(path.as_ref()).await.unwrap();
     cx.executor().run_until_parked();
 
     assert_eq!(
-        fs.read_dir_call_count() + fs.metadata_call_count() - prev_fs_call_count - ancestors,
+        fs.read_dir_call_count() + fs.metadata_call_count() - prev_fs_call_count,
         0
     );
 }
@@ -3495,6 +3495,107 @@ async fn test_repository_above_root(executor: BackgroundExecutor, cx: &mut TestA
 }
 
 #[gpui::test]
+async fn test_invalid_nested_git_dir_is_not_registered_as_repository(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".git": {},
+            "nested": {
+                "file.txt": "content",
+            },
+        }),
+    )
+    .await;
+    // A leftover, empty `.git` directory (no HEAD/objects/refs) is not a real
+    // repository: git ignores it and walks up to the parent, and so must we. If it
+    // were registered, it would shadow the parent repo for `nested/`'s files and
+    // load an empty diff base, rendering them as wholly added.
+    fs.create_dir(Path::new(path!("/root/nested/.git")))
+        .await
+        .unwrap();
+
+    let worktree = Worktree::local(
+        path!("/root").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    let repos = worktree.update(cx, |worktree, _| {
+        worktree.as_local().unwrap().repositories()
+    });
+    pretty_assertions::assert_eq!(repos, [Path::new(path!("/root")).into()]);
+}
+
+#[gpui::test]
+async fn test_gitfile_pointing_at_non_repository_is_not_registered(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".git": {},
+            "nested": {
+                // A `.git` *file* (gitfile) pointing at a directory that isn't a git
+                // repository — the same phantom-shadowing bug as an empty `.git`
+                // directory, but reached via gitfile indirection. Real git rejects it,
+                // so `nested/`'s files belong to the `/root` repo.
+                ".git": "gitdir: /root/phantom_gitdir\n",
+                "file.txt": "content",
+            },
+            // The gitfile's target exists but is not a valid repository (no
+            // HEAD/objects/refs), so it must not register `nested` as its own repo.
+            "phantom_gitdir": {},
+        }),
+    )
+    .await;
+
+    let worktree = Worktree::local(
+        path!("/root").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    let repos = worktree.update(cx, |worktree, _| {
+        worktree.as_local().unwrap().repositories()
+    });
+    pretty_assertions::assert_eq!(repos, [Path::new(path!("/root")).into()]);
+}
+
+#[gpui::test]
 async fn test_global_gitignore(executor: BackgroundExecutor, cx: &mut TestAppContext) {
     init_test(cx);
 
@@ -3620,11 +3721,17 @@ async fn test_repo_exclude_in_worktree(executor: BackgroundExecutor, cx: &mut Te
         path!("/repo"),
         json!({
             ".git": {
+                "HEAD": "ref: refs/heads/main\n",
+                "objects": {},
+                "refs": {},
                 "info": {
                     "exclude": ".env.*"
                 },
                 "worktrees": {
                     "my-worktree": {
+                        // A real linked worktree has its own per-worktree HEAD; the
+                        // shared object/ref stores live in the common dir (`../..`).
+                        "HEAD": "ref: refs/heads/main\n",
                         "commondir": "../.."
                     }
                 }
@@ -3750,6 +3857,545 @@ async fn test_repo_exclude(executor: BackgroundExecutor, cx: &mut TestAppContext
             worktree,
             WorktreeExpectations {
                 tracked_paths: &[".env.example", ".env.local", "README.md", "src/main.rs"],
+                ..Default::default()
+            },
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_info_exclude_unparsable_preserves_last_good_and_clears_dirty(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    // A deterministically unparsable info/exclude must not leave the cache dirty
+    // forever (infinite re-read loop) and must keep last-good rules so one bad
+    // line does not suddenly expose previously excluded files.
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    let project_dir = Path::new(path!("/project"));
+    fs.insert_tree(
+        project_dir,
+        json!({
+            ".git": {
+                "info": {
+                    "exclude": "secret.env\n"
+                }
+            },
+            "secret.env": "x=1",
+            "tracked.txt": "ok",
+        }),
+    )
+    .await;
+
+    let worktree = Worktree::local(
+        project_dir,
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    worktree.update(cx, |worktree, _cx| {
+        check_worktree_entries(
+            worktree,
+            WorktreeExpectations {
+                ignored_paths: &["secret.env"],
+                tracked_paths: &["tracked.txt"],
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            worktree
+                .as_local()
+                .unwrap()
+                .repo_exclude_needs_update(project_dir),
+            Some(false),
+            "valid exclude should be clean after registration"
+        );
+    });
+
+    // `[z-a]` is rejected by globset (reversed character range). Unclosed `[` is
+    // accepted as a literal by the ignore crate's `allow_unclosed_class`.
+    fs.write(&project_dir.join(DOT_GIT).join(REPO_EXCLUDE), b"[z-a]\n")
+        .await
+        .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    worktree.update(cx, |worktree, _cx| {
+        check_worktree_entries(
+            worktree,
+            WorktreeExpectations {
+                ignored_paths: &["secret.env"],
+                tracked_paths: &["tracked.txt"],
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            worktree
+                .as_local()
+                .unwrap()
+                .repo_exclude_needs_update(project_dir),
+            Some(false),
+            "unparsable exclude must clear dirty so later batches do not re-read forever"
+        );
+    });
+
+    // A later scan with no exclude content change must not re-dirty or drop rules.
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    worktree.update(cx, |worktree, _cx| {
+        check_worktree_entries(
+            worktree,
+            WorktreeExpectations {
+                ignored_paths: &["secret.env"],
+                tracked_paths: &["tracked.txt"],
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            worktree
+                .as_local()
+                .unwrap()
+                .repo_exclude_needs_update(project_dir),
+            Some(false),
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_nested_repo_info_exclude_on_initial_scan(cx: &mut TestAppContext) {
+    // Nested repos register during the initial scan after their scan job's
+    // ignore stack was already built (cache miss). info/exclude must still
+    // apply to siblings on that first scan without any FS event rescue.
+    init_test(cx);
+    cx.executor().allow_parking();
+
+    let dir = TempTree::new(json!({
+        "outer.txt": "ok",
+        "nested": {
+            ".git": {},
+            "hidden.secret": "secret",
+            "visible.txt": "visible",
+        },
+    }));
+
+    std::fs::write(
+        dir.path().join("nested").join(DOT_GIT).join(REPO_EXCLUDE),
+        "*.secret\n",
+    )
+    .expect("write nested info/exclude before worktree open");
+
+    let worktree = Worktree::local(
+        dir.path(),
+        true,
+        Arc::new(RealFs::new(None, cx.executor())),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    // Initial scan only — no flush_fs_events so the event path cannot rescue.
+    cx.read(|cx| worktree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    worktree.read_with(cx, |tree, _| {
+        let secret = tree
+            .entry_for_path(rel_path("nested/hidden.secret"))
+            .expect("hidden.secret should be indexed");
+        let visible = tree
+            .entry_for_path(rel_path("nested/visible.txt"))
+            .expect("visible.txt should be indexed");
+        assert!(
+            secret.is_ignored,
+            "nested info/exclude must apply on initial scan, got entry: {secret:?}"
+        );
+        assert!(
+            !visible.is_ignored,
+            "sibling not matching exclude must stay unignored, got entry: {visible:?}"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_info_exclude_loaded_when_repository_becomes_valid(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    // Registration owns exclude state: a nested `.git` that becomes valid after
+    // open (objects created last) must still pick up a pre-existing info/exclude.
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            ".git": {},
+            "nested": {
+                "secret.env": "x=1",
+                "tracked.txt": "ok",
+            },
+        }),
+    )
+    .await;
+
+    // Incomplete nested .git: valid HEAD + refs + info/exclude, but no objects yet.
+    fs.create_dir(Path::new(path!("/root/nested/.git")))
+        .await
+        .unwrap();
+    fs.write(
+        Path::new(path!("/root/nested/.git/HEAD")),
+        b"ref: refs/heads/main\n",
+    )
+    .await
+    .unwrap();
+    fs.create_dir(Path::new(path!("/root/nested/.git/refs")))
+        .await
+        .unwrap();
+    fs.create_dir(Path::new(path!("/root/nested/.git/info")))
+        .await
+        .unwrap();
+    fs.write(
+        Path::new(path!("/root/nested/.git/info/exclude")),
+        b"*.env\n",
+    )
+    .await
+    .unwrap();
+
+    let worktree = Worktree::local(
+        path!("/root").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    worktree.read_with(cx, |worktree, _| {
+        let repos = worktree.as_local().unwrap().repositories();
+        assert!(
+            !repos
+                .iter()
+                .any(|path| path.as_ref() == Path::new(path!("/root/nested"))),
+            "nested without objects must not be registered yet"
+        );
+    });
+
+    fs.create_dir(Path::new(path!("/root/nested/.git/objects")))
+        .await
+        .unwrap();
+    worktree.flush_fs_events(cx).await;
+
+    worktree.update(cx, |worktree, _cx| {
+        assert!(
+            worktree
+                .as_local()
+                .unwrap()
+                .repositories()
+                .iter()
+                .any(|path| path.as_ref() == Path::new(path!("/root/nested"))),
+            "nested must register once objects appears"
+        );
+        check_worktree_entries(
+            worktree,
+            WorktreeExpectations {
+                ignored_paths: &["nested/secret.env"],
+                tracked_paths: &["nested/tracked.txt"],
+                ..Default::default()
+            },
+        );
+    });
+}
+
+/// Repositories A and B, linked checkout of A at `/linked`, B's admin dir, and a
+/// scanned worktree. Parameterized by what actually differs across retarget tests.
+async fn setup_linked_worktree_retarget(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+    source_exclude: Option<&str>,
+    target_exclude: Option<&str>,
+    linked_files: &[(&str, &str)],
+) -> (Arc<FakeFs>, Entity<Worktree>, PathBuf) {
+    use git::repository::Worktree as GitWorktree;
+
+    let fs = FakeFs::new(executor);
+
+    let repo_a = match source_exclude {
+        Some(exclude) => json!({
+            ".git": { "info": { "exclude": exclude } },
+            "file.txt": "a",
+        }),
+        None => json!({
+            ".git": {},
+            "file.txt": "a",
+        }),
+    };
+    let repo_b = match target_exclude {
+        Some(exclude) => json!({
+            ".git": { "info": { "exclude": exclude } },
+            "file.txt": "b",
+        }),
+        None => json!({
+            ".git": {},
+            "file.txt": "b",
+        }),
+    };
+    fs.insert_tree(path!("/repo_a"), repo_a).await;
+    fs.insert_tree(path!("/repo_b"), repo_b).await;
+
+    fs.add_linked_worktree_for_repo(
+        Path::new(path!("/repo_a/.git")),
+        false,
+        GitWorktree {
+            path: PathBuf::from(path!("/linked")),
+            ref_name: Some("refs/heads/feature".into()),
+            sha: "abc123".into(),
+            is_main: false,
+            is_bare: false,
+        },
+    )
+    .await;
+    for (name, content) in linked_files {
+        let file_path = Path::new(path!("/linked")).join(name);
+        fs.write(&file_path, content.as_bytes()).await.unwrap();
+    }
+
+    let admin_b = PathBuf::from(path!("/repo_b/.git/worktrees/feature"));
+    fs.create_dir(&admin_b).await.unwrap();
+    fs.write(&admin_b.join("HEAD"), b"ref: refs/heads/feature\n")
+        .await
+        .unwrap();
+    fs.write(&admin_b.join("commondir"), path!("/repo_b/.git").as_bytes())
+        .await
+        .unwrap();
+    fs.write(&admin_b.join("gitdir"), path!("/linked/.git").as_bytes())
+        .await
+        .unwrap();
+
+    let worktree = Worktree::local(
+        path!("/linked").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    (fs, worktree, admin_b)
+}
+
+#[gpui::test]
+async fn test_info_exclude_follows_gitfile_retarget(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    // After gitfile retarget A→B, B's info/exclude must apply and A's must not.
+    init_test(cx);
+    let (fs, worktree, admin_b) = setup_linked_worktree_retarget(
+        executor,
+        cx,
+        Some("from-a.txt"),
+        Some("from-b.txt"),
+        &[("from-a.txt", "a"), ("from-b.txt", "b"), ("other.txt", "o")],
+    )
+    .await;
+
+    worktree.update(cx, |worktree, _cx| {
+        check_worktree_entries(
+            worktree,
+            WorktreeExpectations {
+                ignored_paths: &["from-a.txt"],
+                tracked_paths: &["from-b.txt", "other.txt"],
+                ..Default::default()
+            },
+        );
+    });
+
+    fs.pause_events();
+    fs.remove_file(path!("/linked/.git").as_ref(), Default::default())
+        .await
+        .unwrap();
+    fs.write(
+        path!("/linked/.git").as_ref(),
+        format!("gitdir: {}\n", admin_b.display()).as_bytes(),
+    )
+    .await
+    .unwrap();
+    fs.unpause_events_and_flush();
+    worktree.flush_fs_events(cx).await;
+
+    worktree.update(cx, |worktree, _cx| {
+        check_worktree_entries(
+            worktree,
+            WorktreeExpectations {
+                ignored_paths: &["from-b.txt"],
+                tracked_paths: &["from-a.txt", "other.txt"],
+                ..Default::default()
+            },
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_info_exclude_cleared_on_retarget_to_repo_without_exclude(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    // Retarget A→B where B has no info/exclude must install empty rules, not
+    // keep A's exclude permanently (confirmed absence vs I/O error).
+    init_test(cx);
+    let (fs, worktree, admin_b) = setup_linked_worktree_retarget(
+        executor,
+        cx,
+        Some("from-a.txt"),
+        None,
+        &[("from-a.txt", "a"), ("other.txt", "o")],
+    )
+    .await;
+
+    worktree.update(cx, |worktree, _cx| {
+        check_worktree_entries(
+            worktree,
+            WorktreeExpectations {
+                ignored_paths: &["from-a.txt"],
+                tracked_paths: &["other.txt"],
+                ..Default::default()
+            },
+        );
+    });
+
+    fs.pause_events();
+    fs.remove_file(path!("/linked/.git").as_ref(), Default::default())
+        .await
+        .unwrap();
+    fs.write(
+        path!("/linked/.git").as_ref(),
+        format!("gitdir: {}\n", admin_b.display()).as_bytes(),
+    )
+    .await
+    .unwrap();
+    fs.unpause_events_and_flush();
+    worktree.flush_fs_events(cx).await;
+
+    worktree.update(cx, |worktree, _cx| {
+        check_worktree_entries(
+            worktree,
+            WorktreeExpectations {
+                tracked_paths: &["from-a.txt", "other.txt"],
+                ..Default::default()
+            },
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_info_exclude_cleared_when_file_deleted(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    // Deleting info/exclude must stop its rules; confirmed absence installs empty.
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    let project_dir = Path::new(path!("/project"));
+    fs.insert_tree(
+        project_dir,
+        json!({
+            ".git": {
+                "info": {
+                    "exclude": "stale.txt"
+                }
+            },
+            "stale.txt": "was excluded",
+            "keep.txt": "tracked",
+        }),
+    )
+    .await;
+
+    let worktree = Worktree::local(
+        project_dir,
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    worktree
+        .update(cx, |worktree, _| {
+            worktree.as_local().unwrap().scan_complete()
+        })
+        .await;
+    cx.run_until_parked();
+
+    worktree.update(cx, |worktree, _cx| {
+        check_worktree_entries(
+            worktree,
+            WorktreeExpectations {
+                ignored_paths: &["stale.txt"],
+                tracked_paths: &["keep.txt"],
+                ..Default::default()
+            },
+        );
+    });
+
+    fs.remove_file(
+        &project_dir.join(DOT_GIT).join(REPO_EXCLUDE),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    worktree.flush_fs_events(cx).await;
+
+    worktree.update(cx, |worktree, _cx| {
+        check_worktree_entries(
+            worktree,
+            WorktreeExpectations {
+                tracked_paths: &["stale.txt", "keep.txt"],
                 ..Default::default()
             },
         );
@@ -4130,19 +4776,15 @@ async fn test_invisible_worktree_does_not_track_ancestor_git_repository(
 }
 
 #[gpui::test]
-async fn test_linked_worktree_gitfile_event_preserves_repo(
+async fn test_linked_worktree_invalid_gitfile_unregisters_repo(
     executor: BackgroundExecutor,
     cx: &mut TestAppContext,
 ) {
-    // Regression test: in a linked worktree, `.git` is a file (containing
-    // "gitdir: ..."), not a directory. When the background scanner receives
-    // a filesystem event for a path inside the main repo's `.git` directory
-    // (which it watches via the commondir), the ancestor-walking code in
-    // `process_events` calls `is_git_dir` on each ancestor. If `is_git_dir`
-    // treats `.git` files the same as `.git` directories, it incorrectly
-    // identifies the gitfile as a git dir, adds it to `dot_git_abs_paths`,
-    // and `update_git_repositories` panics because the path is outside the
-    // worktree root.
+    // A linked worktree's `.git` is a gitfile (`gitdir: ...`). When that gitfile is
+    // overwritten with garbage, the repository is no longer resolvable, so event
+    // revalidation must unregister it — and never panic (a corrupt gitfile once
+    // tripped the ancestor-walking classifier). Restoring a valid gitfile re-registers
+    // the repository.
     init_test(cx);
     use git::repository::Worktree as GitWorktree;
 
@@ -4180,21 +4822,268 @@ async fn test_linked_worktree_gitfile_event_preserves_repo(
         .await;
     cx.run_until_parked();
 
-    // Overwrite the .git gitfile with garbage to trigger an event for the
-    // gitfile path itself, which only matches `dot_git_abs_path`.
-    fs.write(path!("/linked_worktree/.git").as_ref(), b"garbage")
+    let original_gitfile = fs
+        .load(path!("/linked_worktree/.git").as_ref())
         .await
         .unwrap();
-    tree.flush_fs_events(cx).await;
-
-    // The worktree should still be intact.
     tree.read_with(cx, |tree, _| {
         assert_eq!(
             tree.snapshot().root_repo_common_dir().map(|p| p.as_ref()),
             Some(Path::new(path!("/main_repo/.git"))),
-            "linked worktree repo should survive a gitfile change event"
+            "linked worktree repo should be registered after the initial scan"
         );
     });
+
+    fs.write(path!("/linked_worktree/.git").as_ref(), b"garbage")
+        .await
+        .unwrap();
+    tree.flush_fs_events(cx).await;
+    tree.read_with(cx, |tree, _| {
+        assert_eq!(
+            tree.snapshot().root_repo_common_dir(),
+            None,
+            "an unresolvable gitfile should unregister the repository"
+        );
+    });
+
+    fs.write(
+        path!("/linked_worktree/.git").as_ref(),
+        original_gitfile.as_bytes(),
+    )
+    .await
+    .unwrap();
+    tree.flush_fs_events(cx).await;
+    tree.read_with(cx, |tree, _| {
+        assert_eq!(
+            tree.snapshot().root_repo_common_dir().map(|p| p.as_ref()),
+            Some(Path::new(path!("/main_repo/.git"))),
+            "a restored gitfile should re-register the linked worktree repository"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_objects_dir_transition_registers_and_unregisters_repository(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    // The exact `.git/objects` path is a repository-validity input and must reach
+    // revalidation: creating it registers a previously incomplete `.git`, and deleting
+    // it unregisters a live one. Loose-object descendants remain suppressed for perf.
+    init_test(cx);
+
+    let fs = FakeFs::new(executor);
+    // Do not use `insert_tree({".git": {}})`: that attaches in-memory git state and
+    // would treat the repo as valid without literal store directories.
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "file.txt": "content",
+        }),
+    )
+    .await;
+    fs.create_dir(Path::new(path!("/root/.git"))).await.unwrap();
+    fs.write(
+        Path::new(path!("/root/.git/HEAD")),
+        b"ref: refs/heads/main\n",
+    )
+    .await
+    .unwrap();
+    fs.create_dir(Path::new(path!("/root/.git/refs")))
+        .await
+        .unwrap();
+
+    let tree = Worktree::local(
+        path!("/root").as_ref(),
+        true,
+        fs.clone(),
+        Arc::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    tree.update(cx, |tree, _| tree.as_local().unwrap().scan_complete())
+        .await;
+    cx.run_until_parked();
+
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.as_local().unwrap().repositories().is_empty(),
+            "HEAD+refs without objects is not a repository"
+        );
+    });
+
+    fs.create_dir(Path::new(path!("/root/.git/objects")))
+        .await
+        .unwrap();
+    tree.flush_fs_events(cx).await;
+    tree.read_with(cx, |tree, _| {
+        pretty_assertions::assert_eq!(
+            tree.as_local().unwrap().repositories(),
+            [Path::new(path!("/root")).into()],
+            "creating the bare objects directory should register the repository"
+        );
+    });
+
+    fs.remove_dir(
+        Path::new(path!("/root/.git/objects")),
+        RemoveOptions {
+            recursive: true,
+            ignore_if_not_exists: false,
+        },
+    )
+    .await
+    .unwrap();
+    tree.flush_fs_events(cx).await;
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.as_local().unwrap().repositories().is_empty(),
+            "deleting the bare objects directory should unregister the repository"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_gitfile_retarget_updates_repository_paths(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    // Path-retarget coverage: rewriting a linked worktree's gitfile from admin A
+    // to admin B (same work-dir path) updates repository_dir/common_dir to B while
+    // the work-directory entry remains registered.
+    init_test(cx);
+    let (fs, tree, admin_b) =
+        setup_linked_worktree_retarget(executor, cx, None, None, &[("file.txt", "content")]).await;
+
+    let identities_before = tree.read_with(cx, |tree, _| {
+        tree.as_local().unwrap().repository_identities()
+    });
+    assert_eq!(
+        identities_before.len(),
+        1,
+        "linked worktree should be registered"
+    );
+    let (repository_dir_before, common_dir_before) = identities_before.into_iter().next().unwrap();
+    assert_eq!(
+        common_dir_before.as_ref(),
+        Path::new(path!("/repo_a/.git")),
+        "initially pointed at repository A"
+    );
+    assert!(
+        repository_dir_before
+            .as_ref()
+            .starts_with(path!("/repo_a/.git")),
+        "admin dir should be under A: {repository_dir_before:?}"
+    );
+
+    fs.write(
+        path!("/linked/.git").as_ref(),
+        format!("gitdir: {}\n", admin_b.display()).as_bytes(),
+    )
+    .await
+    .unwrap();
+    tree.flush_fs_events(cx).await;
+
+    let identities_after = tree.read_with(cx, |tree, _| {
+        tree.as_local().unwrap().repository_identities()
+    });
+    assert_eq!(
+        identities_after.len(),
+        1,
+        "retarget must keep a single registration"
+    );
+    let (repository_dir_after, common_dir_after) = identities_after.into_iter().next().unwrap();
+    assert_eq!(
+        common_dir_after.as_ref(),
+        Path::new(path!("/repo_b/.git")),
+        "common_dir should now point at repository B"
+    );
+    assert_eq!(
+        repository_dir_after.as_ref(),
+        admin_b.as_path(),
+        "repository_dir should now be B's admin dir"
+    );
+}
+
+#[cfg(unix)]
+#[gpui::test]
+async fn test_resolve_io_error_preserves_repository_registration(cx: &mut TestAppContext) {
+    // A non-absence I/O failure during revalidation must preserve the existing
+    // registration, not treat the repository as gone.
+    use std::os::unix::fs::PermissionsExt;
+
+    init_test(cx);
+    cx.executor().allow_parking();
+
+    let dir = TempTree::new(json!({
+        ".git": {},
+        "file.txt": "content",
+    }));
+    let head_path = dir.path().join(".git/HEAD");
+
+    let tree = Worktree::local(
+        dir.path(),
+        true,
+        Arc::new(RealFs::new(None, cx.executor())),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+    tree.flush_fs_events(cx).await;
+
+    let identities_before = tree.read_with(cx, |tree, _| {
+        tree.as_local().unwrap().repository_identities()
+    });
+    assert_eq!(
+        identities_before.len(),
+        1,
+        "valid git repo should be registered after scan"
+    );
+
+    // Permission failure on HEAD is a non-absence I/O error during resolve.
+    let original_mode = std::fs::metadata(&head_path).unwrap().permissions();
+    std::fs::set_permissions(&head_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    // Root bypasses permission checks, so chmod 0o000 would not induce an I/O
+    // error and the test would pass for the wrong reason (Ok(Some) keep). Fail
+    // hard when the denial is ineffective rather than skip silently — these
+    // suites have no idiomatic dynamic-skip, and a false green is worse.
+    let head_read = std::fs::File::open(&head_path);
+    if head_read.is_ok() {
+        std::fs::set_permissions(&head_path, original_mode)
+            .expect("restore HEAD permissions before root-bypass panic");
+        panic!(
+            "chmod 0o000 on HEAD did not deny reads (running as root?); \
+             cannot prove Err-preserves-registration without a real I/O failure"
+        );
+    }
+
+    // Trigger revalidation via a non-skipped git metadata event.
+    std::fs::write(
+        dir.path().join(".git/refs/heads/main"),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+    )
+    .unwrap();
+    tree.flush_fs_events(cx).await;
+
+    let identities_after = tree.read_with(cx, |tree, _| {
+        tree.as_local().unwrap().repository_identities()
+    });
+    assert_eq!(
+        identities_after.len(),
+        1,
+        "permission error must preserve the registration"
+    );
+
+    // Restore so TempTree cleanup can remove the tree.
+    std::fs::set_permissions(&head_path, original_mode).unwrap();
 }
 
 #[gpui::test]
@@ -4205,7 +5094,8 @@ async fn test_shared_common_dir_event_updates_all_repositories(
     // A main checkout and one of its linked worktrees can both live inside the
     // same project worktree, sharing a common git directory. An event in that
     // common directory (e.g. a ref update) must refresh every repository that
-    // reads from it, not just the first match.
+    // reads from it, not just the first match. The shared info/exclude must
+    // also dirty both exclude caches so both work dirs observe new rules.
     init_test(cx);
 
     use git::repository::Worktree as GitWorktree;
@@ -4217,6 +5107,8 @@ async fn test_shared_common_dir_event_updates_all_repositories(
             "main_repo": {
                 ".git": {},
                 "file.txt": "content",
+                "shared-ignored.txt": "ignored",
+                "visible.txt": "visible",
             },
         }),
     )
@@ -4233,6 +5125,15 @@ async fn test_shared_common_dir_event_updates_all_repositories(
         },
     )
     .await;
+    fs.write(
+        path!("/project/linked/shared-ignored.txt").as_ref(),
+        b"ignored",
+    )
+    .await
+    .unwrap();
+    fs.write(path!("/project/linked/visible.txt").as_ref(), b"visible")
+        .await
+        .unwrap();
 
     let tree = Worktree::local(
         path!("/project").as_ref(),
@@ -4275,6 +5176,64 @@ async fn test_shared_common_dir_event_updates_all_repositories(
         ],
         "a ref update in the shared common dir should refresh both repositories"
     );
+
+    // Shared info/exclude: both registered work dirs have separate cache entries
+    // keyed by their own work directory. A write under the shared common dir
+    // must dirty every matching entry, not only the first .find match.
+    fs.create_dir(path!("/project/main_repo/.git/info").as_ref())
+        .await
+        .unwrap();
+    fs.write(
+        path!("/project/main_repo/.git/info/exclude").as_ref(),
+        b"shared-ignored.txt\n",
+    )
+    .await
+    .unwrap();
+    tree.flush_fs_events(cx).await;
+
+    tree.update(cx, |tree, _cx| {
+        check_worktree_entries(
+            tree,
+            WorktreeExpectations {
+                ignored_paths: &["main_repo/shared-ignored.txt", "linked/shared-ignored.txt"],
+                tracked_paths: &["main_repo/visible.txt", "linked/visible.txt"],
+                ..Default::default()
+            },
+        );
+    });
+
+    fs.write(
+        path!("/project/main_repo/.git/info/exclude").as_ref(),
+        b"newly-ignored.txt\n",
+    )
+    .await
+    .unwrap();
+    fs.write(
+        path!("/project/main_repo/newly-ignored.txt").as_ref(),
+        b"new",
+    )
+    .await
+    .unwrap();
+    fs.write(path!("/project/linked/newly-ignored.txt").as_ref(), b"new")
+        .await
+        .unwrap();
+    tree.flush_fs_events(cx).await;
+
+    tree.update(cx, |tree, _cx| {
+        check_worktree_entries(
+            tree,
+            WorktreeExpectations {
+                ignored_paths: &["main_repo/newly-ignored.txt", "linked/newly-ignored.txt"],
+                tracked_paths: &[
+                    "main_repo/shared-ignored.txt",
+                    "linked/shared-ignored.txt",
+                    "main_repo/visible.txt",
+                    "linked/visible.txt",
+                ],
+                ..Default::default()
+            },
+        );
+    });
 }
 
 #[gpui::test]


### PR DESCRIPTION
# Objective

Improve recognition of valid .git directories to avoid weird/bad UI states. Specifically, I noticed that zed treats empty .git directory as valid repo causing odd things to happen. For example I have a monorepo where it wrongly detected nested .git repos that caused the diffs to be completely borked: showed all changes as additions, despite the sidebar showing proper additions/removal loc count.

## Solution

The proposed solution is now more compliant in, my opinion, practical and common cases that may happen, while avoiding reinventing of the git behavior. I run several AI validation runs comparing the new implementation with the official git client. I wanted this to strike a good balance of speed and correctness.

When iterating on the detection, I noticed the .git handling logic is messy and duplicated so I run a refactor on it. To improve overall consistency and design. Some dead code was then pruned. Tests coverage was expanded too.

## Testing

- `cargo nextest run -p git -p fs -p worktree` (154), `-p worktree --lib` (9),
  `-p project --features test-support` (273 + 43 lib), `-p workspace` (219); fmt and
  clippy clean.
- The new tests were each checked to fail without their production change (e.g.
  reverting the identity gate makes the retarget test fail with GitStore stuck on
  the old repo; the malformed-`info/exclude` fixture uses `[z-a]`, which globset
  actually rejects — an unclosed `[` does not).
- Detection behaviors were compared against real git 2.54 directly: empty `.git`,
  broken gitfiles, missing `objects`/`refs`, symlink HEADs, linked worktrees,
  submodules, and bare/reftable layouts.
- Tested on Linux only. One test is `#[cfg(unix)]` (permission-based) and fails
  loudly instead of passing when run as root. I can't test Windows/macOS; the
  watcher-adjacent changes would benefit from a look there.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments

^ btw, there's a nice clippy linter rule for exactly that and this can be automated nicely.

- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed an empty or invalid nested `.git` directory shadowing the real repository.