### PR TITLE
repl: Fix notebook kernel launch stalling silently

### DIFF
--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -336,11 +336,33 @@ impl NotebookEditor {
     }
 
     fn launch_kernel(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let spec = self.kernel_specification.clone().or_else(|| {
-            ReplStore::global(cx)
-                .read(cx)
-                .active_kernelspec(self.worktree_id, None, cx)
-        });
+        let spec = self
+            .kernel_specification
+            .clone()
+            .or_else(|| {
+                ReplStore::global(cx)
+                    .read(cx)
+                    .active_kernelspec(self.worktree_id, None, cx)
+            })
+            .or_else(|| {
+                // Honor `jupyter.kernel_selections` for the notebook's language
+                // before falling back to a bare `python3` from PATH.
+                let language_name = self
+                    .notebook_item
+                    .read(cx)
+                    .language_name()
+                    .unwrap_or_else(|| "python".to_string())
+                    .to_lowercase();
+                let selected_name = crate::JupyterSettings::get_global(cx)
+                    .kernel_selections
+                    .get(&language_name)
+                    .cloned()?;
+                ReplStore::global(cx)
+                    .read(cx)
+                    .kernel_specifications_for_worktree(self.worktree_id)
+                    .find(|spec| spec.name().eq_ignore_ascii_case(&selected_name))
+                    .cloned()
+            });
 
         let spec = spec.unwrap_or_else(|| {
             KernelSpecification::Jupyter(LocalKernelSpecification {
@@ -466,6 +488,29 @@ impl NotebookEditor {
 
         self.kernel = Kernel::StartingKernel(pending_kernel);
         cx.notify();
+
+        // The connection setup can hang forever if the kernel process dies
+        // before binding its sockets (e.g. ipykernel is not installed), which
+        // would leave the notebook reporting "the kernel is still starting"
+        // indefinitely. Surface an actionable error instead.
+        cx.spawn_in(window, async move |this, cx| {
+            cx.background_executor()
+                .timer(std::time::Duration::from_secs(30))
+                .await;
+            this.update(cx, |editor, cx| {
+                if matches!(editor.kernel, Kernel::StartingKernel(_)) {
+                    editor.kernel = Kernel::ErroredLaunch(
+                        "the kernel did not become ready within 30 seconds; check that \
+                         `ipykernel` is installed for the selected interpreter \
+                         (pip install ipykernel), or pick another kernel"
+                            .to_string(),
+                    );
+                    cx.notify();
+                }
+            })
+            .ok();
+        })
+        .detach();
     }
 
     // Note: Python environments are only detected as kernels if ipykernel is installed.


### PR DESCRIPTION
Two fixes for kernel startup in the notebook editor:

1. **Honor `jupyter.kernel_selections`.** `launch_kernel` consulted `active_kernelspec` with no language (which only returns an explicit per-worktree selection) and then fell back directly to a hardcoded `python3 -m ipykernel_launcher` from PATH, ignoring the user's configured kernel for the language. Look up the configured kernel for the notebook's language before using the hardcoded fallback.

2. **Surface hung launches.** If the kernel process dies before binding its sockets (the common case: `ipykernel` not installed for the resolved interpreter), connection setup never completes and the notebook reports "the kernel is still starting" indefinitely, with no path to an error. Add a 30-second watchdog that transitions a still-starting kernel to `ErroredLaunch` with an actionable message (reproduced on a machine whose `python3` lacked ipykernel: previously stuck forever on "kernel is still starting"; run attempts now produce a clear error suggesting `pip install ipykernel`).

Tested locally on macOS with the notebook feature enabled.

Release Notes:

- Fixed the notebook editor ignoring `jupyter.kernel_selections` and hanging on "kernel is still starting" when the kernel process fails to launch (preview-only).