### PR TITLE
workspace: Fix Close Project intermittently not closing the project

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -908,15 +908,17 @@ impl MultiWorkspace {
         key: &ProjectGroupKey,
         cx: &App,
     ) -> Option<Vec<Entity<Workspace>>> {
+        // Use `workspaces()` rather than `retained_workspaces` directly: the
+        // active workspace is not always retained (e.g. when the sidebar has
+        // never been opened), and omitting it here makes `remove_project_group`
+        // find nothing to close, so `Close Project` silently no-ops (zed#61316).
         let has_group = self.project_groups.iter().any(|group| group.key == *key)
             || self
-                .retained_workspaces
-                .iter()
+                .workspaces()
                 .any(|workspace| workspace.read(cx).project_group_key(cx) == *key);
 
         has_group.then(|| {
-            self.retained_workspaces
-                .iter()
+            self.workspaces()
                 .filter(|workspace| workspace.read(cx).project_group_key(cx) == *key)
                 .cloned()
                 .collect()
@@ -2013,7 +2015,30 @@ impl MultiWorkspace {
                     }
                 }
 
-                if removed_any {
+                // A workspace that was not retained when removal began can be
+                // re-retained by `activate()` during fallback, which also
+                // re-creates its project group. Now that these workspaces are
+                // detached, drop any project group whose key is no longer
+                // backed by a retained workspace, so closing a project does not
+                // leave stale, serializable group metadata (zed#61316).
+                let mut pruned_group = false;
+                for workspace in &workspaces {
+                    let key = workspace.read(cx).project_group_key(cx);
+                    let still_backed = this
+                        .retained_workspaces
+                        .iter()
+                        .any(|retained| retained.read(cx).project_group_key(cx) == key);
+                    if !still_backed {
+                        let before = this.project_groups.len();
+                        this.project_groups.retain(|group| group.key != key);
+                        pruned_group |= this.project_groups.len() != before;
+                    }
+                }
+                if pruned_group {
+                    cx.emit(MultiWorkspaceEvent::ProjectGroupsChanged);
+                }
+
+                if removed_any || pruned_group {
                     this.serialize(cx);
                     cx.notify();
                 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -435,6 +435,33 @@ pub fn initialize_workspace(app_state: Arc<AppState>, cx: &mut App) {
     })
     .detach();
 
+    // `CloseProject` is handled globally rather than as a workspace-scoped
+    // action. After switching the active workspace (e.g. closing one project in
+    // a multi-project window), the app menu can dispatch this action while the
+    // window's focus resolves to the window root, so a workspace-scoped handler
+    // is never reached and the menu item silently does nothing. A global
+    // handler fires in the dispatch capture phase regardless of focus, like
+    // `CloseWindow` (zed#61316).
+    cx.on_action(|_: &CloseProject, cx| {
+        let Some(multi_workspace) = cx
+            .active_window()
+            .and_then(|window| window.downcast::<MultiWorkspace>())
+        else {
+            return;
+        };
+        // Defer so this does not run inside the dispatch's window update.
+        cx.defer(move |cx| {
+            multi_workspace
+                .update(cx, |multi_workspace, window, cx| {
+                    let group_key = multi_workspace.workspace().read(cx).project_group_key(cx);
+                    multi_workspace
+                        .remove_project_group(&group_key, window, cx)
+                        .detach_and_log_err(cx);
+                })
+                .log_err();
+        });
+    });
+
     init_cursor_hide_mode(cx);
     init_reduce_motion(cx);
 
@@ -1289,22 +1316,6 @@ fn register_actions(
                     },
                 )
                 .detach();
-            }
-        })
-        .register_action({
-            move |workspace, _: &CloseProject, window, cx| {
-                let Some(window_handle) = window.window_handle().downcast::<MultiWorkspace>() else {
-                    return;
-                };
-                let old_group_key = workspace.project_group_key(cx);
-                cx.spawn_in(window, async move |_, cx| {
-                    let task = window_handle.update(cx, |multi_workspace, window, cx| {
-                        multi_workspace.remove_project_group(&old_group_key, window, cx)
-                    })?;
-                    task.await?;
-                    anyhow::Ok(())
-                })
-                .detach_and_log_err(cx);
             }
         })
         .register_action({
@@ -7157,6 +7168,116 @@ mod tests {
         assert!(
             keys.is_empty(),
             "project group should be removed after CloseProject: {keys:?}"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_close_project_when_active_workspace_not_retained(cx: &mut TestAppContext) {
+        use workspace::OpenMode;
+
+        let app_state = init_test(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(path!("/my-project"), json!({}))
+            .await;
+
+        let workspace::OpenResult { window, .. } = cx
+            .update(|cx| {
+                workspace::Workspace::new_local(
+                    vec![path!("/my-project").into()],
+                    app_state.clone(),
+                    None,
+                    None,
+                    None,
+                    OpenMode::Activate,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        cx.background_executor.run_until_parked();
+
+        // Deliberately do NOT open the sidebar: the active workspace is then
+        // never retained. `Close Project` used to look for the project only
+        // among retained workspaces, find nothing, and silently no-op, leaving
+        // the project open (zed#61316).
+        let root_paths = window
+            .read_with(cx, |mw, cx| mw.workspace().read(cx).root_paths(cx))
+            .unwrap();
+        assert_eq!(
+            root_paths,
+            vec![Arc::from(Path::new(path!("/my-project")))],
+            "project should be open before CloseProject: {root_paths:?}"
+        );
+
+        cx.dispatch_action(window.into(), CloseProject);
+
+        // The project is closed by replacing the active workspace with an empty
+        // one, so the active workspace should no longer contain the project.
+        let root_paths = window
+            .read_with(cx, |mw, cx| mw.workspace().read(cx).root_paths(cx))
+            .unwrap();
+        assert!(
+            root_paths.is_empty(),
+            "project should be closed after CloseProject, but workspace still has: {root_paths:?}"
+        );
+
+        // Closing the project must not leave stale, serializable project group
+        // metadata behind: `activate()` can transiently re-create the group for
+        // the workspace being torn down during fallback (zed#61316).
+        let keys = window
+            .read_with(cx, |mw, _| mw.project_group_keys())
+            .unwrap();
+        assert!(
+            keys.is_empty(),
+            "no stale project group should remain after CloseProject: {keys:?}"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_close_project_dispatched_at_window_root(cx: &mut TestAppContext) {
+        use workspace::OpenMode;
+
+        let app_state = init_test(cx);
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(path!("/my-project"), json!({}))
+            .await;
+
+        let workspace::OpenResult { window, .. } = cx
+            .update(|cx| {
+                workspace::Workspace::new_local(
+                    vec![path!("/my-project").into()],
+                    app_state.clone(),
+                    None,
+                    None,
+                    None,
+                    OpenMode::Activate,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        cx.background_executor.run_until_parked();
+
+        // Reproduce the state seen after switching the active workspace, where
+        // the focused element is no longer in the rendered dispatch tree and
+        // action dispatch falls back to the window root. A workspace-scoped
+        // handler would never be reached; `CloseProject` is global so it still
+        // runs (zed#61316).
+        window
+            .update(cx, |_, window, _| window.disable_focus())
+            .unwrap();
+        cx.dispatch_action(window.into(), CloseProject);
+
+        let root_paths = window
+            .read_with(cx, |mw, cx| mw.workspace().read(cx).root_paths(cx))
+            .unwrap();
+        assert!(
+            root_paths.is_empty(),
+            "CloseProject dispatched at the window root should still close the project: {root_paths:?}"
         );
     }
 


### PR DESCRIPTION
## Context

Closes #61316

Selecting File > Close Project sometimes did nothing: the menu dismissed but the project stayed open, with no error. It was intermittent and more frequent in multi-project windows. Investigation (via temporary dispatch-path logging) turned up three separate defects, any of which drops the close:

1. **The active workspace is not always retained.** `MultiWorkspace::remove_project_group` asked `workspaces_for_project_group` which workspaces to close, but that helper only searched `retained_workspaces`. The active workspace is not retained until the sidebar is opened (or a workspace switch retains it), so on a plain single-project window the lookup returned nothing and `remove()` early-returned without closing anything.

2. **`CloseProject` was a workspace-scoped action.** After switching the active workspace (for example, closing one project in a multi-project window), the app menu dispatches `CloseProject` while the window's focus resolves to the window root, so the dispatch path never includes the workspace node and the handler is never reached. `Close Window` never had this problem because it is a global action.

3. **Closing left stale project-group metadata.** During fallback, `activate()` re-retains the workspace being torn down and re-creates its project group, but `detach_workspace` only removes the workspace from `retained_workspaces`, leaving an orphaned group entry that then gets serialized.

Manual test after the changes :

[Screencast from 2026-07-20 15-10-39.webm](https://github.com/user-attachments/assets/10a5d89f-227f-4e1f-9316-5a98ca5b1935)


## How to Review

**`crates/workspace/src/multi_workspace.rs`**

`workspaces_for_project_group` now iterates `self.workspaces()` instead of `self.retained_workspaces` directly. `workspaces()` already yields the retained workspaces plus the active workspace when it is not retained (the same complete set `close_window` uses), so `remove_project_group` finds the active project to close even when the sidebar was never opened (defect 1).

In `remove()`, after detaching the workspaces, any project group whose key is no longer backed by a retained workspace is pruned (scoped to the workspaces just removed), then `ProjectGroupsChanged` is emitted and the state re-serialized. This drops the group `activate()` transiently re-creates during fallback, so closing a project does not leave stale, serializable group metadata (defect 3).

**`crates/zed/src/zed.rs`**

`CloseProject` is moved from a workspace-scoped `register_action` to a global `cx.on_action` in `initialize_workspace`. Global action listeners fire in the dispatch capture phase regardless of the resolved node, so the action runs even when focus resolves to the window root, matching how `CloseWindow` is handled (defect 2). The handler resolves the active window's `MultiWorkspace` and removes the active workspace's project group.

**`crates/zed/src/zed.rs` (tests)**

Two new tests alongside the existing `test_close_project_removes_project_group` and `test_close_project_switches_to_neighbor_in_multi_project`:

- `test_close_project_when_active_workspace_not_retained` opens a project without opening the sidebar (active workspace unretained), closes it, and asserts both that the workspace no longer holds the project and that no stale project group remains (covers defects 1 and 3).
- `test_close_project_dispatched_at_window_root` uses `window.disable_focus()` to force dispatch to fall back to the window root, then asserts `CloseProject` still closes the project (covers defect 2). It fails against a workspace-scoped handler and passes with the global one.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed File > Close Project sometimes doing nothing instead of closing the current project
