### PR TITLE
repl: Seed new notebooks with one empty code cell

### DIFF
--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -1523,11 +1523,29 @@ impl project::ProjectItem for NotebookItem {
                 let file_content = buffer.read_with(cx, |buffer, _| buffer.text());
 
                 let notebook = if file_content.trim().is_empty() {
-                    nbformat::v4::Notebook {
-                        nbformat: 4,
-                        nbformat_minor: 5,
-                        cells: vec![],
-                        metadata: serde_json::from_str("{}").unwrap(),
+                    // Start new notebooks with one empty code cell, like
+                    // Jupyter, so the editor doesn't render an empty pane.
+                    let empty_notebook = serde_json::json!({
+                        "cells": [{
+                            "cell_type": "code",
+                            "id": Uuid::new_v4().to_string(),
+                            "metadata": {},
+                            "execution_count": null,
+                            "outputs": [],
+                            "source": []
+                        }],
+                        "metadata": {},
+                        "nbformat": 4,
+                        "nbformat_minor": 5
+                    });
+                    match nbformat::parse_notebook(&empty_notebook.to_string())? {
+                        nbformat::Notebook::V4(notebook) => notebook,
+                        nbformat::Notebook::Legacy(legacy_notebook) => {
+                            nbformat::upgrade_legacy_notebook(legacy_notebook)?
+                        }
+                        nbformat::Notebook::V3(v3_notebook) => {
+                            nbformat::upgrade_v3_notebook(v3_notebook)?
+                        }
                     }
                 } else {
                     let notebook = match nbformat::parse_notebook(&file_content) {


### PR DESCRIPTION
Opening an empty `.ipynb` produced a notebook with zero cells, which renders as a blank pane with no visible way to start typing (cells can only be added via `cmd-m`/toolbar, which is not discoverable from an empty editor). Match Jupyter's new-notebook behavior by seeding a single empty code cell when the file is empty.

Tested locally on macOS with the notebook feature enabled: `touch fresh.ipynb`, open it, and the editor shows one empty Python cell ready for input; typing and saving produces a valid notebook.

Release Notes:

- Fixed empty notebook files opening as a blank pane; new notebooks now start with one empty code cell (preview-only).