### PR TITLE
cloud_api_client: Make `cloud_host` method public

### DIFF
--- a/crates/cloud_api_client/src/cloud_api_client.rs
+++ b/crates/cloud_api_client/src/cloud_api_client.rs
@@ -87,7 +87,7 @@ impl CloudApiClient {
         *self.credentials.write() = None;
     }
 
-    fn cloud_host(&self) -> String {
+    pub fn cloud_host(&self) -> String {
         self.http_client
             .build_zed_cloud_url("/")
             .ok()


### PR DESCRIPTION
This PR makes the `cloud_host` method on `CloudApiClient` public.

Release Notes:

- N/A
