### PR TITLE
editor: Fix right-click context menus failing to appear at pixel-snapped scroll positions

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -165,7 +165,7 @@ use gpui::{
     Action, Animation, AnimationExt, AnyElement, App, AppContext, AsyncWindowContext,
     AvailableSpace, Background, Bounds, ClickEvent, ClipboardEntry, ClipboardItem, Context,
     DispatchPhase, Edges, Entity, EntityId, EntityInputHandler, EventEmitter, FocusHandle,
-    FocusOutEvent, Focusable, FontId, FontStyle, FontWeight, Global, HighlightStyle, Hsla,
+    FocusOutEvent, Focusable, FontId, FontStyle, FontWeight, Global, HighlightStyle, Hsla, IsZero,
     KeyContext, Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, PaintQuad, ParentElement,
     Pixels, PressureStage, Render, ScrollHandle, SharedString, SharedUri, Size, Stateful, Styled,
     Subscription, Task, TextRun, TextStyle, TextStyleRefinement, UTF16Selection, UnderlineStyle,
@@ -10570,10 +10570,14 @@ impl Editor {
     ) -> Option<gpui::Point<Pixels>> {
         let line_height = self.style(cx).text.line_height_in_pixels(window.rem_size());
         let text_layout_details = self.text_layout_details(window, cx);
-        let scroll_top = text_layout_details
+        let mut scroll_top = text_layout_details
             .scroll_anchor
             .scroll_position(editor_snapshot)
             .y;
+        if !line_height.is_zero() {
+            scroll_top =
+                window.pixel_snap_f64(scroll_top * f64::from(line_height)) / f64::from(line_height);
+        }
 
         if source.row().as_f64() < scroll_top.floor() {
             return None;

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -352,7 +352,12 @@ pub fn deploy_context_menu(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{editor_tests::init_test, test::editor_lsp_test_context::EditorLspTestContext};
+    use crate::{
+        editor_tests::init_test,
+        test::{
+            editor_lsp_test_context::EditorLspTestContext, editor_test_context::EditorTestContext,
+        },
+    };
     use indoc::indoc;
 
     #[gpui::test]
@@ -399,5 +404,49 @@ mod tests {
             }
         "});
         cx.editor(|editor, _window, _app| assert!(editor.mouse_context_menu.is_some()));
+    }
+
+    #[gpui::test]
+    async fn test_mouse_context_menu_at_pixel_snapped_scroll_position(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        init_test(cx, |_| {});
+
+        let mut cx = EditorTestContext::new(cx).await;
+        cx.set_state(&format!("ˇ{}", "aaaaa\n".repeat(100)));
+        cx.update(|window, _| window.set_scale_factor(1.25));
+        cx.update_editor(|editor, _, cx| {
+            editor.set_text_style_refinement(gpui::TextStyleRefinement {
+                font_size: Some(gpui::px(14.).into()),
+                line_height: Some(gpui::relative(1.3)),
+                ..Default::default()
+            });
+            cx.notify();
+        });
+        cx.run_until_parked();
+
+        cx.update_editor(|editor, window, cx| {
+            assert_eq!(window.scale_factor(), 1.25);
+            let line_height = editor
+                .style(cx)
+                .text
+                .line_height_in_pixels(window.rem_size());
+            assert_eq!(line_height, gpui::px(18.));
+            assert!(window.pixel_snap_f64(f64::from(line_height)) / f64::from(line_height) < 1.);
+            editor.set_scroll_position(gpui::point(0., 1.), window, cx);
+            assert_eq!(editor.snapshot(window, cx).scroll_position().y, 1.);
+
+            deploy_context_menu(
+                editor,
+                Some(gpui::point(gpui::px(200.), gpui::px(200.))),
+                DisplayPoint::new(crate::display_map::DisplayRow(5), 0),
+                window,
+                cx,
+            );
+            assert!(editor.mouse_context_menu.is_some());
+        });
+        cx.run_until_parked();
+
+        assert!(cx.debug_bounds("MENU_ITEM-Copy").is_some());
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2461,6 +2461,13 @@ impl Window {
         self.scale_factor
     }
 
+    /// Overrides the display scale factor for tests.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn set_scale_factor(&mut self, scale_factor: f32) {
+        self.scale_factor = scale_factor;
+        self.refresh();
+    }
+
     /// The size of an em for the base font of the application. Adjusting this value allows the
     /// UI to scale, just like zooming a web page.
     pub fn rem_size(&self) -> Pixels {


### PR DESCRIPTION
# Objective

Fixes #56136.

The issue was initially reported while an agent was generating code. Later reports reproduced it during manual editing and with AI disabled, ruling out the agent as the cause.

At fractional display scales, the editor's right-click context menu could fail to appear at specific discrete scroll positions. Scrolling one line at a time could make the menu alternate between hidden and visible, even when its anchor remained within the viewport.



## Solution

The editor-specific changes in #54728 started pixel-snapping the vertical scroll position used by `EditorElement` to derive and render visible rows. However, `Editor::display_to_pixel_point` continued using the raw scroll position for its visibility check and vertical projection.

When a downward pixel snap crossed an integer display-row boundary, `EditorElement` treated the preceding row as the visible range start. `display_to_pixel_point` then rejected that row as being above the raw viewport. Mouse context menu layout returned early before inspecting the actual clicked anchor, leaving the menu state present without rendering its element.

This change applies the same line-height and display-scale pixel snapping in `display_to_pixel_point`. Its visibility check and coordinate projection now use the coordinate space actually rendered by the editor.

A test-support-only scale-factor setter was also added so GPUI tests can exercise fractional display scaling without depending on the host display.

## Testing

Added a GPUI regression test using 100 plain-text lines so the editor can scroll. The test uses a `1.25` scale factor and a `14px` font with `1.3` relative line height. The resulting `18.2px` line height is rounded to `18px`, producing exactly `22.5` device pixels per row.

At a raw scroll position of one row, midpoint-toward-zero snapping maps `22.5` device pixels to `22`, or approximately `0.978` rows. This reproduces the old boundary mismatch where the snapped visible range starts at row zero while the raw visibility check starts at row one.

The test pins these values with precondition assertions. Row five and an in-bounds click keep the actual source visible, while checking the rendered bounds of the `Copy` item ensures the test does not pass merely because menu state was created.

Manually verified that scrolling from the start of a document no longer makes the context menu alternate between hidden and visible.

## Self-Review Checklist:

- [x] I've reviewed my own diff for quality, security, and reliability
- [x] Unsafe blocks (if any) have justifying comments
- [x] The content adheres to Zed's UI standards ([UX/UI](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) and [icon](https://github.com/zed-industries/zed/blob/main/crates/icons/README.md) guidelines)
- [x] Tests cover the new/changed behavior
- [x] Performance impact has been considered and is acceptable

## Showcase

Before:

https://github.com/user-attachments/assets/e14c030f-1587-4172-aed2-fecfbfcb65ed


After:


https://github.com/user-attachments/assets/3080db1e-46eb-4e20-a619-b1608f233668



---

Release Notes:

- Fixed editor right-click context menus intermittently failing to appear at certain scroll positions.
