### PR TITLE
editor: Fix Git blame gutter width with avatars

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11586,15 +11586,12 @@ impl EditorSnapshot {
                         let renderer = cx.global::<GlobalBlameRenderer>().0.clone();
                         const MAX_RELATIVE_TIMESTAMP: &str = "2 years, 11 months ago";
 
-                        /// The number of characters to dedicate to gaps and margins.
-                        const SPACING_WIDTH: usize = 4;
-
                         let max_char_count = max_author_length.min(renderer.max_author_length())
                             + ::git::SHORT_SHA_LENGTH
-                            + MAX_RELATIVE_TIMESTAMP.len()
-                            + SPACING_WIDTH;
+                            + MAX_RELATIVE_TIMESTAMP.len();
 
                         ch_advance * max_char_count
+                            + renderer.blame_entry_non_text_width(window, cx)
                     });
 
             let is_singleton = self.buffer_snapshot().is_singleton();

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -8,7 +8,7 @@ use git::{
     commit::ParsedCommitMessage,
 };
 use gpui::{
-    AnyElement, App, AppContext as _, Context, Entity, Hsla, ScrollHandle, SharedString,
+    AnyElement, App, AppContext as _, Context, Entity, Hsla, Pixels, ScrollHandle, SharedString,
     Subscription, Task, TextStyle, WeakEntity, Window,
 };
 use itertools::Itertools;
@@ -86,6 +86,10 @@ pub struct GitBlame {
 
 pub trait BlameRenderer {
     fn max_author_length(&self) -> usize;
+
+    fn blame_entry_non_text_width(&self, _: &Window, _: &App) -> Pixels {
+        Pixels::ZERO
+    }
 
     fn render_blame_entry(
         &self,

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -5,7 +5,7 @@ use crate::{
 use editor::{BlameRenderer, Editor, hover_markdown_style};
 use git::{blame::BlameEntry, commit::ParsedCommitMessage, repository::CommitSummary};
 use gpui::{
-    ClipboardItem, Entity, Hsla, MouseButton, ScrollHandle, Subscription, TextStyle,
+    ClipboardItem, Entity, Hsla, MouseButton, Pixels, Rems, ScrollHandle, Subscription, TextStyle,
     TextStyleRefinement, UnderlineStyle, WeakEntity, prelude::*,
 };
 use markdown::{Markdown, MarkdownElement};
@@ -20,6 +20,9 @@ use ui::{ContextMenu, CopyButton, Divider, prelude::*, tooltip_container};
 use workspace::Workspace;
 
 const GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED: usize = 20;
+const GIT_BLAME_GUTTER_MARGIN: Rems = rems(0.5);
+const GIT_BLAME_GUTTER_GAP: Rems = rems(0.5);
+const GIT_BLAME_AVATAR_SIZE: Rems = rems(1.);
 
 pub struct GitBlameRenderer;
 
@@ -126,6 +129,19 @@ impl BlameRenderer for GitBlameRenderer {
         GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED
     }
 
+    fn blame_entry_non_text_width(&self, window: &Window, cx: &App) -> Pixels {
+        let show_avatar = ProjectSettings::get_global(cx).git.blame.show_avatar;
+        let gap_count = if show_avatar { 3. } else { 2. };
+        let width = GIT_BLAME_GUTTER_MARGIN.to_pixels(window.rem_size())
+            + GIT_BLAME_GUTTER_GAP.to_pixels(window.rem_size()) * gap_count;
+
+        if show_avatar {
+            width + CommitAvatar::rendered_size(GIT_BLAME_AVATAR_SIZE, window)
+        } else {
+            width
+        }
+    }
+
     fn render_blame_entry(
         &self,
         style: &TextStyle,
@@ -160,6 +176,7 @@ impl BlameRenderer for GitBlameRenderer {
                     author_email,
                     details.as_ref().and_then(|it| it.remote.as_ref()),
                 )
+                .size(GIT_BLAME_AVATAR_SIZE)
                 .render(window, cx),
             )
         } else {

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -5,8 +5,8 @@ use git::blame::BlameEntry;
 use git::repository::CommitSummary;
 use git::{GitRemote, commit::ParsedCommitMessage};
 use gpui::{
-    AbsoluteLength, App, Asset, Element, Entity, MouseButton, ParentElement, Render, ScrollHandle,
-    StatefulInteractiveElement, WeakEntity, prelude::*,
+    AbsoluteLength, App, Asset, Element, Entity, MouseButton, ParentElement, Pixels, Render,
+    ScrollHandle, StatefulInteractiveElement, WeakEntity, prelude::*,
 };
 use markdown::{Markdown, MarkdownElement};
 use project::git_store::Repository;
@@ -71,6 +71,8 @@ pub(crate) fn commit_tag_chips(tag_names: &[SharedString]) -> Option<impl IntoEl
     )
 }
 
+const COMMIT_AVATAR_BORDER_WIDTH: Pixels = px(1.);
+
 pub struct CommitAvatar<'a> {
     sha: &'a SharedString,
     author_email: Option<SharedString>,
@@ -109,21 +111,22 @@ impl<'a> CommitAvatar<'a> {
         self
     }
 
+    pub fn rendered_size(size: impl Into<AbsoluteLength>, window: &Window) -> Pixels {
+        size.into().to_pixels(window.rem_size()) + COMMIT_AVATAR_BORDER_WIDTH * 2.
+    }
+
     pub fn render(&'a self, window: &mut Window, cx: &mut App) -> AnyElement {
         let border_color = cx.theme().colors().border_variant;
-        let border_width = px(1.);
 
         match self.avatar(window, cx) {
             None => {
-                let container_size = self
-                    .size
-                    .map(|s| s.to_pixels(window.rem_size()) + border_width * 2.);
+                let container_size = self.size.map(|size| Self::rendered_size(size, window));
 
                 h_flex()
                     .when_some(container_size, |this, size| this.size(size))
                     .justify_center()
                     .rounded_full()
-                    .border(border_width)
+                    .border(COMMIT_AVATAR_BORDER_WIDTH)
                     .border_color(border_color)
                     .bg(cx.theme().colors().element_disabled)
                     .child(


### PR DESCRIPTION
# Objective

When using column Git blame with avatars enabled, blame entries whose author name is the longest in the buffer can exceed the blame border.

For example, line 10 of `crates/vim/src/visual.rs` is displayed as follows:

<img width="998" height="121" alt="issue" src="https://github.com/user-attachments/assets/eff3e1ff-bd1c-42af-ae9b-da8efb0a7c22" />

The blame contents exceeds the width.

The root cause is in the blame width calculation:
https://github.com/zed-industries/zed/blob/0c51c7fd2481859e9da5c490ef8e41ddbcf1a341/crates/editor/src/editor.rs#L11583-L11598
The calculation accounts for the commit SHA, author name, and timestamp. Other elements, including spacing, margins, and the avatar, are represented by the fixed `SPACING_WIDTH` constant.

For typical fonts, `ch_advance` is approximately `0.5rem` to `0.6rem`, so `SPACING_WIDTH` provides approximately `2rem` to `2.4rem` for non-text content. However, the avatar itself occupies `1rem`:
https://github.com/zed-industries/zed/blob/0c51c7fd2481859e9da5c490ef8e41ddbcf1a341/crates/ui/src/components/avatar.rs#L81
When avatars are displayed, the entry also contains three `0.5rem` gaps and also one `0.5rem` right margin:
https://github.com/zed-industries/zed/blob/0c51c7fd2481859e9da5c490ef8e41ddbcf1a341/crates/git_ui/src/blame_ui.rs#L170-L188

This requires approximately `3.0rem`, which can exceed the space provided by `SPACING_WIDTH`. When an entry contains both the longest author name in the buffer and a long timestamp, its content can therefore exceed the blame border.

## Solution

The simplest fix would be to increase `SPACING_WIDTH`, but that would still rely on an approximate conversion between editor character widths and UI dimensions.

Instead, this PR adds a method to the blame renderer for calculating the non-text width of a blame entry. The editor uses this value together with the measured text width when calculating the final blame width.

## Testing

Tested locally. A before-and-after comparison is included below.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

| Before | After |
| :--: | :--: | 
| <img width="551" height="94" alt="Before" src="https://github.com/user-attachments/assets/b6741a41-6531-4fae-adaa-f9ae0b298e0f" /> |<img width="566" height="93" alt="After" src="https://github.com/user-attachments/assets/e8d75d2a-6b07-43f6-b2a8-bfb76d118611" /> | 

Release Notes:

- Fixed Git blame entries overflowing the gutter when avatars are displayed.





