### PR TITLE
Replace panicking unwraps in iterator and Option chains

### DIFF
--- a/crates/agent_ui/src/entry_view_state.rs
+++ b/crates/agent_ui/src/entry_view_state.rs
@@ -566,7 +566,7 @@ impl Entry {
         self.content_map()?
             .get(&diff.entity_id())
             .cloned()
-            .map(|entity| entity.downcast::<Editor>().unwrap())
+            .and_then(|entity| entity.downcast::<Editor>().ok())
     }
 
     pub fn terminal(
@@ -576,7 +576,7 @@ impl Entry {
         self.content_map()?
             .get(&terminal.entity_id())
             .cloned()
-            .map(|entity| entity.downcast::<TerminalView>().unwrap())
+            .and_then(|entity| entity.downcast::<TerminalView>().ok())
     }
 
     pub fn scroll_handle_for_assistant_message_chunk(

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3624,7 +3624,12 @@ impl BufferSnapshot {
         let indent_configs = matches
             .grammars()
             .iter()
-            .map(|grammar| grammar.indents_config.as_ref().unwrap())
+            .map(|grammar| {
+                grammar
+                    .indents_config
+                    .as_ref()
+                    .expect("grammar in indent match set has indents_config")
+            })
             .collect::<Vec<_>>();
 
         let mut indent_ranges = Vec::<Range<Point>>::new();

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -771,7 +771,7 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
         let keystrokes = action
             .command
             .chars()
-            .map(|c| Keystroke::parse(&c.to_string()).unwrap())
+            .filter_map(|c| Keystroke::parse(&c.to_string()).ok())
             .collect();
         vim.switch_mode(Mode::Normal, true, window, cx);
         if let Some(override_rows) = &action.override_rows {


### PR DESCRIPTION
# Objective

Remove `.unwrap()` calls in iterator/`Option` chains that could panic at runtime.

## Solution

Use `and_then`/`filter_map` with `.ok()` for fallible downcasts (`entry_view_state.rs`) and keystroke parsing (`vim/command.rs`); use a descriptive `expect` in `suggest_autoindents` where the invariant is intentional (`buffer.rs`).

## Testing

- `cargo test -p language buffer` (69 passed)
- `cargo test -p vim command` (26 passed)
- `cargo test -p agent_ui entry_view` (3 passed)

## Self-Review Checklist:

- [x] I have reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [ ] The content adheres to Zed's UI standards
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- N/A