### PR TITLE
workspace: Preserve zoomed panels when focus changes

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -453,9 +453,18 @@ impl Dock {
                 && let Some(panel) = dock.read(cx).active_panel()
                 && panel.is_zoomed(window, cx)
             {
-                workspace.zoomed = Some(panel.to_any().downgrade());
-                workspace.zoomed_position = Some(position);
-                cx.emit(Event::ZoomChanged);
+                // A zoomed panel can stay open at normal dock size while focus is
+                // elsewhere (see dismiss_zoomed_items_to_reveal), so a stray notify
+                // (e.g. a streaming agent panel) must not resurrect the fullscreen
+                // overlay unless it's already attributed to this dock or the panel
+                // actually has focus.
+                if workspace.zoomed_position == Some(position)
+                    || panel.panel_focus_handle(cx).contains_focused(window, cx)
+                {
+                    workspace.zoomed = Some(panel.to_any().downgrade());
+                    workspace.zoomed_position = Some(position);
+                    cx.emit(Event::ZoomChanged);
+                }
                 return;
             }
             if workspace.zoomed_position == Some(position) {
@@ -596,8 +605,8 @@ impl Dock {
                         return;
                     }
 
-                    let Ok(new_dock) = workspace.update(cx, |workspace, cx| {
-                        if panel.is_zoomed(window, cx) {
+                    let Ok(new_dock) = workspace.update(cx, |workspace, _cx| {
+                        if workspace.zoomed_position == Some(this.position) {
                             workspace.zoomed_position = Some(new_position);
                         }
                         match new_position {
@@ -764,7 +773,26 @@ impl Dock {
             if serialized.zoom
                 && let Some(panel) = self.active_panel()
             {
-                panel.set_zoomed(true, window, cx)
+                panel.set_zoomed(true, window, cx);
+                if serialized.visible {
+                    // The observer in Dock::new only re-derives `workspace.zoomed` from
+                    // state when the overlay is already attributed to this dock or the
+                    // panel has focus, so on startup we need to attribute it explicitly.
+                    // Deferred because `restore_state` runs inside `Workspace::add_panel`,
+                    // which is already updating the workspace.
+                    let workspace = self.workspace.clone();
+                    let panel = panel.to_any().downgrade();
+                    let position = self.position;
+                    window.defer(cx, move |_, cx| {
+                        workspace
+                            .update(cx, |workspace, cx| {
+                                workspace.zoomed = Some(panel);
+                                workspace.zoomed_position = Some(position);
+                                cx.emit(Event::ZoomChanged);
+                            })
+                            .ok();
+                    });
+                }
             }
             self.set_open(serialized.visible, window, cx);
             return true;

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -1685,21 +1685,22 @@ impl MultiWorkspace {
     }
 
     pub fn focus_active_workspace(&self, window: &mut Window, cx: &mut App) {
-        // If a dock panel is zoomed, focus it instead of the center pane.
-        // Otherwise, focusing the center pane triggers dismiss_zoomed_items_to_reveal
-        // which closes the zoomed dock.
+        // If a dock panel's fullscreen overlay is currently showing, focus it instead
+        // of the center pane so we don't drop the user out of it. A panel can be
+        // zoomed but not overlaid (e.g. after focus moved to another panel while it
+        // stayed zoomed - see dismiss_zoomed_items_to_reveal), in which case there's
+        // nothing to preserve and we should focus the center pane as usual.
         let focus_handle = {
             let workspace = self.workspace().read(cx);
             let mut target = None;
             for dock in workspace.all_docks() {
                 let dock = dock.read(cx);
-                if dock.is_open() {
-                    if let Some(panel) = dock.active_panel() {
-                        if panel.is_zoomed(window, cx) {
-                            target = Some(panel.panel_focus_handle(cx));
-                            break;
-                        }
-                    }
+                if dock.is_open()
+                    && workspace.zoomed_position == Some(dock.position())
+                    && let Some(panel) = dock.active_panel()
+                {
+                    target = Some(panel.panel_focus_handle(cx));
+                    break;
                 }
             }
             target.unwrap_or_else(|| {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2215,29 +2215,27 @@ impl Workspace {
         [&self.left_dock, &self.bottom_dock, &self.right_dock]
     }
 
-    pub fn capture_dock_state(&self, _window: &Window, cx: &App) -> DockStructure {
+    pub fn capture_dock_state(&self, window: &Window, cx: &App) -> DockStructure {
         let left_dock = self.left_dock.read(cx);
         let left_visible = left_dock.is_open();
         let left_active_panel = left_dock
             .active_panel()
             .map(|panel| panel.persistent_name().to_string());
-        // `zoomed_position` is kept in sync with individual panel zoom state
-        // by the dock code in `Dock::new` and `Dock::add_panel`.
-        let left_dock_zoom = self.zoomed_position == Some(DockPosition::Left);
+        let left_dock_zoom = left_dock.zoomed_panel(window, cx).is_some();
 
         let right_dock = self.right_dock.read(cx);
         let right_visible = right_dock.is_open();
         let right_active_panel = right_dock
             .active_panel()
             .map(|panel| panel.persistent_name().to_string());
-        let right_dock_zoom = self.zoomed_position == Some(DockPosition::Right);
+        let right_dock_zoom = right_dock.zoomed_panel(window, cx).is_some();
 
         let bottom_dock = self.bottom_dock.read(cx);
         let bottom_visible = bottom_dock.is_open();
         let bottom_active_panel = bottom_dock
             .active_panel()
             .map(|panel| panel.persistent_name().to_string());
-        let bottom_dock_zoom = self.zoomed_position == Some(DockPosition::Bottom);
+        let bottom_dock_zoom = bottom_dock.zoomed_panel(window, cx).is_some();
 
         DockStructure {
             left: DockData {
@@ -4487,18 +4485,18 @@ impl Workspace {
             }
         }
 
-        // If another dock is zoomed, hide it.
+        // If another dock's panel is zoomed, drop the zoom overlay but keep the dock
+        // open at its normal size. The panel keeps its zoomed flag so the overlay is
+        // restored when it regains focus (see Dock's on_focus_in).
         let mut focus_center = false;
         for dock in self.all_docks() {
-            dock.update(cx, |dock, cx| {
-                if Some(dock.position()) != dock_to_reveal
-                    && let Some(panel) = dock.active_panel()
-                    && panel.is_zoomed(window, cx)
-                {
-                    focus_center |= panel.panel_focus_handle(cx).contains_focused(window, cx);
-                    dock.set_open(false, window, cx);
-                }
-            });
+            let dock = dock.read(cx);
+            if Some(dock.position()) != dock_to_reveal
+                && let Some(panel) = dock.active_panel()
+                && panel.is_zoomed(window, cx)
+            {
+                focus_center |= panel.panel_focus_handle(cx).contains_focused(window, cx);
+            }
         }
 
         if focus_center {
@@ -13345,18 +13343,8 @@ mod tests {
             assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
         });
 
-        // Transfer focus to the center closes the dock
-        workspace.update_in(cx, |workspace, window, cx| {
-            workspace.toggle_panel_focus::<TestPanel>(window, cx);
-        });
-
-        workspace.update_in(cx, |workspace, window, cx| {
-            assert!(!workspace.right_dock().read(cx).is_open());
-            assert!(panel.is_zoomed(window, cx));
-            assert!(!panel.read(cx).focus_handle(cx).contains_focused(window, cx));
-        });
-
-        // Transferring focus back to the panel keeps it zoomed
+        // Transfer focus to the center no longer closes the dock; it stays open at
+        // normal size and the fullscreen overlay is dropped.
         workspace.update_in(cx, |workspace, window, cx| {
             workspace.toggle_panel_focus::<TestPanel>(window, cx);
         });
@@ -13364,6 +13352,19 @@ mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             assert!(workspace.right_dock().read(cx).is_open());
             assert!(panel.is_zoomed(window, cx));
+            assert!(workspace.zoomed.is_none());
+            assert!(!panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+        });
+
+        // Transferring focus back to the panel restores the zoomed overlay
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_panel_focus::<TestPanel>(window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.right_dock().read(cx).is_open());
+            assert!(panel.is_zoomed(window, cx));
+            assert!(workspace.zoomed.is_some());
             assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
         });
 
@@ -14923,13 +14924,16 @@ mod tests {
             assert_eq!(workspace.zoomed_position, Some(DockPosition::Right));
         });
 
-        // If focus is transferred elsewhere in the workspace, the panel is no longer zoomed.
+        // If focus is transferred elsewhere in the workspace, the zoom overlay is
+        // dropped, but the dock stays open and the panel keeps its zoomed flag.
         workspace.update_in(cx, |_workspace, window, cx| {
             cx.focus_self(window);
         });
-        workspace.read_with(cx, |workspace, _| {
+        workspace.update_in(cx, |workspace, window, cx| {
             assert_eq!(workspace.zoomed, None);
             assert_eq!(workspace.zoomed_position, None);
+            assert!(workspace.right_dock().read(cx).is_open());
+            assert!(panel_1.is_zoomed(window, cx));
         });
 
         // If focus is transferred again to another view that's not a panel or a pane, we won't
@@ -14940,8 +14944,11 @@ mod tests {
             assert_eq!(workspace.zoomed_position, None);
         });
 
-        // When the panel is activated, it is zoomed again.
-        cx.dispatch_action(ToggleRightDock);
+        // Focusing the panel again restores the zoom overlay.
+        workspace.update_in(cx, |_workspace, window, cx| {
+            let focus_handle = panel_1.read(cx).focus_handle(cx);
+            window.focus(&focus_handle, cx);
+        });
         workspace.read_with(cx, |workspace, _| {
             assert_eq!(workspace.zoomed, Some(panel_1.to_any().downgrade()));
             assert_eq!(workspace.zoomed_position, Some(DockPosition::Right));
@@ -16872,6 +16879,188 @@ mod tests {
                 "Dock should stay open when its zoomed panel (without pane()) still has focus"
             );
             assert!(panel.is_zoomed(window, cx));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_zoomed_dock_stays_open_when_other_dock_focused(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let (right_panel, left_panel) = workspace.update_in(cx, |workspace, window, cx| {
+            let right_panel = cx.new(|cx| TestPanel::new(DockPosition::Right, 100, cx));
+            workspace.add_panel(right_panel.clone(), window, cx);
+            workspace.right_dock().update(cx, |dock, cx| {
+                dock.activate_panel(0, window, cx);
+                dock.set_open(true, window, cx);
+            });
+
+            let left_panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 101, cx));
+            workspace.add_panel(left_panel.clone(), window, cx);
+            workspace
+                .left_dock()
+                .update(cx, |dock, cx| dock.activate_panel(0, window, cx));
+
+            (right_panel, left_panel)
+        });
+
+        // Zoom the right panel, mirroring shift-escape on the agent panel.
+        right_panel.update(cx, |_, cx| cx.emit(PanelEvent::ZoomIn));
+
+        workspace.read_with(cx, |workspace, _| {
+            assert_eq!(workspace.zoomed_position, Some(DockPosition::Right));
+        });
+
+        // Focusing another dock (e.g. opening the Project Panel) must not close the
+        // zoomed dock - this is the scenario from issue #61226.
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_dock(DockPosition::Left, window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(
+                workspace.right_dock().read(cx).is_open(),
+                "zoomed dock must stay open when another dock is focused"
+            );
+            assert!(right_panel.is_zoomed(window, cx));
+            assert!(workspace.zoomed.is_none());
+            assert!(
+                left_panel
+                    .read(cx)
+                    .focus_handle(cx)
+                    .contains_focused(window, cx)
+            );
+
+            let dock_state = workspace.capture_dock_state(window, cx);
+            assert!(
+                dock_state.right.zoom,
+                "the dormant zoom state must be persisted"
+            );
+        });
+
+        // A stray notify from the still-zoomed, unfocused panel (e.g. a streaming
+        // agent response) must not resurrect the fullscreen overlay.
+        right_panel.update(cx, |_, cx| cx.notify());
+        cx.run_until_parked();
+        workspace.read_with(cx, |workspace, _| {
+            assert!(workspace.zoomed.is_none());
+        });
+
+        // Refocusing the panel restores the overlay.
+        workspace.update_in(cx, |_workspace, window, cx| {
+            let focus_handle = right_panel.read(cx).focus_handle(cx);
+            window.focus(&focus_handle, cx);
+        });
+        workspace.read_with(cx, |workspace, _| {
+            assert_eq!(workspace.zoomed_position, Some(DockPosition::Right));
+            assert_eq!(workspace.zoomed, Some(right_panel.to_any().downgrade()));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_moving_dormant_zoomed_panel_does_not_restore_overlay(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Right, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.right_dock().update(cx, |dock, cx| {
+                dock.activate_panel(0, window, cx);
+                dock.set_open(true, window, cx);
+            });
+            panel
+        });
+
+        panel.update(cx, |_, cx| cx.emit(PanelEvent::ZoomIn));
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.toggle_panel_focus::<TestPanel>(window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(panel.is_zoomed(window, cx));
+            assert!(workspace.zoomed.is_none());
+            assert!(workspace.zoomed_position.is_none());
+        });
+
+        workspace.update_in(cx, |_workspace, _window, cx| {
+            panel.update(cx, |panel, _| panel.position = DockPosition::Bottom);
+            cx.update_global::<SettingsStore, _>(|_, _| {});
+        });
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(workspace.bottom_dock().read(cx).is_open());
+            assert!(panel.is_zoomed(window, cx));
+            assert!(workspace.zoomed.is_none());
+            assert!(workspace.zoomed_position.is_none());
+        });
+
+        workspace.update_in(cx, |_workspace, window, cx| {
+            window.focus(&panel.read(cx).focus_handle(cx), cx);
+        });
+        workspace.read_with(cx, |workspace, _| {
+            assert_eq!(workspace.zoomed, Some(panel.to_any().downgrade()));
+            assert_eq!(workspace.zoomed_position, Some(DockPosition::Bottom));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_dismiss_keeps_zoomed_dock_open_and_moves_focus(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let panel = workspace.update_in(cx, |workspace, window, cx| {
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Bottom, 100, cx));
+            workspace.add_panel(panel.clone(), window, cx);
+            workspace.bottom_dock().update(cx, |dock, cx| {
+                dock.activate_panel(0, window, cx);
+                dock.set_open(true, window, cx);
+            });
+            panel
+        });
+
+        panel.update(cx, |_, cx| cx.emit(PanelEvent::ZoomIn));
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(panel.is_zoomed(window, cx));
+            assert!(panel.read(cx).focus_handle(cx).contains_focused(window, cx));
+            assert!(workspace.zoomed.is_some());
+            workspace.dismiss_zoomed_items_to_reveal(Some(DockPosition::Right), window, cx);
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert!(
+                workspace.bottom_dock().read(cx).is_open(),
+                "dismissing a zoomed panel should keep its dock open"
+            );
+            assert!(panel.is_zoomed(window, cx));
+            assert!(workspace.zoomed.is_none());
+            assert!(
+                !panel.read(cx).focus_handle(cx).contains_focused(window, cx),
+                "focus should move away from the dismissed panel"
+            );
+            assert!(
+                workspace
+                    .active_pane()
+                    .read(cx)
+                    .focus_handle(cx)
+                    .contains_focused(window, cx)
+            );
         });
     }
 


### PR DESCRIPTION
## Context

Focusing another dock while the Agent Panel was zoomed caused the Agent dock to close. This keeps the dock open, preserves its zoom state, and restores fullscreen when the panel regains focus.

Closes #61226

Behavior after the changes :

[Screencast from 2026-07-18 17-24-32.webm](https://github.com/user-attachments/assets/2e5cb4a4-1bc9-4b1f-a3d5-ad5ff3677d4e)


## How to Review

**crates/workspace/src/workspace.rs**  
`dismiss_zoomed_items_to_reveal` now clears the fullscreen overlay without closing the underlying dock or resetting the panel’s zoom flag. `capture_dock_state` reads zoom state from each dock’s active panel so dormant zoom remains persisted. The tests cover changing focus, persistence, panel notifications, moving dormant panels, and restoring fullscreen on refocus.

**crates/workspace/src/dock.rs**  
The dock observer now recreates the fullscreen overlay only when the dock already owns it or its panel has focus. This prevents background notifications, such as streaming Agent updates, from restoring fullscreen. State restoration explicitly recreates persisted overlays, while panel relocation updates `zoomed_position` only for an overlay that is currently visible.

**crates/workspace/src/multi_workspace.rs**  
`focus_active_workspace` now distinguishes a visible fullscreen overlay from a panel that only retains its zoom flag. It focuses the dock only when its overlay is currently displayed.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed zoomed Agent panels closing when focus moves to another panel.