### PR TITLE
terminal: Keep alternate screen bottom-aligned

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1035,7 +1035,8 @@ impl Element for TerminalElement {
                     if matches!(self.terminal_view.read(cx).mode, TerminalMode::Standalone) {
                         let should_anchor_to_bottom = {
                             let content = self.terminal.read(cx).last_content();
-                            content.scrolled_to_bottom && content.bottom_row_occupied
+                            content.mode.contains(Modes::ALT_SCREEN)
+                                || (content.scrolled_to_bottom && content.bottom_row_occupied)
                         };
                         let scale_factor = window.scale_factor();
                         let line_height_pixels = px(line_height);

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -3120,6 +3120,13 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_short_alt_screen_stays_bottom_anchored_on_resize(cx: &mut TestAppContext) {
+        let (bounds, draw_size) = draw_standalone_terminal(b"\x1b[?1049h$ ", cx).await;
+        assert!(bounds.origin.y > px(0.));
+        assert_eq!(bounds.bottom(), draw_size.height);
+    }
+
+    #[gpui::test]
     async fn test_tab_content_shows_terminal_title_when_custom_title_directly_set_empty(
         cx: &mut TestAppContext,
     ) {


### PR DESCRIPTION
# Objective

Fixes #61236

## Solution

This regression was introduced by #56715, which switches the alignment based on whether the last row contains any content. However, this logic can cause issues in the alternate screen. This PR fixes the problem by excluding the alternate screen from the detection logic.

## Testing

Open Zed’s integrated terminal and run a program that uses the alternate screen, such as Vim or Helix.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

https://github.com/user-attachments/assets/ffc1ca56-596a-439a-8672-12868f9dc112

---

Release Notes:

- Fixed flickering in the integrated terminal when using the alternate screen.
