### PR TITLE
gpui: Prevent modifier chord characters from being inserted as text i…

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -18,7 +18,7 @@ use buffer_diff::{BufferDiff, DiffHunkSecondaryStatus, DiffHunkStatus, DiffHunkS
 use collections::HashMap;
 use futures::{StreamExt, channel::oneshot};
 use gpui::{
-    BackgroundExecutor, DismissEvent, Task, TaskExt, TestAppContext, UpdateGlobal,
+    BackgroundExecutor, DismissEvent, KeyBinding, Task, TaskExt, TestAppContext, UpdateGlobal,
     VisualTestContext, WindowBounds, WindowOptions, div,
 };
 use indoc::indoc;
@@ -212,6 +212,29 @@ fn test_edit_events(cx: &mut TestAppContext) {
         editor.backspace(&Backspace, window, cx);
     });
     assert_eq!(mem::take(&mut *events.borrow_mut()), []);
+}
+
+#[gpui::test]
+fn test_modified_pending_keybinding_does_not_insert_text(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    cx.update(|cx| {
+        cx.bind_keys([
+            KeyBinding::new("alt-g b", SelectAll, Some("Editor")),
+            KeyBinding::new("alt-s k", SelectAll, Some("Editor")),
+        ]);
+    });
+
+    let mut editor = EditorTestContext::new_multibuffer(cx, ["ˇabc"]);
+    editor.simulate_keystroke("alt-g->g");
+    assert_eq!(editor.buffer_text(), "abc");
+    editor.simulate_keystroke("escape");
+    assert_eq!(editor.buffer_text(), "abc");
+
+    let mut editor = EditorTestContext::new_multibuffer(cx, ["ˇabc"]);
+    editor.simulate_keystroke("alt-s->ß");
+    assert_eq!(editor.buffer_text(), "ßabc");
+    editor.simulate_keystroke("escape");
+    assert_eq!(editor.buffer_text(), "ßabc");
 }
 
 #[gpui::test]

--- a/crates/editor/src/input.rs
+++ b/crates/editor/src/input.rs
@@ -1782,7 +1782,7 @@ impl Editor {
             .pending_input_keystrokes()
             .into_iter()
             .flatten()
-            .filter_map(|keystroke| keystroke.key_char.clone())
+            .filter_map(|keystroke| keystroke.key_char_for_text_input().map(str::to_owned))
             .collect();
 
         if !self.input_enabled || self.read_only || !self.focus_handle.is_focused(window) {

--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -235,6 +235,28 @@ impl Keystroke {
                 || self.modifiers.alt)
     }
 
+    /// Returns the character this keystroke should insert as text input.
+    ///
+    /// Modifier shortcuts can carry a `key_char` that is identical to the key,
+    /// such as `alt-g` on Linux. These must not be treated as text input. A
+    /// modifier-generated character, such as `option-s` producing `ß`, is
+    /// still text input.
+    pub fn key_char_for_text_input(&self) -> Option<&str> {
+        let key_char = self.key_char.as_deref()?;
+        let key = match self.key.as_str() {
+            "space" => " ",
+            "tab" => "\t",
+            "enter" => "\n",
+            key => key,
+        };
+
+        if self.modifiers.is_subset_of(&Modifiers::shift()) || !key.eq_ignore_ascii_case(key_char) {
+            Some(key_char)
+        } else {
+            None
+        }
+    }
+
     /// Returns a new keystroke with the key_char filled.
     /// This is used for dispatch_keystroke where we want users to
     /// be able to simulate typing "space", etc.
@@ -773,4 +795,54 @@ fn unparse(modifiers: &Modifiers, key: &str) -> String {
     }
     result.push_str(&key);
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Keystroke, Modifiers};
+
+    #[test]
+    fn test_key_char_for_text_input_distinguishes_shortcuts_from_text() {
+        let text = Keystroke {
+            key: "g".into(),
+            key_char: Some("g".into()),
+            ..Default::default()
+        };
+        assert_eq!(text.key_char_for_text_input(), Some("g"));
+
+        let shifted_text = Keystroke {
+            modifiers: Modifiers::shift(),
+            key: "g".into(),
+            key_char: Some("G".into()),
+        };
+        assert_eq!(shifted_text.key_char_for_text_input(), Some("G"));
+
+        let shortcut = Keystroke {
+            modifiers: Modifiers::alt(),
+            key: "g".into(),
+            key_char: Some("g".into()),
+        };
+        assert_eq!(shortcut.key_char_for_text_input(), None);
+
+        let shortcut_with_caps_lock = Keystroke {
+            modifiers: Modifiers::alt(),
+            key: "g".into(),
+            key_char: Some("G".into()),
+        };
+        assert_eq!(shortcut_with_caps_lock.key_char_for_text_input(), None);
+
+        let option_text = Keystroke {
+            modifiers: Modifiers::alt(),
+            key: "s".into(),
+            key_char: Some("ß".into()),
+        };
+        assert_eq!(option_text.key_char_for_text_input(), Some("ß"));
+
+        let shortcut_space = Keystroke {
+            modifiers: Modifiers::alt(),
+            key: "space".into(),
+            key_char: Some(" ".into()),
+        };
+        assert_eq!(shortcut_space.key_char_for_text_input(), None);
+    }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4585,10 +4585,10 @@ impl Window {
             return true;
         }
 
-        if let Some(input) = keystroke.key_char
+        if let Some(input) = keystroke.key_char_for_text_input()
             && let Some(mut input_handler) = self.platform_window.take_input_handler()
         {
-            input_handler.dispatch_input(&input, self, cx);
+            input_handler.dispatch_input(input, self, cx);
             self.platform_window.set_input_handler(input_handler);
             return true;
         }
@@ -4888,7 +4888,7 @@ impl Window {
 
             let text_input_requires_timeout = event
                 .downcast_ref::<KeyDownEvent>()
-                .filter(|key_down| key_down.keystroke.key_char.is_some())
+                .filter(|key_down| key_down.keystroke.key_char_for_text_input().is_some())
                 .and_then(|_| self.platform_window.take_input_handler())
                 .map_or(false, |mut input_handler| {
                     let accepts = input_handler.accepts_text_input(self, cx);
@@ -5092,10 +5092,10 @@ impl Window {
             if !cx.propagate_event {
                 continue 'replay;
             }
-            if let Some(input) = replay.keystroke.key_char.as_ref().cloned()
+            if let Some(input) = replay.keystroke.key_char_for_text_input()
                 && let Some(mut input_handler) = self.platform_window.take_input_handler()
             {
-                input_handler.dispatch_input(&input, self, cx);
+                input_handler.dispatch_input(input, self, cx);
                 self.platform_window.set_input_handler(input_handler)
             }
         }


### PR DESCRIPTION
## Context

On Linux, pressing a multi-stroke binding with a modifier, such as `alt-g b` for toggling git blame, inserted the letter of the chord (`g`) into the buffer. The xkb layer reports a `key_char` for chords like `alt-g` because alt does not participate in symbol translation, and GPUI's fallback text dispatch treated any `key_char` as typed text: immediately when the chord was unbound, or via the pending-input replay when a multi-stroke binding was abandoned (for example by pressing `escape` or letting the timeout expire).

The fix adds `Keystroke::key_char_for_text_input`, which only treats a `key_char` as text when no modifiers beyond shift are held, or when the produced character differs from the key itself (so macOS option composition such as `option-s` producing `ß`, AltGr characters, and IME/compose output keep working). All text-dispatch call sites now go through this predicate.

Video for manual test below :

[Screencast from 2026-07-18 16-21-03.webm](https://github.com/user-attachments/assets/fdfbcc7c-6380-40d4-ad27-6d51c3174aca)

Closes #44115

## How to Review

**crates/gpui/src/platform/keystroke.rs**  
Adds the `key_char_for_text_input` predicate. It returns the `key_char` when the modifiers are a subset of shift, or when the character differs from the key (compared case-insensitively, with `space`/`tab`/`enter` mapped to their literal characters because macOS stores named keys with literal key_chars). A new unit test covers plain typing, shifted typing, caps lock, `alt-g` style chords, `option-s` producing `ß`, and `alt-space`.

**crates/gpui/src/window.rs**  
Switches the three text-dispatch consumers of `key_char` to the new predicate: the unbound-keystroke input dispatch in `dispatch_keystroke`, the `text_input_requires_timeout` check for pending multi-stroke bindings, and the pending-input replay path (the path that inserted the stray `g` when a chord was abandoned).

**crates/editor/src/input.rs**  
`observe_pending_input` builds the inline preview of pending keystrokes from the same predicate, so a pending `alt-g` no longer shows a ghost `g` in the buffer while waiting for the second stroke.

**crates/editor/src/editor_tests.rs**  
Integration test binding `alt-g b` and `alt-s k`: simulates `alt-g` carrying key_char `g` (Linux behavior) and asserts nothing is inserted while pending or after `escape` triggers the replay, then simulates `alt-s` carrying `ß` (macOS behavior) and asserts the text is still inserted in both cases.

Known limitation: on non-ASCII layouts (for example `alt-ö` on German or `alt-п` on Russian), the produced character differs from the resolved key, so those chords still insert text. This is indistinguishable from legitimate option composition at this layer and matches the previous behavior.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed multi-stroke keybindings with modifiers (such as `alt-g b`) inserting the chord's character into the editor on Linux