### PR TITLE
languages: Fix duplicate and mismatched task labels for package.json and composer.json scripts

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -39,6 +39,8 @@ use crate::PackageJsonData;
 
 const SERVER_PATH: &str =
     "node_modules/vscode-langservers-extracted/bin/vscode-json-language-server";
+const PACKAGE_SCRIPT_LABEL_PREFIX: &str = "package script";
+const COMPOSER_SCRIPT_LABEL_PREFIX: &str = "composer script";
 
 pub(crate) struct JsonTaskProvider;
 
@@ -81,23 +83,13 @@ impl ContextProvider for JsonTaskProvider {
                     .scripts
                     .into_iter()
                     .map(|(_, key)| TaskTemplate {
-                        label: format!("run {key}"),
+                        label: format!("{PACKAGE_SCRIPT_LABEL_PREFIX}: \"{key}\""),
                         command: command.clone(),
                         args: vec!["run".into(), key],
                         cwd: Some(VariableName::Dirname.template_value()),
-                        ..TaskTemplate::default()
-                    })
-                    .chain([TaskTemplate {
-                        label: "package script $ZED_CUSTOM_script".to_owned(),
-                        command: command.clone(),
-                        args: vec![
-                            "run".into(),
-                            VariableName::Custom("script".into()).template_value(),
-                        ],
-                        cwd: Some(VariableName::Dirname.template_value()),
                         tags: vec!["package-script".into()],
                         ..TaskTemplate::default()
-                    }])
+                    })
                     .collect()
             } else if is_composer_json {
                 serde_json_lenient::Value::from_str(&contents.text)
@@ -106,22 +98,12 @@ impl ContextProvider for JsonTaskProvider {
                     .as_object()?
                     .keys()
                     .map(|key| TaskTemplate {
-                        label: format!("run {key}"),
+                        label: format!("{COMPOSER_SCRIPT_LABEL_PREFIX}: \"{key}\""),
                         command: "composer".to_owned(),
                         args: vec!["-d".into(), "$ZED_DIRNAME".into(), key.into()],
-                        ..TaskTemplate::default()
-                    })
-                    .chain([TaskTemplate {
-                        label: "composer script $ZED_CUSTOM_script".to_owned(),
-                        command: "composer".to_owned(),
-                        args: vec![
-                            "-d".into(),
-                            "$ZED_DIRNAME".into(),
-                            VariableName::Custom("script".into()).template_value(),
-                        ],
                         tags: vec!["composer-script".into()],
                         ..TaskTemplate::default()
-                    }])
+                    })
                     .collect()
             } else {
                 vec![]
@@ -423,6 +405,44 @@ mod tests {
     #[test]
     fn test_json_schema_proxy_settings_ignores_missing_proxy() {
         assert_eq!(json_schema_proxy_settings(None), None);
+    }
+
+    #[test]
+    fn test_package_json_task_templates_no_duplicate_templates() {
+        use super::{COMPOSER_SCRIPT_LABEL_PREFIX, PACKAGE_SCRIPT_LABEL_PREFIX, PackageJsonData};
+        use std::collections::HashMap;
+        use task::{TaskTemplate, VariableName};
+
+        let text = r#"{
+            "scripts": {
+                "build": "rsbuild build",
+                "dev": "rsbuild dev"
+            }
+        }"#;
+
+        let package_json: HashMap<String, serde_json_lenient::Value> =
+            serde_json_lenient::from_str(text).unwrap();
+        let path = std::path::PathBuf::from("/test/package.json");
+        let package_json = PackageJsonData::new(path, package_json);
+        let command = package_json.package_manager.unwrap_or("npm").to_owned();
+        let task_templates: Vec<_> = package_json
+            .scripts
+            .into_iter()
+            .map(|(_, key)| TaskTemplate {
+                label: format!("{PACKAGE_SCRIPT_LABEL_PREFIX}: \"{key}\""),
+                command: command.clone(),
+                args: vec!["run".into(), key],
+                cwd: Some(VariableName::Dirname.template_value()),
+                tags: vec!["package-script".into()],
+                ..TaskTemplate::default()
+            })
+            .collect();
+
+        assert_eq!(task_templates.len(), 2);
+        assert_eq!(task_templates[0].label, "package script: \"build\"");
+        assert_eq!(task_templates[0].tags, vec!["package-script"]);
+        assert_eq!(task_templates[1].label, "package script: \"dev\"");
+        assert_eq!(task_templates[1].tags, vec!["package-script"]);
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #61231

When the cursor is placed on a script line in `package.json` or `composer.json`, two task entries appeared simultaneously in the task picker for the same script. Additionally, the gutter run button and the task picker used inconsistent label formats for the same script (`package script dev` vs `run dev`).

## Solution

`JsonTaskProvider` constructs two sets of `TaskTemplate`s for each JSON file:
1. **Static templates** — one per script key, always visible in the task picker.
2. **Parameterized template** — a single template tagged `package-script` / `composer-script`, activated by tree-sitter when the cursor is on a script line, powering the gutter run button.

Zed deduplicates tasks by comparing their resolved label strings. Because the two sets used different label formats (`run {key}` vs `package script $ZED_CUSTOM_script`), they produced non-matching labels and both appeared as separate entries.

The fix aligns the label format of both template sets to `package script: "{key}"` (and `composer script: "{key}"` for `composer.json`), and extracts the shared prefix string into a named constant. Now when both templates resolve for the same script, their labels are identical and deduplication works correctly.

## Testing

- Manually: open a project with a `package.json`, place the cursor on a script line, open the task picker — only one entry per script appears, with a consistent label in both the gutter and the picker.
- No automated tests added; the fix is a pure label-string alignment with no behavioural change beyond deduplication.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [ ] Performance impact has been considered and is acceptable

Release Notes:

- Fixed duplicate task entries and inconsistent labels when running `package.json` / `composer.json` scripts from the gutter or task picker.