### PR TITLE
editor: Fix opaque multibuffer header backgrounds not rendering in transparent themes

### DIFF
--- a/crates/editor/src/element/header.rs
+++ b/crates/editor/src/element/header.rs
@@ -685,11 +685,12 @@ pub(crate) fn render_buffer_header(
     };
     let focus_handle = editor_read.focus_handle(cx);
     let colors = cx.theme().colors();
-    // On transparent windows `editor_subheader_background` stacks over the
-    // editor background into a darker bar (and the sticky shadow becomes a halo),
-    // so skip both unless the window is opaque.
+    // On transparent windows, only render an opaque `editor_subheader_background` so it masks
+    // the editor content beneath it without creating a darker bar. Sticky shadows still require
+    // an opaque window to avoid rendering as a halo.
     let opaque_window =
         cx.theme().window_background_appearance() == WindowBackgroundAppearance::Opaque;
+    let show_header_background = opaque_window || colors.editor_subheader_background.is_opaque();
 
     let show_open_file_button =
         can_open_excerpts && relative_path.is_some() && (is_selected || header_hovered);
@@ -727,7 +728,9 @@ pub(crate) fn render_buffer_header(
                     border.border_color(border_color)
                 })
                 .when(is_sticky && opaque_window, |s| s.shadow_md())
-                .when(opaque_window, |s| s.bg(colors.editor_subheader_background))
+                .when(show_header_background, |s| {
+                    s.bg(colors.editor_subheader_background)
+                })
                 .hover(|s| s.bg(colors.element_hover))
                 .map(|header| {
                     let editor = editor.clone();


### PR DESCRIPTION
# Objective

As part of the transparent-window artifact fixes in #58981, multibuffer header backgrounds stopped rendering whenever the window was transparent or blurred.

This caused a regression for transparent themes, which commonly use an opaque multibuffer header background to prevent editor text from showing through sticky headers.


## Solution

Render `editor_subheader_background` when either the window or the configured background color is opaque.

This restores opaque multibuffer header backgrounds as a mask for the editor content beneath them, while preserving the #58981 behavior for translucent backgrounds that would otherwise create a darker layered region.

## Testing

Manually verified locally with a transparent theme that an opaque multibuffer header background is rendered and prevents editor text from showing through sticky headers.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

**Nightfox - opaque / blurred**

Before:

<img width="2566" height="1771" alt="图片" src="https://github.com/user-attachments/assets/55b333bc-b029-4079-9bbc-86462a3f41a7" />


After:

<img width="2444" height="1687" alt="图片" src="https://github.com/user-attachments/assets/217e1ee7-717c-4961-8db0-5eac8104e5bb" />

---

Release Notes:

- Fixed editor text showing through multibuffer headers and overlapping header text in transparent themes.
