### PR TITLE
Fix preview button acting on the focused editor instead of its own pane

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2083,6 +2083,19 @@ impl Thread {
         self.messages.last().map(std::ops::Deref::deref)
     }
 
+    /// Append a user message to the thread's history WITHOUT starting a turn, so
+    /// its text becomes context the model sees on the next prompt. Used for
+    /// pi-style `!` inline shell: the command output is added to context
+    /// silently (no immediate response), while the run itself is shown as a
+    /// UI-only terminal card.
+    pub fn inject_user_context(&mut self, text: String, cx: &mut Context<Self>) {
+        self.messages.push(Arc::new(Message::User(UserMessage {
+            id: ClientUserMessageId::new(),
+            content: Arc::from([UserMessageContent::Text(text)]),
+        })));
+        cx.notify();
+    }
+
     #[cfg(any(test, feature = "test-support"))]
     pub fn last_received_or_pending_message(&self) -> Option<Arc<Message>> {
         if let Some(message) = self.pending_message.clone() {

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -1821,13 +1821,16 @@ impl ConversationView {
             }
             AcpThreadEvent::AvailableCommandsUpdated(available_commands) => {
                 if let Some(thread_view) = self.thread_view(&session_id) {
-                    let available_skills = thread
+                    let native_connection = thread
                         .read(cx)
                         .connection()
                         .clone()
-                        .downcast::<agent::NativeAgentConnection>()
+                        .downcast::<agent::NativeAgentConnection>();
+                    let supports_inline_shell = native_connection.is_some();
+                    let available_skills = native_connection
+                        .as_ref()
                         .map(|native_connection| {
-                            native_available_skills(&native_connection, &session_id, cx)
+                            native_available_skills(native_connection.as_ref(), &session_id, cx)
                         })
                         .unwrap_or_default();
                     let has_slash_completions =
@@ -1839,8 +1842,11 @@ impl ConversationView {
                         .agent_display_name(&self.agent.agent_id())
                         .unwrap_or_else(|| self.agent.agent_id().0.to_string().into());
 
-                    let new_placeholder =
-                        placeholder_text(agent_display_name.as_ref(), has_slash_completions);
+                    let new_placeholder = placeholder_text(
+                        agent_display_name.as_ref(),
+                        has_slash_completions,
+                        supports_inline_shell,
+                    );
 
                     thread_view.update(cx, |thread_view, cx| {
                         let mut session_capabilities = thread_view.session_capabilities.write();
@@ -3278,19 +3284,28 @@ fn native_available_skills(
         .collect()
 }
 
-fn placeholder_text(agent_name: &str, has_commands: bool) -> String {
+fn placeholder_text(agent_name: &str, has_commands: bool, supports_inline_shell: bool) -> String {
+    let shell_suffix = if supports_inline_shell {
+        ", ! to run a shell command"
+    } else {
+        ""
+    };
+
     if agent_name == agent::ZED_AGENT_ID.as_ref() {
         format!(
-            "Message the {}, @ to include context, / for commands",
-            agent_name
+            "Message the {}, @ to include context, / for commands{}",
+            agent_name, shell_suffix
         )
     } else if has_commands {
         format!(
-            "Message {} — @ to include context, / for commands",
-            agent_name
+            "Message {} — @ to include context, / for commands{}",
+            agent_name, shell_suffix
         )
     } else {
-        format!("Message {} — @ to include context", agent_name)
+        format!(
+            "Message {} — @ to include context{}",
+            agent_name, shell_suffix
+        )
     }
 }
 

--- a/crates/agent_ui/src/conversation_view.rs
+++ b/crates/agent_ui/src/conversation_view.rs
@@ -29,12 +29,12 @@ use fs::Fs;
 use futures::FutureExt as _;
 use gpui::{
     Action, Animation, AnimationExt, App, ClickEvent, ClipboardItem, CursorStyle, ElementId, Empty,
-    Entity, EventEmitter, FocusHandle, Focusable, Hsla, ListOffset, ListState, ObjectFit,
-    PlatformDisplay, ScrollHandle, SharedString, StyledText, Subscription, Task, TextRun,
-    TextStyle, WeakEntity, Window, WindowHandle, div, ease_in_out, img, linear_color_stop,
-    linear_gradient, list, pulsating_between,
+    Entity, EntityId, EventEmitter, FocusHandle, Focusable, Hsla, ListOffset, ListState, ObjectFit,
+    PlatformDisplay, ScrollHandle, SharedString, StyledText, Subscription, Task, TextStyle,
+    WeakEntity, Window, WindowHandle, div, ease_in_out, img, linear_color_stop, linear_gradient,
+    list, pulsating_between,
 };
-use language::{Buffer, Language, Rope};
+use language::Buffer;
 use language_model::LanguageModelCompletionError;
 use markdown::{
     CodeBlockRenderer, CopyButtonVisibility, Markdown, MarkdownElement, MarkdownFont, MarkdownStyle,
@@ -57,7 +57,7 @@ use std::time::Instant;
 use std::{rc::Rc, time::Duration};
 use terminal_view::terminal_panel::TerminalPanel;
 use text::Anchor;
-use theme_settings::{AgentBufferFontSize, AgentUiFontSize};
+use theme_settings::{AgentBufferFontSize, AgentUiFontSize, ThemeSettings};
 use ui::{
     Callout, CircularProgress, CommonAnimationExt, ContextMenu, ContextMenuEntry, CopyButton,
     DecoratedIcon, DiffStat, Disclosure, Divider, DividerColor, IconDecoration, IconDecorationKind,

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -242,19 +242,140 @@ pub enum AcpThreadViewEvent {
 
 impl EventEmitter<AcpThreadViewEvent> for ThreadView {}
 
-/// `cat -n`-style numbered code block, already stripped of its line-number
-/// prefixes and ready to render. Line numbers are guaranteed to be contiguous
-/// starting at `first_number`, so we only store the first number and the line
-/// count rather than allocating a per-line `Vec`.
-struct ParsedCatNumberedCode {
-    code: String,
-    first_number: u32,
-    line_count: usize,
+struct PiStyleToolTitle {
+    name: String,
+    args: String,
+    dim: String,
 }
 
-fn parse_cat_numbered_markdown_code_block(markdown: &str) -> Option<ParsedCatNumberedCode> {
-    let (_tag, code) = parse_single_fenced_code_block(markdown)?;
-    parse_cat_numbered_code(code)
+fn json_string(input: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<String> {
+    input
+        .get(key)
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
+}
+
+fn compact_json_summary(value: &serde_json::Value) -> String {
+    match serde_json::to_string(value) {
+        Ok(mut json) => {
+            const MAX_LEN: usize = 140;
+            if json.len() > MAX_LEN {
+                json.truncate(MAX_LEN - 1);
+                json.push('…');
+            }
+            json
+        }
+        Err(_) => String::new(),
+    }
+}
+
+fn read_file_tool_line_range(raw_input: Option<&serde_json::Value>) -> String {
+    let Some(input) = raw_input.and_then(|input| input.as_object()) else {
+        return String::new();
+    };
+
+    let offset = input.get("offset").and_then(|offset| offset.as_u64());
+    let limit = input.get("limit").and_then(|limit| limit.as_u64());
+    if offset.is_none() && limit.is_none() {
+        return String::new();
+    }
+
+    let start = offset.unwrap_or(1);
+    if let Some(limit) = limit
+        && limit > 0
+    {
+        return format!(":{start}-{}", start + limit - 1);
+    }
+
+    format!(":{start}")
+}
+
+fn build_simple_unified_diff(path: &str, old_text: &str, new_text: &str) -> String {
+    if old_text == new_text {
+        return String::new();
+    }
+
+    const CONTEXT_LINES: usize = 3;
+    const MAX_DIFF_LINES: usize = 400;
+
+    let old_lines = old_text.lines().collect::<Vec<_>>();
+    let new_lines = new_text.lines().collect::<Vec<_>>();
+
+    let mut prefix_len = 0;
+    while prefix_len < old_lines.len()
+        && prefix_len < new_lines.len()
+        && old_lines[prefix_len] == new_lines[prefix_len]
+    {
+        prefix_len += 1;
+    }
+
+    let mut suffix_len = 0;
+    while suffix_len < old_lines.len().saturating_sub(prefix_len)
+        && suffix_len < new_lines.len().saturating_sub(prefix_len)
+        && old_lines[old_lines.len() - 1 - suffix_len]
+            == new_lines[new_lines.len() - 1 - suffix_len]
+    {
+        suffix_len += 1;
+    }
+
+    let old_changed_end = old_lines.len() - suffix_len;
+    let new_changed_end = new_lines.len() - suffix_len;
+    let old_hunk_start = prefix_len.saturating_sub(CONTEXT_LINES);
+    let new_hunk_start = prefix_len.saturating_sub(CONTEXT_LINES);
+    let old_hunk_end = (old_changed_end + CONTEXT_LINES).min(old_lines.len());
+    let new_hunk_end = (new_changed_end + CONTEXT_LINES).min(new_lines.len());
+
+    let old_count = old_hunk_end.saturating_sub(old_hunk_start).max(1);
+    let new_count = new_hunk_end.saturating_sub(new_hunk_start).max(1);
+
+    let mut output = String::new();
+    output.push_str(&format!("--- {path}\n+++ {path}\n"));
+    output.push_str(&format!(
+        "@@ -{},{} +{},{} @@\n",
+        old_hunk_start + 1,
+        old_count,
+        new_hunk_start + 1,
+        new_count
+    ));
+
+    let mut emitted = 0;
+    let mut push_line = |output: &mut String, prefix: char, line: &str| -> bool {
+        if emitted >= MAX_DIFF_LINES {
+            return false;
+        }
+        output.push(prefix);
+        output.push_str(line);
+        output.push('\n');
+        emitted += 1;
+        true
+    };
+
+    for line in &old_lines[old_hunk_start..prefix_len] {
+        if !push_line(&mut output, ' ', line) {
+            break;
+        }
+    }
+    for line in &old_lines[prefix_len..old_changed_end] {
+        if !push_line(&mut output, '-', line) {
+            break;
+        }
+    }
+    for line in &new_lines[prefix_len..new_changed_end] {
+        if !push_line(&mut output, '+', line) {
+            break;
+        }
+    }
+    for line in &old_lines[old_changed_end..old_hunk_end] {
+        if !push_line(&mut output, ' ', line) {
+            break;
+        }
+    }
+
+    if emitted >= MAX_DIFF_LINES {
+        output.push_str("… diff truncated …\n");
+    }
+
+    output
 }
 
 fn parse_single_fenced_code_block(markdown: &str) -> Option<(&str, &str)> {
@@ -271,242 +392,6 @@ fn parse_single_fenced_code_block(markdown: &str) -> Option<(&str, &str)> {
     let closing_fence = format!("\n{fence}\n");
     let code = after_tag.strip_suffix(&closing_fence)?;
     Some((tag, code))
-}
-
-/// Walks `code` exactly once: for each line it validates and strips the
-/// `NNN\t` prefix, then pushes the line's content into the accumulating
-/// code buffer (with `\n` between lines, no trailing newline). Verifies that
-/// the line numbers form a contiguous, increasing sequence.
-fn parse_cat_numbered_code(code: &str) -> Option<ParsedCatNumberedCode> {
-    if code.is_empty() {
-        return None;
-    }
-
-    let mut output = String::with_capacity(code.len());
-    let mut first_number = None;
-    let mut expected_number = None;
-    let mut line_count: usize = 0;
-    for raw_line in code.split_inclusive('\n') {
-        let line = strip_line_ending(raw_line);
-        let (number, text) = parse_cat_numbered_line(line)?;
-        if let Some(expected) = expected_number {
-            if number != expected {
-                return None;
-            }
-        } else {
-            first_number = Some(number);
-        }
-        expected_number = number.checked_add(1);
-        if line_count > 0 {
-            output.push('\n');
-        }
-        output.push_str(text);
-        line_count += 1;
-    }
-
-    Some(ParsedCatNumberedCode {
-        code: output,
-        first_number: first_number?,
-        line_count,
-    })
-}
-
-fn strip_line_ending(line: &str) -> &str {
-    let without_lf = line.strip_suffix('\n').unwrap_or(line);
-    without_lf.strip_suffix('\r').unwrap_or(without_lf)
-}
-
-fn parse_cat_numbered_line(line: &str) -> Option<(u32, &str)> {
-    let (prefix, text) = line.split_once('\t')?;
-    let number = prefix.trim();
-    if number.is_empty()
-        || !prefix
-            .chars()
-            .all(|character| character == ' ' || character.is_ascii_digit())
-    {
-        return None;
-    }
-
-    Some((number.parse().ok()?, text))
-}
-
-fn render_cat_numbered_code_block(
-    parsed: ParsedCatNumberedCode,
-    language: Option<Arc<Language>>,
-    markdown_style: MarkdownStyle,
-    copy_button_id: String,
-    cx: &App,
-) -> AnyElement {
-    use std::fmt::Write as _;
-
-    let ParsedCatNumberedCode {
-        code,
-        first_number,
-        line_count,
-    } = parsed;
-
-    // Line numbers are contiguous (verified during parsing), so the largest
-    // line number is `first_number + line_count - 1`. Sizing the gutter to
-    // that number's digit count means every rendered line contributes exactly
-    // `gutter_width` bytes to the gutter, plus a newline between adjacent
-    // lines.
-    let last_number = first_number
-        .saturating_add(u32::try_from(line_count.saturating_sub(1)).unwrap_or(u32::MAX));
-    let gutter_width = last_number.to_string().len().max(1);
-    let gutter_capacity = line_count * gutter_width + line_count.saturating_sub(1);
-
-    let mut gutter = String::with_capacity(gutter_capacity);
-    for i in 0..line_count {
-        if i > 0 {
-            gutter.push('\n');
-        }
-        let line_number = first_number.saturating_add(u32::try_from(i).unwrap_or(u32::MAX));
-        // Writes to a `String` are infallible, so the `Result` can be ignored.
-        let _ = write!(&mut gutter, "{line_number:>gutter_width$}");
-    }
-
-    let mut code_text_style = markdown_style.base_text_style.clone();
-    code_text_style.refine(&markdown_style.code_block.text);
-
-    let mut gutter_text_style = code_text_style.clone();
-    gutter_text_style.color = cx.theme().colors().text_muted;
-
-    let gutter_len = gutter.len();
-    let gutter = StyledText::new(gutter).with_runs(vec![gutter_text_style.to_run(gutter_len)]);
-
-    // Share `code` between syntax highlighting, the rendered `StyledText`, and
-    // the copy button via a single `SharedString` (cheap `Arc` clones) instead
-    // of cloning the underlying `String`.
-    let code: SharedString = code.into();
-    let code_runs = highlight_code_runs(&code, language.as_ref(), code_text_style, &markdown_style);
-    let code_text = StyledText::new(code.clone()).with_runs(code_runs);
-
-    let code_block_id = format!("read-file-code-block-{copy_button_id}");
-    let code_scroll_id = format!("read-file-code-scroll-{copy_button_id}");
-    let mut container = div()
-        .id(code_block_id)
-        .group("read-file-code-block")
-        .relative()
-        .w_full()
-        .whitespace_nowrap();
-    container.style().refine(&markdown_style.code_block);
-
-    // `overflow_x_scroll` only actually scrolls when the container is laid out
-    // as a flex container: in GPUI the default `Display` is `Block`, and a
-    // block-level child fills its parent's content width instead of overflowing
-    // it, so there is nothing for the scroll viewport to scroll. Using `flex()`
-    // on the scroll wrapper plus `flex_none()` on the inner item lets the inner
-    // item take its natural width (the unwrapped code), which is what overflows.
-    // `restrict_scroll_to_axis` then keeps vertical wheel events flowing through
-    // to the outer thread scroller. This mirrors the standard markdown
-    // code-block path in `crates/markdown/src/markdown.rs`.
-    let mut code_scroll = div()
-        .id(code_scroll_id)
-        .flex()
-        .flex_1()
-        .min_w_0()
-        .overflow_x_scroll()
-        .child(div().flex_none().child(code_text));
-    code_scroll.style().restrict_scroll_to_axis = Some(true);
-
-    container
-        .child(
-            h_flex()
-                .items_start()
-                .min_w_0()
-                .w_full()
-                .child(div().flex_none().pr_3().child(gutter))
-                .child(code_scroll),
-        )
-        .child(
-            h_flex()
-                .w_4()
-                .absolute()
-                .top_0()
-                .right_0()
-                .justify_end()
-                .visible_on_hover("read-file-code-block")
-                .child(CopyButton::new(copy_button_id, code).tooltip_label("Copy Code")),
-        )
-        .into_any_element()
-}
-
-fn highlight_code_runs(
-    code: &str,
-    language: Option<&Arc<Language>>,
-    code_text_style: TextStyle,
-    markdown_style: &MarkdownStyle,
-) -> Vec<TextRun> {
-    if code.is_empty() {
-        return Vec::new();
-    }
-
-    let Some(language) = language else {
-        return vec![code_text_style.to_run(code.len())];
-    };
-
-    let mut runs = Vec::new();
-    let mut offset = 0;
-    for (range, highlight_id) in language.highlight_text(&Rope::from(code), 0..code.len()) {
-        if range.start > offset {
-            runs.push(code_text_style.to_run(range.start - offset));
-        }
-
-        let mut run_style = code_text_style.clone();
-        if let Some(highlight) = markdown_style.syntax.get(highlight_id).cloned() {
-            run_style = run_style.highlight(highlight);
-        }
-        runs.push(run_style.to_run(range.len()));
-        offset = range.end;
-    }
-
-    if offset < code.len() {
-        runs.push(code_text_style.to_run(code.len() - offset));
-    }
-
-    runs
-}
-
-#[cfg(test)]
-mod numbered_code_block_tests {
-    use super::*;
-
-    #[test]
-    fn parses_cat_numbered_markdown_code_block() {
-        let parsed = parse_cat_numbered_markdown_code_block(
-            "```rs zed/crates/example.rs\n     2\tfn main() {\n     3\t    println!(\"hi\");\n     4\t}\n```\n",
-        )
-        .expect("cat-numbered block should parse");
-
-        assert_eq!(parsed.line_count, 3);
-        assert_eq!(parsed.first_number, 2);
-        assert_eq!(parsed.code, "fn main() {\n    println!(\"hi\");\n}");
-    }
-
-    #[test]
-    fn parses_cat_numbered_code_with_crlf_line_endings() {
-        let parsed = parse_cat_numbered_code("     1\tline one\r\n     2\tline two\r\n")
-            .expect("crlf-terminated cat-numbered code should parse");
-
-        assert_eq!(parsed.line_count, 2);
-        assert_eq!(parsed.first_number, 1);
-        assert_eq!(parsed.code, "line one\nline two");
-    }
-
-    #[test]
-    fn rejects_non_cat_numbered_code_block() {
-        assert!(parse_cat_numbered_markdown_code_block("```rs\nfn main() {}\n```\n").is_none());
-    }
-
-    #[test]
-    fn rejects_non_contiguous_cat_numbers() {
-        assert!(
-            parse_cat_numbered_markdown_code_block(
-                "```rs\n     2\tlet a = 1;\n     4\tlet b = 2;\n```\n"
-            )
-            .is_none()
-        );
-    }
 }
 
 /// Tracks the user's permission dropdown selection state for a specific tool call.
@@ -3185,6 +3070,12 @@ impl ThreadView {
         let changed_buffers = action_log.read(cx).changed_buffers(cx).collect::<Vec<_>>();
         let plan = thread.plan();
         let queue_is_empty = !self.has_queued_messages();
+        let is_generating =
+            matches!(thread.status(), ThreadStatus::Generating) && !thread.is_compacting();
+        let confirmation = thread
+            .entries()
+            .last()
+            .is_some_and(|entry| self.is_waiting_for_confirmation(entry, cx));
 
         let awaiting_permission = self
             .render_main_agent_awaiting_permission(window, cx)
@@ -3194,6 +3085,7 @@ impl ThreadView {
         if changed_buffers.is_empty()
             && plan.is_empty()
             && queue_is_empty
+            && !is_generating
             && !has_awaiting_permission
         {
             return None;
@@ -3281,6 +3173,13 @@ impl ThreadView {
                         .when(queue_expanded, |parent| {
                             parent.child(self.render_message_queue_entries(window, cx))
                         })
+                    })
+                    .when(is_generating, |this| {
+                        this.when(
+                            !queue_is_empty || !plan.is_empty() || !changed_buffers.is_empty(),
+                            |this| this.child(Divider::horizontal().color(DividerColor::Border)),
+                        )
+                        .child(self.render_generating(confirmation, cx))
                     }),
             )
             .into_any()
@@ -3731,6 +3630,7 @@ impl ThreadView {
         _window: &mut Window,
         cx: &Context<Self>,
     ) -> impl IntoElement {
+        let palette = AgentStylePalette::new(cx);
         let queue_count = self.message_queue.len();
         let title: SharedString = if queue_count == 1 {
             "1 Queued Message".into()
@@ -3740,9 +3640,13 @@ impl ThreadView {
 
         h_flex()
             .p_1()
+            .pl_2()
             .w_full()
             .gap_1()
             .justify_between()
+            .border_l_2()
+            .border_color(palette.text_accent)
+            .bg(palette.tool_pending_bg)
             .when(self.queue_expanded, |this| {
                 this.border_b_1().border_color(cx.theme().colors().border)
             })
@@ -4416,12 +4320,23 @@ impl ThreadView {
         }
 
         let focus_handle = self.message_editor.focus_handle(cx);
-        let editor_bg_color = cx.theme().colors().editor_background;
+        let palette = AgentStylePalette::new(cx);
+        let editor_bg_color = palette.panel;
         // pi-style bash-mode left-rail tint on the composer.
         let shell_mode = if self.editing_message.is_none() && self.as_native_thread(cx).is_some() {
             self.message_editor.read(cx).shell_mode()
         } else {
             None
+        };
+
+        let editor_focused = focus_handle.is_focused(window);
+        let input_border_color = match (editor_focused, shell_mode) {
+            (_, Some(crate::message_editor::InlineShellMode::Visible)) => palette.text_accent,
+            (_, Some(crate::message_editor::InlineShellMode::Hidden)) => {
+                palette.text_accent.opacity(0.45)
+            }
+            (true, None) => cx.theme().colors().border_focused,
+            (false, None) => palette.line,
         };
 
         let editor_expanded = self.editor_expanded;
@@ -4437,14 +4352,14 @@ impl ThreadView {
 
         h_flex()
             .py_2()
-            .bg(editor_bg_color)
+            .bg(cx.theme().colors().panel_background)
             .justify_center()
             .on_action(cx.listener(Self::handle_message_editor_move_up))
             .map(|this| {
                 if has_messages {
                     this.on_action(cx.listener(Self::expand_message_editor))
                         .border_t_1()
-                        .border_color(cx.theme().colors().border)
+                        .border_color(palette.line)
                         .when(editor_expanded, |this| this.h(vh(0.8, window)))
                 } else {
                     this.flex_1().size_full()
@@ -4466,18 +4381,11 @@ impl ThreadView {
                             .w_full()
                             .min_h_0()
                             .when(fills_container, |this| this.flex_1())
-                            .border_l_2()
-                            .border_color(match shell_mode {
-                                Some(crate::message_editor::InlineShellMode::Visible) => {
-                                    cx.theme().colors().text_accent
-                                }
-                                Some(crate::message_editor::InlineShellMode::Hidden) => {
-                                    cx.theme().colors().text_accent.opacity(0.45)
-                                }
-                                None => cx.theme().colors().border.opacity(0.),
-                            })
-                            .when(shell_mode.is_some(), |this| this.pl_1p5())
-                            .pt_1()
+                            .rounded_md()
+                            .border_1()
+                            .border_color(input_border_color)
+                            .bg(editor_bg_color)
+                            .p_1()
                             .pr_2p5()
                             .child(self.message_editor.clone())
                             .when(has_messages, |this| {
@@ -4585,10 +4493,10 @@ impl ThreadView {
         _window: &mut Window,
         cx: &Context<Self>,
     ) -> impl IntoElement {
+        let palette = AgentStylePalette::new(cx);
         let message_editor = self.message_editor.read(cx);
         let focus_handle = message_editor.focus_handle(cx);
 
-        let queue_len = self.message_queue.len();
         let can_fast_track = self.message_queue.can_fast_track();
         let is_native = self.as_native_thread(cx).is_some();
 
@@ -4596,6 +4504,8 @@ impl ThreadView {
             .id("message_queue_list")
             .max_h_40()
             .overflow_y_scroll()
+            .gap_1()
+            .p_1()
             .children(self.message_queue.iter().enumerate().map(|(index, entry)| {
                 let entry_id = entry.id;
                 let editor = &entry.editor;
@@ -4617,11 +4527,13 @@ impl ThreadView {
                     .w_full()
                     .p_1p5()
                     .gap_1()
-                    .bg(cx.theme().colors().editor_background)
-                    .when(index < queue_len - 1, |this| {
-                        this.border_b_1()
-                            .border_color(cx.theme().colors().border_variant)
+                    .border_l_2()
+                    .border_color(if is_next {
+                        palette.text_accent
+                    } else {
+                        palette.line.opacity(0.8)
                     })
+                    .bg(palette.tool_pending_bg)
                     .child(
                         div()
                             .id("next_in_queue")
@@ -6167,6 +6079,56 @@ fn sandbox_network_rows(network: &SandboxNetPolicy) -> Vec<SandboxRow> {
     }
 }
 
+#[derive(Clone, Copy)]
+struct AgentStylePalette {
+    panel: Hsla,
+    line: Hsla,
+    text_accent: Hsla,
+    user_message_bg: Hsla,
+    tool_pending_bg: Hsla,
+    tool_success_bg: Hsla,
+    tool_error_bg: Hsla,
+    tool_pending_border: Hsla,
+    tool_success_border: Hsla,
+    tool_error_border: Hsla,
+    tool_output: Hsla,
+    diff_added: Hsla,
+    diff_removed: Hsla,
+    diff_context: Hsla,
+    thinking_border: Hsla,
+    thinking_text: Hsla,
+}
+
+impl AgentStylePalette {
+    fn new(cx: &App) -> Self {
+        let colors = cx.theme().colors();
+        let status = cx.theme().status();
+        let panel = colors.editor_background;
+        let text_accent = colors.text_accent;
+        let success = status.success;
+        let error = status.error;
+
+        Self {
+            panel,
+            line: colors.border,
+            text_accent,
+            user_message_bg: panel,
+            tool_pending_bg: panel.blend(text_accent.opacity(0.06)),
+            tool_success_bg: panel.blend(success.opacity(0.05)),
+            tool_error_bg: panel.blend(error.opacity(0.08)),
+            tool_pending_border: text_accent.opacity(0.7),
+            tool_success_border: success.opacity(0.6),
+            tool_error_border: error.opacity(0.7),
+            tool_output: colors.text_muted,
+            diff_added: success,
+            diff_removed: error,
+            diff_context: colors.text_muted,
+            thinking_border: text_accent.opacity(0.6),
+            thinking_text: colors.text_muted,
+        }
+    }
+}
+
 impl ThreadView {
     fn render_entries(&mut self, cx: &mut Context<Self>) -> List {
         let max_content_width = AgentSettings::get_global(cx).max_content_width;
@@ -6233,6 +6195,9 @@ impl ThreadView {
                 let editing = self.editing_message == Some(entry_ix);
                 let editor_focus = editor.focus_handle(cx).is_focused(window);
                 let focus_border = cx.theme().colors().border_focused;
+                let palette = AgentStylePalette::new(cx);
+                let user_message_bg = palette.user_message_bg;
+                let use_bubble_style = !editing && !editor_focus;
                 // Drop shadows render as a dark halo on transparent windows.
                 let opaque_window = cx.theme().window_background_appearance()
                     == gpui::WindowBackgroundAppearance::Opaque;
@@ -6288,18 +6253,25 @@ impl ThreadView {
                             .relative()
                             .child(
                                 div()
-                                    .py_3()
-                                    .px_2()
                                     .rounded_md()
-                                    .bg(cx.theme().colors().editor_background)
-                                    .border_1()
-                                    .when(is_indented, |this| {
-                                        this.py_2().px_2().when(opaque_window, |this| {
-                                            this.shadow_sm()
-                                        })
-                                    })
-                                    .border_color(cx.theme().colors().border)
+                                    .bg(user_message_bg)
                                     .map(|this| {
+                                        if use_bubble_style {
+                                            return this.py_1p5().px_2p5();
+                                        }
+
+                                        let this = this
+                                            .py_3()
+                                            .px_2()
+                                            .bg(cx.theme().colors().editor_background)
+                                            .border_1()
+                                            .when(is_indented, |this| {
+                                                this.py_2().px_2().when(opaque_window, |this| {
+                                                    this.shadow_sm()
+                                                })
+                                            })
+                                            .border_color(cx.theme().colors().border);
+
                                         if !is_editable {
                                             if is_subagent {
                                                 return this.border_dashed();
@@ -7282,18 +7254,10 @@ impl ThreadView {
         });
     }
 
-    /// Ensures the list item count includes (or excludes) an extra item for the generating indicator
+    /// Ensures the list does not include an extra item for the generating indicator.
+    /// The working indicator is rendered above the composer, after queued messages.
     pub(crate) fn sync_generating_indicator(&mut self, cx: &App) {
-        let thread = self.thread.read(cx);
-
-        let is_generating =
-            matches!(thread.status(), ThreadStatus::Generating) && !thread.is_compacting();
-
-        if is_generating && !self.generating_indicator_in_list {
-            let entries_count = self.thread.read(cx).entries().len();
-            self.list_state.splice(entries_count..entries_count, 1);
-            self.generating_indicator_in_list = true;
-        } else if !is_generating && self.generating_indicator_in_list {
+        if self.generating_indicator_in_list {
             let entries_count = self.thread.read(cx).entries().len();
             self.list_state.splice(entries_count..entries_count + 1, 0);
             self.generating_indicator_in_list = false;
@@ -7333,8 +7297,8 @@ impl ThreadView {
 
         h_flex()
             .id("generating-spinner")
-            .py_2()
-            .px(rems_from_px(22.))
+            .py_1()
+            .px_3()
             .gap_2()
             .map(|this| {
                 if confirmation {
@@ -7454,7 +7418,8 @@ impl ThreadView {
             }
         }
 
-        let panel_bg = cx.theme().colors().panel_background;
+        let palette = AgentStylePalette::new(cx);
+        let panel_bg = palette.panel;
 
         v_flex()
             .gap_1()
@@ -7473,15 +7438,10 @@ impl ThreadView {
                                 .gap_1p5()
                                 .overflow_hidden()
                                 .child(
-                                    Icon::new(IconName::ToolThink)
-                                        .size(IconSize::Small)
-                                        .color(Color::Muted),
-                                )
-                                .child(
-                                    div()
-                                        .text_size(self.tool_name_font_size())
-                                        .text_color(cx.theme().colors().text_muted)
-                                        .child("Thinking"),
+                                    Label::new("Thinking...")
+                                        .size(LabelSize::Small)
+                                        .color(Color::Muted)
+                                        .italic(),
                                 ),
                         )
                         .child(
@@ -7513,7 +7473,7 @@ impl ThreadView {
                                 .id(("thinking-content", chunk_ix))
                                 .pl_3p5()
                                 .border_l_2()
-                                .border_color(cx.theme().colors().text_accent.opacity(0.6))
+                                .border_color(palette.thinking_border)
                                 .when(is_constrained, |this| this.max_h_64())
                                 .when_some(scroll_handle, |this, scroll_handle| {
                                     this.track_scroll(&scroll_handle)
@@ -7523,8 +7483,8 @@ impl ThreadView {
                                     chunk,
                                     {
                                         let mut style =
-                                            MarkdownStyle::themed(MarkdownFont::Agent, window, cx)
-                                                .with_muted_text(cx);
+                                            MarkdownStyle::themed(MarkdownFont::Agent, window, cx);
+                                        style.base_text_style.color = palette.thinking_text;
                                         style.base_text_style.font_style = gpui::FontStyle::Italic;
                                         style
                                     },
@@ -7791,7 +7751,7 @@ impl ThreadView {
     fn render_collapsible_command(
         &self,
         group: SharedString,
-        is_preview: bool,
+        _is_preview: bool,
         command: Entity<Markdown>,
         window: &Window,
         cx: &Context<Self>,
@@ -7810,7 +7770,7 @@ impl ThreadView {
         style.container_style.text.line_height = Some(rems_from_px(17.).into());
         style.height_is_multiple_of_line_height = true;
         // pi renders the bash command string in the accent color.
-        style.base_text_style.color = cx.theme().colors().text_accent;
+        style.base_text_style.color = AgentStylePalette::new(cx).text_accent;
         // Soft-wrap the command instead of horizontally scrolling it: the card is
         // narrow, and in scroll mode a long command wraps anyway but its wrapped
         // lines don't pick up the code block's left padding. Wrap mode lays the
@@ -7818,18 +7778,6 @@ impl ThreadView {
         // line (wrapped or not) is padded consistently.
         style.code_block_overflow_x_scroll = false;
 
-        let run_command_label = if is_preview {
-            Some(
-                h_flex().h_6().child(
-                    Label::new("Run Command")
-                        .buffer_font(cx)
-                        .size(LabelSize::XSmall)
-                        .color(Color::Muted),
-                ),
-            )
-        } else {
-            None
-        };
         // Suppress the code block's built-in copy button so we don't stack two
         // copy buttons on top of each other; the outer button below is the one
         // we want, because it copies the unfenced command text.
@@ -7849,7 +7797,6 @@ impl ThreadView {
             .group(group)
             .relative()
             .p_1p5()
-            .when(is_preview, |this| this.pt_1().children(run_command_label))
             .child(
                 h_flex()
                     .w_full()
@@ -7878,7 +7825,6 @@ impl ThreadView {
         cx: &Context<Self>,
     ) -> AnyElement {
         let terminal_data = terminal.read(cx);
-        let working_dir = terminal_data.working_dir();
         let started_at = terminal_data.started_at();
 
         let tool_failed = matches!(
@@ -7927,11 +7873,6 @@ impl ThreadView {
             .blend(cx.theme().colors().editor_foreground.opacity(0.025));
         let border_color = cx.theme().colors().border.opacity(0.6);
 
-        let working_dir = working_dir
-            .as_ref()
-            .map(|path| path.display().to_string())
-            .unwrap_or_else(|| "current directory".to_string());
-
         let command_element = self.render_collapsible_command(
             header_group.clone(),
             false,
@@ -7945,6 +7886,12 @@ impl ThreadView {
             .read(cx)
             .is_tool_call_expanded(&tool_call.id);
 
+        let show_header = time_elapsed > Duration::from_secs(10)
+            || (!command_finished && !needs_confirmation)
+            || truncated_output
+            || tool_failed
+            || command_failed;
+
         let header = h_flex()
             .id(header_id)
             .pt_1()
@@ -7952,20 +7899,7 @@ impl ThreadView {
             .pr_1()
             .flex_none()
             .gap_1()
-            .justify_between()
-            .child(
-                div()
-                    .id(("command-target-path", terminal.entity_id()))
-                    .w_full()
-                    .max_w_full()
-                    .overflow_x_scroll()
-                    .child(
-                        Label::new(working_dir)
-                            .buffer_font(cx)
-                            .size(LabelSize::XSmall)
-                            .color(Color::Muted),
-                    ),
-            )
+            .justify_end()
             .child(
                 Disclosure::new(
                     SharedString::from(format!(
@@ -8086,6 +8020,10 @@ impl ThreadView {
                 )
             });
 
+        let terminal_output = output
+            .map(|output| output.content.trim_end_matches('\n').to_string())
+            .filter(|output| !output.is_empty());
+
         let terminal_view = self
             .entry_view_state
             .read(cx)
@@ -8109,11 +8047,20 @@ impl ThreadView {
                     .group(&header_group)
                     .bg(header_bg)
                     .text_xs()
-                    .child(header)
+                    .when(show_header, |this| this.child(header))
                     .child(command_element),
             )
             .when_some(tool_call.sandbox_not_applied.as_ref(), |this, reason| {
                 this.child(self.render_sandbox_not_applied_warning(reason, cx))
+            })
+            .when_some(terminal_output.filter(|_| !is_expanded), |this, output| {
+                this.child(self.render_terminal_output_text(
+                    terminal.entity_id(),
+                    output,
+                    border_color,
+                    window,
+                    cx,
+                ))
             })
             .when(is_expanded && terminal_view.is_some(), |this| {
                 this.child(
@@ -8159,6 +8106,34 @@ impl ThreadView {
                 ))
             })
             .into_any()
+    }
+
+    fn render_terminal_output_text(
+        &self,
+        terminal_id: EntityId,
+        output: String,
+        border_color: Hsla,
+        window: &Window,
+        cx: &Context<Self>,
+    ) -> AnyElement {
+        let text: SharedString = output.into();
+        let mut text_style = MarkdownStyle::themed(MarkdownFont::Agent, window, cx)
+            .with_buffer_font(cx)
+            .base_text_style;
+        text_style.color = AgentStylePalette::new(cx).tool_output;
+        let text_len = text.len();
+        let text = StyledText::new(text).with_runs(vec![text_style.to_run(text_len)]);
+
+        div()
+            .id(("terminal-tool-output", terminal_id))
+            .pt_2()
+            .p_1p5()
+            .border_t_1()
+            .border_color(border_color)
+            .bg(cx.theme().colors().editor_background)
+            .overflow_x_scroll()
+            .child(div().flex_none().whitespace_nowrap().child(text))
+            .into_any_element()
     }
 
     /// Render the "ran without sandbox" warning shown on a terminal tool card,
@@ -9740,6 +9715,12 @@ impl ThreadView {
         cx: &Context<Self>,
     ) -> Div {
         let has_location = tool_call.locations.len() == 1;
+        if let Some(label) =
+            self.render_pi_style_tool_call_label(tool_call, use_card_layout, window, cx)
+        {
+            return label;
+        }
+
         let is_file = tool_call.kind == acp::ToolKind::Edit && has_location;
         let is_subagent_tool_call = tool_call.is_subagent();
 
@@ -9856,7 +9837,7 @@ impl ThreadView {
                             // pi accents the primary argument (tool paths /
                             // patterns are inline code in the title) as bright
                             // accent text rather than a boxed code chip.
-                            style.inline_code.color = Some(cx.theme().colors().text_accent);
+                            style.inline_code.color = Some(AgentStylePalette::new(cx).text_accent);
                             style.inline_code.background_color = None;
                             style
                         },
@@ -9876,7 +9857,7 @@ impl ThreadView {
                             let mut style = MarkdownStyle::themed(MarkdownFont::Agent, window, cx);
                             // pi accents the primary argument (inline code in the
                             // title) as bright accent text, not a boxed chip.
-                            style.inline_code.color = Some(cx.theme().colors().text_accent);
+                            style.inline_code.color = Some(AgentStylePalette::new(cx).text_accent);
                             style.inline_code.background_color = None;
                             style
                         },
@@ -9885,6 +9866,207 @@ impl ThreadView {
                     .into_any()
             })
             .when(!is_edit, |this| this.child(gradient_overlay))
+    }
+
+    fn render_pi_style_tool_call_label(
+        &self,
+        tool_call: &ToolCall,
+        use_card_layout: bool,
+        window: &Window,
+        cx: &Context<Self>,
+    ) -> Option<Div> {
+        let title = self.pi_style_tool_title(tool_call, cx)?;
+        let label = h_flex()
+            .relative()
+            .w_full()
+            .h(window.line_height() - px(2.))
+            .text_size(self.tool_name_font_size())
+            .gap_1p5()
+            .when(use_card_layout, |this| this.px_1())
+            .overflow_hidden()
+            .child(
+                Label::new(title.name)
+                    .buffer_font(cx)
+                    .size(LabelSize::Small)
+                    .weight(gpui::FontWeight::BOLD)
+                    .color(Color::Accent),
+            )
+            .when(!title.args.is_empty(), |this| {
+                this.child(
+                    div().min_w_0().overflow_hidden().text_ellipsis().child(
+                        Label::new(title.args)
+                            .buffer_font(cx)
+                            .size(LabelSize::Small)
+                            .color(Color::Accent),
+                    ),
+                )
+            })
+            .when(!title.dim.is_empty(), |this| {
+                this.child(
+                    Label::new(title.dim)
+                        .buffer_font(cx)
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                )
+            });
+
+        Some(label)
+    }
+
+    fn pi_style_tool_title(
+        &self,
+        tool_call: &ToolCall,
+        cx: &Context<Self>,
+    ) -> Option<PiStyleToolTitle> {
+        let tool_name = tool_call.tool_name.as_ref()?.as_ref();
+        let input = tool_call
+            .raw_input
+            .as_ref()
+            .and_then(|input| input.as_object());
+        let path = self.tool_call_path_display(tool_call, input, cx);
+
+        let title = match tool_name {
+            "read" | "read_file" => PiStyleToolTitle {
+                name: "read".into(),
+                args: path?,
+                dim: read_file_tool_line_range(tool_call.raw_input.as_ref()),
+            },
+            "grep" => {
+                let pattern = input
+                    .and_then(|input| {
+                        json_string(input, "pattern").or_else(|| json_string(input, "regex"))
+                    })
+                    .unwrap_or_default();
+                let mut dim = String::new();
+                if let Some(include_pattern) =
+                    input.and_then(|input| json_string(input, "include_pattern"))
+                {
+                    dim.push_str(" in ");
+                    dim.push_str(&include_pattern);
+                }
+                if input
+                    .and_then(|input| input.get("case_sensitive"))
+                    .and_then(|value| value.as_bool())
+                    == Some(true)
+                {
+                    dim.push_str(" (case-sensitive)");
+                }
+                PiStyleToolTitle {
+                    name: "grep".into(),
+                    args: format!("/{pattern}/"),
+                    dim,
+                }
+            }
+            "find" | "find_path" => PiStyleToolTitle {
+                name: "find".into(),
+                args: input
+                    .and_then(|input| {
+                        json_string(input, "pattern").or_else(|| json_string(input, "glob"))
+                    })
+                    .unwrap_or_default(),
+                dim: String::new(),
+            },
+            "terminal" | "sandboxed_terminal" => PiStyleToolTitle {
+                name: "$".into(),
+                args: input
+                    .and_then(|input| {
+                        json_string(input, "command").or_else(|| json_string(input, "cmd"))
+                    })
+                    .unwrap_or_default(),
+                dim: String::new(),
+            },
+            "fetch" => PiStyleToolTitle {
+                name: "fetch".into(),
+                args: input
+                    .and_then(|input| json_string(input, "url"))
+                    .unwrap_or_default(),
+                dim: String::new(),
+            },
+            "search_web" | "web_search" => PiStyleToolTitle {
+                name: "search".into(),
+                args: input
+                    .and_then(|input| json_string(input, "query"))
+                    .unwrap_or_default(),
+                dim: String::new(),
+            },
+            "list_directory" => PiStyleToolTitle {
+                name: "ls".into(),
+                args: path.unwrap_or_default(),
+                dim: String::new(),
+            },
+            "edit_file" => PiStyleToolTitle {
+                name: "edit".into(),
+                args: path.unwrap_or_default(),
+                dim: String::new(),
+            },
+            "write_file" => PiStyleToolTitle {
+                name: "write".into(),
+                args: path.unwrap_or_default(),
+                dim: String::new(),
+            },
+            "delete_path" => PiStyleToolTitle {
+                name: "delete".into(),
+                args: path.unwrap_or_default(),
+                dim: String::new(),
+            },
+            "move_path" => PiStyleToolTitle {
+                name: "move".into(),
+                args: input
+                    .and_then(|input| json_string(input, "source_path"))
+                    .or(path)
+                    .unwrap_or_default(),
+                dim: input
+                    .and_then(|input| json_string(input, "destination_path"))
+                    .map(|destination| format!(" to {destination}"))
+                    .unwrap_or_default(),
+            },
+            _ => PiStyleToolTitle {
+                name: tool_name.to_string(),
+                args: path
+                    .or_else(|| tool_call.raw_input.as_ref().map(compact_json_summary))
+                    .unwrap_or_default(),
+                dim: String::new(),
+            },
+        };
+
+        if title.args.is_empty() && title.dim.is_empty() {
+            return None;
+        }
+        Some(title)
+    }
+
+    fn tool_call_path_display(
+        &self,
+        tool_call: &ToolCall,
+        input: Option<&serde_json::Map<String, serde_json::Value>>,
+        cx: &Context<Self>,
+    ) -> Option<String> {
+        if let Some(location) = tool_call.locations.first() {
+            if let Some(project) = self.project.upgrade() {
+                if let Some(project_path) = project.read(cx).find_project_path(&location.path, cx)
+                    && let Some(worktree) = project
+                        .read(cx)
+                        .worktree_for_id(project_path.worktree_id, cx)
+                {
+                    return Some(
+                        worktree
+                            .read(cx)
+                            .full_path(&project_path.path)
+                            .to_string_lossy()
+                            .to_string(),
+                    );
+                }
+            }
+
+            return Some(location.path.display().to_string());
+        }
+
+        input.and_then(|input| {
+            json_string(input, "path")
+                .or_else(|| json_string(input, "file_path"))
+                .or_else(|| json_string(input, "filePath"))
+                .or_else(|| json_string(input, "source_path"))
+        })
     }
 
     fn open_tool_call_location(
@@ -10156,17 +10338,14 @@ impl ThreadView {
             ToolCallStatus::InProgress | ToolCallStatus::Pending
         );
 
-        let revealed_diff_editor = if let Some(entry) =
-            self.entry_view_state.read(cx).entry(entry_ix)
-            && let Some(editor) = entry.editor_for_diff(diff)
-            && diff.read(cx).has_revealed_range(cx)
-        {
-            Some(editor)
-        } else {
-            None
-        };
+        let diff_editor = self
+            .entry_view_state
+            .read(cx)
+            .entry(entry_ix)
+            .and_then(|entry| entry.editor_for_diff(diff));
+        let diff_has_revealed_range = diff.read(cx).has_revealed_range(cx);
 
-        let show_top_border = !has_failed || revealed_diff_editor.is_some();
+        let show_top_border = !has_failed || diff_editor.is_some();
 
         v_flex()
             .h_full()
@@ -10175,20 +10354,74 @@ impl ThreadView {
                     .when(has_failed, |this| this.border_dashed())
                     .border_color(self.tool_card_border_color(cx))
             })
-            .child(if let Some(editor) = revealed_diff_editor {
+            .child(if let Some(editor) = diff_editor {
                 editor.into_any_element()
             } else if tool_progress && self.as_native_connection(cx).is_some() {
                 self.render_diff_loading(cx)
+            } else if diff_has_revealed_range {
+                self.render_text_diff_output(entry_ix, diff, cx)
             } else {
-                Empty.into_any()
+                Empty.into_any_element()
             })
             .into_any()
+    }
+
+    fn render_text_diff_output(
+        &self,
+        entry_ix: usize,
+        diff: &Entity<acp_thread::Diff>,
+        cx: &Context<Self>,
+    ) -> AnyElement {
+        let diff = diff.read(cx);
+        let path = diff.file_path(cx).unwrap_or_else(|| "untitled".to_string());
+        let old_text = diff.base_text().as_ref();
+        let new_text = diff.buffer().read(cx).text();
+        let diff_text = build_simple_unified_diff(&path, old_text, &new_text);
+        if diff_text.is_empty() {
+            return Empty.into_any_element();
+        }
+
+        let palette = AgentStylePalette::new(cx);
+        let mut base_style = TextStyle::default();
+        base_style.font_family = ThemeSettings::get_global(cx).buffer_font.family.clone();
+        base_style.font_fallbacks = ThemeSettings::get_global(cx).buffer_font.fallbacks.clone();
+        base_style.font_features = ThemeSettings::get_global(cx).buffer_font.features.clone();
+        base_style.font_size = ThemeSettings::get_global(cx)
+            .agent_buffer_font_size(cx)
+            .into();
+        base_style.font_weight = ThemeSettings::get_global(cx).buffer_font.weight;
+        base_style.color = palette.diff_context;
+
+        let mut runs = Vec::new();
+        for line in diff_text.split_inclusive('\n') {
+            let mut line_style = base_style.clone();
+            if line.starts_with('+') && !line.starts_with("+++") {
+                line_style.color = palette.diff_added;
+            } else if line.starts_with('-') && !line.starts_with("---") {
+                line_style.color = palette.diff_removed;
+            } else if line.starts_with("@@") {
+                line_style.color = palette.text_accent;
+            }
+            runs.push(line_style.to_run(line.len()));
+        }
+
+        let diff_text: SharedString = diff_text.into();
+        let styled_diff = StyledText::new(diff_text).with_runs(runs);
+
+        div()
+            .id(("edit-tool-diff-output", entry_ix))
+            .flex()
+            .flex_1()
+            .min_w_0()
+            .overflow_x_scroll()
+            .child(div().flex_none().whitespace_nowrap().child(styled_diff))
+            .into_any_element()
     }
 
     fn render_markdown_output(
         &self,
         markdown: Entity<Markdown>,
-        entry_ix: usize,
+        _entry_ix: usize,
         context_ix: usize,
         tool_call: &ToolCall,
         card_layout: bool,
@@ -10197,14 +10430,7 @@ impl ThreadView {
     ) -> AnyElement {
         let markdown_style = MarkdownStyle::themed(MarkdownFont::Agent, window, cx);
         let output = self
-            .render_numbered_read_file_output(
-                markdown.clone(),
-                entry_ix,
-                context_ix,
-                tool_call,
-                markdown_style.clone(),
-                cx,
-            )
+            .render_plain_read_file_output(markdown.clone(), tool_call, window, cx)
             .unwrap_or_else(|| {
                 self.render_markdown(markdown, markdown_style, cx)
                     .into_any()
@@ -10226,18 +10452,16 @@ impl ThreadView {
                 }
             })
             .text_xs()
-            .text_color(cx.theme().colors().text_muted)
+            .text_color(AgentStylePalette::new(cx).tool_output)
             .child(output)
             .into_any_element()
     }
 
-    fn render_numbered_read_file_output(
+    fn render_plain_read_file_output(
         &self,
         markdown: Entity<Markdown>,
-        entry_ix: usize,
-        context_ix: usize,
         tool_call: &ToolCall,
-        markdown_style: MarkdownStyle,
+        window: &Window,
         cx: &Context<Self>,
     ) -> Option<AnyElement> {
         let is_read_file = tool_call
@@ -10249,15 +10473,28 @@ impl ThreadView {
         }
 
         let markdown = markdown.read(cx);
-        let parsed = parse_cat_numbered_markdown_code_block(markdown.source())?;
-        let language = markdown.first_code_block_language();
-        Some(render_cat_numbered_code_block(
-            parsed,
-            language,
-            markdown_style,
-            format!("copy-read-file-output-{entry_ix}-{context_ix}"),
-            cx,
-        ))
+        let source = markdown.source();
+        let text = parse_single_fenced_code_block(source)
+            .map(|(_, code)| code)
+            .unwrap_or(source);
+        let text: SharedString = text.into();
+        let mut text_style = MarkdownStyle::themed(MarkdownFont::Agent, window, cx)
+            .with_buffer_font(cx)
+            .base_text_style;
+        text_style.color = AgentStylePalette::new(cx).tool_output;
+        let text_len = text.len();
+        let text = StyledText::new(text).with_runs(vec![text_style.to_run(text_len)]);
+
+        Some(
+            div()
+                .id("read-file-tool-output")
+                .flex()
+                .flex_1()
+                .min_w_0()
+                .overflow_x_scroll()
+                .child(div().flex_none().whitespace_nowrap().child(text))
+                .into_any_element(),
+        )
     }
 
     fn render_image_output(
@@ -10754,41 +10991,37 @@ impl ThreadView {
     }
 
     fn tool_card_header_bg(&self, cx: &Context<Self>) -> Hsla {
-        cx.theme()
-            .colors()
-            .element_background
-            .blend(cx.theme().colors().editor_foreground.opacity(0.025))
+        let palette = AgentStylePalette::new(cx);
+        palette.panel.blend(palette.line.opacity(0.25))
     }
 
     fn tool_card_border_color(&self, cx: &Context<Self>) -> Hsla {
-        cx.theme().colors().border.opacity(0.8)
+        AgentStylePalette::new(cx).line.opacity(0.8)
     }
 
     fn tool_status_bg(&self, status: &ToolCallStatus, cx: &Context<Self>) -> Hsla {
-        let colors = cx.theme().colors();
-        let base = colors.editor_background;
-        let (tint, alpha) = match status {
+        let palette = AgentStylePalette::new(cx);
+        match status {
             ToolCallStatus::Failed | ToolCallStatus::Rejected | ToolCallStatus::Canceled => {
-                (cx.theme().status().error, 0.08)
+                palette.tool_error_bg
             }
             ToolCallStatus::WaitingForConfirmation { .. }
             | ToolCallStatus::Pending
-            | ToolCallStatus::InProgress => (colors.text_accent, 0.06),
-            ToolCallStatus::Completed => (cx.theme().status().success, 0.05),
-        };
-        base.blend(tint.opacity(alpha))
+            | ToolCallStatus::InProgress => palette.tool_pending_bg,
+            ToolCallStatus::Completed => palette.tool_success_bg,
+        }
     }
 
     fn tool_status_border(&self, status: &ToolCallStatus, cx: &Context<Self>) -> Hsla {
-        let colors = cx.theme().colors();
+        let palette = AgentStylePalette::new(cx);
         match status {
             ToolCallStatus::Failed | ToolCallStatus::Rejected | ToolCallStatus::Canceled => {
-                cx.theme().status().error.opacity(0.7)
+                palette.tool_error_border
             }
             ToolCallStatus::WaitingForConfirmation { .. }
             | ToolCallStatus::Pending
-            | ToolCallStatus::InProgress => colors.text_accent.opacity(0.7),
-            ToolCallStatus::Completed => cx.theme().status().success.opacity(0.6),
+            | ToolCallStatus::InProgress => palette.tool_pending_border,
+            ToolCallStatus::Completed => palette.tool_success_border,
         }
     }
 

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -788,7 +788,17 @@ impl ThreadView {
         let parent_session_id = thread.read(cx).parent_session_id().cloned();
 
         let has_slash_completions = session_capabilities.read().has_slash_completions();
-        let placeholder = placeholder_text(agent_display_name.as_ref(), has_slash_completions);
+        let supports_inline_shell = thread
+            .read(cx)
+            .connection()
+            .clone()
+            .downcast::<agent::NativeAgentConnection>()
+            .is_some();
+        let placeholder = placeholder_text(
+            agent_display_name.as_ref(),
+            has_slash_completions,
+            supports_inline_shell,
+        );
 
         let mut should_auto_submit = false;
         let mut show_external_source_prompt_warning = false;
@@ -808,6 +818,8 @@ impl ThreadView {
                 window,
                 cx,
             );
+            // Only the live composer participates in `!`/`!!` shell mode.
+            editor.set_shell_mode_enabled(supports_inline_shell);
             if let Some(content) = initial_content {
                 match content {
                     AgentInitialContent::ThreadSummary { session_id, title } => {
@@ -1487,6 +1499,33 @@ impl ThreadView {
 
         let text = message_editor.read(cx).text(cx);
         let text = text.trim();
+
+        // pi-style inline shell execution from the composer:
+        //   `!cmd`  runs in the project shell and sends its output to the model.
+        //   `!!cmd` runs in a live terminal card in the transcript, not sent to
+        //           the model (matches pi's "excluded from context").
+        if self.as_native_thread(cx).is_some() {
+            if let Some(after_bang) = text.strip_prefix('!') {
+                if let Some(rest) = after_bang.strip_prefix('!') {
+                    let command = rest.trim().to_string();
+                    if !command.is_empty() {
+                        message_editor.update(cx, |editor, cx| editor.clear(window, cx));
+                        self.run_inline_shell_card(command, false, window, cx);
+                        cx.notify();
+                        return;
+                    }
+                } else {
+                    let command = after_bang.trim().to_string();
+                    if !command.is_empty() {
+                        message_editor.update(cx, |editor, cx| editor.clear(window, cx));
+                        self.run_inline_shell_card(command, true, window, cx);
+                        cx.notify();
+                        return;
+                    }
+                }
+            }
+        }
+
         if text == "/login" || text == "/logout" {
             let connection = thread.read(cx).connection().clone();
             let can_login = !connection.auth_methods().is_empty();
@@ -1594,6 +1633,107 @@ impl ThreadView {
             anyhow::Ok(())
         })
         .detach_and_log_err(cx);
+    }
+
+    /// Run a command in a live terminal rendered as a pi-style `$ cmd` tool-call
+    /// card in the transcript (streaming output, Stop/Esc). The card itself is
+    /// UI-only; when `include_in_context` is true (`!cmd`) the finished output is
+    /// also injected into the native agent's history as silent context (no model
+    /// turn), and when false (`!!cmd`) it stays display-only — pi's "excluded
+    /// from context" semantics.
+    fn run_inline_shell_card(
+        &mut self,
+        command: String,
+        include_in_context: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(project) = self.project.upgrade() else {
+            return;
+        };
+        let cwd = project.read(cx).first_project_directory(cx);
+        let thread = self.thread.clone();
+
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // `!!` (excluded-from-context) cards get a distinct id prefix so the
+        // terminal renderer can show them dimmed.
+        let id_prefix = if include_in_context {
+            "user-bash"
+        } else {
+            "user-bash-hidden"
+        };
+        let tool_call_id = acp::ToolCallId::new(format!("{id_prefix}-{seq}"));
+
+        cx.spawn_in(window, async move |this, cx| {
+            let terminal = thread
+                .update(cx, |thread, cx| {
+                    thread.create_terminal(
+                        command.clone(),
+                        Vec::new(),
+                        Vec::new(),
+                        cwd,
+                        Some(1_000_000),
+                        None,
+                        cx,
+                    )
+                })
+                .await?;
+            let terminal_id = terminal.read_with(cx, |terminal, _| terminal.id().clone());
+
+            let build = |status: acp::ToolCallStatus| {
+                acp::ToolCall::new(tool_call_id.clone(), command.clone())
+                    .kind(acp::ToolKind::Execute)
+                    .status(status)
+                    .content(vec![acp::ToolCallContent::Terminal(acp::Terminal::new(
+                        terminal_id.clone(),
+                    ))])
+            };
+
+            thread.update(cx, |thread, cx| {
+                thread.upsert_tool_call(build(acp::ToolCallStatus::InProgress), cx)
+            })?;
+
+            let wait = terminal.read_with(cx, |terminal, _| terminal.wait_for_exit());
+            let exit = wait.await;
+            let status = if exit.exit_code == Some(0) {
+                acp::ToolCallStatus::Completed
+            } else {
+                acp::ToolCallStatus::Failed
+            };
+
+            thread.update(cx, |thread, cx| thread.upsert_tool_call(build(status), cx))?;
+
+            if include_in_context {
+                let output = terminal.read_with(cx, |terminal, cx| terminal.current_output(cx));
+                let mut body = output.output.trim_end().to_string();
+                const MAX_CHARS: usize = 16_000;
+                if body.chars().count() > MAX_CHARS {
+                    let kept: String = body.chars().take(MAX_CHARS).collect();
+                    body = format!("{kept}\n[output truncated]");
+                }
+                let mut block = if body.is_empty() {
+                    format!("$ {command}")
+                } else {
+                    format!("$ {command}\n{body}")
+                };
+                if exit.exit_code != Some(0) {
+                    if let Some(code) = exit.exit_code {
+                        block.push_str(&format!("\n[exited with code {code}]"));
+                    } else if let Some(signal) = &exit.signal {
+                        block.push_str(&format!("\n[terminated by signal {signal}]"));
+                    }
+                }
+                this.update(cx, |this, cx| {
+                    if let Some(native) = this.as_native_thread(cx) {
+                        native.update(cx, |native, cx| native.inject_user_context(block, cx));
+                    }
+                })
+                .ok();
+            }
+            anyhow::Ok(())
+        })
+        .detach();
     }
 
     pub fn send_impl(
@@ -4277,6 +4417,12 @@ impl ThreadView {
 
         let focus_handle = self.message_editor.focus_handle(cx);
         let editor_bg_color = cx.theme().colors().editor_background;
+        // pi-style bash-mode left-rail tint on the composer.
+        let shell_mode = if self.editing_message.is_none() && self.as_native_thread(cx).is_some() {
+            self.message_editor.read(cx).shell_mode()
+        } else {
+            None
+        };
 
         let editor_expanded = self.editor_expanded;
         let (expand_icon, expand_tooltip) = if editor_expanded {
@@ -4320,6 +4466,17 @@ impl ThreadView {
                             .w_full()
                             .min_h_0()
                             .when(fills_container, |this| this.flex_1())
+                            .border_l_2()
+                            .border_color(match shell_mode {
+                                Some(crate::message_editor::InlineShellMode::Visible) => {
+                                    cx.theme().colors().text_accent
+                                }
+                                Some(crate::message_editor::InlineShellMode::Hidden) => {
+                                    cx.theme().colors().text_accent.opacity(0.45)
+                                }
+                                None => cx.theme().colors().border.opacity(0.),
+                            })
+                            .when(shell_mode.is_some(), |this| this.pl_1p5())
                             .pt_1()
                             .pr_2p5()
                             .child(self.message_editor.clone())
@@ -7197,11 +7354,18 @@ impl ThreadView {
                 } else if is_blocked_on_terminal_command {
                     this
                 } else {
+                    // Spinner + a plain, non-animated "Working…" label (pi shows
+                    // the message static rather than pulsing it).
                     this.child(
                         h_flex()
                             .w_2()
                             .justify_center()
                             .child(GeneratingSpinnerElement::new(SpinnerVariant::Dots)),
+                    )
+                    .child(
+                        Label::new("Working…")
+                            .size(LabelSize::Small)
+                            .color(Color::Muted),
                     )
                 }
             })
@@ -7721,6 +7885,9 @@ impl ThreadView {
             &tool_call.status,
             ToolCallStatus::Rejected | ToolCallStatus::Canceled | ToolCallStatus::Failed
         );
+        // `!!` inline-shell runs carry this id prefix and are rendered dim to
+        // signal they are excluded from the model's context (pi's `!!`).
+        let excluded_from_context = tool_call.id.0.starts_with("user-bash-hidden-");
 
         let confirmation_options = match &tool_call.status {
             ToolCallStatus::WaitingForConfirmation { options, .. } => Some(options),
@@ -7927,7 +8094,7 @@ impl ThreadView {
 
         v_flex()
             .when(layout == ToolCallLayout::Standalone, |this| {
-                this.my_1p5()
+                this.my_1()
                     .mx_5()
                     .border_l_2()
                     .when(tool_failed || command_failed, |card| card.border_dashed())
@@ -7935,6 +8102,8 @@ impl ThreadView {
                     .bg(self.tool_status_bg(&tool_call.status, cx))
             })
             .overflow_hidden()
+            // pi renders `!!` (excluded-from-context) shell runs dimmed.
+            .when(excluded_from_context, |this| this.opacity(0.55))
             .child(
                 v_flex()
                     .group(&header_group)
@@ -8439,14 +8608,14 @@ impl ThreadView {
                 } else if use_card_layout {
                     // pi keeps tools flat: a status wash + 2px status-colored
                     // left rail with square corners, not a rounded boxed card.
-                    this.my_1p5()
+                    this.my_1()
                         .border_l_2()
                         .when(failed_or_canceled, |this| this.border_dashed())
                         .border_color(self.tool_status_border(&tool_call.status, cx))
                         .bg(self.tool_status_bg(&tool_call.status, cx))
                         .overflow_hidden()
                 } else {
-                    this.my_1()
+                    this.my_0p5()
                         .border_l_2()
                         .border_color(self.tool_status_border(&tool_call.status, cx))
                         .bg(self.tool_status_bg(&tool_call.status, cx))
@@ -10158,7 +10327,7 @@ impl ThreadView {
             cx,
         );
 
-        v_flex().mx_5().my_1p5().gap_3().child(content)
+        v_flex().mx_5().my_1().gap_3().child(content)
     }
 
     fn render_subagent_card(

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -7294,55 +7294,62 @@ impl ThreadView {
 
         v_flex()
             .gap_1()
-            .child(
-                h_flex()
-                    .id(header_id)
-                    .group(&card_header_id)
-                    .relative()
-                    .w_full()
-                    .pr_1()
-                    .justify_between()
-                    .child(
-                        h_flex()
-                            .h(window.line_height() - px(2.))
-                            .gap_1p5()
-                            .overflow_hidden()
-                            .child(
-                                Icon::new(IconName::ToolThink)
-                                    .size(IconSize::Small)
-                                    .color(Color::Muted),
-                            )
-                            .child(
-                                div()
-                                    .text_size(self.tool_name_font_size())
-                                    .text_color(cx.theme().colors().text_muted)
-                                    .child("Thinking"),
-                            ),
-                    )
-                    .child(
-                        Disclosure::new(("expand", entry_ix), is_open)
-                            .opened_icon(IconName::ChevronUp)
-                            .closed_icon(IconName::ChevronDown)
-                            .visible_on_hover(&card_header_id)
-                            .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                                this.toggle_thinking_block_expansion(key, window, cx);
-                            })),
-                    )
-                    .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
-                        this.toggle_thinking_block_expansion(key, window, cx);
-                    })),
-            )
+            .when(!is_open, |this| {
+                this.child(
+                    h_flex()
+                        .id(header_id)
+                        .group(&card_header_id)
+                        .relative()
+                        .w_full()
+                        .pr_1()
+                        .justify_between()
+                        .child(
+                            h_flex()
+                                .h(window.line_height() - px(2.))
+                                .gap_1p5()
+                                .overflow_hidden()
+                                .child(
+                                    Icon::new(IconName::ToolThink)
+                                        .size(IconSize::Small)
+                                        .color(Color::Muted),
+                                )
+                                .child(
+                                    div()
+                                        .text_size(self.tool_name_font_size())
+                                        .text_color(cx.theme().colors().text_muted)
+                                        .child("Thinking"),
+                                ),
+                        )
+                        .child(
+                            Disclosure::new(("expand", entry_ix), is_open)
+                                .opened_icon(IconName::ChevronUp)
+                                .closed_icon(IconName::ChevronDown)
+                                .visible_on_hover(&card_header_id)
+                                .on_click(cx.listener(
+                                    move |this, _event: &ClickEvent, window, cx| {
+                                        this.toggle_thinking_block_expansion(key, window, cx);
+                                    },
+                                )),
+                        )
+                        .on_click(cx.listener(move |this, _event: &ClickEvent, window, cx| {
+                            this.toggle_thinking_block_expansion(key, window, cx);
+                        })),
+                )
+            })
             .when(is_open, |this| {
                 this.child(
                     div()
+                        .relative()
+                        .group(SharedString::from(format!(
+                            "thinking-body-{entry_ix}-{chunk_ix}"
+                        )))
                         .when(is_constrained, |this| this.relative())
                         .child(
                             div()
                                 .id(("thinking-content", chunk_ix))
-                                .ml_1p5()
                                 .pl_3p5()
-                                .border_l_1()
-                                .border_color(self.tool_card_border_color(cx))
+                                .border_l_2()
+                                .border_color(cx.theme().colors().text_accent.opacity(0.6))
                                 .when(is_constrained, |this| this.max_h_64())
                                 .when_some(scroll_handle, |this, scroll_handle| {
                                     this.track_scroll(&scroll_handle)
@@ -7350,9 +7357,41 @@ impl ThreadView {
                                 .overflow_hidden()
                                 .child(self.render_markdown(
                                     chunk,
-                                    MarkdownStyle::themed(MarkdownFont::Agent, window, cx),
+                                    {
+                                        let mut style =
+                                            MarkdownStyle::themed(MarkdownFont::Agent, window, cx)
+                                                .with_muted_text(cx);
+                                        style.base_text_style.font_style = gpui::FontStyle::Italic;
+                                        style
+                                    },
                                     cx,
                                 )),
+                        )
+                        // pi-style: hover reveals a collapse chevron so the
+                        // expanded trace stays chrome-free by default.
+                        .child(
+                            div()
+                                .absolute()
+                                .top_0()
+                                .right_1()
+                                .visible_on_hover(SharedString::from(format!(
+                                    "thinking-body-{entry_ix}-{chunk_ix}"
+                                )))
+                                .child(
+                                    Disclosure::new(
+                                        SharedString::from(format!(
+                                            "collapse-thinking-{entry_ix}-{chunk_ix}"
+                                        )),
+                                        true,
+                                    )
+                                    .opened_icon(IconName::ChevronUp)
+                                    .closed_icon(IconName::ChevronDown)
+                                    .on_click(cx.listener(
+                                        move |this, _event: &ClickEvent, window, cx| {
+                                            this.toggle_thinking_block_expansion(key, window, cx);
+                                        },
+                                    )),
+                                ),
                         )
                         .when(is_constrained, |this| {
                             this.child(
@@ -7606,6 +7645,8 @@ impl ThreadView {
         style.container_style.text.font_size = Some(rems_from_px(12.).into());
         style.container_style.text.line_height = Some(rems_from_px(17.).into());
         style.height_is_multiple_of_line_height = true;
+        // pi renders the bash command string in the accent color.
+        style.base_text_style.color = cx.theme().colors().text_accent;
         // Soft-wrap the command instead of horizontally scrolling it: the card is
         // narrow, and in scroll mode a long command wraps anyway but its wrapped
         // lines don't pick up the code block's left padding. Wrap mode lays the
@@ -7613,7 +7654,6 @@ impl ThreadView {
         // line (wrapped or not) is padded consistently.
         style.code_block_overflow_x_scroll = false;
 
-        let header_bg = self.tool_card_header_bg(cx);
         let run_command_label = if is_preview {
             Some(
                 h_flex().h_6().child(
@@ -7645,9 +7685,20 @@ impl ThreadView {
             .group(group)
             .relative()
             .p_1p5()
-            .bg(header_bg)
             .when(is_preview, |this| this.pt_1().children(run_command_label))
-            .child(markdown_element)
+            .child(
+                h_flex()
+                    .w_full()
+                    .items_start()
+                    .gap_1p5()
+                    .child(
+                        Label::new("$")
+                            .buffer_font(cx)
+                            .size(LabelSize::Small)
+                            .color(Color::Accent),
+                    )
+                    .child(div().flex_1().min_w_0().child(markdown_element)),
+            )
             .child(div().absolute().top_1().right_1().child(copy_button))
     }
 
@@ -7735,7 +7786,6 @@ impl ThreadView {
             .flex_none()
             .gap_1()
             .justify_between()
-            .rounded_t_md()
             .child(
                 div()
                     .id(("command-target-path", terminal.entity_id()))
@@ -7867,8 +7917,7 @@ impl ThreadView {
                             )))
                         }),
                 )
-            })
-;
+            });
 
         let terminal_view = self
             .entry_view_state
@@ -7880,10 +7929,10 @@ impl ThreadView {
             .when(layout == ToolCallLayout::Standalone, |this| {
                 this.my_1p5()
                     .mx_5()
-                    .border_1()
+                    .border_l_2()
                     .when(tool_failed || command_failed, |card| card.border_dashed())
-                    .border_color(border_color)
-                    .rounded_md()
+                    .border_color(self.tool_status_border(&tool_call.status, cx))
+                    .bg(self.tool_status_bg(&tool_call.status, cx))
             })
             .overflow_hidden()
             .child(
@@ -7905,7 +7954,6 @@ impl ThreadView {
                         .when(tool_failed || command_failed, |card| card.border_dashed())
                         .border_color(border_color)
                         .bg(cx.theme().colors().editor_background)
-                        .rounded_b_md()
                         .text_ui_sm(cx)
                         .h_full()
                         .children(terminal_view.map(|terminal_view| {
@@ -8389,15 +8437,20 @@ impl ThreadView {
                 ) {
                     this
                 } else if use_card_layout {
+                    // pi keeps tools flat: a status wash + 2px status-colored
+                    // left rail with square corners, not a rounded boxed card.
                     this.my_1p5()
-                        .rounded_md()
-                        .border_1()
+                        .border_l_2()
                         .when(failed_or_canceled, |this| this.border_dashed())
-                        .border_color(self.tool_card_border_color(cx))
-                        .bg(cx.theme().colors().editor_background)
+                        .border_color(self.tool_status_border(&tool_call.status, cx))
+                        .bg(self.tool_status_bg(&tool_call.status, cx))
                         .overflow_hidden()
                 } else {
                     this.my_1()
+                        .border_l_2()
+                        .border_color(self.tool_status_border(&tool_call.status, cx))
+                        .bg(self.tool_status_bg(&tool_call.status, cx))
+                        .pl_1p5()
                 }
             })
             .when(layout == ToolCallLayout::Standalone, |this| {
@@ -8428,8 +8481,6 @@ impl ThreadView {
                             .justify_between()
                             .when(use_card_layout, |this| {
                                 this.p_0p5()
-                                    .rounded_t(rems_from_px(5.))
-                                    .bg(self.tool_card_header_bg(cx))
                             })
                             .child(self.render_tool_call_label(
                                 entry_ix,
@@ -9628,17 +9679,20 @@ impl ThreadView {
                             this.text_color(cx.theme().colors().text_muted)
                         }
                     })
-                    .child(
-                        self.render_markdown(
-                            tool_call.label.clone(),
-                            MarkdownStyle {
-                                prevent_mouse_interaction: true,
-                                ..MarkdownStyle::themed(MarkdownFont::Agent, window, cx)
-                                    .with_muted_text(cx)
-                            },
-                            cx,
-                        ),
-                    )
+                    .child(self.render_markdown(
+                        tool_call.label.clone(),
+                        {
+                            let mut style = MarkdownStyle::themed(MarkdownFont::Agent, window, cx);
+                            style.prevent_mouse_interaction = true;
+                            // pi accents the primary argument (tool paths /
+                            // patterns are inline code in the title) as bright
+                            // accent text rather than a boxed code chip.
+                            style.inline_code.color = Some(cx.theme().colors().text_accent);
+                            style.inline_code.background_color = None;
+                            style
+                        },
+                        cx,
+                    ))
                     .tooltip(Tooltip::text("Go to File"))
                     .on_click(cx.listener(move |this, _, window, cx| {
                         this.open_tool_call_location(entry_ix, 0, window, cx);
@@ -9649,7 +9703,14 @@ impl ThreadView {
                     .w_full()
                     .child(self.render_markdown(
                         tool_call.label.clone(),
-                        MarkdownStyle::themed(MarkdownFont::Agent, window, cx).with_muted_text(cx),
+                        {
+                            let mut style = MarkdownStyle::themed(MarkdownFont::Agent, window, cx);
+                            // pi accents the primary argument (inline code in the
+                            // title) as bright accent text, not a boxed chip.
+                            style.inline_code.color = Some(cx.theme().colors().text_accent);
+                            style.inline_code.background_color = None;
+                            style
+                        },
                         cx,
                     ))
                     .into_any()
@@ -10179,39 +10240,19 @@ impl ThreadView {
         };
 
         let card_header_id = format!("subagent-header-{}", entry_ix);
-        let status_icon = format!("status-icon-{}", entry_ix);
         let diff_stat_id = format!("subagent-diff-{}", entry_ix);
 
+        // pi conveys status by tinting the whole card (below), not with a ✓/✗
+        // glyph: keep the spinner while the subagent runs, otherwise show a
+        // neutral agent marker regardless of success/failure/cancel.
         let icon = h_flex().w_4().justify_center().child(if is_running {
             SpinnerLabel::new()
                 .size(LabelSize::Small)
                 .into_any_element()
-        } else if is_cancelled {
-            div()
-                .id(status_icon)
-                .child(
-                    Icon::new(IconName::Circle)
-                        .size(IconSize::Small)
-                        .color(Color::Custom(
-                            cx.theme().colors().icon_disabled.opacity(0.5),
-                        )),
-                )
-                .tooltip(Tooltip::text("Subagent Cancelled"))
-                .into_any_element()
-        } else if is_failed {
-            div()
-                .id(status_icon)
-                .child(
-                    Icon::new(IconName::Close)
-                        .size(IconSize::Small)
-                        .color(Color::Error),
-                )
-                .tooltip(Tooltip::text("Subagent Failed"))
-                .into_any_element()
         } else {
-            Icon::new(IconName::Check)
+            Icon::new(self.agent_icon)
                 .size(IconSize::Small)
-                .color(Color::Success)
+                .color(Color::Muted)
                 .into_any_element()
         });
 
@@ -10229,10 +10270,12 @@ impl ThreadView {
 
         v_flex()
             .w_full()
-            .rounded_md()
-            .border_1()
+            // pi-style: a flat block with a status-colored left rail + wash
+            // instead of a neutral rounded border box.
+            .border_l_2()
             .when(has_no_title_or_canceled, |this| this.border_dashed())
-            .border_color(self.tool_card_border_color(cx))
+            .border_color(self.tool_status_border(&tool_call.status, cx))
+            .bg(self.tool_status_bg(&tool_call.status, cx))
             .overflow_hidden()
             .child(
                 h_flex()
@@ -10241,9 +10284,6 @@ impl ThreadView {
                     .p_1()
                     .w_full()
                     .justify_between()
-                    .when(!has_no_title_or_canceled, |this| {
-                        this.bg(self.tool_card_header_bg(cx))
-                    })
                     .child(
                         h_flex()
                             .id(format!("subagent-title-{}", entry_ix))
@@ -10553,6 +10593,34 @@ impl ThreadView {
 
     fn tool_card_border_color(&self, cx: &Context<Self>) -> Hsla {
         cx.theme().colors().border.opacity(0.8)
+    }
+
+    fn tool_status_bg(&self, status: &ToolCallStatus, cx: &Context<Self>) -> Hsla {
+        let colors = cx.theme().colors();
+        let base = colors.editor_background;
+        let (tint, alpha) = match status {
+            ToolCallStatus::Failed | ToolCallStatus::Rejected | ToolCallStatus::Canceled => {
+                (cx.theme().status().error, 0.08)
+            }
+            ToolCallStatus::WaitingForConfirmation { .. }
+            | ToolCallStatus::Pending
+            | ToolCallStatus::InProgress => (colors.text_accent, 0.06),
+            ToolCallStatus::Completed => (cx.theme().status().success, 0.05),
+        };
+        base.blend(tint.opacity(alpha))
+    }
+
+    fn tool_status_border(&self, status: &ToolCallStatus, cx: &Context<Self>) -> Hsla {
+        let colors = cx.theme().colors();
+        match status {
+            ToolCallStatus::Failed | ToolCallStatus::Rejected | ToolCallStatus::Canceled => {
+                cx.theme().status().error.opacity(0.7)
+            }
+            ToolCallStatus::WaitingForConfirmation { .. }
+            | ToolCallStatus::Pending
+            | ToolCallStatus::InProgress => colors.text_accent.opacity(0.7),
+            ToolCallStatus::Completed => cx.theme().status().success.opacity(0.6),
+        }
     }
 
     fn tool_name_font_size(&self) -> Rems {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -4320,23 +4320,11 @@ impl ThreadView {
         }
 
         let focus_handle = self.message_editor.focus_handle(cx);
-        let palette = AgentStylePalette::new(cx);
-        let editor_bg_color = palette.panel;
-        // pi-style bash-mode left-rail tint on the composer.
+        let editor_bg_color = cx.theme().colors().editor_background;
         let shell_mode = if self.editing_message.is_none() && self.as_native_thread(cx).is_some() {
             self.message_editor.read(cx).shell_mode()
         } else {
             None
-        };
-
-        let editor_focused = focus_handle.is_focused(window);
-        let input_border_color = match (editor_focused, shell_mode) {
-            (_, Some(crate::message_editor::InlineShellMode::Visible)) => palette.text_accent,
-            (_, Some(crate::message_editor::InlineShellMode::Hidden)) => {
-                palette.text_accent.opacity(0.45)
-            }
-            (true, None) => cx.theme().colors().border_focused,
-            (false, None) => palette.line,
         };
 
         let editor_expanded = self.editor_expanded;
@@ -4352,14 +4340,14 @@ impl ThreadView {
 
         h_flex()
             .py_2()
-            .bg(cx.theme().colors().panel_background)
+            .bg(editor_bg_color)
             .justify_center()
             .on_action(cx.listener(Self::handle_message_editor_move_up))
             .map(|this| {
                 if has_messages {
                     this.on_action(cx.listener(Self::expand_message_editor))
                         .border_t_1()
-                        .border_color(palette.line)
+                        .border_color(cx.theme().colors().border)
                         .when(editor_expanded, |this| this.h(vh(0.8, window)))
                 } else {
                     this.flex_1().size_full()
@@ -4381,11 +4369,18 @@ impl ThreadView {
                             .w_full()
                             .min_h_0()
                             .when(fills_container, |this| this.flex_1())
-                            .rounded_md()
-                            .border_1()
-                            .border_color(input_border_color)
-                            .bg(editor_bg_color)
-                            .p_1()
+                            .border_l_2()
+                            .border_color(match shell_mode {
+                                Some(crate::message_editor::InlineShellMode::Visible) => {
+                                    cx.theme().colors().text_accent
+                                }
+                                Some(crate::message_editor::InlineShellMode::Hidden) => {
+                                    cx.theme().colors().text_accent.opacity(0.45)
+                                }
+                                None => cx.theme().colors().border.opacity(0.),
+                            })
+                            .when(shell_mode.is_some(), |this| this.pl_1p5())
+                            .pt_1()
                             .pr_2p5()
                             .child(self.message_editor.clone())
                             .when(has_messages, |this| {

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -6079,7 +6079,6 @@ struct AgentStylePalette {
     panel: Hsla,
     line: Hsla,
     text_accent: Hsla,
-    user_message_bg: Hsla,
     tool_pending_bg: Hsla,
     tool_success_bg: Hsla,
     tool_error_bg: Hsla,
@@ -6107,7 +6106,6 @@ impl AgentStylePalette {
             panel,
             line: colors.border,
             text_accent,
-            user_message_bg: panel,
             tool_pending_bg: panel.blend(text_accent.opacity(0.06)),
             tool_success_bg: panel.blend(success.opacity(0.05)),
             tool_error_bg: panel.blend(error.opacity(0.08)),
@@ -6190,9 +6188,6 @@ impl ThreadView {
                 let editing = self.editing_message == Some(entry_ix);
                 let editor_focus = editor.focus_handle(cx).is_focused(window);
                 let focus_border = cx.theme().colors().border_focused;
-                let palette = AgentStylePalette::new(cx);
-                let user_message_bg = palette.user_message_bg;
-                let use_bubble_style = !editing && !editor_focus;
                 // Drop shadows render as a dark halo on transparent windows.
                 let opaque_window = cx.theme().window_background_appearance()
                     == gpui::WindowBackgroundAppearance::Opaque;
@@ -6248,25 +6243,18 @@ impl ThreadView {
                             .relative()
                             .child(
                                 div()
+                                    .py_3()
+                                    .px_2()
                                     .rounded_md()
-                                    .bg(user_message_bg)
+                                    .bg(cx.theme().colors().editor_background)
+                                    .border_1()
+                                    .when(is_indented, |this| {
+                                        this.py_2().px_2().when(opaque_window, |this| {
+                                            this.shadow_sm()
+                                        })
+                                    })
+                                    .border_color(cx.theme().colors().border)
                                     .map(|this| {
-                                        if use_bubble_style {
-                                            return this.py_1p5().px_2p5();
-                                        }
-
-                                        let this = this
-                                            .py_3()
-                                            .px_2()
-                                            .bg(cx.theme().colors().editor_background)
-                                            .border_1()
-                                            .when(is_indented, |this| {
-                                                this.py_2().px_2().when(opaque_window, |this| {
-                                                    this.shadow_sm()
-                                                })
-                                            })
-                                            .border_color(cx.theme().colors().border);
-
                                         if !is_editable {
                                             if is_subagent {
                                                 return this.border_dashed();

--- a/crates/agent_ui/src/conversation_view/thread_view.rs
+++ b/crates/agent_ui/src/conversation_view/thread_view.rs
@@ -8281,7 +8281,6 @@ impl ThreadView {
         window: &Window,
         cx: &Context<Self>,
     ) -> Div {
-        let has_location = tool_call.locations.len() == 1;
         let card_header_id = SharedString::from(format!("inner-tool-call-header-{entry_ix}"));
 
         let failed_or_canceled = match &tool_call.status {
@@ -8597,16 +8596,7 @@ impl ThreadView {
                         .pl_1p5()
                 }
             })
-            .when(layout == ToolCallLayout::Standalone, |this| {
-                this.map(|this| {
-                    if has_location && !use_card_layout {
-                        this.ml_4()
-                    } else {
-                        this.ml_5()
-                    }
-                })
-                .mr_5()
-            })
+            .when(layout == ToolCallLayout::Standalone, |this| this.ml_5().mr_5())
             .map(|this| {
                 if is_terminal_tool {
                     this.child(self.render_collapsible_command(

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -199,7 +199,22 @@ impl PromptCompletionProviderDelegate for MessageEditorCompletionDelegate {
     }
 }
 
+/// Which inline-shell mode the composer is in, based on a leading `!`/`!!`
+/// (pi-style bash mode). Drives the composer's shell badge.
+#[derive(Clone, Copy, PartialEq)]
+pub enum InlineShellMode {
+    /// `!` — run and send output to the agent.
+    Visible,
+    /// `!!` — run locally, hidden from the agent.
+    Hidden,
+}
+
 pub struct MessageEditor {
+    shell_mode: Option<InlineShellMode>,
+    /// Whether this editor participates in pi-style `!`/`!!` shell mode. Only
+    /// the live composer sets this; edit-message editors leave it false so a
+    /// past message that happens to start with `!` doesn't light the rail.
+    shell_mode_enabled: bool,
     mention_set: Entity<MentionSet>,
     editor: Entity<Editor>,
     workspace: WeakEntity<Workspace>,
@@ -558,6 +573,23 @@ impl MessageEditor {
                 if let EditorEvent::Edited { .. } = event
                     && !editor.read(cx).read_only(cx)
                 {
+                    // pi-style bash mode (live composer only): a leading `!`/`!!`
+                    // flips the composer into shell mode (drives the rail).
+                    if this.shell_mode_enabled {
+                        let trimmed_start =
+                            editor.read(cx).text(cx).trim_start().to_string();
+                        let new_mode = if trimmed_start.starts_with("!!") {
+                            Some(InlineShellMode::Hidden)
+                        } else if trimmed_start.starts_with('!') {
+                            Some(InlineShellMode::Visible)
+                        } else {
+                            None
+                        };
+                        if this.shell_mode != new_mode {
+                            this.shell_mode = new_mode;
+                            cx.notify();
+                        }
+                    }
                     cx.emit(MessageEditorEvent::Edited);
                     editor.update(cx, |editor, cx| {
                         let snapshot = editor.snapshot(window, cx);
@@ -611,11 +643,24 @@ impl MessageEditor {
             thread_store,
             _subscriptions: subscriptions,
             _parse_slash_command_task: Task::ready(()),
+            shell_mode: None,
+            shell_mode_enabled: false,
         }
     }
 
     pub fn set_local_commands(&self, commands: Vec<PromptLocalCommand>) {
         *self.local_commands.write() = commands;
+    }
+
+    /// The composer's current pi-style shell mode (leading `!`/`!!`), or `None`.
+    pub fn shell_mode(&self) -> Option<InlineShellMode> {
+        self.shell_mode
+    }
+
+    /// Enable pi-style `!`/`!!` shell-mode detection for this editor. Called
+    /// only for the live composer.
+    pub fn set_shell_mode_enabled(&mut self, enabled: bool) {
+        self.shell_mode_enabled = enabled;
     }
 
     pub fn set_session_capabilities(

--- a/crates/csv_preview/src/csv_preview.rs
+++ b/crates/csv_preview/src/csv_preview.rs
@@ -13,7 +13,7 @@ use ui::{
     AbsoluteLength, ResizableColumnsState, SharedString, TableInteractionState,
     TableResizeBehavior, prelude::*,
 };
-use workspace::{Item, SplitDirection, Workspace};
+use workspace::{Item, Pane, Workspace};
 
 use crate::{parser::EditorState, settings::CsvPreviewSettings, types::TableLikeContent};
 
@@ -85,67 +85,76 @@ impl CsvPreviewView {
         workspace.register_action_renderer(|div, _, _, cx| {
             div.when(cx.has_flag::<TabularDataPreviewFeatureFlag>(), |div| {
                 div.on_action(cx.listener(|workspace, _: &OpenPreview, window, cx| {
-                    if let Some(editor) = workspace
-                        .active_item(cx)
-                        .and_then(|item| item.act_as::<Editor>(cx))
-                        .filter(|editor| Self::is_csv_file(editor, cx))
-                    {
-                        let csv_preview = Self::new(&editor, cx);
-                        workspace.active_pane().update(cx, |pane, cx| {
-                            let existing = pane
-                                .items_of_type::<CsvPreviewView>()
-                                .find(|view| view.read(cx).active_editor_state.editor == editor);
-                            if let Some(idx) = existing.and_then(|e| pane.index_for_item(&e)) {
-                                pane.activate_item(idx, true, true, window, cx);
-                            } else {
-                                pane.add_item(Box::new(csv_preview), true, true, None, window, cx);
-                            }
-                        });
-                        cx.notify();
+                    if let Some(editor) = Self::resolve_active_item_as_csv_editor(workspace, cx) {
+                        let pane = workspace.active_pane().clone();
+                        Self::open_preview_in_pane(editor, pane, window, cx);
                     }
                 }))
                 .on_action(cx.listener(
                     |workspace, _: &OpenPreviewToTheSide, window, cx| {
-                        if let Some(editor) = workspace
-                            .active_item(cx)
-                            .and_then(|item| item.act_as::<Editor>(cx))
-                            .filter(|editor| Self::is_csv_file(editor, cx))
+                        if let Some(editor) =
+                            Self::resolve_active_item_as_csv_editor(workspace, cx)
                         {
-                            let csv_preview = Self::new(&editor, cx);
-                            let pane = workspace
-                                .find_pane_in_direction(SplitDirection::Right, cx)
-                                .unwrap_or_else(|| {
-                                    workspace.split_pane(
-                                        workspace.active_pane().clone(),
-                                        SplitDirection::Right,
-                                        window,
-                                        cx,
-                                    )
-                                });
-                            pane.update(cx, |pane, cx| {
-                                let existing =
-                                    pane.items_of_type::<CsvPreviewView>().find(|view| {
-                                        view.read(cx).active_editor_state.editor == editor
-                                    });
-                                if let Some(idx) = existing.and_then(|e| pane.index_for_item(&e)) {
-                                    pane.activate_item(idx, true, true, window, cx);
-                                } else {
-                                    pane.add_item(
-                                        Box::new(csv_preview),
-                                        false,
-                                        false,
-                                        None,
-                                        window,
-                                        cx,
-                                    );
-                                }
-                            });
-                            cx.notify();
+                            let pane = workspace.active_pane().clone();
+                            Self::open_preview_to_the_side_of_pane(
+                                workspace, editor, pane, window, cx,
+                            );
                         }
                     },
                 ))
             })
         });
+    }
+
+    pub fn open_preview_in_pane(
+        editor: Entity<Editor>,
+        pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        Self::activate_or_add_preview(editor, pane, true, window, cx);
+    }
+
+    pub fn open_preview_to_the_side_of_pane(
+        workspace: &mut Workspace,
+        editor: Entity<Editor>,
+        origin_pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let target_pane = workspace.adjacent_pane_of(&origin_pane, window, cx);
+        Self::activate_or_add_preview(editor, target_pane, false, window, cx);
+    }
+
+    fn activate_or_add_preview(
+        editor: Entity<Editor>,
+        pane: Entity<Pane>,
+        focus: bool,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let existing_view_idx = Self::find_existing_preview_item_idx(pane.read(cx), &editor, cx);
+        if let Some(existing_view_idx) = existing_view_idx {
+            pane.update(cx, |pane, cx| {
+                pane.activate_item(existing_view_idx, focus, focus, window, cx);
+            });
+        } else {
+            let csv_preview = Self::new(&editor, cx);
+            pane.update(cx, |pane, cx| {
+                pane.add_item(Box::new(csv_preview), focus, focus, None, window, cx);
+            });
+        }
+        cx.notify();
+    }
+
+    fn find_existing_preview_item_idx(
+        pane: &Pane,
+        editor: &Entity<Editor>,
+        cx: &App,
+    ) -> Option<usize> {
+        pane.items_of_type::<CsvPreviewView>()
+            .find(|view| &view.read(cx).active_editor_state.editor == editor)
+            .and_then(|view| pane.index_for_item(&view))
     }
 
     fn new(editor: &Entity<Editor>, cx: &mut Context<Workspace>) -> Entity<Self> {
@@ -222,7 +231,7 @@ impl CsvPreviewView {
         Self::is_csv_file(&editor, cx).then_some(editor)
     }
 
-    fn is_csv_file(editor: &Entity<Editor>, cx: &App) -> bool {
+    pub fn is_csv_file(editor: &Entity<Editor>, cx: &App) -> bool {
         editor
             .read(cx)
             .buffer()

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -201,7 +201,11 @@ impl MarkdownStyle {
         };
 
         let mut text_style = window.text_style();
-        let line_height = buffer_font_size * 1.75;
+        let line_height = if is_agent {
+            ui_font_size * 1.5
+        } else {
+            buffer_font_size * 1.75
+        };
 
         text_style.refine(&TextStyleRefinement {
             font_family: Some(body_font_family),
@@ -242,10 +246,10 @@ impl MarkdownStyle {
                     bottom: Some(DefiniteLength::Absolute(AbsoluteLength::Pixels(px(8.)))),
                 },
                 margin: EdgesRefinement {
-                    top: Some(Length::Definite(px(8.).into())),
+                    top: Some(Length::Definite(px(if is_agent { 6. } else { 8. }).into())),
                     left: Some(Length::Definite(px(0.).into())),
                     right: Some(Length::Definite(px(0.).into())),
-                    bottom: Some(Length::Definite(px(12.).into())),
+                    bottom: Some(Length::Definite(px(if is_agent { 6. } else { 12. }).into())),
                 },
                 border_style: Some(BorderStyle::Solid),
                 border_widths: EdgesRefinement {
@@ -278,11 +282,11 @@ impl MarkdownStyle {
                 font_features: Some(theme_settings.buffer_font.features.clone()),
                 font_size: Some(buffer_font_size.into()),
                 font_weight: Some(buffer_font_weight),
-                background_color: Some(
-                    colors
-                        .editor_foreground
-                        .opacity(if is_agent { 0.12 } else { 0.08 }),
-                ),
+                background_color: Some(colors.editor_foreground.opacity(if is_agent {
+                    0.12
+                } else {
+                    0.08
+                })),
                 ..Default::default()
             },
             link: TextStyleRefinement {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -298,28 +298,36 @@ impl MarkdownStyle {
             soft_break_as_hard_break: matches!(font, MarkdownFont::Agent),
             heading_level_styles: matches!(font, MarkdownFont::Agent).then_some(
                 HeadingLevelStyles {
+                    // pi colors transcript headings (its `--md-heading`); use the
+                    // theme accent so they stand out from body text.
                     h1: Some(TextStyleRefinement {
                         font_size: Some(rems(1.15).into()),
+                        color: Some(colors.text_accent),
                         ..Default::default()
                     }),
                     h2: Some(TextStyleRefinement {
                         font_size: Some(rems(1.1).into()),
+                        color: Some(colors.text_accent),
                         ..Default::default()
                     }),
                     h3: Some(TextStyleRefinement {
                         font_size: Some(rems(1.05).into()),
+                        color: Some(colors.text_accent),
                         ..Default::default()
                     }),
                     h4: Some(TextStyleRefinement {
                         font_size: Some(rems(1.).into()),
+                        color: Some(colors.text_accent),
                         ..Default::default()
                     }),
                     h5: Some(TextStyleRefinement {
                         font_size: Some(rems(0.95).into()),
+                        color: Some(colors.text_accent),
                         ..Default::default()
                     }),
                     h6: Some(TextStyleRefinement {
                         font_size: Some(rems(0.875).into()),
+                        color: Some(colors.text_accent),
                         ..Default::default()
                     }),
                 },

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -168,6 +168,10 @@ impl MarkdownStyle {
     ) -> Self {
         let theme_settings = ThemeSettings::get_global(cx);
         let is_preview = matches!(font, MarkdownFont::Preview);
+        // pi gives assistant code blocks rounded corners and more-defined inline
+        // code; scope these to the agent transcript so other markdown surfaces
+        // keep their current look.
+        let is_agent = matches!(font, MarkdownFont::Agent);
 
         let buffer_font_weight = theme_settings.buffer_font.weight;
         let (buffer_font_size, ui_font_size) = match font {
@@ -250,6 +254,12 @@ impl MarkdownStyle {
                     right: Some(AbsoluteLength::Pixels(px(1.))),
                     bottom: Some(AbsoluteLength::Pixels(px(1.))),
                 },
+                corner_radii: gpui::CornersRefinement {
+                    top_left: is_agent.then(|| AbsoluteLength::Pixels(px(6.))),
+                    top_right: is_agent.then(|| AbsoluteLength::Pixels(px(6.))),
+                    bottom_right: is_agent.then(|| AbsoluteLength::Pixels(px(6.))),
+                    bottom_left: is_agent.then(|| AbsoluteLength::Pixels(px(6.))),
+                },
                 border_color: Some(colors.border_variant),
                 background: Some(colors.editor_background.into()),
                 text: TextStyleRefinement {
@@ -268,7 +278,11 @@ impl MarkdownStyle {
                 font_features: Some(theme_settings.buffer_font.features.clone()),
                 font_size: Some(buffer_font_size.into()),
                 font_weight: Some(buffer_font_weight),
-                background_color: Some(colors.editor_foreground.opacity(0.08)),
+                background_color: Some(
+                    colors
+                        .editor_foreground
+                        .opacity(if is_agent { 0.12 } else { 0.08 }),
+                ),
                 ..Default::default()
             },
             link: TextStyleRefinement {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -96,44 +96,15 @@ impl MarkdownPreviewView {
     pub fn register(workspace: &mut Workspace, _window: &mut Window, _cx: &mut Context<Workspace>) {
         workspace.register_action(move |workspace, _: &OpenPreview, window, cx| {
             if let Some(editor) = Self::resolve_active_item_as_markdown_editor(workspace, cx) {
-                let view = Self::create_markdown_view(workspace, editor.clone(), window, cx);
-                workspace.active_pane().update(cx, |pane, cx| {
-                    if let Some(existing_view_idx) =
-                        Self::find_existing_independent_preview_item_idx(pane, &editor, cx)
-                    {
-                        pane.activate_item(existing_view_idx, true, true, window, cx);
-                    } else {
-                        pane.add_item(Box::new(view.clone()), true, true, None, window, cx)
-                    }
-                });
-                cx.notify();
+                let pane = workspace.active_pane().clone();
+                Self::open_preview_in_pane(workspace, editor, pane, window, cx);
             }
         });
 
         workspace.register_action(move |workspace, _: &OpenPreviewToTheSide, window, cx| {
             if let Some(editor) = Self::resolve_active_item_as_markdown_editor(workspace, cx) {
-                let view = Self::create_markdown_view(workspace, editor.clone(), window, cx);
-                let pane = workspace
-                    .find_pane_in_direction(workspace::SplitDirection::Right, cx)
-                    .unwrap_or_else(|| {
-                        workspace.split_pane(
-                            workspace.active_pane().clone(),
-                            workspace::SplitDirection::Right,
-                            window,
-                            cx,
-                        )
-                    });
-                pane.update(cx, |pane, cx| {
-                    if let Some(existing_view_idx) =
-                        Self::find_existing_independent_preview_item_idx(pane, &editor, cx)
-                    {
-                        pane.activate_item(existing_view_idx, true, true, window, cx);
-                    } else {
-                        pane.add_item(Box::new(view.clone()), false, false, None, window, cx)
-                    }
-                });
-                editor.focus_handle(cx).focus(window, cx);
-                cx.notify();
+                let pane = workspace.active_pane().clone();
+                Self::open_preview_to_the_side_of_pane(workspace, editor, pane, window, cx);
             }
         });
 
@@ -161,6 +132,51 @@ impl MarkdownPreviewView {
                 cx.notify();
             }
         });
+    }
+
+    pub fn open_preview_in_pane(
+        workspace: &mut Workspace,
+        editor: Entity<Editor>,
+        pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        Self::activate_or_add_preview(workspace, editor, pane, true, window, cx);
+    }
+
+    pub fn open_preview_to_the_side_of_pane(
+        workspace: &mut Workspace,
+        editor: Entity<Editor>,
+        origin_pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let target_pane = workspace.adjacent_pane_of(&origin_pane, window, cx);
+        Self::activate_or_add_preview(workspace, editor.clone(), target_pane, false, window, cx);
+        editor.focus_handle(cx).focus(window, cx);
+    }
+
+    fn activate_or_add_preview(
+        workspace: &mut Workspace,
+        editor: Entity<Editor>,
+        pane: Entity<Pane>,
+        focus: bool,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let existing_view_idx =
+            Self::find_existing_independent_preview_item_idx(pane.read(cx), &editor, cx);
+        if let Some(existing_view_idx) = existing_view_idx {
+            pane.update(cx, |pane, cx| {
+                pane.activate_item(existing_view_idx, focus, focus, window, cx);
+            });
+        } else {
+            let view = Self::create_markdown_view(workspace, editor, window, cx);
+            pane.update(cx, |pane, cx| {
+                pane.add_item(Box::new(view), focus, focus, None, window, cx)
+            });
+        }
+        cx.notify();
     }
 
     fn find_existing_independent_preview_item_idx(
@@ -375,7 +391,7 @@ impl MarkdownPreviewView {
         .detach();
     }
 
-    pub fn is_markdown_file<V>(editor: &Entity<Editor>, cx: &mut Context<V>) -> bool {
+    pub fn is_markdown_file(editor: &Entity<Editor>, cx: &App) -> bool {
         let buffer = editor.read(cx).buffer().read(cx);
         if let Some(buffer) = buffer.as_singleton()
             && let Some(language) = buffer.read(cx).language()
@@ -2246,6 +2262,125 @@ mod tests {
             "a Default preview must stay bound to the editor it was opened from, not another \
              editor that happens to share the same buffer in a different split"
         );
+    }
+
+    #[gpui::test]
+    async fn preview_opens_for_the_given_pane_not_the_focused_editor(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                path!("/dir"),
+                json!({
+                    "a.md": "# A\n",
+                    "b.md": "# B\n"
+                }),
+            )
+            .await;
+
+        cx.update(|cx| {
+            open_paths(
+                &[PathBuf::from(path!("/dir/a.md"))],
+                app_state.clone(),
+                workspace::OpenOptions::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+        let multi_workspace = cx.update(|cx| cx.windows()[0].downcast::<MultiWorkspace>().unwrap());
+        let workspace = multi_workspace
+            .update(cx, |multi_workspace, _, _| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        let project = workspace.read_with(cx, |workspace, _| workspace.project().clone());
+        let b_buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/dir/b.md"), cx)
+            })
+            .await
+            .unwrap();
+
+        let (first_pane, a_editor, second_pane, b_editor) = multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    let first_pane = workspace.active_pane().clone();
+                    let a_editor: Entity<Editor> = workspace
+                        .active_item(cx)
+                        .and_then(|item| item.act_as::<Editor>(cx))
+                        .unwrap();
+                    let project = workspace.project().clone();
+                    let second_pane = workspace.split_pane(
+                        first_pane.clone(),
+                        workspace::SplitDirection::Right,
+                        window,
+                        cx,
+                    );
+                    let b_editor =
+                        cx.new(|cx| Editor::for_buffer(b_buffer, Some(project), window, cx));
+                    second_pane.update(cx, |pane, cx| {
+                        pane.add_item(Box::new(b_editor.clone()), true, true, None, window, cx)
+                    });
+                    (first_pane, a_editor, second_pane, b_editor)
+                })
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        // With focus in the second pane (`b.md`), simulate clicking the
+        // preview button in the first pane's toolbar, which targets that
+        // pane's own editor (`a.md`).
+        multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    assert_eq!(
+                        workspace.active_pane(),
+                        &second_pane,
+                        "test precondition: focus must be in the second pane"
+                    );
+                    MarkdownPreviewView::open_preview_in_pane(
+                        workspace,
+                        a_editor.clone(),
+                        first_pane.clone(),
+                        window,
+                        cx,
+                    );
+                })
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        cx.update(|cx| {
+            let preview = first_pane
+                .read(cx)
+                .active_item()
+                .and_then(|item| item.downcast::<MarkdownPreviewView>())
+                .expect("the preview must open in the pane whose button was clicked");
+            let bound_editor = preview
+                .read(cx)
+                .active_editor
+                .as_ref()
+                .unwrap()
+                .editor
+                .clone();
+            assert_eq!(
+                bound_editor, a_editor,
+                "the preview must be bound to the clicked pane's editor, not the focused editor"
+            );
+            assert_eq!(
+                second_pane
+                    .read(cx)
+                    .active_item()
+                    .and_then(|item| item.downcast::<Editor>()),
+                Some(b_editor),
+                "the focused pane's content must be unaffected"
+            );
+        });
     }
 
     fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {

--- a/crates/svg_preview/src/svg_preview_view.rs
+++ b/crates/svg_preview/src/svg_preview_view.rs
@@ -202,63 +202,61 @@ impl SvgPreviewView {
             })
     }
 
+    pub fn open_preview_in_pane(
+        workspace: &mut Workspace,
+        buffer: Entity<MultiBuffer>,
+        pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        Self::activate_or_add_preview(workspace, buffer, pane, true, window, cx);
+    }
+
+    pub fn open_preview_to_the_side_of_pane(
+        workspace: &mut Workspace,
+        buffer: Entity<MultiBuffer>,
+        origin_pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let target_pane = workspace.adjacent_pane_of(&origin_pane, window, cx);
+        Self::activate_or_add_preview(workspace, buffer, target_pane, false, window, cx);
+    }
+
+    fn activate_or_add_preview(
+        workspace: &mut Workspace,
+        buffer: Entity<MultiBuffer>,
+        pane: Entity<Pane>,
+        focus: bool,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let existing_view_idx = Self::find_existing_preview_item_idx(pane.read(cx), &buffer, cx);
+        if let Some(existing_view_idx) = existing_view_idx {
+            pane.update(cx, |pane, cx| {
+                pane.activate_item(existing_view_idx, focus, focus, window, cx);
+            });
+        } else {
+            let view = Self::create_svg_view(SvgPreviewMode::Default, workspace, buffer, window, cx);
+            pane.update(cx, |pane, cx| {
+                pane.add_item(Box::new(view), focus, focus, None, window, cx)
+            });
+        }
+        cx.notify();
+    }
+
     pub fn register(workspace: &mut Workspace, _window: &mut Window, _cx: &mut Context<Workspace>) {
         workspace.register_action(move |workspace, _: &OpenPreview, window, cx| {
-            if let Some(buffer) = Self::resolve_active_item_as_svg_buffer(workspace, cx)
-                && Self::is_svg_file(&buffer, cx)
-            {
-                let view = Self::create_svg_view(
-                    SvgPreviewMode::Default,
-                    workspace,
-                    buffer.clone(),
-                    window,
-                    cx,
-                );
-                workspace.active_pane().update(cx, |pane, cx| {
-                    if let Some(existing_view_idx) =
-                        Self::find_existing_preview_item_idx(pane, &buffer, cx)
-                    {
-                        pane.activate_item(existing_view_idx, true, true, window, cx);
-                    } else {
-                        pane.add_item(Box::new(view), true, true, None, window, cx)
-                    }
-                });
-                cx.notify();
+            if let Some(buffer) = Self::resolve_active_item_as_svg_buffer(workspace, cx) {
+                let pane = workspace.active_pane().clone();
+                Self::open_preview_in_pane(workspace, buffer, pane, window, cx);
             }
         });
 
         workspace.register_action(move |workspace, _: &OpenPreviewToTheSide, window, cx| {
-            if let Some(editor) = Self::resolve_active_item_as_svg_buffer(workspace, cx)
-                && Self::is_svg_file(&editor, cx)
-            {
-                let editor_clone = editor.clone();
-                let view = Self::create_svg_view(
-                    SvgPreviewMode::Default,
-                    workspace,
-                    editor_clone,
-                    window,
-                    cx,
-                );
-                let pane = workspace
-                    .find_pane_in_direction(workspace::SplitDirection::Right, cx)
-                    .unwrap_or_else(|| {
-                        workspace.split_pane(
-                            workspace.active_pane().clone(),
-                            workspace::SplitDirection::Right,
-                            window,
-                            cx,
-                        )
-                    });
-                pane.update(cx, |pane, cx| {
-                    if let Some(existing_view_idx) =
-                        Self::find_existing_preview_item_idx(pane, &editor, cx)
-                    {
-                        pane.activate_item(existing_view_idx, true, true, window, cx);
-                    } else {
-                        pane.add_item(Box::new(view), false, false, None, window, cx)
-                    }
-                });
-                cx.notify();
+            if let Some(buffer) = Self::resolve_active_item_as_svg_buffer(workspace, cx) {
+                let pane = workspace.active_pane().clone();
+                Self::open_preview_to_the_side_of_pane(workspace, buffer, pane, window, cx);
             }
         });
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5845,10 +5845,19 @@ impl Workspace {
     }
 
     pub fn adjacent_pane(&mut self, window: &mut Window, cx: &mut Context<Self>) -> Entity<Pane> {
-        self.find_pane_in_direction(SplitDirection::Right, cx)
-            .unwrap_or_else(|| {
-                self.split_pane(self.active_pane.clone(), SplitDirection::Right, window, cx)
-            })
+        self.adjacent_pane_of(&self.active_pane.clone(), window, cx)
+    }
+
+    pub fn adjacent_pane_of(
+        &mut self,
+        origin: &Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<Pane> {
+        self.center
+            .find_pane_in_direction(origin, SplitDirection::Right, cx)
+            .cloned()
+            .unwrap_or_else(|| self.split_pane(origin.clone(), SplitDirection::Right, window, cx))
     }
 
     pub fn pane_for(&self, handle: &dyn ItemHandle) -> Option<Entity<Pane>> {

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -677,7 +677,7 @@ impl Render for QuickActionBar {
             .id("quick action bar")
             .gap(DynamicSpacing::Base01.rems(cx))
             .children(self.render_repl_menu(cx))
-            .children(self.render_preview_button(self.workspace.clone(), cx))
+            .children(self.render_preview_button(cx))
             .children(search_button)
             .when(
                 AgentSettings::get_global(cx).enabled(cx) && AgentSettings::get_global(cx).button,

--- a/crates/zed/src/zed/quick_action_bar/preview.rs
+++ b/crates/zed/src/zed/quick_action_bar/preview.rs
@@ -1,80 +1,61 @@
-use csv_preview::{
-    CsvPreviewView, OpenPreview as CsvOpenPreview, OpenPreviewToTheSide as CsvOpenPreviewToTheSide,
-    TabularDataPreviewFeatureFlag,
-};
+use csv_preview::{CsvPreviewView, TabularDataPreviewFeatureFlag};
+use editor::{Editor, MultiBuffer};
 use feature_flags::FeatureFlagAppExt as _;
-use gpui::{AnyElement, Modifiers, WeakEntity};
-use markdown_preview::{
-    OpenPreview as MarkdownOpenPreview, OpenPreviewToTheSide as MarkdownOpenPreviewToTheSide,
-    markdown_preview_view::MarkdownPreviewView,
-};
-use svg_preview::{
-    OpenPreview as SvgOpenPreview, OpenPreviewToTheSide as SvgOpenPreviewToTheSide,
-    svg_preview_view::SvgPreviewView,
-};
+use gpui::{AnyElement, Entity, Modifiers};
+use markdown_preview::markdown_preview_view::MarkdownPreviewView;
+use svg_preview::svg_preview_view::SvgPreviewView;
 use ui::{Tooltip, prelude::*, text_for_keystroke};
-use workspace::Workspace;
 
 use super::QuickActionBar;
 
-#[derive(Clone, Copy)]
-enum PreviewType {
-    Markdown,
-    Svg,
-    Csv,
+enum PreviewTarget {
+    Markdown(Entity<Editor>),
+    Svg(Entity<MultiBuffer>),
+    Csv(Entity<Editor>),
 }
 
 impl QuickActionBar {
-    pub fn render_preview_button(
-        &self,
-        workspace_handle: WeakEntity<Workspace>,
-        cx: &mut Context<Self>,
-    ) -> Option<AnyElement> {
-        let mut preview_type = None;
+    pub fn render_preview_button(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        // Resolve against this toolbar's own pane item rather than the
+        // workspace's focused item, so each pane's button reflects and
+        // targets the content of the pane it belongs to.
+        let active_item = self.active_item.as_ref()?;
+        let editor = active_item.act_as::<Editor>(cx);
 
-        if let Some(workspace) = self.workspace.upgrade() {
-            workspace.update(cx, |workspace, cx| {
-                if MarkdownPreviewView::resolve_active_item_as_markdown_editor(workspace, cx)
-                    .is_some()
-                {
-                    preview_type = Some(PreviewType::Markdown);
-                } else if SvgPreviewView::resolve_active_item_as_svg_buffer(workspace, cx).is_some()
-                {
-                    preview_type = Some(PreviewType::Svg);
-                } else if cx.has_flag::<TabularDataPreviewFeatureFlag>()
-                    && CsvPreviewView::resolve_active_item_as_csv_editor(workspace, cx).is_some()
-                {
-                    preview_type = Some(PreviewType::Csv);
-                }
-            });
-        }
+        let preview_target = if let Some(editor) = &editor
+            && MarkdownPreviewView::is_markdown_file(editor, cx)
+        {
+            PreviewTarget::Markdown(editor.clone())
+        } else if let Some(buffer) = active_item.act_as::<MultiBuffer>(cx)
+            && SvgPreviewView::is_svg_file(&buffer, cx)
+        {
+            PreviewTarget::Svg(buffer)
+        } else if let Some(editor) = editor
+            && cx.has_flag::<TabularDataPreviewFeatureFlag>()
+            && CsvPreviewView::is_csv_file(&editor, cx)
+        {
+            PreviewTarget::Csv(editor)
+        } else {
+            return None;
+        };
 
-        let preview_type = preview_type?;
-
-        let (button_id, tooltip_text, open_action, open_to_side_action, open_action_for_tooltip) =
-            match preview_type {
-                PreviewType::Markdown => (
-                    "toggle-markdown-preview",
-                    "Preview Markdown",
-                    Box::new(MarkdownOpenPreview) as Box<dyn gpui::Action>,
-                    Box::new(MarkdownOpenPreviewToTheSide) as Box<dyn gpui::Action>,
-                    &markdown_preview::OpenPreview as &dyn gpui::Action,
-                ),
-                PreviewType::Svg => (
-                    "toggle-svg-preview",
-                    "Preview SVG",
-                    Box::new(SvgOpenPreview) as Box<dyn gpui::Action>,
-                    Box::new(SvgOpenPreviewToTheSide) as Box<dyn gpui::Action>,
-                    &svg_preview::OpenPreview as &dyn gpui::Action,
-                ),
-                PreviewType::Csv => (
-                    "toggle-csv-preview",
-                    "Preview CSV",
-                    Box::new(CsvOpenPreview) as Box<dyn gpui::Action>,
-                    Box::new(CsvOpenPreviewToTheSide) as Box<dyn gpui::Action>,
-                    &csv_preview::OpenPreview as &dyn gpui::Action,
-                ),
-            };
+        let (button_id, tooltip_text, open_action_for_tooltip) = match &preview_target {
+            PreviewTarget::Markdown(_) => (
+                "toggle-markdown-preview",
+                "Preview Markdown",
+                &markdown_preview::OpenPreview as &dyn gpui::Action,
+            ),
+            PreviewTarget::Svg(_) => (
+                "toggle-svg-preview",
+                "Preview SVG",
+                &svg_preview::OpenPreview as &dyn gpui::Action,
+            ),
+            PreviewTarget::Csv(_) => (
+                "toggle-csv-preview",
+                "Preview CSV",
+                &csv_preview::OpenPreview as &dyn gpui::Action,
+            ),
+        };
 
         let alt_click = gpui::Keystroke {
             key: "click".into(),
@@ -96,13 +77,53 @@ impl QuickActionBar {
                     cx,
                 )
             })
-            .on_click(move |_, window, cx| {
-                if let Some(workspace) = workspace_handle.upgrade() {
-                    workspace.update(cx, |_, cx| {
-                        if window.modifiers().alt {
-                            window.dispatch_action(open_to_side_action.boxed_clone(), cx);
-                        } else {
-                            window.dispatch_action(open_action.boxed_clone(), cx);
+            .on_click({
+                let workspace_handle = self.workspace.clone();
+                let active_item = active_item.boxed_clone();
+                move |_, window, cx| {
+                    let Some(workspace) = workspace_handle.upgrade() else {
+                        return;
+                    };
+                    workspace.update(cx, |workspace, cx| {
+                        let Some(pane) = workspace.pane_for(active_item.as_ref()) else {
+                            return;
+                        };
+                        let open_to_the_side = window.modifiers().alt;
+                        match &preview_target {
+                            PreviewTarget::Markdown(editor) => {
+                                let editor = editor.clone();
+                                if open_to_the_side {
+                                    MarkdownPreviewView::open_preview_to_the_side_of_pane(
+                                        workspace, editor, pane, window, cx,
+                                    );
+                                } else {
+                                    MarkdownPreviewView::open_preview_in_pane(
+                                        workspace, editor, pane, window, cx,
+                                    );
+                                }
+                            }
+                            PreviewTarget::Svg(buffer) => {
+                                let buffer = buffer.clone();
+                                if open_to_the_side {
+                                    SvgPreviewView::open_preview_to_the_side_of_pane(
+                                        workspace, buffer, pane, window, cx,
+                                    );
+                                } else {
+                                    SvgPreviewView::open_preview_in_pane(
+                                        workspace, buffer, pane, window, cx,
+                                    );
+                                }
+                            }
+                            PreviewTarget::Csv(editor) => {
+                                let editor = editor.clone();
+                                if open_to_the_side {
+                                    CsvPreviewView::open_preview_to_the_side_of_pane(
+                                        workspace, editor, pane, window, cx,
+                                    );
+                                } else {
+                                    CsvPreviewView::open_preview_in_pane(editor, pane, window, cx);
+                                }
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
Closes #54951

## Problem

The quick action bar's preview button (markdown, SVG, and CSV behind the feature flag) resolved everything through `workspace.active_item()` — the globally *focused* item — instead of the item of the pane the button sits in. With `A.md` in the left pane and focus in `B.md` in the right pane:

- Clicking the eye button in **A.md's** toolbar opened a preview of **B.md**, in the right pane.
- Focusing a non-previewable file (e.g. `B.sh`) in one pane hid the button in **every** pane's toolbar, making `A.md` unpreviewable by mouse.

Clicking the button dispatched the `OpenPreview` action, whose workspace-level handler re-resolved the focused editor — so a click on a specific pane's toolbar was functionally identical to pressing the keybinding, discarding the pane the click happened in.

## Fix

Make the flow pane-explicit end to end:

- **Visibility:** each pane's `QuickActionBar` resolves the preview type from its own `active_item` (set via `set_active_pane_item`) instead of the workspace's focused item.
- **Click:** no more action dispatch. The handler resolves its pane via `Workspace::pane_for` and calls new pane-explicit helpers — `open_preview_in_pane` / `open_preview_to_the_side_of_pane` — extracted from the action-handler bodies in all three preview crates. Keyboard actions keep their focus-based semantics and route through the same helpers with the focused editor and active pane.
- **Alt-click** (open in split) now splits relative to the button's pane via the new `Workspace::adjacent_pane_of` (the existing `adjacent_pane` delegates to it).

Notably *not* done: focusing the button's pane and re-dispatching the action. `workspace.active_pane` only updates when pane focus-in listeners fire at the end of the next draw, while dispatched actions run before it — the handler would still read the stale pane.

## Additional changes

- Existing-preview lookup now happens **before** view construction, instead of building a full preview view (subscriptions, initial parse) and discarding it when one already exists.
- The `focus` flag now also applies to the activate-existing branch, so open-to-the-side never steals focus — previously the *first* invocation left focus in the editor but a *repeat* invocation focused the existing preview (and cancelled collaborator-following in that pane as a side effect).
- SVG handlers no longer double-check `is_svg_file`; CSV handlers reuse `resolve_active_item_as_csv_editor` instead of inlining it; `is_markdown_file` takes `&App` instead of a needless `&mut Context<V>`.

## Testing

- New regression test `preview_opens_for_the_given_pane_not_the_focused_editor` reproducing the issue's setup (two panes, focus in the second, preview invoked for the first pane's editor), asserting the preview opens in the invoking pane bound to that pane's editor with the focused pane untouched.
- Markdown/SVG/CSV preview suites and the full `workspace` suite pass; `./script/clippy` is clean.

Release Notes:

- Fixed the preview button (Markdown/SVG) previewing the focused file instead of the file in the pane the button belongs to when multiple panes are open
