### PR TITLE
editor: Support separate indentation and tab widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> Remove this line to confirm you've reviewed this PR before submitting.
+
 # Zed
 
 [![Zed](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/zed-industries/zed/main/assets/badge/v0.json)](https://zed.dev)

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1591,8 +1591,11 @@
   // Whether to indent lines using tab characters, as opposed to multiple
   // spaces.
   "hard_tabs": false,
-  // How many columns a tab should occupy.
+  // How many columns each indentation level should occupy.
   "tab_size": 4,
+  // How many columns a literal tab character should occupy. When omitted, this
+  // uses tab_size.
+  // "tab_width": 4,
   // Number of lines to search for modelines at the beginning and end of files.
   // Modelines contain editor directives (e.g., vim/emacs settings) that configure
   // the editor behavior for specific files.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1540,8 +1540,11 @@
   // Whether to indent lines using tab characters, as opposed to multiple
   // spaces.
   "hard_tabs": false,
-  // How many columns a tab should occupy.
+  // How many columns each indentation level should occupy.
   "tab_size": 4,
+  // How many columns a literal tab character should occupy. When omitted, this
+  // uses tab_size.
+  // "tab_width": 4,
   // Number of lines to search for modelines at the beginning and end of files.
   // Modelines contain editor directives (e.g., vim/emacs settings) that configure
   // the editor behavior for specific files.

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -885,6 +885,7 @@ impl ToolCall {
         language_registry: Arc<LanguageRegistry>,
         path_style: PathStyle,
         terminals: &HashMap<acp::TerminalId, Entity<Terminal>>,
+        project: &Entity<Project>,
         cx: &mut App,
     ) -> Result<Self> {
         let title = if tool_call.kind == acp::ToolKind::Execute {
@@ -903,6 +904,7 @@ impl ToolCall {
                 language_registry.clone(),
                 path_style,
                 terminals,
+                project,
                 cx,
             )? {
                 content.push(item);
@@ -956,6 +958,7 @@ impl ToolCall {
         language_registry: Arc<LanguageRegistry>,
         path_style: PathStyle,
         terminals: &HashMap<acp::TerminalId, Entity<Terminal>>,
+        project: &Entity<Project>,
         cx: &mut App,
     ) -> Result<()> {
         let acp::ToolCallUpdateFields {
@@ -1021,8 +1024,14 @@ impl ToolCall {
 
             // Reuse existing content if we can
             for (old, new) in self.content.iter_mut().zip(content.by_ref()) {
-                let valid_content =
-                    old.update_from_acp(new, language_registry.clone(), path_style, terminals, cx)?;
+                let valid_content = old.update_from_acp(
+                    new,
+                    language_registry.clone(),
+                    path_style,
+                    terminals,
+                    project,
+                    cx,
+                )?;
                 if !valid_content {
                     new_content_len -= 1;
                 }
@@ -1033,6 +1042,7 @@ impl ToolCall {
                     language_registry.clone(),
                     path_style,
                     terminals,
+                    project,
                     cx,
                 )? {
                     self.content.push(new);
@@ -1817,6 +1827,7 @@ impl ToolCallContent {
         language_registry: Arc<LanguageRegistry>,
         path_style: PathStyle,
         terminals: &HashMap<acp::TerminalId, Entity<Terminal>>,
+        project: &Entity<Project>,
         cx: &mut App,
     ) -> Result<Option<Self>> {
         match content {
@@ -1829,8 +1840,10 @@ impl ToolCallContent {
                 )),
             )),
             acp::ToolCallContent::Diff(diff) => Ok(Some(Self::Diff(cx.new(|cx| {
+                let file = file_for_path(project, &diff.path, cx);
                 Diff::finalized(
                     diff.path.to_string_lossy().into_owned(),
+                    file,
                     diff.old_text,
                     diff.new_text,
                     language_registry,
@@ -1852,6 +1865,7 @@ impl ToolCallContent {
         language_registry: Arc<LanguageRegistry>,
         path_style: PathStyle,
         terminals: &HashMap<acp::TerminalId, Entity<Terminal>>,
+        project: &Entity<Project>,
         cx: &mut App,
     ) -> Result<bool> {
         // Update streaming text in place so the rendered markdown element is
@@ -1876,7 +1890,9 @@ impl ToolCallContent {
             _ => true,
         };
 
-        if let Some(update) = Self::from_acp(new, language_registry, path_style, terminals, cx)? {
+        if let Some(update) =
+            Self::from_acp(new, language_registry, path_style, terminals, project, cx)?
+        {
             if needs_update {
                 *self = update;
             }
@@ -3164,6 +3180,7 @@ impl AcpThread {
                     languages,
                     path_style,
                     &self.terminals,
+                    &self.project,
                     cx,
                 )?;
                 if location_updated {
@@ -3236,6 +3253,7 @@ impl AcpThread {
                 language_registry,
                 path_style,
                 &self.terminals,
+                &self.project,
                 cx,
             )?;
             call.update_status(status);
@@ -3248,6 +3266,7 @@ impl AcpThread {
                 language_registry,
                 self.project.read(cx).path_style(cx),
                 &self.terminals,
+                &self.project,
                 cx,
             )?;
             self.push_entry(AgentThreadEntry::ToolCall(call), cx);

--- a/crates/acp_thread/src/diff.rs
+++ b/crates/acp_thread/src/diff.rs
@@ -3,10 +3,12 @@ use buffer_diff::BufferDiff;
 use gpui::{App, AppContext, AsyncApp, Context, Entity, Subscription, Task};
 use itertools::Itertools;
 use language::{
-    Anchor, Buffer, Capability, LanguageRegistry, OffsetRangeExt as _, Point, TextBuffer,
+    Anchor, Buffer, Capability, File, LanguageRegistry, OffsetRangeExt as _, Point, TextBuffer,
 };
 use multi_buffer::{MultiBuffer, PathKey, excerpt_context_lines};
+use project::Project;
 use std::{cmp::Reverse, ops::Range, path::Path, sync::Arc};
+use text::ReplicaId;
 use util::ResultExt;
 
 pub enum Diff {
@@ -17,13 +19,21 @@ pub enum Diff {
 impl Diff {
     pub fn finalized(
         path: String,
+        file: Option<Arc<dyn File>>,
         old_text: Option<String>,
         new_text: String,
         language_registry: Arc<LanguageRegistry>,
         cx: &mut Context<Self>,
     ) -> Self {
         let multibuffer = cx.new(|_cx| MultiBuffer::without_headers(Capability::ReadOnly));
-        let new_buffer = cx.new(|cx| Buffer::local(new_text, cx));
+        let new_buffer = cx.new(|cx| {
+            let text_buffer = TextBuffer::new(
+                ReplicaId::LOCAL,
+                cx.entity_id().as_non_zero_u64().into(),
+                new_text,
+            );
+            Buffer::build(text_buffer, file, Capability::ReadWrite)
+        });
         let base_text_exists = old_text.is_some();
         let base_text = old_text.clone().unwrap_or(String::new()).into();
         let task = cx.spawn({
@@ -270,13 +280,14 @@ impl PendingDiff {
         // Replace the buffer in the multibuffer with the snapshot
         let buffer = cx.new(|cx| {
             let language = self.new_buffer.read(cx).language().cloned();
+            let file = self.new_buffer.read(cx).file().cloned();
             let buffer = TextBuffer::new_normalized(
                 replica_id,
                 cx.entity_id().as_non_zero_u64().into(),
                 self.new_buffer.read(cx).line_ending(),
                 self.new_buffer.read(cx).as_rope().clone(),
             );
-            let mut buffer = Buffer::build(buffer, None, Capability::ReadWrite, cx);
+            let mut buffer = Buffer::build(buffer, file, Capability::ReadWrite, cx);
             buffer.set_language(language, cx);
             buffer
         });
@@ -381,6 +392,21 @@ pub struct FinalizedDiff {
     _update_diff: Task<Result<()>>,
 }
 
+/// Resolves a worktree file handle for `path` so that the detached buffers
+/// backing finalized diff cards resolve path-dependent settings (such as
+/// .editorconfig and worktree-specific overrides) like the real buffer would.
+pub fn file_for_path(project: &Entity<Project>, path: &Path, cx: &App) -> Option<Arc<dyn File>> {
+    let project = project.read(cx);
+    let project_path = project.find_project_path(path, cx)?;
+    let worktree = project.worktree_for_id(project_path.worktree_id, cx)?;
+    let entry = worktree
+        .read(cx)
+        .entry_for_path(&project_path.path)?
+        .clone();
+    let file: Arc<dyn File> = project::File::for_entry(entry, worktree);
+    Some(file)
+}
+
 async fn build_buffer_diff(
     old_text: Arc<str>,
     base_text_exists: bool,
@@ -408,8 +434,20 @@ async fn build_buffer_diff(
 mod tests {
     use gpui::{AppContext as _, TestAppContext};
     use language::Buffer;
+    use project::{FakeFs, Project};
+    use serde_json::json;
+    use settings::SettingsStore;
+    use std::path::Path;
+    use util::path;
 
-    use crate::Diff;
+    use crate::{Diff, diff::file_for_path};
+
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+    }
 
     #[gpui::test]
     async fn test_pending_diff(cx: &mut TestAppContext) {
@@ -419,5 +457,73 @@ mod tests {
             buffer.set_text("HELLO!", cx);
         });
         cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    async fn test_finalized_diff_carries_file_association(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/project"), json!({ "a.txt": "one\ntwo\n" }))
+            .await;
+        let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+        let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+
+        let diff = cx.new(|cx| {
+            let file = file_for_path(&project, Path::new(path!("/project/a.txt")), cx);
+            assert!(file.is_some());
+            Diff::finalized(
+                "a.txt".to_string(),
+                file,
+                Some("one\ntwo\n".to_string()),
+                "one\nTWO\n".to_string(),
+                language_registry,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        diff.read_with(cx, |diff, cx| {
+            let buffers = diff.multibuffer().read(cx).all_buffers();
+            assert_eq!(buffers.len(), 1);
+            for buffer in buffers {
+                let buffer = buffer.read(cx);
+                let file = buffer.file().expect("diff buffer should have a file");
+                assert_eq!(file.path().as_unix_str(), "a.txt");
+            }
+        });
+    }
+
+    #[gpui::test]
+    async fn test_finalize_preserves_file_association(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/project"), json!({ "a.txt": "one\ntwo\n" }))
+            .await;
+        let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/project/a.txt"), cx)
+            })
+            .await
+            .unwrap();
+
+        let diff = cx.new(|cx| Diff::new(buffer.clone(), cx));
+        buffer.update(cx, |buffer, cx| buffer.set_text("one\nTWO\n", cx));
+        cx.run_until_parked();
+
+        diff.update(cx, |diff, cx| diff.finalize(cx));
+        cx.run_until_parked();
+
+        diff.read_with(cx, |diff, cx| {
+            let buffers = diff.multibuffer().read(cx).all_buffers();
+            assert_eq!(buffers.len(), 1);
+            for buffer in buffers {
+                let buffer = buffer.read(cx);
+                let file = buffer
+                    .file()
+                    .expect("finalized diff buffer should keep its file");
+                assert_eq!(file.path().as_unix_str(), "a.txt");
+            }
+        });
     }
 }

--- a/crates/acp_thread/src/diff.rs
+++ b/crates/acp_thread/src/diff.rs
@@ -398,15 +398,14 @@ pub struct FinalizedDiff {
 /// Resolves a worktree file handle for `path` so that the detached buffers
 /// backing finalized diff cards resolve path-dependent settings (such as
 /// .editorconfig and worktree-specific overrides) like the real buffer would.
-pub fn file_for_path(
-    project: &Entity<Project>,
-    path: &Path,
-    cx: &App,
-) -> Option<Arc<dyn File>> {
+pub fn file_for_path(project: &Entity<Project>, path: &Path, cx: &App) -> Option<Arc<dyn File>> {
     let project = project.read(cx);
     let project_path = project.find_project_path(path, cx)?;
     let worktree = project.worktree_for_id(project_path.worktree_id, cx)?;
-    let entry = worktree.read(cx).entry_for_path(&project_path.path)?.clone();
+    let entry = worktree
+        .read(cx)
+        .entry_for_path(&project_path.path)?
+        .clone();
     let file: Arc<dyn File> = project::File::for_entry(entry, worktree);
     Some(file)
 }

--- a/crates/acp_thread/src/diff.rs
+++ b/crates/acp_thread/src/diff.rs
@@ -3,10 +3,12 @@ use buffer_diff::BufferDiff;
 use gpui::{App, AppContext, AsyncApp, Context, Entity, Subscription, Task};
 use itertools::Itertools;
 use language::{
-    Anchor, Buffer, Capability, LanguageRegistry, OffsetRangeExt as _, Point, TextBuffer,
+    Anchor, Buffer, Capability, File, LanguageRegistry, OffsetRangeExt as _, Point, TextBuffer,
 };
 use multi_buffer::{MultiBuffer, PathKey, excerpt_context_lines};
+use project::Project;
 use std::{cmp::Reverse, ops::Range, path::Path, sync::Arc};
+use text::ReplicaId;
 use util::ResultExt;
 
 pub enum Diff {
@@ -17,13 +19,21 @@ pub enum Diff {
 impl Diff {
     pub fn finalized(
         path: String,
+        file: Option<Arc<dyn File>>,
         old_text: Option<String>,
         new_text: String,
         language_registry: Arc<LanguageRegistry>,
         cx: &mut Context<Self>,
     ) -> Self {
         let multibuffer = cx.new(|_cx| MultiBuffer::without_headers(Capability::ReadOnly));
-        let new_buffer = cx.new(|cx| Buffer::local(new_text, cx));
+        let new_buffer = cx.new(|cx| {
+            let text_buffer = TextBuffer::new(
+                ReplicaId::LOCAL,
+                cx.entity_id().as_non_zero_u64().into(),
+                new_text,
+            );
+            Buffer::build(text_buffer, file, Capability::ReadWrite)
+        });
         let base_text_exists = old_text.is_some();
         let base_text = old_text.clone().unwrap_or(String::new()).into();
         let task = cx.spawn({
@@ -273,13 +283,14 @@ impl PendingDiff {
         // Replace the buffer in the multibuffer with the snapshot
         let buffer = cx.new(|cx| {
             let language = self.new_buffer.read(cx).language().cloned();
+            let file = self.new_buffer.read(cx).file().cloned();
             let buffer = TextBuffer::new_normalized(
                 replica_id,
                 cx.entity_id().as_non_zero_u64().into(),
                 self.new_buffer.read(cx).line_ending(),
                 self.new_buffer.read(cx).as_rope().clone(),
             );
-            let mut buffer = Buffer::build(buffer, None, Capability::ReadWrite);
+            let mut buffer = Buffer::build(buffer, file, Capability::ReadWrite);
             buffer.set_language(language, cx);
             buffer
         });
@@ -384,6 +395,22 @@ pub struct FinalizedDiff {
     _update_diff: Task<Result<()>>,
 }
 
+/// Resolves a worktree file handle for `path` so that the detached buffers
+/// backing finalized diff cards resolve path-dependent settings (such as
+/// .editorconfig and worktree-specific overrides) like the real buffer would.
+pub fn file_for_path(
+    project: &Entity<Project>,
+    path: &Path,
+    cx: &App,
+) -> Option<Arc<dyn File>> {
+    let project = project.read(cx);
+    let project_path = project.find_project_path(path, cx)?;
+    let worktree = project.worktree_for_id(project_path.worktree_id, cx)?;
+    let entry = worktree.read(cx).entry_for_path(&project_path.path)?.clone();
+    let file: Arc<dyn File> = project::File::for_entry(entry, worktree);
+    Some(file)
+}
+
 async fn build_buffer_diff(
     old_text: Arc<str>,
     base_text_exists: bool,
@@ -415,8 +442,20 @@ async fn build_buffer_diff(
 mod tests {
     use gpui::{AppContext as _, TestAppContext};
     use language::Buffer;
+    use project::{FakeFs, Project};
+    use serde_json::json;
+    use settings::SettingsStore;
+    use std::path::Path;
+    use util::path;
 
-    use crate::Diff;
+    use crate::{Diff, diff::file_for_path};
+
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+    }
 
     #[gpui::test]
     async fn test_pending_diff(cx: &mut TestAppContext) {
@@ -426,5 +465,73 @@ mod tests {
             buffer.set_text("HELLO!", cx);
         });
         cx.run_until_parked();
+    }
+
+    #[gpui::test]
+    async fn test_finalized_diff_carries_file_association(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/project"), json!({ "a.txt": "one\ntwo\n" }))
+            .await;
+        let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+        let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+
+        let diff = cx.new(|cx| {
+            let file = file_for_path(&project, Path::new(path!("/project/a.txt")), cx);
+            assert!(file.is_some());
+            Diff::finalized(
+                "a.txt".to_string(),
+                file,
+                Some("one\ntwo\n".to_string()),
+                "one\nTWO\n".to_string(),
+                language_registry,
+                cx,
+            )
+        });
+        cx.run_until_parked();
+
+        diff.read_with(cx, |diff, cx| {
+            let buffers = diff.multibuffer().read(cx).all_buffers();
+            assert_eq!(buffers.len(), 1);
+            for buffer in buffers {
+                let buffer = buffer.read(cx);
+                let file = buffer.file().expect("diff buffer should have a file");
+                assert_eq!(file.path().as_unix_str(), "a.txt");
+            }
+        });
+    }
+
+    #[gpui::test]
+    async fn test_finalize_preserves_file_association(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/project"), json!({ "a.txt": "one\ntwo\n" }))
+            .await;
+        let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/project/a.txt"), cx)
+            })
+            .await
+            .unwrap();
+
+        let diff = cx.new(|cx| Diff::new(buffer.clone(), cx));
+        buffer.update(cx, |buffer, cx| buffer.set_text("one\nTWO\n", cx));
+        cx.run_until_parked();
+
+        diff.update(cx, |diff, cx| diff.finalize(cx));
+        cx.run_until_parked();
+
+        diff.read_with(cx, |diff, cx| {
+            let buffers = diff.multibuffer().read(cx).all_buffers();
+            assert_eq!(buffers.len(), 1);
+            for buffer in buffers {
+                let buffer = buffer.read(cx);
+                let file = buffer
+                    .file()
+                    .expect("finalized diff buffer should keep its file");
+                assert_eq!(file.path().as_unix_str(), "a.txt");
+            }
+        });
     }
 }

--- a/crates/agent/src/tools/edit_session.rs
+++ b/crates/agent/src/tools/edit_session.rs
@@ -249,8 +249,10 @@ impl EditSessionContext {
                 ..
             } => {
                 event_stream.update_diff(cx.new(|cx| {
+                    let file = acp_thread::file_for_path(&self.project, &input_path, cx);
                     Diff::finalized(
                         input_path.to_string_lossy().into_owned(),
+                        file,
                         Some(old_text.to_string()),
                         new_text,
                         self.language_registry.clone(),

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -1101,17 +1101,22 @@ async fn heuristic_syntactic_expand(
             return Some(node_row_range);
         } else if node_name.ends_with("statement") || node_name.ends_with("declaration") {
             // Expand to the nearest dedent or blank line for statements and declarations.
-            let tab_size =
-                cx.update(|cx| snapshot.settings_at(node_range.start, cx).tab_size.get());
+            let indentation =
+                cx.update(|cx| snapshot.settings_at(node_range.start, cx).indentation());
             let indent_level = snapshot
-                .line_indent_for_row(node_range.start.row)
-                .len(tab_size);
+                .indentation_size_for_line(node_range.start.row, indentation)
+                .len;
             let rows_remaining = max_row_count.saturating_sub(row_count);
             let Some(start_row) = (node_range.start.row.saturating_sub(rows_remaining)
                 ..node_range.start.row)
                 .rev()
                 .find(|row| {
-                    is_line_blank_or_indented_less(indent_level, *row, tab_size, &snapshot.clone())
+                    is_line_blank_or_indented_less(
+                        indent_level,
+                        *row,
+                        indentation,
+                        &snapshot.clone(),
+                    )
                 })
             else {
                 return Some(node_row_range);
@@ -1123,7 +1128,12 @@ async fn heuristic_syntactic_expand(
                     snapshot.row_count(),
                 ))
                 .find(|row| {
-                    is_line_blank_or_indented_less(indent_level, *row, tab_size, &snapshot.clone())
+                    is_line_blank_or_indented_less(
+                        indent_level,
+                        *row,
+                        indentation,
+                        &snapshot.clone(),
+                    )
                 })
             else {
                 return Some(node_row_range);
@@ -1146,9 +1156,10 @@ async fn heuristic_syntactic_expand(
 fn is_line_blank_or_indented_less(
     indent_level: u32,
     row: u32,
-    tab_size: u32,
+    indentation: language::language_settings::IndentationSettings,
     snapshot: &BufferSnapshot,
 ) -> bool {
     let line_indent = snapshot.line_indent_for_row(row);
-    line_indent.is_line_blank() || line_indent.len(tab_size) < indent_level
+    line_indent.is_line_blank()
+        || snapshot.indentation_size_for_line(row, indentation).len < indent_level
 }

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -1104,17 +1104,22 @@ async fn heuristic_syntactic_expand(
             return Some(node_row_range);
         } else if node_name.ends_with("statement") || node_name.ends_with("declaration") {
             // Expand to the nearest dedent or blank line for statements and declarations.
-            let tab_size =
-                cx.update(|cx| snapshot.settings_at(node_range.start, cx).tab_size.get());
+            let indentation =
+                cx.update(|cx| snapshot.settings_at(node_range.start, cx).indentation());
             let indent_level = snapshot
-                .line_indent_for_row(node_range.start.row)
-                .len(tab_size);
+                .indentation_size_for_line(node_range.start.row, indentation)
+                .len;
             let rows_remaining = max_row_count.saturating_sub(row_count);
             let Some(start_row) = (node_range.start.row.saturating_sub(rows_remaining)
                 ..node_range.start.row)
                 .rev()
                 .find(|row| {
-                    is_line_blank_or_indented_less(indent_level, *row, tab_size, &snapshot.clone())
+                    is_line_blank_or_indented_less(
+                        indent_level,
+                        *row,
+                        indentation,
+                        &snapshot.clone(),
+                    )
                 })
             else {
                 return Some(node_row_range);
@@ -1126,7 +1131,12 @@ async fn heuristic_syntactic_expand(
                     snapshot.row_count(),
                 ))
                 .find(|row| {
-                    is_line_blank_or_indented_less(indent_level, *row, tab_size, &snapshot.clone())
+                    is_line_blank_or_indented_less(
+                        indent_level,
+                        *row,
+                        indentation,
+                        &snapshot.clone(),
+                    )
                 })
             else {
                 return Some(node_row_range);
@@ -1149,9 +1159,10 @@ async fn heuristic_syntactic_expand(
 fn is_line_blank_or_indented_less(
     indent_level: u32,
     row: u32,
-    tab_size: u32,
+    indentation: language::language_settings::IndentationSettings,
     snapshot: &BufferSnapshot,
 ) -> bool {
     let line_indent = snapshot.line_indent_for_row(row);
-    line_indent.is_line_blank() || line_indent.len(tab_size) < indent_level
+    line_indent.is_line_blank()
+        || snapshot.indentation_size_for_line(row, indentation).len < indent_level
 }

--- a/crates/diagnostics/src/diagnostics_tests.rs
+++ b/crates/diagnostics/src/diagnostics_tests.rs
@@ -23,6 +23,7 @@ use serde_json::json;
 use settings::SettingsStore;
 use std::{
     env,
+    num::NonZeroU32,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -33,6 +34,30 @@ use workspace::MultiWorkspace;
 #[ctor::ctor(unsafe)]
 fn init_logger() {
     zlog::init_test();
+}
+
+#[gpui::test]
+fn test_diagnostic_context_compares_indentation_columns(cx: &mut gpui::App) {
+    cx.new(|cx| {
+        let buffer = Buffer::local("  \tchild\n\t  sibling\nroot\n", cx);
+        let snapshot = buffer.snapshot();
+        let indentation = language::language_settings::IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(4).unwrap(),
+            true,
+        );
+
+        assert!(is_line_blank_or_indented_less(5, 0, indentation, &snapshot));
+        assert!(!is_line_blank_or_indented_less(
+            5,
+            1,
+            indentation,
+            &snapshot
+        ));
+        assert!(is_line_blank_or_indented_less(5, 2, indentation, &snapshot));
+
+        buffer
+    });
 }
 
 #[gpui::test]

--- a/crates/editor/src/clipboard.rs
+++ b/crates/editor/src/clipboard.rs
@@ -24,9 +24,9 @@ impl ClipboardSelection {
         project: Option<&Entity<Project>>,
         cx: &App,
     ) -> Self {
-        let first_line_indent = buffer
-            .indent_size_for_line(MultiBufferRow(range.start.row))
-            .len;
+        let indentation = buffer.language_settings_at(range.start, cx).indentation();
+        let first_line_indent =
+            buffer.indentation_column_for_line(MultiBufferRow(range.start.row), indentation);
 
         let file_path = util::maybe!({
             let project = project?.read(cx);
@@ -728,6 +728,32 @@ fn edit_for_markdown_paste<'a>(
         Cow::Owned(format!("[{old_text}]({to_insert})"))
     };
     (range, new_text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editor_tests::init_test;
+
+    #[gpui::test]
+    fn test_clipboard_selection_records_indentation_column(cx: &mut gpui::TestAppContext) {
+        init_test(cx, |_| {});
+        let selection = cx.update(|cx| {
+            let buffer = MultiBuffer::build_simple("  \ttext", cx);
+            let snapshot = buffer.read(cx).snapshot(cx);
+
+            ClipboardSelection::for_buffer(
+                4,
+                false,
+                Point::new(0, 3)..Point::new(0, 7),
+                &snapshot,
+                None,
+                cx,
+            )
+        });
+
+        assert_eq!(selection.first_line_indent, 4);
+    }
 }
 
 /// Returns a filename of the form `image.{extension}` (or `image_{N}.{extension}`

--- a/crates/editor/src/code_lens.rs
+++ b/crates/editor/src/code_lens.rs
@@ -4,7 +4,7 @@ use collections::{HashMap, HashSet};
 use futures::{StreamExt as _, future::join_all, stream::FuturesUnordered};
 use gpui::{MouseButton, SharedString, Task, TaskExt, WeakEntity};
 use itertools::Itertools;
-use language::{BufferId, ClientCommand};
+use language::{BufferId, ClientCommand, Point};
 use multi_buffer::{Anchor, BufferOffset, MultiBufferRow, MultiBufferSnapshot, ToPoint as _};
 use project::{CodeAction, TaskSourceKind, lsp_store::code_lens::CodeLensActions};
 use task::TaskContext;
@@ -323,7 +323,7 @@ impl Editor {
             }
         }
 
-        let mut new_lines_by_row = group_lenses_by_row(all_lenses, snapshot)
+        let mut new_lines_by_row = group_lenses_by_row(all_lenses, snapshot, cx)
             .map(|line| (MultiBufferRow(line.position.to_point(snapshot).row), line))
             .collect::<HashMap<_, _>>();
 
@@ -580,6 +580,7 @@ fn displayed_title(item: &CodeLensItem) -> Option<&SharedString> {
 fn group_lenses_by_row(
     lenses: Vec<(Anchor, CodeLensItem)>,
     snapshot: &MultiBufferSnapshot,
+    cx: &App,
 ) -> impl Iterator<Item = CodeLensLine> {
     lenses
         .into_iter()
@@ -592,7 +593,10 @@ fn group_lenses_by_row(
         .filter_map(|(row, entries)| {
             let position = entries.first()?.0;
             let items = entries.into_iter().map(|(_, item)| item).collect();
-            let indent_column = snapshot.indent_size_for_line(row).len;
+            let indentation = snapshot
+                .language_settings_at(Point::new(row.0, 0), cx)
+                .indentation();
+            let indent_column = snapshot.indentation_column_for_line(row, indentation);
             Some(CodeLensLine {
                 position,
                 indent_column,
@@ -776,7 +780,7 @@ mod tests {
                 ]))
             });
 
-        cx.set_state("ˇfunction hello() {}\nfunction world() {}");
+        cx.set_state("ˇ\tfunction hello() {}\n  \tfunction world() {}");
 
         assert!(
             code_lens_request.next().await.is_some(),
@@ -791,14 +795,23 @@ mod tests {
                 "code lens should be enabled"
             );
             assert_eq!(
+                editor
+                    .code_lens
+                    .as_ref()
+                    .unwrap()
+                    .blocks
+                    .values()
+                    .flatten()
+                    .map(|block| block.line.indent_column)
+                    .collect::<Vec<_>>(),
+                vec![4, 4],
+            );
+            assert_eq!(
                 code_lens_assertion_text(editor, cx),
-                indoc! {r#"
-                    Lenses: 2 references
-                    Line 1: function hello() {}
-
-                    Lenses: 0 references
-                    Line 2: function world() {}
-                "#},
+                "Lenses: 2 references\n\
+                 Line 1: \tfunction hello() {}\n\n\
+                 Lenses: 0 references\n\
+                 Line 2:   \tfunction world() {}\n",
                 "both lenses should render their server-provided titles"
             );
         });

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -100,7 +100,7 @@ use gpui::{
 };
 use language::{
     LanguageAwareStyling, Point, Subscription as BufferSubscription,
-    language_settings::{AllLanguageSettings, LanguageSettings},
+    language_settings::LanguageSettings,
 };
 
 use multi_buffer::{
@@ -110,7 +110,7 @@ use multi_buffer::{
 use project::project_settings::DiagnosticSeverity;
 use project::{InlayId, lsp_store::LspFoldingRange, lsp_store::TokenType};
 use serde::Deserialize;
-use settings::Settings;
+use settings::SettingsStore;
 use smallvec::SmallVec;
 use sum_tree::{Bias, TreeMap};
 use text::{BufferId, LineIndent, Patch};
@@ -126,7 +126,6 @@ use std::{
     borrow::Cow,
     fmt::Debug,
     iter,
-    num::NonZeroU32,
     ops::{self, Add, Range, Sub},
     sync::Arc,
 };
@@ -137,7 +136,7 @@ use crate::{
 use block_map::{BlockPointCursor, BlockRow, BlockSnapshot};
 use fold_map::{FoldPointCursor, FoldSnapshot};
 use inlay_map::{BufferOffsetToInlayPointCursor, InlaySnapshot};
-use tab_map::{TabPoint, TabPointCursor, TabSnapshot};
+use tab_map::{PerBufferIndentationSettings, TabPoint, TabPointCursor, TabSnapshot};
 use wrap_map::{WrapMap, WrapPatch, WrapPointCursor};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -222,6 +221,8 @@ pub struct DisplayMap {
     fold_map: FoldMap,
     /// Keeps track of hard tabs in a buffer.
     tab_map: TabMap,
+    indentation_settings: PerBufferIndentationSettings,
+    indentation_settings_dirty: bool,
     /// Handles soft wrapping.
     wrap_map: Entity<WrapMap>,
     /// Tracks custom blocks such as diagnostics that should be displayed within buffer.
@@ -376,7 +377,7 @@ impl DisplayMap {
         diagnostics_max_severity: DiagnosticSeverity,
         cx: &mut Context<Self>,
     ) -> Self {
-        let tab_size = Self::tab_size(&buffer, cx);
+        let indentation_settings = Self::resolve_indentation_settings(&buffer, cx);
         // Important: obtain the snapshot BEFORE creating the subscription.
         // snapshot() may call sync() which publishes edits. If we subscribe first,
         // those edits would be captured but the InlayMap would already be at the
@@ -386,11 +387,27 @@ impl DisplayMap {
         let crease_map = CreaseMap::new(&buffer_snapshot);
         let (inlay_map, snapshot) = InlayMap::new(buffer_snapshot);
         let (fold_map, snapshot) = FoldMap::new(snapshot);
-        let (tab_map, snapshot) = TabMap::new(snapshot, tab_size);
+        let (tab_map, snapshot) =
+            TabMap::new_with_indentation_settings(snapshot, indentation_settings.clone());
         let (wrap_map, snapshot) = WrapMap::new(snapshot, font, font_size, wrap_width, cx);
         let block_map = BlockMap::new(snapshot, buffer_header_height, excerpt_header_height);
 
         cx.observe(&wrap_map, |_, _, cx| cx.notify()).detach();
+        cx.observe(&buffer, |this, _, cx| {
+            this.indentation_settings_dirty = true;
+            cx.notify();
+        })
+        .detach();
+        cx.subscribe(&buffer, |this, _, _, cx| {
+            this.indentation_settings_dirty = true;
+            cx.notify();
+        })
+        .detach();
+        cx.observe_global::<SettingsStore>(|this, cx| {
+            this.indentation_settings_dirty = true;
+            cx.notify();
+        })
+        .detach();
 
         DisplayMap {
             entity_id: cx.entity_id(),
@@ -399,6 +416,8 @@ impl DisplayMap {
             fold_map,
             inlay_map,
             tab_map,
+            indentation_settings,
+            indentation_settings_dirty: false,
             wrap_map,
             block_map,
             crease_map,
@@ -454,16 +473,22 @@ impl DisplayMap {
         let snapshot = {
             let edits = self.buffer_subscription.consume();
             let snapshot = self.buffer.read(cx).snapshot(cx);
-            let tab_size = Self::tab_size(&self.buffer, cx);
+            let indentation_settings = self.indentation_settings(cx);
             let (snapshot, edits) = self.inlay_map.sync(snapshot, edits.into_inner());
             let (mut writer, snapshot, edits) = self.fold_map.write(snapshot, edits);
-            let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+            let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+                snapshot,
+                edits,
+                indentation_settings.clone(),
+            );
             let (_snapshot, _edits) = self
                 .wrap_map
                 .update(cx, |wrap_map, cx| wrap_map.sync(snapshot, edits, cx));
 
             let (snapshot, edits) = writer.unfold_intersecting([Anchor::Min..Anchor::Max], true);
-            let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+            let (snapshot, edits) =
+                self.tab_map
+                    .sync_with_indentation_settings(snapshot, edits, indentation_settings);
             let (snapshot, _edits) = self
                 .wrap_map
                 .update(cx, |wrap_map, cx| wrap_map.sync(snapshot, edits, cx));
@@ -557,13 +582,15 @@ impl DisplayMap {
     }
 
     fn sync_through_wrap(&mut self, cx: &mut App) -> (WrapSnapshot, WrapPatch) {
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
         let buffer_snapshot = self.buffer.read(cx).snapshot(cx);
         let edits = self.buffer_subscription.consume().into_inner();
 
         let (snapshot, edits) = self.inlay_map.sync(buffer_snapshot, edits);
         let (snapshot, edits) = self.fold_map.read(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         self.wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx))
     }
@@ -724,11 +751,15 @@ impl DisplayMap {
 
         let buffer_snapshot = self.buffer.read(cx).snapshot(cx);
         let edits = self.buffer_subscription.consume().into_inner();
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
 
         let (snapshot, edits) = self.inlay_map.sync(buffer_snapshot.clone(), edits);
         let (mut fold_map, snapshot, edits) = self.fold_map.write(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+            snapshot,
+            edits,
+            indentation_settings.clone(),
+        );
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -746,7 +777,9 @@ impl DisplayMap {
         });
         let (snapshot, edits) = fold_map.fold(inline);
 
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -799,18 +832,24 @@ impl DisplayMap {
     ) {
         let snapshot = self.buffer.read(cx).snapshot(cx);
         let edits = self.buffer_subscription.consume().into_inner();
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
 
         let (snapshot, edits) = self.inlay_map.sync(snapshot, edits);
         let (mut fold_map, snapshot, edits) = self.fold_map.write(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+            snapshot,
+            edits,
+            indentation_settings.clone(),
+        );
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
         self.block_map.read(snapshot, edits, None);
 
         let (snapshot, edits) = fold_map.remove_folds(ranges, type_id);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         let (self_new_wrap_snapshot, self_new_wrap_edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -833,11 +872,15 @@ impl DisplayMap {
             .map(|range| range.start.to_offset(&snapshot)..range.end.to_offset(&snapshot))
             .collect::<Vec<_>>();
         let edits = self.buffer_subscription.consume().into_inner();
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
 
         let (snapshot, edits) = self.inlay_map.sync(snapshot, edits);
         let (mut fold_map, snapshot, edits) = self.fold_map.write(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+            snapshot,
+            edits,
+            indentation_settings.clone(),
+        );
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -845,7 +888,9 @@ impl DisplayMap {
 
         let (snapshot, edits) =
             fold_map.unfold_intersecting(offset_ranges.iter().cloned(), inclusive);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         let (self_new_wrap_snapshot, self_new_wrap_edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -1256,11 +1301,15 @@ impl DisplayMap {
     ) -> bool {
         let snapshot = self.buffer.read(cx).snapshot(cx);
         let edits = self.buffer_subscription.consume().into_inner();
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
 
         let (snapshot, edits) = self.inlay_map.sync(snapshot, edits);
         let (mut fold_map, snapshot, edits) = self.fold_map.write(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+            snapshot,
+            edits,
+            indentation_settings.clone(),
+        );
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -1268,7 +1317,9 @@ impl DisplayMap {
 
         let (snapshot, edits) = fold_map.update_fold_widths(widths);
         let widths_changed = !edits.is_empty();
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         let (self_new_wrap_snapshot, self_new_wrap_edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -1295,7 +1346,7 @@ impl DisplayMap {
         }
         let buffer_snapshot = self.buffer.read(cx).snapshot(cx);
         let edits = self.buffer_subscription.consume().into_inner();
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
 
         let companion_wrap_data = self.companion.as_ref().and_then(|(companion_dm, _)| {
             companion_dm
@@ -1305,7 +1356,11 @@ impl DisplayMap {
 
         let (snapshot, edits) = self.inlay_map.sync(buffer_snapshot, edits);
         let (snapshot, edits) = self.fold_map.read(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+            snapshot,
+            edits,
+            indentation_settings.clone(),
+        );
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -1322,7 +1377,9 @@ impl DisplayMap {
 
         let (snapshot, edits) = self.inlay_map.splice(to_remove, to_insert);
         let (snapshot, edits) = self.fold_map.read(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         let (self_new_wrap_snapshot, self_new_wrap_edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -1363,17 +1420,21 @@ impl DisplayMap {
     }
 
     #[instrument(skip_all)]
-    fn tab_size(buffer: &Entity<MultiBuffer>, cx: &App) -> NonZeroU32 {
-        if let Some(buffer) = buffer.read(cx).as_singleton().map(|buffer| buffer.read(cx)) {
-            LanguageSettings::for_buffer(buffer, cx)
-                .indentation()
-                .tab_width()
-        } else {
-            AllLanguageSettings::get_global(cx)
-                .defaults
-                .indentation()
-                .tab_width()
+    fn indentation_settings(&mut self, cx: &App) -> PerBufferIndentationSettings {
+        if self.indentation_settings_dirty {
+            self.indentation_settings = Self::resolve_indentation_settings(&self.buffer, cx);
+            self.indentation_settings_dirty = false;
         }
+        self.indentation_settings.clone()
+    }
+
+    fn resolve_indentation_settings(
+        buffer: &Entity<MultiBuffer>,
+        cx: &App,
+    ) -> PerBufferIndentationSettings {
+        let buffer = buffer.read(cx);
+        let (default, by_buffer) = buffer.indentation_settings(cx);
+        (default, Arc::new(by_buffer))
     }
 
     pub fn is_rewrapping(&self, cx: &gpui::App) -> bool {
@@ -2713,20 +2774,21 @@ pub mod tests {
     };
     use Bias::*;
     use block_map::BlockPlacement;
+    use buffer_diff::BufferDiff;
     use gpui::{
         App, AppContext as _, BorrowAppContext, Element, Hsla, Rgba, div, font, observe, px,
     };
     use language::{
-        Buffer, Diagnostic, DiagnosticEntry, DiagnosticSet, Language, LanguageConfig,
-        LanguageMatcher,
+        Buffer, Capability, Diagnostic, DiagnosticEntry, DiagnosticSet, Language, LanguageConfig,
+        LanguageMatcher, ModelineSettings,
     };
     use lsp::LanguageServerId;
 
     use futures::stream::StreamExt;
     use multi_buffer::PathKey;
     use rand::{Rng, prelude::*};
-    use settings::{SettingsContent, SettingsStore};
-    use std::{env, sync::Arc};
+    use settings::SettingsContent;
+    use std::{env, num::NonZeroU32, sync::Arc};
     use text::PointUtf16;
     use theme::{LoadThemes, SyntaxTheme};
     use unindent::Unindent as _;
@@ -4012,6 +4074,152 @@ pub mod tests {
         let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
 
         assert!(snapshot.starts_indent(MultiBufferRow(0)));
+    }
+
+    #[gpui::test]
+    fn test_literal_tabs_use_per_buffer_tab_widths(cx: &mut gpui::App) {
+        init_test(cx, &|settings| {
+            settings.project.all_languages.defaults.tab_size = NonZeroU32::new(4);
+        });
+
+        let buffer_with_indentation_settings = |text, indent_size, tab_width, cx: &mut App| {
+            cx.new(|cx| {
+                let mut buffer = Buffer::local(text, cx);
+                buffer.set_modeline(Some(ModelineSettings {
+                    tab_size: NonZeroU32::new(tab_width),
+                    indent_size: NonZeroU32::new(indent_size),
+                    ..Default::default()
+                }));
+                buffer
+            })
+        };
+        let narrow_buffer = buffer_with_indentation_settings("x\tnarrow", 8, 2, cx);
+        let wide_buffer = buffer_with_indentation_settings("x\twide", 2, 8, cx);
+        let multi_buffer = cx.new(|cx| {
+            let mut multi_buffer = MultiBuffer::without_headers(Capability::ReadOnly);
+            multi_buffer.set_excerpts_for_path(
+                multi_buffer::PathKey::sorted(0),
+                narrow_buffer.clone(),
+                [Point::zero()..narrow_buffer.read(cx).max_point()],
+                0,
+                cx,
+            );
+            multi_buffer.set_excerpts_for_path(
+                multi_buffer::PathKey::sorted(1),
+                wide_buffer.clone(),
+                [Point::zero()..wide_buffer.read(cx).max_point()],
+                0,
+                cx,
+            );
+            multi_buffer
+        });
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                multi_buffer,
+                font("Helvetica"),
+                px(14.0),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+
+        assert_eq!(
+            snapshot
+                .tab_snapshot()
+                .text()
+                .lines()
+                .filter(|line| !line.is_empty())
+                .collect::<Vec<_>>(),
+            ["x narrow", "x       wide"]
+        );
+        let wide_buffer_id = wide_buffer.read(cx).remote_id();
+        let wide_row = snapshot
+            .buffer_snapshot()
+            .row_infos(MultiBufferRow(0))
+            .find_map(|row| {
+                (row.buffer_id == Some(wide_buffer_id))
+                    .then_some(row.multibuffer_row)
+                    .flatten()
+            })
+            .expect("wide buffer should have a multibuffer row");
+        let wide_display_point =
+            snapshot.point_to_display_point(MultiBufferPoint::new(wide_row.0, 2), Bias::Left);
+        assert_eq!(wide_display_point.column(), 8);
+        assert_eq!(
+            snapshot.display_point_to_point(wide_display_point, Bias::Right),
+            MultiBufferPoint::new(wide_row.0, 2),
+        );
+
+        wide_buffer.update(cx, |buffer, cx| {
+            if buffer.set_modeline(Some(ModelineSettings {
+                tab_size: NonZeroU32::new(4),
+                indent_size: NonZeroU32::new(2),
+                ..Default::default()
+            })) {
+                cx.notify();
+            }
+        });
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+        assert_eq!(
+            snapshot
+                .tab_snapshot()
+                .text()
+                .lines()
+                .filter(|line| !line.is_empty())
+                .collect::<Vec<_>>(),
+            ["x narrow", "x   wide"]
+        );
+    }
+
+    #[gpui::test]
+    fn test_literal_tabs_use_per_buffer_width_in_singleton_inverted_diff(cx: &mut gpui::App) {
+        init_test(cx, &|settings| {
+            settings.project.all_languages.defaults.tab_size = NonZeroU32::new(4);
+        });
+
+        let main_buffer = cx.new(|cx| {
+            let mut buffer = Buffer::local("\ttext", cx);
+            buffer.set_modeline(Some(ModelineSettings {
+                tab_size: NonZeroU32::new(8),
+                indent_size: NonZeroU32::new(2),
+                ..Default::default()
+            }));
+            buffer
+        });
+        let diff = cx.new(|cx| {
+            BufferDiff::new_with_base_text("\ttext", &main_buffer.read(cx).text_snapshot(), cx)
+        });
+        let base_buffer = diff.read(cx).base_text_buffer().clone();
+        let multi_buffer = cx.new(|cx| {
+            let mut multi_buffer = MultiBuffer::singleton(base_buffer, cx);
+            multi_buffer.add_inverted_diff(diff, main_buffer, cx);
+            multi_buffer
+        });
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                multi_buffer,
+                font("Helvetica"),
+                px(14.0),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+
+        assert_eq!(
+            map.update(cx, |map, cx| map.snapshot(cx))
+                .tab_snapshot()
+                .text(),
+            "        text",
+        );
     }
 
     #[gpui::test]

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -4223,6 +4223,36 @@ pub mod tests {
     }
 
     #[gpui::test]
+    fn test_literal_tabs_use_tab_width(cx: &mut gpui::App) {
+        init_test(cx, &|settings| {
+            settings.project.all_languages.defaults.tab_size = NonZeroU32::new(4);
+            settings.project.all_languages.defaults.tab_width = NonZeroU32::new(8);
+        });
+
+        let buffer = MultiBuffer::build_simple("\ttext\n    \ttext", cx);
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer,
+                font("Helvetica"),
+                px(14.0),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+
+        assert_eq!(snapshot.text(), "        text\n        text");
+        assert_eq!(
+            snapshot.point_to_display_point(MultiBufferPoint::new(0, 1), Bias::Left),
+            DisplayPoint::new(DisplayRow(0), 8),
+        );
+    }
+
+    #[gpui::test]
     fn test_tabs_with_multibyte_chars(cx: &mut gpui::App) {
         init_test(cx, &|_| {});
 

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1365,9 +1365,14 @@ impl DisplayMap {
     #[instrument(skip_all)]
     fn tab_size(buffer: &Entity<MultiBuffer>, cx: &App) -> NonZeroU32 {
         if let Some(buffer) = buffer.read(cx).as_singleton().map(|buffer| buffer.read(cx)) {
-            LanguageSettings::for_buffer(buffer, cx).tab_size
+            LanguageSettings::for_buffer(buffer, cx)
+                .indentation()
+                .tab_width()
         } else {
-            AllLanguageSettings::get_global(cx).defaults.tab_size
+            AllLanguageSettings::get_global(cx)
+                .defaults
+                .indentation()
+                .tab_width()
         }
     }
 
@@ -2226,6 +2231,13 @@ impl DisplaySnapshot {
         self.buffer_snapshot().line_indent_for_row(buffer_row)
     }
 
+    fn indentation_column_for_buffer_row(&self, buffer_row: MultiBufferRow) -> u32 {
+        let indent = self.line_indent_for_buffer_row(buffer_row);
+        Point::new(buffer_row.0, indent.raw_len())
+            .to_display_point(self)
+            .column()
+    }
+
     pub fn line_len(&self, row: DisplayRow) -> u32 {
         self.block_snapshot.line_len(BlockRow(row.0))
     }
@@ -2250,11 +2262,14 @@ impl DisplaySnapshot {
         if line_indent.is_line_blank() {
             return false;
         }
+        let indentation_column = self.indentation_column_for_buffer_row(buffer_row);
 
         (buffer_row.0 + 1..=max_row.0)
             .find_map(|next_row| {
                 let next_line_indent = self.line_indent_for_buffer_row(MultiBufferRow(next_row));
-                if next_line_indent.raw_len() > line_indent.raw_len() {
+                if self.indentation_column_for_buffer_row(MultiBufferRow(next_row))
+                    > indentation_column
+                {
                     Some(true)
                 } else if !next_line_indent.is_line_blank() {
                     Some(false)
@@ -2330,7 +2345,7 @@ impl DisplaySnapshot {
             && self.starts_indent(MultiBufferRow(start.row))
             && !self.is_line_folded(MultiBufferRow(start.row))
         {
-            let start_line_indent = self.line_indent_for_buffer_row(buffer_row);
+            let start_indent_column = self.indentation_column_for_buffer_row(buffer_row);
             let snapshot = self.buffer_snapshot();
             let max_point = snapshot.max_point();
             let mut closing_row = None;
@@ -2350,7 +2365,8 @@ impl DisplaySnapshot {
             for row in (buffer_row.0 + 1)..=max_point.row {
                 let line_indent = self.line_indent_for_buffer_row(MultiBufferRow(row));
                 if !line_indent.is_line_blank()
-                    && line_indent.raw_len() <= start_line_indent.raw_len()
+                    && self.indentation_column_for_buffer_row(MultiBufferRow(row))
+                        <= start_indent_column
                 {
                     let in_string_or_comment_scope = snapshot
                         .language_scope_at(Point::new(row, 0))
@@ -3971,6 +3987,31 @@ pub mod tests {
 
             map
         });
+    }
+
+    #[gpui::test]
+    fn test_indent_folding_uses_display_columns(cx: &mut gpui::App) {
+        init_test(cx, &|settings| {
+            settings.project.all_languages.defaults.tab_size = NonZeroU32::new(4);
+        });
+
+        let buffer = MultiBuffer::build_simple("    parent\n\t child\nnext", cx);
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer,
+                font("Helvetica"),
+                px(14.0),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+
+        assert!(snapshot.starts_indent(MultiBufferRow(0)));
     }
 
     #[gpui::test]

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1364,9 +1364,14 @@ impl DisplayMap {
     #[instrument(skip_all)]
     fn tab_size(buffer: &Entity<MultiBuffer>, cx: &App) -> NonZeroU32 {
         if let Some(buffer) = buffer.read(cx).as_singleton().map(|buffer| buffer.read(cx)) {
-            LanguageSettings::for_buffer(buffer, cx).tab_size
+            LanguageSettings::for_buffer(buffer, cx)
+                .indentation()
+                .tab_width()
         } else {
-            AllLanguageSettings::get_global(cx).defaults.tab_size
+            AllLanguageSettings::get_global(cx)
+                .defaults
+                .indentation()
+                .tab_width()
         }
     }
 
@@ -2251,6 +2256,13 @@ impl DisplaySnapshot {
         self.buffer_snapshot().line_indent_for_row(buffer_row)
     }
 
+    fn indentation_column_for_buffer_row(&self, buffer_row: MultiBufferRow) -> u32 {
+        let indent = self.line_indent_for_buffer_row(buffer_row);
+        Point::new(buffer_row.0, indent.raw_len())
+            .to_display_point(self)
+            .column()
+    }
+
     pub fn line_len(&self, row: DisplayRow) -> u32 {
         self.block_snapshot.line_len(BlockRow(row.0))
     }
@@ -2275,11 +2287,14 @@ impl DisplaySnapshot {
         if line_indent.is_line_blank() {
             return false;
         }
+        let indentation_column = self.indentation_column_for_buffer_row(buffer_row);
 
         (buffer_row.0 + 1..=max_row.0)
             .find_map(|next_row| {
                 let next_line_indent = self.line_indent_for_buffer_row(MultiBufferRow(next_row));
-                if next_line_indent.raw_len() > line_indent.raw_len() {
+                if self.indentation_column_for_buffer_row(MultiBufferRow(next_row))
+                    > indentation_column
+                {
                     Some(true)
                 } else if !next_line_indent.is_line_blank() {
                     Some(false)
@@ -2355,7 +2370,7 @@ impl DisplaySnapshot {
             && self.starts_indent(MultiBufferRow(start.row))
             && !self.is_line_folded(MultiBufferRow(start.row))
         {
-            let start_line_indent = self.line_indent_for_buffer_row(buffer_row);
+            let start_indent_column = self.indentation_column_for_buffer_row(buffer_row);
             let snapshot = self.buffer_snapshot();
             let max_point = snapshot.max_point();
             let mut closing_row = None;
@@ -2375,7 +2390,8 @@ impl DisplaySnapshot {
             for row in (buffer_row.0 + 1)..=max_point.row {
                 let line_indent = self.line_indent_for_buffer_row(MultiBufferRow(row));
                 if !line_indent.is_line_blank()
-                    && line_indent.raw_len() <= start_line_indent.raw_len()
+                    && self.indentation_column_for_buffer_row(MultiBufferRow(row))
+                        <= start_indent_column
                 {
                     let in_string_or_comment_scope = snapshot
                         .language_scope_at(Point::new(row, 0))
@@ -3995,6 +4011,31 @@ pub mod tests {
 
             map
         });
+    }
+
+    #[gpui::test]
+    fn test_indent_folding_uses_display_columns(cx: &mut gpui::App) {
+        init_test(cx, &|settings| {
+            settings.project.all_languages.defaults.tab_size = NonZeroU32::new(4);
+        });
+
+        let buffer = MultiBuffer::build_simple("    parent\n\t child\nnext", cx);
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer,
+                font("Helvetica"),
+                px(14.0),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+
+        assert!(snapshot.starts_indent(MultiBufferRow(0)));
     }
 
     #[gpui::test]

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -99,7 +99,7 @@ use gpui::{
 };
 use language::{
     LanguageAwareStyling, Point, Subscription as BufferSubscription,
-    language_settings::{AllLanguageSettings, LanguageSettings},
+    language_settings::LanguageSettings,
 };
 
 use multi_buffer::{
@@ -109,7 +109,7 @@ use multi_buffer::{
 use project::project_settings::DiagnosticSeverity;
 use project::{InlayId, lsp_store::LspFoldingRange, lsp_store::TokenType};
 use serde::Deserialize;
-use settings::Settings;
+use settings::SettingsStore;
 use smallvec::SmallVec;
 use sum_tree::{Bias, TreeMap};
 use text::{BufferId, LineIndent, Patch};
@@ -125,7 +125,6 @@ use std::{
     borrow::Cow,
     fmt::Debug,
     iter,
-    num::NonZeroU32,
     ops::{self, Add, Range, Sub},
     sync::Arc,
 };
@@ -136,7 +135,7 @@ use crate::{
 use block_map::{BlockPointCursor, BlockRow, BlockSnapshot};
 use fold_map::{FoldPointCursor, FoldSnapshot};
 use inlay_map::{BufferOffsetToInlayPointCursor, InlaySnapshot};
-use tab_map::{TabPoint, TabPointCursor, TabSnapshot};
+use tab_map::{PerBufferIndentationSettings, TabPoint, TabPointCursor, TabSnapshot};
 use wrap_map::{WrapMap, WrapPatch, WrapPointCursor};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -221,6 +220,8 @@ pub struct DisplayMap {
     fold_map: FoldMap,
     /// Keeps track of hard tabs in a buffer.
     tab_map: TabMap,
+    indentation_settings: PerBufferIndentationSettings,
+    indentation_settings_dirty: bool,
     /// Handles soft wrapping.
     wrap_map: Entity<WrapMap>,
     /// Tracks custom blocks such as diagnostics that should be displayed within buffer.
@@ -375,7 +376,7 @@ impl DisplayMap {
         diagnostics_max_severity: DiagnosticSeverity,
         cx: &mut Context<Self>,
     ) -> Self {
-        let tab_size = Self::tab_size(&buffer, cx);
+        let indentation_settings = Self::resolve_indentation_settings(&buffer, cx);
         // Important: obtain the snapshot BEFORE creating the subscription.
         // snapshot() may call sync() which publishes edits. If we subscribe first,
         // those edits would be captured but the InlayMap would already be at the
@@ -385,11 +386,27 @@ impl DisplayMap {
         let crease_map = CreaseMap::new(&buffer_snapshot);
         let (inlay_map, snapshot) = InlayMap::new(buffer_snapshot);
         let (fold_map, snapshot) = FoldMap::new(snapshot);
-        let (tab_map, snapshot) = TabMap::new(snapshot, tab_size);
+        let (tab_map, snapshot) =
+            TabMap::new_with_indentation_settings(snapshot, indentation_settings.clone());
         let (wrap_map, snapshot) = WrapMap::new(snapshot, font, font_size, wrap_width, cx);
         let block_map = BlockMap::new(snapshot, buffer_header_height, excerpt_header_height);
 
         cx.observe(&wrap_map, |_, _, cx| cx.notify()).detach();
+        cx.observe(&buffer, |this, _, cx| {
+            this.indentation_settings_dirty = true;
+            cx.notify();
+        })
+        .detach();
+        cx.subscribe(&buffer, |this, _, _, cx| {
+            this.indentation_settings_dirty = true;
+            cx.notify();
+        })
+        .detach();
+        cx.observe_global::<SettingsStore>(|this, cx| {
+            this.indentation_settings_dirty = true;
+            cx.notify();
+        })
+        .detach();
 
         DisplayMap {
             entity_id: cx.entity_id(),
@@ -398,6 +415,8 @@ impl DisplayMap {
             fold_map,
             inlay_map,
             tab_map,
+            indentation_settings,
+            indentation_settings_dirty: false,
             wrap_map,
             block_map,
             crease_map,
@@ -453,16 +472,22 @@ impl DisplayMap {
         let snapshot = {
             let edits = self.buffer_subscription.consume();
             let snapshot = self.buffer.read(cx).snapshot(cx);
-            let tab_size = Self::tab_size(&self.buffer, cx);
+            let indentation_settings = self.indentation_settings(cx);
             let (snapshot, edits) = self.inlay_map.sync(snapshot, edits.into_inner());
             let (mut writer, snapshot, edits) = self.fold_map.write(snapshot, edits);
-            let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+            let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+                snapshot,
+                edits,
+                indentation_settings.clone(),
+            );
             let (_snapshot, _edits) = self
                 .wrap_map
                 .update(cx, |wrap_map, cx| wrap_map.sync(snapshot, edits, cx));
 
             let (snapshot, edits) = writer.unfold_intersecting([Anchor::Min..Anchor::Max], true);
-            let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+            let (snapshot, edits) =
+                self.tab_map
+                    .sync_with_indentation_settings(snapshot, edits, indentation_settings);
             let (snapshot, _edits) = self
                 .wrap_map
                 .update(cx, |wrap_map, cx| wrap_map.sync(snapshot, edits, cx));
@@ -556,13 +581,15 @@ impl DisplayMap {
     }
 
     fn sync_through_wrap(&mut self, cx: &mut App) -> (WrapSnapshot, WrapPatch) {
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
         let buffer_snapshot = self.buffer.read(cx).snapshot(cx);
         let edits = self.buffer_subscription.consume().into_inner();
 
         let (snapshot, edits) = self.inlay_map.sync(buffer_snapshot, edits);
         let (snapshot, edits) = self.fold_map.read(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         self.wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx))
     }
@@ -723,11 +750,15 @@ impl DisplayMap {
 
         let buffer_snapshot = self.buffer.read(cx).snapshot(cx);
         let edits = self.buffer_subscription.consume().into_inner();
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
 
         let (snapshot, edits) = self.inlay_map.sync(buffer_snapshot.clone(), edits);
         let (mut fold_map, snapshot, edits) = self.fold_map.write(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+            snapshot,
+            edits,
+            indentation_settings.clone(),
+        );
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -745,7 +776,9 @@ impl DisplayMap {
         });
         let (snapshot, edits) = fold_map.fold(inline);
 
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -798,18 +831,24 @@ impl DisplayMap {
     ) {
         let snapshot = self.buffer.read(cx).snapshot(cx);
         let edits = self.buffer_subscription.consume().into_inner();
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
 
         let (snapshot, edits) = self.inlay_map.sync(snapshot, edits);
         let (mut fold_map, snapshot, edits) = self.fold_map.write(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+            snapshot,
+            edits,
+            indentation_settings.clone(),
+        );
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
         self.block_map.read(snapshot, edits, None);
 
         let (snapshot, edits) = fold_map.remove_folds(ranges, type_id);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         let (self_new_wrap_snapshot, self_new_wrap_edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -832,11 +871,15 @@ impl DisplayMap {
             .map(|range| range.start.to_offset(&snapshot)..range.end.to_offset(&snapshot))
             .collect::<Vec<_>>();
         let edits = self.buffer_subscription.consume().into_inner();
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
 
         let (snapshot, edits) = self.inlay_map.sync(snapshot, edits);
         let (mut fold_map, snapshot, edits) = self.fold_map.write(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+            snapshot,
+            edits,
+            indentation_settings.clone(),
+        );
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -844,7 +887,9 @@ impl DisplayMap {
 
         let (snapshot, edits) =
             fold_map.unfold_intersecting(offset_ranges.iter().cloned(), inclusive);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         let (self_new_wrap_snapshot, self_new_wrap_edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -1255,11 +1300,15 @@ impl DisplayMap {
     ) -> bool {
         let snapshot = self.buffer.read(cx).snapshot(cx);
         let edits = self.buffer_subscription.consume().into_inner();
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
 
         let (snapshot, edits) = self.inlay_map.sync(snapshot, edits);
         let (mut fold_map, snapshot, edits) = self.fold_map.write(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+            snapshot,
+            edits,
+            indentation_settings.clone(),
+        );
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -1267,7 +1316,9 @@ impl DisplayMap {
 
         let (snapshot, edits) = fold_map.update_fold_widths(widths);
         let widths_changed = !edits.is_empty();
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         let (self_new_wrap_snapshot, self_new_wrap_edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -1294,7 +1345,7 @@ impl DisplayMap {
         }
         let buffer_snapshot = self.buffer.read(cx).snapshot(cx);
         let edits = self.buffer_subscription.consume().into_inner();
-        let tab_size = Self::tab_size(&self.buffer, cx);
+        let indentation_settings = self.indentation_settings(cx);
 
         let companion_wrap_data = self.companion.as_ref().and_then(|(companion_dm, _)| {
             companion_dm
@@ -1304,7 +1355,11 @@ impl DisplayMap {
 
         let (snapshot, edits) = self.inlay_map.sync(buffer_snapshot, edits);
         let (snapshot, edits) = self.fold_map.read(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) = self.tab_map.sync_with_indentation_settings(
+            snapshot,
+            edits,
+            indentation_settings.clone(),
+        );
         let (snapshot, edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -1321,7 +1376,9 @@ impl DisplayMap {
 
         let (snapshot, edits) = self.inlay_map.splice(to_remove, to_insert);
         let (snapshot, edits) = self.fold_map.read(snapshot, edits);
-        let (snapshot, edits) = self.tab_map.sync(snapshot, edits, tab_size);
+        let (snapshot, edits) =
+            self.tab_map
+                .sync_with_indentation_settings(snapshot, edits, indentation_settings);
         let (self_new_wrap_snapshot, self_new_wrap_edits) = self
             .wrap_map
             .update(cx, |map, cx| map.sync(snapshot, edits, cx));
@@ -1362,17 +1419,21 @@ impl DisplayMap {
     }
 
     #[instrument(skip_all)]
-    fn tab_size(buffer: &Entity<MultiBuffer>, cx: &App) -> NonZeroU32 {
-        if let Some(buffer) = buffer.read(cx).as_singleton().map(|buffer| buffer.read(cx)) {
-            LanguageSettings::for_buffer(buffer, cx)
-                .indentation()
-                .tab_width()
-        } else {
-            AllLanguageSettings::get_global(cx)
-                .defaults
-                .indentation()
-                .tab_width()
+    fn indentation_settings(&mut self, cx: &App) -> PerBufferIndentationSettings {
+        if self.indentation_settings_dirty {
+            self.indentation_settings = Self::resolve_indentation_settings(&self.buffer, cx);
+            self.indentation_settings_dirty = false;
         }
+        self.indentation_settings.clone()
+    }
+
+    fn resolve_indentation_settings(
+        buffer: &Entity<MultiBuffer>,
+        cx: &App,
+    ) -> PerBufferIndentationSettings {
+        let buffer = buffer.read(cx);
+        let (default, by_buffer) = buffer.indentation_settings(cx);
+        (default, Arc::new(by_buffer))
     }
 
     #[cfg(test)]
@@ -2738,19 +2799,20 @@ pub mod tests {
     };
     use Bias::*;
     use block_map::BlockPlacement;
+    use buffer_diff::BufferDiff;
     use gpui::{
         App, AppContext as _, BorrowAppContext, Element, Hsla, Rgba, div, font, observe, px,
     };
     use language::{
-        Buffer, Diagnostic, DiagnosticEntry, DiagnosticSet, Language, LanguageConfig,
-        LanguageMatcher,
+        Buffer, Capability, Diagnostic, DiagnosticEntry, DiagnosticSet, Language, LanguageConfig,
+        LanguageMatcher, ModelineSettings,
     };
     use lsp::LanguageServerId;
 
     use futures::stream::StreamExt;
     use rand::{Rng, prelude::*};
-    use settings::{SettingsContent, SettingsStore};
-    use std::{env, sync::Arc};
+    use settings::SettingsContent;
+    use std::{env, num::NonZeroU32, sync::Arc};
     use text::PointUtf16;
     use theme::{LoadThemes, SyntaxTheme};
     use unindent::Unindent as _;
@@ -4036,6 +4098,152 @@ pub mod tests {
         let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
 
         assert!(snapshot.starts_indent(MultiBufferRow(0)));
+    }
+
+    #[gpui::test]
+    fn test_literal_tabs_use_per_buffer_tab_widths(cx: &mut gpui::App) {
+        init_test(cx, &|settings| {
+            settings.project.all_languages.defaults.tab_size = NonZeroU32::new(4);
+        });
+
+        let buffer_with_indentation_settings = |text, indent_size, tab_width, cx: &mut App| {
+            cx.new(|cx| {
+                let mut buffer = Buffer::local(text, cx);
+                buffer.set_modeline(Some(ModelineSettings {
+                    tab_size: NonZeroU32::new(tab_width),
+                    indent_size: NonZeroU32::new(indent_size),
+                    ..Default::default()
+                }));
+                buffer
+            })
+        };
+        let narrow_buffer = buffer_with_indentation_settings("x\tnarrow", 8, 2, cx);
+        let wide_buffer = buffer_with_indentation_settings("x\twide", 2, 8, cx);
+        let multi_buffer = cx.new(|cx| {
+            let mut multi_buffer = MultiBuffer::without_headers(Capability::ReadOnly);
+            multi_buffer.set_excerpts_for_path(
+                multi_buffer::PathKey::sorted(0),
+                narrow_buffer.clone(),
+                [Point::zero()..narrow_buffer.read(cx).max_point()],
+                0,
+                cx,
+            );
+            multi_buffer.set_excerpts_for_path(
+                multi_buffer::PathKey::sorted(1),
+                wide_buffer.clone(),
+                [Point::zero()..wide_buffer.read(cx).max_point()],
+                0,
+                cx,
+            );
+            multi_buffer
+        });
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                multi_buffer,
+                font("Helvetica"),
+                px(14.0),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+
+        assert_eq!(
+            snapshot
+                .tab_snapshot()
+                .text()
+                .lines()
+                .filter(|line| !line.is_empty())
+                .collect::<Vec<_>>(),
+            ["x narrow", "x       wide"]
+        );
+        let wide_buffer_id = wide_buffer.read(cx).remote_id();
+        let wide_row = snapshot
+            .buffer_snapshot()
+            .row_infos(MultiBufferRow(0))
+            .find_map(|row| {
+                (row.buffer_id == Some(wide_buffer_id))
+                    .then_some(row.multibuffer_row)
+                    .flatten()
+            })
+            .expect("wide buffer should have a multibuffer row");
+        let wide_display_point =
+            snapshot.point_to_display_point(MultiBufferPoint::new(wide_row.0, 2), Bias::Left);
+        assert_eq!(wide_display_point.column(), 8);
+        assert_eq!(
+            snapshot.display_point_to_point(wide_display_point, Bias::Right),
+            MultiBufferPoint::new(wide_row.0, 2),
+        );
+
+        wide_buffer.update(cx, |buffer, cx| {
+            if buffer.set_modeline(Some(ModelineSettings {
+                tab_size: NonZeroU32::new(4),
+                indent_size: NonZeroU32::new(2),
+                ..Default::default()
+            })) {
+                cx.notify();
+            }
+        });
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+        assert_eq!(
+            snapshot
+                .tab_snapshot()
+                .text()
+                .lines()
+                .filter(|line| !line.is_empty())
+                .collect::<Vec<_>>(),
+            ["x narrow", "x   wide"]
+        );
+    }
+
+    #[gpui::test]
+    fn test_literal_tabs_use_per_buffer_width_in_singleton_inverted_diff(cx: &mut gpui::App) {
+        init_test(cx, &|settings| {
+            settings.project.all_languages.defaults.tab_size = NonZeroU32::new(4);
+        });
+
+        let main_buffer = cx.new(|cx| {
+            let mut buffer = Buffer::local("\ttext", cx);
+            buffer.set_modeline(Some(ModelineSettings {
+                tab_size: NonZeroU32::new(8),
+                indent_size: NonZeroU32::new(2),
+                ..Default::default()
+            }));
+            buffer
+        });
+        let diff = cx.new(|cx| {
+            BufferDiff::new_with_base_text("\ttext", &main_buffer.read(cx).text_snapshot(), cx)
+        });
+        let base_buffer = diff.read(cx).base_text_buffer().clone();
+        let multi_buffer = cx.new(|cx| {
+            let mut multi_buffer = MultiBuffer::singleton(base_buffer, cx);
+            multi_buffer.add_inverted_diff(diff, main_buffer, cx);
+            multi_buffer
+        });
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                multi_buffer,
+                font("Helvetica"),
+                px(14.0),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+
+        assert_eq!(
+            map.update(cx, |map, cx| map.snapshot(cx))
+                .tab_snapshot()
+                .text(),
+            "        text",
+        );
     }
 
     #[gpui::test]

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -4247,6 +4247,36 @@ pub mod tests {
     }
 
     #[gpui::test]
+    fn test_literal_tabs_use_tab_width(cx: &mut gpui::App) {
+        init_test(cx, &|settings| {
+            settings.project.all_languages.defaults.tab_size = NonZeroU32::new(4);
+            settings.project.all_languages.defaults.tab_width = NonZeroU32::new(8);
+        });
+
+        let buffer = MultiBuffer::build_simple("\ttext\n    \ttext", cx);
+        let map = cx.new(|cx| {
+            DisplayMap::new(
+                buffer,
+                font("Helvetica"),
+                px(14.0),
+                None,
+                1,
+                1,
+                FoldPlaceholder::test(),
+                DiagnosticSeverity::Warning,
+                cx,
+            )
+        });
+        let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
+
+        assert_eq!(snapshot.text(), "        text\n        text");
+        assert_eq!(
+            snapshot.point_to_display_point(MultiBufferPoint::new(0, 1), Bias::Left),
+            DisplayPoint::new(DisplayRow(0), 8),
+        );
+    }
+
+    #[gpui::test]
     fn test_tabs_with_multibyte_chars(cx: &mut gpui::App) {
         init_test(cx, &|_| {});
 

--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -3,9 +3,10 @@ use super::{
     fold_map::{self, Chunk, FoldChunks, FoldEdit, FoldPoint, FoldSnapshot},
 };
 
-use language::{LanguageAwareStyling, Point};
+use collections::HashMap;
+use language::{BufferId, LanguageAwareStyling, Point, language_settings::IndentationSettings};
 use multi_buffer::{MultiBufferRow, MultiBufferSnapshot};
-use std::{cmp, num::NonZeroU32, ops::Range};
+use std::{cmp, num::NonZeroU32, ops::Range, sync::Arc};
 use sum_tree::Bias;
 
 const MAX_EXPANSION_COLUMN: u32 = 256;
@@ -19,12 +20,31 @@ const MAX_TABS: NonZeroU32 = NonZeroU32::new(SPACES.len() as u32).unwrap();
 /// See the [`display_map` module documentation](crate::display_map) for more information.
 pub struct TabMap(TabSnapshot);
 
+pub(super) type PerBufferIndentationSettings = (
+    IndentationSettings,
+    Arc<HashMap<BufferId, IndentationSettings>>,
+);
+
 impl TabMap {
     #[ztracing::instrument(skip_all)]
     pub fn new(fold_snapshot: FoldSnapshot, tab_size: NonZeroU32) -> (Self, TabSnapshot) {
+        Self::new_with_indentation_settings(
+            fold_snapshot,
+            (
+                IndentationSettings::new(tab_size, tab_size, false),
+                Arc::default(),
+            ),
+        )
+    }
+
+    #[ztracing::instrument(skip_all)]
+    pub(super) fn new_with_indentation_settings(
+        fold_snapshot: FoldSnapshot,
+        indentation_settings: PerBufferIndentationSettings,
+    ) -> (Self, TabSnapshot) {
         let snapshot = TabSnapshot {
             fold_snapshot,
-            tab_size: tab_size.min(MAX_TABS),
+            indentation_settings,
             max_expansion_column: MAX_EXPANSION_COLUMN,
             version: 0,
         };
@@ -41,16 +61,31 @@ impl TabMap {
     pub fn sync(
         &mut self,
         fold_snapshot: FoldSnapshot,
-        mut fold_edits: Vec<FoldEdit>,
+        fold_edits: Vec<FoldEdit>,
         tab_size: NonZeroU32,
     ) -> (TabSnapshot, Vec<TabEdit>) {
-        let tab_size = tab_size.min(MAX_TABS);
+        self.sync_with_indentation_settings(
+            fold_snapshot,
+            fold_edits,
+            (
+                IndentationSettings::new(tab_size, tab_size, false),
+                Arc::default(),
+            ),
+        )
+    }
 
-        if self.0.tab_size != tab_size {
+    #[ztracing::instrument(skip_all)]
+    pub(super) fn sync_with_indentation_settings(
+        &mut self,
+        fold_snapshot: FoldSnapshot,
+        mut fold_edits: Vec<FoldEdit>,
+        indentation_settings: PerBufferIndentationSettings,
+    ) -> (TabSnapshot, Vec<TabEdit>) {
+        if self.0.indentation_settings != indentation_settings {
             let old_max_point = self.0.max_point();
             self.0.version += 1;
             self.0.fold_snapshot = fold_snapshot;
-            self.0.tab_size = tab_size;
+            self.0.indentation_settings = indentation_settings;
             return (
                 self.0.clone(),
                 vec![TabEdit {
@@ -69,10 +104,10 @@ impl TabMap {
         if fold_edits.is_empty() {
             old_snapshot.version = new_version;
             old_snapshot.fold_snapshot = fold_snapshot;
-            old_snapshot.tab_size = tab_size;
             return (old_snapshot.clone(), vec![]);
         }
 
+        let indentation_settings = old_snapshot.indentation_settings.clone();
         let old_fold_max_point = old_snapshot.fold_snapshot.max_point();
 
         // Expand each edit to include the next tab on the same line as the edit,
@@ -145,7 +180,7 @@ impl TabMap {
 
         let new_snapshot = TabSnapshot {
             fold_snapshot,
-            tab_size,
+            indentation_settings,
             max_expansion_column: old_snapshot.max_expansion_column,
             version: new_version,
         };
@@ -196,7 +231,7 @@ impl TabMap {
 #[derive(Clone)]
 pub struct TabSnapshot {
     pub fold_snapshot: FoldSnapshot,
-    pub tab_size: NonZeroU32,
+    indentation_settings: PerBufferIndentationSettings,
     /// The maximum column up to which a tab can expand.
     /// Any tab after this column will not expand.
     pub max_expansion_column: u32,
@@ -317,7 +352,8 @@ impl TabSnapshot {
             max_expansion_column: self.max_expansion_column,
             output_position: range.start.0,
             max_output_position: range.end.0,
-            tab_size: self.tab_size,
+            current_indentation_settings_row: None,
+            current_indentation_settings: self.indentation_settings.0,
             chunk: Chunk {
                 text: unsafe { std::str::from_utf8_unchecked(&SPACES[..to_next_stop as usize]) },
                 is_tab: true,
@@ -365,7 +401,11 @@ impl TabSnapshot {
     pub fn fold_point_to_tab_point(&self, input: FoldPoint) -> TabPoint {
         let chunks = self.fold_snapshot.chunks_at(FoldPoint::new(input.row(), 0));
         let tab_cursor = TabStopCursor::new(chunks);
-        let expanded = self.expand_tabs(tab_cursor, input.column());
+        let expanded = self.expand_tabs(
+            tab_cursor,
+            input.column(),
+            self.indentation_settings_for_row(input.row()),
+        );
         TabPoint::new(input.row(), expanded)
     }
 
@@ -382,8 +422,12 @@ impl TabSnapshot {
 
         let tab_cursor = TabStopCursor::new(chunks);
         let expanded = output.column();
-        let (collapsed, expanded_char_column, to_next_stop) =
-            self.collapse_tabs(tab_cursor, expanded, bias);
+        let (collapsed, expanded_char_column, to_next_stop) = self.collapse_tabs(
+            tab_cursor,
+            expanded,
+            bias,
+            self.indentation_settings_for_row(output.row()),
+        );
 
         (
             FoldPoint::new(output.row(), collapsed),
@@ -414,12 +458,17 @@ impl TabSnapshot {
     }
 
     #[ztracing::instrument(skip_all)]
-    fn expand_tabs<'a>(&self, mut cursor: TabStopCursor<'a>, column: u32) -> u32 {
+    fn expand_tabs<'a>(
+        &self,
+        mut cursor: TabStopCursor<'a>,
+        column: u32,
+        indentation_settings: IndentationSettings,
+    ) -> u32 {
         // we only ever act on a single row at a time
         // so the main difference is that other layers build a transform sumtree, and can then just run through that
         // we cant quite do this here, as we need to work with the previous layer chunk to understand the tabs of the corresponding row
         // we can still do forward searches for this though, we search for a row, then traverse the column up to where we need to be
-        let tab_size = self.tab_size.get();
+        let tab_size = indentation_settings.tab_width().min(MAX_TABS).get();
 
         let end_column = column.min(self.max_expansion_column);
         let mut seek_target = end_column;
@@ -454,8 +503,9 @@ impl TabSnapshot {
         mut cursor: TabStopCursor<'a>,
         column: u32,
         bias: Bias,
+        indentation_settings: IndentationSettings,
     ) -> (u32, u32, u32) {
-        let tab_size = self.tab_size.get();
+        let tab_size = indentation_settings.tab_width().min(MAX_TABS).get();
         let mut collapsed_column = column;
         let mut seek_target = column.min(self.max_expansion_column);
         let mut tab_count = 0;
@@ -502,6 +552,27 @@ impl TabSnapshot {
             expanded_chars,
             0,
         )
+    }
+
+    fn indentation_settings_for_row(&self, row: u32) -> IndentationSettings {
+        if self.indentation_settings.1.is_empty() {
+            return self.indentation_settings.0;
+        }
+
+        let inlay_point = FoldPoint::new(row, 0).to_inlay_point(&self.fold_snapshot);
+        let buffer_point = self
+            .fold_snapshot
+            .inlay_snapshot
+            .to_buffer_point(inlay_point);
+        self.buffer_snapshot()
+            .point_to_buffer_point(buffer_point)
+            .and_then(|(buffer, _)| {
+                self.indentation_settings
+                    .1
+                    .get(&buffer.remote_id())
+                    .copied()
+            })
+            .unwrap_or(self.indentation_settings.0)
     }
 }
 
@@ -605,7 +676,8 @@ pub struct TabChunks<'a> {
     snapshot: &'a TabSnapshot,
     max_expansion_column: u32,
     max_output_position: Point,
-    tab_size: NonZeroU32,
+    current_indentation_settings_row: Option<u32>,
+    current_indentation_settings: IndentationSettings,
     // region: iteration state
     fold_chunks: FoldChunks<'a>,
     chunk: Chunk<'a>,
@@ -640,6 +712,8 @@ impl TabChunks<'_> {
         self.column = expanded_char_column;
         self.output_position = range.start.0;
         self.max_output_position = range.end.0;
+        self.current_indentation_settings_row = None;
+        self.current_indentation_settings = self.snapshot.indentation_settings.0;
         self.chunk = Chunk {
             text: unsafe { std::str::from_utf8_unchecked(&SPACES[..to_next_stop as usize]) },
             is_tab: true,
@@ -675,7 +749,16 @@ impl<'a> Iterator for TabChunks<'a> {
             self.chunk.newlines >>= 1;
 
             let tab_size = if self.input_column < self.max_expansion_column {
-                self.tab_size.get()
+                if self.current_indentation_settings_row != Some(self.output_position.row) {
+                    self.current_indentation_settings_row = Some(self.output_position.row);
+                    self.current_indentation_settings = self
+                        .snapshot
+                        .indentation_settings_for_row(self.output_position.row);
+                }
+                self.current_indentation_settings
+                    .tab_width()
+                    .min(MAX_TABS)
+                    .get()
             } else {
                 1
             };
@@ -944,7 +1027,7 @@ mod tests {
             column: u32,
             bias: Bias,
         ) -> (u32, u32, u32) {
-            let tab_size = self.tab_size.get();
+            let tab_size = self.indentation_settings.0.tab_width().min(MAX_TABS).get();
 
             let mut expanded_bytes = 0;
             let mut expanded_chars = 0;
@@ -997,7 +1080,7 @@ mod tests {
         }
 
         fn expected_expand_tabs(&self, chars: impl Iterator<Item = char>, column: u32) -> u32 {
-            let tab_size = self.tab_size.get();
+            let tab_size = self.indentation_settings.0.tab_width().min(MAX_TABS).get();
 
             let mut expanded_chars = 0;
             let mut expanded_bytes = 0;
@@ -1143,7 +1226,7 @@ mod tests {
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, mut tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
         tab_snapshot.max_expansion_column = rng.random_range(0..323);
-        tab_snapshot.tab_size = tab_size;
+        tab_snapshot.indentation_settings.0 = IndentationSettings::new(tab_size, tab_size, false);
 
         for (ix, _) in input.char_indices() {
             let range = TabPoint::new(0, ix as u32)..tab_snapshot.max_point();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5132,6 +5132,53 @@ impl Editor {
 
             let display_map = this.display_map.update(cx, |map, cx| map.snapshot(cx));
             let mut selections = this.selections.all::<MultiBufferPoint>(&display_map);
+            let snapshot = display_map.buffer_snapshot();
+
+            // Buffer columns count indentation characters, while indentation stops are
+            // measured in display columns. Replace the prefix when every cursor is in
+            // leading whitespace so backspace performs one logical outdent even for a
+            // mixed prefix. Require distinct rows because each edit replaces its row's
+            // entire prefix.
+            if selections.iter().all(|selection| {
+                let head = selection.head();
+                selection.is_empty()
+                    && head.column > 0
+                    && head.column <= snapshot.indent_size_for_line(MultiBufferRow(head.row)).len
+            }) && selections
+                .windows(2)
+                .all(|pair| pair[0].head().row != pair[1].head().row)
+            {
+                let mut edits = Vec::with_capacity(selections.len());
+
+                for selection in &mut selections {
+                    let old_head = selection.head();
+                    let indentation = snapshot.language_settings_at(old_head, cx).indentation();
+                    let current_column = indentation.column_for_prefix(
+                        snapshot
+                            .text_for_range(Point::new(old_head.row, 0)..old_head)
+                            .flat_map(str::chars),
+                    );
+                    let target_column = indentation.previous_indent_stop(current_column);
+                    let replacement = indentation.indentation_for_column(target_column);
+                    let new_head = MultiBufferPoint::new(old_head.row, replacement.len() as u32);
+                    edits.push((Point::new(old_head.row, 0)..old_head, replacement));
+                    selection.collapse_to(new_head, SelectionGoal::None);
+                }
+
+                this.edit(edits, cx);
+                this.change_selections(Default::default(), window, cx, |s| s.select(selections));
+                linked_edits.apply_with_left_expansion(cx);
+                this.refresh_edit_prediction(
+                    true,
+                    false,
+                    EditPredictionRequestTrigger::BufferEdit,
+                    window,
+                    cx,
+                );
+                refresh_linked_ranges(this, window, cx);
+                return;
+            }
+
             for selection in &mut selections {
                 if selection.is_empty() {
                     let old_head = selection.head();
@@ -5283,7 +5330,7 @@ impl Editor {
 
         let mut edits = Vec::new();
         let mut prev_edited_row = 0;
-        let mut row_delta = 0;
+        let mut row_delta: i32 = 0;
         for selection in &mut selections {
             if selection.start.row != prev_edited_row {
                 row_delta = 0;
@@ -5319,70 +5366,102 @@ impl Editor {
 
             let cursor = selection.head();
             let current_indent = snapshot.indent_size_for_line(MultiBufferRow(cursor.row));
+            let settings = buffer.language_settings_at(cursor, cx);
+            let indentation = settings.indentation();
+            let current_indent_column =
+                snapshot.indentation_column_for_line(MultiBufferRow(cursor.row), indentation);
             if let Some(suggested_indent) =
                 suggested_indents.get(&MultiBufferRow(cursor.row)).copied()
             {
+                let suggested_indent_text =
+                    indentation.indentation_for_column(suggested_indent.len);
+                let suggested_indent_len = suggested_indent_text.len() as u32;
                 // Don't do anything if already at suggested indent
                 // and there is any other cursor which is not
                 if has_some_cursor_in_whitespace
                     && cursor.column == current_indent.len
-                    && current_indent.len == suggested_indent.len
+                    && current_indent_column == suggested_indent.len
                 {
                     continue;
                 }
 
                 // Adjust line and move cursor to suggested indent
                 // if cursor is not at suggested indent
-                if cursor.column < suggested_indent.len
+                if cursor.column < suggested_indent_len
                     && cursor.column <= current_indent.len
-                    && current_indent.len <= suggested_indent.len
+                    && current_indent_column <= suggested_indent.len
                 {
-                    selection.start = Point::new(cursor.row, suggested_indent.len);
+                    selection.start = Point::new(cursor.row, suggested_indent_len);
                     selection.end = selection.start;
                     if row_delta == 0 {
-                        edits.extend(Buffer::edit_for_indent_size_adjustment(
-                            cursor.row,
-                            current_indent,
-                            suggested_indent,
+                        edits.push((
+                            Point::new(cursor.row, 0)..Point::new(cursor.row, current_indent.len),
+                            suggested_indent_text,
                         ));
-                        row_delta = suggested_indent.len - current_indent.len;
+                        row_delta = suggested_indent_len as i32 - current_indent.len as i32;
                     }
                     continue;
                 }
 
                 // If current indent is more than suggested indent
                 // only move cursor to current indent and skip indent
-                if cursor.column < current_indent.len && current_indent.len > suggested_indent.len {
+                if cursor.column < current_indent.len
+                    && current_indent_column > suggested_indent.len
+                {
                     selection.start = Point::new(cursor.row, current_indent.len);
                     selection.end = selection.start;
                     continue;
                 }
             }
 
-            // Otherwise, insert a hard or soft tab.
-            let settings = buffer.language_settings_at(cursor, cx);
-            let tab_size = if settings.hard_tabs {
-                IndentSize::tab()
-            } else {
-                let tab_size = settings.tab_size.get();
-                let indent_remainder = snapshot
-                    .text_for_range(Point::new(cursor.row, 0)..cursor)
-                    .flat_map(str::chars)
-                    .fold(row_delta % tab_size, |counter: u32, c| {
-                        if c == '\t' {
-                            0
-                        } else {
-                            (counter + 1) % tab_size
-                        }
-                    });
+            // Otherwise, insert a hard or soft tab. Rebuild hard-tab indentation
+            // from its display column because a mixed prefix's character count does
+            // not identify its indentation column.
+            let (edit_range, text) =
+                if indentation.hard_tabs() && cursor.column <= current_indent.len {
+                    let target_column = indentation.next_indent_stop(current_indent_column);
+                    (
+                        Point::new(cursor.row, 0)..Point::new(cursor.row, current_indent.len),
+                        indentation.indentation_for_column(target_column),
+                    )
+                } else if indentation.hard_tabs() {
+                    (cursor..cursor, "\t".to_owned())
+                } else {
+                    let current_column = indentation
+                        .column_for_text(
+                            snapshot
+                                .text_for_range(Point::new(cursor.row, 0)..cursor)
+                                .flat_map(str::chars),
+                        )
+                        .saturating_add_signed(row_delta);
 
-                let chars_to_next_tab_stop = tab_size - indent_remainder;
-                IndentSize::spaces(chars_to_next_tab_stop)
-            };
-            selection.start = Point::new(cursor.row, cursor.column + row_delta + tab_size.len);
+                    let chars_to_next_indent_stop =
+                        indentation.next_indent_stop(current_column) - current_column;
+                    (
+                        cursor..cursor,
+                        " ".repeat(chars_to_next_indent_stop as usize),
+                    )
+                };
+            let replaced_len = edit_range.end.column - edit_range.start.column;
+            let edit_delta = text.len() as i32 - replaced_len as i32;
+            let replacement_end = edit_range.start.column + text.chars().count() as u32;
+            selection.start = Point::new(
+                cursor.row,
+                // Applying the edit delta is only valid for points after the replaced
+                // range. A cursor inside a rewritten indentation prefix belongs at the
+                // end of the canonical replacement.
+                if edit_range.start.column == 0 && cursor.column <= edit_range.end.column {
+                    replacement_end
+                } else {
+                    cursor
+                        .column
+                        .saturating_add_signed(row_delta)
+                        .saturating_add_signed(edit_delta)
+                },
+            );
             selection.end = selection.start;
-            edits.push((cursor..cursor, tab_size.chars().collect::<String>()));
-            row_delta += tab_size.len;
+            edits.push((edit_range, text));
+            row_delta += edit_delta;
         }
 
         self.transact(window, cx, |this, window, cx| {
@@ -5409,7 +5488,7 @@ impl Editor {
 
         let mut selections = self.selections.all::<Point>(&self.display_snapshot(cx));
         let mut prev_edited_row = 0;
-        let mut row_delta = 0;
+        let mut row_delta: i32 = 0;
         let mut edits = Vec::new();
         let buffer = self.buffer.read(cx);
         let snapshot = buffer.snapshot(cx);
@@ -5434,16 +5513,11 @@ impl Editor {
         snapshot: &MultiBufferSnapshot,
         selection: &mut Selection<Point>,
         edits: &mut Vec<(Range<Point>, String)>,
-        delta_for_start_row: u32,
+        delta_for_start_row: i32,
         cx: &App,
-    ) -> u32 {
+    ) -> i32 {
         let settings = buffer.language_settings_at(selection.start, cx);
-        let tab_size = settings.tab_size.get();
-        let indent_kind = if settings.hard_tabs {
-            IndentKind::Tab
-        } else {
-            IndentKind::Space
-        };
+        let indentation = settings.indentation();
         let mut start_row = selection.start.row;
         let mut end_row = selection.end.row + 1;
 
@@ -5456,45 +5530,42 @@ impl Editor {
         // Avoid re-indenting a row that has already been indented by a
         // previous selection, but still update this selection's column
         // to reflect that indentation.
-        if delta_for_start_row > 0 {
+        if delta_for_start_row != 0 {
             start_row += 1;
-            selection.start.column += delta_for_start_row;
+            selection.start.column = selection
+                .start
+                .column
+                .saturating_add_signed(delta_for_start_row);
             if selection.end.row == selection.start.row {
-                selection.end.column += delta_for_start_row;
+                selection.end.column = selection
+                    .end
+                    .column
+                    .saturating_add_signed(delta_for_start_row);
             }
         }
 
-        let mut delta_for_end_row = 0;
-        let has_multiple_rows = start_row + 1 != end_row;
+        let mut delta_for_end_row: i32 = 0;
         for row in start_row..end_row {
             let current_indent = snapshot.indent_size_for_line(MultiBufferRow(row));
-            let indent_delta = match (current_indent.kind, indent_kind) {
-                (IndentKind::Space, IndentKind::Space) => {
-                    let columns_to_next_tab_stop = tab_size - (current_indent.len % tab_size);
-                    IndentSize::spaces(columns_to_next_tab_stop)
-                }
-                (IndentKind::Tab, IndentKind::Space) => IndentSize::spaces(tab_size),
-                (_, IndentKind::Tab) => IndentSize::tab(),
-            };
-
-            let start = if has_multiple_rows || current_indent.len < selection.start.column {
-                0
-            } else {
-                selection.start.column
-            };
-            let row_start = Point::new(row, start);
+            let current_column =
+                snapshot.indentation_column_for_line(MultiBufferRow(row), indentation);
+            let target_column = indentation.next_indent_stop(current_column);
+            // Replacing the complete prefix keeps the edit column-correct when the
+            // canonical representation has a different number of characters.
+            let replacement = indentation.indentation_for_column(target_column);
+            let edit_delta = replacement.len() as i32 - current_indent.len as i32;
             edits.push((
-                row_start..row_start,
-                indent_delta.chars().collect::<String>(),
+                Point::new(row, 0)..Point::new(row, current_indent.len),
+                replacement,
             ));
 
             // Update this selection's endpoints to reflect the indentation.
             if row == selection.start.row {
-                selection.start.column += indent_delta.len;
+                selection.start.column = selection.start.column.saturating_add_signed(edit_delta);
             }
             if row == selection.end.row {
-                selection.end.column += indent_delta.len;
-                delta_for_end_row = indent_delta.len;
+                selection.end.column = selection.end.column.saturating_add_signed(edit_delta);
+                delta_for_end_row = edit_delta;
             }
         }
 
@@ -5516,14 +5587,14 @@ impl Editor {
 
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let selections = self.selections.all::<Point>(&display_map);
-        let mut deletion_ranges = Vec::new();
+        let mut edits = Vec::new();
         let mut last_outdent = None;
         {
             let buffer = self.buffer.read(cx);
             let snapshot = buffer.snapshot(cx);
             for selection in &selections {
                 let settings = buffer.language_settings_at(selection.start, cx);
-                let tab_size = settings.tab_size;
+                let indentation = settings.indentation();
                 let mut rows = selection.spanned_rows(false, &display_map);
 
                 // Avoid re-outdenting a row that has already been outdented by a
@@ -5533,22 +5604,17 @@ impl Editor {
                 {
                     rows.start = rows.start.next_row();
                 }
-                let has_multiple_rows = rows.len() > 1;
                 for row in rows.iter_rows() {
                     let indent_size = snapshot.indent_size_for_line(row);
                     if indent_size.len > 0 {
-                        let deletion_len = indent_size.outdent_len(tab_size);
-                        let start = if has_multiple_rows
-                            || deletion_len > selection.start.column
-                            || indent_size.len < selection.start.column
-                        {
-                            0
-                        } else {
-                            selection.start.column - deletion_len
-                        };
-                        deletion_ranges.push(
-                            Point::new(row.0, start)..Point::new(row.0, start + deletion_len),
-                        );
+                        let current_column = snapshot.indentation_column_for_line(row, indentation);
+                        let target_column = indentation.previous_indent_stop(current_column);
+                        // A partial character deletion cannot reliably reach a display-column
+                        // stop when the existing prefix mixes tabs and spaces.
+                        edits.push((
+                            Point::new(row.0, 0)..Point::new(row.0, indent_size.len),
+                            indentation.indentation_for_column(target_column),
+                        ));
                         last_outdent = Some(row);
                     }
                 }
@@ -5557,14 +5623,7 @@ impl Editor {
 
         self.transact(window, cx, |this, window, cx| {
             this.buffer.update(cx, |buffer, cx| {
-                let empty_str: Arc<str> = Arc::default();
-                buffer.edit(
-                    deletion_ranges
-                        .into_iter()
-                        .map(|range| (range, empty_str.clone())),
-                    None,
-                    cx,
-                );
+                buffer.edit(edits, None, cx);
             });
             let selections = this
                 .selections
@@ -6983,7 +7042,7 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         let settings = self.buffer.read(cx).language_settings(cx);
-        let tab_size = settings.tab_size.get() as usize;
+        let tab_size = settings.indentation().tab_width().get() as usize;
 
         self.manipulate_mutable_lines(window, cx, |lines| {
             // Allocates a reasonably sized scratch buffer once for the whole loop
@@ -7038,7 +7097,7 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         let settings = self.buffer.read(cx).language_settings(cx);
-        let tab_size = settings.tab_size.get() as usize;
+        let tab_size = settings.indentation().tab_width().get() as usize;
 
         self.manipulate_mutable_lines(window, cx, |lines| {
             // Allocates a reasonably sized buffer once for the whole loop

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4988,6 +4988,53 @@ impl Editor {
 
             let display_map = this.display_map.update(cx, |map, cx| map.snapshot(cx));
             let mut selections = this.selections.all::<MultiBufferPoint>(&display_map);
+            let snapshot = display_map.buffer_snapshot();
+
+            // Buffer columns count indentation characters, while indentation stops are
+            // measured in display columns. Replace the prefix when every cursor is in
+            // leading whitespace so backspace performs one logical outdent even for a
+            // mixed prefix. Require distinct rows because each edit replaces its row's
+            // entire prefix.
+            if selections.iter().all(|selection| {
+                let head = selection.head();
+                selection.is_empty()
+                    && head.column > 0
+                    && head.column <= snapshot.indent_size_for_line(MultiBufferRow(head.row)).len
+            }) && selections
+                .windows(2)
+                .all(|pair| pair[0].head().row != pair[1].head().row)
+            {
+                let mut edits = Vec::with_capacity(selections.len());
+
+                for selection in &mut selections {
+                    let old_head = selection.head();
+                    let indentation = snapshot.language_settings_at(old_head, cx).indentation();
+                    let current_column = indentation.column_for_prefix(
+                        snapshot
+                            .text_for_range(Point::new(old_head.row, 0)..old_head)
+                            .flat_map(str::chars),
+                    );
+                    let target_column = indentation.previous_indent_stop(current_column);
+                    let replacement = indentation.indentation_for_column(target_column);
+                    let new_head = MultiBufferPoint::new(old_head.row, replacement.len() as u32);
+                    edits.push((Point::new(old_head.row, 0)..old_head, replacement));
+                    selection.collapse_to(new_head, SelectionGoal::None);
+                }
+
+                this.edit(edits, cx);
+                this.change_selections(Default::default(), window, cx, |s| s.select(selections));
+                linked_edits.apply_with_left_expansion(cx);
+                this.refresh_edit_prediction(
+                    true,
+                    false,
+                    EditPredictionRequestTrigger::BufferEdit,
+                    window,
+                    cx,
+                );
+                refresh_linked_ranges(this, window, cx);
+                return;
+            }
+
             for selection in &mut selections {
                 if selection.is_empty() {
                     let old_head = selection.head();
@@ -5139,7 +5186,7 @@ impl Editor {
 
         let mut edits = Vec::new();
         let mut prev_edited_row = 0;
-        let mut row_delta = 0;
+        let mut row_delta: i32 = 0;
         for selection in &mut selections {
             if selection.start.row != prev_edited_row {
                 row_delta = 0;
@@ -5175,70 +5222,102 @@ impl Editor {
 
             let cursor = selection.head();
             let current_indent = snapshot.indent_size_for_line(MultiBufferRow(cursor.row));
+            let settings = buffer.language_settings_at(cursor, cx);
+            let indentation = settings.indentation();
+            let current_indent_column =
+                snapshot.indentation_column_for_line(MultiBufferRow(cursor.row), indentation);
             if let Some(suggested_indent) =
                 suggested_indents.get(&MultiBufferRow(cursor.row)).copied()
             {
+                let suggested_indent_text =
+                    indentation.indentation_for_column(suggested_indent.len);
+                let suggested_indent_len = suggested_indent_text.len() as u32;
                 // Don't do anything if already at suggested indent
                 // and there is any other cursor which is not
                 if has_some_cursor_in_whitespace
                     && cursor.column == current_indent.len
-                    && current_indent.len == suggested_indent.len
+                    && current_indent_column == suggested_indent.len
                 {
                     continue;
                 }
 
                 // Adjust line and move cursor to suggested indent
                 // if cursor is not at suggested indent
-                if cursor.column < suggested_indent.len
+                if cursor.column < suggested_indent_len
                     && cursor.column <= current_indent.len
-                    && current_indent.len <= suggested_indent.len
+                    && current_indent_column <= suggested_indent.len
                 {
-                    selection.start = Point::new(cursor.row, suggested_indent.len);
+                    selection.start = Point::new(cursor.row, suggested_indent_len);
                     selection.end = selection.start;
                     if row_delta == 0 {
-                        edits.extend(Buffer::edit_for_indent_size_adjustment(
-                            cursor.row,
-                            current_indent,
-                            suggested_indent,
+                        edits.push((
+                            Point::new(cursor.row, 0)..Point::new(cursor.row, current_indent.len),
+                            suggested_indent_text,
                         ));
-                        row_delta = suggested_indent.len - current_indent.len;
+                        row_delta = suggested_indent_len as i32 - current_indent.len as i32;
                     }
                     continue;
                 }
 
                 // If current indent is more than suggested indent
                 // only move cursor to current indent and skip indent
-                if cursor.column < current_indent.len && current_indent.len > suggested_indent.len {
+                if cursor.column < current_indent.len
+                    && current_indent_column > suggested_indent.len
+                {
                     selection.start = Point::new(cursor.row, current_indent.len);
                     selection.end = selection.start;
                     continue;
                 }
             }
 
-            // Otherwise, insert a hard or soft tab.
-            let settings = buffer.language_settings_at(cursor, cx);
-            let tab_size = if settings.hard_tabs {
-                IndentSize::tab()
-            } else {
-                let tab_size = settings.tab_size.get();
-                let indent_remainder = snapshot
-                    .text_for_range(Point::new(cursor.row, 0)..cursor)
-                    .flat_map(str::chars)
-                    .fold(row_delta % tab_size, |counter: u32, c| {
-                        if c == '\t' {
-                            0
-                        } else {
-                            (counter + 1) % tab_size
-                        }
-                    });
+            // Otherwise, insert a hard or soft tab. Rebuild hard-tab indentation
+            // from its display column because a mixed prefix's character count does
+            // not identify its indentation column.
+            let (edit_range, text) =
+                if indentation.hard_tabs() && cursor.column <= current_indent.len {
+                    let target_column = indentation.next_indent_stop(current_indent_column);
+                    (
+                        Point::new(cursor.row, 0)..Point::new(cursor.row, current_indent.len),
+                        indentation.indentation_for_column(target_column),
+                    )
+                } else if indentation.hard_tabs() {
+                    (cursor..cursor, "\t".to_owned())
+                } else {
+                    let current_column = indentation
+                        .column_for_text(
+                            snapshot
+                                .text_for_range(Point::new(cursor.row, 0)..cursor)
+                                .flat_map(str::chars),
+                        )
+                        .saturating_add_signed(row_delta);
 
-                let chars_to_next_tab_stop = tab_size - indent_remainder;
-                IndentSize::spaces(chars_to_next_tab_stop)
-            };
-            selection.start = Point::new(cursor.row, cursor.column + row_delta + tab_size.len);
+                    let chars_to_next_indent_stop =
+                        indentation.next_indent_stop(current_column) - current_column;
+                    (
+                        cursor..cursor,
+                        " ".repeat(chars_to_next_indent_stop as usize),
+                    )
+                };
+            let replaced_len = edit_range.end.column - edit_range.start.column;
+            let edit_delta = text.len() as i32 - replaced_len as i32;
+            let replacement_end = edit_range.start.column + text.chars().count() as u32;
+            selection.start = Point::new(
+                cursor.row,
+                // Applying the edit delta is only valid for points after the replaced
+                // range. A cursor inside a rewritten indentation prefix belongs at the
+                // end of the canonical replacement.
+                if edit_range.start.column == 0 && cursor.column <= edit_range.end.column {
+                    replacement_end
+                } else {
+                    cursor
+                        .column
+                        .saturating_add_signed(row_delta)
+                        .saturating_add_signed(edit_delta)
+                },
+            );
             selection.end = selection.start;
-            edits.push((cursor..cursor, tab_size.chars().collect::<String>()));
-            row_delta += tab_size.len;
+            edits.push((edit_range, text));
+            row_delta += edit_delta;
         }
 
         self.transact(window, cx, |this, window, cx| {
@@ -5265,7 +5344,7 @@ impl Editor {
 
         let mut selections = self.selections.all::<Point>(&self.display_snapshot(cx));
         let mut prev_edited_row = 0;
-        let mut row_delta = 0;
+        let mut row_delta: i32 = 0;
         let mut edits = Vec::new();
         let buffer = self.buffer.read(cx);
         let snapshot = buffer.snapshot(cx);
@@ -5290,16 +5369,11 @@ impl Editor {
         snapshot: &MultiBufferSnapshot,
         selection: &mut Selection<Point>,
         edits: &mut Vec<(Range<Point>, String)>,
-        delta_for_start_row: u32,
+        delta_for_start_row: i32,
         cx: &App,
-    ) -> u32 {
+    ) -> i32 {
         let settings = buffer.language_settings_at(selection.start, cx);
-        let tab_size = settings.tab_size.get();
-        let indent_kind = if settings.hard_tabs {
-            IndentKind::Tab
-        } else {
-            IndentKind::Space
-        };
+        let indentation = settings.indentation();
         let mut start_row = selection.start.row;
         let mut end_row = selection.end.row + 1;
 
@@ -5312,45 +5386,42 @@ impl Editor {
         // Avoid re-indenting a row that has already been indented by a
         // previous selection, but still update this selection's column
         // to reflect that indentation.
-        if delta_for_start_row > 0 {
+        if delta_for_start_row != 0 {
             start_row += 1;
-            selection.start.column += delta_for_start_row;
+            selection.start.column = selection
+                .start
+                .column
+                .saturating_add_signed(delta_for_start_row);
             if selection.end.row == selection.start.row {
-                selection.end.column += delta_for_start_row;
+                selection.end.column = selection
+                    .end
+                    .column
+                    .saturating_add_signed(delta_for_start_row);
             }
         }
 
-        let mut delta_for_end_row = 0;
-        let has_multiple_rows = start_row + 1 != end_row;
+        let mut delta_for_end_row: i32 = 0;
         for row in start_row..end_row {
             let current_indent = snapshot.indent_size_for_line(MultiBufferRow(row));
-            let indent_delta = match (current_indent.kind, indent_kind) {
-                (IndentKind::Space, IndentKind::Space) => {
-                    let columns_to_next_tab_stop = tab_size - (current_indent.len % tab_size);
-                    IndentSize::spaces(columns_to_next_tab_stop)
-                }
-                (IndentKind::Tab, IndentKind::Space) => IndentSize::spaces(tab_size),
-                (_, IndentKind::Tab) => IndentSize::tab(),
-            };
-
-            let start = if has_multiple_rows || current_indent.len < selection.start.column {
-                0
-            } else {
-                selection.start.column
-            };
-            let row_start = Point::new(row, start);
+            let current_column =
+                snapshot.indentation_column_for_line(MultiBufferRow(row), indentation);
+            let target_column = indentation.next_indent_stop(current_column);
+            // Replacing the complete prefix keeps the edit column-correct when the
+            // canonical representation has a different number of characters.
+            let replacement = indentation.indentation_for_column(target_column);
+            let edit_delta = replacement.len() as i32 - current_indent.len as i32;
             edits.push((
-                row_start..row_start,
-                indent_delta.chars().collect::<String>(),
+                Point::new(row, 0)..Point::new(row, current_indent.len),
+                replacement,
             ));
 
             // Update this selection's endpoints to reflect the indentation.
             if row == selection.start.row {
-                selection.start.column += indent_delta.len;
+                selection.start.column = selection.start.column.saturating_add_signed(edit_delta);
             }
             if row == selection.end.row {
-                selection.end.column += indent_delta.len;
-                delta_for_end_row = indent_delta.len;
+                selection.end.column = selection.end.column.saturating_add_signed(edit_delta);
+                delta_for_end_row = edit_delta;
             }
         }
 
@@ -5372,14 +5443,14 @@ impl Editor {
 
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let selections = self.selections.all::<Point>(&display_map);
-        let mut deletion_ranges = Vec::new();
+        let mut edits = Vec::new();
         let mut last_outdent = None;
         {
             let buffer = self.buffer.read(cx);
             let snapshot = buffer.snapshot(cx);
             for selection in &selections {
                 let settings = buffer.language_settings_at(selection.start, cx);
-                let tab_size = settings.tab_size;
+                let indentation = settings.indentation();
                 let mut rows = selection.spanned_rows(false, &display_map);
 
                 // Avoid re-outdenting a row that has already been outdented by a
@@ -5389,22 +5460,17 @@ impl Editor {
                 {
                     rows.start = rows.start.next_row();
                 }
-                let has_multiple_rows = rows.len() > 1;
                 for row in rows.iter_rows() {
                     let indent_size = snapshot.indent_size_for_line(row);
                     if indent_size.len > 0 {
-                        let deletion_len = indent_size.outdent_len(tab_size);
-                        let start = if has_multiple_rows
-                            || deletion_len > selection.start.column
-                            || indent_size.len < selection.start.column
-                        {
-                            0
-                        } else {
-                            selection.start.column - deletion_len
-                        };
-                        deletion_ranges.push(
-                            Point::new(row.0, start)..Point::new(row.0, start + deletion_len),
-                        );
+                        let current_column = snapshot.indentation_column_for_line(row, indentation);
+                        let target_column = indentation.previous_indent_stop(current_column);
+                        // A partial character deletion cannot reliably reach a display-column
+                        // stop when the existing prefix mixes tabs and spaces.
+                        edits.push((
+                            Point::new(row.0, 0)..Point::new(row.0, indent_size.len),
+                            indentation.indentation_for_column(target_column),
+                        ));
                         last_outdent = Some(row);
                     }
                 }
@@ -5413,14 +5479,7 @@ impl Editor {
 
         self.transact(window, cx, |this, window, cx| {
             this.buffer.update(cx, |buffer, cx| {
-                let empty_str: Arc<str> = Arc::default();
-                buffer.edit(
-                    deletion_ranges
-                        .into_iter()
-                        .map(|range| (range, empty_str.clone())),
-                    None,
-                    cx,
-                );
+                buffer.edit(edits, None, cx);
             });
             let selections = this
                 .selections
@@ -6796,7 +6855,7 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         let settings = self.buffer.read(cx).language_settings(cx);
-        let tab_size = settings.tab_size.get() as usize;
+        let tab_size = settings.indentation().tab_width().get() as usize;
 
         self.manipulate_mutable_lines(window, cx, |lines| {
             // Allocates a reasonably sized scratch buffer once for the whole loop
@@ -6851,7 +6910,7 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         let settings = self.buffer.read(cx).language_settings(cx);
-        let tab_size = settings.tab_size.get() as usize;
+        let tab_size = settings.indentation().tab_width().get() as usize;
 
         self.manipulate_mutable_lines(window, cx, |lines| {
             // Allocates a reasonably sized buffer once for the whole loop

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -31,8 +31,8 @@ use language::{
     LanguageConfig, LanguageConfigOverride, LanguageMatcher, LanguageName, LanguageQueries,
     LanguageToolchainStore, Override, PLAIN_TEXT, Point,
     language_settings::{
-        CompletionSettingsContent, FormatOnSave, FormatterList, LanguageSettingsContent,
-        LspInsertMode,
+        CompletionSettingsContent, FormatOnSave, FormatterList, IndentationSettings,
+        LanguageSettingsContent, LspInsertMode,
     },
     tree_sitter_python,
 };
@@ -6032,6 +6032,42 @@ fn test_insert_with_old_selections(cx: &mut TestAppContext) {
                 MultiBufferOffset(9)..MultiBufferOffset(9),
                 MultiBufferOffset(15)..MultiBufferOffset(15)
             ],
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_mixed_indentation_prefixes_are_preserved(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(4);
+        settings.defaults.hard_tabs = Some(true);
+        settings.defaults.auto_indent = Some(language_settings::AutoIndentMode::PreserveIndent);
+        settings.defaults.allow_rewrap = Some(language_settings::RewrapBehavior::Anywhere);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("\t  ˇline");
+    cx.update_editor(|editor, window, cx| editor.backspace(&Backspace, window, cx));
+    cx.assert_editor_state("\tˇline");
+
+    cx.set_state("  ˇ\tline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("\t\tˇline");
+
+    cx.set_state("  \tlineˇ");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("  \tline\n  \tˇ");
+
+    cx.set_state("  \tlineˇ");
+    cx.update_editor(|editor, _, cx| editor.rewrap(RewrapOptions::default(), cx));
+    cx.assert_editor_state("  \tlineˇ");
+
+    cx.update_editor(|editor, _, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        assert_eq!(
+            snapshot.indent_and_comment_for_line(MultiBufferRow(0), cx),
+            "  \t"
         );
     });
 }
@@ -29399,7 +29435,11 @@ fn indent_guide(buffer_id: BufferId, start_row: u32, end_row: u32, depth: u32) -
         start_row: MultiBufferRow(start_row),
         end_row: MultiBufferRow(end_row),
         depth,
-        tab_size: 4,
+        indentation: IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(4).unwrap(),
+            false,
+        ),
         settings: IndentGuideSettings {
             enabled: true,
             line_width: 1,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6073,6 +6073,119 @@ async fn test_mixed_indentation_prefixes_are_preserved(cx: &mut TestAppContext) 
 }
 
 #[gpui::test]
+async fn test_modeline_separates_indent_size_and_tab_width(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(2);
+        settings.defaults.tab_width = NonZeroU32::new(8);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_modeline(Some(language::ModelineSettings {
+            tab_size: NonZeroU32::new(8),
+            indent_size: NonZeroU32::new(4),
+            hard_tabs: Some(true),
+            ..Default::default()
+        }));
+
+        let settings = language::language_settings::LanguageSettings::for_buffer(buffer, cx);
+        assert_eq!(settings.tab_size.get(), 4);
+        assert_eq!(settings.tab_width.get(), 8);
+        assert!(settings.hard_tabs);
+
+        buffer.set_modeline(Some(language::ModelineSettings {
+            indent_size: NonZeroU32::new(4),
+            ..Default::default()
+        }));
+        let settings = language::language_settings::LanguageSettings::for_buffer(buffer, cx);
+        assert_eq!(settings.tab_size.get(), 4);
+        assert_eq!(settings.tab_width.get(), 8);
+    });
+}
+
+#[gpui::test]
+async fn test_split_width_indentation_edge_cases(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(4);
+        settings.defaults.tab_width = NonZeroU32::new(8);
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("\tˇline");
+    cx.update_editor(|editor, window, cx| editor.backspace(&Backspace, window, cx));
+    cx.assert_editor_state("    ˇline");
+
+    cx.update_buffer(|buffer, _| {
+        buffer.set_modeline(Some(language::ModelineSettings {
+            auto_indent: Some(false),
+            ..Default::default()
+        }));
+    });
+    cx.set_state("  ˇ  line");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("    ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("\tˇline");
+}
+
+#[gpui::test]
+async fn test_hard_tab_indentation_does_not_overshoot_tab_stops(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(3);
+        settings.defaults.tab_width = NonZeroU32::new(8);
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state("ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("   ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("      ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("\t ˇline");
+}
+
+#[gpui::test]
+async fn test_indentation_width_can_differ_from_tab_width(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(4);
+        settings.defaults.tab_width = NonZeroU32::new(8);
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    let language = Arc::new(
+        Language::new(
+            LanguageConfig::default(),
+            Some(tree_sitter_rust::LANGUAGE.into()),
+        )
+        .with_indents_query(r#"(_ "{" "}" @end) @indent"#)
+        .unwrap(),
+    );
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
+
+    cx.set_state("ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("    ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("\tˇline");
+    cx.update_editor(|editor, window, cx| editor.outdent(&Outdent, window, cx));
+    cx.assert_editor_state("    ˇline");
+
+    cx.set_state("fn main() {ˇ\n}");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("fn main() {\n    ˇ\n}");
+
+    cx.set_state("fn main() {\n    if true {ˇ\n    }\n}");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("fn main() {\n    if true {\n\tˇ\n    }\n}");
+}
+
+#[gpui::test]
 async fn test_tab(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.tab_size = NonZeroU32::new(3)
@@ -16380,7 +16493,9 @@ async fn test_save_actions_are_hidden_for_read_only_files(cx: &mut TestAppContex
 
 #[gpui::test]
 async fn test_document_format_during_save(cx: &mut TestAppContext) {
-    init_test(cx, |_| {});
+    init_test(cx, |settings| {
+        settings.defaults.tab_width = NonZeroU32::new(8);
+    });
 
     let fs = FakeFs::new(cx.executor());
     fs.insert_file(path!("/file.rs"), Default::default()).await;
@@ -29430,16 +29545,32 @@ fn assert_indent_guides(
 }
 
 fn indent_guide(buffer_id: BufferId, start_row: u32, end_row: u32, depth: u32) -> IndentGuide {
+    indent_guide_with_indentation(
+        buffer_id,
+        start_row,
+        end_row,
+        depth,
+        IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(4).unwrap(),
+            false,
+        ),
+    )
+}
+
+fn indent_guide_with_indentation(
+    buffer_id: BufferId,
+    start_row: u32,
+    end_row: u32,
+    depth: u32,
+    indentation: IndentationSettings,
+) -> IndentGuide {
     IndentGuide {
         buffer_id,
         start_row: MultiBufferRow(start_row),
         end_row: MultiBufferRow(end_row),
         depth,
-        indentation: IndentationSettings::new(
-            NonZeroU32::new(4).unwrap(),
-            NonZeroU32::new(4).unwrap(),
-            false,
-        ),
+        indentation,
         settings: IndentGuideSettings {
             enabled: true,
             line_width: 1,
@@ -29864,6 +29995,40 @@ async fn test_indent_guide_tabs(cx: &mut TestAppContext) {
         vec![
             indent_guide(buffer_id, 1, 5, 0),
             indent_guide(buffer_id, 3, 4, 1),
+        ],
+        None,
+        &mut cx,
+    );
+}
+
+#[gpui::test]
+async fn test_indent_guides_use_logical_indentation_width(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(4);
+        settings.defaults.tab_width = NonZeroU32::new(8);
+    });
+    let mut cx = EditorTestContext::new(cx).await;
+    let buffer_id = cx.update_editor(|editor, window, cx| {
+        editor.set_text("root\n\tchild\nroot", window, cx);
+        editor
+            .buffer()
+            .read(cx)
+            .as_singleton()
+            .unwrap()
+            .read(cx)
+            .remote_id()
+    });
+    let indentation = IndentationSettings::new(
+        NonZeroU32::new(4).unwrap(),
+        NonZeroU32::new(8).unwrap(),
+        false,
+    );
+
+    assert_indent_guides(
+        0..3,
+        vec![
+            indent_guide_with_indentation(buffer_id, 1, 1, 0, indentation),
+            indent_guide_with_indentation(buffer_id, 1, 1, 1, indentation),
         ],
         None,
         &mut cx,
@@ -42002,6 +42167,18 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
         .replace("$", " ")
         .as_str(),
     );
+
+    update_test_language_settings(&mut cx, &|settings| {
+        settings.defaults.tab_size = Some(4.try_into().unwrap());
+        settings.defaults.tab_width = Some(8.try_into().unwrap());
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    // Case 11: A literal tab can span multiple logical indentation levels.
+    cx.set_state("\t- ˇ");
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state("    - ˇ");
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5596,6 +5596,119 @@ async fn test_mixed_indentation_prefixes_are_preserved(cx: &mut TestAppContext) 
 }
 
 #[gpui::test]
+async fn test_modeline_separates_indent_size_and_tab_width(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(2);
+        settings.defaults.tab_width = NonZeroU32::new(8);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_modeline(Some(language::ModelineSettings {
+            tab_size: NonZeroU32::new(8),
+            indent_size: NonZeroU32::new(4),
+            hard_tabs: Some(true),
+            ..Default::default()
+        }));
+
+        let settings = language::language_settings::LanguageSettings::for_buffer(buffer, cx);
+        assert_eq!(settings.tab_size.get(), 4);
+        assert_eq!(settings.tab_width.get(), 8);
+        assert!(settings.hard_tabs);
+
+        buffer.set_modeline(Some(language::ModelineSettings {
+            indent_size: NonZeroU32::new(4),
+            ..Default::default()
+        }));
+        let settings = language::language_settings::LanguageSettings::for_buffer(buffer, cx);
+        assert_eq!(settings.tab_size.get(), 4);
+        assert_eq!(settings.tab_width.get(), 8);
+    });
+}
+
+#[gpui::test]
+async fn test_split_width_indentation_edge_cases(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(4);
+        settings.defaults.tab_width = NonZeroU32::new(8);
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("\tˇline");
+    cx.update_editor(|editor, window, cx| editor.backspace(&Backspace, window, cx));
+    cx.assert_editor_state("    ˇline");
+
+    cx.update_buffer(|buffer, _| {
+        buffer.set_modeline(Some(language::ModelineSettings {
+            auto_indent: Some(false),
+            ..Default::default()
+        }));
+    });
+    cx.set_state("  ˇ  line");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("    ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("\tˇline");
+}
+
+#[gpui::test]
+async fn test_hard_tab_indentation_does_not_overshoot_tab_stops(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(3);
+        settings.defaults.tab_width = NonZeroU32::new(8);
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state("ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("   ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("      ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("\t ˇline");
+}
+
+#[gpui::test]
+async fn test_indentation_width_can_differ_from_tab_width(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(4);
+        settings.defaults.tab_width = NonZeroU32::new(8);
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    let language = Arc::new(
+        Language::new(
+            LanguageConfig::default(),
+            Some(tree_sitter_rust::LANGUAGE.into()),
+        )
+        .with_indents_query(r#"(_ "{" "}" @end) @indent"#)
+        .unwrap(),
+    );
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
+
+    cx.set_state("ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("    ˇline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("\tˇline");
+    cx.update_editor(|editor, window, cx| editor.outdent(&Outdent, window, cx));
+    cx.assert_editor_state("    ˇline");
+
+    cx.set_state("fn main() {ˇ\n}");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("fn main() {\n    ˇ\n}");
+
+    cx.set_state("fn main() {\n    if true {ˇ\n    }\n}");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("fn main() {\n    if true {\n\tˇ\n    }\n}");
+}
+
+#[gpui::test]
 async fn test_tab(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.tab_size = NonZeroU32::new(3)
@@ -15240,7 +15353,9 @@ async fn test_snippet_with_multi_word_prefix(cx: &mut TestAppContext) {
 
 #[gpui::test]
 async fn test_document_format_during_save(cx: &mut TestAppContext) {
-    init_test(cx, |_| {});
+    init_test(cx, |settings| {
+        settings.defaults.tab_width = NonZeroU32::new(8);
+    });
 
     let fs = FakeFs::new(cx.executor());
     fs.insert_file(path!("/file.rs"), Default::default()).await;
@@ -28167,16 +28282,32 @@ fn assert_indent_guides(
 }
 
 fn indent_guide(buffer_id: BufferId, start_row: u32, end_row: u32, depth: u32) -> IndentGuide {
+    indent_guide_with_indentation(
+        buffer_id,
+        start_row,
+        end_row,
+        depth,
+        IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(4).unwrap(),
+            false,
+        ),
+    )
+}
+
+fn indent_guide_with_indentation(
+    buffer_id: BufferId,
+    start_row: u32,
+    end_row: u32,
+    depth: u32,
+    indentation: IndentationSettings,
+) -> IndentGuide {
     IndentGuide {
         buffer_id,
         start_row: MultiBufferRow(start_row),
         end_row: MultiBufferRow(end_row),
         depth,
-        indentation: IndentationSettings::new(
-            NonZeroU32::new(4).unwrap(),
-            NonZeroU32::new(4).unwrap(),
-            false,
-        ),
+        indentation,
         settings: IndentGuideSettings {
             enabled: true,
             line_width: 1,
@@ -28601,6 +28732,40 @@ async fn test_indent_guide_tabs(cx: &mut TestAppContext) {
         vec![
             indent_guide(buffer_id, 1, 5, 0),
             indent_guide(buffer_id, 3, 4, 1),
+        ],
+        None,
+        &mut cx,
+    );
+}
+
+#[gpui::test]
+async fn test_indent_guides_use_logical_indentation_width(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(4);
+        settings.defaults.tab_width = NonZeroU32::new(8);
+    });
+    let mut cx = EditorTestContext::new(cx).await;
+    let buffer_id = cx.update_editor(|editor, window, cx| {
+        editor.set_text("root\n\tchild\nroot", window, cx);
+        editor
+            .buffer()
+            .read(cx)
+            .as_singleton()
+            .unwrap()
+            .read(cx)
+            .remote_id()
+    });
+    let indentation = IndentationSettings::new(
+        NonZeroU32::new(4).unwrap(),
+        NonZeroU32::new(8).unwrap(),
+        false,
+    );
+
+    assert_indent_guides(
+        0..3,
+        vec![
+            indent_guide_with_indentation(buffer_id, 1, 1, 0, indentation),
+            indent_guide_with_indentation(buffer_id, 1, 1, 1, indentation),
         ],
         None,
         &mut cx,
@@ -39452,6 +39617,18 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
         .replace("$", " ")
         .as_str(),
     );
+
+    update_test_language_settings(&mut cx, &|settings| {
+        settings.defaults.tab_size = Some(4.try_into().unwrap());
+        settings.defaults.tab_width = Some(8.try_into().unwrap());
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    // Case 11: A literal tab can span multiple logical indentation levels.
+    cx.set_state("\t- ˇ");
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state("    - ˇ");
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -31,8 +31,8 @@ use language::{
     LanguageConfig, LanguageConfigOverride, LanguageMatcher, LanguageName, LanguageQueries,
     LanguageToolchainStore, Override, PLAIN_TEXT, Point,
     language_settings::{
-        CompletionSettingsContent, FormatOnSave, FormatterList, LanguageSettingsContent,
-        LspInsertMode,
+        CompletionSettingsContent, FormatOnSave, FormatterList, IndentationSettings,
+        LanguageSettingsContent, LspInsertMode,
     },
     tree_sitter_python,
 };
@@ -5555,6 +5555,42 @@ fn test_insert_with_old_selections(cx: &mut TestAppContext) {
                 MultiBufferOffset(9)..MultiBufferOffset(9),
                 MultiBufferOffset(15)..MultiBufferOffset(15)
             ],
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_mixed_indentation_prefixes_are_preserved(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = NonZeroU32::new(4);
+        settings.defaults.hard_tabs = Some(true);
+        settings.defaults.auto_indent = Some(language_settings::AutoIndentMode::PreserveIndent);
+        settings.defaults.allow_rewrap = Some(language_settings::RewrapBehavior::Anywhere);
+    });
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("\t  ˇline");
+    cx.update_editor(|editor, window, cx| editor.backspace(&Backspace, window, cx));
+    cx.assert_editor_state("\tˇline");
+
+    cx.set_state("  ˇ\tline");
+    cx.update_editor(|editor, window, cx| editor.tab(&Tab, window, cx));
+    cx.assert_editor_state("\t\tˇline");
+
+    cx.set_state("  \tlineˇ");
+    cx.update_editor(|editor, window, cx| editor.newline(&Newline, window, cx));
+    cx.assert_editor_state("  \tline\n  \tˇ");
+
+    cx.set_state("  \tlineˇ");
+    cx.update_editor(|editor, _, cx| editor.rewrap(RewrapOptions::default(), cx));
+    cx.assert_editor_state("  \tlineˇ");
+
+    cx.update_editor(|editor, _, cx| {
+        let snapshot = editor.buffer().read(cx).snapshot(cx);
+        assert_eq!(
+            snapshot.indent_and_comment_for_line(MultiBufferRow(0), cx),
+            "  \t"
         );
     });
 }
@@ -28136,7 +28172,11 @@ fn indent_guide(buffer_id: BufferId, start_row: u32, end_row: u32, depth: u32) -
         start_row: MultiBufferRow(start_row),
         end_row: MultiBufferRow(end_row),
         depth,
-        tab_size: 4,
+        indentation: IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(4).unwrap(),
+            false,
+        ),
         settings: IndentGuideSettings {
             enabled: true,
             line_width: 1,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1927,6 +1927,10 @@ impl EditorElement {
         const MAX_ALTERNATE_DISTANCE: u32 = 8;
 
         let is_valid_row = |row_candidate: u32| -> bool {
+            let candidate_point = MultiBufferPoint {
+                row: row_candidate,
+                column: 0,
+            };
             // move to other row if folded row
             if snapshot.is_line_folded(MultiBufferRow(row_candidate)) {
                 return false;
@@ -1937,10 +1941,6 @@ impl EditorElement {
                     return false;
                 }
             } else {
-                let candidate_point = MultiBufferPoint {
-                    row: row_candidate,
-                    column: 0,
-                };
                 // move to other row if different excerpt
                 let range = if candidate_point < buffer_point {
                     candidate_point..buffer_point
@@ -1965,11 +1965,13 @@ impl EditorElement {
                 true
             } else {
                 // use this row if code starts after slot
-                let indent_size = snapshot
-                    .display_snapshot
-                    .buffer_snapshot()
-                    .indent_size_for_line(MultiBufferRow(row_candidate));
-                indent_size.len >= INLINE_SLOT_CHAR_LIMIT
+                let buffer_snapshot = snapshot.display_snapshot.buffer_snapshot();
+                let indentation = buffer_snapshot
+                    .language_settings_at(candidate_point, cx)
+                    .indentation();
+                buffer_snapshot
+                    .indentation_column_for_line(MultiBufferRow(row_candidate), indentation)
+                    >= INLINE_SLOT_CHAR_LIMIT
             }
         };
 
@@ -2307,8 +2309,11 @@ impl EditorElement {
                 .into_iter()
                 .enumerate()
                 .filter_map(|(i, indent_guide)| {
-                    let single_indent_width =
-                        column_pixels(&self.style, indent_guide.tab_size as usize, window);
+                    let single_indent_width = column_pixels(
+                        &self.style,
+                        indent_guide.indentation.indent_size().get() as usize,
+                        window,
+                    );
                     let total_width = single_indent_width * indent_guide.depth as f32;
                     let start_x = Pixels::from(
                         ScrollOffset::from(content_origin.x + total_width)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1915,6 +1915,10 @@ impl EditorElement {
         const MAX_ALTERNATE_DISTANCE: u32 = 8;
 
         let is_valid_row = |row_candidate: u32| -> bool {
+            let candidate_point = MultiBufferPoint {
+                row: row_candidate,
+                column: 0,
+            };
             // move to other row if folded row
             if snapshot.is_line_folded(MultiBufferRow(row_candidate)) {
                 return false;
@@ -1925,10 +1929,6 @@ impl EditorElement {
                     return false;
                 }
             } else {
-                let candidate_point = MultiBufferPoint {
-                    row: row_candidate,
-                    column: 0,
-                };
                 // move to other row if different excerpt
                 let range = if candidate_point < buffer_point {
                     candidate_point..buffer_point
@@ -1953,11 +1953,13 @@ impl EditorElement {
                 true
             } else {
                 // use this row if code starts after slot
-                let indent_size = snapshot
-                    .display_snapshot
-                    .buffer_snapshot()
-                    .indent_size_for_line(MultiBufferRow(row_candidate));
-                indent_size.len >= INLINE_SLOT_CHAR_LIMIT
+                let buffer_snapshot = snapshot.display_snapshot.buffer_snapshot();
+                let indentation = buffer_snapshot
+                    .language_settings_at(candidate_point, cx)
+                    .indentation();
+                buffer_snapshot
+                    .indentation_column_for_line(MultiBufferRow(row_candidate), indentation)
+                    >= INLINE_SLOT_CHAR_LIMIT
             }
         };
 
@@ -2295,8 +2297,11 @@ impl EditorElement {
                 .into_iter()
                 .enumerate()
                 .filter_map(|(i, indent_guide)| {
-                    let single_indent_width =
-                        column_pixels(&self.style, indent_guide.tab_size as usize, window);
+                    let single_indent_width = column_pixels(
+                        &self.style,
+                        indent_guide.indentation.indent_size().get() as usize,
+                        window,
+                    );
                     let total_width = single_indent_width * indent_guide.depth as f32;
                     let start_x = Pixels::from(
                         ScrollOffset::from(content_origin.x + total_width)

--- a/crates/editor/src/indent_guides.rs
+++ b/crates/editor/src/indent_guides.rs
@@ -4,14 +4,14 @@ use collections::HashSet;
 use gpui::{App, AppContext as _, Context, Task, Window};
 use language::language_settings::LanguageSettings;
 use multi_buffer::{IndentGuide, MultiBufferRow, ToPoint};
-use text::{LineIndent, Point};
+use text::Point;
 use util::ResultExt;
 
 use crate::{DisplaySnapshot, Editor};
 
 struct ActiveIndentedRange {
     row_range: Range<MultiBufferRow>,
-    indent: LineIndent,
+    indent_column: u32,
 }
 
 #[derive(Default)]
@@ -97,8 +97,13 @@ impl Editor {
             }
 
             let snapshot = snapshot.clone();
+            let indentation = snapshot
+                .buffer_snapshot()
+                .language_settings_at(selection.head(), cx)
+                .indentation();
 
-            let task = cx.background_spawn(resolve_indented_range(snapshot, cursor_row));
+            let task =
+                cx.background_spawn(resolve_indented_range(snapshot, cursor_row, indentation));
 
             // Try to resolve the indent in a short amount of time, otherwise move it to a background task.
             match cx
@@ -127,7 +132,7 @@ impl Editor {
             .iter()
             .enumerate()
             .filter(|(_, indent_guide)| {
-                indent_guide.indent_level() == active_indent_range.indent.len(indent_guide.tab_size)
+                indent_guide.indent_level() == active_indent_range.indent_column
             });
 
         let mut matches = HashSet::default();
@@ -205,12 +210,16 @@ pub fn indent_guides_in_range(
 async fn resolve_indented_range(
     snapshot: DisplaySnapshot,
     buffer_row: MultiBufferRow,
+    indentation: language::language_settings::IndentationSettings,
 ) -> Option<ActiveIndentedRange> {
     snapshot
         .buffer_snapshot()
-        .enclosing_indent(buffer_row)
+        .enclosing_indent(buffer_row, indentation)
         .await
-        .map(|(row_range, indent)| ActiveIndentedRange { row_range, indent })
+        .map(|(row_range, indent_column)| ActiveIndentedRange {
+            row_range,
+            indent_column,
+        })
 }
 
 fn should_recalculate_indented_range(

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -554,6 +554,12 @@ impl Editor {
                             buffer.indent_size_for_line(MultiBufferRow(start_point.row));
                         let full_indent_len = existing_indent.len;
                         existing_indent.len = cmp::min(existing_indent.len, start_point.column);
+                        let existing_indent_text = buffer
+                            .text_for_range(
+                                Point::new(start_point.row, 0)
+                                    ..Point::new(start_point.row, existing_indent.len),
+                            )
+                            .collect::<String>();
                         let mut start = selection.start;
                         let end = selection.end;
                         let selection_is_empty = start == end;
@@ -660,12 +666,14 @@ impl Editor {
                             NewlineConfig::UnindentCurrentLine { continuation } => {
                                 let row_start =
                                     buffer.point_to_offset(Point::new(start_point.row, 0));
-                                let tab_size = buffer.language_settings_at(start, cx).tab_size;
-                                existing_indent.len = existing_indent
-                                    .len
-                                    .saturating_sub(existing_indent.outdent_len(tab_size));
-                                let mut new_text = String::new();
-                                new_text.extend(existing_indent.chars());
+                                let indentation =
+                                    buffer.language_settings_at(start, cx).indentation();
+                                let current_column =
+                                    indentation.column_for_prefix(existing_indent_text.chars());
+                                let target_column =
+                                    indentation.previous_indent_stop(current_column);
+                                let mut new_text =
+                                    indentation.indentation_for_column(target_column);
                                 new_text.push_str(continuation);
                                 (row_start, new_text, true)
                             }
@@ -683,7 +691,7 @@ impl Editor {
                                 let capacity_for_delimiter =
                                     delimiter.as_deref().map(str::len).unwrap_or_default();
                                 let existing_indent_len = if preserve_indent {
-                                    existing_indent.len as usize
+                                    existing_indent_text.len()
                                 } else {
                                     0
                                 };
@@ -698,7 +706,7 @@ impl Editor {
                                 );
                                 new_text.push('\n');
                                 if preserve_indent {
-                                    new_text.extend(existing_indent.chars());
+                                    new_text.push_str(&existing_indent_text);
                                 }
                                 new_text.extend(additional_indent.chars());
                                 if let Some(delimiter) = &delimiter {
@@ -707,7 +715,7 @@ impl Editor {
                                 if let Some(extra_indent) = extra_line_additional_indent {
                                     new_text.push('\n');
                                     if preserve_indent {
-                                        new_text.extend(existing_indent.chars());
+                                        new_text.push_str(&existing_indent_text);
                                     }
                                     new_text.extend(extra_indent.chars());
                                 }
@@ -943,6 +951,15 @@ impl Editor {
             original_indent_columns: Vec::new(),
         });
         self.replace_selections(text, autoindent, window, cx, false);
+    }
+
+    pub fn insert_without_autoindent(
+        &mut self,
+        text: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.replace_selections(text, None, window, cx, false);
     }
 
     /// Collects linked edits for the current selections, pairing each linked

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -551,6 +551,12 @@ impl Editor {
                             buffer.indent_size_for_line(MultiBufferRow(start_point.row));
                         let full_indent_len = existing_indent.len;
                         existing_indent.len = cmp::min(existing_indent.len, start_point.column);
+                        let existing_indent_text = buffer
+                            .text_for_range(
+                                Point::new(start_point.row, 0)
+                                    ..Point::new(start_point.row, existing_indent.len),
+                            )
+                            .collect::<String>();
                         let mut start = selection.start;
                         let end = selection.end;
                         let selection_is_empty = start == end;
@@ -659,12 +665,14 @@ impl Editor {
                             NewlineConfig::UnindentCurrentLine { continuation } => {
                                 let row_start =
                                     buffer.point_to_offset(Point::new(start_point.row, 0));
-                                let tab_size = buffer.language_settings_at(start, cx).tab_size;
-                                existing_indent.len = existing_indent
-                                    .len
-                                    .saturating_sub(existing_indent.outdent_len(tab_size));
-                                let mut new_text = String::new();
-                                new_text.extend(existing_indent.chars());
+                                let indentation =
+                                    buffer.language_settings_at(start, cx).indentation();
+                                let current_column =
+                                    indentation.column_for_prefix(existing_indent_text.chars());
+                                let target_column =
+                                    indentation.previous_indent_stop(current_column);
+                                let mut new_text =
+                                    indentation.indentation_for_column(target_column);
                                 new_text.push_str(continuation);
                                 (row_start, new_text, true)
                             }
@@ -682,7 +690,7 @@ impl Editor {
                                 let capacity_for_delimiter =
                                     delimiter.as_deref().map(str::len).unwrap_or_default();
                                 let existing_indent_len = if preserve_indent {
-                                    existing_indent.len as usize
+                                    existing_indent_text.len()
                                 } else {
                                     0
                                 };
@@ -697,7 +705,7 @@ impl Editor {
                                 );
                                 new_text.push('\n');
                                 if preserve_indent {
-                                    new_text.extend(existing_indent.chars());
+                                    new_text.push_str(&existing_indent_text);
                                 }
                                 new_text.extend(additional_indent.chars());
                                 if let Some(delimiter) = &delimiter {
@@ -706,7 +714,7 @@ impl Editor {
                                 if let Some(extra_indent) = extra_line_additional_indent {
                                     new_text.push('\n');
                                     if preserve_indent {
-                                        new_text.extend(existing_indent.chars());
+                                        new_text.push_str(&existing_indent_text);
                                     }
                                     new_text.extend(extra_indent.chars());
                                 }
@@ -942,6 +950,15 @@ impl Editor {
             original_indent_columns: Vec::new(),
         });
         self.replace_selections(text, autoindent, window, cx, false);
+    }
+
+    pub fn insert_without_autoindent(
+        &mut self,
+        text: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.replace_selections(text, None, window, cx, false);
     }
 
     /// Collects linked edits for the current selections, pairing each linked

--- a/crates/editor/src/rewrap.rs
+++ b/crates/editor/src/rewrap.rs
@@ -26,8 +26,11 @@ impl Editor {
             let language_scope = buffer.language_scope_at(selection.head());
 
             let indent_and_prefix_for_row =
-                |row: u32| -> (IndentSize, Option<CommentFormat>, Option<String>) {
+                |row: u32| -> (String, Option<CommentFormat>, Option<String>) {
                     let indent = buffer.indent_size_for_line(MultiBufferRow(row));
+                    let indent_prefix = buffer
+                        .text_for_range(Point::new(row, 0)..Point::new(row, indent.len))
+                        .collect::<String>();
                     let (comment_prefix, rewrap_prefix) = if let Some(language_scope) =
                         &language_scope
                     {
@@ -96,7 +99,7 @@ impl Editor {
                     } else {
                         (None, None)
                     };
-                    (indent, comment_prefix, rewrap_prefix)
+                    (indent_prefix, comment_prefix, rewrap_prefix)
                 };
 
             let mut start_row = selection.start.row;
@@ -105,7 +108,7 @@ impl Editor {
             if selection.is_empty() {
                 let cursor_row = selection.start.row;
 
-                let (mut indent_size, comment_prefix, _) = indent_and_prefix_for_row(cursor_row);
+                let (mut indent_prefix, comment_prefix, _) = indent_and_prefix_for_row(cursor_row);
                 let line_prefix = match &comment_prefix {
                     Some(CommentFormat::Line(prefix) | CommentFormat::BlockLine(prefix)) => {
                         Some(prefix.as_str())
@@ -119,12 +122,11 @@ impl Editor {
                         prefix,
                         tab_size,
                     })) => {
-                        indent_size.len += tab_size;
+                        indent_prefix.push_str(&" ".repeat(*tab_size as usize));
                         Some(prefix.as_ref())
                     }
                     None => None,
                 };
-                let indent_prefix = indent_size.chars().collect::<String>();
                 let line_prefix = format!("{indent_prefix}{}", line_prefix.unwrap_or(""));
 
                 'expand_upwards: while start_row > 0 {
@@ -217,7 +219,7 @@ impl Editor {
         let mut edits = Vec::new();
         let mut rewrapped_row_ranges = Vec::<RangeInclusive<u32>>::new();
 
-        for (language_settings, wrap_range, mut indent_size, comment_prefix, rewrap_prefix) in
+        for (language_settings, wrap_range, mut indent_prefix, comment_prefix, rewrap_prefix) in
             wrap_ranges
         {
             let start_row = wrap_range.start.row;
@@ -232,8 +234,9 @@ impl Editor {
                 continue;
             }
 
-            let tab_size = language_settings.tab_size;
+            let tab_width = language_settings.indentation().tab_width();
 
+            let base_indent_prefix = indent_prefix.clone();
             let (line_prefix, inside_comment) = match &comment_prefix {
                 Some(CommentFormat::Line(prefix) | CommentFormat::BlockLine(prefix)) => {
                     (Some(prefix.as_str()), true)
@@ -247,12 +250,11 @@ impl Editor {
                     prefix,
                     tab_size,
                 })) => {
-                    indent_size.len += tab_size;
+                    indent_prefix.push_str(&" ".repeat(*tab_size as usize));
                     (Some(prefix.as_ref()), true)
                 }
                 None => (None, false),
             };
-            let indent_prefix = indent_size.chars().collect::<String>();
             let line_prefix = format!("{indent_prefix}{}", line_prefix.unwrap_or(""));
 
             let allow_rewrap_based_on_language = match language_settings.allow_rewrap {
@@ -286,23 +288,20 @@ impl Editor {
                             start,
                             prefix,
                             end,
-                            tab_size,
+                            tab_size: _,
                         })
                         | CommentFormat::BlockCommentWithEnd(BlockCommentConfig {
                             start,
                             prefix,
                             end,
-                            tab_size,
+                            tab_size: _,
                         }),
                     ) = &comment_prefix
                     {
                         let line_trimmed = line_trimmed
                             .strip_prefix(start.as_ref())
                             .map(|s| {
-                                let mut indent_size = indent_size;
-                                indent_size.len -= tab_size;
-                                let indent_prefix: String = indent_size.chars().collect();
-                                first_line_delimiter = Some((indent_prefix, start));
+                                first_line_delimiter = Some((base_indent_prefix.clone(), start));
                                 s.trim_start()
                             })
                             .unwrap_or(line_trimmed);
@@ -353,7 +352,7 @@ impl Editor {
                     subsequent_lines_prefix,
                     lines_without_prefixes.join("\n"),
                     wrap_column,
-                    tab_size,
+                    tab_width,
                     options.preserve_existing_whitespace,
                 );
 

--- a/crates/editor/src/rewrap.rs
+++ b/crates/editor/src/rewrap.rs
@@ -26,8 +26,11 @@ impl Editor {
             let language_scope = buffer.language_scope_at(selection.head());
 
             let indent_and_prefix_for_row =
-                |row: u32| -> (IndentSize, Option<CommentFormat>, Option<String>) {
+                |row: u32| -> (String, Option<CommentFormat>, Option<String>) {
                     let indent = buffer.indent_size_for_line(MultiBufferRow(row));
+                    let indent_prefix = buffer
+                        .text_for_range(Point::new(row, 0)..Point::new(row, indent.len))
+                        .collect::<String>();
                     let (comment_prefix, rewrap_prefix) = if let Some(language_scope) =
                         &language_scope
                     {
@@ -96,7 +99,7 @@ impl Editor {
                     } else {
                         (None, None)
                     };
-                    (indent, comment_prefix, rewrap_prefix)
+                    (indent_prefix, comment_prefix, rewrap_prefix)
                 };
 
             let mut start_row = selection.start.row;
@@ -105,7 +108,7 @@ impl Editor {
             if selection.is_empty() {
                 let cursor_row = selection.start.row;
 
-                let (mut indent_size, comment_prefix, _) = indent_and_prefix_for_row(cursor_row);
+                let (mut indent_prefix, comment_prefix, _) = indent_and_prefix_for_row(cursor_row);
                 let line_prefix = match &comment_prefix {
                     Some(CommentFormat::Line(prefix) | CommentFormat::BlockLine(prefix)) => {
                         Some(prefix.as_str())
@@ -119,12 +122,11 @@ impl Editor {
                         prefix,
                         tab_size,
                     })) => {
-                        indent_size.len += tab_size;
+                        indent_prefix.push_str(&" ".repeat(*tab_size as usize));
                         Some(prefix.as_ref())
                     }
                     None => None,
                 };
-                let indent_prefix = indent_size.chars().collect::<String>();
                 let line_prefix = format!("{indent_prefix}{}", line_prefix.unwrap_or(""));
 
                 'expand_upwards: while start_row > 0 {
@@ -218,7 +220,7 @@ impl Editor {
         let mut edits = Vec::new();
         let mut rewrapped_row_ranges = Vec::<RangeInclusive<u32>>::new();
 
-        for (language_settings, wrap_range, mut indent_size, comment_prefix, rewrap_prefix) in
+        for (language_settings, wrap_range, mut indent_prefix, comment_prefix, rewrap_prefix) in
             wrap_ranges
         {
             let start_row = wrap_range.start.row;
@@ -233,8 +235,9 @@ impl Editor {
                 continue;
             }
 
-            let tab_size = language_settings.tab_size;
+            let tab_width = language_settings.indentation().tab_width();
 
+            let base_indent_prefix = indent_prefix.clone();
             let (line_prefix, inside_comment) = match &comment_prefix {
                 Some(CommentFormat::Line(prefix) | CommentFormat::BlockLine(prefix)) => {
                     (Some(prefix.as_str()), true)
@@ -248,12 +251,11 @@ impl Editor {
                     prefix,
                     tab_size,
                 })) => {
-                    indent_size.len += tab_size;
+                    indent_prefix.push_str(&" ".repeat(*tab_size as usize));
                     (Some(prefix.as_ref()), true)
                 }
                 None => (None, false),
             };
-            let indent_prefix = indent_size.chars().collect::<String>();
             let line_prefix = format!("{indent_prefix}{}", line_prefix.unwrap_or(""));
 
             let allow_rewrap_based_on_language = match language_settings.allow_rewrap {
@@ -287,23 +289,20 @@ impl Editor {
                             start,
                             prefix,
                             end,
-                            tab_size,
+                            tab_size: _,
                         })
                         | CommentFormat::BlockCommentWithEnd(BlockCommentConfig {
                             start,
                             prefix,
                             end,
-                            tab_size,
+                            tab_size: _,
                         }),
                     ) = &comment_prefix
                     {
                         let line_trimmed = line_trimmed
                             .strip_prefix(start.as_ref())
                             .map(|s| {
-                                let mut indent_size = indent_size;
-                                indent_size.len -= tab_size;
-                                let indent_prefix: String = indent_size.chars().collect();
-                                first_line_delimiter = Some((indent_prefix, start));
+                                first_line_delimiter = Some((base_indent_prefix.clone(), start));
                                 s.trim_start()
                             })
                             .unwrap_or(line_trimmed);
@@ -354,7 +353,7 @@ impl Editor {
                     subsequent_lines_prefix,
                     lines_without_prefixes.join("\n"),
                     wrap_column,
-                    tab_size,
+                    tab_width,
                     options.preserve_existing_whitespace,
                 );
 

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -2317,7 +2317,7 @@ impl Render for SplittableEditor {
 
 #[cfg(test)]
 mod tests {
-    use std::{any::TypeId, sync::Arc};
+    use std::{any::TypeId, num::NonZeroU32, sync::Arc};
 
     use buffer_diff::BufferDiff;
     use collections::{HashMap, HashSet};
@@ -2325,7 +2325,7 @@ mod tests {
     use gpui::{AppContext as _, Entity, Pixels, VisualTestContext};
     use gpui::{BorrowAppContext as _, Element as _};
     use language::language_settings::SoftWrap;
-    use language::{Buffer, Capability};
+    use language::{Buffer, Capability, ModelineSettings};
     use multi_buffer::{MultiBuffer, PathKey};
     use pretty_assertions::assert_eq;
     use project::Project;
@@ -2869,6 +2869,106 @@ mod tests {
             fff"
             .unindent(),
             &mut cx,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_split_diff_uses_per_buffer_tab_widths(cx: &mut gpui::TestAppContext) {
+        use rope::Point;
+
+        let (editor, mut cx) = init_test(cx, SoftWrap::None, DiffViewStyle::Split).await;
+        let (narrow_buffer, narrow_diff) =
+            buffer_with_diff("x\tnarrow old", "x\tnarrow new", &mut cx);
+        let (wide_buffer, wide_diff) = buffer_with_diff("x\twide old", "x\twide new", &mut cx);
+
+        narrow_buffer.update(cx, |buffer, _| {
+            buffer.set_modeline(Some(ModelineSettings {
+                tab_size: NonZeroU32::new(2),
+                indent_size: NonZeroU32::new(8),
+                ..Default::default()
+            }));
+        });
+        wide_buffer.update(cx, |buffer, _| {
+            buffer.set_modeline(Some(ModelineSettings {
+                tab_size: NonZeroU32::new(8),
+                indent_size: NonZeroU32::new(2),
+                ..Default::default()
+            }));
+        });
+
+        editor.update(cx, |editor, cx| {
+            editor.update_excerpts_for_path(
+                PathKey::sorted(0),
+                narrow_buffer.clone(),
+                [Point::zero()..narrow_buffer.read(cx).max_point()],
+                0,
+                narrow_diff,
+                cx,
+            );
+            editor.update_excerpts_for_path(
+                PathKey::sorted(1),
+                wide_buffer.clone(),
+                [Point::zero()..wide_buffer.read(cx).max_point()],
+                0,
+                wide_diff,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        let (rhs_editor, lhs_editor) = editor.update(cx, |editor, _| {
+            (
+                editor.rhs_editor.clone(),
+                editor
+                    .lhs
+                    .as_ref()
+                    .expect("split editor should have an lhs editor")
+                    .editor
+                    .clone(),
+            )
+        });
+        let expanded_lines = |editor: &Entity<Editor>, cx: &mut VisualTestContext| {
+            editor.update(cx, |editor, cx| {
+                editor.display_map.update(cx, |display_map, cx| {
+                    display_map
+                        .snapshot(cx)
+                        .tab_snapshot()
+                        .text()
+                        .lines()
+                        .filter(|line| !line.is_empty())
+                        .map(str::to_owned)
+                        .collect::<Vec<_>>()
+                })
+            })
+        };
+
+        assert_eq!(
+            expanded_lines(&rhs_editor, &mut cx),
+            ["x narrow new".to_owned(), "x       wide new".to_owned()]
+        );
+        assert_eq!(
+            expanded_lines(&lhs_editor, &mut cx),
+            ["x narrow old".to_owned(), "x       wide old".to_owned()]
+        );
+
+        wide_buffer.update(cx, |buffer, cx| {
+            if buffer.set_modeline(Some(ModelineSettings {
+                tab_size: NonZeroU32::new(4),
+                indent_size: NonZeroU32::new(2),
+                ..Default::default()
+            })) {
+                cx.notify();
+            }
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            expanded_lines(&rhs_editor, &mut cx),
+            ["x narrow new".to_owned(), "x   wide new".to_owned()]
+        );
+        assert_eq!(
+            expanded_lines(&lhs_editor, &mut cx),
+            ["x narrow old".to_owned(), "x   wide old".to_owned()]
         );
     }
 

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -2367,7 +2367,7 @@ impl Render for SplittableEditor {
 
 #[cfg(test)]
 mod tests {
-    use std::{any::TypeId, sync::Arc};
+    use std::{any::TypeId, num::NonZeroU32, sync::Arc};
 
     use buffer_diff::BufferDiff;
     use collections::{HashMap, HashSet};
@@ -2375,7 +2375,7 @@ mod tests {
     use gpui::{AppContext as _, Entity, Pixels, VisualTestContext};
     use gpui::{BorrowAppContext as _, Element as _};
     use language::language_settings::SoftWrap;
-    use language::{Buffer, Capability};
+    use language::{Buffer, Capability, ModelineSettings};
     use multi_buffer::{MultiBuffer, PathKey};
     use pretty_assertions::assert_eq;
     use project::Project;
@@ -2919,6 +2919,106 @@ mod tests {
             fff"
             .unindent(),
             &mut cx,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_split_diff_uses_per_buffer_tab_widths(cx: &mut gpui::TestAppContext) {
+        use rope::Point;
+
+        let (editor, mut cx) = init_test(cx, SoftWrap::None, DiffViewStyle::Split).await;
+        let (narrow_buffer, narrow_diff) =
+            buffer_with_diff("x\tnarrow old", "x\tnarrow new", &mut cx);
+        let (wide_buffer, wide_diff) = buffer_with_diff("x\twide old", "x\twide new", &mut cx);
+
+        narrow_buffer.update(cx, |buffer, _| {
+            buffer.set_modeline(Some(ModelineSettings {
+                tab_size: NonZeroU32::new(2),
+                indent_size: NonZeroU32::new(8),
+                ..Default::default()
+            }));
+        });
+        wide_buffer.update(cx, |buffer, _| {
+            buffer.set_modeline(Some(ModelineSettings {
+                tab_size: NonZeroU32::new(8),
+                indent_size: NonZeroU32::new(2),
+                ..Default::default()
+            }));
+        });
+
+        editor.update(cx, |editor, cx| {
+            editor.update_excerpts_for_path(
+                PathKey::sorted(0),
+                narrow_buffer.clone(),
+                [Point::zero()..narrow_buffer.read(cx).max_point()],
+                0,
+                narrow_diff,
+                cx,
+            );
+            editor.update_excerpts_for_path(
+                PathKey::sorted(1),
+                wide_buffer.clone(),
+                [Point::zero()..wide_buffer.read(cx).max_point()],
+                0,
+                wide_diff,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        let (rhs_editor, lhs_editor) = editor.update(cx, |editor, _| {
+            (
+                editor.rhs_editor.clone(),
+                editor
+                    .lhs
+                    .as_ref()
+                    .expect("split editor should have an lhs editor")
+                    .editor
+                    .clone(),
+            )
+        });
+        let expanded_lines = |editor: &Entity<Editor>, cx: &mut VisualTestContext| {
+            editor.update(cx, |editor, cx| {
+                editor.display_map.update(cx, |display_map, cx| {
+                    display_map
+                        .snapshot(cx)
+                        .tab_snapshot()
+                        .text()
+                        .lines()
+                        .filter(|line| !line.is_empty())
+                        .map(str::to_owned)
+                        .collect::<Vec<_>>()
+                })
+            })
+        };
+
+        assert_eq!(
+            expanded_lines(&rhs_editor, &mut cx),
+            ["x narrow new".to_owned(), "x       wide new".to_owned()]
+        );
+        assert_eq!(
+            expanded_lines(&lhs_editor, &mut cx),
+            ["x narrow old".to_owned(), "x       wide old".to_owned()]
+        );
+
+        wide_buffer.update(cx, |buffer, cx| {
+            if buffer.set_modeline(Some(ModelineSettings {
+                tab_size: NonZeroU32::new(4),
+                indent_size: NonZeroU32::new(2),
+                ..Default::default()
+            })) {
+                cx.notify();
+            }
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            expanded_lines(&rhs_editor, &mut cx),
+            ["x narrow new".to_owned(), "x   wide new".to_owned()]
+        );
+        assert_eq!(
+            expanded_lines(&lhs_editor, &mut cx),
+            ["x narrow old".to_owned(), "x   wide old".to_owned()]
         );
     }
 

--- a/crates/extension_api/wit/since_v0.0.6/settings.rs
+++ b/crates/extension_api/wit/since_v0.0.6/settings.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU32;
 /// The settings for a particular language.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LanguageSettings {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     pub tab_size: NonZeroU32,
 }
 

--- a/crates/extension_api/wit/since_v0.1.0/settings.rs
+++ b/crates/extension_api/wit/since_v0.1.0/settings.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU32;
 /// The settings for a particular language.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LanguageSettings {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     pub tab_size: NonZeroU32,
 }
 

--- a/crates/extension_api/wit/since_v0.2.0/settings.rs
+++ b/crates/extension_api/wit/since_v0.2.0/settings.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, num::NonZeroU32};
 /// The settings for a particular language.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LanguageSettings {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     pub tab_size: NonZeroU32,
 }
 

--- a/crates/extension_api/wit/since_v0.3.0/settings.rs
+++ b/crates/extension_api/wit/since_v0.3.0/settings.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, num::NonZeroU32};
 /// The settings for a particular language.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LanguageSettings {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     pub tab_size: NonZeroU32,
 }
 

--- a/crates/extension_api/wit/since_v0.4.0/settings.rs
+++ b/crates/extension_api/wit/since_v0.4.0/settings.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, num::NonZeroU32};
 /// The settings for a particular language.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LanguageSettings {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     pub tab_size: NonZeroU32,
 }
 

--- a/crates/extension_api/wit/since_v0.5.0/settings.rs
+++ b/crates/extension_api/wit/since_v0.5.0/settings.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, num::NonZeroU32};
 /// The settings for a particular language.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LanguageSettings {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     pub tab_size: NonZeroU32,
 }
 

--- a/crates/extension_api/wit/since_v0.6.0/settings.rs
+++ b/crates/extension_api/wit/since_v0.6.0/settings.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, num::NonZeroU32};
 /// The settings for a particular language.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LanguageSettings {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     pub tab_size: NonZeroU32,
 }
 

--- a/crates/extension_api/wit/since_v0.8.0/settings.rs
+++ b/crates/extension_api/wit/since_v0.8.0/settings.rs
@@ -4,8 +4,10 @@ use std::{collections::HashMap, num::NonZeroU32};
 /// The settings for a particular language.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LanguageSettings {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     pub tab_size: NonZeroU32,
+    /// How many columns a literal tab character should occupy.
+    pub tab_width: NonZeroU32,
     /// Whether to indent with hard tabs (true) or spaces (false).
     pub hard_tabs: bool,
     /// The preferred line length (column at which to wrap).

--- a/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
@@ -968,6 +968,7 @@ impl ExtensionImports for WasmState {
                         );
                         Ok(serde_json::to_string(&settings::LanguageSettings {
                             tab_size: settings.tab_size,
+                            tab_width: settings.tab_width,
                             hard_tabs: settings.hard_tabs,
                             preferred_line_length: settings.preferred_line_length,
                         })?)

--- a/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
@@ -979,6 +979,7 @@ impl ExtensionImports for WasmState {
                         );
                         Ok(serde_json::to_string(&settings::LanguageSettings {
                             tab_size: settings.tab_size,
+                            tab_width: settings.tab_width,
                             hard_tabs: settings.hard_tabs,
                             preferred_line_length: settings.preferred_line_length,
                         })?)

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -7,7 +7,7 @@ use crate::{
     ByteContent, DebuggerTextObject, LanguageScope, ModelineSettings, Outline, OutlineConfig,
     PLAIN_TEXT, RunnableTag, TextObject, TreeSitterOptions, analyze_byte_content,
     diagnostic_set::{DiagnosticEntry, DiagnosticEntryRef, DiagnosticGroup},
-    language_settings::{AutoIndentMode, LanguageSettings},
+    language_settings::{AutoIndentMode, IndentationSettings, LanguageSettings},
     outline::OutlineItem,
     row_chunk::RowChunks,
     runnable::{self, RunnableRange},
@@ -501,7 +501,7 @@ struct AutoindentRequestEntry {
     /// This is stored here because the anchor in range is created after
     /// the edit, so it cannot be used with the before_edit snapshot.
     old_row: Option<u32>,
-    indent_size: IndentSize,
+    indentation: IndentationSettings,
     original_indent_column: Option<u32>,
 }
 
@@ -2118,7 +2118,7 @@ impl Buffer {
                     let position = entry.range.start;
                     let new_row = position.to_point(&snapshot).row;
                     let new_end_row = entry.range.end.to_point(&snapshot).row + 1;
-                    language_indent_sizes_by_new_row.push((new_row, entry.indent_size));
+                    language_indent_sizes_by_new_row.push((new_row, entry.indentation));
 
                     if let Some(old_row) = entry.old_row {
                         old_to_new_rows.insert(old_row, new_row);
@@ -2133,7 +2133,7 @@ impl Buffer {
                 let old_edited_ranges =
                     contiguous_ranges(old_to_new_rows.keys().copied(), max_rows_between_yields);
                 let mut language_indent_sizes = language_indent_sizes_by_new_row.iter().peekable();
-                let mut language_indent_size = IndentSize::default();
+                let mut language_indentation = None;
                 for old_edited_range in old_edited_ranges {
                     let suggestions = request
                         .before_edit
@@ -2145,25 +2145,32 @@ impl Buffer {
                             let new_row = *old_to_new_rows.get(&old_row).unwrap();
 
                             // Find the indent size based on the language for this row.
-                            while let Some((row, size)) = language_indent_sizes.peek() {
+                            while let Some((row, indentation)) = language_indent_sizes.peek() {
                                 if *row > new_row {
                                     break;
                                 }
-                                language_indent_size = *size;
+                                language_indentation = Some(*indentation);
                                 language_indent_sizes.next();
                             }
 
+                            let Some(indentation) = language_indentation else {
+                                continue;
+                            };
                             let suggested_indent = old_to_new_rows
                                 .get(&suggestion.basis_row)
                                 .and_then(|from_row| {
                                     Some(old_suggestions.get(from_row).copied()?.0)
                                 })
                                 .unwrap_or_else(|| {
-                                    request
-                                        .before_edit
-                                        .logical_indent_size_for_line(suggestion.basis_row)
+                                    request.before_edit.logical_indentation_size_for_line(
+                                        suggestion.basis_row,
+                                        indentation,
+                                    )
                                 })
-                                .with_delta(suggestion.delta, language_indent_size);
+                                .with_delta(
+                                    suggestion.delta,
+                                    IndentSize::spaces(indentation.indent_size().get()),
+                                );
                             old_suggestions
                                 .insert(new_row, (suggested_indent, suggestion.within_error));
                         }
@@ -2174,7 +2181,7 @@ impl Buffer {
                 // Compute new suggestions for each line, but only include them in the result
                 // if they differ from the old suggestion for that line.
                 let mut language_indent_sizes = language_indent_sizes_by_new_row.iter().peekable();
-                let mut language_indent_size = IndentSize::default();
+                let mut language_indentation = None;
                 for (row_range, original_indent_column) in row_ranges {
                     let new_edited_row_range = if request.is_block_mode {
                         row_range.start..row_range.start + 1
@@ -2189,22 +2196,31 @@ impl Buffer {
                     for (new_row, suggestion) in new_edited_row_range.zip(suggestions) {
                         if let Some(suggestion) = suggestion {
                             // Find the indent size based on the language for this row.
-                            while let Some((row, size)) = language_indent_sizes.peek() {
+                            while let Some((row, indentation)) = language_indent_sizes.peek() {
                                 if *row > new_row {
                                     break;
                                 }
-                                language_indent_size = *size;
+                                language_indentation = Some(*indentation);
                                 language_indent_sizes.next();
                             }
 
+                            let Some(indentation) = language_indentation else {
+                                continue;
+                            };
                             let suggested_indent = indent_sizes
                                 .get(&suggestion.basis_row)
                                 .copied()
                                 .map(|e| e.0)
                                 .unwrap_or_else(|| {
-                                    snapshot.logical_indent_size_for_line(suggestion.basis_row)
+                                    snapshot.logical_indentation_size_for_line(
+                                        suggestion.basis_row,
+                                        indentation,
+                                    )
                                 })
-                                .with_delta(suggestion.delta, language_indent_size);
+                                .with_delta(
+                                    suggestion.delta,
+                                    IndentSize::spaces(indentation.indent_size().get()),
+                                );
 
                             if old_suggestions.get(&new_row).is_none_or(
                                 |(old_indentation, was_within_error)| {
@@ -2223,30 +2239,27 @@ impl Buffer {
                     if let (true, Some(original_indent_column)) =
                         (request.is_block_mode, original_indent_column)
                     {
+                        let Some(indentation) = language_indentation else {
+                            continue;
+                        };
                         let new_indent =
                             if let Some((indent, _)) = indent_sizes.get(&row_range.start) {
                                 *indent
                             } else {
-                                snapshot.indent_size_for_line(row_range.start)
+                                snapshot.indentation_size_for_line(row_range.start, indentation)
                             };
                         let delta = new_indent.len as i64 - original_indent_column as i64;
                         if delta != 0 {
                             for row in row_range.skip(1) {
                                 indent_sizes.entry(row).or_insert_with(|| {
-                                    let mut size = snapshot.indent_size_for_line(row);
-                                    // A line with no indentation has an arbitrary
-                                    // indent kind, so it can adopt the new kind.
-                                    if size.len == 0 {
-                                        size.kind = new_indent.kind;
-                                    }
-                                    if size.kind == new_indent.kind {
-                                        match delta.cmp(&0) {
-                                            Ordering::Greater => size.len += delta as u32,
-                                            Ordering::Less => {
-                                                size.len = size.len.saturating_sub(-delta as u32)
-                                            }
-                                            Ordering::Equal => {}
+                                    let mut size =
+                                        snapshot.indentation_size_for_line(row, indentation);
+                                    match delta.cmp(&0) {
+                                        Ordering::Greater => size.len += delta as u32,
+                                        Ordering::Less => {
+                                            size.len = size.len.saturating_sub(-delta as u32)
                                         }
+                                        Ordering::Equal => {}
                                     }
                                     (size, request.ignore_empty_lines)
                                 });
@@ -2284,8 +2297,8 @@ impl Buffer {
         let edits: Vec<_> = indent_sizes
             .into_iter()
             .filter_map(|(row, indent_size)| {
-                let current_size = indent_size_for_line(self, row);
-                Self::edit_for_indent_size_adjustment(row, current_size, indent_size)
+                let settings = LanguageSettings::for_buffer_at(self, Point::new(row, 0), cx);
+                self.edit_for_indentation_column(row, indent_size.len, settings.indentation())
             })
             .collect();
 
@@ -2296,41 +2309,21 @@ impl Buffer {
         }
     }
 
-    /// Create a minimal edit that will cause the given row to be indented
-    /// with the given size. After applying this edit, the length of the line
-    /// will always be at least `new_size.len`.
-    pub fn edit_for_indent_size_adjustment(
+    fn edit_for_indentation_column(
+        &self,
         row: u32,
-        current_size: IndentSize,
-        new_size: IndentSize,
+        target_column: u32,
+        indentation: IndentationSettings,
     ) -> Option<(Range<Point>, String)> {
-        if new_size.kind == current_size.kind {
-            match new_size.len.cmp(&current_size.len) {
-                Ordering::Greater => {
-                    let point = Point::new(row, 0);
-                    Some((
-                        point..point,
-                        iter::repeat(new_size.char())
-                            .take((new_size.len - current_size.len) as usize)
-                            .collect::<String>(),
-                    ))
-                }
-
-                Ordering::Less => Some((
-                    Point::new(row, 0)..Point::new(row, current_size.len - new_size.len),
-                    String::new(),
-                )),
-
-                Ordering::Equal => None,
-            }
-        } else {
-            Some((
-                Point::new(row, 0)..Point::new(row, current_size.len),
-                iter::repeat(new_size.char())
-                    .take(new_size.len as usize)
-                    .collect::<String>(),
-            ))
-        }
+        let current_indent_len = indent_size_for_line(self, row).len;
+        let current_indent = self
+            .text_for_range(Point::new(row, 0)..Point::new(row, current_indent_len))
+            .collect::<String>();
+        let replacement = indentation.indentation_for_column(target_column);
+        (current_indent != replacement).then_some((
+            Point::new(row, 0)..Point::new(row, current_indent_len),
+            replacement,
+        ))
     }
 
     /// Spawns a background task that asynchronously computes a `Diff` between the buffer's text
@@ -3003,21 +2996,22 @@ impl Buffer {
                         original_indent_columns,
                     } = &mode
                     {
+                        let indentation = before_edit.language_indentation_at(range.start, cx);
                         original_indent_column = Some(if new_text.starts_with('\n') {
-                            indent_size_for_text(
+                            indentation_width_for_text(
                                 new_text[range_of_insertion_to_indent.clone()].chars(),
+                                indentation,
                             )
-                            .len
                         } else {
                             original_indent_columns
                                 .get(ix)
                                 .copied()
                                 .flatten()
                                 .unwrap_or_else(|| {
-                                    indent_size_for_text(
+                                    indentation_width_for_text(
                                         new_text[range_of_insertion_to_indent.clone()].chars(),
+                                        indentation,
                                     )
-                                    .len
                                 })
                         });
 
@@ -3034,7 +3028,7 @@ impl Buffer {
                         } else {
                             Some(old_start.row)
                         },
-                        indent_size: before_edit.language_indent_size_at(range.start, cx),
+                        indentation: before_edit.language_indentation_at(range.start, cx),
                         range: self.anchor_before(new_start + range_of_insertion_to_indent.start)
                             ..self.anchor_after(new_start + range_of_insertion_to_indent.end),
                     }
@@ -3098,7 +3092,7 @@ impl Buffer {
             .map(|range| AutoindentRequestEntry {
                 range: before_edit.anchor_before(range.start)..before_edit.anchor_after(range.end),
                 old_row: None,
-                indent_size: before_edit.language_indent_size_at(range.start, cx),
+                indentation: before_edit.language_indentation_at(range.start, cx),
                 original_indent_column: None,
             })
             .collect();
@@ -3688,6 +3682,11 @@ impl BufferSnapshot {
     /// containing the delimiter to end there, so that a line which merely looks
     /// like a closing delimiter is not mistaken for one.
     pub fn block_comment_closing_indent(&self, position: Point) -> Option<IndentSize> {
+        let opening_row = self.block_comment_opening_row(position)?;
+        Some(self.indent_size_for_line(opening_row))
+    }
+
+    fn block_comment_opening_row(&self, position: Point) -> Option<u32> {
         let row = position.row;
         let indent_len = self.indent_size_for_line(row).len;
         let delimiter_start = Point::new(row, indent_len);
@@ -3730,26 +3729,46 @@ impl BufferSnapshot {
             return None;
         }
         let opening_row = Point::from_ts_point(node.start_position()).row;
-        (opening_row < row).then(|| self.indent_size_for_line(opening_row))
+        (opening_row < row).then_some(opening_row)
     }
 
-    /// Like [`Self::indent_size_for_line`], but reports the indentation a row
-    /// logically sits at, which differs from its physical indentation on the
-    /// closing line of a block comment. See [`Self::block_comment_closing_indent`].
-    fn logical_indent_size_for_line(&self, row: u32) -> IndentSize {
-        self.block_comment_closing_indent(Point::new(row, self.line_len(row)))
-            .unwrap_or_else(|| self.indent_size_for_line(row))
+    fn logical_indentation_size_for_line(
+        &self,
+        row: u32,
+        indentation: IndentationSettings,
+    ) -> IndentSize {
+        let row = self
+            .block_comment_opening_row(Point::new(row, self.line_len(row)))
+            .unwrap_or(row);
+        self.indentation_size_for_line(row, indentation)
     }
 
     /// Returns [`IndentSize`] for a given position that respects user settings
     /// and language preferences.
     pub fn language_indent_size_at<T: ToOffset>(&self, position: T, cx: &App) -> IndentSize {
-        let settings = self.settings_at(position, cx);
-        if settings.hard_tabs {
-            IndentSize::tab()
-        } else {
-            IndentSize::spaces(settings.tab_size.get())
-        }
+        IndentSize::spaces(
+            self.language_indentation_at(position, cx)
+                .indent_size()
+                .get(),
+        )
+    }
+
+    pub fn language_indentation_at<T: ToOffset>(
+        &self,
+        position: T,
+        cx: &App,
+    ) -> IndentationSettings {
+        self.settings_at(position, cx).indentation()
+    }
+
+    /// Returns the indentation width in columns, expanding literal tabs using
+    /// the configured tab stops.
+    pub fn indentation_size_for_line(
+        &self,
+        row: u32,
+        indentation: IndentationSettings,
+    ) -> IndentSize {
+        IndentSize::spaces(indentation.column_for_prefix(self.chars_at(Point::new(row, 0))))
     }
 
     /// Retrieve the suggested indent size for all of the given rows. The unit of indentation
@@ -3758,6 +3777,7 @@ impl BufferSnapshot {
         &self,
         rows: impl Iterator<Item = u32>,
         single_indent_size: IndentSize,
+        indentation: IndentationSettings,
     ) -> BTreeMap<u32, IndentSize> {
         let mut result = BTreeMap::new();
 
@@ -3772,10 +3792,15 @@ impl BufferSnapshot {
                     result
                         .get(&suggestion.basis_row)
                         .copied()
-                        .unwrap_or_else(|| self.logical_indent_size_for_line(suggestion.basis_row))
+                        .unwrap_or_else(|| {
+                            self.logical_indentation_size_for_line(
+                                suggestion.basis_row,
+                                indentation,
+                            )
+                        })
                         .with_delta(suggestion.delta, single_indent_size)
                 } else {
-                    self.indent_size_for_line(row)
+                    self.indentation_size_for_line(row, indentation)
                 };
 
                 result.insert(row, indent_size);
@@ -5472,6 +5497,13 @@ fn indent_size_for_text(text: impl Iterator<Item = char>) -> IndentSize {
     result
 }
 
+fn indentation_width_for_text(
+    text: impl Iterator<Item = char>,
+    indentation: IndentationSettings,
+) -> u32 {
+    indentation.column_for_prefix(text)
+}
+
 impl Clone for BufferSnapshot {
     fn clone(&self) -> Self {
         Self {
@@ -5839,34 +5871,6 @@ impl IndentSize {
             }
         }
         self
-    }
-
-    /// Returns the number of indentation characters to remove when outdenting to the
-    /// previous editor tab stop.
-    pub fn outdent_len(self, tab_size: NonZeroU32) -> u32 {
-        if self.len == 0 {
-            return 0;
-        }
-
-        match self.kind {
-            IndentKind::Space => {
-                let tab_size = tab_size.get();
-                let columns_to_prev_tab_stop = self.len % tab_size;
-                if columns_to_prev_tab_stop == 0 {
-                    tab_size
-                } else {
-                    columns_to_prev_tab_stop
-                }
-            }
-            IndentKind::Tab => 1,
-        }
-    }
-
-    pub fn len_with_expanded_tabs(&self, tab_size: NonZeroU32) -> usize {
-        match self.kind {
-            IndentKind::Space => self.len as usize,
-            IndentKind::Tab => self.len as usize * tab_size.get() as usize,
-        }
     }
 }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -7,7 +7,7 @@ use crate::{
     ByteContent, DebuggerTextObject, LanguageScope, ModelineSettings, Outline, OutlineConfig,
     PLAIN_TEXT, RunnableTag, TextObject, TreeSitterOptions, analyze_byte_content,
     diagnostic_set::{DiagnosticEntry, DiagnosticEntryRef, DiagnosticGroup},
-    language_settings::{AutoIndentMode, LanguageSettings},
+    language_settings::{AutoIndentMode, IndentationSettings, LanguageSettings},
     outline::OutlineItem,
     row_chunk::RowChunks,
     runnable::{self, RunnableRange},
@@ -496,7 +496,7 @@ struct AutoindentRequestEntry {
     /// This is stored here because the anchor in range is created after
     /// the edit, so it cannot be used with the before_edit snapshot.
     old_row: Option<u32>,
-    indent_size: IndentSize,
+    indentation: IndentationSettings,
     original_indent_column: Option<u32>,
 }
 
@@ -2041,7 +2041,7 @@ impl Buffer {
                     let position = entry.range.start;
                     let new_row = position.to_point(&snapshot).row;
                     let new_end_row = entry.range.end.to_point(&snapshot).row + 1;
-                    language_indent_sizes_by_new_row.push((new_row, entry.indent_size));
+                    language_indent_sizes_by_new_row.push((new_row, entry.indentation));
 
                     if let Some(old_row) = entry.old_row {
                         old_to_new_rows.insert(old_row, new_row);
@@ -2056,7 +2056,7 @@ impl Buffer {
                 let old_edited_ranges =
                     contiguous_ranges(old_to_new_rows.keys().copied(), max_rows_between_yields);
                 let mut language_indent_sizes = language_indent_sizes_by_new_row.iter().peekable();
-                let mut language_indent_size = IndentSize::default();
+                let mut language_indentation = None;
                 for old_edited_range in old_edited_ranges {
                     let suggestions = request
                         .before_edit
@@ -2068,25 +2068,32 @@ impl Buffer {
                             let new_row = *old_to_new_rows.get(&old_row).unwrap();
 
                             // Find the indent size based on the language for this row.
-                            while let Some((row, size)) = language_indent_sizes.peek() {
+                            while let Some((row, indentation)) = language_indent_sizes.peek() {
                                 if *row > new_row {
                                     break;
                                 }
-                                language_indent_size = *size;
+                                language_indentation = Some(*indentation);
                                 language_indent_sizes.next();
                             }
 
+                            let Some(indentation) = language_indentation else {
+                                continue;
+                            };
                             let suggested_indent = old_to_new_rows
                                 .get(&suggestion.basis_row)
                                 .and_then(|from_row| {
                                     Some(old_suggestions.get(from_row).copied()?.0)
                                 })
                                 .unwrap_or_else(|| {
-                                    request
-                                        .before_edit
-                                        .indent_size_for_line(suggestion.basis_row)
+                                    request.before_edit.indentation_size_for_line(
+                                        suggestion.basis_row,
+                                        indentation,
+                                    )
                                 })
-                                .with_delta(suggestion.delta, language_indent_size);
+                                .with_delta(
+                                    suggestion.delta,
+                                    IndentSize::spaces(indentation.indent_size().get()),
+                                );
                             old_suggestions
                                 .insert(new_row, (suggested_indent, suggestion.within_error));
                         }
@@ -2097,7 +2104,7 @@ impl Buffer {
                 // Compute new suggestions for each line, but only include them in the result
                 // if they differ from the old suggestion for that line.
                 let mut language_indent_sizes = language_indent_sizes_by_new_row.iter().peekable();
-                let mut language_indent_size = IndentSize::default();
+                let mut language_indentation = None;
                 for (row_range, original_indent_column) in row_ranges {
                     let new_edited_row_range = if request.is_block_mode {
                         row_range.start..row_range.start + 1
@@ -2112,22 +2119,31 @@ impl Buffer {
                     for (new_row, suggestion) in new_edited_row_range.zip(suggestions) {
                         if let Some(suggestion) = suggestion {
                             // Find the indent size based on the language for this row.
-                            while let Some((row, size)) = language_indent_sizes.peek() {
+                            while let Some((row, indentation)) = language_indent_sizes.peek() {
                                 if *row > new_row {
                                     break;
                                 }
-                                language_indent_size = *size;
+                                language_indentation = Some(*indentation);
                                 language_indent_sizes.next();
                             }
 
+                            let Some(indentation) = language_indentation else {
+                                continue;
+                            };
                             let suggested_indent = indent_sizes
                                 .get(&suggestion.basis_row)
                                 .copied()
                                 .map(|e| e.0)
                                 .unwrap_or_else(|| {
-                                    snapshot.indent_size_for_line(suggestion.basis_row)
+                                    snapshot.indentation_size_for_line(
+                                        suggestion.basis_row,
+                                        indentation,
+                                    )
                                 })
-                                .with_delta(suggestion.delta, language_indent_size);
+                                .with_delta(
+                                    suggestion.delta,
+                                    IndentSize::spaces(indentation.indent_size().get()),
+                                );
 
                             if old_suggestions.get(&new_row).is_none_or(
                                 |(old_indentation, was_within_error)| {
@@ -2146,30 +2162,27 @@ impl Buffer {
                     if let (true, Some(original_indent_column)) =
                         (request.is_block_mode, original_indent_column)
                     {
+                        let Some(indentation) = language_indentation else {
+                            continue;
+                        };
                         let new_indent =
                             if let Some((indent, _)) = indent_sizes.get(&row_range.start) {
                                 *indent
                             } else {
-                                snapshot.indent_size_for_line(row_range.start)
+                                snapshot.indentation_size_for_line(row_range.start, indentation)
                             };
                         let delta = new_indent.len as i64 - original_indent_column as i64;
                         if delta != 0 {
                             for row in row_range.skip(1) {
                                 indent_sizes.entry(row).or_insert_with(|| {
-                                    let mut size = snapshot.indent_size_for_line(row);
-                                    // A line with no indentation has an arbitrary
-                                    // indent kind, so it can adopt the new kind.
-                                    if size.len == 0 {
-                                        size.kind = new_indent.kind;
-                                    }
-                                    if size.kind == new_indent.kind {
-                                        match delta.cmp(&0) {
-                                            Ordering::Greater => size.len += delta as u32,
-                                            Ordering::Less => {
-                                                size.len = size.len.saturating_sub(-delta as u32)
-                                            }
-                                            Ordering::Equal => {}
+                                    let mut size =
+                                        snapshot.indentation_size_for_line(row, indentation);
+                                    match delta.cmp(&0) {
+                                        Ordering::Greater => size.len += delta as u32,
+                                        Ordering::Less => {
+                                            size.len = size.len.saturating_sub(-delta as u32)
                                         }
+                                        Ordering::Equal => {}
                                     }
                                     (size, request.ignore_empty_lines)
                                 });
@@ -2207,8 +2220,8 @@ impl Buffer {
         let edits: Vec<_> = indent_sizes
             .into_iter()
             .filter_map(|(row, indent_size)| {
-                let current_size = indent_size_for_line(self, row);
-                Self::edit_for_indent_size_adjustment(row, current_size, indent_size)
+                let settings = LanguageSettings::for_buffer_at(self, Point::new(row, 0), cx);
+                self.edit_for_indentation_column(row, indent_size.len, settings.indentation())
             })
             .collect();
 
@@ -2219,41 +2232,21 @@ impl Buffer {
         }
     }
 
-    /// Create a minimal edit that will cause the given row to be indented
-    /// with the given size. After applying this edit, the length of the line
-    /// will always be at least `new_size.len`.
-    pub fn edit_for_indent_size_adjustment(
+    fn edit_for_indentation_column(
+        &self,
         row: u32,
-        current_size: IndentSize,
-        new_size: IndentSize,
+        target_column: u32,
+        indentation: IndentationSettings,
     ) -> Option<(Range<Point>, String)> {
-        if new_size.kind == current_size.kind {
-            match new_size.len.cmp(&current_size.len) {
-                Ordering::Greater => {
-                    let point = Point::new(row, 0);
-                    Some((
-                        point..point,
-                        iter::repeat(new_size.char())
-                            .take((new_size.len - current_size.len) as usize)
-                            .collect::<String>(),
-                    ))
-                }
-
-                Ordering::Less => Some((
-                    Point::new(row, 0)..Point::new(row, current_size.len - new_size.len),
-                    String::new(),
-                )),
-
-                Ordering::Equal => None,
-            }
-        } else {
-            Some((
-                Point::new(row, 0)..Point::new(row, current_size.len),
-                iter::repeat(new_size.char())
-                    .take(new_size.len as usize)
-                    .collect::<String>(),
-            ))
-        }
+        let current_indent_len = indent_size_for_line(self, row).len;
+        let current_indent = self
+            .text_for_range(Point::new(row, 0)..Point::new(row, current_indent_len))
+            .collect::<String>();
+        let replacement = indentation.indentation_for_column(target_column);
+        (current_indent != replacement).then_some((
+            Point::new(row, 0)..Point::new(row, current_indent_len),
+            replacement,
+        ))
     }
 
     /// Spawns a background task that asynchronously computes a `Diff` between the buffer's text
@@ -2926,21 +2919,22 @@ impl Buffer {
                         original_indent_columns,
                     } = &mode
                     {
+                        let indentation = before_edit.language_indentation_at(range.start, cx);
                         original_indent_column = Some(if new_text.starts_with('\n') {
-                            indent_size_for_text(
+                            indentation_width_for_text(
                                 new_text[range_of_insertion_to_indent.clone()].chars(),
+                                indentation,
                             )
-                            .len
                         } else {
                             original_indent_columns
                                 .get(ix)
                                 .copied()
                                 .flatten()
                                 .unwrap_or_else(|| {
-                                    indent_size_for_text(
+                                    indentation_width_for_text(
                                         new_text[range_of_insertion_to_indent.clone()].chars(),
+                                        indentation,
                                     )
-                                    .len
                                 })
                         });
 
@@ -2957,7 +2951,7 @@ impl Buffer {
                         } else {
                             Some(old_start.row)
                         },
-                        indent_size: before_edit.language_indent_size_at(range.start, cx),
+                        indentation: before_edit.language_indentation_at(range.start, cx),
                         range: self.anchor_before(new_start + range_of_insertion_to_indent.start)
                             ..self.anchor_after(new_start + range_of_insertion_to_indent.end),
                     }
@@ -3021,7 +3015,7 @@ impl Buffer {
             .map(|range| AutoindentRequestEntry {
                 range: before_edit.anchor_before(range.start)..before_edit.anchor_after(range.end),
                 old_row: None,
-                indent_size: before_edit.language_indent_size_at(range.start, cx),
+                indentation: before_edit.language_indentation_at(range.start, cx),
                 original_indent_column: None,
             })
             .collect();
@@ -3590,12 +3584,29 @@ impl BufferSnapshot {
     /// Returns [`IndentSize`] for a given position that respects user settings
     /// and language preferences.
     pub fn language_indent_size_at<T: ToOffset>(&self, position: T, cx: &App) -> IndentSize {
-        let settings = self.settings_at(position, cx);
-        if settings.hard_tabs {
-            IndentSize::tab()
-        } else {
-            IndentSize::spaces(settings.tab_size.get())
-        }
+        IndentSize::spaces(
+            self.language_indentation_at(position, cx)
+                .indent_size()
+                .get(),
+        )
+    }
+
+    pub fn language_indentation_at<T: ToOffset>(
+        &self,
+        position: T,
+        cx: &App,
+    ) -> IndentationSettings {
+        self.settings_at(position, cx).indentation()
+    }
+
+    /// Returns the indentation width in columns, expanding literal tabs using
+    /// the configured tab stops.
+    pub fn indentation_size_for_line(
+        &self,
+        row: u32,
+        indentation: IndentationSettings,
+    ) -> IndentSize {
+        IndentSize::spaces(indentation.column_for_prefix(self.chars_at(Point::new(row, 0))))
     }
 
     /// Retrieve the suggested indent size for all of the given rows. The unit of indentation
@@ -3604,6 +3615,7 @@ impl BufferSnapshot {
         &self,
         rows: impl Iterator<Item = u32>,
         single_indent_size: IndentSize,
+        indentation: IndentationSettings,
     ) -> BTreeMap<u32, IndentSize> {
         let mut result = BTreeMap::new();
 
@@ -3618,10 +3630,12 @@ impl BufferSnapshot {
                     result
                         .get(&suggestion.basis_row)
                         .copied()
-                        .unwrap_or_else(|| self.indent_size_for_line(suggestion.basis_row))
+                        .unwrap_or_else(|| {
+                            self.indentation_size_for_line(suggestion.basis_row, indentation)
+                        })
                         .with_delta(suggestion.delta, single_indent_size)
                 } else {
-                    self.indent_size_for_line(row)
+                    self.indentation_size_for_line(row, indentation)
                 };
 
                 result.insert(row, indent_size);
@@ -5289,6 +5303,13 @@ fn indent_size_for_text(text: impl Iterator<Item = char>) -> IndentSize {
     result
 }
 
+fn indentation_width_for_text(
+    text: impl Iterator<Item = char>,
+    indentation: IndentationSettings,
+) -> u32 {
+    indentation.column_for_prefix(text)
+}
+
 impl Clone for BufferSnapshot {
     fn clone(&self) -> Self {
         Self {
@@ -5655,34 +5676,6 @@ impl IndentSize {
             }
         }
         self
-    }
-
-    /// Returns the number of indentation characters to remove when outdenting to the
-    /// previous editor tab stop.
-    pub fn outdent_len(self, tab_size: NonZeroU32) -> u32 {
-        if self.len == 0 {
-            return 0;
-        }
-
-        match self.kind {
-            IndentKind::Space => {
-                let tab_size = tab_size.get();
-                let columns_to_prev_tab_stop = self.len % tab_size;
-                if columns_to_prev_tab_stop == 0 {
-                    tab_size
-                } else {
-                    columns_to_prev_tab_stop
-                }
-            }
-            IndentKind::Tab => 1,
-        }
-    }
-
-    pub fn len_with_expanded_tabs(&self, tab_size: NonZeroU32) -> usize {
-        match self.kind {
-            IndentKind::Space => self.len as usize,
-            IndentKind::Tab => self.len as usize * tab_size.get() as usize,
-        }
     }
 }
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -16,6 +16,7 @@ use settings::{AllLanguageSettingsContent, LanguageSettingsContent};
 use std::collections::BTreeSet;
 use std::{
     env,
+    num::NonZeroU32,
     ops::Range,
     sync::LazyLock,
     time::{Duration, Instant},
@@ -2034,6 +2035,34 @@ fn test_range_for_syntax_ancestor(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_indentation_size_for_line_uses_indentation_settings(cx: &mut App) {
+    cx.new(|cx| {
+        let buffer = Buffer::local("\t  text\n  \ttext\n    text", cx);
+        let snapshot = buffer.snapshot();
+        let indentation = crate::language_settings::IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(8).unwrap(),
+            true,
+        );
+
+        assert_eq!(
+            snapshot.indentation_size_for_line(0, indentation),
+            IndentSize::spaces(10)
+        );
+        assert_eq!(
+            snapshot.indentation_size_for_line(1, indentation),
+            IndentSize::spaces(8)
+        );
+        assert_eq!(
+            snapshot.indentation_size_for_line(2, indentation),
+            IndentSize::spaces(4)
+        );
+
+        buffer
+    });
+}
+
+#[gpui::test]
 fn test_autoindent_with_soft_tabs(cx: &mut App) {
     init_settings(cx, |_| {});
 
@@ -2110,6 +2139,26 @@ fn test_autoindent_with_hard_tabs(cx: &mut App) {
             cx,
         );
         assert_eq!(buffer.text(), "fn a() {\n\tb()\n\tc\n}");
+
+        buffer
+    });
+}
+
+#[gpui::test]
+fn test_autoindent_canonicalizes_mixed_indentation(cx: &mut App) {
+    init_settings(cx, |settings| {
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    cx.new(|cx| {
+        let mut buffer = Buffer::local("fn a() {\n}", cx).with_language(rust_lang(), cx);
+
+        buffer.edit(
+            [(Point::new(1, 0)..Point::new(1, 0), "  \tchild\n")],
+            Some(AutoindentMode::EachLine),
+            cx,
+        );
+        assert_eq!(buffer.text(), "fn a() {\n\tchild\n}");
 
         buffer
     });

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -16,6 +16,7 @@ use settings::{AllLanguageSettingsContent, LanguageSettingsContent};
 use std::collections::BTreeSet;
 use std::{
     env,
+    num::NonZeroU32,
     ops::Range,
     sync::LazyLock,
     time::{Duration, Instant},
@@ -1873,6 +1874,34 @@ fn test_range_for_syntax_ancestor(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_indentation_size_for_line_uses_indentation_settings(cx: &mut App) {
+    cx.new(|cx| {
+        let buffer = Buffer::local("\t  text\n  \ttext\n    text", cx);
+        let snapshot = buffer.snapshot();
+        let indentation = crate::language_settings::IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(8).unwrap(),
+            true,
+        );
+
+        assert_eq!(
+            snapshot.indentation_size_for_line(0, indentation),
+            IndentSize::spaces(10)
+        );
+        assert_eq!(
+            snapshot.indentation_size_for_line(1, indentation),
+            IndentSize::spaces(8)
+        );
+        assert_eq!(
+            snapshot.indentation_size_for_line(2, indentation),
+            IndentSize::spaces(4)
+        );
+
+        buffer
+    });
+}
+
+#[gpui::test]
 fn test_autoindent_with_soft_tabs(cx: &mut App) {
     init_settings(cx, |_| {});
 
@@ -1949,6 +1978,26 @@ fn test_autoindent_with_hard_tabs(cx: &mut App) {
             cx,
         );
         assert_eq!(buffer.text(), "fn a() {\n\tb()\n\tc\n}");
+
+        buffer
+    });
+}
+
+#[gpui::test]
+fn test_autoindent_canonicalizes_mixed_indentation(cx: &mut App) {
+    init_settings(cx, |settings| {
+        settings.defaults.hard_tabs = Some(true);
+    });
+
+    cx.new(|cx| {
+        let mut buffer = Buffer::local("fn a() {\n}", cx).with_language(rust_lang(), cx);
+
+        buffer.edit(
+            [(Point::new(1, 0)..Point::new(1, 0), "  \tchild\n")],
+            Some(AutoindentMode::EachLine),
+            cx,
+        );
+        assert_eq!(buffer.text(), "fn a() {\n\tchild\n}");
 
         buffer
     });

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -128,8 +128,10 @@ impl IndentationSettings {
 /// The settings for a particular language.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LanguageSettings {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     pub tab_size: NonZeroU32,
+    /// How many columns a literal tab character should occupy.
+    pub tab_width: NonZeroU32,
     /// Whether to indent lines using tab characters, as opposed to multiple
     /// spaces.
     pub hard_tabs: bool,
@@ -348,7 +350,7 @@ pub struct PrettierSettings {
 
 impl LanguageSettings {
     pub fn indentation(&self) -> IndentationSettings {
-        IndentationSettings::new(self.tab_size, self.tab_size, self.hard_tabs)
+        IndentationSettings::new(self.tab_size, self.tab_width, self.hard_tabs)
     }
 
     pub fn for_buffer(buffer: &Buffer, cx: &App) -> Arc<LanguageSettings> {
@@ -789,8 +791,12 @@ fn merge_with_modeline(settings: &mut LanguageSettings, modeline: &ModelineSetti
         }
     });
 
+    let modeline_indent_size = modeline.indent_size.or(modeline.tab_size);
     settings
         .tab_size
+        .merge_from_option(modeline_indent_size.as_ref());
+    settings
+        .tab_width
         .merge_from_option(modeline.tab_size.as_ref());
     settings
         .hard_tabs
@@ -821,12 +827,17 @@ fn merge_with_editorconfig(settings: &mut LanguageSettings, cfg: &EditorconfigPr
         MaxLineLen::Value(u) => Some(u as u32),
         MaxLineLen::Off => None,
     });
-    let tab_size = cfg.get::<IndentSize>().ok().and_then(|v| match v {
-        IndentSize::Value(u) => NonZeroU32::new(u as u32),
-        IndentSize::UseTabWidth => cfg.get::<TabWidth>().ok().and_then(|w| match w {
-            TabWidth::Value(u) => NonZeroU32::new(u as u32),
-        }),
+    let configured_tab_width = cfg.get::<TabWidth>().ok().and_then(|w| match w {
+        TabWidth::Value(u) => NonZeroU32::new(u as u32),
     });
+    let configured_indent_size = cfg.get::<IndentSize>().ok().and_then(|v| match v {
+        IndentSize::Value(u) => NonZeroU32::new(u as u32),
+        IndentSize::UseTabWidth => configured_tab_width,
+    });
+    // EditorConfig defines either width in terms of the other when just one is
+    // present, so apply the pair together at the same precedence.
+    let tab_size = configured_indent_size.or(configured_tab_width);
+    let tab_width = configured_tab_width.or(configured_indent_size);
     let hard_tabs = cfg
         .get::<IndentStyle>()
         .map(|v| v.eq(&IndentStyle::Tabs))
@@ -853,6 +864,7 @@ fn merge_with_editorconfig(settings: &mut LanguageSettings, cfg: &EditorconfigPr
         .preferred_line_length
         .merge_from_option(preferred_line_length.as_ref());
     settings.tab_size.merge_from_option(tab_size.as_ref());
+    settings.tab_width.merge_from_option(tab_width.as_ref());
     settings.hard_tabs.merge_from_option(hard_tabs.as_ref());
     // Avoid re-enabling destructive whitespace trimming when Zed settings have
     // disabled it, e.g. for Markdown hard breaks.
@@ -881,8 +893,10 @@ impl settings::Settings for AllLanguageSettings {
             let tasks = settings.tasks.unwrap();
             let whitespace_map = settings.whitespace_map.unwrap();
 
+            let tab_size = settings.tab_size.unwrap();
             LanguageSettings {
-                tab_size: settings.tab_size.unwrap(),
+                tab_size,
+                tab_width: settings.tab_width.unwrap_or(tab_size),
                 hard_tabs: settings.hard_tabs.unwrap(),
                 soft_wrap: settings.soft_wrap.unwrap(),
                 preferred_line_length: settings.preferred_line_length.unwrap(),

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -55,6 +55,76 @@ pub struct WhitespaceMap {
     pub tab: SharedString,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndentationSettings {
+    indent_size: NonZeroU32,
+    tab_width: NonZeroU32,
+    hard_tabs: bool,
+}
+
+impl IndentationSettings {
+    pub fn new(indent_size: NonZeroU32, tab_width: NonZeroU32, hard_tabs: bool) -> Self {
+        Self {
+            indent_size,
+            tab_width,
+            hard_tabs,
+        }
+    }
+
+    pub fn indent_size(self) -> NonZeroU32 {
+        self.indent_size
+    }
+
+    pub fn tab_width(self) -> NonZeroU32 {
+        self.tab_width
+    }
+
+    pub fn hard_tabs(self) -> bool {
+        self.hard_tabs
+    }
+
+    pub fn column_for_prefix(self, text: impl Iterator<Item = char>) -> u32 {
+        self.column_for_text(text.take_while(|character| matches!(character, ' ' | '\t')))
+    }
+
+    pub fn column_for_text(self, text: impl Iterator<Item = char>) -> u32 {
+        let tab_width = self.tab_width.get();
+        text.fold(0, |column, character| {
+            if character == '\t' {
+                column + tab_width - column % tab_width
+            } else {
+                column + 1
+            }
+        })
+    }
+
+    pub fn indentation_for_column(self, column: u32) -> String {
+        if self.hard_tabs {
+            let tab_width = self.tab_width.get();
+            let tabs = column / tab_width;
+            let spaces = column % tab_width;
+            "\t".repeat(tabs as usize) + &" ".repeat(spaces as usize)
+        } else {
+            " ".repeat(column as usize)
+        }
+    }
+
+    pub fn next_indent_stop(self, column: u32) -> u32 {
+        let indent_size = self.indent_size.get();
+        column + indent_size - column % indent_size
+    }
+
+    pub fn previous_indent_stop(self, column: u32) -> u32 {
+        let indent_size = self.indent_size.get();
+        let remainder = column % indent_size;
+        if remainder == 0 {
+            column.saturating_sub(indent_size)
+        } else {
+            column - remainder
+        }
+    }
+}
+
 /// The settings for a particular language.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LanguageSettings {
@@ -277,6 +347,10 @@ pub struct PrettierSettings {
 }
 
 impl LanguageSettings {
+    pub fn indentation(&self) -> IndentationSettings {
+        IndentationSettings::new(self.tab_size, self.tab_size, self.hard_tabs)
+    }
+
     pub fn for_buffer(buffer: &Buffer, cx: &App) -> Arc<LanguageSettings> {
         Self::resolve(Some(buffer), None, cx)
     }
@@ -1035,6 +1109,46 @@ mod tests {
     use gpui::TestAppContext;
     use settings::{LocalSettingsKind, LocalSettingsPath, WorktreeId};
     use util::rel_path::rel_path;
+
+    #[test]
+    fn test_indentation_settings_measure_and_generate_indentation() {
+        let indentation = IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(8).unwrap(),
+            true,
+        );
+
+        assert_eq!(indentation.column_for_prefix("\t  text".chars()), 10);
+        assert_eq!(indentation.column_for_text("\t  x\t".chars()), 16);
+        assert_eq!(indentation.indentation_for_column(4), "    ");
+        assert_eq!(indentation.indentation_for_column(8), "\t");
+        assert_eq!(indentation.indentation_for_column(10), "\t  ");
+
+        assert_eq!(indentation.next_indent_stop(0), 4);
+        assert_eq!(indentation.next_indent_stop(4), 8);
+        assert_eq!(indentation.next_indent_stop(6), 8);
+        assert_eq!(indentation.previous_indent_stop(0), 0);
+        assert_eq!(indentation.previous_indent_stop(4), 0);
+        assert_eq!(indentation.previous_indent_stop(6), 4);
+    }
+
+    #[test]
+    fn test_indentation_settings_preserve_equal_width_behavior() {
+        let hard_tabs = IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(4).unwrap(),
+            true,
+        );
+        let soft_tabs = IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(4).unwrap(),
+            false,
+        );
+
+        assert_eq!(hard_tabs.column_for_prefix("\t  text".chars()), 6);
+        assert_eq!(hard_tabs.indentation_for_column(6), "\t  ");
+        assert_eq!(soft_tabs.indentation_for_column(6), "      ");
+    }
 
     #[gpui::test]
     fn test_edit_predictions_enabled_for_file(cx: &mut TestAppContext) {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -128,8 +128,10 @@ impl IndentationSettings {
 /// The settings for a particular language.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LanguageSettings {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     pub tab_size: NonZeroU32,
+    /// How many columns a literal tab character should occupy.
+    pub tab_width: NonZeroU32,
     /// Whether to indent lines using tab characters, as opposed to multiple
     /// spaces.
     pub hard_tabs: bool,
@@ -348,7 +350,7 @@ pub struct PrettierSettings {
 
 impl LanguageSettings {
     pub fn indentation(&self) -> IndentationSettings {
-        IndentationSettings::new(self.tab_size, self.tab_size, self.hard_tabs)
+        IndentationSettings::new(self.tab_size, self.tab_width, self.hard_tabs)
     }
 
     pub fn for_buffer<'a>(buffer: &'a Buffer, cx: &'a App) -> Cow<'a, LanguageSettings> {
@@ -710,8 +712,12 @@ fn merge_with_modeline(settings: &mut LanguageSettings, modeline: &ModelineSetti
         }
     });
 
+    let modeline_indent_size = modeline.indent_size.or(modeline.tab_size);
     settings
         .tab_size
+        .merge_from_option(modeline_indent_size.as_ref());
+    settings
+        .tab_width
         .merge_from_option(modeline.tab_size.as_ref());
     settings
         .hard_tabs
@@ -742,12 +748,17 @@ fn merge_with_editorconfig(settings: &mut LanguageSettings, cfg: &EditorconfigPr
         MaxLineLen::Value(u) => Some(u as u32),
         MaxLineLen::Off => None,
     });
-    let tab_size = cfg.get::<IndentSize>().ok().and_then(|v| match v {
-        IndentSize::Value(u) => NonZeroU32::new(u as u32),
-        IndentSize::UseTabWidth => cfg.get::<TabWidth>().ok().and_then(|w| match w {
-            TabWidth::Value(u) => NonZeroU32::new(u as u32),
-        }),
+    let configured_tab_width = cfg.get::<TabWidth>().ok().and_then(|w| match w {
+        TabWidth::Value(u) => NonZeroU32::new(u as u32),
     });
+    let configured_indent_size = cfg.get::<IndentSize>().ok().and_then(|v| match v {
+        IndentSize::Value(u) => NonZeroU32::new(u as u32),
+        IndentSize::UseTabWidth => configured_tab_width,
+    });
+    // EditorConfig defines either width in terms of the other when just one is
+    // present, so apply the pair together at the same precedence.
+    let tab_size = configured_indent_size.or(configured_tab_width);
+    let tab_width = configured_tab_width.or(configured_indent_size);
     let hard_tabs = cfg
         .get::<IndentStyle>()
         .map(|v| v.eq(&IndentStyle::Tabs))
@@ -774,6 +785,7 @@ fn merge_with_editorconfig(settings: &mut LanguageSettings, cfg: &EditorconfigPr
         .preferred_line_length
         .merge_from_option(preferred_line_length.as_ref());
     settings.tab_size.merge_from_option(tab_size.as_ref());
+    settings.tab_width.merge_from_option(tab_width.as_ref());
     settings.hard_tabs.merge_from_option(hard_tabs.as_ref());
     // Avoid re-enabling destructive whitespace trimming when Zed settings have
     // disabled it, e.g. for Markdown hard breaks.
@@ -802,8 +814,10 @@ impl settings::Settings for AllLanguageSettings {
             let tasks = settings.tasks.unwrap();
             let whitespace_map = settings.whitespace_map.unwrap();
 
+            let tab_size = settings.tab_size.unwrap();
             LanguageSettings {
-                tab_size: settings.tab_size.unwrap(),
+                tab_size,
+                tab_width: settings.tab_width.unwrap_or(tab_size),
                 hard_tabs: settings.hard_tabs.unwrap(),
                 soft_wrap: settings.soft_wrap.unwrap(),
                 preferred_line_length: settings.preferred_line_length.unwrap(),

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -55,6 +55,76 @@ pub struct WhitespaceMap {
     pub tab: SharedString,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndentationSettings {
+    indent_size: NonZeroU32,
+    tab_width: NonZeroU32,
+    hard_tabs: bool,
+}
+
+impl IndentationSettings {
+    pub fn new(indent_size: NonZeroU32, tab_width: NonZeroU32, hard_tabs: bool) -> Self {
+        Self {
+            indent_size,
+            tab_width,
+            hard_tabs,
+        }
+    }
+
+    pub fn indent_size(self) -> NonZeroU32 {
+        self.indent_size
+    }
+
+    pub fn tab_width(self) -> NonZeroU32 {
+        self.tab_width
+    }
+
+    pub fn hard_tabs(self) -> bool {
+        self.hard_tabs
+    }
+
+    pub fn column_for_prefix(self, text: impl Iterator<Item = char>) -> u32 {
+        self.column_for_text(text.take_while(|character| matches!(character, ' ' | '\t')))
+    }
+
+    pub fn column_for_text(self, text: impl Iterator<Item = char>) -> u32 {
+        let tab_width = self.tab_width.get();
+        text.fold(0, |column, character| {
+            if character == '\t' {
+                column + tab_width - column % tab_width
+            } else {
+                column + 1
+            }
+        })
+    }
+
+    pub fn indentation_for_column(self, column: u32) -> String {
+        if self.hard_tabs {
+            let tab_width = self.tab_width.get();
+            let tabs = column / tab_width;
+            let spaces = column % tab_width;
+            "\t".repeat(tabs as usize) + &" ".repeat(spaces as usize)
+        } else {
+            " ".repeat(column as usize)
+        }
+    }
+
+    pub fn next_indent_stop(self, column: u32) -> u32 {
+        let indent_size = self.indent_size.get();
+        column + indent_size - column % indent_size
+    }
+
+    pub fn previous_indent_stop(self, column: u32) -> u32 {
+        let indent_size = self.indent_size.get();
+        let remainder = column % indent_size;
+        if remainder == 0 {
+            column.saturating_sub(indent_size)
+        } else {
+            column - remainder
+        }
+    }
+}
+
 /// The settings for a particular language.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LanguageSettings {
@@ -277,6 +347,10 @@ pub struct PrettierSettings {
 }
 
 impl LanguageSettings {
+    pub fn indentation(&self) -> IndentationSettings {
+        IndentationSettings::new(self.tab_size, self.tab_size, self.hard_tabs)
+    }
+
     pub fn for_buffer<'a>(buffer: &'a Buffer, cx: &'a App) -> Cow<'a, LanguageSettings> {
         Self::resolve(Some(buffer), None, cx)
     }
@@ -944,6 +1018,46 @@ mod tests {
     use gpui::TestAppContext;
     use settings::{LocalSettingsKind, LocalSettingsPath, WorktreeId};
     use util::rel_path::rel_path;
+
+    #[test]
+    fn test_indentation_settings_measure_and_generate_indentation() {
+        let indentation = IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(8).unwrap(),
+            true,
+        );
+
+        assert_eq!(indentation.column_for_prefix("\t  text".chars()), 10);
+        assert_eq!(indentation.column_for_text("\t  x\t".chars()), 16);
+        assert_eq!(indentation.indentation_for_column(4), "    ");
+        assert_eq!(indentation.indentation_for_column(8), "\t");
+        assert_eq!(indentation.indentation_for_column(10), "\t  ");
+
+        assert_eq!(indentation.next_indent_stop(0), 4);
+        assert_eq!(indentation.next_indent_stop(4), 8);
+        assert_eq!(indentation.next_indent_stop(6), 8);
+        assert_eq!(indentation.previous_indent_stop(0), 0);
+        assert_eq!(indentation.previous_indent_stop(4), 0);
+        assert_eq!(indentation.previous_indent_stop(6), 4);
+    }
+
+    #[test]
+    fn test_indentation_settings_preserve_equal_width_behavior() {
+        let hard_tabs = IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(4).unwrap(),
+            true,
+        );
+        let soft_tabs = IndentationSettings::new(
+            NonZeroU32::new(4).unwrap(),
+            NonZeroU32::new(4).unwrap(),
+            false,
+        );
+
+        assert_eq!(hard_tabs.column_for_prefix("\t  text".chars()), 6);
+        assert_eq!(hard_tabs.indentation_for_column(6), "\t  ");
+        assert_eq!(soft_tabs.indentation_for_column(6), "      ");
+    }
 
     #[gpui::test]
     fn test_edit_predictions_enabled_for_file(cx: &mut TestAppContext) {

--- a/crates/language/src/modeline.rs
+++ b/crates/language/src/modeline.rs
@@ -12,12 +12,12 @@ use std::{num::NonZeroU32, sync::LazyLock};
 pub struct ModelineSettings {
     /// The emacs mode or vim filetype.
     pub mode: Option<String>,
-    /// How many columns a tab should occupy.
+    /// How many columns a literal tab character should occupy.
     pub tab_size: Option<NonZeroU32>,
     /// Whether to indent lines using tab characters, as opposed to multiple
     /// spaces.
     pub hard_tabs: Option<bool>,
-    /// The number of bytes that comprise the indentation.
+    /// How many columns each indentation level should occupy.
     pub indent_size: Option<NonZeroU32>,
     /// Whether to auto-indent lines.
     pub auto_indent: Option<bool>,

--- a/crates/language_core/src/language_config.rs
+++ b/crates/language_core/src/language_config.rs
@@ -115,7 +115,7 @@ pub struct LanguageConfig {
     /// spaces.
     #[serde(default)]
     pub hard_tabs: Option<bool>,
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     #[serde(default)]
     #[schemars(range(min = 1, max = 128))]
     pub tab_size: Option<NonZeroU32>,

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -26,7 +26,7 @@ use language::{
     LanguageScope, OffsetRangeExt, OffsetUtf16, Outline, OutlineItem, Point, PointUtf16, Selection,
     TextDimension, TextObject, ToOffset as _, ToPoint as _, TransactionId, TreeSitterOptions,
     Unclipped,
-    language_settings::{AllLanguageSettings, LanguageSettings},
+    language_settings::{AllLanguageSettings, IndentationSettings, LanguageSettings},
 };
 
 #[cfg(any(test, feature = "test-support"))]
@@ -1224,13 +1224,13 @@ pub struct IndentGuide {
     pub start_row: MultiBufferRow,
     pub end_row: MultiBufferRow,
     pub depth: u32,
-    pub tab_size: u32,
+    pub indentation: IndentationSettings,
     pub settings: IndentGuideSettings,
 }
 
 impl IndentGuide {
     pub fn indent_level(&self) -> u32 {
-        self.depth * self.tab_size
+        self.depth * self.indentation.indent_size().get()
     }
 }
 
@@ -4453,7 +4453,7 @@ impl MultiBufferSnapshot {
         let mut cursor = self.cursor::<Point, Point>();
         let mut rows = rows.into_iter().peekable();
         let mut prev_row = u32::MAX;
-        let mut prev_language_indent_size = IndentSize::default();
+        let mut prev_indentation = None;
 
         while let Some(row) = rows.next() {
             cursor.seek(&Point::new(row, 0));
@@ -4462,14 +4462,19 @@ impl MultiBufferSnapshot {
             };
 
             // Retrieve the language and indent size once for each disjoint region being indented.
-            let single_indent_size = if row.saturating_sub(1) == prev_row {
-                prev_language_indent_size
+            let indentation = if row.saturating_sub(1) == prev_row {
+                prev_indentation
             } else {
-                region
-                    .buffer
-                    .language_indent_size_at(Point::new(row, 0), cx)
+                Some(
+                    region
+                        .buffer
+                        .language_indentation_at(Point::new(row, 0), cx),
+                )
             };
-            prev_language_indent_size = single_indent_size;
+            let Some(indentation) = indentation else {
+                continue;
+            };
+            prev_indentation = Some(indentation);
             prev_row = row;
 
             let start_buffer_row = region.buffer_range.start.row;
@@ -4489,9 +4494,11 @@ impl MultiBufferSnapshot {
             let buffer_rows = rows_for_excerpt
                 .drain(..)
                 .map(|row| start_buffer_row + row - start_multibuffer_row);
-            let buffer_indents = region
-                .buffer
-                .suggested_indents(buffer_rows, single_indent_size);
+            let buffer_indents = region.buffer.suggested_indents(
+                buffer_rows,
+                IndentSize::spaces(indentation.indent_size().get()),
+                indentation,
+            );
             for (row, indent) in buffer_indents {
                 if cb(
                     MultiBufferRow(start_multibuffer_row + row - start_buffer_row),
@@ -4518,6 +4525,14 @@ impl MultiBufferSnapshot {
         }
     }
 
+    pub fn indentation_column_for_line(
+        &self,
+        row: MultiBufferRow,
+        indentation: IndentationSettings,
+    ) -> u32 {
+        indentation.column_for_prefix(self.chars_at(Point::new(row.0, 0)))
+    }
+
     pub fn line_indent_for_row(&self, row: MultiBufferRow) -> LineIndent {
         if let Some((buffer, range)) = self.buffer_line_for_row(row) {
             LineIndent::from_iter(buffer.text_for_range(range).flat_map(|s| s.chars()))
@@ -4527,7 +4542,10 @@ impl MultiBufferSnapshot {
     }
 
     pub fn indent_and_comment_for_line(&self, row: MultiBufferRow, cx: &App) -> String {
-        let mut indent = self.indent_size_for_line(row).chars().collect::<String>();
+        let indent_len = self.indent_size_for_line(row).len;
+        let mut indent = self
+            .text_for_range(Point::new(row.0, 0)..Point::new(row.0, indent_len))
+            .collect::<String>();
 
         if self.language_settings(cx).extend_comment_on_newline
             && let Some(language_scope) = self.language_scope_at(Point::new(row.0, 0))
@@ -4535,7 +4553,7 @@ impl MultiBufferSnapshot {
             let delimiters = language_scope.line_comment_prefixes();
             for delimiter in delimiters {
                 if *self
-                    .chars_at(Point::new(row.0, indent.len() as u32))
+                    .chars_at(Point::new(row.0, indent_len))
                     .take(delimiter.chars().count())
                     .collect::<String>()
                     .as_str()
@@ -6033,22 +6051,25 @@ impl MultiBufferSnapshot {
     pub async fn enclosing_indent(
         &self,
         mut target_row: MultiBufferRow,
-    ) -> Option<(Range<MultiBufferRow>, LineIndent)> {
+        indentation: IndentationSettings,
+    ) -> Option<(Range<MultiBufferRow>, u32)> {
         let max_row = MultiBufferRow(self.max_point().row);
         if target_row >= max_row {
             return None;
         }
 
         let mut target_indent = self.line_indent_for_row(target_row);
+        let mut target_indent_column = self.indentation_column_for_line(target_row, indentation);
 
         // If the current row is at the start of an indented block, we want to return this
         // block as the enclosing indent.
         if !target_indent.is_line_empty() && target_row < max_row {
-            let next_line_indent = self.line_indent_for_row(MultiBufferRow(target_row.0 + 1));
-            if !next_line_indent.is_line_empty()
-                && target_indent.raw_len() < next_line_indent.raw_len()
-            {
+            let next_row = MultiBufferRow(target_row.0 + 1);
+            let next_line_indent = self.line_indent_for_row(next_row);
+            let next_indent_column = self.indentation_column_for_line(next_row, indentation);
+            if !next_line_indent.is_line_empty() && target_indent_column < next_indent_column {
                 target_indent = next_line_indent;
+                target_indent_column = next_indent_column;
                 target_row.0 += 1;
             }
         }
@@ -6076,7 +6097,8 @@ impl MultiBufferSnapshot {
                     yield_now().await;
                 }
                 if !indent.is_line_empty() {
-                    non_empty_line_above = Some((row, indent));
+                    non_empty_line_above =
+                        Some((row, self.indentation_column_for_line(row, indentation)));
                     break;
                 }
             }
@@ -6092,17 +6114,18 @@ impl MultiBufferSnapshot {
                     yield_now().await;
                 }
                 if !indent.is_line_empty() {
-                    non_empty_line_below = Some((row, indent));
+                    non_empty_line_below =
+                        Some((row, self.indentation_column_for_line(row, indentation)));
                     break;
                 }
             }
 
-            let (row, indent) = match (non_empty_line_above, non_empty_line_below) {
-                (Some((above_row, above_indent)), Some((below_row, below_indent))) => {
-                    if above_indent.raw_len() >= below_indent.raw_len() {
-                        (above_row, above_indent)
+            let (row, indent_column) = match (non_empty_line_above, non_empty_line_below) {
+                (Some((above_row, above_column)), Some((below_row, below_column))) => {
+                    if above_column >= below_column {
+                        (above_row, above_column)
                     } else {
-                        (below_row, below_indent)
+                        (below_row, below_column)
                     }
                 }
                 (Some(above), None) => above,
@@ -6110,7 +6133,7 @@ impl MultiBufferSnapshot {
                 _ => return None,
             };
 
-            target_indent = indent;
+            target_indent_column = indent_column;
             target_row = row;
         }
 
@@ -6127,12 +6150,13 @@ impl MultiBufferSnapshot {
                 accessed_row_counter = 0;
                 yield_now().await;
             }
-            if !indent.is_line_empty() && indent.raw_len() < target_indent.raw_len() {
-                start_indent = Some((row, indent));
+            let indent_column = self.indentation_column_for_line(row, indentation);
+            if !indent.is_line_empty() && indent_column < target_indent_column {
+                start_indent = Some((row, indent_column));
                 break;
             }
         }
-        let (start_row, start_indent_size) = start_indent?;
+        let (start_row, start_indent_column) = start_indent?;
 
         let mut end_indent = (end, None);
         for (row, indent, _) in self.line_indents(target_row, |_| true) {
@@ -6144,24 +6168,25 @@ impl MultiBufferSnapshot {
                 accessed_row_counter = 0;
                 yield_now().await;
             }
-            if !indent.is_line_empty() && indent.raw_len() < target_indent.raw_len() {
-                end_indent = (MultiBufferRow(row.0.saturating_sub(1)), Some(indent));
+            let indent_column = self.indentation_column_for_line(row, indentation);
+            if !indent.is_line_empty() && indent_column < target_indent_column {
+                end_indent = (MultiBufferRow(row.0.saturating_sub(1)), Some(indent_column));
                 break;
             }
         }
-        let (end_row, end_indent_size) = end_indent;
+        let (end_row, end_indent_column) = end_indent;
 
-        let indent = if let Some(end_indent_size) = end_indent_size {
-            if start_indent_size.raw_len() > end_indent_size.raw_len() {
-                start_indent_size
+        let indent_column = if let Some(end_indent_column) = end_indent_column {
+            if start_indent_column > end_indent_column {
+                start_indent_column
             } else {
-                end_indent_size
+                end_indent_column
             }
         } else {
-            start_indent_size
+            start_indent_column
         };
 
-        Some((start_row..end_row, indent))
+        Some((start_row..end_row, indent_column))
     }
 
     pub fn indent_guides_in_range<T: ToPoint>(
@@ -6183,7 +6208,7 @@ impl MultiBufferSnapshot {
         let mut indent_stack = SmallVec::<[IndentGuide; 8]>::new();
 
         let mut prev_settings = None;
-        while let Some((first_row, mut line_indent, buffer)) = row_indents.next() {
+        while let Some((first_row, line_indent, buffer)) = row_indents.next() {
             if first_row > end_row {
                 break;
             }
@@ -6203,12 +6228,13 @@ impl MultiBufferSnapshot {
                     )
                 })
                 .1;
-            let tab_size = settings.tab_size.get();
+            let indentation = settings.indentation();
 
             // When encountering empty, continue until found useful line indent
             // then add to the indent stack with the depth found
             let mut found_indent = false;
             let mut last_row = first_row;
+            let mut indentation_row = first_row;
             if line_indent.is_line_blank() {
                 while !found_indent {
                     let Some((target_row, new_line_indent, _)) = row_indents.next() else {
@@ -6223,7 +6249,7 @@ impl MultiBufferSnapshot {
                         continue;
                     }
                     last_row = target_row.min(end_row);
-                    line_indent = new_line_indent;
+                    indentation_row = target_row;
                     found_indent = true;
                     break;
                 }
@@ -6232,7 +6258,8 @@ impl MultiBufferSnapshot {
             }
 
             let depth = if found_indent {
-                line_indent.len(tab_size) / tab_size
+                self.indentation_column_for_line(indentation_row, indentation)
+                    / indentation.indent_size().get()
             } else {
                 0
             };
@@ -6260,7 +6287,7 @@ impl MultiBufferSnapshot {
                             start_row: first_row,
                             end_row: last_row,
                             depth: next_depth,
-                            tab_size,
+                            indentation,
                             settings: settings.indent_guides.clone(),
                         });
                     }

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -512,6 +512,7 @@ struct DiffState {
     diff: Entity<BufferDiff>,
     main_buffer: Option<Entity<language::Buffer>>,
     _subscription: gpui::Subscription,
+    _main_buffer_subscription: Option<gpui::Subscription>,
 }
 
 impl DiffState {
@@ -633,6 +634,7 @@ impl DiffState {
             }),
             diff,
             main_buffer: None,
+            _main_buffer_subscription: None,
         }
     }
 
@@ -642,6 +644,7 @@ impl DiffState {
         cx: &mut Context<MultiBuffer>,
     ) -> Self {
         let weak_main_buffer = main_buffer.downgrade();
+        let main_buffer_subscription = cx.observe(&main_buffer, |_, _, cx| cx.notify());
         DiffState {
             _subscription: cx.subscribe(&diff, {
                 move |this, diff, event, cx| {
@@ -669,6 +672,7 @@ impl DiffState {
             }),
             diff,
             main_buffer: Some(main_buffer),
+            _main_buffer_subscription: Some(main_buffer_subscription),
         }
     }
 }
@@ -1311,7 +1315,12 @@ impl MultiBuffer {
         }
         let mut diff_bases = HashMap::default();
         for (buffer_id, diff) in self.diffs.iter() {
-            diff_bases.insert(*buffer_id, DiffState::new(diff.diff.clone(), new_cx));
+            let diff_state = if let Some(main_buffer) = &diff.main_buffer {
+                DiffState::new_inverted(diff.diff.clone(), main_buffer.clone(), new_cx)
+            } else {
+                DiffState::new(diff.diff.clone(), new_cx)
+            };
+            diff_bases.insert(*buffer_id, diff_state);
         }
         Self {
             snapshot: RefCell::new(self.snapshot.borrow().clone()),
@@ -2182,6 +2191,76 @@ impl MultiBuffer {
         } else {
             AllLanguageSettings::get_global(cx).defaults.clone()
         }
+    }
+
+    pub fn indentation_settings(
+        &self,
+        cx: &App,
+    ) -> (IndentationSettings, HashMap<BufferId, IndentationSettings>) {
+        let default = self
+            .as_singleton()
+            .map(|buffer| {
+                let buffer_id = buffer.read(cx).remote_id();
+                let settings_buffer = self
+                    .diffs
+                    .get(&buffer_id)
+                    .and_then(|diff_state| diff_state.main_buffer.as_ref())
+                    .unwrap_or(&buffer);
+                LanguageSettings::for_buffer(&settings_buffer.read(cx), cx).indentation()
+            })
+            .unwrap_or_else(|| AllLanguageSettings::get_global(cx).defaults.indentation());
+        if self.singleton {
+            return (default, HashMap::default());
+        }
+        let mut by_buffer = HashMap::default();
+
+        for (buffer_id, buffer_state) in &self.buffers {
+            if self
+                .diffs
+                .get(buffer_id)
+                .is_some_and(|diff_state| diff_state.main_buffer.is_some())
+            {
+                continue;
+            }
+            let indentation =
+                LanguageSettings::for_buffer(&buffer_state.buffer.read(cx), cx).indentation();
+            if indentation != default {
+                by_buffer.insert(*buffer_id, indentation);
+                if let Some(diff_state) = self.diffs.get(buffer_id) {
+                    by_buffer.insert(
+                        diff_state
+                            .diff
+                            .read(cx)
+                            .base_text_buffer()
+                            .read(cx)
+                            .remote_id(),
+                        indentation,
+                    );
+                }
+            }
+        }
+
+        for (buffer_id, diff_state) in &self.diffs {
+            let Some(main_buffer) = &diff_state.main_buffer else {
+                continue;
+            };
+            let indentation = LanguageSettings::for_buffer(&main_buffer.read(cx), cx).indentation();
+            if indentation != default {
+                by_buffer.insert(*buffer_id, indentation);
+                by_buffer.insert(
+                    diff_state
+                        .diff
+                        .read(cx)
+                        .base_text_buffer()
+                        .read(cx)
+                        .remote_id(),
+                    indentation,
+                );
+                by_buffer.insert(main_buffer.read(cx).remote_id(), indentation);
+            }
+        }
+
+        (default, by_buffer)
     }
 
     pub fn for_each_buffer(&self, f: &mut dyn FnMut(&Entity<Buffer>)) {

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -510,6 +510,7 @@ struct DiffState {
     diff: Entity<BufferDiff>,
     main_buffer: Option<Entity<language::Buffer>>,
     _subscription: gpui::Subscription,
+    _main_buffer_subscription: Option<gpui::Subscription>,
 }
 
 impl DiffState {
@@ -631,6 +632,7 @@ impl DiffState {
             }),
             diff,
             main_buffer: None,
+            _main_buffer_subscription: None,
         }
     }
 
@@ -640,6 +642,7 @@ impl DiffState {
         cx: &mut Context<MultiBuffer>,
     ) -> Self {
         let weak_main_buffer = main_buffer.downgrade();
+        let main_buffer_subscription = cx.observe(&main_buffer, |_, _, cx| cx.notify());
         DiffState {
             _subscription: cx.subscribe(&diff, {
                 move |this, diff, event, cx| {
@@ -667,6 +670,7 @@ impl DiffState {
             }),
             diff,
             main_buffer: Some(main_buffer),
+            _main_buffer_subscription: Some(main_buffer_subscription),
         }
     }
 }
@@ -1279,7 +1283,12 @@ impl MultiBuffer {
         }
         let mut diff_bases = HashMap::default();
         for (buffer_id, diff) in self.diffs.iter() {
-            diff_bases.insert(*buffer_id, DiffState::new(diff.diff.clone(), new_cx));
+            let diff_state = if let Some(main_buffer) = &diff.main_buffer {
+                DiffState::new_inverted(diff.diff.clone(), main_buffer.clone(), new_cx)
+            } else {
+                DiffState::new(diff.diff.clone(), new_cx)
+            };
+            diff_bases.insert(*buffer_id, diff_state);
         }
         Self {
             snapshot: RefCell::new(self.snapshot.borrow().clone()),
@@ -2153,6 +2162,76 @@ impl MultiBuffer {
         } else {
             Cow::Borrowed(&AllLanguageSettings::get_global(cx).defaults)
         }
+    }
+
+    pub fn indentation_settings(
+        &self,
+        cx: &App,
+    ) -> (IndentationSettings, HashMap<BufferId, IndentationSettings>) {
+        let default = self
+            .as_singleton()
+            .map(|buffer| {
+                let buffer_id = buffer.read(cx).remote_id();
+                let settings_buffer = self
+                    .diffs
+                    .get(&buffer_id)
+                    .and_then(|diff_state| diff_state.main_buffer.as_ref())
+                    .unwrap_or(&buffer);
+                LanguageSettings::for_buffer(&settings_buffer.read(cx), cx).indentation()
+            })
+            .unwrap_or_else(|| AllLanguageSettings::get_global(cx).defaults.indentation());
+        if self.singleton {
+            return (default, HashMap::default());
+        }
+        let mut by_buffer = HashMap::default();
+
+        for (buffer_id, buffer_state) in &self.buffers {
+            if self
+                .diffs
+                .get(buffer_id)
+                .is_some_and(|diff_state| diff_state.main_buffer.is_some())
+            {
+                continue;
+            }
+            let indentation =
+                LanguageSettings::for_buffer(&buffer_state.buffer.read(cx), cx).indentation();
+            if indentation != default {
+                by_buffer.insert(*buffer_id, indentation);
+                if let Some(diff_state) = self.diffs.get(buffer_id) {
+                    by_buffer.insert(
+                        diff_state
+                            .diff
+                            .read(cx)
+                            .base_text_buffer()
+                            .read(cx)
+                            .remote_id(),
+                        indentation,
+                    );
+                }
+            }
+        }
+
+        for (buffer_id, diff_state) in &self.diffs {
+            let Some(main_buffer) = &diff_state.main_buffer else {
+                continue;
+            };
+            let indentation = LanguageSettings::for_buffer(&main_buffer.read(cx), cx).indentation();
+            if indentation != default {
+                by_buffer.insert(*buffer_id, indentation);
+                by_buffer.insert(
+                    diff_state
+                        .diff
+                        .read(cx)
+                        .base_text_buffer()
+                        .read(cx)
+                        .remote_id(),
+                    indentation,
+                );
+                by_buffer.insert(main_buffer.read(cx).remote_id(), indentation);
+            }
+        }
+
+        (default, by_buffer)
     }
 
     pub fn for_each_buffer(&self, f: &mut dyn FnMut(&Entity<Buffer>)) {

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -26,7 +26,7 @@ use language::{
     LanguageScope, OffsetRangeExt, OffsetUtf16, Outline, OutlineItem, Point, PointUtf16, Selection,
     TextDimension, TextObject, ToOffset as _, ToPoint as _, TransactionId, TreeSitterOptions,
     Unclipped,
-    language_settings::{AllLanguageSettings, LanguageSettings},
+    language_settings::{AllLanguageSettings, IndentationSettings, LanguageSettings},
 };
 
 #[cfg(any(test, feature = "test-support"))]
@@ -1192,13 +1192,13 @@ pub struct IndentGuide {
     pub start_row: MultiBufferRow,
     pub end_row: MultiBufferRow,
     pub depth: u32,
-    pub tab_size: u32,
+    pub indentation: IndentationSettings,
     pub settings: IndentGuideSettings,
 }
 
 impl IndentGuide {
     pub fn indent_level(&self) -> u32 {
-        self.depth * self.tab_size
+        self.depth * self.indentation.indent_size().get()
     }
 }
 
@@ -4424,7 +4424,7 @@ impl MultiBufferSnapshot {
         let mut cursor = self.cursor::<Point, Point>();
         let mut rows = rows.into_iter().peekable();
         let mut prev_row = u32::MAX;
-        let mut prev_language_indent_size = IndentSize::default();
+        let mut prev_indentation = None;
 
         while let Some(row) = rows.next() {
             cursor.seek(&Point::new(row, 0));
@@ -4433,14 +4433,19 @@ impl MultiBufferSnapshot {
             };
 
             // Retrieve the language and indent size once for each disjoint region being indented.
-            let single_indent_size = if row.saturating_sub(1) == prev_row {
-                prev_language_indent_size
+            let indentation = if row.saturating_sub(1) == prev_row {
+                prev_indentation
             } else {
-                region
-                    .buffer
-                    .language_indent_size_at(Point::new(row, 0), cx)
+                Some(
+                    region
+                        .buffer
+                        .language_indentation_at(Point::new(row, 0), cx),
+                )
             };
-            prev_language_indent_size = single_indent_size;
+            let Some(indentation) = indentation else {
+                continue;
+            };
+            prev_indentation = Some(indentation);
             prev_row = row;
 
             let start_buffer_row = region.buffer_range.start.row;
@@ -4460,9 +4465,11 @@ impl MultiBufferSnapshot {
             let buffer_rows = rows_for_excerpt
                 .drain(..)
                 .map(|row| start_buffer_row + row - start_multibuffer_row);
-            let buffer_indents = region
-                .buffer
-                .suggested_indents(buffer_rows, single_indent_size);
+            let buffer_indents = region.buffer.suggested_indents(
+                buffer_rows,
+                IndentSize::spaces(indentation.indent_size().get()),
+                indentation,
+            );
             for (row, indent) in buffer_indents {
                 if cb(
                     MultiBufferRow(start_multibuffer_row + row - start_buffer_row),
@@ -4489,6 +4496,14 @@ impl MultiBufferSnapshot {
         }
     }
 
+    pub fn indentation_column_for_line(
+        &self,
+        row: MultiBufferRow,
+        indentation: IndentationSettings,
+    ) -> u32 {
+        indentation.column_for_prefix(self.chars_at(Point::new(row.0, 0)))
+    }
+
     pub fn line_indent_for_row(&self, row: MultiBufferRow) -> LineIndent {
         if let Some((buffer, range)) = self.buffer_line_for_row(row) {
             LineIndent::from_iter(buffer.text_for_range(range).flat_map(|s| s.chars()))
@@ -4498,7 +4513,10 @@ impl MultiBufferSnapshot {
     }
 
     pub fn indent_and_comment_for_line(&self, row: MultiBufferRow, cx: &App) -> String {
-        let mut indent = self.indent_size_for_line(row).chars().collect::<String>();
+        let indent_len = self.indent_size_for_line(row).len;
+        let mut indent = self
+            .text_for_range(Point::new(row.0, 0)..Point::new(row.0, indent_len))
+            .collect::<String>();
 
         if self.language_settings(cx).extend_comment_on_newline
             && let Some(language_scope) = self.language_scope_at(Point::new(row.0, 0))
@@ -4506,7 +4524,7 @@ impl MultiBufferSnapshot {
             let delimiters = language_scope.line_comment_prefixes();
             for delimiter in delimiters {
                 if *self
-                    .chars_at(Point::new(row.0, indent.len() as u32))
+                    .chars_at(Point::new(row.0, indent_len))
                     .take(delimiter.chars().count())
                     .collect::<String>()
                     .as_str()
@@ -5906,22 +5924,25 @@ impl MultiBufferSnapshot {
     pub async fn enclosing_indent(
         &self,
         mut target_row: MultiBufferRow,
-    ) -> Option<(Range<MultiBufferRow>, LineIndent)> {
+        indentation: IndentationSettings,
+    ) -> Option<(Range<MultiBufferRow>, u32)> {
         let max_row = MultiBufferRow(self.max_point().row);
         if target_row >= max_row {
             return None;
         }
 
         let mut target_indent = self.line_indent_for_row(target_row);
+        let mut target_indent_column = self.indentation_column_for_line(target_row, indentation);
 
         // If the current row is at the start of an indented block, we want to return this
         // block as the enclosing indent.
         if !target_indent.is_line_empty() && target_row < max_row {
-            let next_line_indent = self.line_indent_for_row(MultiBufferRow(target_row.0 + 1));
-            if !next_line_indent.is_line_empty()
-                && target_indent.raw_len() < next_line_indent.raw_len()
-            {
+            let next_row = MultiBufferRow(target_row.0 + 1);
+            let next_line_indent = self.line_indent_for_row(next_row);
+            let next_indent_column = self.indentation_column_for_line(next_row, indentation);
+            if !next_line_indent.is_line_empty() && target_indent_column < next_indent_column {
                 target_indent = next_line_indent;
+                target_indent_column = next_indent_column;
                 target_row.0 += 1;
             }
         }
@@ -5949,7 +5970,8 @@ impl MultiBufferSnapshot {
                     yield_now().await;
                 }
                 if !indent.is_line_empty() {
-                    non_empty_line_above = Some((row, indent));
+                    non_empty_line_above =
+                        Some((row, self.indentation_column_for_line(row, indentation)));
                     break;
                 }
             }
@@ -5965,17 +5987,18 @@ impl MultiBufferSnapshot {
                     yield_now().await;
                 }
                 if !indent.is_line_empty() {
-                    non_empty_line_below = Some((row, indent));
+                    non_empty_line_below =
+                        Some((row, self.indentation_column_for_line(row, indentation)));
                     break;
                 }
             }
 
-            let (row, indent) = match (non_empty_line_above, non_empty_line_below) {
-                (Some((above_row, above_indent)), Some((below_row, below_indent))) => {
-                    if above_indent.raw_len() >= below_indent.raw_len() {
-                        (above_row, above_indent)
+            let (row, indent_column) = match (non_empty_line_above, non_empty_line_below) {
+                (Some((above_row, above_column)), Some((below_row, below_column))) => {
+                    if above_column >= below_column {
+                        (above_row, above_column)
                     } else {
-                        (below_row, below_indent)
+                        (below_row, below_column)
                     }
                 }
                 (Some(above), None) => above,
@@ -5983,7 +6006,7 @@ impl MultiBufferSnapshot {
                 _ => return None,
             };
 
-            target_indent = indent;
+            target_indent_column = indent_column;
             target_row = row;
         }
 
@@ -6000,12 +6023,13 @@ impl MultiBufferSnapshot {
                 accessed_row_counter = 0;
                 yield_now().await;
             }
-            if !indent.is_line_empty() && indent.raw_len() < target_indent.raw_len() {
-                start_indent = Some((row, indent));
+            let indent_column = self.indentation_column_for_line(row, indentation);
+            if !indent.is_line_empty() && indent_column < target_indent_column {
+                start_indent = Some((row, indent_column));
                 break;
             }
         }
-        let (start_row, start_indent_size) = start_indent?;
+        let (start_row, start_indent_column) = start_indent?;
 
         let mut end_indent = (end, None);
         for (row, indent, _) in self.line_indents(target_row, |_| true) {
@@ -6017,24 +6041,25 @@ impl MultiBufferSnapshot {
                 accessed_row_counter = 0;
                 yield_now().await;
             }
-            if !indent.is_line_empty() && indent.raw_len() < target_indent.raw_len() {
-                end_indent = (MultiBufferRow(row.0.saturating_sub(1)), Some(indent));
+            let indent_column = self.indentation_column_for_line(row, indentation);
+            if !indent.is_line_empty() && indent_column < target_indent_column {
+                end_indent = (MultiBufferRow(row.0.saturating_sub(1)), Some(indent_column));
                 break;
             }
         }
-        let (end_row, end_indent_size) = end_indent;
+        let (end_row, end_indent_column) = end_indent;
 
-        let indent = if let Some(end_indent_size) = end_indent_size {
-            if start_indent_size.raw_len() > end_indent_size.raw_len() {
-                start_indent_size
+        let indent_column = if let Some(end_indent_column) = end_indent_column {
+            if start_indent_column > end_indent_column {
+                start_indent_column
             } else {
-                end_indent_size
+                end_indent_column
             }
         } else {
-            start_indent_size
+            start_indent_column
         };
 
-        Some((start_row..end_row, indent))
+        Some((start_row..end_row, indent_column))
     }
 
     pub fn indent_guides_in_range<T: ToPoint>(
@@ -6056,7 +6081,7 @@ impl MultiBufferSnapshot {
         let mut indent_stack = SmallVec::<[IndentGuide; 8]>::new();
 
         let mut prev_settings = None;
-        while let Some((first_row, mut line_indent, buffer)) = row_indents.next() {
+        while let Some((first_row, line_indent, buffer)) = row_indents.next() {
             if first_row > end_row {
                 break;
             }
@@ -6076,12 +6101,13 @@ impl MultiBufferSnapshot {
                     )
                 })
                 .1;
-            let tab_size = settings.tab_size.get();
+            let indentation = settings.indentation();
 
             // When encountering empty, continue until found useful line indent
             // then add to the indent stack with the depth found
             let mut found_indent = false;
             let mut last_row = first_row;
+            let mut indentation_row = first_row;
             if line_indent.is_line_blank() {
                 while !found_indent {
                     let Some((target_row, new_line_indent, _)) = row_indents.next() else {
@@ -6096,7 +6122,7 @@ impl MultiBufferSnapshot {
                         continue;
                     }
                     last_row = target_row.min(end_row);
-                    line_indent = new_line_indent;
+                    indentation_row = target_row;
                     found_indent = true;
                     break;
                 }
@@ -6105,7 +6131,8 @@ impl MultiBufferSnapshot {
             }
 
             let depth = if found_indent {
-                line_indent.len(tab_size) / tab_size
+                self.indentation_column_for_line(indentation_row, indentation)
+                    / indentation.indent_size().get()
             } else {
                 0
             };
@@ -6133,7 +6160,7 @@ impl MultiBufferSnapshot {
                             start_row: first_row,
                             end_row: last_row,
                             depth: next_depth,
-                            tab_size,
+                            indentation,
                             settings: settings.indent_guides.clone(),
                         });
                     }

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use buffer_diff::{DiffHunkStatus, DiffHunkStatusKind};
 use gpui::{App, Entity, TestAppContext};
 use indoc::indoc;
-use language::{Buffer, Rope};
+use language::{Buffer, Rope, language_settings::IndentationSettings};
 use parking_lot::RwLock;
 use rand::prelude::*;
 use settings::SettingsStore;
@@ -4336,16 +4336,39 @@ fn test_history(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_indentation_column_for_line_uses_indentation_settings(cx: &mut TestAppContext) {
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("\t  text\n  \ttext\n    text", cx));
+    let snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
+    let indentation = IndentationSettings::new(4.try_into().unwrap(), 8.try_into().unwrap(), true);
+
+    assert_eq!(
+        snapshot.indentation_column_for_line(MultiBufferRow(0), indentation),
+        10
+    );
+    assert_eq!(
+        snapshot.indentation_column_for_line(MultiBufferRow(1), indentation),
+        8
+    );
+    assert_eq!(
+        snapshot.indentation_column_for_line(MultiBufferRow(2), indentation),
+        4
+    );
+}
+
+#[gpui::test]
 async fn test_enclosing_indent(cx: &mut TestAppContext) {
     async fn enclosing_indent(
         text: &str,
         buffer_row: u32,
         cx: &mut TestAppContext,
-    ) -> Option<(Range<u32>, LineIndent)> {
+    ) -> Option<(Range<u32>, u32)> {
         let buffer = cx.update(|cx| MultiBuffer::build_simple(text, cx));
         let snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
         let (range, indent) = snapshot
-            .enclosing_indent(MultiBufferRow(buffer_row))
+            .enclosing_indent(
+                MultiBufferRow(buffer_row),
+                IndentationSettings::new(4.try_into().unwrap(), 4.try_into().unwrap(), false),
+            )
             .await?;
         Some((range.start.0..range.end.0, indent))
     }
@@ -4365,14 +4388,7 @@ async fn test_enclosing_indent(cx: &mut TestAppContext) {
             cx,
         )
         .await,
-        Some((
-            1..2,
-            LineIndent {
-                tabs: 0,
-                spaces: 4,
-                line_blank: false,
-            }
-        ))
+        Some((1..2, 4))
     );
 
     assert_eq!(
@@ -4390,14 +4406,7 @@ async fn test_enclosing_indent(cx: &mut TestAppContext) {
             cx,
         )
         .await,
-        Some((
-            1..2,
-            LineIndent {
-                tabs: 0,
-                spaces: 4,
-                line_blank: false,
-            }
-        ))
+        Some((1..2, 4))
     );
 
     assert_eq!(
@@ -4417,14 +4426,18 @@ async fn test_enclosing_indent(cx: &mut TestAppContext) {
             cx,
         )
         .await,
-        Some((
-            1..4,
-            LineIndent {
-                tabs: 0,
-                spaces: 4,
-                line_blank: false,
-            }
-        ))
+        Some((1..4, 4))
+    );
+
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("root\n    parent\n\tchild\nroot", cx));
+    let snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
+    let indentation = IndentationSettings::new(4.try_into().unwrap(), 8.try_into().unwrap(), true);
+    assert_eq!(
+        snapshot
+            .enclosing_indent(MultiBufferRow(2), indentation)
+            .await
+            .map(|(range, indent)| (range.start.0..range.end.0, indent)),
+        Some((1..2, 4)),
     );
 }
 

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use buffer_diff::{DiffHunkStatus, DiffHunkStatusKind};
 use gpui::{App, Entity, TestAppContext};
 use indoc::indoc;
-use language::{Buffer, Rope};
+use language::{Buffer, Rope, language_settings::IndentationSettings};
 use parking_lot::RwLock;
 use rand::prelude::*;
 use settings::SettingsStore;
@@ -4720,16 +4720,39 @@ fn test_history(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_indentation_column_for_line_uses_indentation_settings(cx: &mut TestAppContext) {
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("\t  text\n  \ttext\n    text", cx));
+    let snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
+    let indentation = IndentationSettings::new(4.try_into().unwrap(), 8.try_into().unwrap(), true);
+
+    assert_eq!(
+        snapshot.indentation_column_for_line(MultiBufferRow(0), indentation),
+        10
+    );
+    assert_eq!(
+        snapshot.indentation_column_for_line(MultiBufferRow(1), indentation),
+        8
+    );
+    assert_eq!(
+        snapshot.indentation_column_for_line(MultiBufferRow(2), indentation),
+        4
+    );
+}
+
+#[gpui::test]
 async fn test_enclosing_indent(cx: &mut TestAppContext) {
     async fn enclosing_indent(
         text: &str,
         buffer_row: u32,
         cx: &mut TestAppContext,
-    ) -> Option<(Range<u32>, LineIndent)> {
+    ) -> Option<(Range<u32>, u32)> {
         let buffer = cx.update(|cx| MultiBuffer::build_simple(text, cx));
         let snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
         let (range, indent) = snapshot
-            .enclosing_indent(MultiBufferRow(buffer_row))
+            .enclosing_indent(
+                MultiBufferRow(buffer_row),
+                IndentationSettings::new(4.try_into().unwrap(), 4.try_into().unwrap(), false),
+            )
             .await?;
         Some((range.start.0..range.end.0, indent))
     }
@@ -4749,14 +4772,7 @@ async fn test_enclosing_indent(cx: &mut TestAppContext) {
             cx,
         )
         .await,
-        Some((
-            1..2,
-            LineIndent {
-                tabs: 0,
-                spaces: 4,
-                line_blank: false,
-            }
-        ))
+        Some((1..2, 4))
     );
 
     assert_eq!(
@@ -4774,14 +4790,7 @@ async fn test_enclosing_indent(cx: &mut TestAppContext) {
             cx,
         )
         .await,
-        Some((
-            1..2,
-            LineIndent {
-                tabs: 0,
-                spaces: 4,
-                line_blank: false,
-            }
-        ))
+        Some((1..2, 4))
     );
 
     assert_eq!(
@@ -4801,14 +4810,18 @@ async fn test_enclosing_indent(cx: &mut TestAppContext) {
             cx,
         )
         .await,
-        Some((
-            1..4,
-            LineIndent {
-                tabs: 0,
-                spaces: 4,
-                line_blank: false,
-            }
-        ))
+        Some((1..4, 4))
+    );
+
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("root\n    parent\n\tchild\nroot", cx));
+    let snapshot = cx.read(|cx| buffer.read(cx).snapshot(cx));
+    let indentation = IndentationSettings::new(4.try_into().unwrap(), 8.try_into().unwrap(), true);
+    assert_eq!(
+        snapshot
+            .enclosing_indent(MultiBufferRow(2), indentation)
+            .await
+            .map(|(range, indent)| (range.start.0..range.end.0, indent)),
+        Some((1..2, 4)),
     );
 }
 

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -248,7 +248,8 @@ async fn test_editorconfig_support(cx: &mut gpui::TestAppContext) {
         root = true
         [*.rs]
             indent_style = tab
-            indent_size = 3
+            indent_size = 4
+            tab_width = 8
             end_of_line = lf
             insert_final_newline = true
             trim_trailing_whitespace = true
@@ -344,7 +345,8 @@ async fn test_editorconfig_support(cx: &mut gpui::TestAppContext) {
     let settings_readme = settings_for("README.json", cx).await;
     let settings_markdown = settings_for("README.md", cx).await;
     // .editorconfig overrides .zed/settings
-    assert_eq!(Some(settings_a.tab_size), NonZeroU32::new(3));
+    assert_eq!(Some(settings_a.tab_size), NonZeroU32::new(4));
+    assert_eq!(Some(settings_a.tab_width), NonZeroU32::new(8));
     assert_eq!(settings_a.hard_tabs, true);
     assert_eq!(settings_a.ensure_final_newline_on_save, true);
     // .editorconfig can disable trailing whitespace removal, but should not
@@ -355,12 +357,15 @@ async fn test_editorconfig_support(cx: &mut gpui::TestAppContext) {
 
     // .editorconfig in b/ overrides .editorconfig in root
     assert_eq!(Some(settings_b.tab_size), NonZeroU32::new(2));
+    assert_eq!(Some(settings_b.tab_width), NonZeroU32::new(8));
 
     // .editorconfig in subdirectory overrides .editorconfig in root
     assert_eq!(Some(settings_d.tab_size), NonZeroU32::new(1));
+    assert_eq!(Some(settings_d.tab_width), NonZeroU32::new(8));
 
     // Non-empty values in e/ are parsed and applied as usual.
     assert_eq!(Some(settings_e.tab_size), NonZeroU32::new(5));
+    assert_eq!(Some(settings_e.tab_width), NonZeroU32::new(8));
     assert_eq!(settings_e.hard_tabs, false);
     // An empty value opts out of the inherited `max_line_length = 120`,
     // falling back to .zed/settings.json instead of rejecting the whole file.
@@ -368,6 +373,7 @@ async fn test_editorconfig_support(cx: &mut gpui::TestAppContext) {
 
     // "indent_size" is not set, so "tab_width" is used
     assert_eq!(Some(settings_c.tab_size), NonZeroU32::new(10));
+    assert_eq!(Some(settings_c.tab_width), NonZeroU32::new(10));
     assert_eq!(settings_c.remove_trailing_whitespace_on_save, false);
     assert_eq!(settings_readme.remove_trailing_whitespace_on_save, true);
     assert_eq!(settings_markdown.remove_trailing_whitespace_on_save, true);
@@ -378,6 +384,7 @@ async fn test_editorconfig_support(cx: &mut gpui::TestAppContext) {
 
     // README.md should not be affected by .editorconfig's globe "*.rs"
     assert_eq!(Some(settings_readme.tab_size), NonZeroU32::new(8));
+    assert_eq!(Some(settings_readme.tab_width), NonZeroU32::new(8));
 }
 
 #[gpui::test]
@@ -427,12 +434,15 @@ async fn test_external_editorconfig_support(cx: &mut gpui::TestAppContext) {
 
     // main.rs gets indent_size = 2 from parent's external .editorconfig
     assert_eq!(Some(settings_rs.tab_size), NonZeroU32::new(2));
+    assert_eq!(Some(settings_rs.tab_width), NonZeroU32::new(2));
 
     // README.md gets indent_size = 3 from internal worktree .editorconfig
     assert_eq!(Some(settings_md.tab_size), NonZeroU32::new(3));
+    assert_eq!(Some(settings_md.tab_width), NonZeroU32::new(3));
 
     // other.txt gets indent_size = 4 from grandparent's external .editorconfig
     assert_eq!(Some(settings_txt.tab_size), NonZeroU32::new(4));
+    assert_eq!(Some(settings_txt.tab_width), NonZeroU32::new(4));
 }
 
 #[gpui::test]

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -625,6 +625,7 @@ impl VsCodeSettings {
             tab_size: self
                 .read_u32("editor.tabSize")
                 .and_then(|n| NonZeroU32::new(n)),
+            tab_width: None,
             tasks: None,
             use_auto_surround: self.read_enum("editor.autoSurround", |s| match s {
                 "languageDefined" | "quotes" | "brackets" => Some(true),

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -622,6 +622,7 @@ impl VsCodeSettings {
             tab_size: self
                 .read_u32("editor.tabSize")
                 .and_then(|n| NonZeroU32::new(n)),
+            tab_width: None,
             tasks: None,
             use_auto_surround: self.read_enum("editor.autoSurround", |s| match s {
                 "languageDefined" | "quotes" | "brackets" => Some(true),

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -510,11 +510,15 @@ impl<'de> Deserialize<'de> for ConfiguredLanguageServer {
 #[with_fallible_options]
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct LanguageSettingsContent {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     ///
     /// Default: 4
     #[schemars(range(min = 1, max = 128))]
     pub tab_size: Option<NonZeroU32>,
+    /// How many columns a literal tab character should occupy. If unset, this
+    /// defaults to `tab_size`.
+    #[schemars(range(min = 1, max = 128))]
+    pub tab_width: Option<NonZeroU32>,
     /// Whether to indent lines using tab characters, as opposed to multiple
     /// spaces.
     ///

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -456,11 +456,15 @@ impl<'de> Deserialize<'de> for ConfiguredLanguageServer {
 #[with_fallible_options]
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct LanguageSettingsContent {
-    /// How many columns a tab should occupy.
+    /// How many columns each indentation level should occupy.
     ///
     /// Default: 4
     #[schemars(range(min = 1, max = 128))]
     pub tab_size: Option<NonZeroU32>,
+    /// How many columns a literal tab character should occupy. If unset, this
+    /// defaults to `tab_size`.
+    #[schemars(range(min = 1, max = 128))]
+    pub tab_width: Option<NonZeroU32>,
     /// Whether to indent lines using tab characters, as opposed to multiple
     /// spaces.
     ///

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8985,12 +8985,12 @@ fn language_settings_field_mut<T>(
 }
 
 fn language_settings_data() -> Box<[SettingsPageItem]> {
-    fn indentation_section() -> [SettingsPageItem; 5] {
+    fn indentation_section() -> [SettingsPageItem; 6] {
         [
             SettingsPageItem::SectionHeader("Indentation"),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Tab Size",
-                description: "How many columns a tab should occupy.",
+                description: "How many columns each indentation level should occupy.",
                 field: Box::new(SettingField {
                     organization_override: None,
                     json_path: Some("languages.$(language).tab_size"), // TODO(cameron): not JQ syntax because not URL-safe
@@ -9002,6 +9002,26 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                     write: |settings_content, value, _| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.tab_size = value;
+                        })
+                    },
+                }),
+                metadata: None,
+                files: USER | PROJECT,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Tab Width",
+                description: "How many columns a literal tab character should occupy.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("languages.$(language).tab_width"),
+                    pick: |settings_content| {
+                        language_settings_field(settings_content, |language| {
+                            language.tab_width.as_ref()
+                        })
+                    },
+                    write: |settings_content, value, _| {
+                        language_settings_field_mut(settings_content, value, |language, value| {
+                            language.tab_width = value;
                         })
                     },
                 }),

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8767,12 +8767,12 @@ fn language_settings_field_mut<T>(
 }
 
 fn language_settings_data() -> Box<[SettingsPageItem]> {
-    fn indentation_section() -> [SettingsPageItem; 5] {
+    fn indentation_section() -> [SettingsPageItem; 6] {
         [
             SettingsPageItem::SectionHeader("Indentation"),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Tab Size",
-                description: "How many columns a tab should occupy.",
+                description: "How many columns each indentation level should occupy.",
                 field: Box::new(SettingField {
                     organization_override: None,
                     json_path: Some("languages.$(language).tab_size"), // TODO(cameron): not JQ syntax because not URL-safe
@@ -8784,6 +8784,26 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                     write: |settings_content, value, _| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.tab_size = value;
+                        })
+                    },
+                }),
+                metadata: None,
+                files: USER | PROJECT,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Tab Width",
+                description: "How many columns a literal tab character should occupy.",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("languages.$(language).tab_width"),
+                    pick: |settings_content| {
+                        language_settings_field(settings_content, |language| {
+                            language.tab_width.as_ref()
+                        })
+                    },
+                    write: |settings_content, value, _| {
+                        language_settings_field_mut(settings_content, value, |language, value| {
+                            language.tab_width = value;
                         })
                     },
                 }),

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -706,11 +706,6 @@ impl LineIndent {
     pub fn raw_len(&self) -> u32 {
         self.tabs + self.spaces
     }
-
-    /// Returns the number of indentation characters (tabs or spaces), taking tab size into account.
-    pub fn len(&self, tab_size: u32) -> u32 {
-        self.tabs * tab_size + self.spaces
-    }
 }
 
 impl From<&str> for LineIndent {

--- a/crates/vim/src/digraph.rs
+++ b/crates/vim/src/digraph.rs
@@ -215,7 +215,9 @@ impl Vim {
         text.push_str(suffix);
 
         if self.editor_input_enabled() {
-            self.update_editor(cx, |_, editor, cx| editor.insert(&text, window, cx));
+            self.update_editor(cx, |_, editor, cx| {
+                editor.insert_without_autoindent(&text, window, cx)
+            });
         } else {
             self.input_ignored(text.into(), window, cx);
         }

--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -42,6 +42,8 @@ Here's an example of language-specific settings:
 You can customize a wide range of settings for each language, including:
 
 - [`tab_size`](./reference/all-settings.md#tab-size): The number of spaces for each indentation level
+- [`tab_width`](./reference/all-settings.md#tab-width): The display width of
+  literal tab characters; defaults to `tab_size`
 - [`formatter`](./reference/all-settings.md#formatter): The tool used for code formatting
 - [`format_on_save`](./reference/all-settings.md#format-on-save): Whether to automatically format code when saving
 - [`enable_language_server`](./reference/all-settings.md#enable-language-server): Toggle language server support

--- a/docs/src/extensions/languages.md
+++ b/docs/src/extensions/languages.md
@@ -29,7 +29,7 @@ line_comments = ["# "]
 - `grammar` (required) is the name of a grammar. Grammars are registered separately, described below.
 - `path_suffixes` is an array of file suffixes that should be associated with this language. Unlike `file_types` in settings, this does not support glob patterns.
 - `line_comments` is an array of strings that are used to identify line comments in the language. This is used for the `editor::ToggleComments` keybind: {#kb editor::ToggleComments} for toggling lines of code.
-- `tab_size` defines the indentation/tab size used for this language (default is `4`).
+- `tab_size` defines the indentation width used for this language (default is `4`).
 - `hard_tabs` whether to indent with tabs (`true`) or spaces (`false`, the default).
 - `first_line_pattern` is a regular expression that can be used alongside `path_suffixes` (above) or `file_types` in settings to match files that should use this language. For example, Zed uses this to identify Shell Scripts by matching [shebang lines](https://github.com/zed-industries/zed/blob/main/crates/languages/src/bash/config.toml) in the first line of a script.
 - `debuggers` is an array of strings that are used to identify debuggers in the language. When launching a debugger's `New Process Modal`, Zed will order available debuggers by the order of entries in this array.

--- a/docs/src/modelines.md
+++ b/docs/src/modelines.md
@@ -29,7 +29,9 @@ Example:
 | Variable                   | Description                    | Zed Setting                                                                                |
 | -------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------ |
 | `mode`                     | Major mode/language            | Language detection                                                                         |
-| `tab-width`                | Tab display width              | [`tab_size`](./reference/all-settings.md#tab-size)                                         |
+| `tab-width`                | Tab display width              | [`tab_width`](./reference/all-settings.md#tab-width)                                       |
+| `c-basic-offset`           | C indentation width            | [`tab_size`](./reference/all-settings.md#tab-size)                                         |
+| `python-indent-offset`     | Python indentation width       | [`tab_size`](./reference/all-settings.md#tab-size)                                         |
 | `fill-column`              | Line wrap column               | [`preferred_line_length`](./reference/all-settings.md#preferred-line-length)               |
 | `indent-tabs-mode`         | `nil` for spaces, `t` for tabs | [`hard_tabs`](./reference/all-settings.md#hard-tabs)                                       |
 | `electric-indent-mode`     | Auto-indentation               | [`auto_indent`](./reference/all-settings.md#auto-indent)                                   |
@@ -51,7 +53,8 @@ Example:
 | Option         | Aliases | Description                       | Zed Setting                                                                                |
 | -------------- | ------- | --------------------------------- | ------------------------------------------------------------------------------------------ |
 | `filetype`     | `ft`    | File type/language                | Language detection                                                                         |
-| `tabstop`      | `ts`    | Number of spaces a tab counts for | [`tab_size`](./reference/all-settings.md#tab-size)                                         |
+| `tabstop`      | `ts`    | Number of spaces a tab counts for | [`tab_width`](./reference/all-settings.md#tab-width)                                       |
+| `shiftwidth`   | `sw`    | Number of columns per indent      | [`tab_size`](./reference/all-settings.md#tab-size)                                         |
 | `textwidth`    | `tw`    | Maximum line width                | [`preferred_line_length`](./reference/all-settings.md#preferred-line-length)               |
 | `expandtab`    | `et`    | Use spaces instead of tabs        | [`hard_tabs`](./reference/all-settings.md#hard-tabs)                                       |
 | `noexpandtab`  | `noet`  | Use tabs instead of spaces        | [`hard_tabs`](./reference/all-settings.md#hard-tabs)                                       |

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4319,9 +4319,21 @@ List of `integer` column numbers
 
 ## Tab Size
 
-- Description: The number of spaces to use for each tab character.
+- Description: The number of columns in each indentation level. This value is
+  also sent to language servers and formatters as their indentation width.
 - Setting: `tab_size`
 - Default: `4`
+
+**Options**
+
+`integer` values
+
+## Tab Width
+
+- Description: The number of columns used to display a literal tab character.
+  When omitted, this uses `tab_size`.
+- Setting: `tab_width`
+- Default: The configured `tab_size`
 
 **Options**
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4188,9 +4188,21 @@ List of `integer` column numbers
 
 ## Tab Size
 
-- Description: The number of spaces to use for each tab character.
+- Description: The number of columns in each indentation level. This value is
+  also sent to language servers and formatters as their indentation width.
 - Setting: `tab_size`
 - Default: `4`
+
+**Options**
+
+`integer` values
+
+## Tab Width
+
+- Description: The number of columns used to display a literal tab character.
+  When omitted, this uses `tab_size`.
+- Setting: `tab_width`
+- Default: The configured `tab_size`
 
 **Options**
 


### PR DESCRIPTION
# Objective

Fix Zed's handling of EditorConfig configurations where logical indentation
width differs from the display width of literal tab characters.

For example:

```editorconfig
indent_style = tab
indent_size = 4
tab_width = 8
```

Fixes #24108

## Solution

- Introduce `IndentationSettings` as the shared policy for indentation stops,
  literal-tab expansion, prefix measurement, and canonical indentation text.
- Keep `tab_size` as the logical indentation width and add an optional
  `tab_width` that defaults to `tab_size`.
- Use `tab_width` when rendering or measuring literal tabs, while continuing to
  use `tab_size` for editor operations, auto-indentation, formatters, language
  servers, folding, and indentation guides.
- Generate hard-tab indentation using tabs wherever they fit without
  overshooting, supplemented by spaces as necessary.
- Map EditorConfig, modeline, extension, schema, settings UI, and documentation
  values to the appropriate width while preserving existing configurations.

## Testing

- `cargo fmt --all`
- `cargo test -p editor test_mixed_indentation_prefixes_are_preserved --lib`
- `cargo test -p editor test_split_width_indentation_edge_cases --lib`
- `cargo test -p editor test_tab_with_mixed_whitespace --lib`
- `cargo test -p editor test_backspace --lib`

Regression coverage also exercises EditorConfig precedence, literal-tab
rendering, auto-indent, explicit indent/outdent, mixed and non-multiple widths,
modelines, folding, indentation guides, and formatter settings.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed EditorConfig handling when indentation width and tab display width differ.
