### PR TITLE
gpui_linux: Resolve wayland clipboard eviction and `text/plain` MIME type

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -2352,8 +2352,13 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
             wl_data_device::Event::DataOffer { id: data_offer } => {
                 state.data_offers.push(DataOffer::new(data_offer));
                 if state.data_offers.len() > 2 {
-                    // At most we store a clipboard offer and a drag and drop offer.
-                    state.data_offers.remove(0).inner.destroy();
+                    let active_offer_id = state.clipboard.current_offer().map(|o| o.inner.id());
+                    let remove_index = state
+                        .data_offers
+                        .iter()
+                        .position(|o| Some(o.inner.id()) != active_offer_id)
+                        .unwrap_or(0);
+                    state.data_offers.remove(remove_index).inner.destroy();
                 }
             }
             wl_data_device::Event::Selection { id: data_offer } => {

--- a/crates/gpui_linux/src/linux/wayland/clipboard.rs
+++ b/crates/gpui_linux/src/linux/wayland/clipboard.rs
@@ -22,7 +22,7 @@ pub(crate) const TEXT_MIME_TYPES: [&str; 3] =
 pub(crate) const FILE_LIST_MIME_TYPE: &str = "text/uri-list";
 
 /// Text mime types that we'll accept from other programs.
-pub(crate) const ALLOWED_TEXT_MIME_TYPES: [&str; 2] = ["text/plain;charset=utf-8", "UTF8_STRING"];
+pub(crate) const ALLOWED_TEXT_MIME_TYPES: [&str; 3] = ["text/plain;charset=utf-8", "UTF8_STRING", "text/plain"];
 
 pub(crate) struct Clipboard {
     connection: Connection,
@@ -169,6 +169,10 @@ impl Clipboard {
     pub fn set_offer(&mut self, data_offer: Option<DataOffer<WlDataOffer>>) {
         self.cached_read = None;
         self.current_offer = data_offer;
+    }
+
+    pub fn current_offer(&self) -> Option<&DataOffer<WlDataOffer>> {
+        self.current_offer.as_ref()
     }
 
     pub fn set_primary_offer(&mut self, data_offer: Option<DataOffer<ZwpPrimarySelectionOfferV1>>) {


### PR DESCRIPTION
### Describe the bug

When running Zed natively on Linux Wayland, copy-pasting from other native Wayland applications (like Google Chrome) frequently fails, freezes, or registers as empty.

This is caused by two distinct issues in GPUI's custom Wayland clipboard implementation:

1. **Premature Eviction of Active Clipboard Offers:**
   The `data_offers` list in `gpui_linux` is hard-capped at a length of `2`. When a new `DataOffer` is received (e.g., from hover events, drag-and-drop, or other background clipboard updates), the oldest offer is evicted and destroyed. If the evicted offer was the active clipboard selection, it is destroyed, making subsequent paste attempts fail silently.
   
2. **Omission of standard `text/plain` MIME type:**
   While Zed offers `text/plain` when copying, it only accepts `"text/plain;charset=utf-8"` and `"UTF8_STRING"` when pasting. Any Wayland source offering only `"text/plain"` is ignored.

### Solution

1. **Protect the Active Selection from Eviction:**
   - Added a public getter `current_offer()` to `Clipboard` in `crates/gpui_linux/src/linux/wayland/clipboard.rs`.
   - Updated the eviction logic in `crates/gpui_linux/src/linux/wayland/client.rs` to find and evict an offer that is **not** the active clipboard selection, ensuring the active selection is never prematurely destroyed.

2. **Allow Standard `text/plain` MIME Type:**
   - Added `"text/plain"` to the list of accepted text MIME types in `crates/gpui_linux/src/linux/wayland/clipboard.rs`.

### Release Notes

- Fixed copy-pasting from native Wayland applications (like Google Chrome) into Zed by preventing premature clipboard offer eviction and supporting the standard `text/plain` MIME type.
