### PR TITLE
repl: Open notebooks from single-file worktrees in the notebook editor

### DIFF
--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -69,6 +69,8 @@ pub(crate) const GUTTER_WIDTH: f32 = 19.0;
 pub(crate) const CODE_BLOCK_INSET: f32 = MEDIUM_SPACING_SIZE;
 pub(crate) const CONTROL_SIZE: f32 = 20.0;
 
+const NOTEBOOK_EXTENSION: &str = "ipynb";
+
 pub fn init(cx: &mut App) {
     if cx.has_flag::<NotebookFeatureFlag>() || std::env::var("LOCAL_NOTEBOOK_DEV").is_ok() {
         workspace::register_project_item::<NotebookEditor>(cx);
@@ -1510,11 +1512,19 @@ impl project::ProjectItem for NotebookItem {
         let fs = project.read(cx).fs().clone();
         let languages = project.read(cx).languages().clone();
 
-        if path.path.extension().unwrap_or_default() == "ipynb" {
+        // For single-file worktrees the relative path is empty, so fall back
+        // to the absolute path to detect notebooks opened directly.
+        let abs_path = project.read(cx).absolute_path(&path, cx);
+        let is_notebook = path.path.extension().unwrap_or_default() == NOTEBOOK_EXTENSION
+            || abs_path
+                .as_ref()
+                .and_then(|abs_path| abs_path.extension())
+                .is_some_and(|extension| extension == NOTEBOOK_EXTENSION);
+
+        if is_notebook {
             Some(cx.spawn(async move |cx| {
-                let abs_path = project
-                    .read_with(cx, |project, cx| project.absolute_path(&path, cx))
-                    .with_context(|| format!("finding the absolute path of {path:?}"))?;
+                let abs_path =
+                    abs_path.with_context(|| format!("finding the absolute path of {path:?}"))?;
 
                 // todo: watch for changes to the file
                 let buffer = project
@@ -2095,6 +2105,60 @@ mod tests {
                 }
                 other => panic!("expected a single error output, got: {other:?}"),
             }
+        });
+    }
+
+    /// Opening a notebook as a single file (its own worktree) leaves the
+    /// worktree-relative path empty, so only the absolute path carries the
+    /// `.ipynb` extension. `try_open` must still recognize it as a notebook.
+    #[gpui::test]
+    async fn test_open_single_file_notebook(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme_settings::init(theme::LoadThemes::JustBase, cx);
+            editor::init(cx);
+        });
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/notebooks"),
+            json!({ "single.ipynb": NOTEBOOK_WITH_ONE_CODE_CELL }),
+        )
+        .await;
+
+        let project =
+            Project::test(fs.clone(), [path!("/notebooks/single.ipynb").as_ref()], cx).await;
+        cx.update(|cx| ReplStore::init(fs.clone(), cx));
+
+        let project_path = project.read_with(cx, |project, cx| {
+            let worktree = project.worktrees(cx).next().unwrap();
+            let worktree = worktree.read(cx);
+            assert!(
+                worktree.is_single_file(),
+                "opening a bare .ipynb should create a single-file worktree"
+            );
+            ProjectPath {
+                worktree_id: worktree.id(),
+                path: worktree.root_entry().unwrap().path.clone(),
+            }
+        });
+
+        assert!(
+            project_path.path.extension().is_none(),
+            "single-file worktree relative path should have no extension"
+        );
+
+        let notebook_item = cx
+            .update(|cx| {
+                NotebookItem::try_open(&project, &project_path, cx)
+                    .expect("single-file .ipynb should open as a notebook")
+            })
+            .await
+            .expect("notebook should parse");
+
+        notebook_item.read_with(cx, |item, _| {
+            assert_eq!(item.notebook.cells.len(), 1);
         });
     }
 }


### PR DESCRIPTION
`NotebookItem::try_open` only checked the worktree-relative path's extension, which is empty for single-file worktrees. As a result, opening a notebook directly (`zed foo.ipynb`, or any open outside a folder worktree) fell through to the text editor and showed raw JSON, while the same file opened from within a folder workspace opened in the notebook editor. Fall back to the absolute path when detecting notebooks.

Tested locally (macOS, with the notebook feature enabled via `LOCAL_NOTEBOOK_DEV`): `zed /tmp/solo.ipynb` now opens the rendered notebook view; folder-workspace behavior unchanged.

Release Notes:

- N/A