### PR TITLE
Center minimap clicks on clicked position

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1501,7 +1501,6 @@ impl EditorElement {
             thumb_layout: layout,
             thumb_border_style: minimap_settings.thumb_border,
             minimap_line_height,
-            minimap_scroll_top,
             max_scroll_top: total_editor_lines,
         })
     }
@@ -6466,15 +6465,12 @@ impl EditorElement {
                                 let click_position =
                                     event_position.relative_to(&minimap_hitbox.origin).y;
 
-                                let top_position = (click_position
-                                    - thumb_bounds.size.along(minimap_axis) / 2.0)
-                                    .max(Pixels::ZERO);
-
-                                let scroll_offset = (layout.minimap_scroll_top
-                                    + ScrollPixelOffset::from(
-                                        top_position / layout.minimap_line_height,
-                                    ))
-                                .min(layout.max_scroll_top);
+                                let clicked_line =
+                                    ScrollPixelOffset::from(click_position / pixels_per_line);
+                                let visible_lines = layout.thumb_layout.visible_range.end
+                                    - layout.thumb_layout.visible_range.start;
+                                let scroll_offset = (clicked_line - visible_lines / 2.0)
+                                    .clamp(0.0, layout.max_scroll_top);
 
                                 let scroll_position = editor
                                     .scroll_position(cx)
@@ -10038,7 +10034,6 @@ impl ScrollbarLayout {
 struct MinimapLayout {
     pub minimap: AnyElement,
     pub thumb_layout: ScrollbarLayout,
-    pub minimap_scroll_top: ScrollOffset,
     pub minimap_line_height: Pixels,
     pub thumb_border_style: MinimapThumbBorder,
     pub max_scroll_top: ScrollOffset,


### PR DESCRIPTION
# Objective

- Make minimap clicks jump directly to the clicked document position.
- Previously, clicking far away in the minimap could scroll only a small distance on long files.

## Solution

- Map the minimap click position to a document line using the minimap scroll scale.
- Center the editor viewport on the clicked position when possible.
- Clamp the resulting scroll position near the beginning and end of the file.

## Testing

- Ran `cargo check -p editor`.
- Ran `cargo clippy -p editor --all-targets -- --deny warnings`.
- Manually verified that clicking near the top, middle, and bottom of the minimap scrolls the editor so the clicked document position is centered when possible.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before:

[before.webm](https://github.com/user-attachments/assets/eff02eab-4a3b-4b16-b958-3f13327f9f3e)

After:

[after.webm](https://github.com/user-attachments/assets/cc814e4b-cdf9-4ec8-a50d-5898d5a6531c)

---

Release Notes:

- Improved minimap clicks to center the editor on the clicked document position.