### PR TITLE
title_bar: Fix drop down arrow shifting upon user logging in

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -345,8 +345,6 @@ impl Render for TitleBar {
         let status = self.client.status();
         let status = &*status.borrow();
         let user = self.user_store.read(cx).current_user();
-
-        let signed_in = user.is_some();
         let is_signing_in = user.is_none()
             && matches!(
                 status,
@@ -362,13 +360,7 @@ impl Render for TitleBar {
 
         children.push(
             h_flex()
-                .map(|this| {
-                    if signed_in {
-                        this.pr_1p5()
-                    } else {
-                        this.pr_1()
-                    }
-                })
+                .pr_1()
                 .gap_1()
                 .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                 .child(self.render_call_controls(window, cx))


### PR DESCRIPTION
# Objective

Fixes #44529

## Solution

Earlier, the container holding the right side of the title bar applied a conditional right padding depending on the whether the user was signed in or not. This PR removes the conditional padding and replaces it with a constant. 

## Testing

The changes where visually verified by replicating the issue and seeing if the fix works. 

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

[](https://github.com/user-attachments/assets/017099c3-224e-4e32-9f28-66961e244d1b)

---

## Release Notes:

Fixed drop down arrow shifting upon logging in. 


