### PR TITLE
editor: Fix scrollbar auto-hide in files with uncommitted changes

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1315,9 +1315,6 @@ impl EditorElement {
             ShowScrollbar::Auto => {
                 let editor = self.editor.read(cx);
                 let is_singleton = editor.buffer_kind(cx) == ItemBufferKind::Singleton;
-                // Git
-                (is_singleton && scrollbar_settings.git_diff && snapshot.buffer_snapshot().has_diff_hunks())
-                ||
                 // Buffer Search Results
                 (is_singleton && scrollbar_settings.search_results && editor.has_background_highlights(HighlightKey::BufferSearchHighlights))
                 ||


### PR DESCRIPTION
# Objective

Issue: When there are uncommitted changes, the scrollbar will never auto-hide. 

Fixes #60065

## Solution

Fix the condition under which scrollbars are visible to ignore git changes.

There are some open design decisions when it comes to implementing the fix. Zed currently tightly couples the scrollbar and the colored git change highlights, which means that these highlights would now also fade away when the scrollbar is hidden. This is likely why previously having git changes did not hide the scrollbar.

VSCode auto-hides the scrollbar, but retains the git highlights indicating changes. This seems like the right approach, as it removes the visual clutter of having the highlights fade in and out, which is quite attention-grabbing, as Zed doesn't use much color.

What to do when the user disables the scrollbar entirely? Do we still display the git markers?

## Testing

I've written a test locally which tests the behavior, but it needed additional changes to get more visibility into the scrollbar rendering process. I'm still evaluating how to expose that information to keep the diff clean.

The changes can be manually tested by building Zed and following the reproduction steps in the linked issue.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed scrollbar auto-hide in files with uncommitted changes
