### PR TITLE
Fix preview button acting on the focused editor instead of its own pane

### DIFF
--- a/crates/csv_preview/src/csv_preview.rs
+++ b/crates/csv_preview/src/csv_preview.rs
@@ -13,7 +13,7 @@ use ui::{
     AbsoluteLength, ResizableColumnsState, SharedString, TableInteractionState,
     TableResizeBehavior, prelude::*,
 };
-use workspace::{Item, SplitDirection, Workspace};
+use workspace::{Item, Pane, Workspace};
 
 use crate::{parser::EditorState, settings::CsvPreviewSettings, types::TableLikeContent};
 
@@ -93,67 +93,75 @@ impl CsvPreviewView {
         workspace.register_action_renderer(|div, _, _, cx| {
             div.when(cx.has_flag::<TabularDataPreviewFeatureFlag>(), |div| {
                 div.on_action(cx.listener(|workspace, _: &OpenPreview, window, cx| {
-                    if let Some(editor) = workspace
-                        .active_item(cx)
-                        .and_then(|item| item.act_as::<Editor>(cx))
-                        .filter(|editor| Self::is_csv_file(editor, cx))
-                    {
-                        let csv_preview = Self::new(&editor, window, cx);
-                        workspace.active_pane().update(cx, |pane, cx| {
-                            let existing = pane
-                                .items_of_type::<CsvPreviewView>()
-                                .find(|view| view.read(cx).active_editor_state.editor == editor);
-                            if let Some(idx) = existing.and_then(|e| pane.index_for_item(&e)) {
-                                pane.activate_item(idx, true, true, window, cx);
-                            } else {
-                                pane.add_item(Box::new(csv_preview), true, true, None, window, cx);
-                            }
-                        });
-                        cx.notify();
+                    if let Some(editor) = Self::resolve_active_item_as_csv_editor(workspace, cx) {
+                        let pane = workspace.active_pane().clone();
+                        Self::open_preview_in_pane(editor, pane, window, cx);
                     }
                 }))
                 .on_action(cx.listener(
                     |workspace, _: &OpenPreviewToTheSide, window, cx| {
-                        if let Some(editor) = workspace
-                            .active_item(cx)
-                            .and_then(|item| item.act_as::<Editor>(cx))
-                            .filter(|editor| Self::is_csv_file(editor, cx))
+                        if let Some(editor) = Self::resolve_active_item_as_csv_editor(workspace, cx)
                         {
-                            let csv_preview = Self::new(&editor, window, cx);
-                            let pane = workspace
-                                .find_pane_in_direction(SplitDirection::Right, cx)
-                                .unwrap_or_else(|| {
-                                    workspace.split_pane(
-                                        workspace.active_pane().clone(),
-                                        SplitDirection::Right,
-                                        window,
-                                        cx,
-                                    )
-                                });
-                            pane.update(cx, |pane, cx| {
-                                let existing =
-                                    pane.items_of_type::<CsvPreviewView>().find(|view| {
-                                        view.read(cx).active_editor_state.editor == editor
-                                    });
-                                if let Some(idx) = existing.and_then(|e| pane.index_for_item(&e)) {
-                                    pane.activate_item(idx, true, true, window, cx);
-                                } else {
-                                    pane.add_item(
-                                        Box::new(csv_preview),
-                                        false,
-                                        false,
-                                        None,
-                                        window,
-                                        cx,
-                                    );
-                                }
-                            });
-                            cx.notify();
+                            let pane = workspace.active_pane().clone();
+                            Self::open_preview_to_the_side_of_pane(
+                                workspace, editor, pane, window, cx,
+                            );
                         }
                     },
                 ))
             })
         });
+    }
+
+    pub fn open_preview_in_pane(
+        editor: Entity<Editor>,
+        pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        Self::activate_or_add_preview(editor, pane, true, window, cx);
+    }
+
+    pub fn open_preview_to_the_side_of_pane(
+        workspace: &mut Workspace,
+        editor: Entity<Editor>,
+        origin_pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let target_pane = workspace.adjacent_pane_of(&origin_pane, window, cx);
+        Self::activate_or_add_preview(editor, target_pane, false, window, cx);
+    }
+
+    fn activate_or_add_preview(
+        editor: Entity<Editor>,
+        pane: Entity<Pane>,
+        focus: bool,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let existing_view_idx = Self::find_existing_preview_item_idx(pane.read(cx), &editor, cx);
+        if let Some(existing_view_idx) = existing_view_idx {
+            pane.update(cx, |pane, cx| {
+                pane.activate_item(existing_view_idx, focus, focus, window, cx);
+            });
+        } else {
+            let csv_preview = Self::new(&editor, window, cx);
+            pane.update(cx, |pane, cx| {
+                pane.add_item(Box::new(csv_preview), focus, focus, None, window, cx);
+            });
+        }
+        cx.notify();
+    }
+
+    fn find_existing_preview_item_idx(
+        pane: &Pane,
+        editor: &Entity<Editor>,
+        cx: &App,
+    ) -> Option<usize> {
+        pane.items_of_type::<CsvPreviewView>()
+            .find(|view| &view.read(cx).active_editor_state.editor == editor)
+            .and_then(|view| pane.index_for_item(&view))
     }
 
     fn new(editor: &Entity<Editor>, window: &Window, cx: &mut Context<Workspace>) -> Entity<Self> {
@@ -265,7 +273,7 @@ impl CsvPreviewView {
         Self::is_csv_file(&editor, cx).then_some(editor)
     }
 
-    fn is_csv_file(editor: &Entity<Editor>, cx: &App) -> bool {
+    pub fn is_csv_file(editor: &Entity<Editor>, cx: &App) -> bool {
         editor
             .read(cx)
             .buffer()

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -97,44 +97,15 @@ impl MarkdownPreviewView {
     pub fn register(workspace: &mut Workspace, _window: &mut Window, _cx: &mut Context<Workspace>) {
         workspace.register_action(move |workspace, _: &OpenPreview, window, cx| {
             if let Some(editor) = Self::resolve_active_item_as_markdown_editor(workspace, cx) {
-                let view = Self::create_markdown_view(workspace, editor.clone(), window, cx);
-                workspace.active_pane().update(cx, |pane, cx| {
-                    if let Some(existing_view_idx) =
-                        Self::find_existing_independent_preview_item_idx(pane, &editor, cx)
-                    {
-                        pane.activate_item(existing_view_idx, true, true, window, cx);
-                    } else {
-                        pane.add_item(Box::new(view.clone()), true, true, None, window, cx)
-                    }
-                });
-                cx.notify();
+                let pane = workspace.active_pane().clone();
+                Self::open_preview_in_pane(workspace, editor, pane, window, cx);
             }
         });
 
         workspace.register_action(move |workspace, _: &OpenPreviewToTheSide, window, cx| {
             if let Some(editor) = Self::resolve_active_item_as_markdown_editor(workspace, cx) {
-                let view = Self::create_markdown_view(workspace, editor.clone(), window, cx);
-                let pane = workspace
-                    .find_pane_in_direction(workspace::SplitDirection::Right, cx)
-                    .unwrap_or_else(|| {
-                        workspace.split_pane(
-                            workspace.active_pane().clone(),
-                            workspace::SplitDirection::Right,
-                            window,
-                            cx,
-                        )
-                    });
-                pane.update(cx, |pane, cx| {
-                    if let Some(existing_view_idx) =
-                        Self::find_existing_independent_preview_item_idx(pane, &editor, cx)
-                    {
-                        pane.activate_item(existing_view_idx, true, true, window, cx);
-                    } else {
-                        pane.add_item(Box::new(view.clone()), false, false, None, window, cx)
-                    }
-                });
-                editor.focus_handle(cx).focus(window, cx);
-                cx.notify();
+                let pane = workspace.active_pane().clone();
+                Self::open_preview_to_the_side_of_pane(workspace, editor, pane, window, cx);
             }
         });
 
@@ -162,6 +133,51 @@ impl MarkdownPreviewView {
                 cx.notify();
             }
         });
+    }
+
+    pub fn open_preview_in_pane(
+        workspace: &mut Workspace,
+        editor: Entity<Editor>,
+        pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        Self::activate_or_add_preview(workspace, editor, pane, true, window, cx);
+    }
+
+    pub fn open_preview_to_the_side_of_pane(
+        workspace: &mut Workspace,
+        editor: Entity<Editor>,
+        origin_pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let target_pane = workspace.adjacent_pane_of(&origin_pane, window, cx);
+        Self::activate_or_add_preview(workspace, editor.clone(), target_pane, false, window, cx);
+        editor.focus_handle(cx).focus(window, cx);
+    }
+
+    fn activate_or_add_preview(
+        workspace: &mut Workspace,
+        editor: Entity<Editor>,
+        pane: Entity<Pane>,
+        focus: bool,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let existing_view_idx =
+            Self::find_existing_independent_preview_item_idx(pane.read(cx), &editor, cx);
+        if let Some(existing_view_idx) = existing_view_idx {
+            pane.update(cx, |pane, cx| {
+                pane.activate_item(existing_view_idx, focus, focus, window, cx);
+            });
+        } else {
+            let view = Self::create_markdown_view(workspace, editor, window, cx);
+            pane.update(cx, |pane, cx| {
+                pane.add_item(Box::new(view), focus, focus, None, window, cx)
+            });
+        }
+        cx.notify();
     }
 
     fn find_existing_independent_preview_item_idx(
@@ -376,7 +392,7 @@ impl MarkdownPreviewView {
         .detach();
     }
 
-    pub fn is_markdown_file<V>(editor: &Entity<Editor>, cx: &mut Context<V>) -> bool {
+    pub fn is_markdown_file(editor: &Entity<Editor>, cx: &App) -> bool {
         let buffer = editor.read(cx).buffer().read(cx);
         if let Some(buffer) = buffer.as_singleton()
             && let Some(language) = buffer.read(cx).language()
@@ -2471,6 +2487,125 @@ mod tests {
                 );
             })
             .unwrap();
+    }
+
+    #[gpui::test]
+    async fn preview_opens_for_the_given_pane_not_the_focused_editor(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                path!("/dir"),
+                json!({
+                    "a.md": "# A\n",
+                    "b.md": "# B\n"
+                }),
+            )
+            .await;
+
+        cx.update(|cx| {
+            open_paths(
+                &[PathBuf::from(path!("/dir/a.md"))],
+                app_state.clone(),
+                workspace::OpenOptions::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+        let multi_workspace = cx.update(|cx| cx.windows()[0].downcast::<MultiWorkspace>().unwrap());
+        let workspace = multi_workspace
+            .update(cx, |multi_workspace, _, _| {
+                multi_workspace.workspace().clone()
+            })
+            .unwrap();
+        let project = workspace.read_with(cx, |workspace, _| workspace.project().clone());
+        let b_buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/dir/b.md"), cx)
+            })
+            .await
+            .unwrap();
+
+        let (first_pane, a_editor, second_pane, b_editor) = multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    let first_pane = workspace.active_pane().clone();
+                    let a_editor: Entity<Editor> = workspace
+                        .active_item(cx)
+                        .and_then(|item| item.act_as::<Editor>(cx))
+                        .unwrap();
+                    let project = workspace.project().clone();
+                    let second_pane = workspace.split_pane(
+                        first_pane.clone(),
+                        workspace::SplitDirection::Right,
+                        window,
+                        cx,
+                    );
+                    let b_editor =
+                        cx.new(|cx| Editor::for_buffer(b_buffer, Some(project), window, cx));
+                    second_pane.update(cx, |pane, cx| {
+                        pane.add_item(Box::new(b_editor.clone()), true, true, None, window, cx)
+                    });
+                    (first_pane, a_editor, second_pane, b_editor)
+                })
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        // With focus in the second pane (`b.md`), simulate clicking the
+        // preview button in the first pane's toolbar, which targets that
+        // pane's own editor (`a.md`).
+        multi_workspace
+            .update(cx, |multi_workspace, window, cx| {
+                let workspace = multi_workspace.workspace().clone();
+                workspace.update(cx, |workspace, cx| {
+                    assert_eq!(
+                        workspace.active_pane(),
+                        &second_pane,
+                        "test precondition: focus must be in the second pane"
+                    );
+                    MarkdownPreviewView::open_preview_in_pane(
+                        workspace,
+                        a_editor.clone(),
+                        first_pane.clone(),
+                        window,
+                        cx,
+                    );
+                })
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        cx.update(|cx| {
+            let preview = first_pane
+                .read(cx)
+                .active_item()
+                .and_then(|item| item.downcast::<MarkdownPreviewView>())
+                .expect("the preview must open in the pane whose button was clicked");
+            let bound_editor = preview
+                .read(cx)
+                .active_editor
+                .as_ref()
+                .unwrap()
+                .editor
+                .clone();
+            assert_eq!(
+                bound_editor, a_editor,
+                "the preview must be bound to the clicked pane's editor, not the focused editor"
+            );
+            assert_eq!(
+                second_pane
+                    .read(cx)
+                    .active_item()
+                    .and_then(|item| item.downcast::<Editor>()),
+                Some(b_editor),
+                "the focused pane's content must be unaffected"
+            );
+        });
     }
 
     fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {

--- a/crates/svg_preview/src/svg_preview_view.rs
+++ b/crates/svg_preview/src/svg_preview_view.rs
@@ -202,63 +202,62 @@ impl SvgPreviewView {
             })
     }
 
+    pub fn open_preview_in_pane(
+        workspace: &mut Workspace,
+        buffer: Entity<MultiBuffer>,
+        pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        Self::activate_or_add_preview(workspace, buffer, pane, true, window, cx);
+    }
+
+    pub fn open_preview_to_the_side_of_pane(
+        workspace: &mut Workspace,
+        buffer: Entity<MultiBuffer>,
+        origin_pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let target_pane = workspace.adjacent_pane_of(&origin_pane, window, cx);
+        Self::activate_or_add_preview(workspace, buffer, target_pane, false, window, cx);
+    }
+
+    fn activate_or_add_preview(
+        workspace: &mut Workspace,
+        buffer: Entity<MultiBuffer>,
+        pane: Entity<Pane>,
+        focus: bool,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        let existing_view_idx = Self::find_existing_preview_item_idx(pane.read(cx), &buffer, cx);
+        if let Some(existing_view_idx) = existing_view_idx {
+            pane.update(cx, |pane, cx| {
+                pane.activate_item(existing_view_idx, focus, focus, window, cx);
+            });
+        } else {
+            let view =
+                Self::create_svg_view(SvgPreviewMode::Default, workspace, buffer, window, cx);
+            pane.update(cx, |pane, cx| {
+                pane.add_item(Box::new(view), focus, focus, None, window, cx)
+            });
+        }
+        cx.notify();
+    }
+
     pub fn register(workspace: &mut Workspace, _window: &mut Window, _cx: &mut Context<Workspace>) {
         workspace.register_action(move |workspace, _: &OpenPreview, window, cx| {
-            if let Some(buffer) = Self::resolve_active_item_as_svg_buffer(workspace, cx)
-                && Self::is_svg_file(&buffer, cx)
-            {
-                let view = Self::create_svg_view(
-                    SvgPreviewMode::Default,
-                    workspace,
-                    buffer.clone(),
-                    window,
-                    cx,
-                );
-                workspace.active_pane().update(cx, |pane, cx| {
-                    if let Some(existing_view_idx) =
-                        Self::find_existing_preview_item_idx(pane, &buffer, cx)
-                    {
-                        pane.activate_item(existing_view_idx, true, true, window, cx);
-                    } else {
-                        pane.add_item(Box::new(view), true, true, None, window, cx)
-                    }
-                });
-                cx.notify();
+            if let Some(buffer) = Self::resolve_active_item_as_svg_buffer(workspace, cx) {
+                let pane = workspace.active_pane().clone();
+                Self::open_preview_in_pane(workspace, buffer, pane, window, cx);
             }
         });
 
         workspace.register_action(move |workspace, _: &OpenPreviewToTheSide, window, cx| {
-            if let Some(editor) = Self::resolve_active_item_as_svg_buffer(workspace, cx)
-                && Self::is_svg_file(&editor, cx)
-            {
-                let editor_clone = editor.clone();
-                let view = Self::create_svg_view(
-                    SvgPreviewMode::Default,
-                    workspace,
-                    editor_clone,
-                    window,
-                    cx,
-                );
-                let pane = workspace
-                    .find_pane_in_direction(workspace::SplitDirection::Right, cx)
-                    .unwrap_or_else(|| {
-                        workspace.split_pane(
-                            workspace.active_pane().clone(),
-                            workspace::SplitDirection::Right,
-                            window,
-                            cx,
-                        )
-                    });
-                pane.update(cx, |pane, cx| {
-                    if let Some(existing_view_idx) =
-                        Self::find_existing_preview_item_idx(pane, &editor, cx)
-                    {
-                        pane.activate_item(existing_view_idx, true, true, window, cx);
-                    } else {
-                        pane.add_item(Box::new(view), false, false, None, window, cx)
-                    }
-                });
-                cx.notify();
+            if let Some(buffer) = Self::resolve_active_item_as_svg_buffer(workspace, cx) {
+                let pane = workspace.active_pane().clone();
+                Self::open_preview_to_the_side_of_pane(workspace, buffer, pane, window, cx);
             }
         });
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5885,10 +5885,19 @@ impl Workspace {
     }
 
     pub fn adjacent_pane(&mut self, window: &mut Window, cx: &mut Context<Self>) -> Entity<Pane> {
-        self.find_pane_in_direction(SplitDirection::Right, cx)
-            .unwrap_or_else(|| {
-                self.split_pane(self.active_pane.clone(), SplitDirection::Right, window, cx)
-            })
+        self.adjacent_pane_of(&self.active_pane.clone(), window, cx)
+    }
+
+    pub fn adjacent_pane_of(
+        &mut self,
+        origin: &Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<Pane> {
+        self.center
+            .find_pane_in_direction(origin, SplitDirection::Right, cx)
+            .cloned()
+            .unwrap_or_else(|| self.split_pane(origin.clone(), SplitDirection::Right, window, cx))
     }
 
     pub fn pane_for(&self, handle: &dyn ItemHandle) -> Option<Entity<Pane>> {

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -676,7 +676,7 @@ impl Render for QuickActionBar {
             .id("quick action bar")
             .gap(DynamicSpacing::Base01.rems(cx))
             .children(self.render_repl_menu(cx))
-            .children(self.render_preview_button(self.workspace.clone(), cx))
+            .children(self.render_preview_button(cx))
             .children(search_button)
             .when(
                 AgentSettings::get_global(cx).enabled(cx) && AgentSettings::get_global(cx).button,

--- a/crates/zed/src/zed/quick_action_bar/preview.rs
+++ b/crates/zed/src/zed/quick_action_bar/preview.rs
@@ -1,80 +1,61 @@
-use csv_preview::{
-    CsvPreviewView, OpenPreview as CsvOpenPreview, OpenPreviewToTheSide as CsvOpenPreviewToTheSide,
-    TabularDataPreviewFeatureFlag,
-};
+use csv_preview::{CsvPreviewView, TabularDataPreviewFeatureFlag};
+use editor::{Editor, MultiBuffer};
 use feature_flags::FeatureFlagAppExt as _;
-use gpui::{AnyElement, Modifiers, WeakEntity};
-use markdown_preview::{
-    OpenPreview as MarkdownOpenPreview, OpenPreviewToTheSide as MarkdownOpenPreviewToTheSide,
-    markdown_preview_view::MarkdownPreviewView,
-};
-use svg_preview::{
-    OpenPreview as SvgOpenPreview, OpenPreviewToTheSide as SvgOpenPreviewToTheSide,
-    svg_preview_view::SvgPreviewView,
-};
+use gpui::{AnyElement, Entity, Modifiers};
+use markdown_preview::markdown_preview_view::MarkdownPreviewView;
+use svg_preview::svg_preview_view::SvgPreviewView;
 use ui::{Tooltip, prelude::*, text_for_keystroke};
-use workspace::Workspace;
 
 use super::QuickActionBar;
 
-#[derive(Clone, Copy)]
-enum PreviewType {
-    Markdown,
-    Svg,
-    Csv,
+enum PreviewTarget {
+    Markdown(Entity<Editor>),
+    Svg(Entity<MultiBuffer>),
+    Csv(Entity<Editor>),
 }
 
 impl QuickActionBar {
-    pub fn render_preview_button(
-        &self,
-        workspace_handle: WeakEntity<Workspace>,
-        cx: &mut Context<Self>,
-    ) -> Option<AnyElement> {
-        let mut preview_type = None;
+    pub fn render_preview_button(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        // Resolve against this toolbar's own pane item rather than the
+        // workspace's focused item, so each pane's button reflects and
+        // targets the content of the pane it belongs to.
+        let active_item = self.active_item.as_ref()?;
+        let editor = active_item.act_as::<Editor>(cx);
 
-        if let Some(workspace) = self.workspace.upgrade() {
-            workspace.update(cx, |workspace, cx| {
-                if MarkdownPreviewView::resolve_active_item_as_markdown_editor(workspace, cx)
-                    .is_some()
-                {
-                    preview_type = Some(PreviewType::Markdown);
-                } else if SvgPreviewView::resolve_active_item_as_svg_buffer(workspace, cx).is_some()
-                {
-                    preview_type = Some(PreviewType::Svg);
-                } else if cx.has_flag::<TabularDataPreviewFeatureFlag>()
-                    && CsvPreviewView::resolve_active_item_as_csv_editor(workspace, cx).is_some()
-                {
-                    preview_type = Some(PreviewType::Csv);
-                }
-            });
-        }
+        let preview_target = if let Some(editor) = &editor
+            && MarkdownPreviewView::is_markdown_file(editor, cx)
+        {
+            PreviewTarget::Markdown(editor.clone())
+        } else if let Some(buffer) = active_item.act_as::<MultiBuffer>(cx)
+            && SvgPreviewView::is_svg_file(&buffer, cx)
+        {
+            PreviewTarget::Svg(buffer)
+        } else if let Some(editor) = editor
+            && cx.has_flag::<TabularDataPreviewFeatureFlag>()
+            && CsvPreviewView::is_csv_file(&editor, cx)
+        {
+            PreviewTarget::Csv(editor)
+        } else {
+            return None;
+        };
 
-        let preview_type = preview_type?;
-
-        let (button_id, tooltip_text, open_action, open_to_side_action, open_action_for_tooltip) =
-            match preview_type {
-                PreviewType::Markdown => (
-                    "toggle-markdown-preview",
-                    "Preview Markdown",
-                    Box::new(MarkdownOpenPreview) as Box<dyn gpui::Action>,
-                    Box::new(MarkdownOpenPreviewToTheSide) as Box<dyn gpui::Action>,
-                    &markdown_preview::OpenPreview as &dyn gpui::Action,
-                ),
-                PreviewType::Svg => (
-                    "toggle-svg-preview",
-                    "Preview SVG",
-                    Box::new(SvgOpenPreview) as Box<dyn gpui::Action>,
-                    Box::new(SvgOpenPreviewToTheSide) as Box<dyn gpui::Action>,
-                    &svg_preview::OpenPreview as &dyn gpui::Action,
-                ),
-                PreviewType::Csv => (
-                    "toggle-csv-preview",
-                    "Preview CSV",
-                    Box::new(CsvOpenPreview) as Box<dyn gpui::Action>,
-                    Box::new(CsvOpenPreviewToTheSide) as Box<dyn gpui::Action>,
-                    &csv_preview::OpenPreview as &dyn gpui::Action,
-                ),
-            };
+        let (button_id, tooltip_text, open_action_for_tooltip) = match &preview_target {
+            PreviewTarget::Markdown(_) => (
+                "toggle-markdown-preview",
+                "Preview Markdown",
+                &markdown_preview::OpenPreview as &dyn gpui::Action,
+            ),
+            PreviewTarget::Svg(_) => (
+                "toggle-svg-preview",
+                "Preview SVG",
+                &svg_preview::OpenPreview as &dyn gpui::Action,
+            ),
+            PreviewTarget::Csv(_) => (
+                "toggle-csv-preview",
+                "Preview CSV",
+                &csv_preview::OpenPreview as &dyn gpui::Action,
+            ),
+        };
 
         let alt_click = gpui::Keystroke {
             key: "click".into(),
@@ -96,13 +77,53 @@ impl QuickActionBar {
                     cx,
                 )
             })
-            .on_click(move |_, window, cx| {
-                if let Some(workspace) = workspace_handle.upgrade() {
-                    workspace.update(cx, |_, cx| {
-                        if window.modifiers().alt {
-                            window.dispatch_action(open_to_side_action.boxed_clone(), cx);
-                        } else {
-                            window.dispatch_action(open_action.boxed_clone(), cx);
+            .on_click({
+                let workspace_handle = self.workspace.clone();
+                let active_item = active_item.boxed_clone();
+                move |_, window, cx| {
+                    let Some(workspace) = workspace_handle.upgrade() else {
+                        return;
+                    };
+                    workspace.update(cx, |workspace, cx| {
+                        let Some(pane) = workspace.pane_for(active_item.as_ref()) else {
+                            return;
+                        };
+                        let open_to_the_side = window.modifiers().alt;
+                        match &preview_target {
+                            PreviewTarget::Markdown(editor) => {
+                                let editor = editor.clone();
+                                if open_to_the_side {
+                                    MarkdownPreviewView::open_preview_to_the_side_of_pane(
+                                        workspace, editor, pane, window, cx,
+                                    );
+                                } else {
+                                    MarkdownPreviewView::open_preview_in_pane(
+                                        workspace, editor, pane, window, cx,
+                                    );
+                                }
+                            }
+                            PreviewTarget::Svg(buffer) => {
+                                let buffer = buffer.clone();
+                                if open_to_the_side {
+                                    SvgPreviewView::open_preview_to_the_side_of_pane(
+                                        workspace, buffer, pane, window, cx,
+                                    );
+                                } else {
+                                    SvgPreviewView::open_preview_in_pane(
+                                        workspace, buffer, pane, window, cx,
+                                    );
+                                }
+                            }
+                            PreviewTarget::Csv(editor) => {
+                                let editor = editor.clone();
+                                if open_to_the_side {
+                                    CsvPreviewView::open_preview_to_the_side_of_pane(
+                                        workspace, editor, pane, window, cx,
+                                    );
+                                } else {
+                                    CsvPreviewView::open_preview_in_pane(editor, pane, window, cx);
+                                }
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
Closes #54951

## Problem

The quick action bar's preview button (markdown, SVG, and CSV behind the feature flag) resolved everything through `workspace.active_item()` — the globally *focused* item — instead of the item of the pane the button sits in. With `A.md` in the left pane and focus in `B.md` in the right pane:

- Clicking the eye button in **A.md's** toolbar opened a preview of **B.md**, in the right pane.
- Focusing a non-previewable file (e.g. `B.sh`) in one pane hid the button in **every** pane's toolbar, making `A.md` unpreviewable by mouse.

Clicking the button dispatched the `OpenPreview` action, whose workspace-level handler re-resolved the focused editor — so a click on a specific pane's toolbar was functionally identical to pressing the keybinding, discarding the pane the click happened in.

## Fix

Make the flow pane-explicit end to end:

- **Visibility:** each pane's `QuickActionBar` resolves the preview type from its own `active_item` (set via `set_active_pane_item`) instead of the workspace's focused item.
- **Click:** no more action dispatch. The handler resolves its pane via `Workspace::pane_for` and calls new pane-explicit helpers — `open_preview_in_pane` / `open_preview_to_the_side_of_pane` — extracted from the action-handler bodies in all three preview crates. Keyboard actions keep their focus-based semantics and route through the same helpers with the focused editor and active pane.
- **Alt-click** (open in split) now splits relative to the button's pane via the new `Workspace::adjacent_pane_of` (the existing `adjacent_pane` delegates to it).

Notably *not* done: focusing the button's pane and re-dispatching the action. `workspace.active_pane` only updates when pane focus-in listeners fire at the end of the next draw, while dispatched actions run before it — the handler would still read the stale pane.

## Additional changes

- Existing-preview lookup now happens **before** view construction, instead of building a full preview view (subscriptions, initial parse) and discarding it when one already exists.
- The `focus` flag now also applies to the activate-existing branch, so open-to-the-side never steals focus — previously the *first* invocation left focus in the editor but a *repeat* invocation focused the existing preview (and cancelled collaborator-following in that pane as a side effect).
- SVG handlers no longer double-check `is_svg_file`; CSV handlers reuse `resolve_active_item_as_csv_editor` instead of inlining it; `is_markdown_file` takes `&App` instead of a needless `&mut Context<V>`.

## Testing

- New regression test `preview_opens_for_the_given_pane_not_the_focused_editor` reproducing the issue's setup (two panes, focus in the second, preview invoked for the first pane's editor), asserting the preview opens in the invoking pane bound to that pane's editor with the focused pane untouched.
- Markdown/SVG/CSV preview suites and the full `workspace` suite pass; `./script/clippy` is clean.

Release Notes:

- Fixed the preview button (Markdown/SVG) previewing the focused file instead of the file in the pane the button belongs to when multiple panes are open
