### PR TITLE
Fix musl linking failure in bundle-linux by setting CC for musl target

### DIFF
--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -88,6 +88,8 @@ cargo build --release --target "${target_triple}" --package zed --package cli
 # from influencing dynamic libraries required by it.
 if [[ "$remote_server_triple" == "$musl_triple" ]]; then
     export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
+    musl_cc_var="CC_$(echo "$remote_server_triple" | tr '-' '_')"
+    export "$musl_cc_var"=musl-gcc
 fi
 cargo build --release --target "${remote_server_triple}" --package remote_server
 


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/24880 

# Objective
"Assisted/analysed by AI"
> The remote_server musl build failed with undefined references to __isoc23_sscanf and __isoc23_strtol from aws-lc-sys because the default C compiler used glibc headers while linking against musl libc. Setting CC_<target>=musl-gcc ensures C dependencies compile with musl headers.

I have tested the fix, and it seems to have fixed the compilation issue I faced on Fedora 44, without resorting to the [hack noted in docs](https://zed.dev/docs/development/linux#installing-a-development-build).
Initially reported in this [issue](https://github.com/zed-industries/zed/issues/24880).

I'd want someone with expertise in the domain to take a look at this fix, as from what I understand, the process in the doc is a hacky workaround. 

## Solution

Setting CC_<target>=musl-gcc ensures C dependencies compile with musl headers.

## Testing

- Did you test these changes? If so, how?

    <details><summary>Here's my steps to repro:</summary>
    1. install [toolbox](https://github.com/containers/toolbox) (or podman-toolbox)
      (I used toolbox as it's easy to reuse the cloned repo, as the whole home dir is mounted in the devcontainer)
      Used the main branch - commit 5d6c88cdb71168d31c35a1057702f2fa26d5494e
    2. toolbox create -d fedora -r 44
    3. toolbox enter fedora-toolbox-44
    4. then run the `scripts/linux` script to install prereqs
    5. try compiling remote-server using the commands in `scripts/install-linux` (I just ran the script wholly)
    
    LDD version:
    ```
    ⬢[root@toolbox zed]# ldd --version
    ldd (GNU libc) 2.43
    ```
    
    GCC/MUSL versions:
    ```
    musl-gcc  : 1.2.5
    gcc : 16.1.1
    ```
    
    Error:
    ```
    error: linking with `cc` failed: exit status: 1
      |
      = note:  "cc" "-m64" "<sysroot>/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained/rcrt1.o" "<sysroot>/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained/crti.o" "<sysroot>/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained/crtbeginS.o" "<747 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "/root/zed/target/x86_64-unknown-linux-musl/release/deps/rustceHhjo8/{libzstd_sys-5c3eb6739555ecf4,libtree_sitter_json-ad90c8af7e8a3750,libtree_sitter-f91a92b688e12e56,libwasmtime-decd3377028506ce,libaws_lc_sys-a051f708b6dafc2a,libring-fcc1b43e3092bc93,libpsm-d967f50c6f2b67a4}.rlib" "-lunwind" "-lc" "<sysroot>/lib/rustlib/x86_64-unknown-linux-musl/lib/libcompiler_builtins-*.rlib" "-L" "/root/zed/target/x86_64-unknown-linux-musl/release/deps/rustceHhjo8/raw-dylibs" "-Wl,-Bdynamic" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-nostartfiles" "-L" "/root/zed/target/x86_64-unknown-linux-musl/release/build/psm-dc603221f407eabc/out" "-L" "/root/zed/target/x86_64-unknown-linux-musl/release/build/tree-sitter-28f7b87c1db3fab9/out" "-L" "/root/zed/target/x86_64-unknown-linux-musl/release/build/wasmtime-f0bb0950e09a7352/out" "-L" "/root/zed/target/x86_64-unknown-linux-musl/release/build/aws-lc-sys-2a7ca8eafafe18fa/out" "-L" "/root/zed/target/x86_64-unknown-linux-musl/release/build/ring-d7857a166bac60a6/out" "-L" "/root/zed/target/x86_64-unknown-linux-musl/release/build/zstd-sys-0e04609af7157148/out" "-L" "/root/zed/target/x86_64-unknown-linux-musl/release/build/tree-sitter-json-b1e2eeaba7bbb519/out" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-musl/lib" "-o" "/root/zed/target/x86_64-unknown-linux-musl/release/deps/remote_server-3782b255c59d4e14" "-Wl,--gc-sections" "-static-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-nodefaultlibs" "-Wl,--disable-new-dtags,-rpath,$ORIGIN/../lib" "<sysroot>/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained/crtendS.o" "<sysroot>/lib/rustlib/x86_64-unknown-linux-musl/lib/self-contained/crtn.o"
      = note: some arguments are omitted. use `--verbose` to show all linker arguments
      = note: /usr/bin/ld.bfd: /root/zed/target/x86_64-unknown-linux-musl/release/deps/rustceHhjo8/libaws_lc_sys-a051f708b6dafc2a.rlib(f8e4fd781484bd36-bcm.o): in function `aws_lc_0_40_0_handle_cpu_env':
              /aws-lc/crypto/fipsmodule/cpucap/cpu_intel.c:(.text.aws_lc_0_40_0_handle_cpu_env+0x63): undefined reference to `__isoc23_sscanf'
              /usr/bin/ld.bfd: /root/zed/target/x86_64-unknown-linux-musl/release/deps/rustceHhjo8/libaws_lc_sys-a051f708b6dafc2a.rlib(f8e4fd781484bd36-bcm.o): in function `pkey_rsa_ctrl_str':
              /aws-lc/crypto/fipsmodule/evp/p_rsa.c:692:(.text.pkey_rsa_ctrl_str+0x222): undefined reference to `__isoc23_strtol'
              /usr/bin/ld.bfd: /aws-lc/crypto/fipsmodule/evp/p_rsa.c:703:(.text.pkey_rsa_ctrl_str+0x261): undefined reference to `__isoc23_strtol'
              collect2: error: ld returned 1 exit status
              
      = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
      = note: use the `-l` flag to specify native libraries to link
      = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)
    
    error: could not compile `remote_server` (bin "remote_server") due to 1 previous error
    ```
    </details>

- Are there any parts that need more testing?  -- Maybe
- How can other people (reviewers) test your changes? Is there anything specific they need to know? -- Steps listed above
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? -- Fedora 44

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new user-facing feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - A before/after comparison is very useful for changes to existing features!

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

My super cool demos here

</details>

---

Release Notes:

- Fixed musl error when building remote server from source for the default musl triple on Linux
