### PR TITLE
agent_ui: Fix project rule pluralization in context usage popover

### DIFF
--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -2223,7 +2223,7 @@ fn diagnostics_crease_label(
     diagnostics_label(summary, include_errors, include_warnings).into()
 }
 
-fn pluralize(noun: &str, count: usize) -> String {
+pub(crate) fn pluralize(noun: &str, count: usize) -> String {
     if count == 1 {
         noun.to_string()
     } else {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -22,7 +22,7 @@ use cloud_api_types::{SubmitAgentThreadFeedbackBody, SubmitAgentThreadFeedbackCo
 use editor::actions::OpenExcerpts;
 use sandbox::{SandboxFsPolicy, SandboxNetPolicy, SandboxPolicy};
 
-use crate::completion_provider::{AvailableSkill, PromptLocalCommand};
+use crate::completion_provider::{AvailableSkill, PromptLocalCommand, pluralize};
 use crate::message_editor::SharedSessionCapabilities;
 use crate::ui::{
     SandboxGroup, SandboxRow, SandboxSection, SandboxStatusTooltip, TerminalSandboxWarning,
@@ -5780,8 +5780,12 @@ impl Render for TokenUsageTooltip {
                                                 Button::new(
                                                     "open-project-rules",
                                                     format!(
-                                                        "{} project rules",
-                                                        project_rules_count
+                                                        "{} {}",
+                                                        project_rules_count,
+                                                        pluralize(
+                                                            "project rule",
+                                                            project_rules_count
+                                                        )
                                                     ),
                                                 )
                                                 .end_icon(


### PR DESCRIPTION
The agent panel's context usage popover showed "1 project rules" when exactly one project rule (e.g. `.rules`) was loaded, because the project-rules button used an unconditional `format!("{} project rules", ...)`.

Reuse the existing `pluralize` helper (already used for diagnostics labels in the same crate) so a single rule renders as "1 project rule" and multiple rules render as "N project rules". The sibling "1 global rule" label is intentionally left unchanged, since there is only ever one global rule.

Closes #57759

Release Notes:

- Fixed the agent panel context usage popover showing "1 project rules" instead of "1 project rule" when a single project rule is loaded.
