### PR TITLE
anthropic: Disable fast mode for Opus 4.6 and 4.7

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -22,10 +22,7 @@ pub const ANTHROPIC_API_URL: &str = "https://api.anthropic.com";
 pub const FAST_MODE_BETA_HEADER: &str = "fast-mode-2026-02-01";
 
 pub fn supports_fast_mode(model_id: &str) -> bool {
-    matches!(
-        model_id,
-        "claude-opus-4-6" | "claude-opus-4-7" | "claude-opus-4-8"
-    )
+    model_id == "claude-opus-4-8"
 }
 
 pub const FABLE_MODEL_ID_PREFIX: &str = "claude-fable-5";


### PR DESCRIPTION
Anthropic no longer supports fast mode for Claude Opus 4.6 or 4.7.
Stop advertising the capability for these models in BYOK mode.

https://platform.claude.com/docs/en/build-with-claude/fast-mode

Release Notes:

- Fixed the fast mode control being shown for Claude Opus 4.6 and 4.7 when using an Anthropic API key. It is [no longer supported for these models](https://platform.claude.com/docs/en/build-with-claude/fast-mode).