### PR TITLE
snippet: Preserve escaped characters in non-default choice options

### DIFF
--- a/crates/snippet/src/snippet.rs
+++ b/crates/snippet/src/snippet.rs
@@ -157,8 +157,8 @@ fn parse_choices<'a>(
                 source = &source[1..];
 
                 if let Some(c) = source.chars().next() {
+                    current_choice.push(c);
                     if !found_default_choice {
-                        current_choice.push(c);
                         text.push(c);
                     }
                     source = &source[c.len_utf8()..];
@@ -274,6 +274,32 @@ mod tests {
         assert_eq!(
             tabstop_choices(&snippet),
             &[&Some(vec!["${1|one,two,tree|}".to_string(),]), &None]
+        );
+    }
+
+    #[test]
+    fn test_snippet_with_escaped_chars_in_non_default_choices() {
+        let snippet = Snippet::parse(r"${1|a,b\,c|}").unwrap();
+        assert_eq!(snippet.text, "a");
+        assert_eq!(tabstops(&snippet), &[vec![0..1], vec![1..1]]);
+        assert_eq!(
+            tabstop_choices(&snippet),
+            &[&Some(vec!["a".to_string(), "b,c".to_string()]), &None]
+        );
+
+        let snippet = Snippet::parse(r"${1|one,two\|2,three\\3|}").unwrap();
+        assert_eq!(snippet.text, "one");
+        assert_eq!(tabstops(&snippet), &[vec![0..3], vec![3..3]]);
+        assert_eq!(
+            tabstop_choices(&snippet),
+            &[
+                &Some(vec![
+                    "one".to_string(),
+                    "two|2".to_string(),
+                    r"three\3".to_string()
+                ]),
+                &None
+            ]
         );
     }
 


### PR DESCRIPTION
Closes #61312

In `parse_choices`, the escape branch only appended the escaped character to `current_choice` when parsing the first choice, because the push was placed inside the `!found_default_choice` guard. That guard is only meant for `text` (the default value inserted into the buffer) — the plain-text branch below handles it that way. As a result, `${1|a,b\,c|}` offered the choices `a` and `bc` instead of `a` and `b,c`, and the same applied to any `\,`, `\|`, or `\\` in choices after the first.

Moved `current_choice.push(c)` out of the guard and added a regression test covering escaped comma, pipe, and backslash in non-first choices. Escapes in the first choice were already covered by the existing test and are unchanged.

Before / after (snippet body `"${1|a,b\\,c|}"`): the choice dropdown showed `a` / `bc`, now shows `a` / `b,c`.

Release Notes:

- Fixed escaped characters (`\,`, `\|`, `\\`) being dropped from snippet choice options after the first one