### PR TITLE
gpui: Complete pending key bindings before IME input

### DIFF
--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -626,12 +626,17 @@ mod tests {
     };
     use core::panic;
     use smallvec::SmallVec;
-    use std::{cell::RefCell, ops::Range, rc::Rc};
+    use std::{
+        cell::{Cell, RefCell},
+        ops::Range,
+        rc::Rc,
+    };
 
     use crate::{
-        ActionRegistry, App, Bounds, Context, DispatchTree, FocusHandle, InputHandler, IntoElement,
-        KeyBinding, KeyContext, Keymap, Pixels, Point, Render, Subscription, TestAppContext,
-        UTF16Selection, Unbind, Window,
+        ActionRegistry, App, Bounds, Context, DispatchPhase, DispatchTree, FocusHandle,
+        InputHandler, IntoElement, KeyBinding, KeyContext, Keymap, Pixels, PlatformWindow, Point,
+        Render, Subscription, TestAppContext, UTF16Selection, Unbind, VisualContext,
+        VisualTestContext, Window,
     };
 
     actions!(dispatch_test, [TestAction, SecondaryTestAction]);
@@ -1037,12 +1042,14 @@ mod tests {
         struct CustomElement {
             focus_handle: FocusHandle,
             text: Rc<RefCell<String>>,
+            action_count: Rc<Cell<usize>>,
         }
         impl CustomElement {
             fn new(cx: &mut Context<Self>) -> Self {
                 Self {
                     focus_handle: cx.focus_handle(),
                     text: Rc::default(),
+                    action_count: Rc::default(),
                 }
             }
         }
@@ -1091,7 +1098,15 @@ mod tests {
                 key_context.add("Terminal");
                 window.set_key_context(key_context);
                 window.handle_input(&self.focus_handle, self.clone(), cx);
-                window.on_action(std::any::TypeId::of::<TestAction>(), |_, _, _, _| {});
+                let action_count = self.action_count.clone();
+                window.on_action(
+                    std::any::TypeId::of::<TestAction>(),
+                    move |_, phase, _, _| {
+                        if phase == DispatchPhase::Bubble {
+                            action_count.set(action_count.get() + 1);
+                        }
+                    },
+                );
             }
         }
         impl IntoElement for CustomElement {
@@ -1155,6 +1170,10 @@ mod tests {
 
             fn unmark_text(&mut self, _: &mut Window, _: &mut App) {}
 
+            fn prefers_ime_for_printable_keys(&mut self, _: &mut Window, _: &mut App) -> bool {
+                true
+            }
+
             fn bounds_for_range(
                 &mut self,
                 _: Range<usize>,
@@ -1182,6 +1201,7 @@ mod tests {
         cx.update(|cx| {
             cx.bind_keys([KeyBinding::new("ctrl-b", TestAction, Some("Terminal"))]);
             cx.bind_keys([KeyBinding::new("ctrl-b h", TestAction, Some("Terminal"))]);
+            cx.bind_keys([KeyBinding::new("ctrl-x k", TestAction, Some("Terminal"))]);
         });
         let (test, cx) = cx.add_window_view(|_, cx| CustomElement::new(cx));
         let focus_handle = test.update(cx, |test, _| test.focus_handle.clone());
@@ -1189,6 +1209,48 @@ mod tests {
             window.focus(&focus_handle, cx);
             window.activate_window();
         });
+
+        let query_prefers_ime_for_printable_keys = |cx: &mut VisualTestContext| {
+            let mut platform_window = cx.test_window(cx.window_handle());
+            let mut input_handler = platform_window.take_input_handler()?;
+            let prefers_ime = input_handler.query_prefers_ime_for_printable_keys();
+            platform_window.set_input_handler(input_handler);
+            Some(prefers_ime)
+        };
+
+        assert_eq!(query_prefers_ime_for_printable_keys(cx), Some(true));
+        cx.simulate_keystrokes("ctrl-x");
+        cx.update(|window, _| assert!(window.has_pending_keystrokes()));
+        assert_eq!(query_prefers_ime_for_printable_keys(cx), Some(false));
+
+        let prefers_ime_after_blur = {
+            let mut platform_window = cx.test_window(cx.window_handle());
+            let mut input_handler = platform_window.take_input_handler();
+            cx.update(|window, _| {
+                window.blur();
+                assert!(!window.has_pending_keystrokes());
+            });
+            let prefers_ime = input_handler
+                .as_mut()
+                .map(|input_handler| input_handler.query_prefers_ime_for_printable_keys());
+            if let Some(input_handler) = input_handler {
+                platform_window.set_input_handler(input_handler);
+            }
+            prefers_ime
+        };
+        assert_eq!(prefers_ime_after_blur, Some(true));
+        cx.update(|window, cx| window.focus(&focus_handle, cx));
+
+        cx.simulate_keystrokes("ctrl-x");
+        assert_eq!(query_prefers_ime_for_printable_keys(cx), Some(false));
+        cx.simulate_keystrokes("k");
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+        assert_eq!(query_prefers_ime_for_printable_keys(cx), Some(true));
+        test.update(cx, |test, _| {
+            assert_eq!(test.action_count.get(), 1);
+            assert_eq!(test.text.borrow().as_str(), "");
+        });
+
         cx.simulate_keystrokes("ctrl-b [");
         test.update(cx, |test, _| assert_eq!(test.text.borrow().as_str(), "["))
     }

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -1229,6 +1229,7 @@ mod tests {
             cx.update(|window, _| {
                 window.blur();
                 assert!(!window.has_pending_keystrokes());
+                assert!(window.pending_input_keystrokes().is_none());
             });
             let prefers_ime = input_handler
                 .as_mut()

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1602,7 +1602,11 @@ impl PlatformInputHandler {
             .unwrap_or(true)
     }
 
-    #[allow(dead_code)]
+    /// See [`InputHandler::prefers_ime_for_printable_keys`].
+    ///
+    /// This is not a pure delegation to the handler: while a multi-stroke binding is pending this
+    /// returns `false` regardless of the handler's preference, because the next printable key may
+    /// complete a binding whose prefix already bypassed the IME.
     pub fn query_prefers_ime_for_printable_keys(&mut self) -> bool {
         self.cx
             .update(|window, cx| {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1605,7 +1605,11 @@ impl PlatformInputHandler {
     #[allow(dead_code)]
     pub fn query_prefers_ime_for_printable_keys(&mut self) -> bool {
         self.cx
-            .update(|window, cx| self.handler.prefers_ime_for_printable_keys(window, cx))
+            .update(|window, cx| {
+                // The next printable key may complete a chord whose prefix bypassed the IME.
+                !window.has_pending_keystrokes()
+                    && self.handler.prefers_ime_for_printable_keys(window, cx)
+            })
             .unwrap_or(false)
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -5301,7 +5301,9 @@ impl Window {
 
     /// Determine whether a potential multi-stroke key binding is in progress on this window.
     pub fn has_pending_keystrokes(&self) -> bool {
-        self.pending_input.is_some()
+        self.pending_input
+            .as_ref()
+            .is_some_and(|pending_input| pending_input.focus == self.focus)
     }
 
     pub(crate) fn clear_pending_keystrokes(&mut self) {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -5299,11 +5299,17 @@ impl Window {
         }
     }
 
-    /// Determine whether a potential multi-stroke key binding is in progress on this window.
-    pub fn has_pending_keystrokes(&self) -> bool {
+    /// Pending input that can still complete a binding. Input left over from a previous focus can
+    /// never complete one.
+    fn active_pending_input(&self) -> Option<&PendingInput> {
         self.pending_input
             .as_ref()
-            .is_some_and(|pending_input| pending_input.focus == self.focus)
+            .filter(|pending_input| pending_input.focus == self.focus)
+    }
+
+    /// Determine whether a potential multi-stroke key binding is in progress on this window.
+    pub fn has_pending_keystrokes(&self) -> bool {
+        self.active_pending_input().is_some()
     }
 
     pub(crate) fn clear_pending_keystrokes(&mut self) {
@@ -5312,8 +5318,7 @@ impl Window {
 
     /// Returns the currently pending input keystrokes that might result in a multi-stroke key binding.
     pub fn pending_input_keystrokes(&self) -> Option<&[Keystroke]> {
-        self.pending_input
-            .as_ref()
+        self.active_pending_input()
             .map(|pending_input| pending_input.keystrokes.as_slice())
     }
 


### PR DESCRIPTION
# Objective

- Fix multi-stroke keybindings such as `ctrl-x k` being intercepted by the macOS Japanese IME before GPUI can complete the binding.
- Preserve IME-first handling for ordinary Japanese text input and active marked-text composition.
- Fixes #56043.

## Solution

- Stop preferring IME-first printable input while a valid multi-stroke keybinding is pending. This allows the next printable keystroke to reach GPUI and complete the binding.
- Consider pending input active only when it belongs to the window's current focus. This prevents stale pending state after a focus change or blur from bypassing normal IME handling.
- Preserve the existing macOS active-composition path, so marked text, candidate selection, and composition commands continue to reach `NSTextInputContext` first.

## Testing

Manually tested on macOS using Apple’s built-in Japanese–Romaji/Hiragana input source with a `ctrl-x k` keybinding. Also added regression test for pending keybinding routing.


## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- Fixed multi-stroke keybindings not completing when using an IME on macOS.
