### PR TITLE
workspace: Fix crash when closing the active item from a focused panel

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7854,9 +7854,15 @@ impl Workspace {
                         if let Some(active_panel) = dock.active_panel() {
                             if active_panel.pane(cx).is_none() {
                                 let active_pane = workspace.active_pane().clone();
-                                active_pane.update(cx, |pane, cx| {
-                                    pane.close_active_item(action, window, cx)
-                                        .detach_and_log_err(cx);
+                                let action = action.clone();
+                                // Defer so the workspace isn't mid-update when a fully
+                                // pinned pane makes `close_active_item` reach back into
+                                // it to look for an unpinned tab elsewhere.
+                                window.defer(cx, move |window, cx| {
+                                    active_pane.update(cx, |pane, cx| {
+                                        pane.close_active_item(&action, window, cx)
+                                            .detach_and_log_err(cx);
+                                    });
                                 });
                                 return;
                             }
@@ -16521,6 +16527,57 @@ mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             assert!(workspace.right_dock().read(cx).is_open());
             assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_pane_close_active_item_from_dock_with_all_tabs_pinned(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = multi_workspace.read_with(cx, |mw, _| mw.workspace().clone());
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Right, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+
+            workspace
+                .right_dock()
+                .update(cx, |right_dock, cx| right_dock.set_open(true, window, cx));
+
+            panel
+        });
+
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+        let item_a = cx.new(TestItem::new);
+        let item_b = cx.new(TestItem::new);
+        let item_b_id = item_b.entity_id();
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.add_item(Box::new(item_a.clone()), true, true, None, window, cx);
+            pane.add_item(Box::new(item_b.clone()), true, true, None, window, cx);
+            pane.set_pinned_count(2);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_panel_focus::<TestPanel>(window, cx);
+        });
+
+        workspace.update_in(cx, |_, window, cx| {
+            assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+        });
+
+        // Every center tab is pinned, so with `close_pinned` unset this must be
+        // a no-op. Dispatching it from the focused dock used to panic by
+        // re-entering the workspace while it was still mid-update.
+        cx.dispatch_action(pane::CloseActiveItem::default());
+        cx.run_until_parked();
+
+        pane.read_with(cx, |pane, _| {
+            assert_eq!(pane.items_len(), 2);
+            assert_eq!(pane.active_item().unwrap().item_id(), item_b_id);
         });
     }
 


### PR DESCRIPTION
If you remap `cmd-w` to `pane::CloseActiveItem` at the `Workspace` context (the usual trick for closing the center tab while a dock is focused) and every center tab is pinned, Zed crashes instead of doing nothing.

The workspace handler forwards the close into the active pane while it's still mid-update. With all tabs pinned, `close_active_item` reaches back into the workspace to look for an unpinned tab in another pane, and that re-entrant update panics. Deferring the forward so it runs after the update finishes fixes it, same as the dock-focus handler right above already does. Now it's a clean no-op.

closes #61182

Release Notes:

- Fixed a crash when closing the active item from a focused panel while every tab was pinned
