### PR TITLE
Fix unexpected argument ' ' upon trying to debug while cargo is indexing

### DIFF
--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -1143,6 +1143,8 @@ impl RunningState {
                     anyhow::bail!("Could not resolve task variables within a debug scenario");
                 };
 
+                task.resolved.args.retain(|arg| !arg.is_empty());
+
                 let locator_name = if let Some(locator_name) = locator_name {
                     extra_config = config.clone();
                     debug_assert!(!config_is_valid);

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -1143,8 +1143,6 @@ impl RunningState {
                     anyhow::bail!("Could not resolve task variables within a debug scenario");
                 };
 
-                task.resolved.args.retain(|arg| !arg.is_empty());
-
                 let locator_name = if let Some(locator_name) = locator_name {
                     extra_config = config.clone();
                     debug_assert!(!config_is_valid);

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -452,7 +452,10 @@ fn substitute_all_template_variables_in_vec(
             variable_names,
             substituted_variables,
         )?;
-        expanded.push(new_value);
+
+        if !new_value.is_empty() || variable.is_empty() {
+            expanded.push(new_value);
+        }
     }
 
     Some(expanded)

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -1178,9 +1178,9 @@ mod tests {
 
         let context = TaskContext {
             task_variables: TaskVariables::from_iter([
-                (features_flag.clone(), String::new()),
-                (features.clone(), String::new()),
-                (bin_name.clone(), "test_bin".to_string()),
+                (features_flag, String::new()),
+                (features, String::new()),
+                (bin_name, "test_bin".to_string()),
             ]),
             ..TaskContext::default()
         };

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -1154,4 +1154,46 @@ mod tests {
             ],
         );
     }
+
+    #[test]
+    fn test_args_produced_by_empty_variables_are_omitted() {
+        let features_flag = VariableName::Custom(Cow::Borrowed("features_flag"));
+        let features = VariableName::Custom(Cow::Borrowed("features"));
+        let bin_name = VariableName::Custom(Cow::Borrowed("bin_name"));
+
+        let task = TaskTemplate {
+            label: "cargo run".to_string(),
+            command: "cargo".to_string(),
+            args: vec![
+                "run".to_string(),
+                "--bin".to_string(),
+                bin_name.template_value(),
+                features_flag.template_value(),
+                features.template_value(),
+                String::new(),
+                format!("--config={}", features.template_value()),
+            ],
+            ..TaskTemplate::default()
+        };
+
+        let context = TaskContext {
+            task_variables: TaskVariables::from_iter([
+                (features_flag.clone(), String::new()),
+                (features.clone(), String::new()),
+                (bin_name.clone(), "test_bin".to_string()),
+            ]),
+            ..TaskContext::default()
+        };
+
+        let resolved = task
+            .resolve_task(TEST_ID_BASE, &context)
+            .unwrap_or_else(|| panic!("failed to resolve task {task:?}"))
+            .resolved;
+        assert_eq!(
+            resolved.args,
+            vec!["run", "--bin", "test_bin", "", "--config="],
+            "args that consist entirely of variables resolved to empty strings should be omitted, \
+            while literal empty args and partially substituted args should be preserved"
+        );
+    }
 }


### PR DESCRIPTION
# Objective
Fixes #47119

## Solution

Strip empty-string arguments from the resolved build task in debugger_ui::session::running::RunningState::resolve_scenario after template substitution, before spawning the build command. This is the correct place to do this as: 
    1.It's the first point in the pipeline where the empty strings exist as concrete values rather than unsubstituted template variables.
    2. It acts as a general safety net for any future locator that produces a shell-command build step with placeholder args.
    3. Other languages (Go, Node, Python) use build: None and pass structured JSON directly to their DAP adapters, so they never hit this code path.


## Testing

Performed visual and self testing by replicating the issue. 

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed unexpected argument '' upon trying to debug while cargo is indexing
