### PR TITLE
recent_projects: Fix open folder keybinding

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1193,6 +1193,7 @@
     "context": "RecentProjects || (RecentProjects > Picker > Editor)",
     "bindings": {
       "ctrl-k": "recent_projects::ToggleActionsMenu",
+      "ctrl-k ctrl-o": "workspace::Open",
       "ctrl-shift-a": "workspace::AddFolderToProject",
       "shift-backspace": "recent_projects::RemoveSelected",
       "ctrl-shift-enter": "recent_projects::AddToWorkspace",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1201,6 +1201,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-k": "recent_projects::ToggleActionsMenu",
+      "ctrl-k ctrl-o": "workspace::Open",
       "ctrl-shift-a": "workspace::AddFolderToProject",
       "shift-backspace": "recent_projects::RemoveSelected",
       "ctrl-shift-enter": "recent_projects::AddToWorkspace",


### PR DESCRIPTION
# Objective

Closes #58986

This PR fixes `Ctrl-K Ctrl-O` opening a file picker while the Recent Projects picker is focused.

The keymaps globally bind `Ctrl-O` to `workspace::OpenFiles` and `Ctrl-K Ctrl-O` to `workspace::Open`

The Recent Projects context also binds `Ctrl-K` to toggle its actions menu. The more specific binding ate `Ctrl-K` stopping the global `Ctrl-K Ctrl-O` bind occuring.

## Solution

Add a `RecentProjects`-specific `Ctrl-K Ctrl-O` binding to `workspace::Open` after the existing contextual `Ctrl-K` binding.
This matches the action associated with “Open Local Folders,” including its multiple-selection and open-mode behavior.
macOS is unchanged because its primary `Cmd-O` shortcut already maps to `workspace::Open`.

## Testing

Try #58986, then this.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [ ] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed `Ctrl-K Ctrl-O` opening a file picker instead of the local folder picker from Recent Projects.
