### PR TITLE
settings: Fix broken rustdoc intra-doc link in `Settings::PRESERVED_KEYS`

### DIFF
--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -58,11 +58,11 @@ pub trait SettingsKey: 'static + Send + Sync {
 ///
 /// Settings can be loaded from a combination of multiple JSON files.
 pub trait Settings: 'static + Send + Sync + Sized {
-    /// The name of the keys in the [`FileContent`](Self::FileContent) that should
+    /// The name of the keys in the [`SettingsContent`] that should
     /// always be written to a settings file, even if their value matches the default
     /// value.
     ///
-    /// This is useful for tagged [`FileContent`](Self::FileContent)s where the tag
+    /// This is useful for tagged [`SettingsContent`]s where the tag
     /// is a "version" field that should always be persisted, even if the current
     /// user settings match the current version of the settings.
     const PRESERVED_KEYS: Option<&'static [&'static str]> = None;


### PR DESCRIPTION
## Objective

The doc comment links for `Settings::PRESERVED_KEYS` point to `[FileContent](Self::FileContent)` but that associated type was removed by the settings refactor in https://github.com/zed-industries/zed/pull/38367. `Settings::from_settings` now takes `&SettingsContent` directly. The dead link causes `rustdoc::broken_intra_doc_links` warnings when building docs for the `settings` crate:

```
warning: unresolved link to `Self::FileContent`
  --> crates/settings/src/settings_store.rs:61:53
    |
61 |     /// The name of the keys in the [`FileContent`](Self::FileContent) that should
    |                                                     ^^^^^^^^^^^^^^^^^ the trait `Settings` has no associated item named `FileContent`
```

Fixes #57310

## Solution

Replaced both `[FileContent](Self::FileContent)` occurrences in `crates/settings/src/settings_store.rs` with `[SettingsContent]`, which is already in scope via the existing `use` at the top of the file and resolves correctly. Docs-only change, no runtime behavior change.

## Testing

- Verified with `cargo doc -p settings --no-deps`, which now completes without any `broken_intra_doc_links` warnings (previously emitted two).
- No runtime code touched — doc comments only, so no other testing applies.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

---

Release Notes:

- N/A
