### PR TITLE
editor: Make inline blame wrap-aware instead of reserving scroll width

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8582,6 +8582,17 @@ impl Element for EditorElement {
                             if !editor.show_git_blame_inline {
                                 return None;
                             }
+                            // When soft wrap bounds rows to the editor width, the longest
+                            // row already fills the viewport, so reserving extra width for
+                            // inline blame would allow spurious horizontal scrolling in a
+                            // mode that should never scroll horizontally (#24752). The
+                            // blame text is clipped at the viewport edge instead.
+                            if matches!(
+                                editor.soft_wrap_mode(cx),
+                                SoftWrap::EditorWidth | SoftWrap::Bounded(_)
+                            ) {
+                                return None;
+                            }
                             let blame = editor.blame.as_ref()?;
                             let (_, blame_entry) = blame
                                 .update(cx, |blame, cx| {
@@ -10980,6 +10991,186 @@ mod tests {
                 "Soft wrapped editor should have no horizontal scrolling!"
             );
         }
+    }
+
+    #[gpui::test]
+    async fn test_soft_wrap_editor_width_no_scroll_with_inline_blame(cx: &mut TestAppContext) {
+        struct FixedWidthBlameRenderer;
+
+        impl BlameRenderer for FixedWidthBlameRenderer {
+            fn max_author_length(&self) -> usize {
+                20
+            }
+
+            fn render_blame_entry(
+                &self,
+                _: &gpui::TextStyle,
+                _: BlameEntry,
+                _: Option<ParsedCommitMessage>,
+                _: Vec<SharedString>,
+                _: Entity<project::git_store::Repository>,
+                _: WeakEntity<Workspace>,
+                _: Entity<Editor>,
+                _: usize,
+                _: Hsla,
+                _: &mut Window,
+                _: &mut App,
+            ) -> Option<AnyElement> {
+                None
+            }
+
+            fn render_inline_blame_entry(
+                &self,
+                _: &gpui::TextStyle,
+                _: BlameEntry,
+                _: &mut App,
+            ) -> Option<AnyElement> {
+                Some(div().w(px(160.)).into_any_element())
+            }
+
+            fn render_blame_entry_popover(
+                &self,
+                _: BlameEntry,
+                _: ScrollHandle,
+                _: Option<ParsedCommitMessage>,
+                _: Vec<SharedString>,
+                _: Entity<Markdown>,
+                _: Entity<project::git_store::Repository>,
+                _: WeakEntity<Workspace>,
+                _: &mut Window,
+                _: &mut App,
+            ) -> Option<AnyElement> {
+                None
+            }
+
+            fn open_blame_commit(
+                &self,
+                _: BlameEntry,
+                _: Entity<project::git_store::Repository>,
+                _: WeakEntity<Workspace>,
+                _: &mut Window,
+                _: &mut App,
+            ) {
+            }
+        }
+
+        init_test(cx, |_| {});
+        cx.update(|cx| crate::git::set_blame_renderer(FixedWidthBlameRenderer, cx));
+
+        let fs = project::FakeFs::new(cx.executor());
+        fs.insert_tree(
+            util::path!("/my-repo"),
+            serde_json::json!({
+                ".git": {},
+                "file.txt": "a ".repeat(100),
+            }),
+        )
+        .await;
+        fs.set_blame_for_repo(
+            std::path::Path::new(util::path!("/my-repo/.git")),
+            vec![(
+                git::repository::repo_path("file.txt"),
+                git::blame::Blame {
+                    entries: vec![BlameEntry {
+                        sha: "1b1b1b".parse().unwrap(),
+                        range: 0..1,
+                        original_line_number: 0,
+                        author: None,
+                        author_mail: None,
+                        author_time: None,
+                        author_tz: None,
+                        committer_name: None,
+                        committer_email: None,
+                        committer_time: None,
+                        committer_tz: None,
+                        summary: None,
+                        previous: None,
+                        filename: String::new(),
+                    }],
+                    ..Default::default()
+                },
+            )],
+        );
+
+        let project = project::Project::test(fs, [util::path!("/my-repo").as_ref()], cx).await;
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(util::path!("/my-repo/file.txt"), cx)
+            })
+            .await
+            .unwrap();
+        let buffer_id = buffer.read_with(cx, |buffer, _| buffer.remote_id());
+        let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+
+        let window = cx.add_window(|window, cx| {
+            let mut editor = Editor::new(EditorMode::full(), buffer, Some(project), window, cx);
+            editor.set_soft_wrap_mode(language_settings::SoftWrap::EditorWidth, cx);
+            editor
+        });
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        let editor = window.root(cx).unwrap();
+        cx.update(|window, cx| window.focus(&editor.read(cx).focus_handle(cx), cx));
+        editor.update(cx, |editor, cx| {
+            editor
+                .blame()
+                .expect("inline blame should be running")
+                .clone()
+                .update(cx, |blame, cx| blame.focus(cx))
+        });
+        cx.executor().run_until_parked();
+
+        // Ensure the blame entry actually loaded, so a broken setup can't let
+        // this test pass vacuously with a zero-width blame reservation.
+        editor.update(cx, |editor, cx| {
+            assert!(editor.show_git_blame_inline);
+            let blame = editor
+                .blame()
+                .expect("inline blame should be running")
+                .clone();
+            let entry = blame.update(cx, |blame, cx| {
+                blame
+                    .blame_for_rows(
+                        &[RowInfo {
+                            buffer_row: Some(0),
+                            buffer_id: Some(buffer_id),
+                            ..Default::default()
+                        }],
+                        cx,
+                    )
+                    .next()
+                    .flatten()
+            });
+            assert!(entry.is_some(), "blame entry should be available");
+        });
+
+        let style = cx.update(|_, cx| editor.update(cx, |editor, cx| editor.style(cx).clone()));
+
+        for x in 1..=100 {
+            let (_, state) = cx.draw(
+                Default::default(),
+                size(px(200. + 0.13 * x as f32), px(500.)),
+                |_, _| EditorElement::new(&editor, style.clone()),
+            );
+
+            assert!(
+                state.position_map.scroll_max.x == 0.,
+                "Soft wrapped editor should have no horizontal scrolling even with inline blame enabled!"
+            );
+        }
+
+        // Without soft wrap the blame width reservation is legitimate: long
+        // lines really do scroll horizontally (the original #23374 behavior).
+        editor.update(cx, |editor, cx| {
+            editor.set_soft_wrap_mode(language_settings::SoftWrap::None, cx);
+        });
+
+        let (_, state) = cx.draw(Default::default(), size(px(226.), px(500.)), |_, _| {
+            EditorElement::new(&editor, style.clone())
+        });
+        assert!(
+            state.position_map.scroll_max.x > 0.,
+            "Without soft wrap the blame width should still be reserved"
+        );
     }
 
     #[gpui::test]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8901,28 +8901,67 @@ impl Element for EditorElement {
                             );
 
                             let line_ix = display_row.minus(start_row) as usize;
-                            if let (Some(row_info), Some(line_layout), Some(crease_trailer)) = (
+                            if let (Some(row_info), Some(_), Some(_)) = (
                                 row_infos.get(line_ix),
                                 line_layouts.get(line_ix),
                                 crease_trailers.get(line_ix),
                             ) {
-                                let crease_trailer_layout = crease_trailer.as_ref();
-                                if let Some(layout) = self.layout_inline_blame(
-                                    display_row,
-                                    row_info,
-                                    line_layout,
-                                    crease_trailer_layout,
-                                    em_width,
-                                    content_origin,
-                                    scroll_position,
-                                    scroll_pixel_position,
-                                    line_height,
-                                    window,
-                                    cx,
+                                // A soft-wrapped logical line is one line of blame history, so
+                                // render it at the end of the line's last (shortest) continuation
+                                // row instead of after the cursor's row, which for non-final rows
+                                // sits at the wrap boundary and gets clipped.
+                                let mut target_ix = line_ix;
+                                while row_infos.get(target_ix + 1).is_some_and(|next| {
+                                    next.buffer_row.is_none() && next.wrapped_buffer_row.is_some()
+                                }) {
+                                    target_ix += 1;
+                                }
+
+                                let buffer_id = row_info.buffer_id.or_else(|| {
+                                    row_infos[..=line_ix]
+                                        .iter()
+                                        .rev()
+                                        .find_map(|info| info.buffer_id)
+                                });
+                                let buffer_row =
+                                    row_info.buffer_row.or(row_info.wrapped_buffer_row);
+
+                                if let (
+                                    Some(buffer_id),
+                                    Some(buffer_row),
+                                    Some(target_line_layout),
+                                    Some(target_crease_trailer),
+                                ) = (
+                                    buffer_id,
+                                    buffer_row,
+                                    line_layouts.get(target_ix),
+                                    crease_trailers.get(target_ix),
                                 ) {
-                                    inline_blame_layout = Some(layout);
-                                    // Blame overrides inline diagnostics
-                                    inline_diagnostics.remove(&display_row);
+                                    let resolved_row_info = RowInfo {
+                                        buffer_id: Some(buffer_id),
+                                        buffer_row: Some(buffer_row),
+                                        ..Default::default()
+                                    };
+                                    let target_display_row =
+                                        DisplayRow(start_row.0 + target_ix as u32);
+                                    let crease_trailer_layout = target_crease_trailer.as_ref();
+                                    if let Some(layout) = self.layout_inline_blame(
+                                        target_display_row,
+                                        &resolved_row_info,
+                                        target_line_layout,
+                                        crease_trailer_layout,
+                                        em_width,
+                                        content_origin,
+                                        scroll_position,
+                                        scroll_pixel_position,
+                                        line_height,
+                                        window,
+                                        cx,
+                                    ) {
+                                        inline_blame_layout = Some(layout);
+                                        // Blame overrides inline diagnostics
+                                        inline_diagnostics.remove(&target_display_row);
+                                    }
                                 }
                             } else {
                                 log::error!(
@@ -11170,6 +11209,178 @@ mod tests {
         assert!(
             state.position_map.scroll_max.x > 0.,
             "Without soft wrap the blame width should still be reserved"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_inline_blame_on_wrapped_line_cursor_on_continuation_row(cx: &mut TestAppContext) {
+        struct FixedWidthBlameRenderer;
+
+        impl BlameRenderer for FixedWidthBlameRenderer {
+            fn max_author_length(&self) -> usize {
+                20
+            }
+
+            fn render_blame_entry(
+                &self,
+                _: &gpui::TextStyle,
+                _: BlameEntry,
+                _: Option<ParsedCommitMessage>,
+                _: Vec<SharedString>,
+                _: Entity<project::git_store::Repository>,
+                _: WeakEntity<Workspace>,
+                _: Entity<Editor>,
+                _: usize,
+                _: Hsla,
+                _: &mut Window,
+                _: &mut App,
+            ) -> Option<AnyElement> {
+                None
+            }
+
+            fn render_inline_blame_entry(
+                &self,
+                _: &gpui::TextStyle,
+                _: BlameEntry,
+                _: &mut App,
+            ) -> Option<AnyElement> {
+                Some(div().w(px(80.)).into_any_element())
+            }
+
+            fn render_blame_entry_popover(
+                &self,
+                _: BlameEntry,
+                _: ScrollHandle,
+                _: Option<ParsedCommitMessage>,
+                _: Vec<SharedString>,
+                _: Entity<Markdown>,
+                _: Entity<project::git_store::Repository>,
+                _: WeakEntity<Workspace>,
+                _: &mut Window,
+                _: &mut App,
+            ) -> Option<AnyElement> {
+                None
+            }
+
+            fn open_blame_commit(
+                &self,
+                _: BlameEntry,
+                _: Entity<project::git_store::Repository>,
+                _: WeakEntity<Workspace>,
+                _: &mut Window,
+                _: &mut App,
+            ) {
+            }
+        }
+
+        init_test(cx, |_| {});
+        cx.update(|cx| crate::git::set_blame_renderer(FixedWidthBlameRenderer, cx));
+
+        let fs = project::FakeFs::new(cx.executor());
+        fs.insert_tree(
+            util::path!("/my-repo"),
+            serde_json::json!({
+                ".git": {},
+                "file.txt": "a ".repeat(100),
+            }),
+        )
+        .await;
+        fs.set_blame_for_repo(
+            std::path::Path::new(util::path!("/my-repo/.git")),
+            vec![(
+                git::repository::repo_path("file.txt"),
+                git::blame::Blame {
+                    entries: vec![BlameEntry {
+                        sha: "1b1b1b".parse().unwrap(),
+                        range: 0..1,
+                        original_line_number: 0,
+                        author: None,
+                        author_mail: None,
+                        author_time: None,
+                        author_tz: None,
+                        committer_name: None,
+                        committer_email: None,
+                        committer_time: None,
+                        committer_tz: None,
+                        summary: None,
+                        previous: None,
+                        filename: String::new(),
+                    }],
+                    ..Default::default()
+                },
+            )],
+        );
+
+        let project = project::Project::test(fs, [util::path!("/my-repo").as_ref()], cx).await;
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(util::path!("/my-repo/file.txt"), cx)
+            })
+            .await
+            .unwrap();
+        let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+
+        let window = cx.add_window(|window, cx| {
+            let mut editor = Editor::new(EditorMode::full(), buffer, Some(project), window, cx);
+            editor.set_soft_wrap_mode(language_settings::SoftWrap::EditorWidth, cx);
+            editor
+        });
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        let editor = window.root(cx).unwrap();
+        cx.update(|window, cx| window.focus(&editor.read(cx).focus_handle(cx), cx));
+        editor.update(cx, |editor, cx| {
+            editor
+                .blame()
+                .expect("inline blame should be running")
+                .clone()
+                .update(cx, |blame, cx| blame.focus(cx))
+        });
+        cx.executor().run_until_parked();
+
+        // Move the cursor into the middle of the (single, wrapped) logical line, so
+        // it lands on a soft-wrap continuation row rather than the row the line
+        // starts on.
+        editor.update_in(cx, |editor, window, cx| {
+            editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                s.select_ranges([Point::new(0, 100)..Point::new(0, 100)]);
+            });
+        });
+
+        let style = cx.update(|_, cx| editor.update(cx, |editor, cx| editor.style(cx).clone()));
+
+        let editor_width = px(300.);
+        let (_, state) = cx.draw(Default::default(), size(editor_width, px(500.)), |_, _| {
+            EditorElement::new(&editor, style.clone())
+        });
+
+        let snapshot = &state.position_map.snapshot;
+        let cursor_display_row = Point::new(0, 100).to_display_point(snapshot).row();
+        let last_display_row = snapshot.max_point().row();
+        assert!(
+            cursor_display_row.0 > 0 && cursor_display_row < last_display_row,
+            "test setup should place the cursor on a continuation row that isn't the line's last row"
+        );
+
+        let (bounds, _, _) =
+            state.position_map.inline_blame_bounds.clone().expect(
+                "inline blame should still render when the cursor is on a continuation row",
+            );
+
+        let expected_y = state.content_origin.y
+            + state.position_map.line_height
+                * ((last_display_row.as_f64() - state.position_map.scroll_position.y) as f32);
+        assert!(
+            (bounds.origin.y - expected_y).abs() < px(1.),
+            "inline blame should render on the wrapped line's last display row ({:?}), not the cursor's row ({:?}); got y={:?}, expected y={:?}",
+            last_display_row,
+            cursor_display_row,
+            bounds.origin.y,
+            expected_y,
+        );
+
+        assert!(
+            bounds.origin.x + bounds.size.width <= editor_width,
+            "inline blame should be laid out within the visible editor width, not past the right edge"
         );
     }
 


### PR DESCRIPTION
Closes #24752

## Problem

With `soft_wrap` set to `editor_width` (or `bounded`) and inline git blame enabled, any buffer containing a soft-wrapped line gets a spurious horizontal scroll range: the editor scrolls sideways, and shows a horizontal scrollbar, even though every display row fits the viewport.

Cause: #23374 made the scroll width reserve the inline blame width of the longest row (`longest_line_blame_width` → `ScrollbarLayoutInformation::new` in `crates/editor/src/element.rs`). Under soft wrap the longest *display* row is, by construction, nearly as wide as the editor, so any nonzero blame width pushes `scroll_max.x` above zero. The soft-wrap regression tests added in #36411 couldn't catch this: the test-environment `BlameRenderer` is `()` and returns `None`, so the blame width is always zero there.

That reservation was papering over a second, separate problem: **inline blame is not wrap-aware**, so under soft wrap it is drawn where it cannot be seen.

- `WrapRows::next` (`crates/editor/src/display_map/wrap_map.rs`) gives every soft-wrapped *continuation* row a `RowInfo` with `buffer_id: None, buffer_row: None`, keeping the real row in `wrapped_buffer_row`. `layout_inline_blame` resolves its entry through `blame_for_rows`, which needs `buffer_id` + `buffer_row` — so with the cursor on a continuation row, no blame is rendered at all.
- With the cursor on the line's *first* display row, blame is rendered at `content_origin.x + line_layout.width + padding`. For a row that fills the viewport up to the wrap boundary, that lands at or past the right edge.

So the reserved scroll room existed to let you scroll sideways to reach blame that had been placed off-screen — which is exactly the reported bug.

## Fix

Two commits:

1. **Make inline blame wrap-aware.** A soft-wrapped logical line is one line of history, so its blame is now rendered at the end of that line's *last* display row — the short one, where there is room — instead of after the cursor's row. The buffer row is recovered with the existing `row_info.buffer_row.or(row_info.wrapped_buffer_row)` idiom already used for gutter line numbers (`element.rs:2778`); `buffer_id`, which continuation rows also clear, is recovered by scanning back to the logical line's start row (a wrap cannot cross an excerpt boundary, so the nearest preceding one is always the right line). `inline_diagnostics` suppression is re-keyed to the row blame actually occupies. Unwrapped lines are unchanged.

2. **Stop reserving blame width in the scroll range under soft wrap** (`SoftWrap::EditorWidth` / `SoftWrap::Bounded`), restoring the "no horizontal scrolling with soft wrap" invariant. With (1) in place the blame is inside the viewport by construction, so the reservation has nothing left to buy. It is kept for `SoftWrap::None` / `GitDiff`, where long lines legitimately scroll and the blame still needs the room — the original #23374 behaviour.

No `DisplayMap` or wrap-map changes: this is entirely the element's prepaint and the scroll-range computation, so blame remains a paint-time decoration and text layout is untouched.

## Test

- `test_soft_wrap_editor_width_no_scroll_with_inline_blame` — asserts `scroll_max.x == 0` across 100 editor widths with soft wrap on, and that the reservation still applies with soft wrap off.
- `test_inline_blame_on_wrapped_line_cursor_on_continuation_row` — with the cursor on a continuation row, asserts blame is laid out at all, that it sits on the line's last display row, and that it ends within the editor width.

Both need a fixed-width test `BlameRenderer` installed via `crate::git::set_blame_renderer`, since the default test renderer suppresses blame entirely — the coverage gap noted above.

Also verified by hand in a WSL/Linux build against a real repository: no horizontal scrollbar and no sideways scrolling on wrapped buffers, and blame visible at the end of wrapped lines including lines that wrap several times.

Release Notes:

- Fixed inline git blame adding phantom horizontal scrolling when soft wrap is enabled, and not being visible on soft-wrapped lines ([#24752](https://github.com/zed-industries/zed/issues/24752)).
