### PR TITLE
Fix git commit button alignment with larger font sizes

### DIFF
--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -1133,7 +1133,7 @@ pub(crate) fn render_split_button_chevron_trigger(
     id: impl Into<ElementId>,
     menu_open: bool,
 ) -> ButtonLike {
-    let chevron_button_size = rems_from_px(20.);
+    let chevron_button_size = ButtonSize::Compact.rems();
     let chevron_icon = if menu_open {
         IconName::ChevronUp
     } else {


### PR DESCRIPTION
# Objective

Fixes #60856

## Solution
The issue was caused by `render_split_button_chevron_trigger` using a hardcoded `20px` button size. This prevented the button from scaling correctly with larger font sizes. The size has been changed to use `Button::Compact.rem()` so it follows the existing UI scaling behavior.

## Testing

Visually verified the fix by changing the font size and confirming that the Git commit button remains correctly aligned with the UI.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

<img width="381" height="275" alt="2026-07-17-123308_hyprshot" src="https://github.com/user-attachments/assets/8192e7fa-8a42-492f-922c-08342e37376c" />

---

Release Notes:

- Git commit button is now correctly aligned to UI when using larger font size. 
