### PR TITLE
search: Keep search input focused after running a project search

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1750,9 +1750,6 @@ impl ProjectSearchView {
                     editor.scroll(Point::default(), Some(Axis::Vertical), window, cx);
                 }
             });
-            if is_new_search && self.query_editor.focus_handle(cx).is_focused(window) {
-                self.focus_results_editor(window, cx);
-            }
         }
 
         cx.emit(ViewEvent::UpdateTab);
@@ -2002,6 +1999,9 @@ impl ProjectSearchBar {
                     project_view.included_files_editor.focus_handle(cx),
                     project_view.excluded_files_editor.focus_handle(cx),
                 ]);
+            }
+            if project_view.has_matches() {
+                views.push(project_view.results_editor.focus_handle(cx));
             }
             let current_index = match views.iter().position(|focus| focus.is_focused(window)) {
                 Some(index) => index,
@@ -3276,11 +3276,13 @@ pub mod tests {
             "Expected no search panel to be active"
         );
 
+        let search_bar_for_toolbar = search_bar.clone();
         workspace.update_in(cx, move |workspace, window, cx| {
             assert_eq!(workspace.panes().len(), 1);
             workspace.panes()[0].update(cx, |pane, cx| {
-                pane.toolbar()
-                    .update(cx, |toolbar, cx| toolbar.add_item(search_bar, window, cx))
+                pane.toolbar().update(cx, |toolbar, cx| {
+                    toolbar.add_item(search_bar_for_toolbar, window, cx)
+                })
             });
 
             ProjectSearchView::deploy_search(
@@ -3410,11 +3412,49 @@ pub mod tests {
                     "Search view results should match the query"
                 );
                 assert!(
-                    search_view.results_editor.focus_handle(cx).is_focused(window),
-                    "Search view with mismatching query should be focused after search results are available",
+                    search_view.query_editor.focus_handle(cx).is_focused(window),
+                    "Search query should remain focused after search results are available",
                 );
             });
         }).unwrap();
+        window
+            .update(cx, |_, window, cx| {
+                search_bar.update(cx, |search_bar, cx| {
+                    search_bar.confirm(&Confirm, window, cx);
+                });
+            })
+            .unwrap();
+        cx.background_executor.run_until_parked();
+        window
+            .update(cx, |_, window, cx| {
+                search_view.update(cx, |search_view, cx| {
+                    assert!(
+                        search_view.query_editor.focus_handle(cx).is_focused(window),
+                        "Search query should remain focused after confirming the search",
+                    );
+                });
+            })
+            .unwrap();
+        window
+            .update(cx, |_, window, cx| {
+                search_bar.update(cx, |search_bar, cx| {
+                    search_bar.tab(&Tab, window, cx);
+                });
+            })
+            .unwrap();
+        window
+            .update(cx, |_, window, cx| {
+                search_view.update(cx, |search_view, cx| {
+                    assert!(
+                        search_view
+                            .results_editor
+                            .focus_handle(cx)
+                            .is_focused(window),
+                        "Tab should move focus from the search query to the results editor",
+                    );
+                });
+            })
+            .unwrap();
         cx.spawn(|mut cx| async move {
             window
                 .update(&mut cx, |_, window, cx| {
@@ -3765,8 +3805,8 @@ pub mod tests {
                     "Search view results should match the query"
                 );
                 assert!(
-                    search_view.results_editor.focus_handle(cx).is_focused(window),
-                    "Search view with mismatching query should be focused after search results are available",
+                    search_view.query_editor.focus_handle(cx).is_focused(window),
+                    "Search query should remain focused after search results are available",
                 );
             })).unwrap();
         cx.spawn(|mut cx| async move {
@@ -3856,8 +3896,9 @@ pub mod tests {
             .unwrap();
 
         cx.background_executor.run_until_parked();
-        window.update(cx, |_, window, cx| {
-            search_view_2.update(cx, |search_view_2, cx| {
+        window
+            .update(cx, |_, window, cx| {
+                search_view_2.update(cx, |search_view_2, cx| {
                     assert_eq!(
                         search_view_2
                             .results_editor
@@ -3866,11 +3907,15 @@ pub mod tests {
                         "New search view with the updated query should have new search results"
                     );
                     assert!(
-                        search_view_2.results_editor.focus_handle(cx).is_focused(window),
-                        "Search view with mismatching query should be focused after search results are available",
+                        search_view_2
+                            .query_editor
+                            .focus_handle(cx)
+                            .is_focused(window),
+                        "Search query should remain focused after search results are available",
                     );
                 });
-        }).unwrap();
+            })
+            .unwrap();
 
         cx.spawn(|mut cx| async move {
             window


### PR DESCRIPTION
## Context

Running a project search moved keyboard focus off the query input and onto the results editor the moment the first matches arrived. `entity_changed` fires on every entity update, and on a new search it would call `focus_results_editor` whenever the query editor happened to be focused. That made it awkward to iterate on a query — after each search you had to click or navigate back into the input to keep typing. This keeps focus on the query input after a search and instead exposes the results editor through the existing Tab cycle, so it stays reachable from the keyboard.

Closes #61179.

Behavior before the fix :

[Screencast from 2026-07-17 13-47-27.webm](https://github.com/user-attachments/assets/a654eca6-eeac-42e6-b723-251884f03092)

Behavior after the fix :

[Screencast from 2026-07-17 13-48-25.webm](https://github.com/user-attachments/assets/705c20b3-44c8-47eb-9ec2-98fc530e6fd3)


## How to Review

**crates/search/src/project_search.rs**

`entity_changed` no longer focuses the results editor on a new search. The block that called `focus_results_editor` when the query editor was focused is removed; `is_new_search` still gates first-match selection and scroll, so results are selected and scrolled into view as before — focus simply stays put. The explicit focus-to-results paths are untouched: the text/semantic finder deploy still calls `focus_results_editor` directly, and `move_focus_to_results` (Escape / ToggleFocus) still moves focus on demand.

`cycle_field` now appends `results_editor` to the focus ring when `has_matches()` is true. Because focus no longer lands on results automatically, this restores keyboard access: Tab moves query → (replacement / include / exclude, when enabled) → results, and Shift+Tab wraps back. It's only added when there are matches, so an empty result set doesn't trap focus on an inert editor.

`test_deploy_project_search_focus` and `test_new_project_search_focus` are updated to assert the new behavior: the query editor stays focused after search results arrive and after confirming a search, and `Tab` then moves focus to the results editor. `test_deploy_search_with_multiple_panes` is updated for the same focus expectation.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


Release Notes:

- Fixed project search moving keyboard focus off the search input after running a search.
