### PR TITLE
acp: Validate registry agent checksums

### DIFF
--- a/crates/http_client/src/github_download.rs
+++ b/crates/http_client/src/github_download.rs
@@ -11,6 +11,10 @@ use sha2::{Digest, Sha256};
 
 use crate::{HttpClient, github::AssetKind};
 
+fn sha256_matches(actual: &str, expected: &str) -> bool {
+    actual.eq_ignore_ascii_case(expected)
+}
+
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct GithubBinaryMetadata {
     pub metadata_version: u64,
@@ -104,7 +108,7 @@ pub async fn download_server_raw_binary(
 
         if let Some(expected_sha_256) = digest {
             anyhow::ensure!(
-                asset_sha_256 == expected_sha_256,
+                sha256_matches(&asset_sha_256, expected_sha_256),
                 "{url} asset got SHA-256 mismatch. Expected: {expected_sha_256}, Got: {asset_sha_256}",
             );
         }
@@ -150,7 +154,7 @@ async fn extract_to_staging(
             let asset_sha_256 = format!("{:x}", writer.hasher.finalize());
 
             anyhow::ensure!(
-                asset_sha_256 == expected_sha_256,
+                sha256_matches(&asset_sha_256, expected_sha_256),
                 "{url} asset got SHA-256 mismatch. Expected: {expected_sha_256}, Got: {asset_sha_256}",
             );
             writer
@@ -403,12 +407,12 @@ mod tests {
     }
 
     #[test]
-    fn downloads_raw_binary_into_destination_dir() {
+    fn downloads_raw_binary_with_uppercase_digest_into_destination_dir() {
         futures::executor::block_on(async {
             let temp_dir = tempfile::tempdir().unwrap();
             let destination_path = temp_dir.path().join("v_1");
             let contents = b"#!/bin/sh\necho hello\n".to_vec();
-            let expected_sha_256 = format!("{:x}", Sha256::digest(&contents));
+            let expected_sha_256 = format!("{:X}", Sha256::digest(&contents));
             let client = StaticResponseClient { body: contents };
 
             download_server_raw_binary(
@@ -453,6 +457,68 @@ mod tests {
                 Some("0000000000000000000000000000000000000000000000000000000000000000"),
                 &destination_path,
                 "agent-binary",
+            )
+            .await
+            .unwrap_err();
+
+            assert!(error.to_string().contains("SHA-256 mismatch"));
+            assert!(!destination_path.exists());
+            let leftover_entries = std::fs::read_dir(temp_dir.path()).unwrap().count();
+            assert_eq!(leftover_entries, 0, "staging directory should be removed");
+        });
+    }
+
+    #[test]
+    fn downloads_archive_with_uppercase_digest_and_extracts_contents() {
+        futures::executor::block_on(async {
+            let archive = vec![
+                0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x00,
+                0x86, 0xa6, 0x10, 0x36, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00,
+                0x00, 0x00, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x50, 0x4b,
+                0x01, 0x02, 0x14, 0x03, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x00,
+                0x86, 0xa6, 0x10, 0x36, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x05, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x01, 0x00, 0x00,
+                0x00, 0x00, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00,
+                0x00, 0x01, 0x00, 0x01, 0x00, 0x33, 0x00, 0x00, 0x00, 0x28, 0x00, 0x00, 0x00, 0x00,
+                0x00,
+            ];
+            let expected_sha_256 = format!("{:X}", Sha256::digest(&archive));
+            let client = StaticResponseClient { body: archive };
+            let temp_dir = tempfile::tempdir().unwrap();
+            let destination_path = temp_dir.path().join("v_1");
+
+            download_server_binary(
+                &client,
+                "https://example.com/agent.zip",
+                Some(&expected_sha_256),
+                &destination_path,
+                AssetKind::Zip,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                std::fs::read(destination_path.join("agent")).unwrap(),
+                b"hello"
+            );
+        });
+    }
+
+    #[test]
+    fn archive_digest_mismatch_prevents_extraction_and_cleans_up_staging() {
+        futures::executor::block_on(async {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let destination_path = temp_dir.path().join("v_1");
+            let client = StaticResponseClient {
+                body: b"not an archive".to_vec(),
+            };
+
+            let error = download_server_binary(
+                &client,
+                "https://example.com/agent.zip",
+                Some("0000000000000000000000000000000000000000000000000000000000000000"),
+                &destination_path,
+                AssetKind::Zip,
             )
             .await
             .unwrap_err();

--- a/crates/project/src/agent_registry_store.rs
+++ b/crates/project/src/agent_registry_store.rs
@@ -412,7 +412,7 @@ async fn build_registry_agents(
                         archive: target.archive.clone(),
                         cmd: target.cmd.clone(),
                         args: target.args.clone(),
-                        sha256: None,
+                        sha256: target.sha256.clone(),
                         env: target.env.clone(),
                     },
                 );
@@ -661,6 +661,8 @@ struct RegistryBinaryTarget {
     cmd: String,
     #[serde(default)]
     args: Vec<String>,
+    #[serde(default)]
+    sha256: Option<String>,
     #[serde(default)]
     env: HashMap<String, String>,
 }

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -400,7 +400,9 @@ impl AgentServerStore {
                                         http_client: http_client.clone(),
                                         node_runtime: node_runtime.clone(),
                                         project_environment: project_environment.clone(),
-                                        registry_id: Arc::from(name.as_str()),
+                                        installation_dir: paths::external_agents_dir()
+                                            .join("registry")
+                                            .join(sanitize_path_component(name)),
                                         version: agent.metadata.version.clone(),
                                         targets: agent.targets.clone(),
                                         env: env.clone(),
@@ -1022,6 +1024,7 @@ fn versioned_archive_cache_dir(
     base_dir: &Path,
     version: Option<&str>,
     archive_url: &str,
+    sha256: Option<&str>,
 ) -> PathBuf {
     let version = version.unwrap_or_default();
     let sanitized_version = sanitize_path_component(version);
@@ -1030,14 +1033,18 @@ fn versioned_archive_cache_dir(
     version_hasher.update(version.as_bytes());
     let version_hash = format!("{:x}", version_hasher.finalize());
 
-    let mut url_hasher = Sha256::new();
-    url_hasher.update(archive_url.as_bytes());
-    let url_hash = format!("{:x}", url_hasher.finalize());
+    let mut archive_hasher = Sha256::new();
+    archive_hasher.update(archive_url.as_bytes());
+    if let Some(sha256) = sha256 {
+        archive_hasher.update(b"\0sha256:");
+        archive_hasher.update(sha256.to_ascii_lowercase().as_bytes());
+    }
+    let archive_hash = format!("{:x}", archive_hasher.finalize());
 
     base_dir.join(format!(
         "v_{sanitized_version}_{}_{}",
         &version_hash[..16],
-        &url_hash[..16],
+        &archive_hash[..16],
     ))
 }
 
@@ -1112,7 +1119,7 @@ struct LocalRegistryArchiveAgent {
     http_client: Arc<dyn HttpClient>,
     node_runtime: NodeRuntime,
     project_environment: Entity<ProjectEnvironment>,
-    registry_id: Arc<str>,
+    installation_dir: PathBuf,
     version: SharedString,
     targets: HashMap<String, RegistryTargetConfig>,
     env: HashMap<String, String>,
@@ -1151,7 +1158,7 @@ impl ExternalAgentServer for LocalRegistryArchiveAgent {
         let http_client = self.http_client.clone();
         let node_runtime = self.node_runtime.clone();
         let project_environment = self.project_environment.downgrade();
-        let registry_id = self.registry_id.clone();
+        let installation_dir = self.installation_dir.clone();
         let targets = self.targets.clone();
         let settings_env = self.env.clone();
         let version = self.version.clone();
@@ -1165,9 +1172,7 @@ impl ExternalAgentServer for LocalRegistryArchiveAgent {
                 .await
                 .unwrap_or_default();
 
-            let dir = paths::external_agents_dir()
-                .join("registry")
-                .join(sanitize_path_component(&registry_id));
+            let dir = installation_dir;
             fs.create_dir(&dir).await?;
 
             let os = if cfg!(target_os = "macos") {
@@ -1206,8 +1211,12 @@ impl ExternalAgentServer for LocalRegistryArchiveAgent {
             env.extend(settings_env);
 
             let archive_url = &target_config.archive;
-            let version_dir =
-                versioned_archive_cache_dir(&dir, Some(version.as_ref()), archive_url);
+            let version_dir = versioned_archive_cache_dir(
+                &dir,
+                Some(version.as_ref()),
+                archive_url,
+                target_config.sha256.as_deref(),
+            );
 
             if !fs.is_dir(&version_dir).await {
                 let mut loading_status_tx = loading_status_tx;
@@ -1669,8 +1678,74 @@ mod tests {
     };
     use crate::worktree_store::{WorktreeIdCounter, WorktreeStore};
     use gpui::TestAppContext;
+    #[cfg(feature = "test-support")]
+    use http_client::{AsyncBody, FakeHttpClient, Response};
     use node_runtime::NodeRuntime;
     use settings::Settings as _;
+
+    #[cfg(feature = "test-support")]
+    const TEST_ARCHIVE_URL: &str = "https://example.test/agent";
+
+    #[cfg(feature = "test-support")]
+    fn static_http_client(body: Vec<u8>) -> Arc<dyn HttpClient> {
+        FakeHttpClient::create(move |_| {
+            let body = body.clone();
+            async move {
+                Ok(Response::builder()
+                    .status(200)
+                    .body(AsyncBody::from(body))?)
+            }
+        })
+    }
+
+    #[cfg(feature = "test-support")]
+    fn make_registry_archive_agent(
+        cx: &mut TestAppContext,
+        installation_dir: PathBuf,
+        http_client: Arc<dyn HttpClient>,
+        sha256: Option<String>,
+    ) -> LocalRegistryArchiveAgent {
+        let fs: Arc<dyn Fs> = Arc::new(fs::RealFs::new(None, cx.executor()));
+        let target = RegistryTargetConfig {
+            archive: TEST_ARCHIVE_URL.to_string(),
+            cmd: "./agent".to_string(),
+            args: Vec::new(),
+            sha256,
+            env: HashMap::default(),
+        };
+        let targets = [
+            "darwin-aarch64",
+            "darwin-x86_64",
+            "linux-aarch64",
+            "linux-x86_64",
+            "windows-aarch64",
+            "windows-x86_64",
+        ]
+        .into_iter()
+        .map(|platform| (platform.to_string(), target.clone()))
+        .collect();
+
+        cx.update(|cx| {
+            let worktree_store =
+                cx.new(|cx| WorktreeStore::local(false, fs.clone(), WorktreeIdCounter::get(cx)));
+            let project_environment = cx.new(|cx| {
+                crate::ProjectEnvironment::new(None, worktree_store.downgrade(), None, false, cx)
+            });
+
+            LocalRegistryArchiveAgent {
+                fs,
+                http_client,
+                node_runtime: NodeRuntime::unavailable(),
+                project_environment,
+                installation_dir,
+                version: "1.0.0".into(),
+                targets,
+                env: HashMap::default(),
+                new_version_available_tx: None,
+                loading_status_tx: None,
+            }
+        })
+    }
 
     fn make_npx_agent(id: &str, version: &str) -> RegistryAgent {
         let id = SharedString::from(id.to_string());
@@ -1896,16 +1971,18 @@ mod tests {
     }
 
     #[test]
-    fn versioned_archive_cache_dir_includes_version_before_url_hash() {
+    fn versioned_archive_cache_dir_includes_artifact_identity() {
         let slash_version_dir = versioned_archive_cache_dir(
             Path::new("/tmp/agents"),
             Some("release/2.3.5"),
             "https://example.com/agent.zip",
+            None,
         );
         let colon_version_dir = versioned_archive_cache_dir(
             Path::new("/tmp/agents"),
             Some("release:2.3.5"),
             "https://example.com/agent.zip",
+            None,
         );
         let file_name = slash_version_dir
             .file_name()
@@ -1914,6 +1991,129 @@ mod tests {
 
         assert!(file_name.starts_with("v_release-2.3.5_"));
         assert_ne!(slash_version_dir, colon_version_dir);
+
+        let lowercase_checksum_dir = versioned_archive_cache_dir(
+            Path::new("/tmp/agents"),
+            Some("release/2.3.5"),
+            "https://example.com/agent.zip",
+            Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        );
+        let uppercase_checksum_dir = versioned_archive_cache_dir(
+            Path::new("/tmp/agents"),
+            Some("release/2.3.5"),
+            "https://example.com/agent.zip",
+            Some("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+        );
+        let changed_checksum_dir = versioned_archive_cache_dir(
+            Path::new("/tmp/agents"),
+            Some("release/2.3.5"),
+            "https://example.com/agent.zip",
+            Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        );
+
+        assert_ne!(slash_version_dir, lowercase_checksum_dir);
+        assert_eq!(lowercase_checksum_dir, uppercase_checksum_dir);
+        assert_ne!(lowercase_checksum_dir, changed_checksum_dir);
+    }
+
+    #[cfg(feature = "test-support")]
+    #[gpui::test]
+    async fn registry_raw_binary_checksum_invalidates_unverified_cache_and_blocks_mismatch(
+        cx: &mut TestAppContext,
+    ) {
+        init_test_settings(cx);
+        cx.executor().allow_parking();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let installation_dir = temp_dir.path().join("agent");
+        let old_version_dir =
+            versioned_archive_cache_dir(&installation_dir, Some("1.0.0"), TEST_ARCHIVE_URL, None);
+        std::fs::create_dir_all(&old_version_dir).unwrap();
+        std::fs::write(old_version_dir.join("agent"), b"unverified agent").unwrap();
+
+        let expected_sha256 = "0000000000000000000000000000000000000000000000000000000000000000";
+        let http_client = static_http_client(b"unexpected agent".to_vec());
+        let mut agent = make_registry_archive_agent(
+            cx,
+            installation_dir.clone(),
+            http_client,
+            Some(expected_sha256.to_string()),
+        );
+        let get_command =
+            cx.update(|cx| agent.get_command(Vec::new(), HashMap::default(), &mut cx.to_async()));
+
+        let error = get_command.await.unwrap_err();
+        assert!(
+            error.to_string().contains("SHA-256 mismatch"),
+            "unexpected error: {error:#}"
+        );
+        assert!(old_version_dir.exists());
+        assert!(
+            !versioned_archive_cache_dir(
+                &installation_dir,
+                Some("1.0.0"),
+                TEST_ARCHIVE_URL,
+                Some(expected_sha256),
+            )
+            .exists()
+        );
+    }
+
+    #[cfg(feature = "test-support")]
+    #[gpui::test]
+    async fn registry_raw_binary_with_checksum_installs(cx: &mut TestAppContext) {
+        init_test_settings(cx);
+        cx.executor().allow_parking();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let installation_dir = temp_dir.path().join("agent");
+        let contents = b"verified agent";
+        let expected_sha256 = format!("{:X}", Sha256::digest(contents));
+        let http_client = static_http_client(contents.to_vec());
+        let mut agent = make_registry_archive_agent(
+            cx,
+            installation_dir.clone(),
+            http_client,
+            Some(expected_sha256.clone()),
+        );
+        let get_command =
+            cx.update(|cx| agent.get_command(Vec::new(), HashMap::default(), &mut cx.to_async()));
+
+        let command = get_command.await.unwrap();
+        cx.run_until_parked();
+        assert_eq!(
+            command.path,
+            versioned_archive_cache_dir(
+                &installation_dir,
+                Some("1.0.0"),
+                TEST_ARCHIVE_URL,
+                Some(&expected_sha256),
+            )
+            .join("agent")
+        );
+        assert_eq!(std::fs::read(command.path).unwrap(), contents);
+    }
+
+    #[cfg(feature = "test-support")]
+    #[gpui::test]
+    async fn registry_raw_binary_without_checksum_installs(cx: &mut TestAppContext) {
+        init_test_settings(cx);
+        cx.executor().allow_parking();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let installation_dir = temp_dir.path().join("agent");
+        let contents = b"unchecked agent";
+        let http_client = static_http_client(contents.to_vec());
+        let mut agent =
+            make_registry_archive_agent(cx, installation_dir.clone(), http_client, None);
+        let get_command =
+            cx.update(|cx| agent.get_command(Vec::new(), HashMap::default(), &mut cx.to_async()));
+
+        let command = get_command.await.unwrap();
+        cx.run_until_parked();
+        assert_eq!(
+            command.path,
+            versioned_archive_cache_dir(&installation_dir, Some("1.0.0"), TEST_ARCHIVE_URL, None,)
+                .join("agent")
+        );
+        assert_eq!(std::fs::read(command.path).unwrap(), contents);
     }
 
     #[gpui::test]

--- a/crates/project/tests/integration/agent_registry_store.rs
+++ b/crates/project/tests/integration/agent_registry_store.rs
@@ -3,7 +3,7 @@ use std::{future, sync::Arc, time::Duration};
 use fs::FakeFs;
 use gpui::TestAppContext;
 use http_client::{AsyncBody, FakeHttpClient, HttpClient, Response};
-use project::AgentRegistryStore;
+use project::{AgentRegistryStore, RegistryAgent};
 use serde_json::json;
 
 use crate::init_test;
@@ -110,6 +110,66 @@ async fn registry_refresh_does_not_block_sequentially_on_hung_icon_downloads(
         assert_eq!(store.agents()[0].id().as_ref(), "slow-icon-a");
         assert_eq!(store.agents()[1].id().as_ref(), "slow-icon-b");
         assert_eq!(store.agents()[2].id().as_ref(), "slow-icon-c");
+        assert_eq!(store.fetch_error(), None);
+    });
+}
+
+#[gpui::test]
+async fn registry_refresh_preserves_optional_binary_checksums(cx: &mut TestAppContext) {
+    init_test(cx);
+
+    let checksum = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let fs = FakeFs::new(cx.executor());
+    let http_client = FakeHttpClient::create(move |_| async move {
+        let body = serde_json::to_vec(&json!({
+            "version": "1",
+            "agents": [{
+                "id": "binary-agent",
+                "name": "Binary Agent",
+                "version": "1.0.0",
+                "description": "A binary agent.",
+                "distribution": {
+                    "binary": {
+                        "darwin-aarch64": {
+                            "archive": "https://example.test/agent.zip",
+                            "sha256": checksum,
+                            "cmd": "./agent"
+                        },
+                        "linux-x86_64": {
+                            "archive": "https://example.test/agent.zip",
+                            "cmd": "./agent"
+                        }
+                    }
+                }
+            }]
+        }))?;
+        Ok(Response::builder()
+            .status(200)
+            .body(AsyncBody::from(body))?)
+    }) as Arc<dyn HttpClient>;
+
+    let registry_store =
+        cx.update(|cx| AgentRegistryStore::init_global(cx, fs.clone(), http_client));
+    cx.run_until_parked();
+
+    registry_store.read_with(cx, |store, _| {
+        let Some(RegistryAgent::Binary(agent)) = store.agents().first() else {
+            panic!("expected a binary registry agent");
+        };
+
+        assert_eq!(
+            agent
+                .targets
+                .get("darwin-aarch64")
+                .and_then(|target| target.sha256.as_deref()),
+            Some(checksum)
+        );
+        assert!(
+            agent
+                .targets
+                .get("linux-x86_64")
+                .is_some_and(|target| target.sha256.is_none())
+        );
         assert_eq!(store.fetch_error(), None);
     });
 }


### PR DESCRIPTION
The registry now has optional checksums that we can use.

Release Notes:

- N/A
