### PR TITLE
editor: Disable gutter breakpoint and bookmark actions in unsaved buf…

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5817,13 +5817,23 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let source = self
-            .buffer
-            .read(cx)
-            .snapshot(cx)
-            .anchor_before(Point::new(display_row.0, 0u32));
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        let source = snapshot.anchor_before(Point::new(display_row.0, 0u32));
+        let anchor = position.unwrap_or(source);
 
-        let context_menu = self.gutter_context_menu(position.unwrap_or(source), window, cx);
+        // Every entry in this menu either requires a worktree-file-backed buffer
+        // (breakpoints, bookmarks, run to cursor) or is meaningless without one
+        // (git blame), so don't open it for e.g. untitled buffers.
+        if !snapshot
+            .anchor_to_buffer_anchor(anchor)
+            .is_some_and(|(_, buffer_snapshot)| {
+                project::File::from_dyn(buffer_snapshot.file()).is_some()
+            })
+        {
+            return;
+        }
+
+        let context_menu = self.gutter_context_menu(anchor, window, cx);
 
         self.mouse_context_menu = MouseContextMenu::pinned_to_editor(
             self,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -30998,6 +30998,168 @@ async fn test_breakpoint_toggling(cx: &mut TestAppContext) {
     assert_breakpoint(&breakpoints, &abs_path, vec![]);
 }
 
+async fn build_gutter_hover_test_editor(saved: bool, cx: &mut TestAppContext) -> EditorTestContext {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/a"),
+        json!({
+            "main.rs": "fn main() {}\n",
+        }),
+    )
+    .await;
+    let project = Project::test(fs, [path!("/a").as_ref()], cx).await;
+
+    let buffer = if saved {
+        let worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+        project
+            .update(cx, |project, cx| {
+                project.open_buffer((worktree_id, rel_path("main.rs")), cx)
+            })
+            .await
+            .unwrap()
+    } else {
+        let buffer = project
+            .update(cx, |project, cx| project.create_buffer(None, true, cx))
+            .await
+            .unwrap();
+        buffer.update(cx, |buffer, cx| {
+            buffer.edit([(0..0, "fn main() {}\n")], None, cx);
+        });
+        buffer
+    };
+
+    let window = cx.add_window(|window, cx| {
+        let editor = build_editor_with_project(
+            project,
+            MultiBuffer::build_from_buffer(buffer, cx),
+            window,
+            cx,
+        );
+        window.focus(&editor.focus_handle(cx), cx);
+        editor
+    });
+
+    EditorTestContext::for_editor(window, cx).await
+}
+
+fn hover_over_gutter_row_zero(cx: &mut EditorTestContext) {
+    cx.update(|window, cx| {
+        window.refresh();
+        let _ = window.draw(cx);
+    });
+
+    let gutter_bounds = cx.update_editor(|editor, _, _| {
+        editor
+            .last_position_map
+            .as_ref()
+            .expect("expected editor position map")
+            .gutter_hitbox
+            .bounds
+    });
+
+    let hover_position = gutter_bounds.center();
+    cx.simulate_mouse_move(hover_position, None, Modifiers::none());
+}
+
+#[gpui::test]
+async fn test_gutter_hover_button_shown_for_saved_buffer(cx: &mut TestAppContext) {
+    let mut cx = build_gutter_hover_test_editor(true, cx).await;
+
+    hover_over_gutter_row_zero(&mut cx);
+    cx.update_editor(|editor, _, _| {
+        assert!(
+            editor.gutter_hover_button.0.is_some(),
+            "expected gutter hover button to be armed for a saved buffer"
+        );
+        assert!(!editor.gutter_hover_button.0.as_ref().unwrap().is_active);
+    });
+
+    cx.executor().advance_clock(Duration::from_millis(250));
+    cx.run_until_parked();
+    cx.update_editor(|editor, _, _| {
+        assert!(
+            editor
+                .gutter_hover_button
+                .0
+                .as_ref()
+                .is_some_and(|indicator| indicator.is_active),
+            "expected gutter hover button to become active after the debounce"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_gutter_hover_button_hidden_for_unsaved_buffer(cx: &mut TestAppContext) {
+    let mut cx = build_gutter_hover_test_editor(false, cx).await;
+
+    hover_over_gutter_row_zero(&mut cx);
+    cx.update_editor(|editor, _, _| {
+        assert!(
+            editor.gutter_hover_button.0.is_none(),
+            "expected no gutter hover button for an unsaved buffer"
+        );
+        assert!(
+            editor.gutter_hover_button.1.is_none(),
+            "expected no debounce task to be armed for an unsaved buffer"
+        );
+    });
+
+    cx.executor().advance_clock(Duration::from_millis(250));
+    cx.run_until_parked();
+    cx.update_editor(|editor, _, _| {
+        assert!(editor.gutter_hover_button.0.is_none());
+    });
+}
+
+fn right_click_gutter_row_zero(cx: &mut EditorTestContext) {
+    cx.update(|window, cx| {
+        window.refresh();
+        let _ = window.draw(cx);
+    });
+
+    let gutter_bounds = cx.update_editor(|editor, _, _| {
+        editor
+            .last_position_map
+            .as_ref()
+            .expect("expected editor position map")
+            .gutter_hitbox
+            .bounds
+    });
+
+    let click_position = gutter_bounds.center();
+    cx.simulate_mouse_down(click_position, MouseButton::Right, Modifiers::none());
+}
+
+#[gpui::test]
+async fn test_gutter_context_menu_shown_for_saved_buffer(cx: &mut TestAppContext) {
+    let mut cx = build_gutter_hover_test_editor(true, cx).await;
+
+    right_click_gutter_row_zero(&mut cx);
+    cx.update_editor(|editor, _, _| {
+        assert!(
+            editor.mouse_context_menu.is_some(),
+            "expected gutter context menu to open for a saved buffer"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_gutter_context_menu_hidden_for_unsaved_buffer(cx: &mut TestAppContext) {
+    let mut cx = build_gutter_hover_test_editor(false, cx).await;
+
+    right_click_gutter_row_zero(&mut cx);
+    cx.update_editor(|editor, _, _| {
+        assert!(
+            editor.mouse_context_menu.is_none(),
+            "expected no gutter context menu for an unsaved buffer"
+        );
+    });
+}
+
 #[gpui::test]
 async fn test_breakpoint_after_save_as_existing_path(cx: &mut TestAppContext) {
     init_test(cx, |_| {});

--- a/crates/editor/src/element/mouse.rs
+++ b/crates/editor/src/element/mouse.rs
@@ -184,11 +184,16 @@ impl EditorElement {
                 .snapshot
                 .display_point_to_anchor(valid_point, Bias::Left);
 
+            // Breakpoints and bookmarks are keyed by absolute file path, so the
+            // gutter button would be a no-op for buffers without a worktree file
+            // (e.g. untitled buffers). Hide it there.
             if position_map
                 .snapshot
                 .buffer_snapshot()
                 .anchor_to_buffer_anchor(buffer_anchor)
-                .is_some()
+                .is_some_and(|(_, buffer_snapshot)| {
+                    project::File::from_dyn(buffer_snapshot.file()).is_some()
+                })
             {
                 let is_visible = editor
                     .gutter_hover_button


### PR DESCRIPTION
## Context

Closes #58818

Breakpoints and bookmarks are keyed by a buffer's absolute file path. In an unsaved (untitled) buffer there is no worktree file, so both `BreakpointStore::toggle_breakpoint` and `BookmarkStore::toggle_bookmark` early-return and do nothing. The gutter still offered the affordances, so clicking (or cmd-clicking) the gutter hover button, or picking an entry from the gutter right-click menu, silently did nothing.

Rather than support these actions on unsaved buffers, this hides them: the gutter hover button and the gutter context menu are both suppressed for buffers without a worktree file, matching the store-level eligibility check (`project::File::from_dyn(...).is_some()`). The buffer is resolved per row via `anchor_to_buffer_anchor`, so multibuffers with a mix of saved and unsaved excerpts behave correctly.

Manual test after the changes :

[Screencast from 2026-07-19 18-46-26.webm](https://github.com/user-attachments/assets/d1fe6704-3843-49bb-bcd6-d84ecdd4f19d)


## How to Review

**`crates/editor/src/element/mouse.rs`**

In the gutter hover-button computation in `mouse_moved`, the existing `anchor_to_buffer_anchor(...).is_some()` guard is tightened to also require the resolved buffer to have a worktree file. When the row belongs to an unsaved buffer the button state stays `None` and the debounce task is never armed, so the add-breakpoint/add-bookmark button no longer appears. This is the single writer of `gutter_hover_button`, and it recomputes on every mouse move, so a buffer that later gets saved picks up the button again immediately.

**`crates/editor/src/editor.rs`**

`set_gutter_context_menu` now binds the multibuffer snapshot once, computes the effective anchor, and returns early when that anchor's buffer is not file-backed, so no menu is opened. This is the shared choke point for all three ways the menu can open (gutter background right-click, breakpoint-marker right-click, bookmark-marker right-click), so every store-backed entry (Set/Unset Breakpoint, log/condition/hit-condition, Enable/Disable, Add/Remove Bookmark, Edit Bookmark, Run to Cursor) and the file-meaningless Git Blame entry are all suppressed together. `gutter_context_menu` itself is unchanged.

**`crates/editor/src/editor_tests.rs`**

Adds a shared `build_gutter_hover_test_editor(saved)` helper that builds either a saved-file editor or an untitled-buffer editor (via `Project::create_buffer`), plus small helpers that draw the window and simulate a mouse move / right-click over row 0 of the gutter hitbox. Four tests cover both surfaces on both buffer kinds: `test_gutter_hover_button_shown_for_saved_buffer` / `test_gutter_hover_button_hidden_for_unsaved_buffer` (asserting the hover button state and its activation debounce), and `test_gutter_context_menu_shown_for_saved_buffer` / `test_gutter_context_menu_hidden_for_unsaved_buffer` (asserting `mouse_context_menu` opens only for the saved buffer). The saved-buffer tests act as positive controls so the negative tests cannot pass vacuously.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed the gutter offering breakpoint and bookmark actions in unsaved buffers, where they could not take effect
