### PR TITLE
gpui: Render polychrome icon-theme SVGs through the SVG pipeline at display size and scale

### DIFF
--- a/crates/gpui/src/elements/svg.rs
+++ b/crates/gpui/src/elements/svg.rs
@@ -7,12 +7,17 @@ use crate::{
 };
 use gpui_util::ResultExt;
 
+enum SvgSource {
+    Embedded(SharedString),
+    External(SharedString),
+}
+
 /// An SVG element.
 pub struct Svg {
     interactivity: Interactivity,
     transformation: Option<Transformation>,
-    path: Option<SharedString>,
-    external_path: Option<SharedString>,
+    source: Option<SvgSource>,
+    polychrome: bool,
 }
 
 /// Create a new SVG element.
@@ -21,21 +26,29 @@ pub fn svg() -> Svg {
     Svg {
         interactivity: Interactivity::new(),
         transformation: None,
-        path: None,
-        external_path: None,
+        source: None,
+        polychrome: false,
     }
 }
 
 impl Svg {
     /// Set the path to the SVG file for this element.
     pub fn path(mut self, path: impl Into<SharedString>) -> Self {
-        self.path = Some(path.into());
+        self.source = Some(SvgSource::Embedded(path.into()));
         self
     }
 
     /// Set the path to the SVG file for this element.
     pub fn external_path(mut self, path: impl Into<SharedString>) -> Self {
-        self.external_path = Some(path.into());
+        self.source = Some(SvgSource::External(path.into()));
+        self
+    }
+
+    /// Render the SVG using its original colors instead of the text color.
+    ///
+    /// Polychrome SVGs do not support [`Self::with_transformation`].
+    pub fn polychrome(mut self) -> Self {
+        self.polychrome = true;
         self
     }
 
@@ -116,28 +129,31 @@ impl Element for Svg {
             window,
             cx,
             |style, window, cx| {
-                if let Some((path, color)) = self.path.as_ref().zip(style.text.color) {
-                    let transformation = self
-                        .transformation
-                        .as_ref()
-                        .map(|transformation| {
-                            transformation.into_matrix(bounds.center(), window.scale_factor())
-                        })
-                        .unwrap_or_default();
+                let Some(source) = self.source.as_ref() else {
+                    return;
+                };
+                let (path, bytes) = match source {
+                    SvgSource::Embedded(path) => (path, None),
+                    SvgSource::External(path) => {
+                        let Some(bytes) = window
+                            .use_asset::<SvgAsset>(path, cx)
+                            .and_then(|asset| asset.log_err())
+                        else {
+                            return;
+                        };
+                        (path, Some(bytes))
+                    }
+                };
 
+                if self.polychrome {
+                    debug_assert!(
+                        self.transformation.is_none(),
+                        "polychrome SVGs do not support transformations"
+                    );
                     window
-                        .paint_svg(bounds, path.clone(), None, transformation, color, cx)
+                        .paint_polychrome_svg(bounds, path.clone(), bytes.as_deref(), cx)
                         .log_err();
-                } else if let Some((path, color)) =
-                    self.external_path.as_ref().zip(style.text.color)
-                {
-                    let Some(bytes) = window
-                        .use_asset::<SvgAsset>(path, cx)
-                        .and_then(|asset| asset.log_err())
-                    else {
-                        return;
-                    };
-
+                } else if let Some(color) = style.text.color {
                     let transformation = self
                         .transformation
                         .as_ref()
@@ -150,7 +166,7 @@ impl Element for Svg {
                         .paint_svg(
                             bounds,
                             path.clone(),
-                            Some(&bytes),
+                            bytes.as_deref(),
                             transformation,
                             color,
                             cx,

--- a/crates/gpui/src/elements/svg.rs
+++ b/crates/gpui/src/elements/svg.rs
@@ -12,14 +12,21 @@ use crate::{
 };
 use gpui_util::ResultExt;
 
+enum SvgSource {
+    Embedded(SharedString),
+    External(SharedString),
+    Data {
+        path: SharedString,
+        bytes: Arc<[u8]>,
+    },
+}
+
 /// An SVG element.
 pub struct Svg {
     interactivity: Interactivity,
     transformation: Option<Transformation>,
-    path: Option<SharedString>,
-    external_path: Option<SharedString>,
-    data: Option<Arc<[u8]>>,
-    data_path: Option<SharedString>,
+    source: Option<SvgSource>,
+    polychrome: bool,
 }
 
 /// Create a new SVG element.
@@ -28,23 +35,29 @@ pub fn svg() -> Svg {
     Svg {
         interactivity: Interactivity::new(),
         transformation: None,
-        path: None,
-        external_path: None,
-        data: None,
-        data_path: None,
+        source: None,
+        polychrome: false,
     }
 }
 
 impl Svg {
     /// Set the path to the SVG file for this element.
     pub fn path(mut self, path: impl Into<SharedString>) -> Self {
-        self.path = Some(path.into());
+        self.source = Some(SvgSource::Embedded(path.into()));
         self
     }
 
     /// Set the path to the SVG file for this element.
     pub fn external_path(mut self, path: impl Into<SharedString>) -> Self {
-        self.external_path = Some(path.into());
+        self.source = Some(SvgSource::External(path.into()));
+        self
+    }
+
+    /// Render the SVG using its original colors instead of the text color.
+    ///
+    /// Polychrome SVGs do not support [`Self::with_transformation`].
+    pub fn polychrome(mut self) -> Self {
+        self.polychrome = true;
         self
     }
 
@@ -56,8 +69,10 @@ impl Svg {
         data.hash(&mut hasher);
         let hash = hasher.finish();
         let path = SharedString::from(format!("__binary_svg__{}", hash));
-        self.data = Some(Arc::from(data));
-        self.data_path = Some(path);
+        self.source = Some(SvgSource::Data {
+            path,
+            bytes: Arc::from(data),
+        });
         self
     }
 
@@ -138,50 +153,49 @@ impl Element for Svg {
             window,
             cx,
             |style, window, cx| {
-                let transformation = self
-                    .transformation
-                    .as_ref()
-                    .map(|transformation| {
-                        transformation.into_matrix(bounds.center(), window.scale_factor())
-                    })
-                    .unwrap_or_default();
-
-                if let Some((data, path)) = self.data.as_ref().zip(self.data_path.as_ref()) {
-                    if let Some(color) = style.text.color {
-                        window
-                            .paint_svg(
-                                bounds,
-                                path.clone(),
-                                Some(&**data),
-                                transformation,
-                                color,
-                                cx,
-                            )
-                            .log_err();
+                let Some(source) = self.source.as_ref() else {
+                    return;
+                };
+                let (path, bytes) = match source {
+                    SvgSource::Embedded(path) => (path, None),
+                    SvgSource::External(path) => {
+                        let Some(bytes) = window
+                            .use_asset::<SvgAsset>(path, cx)
+                            .and_then(|asset| asset.log_err())
+                        else {
+                            return;
+                        };
+                        (path, Some(bytes))
                     }
-                } else if let Some((path, color)) =
-                    self.external_path.as_ref().zip(style.text.color)
-                {
-                    let Some(bytes) = window
-                        .use_asset::<SvgAsset>(path, cx)
-                        .and_then(|asset| asset.log_err())
-                    else {
-                        return;
-                    };
+                    SvgSource::Data { path, bytes } => (path, Some(bytes.clone())),
+                };
+
+                if self.polychrome {
+                    debug_assert!(
+                        self.transformation.is_none(),
+                        "polychrome SVGs do not support transformations"
+                    );
+                    window
+                        .paint_polychrome_svg(bounds, path.clone(), bytes.as_deref(), cx)
+                        .log_err();
+                } else if let Some(color) = style.text.color {
+                    let transformation = self
+                        .transformation
+                        .as_ref()
+                        .map(|transformation| {
+                            transformation.into_matrix(bounds.center(), window.scale_factor())
+                        })
+                        .unwrap_or_default();
 
                     window
                         .paint_svg(
                             bounds,
                             path.clone(),
-                            Some(&bytes),
+                            bytes.as_deref(),
                             transformation,
                             color,
                             cx,
                         )
-                        .log_err();
-                } else if let Some((path, color)) = self.path.as_ref().zip(style.text.color) {
-                    window
-                        .paint_svg(bounds, path.clone(), None, transformation, color, cx)
                         .log_err();
                 }
             },

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1225,6 +1225,7 @@ pub fn get_gamma_correction_ratios(gamma: f32) -> [f32; 4] {
 pub enum AtlasKey {
     Glyph(RenderGlyphParams),
     Svg(RenderSvgParams),
+    PolychromeSvg(RenderSvgParams),
     Image(RenderImageParams),
 }
 
@@ -1249,7 +1250,7 @@ impl AtlasKey {
                 }
             }
             AtlasKey::Svg(_) => AtlasTextureKind::Monochrome,
-            AtlasKey::Image(_) => AtlasTextureKind::Polychrome,
+            AtlasKey::PolychromeSvg(_) | AtlasKey::Image(_) => AtlasTextureKind::Polychrome,
         }
     }
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1376,6 +1376,7 @@ pub fn get_gamma_correction_ratios(gamma: f32) -> [f32; 4] {
 pub enum AtlasKey {
     Glyph(RenderGlyphParams),
     Svg(RenderSvgParams),
+    PolychromeSvg(RenderSvgParams),
     Image(RenderImageParams),
 }
 
@@ -1400,7 +1401,7 @@ impl AtlasKey {
                 }
             }
             AtlasKey::Svg(_) => AtlasTextureKind::Monochrome,
-            AtlasKey::Image(_) => AtlasTextureKind::Polychrome,
+            AtlasKey::PolychromeSvg(_) | AtlasKey::Image(_) => AtlasTextureKind::Polychrome,
         }
     }
 }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -748,7 +748,7 @@ impl From<SubpixelSprite> for Primitive {
 #[expect(missing_docs)]
 pub struct PolychromeSprite {
     pub order: DrawOrder,
-    pub pad: u32,
+    pub premultiplied_alpha: PaddedBool32,
     pub grayscale: PaddedBool32,
     pub opacity: f32,
     pub bounds: Bounds<ScaledPixels>,

--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -199,29 +199,65 @@ impl SvgRenderer {
         params: &RenderSvgParams,
         bytes: Option<&[u8]>,
     ) -> Result<Option<(Size<DevicePixels>, Vec<u8>)>> {
+        Ok(self
+            .render_pixmap_for_params(params, bytes)?
+            .map(|(size, pixmap)| {
+                let alpha_mask = pixmap
+                    .pixels()
+                    .iter()
+                    .map(|pixel| pixel.alpha())
+                    .collect::<Vec<_>>();
+                (size, alpha_mask)
+            }))
+    }
+
+    pub(crate) fn render_polychrome(
+        &self,
+        params: &RenderSvgParams,
+        bytes: Option<&[u8]>,
+    ) -> Result<Option<(Size<DevicePixels>, Vec<u8>)>> {
+        Ok(self
+            .render_pixmap_for_params(params, bytes)?
+            .map(|(size, pixmap)| {
+                let mut bytes = pixmap.take();
+
+                // Swap RGBA to BGRA without unpremultiplying so texture filtering
+                // continues to operate on premultiplied pixels.
+                for pixel in bytes.chunks_exact_mut(4) {
+                    pixel.swap(0, 2);
+                }
+
+                (size, bytes)
+            }))
+    }
+
+    fn render_pixmap_for_params(
+        &self,
+        params: &RenderSvgParams,
+        bytes: Option<&[u8]>,
+    ) -> Result<Option<(Size<DevicePixels>, Pixmap)>> {
         anyhow::ensure!(!params.size.is_zero(), "can't render at a zero size");
 
-        let render_pixmap = |bytes| {
+        self.with_svg_data(params, bytes, |bytes| {
             let pixmap = self.render_pixmap(bytes, SvgSize::Size(params.size))?;
-
-            // Convert the pixmap's pixels into an alpha mask.
             let size = Size::new(
                 DevicePixels(pixmap.width() as i32),
                 DevicePixels(pixmap.height() as i32),
             );
-            let alpha_mask = pixmap
-                .pixels()
-                .iter()
-                .map(|p| p.alpha())
-                .collect::<Vec<_>>();
+            Ok((size, pixmap))
+        })
+    }
 
-            Ok(Some((size, alpha_mask)))
-        };
-
+    fn with_svg_data<T>(
+        &self,
+        params: &RenderSvgParams,
+        bytes: Option<&[u8]>,
+        render: impl FnOnce(&[u8]) -> Result<T>,
+    ) -> Result<Option<T>> {
         if let Some(bytes) = bytes {
-            render_pixmap(bytes)
+            render(bytes).map(Some)
         } else if let Some(bytes) = self.asset_source.load(&params.path)? {
-            render_pixmap(&bytes)
+            render(&bytes).map(Some)
         } else {
             Ok(None)
         }
@@ -235,7 +271,8 @@ impl SvgRenderer {
         let tree = usvg::Tree::from_data(bytes, &self.usvg_options)?;
         let svg_size = tree.size();
         let mut scale = match size {
-            SvgSize::Size(size) => size.width.0 as f32 / svg_size.width(),
+            SvgSize::Size(size) => (size.width.0 as f32 / svg_size.width())
+                .min(size.height.0 as f32 / svg_size.height()),
             SvgSize::ScaleFactor(scale) => scale,
         };
 
@@ -328,6 +365,60 @@ mod tests {
         db.load_font_data(IBM_PLEX_REGULAR.to_vec());
         db.load_font_data(LILEX_REGULAR.to_vec());
         db
+    }
+
+    #[test]
+    fn render_polychrome_svg_preserves_premultiplied_color_and_alpha() {
+        let renderer = SvgRenderer::new(Arc::new(()));
+        let params = RenderSvgParams {
+            path: "test.svg".into(),
+            size: Size::new(DevicePixels(20), DevicePixels(10)),
+        };
+        let svg = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 1"><rect width="2" height="1" fill="#ff0000" fill-opacity="0.5"/></svg>"##;
+
+        let (size, bytes) = renderer
+            .render_polychrome(&params, Some(svg))
+            .expect("polychrome SVG should render")
+            .expect("polychrome SVG should produce pixels");
+
+        assert_eq!(size, params.size);
+        assert_eq!(bytes.len(), 20 * 10 * 4);
+        assert_eq!(
+            &bytes[(5 * 20 + 10) * 4..(5 * 20 + 10) * 4 + 4],
+            &[0, 0, 128, 128]
+        );
+    }
+
+    #[test]
+    fn render_svg_size_uses_contain_semantics() {
+        let renderer = SvgRenderer::new(Arc::new(()));
+        let params = RenderSvgParams {
+            path: "test.svg".into(),
+            size: Size::new(DevicePixels(20), DevicePixels(20)),
+        };
+
+        for (svg, expected_size) in [
+            (
+                br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 1"></svg>"##.as_slice(),
+                Size::new(DevicePixels(20), DevicePixels(10)),
+            ),
+            (
+                br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 2"></svg>"##.as_slice(),
+                Size::new(DevicePixels(10), DevicePixels(20)),
+            ),
+        ] {
+            let (polychrome_size, _) = renderer
+                .render_polychrome(&params, Some(svg))
+                .expect("polychrome SVG should render")
+                .expect("polychrome SVG should produce pixels");
+            assert_eq!(polychrome_size, expected_size);
+
+            let (alpha_mask_size, _) = renderer
+                .render_alpha_mask(&params, Some(svg))
+                .expect("monochrome SVG should render")
+                .expect("monochrome SVG should produce pixels");
+            assert_eq!(alpha_mask_size, expected_size);
+        }
     }
 
     #[test]

--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -105,7 +105,7 @@ pub struct ParsedSvg(usvg::Tree);
 /// The size in which to rasterize the SVG.
 #[derive(Clone, Copy)]
 pub enum SvgSize {
-    /// A width in device pixels. The SVG retains its aspect ratio.
+    /// A bounding size in device pixels. The SVG retains its aspect ratio.
     Size(Size<DevicePixels>),
     /// An exact width and height in device pixels.
     ExactSize(Size<DevicePixels>),
@@ -235,29 +235,65 @@ impl SvgRenderer {
         params: &RenderSvgParams,
         bytes: Option<&[u8]>,
     ) -> Result<Option<(Size<DevicePixels>, Vec<u8>)>> {
+        Ok(self
+            .render_pixmap_for_params(params, bytes)?
+            .map(|(size, pixmap)| {
+                let alpha_mask = pixmap
+                    .pixels()
+                    .iter()
+                    .map(|pixel| pixel.alpha())
+                    .collect::<Vec<_>>();
+                (size, alpha_mask)
+            }))
+    }
+
+    pub(crate) fn render_polychrome(
+        &self,
+        params: &RenderSvgParams,
+        bytes: Option<&[u8]>,
+    ) -> Result<Option<(Size<DevicePixels>, Vec<u8>)>> {
+        Ok(self
+            .render_pixmap_for_params(params, bytes)?
+            .map(|(size, pixmap)| {
+                let mut bytes = pixmap.take();
+
+                // Swap RGBA to BGRA without unpremultiplying so texture filtering
+                // continues to operate on premultiplied pixels.
+                for pixel in bytes.chunks_exact_mut(4) {
+                    pixel.swap(0, 2);
+                }
+
+                (size, bytes)
+            }))
+    }
+
+    fn render_pixmap_for_params(
+        &self,
+        params: &RenderSvgParams,
+        bytes: Option<&[u8]>,
+    ) -> Result<Option<(Size<DevicePixels>, Pixmap)>> {
         anyhow::ensure!(!params.size.is_zero(), "can't render at a zero size");
 
-        let render_pixmap = |bytes| {
+        self.with_svg_data(params, bytes, |bytes| {
             let pixmap = self.render_pixmap(bytes, SvgSize::Size(params.size))?;
-
-            // Convert the pixmap's pixels into an alpha mask.
             let size = Size::new(
                 DevicePixels(pixmap.width() as i32),
                 DevicePixels(pixmap.height() as i32),
             );
-            let alpha_mask = pixmap
-                .pixels()
-                .iter()
-                .map(|p| p.alpha())
-                .collect::<Vec<_>>();
+            Ok((size, pixmap))
+        })
+    }
 
-            Ok(Some((size, alpha_mask)))
-        };
-
+    fn with_svg_data<T>(
+        &self,
+        params: &RenderSvgParams,
+        bytes: Option<&[u8]>,
+        render: impl FnOnce(&[u8]) -> Result<T>,
+    ) -> Result<Option<T>> {
         if let Some(bytes) = bytes {
-            render_pixmap(bytes)
+            render(bytes).map(Some)
         } else if let Some(bytes) = self.asset_source.load(&params.path)? {
-            render_pixmap(&bytes)
+            render(&bytes).map(Some)
         } else {
             Ok(None)
         }
@@ -277,7 +313,8 @@ fn rasterize_tree(tree: &usvg::Tree, size: SvgSize) -> Result<Pixmap, usvg::Erro
     let svg_size = tree.size();
     let (mut width, mut height) = match size {
         SvgSize::Size(size) => {
-            let scale = i32::from(size.width) as f32 / svg_size.width();
+            let scale = (i32::from(size.width) as f32 / svg_size.width())
+                .min(i32::from(size.height) as f32 / svg_size.height());
             (svg_size.width() * scale, svg_size.height() * scale)
         }
         SvgSize::ExactSize(size) => (i32::from(size.width) as f32, i32::from(size.height) as f32),
@@ -397,6 +434,60 @@ mod tests {
         db.load_font_data(IBM_PLEX_REGULAR.to_vec());
         db.load_font_data(LILEX_REGULAR.to_vec());
         db
+    }
+
+    #[test]
+    fn render_polychrome_svg_preserves_premultiplied_color_and_alpha() {
+        let renderer = SvgRenderer::new(Arc::new(()));
+        let params = RenderSvgParams {
+            path: "test.svg".into(),
+            size: Size::new(DevicePixels(20), DevicePixels(10)),
+        };
+        let svg = br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 1"><rect width="2" height="1" fill="#ff0000" fill-opacity="0.5"/></svg>"##;
+
+        let (size, bytes) = renderer
+            .render_polychrome(&params, Some(svg))
+            .expect("polychrome SVG should render")
+            .expect("polychrome SVG should produce pixels");
+
+        assert_eq!(size, params.size);
+        assert_eq!(bytes.len(), 20 * 10 * 4);
+        assert_eq!(
+            &bytes[(5 * 20 + 10) * 4..(5 * 20 + 10) * 4 + 4],
+            &[0, 0, 128, 128]
+        );
+    }
+
+    #[test]
+    fn render_svg_size_uses_contain_semantics() {
+        let renderer = SvgRenderer::new(Arc::new(()));
+        let params = RenderSvgParams {
+            path: "test.svg".into(),
+            size: Size::new(DevicePixels(20), DevicePixels(20)),
+        };
+
+        for (svg, expected_size) in [
+            (
+                br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 1"></svg>"##.as_slice(),
+                Size::new(DevicePixels(20), DevicePixels(10)),
+            ),
+            (
+                br##"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 2"></svg>"##.as_slice(),
+                Size::new(DevicePixels(10), DevicePixels(20)),
+            ),
+        ] {
+            let (polychrome_size, _) = renderer
+                .render_polychrome(&params, Some(svg))
+                .expect("polychrome SVG should render")
+                .expect("polychrome SVG should produce pixels");
+            assert_eq!(polychrome_size, expected_size);
+
+            let (alpha_mask_size, _) = renderer
+                .render_alpha_mask(&params, Some(svg))
+                .expect("monochrome SVG should render")
+                .expect("monochrome SVG should produce pixels");
+            assert_eq!(alpha_mask_size, expected_size);
+        }
     }
 
     #[test]

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2,8 +2,8 @@
 use crate::Inspector;
 use crate::{
     Action, AnyDrag, AnyElement, AnyImageCache, AnyTooltip, AnyView, App, AppContext, Arena, Asset,
-    AsyncWindowContext, AtlasTile, AvailableSpace, Background, BorderStyle, Bounds, BoxShadow,
-    Capslock, Context, Corners, CursorHideMode, CursorStyle, Decorations, DevicePixels,
+    AsyncWindowContext, AtlasKey, AtlasTile, AvailableSpace, Background, BorderStyle, Bounds,
+    BoxShadow, Capslock, Context, Corners, CursorHideMode, CursorStyle, Decorations, DevicePixels,
     DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity,
     EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs,
     Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke,
@@ -4279,7 +4279,7 @@ impl Window {
 
             self.next_frame.scene.insert_primitive(PolychromeSprite {
                 order: 0,
-                pad: 0,
+                premultiplied_alpha: false.into(),
                 grayscale: false.into(),
                 bounds,
                 corner_radii: Default::default(),
@@ -4291,6 +4291,23 @@ impl Window {
         Ok(())
     }
 
+    fn bounds_for_svg(
+        bounds: Bounds<ScaledPixels>,
+        rendered_size: Size<DevicePixels>,
+    ) -> Bounds<ScaledPixels> {
+        let svg_bounds = Bounds {
+            origin: bounds.center()
+                - Point::new(
+                    ScaledPixels(rendered_size.width.0 as f32 / SMOOTH_SVG_SCALE_FACTOR / 2.),
+                    ScaledPixels(rendered_size.height.0 as f32 / SMOOTH_SVG_SCALE_FACTOR / 2.),
+                ),
+            size: rendered_size.map(|value| ScaledPixels(value.0 as f32 / SMOOTH_SVG_SCALE_FACTOR)),
+        };
+        svg_bounds
+            .map_origin(|value| ScaledPixels(round_half_toward_zero(value.0)))
+            .map_size(|size| size.ceil())
+    }
+
     /// Paint a monochrome SVG into the scene for the next frame at the current stacking context.
     ///
     /// This method should only be called as part of the paint phase of element drawing.
@@ -4298,7 +4315,7 @@ impl Window {
         &mut self,
         bounds: Bounds<Pixels>,
         path: SharedString,
-        mut data: Option<&[u8]>,
+        data: Option<&[u8]>,
         transformation: TransformationMatrix,
         color: Hsla,
         cx: &App,
@@ -4317,7 +4334,7 @@ impl Window {
 
         let Some(tile) =
             self.sprite_atlas
-                .get_or_insert_with(&params.clone().into(), &mut || {
+                .get_or_insert_with(&AtlasKey::Svg(params.clone()), &mut || {
                     let Some((size, bytes)) = cx.svg_renderer.render_alpha_mask(&params, data)?
                     else {
                         return Ok(None);
@@ -4328,29 +4345,67 @@ impl Window {
             return Ok(());
         };
         let content_mask = self.snapped_content_mask();
-        let svg_bounds = Bounds {
-            origin: bounds.center()
-                - Point::new(
-                    ScaledPixels(tile.bounds.size.width.0 as f32 / SMOOTH_SVG_SCALE_FACTOR / 2.),
-                    ScaledPixels(tile.bounds.size.height.0 as f32 / SMOOTH_SVG_SCALE_FACTOR / 2.),
-                ),
-            size: tile
-                .bounds
-                .size
-                .map(|value| ScaledPixels(value.0 as f32 / SMOOTH_SVG_SCALE_FACTOR)),
-        };
-        let final_bounds = svg_bounds
-            .map_origin(|value| ScaledPixels(round_half_toward_zero(value.0)))
-            .map_size(|size| size.ceil());
+        let bounds = Self::bounds_for_svg(bounds, tile.bounds.size);
 
         self.next_frame.scene.insert_primitive(MonochromeSprite {
             order: 0,
             pad: 0,
-            bounds: final_bounds,
+            bounds,
             content_mask,
             color: color.opacity(element_opacity),
             tile,
             transformation,
+        });
+
+        Ok(())
+    }
+
+    /// Paint a polychrome SVG into the scene for the next frame at the current stacking context.
+    ///
+    /// This method should only be called as part of the paint phase of element drawing.
+    pub fn paint_polychrome_svg(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        path: SharedString,
+        data: Option<&[u8]>,
+        cx: &App,
+    ) -> Result<()> {
+        self.invalidator.debug_assert_paint();
+
+        let element_opacity = self.element_opacity();
+        let bounds = self.snap_bounds(bounds);
+
+        let params = RenderSvgParams {
+            path,
+            size: bounds.size.map(|pixels| {
+                DevicePixels::from((pixels.0 * SMOOTH_SVG_SCALE_FACTOR).ceil() as i32)
+            }),
+        };
+
+        let Some(tile) = self.sprite_atlas.get_or_insert_with(
+            &AtlasKey::PolychromeSvg(params.clone()),
+            &mut || {
+                let Some((size, bytes)) = cx.svg_renderer.render_polychrome(&params, data)? else {
+                    return Ok(None);
+                };
+                Ok(Some((size, Cow::Owned(bytes))))
+            },
+        )?
+        else {
+            return Ok(());
+        };
+        let content_mask = self.snapped_content_mask();
+        let bounds = Self::bounds_for_svg(bounds, tile.bounds.size);
+
+        self.next_frame.scene.insert_primitive(PolychromeSprite {
+            order: 0,
+            premultiplied_alpha: true.into(),
+            grayscale: false.into(),
+            opacity: element_opacity,
+            bounds,
+            content_mask,
+            corner_radii: Default::default(),
+            tile,
         });
 
         Ok(())
@@ -4451,7 +4506,7 @@ impl Window {
 
         self.next_frame.scene.insert_primitive(PolychromeSprite {
             order: 0,
-            pad: 0,
+            premultiplied_alpha: false.into(),
             grayscale: grayscale.into(),
             bounds: visible_bounds_snapped,
             content_mask,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -6,8 +6,8 @@ use crate::Inspector;
 use crate::profiler;
 use crate::{
     Action, AnyDrag, AnyElement, AnyImageCache, AnyTooltip, AnyView, App, AppContext, Arena, Asset,
-    AsyncWindowContext, AtlasTile, AvailableSpace, Background, BorderStyle, Bounds, BoxShadow,
-    Capslock, Context, Corners, CursorHideMode, CursorStyle, Decorations, DevicePixels,
+    AsyncWindowContext, AtlasKey, AtlasTile, AvailableSpace, Background, BorderStyle, Bounds,
+    BoxShadow, Capslock, Context, Corners, CursorHideMode, CursorStyle, Decorations, DevicePixels,
     DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity,
     EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs,
     Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke,
@@ -4688,7 +4688,7 @@ impl Window {
 
             self.next_frame.scene.insert_primitive(PolychromeSprite {
                 order: 0,
-                pad: 0,
+                premultiplied_alpha: false.into(),
                 grayscale: false.into(),
                 bounds,
                 corner_radii: Default::default(),
@@ -4700,6 +4700,23 @@ impl Window {
         Ok(())
     }
 
+    fn bounds_for_svg(
+        bounds: Bounds<ScaledPixels>,
+        rendered_size: Size<DevicePixels>,
+    ) -> Bounds<ScaledPixels> {
+        let svg_bounds = Bounds {
+            origin: bounds.center()
+                - Point::new(
+                    ScaledPixels(rendered_size.width.0 as f32 / SMOOTH_SVG_SCALE_FACTOR / 2.),
+                    ScaledPixels(rendered_size.height.0 as f32 / SMOOTH_SVG_SCALE_FACTOR / 2.),
+                ),
+            size: rendered_size.map(|value| ScaledPixels(value.0 as f32 / SMOOTH_SVG_SCALE_FACTOR)),
+        };
+        svg_bounds
+            .map_origin(|value| ScaledPixels(round_half_toward_zero(value.0)))
+            .map_size(|size| size.ceil())
+    }
+
     /// Paint a monochrome SVG into the scene for the next frame at the current stacking context.
     ///
     /// This method should only be called as part of the paint phase of element drawing.
@@ -4707,7 +4724,7 @@ impl Window {
         &mut self,
         bounds: Bounds<Pixels>,
         path: SharedString,
-        mut data: Option<&[u8]>,
+        data: Option<&[u8]>,
         transformation: TransformationMatrix,
         color: Hsla,
         cx: &App,
@@ -4726,7 +4743,7 @@ impl Window {
 
         let Some(tile) =
             self.sprite_atlas
-                .get_or_insert_with(&params.clone().into(), &mut || {
+                .get_or_insert_with(&AtlasKey::Svg(params.clone()), &mut || {
                     let Some((size, bytes)) = cx.svg_renderer.render_alpha_mask(&params, data)?
                     else {
                         return Ok(None);
@@ -4737,29 +4754,67 @@ impl Window {
             return Ok(());
         };
         let content_mask = self.snapped_content_mask();
-        let svg_bounds = Bounds {
-            origin: bounds.center()
-                - Point::new(
-                    ScaledPixels(tile.bounds.size.width.0 as f32 / SMOOTH_SVG_SCALE_FACTOR / 2.),
-                    ScaledPixels(tile.bounds.size.height.0 as f32 / SMOOTH_SVG_SCALE_FACTOR / 2.),
-                ),
-            size: tile
-                .bounds
-                .size
-                .map(|value| ScaledPixels(value.0 as f32 / SMOOTH_SVG_SCALE_FACTOR)),
-        };
-        let final_bounds = svg_bounds
-            .map_origin(|value| ScaledPixels(round_half_toward_zero(value.0)))
-            .map_size(|size| size.ceil());
+        let bounds = Self::bounds_for_svg(bounds, tile.bounds.size);
 
         self.next_frame.scene.insert_primitive(MonochromeSprite {
             order: 0,
             pad: 0,
-            bounds: final_bounds,
+            bounds,
             content_mask,
             color: color.opacity(element_opacity),
             tile,
             transformation,
+        });
+
+        Ok(())
+    }
+
+    /// Paint a polychrome SVG into the scene for the next frame at the current stacking context.
+    ///
+    /// This method should only be called as part of the paint phase of element drawing.
+    pub fn paint_polychrome_svg(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        path: SharedString,
+        data: Option<&[u8]>,
+        cx: &App,
+    ) -> Result<()> {
+        self.invalidator.debug_assert_paint();
+
+        let element_opacity = self.element_opacity();
+        let bounds = self.snap_bounds(bounds);
+
+        let params = RenderSvgParams {
+            path,
+            size: bounds.size.map(|pixels| {
+                DevicePixels::from((pixels.0 * SMOOTH_SVG_SCALE_FACTOR).ceil() as i32)
+            }),
+        };
+
+        let Some(tile) = self.sprite_atlas.get_or_insert_with(
+            &AtlasKey::PolychromeSvg(params.clone()),
+            &mut || {
+                let Some((size, bytes)) = cx.svg_renderer.render_polychrome(&params, data)? else {
+                    return Ok(None);
+                };
+                Ok(Some((size, Cow::Owned(bytes))))
+            },
+        )?
+        else {
+            return Ok(());
+        };
+        let content_mask = self.snapped_content_mask();
+        let bounds = Self::bounds_for_svg(bounds, tile.bounds.size);
+
+        self.next_frame.scene.insert_primitive(PolychromeSprite {
+            order: 0,
+            premultiplied_alpha: true.into(),
+            grayscale: false.into(),
+            opacity: element_opacity,
+            bounds,
+            content_mask,
+            corner_radii: Default::default(),
+            tile,
         });
 
         Ok(())
@@ -4860,7 +4915,7 @@ impl Window {
 
         self.next_frame.scene.insert_primitive(PolychromeSprite {
             order: 0,
-            pad: 0,
+            premultiplied_alpha: false.into(),
             grayscale: grayscale.into(),
             bounds: visible_bounds_snapped,
             content_mask,

--- a/crates/gpui_apple/src/shaders.metal
+++ b/crates/gpui_apple/src/shaders.metal
@@ -720,6 +720,10 @@ fragment float4 polychrome_sprite_fragment(
   float distance =
       quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
 
+  if (sprite.premultiplied_alpha && sample.a > 0.0) {
+    sample.rgb /= sample.a;
+  }
+
   float4 color = sample;
   if (sprite.grayscale) {
     float grayscale = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;

--- a/crates/gpui_macos/src/shaders.metal
+++ b/crates/gpui_macos/src/shaders.metal
@@ -720,6 +720,10 @@ fragment float4 polychrome_sprite_fragment(
   float distance =
       quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
 
+  if (sprite.premultiplied_alpha && sample.a > 0.0) {
+    sample.rgb /= sample.a;
+  }
+
   float4 color = sample;
   if (sprite.grayscale) {
     float grayscale = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1263,7 +1263,7 @@ fn fs_mono_sprite(input: MonoSpriteVarying) -> @location(0) vec4<f32> {
 
 struct PolychromeSprite {
     order: u32,
-    pad: u32,
+    premultiplied_alpha: u32,
     grayscale: u32,
     opacity: f32,
     bounds: Bounds,
@@ -1295,7 +1295,7 @@ fn vs_poly_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index
 
 @fragment
 fn fs_poly_sprite(input: PolySpriteVarying) -> @location(0) vec4<f32> {
-    let sample = textureSample(t_sprite, s_sprite, input.tile_position);
+    var sample = textureSample(t_sprite, s_sprite, input.tile_position);
     // Alpha clip after using the derivatives.
     if (any(input.clip_distances < vec4<f32>(0.0))) {
         return vec4<f32>(0.0);
@@ -1303,6 +1303,10 @@ fn fs_poly_sprite(input: PolySpriteVarying) -> @location(0) vec4<f32> {
 
     let sprite = b_poly_sprites[input.sprite_id];
     let distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+
+    if (sprite.premultiplied_alpha != 0u && sample.a > 0.0) {
+        sample = vec4<f32>(sample.rgb / sample.a, sample.a);
+    }
 
     var color = sample;
     if (sprite.grayscale != 0u) {

--- a/crates/gpui_wgpu/src/shaders.wgsl
+++ b/crates/gpui_wgpu/src/shaders.wgsl
@@ -1261,7 +1261,7 @@ fn fs_mono_sprite(input: MonoSpriteVarying) -> @location(0) vec4<f32> {
 
 struct PolychromeSprite {
     order: u32,
-    pad: u32,
+    premultiplied_alpha: u32,
     grayscale: u32,
     opacity: f32,
     bounds: Bounds,
@@ -1293,7 +1293,7 @@ fn vs_poly_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index
 
 @fragment
 fn fs_poly_sprite(input: PolySpriteVarying) -> @location(0) vec4<f32> {
-    let sample = textureSample(t_sprite, s_sprite, input.tile_position);
+    var sample = textureSample(t_sprite, s_sprite, input.tile_position);
     // Alpha clip after using the derivatives.
     if (any(input.clip_distances < vec4<f32>(0.0))) {
         return vec4<f32>(0.0);
@@ -1301,6 +1301,10 @@ fn fs_poly_sprite(input: PolySpriteVarying) -> @location(0) vec4<f32> {
 
     let sprite = load_poly_sprite(input.sprite_id);
     let distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+
+    if (sprite.premultiplied_alpha != 0u && sample.a > 0.0) {
+        sample = vec4<f32>(sample.rgb / sample.a, sample.a);
+    }
 
     var color = sample;
     if (sprite.grayscale != 0u) {

--- a/crates/gpui_windows/src/shaders.hlsl
+++ b/crates/gpui_windows/src/shaders.hlsl
@@ -1203,7 +1203,7 @@ SubpixelSpriteFragmentOutput subpixel_sprite_fragment(MonochromeSpriteFragmentIn
 
 struct PolychromeSprite {
     uint order;
-    uint pad;
+    uint premultiplied_alpha;
     uint grayscale;
     float opacity;
     Bounds bounds;
@@ -1247,6 +1247,10 @@ float4 polychrome_sprite_fragment(PolychromeSpriteFragmentInput input): SV_Targe
     PolychromeSprite sprite = poly_sprites[input.sprite_id];
     float4 sample = t_sprite.Sample(s_sprite, input.tile_position);
     float distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+
+    if (sprite.premultiplied_alpha != 0 && sample.a > 0.0) {
+        sample.rgb /= sample.a;
+    }
 
     float4 color = sample;
     if (sprite.grayscale != 0u) {

--- a/crates/gpui_windows/src/shaders.hlsl
+++ b/crates/gpui_windows/src/shaders.hlsl
@@ -1212,7 +1212,7 @@ SubpixelSpriteFragmentOutput subpixel_sprite_fragment(MonochromeSpriteFragmentIn
 
 struct PolychromeSprite {
     uint order;
-    uint pad;
+    uint premultiplied_alpha;
     uint grayscale;
     float opacity;
     Bounds bounds;
@@ -1257,6 +1257,10 @@ float4 polychrome_sprite_fragment(PolychromeSpriteFragmentInput input): SV_Targe
     PolychromeSprite sprite = poly_sprites[input.sprite_id];
     float4 sample = t_sprite.Sample(s_sprite, input.tile_position);
     float distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+
+    if (sprite.premultiplied_alpha != 0 && sample.a > 0.0) {
+        sample.rgb /= sample.a;
+    }
 
     float4 color = sample;
     if (sprite.grayscale != 0u) {

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -117,14 +117,12 @@ impl From<IconName> for Icon {
 enum IconSource {
     /// An SVG embedded in the Zed binary.
     Embedded(SharedString),
+    /// A polychrome SVG located at the specified path.
+    ExternalPolychromeSvg(SharedString),
     /// An image file located at the specified path.
-    ///
-    /// Currently our SVG renderer is missing support for rendering polychrome SVGs.
-    ///
-    /// In order to support icon themes, we render the icons as images instead.
-    External(Arc<Path>),
-    /// An SVG not embedded in the Zed binary.
-    ExternalSvg(SharedString),
+    ExternalImage(Arc<Path>),
+    /// A monochrome SVG not embedded in the Zed binary.
+    ExternalMonochromeSvg(SharedString),
 }
 
 #[derive(Clone, IntoElement, RegisterComponent)]
@@ -147,13 +145,20 @@ impl Icon {
 
     /// Create an icon from a path. Uses a heuristic to determine if it's embedded or external:
     /// - Paths starting with "icons/" are treated as embedded SVGs
-    /// - Other paths are treated as external raster images (from icon themes)
+    /// - Other SVG paths are treated as external polychrome SVGs (from icon themes)
+    /// - Other paths are treated as external raster images
     pub fn from_path(path: impl Into<SharedString>) -> Self {
         let path = path.into();
         let source = if path.starts_with("icons/") {
             IconSource::Embedded(path)
+        } else if Path::new(path.as_ref())
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("svg"))
+        {
+            IconSource::ExternalPolychromeSvg(path)
         } else {
-            IconSource::External(Arc::from(PathBuf::from(path.as_ref())))
+            IconSource::ExternalImage(Arc::from(PathBuf::from(path.as_ref())))
         };
         Self {
             source,
@@ -165,7 +170,7 @@ impl Icon {
 
     pub fn from_external_svg(svg: SharedString) -> Self {
         Self {
-            source: IconSource::ExternalSvg(svg),
+            source: IconSource::ExternalMonochromeSvg(svg),
             color: Color::default(),
             size: IconSize::default().rems(),
             transformation: Transformation::default(),
@@ -208,14 +213,20 @@ impl RenderOnce for Icon {
                 .path(path)
                 .text_color(self.color.color(cx))
                 .into_any_element(),
-            IconSource::ExternalSvg(path) => svg()
+            IconSource::ExternalPolychromeSvg(path) => svg()
+                .external_path(path)
+                .polychrome()
+                .size(self.size)
+                .flex_none()
+                .into_any_element(),
+            IconSource::ExternalMonochromeSvg(path) => svg()
                 .external_path(path)
                 .with_transformation(self.transformation)
                 .size(self.size)
                 .flex_none()
                 .text_color(self.color.color(cx))
                 .into_any_element(),
-            IconSource::External(path) => img(path)
+            IconSource::ExternalImage(path) => img(path)
                 .size(self.size)
                 .flex_none()
                 .text_color(self.color.color(cx))
@@ -280,6 +291,31 @@ impl RenderOnce for IconWithIndicator {
                         .child(indicator),
                 )
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_path_selects_source_by_path_kind() {
+        assert!(matches!(
+            Icon::from_path("icons/file.svg").source,
+            IconSource::Embedded(_)
+        ));
+        assert!(matches!(
+            Icon::from_path("theme/file.SVG").source,
+            IconSource::ExternalPolychromeSvg(_)
+        ));
+        assert!(matches!(
+            Icon::from_path("theme/file.png").source,
+            IconSource::ExternalImage(_)
+        ));
+        assert!(matches!(
+            Icon::from_external_svg("theme/monochrome.svg".into()).source,
+            IconSource::ExternalMonochromeSvg(_)
+        ));
     }
 }
 

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -131,14 +131,12 @@ pub fn git_hosting_provider_icon(provider_name: &str) -> IconName {
 enum IconSource {
     /// An SVG embedded in the Zed binary.
     Embedded(SharedString),
+    /// A polychrome SVG located at the specified path.
+    ExternalPolychromeSvg(SharedString),
     /// An image file located at the specified path.
-    ///
-    /// Currently our SVG renderer is missing support for rendering polychrome SVGs.
-    ///
-    /// In order to support icon themes, we render the icons as images instead.
-    External(Arc<Path>),
-    /// An SVG not embedded in the Zed binary.
-    ExternalSvg(SharedString),
+    ExternalImage(Arc<Path>),
+    /// A monochrome SVG not embedded in the Zed binary.
+    ExternalMonochromeSvg(SharedString),
 }
 
 #[derive(Clone, IntoElement, RegisterComponent)]
@@ -161,13 +159,20 @@ impl Icon {
 
     /// Create an icon from a path. Uses a heuristic to determine if it's embedded or external:
     /// - Paths starting with "icons/" are treated as embedded SVGs
-    /// - Other paths are treated as external raster images (from icon themes)
+    /// - Other SVG paths are treated as external polychrome SVGs (from icon themes)
+    /// - Other paths are treated as external raster images
     pub fn from_path(path: impl Into<SharedString>) -> Self {
         let path = path.into();
         let source = if path.starts_with("icons/") {
             IconSource::Embedded(path)
+        } else if Path::new(path.as_ref())
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("svg"))
+        {
+            IconSource::ExternalPolychromeSvg(path)
         } else {
-            IconSource::External(Arc::from(PathBuf::from(path.as_ref())))
+            IconSource::ExternalImage(Arc::from(PathBuf::from(path.as_ref())))
         };
         Self {
             source,
@@ -179,7 +184,7 @@ impl Icon {
 
     pub fn from_external_svg(svg: SharedString) -> Self {
         Self {
-            source: IconSource::ExternalSvg(svg),
+            source: IconSource::ExternalMonochromeSvg(svg),
             color: Color::default(),
             size: IconSize::default().rems(),
             transformation: Transformation::default(),
@@ -222,14 +227,20 @@ impl RenderOnce for Icon {
                 .path(path)
                 .text_color(self.color.color(cx))
                 .into_any_element(),
-            IconSource::ExternalSvg(path) => svg()
+            IconSource::ExternalPolychromeSvg(path) => svg()
+                .external_path(path)
+                .polychrome()
+                .size(self.size)
+                .flex_none()
+                .into_any_element(),
+            IconSource::ExternalMonochromeSvg(path) => svg()
                 .external_path(path)
                 .with_transformation(self.transformation)
                 .size(self.size)
                 .flex_none()
                 .text_color(self.color.color(cx))
                 .into_any_element(),
-            IconSource::External(path) => img(path)
+            IconSource::ExternalImage(path) => img(path)
                 .size(self.size)
                 .flex_none()
                 .text_color(self.color.color(cx))
@@ -294,6 +305,31 @@ impl RenderOnce for IconWithIndicator {
                         .child(indicator),
                 )
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_path_selects_source_by_path_kind() {
+        assert!(matches!(
+            Icon::from_path("icons/file.svg").source,
+            IconSource::Embedded(_)
+        ));
+        assert!(matches!(
+            Icon::from_path("theme/file.SVG").source,
+            IconSource::ExternalPolychromeSvg(_)
+        ));
+        assert!(matches!(
+            Icon::from_path("theme/file.png").source,
+            IconSource::ExternalImage(_)
+        ));
+        assert!(matches!(
+            Icon::from_external_svg("theme/monochrome.svg".into()).source,
+            IconSource::ExternalMonochromeSvg(_)
+        ));
     }
 }
 


### PR DESCRIPTION
## Objective

- Fixes #35958
- Fix pixelated and artifact-prone SVG file icons, especially at small UI font sizes and on low-DPI displays.

## Solution

- Render external SVGs from icon themes through GPUI's SVG pipeline at their final on-screen size and display scale instead of loading them as generic images rasterized at a fixed intrinsic size.
- Add a polychrome SVG path that preserves each icon's original colors while keeping monochrome SVG rendering unchanged.
- Cache monochrome SVGs, polychrome SVGs, and raster images separately in the sprite atlas.
- Keep SVG atlas pixels premultiplied while textures are filtered, then convert them to straight alpha in the Metal, WGSL, and DirectX shaders before compositing. This avoids transparent black texels darkening and thinning antialiased edges.
- Use contain semantics for non-square SVGs and continue using the existing image path for raster icon-theme assets.

## Testing

- `cargo fmt --all --check`
- `cargo test -p gpui svg_renderer::tests --lib`
- `cargo test -p ui from_path_selects_source_by_path_kind --lib`
- `cargo check -p gpui_wgpu`
- `./script/clippy -p gpui -p gpui_wgpu -p ui`
- Validated the WGSL shader with Naga.
- Compiled the DirectX polychrome fragment shader with `glslangValidator`.
- Manually compared before-and-after rendering with Catppuccin and Monokai icons on a low-DPI Linux display, including Catppuccin rendering in Zed and VS Code.

Reviewers can reproduce the original issue by installing Catppuccin Icons, selecting the Mocha variant, and setting `ui_font_size` to `12`. Thin strokes and diagonal or curved edges should render more clearly after this change.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

The screenshots below use the same project on a low-DPI display. The improvement is most visible on thin strokes and diagonal or curved edges.

### Catppuccin, UI font size 12

| Before | After |
| --- | --- |
| ![Catppuccin icon rendering before this change at UI font size 12](https://github.com/user-attachments/assets/4db81ffe-f326-4327-8cc2-d0fd77ef6ff2) | ![Catppuccin icon rendering after this change at UI font size 12](https://github.com/user-attachments/assets/c400ea26-53a3-47eb-8360-3f3e71edd760) |

### Catppuccin, UI font size 15

| Before | After |
| --- | --- |
| ![Catppuccin icon rendering before this change at UI font size 15](https://github.com/user-attachments/assets/f9bb7b30-9db0-448b-99ad-96c9c25ee650) | ![Catppuccin icon rendering after this change at UI font size 15](https://github.com/user-attachments/assets/d1e8b2ca-8c4c-423b-b5df-57f8d1940023) |

### Monokai Pro, UI font size 15

| Before | After |
| --- | --- |
| ![Monokai Pro icon rendering before this change at UI font size 15](https://github.com/user-attachments/assets/06b66364-9c8d-48fc-b71d-ab600a792920) | ![Monokai Pro icon rendering after this change at UI font size 15](https://github.com/user-attachments/assets/98e21c34-3f57-46a6-a3b4-493c486b6f14) |

---

Release Notes:

- Improved rendering quality for SVG file icons, especially at small UI font sizes.
