### PR TITLE
Fix two memory leaks in long ACP agent sessions

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1168,8 +1168,8 @@ impl ToolCall {
     }
 }
 
-// Separate so we can hold a strong reference to the buffer
-// for saving on the thread
+// Holds the buffer alive until resolution finishes: `shared_buffers`
+// and `AgentLocation` only keep weak handles.
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ResolvedLocation {
     buffer: Entity<Buffer>,
@@ -2088,7 +2088,7 @@ pub struct AcpThread {
     action_log: Entity<ActionLog>,
     _git_store_subscription: Subscription,
     update_last_checkpoint_if_changed_task: Option<Task<Result<()>>>,
-    shared_buffers: HashMap<Entity<Buffer>, BufferSnapshot>,
+    shared_buffers: HashMap<WeakEntity<Buffer>, BufferSnapshot>,
     turn_id: u32,
     running_turn: Option<RunningTurn>,
     connection: Rc<dyn AgentConnection>,
@@ -3324,9 +3324,12 @@ impl AcpThread {
             this.update(cx, |this, cx| {
                 let project = this.project.clone();
 
+                this.prune_dead_shared_buffers();
                 for location in resolved_locations.iter().flatten() {
-                    this.shared_buffers
-                        .insert(location.buffer.clone(), location.buffer.read(cx).snapshot());
+                    this.shared_buffers.insert(
+                        location.buffer.downgrade(),
+                        location.buffer.read(cx).snapshot(),
+                    );
                 }
                 let Some((ix, tool_call)) = this.tool_call_mut(&id) else {
                     return;
@@ -4178,6 +4181,11 @@ impl AcpThread {
         })
     }
 
+    fn prune_dead_shared_buffers(&mut self) {
+        self.shared_buffers
+            .retain(|buffer, _| buffer.is_upgradable());
+    }
+
     pub fn read_text_file(
         &self,
         path: PathBuf,
@@ -4206,7 +4214,7 @@ impl AcpThread {
 
             let snapshot = if reuse_shared_snapshot {
                 this.read_with(cx, |this, _| {
-                    this.shared_buffers.get(&buffer.clone()).cloned()
+                    this.shared_buffers.get(&buffer.downgrade()).cloned()
                 })
                 .log_err()
                 .flatten()
@@ -4223,7 +4231,9 @@ impl AcpThread {
 
                 let snapshot = buffer.update(cx, |buffer, _| buffer.snapshot());
                 this.update(cx, |this, _| {
-                    this.shared_buffers.insert(buffer.clone(), snapshot.clone());
+                    this.prune_dead_shared_buffers();
+                    this.shared_buffers
+                        .insert(buffer.downgrade(), snapshot.clone());
                 })?;
                 snapshot
             };
@@ -4277,7 +4287,7 @@ impl AcpThread {
             let buffer = load?.await?;
             let snapshot = this.update(cx, |this, cx| {
                 this.shared_buffers
-                    .get(&buffer)
+                    .get(&buffer.downgrade())
                     .cloned()
                     .unwrap_or_else(|| buffer.read(cx).snapshot())
             })?;
@@ -6034,6 +6044,56 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_shared_buffers_do_not_accumulate_dead_entries(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/tmp"), json!({"foo": "one\ntwo\n"}))
+            .await;
+        let project = Project::test(fs.clone(), [], cx).await;
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_worktree(path!("/tmp/foo"), true, cx)
+            })
+            .await
+            .unwrap();
+
+        let connection = Rc::new(FakeAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(project, PathList::new(&[Path::new(path!("/tmp"))]), cx)
+            })
+            .await
+            .unwrap();
+
+        let dead_buffer = cx.new(|cx| Buffer::local("stale", cx));
+        let snapshot = dead_buffer.read_with(cx, |buffer, _| buffer.snapshot());
+        thread.update(cx, |thread, _| {
+            thread
+                .shared_buffers
+                .insert(dead_buffer.downgrade(), snapshot);
+        });
+        drop(dead_buffer);
+
+        thread
+            .update(cx, |thread, cx| {
+                thread.read_text_file(path!("/tmp/foo").into(), None, None, false, cx)
+            })
+            .await
+            .unwrap();
+
+        thread.read_with(cx, |thread, _| {
+            assert_eq!(thread.shared_buffers.len(), 1);
+            assert!(
+                thread
+                    .shared_buffers
+                    .keys()
+                    .all(|buffer| buffer.is_upgradable())
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_reading_from_line(cx: &mut TestAppContext) {
         init_test(cx);
 
@@ -6324,6 +6384,14 @@ mod tests {
         )
         .await;
         let project = Project::test(fs, [], cx).await;
+        // Keeps the buffer alive: `shared_buffers` holds only weak handles,
+        // so it would drop as soon as resolution finishes.
+        let external_buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/tmp/skills/test-skill/SKILL.md"), cx)
+            })
+            .await
+            .unwrap();
         let connection = Rc::new(FakeAgentConnection::new());
         let thread = cx
             .update(|cx| {
@@ -6358,7 +6426,8 @@ mod tests {
             let buffer = agent_location
                 .buffer
                 .upgrade()
-                .expect("resolved location should keep an open buffer");
+                .expect("resolved location should reference the opened buffer");
+            assert_eq!(buffer.entity_id(), external_buffer.entity_id());
             assert_eq!(buffer.read(cx).text(), "skill body");
         });
     }

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1179,8 +1179,8 @@ impl ToolCall {
     }
 }
 
-// Separate so we can hold a strong reference to the buffer
-// for saving on the thread
+// Holds the buffer alive until resolution finishes: `shared_buffers`
+// and `AgentLocation` only keep weak handles.
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ResolvedLocation {
     buffer: Entity<Buffer>,
@@ -2101,7 +2101,7 @@ pub struct AcpThread {
     action_log: Entity<ActionLog>,
     _git_store_subscription: Subscription,
     update_last_checkpoint_if_changed_task: Option<Task<Result<()>>>,
-    shared_buffers: HashMap<Entity<Buffer>, BufferSnapshot>,
+    shared_buffers: HashMap<WeakEntity<Buffer>, BufferSnapshot>,
     turn_id: u32,
     running_turn: Option<RunningTurn>,
     connection: Rc<dyn AgentConnection>,
@@ -3385,9 +3385,12 @@ impl AcpThread {
             this.update(cx, |this, cx| {
                 let project = this.project.clone();
 
+                this.prune_dead_shared_buffers();
                 for location in resolved_locations.iter().flatten() {
-                    this.shared_buffers
-                        .insert(location.buffer.clone(), location.buffer.read(cx).snapshot());
+                    this.shared_buffers.insert(
+                        location.buffer.downgrade(),
+                        location.buffer.read(cx).snapshot(),
+                    );
                 }
                 let Some((ix, tool_call)) = this.tool_call_mut(&id) else {
                     return;
@@ -4307,6 +4310,11 @@ impl AcpThread {
         })
     }
 
+    fn prune_dead_shared_buffers(&mut self) {
+        self.shared_buffers
+            .retain(|buffer, _| buffer.is_upgradable());
+    }
+
     pub fn read_text_file(
         &self,
         path: PathBuf,
@@ -4335,7 +4343,7 @@ impl AcpThread {
 
             let snapshot = if reuse_shared_snapshot {
                 this.read_with(cx, |this, _| {
-                    this.shared_buffers.get(&buffer.clone()).cloned()
+                    this.shared_buffers.get(&buffer.downgrade()).cloned()
                 })
                 .log_err()
                 .flatten()
@@ -4352,7 +4360,9 @@ impl AcpThread {
 
                 let snapshot = buffer.update(cx, |buffer, _| buffer.snapshot());
                 this.update(cx, |this, _| {
-                    this.shared_buffers.insert(buffer.clone(), snapshot.clone());
+                    this.prune_dead_shared_buffers();
+                    this.shared_buffers
+                        .insert(buffer.downgrade(), snapshot.clone());
                 })?;
                 snapshot
             };
@@ -4406,7 +4416,7 @@ impl AcpThread {
             let buffer = load?.await?;
             let snapshot = this.update(cx, |this, cx| {
                 this.shared_buffers
-                    .get(&buffer)
+                    .get(&buffer.downgrade())
                     .cloned()
                     .unwrap_or_else(|| buffer.read(cx).snapshot())
             })?;
@@ -6167,6 +6177,56 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_shared_buffers_do_not_accumulate_dead_entries(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(path!("/tmp"), json!({"foo": "one\ntwo\n"}))
+            .await;
+        let project = Project::test(fs.clone(), [], cx).await;
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_worktree(path!("/tmp/foo"), true, cx)
+            })
+            .await
+            .unwrap();
+
+        let connection = Rc::new(FakeAgentConnection::new());
+        let thread = cx
+            .update(|cx| {
+                connection.new_session(project, PathList::new(&[Path::new(path!("/tmp"))]), cx)
+            })
+            .await
+            .unwrap();
+
+        let dead_buffer = cx.new(|cx| Buffer::local("stale", cx));
+        let snapshot = dead_buffer.read_with(cx, |buffer, _| buffer.snapshot());
+        thread.update(cx, |thread, _| {
+            thread
+                .shared_buffers
+                .insert(dead_buffer.downgrade(), snapshot);
+        });
+        drop(dead_buffer);
+
+        thread
+            .update(cx, |thread, cx| {
+                thread.read_text_file(path!("/tmp/foo").into(), None, None, false, cx)
+            })
+            .await
+            .unwrap();
+
+        thread.read_with(cx, |thread, _| {
+            assert_eq!(thread.shared_buffers.len(), 1);
+            assert!(
+                thread
+                    .shared_buffers
+                    .keys()
+                    .all(|buffer| buffer.is_upgradable())
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn test_reading_from_line(cx: &mut TestAppContext) {
         init_test(cx);
 
@@ -6457,6 +6517,14 @@ mod tests {
         )
         .await;
         let project = Project::test(fs, [], cx).await;
+        // Keeps the buffer alive: `shared_buffers` holds only weak handles,
+        // so it would drop as soon as resolution finishes.
+        let external_buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/tmp/skills/test-skill/SKILL.md"), cx)
+            })
+            .await
+            .unwrap();
         let connection = Rc::new(FakeAgentConnection::new());
         let thread = cx
             .update(|cx| {
@@ -6491,7 +6559,8 @@ mod tests {
             let buffer = agent_location
                 .buffer
                 .upgrade()
-                .expect("resolved location should keep an open buffer");
+                .expect("resolved location should reference the opened buffer");
+            assert_eq!(buffer.entity_id(), external_buffer.entity_id());
             assert_eq!(buffer.read(cx).text(), "skill body");
         });
     }

--- a/crates/agent_ui/src/entry_view_state.rs
+++ b/crates/agent_ui/src/entry_view_state.rs
@@ -302,6 +302,13 @@ impl EntryViewState {
                     &mut tool_call.content
                 };
 
+                let live_views = terminals
+                    .iter()
+                    .map(|terminal| terminal.entity_id())
+                    .chain(diffs.iter().map(|diff| diff.entity_id()))
+                    .collect::<HashSet<_>>();
+                views.retain(|entity_id, _| live_views.contains(entity_id));
+
                 let is_tool_call_completed =
                     matches!(tool_call.status, acp_thread::ToolCallStatus::Completed);
 


### PR DESCRIPTION
# Objective

In long-running conversations with external (ACP) agents, Zed's memory grows steadily and is never reclaimed until the conversation is closed. Two independent, unbounded leaks cause this:

1. **`AcpThread::shared_buffers` pins every buffer the agent ever touched.** The map is insert-only: entries are added on every `fs/read_text_file` request and for every resolved tool-call location, and nothing ever removes them. Since `BufferStore` itself holds buffers weakly (`OpenBuffer::Complete { buffer: WeakEntity<Buffer> }`), the strong `Entity<Buffer>` keys of this map are what keeps every such buffer — full rope, syntax tree, language data — alive for the whole lifetime of the thread, even after the user closes the file everywhere else. Agents like Claude Code read hundreds of files in a long session, so this adds up quickly.

2. **`EntryViewState` leaks an editor each time a tool call's diff is replaced.** The per-tool-call `content: HashMap<EntityId, AnyView>` map in `sync_entry` is also insert-only. When a tool-call update replaces a `Diff`/`Terminal` entity (`ToolCallContent::update_from_acp` creates a new entity whenever the diff text changed), the view for the old entity — a full `Editor` with its `MultiBuffer` and display map, holding the old diff's buffers — stays in the map for the rest of the session. For agents that stream edits as a sequence of tool-call updates this multiplies per update, not per edit.

## Solution

1. `shared_buffers` now uses `WeakEntity<Buffer>` keys, and dead entries are pruned whenever a new snapshot is inserted. This is safe:
   - The snapshot is used as the diff base in `write_text_file`, which already falls back to the buffer's current snapshot when no shared snapshot exists — a buffer dropped between a read and a write simply takes the existing fallback path.
   - Entity ids are generational, so a dead entry can never be confused with a later re-opened buffer for the same path.
   - While a buffer is alive anywhere (open tab, `ActionLog` tracking), lookups behave exactly as before.

2. `sync_entry` now retains only the views whose diff/terminal entity is still present on the tool call. The replacement diff gets its editor created through the existing `NewDiff` path, so visible behavior is unchanged.

## Intentional behavior change

Resolved tool-call locations no longer keep their buffer alive — that pinning *was* leak 1, so removing it is the point, but it is a semantic change worth calling out. A buffer that nothing else holds (an open tab, `ActionLog` tracking from `fs/read_text_file`) may now drop once location resolution finishes. Consequences:

- **Following the agent** still works while it is active: the `AgentLocationChanged` handler runs within the same effect cycle, while the resolution task still holds a strong reference, and the follower's editor keeps the buffer alive from then on. Enabling follow *after* the fact no longer jumps to the last location if its buffer has dropped (`WeakEntity::upgrade` returns `None`); it catches up on the next location update.
- **Clicking a tool-call location** re-opens the file by path as before; if the original buffer is gone, the stored anchor can't be matched and the click falls back to the tool-call's line number.

`test_tool_call_location_resolves_external_file` previously asserted the old pinning as a side effect (it upgraded the agent-location weak handle without holding the buffer — the strong map key was what kept it alive). It now holds the buffer itself, with a comment explaining why, and additionally asserts that resolving reuses the same buffer entity rather than opening a duplicate.

## Testing

- New regression test: `test_shared_buffers_do_not_accumulate_dead_entries` — a dead entry is swept on the next insert, live entries survive.
- `cargo test -p acp_thread`: 122 passed.
- Manual verification: a long Claude Code (ACP) session over a large project while watching process RSS — growth flattens compared to an unpatched build, and buffer memory is reclaimed once files are closed.
- To reproduce as a reviewer: connect any external agent, ask it to read many files (e.g. "summarize every file in crates/gpui/src"), and watch RSS; before this change every file it reads stays resident until the thread is dropped.
- Tested on macOS (x86_64); the changes are platform-independent entity-lifecycle logic.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments — no unsafe blocks added
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines) — no visual/UI changes
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable — pruning is O(map size) on I/O-bound read paths; view retention is O(views per tool call) during sync