### PR TITLE
git_graph: Fix commit message overflowing into changed files section

### DIFF
--- a/crates/git_ui/src/git_graph.rs
+++ b/crates/git_ui/src/git_graph.rs
@@ -3733,12 +3733,12 @@ impl GitGraph {
             .child(
                 div()
                     .relative()
-                    .size_full()
+                    .w_full()
                     .child(
                         div()
                             .id("commit-message")
                             .text_sm()
-                            .size_full()
+                            .w_full()
                             .max_h(line_height * 12.)
                             .overflow_y_scroll()
                             .track_scroll(scroll_handle)


### PR DESCRIPTION
This regressed in https://github.com/zed-industries/zed/pull/59674

Closes FR-125

Release Notes:

- Fixed an issue where the commit message in the git panel could overlap other content
