### PR TITLE
vim: Fix selection motions when trailing newline is selected

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -202,7 +202,7 @@ impl SelectionLayout {
         if cursor_offset && !range.is_empty() && !selection.reversed {
             if head.column() > 0 {
                 head = map.clip_point(DisplayPoint::new(head.row(), head.column() - 1), Bias::Left);
-            } else if head.row().0 > 0 && head != map.max_point() {
+            } else if head.row().0 > 0 {
                 head = map.clip_point(
                     DisplayPoint::new(
                         head.row().previous_row(),
@@ -11528,20 +11528,20 @@ mod tests {
             DisplayPoint::new(DisplayRow(3), 2)
         );
 
-        // leaves cursor on the max point
+        // displays the trailing newline cursor on the preceding row
         assert_eq!(
             local_selections[2].range,
             DisplayPoint::new(DisplayRow(5), 6)..DisplayPoint::new(DisplayRow(6), 0)
         );
         assert_eq!(
             local_selections[2].head,
-            DisplayPoint::new(DisplayRow(6), 0)
+            DisplayPoint::new(DisplayRow(5), 6)
         );
 
         // active lines does not include 1 (even though the range of the selection does)
         assert_eq!(
             state.active_rows.keys().cloned().collect::<Vec<_>>(),
-            vec![DisplayRow(0), DisplayRow(3), DisplayRow(5), DisplayRow(6)]
+            vec![DisplayRow(0), DisplayRow(3), DisplayRow(5)]
         );
     }
 

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -169,14 +169,7 @@ impl Vim {
                     // our motions assume the current character is after the cursor,
                     // but in (forward) visual mode the current character is just
                     // before the end of the selection.
-
-                    // If the file ends with a newline (which is common) we don't do this.
-                    // so that if you go to the end of such a file you can use "up" to go
-                    // to the previous line and have it work somewhat as expected.
-                    if !selection.reversed
-                        && !selection.is_empty()
-                        && !(selection.end.column() == 0 && selection.end == map.max_point())
-                    {
+                    if !selection.reversed && !selection.is_empty() {
                         current_head = movement::left(map, selection.end)
                     }
 
@@ -241,9 +234,7 @@ impl Vim {
                     if !selection.reversed {
                         let next_point = movement::right(map, selection.end);
 
-                        if !(next_point.column() == 0 && next_point == map.max_point()) {
-                            selection.end = next_point;
-                        }
+                        selection.end = next_point;
                     }
 
                     // vim always ensures the anchor character stays selected.
@@ -2667,6 +2658,30 @@ mod test {
         cx.set_state("aˇbcd", Mode::HelixNormal);
         cx.simulate_keystrokes("v a");
         cx.assert_state("abˇcd", Mode::Insert);
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_move_to_trailing_newline(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        cx.set_state("line one\nline two\nline threˇe\n", Mode::HelixNormal);
+        cx.simulate_keystrokes("v");
+        cx.assert_state("line one\nline two\nline thre«eˇ»\n", Mode::HelixSelect);
+        cx.simulate_keystrokes("l");
+        cx.assert_state("line one\nline two\nline thre«e\nˇ»", Mode::HelixSelect);
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_trailing_newline(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        cx.set_state("line one\nline two\nline threeˇ\n", Mode::HelixNormal);
+        cx.simulate_keystrokes("v");
+        cx.assert_state("line one\nline two\nline three«\nˇ»", Mode::HelixSelect);
+        cx.simulate_keystrokes("g h");
+        cx.assert_state("line one\nline two\n«ˇline three\n»", Mode::HelixSelect);
     }
 
     #[gpui::test]

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -247,14 +247,7 @@ impl Vim {
                         // our motions assume the current character is after the cursor,
                         // but in (forward) visual mode the current character is just
                         // before the end of the selection.
-
-                        // If the file ends with a newline (which is common) we don't do this.
-                        // so that if you go to the end of such a file you can use "up" to go
-                        // to the previous line and have it work somewhat as expected.
-                        if !selection.reversed
-                            && !selection.is_empty()
-                            && !(selection.end.column() == 0 && selection.end == map.max_point())
-                        {
+                        if !selection.reversed && !selection.is_empty() {
                             current_head = movement::left(map, selection.end)
                         }
 
@@ -278,9 +271,7 @@ impl Vim {
                                 movement::right(map, selection.end)
                             };
 
-                            if !(next_point.column() == 0 && next_point == map.max_point()) {
-                                selection.end = next_point;
-                            }
+                            selection.end = next_point;
                         }
 
                         // vim always ensures the anchor character stays selected.
@@ -1746,6 +1737,17 @@ mod test {
         //     }
         //     "
         // });
+    }
+
+    #[gpui::test]
+    async fn test_visual_move_trailing_newline(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.set_state("This is a newlinˇe\n", Mode::Normal);
+        cx.simulate_keystrokes("v");
+        cx.assert_state("This is a newlin«eˇ»\n", Mode::Visual);
+        cx.simulate_keystrokes("l");
+        cx.assert_state("This is a newlin«e\nˇ»", Mode::Visual);
     }
 
     #[gpui::test]


### PR DESCRIPTION
# Objective

Closes #41743

When selecting text on the last line, excluding the trailing newline, Vim and Helix modes behave differently from native Vim and Helix when the file has a trailing newline:
1. We cannot use `l` (move right) to include the final `\n` in the selection, while native Vim and Helix allow this.
2. By default, the rendered cursor should appear on the selected character. When that character is the final `\n`, however, Zed renders the cursor on the synthetic empty line after it rather than at the end of the preceding line. This differs from native Vim and Helix, as well as from Zed's behavior for newlines elsewhere in the file.
3. When the final `\n` is selected, it affects subsequent selection motions, as reported in #41743.

The cause is several special-case guards for trailing newlines in Visual and Select modes. These guards exist in the cursor rendering logic:
https://github.com/zed-industries/zed/blob/c9e8e611dbc279afa0914d28c4d37ad07f38c03b/crates/editor/src/element.rs#L201-L213

They also exist in the Visual motion logic for Vim mode and the Select motion logic for Helix mode (the Helix implementation was adopted directly from Vim in #43234):
https://github.com/zed-industries/zed/blob/c9e8e611dbc279afa0914d28c4d37ad07f38c03b/crates/vim/src/visual.rs#L254-L259

Finally, they exist in the selection extension logic for Vim and Helix (the Helix logic was also adopted from Vim):
https://github.com/zed-industries/zed/blob/c9e8e611dbc279afa0914d28c4d37ad07f38c03b/crates/vim/src/visual.rs#L273-L284

These guards cause trailing-newline selections to behave inconsistently with selections containing newlines elsewhere in the file.

## Solution

Remove all the guards mentioned above, including those in cursor rendering, Visual and Select motions, and selection extension. And due to the cursor rendering logic is also changed, an exsisting test is updated.

After removing these guards, I could not reproduce the unexpected behavior described in the existing comments:
https://github.com/zed-industries/zed/blob/c9e8e611dbc279afa0914d28c4d37ad07f38c03b/crates/vim/src/visual.rs#L247-L253

The only remaining difference is that, when the cursor is on the last line in Visual mode, pressing `j` moves it to the final `\n` rather than to the synthetic empty line after it. In comparison, native Vim and Helix do nothing in this case.

## Testing

- Built and tested locally.
- Added new GPUI tests.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable


Release Notes:

- Improved Vim Visual and Helix Select modes when selections include a trailing newline.