### PR TITLE
editor: Refetch inlay hints when a new language server registers for a buffer

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1130,6 +1130,7 @@ pub struct Editor {
     next_scroll_position: NextScrollCursorCenterTopBottom,
     addons: TypeIdHashMap<Box<dyn Addon>>,
     registered_buffers: HashMap<BufferId, OpenLspBufferHandle>,
+    registered_language_servers: HashMap<BufferId, HashSet<LanguageServerId>>,
     load_diff_task: Option<Shared<Task<()>>>,
     diff_hunk_delegate: Option<Arc<dyn DiffHunkDelegate>>,
     selection_mark_mode: bool,
@@ -2030,8 +2031,14 @@ impl Editor {
                             cx,
                         );
                     }
-                    project::Event::LanguageServerRemoved(_) => {
+                    project::Event::LanguageServerRemoved(server_id) => {
                         editor.registered_buffers.clear();
+                        editor
+                            .registered_language_servers
+                            .retain(|_, known_servers| {
+                                known_servers.remove(server_id);
+                                !known_servers.is_empty()
+                            });
                         editor.register_visible_buffers(cx);
                         editor.invalidate_semantic_tokens(None);
                         editor.refresh_runnables(None, window, cx);
@@ -2060,13 +2067,37 @@ impl Editor {
                             }
                         }
                     }
-                    project::Event::LanguageServerBufferRegistered { buffer_id, .. } => {
+                    project::Event::LanguageServerBufferRegistered {
+                        buffer_id,
+                        server_id,
+                        ..
+                    } => {
                         let buffer_id = *buffer_id;
                         if editor.buffer().read(cx).buffer(buffer_id).is_some() {
                             editor.register_buffer(buffer_id, cx);
                             editor.refresh_runnables(Some(buffer_id), window, cx);
                             editor.update_lsp_data(Some(buffer_id), window, cx);
-                            editor.refresh_inlay_hints(InlayHintRefreshReason::NewLinesShown, cx);
+                            // `hint_chunk_fetching` is tracked per buffer, not per server,
+                            // so a newly-added server requires re-fetching visible chunks.
+                            let known_servers = editor
+                                .registered_language_servers
+                                .entry(buffer_id)
+                                .or_default();
+                            let is_new_server = known_servers.insert(*server_id);
+                            if is_new_server && known_servers.len() > 1 {
+                                if let Some(inlay_hints) = editor.inlay_hints.as_mut() {
+                                    inlay_hints.invalidate_for_new_server(&buffer_id);
+                                }
+                                if let Some(semantics_provider) = editor.semantics_provider() {
+                                    let mut buffers = HashSet::default();
+                                    buffers.insert(buffer_id);
+                                    semantics_provider.invalidate_inlay_hints(&buffers, cx);
+                                }
+                                editor.refresh_inlay_hints(InlayHintRefreshReason::ServerAdded, cx);
+                            } else {
+                                editor
+                                    .refresh_inlay_hints(InlayHintRefreshReason::NewLinesShown, cx);
+                            }
                             refresh_linked_ranges(editor, window, cx);
                             editor.refresh_code_actions_for_selection(window, cx);
                             editor.refresh_document_highlights(cx);
@@ -2438,6 +2469,7 @@ impl Editor {
             next_scroll_position: NextScrollCursorCenterTopBottom::default(),
             addons: Default::default(),
             registered_buffers: HashMap::default(),
+            registered_language_servers: HashMap::default(),
             _scroll_cursor_center_top_bottom_task: Task::ready(()),
             selection_mark_mode: false,
             toggle_fold_multiple_buffers: Task::ready(()),
@@ -9612,6 +9644,7 @@ impl Editor {
                 );
                 for buffer_id in removed_buffer_ids {
                     self.registered_buffers.remove(buffer_id);
+                    self.registered_language_servers.remove(buffer_id);
                     self.clear_runnables(Some(*buffer_id));
                     self.semantic_token_state.invalidate_buffer(buffer_id);
                     self.lsp_document_symbols.remove(buffer_id);

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -224,6 +224,13 @@ impl LspInlayHintData {
             self.hint_chunk_fetching.remove(buffer_id);
         }
     }
+
+    pub(crate) fn invalidate_for_new_server(&mut self, buffer_id: &BufferId) {
+        self.hint_refresh_tasks.remove(buffer_id);
+        if let Some((_, chunks)) = self.hint_chunk_fetching.get_mut(buffer_id) {
+            chunks.clear();
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -234,6 +241,7 @@ pub enum InlayHintRefreshReason {
     NewLinesShown,
     BufferEdited(BufferId),
     ServerRemoved,
+    ServerAdded,
     RefreshRequested {
         server_id: LanguageServerId,
         request_id: Option<usize>,
@@ -323,7 +331,8 @@ impl Editor {
             InlayHintRefreshReason::ModifiersChanged(_)
             | InlayHintRefreshReason::Toggle(_)
             | InlayHintRefreshReason::SettingsChange(_)
-            | InlayHintRefreshReason::ServerRemoved => true,
+            | InlayHintRefreshReason::ServerRemoved
+            | InlayHintRefreshReason::ServerAdded => true,
             InlayHintRefreshReason::NewLinesShown
             | InlayHintRefreshReason::RefreshRequested { .. }
             | InlayHintRefreshReason::BuffersRemoved(_) => false,
@@ -539,6 +548,7 @@ impl Editor {
                 return None;
             }
             InlayHintRefreshReason::ServerRemoved => InvalidationStrategy::BufferEdited,
+            InlayHintRefreshReason::ServerAdded => InvalidationStrategy::None,
             InlayHintRefreshReason::NewLinesShown => InvalidationStrategy::None,
             InlayHintRefreshReason::BufferEdited(_) => InvalidationStrategy::BufferEdited,
             InlayHintRefreshReason::RefreshRequested {
@@ -4384,7 +4394,7 @@ let c = 3;"#
             .unwrap();
     }
 
-    #[gpui::test]
+    #[gpui::test(iterations = 30)]
     async fn test_refresh_requested_multi_server(cx: &mut gpui::TestAppContext) {
         // Bug 2: When one LSP server sends workspace/inlayHint/refresh, the editor
         // wipes all tracking state via clear(), then spawns tasks that call


### PR DESCRIPTION
# Objective

`test_refresh_requested_multi_server` is order-dependent: it passes at seed 0, which CI runs, but fails on others (e.g., 1, 11, 15). Any unrelated change that schedules one extra task shifts the deterministic test scheduler enough to flip it at seed 0 too — which is how it surfaced, while working on #61009 (same class of order-dependent test failure as #61147 and #61142).

The test exposes a real bug: both the editor and `LspStore` track fetched inlay-hint chunks per buffer, not per language server. After server A returns hints for the visible range, the chunk is considered complete. When server B later registers for the same buffer, neither the editor's `hint_chunk_fetching` nor `LspStore`'s cached/fetched hints are keyed by server, so server B's hints are never queried.

## Solution

Track the set of registered language servers per buffer. In the `LanguageServerBufferRegistered` handler, when a newly-added server opens a buffer that already has registered servers:

- Clear the editor's `hint_refresh_tasks` and `hint_chunk_fetching` for the buffer.
- Call `semantics_provider.invalidate_inlay_hints` to clear `LspStore`'s cached hints for the buffer.
- Refresh with a new `InlayHintRefreshReason::ServerAdded`, which ignores previous fetches and keeps existing visible hints, so the re-fetch merges hints from all registered servers.

On `LanguageServerRemoved`, remove only the deleted server ID from each buffer's tracked set and drop any entries that become empty. Clear the per-buffer server tracking when the buffer is closed.

Also run `test_refresh_requested_multi_server` for 30 iterations to cover both orderings.

## Testing

- `test_refresh_requested_multi_server` now passes for 30 iterations.
- `cargo test -p editor inlay_hint` — 21 passed, 0 failed
- `cargo test -p editor` — 851 passed, 0 failed, 1 ignored
- `./script/clippy -p editor` — passes

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed inlay hints from a newly-added language server not appearing until the buffer was edited or scrolled
