### PR TITLE
editor: Reload externally changed files on focus

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10371,8 +10371,26 @@ impl Editor {
         self.focus_handle.is_focused(window)
     }
 
+    pub(crate) fn refresh_buffers_from_disk(&self, cx: &mut Context<Self>) {
+        if !self.mode.is_full() {
+            return;
+        }
+        let Some(project) = self.project.as_ref() else {
+            return;
+        };
+        let Some(buffer) = self.active_buffer(cx) else {
+            return;
+        };
+        project
+            .update(cx, |project, cx| {
+                project.refresh_buffers_from_disk([buffer], cx)
+            })
+            .detach();
+    }
+
     fn handle_focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         cx.emit(EditorEvent::Focused);
+        self.refresh_buffers_from_disk(cx);
 
         if let Some(descendant) = self
             .last_focused_descendant

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -42,7 +42,7 @@ use multi_buffer::{IndentGuide, MultiBuffer, MultiBufferOffset, MultiBufferOffse
 use parking_lot::Mutex;
 use pretty_assertions::{assert_eq, assert_ne};
 use project::{
-    FakeFs, Project, ProjectPath,
+    FakeFs, Fs, Project, ProjectPath,
     bookmark_store::SerializedBookmark,
     debugger::breakpoint_store::{BreakpointState, SourceBreakpoint},
     project_settings::LspSettings,
@@ -212,6 +212,88 @@ fn test_edit_events(cx: &mut TestAppContext) {
         editor.backspace(&Backspace, window, cx);
     });
     assert_eq!(mem::take(&mut *events.borrow_mut()), []);
+}
+
+#[gpui::test]
+async fn test_refresh_only_active_multibuffer_from_disk(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "active.txt": "active contents",
+            "inactive.txt": "inactive contents",
+        }),
+    )
+    .await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let active_buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/dir/active.txt"), cx)
+        })
+        .await
+        .unwrap();
+    let inactive_buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/dir/inactive.txt"), cx)
+        })
+        .await
+        .unwrap();
+    let multibuffer = cx.new(|cx| {
+        let mut multibuffer = MultiBuffer::new(ReadWrite);
+        multibuffer.set_excerpts_for_path(
+            PathKey::sorted(0),
+            active_buffer.clone(),
+            [Point::zero()..active_buffer.read(cx).max_point()],
+            0,
+            cx,
+        );
+        multibuffer.set_excerpts_for_path(
+            PathKey::sorted(1),
+            inactive_buffer.clone(),
+            [Point::zero()..inactive_buffer.read(cx).max_point()],
+            0,
+            cx,
+        );
+        multibuffer
+    });
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        build_editor_with_project(project.clone(), multibuffer, window, cx)
+    });
+
+    editor.read_with(cx, |editor, cx| {
+        assert_eq!(editor.active_buffer(cx), Some(active_buffer.clone()));
+    });
+
+    fs.pause_events();
+    fs.save(
+        path!("/dir/active.txt").as_ref(),
+        &"changed active contents".into(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    fs.save(
+        path!("/dir/inactive.txt").as_ref(),
+        &"changed inactive contents".into(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    cx.run_until_parked();
+
+    editor.update(cx, |editor, cx| editor.refresh_buffers_from_disk(cx));
+    cx.run_until_parked();
+
+    active_buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "changed active contents");
+    });
+    inactive_buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "inactive contents");
+    });
+
+    fs.unpause_events_and_flush();
 }
 
 #[gpui::test]

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4261,6 +4261,47 @@ impl Project {
         })
     }
 
+    /// Re-stats the files backing the given buffers so that external changes are picked up
+    /// even when filesystem events were dropped (e.g. files inside git-ignored directories,
+    /// whose parent directories are never watched by the background scanner). The refreshed
+    /// entries flow through the normal `UpdatedEntries` -> `BufferStore::local_worktree_entry_changed`
+    /// -> `Buffer::file_updated` path, so clean buffers auto-reload, dirty buffers gain a
+    /// conflict, and deleted/recreated files transition `DiskState` correctly.
+    pub fn refresh_buffers_from_disk(
+        &self,
+        buffers: impl IntoIterator<Item = Entity<Buffer>>,
+        cx: &mut Context<Self>,
+    ) -> Task<()> {
+        let mut paths_by_worktree: HashMap<Entity<Worktree>, Vec<Arc<RelPath>>> =
+            HashMap::default();
+        for buffer in buffers {
+            let Some(file) = File::from_dyn(buffer.read(cx).file()) else {
+                continue;
+            };
+            if !file.is_local {
+                continue;
+            }
+            paths_by_worktree
+                .entry(file.worktree.clone())
+                .or_default()
+                .push(file.path.clone());
+        }
+
+        let mut receivers = Vec::new();
+        for (worktree, paths) in paths_by_worktree {
+            if let Some(local_worktree) = worktree.read(cx).as_local() {
+                receivers.push(local_worktree.refresh_entries_for_paths(paths));
+            }
+        }
+
+        cx.background_spawn(async move {
+            use postage::stream::Stream as _;
+            for mut receiver in receivers {
+                receiver.recv().await;
+            }
+        })
+    }
+
     pub fn reload_images(
         &self,
         images: HashSet<Entity<ImageItem>>,

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -7069,6 +7069,97 @@ async fn test_buffer_file_changes_on_disk(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_refresh_buffers_from_disk(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "the-file": "initial contents",
+        }),
+    )
+    .await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let buffer = project
+        .update(cx, |p, cx| p.open_local_buffer(path!("/dir/the-file"), cx))
+        .await
+        .unwrap();
+
+    // Simulate a filesystem event that never reaches the worktree (as happens
+    // for files inside git-ignored directories, whose parent directories are
+    // never watched by the background scanner).
+    fs.pause_events();
+    fs.save(
+        path!("/dir/the-file").as_ref(),
+        &"changed on disk".into(),
+        LineEnding::Unix,
+    )
+    .await
+    .unwrap();
+    cx.executor().run_until_parked();
+    buffer.update(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "initial contents");
+        assert!(!buffer.has_conflict());
+    });
+
+    // Refreshing from disk re-stats the file directly, bypassing the dropped
+    // watcher event, and reloads the clean buffer.
+    project
+        .update(cx, |project, cx| {
+            project.refresh_buffers_from_disk([buffer.clone()], cx)
+        })
+        .await;
+    cx.executor().run_until_parked();
+    buffer.update(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "changed on disk");
+        assert!(!buffer.is_dirty());
+        assert!(!buffer.has_conflict());
+    });
+
+    // If the buffer has unsaved edits, refreshing surfaces a conflict instead
+    // of clobbering them.
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "unsaved ")], None, cx);
+        assert!(buffer.is_dirty());
+    });
+    fs.save(
+        path!("/dir/the-file").as_ref(),
+        &"changed again on disk".into(),
+        LineEnding::Unix,
+    )
+    .await
+    .unwrap();
+    project
+        .update(cx, |project, cx| {
+            project.refresh_buffers_from_disk([buffer.clone()], cx)
+        })
+        .await;
+    cx.executor().run_until_parked();
+    buffer.update(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "unsaved changed on disk");
+        assert!(buffer.has_conflict());
+    });
+
+    // Deleting the file on disk is picked up as a `DiskState::Deleted`
+    // transition once refreshed.
+    fs.remove_file(path!("/dir/the-file").as_ref(), RemoveOptions::default())
+        .await
+        .unwrap();
+    project
+        .update(cx, |project, cx| {
+            project.refresh_buffers_from_disk([buffer.clone()], cx)
+        })
+        .await;
+    cx.executor().run_until_parked();
+    buffer.update(cx, |buffer, _| {
+        assert!(buffer.file().unwrap().disk_state().is_deleted());
+    });
+
+    fs.unpause_events_and_flush();
+}
+
+#[gpui::test]
 async fn test_buffer_line_endings(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6860,6 +6860,23 @@ impl Workspace {
                 cx.background_spawn(async move { db.update_timestamp(database_id).await })
                     .detach();
             }
+
+            let buffers = self
+                .panes
+                .iter()
+                .filter_map(|pane| {
+                    let pane = pane.read(cx);
+                    let project_path = pane.active_item()?.project_path(cx)?;
+                    self.project.read(cx).get_open_buffer(&project_path, cx)
+                })
+                .collect::<HashSet<_>>();
+            if !buffers.is_empty() {
+                self.project
+                    .update(cx, |project, cx| {
+                        project.refresh_buffers_from_disk(buffers, cx)
+                    })
+                    .detach();
+            }
         } else {
             // When window is deactivated, flush any deferred saves since focus has left the window
             self.flush_deferred_saves(window, cx);
@@ -11624,7 +11641,7 @@ mod tests {
             test::{TestItem, TestProjectItem},
         },
     };
-    use fs::FakeFs;
+    use fs::{FakeFs, Fs};
     use gpui::{
         DismissEvent, Empty, EventEmitter, FocusHandle, Focusable, Render, TestAppContext,
         UpdateGlobal, VisualTestContext, px,
@@ -12584,6 +12601,67 @@ mod tests {
         left_pane.read_with(cx, |pane, _| {
             assert_eq!(pane.items_len(), 0);
         });
+    }
+
+    #[gpui::test]
+    async fn test_window_activation_refreshes_buffer_for_wrapped_item(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/dir"),
+            json!({
+                "file.txt": "initial contents",
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer(path!("/dir/file.txt"), cx)
+            })
+            .await
+            .unwrap();
+        let worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+        let item = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new_in_worktree(
+                1,
+                "file.txt",
+                worktree_id,
+                cx,
+            )])
+        });
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item), None, true, window, cx);
+        });
+
+        cx.deactivate_window();
+        fs.pause_events();
+        fs.save(
+            path!("/dir/file.txt").as_ref(),
+            &"changed on disk".into(),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+        cx.run_until_parked();
+        buffer.read_with(cx, |buffer, _| {
+            assert_eq!(buffer.text(), "initial contents");
+        });
+
+        cx.update(|window, _| window.activate_window());
+        cx.run_until_parked();
+        buffer.read_with(cx, |buffer, _| {
+            assert_eq!(buffer.text(), "changed on disk");
+        });
+
+        fs.unpause_events_and_flush();
     }
 
     #[gpui::test]


### PR DESCRIPTION
## Context

Closes #18534

Zed normally detects external file changes through worktree filesystem events. Those events can be missed for files in ignored directories whose parents are not watched, or when a filesystem watcher loses synchronization. This can leave an open buffer showing stale content until the user manually reloads it, which is particularly risky when external tools or agents edit the same file.

This change re-stats the active local buffer whenever a full editor receives focus. When the application window is reactivated, the workspace resolves each pane's active project path and refreshes the corresponding open buffer. Resolving the path through the workspace item also covers wrapped editors such as project search, split editors, and Git diff views.

The refreshed entries flow through the existing worktree and buffer update pipeline. Clean buffers reload automatically, dirty buffers retain their edits and surface a conflict, and deleted files transition to the correct disk state. Multibuffers refresh only the buffer containing the active selection, avoiding thousands of filesystem operations for large project-search results.

Manual test after change :

[Screencast from 2026-07-20 16-04-42.webm](https://github.com/user-attachments/assets/43640982-89d8-457f-8473-f9c81c20b9a3)


## How to Review

- `crates/project/src/project.rs`: Adds `Project::refresh_buffers_from_disk`, which extracts local file paths from buffers, groups them by worktree, calls `refresh_entries_for_paths`, and awaits the resulting scan barriers.

- `crates/project/tests/integration/project_tests.rs`: Adds a GPUI test covering clean-buffer refreshes, dirty-buffer conflicts, and deleted-file disk-state updates.

- `crates/editor/src/editor.rs`: Adds `Editor::refresh_buffers_from_disk` and calls it from `handle_focus`. The method passes only the buffer containing the active selection to the project refresh API.

- `crates/editor/src/editor_tests.rs`: Adds a two-buffer multibuffer test that verifies only the active buffer is refreshed.

- `crates/workspace/src/workspace.rs`: Collects the open buffers associated with each pane’s active project path and refreshes them when the window becomes active. Adds a GPUI test for this activation path.

## Self-Review Checklist

- [x] I've reviewed my own diff for quality, security, and reliability
- [ ] Unsafe blocks (if any) have justifying comments
- [x] The content is consistent with the UI/UX checklist
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

Release Notes:

- Fixed open files not reloading changes made by external tools