### PR TITLE
terminal: Add tab_title_from_program setting to name tabs from the running program

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1973,6 +1973,11 @@
       // Example: `echo -e "\e]2;New Title\007";`
       "breadcrumbs": false,
     },
+    // Whether a terminal tab should be titled by the program running inside it,
+    // using the title that program emits via the OSC 0/2 escape sequence
+    // (e.g. tmux, a shell PROMPT_COMMAND, or a TUI like Claude Code). A manual
+    // rename or a running task's label still takes precedence.
+    "tab_title_from_program": false,
     // Scrollbar-related settings
     "scrollbar": {
       // When to show the scrollbar in the terminal.

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -936,6 +936,7 @@ impl VsCodeSettings {
             project: self.project_terminal_settings_content(),
             scrollbar: None,
             scroll_multiplier: None,
+            tab_title_from_program: None,
             toolbar: None,
             show_count_badge: None,
             flexible: None,

--- a/crates/settings_content/src/terminal.rs
+++ b/crates/settings_content/src/terminal.rs
@@ -165,6 +165,18 @@ pub struct TerminalSettingsContent {
     pub scroll_multiplier: Option<f32>,
     /// Toolbar related settings
     pub toolbar: Option<TerminalToolbarContent>,
+    /// Whether a terminal tab should be titled by the program running inside it,
+    /// using the title that program emits via the OSC 0/2 escape sequence (the
+    /// same value shown in breadcrumbs). This is what `tmux`, a shell
+    /// `PROMPT_COMMAND`, or a TUI such as Claude Code use to name the tab.
+    ///
+    /// When enabled, a program-provided title takes precedence over the automatic
+    /// `<directory> — <program>` title and over a shell `title_override`. A
+    /// manually renamed tab, or a running task's label, still takes precedence
+    /// over the program title.
+    ///
+    /// Default: false
+    pub tab_title_from_program: Option<bool>,
     /// Scrollbar-related settings
     pub scrollbar: Option<ScrollbarSettingsContent>,
     /// The minimum APCA perceptual contrast between foreground and background colors.

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -7143,7 +7143,7 @@ fn terminal_page() -> SettingsPage {
         ]
     }
 
-    fn behavior_settings_section() -> [SettingsPageItem; 6] {
+    fn behavior_settings_section() -> [SettingsPageItem; 7] {
         [
             SettingsPageItem::SectionHeader("Behavior Settings"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -7179,6 +7179,29 @@ fn terminal_page() -> SettingsPage {
                             .terminal
                             .get_or_insert_default()
                             .copy_on_select = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Tab Title From Program",
+                description: "Whether to title a terminal tab using the title emitted by the program running inside it (for example tmux, a shell PROMPT_COMMAND, or a TUI like Claude Code).",
+                field: Box::new(SettingField {
+                    organization_override: None,
+                    json_path: Some("terminal.tab_title_from_program"),
+                    pick: |settings_content| {
+                        settings_content
+                            .terminal
+                            .as_ref()?
+                            .tab_title_from_program
+                            .as_ref()
+                    },
+                    write: |settings_content, value, _| {
+                        settings_content
+                            .terminal
+                            .get_or_insert_default()
+                            .tab_title_from_program = value;
                     },
                 }),
                 metadata: None,

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -45,6 +45,7 @@ pub struct TerminalSettings {
     pub max_scroll_history_lines: Option<usize>,
     pub scroll_multiplier: f32,
     pub toolbar: Toolbar,
+    pub tab_title_from_program: bool,
     pub scrollbar: ScrollbarSettings,
     pub minimum_contrast: f32,
     pub path_hyperlink_regexes: Vec<String>,
@@ -118,6 +119,7 @@ impl settings::Settings for TerminalSettings {
             toolbar: Toolbar {
                 breadcrumbs: user_content.toolbar.unwrap().breadcrumbs.unwrap(),
             },
+            tab_title_from_program: user_content.tab_title_from_program.unwrap(),
             scrollbar: ScrollbarSettings {
                 show: user_content.scrollbar.unwrap().show,
             },

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -47,7 +47,7 @@ use ui::{
     prelude::*,
     scrollbars::{self, ScrollbarVisibility},
 };
-use util::ResultExt;
+use util::{ResultExt, truncate_and_trailoff};
 use workspace::{
     CloseActiveItem, DraggedSelection, DraggedTab, NewCenterTerminal, NewTerminal, Pane,
     ToolbarItemLocation, Workspace, WorkspaceId, delete_unloaded_items,
@@ -415,6 +415,43 @@ impl TerminalView {
 
     pub fn custom_title(&self) -> Option<&str> {
         self.custom_title.as_deref()
+    }
+
+    /// Maximum length of a program-provided (OSC) tab title before it is
+    /// truncated. Mirrors the per-segment limit used by `Terminal::title`.
+    const PROGRAM_TAB_TITLE_MAX_CHARS: usize = 25;
+
+    /// Computes the text shown on this terminal's tab.
+    ///
+    /// Precedence: a manual rename always wins; then, when
+    /// `terminal.tab_title_from_program` is enabled and the terminal is not
+    /// running a task, the title the program emitted via OSC 0/2 (stored as the
+    /// breadcrumb text) is used — this intentionally wins over a shell
+    /// `title_override` as well. Otherwise it falls back to `Terminal::title`
+    /// (a running task's label, a `title_override`, or the automatic
+    /// `<directory> — <program>` title).
+    fn tab_title(&self, truncate: bool, cx: &App) -> SharedString {
+        if let Some(custom_title) = self
+            .custom_title
+            .as_ref()
+            .filter(|title| !title.trim().is_empty())
+        {
+            return custom_title.clone().into();
+        }
+
+        let terminal = self.terminal().read(cx);
+        if TerminalSettings::get_global(cx).tab_title_from_program && terminal.task().is_none() {
+            let program_title = terminal.breadcrumb_text.trim();
+            if !program_title.is_empty() {
+                return if truncate {
+                    truncate_and_trailoff(program_title, Self::PROGRAM_TAB_TITLE_MAX_CHARS).into()
+                } else {
+                    program_title.to_string().into()
+                };
+            }
+        }
+
+        terminal.title(truncate).into()
     }
 
     pub fn set_custom_title(&mut self, label: Option<String>, cx: &mut Context<Self>) {
@@ -1221,7 +1258,17 @@ fn subscribe_for_terminal_events(
                         cx,
                     ),
                 },
-                Event::BreadcrumbsChanged => cx.emit(ItemEvent::UpdateBreadcrumbs),
+                Event::BreadcrumbsChanged => {
+                    cx.emit(ItemEvent::UpdateBreadcrumbs);
+                    // The program-emitted (OSC) title also drives the tab title when
+                    // `tab_title_from_program` is enabled, so refresh the tab too.
+                    // When the feature is off the tab title can't depend on the OSC
+                    // title, so skip the emit to avoid re-rendering the tab on every
+                    // prompt for everyone else.
+                    if TerminalSettings::get_global(cx).tab_title_from_program {
+                        cx.emit(ItemEvent::UpdateTab);
+                    }
+                }
                 Event::CloseTerminal => cx.emit(ItemEvent::CloseItem),
                 Event::SelectionsChanged => {
                     window.invalidate_character_coordinates();
@@ -1457,12 +1504,7 @@ impl Item for TerminalView {
 
     fn tab_content(&self, params: TabContentParams, _window: &Window, cx: &App) -> AnyElement {
         let terminal = self.terminal().read(cx);
-        let title = self
-            .custom_title
-            .as_ref()
-            .filter(|title| !title.trim().is_empty())
-            .cloned()
-            .unwrap_or_else(|| terminal.title(true));
+        let title = self.tab_title(true, cx);
 
         let (icon, icon_color, rerun_button) = match terminal.task() {
             Some(terminal_task) => match &terminal_task.status {
@@ -1559,11 +1601,7 @@ impl Item for TerminalView {
     }
 
     fn tab_content_text(&self, detail: usize, cx: &App) -> SharedString {
-        if let Some(custom_title) = self.custom_title.as_ref().filter(|l| !l.trim().is_empty()) {
-            return custom_title.clone().into();
-        }
-        let terminal = self.terminal().read(cx);
-        terminal.title(detail == 0).into()
+        self.tab_title(detail == 0, cx)
     }
 
     fn telemetry_event_text(&self) -> Option<&'static str> {
@@ -2980,6 +3018,82 @@ mod tests {
 
             view.set_custom_title(Some("  ".to_string()), cx);
             assert!(view.custom_title().is_none());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_tab_title_from_program(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+
+        let (project, workspace) = init_test(cx).await;
+
+        let terminal = project
+            .update(cx, |project, cx| project.create_terminal_shell(None, cx))
+            .await
+            .unwrap();
+
+        let terminal_view = cx
+            .add_window(|window, cx| {
+                TerminalView::new(
+                    terminal,
+                    workspace.downgrade(),
+                    None,
+                    project.downgrade(),
+                    window,
+                    cx,
+                )
+            })
+            .root(cx)
+            .unwrap();
+
+        // Simulate the program running in the terminal setting its own title via
+        // an OSC 0/2 escape sequence (the value Zed stores as breadcrumb text).
+        terminal_view.update(cx, |view, cx| {
+            view.terminal().update(cx, |terminal, _| {
+                terminal.breadcrumb_text = "claude".to_string();
+            });
+        });
+
+        // Disabled by default: the tab keeps its automatic title, not the OSC one.
+        terminal_view.update(cx, |view, cx| {
+            let automatic_title = view.terminal().read(cx).title(true);
+            assert_eq!(view.tab_title(true, cx).to_string(), automatic_title);
+            assert_ne!(automatic_title, "claude");
+        });
+
+        // Enabling the setting surfaces the program-provided title on the tab.
+        cx.update_global(|store: &mut settings::SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings
+                    .terminal
+                    .get_or_insert_default()
+                    .tab_title_from_program = Some(true);
+            });
+        });
+        terminal_view.update(cx, |view, cx| {
+            assert_eq!(view.tab_title(true, cx).to_string(), "claude");
+        });
+
+        // A long program title is truncated for the tab, but not for the
+        // untruncated form used by `tab_content_text(detail > 0)`.
+        terminal_view.update(cx, |view, cx| {
+            let long_title = "a-very-long-program-provided-title-that-overflows";
+            view.terminal().update(cx, |terminal, _| {
+                terminal.breadcrumb_text = long_title.to_string();
+            });
+            let truncated = view.tab_title(true, cx).to_string();
+            assert!(
+                truncated.ends_with('…'),
+                "expected truncation, got {truncated:?}"
+            );
+            assert!(truncated.chars().count() <= 26);
+            assert_eq!(view.tab_title(false, cx).to_string(), long_title);
+        });
+
+        // A manual rename always wins over the program-provided title.
+        terminal_view.update(cx, |view, cx| {
+            view.set_custom_title(Some("frontend".to_string()), cx);
+            assert_eq!(view.tab_title(true, cx).to_string(), "frontend");
         });
     }
 


### PR DESCRIPTION
# Objective

Terminal tabs ignore the OSC 0/2 title that the program running inside the terminal emits. That title is captured, but it only feeds the toolbar breadcrumbs, never the tab. As a result, tabs running `tmux`, a shell with a `PROMPT_COMMAND`, or a TUI such as Claude Code all show the same generic `<dir> — <program>` title and can't be told apart.

This is a long-standing request:

Closes #19996 ("Support $PROMPT_COMMAND in terminal tab title", `never stale`)

with the same need raised for tmux, OpenCode, and Claude Code in that thread, and related to #56272.

## Solution

Add an opt-in per-user setting `terminal.tab_title_from_program` (default `false`). When enabled, the program-provided title (the value Zed already stores as `Terminal::breadcrumb_text`) is used as the tab title.

Precedence is preserved and explicit:

1. a manually renamed tab always wins;
2. a running task's label wins next;
3. then the program-provided (OSC) title, when the setting is enabled and non-empty;
4. otherwise the existing `Terminal::title` (a `title_override`, or the automatic `<directory> — <program>` title).

The tab refreshes live when the OSC title changes: with the setting enabled, `BreadcrumbsChanged` additionally emits `ItemEvent::UpdateTab` (previously only breadcrumbs updated, so an OSC title change never reached the tab). The emit is gated on the setting so users who don't opt in get no extra tab re-renders, and default behavior is unchanged.

One precedence decision worth your eyes: with the setting on, the program title also wins over a shell `title_override`. I did this deliberately so remote terminals (which get a `title_override` of `"{host} — Terminal"`) can still show the running program, per #56272 — but it does mean an explicitly configured `terminal.shell.title_override` is superseded when a program sets its own title. Happy to flip that to honor `title_override` instead if you'd prefer.

Files:
- `crates/settings_content/src/terminal.rs` — new `tab_title_from_program` field + docs
- `crates/terminal/src/terminal_settings.rs` — runtime field + `from_settings` mapping
- `assets/settings/default.json` — default `false`
- `crates/settings/src/vscode_import.rs` — field in the importer's struct literal
- `crates/terminal_view/src/terminal_view.rs` — `TerminalView::tab_title` helper (used by `tab_content` and `tab_content_text`), the `UpdateTab` emit, and a test

I kept this behind a setting to avoid changing the tab for users whose shells set noisy OSC titles. **Happy to flip the default to `true` if you'd prefer it on by default** — it's a one-line change.

## Testing

- New unit test `test_tab_title_from_program` in `crates/terminal_view` covers: default-off keeps the automatic title, enabling the setting surfaces the program title, and a manual rename still wins.
- `cargo test -p terminal_view` (new test + existing custom-title tests) passes.
- `cargo test -p settings` passes (31 tests, incl. VS Code import and settings-schema generation).
- `cargo clippy` and `cargo fmt --check` are clean on the touched crates.
- Reviewers can try it by adding `"terminal": { "tab_title_from_program": true }` to settings, then running e.g. `printf '\e]0;my-session\a'` (or `tmux`, or Claude Code) in a terminal and watching the tab rename.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — n/a, no unsafe
- [x] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable — the extra `UpdateTab` fires at the same cadence as the existing breadcrumb update (only when the program sets a title)

## Showcase

This is a text-label change to the tab title. With `terminal.tab_title_from_program` enabled, a terminal running `tmux` / a `PROMPT_COMMAND` shell / Claude Code shows that program's own title on the tab instead of a generic one, so multiple such tabs are distinguishable. (Happy to add a short screen recording.)

---

Release Notes:

- Added a `terminal.tab_title_from_program` setting that titles terminal tabs from the program running inside them (for example `tmux`, a shell `PROMPT_COMMAND`, or a TUI like Claude Code), so tabs running such programs can be told apart. Off by default; a manual rename or a running task's label still takes precedence. ([#19996](https://github.com/zed-industries/zed/issues/19996))
