### PR TITLE
Fall back to path-only mention for binary files in the agent panel

### DIFF
--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -424,7 +424,17 @@ impl MentionSet {
 
         let buffer = project.update(cx, |project, cx| project.open_buffer(project_path, cx));
         cx.spawn(async move |_, cx| {
-            let buffer = buffer.await?;
+            let buffer = match buffer.await {
+                Ok(buffer) => buffer,
+                // Binary files (docx, xlsx, and any other non-text file the user drags in)
+                // can't be opened as a text buffer. Fall back to a path-only link instead of
+                // failing the whole mention, which would delete the text already inserted
+                // into the message editor.
+                Err(error) if error.to_string().contains("Binary files are not supported") => {
+                    return Ok(Mention::Link);
+                }
+                Err(error) => return Err(error),
+            };
             let buffer_content = outline::get_buffer_content_or_outline(
                 buffer.clone(),
                 Some(&abs_path.to_string_lossy()),

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -426,14 +426,9 @@ impl MentionSet {
         cx.spawn(async move |_, cx| {
             let buffer = match buffer.await {
                 Ok(buffer) => buffer,
-                // Binary files (docx, xlsx, and any other non-text file the user drags in)
-                // can't be opened as a text buffer. Fall back to a path-only link instead of
-                // failing the whole mention, which would delete the text already inserted
-                // into the message editor.
-                Err(error) if error.to_string().contains("Binary files are not supported") => {
+                Err(_error) => {
                     return Ok(Mention::Link);
                 }
-                Err(error) => return Err(error),
             };
             let buffer_content = outline::get_buffer_content_or_outline(
                 buffer.clone(),


### PR DESCRIPTION
## Summary

- Dragging a binary file (docx, xlsx, pdf, etc.) into the agent panel's message editor inserted a mention link, then asynchronously tried to load its content as a text buffer. That failed with "Binary files are not supported", which surfaced an error toast **and** deleted the mention text that had already been inserted.
- `confirm_mention_for_file` now catches that specific failure and falls back to `Mention::Link` (a path-only reference, same as directory mentions already use), instead of failing the whole mention and reverting the edit.

## Test plan

- [ ] Drag a `.docx` or `.xlsx` file into the agent panel chat input — the file path mention should stay inserted with no error toast.
- [ ] Drag a regular text file in — content mention still works as before (unaffected code path).

Release Notes:

- Fixed dragging a binary file (docx, xlsx, pdf, etc.) into the agent panel deleting the inserted reference and showing a "Binary files are not supported" error