### PR TITLE
settings: Fix VS Code import appending duplicate file associations

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -892,7 +892,7 @@ impl settings::Settings for AllLanguageSettings {
 
             file_types.insert(
                 language.clone(),
-                (builder.build().unwrap(), patterns.0.clone()),
+                (builder.build().unwrap(), patterns.0.iter().cloned().collect()),
             );
         }
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -892,7 +892,10 @@ impl settings::Settings for AllLanguageSettings {
 
             file_types.insert(
                 language.clone(),
-                (builder.build().unwrap(), patterns.0.iter().cloned().collect()),
+                (
+                    builder.build().unwrap(),
+                    patterns.0.iter().cloned().collect(),
+                ),
             );
         }
 

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -36,7 +36,7 @@ use crate::{
     LanguageToSettingsMap, LspSettings, LspSettingsMap, SemanticTokenRules, ThemeName,
     UserSettingsContentExt, VsCodeSettings, WorktreeId,
     settings_content::{
-        ExtendingVec, ExtensionsSettingsContent, ProfileBase, ProjectSettingsContent,
+        ExtendingSet, ExtensionsSettingsContent, ProfileBase, ProjectSettingsContent,
         RootUserSettings, SettingsContent, UserSettingsContent, merge_from::MergeFrom,
     },
 };
@@ -1203,7 +1203,7 @@ impl SettingsStore {
             });
 
             let file_type_patterns_ref =
-                generator.subschema_for::<ExtendingVec<String>>().to_value();
+                generator.subschema_for::<ExtendingSet<String>>().to_value();
             replace_subschema::<FileTypeMap>(generator, || {
                 json_schema!({
                     "type": "object",
@@ -2611,6 +2611,32 @@ mod tests {
                 "show": "always"
               },
               "format_on_save": "off"
+            }
+            "#
+            .unindent(),
+            cx,
+        );
+
+        // re-importing a file association that is already present should be
+        // idempotent rather than appending a duplicate extension (#56536)
+        check_vscode_import(
+            &mut store,
+            r#"{
+              "file_types": {
+                "c": ["*.keymap"]
+              }
+            }
+            "#
+            .unindent(),
+            r#"{ "files.associations": { "*.keymap": "c" } }"#.to_owned(),
+            r#"{
+              "base_keymap": "VSCode",
+              "minimap": {
+                "show": "always"
+              },
+              "file_types": {
+                "c": ["*.keymap"]
+              }
             }
             "#
             .unindent(),

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -644,11 +644,11 @@ impl VsCodeSettings {
 
     fn file_types(&self) -> Option<FileTypeMap> {
         // vscodes file association map is inverted from ours, so we flip the mapping before merging
-        let mut associations: HashMap<Arc<str>, ExtendingVec<String>> = HashMap::default();
+        let mut associations: HashMap<Arc<str>, ExtendingSet<String>> = HashMap::default();
         let map = self.read_value("files.associations")?.as_object()?;
         for (k, v) in map {
             let Some(v) = v.as_str() else { continue };
-            associations.entry(v.into()).or_default().0.push(k.clone());
+            associations.entry(v.into()).or_default().0.insert(k.clone());
         }
         skip_default(FileTypeMap(associations))
     }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -648,7 +648,11 @@ impl VsCodeSettings {
         let map = self.read_value("files.associations")?.as_object()?;
         for (k, v) in map {
             let Some(v) = v.as_str() else { continue };
-            associations.entry(v.into()).or_default().0.insert(k.clone());
+            associations
+                .entry(v.into())
+                .or_default()
+                .0
+                .insert(k.clone());
         }
         skip_default(FileTypeMap(associations))
     }

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use settings_macros::{MergeFrom, with_fallible_options};
 use std::sync::Arc;
 
-use crate::{DocumentFoldingRanges, DocumentSymbols, ExtendingVec, SemanticTokens, merge_from};
+use crate::{DocumentFoldingRanges, DocumentSymbols, ExtendingSet, SemanticTokens, merge_from};
 
 /// The state of the modifier keys at some point in time
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, MergeFrom)]
@@ -1203,11 +1203,11 @@ pub struct LanguageToSettingsMap(pub HashMap<String, LanguageSettingsContent>);
 /// Map from language name to file patterns.
 #[with_fallible_options]
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
-pub struct FileTypeMap(pub HashMap<Arc<str>, ExtendingVec<String>>);
+pub struct FileTypeMap(pub HashMap<Arc<str>, ExtendingSet<String>>);
 
 impl<'a> IntoIterator for &'a FileTypeMap {
-    type Item = (&'a Arc<str>, &'a ExtendingVec<String>);
-    type IntoIter = std::collections::hash_map::Iter<'a, Arc<str>, ExtendingVec<String>>;
+    type Item = (&'a Arc<str>, &'a ExtendingSet<String>);
+    type IntoIter = std::collections::hash_map::Iter<'a, Arc<str>, ExtendingSet<String>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -32,7 +32,7 @@ pub use theme::*;
 pub use title_bar::*;
 pub use workspace::*;
 
-use collections::{HashMap, IndexMap};
+use collections::{HashMap, IndexMap, IndexSet};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings_macros::{MergeFrom, with_fallible_options};
@@ -1394,6 +1394,27 @@ impl<T> From<Vec<T>> for ExtendingVec<T> {
 impl<T: Clone> merge_from::MergeFrom for ExtendingVec<T> {
     fn merge_from(&mut self, other: &Self) {
         self.0.extend_from_slice(other.0.as_slice());
+    }
+}
+
+// An ExtendingSet in the settings can only accumulate new values, and ignores
+// values that are already present, so merging the same source more than once
+// (e.g. re-importing VS Code settings) is idempotent.
+//
+// Insertion order is preserved, so it round-trips through the user's settings
+// file without reordering their entries.
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ExtendingSet<T: std::hash::Hash + Eq>(pub IndexSet<T>);
+
+impl<T: std::hash::Hash + Eq> From<Vec<T>> for ExtendingSet<T> {
+    fn from(vec: Vec<T>) -> Self {
+        ExtendingSet(vec.into_iter().collect())
+    }
+}
+
+impl<T: Clone + std::hash::Hash + Eq> merge_from::MergeFrom for ExtendingSet<T> {
+    fn merge_from(&mut self, other: &Self) {
+        self.0.extend(other.0.iter().cloned());
     }
 }
 


### PR DESCRIPTION
Closes #56536

## What & why

Running `zed: import vs code settings` more than once kept re-adding the same file extensions to `file_types`, so `files.associations` entries grew without bound:

```json
"file_types": { "c": ["*.keymap", "*.keymap", "*.keymap"] }
```

The import merges the VS Code-derived settings into the user's existing settings, and `file_types` values were `ExtendingVec`s, whose `merge_from` appends every incoming value unconditionally.

Per review feedback, instead of changing `ExtendingVec`'s merge semantics (it also backs ssh/wsl connections, `private_files`, etc.), this adds a new `ExtendingSet` type that actually behaves like a set, and switches `FileTypeMap`'s file associations to it:

- Backed by an insertion-order-preserving `IndexSet`, so users' pattern order round-trips through the settings file unchanged (the import machinery diffs serialized old/new content to produce edits; a sorted set would reorder existing arrays).
- Merging only accumulates new values, so re-importing an already-present association is a no-op.
- Since it's a real set, deserialization also collapses duplicates that earlier imports already wrote into the settings file.
- `ExtendingVec` and all its other users are untouched.

## Testing

- Added a `test_vscode_import` case that re-imports an already-present `files.associations` entry and asserts the extension isn't duplicated. It fails before the change and passes after.
- `cargo test -p settings -p settings_content -p language` pass.
- `./script/clippy -p settings -p settings_content -p language -p recent_projects -p json_schema_store` is clean.

Release Notes:

- Fixed importing VS Code settings repeatedly adding duplicate `file_types` entries for `files.associations`.
