### PR TITLE
project: Refresh inlay hints after dynamic registration

### DIFF
--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -3638,6 +3638,95 @@ let c = 3;"#
     }
 
     #[gpui::test]
+    async fn test_dynamic_inlay_hint_registration_requeries_open_document(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx, &|settings| {
+            settings.defaults.inlay_hints = Some(InlayHintSettingsContent {
+                show_value_hints: Some(true),
+                enabled: Some(true),
+                edit_debounce_ms: Some(0),
+                scroll_debounce_ms: Some(0),
+                show_type_hints: Some(true),
+                show_parameter_hints: Some(true),
+                show_other_hints: Some(true),
+                show_background: Some(false),
+                toggle_on_modifiers_press: None,
+            })
+        });
+
+        let request_count = Arc::new(AtomicU32::new(0));
+        let (_, editor, fake_server) =
+            prepare_test_objects_with_capabilities(cx, lsp::ServerCapabilities::default(), {
+                let request_count = request_count.clone();
+                move |fake_server, file_with_hints| {
+                    fake_server.set_request_handler::<lsp::request::InlayHintRequest, _, _>({
+                        let request_count = request_count.clone();
+                        move |params, _| {
+                            let request_count = request_count.clone();
+                            async move {
+                                assert_eq!(
+                                    params.text_document.uri,
+                                    lsp::Uri::from_file_path(file_with_hints).unwrap(),
+                                );
+                                request_count.fetch_add(1, Ordering::AcqRel);
+                                Ok(Some(vec![lsp::InlayHint {
+                                    position: lsp::Position::new(0, 0),
+                                    label: lsp::InlayHintLabel::String(
+                                        "Dynamically registered".to_string(),
+                                    ),
+                                    kind: None,
+                                    text_edits: None,
+                                    tooltip: None,
+                                    padding_left: None,
+                                    padding_right: None,
+                                    data: None,
+                                }]))
+                            }
+                        }
+                    });
+                }
+            })
+            .await;
+
+        assert_eq!(
+            request_count.load(Ordering::Acquire),
+            0,
+            "no inlay hints should be requested before the capability is registered"
+        );
+
+        fake_server
+            .request::<lsp::request::RegisterCapability>(
+                lsp::RegistrationParams {
+                    registrations: vec![lsp::Registration {
+                        id: "inlay-hints".to_string(),
+                        method: "textDocument/inlayHint".to_string(),
+                        register_options: None,
+                    }],
+                },
+                DEFAULT_LSP_REQUEST_TIMEOUT,
+            )
+            .await
+            .into_response()
+            .expect("register capability request failed");
+        cx.executor().run_until_parked();
+
+        assert_eq!(
+            request_count.load(Ordering::Acquire),
+            1,
+            "dynamic textDocument/inlayHint registration should re-query the open document"
+        );
+        editor
+            .update(cx, |editor, _, cx| {
+                assert_eq!(
+                    visible_hint_labels(editor, cx),
+                    vec!["Dynamically registered".to_string()],
+                );
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
     async fn test_inlays_at_the_same_place(cx: &mut gpui::TestAppContext) {
         init_test(cx, &|settings| {
             settings.defaults.inlay_hints = Some(InlayHintSettingsContent {
@@ -4809,6 +4898,22 @@ let c = 3;"#
         cx: &mut TestAppContext,
         initialize: impl 'static + Send + Fn(&mut FakeLanguageServer, &'static str) + Send + Sync,
     ) -> (&'static str, WindowHandle<Editor>, FakeLanguageServer) {
+        prepare_test_objects_with_capabilities(
+            cx,
+            lsp::ServerCapabilities {
+                inlay_hint_provider: Some(lsp::OneOf::Left(true)),
+                ..lsp::ServerCapabilities::default()
+            },
+            initialize,
+        )
+        .await
+    }
+
+    async fn prepare_test_objects_with_capabilities(
+        cx: &mut TestAppContext,
+        capabilities: lsp::ServerCapabilities,
+        initialize: impl 'static + Send + Fn(&mut FakeLanguageServer, &'static str) + Send + Sync,
+    ) -> (&'static str, WindowHandle<Editor>, FakeLanguageServer) {
         let fs = FakeFs::new(cx.background_executor.clone());
         fs.insert_tree(
             path!("/a"),
@@ -4827,10 +4932,7 @@ let c = 3;"#
         let mut fake_servers = language_registry.register_fake_lsp(
             "Rust",
             FakeLspAdapter {
-                capabilities: lsp::ServerCapabilities {
-                    inlay_hint_provider: Some(lsp::OneOf::Left(true)),
-                    ..lsp::ServerCapabilities::default()
-                },
+                capabilities,
                 initializer: Some(Box::new(move |server| initialize(server, file_path))),
                 ..FakeLspAdapter::default()
             },

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1105,26 +1105,11 @@ impl LocalLspStore {
                     let request_id = request_id.clone();
                     let mut cx = cx.clone();
                     async move {
-                        lsp_store
-                            .update(&mut cx, |lsp_store, cx| {
-                                let request_id =
-                                    Some(request_id.fetch_add(1, atomic::Ordering::AcqRel));
-                                cx.emit(LspStoreEvent::RefreshInlayHints {
-                                    server_id,
-                                    request_id,
-                                });
-                                lsp_store
-                                    .downstream_client
-                                    .as_ref()
-                                    .map(|(client, project_id)| {
-                                        client.send(proto::RefreshInlayHints {
-                                            project_id: *project_id,
-                                            server_id: server_id.to_proto(),
-                                            request_id: request_id.map(|id| id as u64),
-                                        })
-                                    })
-                            })?
-                            .transpose()?;
+                        lsp_store.update(&mut cx, |lsp_store, cx| {
+                            let request_id =
+                                Some(request_id.fetch_add(1, atomic::Ordering::AcqRel));
+                            lsp_store.refresh_inlay_hints(server_id, request_id, cx);
+                        })?;
                         Ok(())
                     }
                 }
@@ -13211,6 +13196,7 @@ impl LspStore {
                         capabilities.inlay_hint_provider = Some(options);
                     });
                     notify_server_capabilities_updated(&server, cx);
+                    self.refresh_inlay_hints(server_id, None, cx);
                 }
                 "textDocument/documentSymbol" => {
                     let options = parse_register_capabilities(reg)?;

--- a/crates/project/src/lsp_store/inlay_hints.rs
+++ b/crates/project/src/lsp_store/inlay_hints.rs
@@ -12,6 +12,7 @@ use lsp::LanguageServerId;
 use rpc::{TypedEnvelope, proto};
 use settings::Settings as _;
 use text::{BufferId, Point};
+use util::ResultExt as _;
 
 use crate::{
     InlayHint, InlayId, LspStore, LspStoreEvent, ResolveState, lsp_command::InlayHints,
@@ -296,6 +297,29 @@ impl LspStore {
                 .await?;
                 Ok(resolved_hint)
             })
+        }
+    }
+
+    /// `request_id` orders per-server refreshes (a higher id invalidates the cache).
+    /// Client-initiated refreshes (e.g. after dynamic registration) pass `None`.
+    pub(crate) fn refresh_inlay_hints(
+        &mut self,
+        server_id: LanguageServerId,
+        request_id: Option<usize>,
+        cx: &mut Context<Self>,
+    ) {
+        cx.emit(LspStoreEvent::RefreshInlayHints {
+            server_id,
+            request_id,
+        });
+        if let Some((client, project_id)) = self.downstream_client.as_ref() {
+            client
+                .send(proto::RefreshInlayHints {
+                    project_id: *project_id,
+                    server_id: server_id.to_proto(),
+                    request_id: request_id.map(|id| id as u64),
+                })
+                .log_err();
         }
     }
 


### PR DESCRIPTION
# Objective

Open editors can miss inlay hints when a language server dynamically registers `textDocument/inlayHint` after the editor's initial inlay-hint refresh. Zed stores the new capability, but without another refresh the open document is not queried until an unrelated editor event occurs.

This occurs with JDT LS, which dynamically registers the capability after initialization.

## Solution

- Add a server-scoped `refresh_inlay_hints` helper matching the semantic-token refresh path.
- Trigger it immediately after a successful dynamic `textDocument/inlayHint` registration.
- Forward the refresh to downstream clients for remote projects.
- Add an editor regression test that starts without the capability, registers it dynamically, and verifies that the already-open document is queried and displays the returned hint.

The regression test reports zero requests without the production change and one request after it.

## Testing

- `cargo test -p editor inlays::inlay_hints::tests --no-fail-fast` (19 passed)
- `cargo check -p project`
- `cargo build -p zed --bin zed`
- Built and launched Zed locally on macOS arm64; exercised the late JDT LS registration path in a Java project alongside a second inlay-hint server.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed inlay hints not appearing after a language server dynamically registers support.
