### PR TITLE
git: stop spamming git status during worktree scans

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -7,6 +7,7 @@ pub mod pending_op;
 use crate::{
     ProjectEnvironment, ProjectItem, ProjectPath,
     buffer_store::{BufferStore, BufferStoreEvent},
+    debounced_delay::DebouncedDelay,
     project_settings::ProjectSettings,
     trusted_worktrees::{
         PathTrust, TrustedWorktrees, TrustedWorktreesEvent, TrustedWorktreesStore,
@@ -514,6 +515,7 @@ pub struct Repository {
     initial_graph_data: HashMap<(LogSource, LogOrder), InitialGitGraphData>,
     commit_data_handler: CommitDataHandlerState,
     commit_data: HashMap<Oid, CommitDataState>,
+    status_refresh_debounce: DebounceDelay<Self>,
 }
 
 impl std::ops::Deref for Repository {
@@ -5588,6 +5590,7 @@ impl Repository {
             initial_graph_data: Default::default(),
             commit_data: Default::default(),
             commit_data_handler: CommitDataHandlerState::Closed,
+            status_refresh_debounce: DebouncedDelay::new(),
         };
         repo.respawn_local_worker(project_environment, fs, is_trusted, cx);
         cx.subscribe_self(Self::handle_subscribe_self).detach();
@@ -5637,6 +5640,7 @@ impl Repository {
             initial_graph_data: Default::default(),
             commit_data: Default::default(),
             commit_data_handler: CommitDataHandlerState::Closed,
+            status_refresh_debounce: DebouncedDelay::new(),
         }
     }
 
@@ -9182,8 +9186,20 @@ impl Repository {
             self.paths_needing_status_update.push(paths);
         }
 
+        const STATUS_REFRESH_DEBOUNCE: Duration = Duration::from_millis(50);
+        self.status_refresh_debounce
+            .fire_new(STATUS_REFRESH_DEBOUNCE, cx, move |this, cx| {
+                this.refresh_statuses_now(updates_tx, cx)
+            });
+    }
+
+    fn refresh_statuses_now(
+        &mut self,
+        updates_tx: Option<mpsc::UnboundedSender<DownstreamUpdate>>,
+        cx: &mut Context<Self>,
+    ) -> Task<()> {
         let this = cx.weak_entity();
-        let _ = self.send_keyed_job(
+        let job_rx = self.send_keyed_job(
             "paths_changed",
             Some(GitJobKey::RefreshStatuses),
             None,
@@ -9317,6 +9333,9 @@ impl Repository {
                 })
             },
         );
+        cx.spawn(async move |_, _cx| {
+            job_rx.await.ok();
+        })
     }
 
     /// currently running git command and when it started


### PR DESCRIPTION
## Objective

Opening a large directory (e.g. `~/`) scans it in many small chunks, and each chunk that touches a git repo triggers its own `git status` subprocess call. The existing queue dedup only collapses *back-to-back* calls, so on a real scan - where each status call finishes before the next chunk arrives - nothing gets coalesced and you end up with one subprocess per chunk.

Fixes #35780

## Solution

Reuse the `DebouncedDelay` already used for git gutter diffing: wait a beat after `paths_changed` fires, and only run the status refresh once things go quiet, instead of firing a status call per chunk. Same debounce pattern, just applied to this path as well.

## Testing

- Could not build Zed itself in my environment - no working toolchain, and `gpui` needs system dependencies this box doesn't have - so I have not run this against the real crate.
- To sanity-check the logic anyway, I pulled the debounce + queue code into a small standalone harness and replayed the actual chunk-arrival timing patterns described in #35780 against it. Behavior lined up with what's reported there (one status call per settle period instead of one per chunk).
- Still needed before merge: someone with a working build should `cargo check`/`cargo test` this against the real crate and reproduce on a large real tree (e.g. a big monorepo or `~/`) to confirm it holds up outside the harness.
- Reviewers: the harness isn't a substitute for integration testing here - please treat this as "logic verified in isolation, not yet verified in Zed."

## Self-Review Checklist:
- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments — N/A, no unsafe blocks introduced
- [ ] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines) — N/A, no UI change
- [ ] Tests cover the new/changed behavior — only exercised via the standalone harness described above, not the actual crate's test suite; needs real coverage before merge
- [x] Performance impact has been considered and is acceptable - this should reduce subprocess spawns during large scans, not increase them; no build to benchmark against though

---

Release Notes:
- Fixed: large directory scans no longer spawn a `git status` call per chunk; status refresh is now debounced ([#35780](https://github.com/zed-industries/zed/issues/35780))